### PR TITLE
fix: Use HGVS spec compact form for allele Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allele `Display` now emits HGVS spec-correct compact form (`ACC:c.[edit1;edit2]`) when sub-variants share an accession and coordinate type, instead of the expanded form (`[ACC:c.edit1;ACC:c.edit2]`). Mixed-accession alleles and alleles containing the per-variant unknown form (`c.?`, `r.?`, etc.) still emit the expanded form. Downstream consumers parsing the previous expanded output (including Python `str(variant)`) will see the new format. ([#48](https://github.com/fulcrumgenomics/ferro-hgvs/pull/48))
+
+### Fixed
+
+- Prevent panic when `NullAllele`/`UnknownAllele` are used as sub-variants in an allele ([#48](https://github.com/fulcrumgenomics/ferro-hgvs/pull/48))
+
 ## [0.3.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.2.0...v0.3.0) - 2026-03-30
 
 ### Added

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -3919,10 +3919,8 @@ mod tests {
             assert_eq!(allele.phase, AllelePhase::Cis);
             assert_eq!(allele.variants.len(), 2);
         }
-        assert_eq!(
-            format!("{}", variant),
-            "[NM_000088.3:c.100A>G;NM_000088.3:c.200C>T]"
-        );
+        // Same-accession cis alleles render in compact form
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.[100A>G;200C>T]");
     }
 
     #[test]
@@ -3934,10 +3932,8 @@ mod tests {
             assert_eq!(allele.phase, AllelePhase::Trans);
             assert_eq!(allele.variants.len(), 2);
         }
-        assert_eq!(
-            format!("{}", variant),
-            "[NM_000088.3:c.100A>G];[NM_000088.3:c.200C>T]"
-        );
+        // Same-accession trans alleles render in compact form
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.[100A>G];[200C>T]");
     }
 
     #[test]
@@ -4030,10 +4026,8 @@ mod tests {
             assert_eq!(allele.phase, AllelePhase::Unknown);
             assert_eq!(allele.variants.len(), 2);
         }
-        assert_eq!(
-            format!("{}", variant),
-            "[NM_000088.3:c.100A>G(;)NM_000088.3:c.200C>T]"
-        );
+        // Same-accession unknown-phase alleles render in compact form
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.100A>G(;)200C>T");
     }
 
     #[test]
@@ -4065,11 +4059,8 @@ mod tests {
                 );
             }
         }
-        // Output expands to full format
-        assert_eq!(
-            format!("{}", variant),
-            "[NM_000088.3:c.145C>T;NM_000088.3:c.147C>G]"
-        );
+        // Output uses compact form (same accession)
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.[145C>T;147C>G]");
     }
 
     #[test]
@@ -4081,10 +4072,8 @@ mod tests {
             assert_eq!(allele.phase, AllelePhase::Unknown);
             assert_eq!(allele.variants.len(), 2);
         }
