### PR TITLE
fix: unify mutalyzer configuration across web service and benchmarks

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -1,0 +1,194 @@
+name: Deploy to Local Server
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'pixi.toml'
+      - 'config/**'
+      - '.github/workflows/deploy-local.yml'
+  workflow_dispatch:  # Allow manual trigger
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BINARY_NAME: ferro-web
+  CONFIG_FILE: /opt/ferro-web/service.toml
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, linux, x64, ferro-deploy]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev
+
+      - name: Setup Rust
+        run: |
+          if ! command -v rustc &> /dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Setup Pixi
+        run: |
+          if ! command -v pixi &> /dev/null; then
+            curl -fsSL https://pixi.sh/install.sh | bash
+          fi
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+
+      - name: Install Python dependencies via Pixi
+        run: |
+          export PATH="$HOME/.pixi/bin:$PATH"
+          pixi install
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-web-hgvs-rs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-web-hgvs-rs-
+
+      - name: Build release binary (with hgvs-rs)
+        run: |
+          source "$HOME/.cargo/env"
+          cargo build --release --features "web-service hgvs-rs" --bin ferro-web
+
+      - name: Deploy binary
+        run: |
+          sudo systemctl stop ferro-web || true
+          sudo cp target/release/${{ env.BINARY_NAME }} /usr/local/bin/
+          sudo chmod +x /usr/local/bin/${{ env.BINARY_NAME }}
+
+      - name: Ensure directories exist
+        run: |
+          sudo mkdir -p /opt/ferro-web
+          sudo mkdir -p /var/lib/ferro-web/reference
+          sudo mkdir -p /var/lib/ferro-web/seqrepo
+          sudo mkdir -p /var/lib/ferro-web/mutalyzer-reference
+
+      - name: Install service config
+        run: |
+          sudo tee ${{ env.CONFIG_FILE }} > /dev/null << 'EOF'
+          [server]
+          host = "127.0.0.1"
+          port = 8080
+          request_timeout_seconds = 120
+          enable_cors = true
+
+          [tools.ferro]
+          enabled = true
+          reference_dir = "/var/lib/ferro-web/reference"
+          shuffle_direction = "3prime"
+          error_mode = "lenient"
+
+          # Mutalyzer runs as a local Python subprocess for reproducibility and
+          # offline operation. The MUTALYZER_SETTINGS env var approach is used
+          # to configure cache and reference paths — see settings_file below.
+          # Requires the mutalyzer Python package installed via pixi.
+          [tools.mutalyzer]
+          enabled = true
+          mode = "local"
+          settings_file = "/var/lib/ferro-web/mutalyzer_settings.txt"
+          allow_network = true
+          timeout_seconds = 60
+
+          [tools.biocommons]
+          enabled = true
+          uta_url = "postgresql://anonymous:anonymous@localhost:5432/uta/uta_20210129b"
+          uta_schema = "uta_20210129b"
+          seqrepo_path = "/var/lib/ferro-web/seqrepo/2021-01-29"
+          docker_container = "ferro-uta"
+          parallel_workers = 1
+
+          [tools.hgvs_rs]
+          enabled = true
+          uta_url = "postgresql://anonymous:anonymous@localhost:5432/uta"
+          uta_schema = "uta_20210129b"
+          seqrepo_path = "/var/lib/ferro-web/seqrepo/2021-01-29"
+          parallel_workers = 4
+          EOF
+
+      - name: Install mutalyzer settings
+        run: |
+          sudo tee /var/lib/ferro-web/mutalyzer_settings.txt > /dev/null << 'EOF'
+          MUTALYZER_CACHE_DIR=/var/lib/ferro-web/mutalyzer-reference
+          MUTALYZER_FILE_CACHE_ADD=true
+          EOF
+
+      - name: Install systemd service
+        run: |
+          sudo tee /etc/systemd/system/ferro-web.service > /dev/null << 'EOF'
+          [Unit]
+          Description=ferro-hgvs web service
+          After=network.target docker.service
+          Requires=docker.service
+
+          [Service]
+          Type=simple
+          User=ubuntu
+          ExecStart=/usr/local/bin/ferro-web serve -c /opt/ferro-web/service.toml
+          Restart=always
+          RestartSec=5
+          Environment=RUST_LOG=info
+          Environment=PATH=%h/.pixi/envs/default/bin:/usr/local/bin:/usr/bin:/bin
+
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+          sudo systemctl daemon-reload
+          sudo systemctl enable ferro-web
+
+      - name: Ensure UTA container is running
+        run: |
+          if ! sudo docker ps -a | grep -q ferro-uta; then
+            sudo docker run -d --name ferro-uta -p 127.0.0.1:5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust biocommons/uta:uta_20210129b
+          else
+            sudo docker start ferro-uta || true
+          fi
+          # Wait for postgres to accept connections
+          ready=0
+          for i in {1..30}; do
+            if sudo docker exec ferro-uta pg_isready -U anonymous 2>/dev/null; then
+              echo "UTA database ready"
+              ready=1
+              break
+            fi
+            echo "Waiting for UTA database ($i/30)..."
+            sleep 2
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "UTA database did not become ready in time"
+            exit 1
+          fi
+
+      - name: Start service
+        run: |
+          sudo systemctl start ferro-web || true
+
+      - name: Verify deployment
+        run: |
+          for i in {1..12}; do
+            if curl -sf http://localhost:8080/health; then
+              echo "Service healthy"
+              exit 0
+            fi
+            echo "Attempt $i/12: waiting for service..."
+            sleep 5
+          done
+          echo "Service failed to become healthy within 60s"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,6 @@ results/
 # Local configuration (generated via `ferro-web config`)
 config/service.toml
 
