### PR TITLE
fix: work-stealing for mutalyzer normalize shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ __pycache__/
 *.pyc
 *.egg-info/
 
+# Manuscript (benchmark workflow, figures, drafts)
+manuscript/
+
 # Pixi
 .pixi/


### PR DESCRIPTION
## Summary

- Replace static round-robin shard-to-worker assignment with a work-stealing pool for mutalyzer normalization benchmarks
- Each non-empty shard becomes an independent task in a shared queue — when a worker finishes, it immediately picks up the next available shard
- Eliminates the straggler problem where one worker gets stuck with disproportionately slow shards while others sit idle
- Add proper child process cleanup on error paths to prevent orphaned subprocesses
- Forward the caller's `settings_file` to the presharded path instead of hardcoding the filename

## Changes

- **`src/benchmark/compare.rs`**: Refactor `run_mutalyzer_normalize_presharded` from static round-robin to work-stealing with a `VecDeque` task queue. Extract `spawn_mutalyzer_worker` helper. Add `cleanup_active_workers` / `cleanup_children` to kill+wait all running subprocesses on error paths (applies to mutalyzer presharded, mutalyzer runtime, and biocommons parallel). Forward `settings_file` parameter instead of hardcoding path.
- **`.gitignore`**: Add `manuscript/` (benchmark Snakemake workflow, plotting scripts, drafts)

## Test plan

- [x] CI passes (Build, Clippy, Format, Test)
- [ ] Re-run medium tier with work-stealing to verify improvement over round-robin