-        assert_eq!(
-            format!("{}", variant),
-            "[NM_000088.3:c.145C>T(;)NM_000088.3:c.147C>G]"
-        );
+        // Output uses compact form (same accession)
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.145C>T(;)147C>G");
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -511,7 +511,10 @@ impl fmt::Display for AlleleVariant {
                 }
             }
             AllelePhase::Unknown => {
-                if use_compact_form(&self.variants) {
+                // Unknown-phase compact form has no surrounding brackets, so a
+                // singleton would print as `ACC:type.edit` and lose the allele
+                // wrapper. Only use compact form when there are 2+ sub-variants.
+                if self.variants.len() > 1 && use_compact_form(&self.variants) {
                     // Compact form: ACC:g.edit1(;)edit2
                     write_compact_prefix(f, &self.variants[0])?;
                     for (i, v) in self.variants.iter().enumerate() {
@@ -1176,6 +1179,32 @@ mod tests {
         assert_eq!(
             format!("{}", HgvsVariant::Allele(allele)),
             "NM_000088.3:c.[100A>G];[200A>C];[300A>T]"
+        );
+    }
+
+    #[test]
+    fn test_allele_unknown_phase_singleton_keeps_wrapper() {
+        use crate::hgvs::location::CdsPos;
+
+        // A singleton unknown-phase allele must keep the bracketed wrapper;
+        // the compact form `ACC:c.edit` would be indistinguishable from a
+        // bare variant and would not round-trip.
+        let var = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+
+        let allele = AlleleVariant::unknown_phase(vec![var]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(allele)),
+            "[NM_000088.3:c.100A>G]"
         );
     }
 

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -437,27 +437,36 @@ impl AlleleVariant {
     }
 }
 
+/// Write the `ACC:<type>.` prefix for compact allele form.
+///
+/// Per HGVS spec, bracketed `?` is only valid as a whole-allele marker (`[?]`),
+/// never mixed with concrete edits inside the same bracket. Compact form is
+/// suppressed when any sub-variant carries the per-variant `?` (e.g. `c.?`).
+fn use_compact_form(variants: &[HgvsVariant]) -> bool {
+    !variants.is_empty()
+        && HgvsVariant::all_share_accession_and_type(variants)
+        && !variants.iter().any(HgvsVariant::is_loc_edit_unknown)
+}
+
+fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt::Result {
+    write!(
+        f,
+        "{}:{}.",
+        first
+            .accession()
+            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
+        first.variant_type()
+    )
+}
+
 impl fmt::Display for AlleleVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Per HGVS spec, bracketed `?` is only valid as a whole-allele marker (`[?]`),
-        // never mixed with concrete edits inside the same bracket. Suppress compact
-        // form when any sub-variant carries the per-variant `?` (e.g. `c.?`, `r.?`).
-        let compact = HgvsVariant::all_share_accession_and_type(&self.variants)
-            && !self.variants.iter().any(HgvsVariant::is_loc_edit_unknown);
-
         match self.phase {
             AllelePhase::Cis => {
-                if compact && !self.variants.is_empty() {
+                if use_compact_form(&self.variants) {
                     // Compact form: ACC:g.[edit1;edit2]
-                    let first = &self.variants[0];
-                    write!(
-                        f,
-                        "{}:{}.[",
-                        first
-                            .accession()
-                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
-                        first.variant_type()
-                    )?;
+                    write_compact_prefix(f, &self.variants[0])?;
+                    write!(f, "[")?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, ";")?;
@@ -478,17 +487,9 @@ impl fmt::Display for AlleleVariant {
                 }
             }
             AllelePhase::Trans => {
-                if compact && !self.variants.is_empty() {
+                if use_compact_form(&self.variants) {
                     // Compact form: ACC:g.[edit1];[edit2]
-                    let first = &self.variants[0];
-                    write!(
-                        f,
-                        "{}:{}.",
-                        first
-                            .accession()
-                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
-                        first.variant_type()
-                    )?;
+                    write_compact_prefix(f, &self.variants[0])?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, ";")?;
@@ -510,17 +511,9 @@ impl fmt::Display for AlleleVariant {
                 }
             }
             AllelePhase::Unknown => {
-                if compact && !self.variants.is_empty() {
+                if use_compact_form(&self.variants) {
                     // Compact form: ACC:g.edit1(;)edit2
-                    let first = &self.variants[0];
-                    write!(
-                        f,
-                        "{}:{}.",
-                        first
-                            .accession()
-                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
-                        first.variant_type()
-                    )?;
+                    write_compact_prefix(f, &self.variants[0])?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, "(;)")?;
@@ -818,7 +811,6 @@ pub struct TxVariant {
 }
 
 impl TxVariant {
-    /// Format just the position+edit portion (without `accession:n.` prefix).
     pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }
@@ -920,7 +912,6 @@ pub struct MtVariant {
 }
 
 impl MtVariant {
-    /// Format just the position+edit portion (without `accession:m.` prefix).
     pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }
@@ -945,7 +936,6 @@ pub struct CircularVariant {
 }
 
 impl CircularVariant {
-    /// Format just the position+edit portion (without `accession:o.` prefix).
     pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -722,9 +722,7 @@ impl HgvsVariant {
 
         // Don't use compact form for types that aren't simple coordinate-based variants,
         // or when the first variant has no accession (e.g. NullAllele, UnknownAllele)
-        if first_acc.is_none()
-            || matches!(first_type, "allele" | "null" | "unknown" | "r::r")
-        {
+        if first_acc.is_none() || matches!(first_type, "allele" | "null" | "unknown" | "r::r") {
             return false;
         }
 

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -439,7 +439,11 @@ impl AlleleVariant {
 
 impl fmt::Display for AlleleVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let compact = HgvsVariant::all_share_accession_and_type(&self.variants);
+        // Per HGVS spec, bracketed `?` is only valid as a whole-allele marker (`[?]`),
+        // never mixed with concrete edits inside the same bracket. Suppress compact
+        // form when any sub-variant carries the per-variant `?` (e.g. `c.?`, `r.?`).
+        let compact = HgvsVariant::all_share_accession_and_type(&self.variants)
+            && !self.variants.iter().any(HgvsVariant::is_loc_edit_unknown);
 
         match self.phase {
             AllelePhase::Cis => {
@@ -449,7 +453,9 @@ impl fmt::Display for AlleleVariant {
                     write!(
                         f,
                         "{}:{}.[",
-                        first.accession().unwrap(),
+                        first
+                            .accession()
+                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
                         first.variant_type()
                     )?;
                     for (i, v) in self.variants.iter().enumerate() {
@@ -478,7 +484,9 @@ impl fmt::Display for AlleleVariant {
                     write!(
                         f,
                         "{}:{}.",
-                        first.accession().unwrap(),
+                        first
+                            .accession()
+                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
                         first.variant_type()
                     )?;
                     for (i, v) in self.variants.iter().enumerate() {
@@ -508,7 +516,9 @@ impl fmt::Display for AlleleVariant {
                     write!(
                         f,
                         "{}:{}.",
-                        first.accession().unwrap(),
+                        first
+                            .accession()
+                            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
                         first.variant_type()
                     )?;
                     for (i, v) in self.variants.iter().enumerate() {
@@ -645,69 +655,53 @@ impl HgvsVariant {
 
     /// Format just the position+edit portion (without accession and coordinate prefix).
     ///
-    /// For `NM_000088.3:c.459A>G`, this writes `459A>G`.
-    /// Used by allele Display to emit the spec-correct compact form.
+    /// For `NM_000088.3:c.459A>G`, this writes `459A>G`. Used by `AlleleVariant::Display`
+    /// to emit the spec-correct compact form (`ACC:c.[edit1;edit2]`).
     ///
-    /// Returns `Err` for variant types that don't support this (Allele, NullAllele, etc.)
-    pub fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /// Variant types that have no simple loc/edit form (`Allele`, `RnaFusion`,
+    /// `NullAllele`, `UnknownAllele`) fall back to their full `Display` output. Callers
+    /// guard against this via `all_share_accession_and_type`, which excludes those
+    /// types from the compact branch.
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            HgvsVariant::Genome(v) => {
-                if let Some(edit) = v.loc_edit.edit.inner() {
-                    if edit.is_whole_entity() {
-                        return write!(f, "{}", v.loc_edit.edit);
-                    }
-                }
-                write!(f, "{}", v.loc_edit)
-            }
-            HgvsVariant::Cds(v) => {
-                if let Some(edit) = v.loc_edit.edit.inner() {
-                    if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
-                        return write!(f, "{}", v.loc_edit.edit);
-                    }
-                }
-                write!(f, "{}", v.loc_edit)
-            }
-            HgvsVariant::Tx(v) => write!(f, "{}", v.loc_edit),
-            HgvsVariant::Rna(v) => match &v.loc_edit.edit {
-                crate::hgvs::uncertainty::Mu::Certain(edit) => {
-                    if edit.is_whole_entity() {
-                        write!(f, "{}", edit.to_rna_string())
-                    } else {
-                        write!(f, "{}{}", v.loc_edit.location, edit.to_rna_string())
-                    }
-                }
-                crate::hgvs::uncertainty::Mu::Uncertain(edit) => {
-                    if edit.is_whole_entity() {
-                        write!(f, "({})", edit.to_rna_string())
-                    } else {
-                        write!(f, "{}({})", v.loc_edit.location, edit.to_rna_string())
-                    }
-                }
-                crate::hgvs::uncertainty::Mu::Unknown => write!(f, "?"),
-            },
-            HgvsVariant::Protein(v) => {
-                if let Some(edit) = v.loc_edit.edit.inner() {
-                    if edit.is_whole_protein_identity()
-                        || edit.is_no_protein()
-                        || edit.is_whole_protein_unknown()
-                    {
-                        return write!(f, "{}", v.loc_edit.edit);
-                    }
-                }
-                if v.loc_edit.edit.is_uncertain() {
-                    if let Some(edit) = v.loc_edit.edit.inner() {
-                        return write!(f, "({}{})", v.loc_edit.location, edit);
-                    }
-                }
-                write!(f, "{}", v.loc_edit)
-            }
-            HgvsVariant::Mt(v) => write!(f, "{}", v.loc_edit),
-            HgvsVariant::Circular(v) => write!(f, "{}", v.loc_edit),
-            // These types don't support compact allele form
+            HgvsVariant::Genome(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Cds(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Tx(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Rna(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Protein(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Mt(v) => v.fmt_loc_edit(f),
+            HgvsVariant::Circular(v) => v.fmt_loc_edit(f),
+            // These types have no compact form — fall back to full Display.
             HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
             HgvsVariant::Allele(a) => write!(f, "{}", a),
             HgvsVariant::NullAllele => write!(f, "0"),
             HgvsVariant::UnknownAllele => write!(f, "?"),
+        }
+    }
+
+    /// True if this variant's loc/edit portion is the per-variant unknown form
+    /// (`g.?`, `c.?`, `n.?`, `r.?`, `p.?`, `m.?`, `o.?`).
+    ///
+    /// The HGVS spec uses bracketed `?` only as a whole-allele marker (`[?]`),
+    /// never mixed with concrete edits inside the same bracket. Compact form is
+    /// suppressed when any sub-variant matches this so the output isn't visually
+    /// ambiguous with the spec-sanctioned `[?]` form.
+    pub(crate) fn is_loc_edit_unknown(&self) -> bool {
+        match self {
+            HgvsVariant::Genome(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Cds(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Tx(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Rna(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Mt(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Circular(v) => is_na_edit_unknown(&v.loc_edit.edit),
+            HgvsVariant::Protein(v) => match &v.loc_edit.edit {
+                Mu::Unknown => true,
+                Mu::Certain(e) | Mu::Uncertain(e) => e.is_whole_protein_unknown(),
+            },
+            HgvsVariant::RnaFusion(_)
+            | HgvsVariant::Allele(_)
+            | HgvsVariant::NullAllele
+            | HgvsVariant::UnknownAllele => false,
         }
     }
 
@@ -729,6 +723,15 @@ impl HgvsVariant {
         variants[1..]
             .iter()
             .all(|v| v.variant_type() == first_type && v.accession() == first_acc)
+    }
+}
+
+/// True if a nucleotide-edit `Mu` wrapper represents the per-variant unknown form
+/// (e.g. `c.?`, `r.?`).
+fn is_na_edit_unknown(edit: &Mu<NaEdit>) -> bool {
+    match edit {
+        Mu::Unknown => true,
+        Mu::Certain(e) | Mu::Uncertain(e) => e.is_whole_entity_unknown(),
     }
 }
 
@@ -758,15 +761,23 @@ pub struct GenomeVariant {
     pub loc_edit: LocEdit<GenomeInterval, NaEdit>,
 }
 
-impl fmt::Display for GenomeVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl GenomeVariant {
+    /// Format just the position+edit portion (without `accession:g.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-entity identity (g.=) or unknown (g.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_entity() {
-                return write!(f, "{}:g.{}", self.accession, self.loc_edit.edit);
+                return write!(f, "{}", self.loc_edit.edit);
             }
         }
-        write!(f, "{}:g.{}", self.accession, self.loc_edit)
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
+impl fmt::Display for GenomeVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:g.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -778,15 +789,23 @@ pub struct CdsVariant {
     pub loc_edit: LocEdit<CdsInterval, NaEdit>,
 }
 
-impl fmt::Display for CdsVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl CdsVariant {
+    /// Format just the position+edit portion (without `accession:c.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-entity identity (c.=) or unknown (c.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
-                return write!(f, "{}:c.{}", self.accession, self.loc_edit.edit);
+                return write!(f, "{}", self.loc_edit.edit);
             }
         }
-        write!(f, "{}:c.{}", self.accession, self.loc_edit)
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
+impl fmt::Display for CdsVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:c.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -798,9 +817,17 @@ pub struct TxVariant {
     pub loc_edit: LocEdit<TxInterval, NaEdit>,
 }
 
+impl TxVariant {
+    /// Format just the position+edit portion (without `accession:n.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
 impl fmt::Display for TxVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:n.{}", self.accession, self.loc_edit)
+        write!(f, "{}:n.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -812,43 +839,37 @@ pub struct RnaVariant {
     pub loc_edit: LocEdit<RnaInterval, NaEdit>,
 }
 
-impl fmt::Display for RnaVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // RNA uses lowercase nucleotides per HGVS spec
-        // Format the edit using to_rna_string() for proper lowercase output
+impl RnaVariant {
+    /// Format just the position+edit portion (without `accession:r.` prefix).
+    ///
+    /// RNA uses lowercase nucleotides per HGVS spec.
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.loc_edit.edit {
-            crate::hgvs::uncertainty::Mu::Certain(edit) => {
+            Mu::Certain(edit) => {
                 // For whole-entity patterns (r.=, r.?, r.spl, r.0), skip the position
                 if edit.is_whole_entity() {
-                    write!(f, "{}:r.{}", self.accession, edit.to_rna_string())
+                    write!(f, "{}", edit.to_rna_string())
                 } else {
-                    write!(
-                        f,
-                        "{}:r.{}{}",
-                        self.accession,
-                        self.loc_edit.location,
-                        edit.to_rna_string()
-                    )
+                    write!(f, "{}{}", self.loc_edit.location, edit.to_rna_string())
                 }
             }
-            crate::hgvs::uncertainty::Mu::Uncertain(edit) => {
+            Mu::Uncertain(edit) => {
                 // For whole-entity patterns, skip the position
                 if edit.is_whole_entity() {
-                    write!(f, "{}:r.({})", self.accession, edit.to_rna_string())
+                    write!(f, "({})", edit.to_rna_string())
                 } else {
-                    write!(
-                        f,
-                        "{}:r.{}({})",
-                        self.accession,
-                        self.loc_edit.location,
-                        edit.to_rna_string()
-                    )
+                    write!(f, "{}({})", self.loc_edit.location, edit.to_rna_string())
                 }
             }
-            crate::hgvs::uncertainty::Mu::Unknown => {
-                write!(f, "{}:r.?", self.accession)
-            }
+            Mu::Unknown => write!(f, "?"),
         }
+    }
+}
+
+impl fmt::Display for RnaVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:r.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -860,29 +881,33 @@ pub struct ProteinVariant {
     pub loc_edit: LocEdit<ProtInterval, ProteinEdit>,
 }
 
-impl fmt::Display for ProteinVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl ProteinVariant {
+    /// Format just the position+edit portion (without `accession:p.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-protein identity (p.= or p.(=)), no-protein (p.0), or whole-protein unknown (p.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_protein_identity()
                 || edit.is_no_protein()
                 || edit.is_whole_protein_unknown()
             {
-                return write!(f, "{}:p.{}", self.accession, self.loc_edit.edit);
+                return write!(f, "{}", self.loc_edit.edit);
             }
         }
         // For predicted protein changes (uncertain edit), wrap position+edit in parentheses
         // e.g., p.(Arg248Gln) instead of p.Arg248(Gln)
         if self.loc_edit.edit.is_uncertain() {
             if let Some(edit) = self.loc_edit.edit.inner() {
-                return write!(
-                    f,
-                    "{}:p.({}{})",
-                    self.accession, self.loc_edit.location, edit
-                );
+                return write!(f, "({}{})", self.loc_edit.location, edit);
             }
         }
-        write!(f, "{}:p.{}", self.accession, self.loc_edit)
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
+impl fmt::Display for ProteinVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:p.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -894,9 +919,17 @@ pub struct MtVariant {
     pub loc_edit: LocEdit<GenomeInterval, NaEdit>,
 }
 
+impl MtVariant {
+    /// Format just the position+edit portion (without `accession:m.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
 impl fmt::Display for MtVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:m.{}", self.accession, self.loc_edit)
+        write!(f, "{}:m.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -911,9 +944,17 @@ pub struct CircularVariant {
     pub loc_edit: LocEdit<GenomeInterval, NaEdit>,
 }
 
+impl CircularVariant {
+    /// Format just the position+edit portion (without `accession:o.` prefix).
+    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.loc_edit)
+    }
+}
+
 impl fmt::Display for CircularVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:o.{}", self.accession, self.loc_edit)
+        write!(f, "{}:o.", self.accession)?;
+        self.fmt_loc_edit(f)
     }
 }
 
@@ -1089,6 +1130,66 @@ mod tests {
     }
 
     #[test]
+    fn test_allele_cis_three_variants() {
+        use crate::hgvs::location::CdsPos;
+
+        let make_var = |pos, alt| {
+            HgvsVariant::Cds(CdsVariant {
+                accession: Accession::new("NM", "000088", Some(3)),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(pos)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: alt,
+                    },
+                ),
+            })
+        };
+
+        let allele = AlleleVariant::cis(vec![
+            make_var(100, Base::G),
+            make_var(200, Base::C),
+            make_var(300, Base::T),
+        ]);
+
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(allele)),
+            "NM_000088.3:c.[100A>G;200A>C;300A>T]"
+        );
+    }
+
+    #[test]
+    fn test_allele_trans_three_variants() {
+        use crate::hgvs::location::CdsPos;
+
+        let make_var = |pos, alt| {
+            HgvsVariant::Cds(CdsVariant {
+                accession: Accession::new("NM", "000088", Some(3)),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(pos)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: alt,
+                    },
+                ),
+            })
+        };
+
+        let allele = AlleleVariant::trans(vec![
+            make_var(100, Base::G),
+            make_var(200, Base::C),
+            make_var(300, Base::T),
+        ]);
+
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(allele)),
+            "NM_000088.3:c.[100A>G];[200A>C];[300A>T]"
+        );
+    }
+
+    #[test]
     fn test_allele_mixed_accession_uses_expanded_form() {
         use crate::hgvs::location::CdsPos;
 
@@ -1126,6 +1227,40 @@ mod tests {
         assert_eq!(
             format!("{}", HgvsVariant::Allele(trans)),
             "[NM_000088.3:c.100A>G];[NM_000099.1:c.200C>T]"
+        );
+    }
+
+    #[test]
+    fn test_allele_with_unknown_sub_variant_uses_expanded_form() {
+        // Per HGVS spec, bracketed `?` is reserved for the whole-allele marker (`[?]`).
+        // An allele containing a `c.?` sub-variant must NOT collapse to `[?;100A>G]` —
+        // that would visually conflict with the spec-sanctioned form.
+        use crate::hgvs::location::CdsPos;
+
+        let unknown = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(1)),
+                NaEdit::whole_entity_unknown(),
+            ),
+        });
+        let concrete = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+
+        let trans = AlleleVariant::trans(vec![concrete, unknown]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(trans)),
+            "[NM_000088.3:c.100A>G];[NM_000088.3:c.?]"
         );
     }
 

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1183,6 +1183,86 @@ mod tests {
     }
 
     #[test]
+    fn test_allele_unknown_phase_compact_form() {
+        // 2+ unknown-phase variants sharing accession + coordinate type emit the
+        // bracket-less compact form `ACC:c.edit1(;)edit2`.
+        use crate::hgvs::location::CdsPos;
+
+        let make_var = |pos, alt| {
+            HgvsVariant::Cds(CdsVariant {
+                accession: Accession::new("NM", "000088", Some(3)),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(pos)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: alt,
+                    },
+                ),
+            })
+        };
+
+        let pair =
+            AlleleVariant::unknown_phase(vec![make_var(100, Base::G), make_var(200, Base::C)]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(pair)),
+            "NM_000088.3:c.100A>G(;)200A>C"
+        );
+
+        let triple = AlleleVariant::unknown_phase(vec![
+            make_var(100, Base::G),
+            make_var(200, Base::C),
+            make_var(300, Base::T),
+        ]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(triple)),
+            "NM_000088.3:c.100A>G(;)200A>C(;)300A>T"
+        );
+    }
+
+    #[test]
+    fn test_allele_mixed_coordinate_types_uses_expanded_form() {
+        // Same accession, different coordinate types (c. and n.) → expanded form.
+        // `all_share_accession_and_type` requires both fields to match.
+        use crate::hgvs::location::{CdsPos, TxPos};
+
+        let coding = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+        let noncoding = HgvsVariant::Tx(TxVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                TxInterval::point(TxPos::new(200)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::T,
+                },
+            ),
+        });
+
+        let cis = AlleleVariant::cis(vec![coding.clone(), noncoding.clone()]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis)),
+            "[NM_000088.3:c.100A>G;NM_000088.3:n.200C>T]"
+        );
+
+        let trans = AlleleVariant::trans(vec![coding, noncoding]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(trans)),
+            "[NM_000088.3:c.100A>G];[NM_000088.3:n.200C>T]"
+        );
+    }
+
+    #[test]
     fn test_allele_unknown_phase_singleton_keeps_wrapper() {
         use crate::hgvs::location::CdsPos;
 

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -658,7 +658,7 @@ impl HgvsVariant {
     /// `NullAllele`, `UnknownAllele`) fall back to their full `Display` output. Callers
     /// guard against this via `all_share_accession_and_type`, which excludes those
     /// types from the compact branch.
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HgvsVariant::Genome(v) => v.fmt_loc_edit(f),
             HgvsVariant::Cds(v) => v.fmt_loc_edit(f),
@@ -759,7 +759,7 @@ pub struct GenomeVariant {
 
 impl GenomeVariant {
     /// Format just the position+edit portion (without `accession:g.` prefix).
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-entity identity (g.=) or unknown (g.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_entity() {
@@ -787,7 +787,7 @@ pub struct CdsVariant {
 
 impl CdsVariant {
     /// Format just the position+edit portion (without `accession:c.` prefix).
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-entity identity (c.=) or unknown (c.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
@@ -814,7 +814,7 @@ pub struct TxVariant {
 }
 
 impl TxVariant {
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }
 }
@@ -838,7 +838,7 @@ impl RnaVariant {
     /// Format just the position+edit portion (without `accession:r.` prefix).
     ///
     /// RNA uses lowercase nucleotides per HGVS spec.
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.loc_edit.edit {
             Mu::Certain(edit) => {
                 // For whole-entity patterns (r.=, r.?, r.spl, r.0), skip the position
@@ -878,7 +878,7 @@ pub struct ProteinVariant {
 
 impl ProteinVariant {
     /// Format just the position+edit portion (without `accession:p.` prefix).
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // For whole-protein identity (p.= or p.(=)), no-protein (p.0), or whole-protein unknown (p.?), skip the position
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_protein_identity()
@@ -915,7 +915,7 @@ pub struct MtVariant {
 }
 
 impl MtVariant {
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }
 }
@@ -939,7 +939,7 @@ pub struct CircularVariant {
 }
 
 impl CircularVariant {
-    pub(crate) fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.loc_edit)
     }
 }

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -714,15 +714,17 @@ impl HgvsVariant {
     /// Check if all variants in a slice share the same accession and coordinate type.
     /// Used to determine whether the compact allele form can be used.
     pub(crate) fn all_share_accession_and_type(variants: &[HgvsVariant]) -> bool {
-        if variants.len() < 2 {
+        let Some(first) = variants.first() else {
             return true;
-        }
-        let first = &variants[0];
+        };
         let first_acc = first.accession();
         let first_type = first.variant_type();
 
-        // Don't use compact form for types that aren't simple coordinate-based variants
-        if matches!(first_type, "allele" | "null" | "unknown" | "r::r") {
+        // Don't use compact form for types that aren't simple coordinate-based variants,
+        // or when the first variant has no accession (e.g. NullAllele, UnknownAllele)
+        if first_acc.is_none()
+            || matches!(first_type, "allele" | "null" | "unknown" | "r::r")
+        {
             return false;
         }
 
@@ -1127,6 +1129,14 @@ mod tests {
             format!("{}", HgvsVariant::Allele(trans)),
             "[NM_000088.3:c.100A>G];[NM_000099.1:c.200C>T]"
         );
+    }
+
+    #[test]
+    fn test_allele_null_variant_uses_expanded_form() {
+        // A single NullAllele has no accession — must not panic, must use expanded form
+        let null = HgvsVariant::NullAllele;
+        let cis = AlleleVariant::cis(vec![null]);
+        assert_eq!(format!("{}", HgvsVariant::Allele(cis)), "[0]");
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -439,41 +439,99 @@ impl AlleleVariant {
 
 impl fmt::Display for AlleleVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let compact = HgvsVariant::all_share_accession_and_type(&self.variants);
+
         match self.phase {
             AllelePhase::Cis => {
-                // [var1;var2]
-                write!(f, "[")?;
-                for (i, v) in self.variants.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ";")?;
+                if compact && !self.variants.is_empty() {
+                    // Compact form: ACC:g.[edit1;edit2]
+                    let first = &self.variants[0];
+                    write!(
+                        f,
+                        "{}:{}.[",
+                        first.accession().unwrap(),
+                        first.variant_type()
+                    )?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ";")?;
+                        }
+                        v.fmt_loc_edit(f)?;
                     }
-                    write!(f, "{}", v)?;
+                    write!(f, "]")
+                } else {
+                    // Expanded form: [ACC:g.edit1;ACC:g.edit2]
+                    write!(f, "[")?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ";")?;
+                        }
+                        write!(f, "{}", v)?;
+                    }
+                    write!(f, "]")
                 }
-                write!(f, "]")
             }
             AllelePhase::Trans => {
-                // [var1];[var2]
-                for (i, v) in self.variants.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ";")?;
+                if compact && !self.variants.is_empty() {
+                    // Compact form: ACC:g.[edit1];[edit2]
+                    let first = &self.variants[0];
+                    write!(
+                        f,
+                        "{}:{}.",
+                        first.accession().unwrap(),
+                        first.variant_type()
+                    )?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ";")?;
+                        }
+                        write!(f, "[")?;
+                        v.fmt_loc_edit(f)?;
+                        write!(f, "]")?;
                     }
-                    write!(f, "[{}]", v)?;
+                    Ok(())
+                } else {
+                    // Expanded form: [ACC:g.edit1];[ACC:g.edit2]
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ";")?;
+                        }
+                        write!(f, "[{}]", v)?;
+                    }
+                    Ok(())
                 }
-                Ok(())
             }
             AllelePhase::Unknown => {
-                // [var1(;)var2] - unknown phase
-                write!(f, "[")?;
-                for (i, v) in self.variants.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, "(;)")?;
+                if compact && !self.variants.is_empty() {
+                    // Compact form: ACC:g.edit1(;)edit2
+                    let first = &self.variants[0];
+                    write!(
+                        f,
+                        "{}:{}.",
+                        first.accession().unwrap(),
+                        first.variant_type()
+                    )?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "(;)")?;
+                        }
+                        v.fmt_loc_edit(f)?;
                     }
-                    write!(f, "{}", v)?;
+                    Ok(())
+                } else {
+                    // Expanded form: [ACC:g.edit1(;)ACC:g.edit2]
+                    write!(f, "[")?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "(;)")?;
+                        }
+                        write!(f, "{}", v)?;
+                    }
+                    write!(f, "]")
                 }
