### PR TITLE
fix: add missing in_memory field to HgvsRsConfig construction

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -3236,9 +3236,10 @@ fn run_normalize_tool(
     workers: usize,
     no_rewrite_intronic: bool,
     allow_network: bool,
-    _in_memory: bool,
+    in_memory: bool,
 ) -> Result<(), ferro_hgvs::FerroError> {
-    // Prerequisite: input file must exist
+    let _ = in_memory; // Used only with hgvs-rs feature
+                       // Prerequisite: input file must exist
     if !input.exists() {
         return Err(ferro_hgvs::FerroError::Io {
             msg: format!(

--- a/src/service/tools/hgvs_rs.rs
+++ b/src/service/tools/hgvs_rs.rs
@@ -39,6 +39,7 @@ impl HgvsRsService {
                     .lrg_mapping_file
                     .as_ref()
                     .map(|p| p.to_string_lossy().to_string()),
+                in_memory: false,
             };
 
             // Create the HGVS-RS normalizer


### PR DESCRIPTION
## Summary

- Adds missing `in_memory` field when constructing `BenchmarkHgvsRsConfig` in the web service, fixing the deploy build (`--features web-service hgvs-rs`)
- Renames `_in_memory` → `in_memory` in `run_normalize_tool` so the parameter is actually used when passed to `run_normalize_hgvs_rs`

Also closed stale release PR #23 so release-plz can regenerate cleanly (it was created before the vendored hgvs-rs removal and could not run `cargo package` on historical commits that referenced the deleted submodule).

## Test plan

- [x] `cargo check --features "web-service hgvs-rs"` passes locally
- [x] `cargo check --features dev` passes locally
- [ ] CI passes
- [ ] Deploy workflow succeeds after merge
- [ ] release-plz creates a fresh release PR after merge