### PR TITLE
fix: clean stale wheels before maturin build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
       - name: Install maturin and pytest
         run: pip install maturin pytest
       - name: Build Python wheel
-        run: maturin build --features python
+        run: |
+          rm -f target/wheels/*.whl
+          maturin build --features python
       - name: Install wheel and run Python tests
         run: |
           pip install target/wheels/*.whl


### PR DESCRIPTION
## Summary

- Remove old `.whl` files from `target/wheels/` before running `maturin build` in CI
- The `target/` directory is cached across runs, so when the crate version bumps, stale wheels from the previous version remain and `pip install target/wheels/*.whl` fails trying to install both versions

This is what's causing the Test failure on PR #2.

## Test plan

- [ ] CI passes on this PR (the wheel step runs successfully)
- [ ] After merging, PR #2 CI should pass on next `release-plz` regeneration