-                write!(f, "]")
             }
             AllelePhase::Mosaic => {
-                // var1/var2 (single forward slash)
+                // var1/var2 (single forward slash) - always expanded
                 for (i, v) in self.variants.iter().enumerate() {
                     if i > 0 {
                         write!(f, "/")?;
@@ -483,7 +541,7 @@ impl fmt::Display for AlleleVariant {
                 Ok(())
             }
             AllelePhase::Chimeric => {
-                // var1//var2 (double forward slash)
+                // var1//var2 (double forward slash) - always expanded
                 for (i, v) in self.variants.iter().enumerate() {
                     if i > 0 {
                         write!(f, "//")?;
@@ -583,6 +641,94 @@ impl HgvsVariant {
     /// Check if this is an unknown allele marker
     pub fn is_unknown_allele(&self) -> bool {
         matches!(self, HgvsVariant::UnknownAllele)
+    }
+
+    /// Format just the position+edit portion (without accession and coordinate prefix).
+    ///
+    /// For `NM_000088.3:c.459A>G`, this writes `459A>G`.
+    /// Used by allele Display to emit the spec-correct compact form.
+    ///
+    /// Returns `Err` for variant types that don't support this (Allele, NullAllele, etc.)
+    pub fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HgvsVariant::Genome(v) => {
+                if let Some(edit) = v.loc_edit.edit.inner() {
+                    if edit.is_whole_entity() {
+                        return write!(f, "{}", v.loc_edit.edit);
+                    }
+                }
+                write!(f, "{}", v.loc_edit)
+            }
+            HgvsVariant::Cds(v) => {
+                if let Some(edit) = v.loc_edit.edit.inner() {
+                    if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
+                        return write!(f, "{}", v.loc_edit.edit);
+                    }
+                }
+                write!(f, "{}", v.loc_edit)
+            }
+            HgvsVariant::Tx(v) => write!(f, "{}", v.loc_edit),
+            HgvsVariant::Rna(v) => match &v.loc_edit.edit {
+                crate::hgvs::uncertainty::Mu::Certain(edit) => {
+                    if edit.is_whole_entity() {
+                        write!(f, "{}", edit.to_rna_string())
+                    } else {
+                        write!(f, "{}{}", v.loc_edit.location, edit.to_rna_string())
+                    }
+                }
+                crate::hgvs::uncertainty::Mu::Uncertain(edit) => {
+                    if edit.is_whole_entity() {
+                        write!(f, "({})", edit.to_rna_string())
+                    } else {
+                        write!(f, "{}({})", v.loc_edit.location, edit.to_rna_string())
+                    }
+                }
+                crate::hgvs::uncertainty::Mu::Unknown => write!(f, "?"),
+            },
+            HgvsVariant::Protein(v) => {
+                if let Some(edit) = v.loc_edit.edit.inner() {
+                    if edit.is_whole_protein_identity()
+                        || edit.is_no_protein()
+                        || edit.is_whole_protein_unknown()
+                    {
+                        return write!(f, "{}", v.loc_edit.edit);
+                    }
+                }
+                if v.loc_edit.edit.is_uncertain() {
+                    if let Some(edit) = v.loc_edit.edit.inner() {
+                        return write!(f, "({}{})", v.loc_edit.location, edit);
+                    }
+                }
+                write!(f, "{}", v.loc_edit)
+            }
+            HgvsVariant::Mt(v) => write!(f, "{}", v.loc_edit),
+            HgvsVariant::Circular(v) => write!(f, "{}", v.loc_edit),
+            // These types don't support compact allele form
+            HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
+            HgvsVariant::Allele(a) => write!(f, "{}", a),
+            HgvsVariant::NullAllele => write!(f, "0"),
+            HgvsVariant::UnknownAllele => write!(f, "?"),
+        }
+    }
+
+    /// Check if all variants in a slice share the same accession and coordinate type.
+    /// Used to determine whether the compact allele form can be used.
+    pub(crate) fn all_share_accession_and_type(variants: &[HgvsVariant]) -> bool {
+        if variants.len() < 2 {
+            return true;
+        }
+        let first = &variants[0];
+        let first_acc = first.accession();
+        let first_type = first.variant_type();
+
+        // Don't use compact form for types that aren't simple coordinate-based variants
+        if matches!(first_type, "allele" | "null" | "unknown" | "r::r") {
+            return false;
+        }
+
+        variants[1..]
+            .iter()
+            .all(|v| v.variant_type() == first_type && v.accession() == first_acc)
     }
 }
 
@@ -902,7 +1048,7 @@ mod tests {
 
         assert_eq!(
             format!("{}", allele_variant),
-            "[NM_000088.3:c.100A>G;NM_000088.3:c.200C>T]"
+            "NM_000088.3:c.[100A>G;200C>T]"
         );
     }
 
@@ -938,7 +1084,48 @@ mod tests {
 
         assert_eq!(
             format!("{}", allele_variant),
-            "[NM_000088.3:c.100A>G];[NM_000088.3:c.200C>T]"
+            "NM_000088.3:c.[100A>G];[200C>T]"
+        );
+    }
+
+    #[test]
+    fn test_allele_mixed_accession_uses_expanded_form() {
+        use crate::hgvs::location::CdsPos;
+
+        // Different accessions → expanded form (no compact shorthand)
+        let var1 = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000088", Some(3)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+        let var2 = HgvsVariant::Cds(CdsVariant {
+            accession: Accession::new("NM", "000099", Some(1)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(200)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::T,
+                },
+            ),
+        });
+
+        let cis = AlleleVariant::cis(vec![var1.clone(), var2.clone()]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis)),
+            "[NM_000088.3:c.100A>G;NM_000099.1:c.200C>T]"
+        );
+
+        let trans = AlleleVariant::trans(vec![var1, var2]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(trans)),
+            "[NM_000088.3:c.100A>G];[NM_000099.1:c.200C>T]"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2370,17 +2370,11 @@ mod tests {
         // Verify it's still an allele
         assert!(matches!(result, HgvsVariant::Allele(_)));
 
-        // Verify output format preserves both variants (compact form: ACC:c.[edit1;edit2])
-        let output = format!("{}", result);
-        assert!(
-            output.contains("10A>G"),
-            "Allele should contain first variant, got: {}",
-            output
-        );
-        assert!(
-            output.contains("20C>T"),
-            "Allele should contain second variant, got: {}",
-            output
+        // Verify output is the canonical compact form (ACC:c.[edit1;edit2])
+        assert_eq!(
+            format!("{}", result),
+            "NM_000088.3:c.[10A>G;20C>T]",
+            "Allele display should use canonical compact form"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2370,15 +2370,15 @@ mod tests {
         // Verify it's still an allele
         assert!(matches!(result, HgvsVariant::Allele(_)));
 
-        // Verify output format preserves both variants
+        // Verify output format preserves both variants (compact form: ACC:c.[edit1;edit2])
         let output = format!("{}", result);
         assert!(
-            output.contains("c.10A>G"),
+            output.contains("10A>G"),
             "Allele should contain first variant, got: {}",
             output
         );
         assert!(
-            output.contains("c.20C>T"),
+            output.contains("20C>T"),
             "Allele should contain second variant, got: {}",
             output
         );

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -3932,7 +3932,7 @@ mod comprehensive_normalization_tests {
             let result = normalize_to_string(provider, "[NM_TEST.1:c.4del;NM_TEST.1:c.13del]");
             // Both should shift to 3'-most positions
             assert!(
-                result.contains("c.9del") || result.contains("c.18del"),
+                result.contains("9del") || result.contains("18del"),
                 "Deletions should shift, got: {}",
                 result
             );

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -3929,8 +3929,8 @@ mod comprehensive_normalization_tests {
             let result = normalize_to_string(provider, "[NM_TEST.1:c.4del;NM_TEST.1:c.13del]");
             // Both should shift to 3'-most positions
             assert!(
-                result.contains("9del") || result.contains("18del"),
-                "Deletions should shift, got: {}",
+                result.contains("9del") && result.contains("18del"),
+                "Both deletions should shift, got: {}",
                 result
             );
         }

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -2790,7 +2790,7 @@ mod ferro_mutalyzer_differences {
     #[rstest]
     #[case(
         "NM_000030.2:c.[299_307dup;308G>A]",
-        "[NM_000030.2:c.299_307dup;NM_000030.2:c.308G>A]"
+        "NM_000030.2:c.[299_307dup;308G>A]"
     )]
     // Mutalyzer outputs: NM_000030.2:c.308delinsTCCTGGTTGA (collapses allele)
     #[ignore]
@@ -3004,11 +3004,8 @@ mod equivalence_derived_normalize {
     // From check_allelic_equivalence.
 
     #[rstest]
-    // Compact allelic → expanded
-    #[case(
-        "NM_000060.2:c.[1207T>G;1330G>C]",
-        "[NM_000060.2:c.1207T>G;NM_000060.2:c.1330G>C]"
-    )]
+    // Compact allelic round-trips through normalization (HGVS spec compact form)
+    #[case("NM_000060.2:c.[1207T>G;1330G>C]", "NM_000060.2:c.[1207T>G;1330G>C]")]
     #[ignore]
     fn test_allelic_expansion_normalization(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input)

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -293,26 +293,11 @@ fn test_verified_roundtrip(#[case] input: &str) {
 // Protein insertion with numeric positions (ferro uses Xaa for unknown AA)
 #[case("NP_000018.2:p.42_43insAspAla", "NP_000018.2:p.Xaa42_Xaa43insAspAla")]
 // Allele notation (ferro uses compact form per HGVS spec)
-#[case(
-    "NM_000060.2:c.[1207T>G;1330G>C]",
-    "NM_000060.2:c.[1207T>G;1330G>C]"
-)]
-#[case(
-    "NM_001040075.1:c.[533C>T;646G>C]",
-    "NM_001040075.1:c.[533C>T;646G>C]"
-)]
-#[case(
-    "NM_000350.2:c.[1622T>C;3113C>T]",
-    "NM_000350.2:c.[1622T>C;3113C>T]"
-)]
-#[case(
-    "NM_000350.3:c.[1531C>T;872C>T]",
-    "NM_000350.3:c.[1531C>T;872C>T]"
-)]
-#[case(
-    "NM_005157.6:c.[1516G>A;1531G>C]",
-    "NM_005157.6:c.[1516G>A;1531G>C]"
-)]
+#[case("NM_000060.2:c.[1207T>G;1330G>C]", "NM_000060.2:c.[1207T>G;1330G>C]")]
+#[case("NM_001040075.1:c.[533C>T;646G>C]", "NM_001040075.1:c.[533C>T;646G>C]")]
+#[case("NM_000350.2:c.[1622T>C;3113C>T]", "NM_000350.2:c.[1622T>C;3113C>T]")]
+#[case("NM_000350.3:c.[1531C>T;872C>T]", "NM_000350.3:c.[1531C>T;872C>T]")]
+#[case("NM_005157.6:c.[1516G>A;1531G>C]", "NM_005157.6:c.[1516G>A;1531G>C]")]
 // Missing ref base substitution (ferro preserves as-is)
 #[case("NG_008029.2:g.5049>A", "NG_008029.2:g.5049>A")]
 #[case("NM_002055.4:c.1086>C", "NM_002055.4:c.1086>C")]

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -292,26 +292,26 @@ fn test_verified_roundtrip(#[case] input: &str) {
 #[case("LRG_673p1:p.Lys903delLys", "LRG_673p1:p.Lys903delLys")]
 // Protein insertion with numeric positions (ferro uses Xaa for unknown AA)
 #[case("NP_000018.2:p.42_43insAspAla", "NP_000018.2:p.Xaa42_Xaa43insAspAla")]
-// Allele notation (ferro expands accession to each variant)
+// Allele notation (ferro uses compact form per HGVS spec)
 #[case(
     "NM_000060.2:c.[1207T>G;1330G>C]",
-    "[NM_000060.2:c.1207T>G;NM_000060.2:c.1330G>C]"
+    "NM_000060.2:c.[1207T>G;1330G>C]"
 )]
 #[case(
     "NM_001040075.1:c.[533C>T;646G>C]",
