### PR TITLE
refactor(prepare): Modularize ReferenceManifest.

### DIFF
--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -71,8 +71,7 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
 
     // Validate transcript files exist
     for fasta in &manifest.transcript_fastas {
-        let full_path = reference_dir.join(fasta);
-        let fna_path = full_path.with_extension("").with_extension("fna");
+        let fna_path = fasta.with_extension("").with_extension("fna");
         if !fna_path.exists() {
             result.warnings.push(format!(
                 "Transcript FASTA not found: {}",
@@ -83,30 +82,27 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
 
     // Validate genome file if specified
     if let Some(ref genome) = manifest.genome_fasta {
-        let full_path = reference_dir.join(genome);
-        if !full_path.exists() {
+        if !genome.exists() {
             result
                 .warnings
-                .push(format!("Genome FASTA not found: {}", full_path.display()));
+                .push(format!("Genome FASTA not found: {}", genome.display()));
         }
     }
 
     // Validate cdot file if specified
     if let Some(ref cdot) = manifest.cdot_json {
-        let full_path = reference_dir.join(cdot);
-        if !full_path.exists() {
+        if !cdot.exists() {
             result
                 .warnings
-                .push(format!("cdot JSON not found: {}", full_path.display()));
+                .push(format!("cdot JSON not found: {}", cdot.display()));
         }
     }
 
     if let Some(ref cdot) = manifest.cdot_grch37_json {
-        let full_path = reference_dir.join(cdot);
-        if !full_path.exists() {
+        if !cdot.exists() {
             result.warnings.push(format!(
                 "cdot GRCh37 JSON not found: {}",
-                full_path.display()
+                cdot.display()
             ));
         }
     }
@@ -235,6 +231,7 @@ mod tests {
             legacy_genbank_metadata: None,
             transcript_count: 0,
             available_prefixes: Vec::new(),
+            reference_dir: dir.path().to_path_buf(),
         };
 
         let mut file = File::create(&manifest_path).unwrap();

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -4,8 +4,6 @@
 //! is properly configured and available for normalization.
 
 use crate::prepare::ReferenceManifest;
-use crate::FerroError;
-use std::fs::File;
 use std::path::Path;
 
 /// Result of checking reference data.
@@ -61,8 +59,8 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         ));
     }
 
-    // Try to load manifest
-    let manifest = match load_manifest(&manifest_path) {
+    // Try to load manifest (paths are automatically made absolute)
+    let manifest = match ReferenceManifest::load_or_default(reference_dir) {
         Ok(m) => m,
         Err(e) => return CheckResult::failure(format!("Failed to load manifest: {}", e)),
     };
@@ -109,16 +107,6 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
     result
 }
 
-/// Load manifest from file.
-fn load_manifest(manifest_path: &Path) -> Result<ReferenceManifest, FerroError> {
-    let file = File::open(manifest_path).map_err(|e| FerroError::Io {
-        msg: format!("Failed to open manifest: {}", e),
-    })?;
-
-    serde_json::from_reader(file).map_err(|e| FerroError::Io {
-        msg: format!("Failed to parse manifest: {}", e),
-    })
-}
 
 /// Print a detailed summary of reference data.
 pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
@@ -196,7 +184,7 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use std::fs::File;
     use tempfile::TempDir;
 
     #[test]
@@ -210,11 +198,14 @@ mod tests {
     #[test]
     fn test_check_valid_manifest() {
         let dir = TempDir::new().unwrap();
-        let manifest_path = dir.path().join("manifest.json");
+
+        // Create a real transcript FASTA file with a relative path (as .fna, the expected format)
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
 
         let manifest = ReferenceManifest {
             prepared_at: "2024-01-01T00:00:00Z".to_string(),
-            transcript_fastas: Vec::new(),
+            transcript_fastas: vec![std::path::PathBuf::from("example.fna")],
             genome_fasta: None,
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),
@@ -228,16 +219,16 @@ mod tests {
             legacy_transcripts_metadata: None,
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
-            transcript_count: 0,
-            available_prefixes: Vec::new(),
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
         };
 
-        let mut file = File::create(&manifest_path).unwrap();
-        write!(file, "{}", serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        manifest.save().unwrap();
 
         let result = check_reference(dir.path());
         assert!(result.valid);
         assert!(result.manifest.is_some());
+        assert!(result.warnings.is_empty(), "Expected no warnings for valid relative paths");
     }
 }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -107,7 +107,6 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
     result
 }
 
-
 /// Print a detailed summary of reference data.
 pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
     if !result.valid {
@@ -229,6 +228,9 @@ mod tests {
         let result = check_reference(dir.path());
         assert!(result.valid);
         assert!(result.manifest.is_some());
-        assert!(result.warnings.is_empty(), "Expected no warnings for valid relative paths");
+        assert!(
+            result.warnings.is_empty(),
+            "Expected no warnings for valid relative paths"
+        );
     }
 }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -100,10 +100,9 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
 
     if let Some(ref cdot) = manifest.cdot_grch37_json {
         if !cdot.exists() {
-            result.warnings.push(format!(
-                "cdot GRCh37 JSON not found: {}",
-                cdot.display()
-            ));
+            result
+                .warnings
+                .push(format!("cdot GRCh37 JSON not found: {}", cdot.display()));
         }
     }
 

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -388,10 +388,7 @@ mod tests {
             manifest.transcript_fastas[0],
             ref_path.join("transcripts.fa")
         );
-        assert_eq!(
-            manifest.cdot_json,
-            Some(ref_path.join("cdot.json"))
-        );
+        assert_eq!(manifest.cdot_json, Some(ref_path.join("cdot.json")));
     }
 
     #[test]

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -107,14 +107,92 @@ impl ReferenceManifest {
         Ok(manifest)
     }
 
+    /// Validate the reference-root invariant before saving.
+    ///
+    /// Ensures that:
+    /// 1. `reference_dir` is set (not empty PathBuf from default)
+    /// 2. All tracked paths can be made relative to `reference_dir`
+    /// 3. No absolute or out-of-root paths are written to manifest
+    ///
+    /// Returns an Io error with a clear message if validation fails.
+    fn validate_reference_root_invariant(&self) -> Result<(), FerroError> {
+        // Check that reference_dir is set (not empty)
+        if self.reference_dir.as_os_str().is_empty() {
+            return Err(FerroError::Io {
+                msg: "Invariant violation: reference_dir must be set before saving manifest. \
+                       Manifest may have been created with default() and not properly initialized. \
+                       Call load_or_default(reference_dir) instead."
+                    .to_string(),
+            });
+        }
+
+        // Create a cloned copy to check path relativity without mutation
+        let mut check_manifest = self.clone();
+        check_manifest.deduplicate_paths();
+
+        // Verify all paths can be made relative to reference_dir
+        let base = self.reference_dir.clone();
+        let mut vec_errors = Vec::new();
+        let mut opt_errors = Vec::new();
+
+        check_manifest.for_each_path_mut(
+            |vec| {
+                for p in vec {
+                    // Check if path is absolute and doesn't start with reference_dir
+                    if p.is_absolute() && !p.starts_with(&base) {
+                        vec_errors.push(format!(
+                            "path '{}' is outside reference_dir '{}'",
+                            p.display(),
+                            base.display()
+                        ));
+                    }
+                }
+            },
+            |opt| {
+                if let Some(p) = opt {
+                    // Check if path is absolute and doesn't start with reference_dir
+                    if p.is_absolute() && !p.starts_with(&base) {
+                        opt_errors.push(format!(
+                            "path '{}' is outside reference_dir '{}'",
+                            p.display(),
+                            base.display()
+                        ));
+                    }
+                }
+            },
+        );
+
+        let mut out_of_root_paths = vec_errors;
+        out_of_root_paths.extend(opt_errors);
+
+        if !out_of_root_paths.is_empty() {
+            return Err(FerroError::Io {
+                msg: format!(
+                    "Invariant violation: {} path(s) are outside reference_dir. \
+                     Manifest can only contain paths relative to reference_dir or within it:\n  {}",
+                    out_of_root_paths.len(),
+                    out_of_root_paths.join("\n  ")
+                ),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Save manifest to its reference directory.
     ///
     /// Automatically deduplicates paths and converts them to relative (for portability)
     /// before serializing to JSON.
+    ///
+    /// Validates the reference-root invariant to ensure all paths are within or can be
+    /// made relative to the reference directory. Returns an Io error if validation fails.
     pub fn save(&self) -> Result<(), FerroError> {
+        // Validate invariant before any modifications
+        self.validate_reference_root_invariant()?;
+
         let mut manifest = self.clone();
-        manifest.deduplicate_paths();
         manifest.make_paths_relative();
+        manifest.deduplicate_paths();
 
         let manifest_path = self.reference_dir.join("manifest.json");
         let file = File::create(&manifest_path).map_err(|e| FerroError::Io {
@@ -376,18 +454,15 @@ mod tests {
 
         // Check that paths are relative (not absolute)
         assert_eq!(
-            json["transcript_fastas"][0],
-            "transcripts.fa",
+            json["transcript_fastas"][0], "transcripts.fa",
             "transcript_fastas should be stored as relative path"
         );
         assert_eq!(
-            json["genome_fasta"],
-            "genome.fa",
+            json["genome_fasta"], "genome.fa",
             "genome_fasta should be stored as relative path"
         );
         assert_eq!(
-            json["cdot_json"],
-            "cdot.json",
+            json["cdot_json"], "cdot.json",
             "cdot_json should be stored as relative path"
         );
 
@@ -395,7 +470,10 @@ mod tests {
         let loaded = ReferenceManifest::load_or_default(ref_dir).unwrap();
 
         // Verify loaded manifest has reference_dir set
-        assert_eq!(loaded.reference_dir, ref_dir, "reference_dir should be set after load");
+        assert_eq!(
+            loaded.reference_dir, ref_dir,
+            "reference_dir should be set after load"
+        );
 
         // Verify paths were converted back to absolute
         assert_eq!(

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -157,7 +157,6 @@ impl ReferenceManifest {
     /// directory containing the manifest, regardless of where `prepare` was run from.
     pub fn make_paths_relative(&mut self) {
         let base = self.reference_dir.clone();
-
         self.for_each_path_mut(
             |vec| {
                 for p in vec {
@@ -180,7 +179,6 @@ impl ReferenceManifest {
     ///
     /// Called when loading a manifest to ensure all paths are absolute for use in the program.
     pub fn make_paths_absolute(&mut self) {
-
         let base = self.reference_dir.clone();
         self.for_each_path_mut(
             |vec| {

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -1,0 +1,319 @@
+//! Reference manifest types and I/O operations.
+//!
+//! This module handles the definition, loading, and display of the `ReferenceManifest`
+//! that tracks all prepared reference data files.
+
+use crate::FerroError;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+/// Manifest of prepared reference data.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReferenceManifest {
+    /// When the data was prepared
+    pub prepared_at: String,
+    /// Transcript FASTA files
+    pub transcript_fastas: Vec<PathBuf>,
+    /// GRCh38 genome FASTA file (if downloaded)
+    pub genome_fasta: Option<PathBuf>,
+    /// GRCh37 genome FASTA file (if downloaded)
+    #[serde(default)]
+    pub genome_grch37_fasta: Option<PathBuf>,
+    /// RefSeqGene FASTA files (NG_* accessions)
+    #[serde(default)]
+    pub refseqgene_fastas: Vec<PathBuf>,
+    /// LRG FASTA files (LRG_* accessions)
+    #[serde(default)]
+    pub lrg_fastas: Vec<PathBuf>,
+    /// LRG XML files with full annotation structure
+    #[serde(default)]
+    pub lrg_xmls: Vec<PathBuf>,
+    /// LRG to RefSeq transcript mapping file
+    #[serde(default)]
+    pub lrg_refseq_mapping: Option<PathBuf>,
+    /// cdot transcript metadata JSON for GRCh38 (if downloaded)
+    pub cdot_json: Option<PathBuf>,
+    /// cdot transcript metadata JSON for GRCh37 (if downloaded)
+    #[serde(default)]
+    pub cdot_grch37_json: Option<PathBuf>,
+    /// Supplemental FASTA file (missing ClinVar transcripts fetched from NCBI)
+    #[serde(default)]
+    pub supplemental_fasta: Option<PathBuf>,
+    /// Legacy transcript versions FASTA (older versions not in current RefSeq)
+    #[serde(default)]
+    pub legacy_transcripts_fasta: Option<PathBuf>,
+    /// Legacy transcript metadata JSON (CDS coordinates, gene names)
+    #[serde(default)]
+    pub legacy_transcripts_metadata: Option<PathBuf>,
+    /// Legacy GenBank sequences FASTA (non-RefSeq sequences like U31929.1)
+    #[serde(default)]
+    pub legacy_genbank_fasta: Option<PathBuf>,
+    /// Legacy GenBank metadata JSON (CDS coordinates, gene names)
+    #[serde(default)]
+    pub legacy_genbank_metadata: Option<PathBuf>,
+    /// Total number of transcripts
+    pub transcript_count: usize,
+    /// List of available accession prefixes
+    pub available_prefixes: Vec<String>,
+    /// Directory containing this manifest (runtime property, not serialized)
+    #[serde(skip)]
+    pub reference_dir: PathBuf,
+}
+
+impl Default for ReferenceManifest {
+    fn default() -> Self {
+        Self {
+            prepared_at: chrono::Utc::now().to_rfc3339(),
+            transcript_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            transcript_count: 0,
+            available_prefixes: Vec::new(),
+            reference_dir: PathBuf::new(),
+        }
+    }
+}
+
+impl ReferenceManifest {
+    /// Load manifest from directory, or create a fresh one if it doesn't exist.
+    pub fn load_or_default(reference_dir: &Path) -> Result<Self, FerroError> {
+        let manifest_path = reference_dir.join("manifest.json");
+
+        let mut manifest = if manifest_path.exists() {
+            let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
+                msg: format!("Failed to open manifest: {}", e),
+            })?;
+
+            serde_json::from_reader(file).map_err(|e| FerroError::Io {
+                msg: format!("Failed to parse manifest: {}", e),
+            })?
+        } else {
+            Self::default()
+        };
+
+        manifest.reference_dir = reference_dir.to_path_buf();
+        manifest.make_paths_absolute();
+        Ok(manifest)
+    }
+
+    /// Save manifest to its reference directory.
+    ///
+    /// Automatically deduplicates paths and converts them to relative (for portability)
+    /// before serializing to JSON.
+    pub fn save(&self) -> Result<(), FerroError> {
+        let mut manifest = self.clone();
+        manifest.deduplicate_paths();
+        manifest.make_paths_relative();
+
+        let manifest_path = self.reference_dir.join("manifest.json");
+        let file = File::create(&manifest_path).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create manifest: {}", e),
+        })?;
+        serde_json::to_writer_pretty(file, &manifest).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write manifest: {}", e),
+        })
+    }
+
+    /// Apply closures to all Vec<PathBuf> and Option<PathBuf> fields.
+    fn for_each_path_mut(
+        &mut self,
+        mut vec_fn: impl FnMut(&mut Vec<PathBuf>),
+        mut opt_fn: impl FnMut(&mut Option<PathBuf>),
+    ) {
+        // Vec<PathBuf> fields
+        vec_fn(&mut self.transcript_fastas);
+        vec_fn(&mut self.refseqgene_fastas);
+        vec_fn(&mut self.lrg_fastas);
+        vec_fn(&mut self.lrg_xmls);
+
+        // Option<PathBuf> fields
+        opt_fn(&mut self.genome_fasta);
+        opt_fn(&mut self.genome_grch37_fasta);
+        opt_fn(&mut self.lrg_refseq_mapping);
+        opt_fn(&mut self.cdot_json);
+        opt_fn(&mut self.cdot_grch37_json);
+        opt_fn(&mut self.supplemental_fasta);
+        opt_fn(&mut self.legacy_transcripts_fasta);
+        opt_fn(&mut self.legacy_transcripts_metadata);
+        opt_fn(&mut self.legacy_genbank_fasta);
+        opt_fn(&mut self.legacy_genbank_metadata);
+    }
+
+
+    /// Convert all paths in the manifest to be relative to the reference directory.
+    ///
+    /// This ensures the manifest is portable - paths work when running from the
+    /// directory containing the manifest, regardless of where `prepare` was run from.
+    pub fn make_paths_relative(&mut self) {
+        let base = self.reference_dir.clone();
+
+        self.for_each_path_mut(
+            |vec| {
+                for p in vec {
+                    if let Ok(stripped) = p.strip_prefix(&base) {
+                        *p = stripped.to_path_buf();
+                    }
+                }
+            },
+            |opt| {
+                if let Some(p) = opt {
+                    if let Ok(stripped) = p.strip_prefix(&base) {
+                        *p = stripped.to_path_buf();
+                    }
+                }
+            },
+        );
+    }
+
+    /// Convert all relative paths to absolute, resolved against the manifest's reference directory.
+    ///
+    /// Called when loading a manifest to ensure all paths are absolute for use in the program.
+    pub fn make_paths_absolute(&mut self) {
+
+        let base = self.reference_dir.clone();
+        self.for_each_path_mut(
+            |vec| {
+                for p in vec {
+                    if !p.is_absolute() {
+                        *p = base.join(p.as_path());
+                    }
+                }
+            },
+            |opt| {
+                if let Some(p) = opt {
+                    if !p.is_absolute() {
+                        *p = base.join(p.as_path());
+                    }
+                }
+            },
+        );
+    }
+
+    /// Deduplicate paths in all path lists.
+    pub fn deduplicate_paths(&mut self) {
+        self.for_each_path_mut(
+            |vec| {
+                vec.sort();
+                vec.dedup();
+            },
+            |_opt| {
+                // no-op: Option<PathBuf> is a single value, so dedup is irrelevant
+            },
+        );
+    }
+
+}
+
+/// Check what reference data is available.
+pub fn check_references(reference_dir: &Path) -> Result<ReferenceManifest, FerroError> {
+    let manifest_path = reference_dir.join("manifest.json");
+
+    if !manifest_path.exists() {
+        return Err(FerroError::Io {
+            msg: format!(
+                "No reference data found at {}. Run 'ferro prepare' first.",
+                reference_dir.display()
+            ),
+        });
+    }
+
+    ReferenceManifest::load_or_default(reference_dir)
+}
+
+/// Print a summary of reference data.
+pub fn print_reference_summary(manifest: &ReferenceManifest) {
+    eprintln!("=== Reference Data Summary ===");
+    eprintln!("  Directory: {}", manifest.reference_dir.display());
+    eprintln!("  Prepared at: {}", manifest.prepared_at);
+    eprintln!("  Transcripts: {}", manifest.transcript_count);
+    eprintln!(
+        "  Available prefixes: {}",
+        manifest.available_prefixes.join(", ")
+    );
+
+    if let Some(ref genome) = manifest.genome_fasta {
+        eprintln!("  GRCh38 genome: {}", genome.display());
+    }
+    if let Some(ref genome) = manifest.genome_grch37_fasta {
+        eprintln!("  GRCh37 genome: {}", genome.display());
+    }
+    if !manifest.refseqgene_fastas.is_empty() {
+        eprintln!("  RefSeqGene files: {}", manifest.refseqgene_fastas.len());
+    }
+    if !manifest.lrg_fastas.is_empty() {
+        eprintln!("  LRG files: {}", manifest.lrg_fastas.len());
+    }
+    if let Some(ref cdot) = manifest.cdot_json {
+        eprintln!("  cdot metadata (GRCh38): {}", cdot.display());
+    }
+    if let Some(ref cdot) = manifest.cdot_grch37_json {
+        eprintln!("  cdot metadata (GRCh37): {}", cdot.display());
+    }
+    if let Some(ref supp) = manifest.supplemental_fasta {
+        eprintln!("  Supplemental transcripts: {}", supp.display());
+    }
+    if let Some(ref legacy) = manifest.legacy_transcripts_fasta {
+        eprintln!("  Legacy transcripts: {}", legacy.display());
+    }
+    if let Some(ref genbank) = manifest.legacy_genbank_fasta {
+        eprintln!("  Legacy GenBank: {}", genbank.display());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_paths_relative() {
+        let mut manifest = ReferenceManifest::default();
+        manifest.reference_dir = PathBuf::from("/ref/data");
+        manifest.transcript_fastas = vec![PathBuf::from("/ref/data/transcripts.fa")];
+        manifest.cdot_json = Some(PathBuf::from("/ref/data/cdot.json"));
+
+        manifest.make_paths_relative();
+
+        assert_eq!(manifest.transcript_fastas[0], PathBuf::from("transcripts.fa"));
+        assert_eq!(manifest.cdot_json, Some(PathBuf::from("cdot.json")));
+    }
+
+    #[test]
+    fn test_make_paths_absolute() {
+        let mut manifest = ReferenceManifest::default();
+        manifest.reference_dir = PathBuf::from("/ref/data");
+        manifest.transcript_fastas = vec![PathBuf::from("transcripts.fa")];
+        manifest.cdot_json = Some(PathBuf::from("cdot.json"));
+
+        manifest.make_paths_absolute();
+
+        assert_eq!(manifest.transcript_fastas[0], PathBuf::from("/ref/data/transcripts.fa"));
+        assert_eq!(manifest.cdot_json, Some(PathBuf::from("/ref/data/cdot.json")));
+    }
+
+    #[test]
+    fn test_deduplicate_paths() {
+        let mut manifest = ReferenceManifest::default();
+        manifest.transcript_fastas =
+            vec![PathBuf::from("b.fa"), PathBuf::from("a.fa"), PathBuf::from("b.fa")];
+        manifest.lrg_fastas = vec![PathBuf::from("lrg.fa"), PathBuf::from("lrg.fa")];
+
+        manifest.deduplicate_paths();
+
+        assert_eq!(
+            manifest.transcript_fastas,
+            vec![PathBuf::from("a.fa"), PathBuf::from("b.fa")]
+        );
+        assert_eq!(manifest.lrg_fastas, vec![PathBuf::from("lrg.fa")]);
+    }
+}

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -150,7 +150,6 @@ impl ReferenceManifest {
         opt_fn(&mut self.legacy_genbank_metadata);
     }
 
-
     /// Convert all paths in the manifest to be relative to the reference directory.
     ///
     /// This ensures the manifest is portable - paths work when running from the
@@ -210,7 +209,6 @@ impl ReferenceManifest {
             },
         );
     }
-
 }
 
 /// Check what reference data is available.
@@ -282,7 +280,10 @@ mod tests {
 
         manifest.make_paths_relative();
 
-        assert_eq!(manifest.transcript_fastas[0], PathBuf::from("transcripts.fa"));
+        assert_eq!(
+            manifest.transcript_fastas[0],
+            PathBuf::from("transcripts.fa")
+        );
         assert_eq!(manifest.cdot_json, Some(PathBuf::from("cdot.json")));
     }
 
@@ -295,15 +296,24 @@ mod tests {
 
         manifest.make_paths_absolute();
 
-        assert_eq!(manifest.transcript_fastas[0], PathBuf::from("/ref/data/transcripts.fa"));
-        assert_eq!(manifest.cdot_json, Some(PathBuf::from("/ref/data/cdot.json")));
+        assert_eq!(
+            manifest.transcript_fastas[0],
+            PathBuf::from("/ref/data/transcripts.fa")
+        );
+        assert_eq!(
+            manifest.cdot_json,
+            Some(PathBuf::from("/ref/data/cdot.json"))
+        );
     }
 
     #[test]
     fn test_deduplicate_paths() {
         let mut manifest = ReferenceManifest::default();
-        manifest.transcript_fastas =
-            vec![PathBuf::from("b.fa"), PathBuf::from("a.fa"), PathBuf::from("b.fa")];
+        manifest.transcript_fastas = vec![
+            PathBuf::from("b.fa"),
+            PathBuf::from("a.fa"),
+            PathBuf::from("b.fa"),
+        ];
         manifest.lrg_fastas = vec![PathBuf::from("lrg.fa"), PathBuf::from("lrg.fa")];
 
         manifest.deduplicate_paths();

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -351,10 +351,15 @@ mod tests {
 
     #[test]
     fn test_make_paths_relative() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let ref_path = temp_dir.path().to_path_buf();
+
         let mut manifest = ReferenceManifest::default();
-        manifest.reference_dir = PathBuf::from("/ref/data");
-        manifest.transcript_fastas = vec![PathBuf::from("/ref/data/transcripts.fa")];
-        manifest.cdot_json = Some(PathBuf::from("/ref/data/cdot.json"));
+        manifest.reference_dir = ref_path.clone();
+        manifest.transcript_fastas = vec![ref_path.join("transcripts.fa")];
+        manifest.cdot_json = Some(ref_path.join("cdot.json"));
 
         manifest.make_paths_relative();
 
@@ -367,8 +372,13 @@ mod tests {
 
     #[test]
     fn test_make_paths_absolute() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let ref_path = temp_dir.path().to_path_buf();
+
         let mut manifest = ReferenceManifest::default();
-        manifest.reference_dir = PathBuf::from("/ref/data");
+        manifest.reference_dir = ref_path.clone();
         manifest.transcript_fastas = vec![PathBuf::from("transcripts.fa")];
         manifest.cdot_json = Some(PathBuf::from("cdot.json"));
 
@@ -376,11 +386,11 @@ mod tests {
 
         assert_eq!(
             manifest.transcript_fastas[0],
-            PathBuf::from("/ref/data/transcripts.fa")
+            ref_path.join("transcripts.fa")
         );
         assert_eq!(
             manifest.cdot_json,
-            Some(PathBuf::from("/ref/data/cdot.json"))
+            Some(ref_path.join("cdot.json"))
         );
     }
 

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -324,4 +324,98 @@ mod tests {
         );
         assert_eq!(manifest.lrg_fastas, vec![PathBuf::from("lrg.fa")]);
     }
+
+    #[test]
+    fn test_roundtrip_save_load_with_relative_paths() {
+        use std::io::Read;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let ref_dir = dir.path();
+
+        // Create manifest with absolute paths
+        let manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![ref_dir.join("transcripts.fa")],
+            genome_fasta: Some(ref_dir.join("genome.fa")),
+            genome_grch37_fasta: Some(ref_dir.join("genome37.fa")),
+            refseqgene_fastas: vec![ref_dir.join("ng.fa")],
+            lrg_fastas: vec![ref_dir.join("lrg.fa")],
+            lrg_xmls: vec![ref_dir.join("lrg.xml")],
+            lrg_refseq_mapping: Some(ref_dir.join("lrg_mapping.txt")),
+            cdot_json: Some(ref_dir.join("cdot.json")),
+            cdot_grch37_json: Some(ref_dir.join("cdot37.json")),
+            supplemental_fasta: Some(ref_dir.join("supplemental.fa")),
+            legacy_transcripts_fasta: Some(ref_dir.join("legacy.fa")),
+            legacy_transcripts_metadata: Some(ref_dir.join("legacy.json")),
+            legacy_genbank_fasta: Some(ref_dir.join("genbank.fa")),
+            legacy_genbank_metadata: Some(ref_dir.join("genbank.json")),
+            transcript_count: 100,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: ref_dir.to_path_buf(),
+        };
+
+        // Save the manifest (which should make paths relative)
+        manifest.save().unwrap();
+
+        // Verify on disk: paths are relative and reference_dir is not serialized
+        let manifest_file = ref_dir.join("manifest.json");
+        let mut contents = String::new();
+        File::open(&manifest_file)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+
+        // Check that reference_dir is not in the serialized JSON
+        assert!(
+            json.get("reference_dir").is_none(),
+            "reference_dir should not be serialized"
+        );
+
+        // Check that paths are relative (not absolute)
+        assert_eq!(
+            json["transcript_fastas"][0],
+            "transcripts.fa",
+            "transcript_fastas should be stored as relative path"
+        );
+        assert_eq!(
+            json["genome_fasta"],
+            "genome.fa",
+            "genome_fasta should be stored as relative path"
+        );
+        assert_eq!(
+            json["cdot_json"],
+            "cdot.json",
+            "cdot_json should be stored as relative path"
+        );
+
+        // Load the manifest back
+        let loaded = ReferenceManifest::load_or_default(ref_dir).unwrap();
+
+        // Verify loaded manifest has reference_dir set
+        assert_eq!(loaded.reference_dir, ref_dir, "reference_dir should be set after load");
+
+        // Verify paths were converted back to absolute
+        assert_eq!(
+            loaded.transcript_fastas[0],
+            ref_dir.join("transcripts.fa"),
+            "transcript_fastas should be absolute after load"
+        );
+        assert_eq!(
+            loaded.genome_fasta,
+            Some(ref_dir.join("genome.fa")),
+            "genome_fasta should be absolute after load"
+        );
+        assert_eq!(
+            loaded.cdot_json,
+            Some(ref_dir.join("cdot.json")),
+            "cdot_json should be absolute after load"
+        );
+
+        // Verify all other fields are preserved
+        assert_eq!(loaded.transcript_count, 100);
+        assert_eq!(loaded.available_prefixes, vec!["NM"]);
+    }
 }

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -169,7 +169,6 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
 
             if config.skip_existing && output_path.exists() {
                 eprintln!("  Skipping {} (exists)", filename);
-                manifest.transcript_fastas.push(output_path);
                 continue;
             }
 
@@ -299,7 +298,6 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
                 if !fai_path.exists() {
                     index_fasta(&fasta_path)?;
                 }
-                manifest.refseqgene_fastas.push(fasta_path);
                 continue;
             }
 
@@ -354,7 +352,6 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
                     index_fasta(&fasta_path)?;
                 }
                 fasta_skipped += 1;
-                manifest.lrg_fastas.push(fasta_path.clone());
                 lrg_exists = true;
             } else {
                 match download_file(&fasta_url, &fasta_path) {
@@ -378,7 +375,6 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             if lrg_exists {
                 if config.skip_existing && xml_path.exists() {
                     xml_skipped += 1;
-                    manifest.lrg_xmls.push(xml_path);
                 } else {
                     match download_file(&xml_url, &xml_path) {
                         Ok(_) => {

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub mod manifest;
-pub use manifest::{ReferenceManifest, check_references, print_reference_summary};
+pub use manifest::{check_references, print_reference_summary, ReferenceManifest};
 
 /// Legacy GenBank accessions referenced in ClinVar but not in RefSeq.
 ///
@@ -492,7 +492,10 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
 
     manifest.save()?;
     eprintln!("\n=== Preparation complete ===");
-    eprintln!("Manifest: {}", manifest.reference_dir.join("manifest.json").display());
+    eprintln!(
+        "Manifest: {}",
+        manifest.reference_dir.join("manifest.json").display()
+    );
     Ok(manifest)
 }
 

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -11,6 +11,9 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub mod manifest;
+pub use manifest::{ReferenceManifest, check_references, print_reference_summary};
+
 /// Legacy GenBank accessions referenced in ClinVar but not in RefSeq.
 ///
 /// These are historical sequence records (non-RefSeq) that are still
@@ -77,6 +80,7 @@ pub mod urls {
     pub const REFSEQ_RNA_BASE: &str =
         "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/mRNA_Prot/human.";
     pub const REFSEQ_RNA_SUFFIX: &str = ".rna.fna.gz";
+    pub const REFSEQ_RNA_COUNT: usize = 20;
 
     /// GRCh38 reference genome (with RefSeq accessions NC_000001.11, etc.)
     pub const GRCH38_GENOME: &str = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_genomic.fna.gz";
@@ -104,147 +108,6 @@ pub mod urls {
     /// Maps LRG transcript IDs (e.g., LRG_1t1) to RefSeq transcripts (e.g., NM_000088.3)
     pub const LRG_REFSEQ_MAPPING: &str =
         "https://ftp.ebi.ac.uk/pub/databases/lrgex/list_LRGs_transcripts_xrefs.txt";
-}
-
-/// Manifest of prepared reference data.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ReferenceManifest {
-    /// When the data was prepared
-    pub prepared_at: String,
-    /// Transcript FASTA files
-    pub transcript_fastas: Vec<PathBuf>,
-    /// GRCh38 genome FASTA file (if downloaded)
-    pub genome_fasta: Option<PathBuf>,
-    /// GRCh37 genome FASTA file (if downloaded)
-    #[serde(default)]
-    pub genome_grch37_fasta: Option<PathBuf>,
-    /// RefSeqGene FASTA files (NG_* accessions)
-    #[serde(default)]
-    pub refseqgene_fastas: Vec<PathBuf>,
-    /// LRG FASTA files (LRG_* accessions)
-    #[serde(default)]
-    pub lrg_fastas: Vec<PathBuf>,
-    /// LRG XML files with full annotation structure
-    #[serde(default)]
-    pub lrg_xmls: Vec<PathBuf>,
-    /// LRG to RefSeq transcript mapping file
-    #[serde(default)]
-    pub lrg_refseq_mapping: Option<PathBuf>,
-    /// cdot transcript metadata JSON for GRCh38 (if downloaded)
-    pub cdot_json: Option<PathBuf>,
-    /// cdot transcript metadata JSON for GRCh37 (if downloaded)
-    #[serde(default)]
-    pub cdot_grch37_json: Option<PathBuf>,
-    /// Supplemental FASTA file (missing ClinVar transcripts fetched from NCBI)
-    #[serde(default)]
-    pub supplemental_fasta: Option<PathBuf>,
-    /// Legacy transcript versions FASTA (older versions not in current RefSeq)
-    #[serde(default)]
-    pub legacy_transcripts_fasta: Option<PathBuf>,
-    /// Legacy transcript metadata JSON (CDS coordinates, gene names)
-    #[serde(default)]
-    pub legacy_transcripts_metadata: Option<PathBuf>,
-    /// Legacy GenBank sequences FASTA (non-RefSeq sequences like U31929.1)
-    #[serde(default)]
-    pub legacy_genbank_fasta: Option<PathBuf>,
-    /// Legacy GenBank metadata JSON (CDS coordinates, gene names)
-    #[serde(default)]
-    pub legacy_genbank_metadata: Option<PathBuf>,
-    /// Total number of transcripts
-    pub transcript_count: usize,
-    /// List of available accession prefixes
-    pub available_prefixes: Vec<String>,
-}
-
-impl ReferenceManifest {
-    /// Convert all paths in the manifest to be relative to the given base directory.
-    ///
-    /// This ensures the manifest is portable - paths work when running from the
-    /// directory containing the manifest, regardless of where `prepare` was run from.
-    pub fn make_paths_relative(&mut self, base: &Path) {
-        fn strip_prefix(path: &Path, base: &Path) -> PathBuf {
-            path.strip_prefix(base)
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(|_| path.to_path_buf())
-        }
-
-        self.transcript_fastas = self
-            .transcript_fastas
-            .iter()
-            .map(|p| strip_prefix(p, base))
-            .collect();
-
-        if let Some(ref p) = self.genome_fasta {
-            self.genome_fasta = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.genome_grch37_fasta {
-            self.genome_grch37_fasta = Some(strip_prefix(p, base));
-        }
-
-        self.refseqgene_fastas = self
-            .refseqgene_fastas
-            .iter()
-            .map(|p| strip_prefix(p, base))
-            .collect();
-
-        self.lrg_fastas = self
-            .lrg_fastas
-            .iter()
-            .map(|p| strip_prefix(p, base))
-            .collect();
-
-        self.lrg_xmls = self
-            .lrg_xmls
-            .iter()
-            .map(|p| strip_prefix(p, base))
-            .collect();
-
-        if let Some(ref p) = self.lrg_refseq_mapping {
-            self.lrg_refseq_mapping = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.cdot_json {
-            self.cdot_json = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.cdot_grch37_json {
-            self.cdot_grch37_json = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.supplemental_fasta {
-            self.supplemental_fasta = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.legacy_transcripts_fasta {
-            self.legacy_transcripts_fasta = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.legacy_transcripts_metadata {
-            self.legacy_transcripts_metadata = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.legacy_genbank_fasta {
-            self.legacy_genbank_fasta = Some(strip_prefix(p, base));
-        }
-
-        if let Some(ref p) = self.legacy_genbank_metadata {
-            self.legacy_genbank_metadata = Some(strip_prefix(p, base));
-        }
-    }
-
-    /// Deduplicate paths in all path lists.
-    pub fn deduplicate_paths(&mut self) {
-        fn dedup_vec(paths: &mut Vec<PathBuf>) {
-            let mut seen = HashSet::new();
-            paths.retain(|p| seen.insert(p.clone()));
-        }
-
-        dedup_vec(&mut self.transcript_fastas);
-        dedup_vec(&mut self.refseqgene_fastas);
-        dedup_vec(&mut self.lrg_fastas);
-        dedup_vec(&mut self.lrg_xmls);
-    }
 }
 
 /// Metadata for a legacy transcript fetched from GenBank.
@@ -287,78 +150,8 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
         ),
     })?;
 
-    // Load existing manifest if present, otherwise start fresh
-    let manifest_path = config.output_dir.join("manifest.json");
-    let mut manifest = if manifest_path.exists() {
-        let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
-            msg: format!("Failed to open existing manifest: {}", e),
-        })?;
-        let mut existing: ReferenceManifest =
-            serde_json::from_reader(file).map_err(|e| FerroError::Io {
-                msg: format!("Failed to parse existing manifest: {}", e),
-            })?;
-        existing.prepared_at = chrono::Utc::now().to_rfc3339();
-
-        // Resolve relative paths in manifest against output directory
-        existing.transcript_fastas = existing
-            .transcript_fastas
-            .into_iter()
-            .map(|p| config.output_dir.join(p))
-            .collect();
-        existing.refseqgene_fastas = existing
-            .refseqgene_fastas
-            .into_iter()
-            .map(|p| config.output_dir.join(p))
-            .collect();
-        existing.lrg_fastas = existing
-            .lrg_fastas
-            .into_iter()
-            .map(|p| config.output_dir.join(p))
-            .collect();
-        existing.lrg_xmls = existing
-            .lrg_xmls
-            .into_iter()
-            .map(|p| config.output_dir.join(p))
-            .collect();
-        existing.genome_fasta = existing.genome_fasta.map(|p| config.output_dir.join(p));
-        existing.genome_grch37_fasta = existing
-            .genome_grch37_fasta
-            .map(|p| config.output_dir.join(p));
-        existing.cdot_json = existing.cdot_json.map(|p| config.output_dir.join(p));
-        existing.cdot_grch37_json = existing.cdot_grch37_json.map(|p| config.output_dir.join(p));
-        existing.lrg_refseq_mapping = existing
-            .lrg_refseq_mapping
-            .map(|p| config.output_dir.join(p));
-        existing.supplemental_fasta = existing
-            .supplemental_fasta
-            .map(|p| config.output_dir.join(p));
-        existing.legacy_transcripts_fasta = existing
-            .legacy_transcripts_fasta
-            .map(|p| config.output_dir.join(p));
-
-        eprintln!("  Loaded existing manifest, will merge updates");
-        existing
-    } else {
-        ReferenceManifest {
-            prepared_at: chrono::Utc::now().to_rfc3339(),
-            transcript_fastas: Vec::new(),
-            genome_fasta: None,
-            genome_grch37_fasta: None,
-            refseqgene_fastas: Vec::new(),
-            lrg_fastas: Vec::new(),
-            lrg_xmls: Vec::new(),
-            lrg_refseq_mapping: None,
-            cdot_json: None,
-            cdot_grch37_json: None,
-            supplemental_fasta: None,
-            legacy_transcripts_fasta: None,
-            legacy_transcripts_metadata: None,
-            legacy_genbank_fasta: None,
-            legacy_genbank_metadata: None,
-            transcript_count: 0,
-            available_prefixes: Vec::new(),
-        }
-    };
+    // Load existing manifest if present, else default
+    let mut manifest = ReferenceManifest::load_or_default(&config.output_dir)?;
 
     // Download transcripts
     if config.download_transcripts {
@@ -369,7 +162,7 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
         })?;
 
         // Download RefSeq RNA files (numbered 1-N)
-        for i in 1..=20 {
+        for i in 1..=urls::REFSEQ_RNA_COUNT {
             let filename = format!("human.{}.rna.fna.gz", i);
             let url = format!("{}{}{}", urls::REFSEQ_RNA_BASE, i, urls::REFSEQ_RNA_SUFFIX);
             let output_path = transcript_dir.join(&filename);
@@ -697,22 +490,9 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
         }
     }
 
-    // Clean up and save manifest
-    // Convert paths to be relative to the output directory for portability
-    manifest.deduplicate_paths();
-    manifest.make_paths_relative(&config.output_dir);
-
-    let manifest_path = config.output_dir.join("manifest.json");
-    let file = File::create(&manifest_path).map_err(|e| FerroError::Io {
-        msg: format!("Failed to create manifest: {}", e),
-    })?;
-    serde_json::to_writer_pretty(file, &manifest).map_err(|e| FerroError::Io {
-        msg: format!("Failed to write manifest: {}", e),
-    })?;
-
+    manifest.save()?;
     eprintln!("\n=== Preparation complete ===");
-    eprintln!("Manifest: {}", manifest_path.display());
-
+    eprintln!("Manifest: {}", manifest.reference_dir.join("manifest.json").display());
     Ok(manifest)
 }
 
@@ -826,68 +606,6 @@ fn fetch_supplemental_data(
     }
 
     Ok(())
-}
-
-/// Check what reference data is available.
-pub fn check_references(reference_dir: &Path) -> Result<ReferenceManifest, FerroError> {
-    let manifest_path = reference_dir.join("manifest.json");
-
-    if !manifest_path.exists() {
-        return Err(FerroError::Io {
-            msg: format!(
-                "No reference data found at {}. Run 'ferro prepare' first.",
-                reference_dir.display()
-            ),
-        });
-    }
-
-    let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
-        msg: format!("Failed to open manifest: {}", e),
-    })?;
-
-    serde_json::from_reader(file).map_err(|e| FerroError::Io {
-        msg: format!("Failed to parse manifest: {}", e),
-    })
-}
-
-/// Print a summary of reference data.
-pub fn print_reference_summary(manifest: &ReferenceManifest, reference_dir: &Path) {
-    eprintln!("=== Reference Data Summary ===");
-    eprintln!("  Directory: {}", reference_dir.display());
-    eprintln!("  Prepared at: {}", manifest.prepared_at);
-    eprintln!("  Transcripts: {}", manifest.transcript_count);
-    eprintln!(
-        "  Available prefixes: {}",
-        manifest.available_prefixes.join(", ")
-    );
-
-    if let Some(ref genome) = manifest.genome_fasta {
-        eprintln!("  GRCh38 genome: {}", genome.display());
-    }
-    if let Some(ref genome) = manifest.genome_grch37_fasta {
-        eprintln!("  GRCh37 genome: {}", genome.display());
-    }
-    if !manifest.refseqgene_fastas.is_empty() {
-        eprintln!("  RefSeqGene files: {}", manifest.refseqgene_fastas.len());
-    }
-    if !manifest.lrg_fastas.is_empty() {
-        eprintln!("  LRG files: {}", manifest.lrg_fastas.len());
-    }
-    if let Some(ref cdot) = manifest.cdot_json {
-        eprintln!("  cdot metadata (GRCh38): {}", cdot.display());
-    }
-    if let Some(ref cdot) = manifest.cdot_grch37_json {
-        eprintln!("  cdot metadata (GRCh37): {}", cdot.display());
-    }
-    if let Some(ref supp) = manifest.supplemental_fasta {
-        eprintln!("  Supplemental transcripts: {}", supp.display());
-    }
-    if let Some(ref legacy) = manifest.legacy_transcripts_fasta {
-        eprintln!("  Legacy transcripts: {}", legacy.display());
-    }
-    if let Some(ref genbank) = manifest.legacy_genbank_fasta {
-        eprintln!("  Legacy GenBank: {}", genbank.display());
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
I encountered a few issues with the ferro prepare during a hackathon yesterday and had a few cycles to investigate the `prepare_references` function.  This PR:

- Separates the manifest handling from the downloading, improving separation of concerns.
- Removes some of the duplication around reading/writing the manifest.
- Clarifies the "relative path at serialization, absolute path at runtime" and DRYs the implementation for the struct fields.