### PR TITLE
Review fixes for #39: macos-system-configuration + py3.13

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --features python -i python3.8 python3.9 python3.10 python3.11 python3.12
+          args: --release --out dist --features python -i python3.8 python3.9 python3.10 python3.11 python3.12 python3.13
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [macos-15-intel, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - runner: macos-15-intel
             target: x86_64
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,9 +1429,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3226,6 +3238,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,6 +4054,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4"
 # Core dependencies for prepare/check/commands (now part of main binary)
 indicatif = "0.17"
 chrono = { version = "0.4", features = ["serde"] }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "stream", "gzip", "deflate", "http2", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "stream", "gzip", "deflate", "http2", "rustls-tls", "macos-system-configuration"] }
 url = "2.4"
 regex = "1.10"
 once_cell = "1.20"


### PR DESCRIPTION
Two small fixes raised in review of #39 (now rebased on main). PR targets `ci/build-python-wheels` so changes flow into #39.

## Summary

- **`macos-system-configuration` added back to reqwest features.** When #38 disabled default features to switch to rustls-tls, this feature was lost — macOS users behind a system proxy would no longer pick up proxy config automatically. Restoring it preserves the previous UX.
- **Python 3.13 added to the wheel build matrix** (Linux `-i` list, macOS and Windows job matrices). GA October 2024; pyo3 0.23 (already in use) supports it. After this change the matrix is Linux × 4, macOS × 12, Windows × 6, sdist × 1 = 23 cells.

Two commits, kept separate so they can be cherry-picked independently if needed.

## Test plan

- [x] `cargo check --features dev` passes locally with the new reqwest feature.
- [ ] After merge into `ci/build-python-wheels`, run `workflow_dispatch` (blank tag) on `release-wheels.yml` to confirm all 23 matrix cells build clean — same dry-run procedure used to validate #39.