-    "[NM_001040075.1:c.533C>T;NM_001040075.1:c.646G>C]"
+    "NM_001040075.1:c.[533C>T;646G>C]"
 )]
 #[case(
     "NM_000350.2:c.[1622T>C;3113C>T]",
-    "[NM_000350.2:c.1622T>C;NM_000350.2:c.3113C>T]"
+    "NM_000350.2:c.[1622T>C;3113C>T]"
 )]
 #[case(
     "NM_000350.3:c.[1531C>T;872C>T]",
-    "[NM_000350.3:c.1531C>T;NM_000350.3:c.872C>T]"
+    "NM_000350.3:c.[1531C>T;872C>T]"
 )]
 #[case(
     "NM_005157.6:c.[1516G>A;1531G>C]",
-    "[NM_005157.6:c.1516G>A;NM_005157.6:c.1531G>C]"
+    "NM_005157.6:c.[1516G>A;1531G>C]"
 )]
 // Missing ref base substitution (ferro preserves as-is)
 #[case("NG_008029.2:g.5049>A", "NG_008029.2:g.5049>A")]
@@ -534,7 +534,7 @@ fn test_expected_parse_errors(#[case] input: &str, #[case] _description: &str) {
 // Allele with separate brackets
 #[case(
     "NM_000350.2:c.[2588G>C];[5882G>A]",
-    "[NM_000350.2:c.2588G>C];[NM_000350.2:c.5882G>A]"
+    "NM_000350.2:c.[2588G>C];[5882G>A]"
 )]
 // Unknown position insertion
 #[case(


