### PR TITLE
fix: add serde defaults to config structs and fix deploy workflow

### DIFF
--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -89,6 +89,8 @@ jobs:
           port = 8080
           request_timeout_seconds = 120
           enable_cors = true
+          max_request_size = "10MB"
+          enable_tracing = true
 
           [tools.ferro]
           enabled = true
@@ -103,6 +105,7 @@ jobs:
           [tools.mutalyzer]
           enabled = true
           mode = "local"
+          api_url = "http://localhost:8082"
           settings_file = "/var/lib/ferro-web/mutalyzer_settings.txt"
           allow_network = true
           timeout_seconds = 60
@@ -145,7 +148,7 @@ jobs:
           Restart=always
           RestartSec=5
           Environment=RUST_LOG=info
-          Environment=PATH=%h/.pixi/envs/default/bin:/usr/local/bin:/usr/bin:/bin
+          Environment=PATH=${{ github.workspace }}/.pixi/envs/default/bin:/usr/local/bin:/usr/bin:/bin
 
           [Install]
           WantedBy=multi-user.target

--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -36,6 +36,7 @@ pub struct LiftoverConfig {
 
 /// Server configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct ServerConfig {
     /// Host to bind to (default: "0.0.0.0")
     pub host: String,
@@ -96,6 +97,7 @@ pub enum MutalyzerMode {
 
 /// Mutalyzer tool configuration
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct MutalyzerConfig {
     /// Whether tool is enabled
     pub enabled: bool,


### PR DESCRIPTION
## Summary

- **serde defaults**: Added `#[serde(default)]` to `ServerConfig` and `MutalyzerConfig` so missing TOML fields use their `Default` impl instead of crashing at startup. These structs already had `Default` impls but deserialization required every field to be present.
- **complete inline config**: Added missing `max_request_size`, `enable_tracing`, and `api_url` fields to the deploy workflow's inline TOML config.
- **correct pixi PATH**: Changed the systemd service `PATH` from `%h/.pixi/envs/default/bin` (user-level, empty) to the project-level pixi env at `/home/ubuntu/actions-runner/_work/ferro-hgvs/ferro-hgvs/.pixi/envs/default/bin` where mutalyzer and biocommons packages are actually installed.

## Context

ferro-web was crash-looping (42,508 restarts) because a code update added new required fields (`max_request_size`, `enable_tracing`, `api_url`) to config structs, but the deployed TOML didn't include them. Additionally, mutalyzer and biocommons tools were unavailable because the systemd PATH pointed to the wrong pixi environment.

## Test plan

- [x] `cargo check --features web-service` passes
- [x] `cargo test --features web-service --lib config` passes (59 tests)
- [ ] Verify deploy workflow produces a healthy service after merge