### PR TITLE
fix: derive Python package version from Cargo.toml via maturin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ferro-hgvs"
-version = "0.1.0"
+dynamic = ["version"]
 description = "HGVS variant normalizer - Python bindings for the ferro bioinformatics toolkit"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Replace hardcoded `version = "0.1.0"` in `pyproject.toml` with `dynamic = ["version"]` so maturin reads the version from `Cargo.toml` at build time
- Prevents version drift between the Rust crate and Python package (already out of sync: pyproject.toml at 0.1.0 while PR #2 bumps Cargo.toml to 0.2.0)
- Single source of truth for version going forward — `release-plz` only needs to bump `Cargo.toml`

## Test plan

- [ ] Verify `maturin develop --features python` builds with correct version
- [ ] Verify `python -c "import ferro_hgvs; print(ferro_hgvs.__version__)"` matches `Cargo.toml`