### PR DESCRIPTION
# PR: Use HGVS spec compact form for allele Display

**Closes #46**

## Summary

When all sub-variants in an allele share the same accession and coordinate type, `AlleleVariant::Display` now emits the compact form recommended by the HGVS nomenclature:

| Phase | Before | After |
|-------|--------|-------|
| Cis | `[NM_000088.3:c.100A>G;NM_000088.3:c.200C>T]` | `NM_000088.3:c.[100A>G;200C>T]` |
| Trans | `[NM_000088.3:c.100A>G];[NM_000088.3:c.200C>T]` | `NM_000088.3:c.[100A>G];[200C>T]` |
| Unknown | `[NM_000088.3:c.100A>G(;)NM_000088.3:c.200C>T]` | `NM_000088.3:c.100A>G(;)200C>T` |

When sub-variants have **different accessions** (cross-reference alleles), the expanded form is retained — that's the correct representation for that case.

Mosaic (`/`) and chimeric (`//`) phases are unchanged (they don't use bracket syntax).

## Motivation

Downstream consumers of ferro-hgvs use the compact form in their outputs (matching mutalyzer's behavior). Aligning ferro's output with the spec's recommended syntax avoids needing a formatting shim downstream.

## Spec reference

From [hgvs-nomenclature.org/stable/recommendations/DNA/alleles](https://hgvs-nomenclature.org/stable/recommendations/DNA/alleles/):

> **Syntax (cis):** `sequence_identifier ":" coordinate_type ".[" position_edit ";" position_edit "]"`
>
> **Examples:** `NC_000001.11:g.[123G>A;345del]`, `NM_004006.2:c.[2376G>C;3103del]`

The expanded form appears in the spec only for cross-reference trans alleles where each variant references a different sequence.

## Implementation

Added two helpers to `impl HgvsVariant`:

- **`fmt_loc_edit(&self, f)`** — writes just the position+edit part (e.g., `100A>G`) without the accession prefix
- **`all_share_accession_and_type(variants)`** — checks whether compact form is applicable

The `Display` impl for `AlleleVariant` now branches on this check, using compact form when possible and falling back to the expanded form for mixed-accession alleles.

## Testing

- All 1850 lib tests pass (updated existing tests to expect compact output)
- Updated 1 integration test (`normalize_tests.rs`) that matched on `c.9del` substring
- Added new test `test_allele_mixed_accession_uses_expanded_form` covering the fallback path
- Verified Python bindings produce compact form:
  ```python
  >>> str(ferro_hgvs.parse("NG_008617.1:g.[100A>G;200C>T]"))
  'NG_008617.1:g.[100A>G;200C>T]'
  ```

## Files changed

- `src/hgvs/variant.rs` — new helpers + updated `AlleleVariant::Display`
- `src/hgvs/parser/variant.rs` — updated test expectations
- `src/normalize/mod.rs` — updated test assertion
- `tests/normalize_tests.rs` — updated integration test assertion
