### PR TITLE
feat: add bincode serialization for fast cdot loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bio"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +923,7 @@ dependencies = [
  "async-trait",
  "atty",
  "axum",
+ "bincode",
  "biocommons-bioutils",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nom = "8.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
+bincode = "1.3"
 clap = { version = "4", features = ["derive"] }
 noodles-vcf = "0.73"
 flate2 = "1.0"

--- a/src/benchmark/biocommons.rs
+++ b/src/benchmark/biocommons.rs
@@ -1131,7 +1131,7 @@ pub fn load_sequences_to_seqrepo(
 
         if let Some(cdot_file) = cdot_files.first() {
             eprintln!("  Loading cdot from {}...", cdot_file.display());
-            CdotMapper::from_json_file(cdot_file).ok()
+            CdotMapper::load(cdot_file).ok()
         } else {
             None
         }

--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -199,11 +199,7 @@ pub fn populate_mutalyzer_cache<P: AsRef<Path>>(
     let cdot_path = reference_dir.join(cdot_relative);
 
     eprintln!("Loading cdot from {}...", cdot_path.display());
-    let mut cdot = if cdot_relative.ends_with(".gz") {
-        CdotMapper::from_json_gz(&cdot_path)?
-    } else {
-        CdotMapper::from_json_file(&cdot_path)?
-    };
+    let mut cdot = CdotMapper::load(&cdot_path)?;
     let transcript_count = cdot.transcript_count();
     eprintln!("  Loaded {} transcripts", transcript_count);
 

--- a/src/benchmark/uta_loader.rs
+++ b/src/benchmark/uta_loader.rs
@@ -85,7 +85,7 @@ async fn load_cdot_alignments_async(
 
     // Phase 0: Load cdot and determine what needs loading
     eprintln!("Loading cdot transcript data...");
-    let cdot = CdotMapper::from_json_file(cdot_path)?;
+    let cdot = CdotMapper::load(cdot_path)?;
 
     let cdot_accessions: Vec<String> = cdot
         .transcript_ids()

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1258,11 +1258,7 @@ fn run_populate_cache(
                 // Join with reference_dir since manifest paths are relative
                 let full_cdot_path = reference_dir.join(cdot_path);
                 eprintln!("Loading cdot from {}...", full_cdot_path.display());
-                let cdot = if cdot_path.ends_with(".gz") {
-                    CdotMapper::from_json_gz(&full_cdot_path)?
-                } else {
-                    CdotMapper::from_json_file(&full_cdot_path)?
-                };
+                let cdot = CdotMapper::load(&full_cdot_path)?;
 
                 let enhanced = enhance_nc_annotations(cache_dir, &cdot)?;
                 println!("Enhanced {} NC_ annotation files", enhanced);
@@ -1701,7 +1697,7 @@ fn derive_proteins_for_ferro(ferro_dir: &Path) -> Result<(), ferro_hgvs::FerroEr
         return Ok(());
     }
     println!("  Loading cdot for CDS coordinates...");
-    let cdot = CdotMapper::from_json_file(&cdot_path)?;
+    let cdot = CdotMapper::load(&cdot_path)?;
 
     // Load supplemental CDS metadata if available
     let mut supplemental_cds: HashMap<String, (Option<u64>, Option<u64>, String)> = HashMap::new();

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -1307,7 +1307,7 @@ mod intronic_debug_tests {
             return;
         }
 
-        let cdot = CdotMapper::from_json_file(&cdot_path).expect("Failed to load cdot");
+        let cdot = CdotMapper::load(&cdot_path).expect("Failed to load cdot");
         let tx = cdot
             .get_transcript("NM_003742.4")
             .expect("NM_003742.4 not in cdot");

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -26,6 +26,7 @@ use crate::error::FerroError;
 use crate::liftover::aliases::ContigAliases;
 use crate::reference::transcript::GenomeBuild;
 use crate::reference::Strand;
+use bincode::Options;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
@@ -521,7 +522,7 @@ pub enum CdsPosition {
 /// - `M` (Match): alignment match — bases align between transcript and genome.
 /// - `I` (Insertion): bases present in the transcript but not the genome.
 /// - `D` (Deletion): bases present in the genome but not the transcript.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CigarOp {
     /// Alignment match of `n` bases.
     Match(u64),
@@ -644,6 +645,88 @@ pub struct CdotFile {
     pub genome_builds: Option<HashMap<String, serde_json::Value>>,
 }
 
+/// Bincode-friendly snapshot of CdotMapper data, without custom JSON deserializers.
+/// Used for deserialization only; serialization uses [`CdotMapperSnapshotRef`].
+#[derive(Deserialize)]
+struct CdotMapperSnapshot {
+    transcripts: HashMap<String, CdotTranscriptSnapshot>,
+    contig_index: HashMap<String, Vec<String>>,
+    contig_alias_to_canonical: HashMap<String, String>,
+    base_to_versioned: HashMap<String, String>,
+    lrg_to_refseq: HashMap<String, String>,
+}
+
+/// Borrowed view of CdotMapper for zero-copy serialization to bincode.
+#[derive(Serialize)]
+struct CdotMapperSnapshotRef<'a> {
+    transcripts: HashMap<&'a String, CdotTranscriptSnapshotRef<'a>>,
+    contig_index: &'a HashMap<String, Vec<String>>,
+    contig_alias_to_canonical: &'a HashMap<String, String>,
+    base_to_versioned: &'a HashMap<String, String>,
+    lrg_to_refseq: &'a HashMap<String, String>,
+}
+
+/// Bincode-friendly snapshot of CdotTranscript, using standard Strand serde.
+/// Used for deserialization only; serialization uses [`CdotTranscriptSnapshotRef`].
+#[derive(Deserialize)]
+struct CdotTranscriptSnapshot {
+    gene_name: Option<String>,
+    contig: String,
+    strand: Strand,
+    exons: Vec<[u64; 4]>,
+    cds_start: Option<u64>,
+    cds_end: Option<u64>,
+    exon_cigars: Vec<Option<Vec<CigarOp>>>,
+    gene_id: Option<String>,
+    protein: Option<String>,
+}
+
+/// Borrowed view of CdotTranscript for zero-copy serialization to bincode.
+#[derive(Serialize)]
+struct CdotTranscriptSnapshotRef<'a> {
+    gene_name: &'a Option<String>,
+    contig: &'a str,
+    strand: Strand,
+    exons: &'a Vec<[u64; 4]>,
+    cds_start: Option<u64>,
+    cds_end: Option<u64>,
+    exon_cigars: &'a Vec<Option<Vec<CigarOp>>>,
+    gene_id: &'a Option<String>,
+    protein: &'a Option<String>,
+}
+
+impl<'a> From<&'a CdotTranscript> for CdotTranscriptSnapshotRef<'a> {
+    fn from(tx: &'a CdotTranscript) -> Self {
+        Self {
+            gene_name: &tx.gene_name,
+            contig: &tx.contig,
+            strand: tx.strand,
+            exons: &tx.exons,
+            cds_start: tx.cds_start,
+            cds_end: tx.cds_end,
+            exon_cigars: &tx.exon_cigars,
+            gene_id: &tx.gene_id,
+            protein: &tx.protein,
+        }
+    }
+}
+
+impl From<CdotTranscriptSnapshot> for CdotTranscript {
+    fn from(snap: CdotTranscriptSnapshot) -> Self {
+        Self {
+            gene_name: snap.gene_name,
+            contig: snap.contig,
+            strand: snap.strand,
+            exons: snap.exons,
+            cds_start: snap.cds_start,
+            cds_end: snap.cds_end,
+            exon_cigars: snap.exon_cigars,
+            gene_id: snap.gene_id,
+            protein: snap.protein,
+        }
+    }
+}
+
 /// Coordinate mapper using cdot data.
 #[derive(Debug, Clone)]
 pub struct CdotMapper {
@@ -690,6 +773,106 @@ impl CdotMapper {
         let decoder = flate2::read::GzDecoder::new(reader);
         let reader = BufReader::new(decoder);
         Self::from_reader(reader)
+    }
+
+    /// Load from a pre-serialized bincode file (much faster than JSON).
+    pub fn from_bincode_file<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        let file = File::open(path.as_ref()).map_err(|e| FerroError::Io {
+            msg: format!("Failed to open cdot bincode file: {}", e),
+        })?;
+        let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let reader = BufReader::new(file);
+        // Use a size limit to prevent OOM on corrupt files. Allow 20x the file size
+        // (bincode is compact, but deserialized HashMap overhead can be significant).
+        // Limit deserialization size to prevent OOM on corrupt files (20x file size or 1MB min).
+        let size_limit = file_size.saturating_mul(20).max(1024 * 1024);
+        let snapshot: CdotMapperSnapshot = bincode::options()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(size_limit)
+            .deserialize_from(reader)
+            .map_err(|e| FerroError::Io {
+                msg: format!("Failed to deserialize cdot bincode: {}", e),
+            })?;
+        Ok(Self {
+            transcripts: snapshot
+                .transcripts
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            contig_index: snapshot.contig_index,
+            contig_alias_to_canonical: snapshot.contig_alias_to_canonical,
+            base_to_versioned: snapshot.base_to_versioned,
+            lrg_to_refseq: snapshot.lrg_to_refseq,
+        })
+    }
+
+    /// Write the mapper to a bincode file for fast subsequent loading.
+    pub fn to_bincode_file<P: AsRef<Path>>(&self, path: P) -> Result<(), FerroError> {
+        let snapshot = CdotMapperSnapshotRef {
+            transcripts: self
+                .transcripts
+                .iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            contig_index: &self.contig_index,
+            contig_alias_to_canonical: &self.contig_alias_to_canonical,
+            base_to_versioned: &self.base_to_versioned,
+            lrg_to_refseq: &self.lrg_to_refseq,
+        };
+        let file = File::create(path.as_ref()).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create cdot bincode file: {}", e),
+        })?;
+        let writer = std::io::BufWriter::new(file);
+        bincode::options()
+            .with_fixint_encoding()
+            .serialize_into(writer, &snapshot)
+            .map_err(|e| FerroError::Io {
+                msg: format!("Failed to serialize cdot bincode: {}", e),
+            })
+    }
+
+    /// Load a cdot file, preferring a sibling `.bin` (bincode) file if available.
+    ///
+    /// Given a path to a `.json` or `.json.gz` file, checks for a `.bin` file in the
+    /// same directory. If the bincode file exists, loads from it (much faster). Otherwise
+    /// falls back to JSON parsing. Also handles `.bin` paths directly.
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        let path = path.as_ref();
+        let path_str = path.to_string_lossy();
+
+        // Direct bincode path — no JSON fallback available
+        if path_str.ends_with(".bin") {
+            return Self::from_bincode_file(path);
+        }
+
+        // Compute the canonical sibling .bin path:
+        // - foo.json.gz -> foo.bin (strip .gz then replace .json with .bin)
+        // - foo.json    -> foo.bin
+        let bin_path = if path_str.ends_with(".json.gz") {
+            path.with_extension("").with_extension("bin")
+        } else {
+            path.with_extension("bin")
+        };
+        if bin_path.exists() {
+            match Self::from_bincode_file(&bin_path) {
+                Ok(mapper) => return Ok(mapper),
+                Err(e) => {
+                    log::warn!(
+                        "Failed to load bincode {}: {}. Falling back to JSON.",
+                        bin_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // Fall back to JSON
+        if path_str.ends_with(".gz") {
+            Self::from_json_gz(path)
+        } else {
+            Self::from_json_file(path)
+        }
     }
 
     /// Load from any reader, defaulting to GRCh38 genome build.
@@ -1355,6 +1538,199 @@ mod tests {
         assert_eq!(tx.gene_name.as_deref(), Some("COL1A1"));
         assert_eq!(tx.strand, Strand::Plus);
         assert_eq!(tx.exons.len(), 2);
+    }
+
+    // =========================================================================
+    // Bincode serialization tests
+    // =========================================================================
+
+    #[test]
+    fn test_bincode_roundtrip() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [
+                        [50184096, 50184169, 0, 73],
+                        [50185022, 50185148, 73, 199]
+                    ],
+                    "cds_start": 149,
+                    "cds_end": 4544
+                },
+                "NM_000059.4": {
+                    "gene_name": "BRCA2",
+                    "contig": "NC_000013.11",
+                    "strand": "+",
+                    "exons": [[32315474, 32315667, 0, 193]],
+                    "cds_start": 40,
+                    "cds_end": 150
+                }
+            }
+        }
+        "#;
+        let original = CdotMapper::from_reader(json.as_bytes()).unwrap();
+        assert_eq!(original.transcript_count(), 2);
+
+        // Roundtrip through bincode file
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("roundtrip.bin");
+        original.to_bincode_file(&bin_path).unwrap();
+        let decoded = CdotMapper::from_bincode_file(&bin_path).unwrap();
+
+        assert_eq!(decoded.transcript_count(), 2);
+        let tx = decoded.get_transcript("NM_000088.3").unwrap();
+        assert_eq!(tx.gene_name.as_deref(), Some("COL1A1"));
+        assert_eq!(tx.contig, "NC_000017.11");
+        assert_eq!(tx.strand, Strand::Plus);
+        assert_eq!(tx.exons.len(), 2);
+
+        let tx2 = decoded.get_transcript("NM_000059.4").unwrap();
+        assert_eq!(tx2.gene_name.as_deref(), Some("BRCA2"));
+
+        // Contig index should be preserved
+        assert_eq!(decoded.transcripts_on_contig("NC_000017.11").len(), 1);
+        assert_eq!(decoded.transcripts_on_contig("NC_000013.11").len(), 1);
+
+        // Base-to-versioned index should be preserved
+        assert!(decoded.get_transcript("NM_000088.4").is_some()); // falls back to .3
+    }
+
+    #[test]
+    fn test_bincode_file_roundtrip() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let original = CdotMapper::from_reader(json.as_bytes()).unwrap();
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let bin_path = temp_dir.path().join("test.bin");
+
+        original.to_bincode_file(&bin_path).unwrap();
+        assert!(bin_path.exists());
+
+        let loaded = CdotMapper::from_bincode_file(&bin_path).unwrap();
+        assert_eq!(loaded.transcript_count(), 1);
+        assert!(loaded.get_transcript("NM_000088.3").is_some());
+    }
+
+    #[test]
+    fn test_load_prefers_bincode() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let original = CdotMapper::from_reader(json.as_bytes()).unwrap();
+
+        // Mutate the mapper so bincode content differs from JSON
+        let mut from_bin = original.clone();
+        from_bin
+            .transcripts
+            .get_mut("NM_000088.3")
+            .unwrap()
+            .gene_name = Some("FROM_BIN".to_string());
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+        let bin_path = temp_dir.path().join("cdot.bin");
+
+        // Write JSON file (gene_name = "COL1A1")
+        std::fs::write(&json_path, json).unwrap();
+
+        // Write bincode file (gene_name = "FROM_BIN")
+        from_bin.to_bincode_file(&bin_path).unwrap();
+
+        // load() given the JSON path should find and use the .bin sibling
+        let loaded = CdotMapper::load(&json_path).unwrap();
+        assert_eq!(loaded.transcript_count(), 1);
+        assert_eq!(
+            loaded
+                .get_transcript("NM_000088.3")
+                .unwrap()
+                .gene_name
+                .as_deref(),
+            Some("FROM_BIN"),
+            "load() should prefer bincode over JSON"
+        );
+    }
+
+    #[test]
+    fn test_load_falls_back_to_json() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+
+        // Write only JSON, no bincode
+        std::fs::write(&json_path, json).unwrap();
+
+        let loaded = CdotMapper::load(&json_path).unwrap();
+        assert_eq!(loaded.transcript_count(), 1);
+    }
+
+    #[test]
+    fn test_load_falls_back_to_json_on_corrupt_bincode() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+        let bin_path = temp_dir.path().join("cdot.bin");
+
+        // Write valid JSON and corrupt bincode
+        std::fs::write(&json_path, json).unwrap();
+        std::fs::write(&bin_path, b"not valid bincode data").unwrap();
+
+        // load() should fall back to JSON despite corrupt .bin
+        let loaded = CdotMapper::load(&json_path).unwrap();
+        assert_eq!(loaded.transcript_count(), 1);
+        assert!(loaded.get_transcript("NM_000088.3").is_some());
     }
 
     // =========================================================================

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -895,7 +895,8 @@ pub fn print_reference_summary(manifest: &ReferenceManifest, reference_dir: &Pat
 // cdot helpers
 // ============================================================================
 
-/// Download and decompress a cdot JSON.gz file from `url` into `cdot_dir`.
+/// Download and decompress a cdot JSON.gz file from `url` into `cdot_dir`,
+/// then serialize to bincode for fast subsequent loading.
 /// Returns the path to the decompressed JSON file.
 fn download_cdot(url: &str, cdot_dir: &Path, skip_existing: bool) -> Result<PathBuf, FerroError> {
     fs::create_dir_all(cdot_dir).map_err(|e| FerroError::Io {
@@ -908,8 +909,9 @@ fn download_cdot(url: &str, cdot_dir: &Path, skip_existing: bool) -> Result<Path
     let gz_path = cdot_dir.join(gz_filename);
     let json_path = gz_path.with_extension("");
 
-    if skip_existing && json_path.exists() {
+    let json_is_fresh = if skip_existing && json_path.exists() {
         eprintln!("  Skipping cdot download (exists)");
+        false
     } else {
         if skip_existing && gz_path.exists() {
             eprintln!(
@@ -925,6 +927,23 @@ fn download_cdot(url: &str, cdot_dir: &Path, skip_existing: bool) -> Result<Path
         }
         eprintln!("  Decompressing...");
         decompress_gzip(&gz_path, &json_path)?;
+        eprintln!("  Done.");
+        true
+    };
+
+    // Parse JSON and serialize to bincode for fast subsequent loading.
+    // Always regenerate bincode when JSON was freshly downloaded to avoid stale cache.
+    let bin_path = json_path.with_extension("bin");
+    if !json_is_fresh && skip_existing && bin_path.exists() {
+        eprintln!("  Skipping cdot bincode conversion (exists)");
+    } else {
+        eprintln!("  Converting cdot JSON to bincode for fast loading...");
+        let mapper = crate::data::cdot::CdotMapper::from_json_file(&json_path).map_err(|e| {
+            FerroError::Io {
+                msg: format!("Failed to parse cdot JSON: {}", e),
+            }
+        })?;
+        mapper.to_bincode_file(&bin_path)?;
         eprintln!("  Done.");
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -295,7 +295,7 @@ impl MultiFastaProvider {
                     "Loading cdot transcript metadata from {}...",
                     cdot_path.display()
                 );
-                match CdotMapper::from_json_file(&cdot_path) {
+                match CdotMapper::load(&cdot_path) {
                     Ok(mut mapper) => {
                         eprintln!(
                             "Loaded {} transcripts with CDS metadata",
@@ -435,12 +435,8 @@ impl MultiFastaProvider {
 
         eprintln!("Loaded {} sequences from FASTA", index.len());
 
-        // Load cdot (auto-detect gzipped or plain JSON)
-        let cdot_mapper = if cdot_path.extension().map(|e| e == "gz").unwrap_or(false) {
-            CdotMapper::from_json_gz(cdot_path)?
-        } else {
-            CdotMapper::from_json_file(cdot_path)?
-        };
+        // Load cdot (prefers bincode if available, falls back to JSON)
+        let cdot_mapper = CdotMapper::load(cdot_path)?;
         eprintln!(
             "Loaded {} transcripts from cdot",
             cdot_mapper.transcript_count()

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -293,16 +293,10 @@ async fn update_health_cache(state: &AppState) {
     }
 }
 
-/// Load CdotMapper from a file path (handles both .json and .json.gz)
+/// Load CdotMapper from a file path (prefers bincode if available, falls back to JSON).
 fn load_cdot(path: &std::path::Path) -> Result<CdotMapper, ServiceError> {
-    let path_str = path.to_string_lossy();
-    if path_str.ends_with(".gz") {
-        CdotMapper::from_json_gz(path)
-            .map_err(|e| ServiceError::ConfigError(format!("Failed to load cdot: {}", e)))
-    } else {
-        CdotMapper::from_json_file(path)
-            .map_err(|e| ServiceError::ConfigError(format!("Failed to load cdot: {}", e)))
-    }
+    CdotMapper::load(path)
+        .map_err(|e| ServiceError::ConfigError(format!("Failed to load cdot: {}", e)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add bincode as a fast binary serialization format for cdot transcript data
- `ferro prepare` now writes a `.bin` file alongside the JSON after parsing
- `CdotMapper::load()` automatically prefers the `.bin` sibling file, falling back to JSON
- All callers updated to use `CdotMapper::load()` for automatic format selection
- Existing users can re-run `ferro prepare` (with `--force`) to generate the `.bin` file

## Motivation

The cdot JSON is ~546 MB uncompressed. Deserializing it via serde_json is a significant
startup cost, especially for CLI tools that pay it on every invocation. Bincode
serialization/deserialization is dramatically faster since it avoids string parsing,
key matching, and intermediate allocations.

## Test plan

- [ ] `test_bincode_roundtrip` - verifies data integrity through bincode serialize/deserialize
- [ ] `test_bincode_file_roundtrip` - verifies file I/O with bincode format
- [ ] `test_load_prefers_bincode` - verifies `.bin` sibling is preferred over `.json`
- [ ] `test_load_falls_back_to_json` - verifies JSON fallback when no `.bin` exists
- [ ] Full test suite passes (2940 tests)