-# Local deployment workflow
-.github/workflows/deploy-local.yml
-
 # Python
 __pycache__/
 *.pyc

--- a/config/service.example.toml
+++ b/config/service.example.toml
@@ -1,0 +1,77 @@
+# ferro-hgvs web service configuration
+#
+# Copy this file to service.toml and adjust paths for your environment:
+#   cp config/service.example.toml config/service.toml
+#
+# Then start the service:
+#   ferro-web serve -c config/service.toml
+
+[server]
+host = "0.0.0.0"
+port = 3000
+request_timeout_seconds = 60
+enable_cors = true
+max_batch_size = 1000
+max_concurrent_batches = 10
+
+# ferro (native Rust normalizer)
+[tools.ferro]
+enabled = true
+reference_dir = "data/ferro-reference"
+shuffle_direction = "3prime"
+error_mode = "lenient"
+
+# Mutalyzer runs as a local Python subprocess for reproducibility and offline
+# operation. This avoids version drift between the mutalyzer.nl API and the
+# locally installed package, and keeps benchmark comparisons consistent.
+#
+# Requirements:
+#   - mutalyzer Python package (installed via pixi, pinned in pixi.toml)
+#   - A mutalyzer settings file (key=value format, sets MUTALYZER_CACHE_DIR
+#     and MUTALYZER_FILE_CACHE_ADD) — passed via the MUTALYZER_SETTINGS env
+#     var at subprocess launch time
+#   - A populated cache directory (built by `ferro prepare` or by running
+#     with allow_network = true to fetch from NCBI/EBI on first access)
+#
+# Available modes:
+#   - "local" (recommended): Spawns python3 subprocess, calls
+#     mutalyzer.description.Description.normalize() directly. Consistent
+#     with benchmark tool (compare.rs) behavior.
+#   - "api": Makes HTTP GET requests to a Mutalyzer API endpoint. Useful
+#     for testing against mutalyzer.nl or a local Mutalyzer HTTP server,
+#     but results may differ from local mode due to version differences.
+[tools.mutalyzer]
+enabled = true
+mode = "local"
+timeout_seconds = 60
+# Path to mutalyzer settings file (key=value format).
+# Must define MUTALYZER_CACHE_DIR and optionally MUTALYZER_FILE_CACHE_ADD.
+settings_file = "data/mutalyzer_settings.txt"
+allow_network = false  # Set to true to allow NCBI/EBI fetches for uncached sequences
+
+# API mode settings (only used when mode = "api"):
+# api_url = "https://mutalyzer.nl"
+# rate_limit_ms = 100
+# [tools.mutalyzer.connection_pool]
+# max_connections = 10
+# idle_timeout_seconds = 30
+# [tools.mutalyzer.circuit_breaker]
+# failure_threshold = 5
+# recovery_timeout_seconds = 60
+
+# Biocommons/hgvs (requires UTA database + SeqRepo)
+[tools.biocommons]
+enabled = true
+uta_url = "postgresql://anonymous:anonymous@localhost:5432/uta/uta_20210129b"
+uta_schema = "uta_20210129b"
+seqrepo_path = "data/seqrepo/2021-01-29"
+docker_container = "ferro-uta"
+parallel_workers = 1
+
+# hgvs-rs (Rust HGVS, requires UTA database + SeqRepo)
+[tools.hgvs_rs]
+enabled = true
+uta_url = "postgresql://anonymous:anonymous@localhost:5432/uta"
+uta_schema = "uta_20210129b"
+seqrepo_path = "data/seqrepo/2021-01-29"
+parallel_workers = 4

