### PR TITLE
fix: CIGAR-aware CDS-to-transcript coordinate mapping

### DIFF
--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -114,6 +114,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -312,6 +312,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }
@@ -799,6 +800,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 

--- a/src/convert/protein.rs
+++ b/src/convert/protein.rs
@@ -84,6 +84,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }

--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -513,6 +513,7 @@ mod tests {
             cds_end: Some(400),  // CDS ends at tx pos 400
             gene_id: None,
             protein: None,
+            exon_cigars: Vec::new(),
         };
         cdot.add_transcript("NM_TEST.1".to_string(), tx);
 
@@ -530,6 +531,7 @@ mod tests {
             cds_end: Some(400),
             gene_id: None,
             protein: None,
+            exon_cigars: Vec::new(),
         };
         cdot.add_transcript("NM_MINUS.1".to_string(), tx_minus);
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -28,6 +28,9 @@ pub mod cdot;
 pub mod mapping;
 pub mod projection;
 
-pub use cdot::{CdotFile, CdotMapper, CdotTranscript, CdsPosition, Exon};
+pub use cdot::{
+    cumulative_insertion_offset, parse_cigar, CdotFile, CdotMapper, CdotTranscript, CdsPosition,
+    CigarOp, Exon,
+};
 pub use mapping::{CoordinateMapper, MappingInfo, MappingResult};
 pub use projection::{ManeStatus, ProjectionResult, Projector, TranscriptProjection};

--- a/src/data/projection.rs
+++ b/src/data/projection.rs
@@ -295,6 +295,7 @@ mod tests {
             cds_end: Some(400),
             gene_id: None,
             protein: None,
+            exon_cigars: Vec::new(),
         };
         cdot.add_transcript("NM_000001.1".to_string(), tx1);
 
@@ -308,6 +309,7 @@ mod tests {
             cds_end: Some(300),
             gene_id: None,
             protein: None,
+            exon_cigars: Vec::new(),
         };
         cdot.add_transcript("NM_000001.2".to_string(), tx2);
 

--- a/src/normalize/boundary.rs
+++ b/src/normalize/boundary.rs
@@ -93,6 +93,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2732,6 +2732,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -2952,6 +2953,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -3055,6 +3057,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -3119,6 +3122,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -3261,6 +3265,7 @@ mod tests {
             mane_status: Default::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: std::sync::OnceLock::new(),
         });
         let normalizer = Normalizer::new(provider);
@@ -3308,6 +3313,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: std::sync::OnceLock::new(),
         });
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -1038,6 +1038,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1072,6 +1073,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1112,6 +1114,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 

--- a/src/reference/loader.rs
+++ b/src/reference/loader.rs
@@ -707,6 +707,7 @@ impl TranscriptBuilder {
             mane_status: self.mane_status,
             refseq_match: self.refseq_match,
             ensembl_match: self.ensembl_match,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         })
     }
@@ -767,6 +768,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -795,6 +797,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -813,6 +816,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -842,6 +846,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -879,6 +884,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -897,6 +903,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -934,6 +941,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -952,6 +960,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1047,6 +1056,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1088,6 +1098,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1106,6 +1117,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1143,6 +1155,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1162,6 +1175,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1193,6 +1207,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1211,6 +1226,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1423,6 +1439,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1759,6 +1776,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1777,6 +1795,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1807,6 +1826,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1832,6 +1852,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
         db.add(tx_plus);
@@ -1856,6 +1877,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
         db.add(tx_select);

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -85,6 +85,7 @@ impl MockProvider {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -108,6 +109,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -127,6 +129,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 
@@ -152,6 +155,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
 

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -477,6 +477,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 

--- a/src/vcf/annotator.rs
+++ b/src/vcf/annotator.rs
@@ -308,6 +308,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -330,6 +331,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -575,6 +577,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -593,6 +596,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -643,6 +647,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -676,6 +681,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 

--- a/src/vcf/batch.rs
+++ b/src/vcf/batch.rs
@@ -413,6 +413,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -740,6 +740,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }

--- a/src/vcf/to_hgvs.rs
+++ b/src/vcf/to_hgvs.rs
@@ -627,6 +627,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
     }
@@ -1024,6 +1025,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 
@@ -1055,6 +1057,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
 


### PR DESCRIPTION
## Summary

- Parse GFF3 Gap (CIGAR) strings from cdot exon alignment data and thread them through to the Transcript model
- Apply net insertion adjustment in `cds_to_tx_exon_aware()` to correctly map CDS positions when exon alignments contain insertions or deletions
- Fixes ~840 intronic normalization failures across CIGAR-affected transcripts, non-contiguous cdot exons, version-mismatched transcripts, and LRG accessions

## Test plan

- [x] 21 CIGAR intronic normalization tests pass
- [x] 33 CIGAR edge case normalization tests pass
- [x] 10 cdot gap normalization tests pass
- [x] 15 version mismatch normalization tests pass
- [x] 16 LRG intronic normalization tests pass
- [x] Full suite: 2894 passed, 0 failed
- [x] `cargo clippy --features dev -- -D warnings` clean