--- a/pixi.toml
+++ b/pixi.toml
@@ -24,8 +24,9 @@ rsync = ">=3.4.1,<4"
 
 [pypi-dependencies]
 # Mutalyzer - independent HGVS implementation with algebra-based normalizer
-mutalyzer = ">=3.0"
-mutalyzer-hgvs-parser = ">=0.3"
+# Pinned for reproducible benchmark results across local and deployed environments.
+mutalyzer = "==3.1.1"
+mutalyzer-hgvs-parser = "==0.3.9"
 
 # biocommons/hgvs - canonical Python HGVS implementation
 # Note: requires UTA database connection (remote by default at uta.biocommons.org)

--- a/src/benchmark/mutalyzer.rs
+++ b/src/benchmark/mutalyzer.rs
@@ -299,72 +299,53 @@ pub fn has_mutalyzer_normalizer() -> bool {
 ///
 /// This calls the mutalyzer package directly for local normalization,
 /// avoiding HTTP API calls for fair performance comparison.
-pub fn run_mutalyzer_normalizer_subprocess(
+///
+/// When `offline` is false, network calls are tracked and reported.
+/// When `offline` is true, network access is blocked to force cache-only operation.
+fn run_mutalyzer_normalizer_impl(
     input_file: &str,
     output_file: &str,
     settings_file: Option<&str>,
+    offline: bool,
 ) -> Result<(), FerroError> {
     use std::process::Command;
 
-    // Python script for local normalization
     let python_code = r#"
 import sys
 import json
 import time
 import os
 
-# Network call tracking - must be set up before any imports that use urllib
+offline = sys.argv[4] == "true"
+
+# Network setup: track calls when online, block when offline
 network_calls = []
-_original_urlopen = None
-
-def _tracking_urlopen(url, *args, **kwargs):
-    """Track network calls made by urllib."""
-    url_str = url if isinstance(url, str) else url.full_url if hasattr(url, 'full_url') else str(url)
-    start = time.perf_counter()
-    try:
-        result = _original_urlopen(url, *args, **kwargs)
-        elapsed = time.perf_counter() - start
-        network_calls.append({"url": url_str[:200], "elapsed_seconds": elapsed, "success": True})
-        return result
-    except Exception as e:
-        elapsed = time.perf_counter() - start
-        network_calls.append({"url": url_str[:200], "elapsed_seconds": elapsed, "success": False, "error": str(e)[:100]})
-        raise
-
-# Install network tracking
 import urllib.request
-_original_urlopen = urllib.request.urlopen
-urllib.request.urlopen = _tracking_urlopen
 
-# Set up mutalyzer settings if provided
-# We must configure the cache BEFORE importing mutalyzer, because
-# mutalyzer_retriever.configuration loads settings at import time.
-cache_dir = None
-cache_add = False
+if offline:
+    def _blocked_urlopen(*args, **kwargs):
+        raise ConnectionError("Network access disabled in offline mode")
+    urllib.request.urlopen = _blocked_urlopen
+else:
+    _original_urlopen = urllib.request.urlopen
+    def _tracking_urlopen(url, *args, **kwargs):
+        url_str = url if isinstance(url, str) else url.full_url if hasattr(url, 'full_url') else str(url)
+        start = time.perf_counter()
+        try:
+            result = _original_urlopen(url, *args, **kwargs)
+            elapsed = time.perf_counter() - start
+            network_calls.append({"url": url_str[:200], "elapsed_seconds": elapsed, "success": True})
+            return result
+        except Exception as e:
+            elapsed = time.perf_counter() - start
+            network_calls.append({"url": url_str[:200], "elapsed_seconds": elapsed, "success": False, "error": str(e)[:100]})
+            raise
+    urllib.request.urlopen = _tracking_urlopen
+
+# Set MUTALYZER_SETTINGS env var BEFORE importing mutalyzer.
+# mutalyzer-retriever reads config from this file at import time.
 if len(sys.argv) > 3 and sys.argv[3]:
-    settings_file = sys.argv[3]
-    try:
-        with open(settings_file, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith('MUTALYZER_CACHE_DIR'):
-                    parts = line.split('=', 1)
-                    if len(parts) == 2:
-                        cache_dir = parts[1].strip()
-                elif line.startswith('MUTALYZER_FILE_CACHE_ADD'):
-                    parts = line.split('=', 1)
-                    if len(parts) == 2:
-                        cache_add = parts[1].strip().lower() in ('true', '1', 'yes')
-    except Exception as e:
-        print(f"WARNING: Failed to parse settings file: {e}", file=sys.stderr)
-
-# Import mutalyzer_retriever first and configure the cache directory
-# directly in its settings dict (env vars don't work after import)
-from mutalyzer_retriever import configuration
-if cache_dir:
-    configuration.settings['MUTALYZER_CACHE_DIR'] = cache_dir
-if cache_add:
-    configuration.settings['MUTALYZER_FILE_CACHE_ADD'] = True
+    os.environ['MUTALYZER_SETTINGS'] = sys.argv[3]
 
 try:
     from mutalyzer.description import Description
@@ -405,6 +386,13 @@ for pattern in patterns:
                 "error": error_msg[:200]
             })
             failed += 1
+    except ConnectionError as e:
+        results.append({
+            "input": pattern,
+            "success": False,
+            "error": f"Network access required but disabled: {str(e)[:150]}"
+        })
+        failed += 1
     except Exception as e:
         results.append({
             "input": pattern,
@@ -423,9 +411,11 @@ output_data = {
     "elapsed_seconds": elapsed,
     "patterns_per_second": len(patterns) / elapsed if elapsed > 0 else 0,
     "network_calls": len(network_calls),
-    "network_stats": network_calls[:50] if network_calls else [],  # First 50 for debugging
     "results": results
 }
+
+if not offline:
+    output_data["network_stats"] = network_calls[:50]
 
 with open(output_file, 'w') as f:
     json.dump(output_data, f, indent=2)
@@ -438,11 +428,9 @@ if network_calls:
     print(f"Network calls per pattern: {len(network_calls) / len(patterns):.2f}", file=sys.stderr)
     print(f"Total network time: {total_network_time:.2f}s", file=sys.stderr)
     print(f"Average time per call: {total_network_time / len(network_calls):.2f}s", file=sys.stderr)
-    # Show unique URLs called
     unique_urls = set()
     for c in network_calls:
         url = c.get('url', '')
-        # Extract domain/path pattern
         if 'ncbi.nlm.nih.gov' in url:
             unique_urls.add('NCBI')
         elif 'ebi.ac.uk' in url:
@@ -450,7 +438,7 @@ if network_calls:
         else:
             unique_urls.add(url[:60])
     print(f"Endpoints hit: {', '.join(sorted(unique_urls))}", file=sys.stderr)
-else:
+elif not offline:
     print(f"\n=== Network Statistics ===", file=sys.stderr)
     print(f"Total network calls: 0 (all cached)", file=sys.stderr)
 "#;
@@ -464,18 +452,33 @@ else:
         cmd.arg("");
     }
 
+    cmd.arg(if offline { "true" } else { "false" });
+
     let output = cmd.output().map_err(|e| FerroError::Io {
         msg: format!("Failed to run Python: {}", e),
     })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let mode = if offline { "offline" } else { "online" };
         return Err(FerroError::Io {
-            msg: format!("Mutalyzer normalizer failed: {}", stderr),
+            msg: format!("Mutalyzer normalizer ({}) failed: {}", mode, stderr),
         });
     }
 
     Ok(())
+}
+
+/// Run local mutalyzer normalization via Python subprocess.
+///
+/// This calls the mutalyzer package directly for local normalization,
+/// avoiding HTTP API calls for fair performance comparison.
+pub fn run_mutalyzer_normalizer_subprocess(
+    input_file: &str,
+    output_file: &str,
+    settings_file: Option<&str>,
+) -> Result<(), FerroError> {
+    run_mutalyzer_normalizer_impl(input_file, output_file, settings_file, false)
 }
 
 /// Normalize a single HGVS variant using local mutalyzer subprocess.
@@ -575,141 +578,7 @@ pub fn run_mutalyzer_normalizer_subprocess_offline(
     output_file: &str,
     settings_file: Option<&str>,
 ) -> Result<(), FerroError> {
-    use std::process::Command;
-
-    // Python script for local normalization with network disabled
-    let python_code = r#"
-import sys
-import json
-import time
-import os
-
-# Block network access
-def _blocked_urlopen(*args, **kwargs):
-    raise ConnectionError("Network access disabled in offline mode")
-
-import urllib.request
-urllib.request.urlopen = _blocked_urlopen
-
-# Set up mutalyzer settings if provided
-cache_dir = None
-cache_add = False
-if len(sys.argv) > 3 and sys.argv[3]:
-    settings_file = sys.argv[3]
-    try:
-        with open(settings_file, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith('MUTALYZER_CACHE_DIR'):
-                    parts = line.split('=', 1)
-                    if len(parts) == 2:
-                        cache_dir = parts[1].strip()
-                elif line.startswith('MUTALYZER_FILE_CACHE_ADD'):
-                    parts = line.split('=', 1)
-                    if len(parts) == 2:
-                        cache_add = parts[1].strip().lower() in ('true', '1', 'yes')
-    except Exception as e:
-        print(f"WARNING: Failed to parse settings file: {e}", file=sys.stderr)
-
-# Import mutalyzer_retriever first and configure the cache directory
-from mutalyzer_retriever import configuration
-if cache_dir:
-    configuration.settings['MUTALYZER_CACHE_DIR'] = cache_dir
-if cache_add:
-    configuration.settings['MUTALYZER_FILE_CACHE_ADD'] = True
-
-try:
-    from mutalyzer.description import Description
-except ImportError:
-    print("ERROR: mutalyzer not installed", file=sys.stderr)
-    print("Install with: pip install mutalyzer", file=sys.stderr)
-    sys.exit(1)
-
-input_file = sys.argv[1]
-output_file = sys.argv[2]
-
-results = []
-successful = 0
-failed = 0
-
-with open(input_file, 'r') as f:
-    patterns = [line.strip() for line in f if line.strip()]
-
-start = time.perf_counter()
-
-for pattern in patterns:
-    try:
-        d = Description(description=pattern)
-        d.normalize()
-        if not d.errors:
-            output = d.output()
-            results.append({
-                "input": pattern,
-                "success": True,
-                "output": output.get("normalized_description", pattern)
-            })
-            successful += 1
-        else:
-            error_msg = str(d.errors[0]) if d.errors else "Unknown error"
-            results.append({
-                "input": pattern,
-                "success": False,
-                "error": error_msg[:200]
-            })
-            failed += 1
-    except ConnectionError as e:
-        results.append({
-            "input": pattern,
-            "success": False,
-            "error": f"Network access required but disabled: {str(e)[:150]}"
-        })
-        failed += 1
-    except Exception as e:
-        results.append({
-            "input": pattern,
-            "success": False,
-            "error": str(e)[:200]
-        })
-        failed += 1
-
-elapsed = time.perf_counter() - start
-
-output_data = {
-    "tool": "mutalyzer",
-    "total_patterns": len(patterns),
-    "successful": successful,
-    "failed": failed,
-    "elapsed_seconds": elapsed,
-    "patterns_per_second": len(patterns) / elapsed if elapsed > 0 else 0,
-    "network_calls": 0,
-    "results": results
-}
-
-with open(output_file, 'w') as f:
-    json.dump(output_data, f, indent=2)
-"#;
-
-    let mut cmd = Command::new("python3");
-    cmd.args(["-c", python_code, input_file, output_file]);
-
-    if let Some(settings) = settings_file {
-        cmd.arg(settings);
-    } else {
-        cmd.arg("");
-    }
-
-    let output = cmd.output().map_err(|e| FerroError::Io {
-        msg: format!("Failed to run Python: {}", e),
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(FerroError::Io {
-            msg: format!("Mutalyzer normalizer (offline) failed: {}", stderr),
-        });
-    }
-
-    Ok(())
+    run_mutalyzer_normalizer_impl(input_file, output_file, settings_file, true)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Pin mutalyzer to 3.1.1 and mutalyzer-hgvs-parser to 0.3.9 for reproducible behavior across environments
- Unify settings loading: replace manual `configuration.settings` dict poking with the documented `MUTALYZER_SETTINGS` env var approach (removes 53 lines of duplicated parsing code)
- Switch deploy workflow from `mode = "api"` to `mode = "local"` to match the actual server configuration, and track the workflow in git
- Add `config/service.example.toml` with documented mutalyzer configuration explaining modes, requirements, and the settings file format

Context: investigating issue #10 revealed that the web service and benchmark tool used different settings loading mechanisms for mutalyzer, which could lead to inconsistent normalization results.

## Test plan

- [x] Full test suite passes (2905 tests, 0 failures)
- [x] `cargo build --features benchmark` succeeds
- [ ] After deploy, verify mutalyzer local mode works on the server

Relates to #10