### PR TITLE
feat: Add variant accessor properties to Python bindings

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1,7 +1,7 @@
 """Type stubs for ferro-hgvs Python bindings."""
 
 from enum import IntEnum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 __version__: str
 
@@ -263,6 +263,81 @@ class HgvsVariant:
     @property
     def edit_type(self) -> str:
         """Get the edit type as a string."""
+        ...
+
+    @property
+    def start(self) -> Optional[int]:
+        """Get the 1-based start position of the variant.
+
+        Returns the base position (without intronic offset) for genomic, coding,
+        non-coding, RNA, and mitochondrial variants. For alleles, returns the start
+        of the first sub-variant. Returns None for protein variants.
+        """
+        ...
+
+    @property
+    def end(self) -> Optional[int]:
+        """Get the 1-based end position (inclusive) of the variant.
+
+        For point variants, end equals start. For alleles, returns the end
+        of the first sub-variant. Returns None for protein variants.
+        """
+        ...
+
+    @property
+    def offset(self) -> Optional[int]:
+        """Get the intronic offset of the start position.
+
+        Only meaningful for coding (c.) variants with intronic positions.
+        For c.93+1G>T, returns 1. For exonic variants, returns None.
+        """
+        ...
+
+    @property
+    def substitution_bases(self) -> Optional[Tuple[str, str]]:
+        """Get the substitution reference and alternative bases.
+
+        Returns a tuple (ref_base, alt_base) for substitution edits,
+        e.g., ("A", "G") for A>G. Returns None for non-substitution edits.
+        """
+        ...
+
+    @property
+    def num_variants(self) -> int:
+        """Get the number of sub-variants.
+
+        Returns 1 for simple variants, N for alleles with N sub-variants.
+        """
+        ...
+
+    @property
+    def indel_length(self) -> Optional[int]:
+        """Get the net indel length (bases gained or lost).
+
+        - Substitution/inversion/identity: 0
+        - Deletion: negative (e.g., -3 for a 3bp deletion)
+        - Insertion: positive (length of inserted sequence)
+        - Delins: inserted_length - deleted_span
+        - Duplication: positive (span of duplicated region)
+
+        Returns None if the length cannot be determined.
+        """
+        ...
+
+    def variants(self) -> List[HgvsVariant]:
+        """Get sub-variants as a list.
+
+        For alleles, returns the constituent variants. For simple variants,
+        returns a single-element list containing self.
+        """
+        ...
+
+    def is_identity(self) -> bool:
+        """Check if this is an identity (no-change) variant."""
+        ...
+
+    def is_frameshift(self) -> bool:
+        """Check if this variant causes a frameshift (indel_length % 3 != 0)."""
         ...
 
     def normalize(self, direction: str = "3prime") -> HgvsVariant:

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -270,8 +270,14 @@ class HgvsVariant:
         """Get the 1-based start position of the variant.
 
         Returns the base position (without intronic offset) for genomic, coding,
-        non-coding, RNA, and mitochondrial variants. For alleles, returns the start
-        of the first sub-variant. Returns None for protein variants.
+        non-coding, RNA, mitochondrial, and circular variants. For single-element
+        alleles, delegates to the sub-variant. Returns None for protein variants,
+        RNA fusions, null/unknown alleles, and alleles with multiple sub-variants
+        (whose start is ambiguous).
+
+        Note: 5' UTR (``c.-5A>G``) and 3' UTR (``c.*5A>G``) positions are returned
+        as raw base values and are indistinguishable from CDS positions at the same
+        numeric value.
         """
         ...
 
@@ -279,8 +285,9 @@ class HgvsVariant:
     def end(self) -> Optional[int]:
         """Get the 1-based end position (inclusive) of the variant.
 
-        For point variants, end equals start. For alleles, returns the end
-        of the first sub-variant. Returns None for protein variants.
+        For point variants, end equals start. For single-element alleles,
+        delegates to the sub-variant. Returns None for protein variants, RNA
+        fusions, null/unknown alleles, and alleles with multiple sub-variants.
         """
         ...
 
@@ -288,8 +295,10 @@ class HgvsVariant:
     def offset(self) -> Optional[int]:
         """Get the intronic offset of the start position.
 
-        Only meaningful for coding (c.) variants with intronic positions.
-        For c.93+1G>T, returns 1. For exonic variants, returns None.
+        Meaningful for coding (c.), non-coding (n.), and RNA (r.) variants with
+        intronic positions. For ``c.93+1G>T``, returns 1. For exonic positions,
+        returns None. Always returns None for variant types without intronic
+        offsets (genomic, mitochondrial, circular, protein, fusion, allele).
         """
         ...
 
@@ -297,8 +306,9 @@ class HgvsVariant:
     def substitution_bases(self) -> Optional[Tuple[str, str]]:
         """Get the substitution reference and alternative bases.
 
-        Returns a tuple (ref_base, alt_base) for substitution edits,
-        e.g., ("A", "G") for A>G. Returns None for non-substitution edits.
+        Returns a tuple (ref_base, alt_base) of single-character strings for
+        substitution edits, e.g., ("A", "G") for A>G. Returns None for
+        non-substitution edits.
         """
         ...
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -22,7 +22,9 @@ use crate::hgvs::variant::HgvsVariant;
 use crate::mave::{is_mave_short_form, parse_mave_hgvs, MaveContext};
 use crate::prepare::{check_references, prepare_references, PrepareConfig, ReferenceManifest};
 use crate::python_helpers::{
-    get_variant_edit_type, get_variant_reference, parse_direction, variant_type_str,
+    get_indel_length, get_num_variants, get_substitution_bases, get_variant_edit_type,
+    get_variant_end, get_variant_offset, get_variant_reference, get_variant_start, is_frameshift,
+    is_identity, parse_direction, variant_type_str,
 };
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::{GenomeBuild, Strand};
@@ -132,6 +134,100 @@ impl PyHgvsVariant {
         get_variant_edit_type(&self.inner)
     }
 
+    /// Get the 1-based start position of the variant.
+    ///
+    /// For genomic (g.), coding (c.), non-coding (n.), RNA (r.), and mitochondrial (m.)
+    /// variants, returns the base position (without intronic offset).
+    /// For alleles, returns the start of the first sub-variant.
+    /// Returns None for protein variants and null/unknown alleles.
+    #[getter]
+    fn start(&self) -> Option<i64> {
+        get_variant_start(&self.inner)
+    }
+
+    /// Get the 1-based end position (inclusive) of the variant.
+    ///
+    /// For point variants, end equals start.
+    /// For alleles, returns the end of the first sub-variant.
+    /// Returns None for protein variants and null/unknown alleles.
+    #[getter]
+    fn end(&self) -> Option<i64> {
+        get_variant_end(&self.inner)
+    }
+
+    /// Get the intronic offset of the start position.
+    ///
+    /// Only meaningful for coding (c.) variants with intronic positions.
+    /// For c.93+1G>T, returns 1. For c.100A>G (exonic), returns None.
+    /// Always returns None for non-CDS variant types.
+    #[getter]
+    fn offset(&self) -> Option<i64> {
+        get_variant_offset(&self.inner)
+    }
+
+    /// Get the substitution reference and alternative bases.
+    ///
+    /// Returns a tuple (ref_base, alt_base) for substitution edits,
+    /// e.g., ("A", "G") for A>G. Returns None for non-substitution edits.
+    #[getter]
+    fn substitution_bases(&self) -> Option<(String, String)> {
+        get_substitution_bases(&self.inner)
+    }
+
+    /// Get the number of sub-variants.
+    ///
+    /// Returns 1 for simple variants, N for alleles with N sub-variants.
+    #[getter]
+    fn num_variants(&self) -> usize {
+        get_num_variants(&self.inner)
+    }
+
+    /// Get sub-variants as a list.
+    ///
+    /// For alleles, returns the constituent variants. For simple variants,
+    /// returns a single-element list containing self.
+    fn variants(&self) -> Vec<PyHgvsVariant> {
+        match &self.inner {
+            HgvsVariant::Allele(a) => a
+                .variants
+                .iter()
+                .map(|v| PyHgvsVariant { inner: v.clone() })
+                .collect(),
+            _ => vec![self.clone()],
+        }
+    }
+
+    /// Get the net indel length (bases gained or lost).
+    ///
+    /// - Substitution/inversion/identity: 0
+    /// - Deletion: negative (e.g., -3 for a 3bp deletion)
+    /// - Insertion: positive (length of inserted sequence)
+    /// - Delins: inserted_length - deleted_span
+    /// - Duplication: positive (span of duplicated region)
+    ///
+    /// Returns None if the length cannot be determined (e.g., uncertain
+    /// inserted sequence, protein variants).
+    #[getter]
+    fn indel_length(&self) -> Option<i64> {
+        get_indel_length(&self.inner)
+    }
+
+    /// Check if this variant is an identity (no-change) variant.
+    ///
+    /// Returns true for variants with the `=` edit type.
+    fn is_identity(&self) -> bool {
+        is_identity(&self.inner)
+    }
+
+    /// Check if this variant causes a frameshift.
+    ///
+    /// Returns true if indel_length % 3 != 0.
+    /// Returns false for substitutions, inversions, identity edits,
+    /// and cases where indel length cannot be determined.
+    fn is_frameshift(&self) -> bool {
+        is_frameshift(&self.inner)
+    }
+
     /// Check if this is a genomic variant (g. prefix)
     fn is_genomic(&self) -> bool {
         matches!(self.inner, HgvsVariant::Genome(_))
@@ -220,6 +316,29 @@ impl PyHgvsVariant {
             dict.set_item("reference", ref_str)?;
         }
         dict.set_item("edit_type", self.edit_type())?;
+
+        // Positional data
+        if let Some(start) = get_variant_start(&self.inner) {
+            dict.set_item("start", start)?;
+        }
+        if let Some(end) = get_variant_end(&self.inner) {
+            dict.set_item("end", end)?;
+        }
+        if let Some(offset) = get_variant_offset(&self.inner) {
+            dict.set_item("offset", offset)?;
+        }
+
+        // Edit details
+        if let Some((ref_base, alt_base)) = get_substitution_bases(&self.inner) {
+            dict.set_item("ref_base", ref_base)?;
+            dict.set_item("alt_base", alt_base)?;
+        }
+        if let Some(indel_len) = get_indel_length(&self.inner) {
+            dict.set_item("indel_length", indel_len)?;
+        }
+
+        // Allele info
+        dict.set_item("num_variants", get_num_variants(&self.inner))?;
 
         Ok(dict.into())
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -136,10 +136,16 @@ impl PyHgvsVariant {
 
     /// Get the 1-based start position of the variant.
     ///
-    /// For genomic (g.), coding (c.), non-coding (n.), RNA (r.), and mitochondrial (m.)
-    /// variants, returns the base position (without intronic offset).
-    /// For alleles, returns the start of the first sub-variant.
-    /// Returns None for protein variants and null/unknown alleles.
+    /// For genomic (g.), coding (c.), non-coding (n.), RNA (r.), mitochondrial (m.),
+    /// and circular (o.) variants, returns the base position (without intronic
+    /// offset). For single-element alleles, delegates to the sub-variant.
+    /// Returns None for protein variants, RNA fusions, null/unknown alleles, and
+    /// alleles with multiple sub-variants (whose start is ambiguous).
+    ///
+    /// 5' UTR (`c.-5A>G`) and 3' UTR (`c.*5A>G`) positions are returned as raw
+    /// base values and are indistinguishable from CDS positions at the same
+    /// numeric value. Use the variant string or `to_dict()` representation when
+    /// the UTR distinction matters.
     #[getter]
     fn start(&self) -> Option<i64> {
         get_variant_start(&self.inner)
@@ -147,9 +153,9 @@ impl PyHgvsVariant {
 
     /// Get the 1-based end position (inclusive) of the variant.
     ///
-    /// For point variants, end equals start.
-    /// For alleles, returns the end of the first sub-variant.
-    /// Returns None for protein variants and null/unknown alleles.
+    /// For point variants, end equals start. For single-element alleles,
+    /// delegates to the sub-variant. Returns None for protein variants, RNA
+    /// fusions, null/unknown alleles, and alleles with multiple sub-variants.
     #[getter]
     fn end(&self) -> Option<i64> {
         get_variant_end(&self.inner)
@@ -157,9 +163,10 @@ impl PyHgvsVariant {
 
     /// Get the intronic offset of the start position.
     ///
-    /// Only meaningful for coding (c.) variants with intronic positions.
-    /// For c.93+1G>T, returns 1. For c.100A>G (exonic), returns None.
-    /// Always returns None for non-CDS variant types.
+    /// Meaningful for coding (c.), non-coding (n.), and RNA (r.) variants with
+    /// intronic positions. For `c.93+1G>T`, returns 1. For exonic positions,
+    /// returns None. Always returns None for variant types without intronic
+    /// offsets (genomic, mitochondrial, circular, protein, fusion, allele).
     #[getter]
     fn offset(&self) -> Option<i64> {
         get_variant_offset(&self.inner)
@@ -168,9 +175,9 @@ impl PyHgvsVariant {
     /// Get the substitution reference and alternative bases.
     ///
     /// Returns a tuple (ref_base, alt_base) for substitution edits,
-    /// e.g., ("A", "G") for A>G. Returns None for non-substitution edits.
+    /// e.g., ('A', 'G') for A>G. Returns None for non-substitution edits.
     #[getter]
-    fn substitution_bases(&self) -> Option<(String, String)> {
+    fn substitution_bases(&self) -> Option<(char, char)> {
         get_substitution_bases(&self.inner)
     }
 

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -246,8 +246,14 @@ fn rna_interval_end(interval: &Interval<RnaPos>) -> Option<i64> {
 /// Get the start position (base only, no offset) for any variant.
 ///
 /// Returns the 1-based start position for genomic, coding, non-coding, RNA, and
-/// mitochondrial variants. For alleles, returns the start of the first sub-variant.
-/// Returns None for protein, fusion, null/unknown allele variants.
+/// mitochondrial variants. For single-element alleles, delegates to that
+/// sub-variant. Returns None for protein, RNA fusion, null/unknown allele
+/// variants, and alleles with multiple sub-variants (whose start is ambiguous).
+///
+/// Note: 5' UTR (`c.-5A>G`) and 3' UTR (`c.*5A>G`) positions are returned as
+/// raw base values and are indistinguishable from CDS positions at the same
+/// numeric value. Callers needing to distinguish these cases should inspect
+/// the variant string or AST directly.
 pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
     match variant {
         HgvsVariant::Genome(v) => genome_interval_start(&v.loc_edit.location),
@@ -256,7 +262,10 @@ pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
         HgvsVariant::Rna(v) => rna_interval_start(&v.loc_edit.location),
         HgvsVariant::Mt(v) => genome_interval_start(&v.loc_edit.location),
         HgvsVariant::Circular(v) => genome_interval_start(&v.loc_edit.location),
-        HgvsVariant::Allele(a) => a.variants.first().and_then(get_variant_start),
+        HgvsVariant::Allele(a) => match a.variants.as_slice() {
+            [single] => get_variant_start(single),
+            _ => None,
+        },
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
         | HgvsVariant::NullAllele
@@ -267,8 +276,9 @@ pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
 /// Get the end position (base only, no offset) for any variant.
 ///
 /// Returns the 1-based end position (inclusive). For point variants, end == start.
-/// For alleles, returns the end of the first sub-variant.
-/// Returns None for protein, fusion, null/unknown allele variants.
+/// For single-element alleles, delegates to that sub-variant. Returns None for
+/// protein, RNA fusion, null/unknown allele variants, and alleles with multiple
+/// sub-variants (whose end is ambiguous).
 pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
     match variant {
         HgvsVariant::Genome(v) => genome_interval_end(&v.loc_edit.location),
@@ -277,7 +287,10 @@ pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
         HgvsVariant::Rna(v) => rna_interval_end(&v.loc_edit.location),
         HgvsVariant::Mt(v) => genome_interval_end(&v.loc_edit.location),
         HgvsVariant::Circular(v) => genome_interval_end(&v.loc_edit.location),
-        HgvsVariant::Allele(a) => a.variants.first().and_then(get_variant_end),
+        HgvsVariant::Allele(a) => match a.variants.as_slice() {
+            [single] => get_variant_end(single),
+            _ => None,
+        },
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
         | HgvsVariant::NullAllele
@@ -285,13 +298,17 @@ pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
     }
 }
 
-/// Get the intronic offset of the start position for CDS variants.
+/// Get the intronic offset of the start position for CDS, transcript, and RNA
+/// variants.
 ///
-/// For c.93+1G>T, returns Some(1). For c.100A>G (exonic), returns None.
-/// Only meaningful for CDS variants; returns None for all other types.
+/// For `c.93+1G>T`, returns `Some(1)`. For exonic positions (no offset), returns
+/// `None`. Returns `None` for variant types without intronic offsets (genomic,
+/// mitochondrial, circular, protein, fusion, allele, null/unknown).
 pub fn get_variant_offset(variant: &HgvsVariant) -> Option<i64> {
     match variant {
         HgvsVariant::Cds(v) => v.loc_edit.location.start.inner().and_then(|pos| pos.offset),
+        HgvsVariant::Tx(v) => v.loc_edit.location.start.inner().and_then(|pos| pos.offset),
+        HgvsVariant::Rna(v) => v.loc_edit.location.start.inner().and_then(|pos| pos.offset),
         _ => None,
     }
 }
@@ -311,10 +328,10 @@ fn get_na_edit(variant: &HgvsVariant) -> Option<&NaEdit> {
     }
 }
 
-/// Get the substitution reference and alternative bases as single-char strings.
+/// Get the substitution reference and alternative bases.
 ///
-/// Returns Some(("A", "G")) for a substitution, None for other edit types.
-pub fn get_substitution_bases(variant: &HgvsVariant) -> Option<(String, String)> {
+/// Returns `Some(('A', 'G'))` for a substitution, `None` for other edit types.
+pub fn get_substitution_bases(variant: &HgvsVariant) -> Option<(char, char)> {
     let edit = get_na_edit(variant)?;
     match edit {
         NaEdit::Substitution {
@@ -323,7 +340,7 @@ pub fn get_substitution_bases(variant: &HgvsVariant) -> Option<(String, String)>
         } => {
             let ref_char = (*reference as u8) as char;
             let alt_char = (*alternative as u8) as char;
-            Some((ref_char.to_string(), alt_char.to_string()))
+            Some((ref_char, alt_char))
         }
         _ => None,
     }
@@ -335,12 +352,21 @@ pub fn is_identity(variant: &HgvsVariant) -> bool {
 }
 
 /// Compute the span of the affected region from the interval.
-/// For point variants (start == end), the span is 1 for deletion/delins
-/// but 0 for insertions (which occur between two positions).
+///
+/// Used for deletion/duplication/delins length calculations; not used for
+/// insertions, whose length comes from the inserted sequence rather than the
+/// flanking positions.
+///
+/// Returns `None` for circular (`o.`) variants where `end < start`, which
+/// represent origin-crossing intervals whose span depends on the contig length
+/// (not available here).
 fn compute_span(variant: &HgvsVariant) -> Option<i64> {
     let start = get_variant_start(variant)?;
     let end = get_variant_end(variant)?;
-    Some((end - start).abs() + 1)
+    if matches!(variant, HgvsVariant::Circular(_)) && end < start {
+        return None;
+    }
+    Some((end - start) + 1)
 }
 
 /// Compute the net indel length (bases gained or lost) for a variant.
@@ -772,10 +798,79 @@ mod tests {
     }
 
     #[test]
-    fn test_get_variant_start_allele() {
+    fn test_get_variant_start_allele_multi() {
+        // Multi-sub-variant alleles have ambiguous start; return None.
         let variant = parse_hgvs("NM_000088.3:c.[100A>G;200C>T]").unwrap();
-        // Returns start of first sub-variant
+        assert_eq!(get_variant_start(&variant), None);
+        assert_eq!(get_variant_end(&variant), None);
+    }
+
+    #[test]
+    fn test_get_variant_start_allele_single() {
+        // Single-sub-variant alleles delegate to that sub-variant.
+        let variant = parse_hgvs("NM_000088.3:c.[100A>G]").unwrap();
         assert_eq!(get_variant_start(&variant), Some(100));
+        assert_eq!(get_variant_end(&variant), Some(100));
+    }
+
+    #[test]
+    fn test_get_variant_start_noncoding() {
+        let variant = parse_hgvs("NR_046018.2:n.100A>G").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(100));
+        assert_eq!(get_variant_end(&variant), Some(100));
+    }
+
+    #[test]
+    fn test_get_variant_offset_noncoding_intronic() {
+        let variant = parse_hgvs("NR_046018.2:n.100+5A>G").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(100));
+        assert_eq!(get_variant_offset(&variant), Some(5));
+    }
+
+    #[test]
+    fn test_get_variant_start_rna() {
+        let variant = parse_hgvs("NM_000088.3:r.100a>g").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(100));
+        assert_eq!(get_variant_end(&variant), Some(100));
+    }
+
+    #[test]
+    fn test_get_variant_offset_rna_intronic() {
+        let variant = parse_hgvs("NM_000088.3:r.100+5a>g").unwrap();
+        assert_eq!(get_variant_offset(&variant), Some(5));
+    }
+
+    #[test]
+    fn test_get_variant_start_utr3() {
+        // c.*5A>G (3' UTR) returns the same base value as c.5A>G — the `*`
+        // marker is not exposed by start/end.
+        let utr = parse_hgvs("NM_000088.3:c.*5A>G").unwrap();
+        let cds = parse_hgvs("NM_000088.3:c.5A>G").unwrap();
+        assert_eq!(get_variant_start(&utr), Some(5));
+        assert_eq!(get_variant_start(&cds), Some(5));
+    }
+
+    #[test]
+    fn test_get_variant_start_protein_is_none() {
+        let variant = parse_hgvs("NP_000001.1:p.Val100Glu").unwrap();
+        assert_eq!(get_variant_start(&variant), None);
+        assert_eq!(get_variant_end(&variant), None);
+        assert_eq!(get_variant_offset(&variant), None);
+        assert_eq!(get_indel_length(&variant), None);
+    }
+
+    #[test]
+    fn test_get_variant_start_null_allele_is_none() {
+        let variant = HgvsVariant::NullAllele;
+        assert_eq!(get_variant_start(&variant), None);
+        assert_eq!(get_variant_end(&variant), None);
+    }
+
+    #[test]
+    fn test_get_variant_start_unknown_allele_is_none() {
+        let variant = HgvsVariant::UnknownAllele;
+        assert_eq!(get_variant_start(&variant), None);
+        assert_eq!(get_variant_end(&variant), None);
     }
 
     // ===== Edit Accessor Tests =====
@@ -783,10 +878,7 @@ mod tests {
     #[test]
     fn test_get_substitution_bases() {
         let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
-        assert_eq!(
-            get_substitution_bases(&variant),
-            Some(("A".to_string(), "G".to_string()))
-        );
+        assert_eq!(get_substitution_bases(&variant), Some(('A', 'G')));
     }
 
     #[test]
@@ -856,6 +948,46 @@ mod tests {
     fn test_indel_length_inversion() {
         let variant = parse_hgvs("NC_000001.11:g.12345_12350inv").unwrap();
         assert_eq!(get_indel_length(&variant), Some(0));
+    }
+
+    #[test]
+    fn test_indel_length_insertion_count_is_none() {
+        // ins10 specifies a count, not a literal sequence — but the count is
+        // a known length, so we still report it.
+        let variant = parse_hgvs("NC_000001.11:g.12345_12346ins10").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(10));
+    }
+
+    #[test]
+    fn test_indel_length_insertion_range_is_none() {
+        // ins(10_20) has unknown exact length — must return None.
+        let variant = parse_hgvs("NC_000001.11:g.12345_12346ins(10_20)").unwrap();
+        assert_eq!(get_indel_length(&variant), None);
+    }
+
+    #[test]
+    fn test_indel_length_circular_normal() {
+        // Non-wrap-around circular variants compute span normally.
+        let variant = parse_hgvs("NC_001416.1:o.100_105del").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(-6));
+    }
+
+    #[test]
+    fn test_indel_length_circular_wraparound_is_none() {
+        // Origin-crossing circular intervals (end < start) have an unknowable
+        // span without contig length, so indel_length must be None. The parser
+        // currently rejects wrap-around at the syntax level, but this guard is
+        // defensive for programmatic construction or future parser changes.
+        let mut variant = parse_hgvs("NC_001416.1:o.197_4344del").unwrap();
+        if let HgvsVariant::Circular(ref mut v) = variant {
+            std::mem::swap(&mut v.loc_edit.location.start, &mut v.loc_edit.location.end);
+        } else {
+            panic!("expected Circular variant");
+        }
+        assert_eq!(get_variant_start(&variant), Some(4344));
+        assert_eq!(get_variant_end(&variant), Some(197));
+        assert_eq!(get_indel_length(&variant), None);
+        assert!(!is_frameshift(&variant));
     }
 
     // ===== Frameshift Tests =====

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -332,16 +332,11 @@ fn get_na_edit(variant: &HgvsVariant) -> Option<&NaEdit> {
 ///
 /// Returns `Some(('A', 'G'))` for a substitution, `None` for other edit types.
 pub fn get_substitution_bases(variant: &HgvsVariant) -> Option<(char, char)> {
-    let edit = get_na_edit(variant)?;
-    match edit {
+    match get_na_edit(variant)? {
         NaEdit::Substitution {
             reference,
             alternative,
-        } => {
-            let ref_char = (*reference as u8) as char;
-            let alt_char = (*alternative as u8) as char;
-            Some((ref_char, alt_char))
-        }
+        } => Some((reference.to_char(), alternative.to_char())),
         _ => None,
     }
 }
@@ -382,27 +377,16 @@ fn compute_span(variant: &HgvsVariant) -> Option<i64> {
 /// Returns None if the indel length cannot be determined (e.g., uncertain inserted
 /// sequence length, protein variants, unknown edits).
 pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
-    let edit = get_na_edit(variant)?;
-    match edit {
-        NaEdit::Substitution { .. } | NaEdit::SubstitutionNoRef { .. } => Some(0),
-        NaEdit::Inversion { .. } => Some(0),
-        NaEdit::Identity { .. } => Some(0),
-        NaEdit::Deletion { .. } => {
-            let span = compute_span(variant)?;
-            Some(-span)
-        }
-        NaEdit::Duplication { .. } => {
-            let span = compute_span(variant)?;
-            Some(span)
-        }
-        NaEdit::Insertion { sequence } => {
-            let ins_len = inserted_sequence_len(sequence)?;
-            Some(ins_len)
-        }
+    match get_na_edit(variant)? {
+        NaEdit::Substitution { .. }
+        | NaEdit::SubstitutionNoRef { .. }
+        | NaEdit::Inversion { .. }
+        | NaEdit::Identity { .. } => Some(0),
+        NaEdit::Deletion { .. } => Some(-compute_span(variant)?),
+        NaEdit::Duplication { .. } => Some(compute_span(variant)?),
+        NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence } => {
-            let span = compute_span(variant)?;
-            let ins_len = inserted_sequence_len(sequence)?;
-            Some(ins_len - span)
+            Some(inserted_sequence_len(sequence)? - compute_span(variant)?)
         }
         _ => None,
     }

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -3,7 +3,9 @@
 //! These functions are separated from the PyO3 code so they can be unit tested
 //! without requiring the Python runtime.
 
-use crate::hgvs::edit::NaEdit;
+use crate::hgvs::edit::{InsertedSequence, NaEdit};
+use crate::hgvs::interval::Interval;
+use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::HgvsVariant;
 use crate::normalize::ShuffleDirection;
@@ -196,6 +198,210 @@ pub fn get_variant_edit_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null",
         HgvsVariant::UnknownAllele => "unknown",
+    }
+}
+
+// ============== Position Accessors ==============
+
+/// Extract the start base position from a genome interval
+fn genome_interval_start(interval: &Interval<GenomePos>) -> Option<i64> {
+    interval.start.inner().map(|pos| pos.base as i64)
+}
+
+/// Extract the end base position from a genome interval
+fn genome_interval_end(interval: &Interval<GenomePos>) -> Option<i64> {
+    interval.end.inner().map(|pos| pos.base as i64)
+}
+
+/// Extract the start base position from a CDS interval
+fn cds_interval_start(interval: &Interval<CdsPos>) -> Option<i64> {
+    interval.start.inner().map(|pos| pos.base)
+}
+
+/// Extract the end base position from a CDS interval
+fn cds_interval_end(interval: &Interval<CdsPos>) -> Option<i64> {
+    interval.end.inner().map(|pos| pos.base)
+}
+
+/// Extract the start base position from a transcript interval
+fn tx_interval_start(interval: &Interval<TxPos>) -> Option<i64> {
+    interval.start.inner().map(|pos| pos.base)
+}
+
+/// Extract the end base position from a transcript interval
+fn tx_interval_end(interval: &Interval<TxPos>) -> Option<i64> {
+    interval.end.inner().map(|pos| pos.base)
+}
+
+/// Extract the start base position from an RNA interval
+fn rna_interval_start(interval: &Interval<RnaPos>) -> Option<i64> {
+    interval.start.inner().map(|pos| pos.base)
+}
+
+/// Extract the end base position from an RNA interval
+fn rna_interval_end(interval: &Interval<RnaPos>) -> Option<i64> {
+    interval.end.inner().map(|pos| pos.base)
+}
+
+/// Get the start position (base only, no offset) for any variant.
+///
+/// Returns the 1-based start position for genomic, coding, non-coding, RNA, and
+/// mitochondrial variants. For alleles, returns the start of the first sub-variant.
+/// Returns None for protein, fusion, null/unknown allele variants.
+pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
+    match variant {
+        HgvsVariant::Genome(v) => genome_interval_start(&v.loc_edit.location),
+        HgvsVariant::Cds(v) => cds_interval_start(&v.loc_edit.location),
+        HgvsVariant::Tx(v) => tx_interval_start(&v.loc_edit.location),
+        HgvsVariant::Rna(v) => rna_interval_start(&v.loc_edit.location),
+        HgvsVariant::Mt(v) => genome_interval_start(&v.loc_edit.location),
+        HgvsVariant::Circular(v) => genome_interval_start(&v.loc_edit.location),
+        HgvsVariant::Allele(a) => a.variants.first().and_then(get_variant_start),
+        HgvsVariant::Protein(_)
+        | HgvsVariant::RnaFusion(_)
+        | HgvsVariant::NullAllele
+        | HgvsVariant::UnknownAllele => None,
+    }
+}
+
+/// Get the end position (base only, no offset) for any variant.
+///
+/// Returns the 1-based end position (inclusive). For point variants, end == start.
+/// For alleles, returns the end of the first sub-variant.
+/// Returns None for protein, fusion, null/unknown allele variants.
+pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
+    match variant {
+        HgvsVariant::Genome(v) => genome_interval_end(&v.loc_edit.location),
+        HgvsVariant::Cds(v) => cds_interval_end(&v.loc_edit.location),
+        HgvsVariant::Tx(v) => tx_interval_end(&v.loc_edit.location),
+        HgvsVariant::Rna(v) => rna_interval_end(&v.loc_edit.location),
+        HgvsVariant::Mt(v) => genome_interval_end(&v.loc_edit.location),
+        HgvsVariant::Circular(v) => genome_interval_end(&v.loc_edit.location),
+        HgvsVariant::Allele(a) => a.variants.first().and_then(get_variant_end),
+        HgvsVariant::Protein(_)
+        | HgvsVariant::RnaFusion(_)
+        | HgvsVariant::NullAllele
+        | HgvsVariant::UnknownAllele => None,
+    }
+}
+
+/// Get the intronic offset of the start position for CDS variants.
+///
+/// For c.93+1G>T, returns Some(1). For c.100A>G (exonic), returns None.
+/// Only meaningful for CDS variants; returns None for all other types.
+pub fn get_variant_offset(variant: &HgvsVariant) -> Option<i64> {
+    match variant {
+        HgvsVariant::Cds(v) => v.loc_edit.location.start.inner().and_then(|pos| pos.offset),
+        _ => None,
+    }
+}
+
+// ============== Edit Accessors ==============
+
+/// Get the NaEdit from a variant, if it has one.
+fn get_na_edit(variant: &HgvsVariant) -> Option<&NaEdit> {
+    match variant {
+        HgvsVariant::Genome(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Cds(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Tx(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Rna(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Mt(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Circular(v) => v.loc_edit.edit.inner(),
+        _ => None,
+    }
+}
+
+/// Get the substitution reference and alternative bases as single-char strings.
+///
+/// Returns Some(("A", "G")) for a substitution, None for other edit types.
+pub fn get_substitution_bases(variant: &HgvsVariant) -> Option<(String, String)> {
+    let edit = get_na_edit(variant)?;
+    match edit {
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => {
+            let ref_char = (*reference as u8) as char;
+            let alt_char = (*alternative as u8) as char;
+            Some((ref_char.to_string(), alt_char.to_string()))
+        }
+        _ => None,
+    }
+}
+
+/// Check if the variant represents an identity (no-change, `=`) edit.
+pub fn is_identity(variant: &HgvsVariant) -> bool {
+    matches!(get_na_edit(variant), Some(NaEdit::Identity { .. }))
+}
+
+/// Compute the span of the affected region from the interval.
+/// For point variants (start == end), the span is 1 for deletion/delins
+/// but 0 for insertions (which occur between two positions).
+fn compute_span(variant: &HgvsVariant) -> Option<i64> {
+    let start = get_variant_start(variant)?;
+    let end = get_variant_end(variant)?;
+    Some((end - start).abs() + 1)
+}
+
+/// Compute the net indel length (bases gained or lost) for a variant.
+///
+/// - Substitution: 0 (same number of bases)
+/// - Deletion: -(span)
+/// - Insertion: +(inserted length), or None if length is unknowable
+/// - Delins: inserted_length - span, or None if inserted length is unknowable
+/// - Duplication: +(span)
+/// - Inversion: 0
+/// - Identity: 0
+///
+/// Returns None if the indel length cannot be determined (e.g., uncertain inserted
+/// sequence length, protein variants, unknown edits).
+pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
+    let edit = get_na_edit(variant)?;
+    match edit {
+        NaEdit::Substitution { .. } | NaEdit::SubstitutionNoRef { .. } => Some(0),
+        NaEdit::Inversion { .. } => Some(0),
+        NaEdit::Identity { .. } => Some(0),
+        NaEdit::Deletion { .. } => {
+            let span = compute_span(variant)?;
+            Some(-span)
+        }
+        NaEdit::Duplication { .. } => {
+            let span = compute_span(variant)?;
+            Some(span)
+        }
+        NaEdit::Insertion { sequence } => {
+            let ins_len = inserted_sequence_len(sequence)?;
+            Some(ins_len)
+        }
+        NaEdit::Delins { sequence } => {
+            let span = compute_span(variant)?;
+            let ins_len = inserted_sequence_len(sequence)?;
+            Some(ins_len - span)
+        }
+        _ => None,
+    }
+}
+
+/// Get the length of an inserted sequence, if deterministic.
+fn inserted_sequence_len(seq: &InsertedSequence) -> Option<i64> {
+    seq.len().map(|n| n as i64)
+}
+
+/// Check if a variant causes a frameshift (indel_length % 3 != 0).
+///
+/// Returns false if the indel length is 0 or cannot be determined.
+pub fn is_frameshift(variant: &HgvsVariant) -> bool {
+    match get_indel_length(variant) {
+        Some(len) if len != 0 => len % 3 != 0,
+        _ => false,
+    }
+}
+
+/// Get the number of sub-variants in an allele, or 1 for simple variants.
+pub fn get_num_variants(variant: &HgvsVariant) -> usize {
+    match variant {
+        HgvsVariant::Allele(a) => a.variants.len(),
+        _ => 1,
     }
 }
 
@@ -512,5 +718,179 @@ mod tests {
     fn test_get_variant_edit_type_unknown() {
         let variant = HgvsVariant::UnknownAllele;
         assert_eq!(get_variant_edit_type(&variant), "unknown");
+    }
+
+    // ===== Position Accessor Tests =====
+
+    #[test]
+    fn test_get_variant_start_genomic() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(12345));
+    }
+
+    #[test]
+    fn test_get_variant_start_coding() {
+        let variant = parse_hgvs("NM_000088.3:c.100A>G").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(100));
+    }
+
+    #[test]
+    fn test_get_variant_start_coding_intronic() {
+        let variant = parse_hgvs("NM_000088.3:c.93+1G>T").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(93));
+    }
+
+    #[test]
+    fn test_get_variant_end_range() {
+        let variant = parse_hgvs("NC_000001.11:g.12345_12350del").unwrap();
+        assert_eq!(get_variant_start(&variant), Some(12345));
+        assert_eq!(get_variant_end(&variant), Some(12350));
+    }
+
+    #[test]
+    fn test_get_variant_end_point() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(get_variant_end(&variant), Some(12345));
+    }
+
+    #[test]
+    fn test_get_variant_offset_intronic() {
+        let variant = parse_hgvs("NM_000088.3:c.93+1G>T").unwrap();
+        assert_eq!(get_variant_offset(&variant), Some(1));
+    }
+
+    #[test]
+    fn test_get_variant_offset_exonic() {
+        let variant = parse_hgvs("NM_000088.3:c.100A>G").unwrap();
+        assert_eq!(get_variant_offset(&variant), None);
+    }
+
+    #[test]
+    fn test_get_variant_offset_genomic() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(get_variant_offset(&variant), None);
+    }
+
+    #[test]
+    fn test_get_variant_start_allele() {
+        let variant = parse_hgvs("NM_000088.3:c.[100A>G;200C>T]").unwrap();
+        // Returns start of first sub-variant
+        assert_eq!(get_variant_start(&variant), Some(100));
+    }
+
+    // ===== Edit Accessor Tests =====
+
+    #[test]
+    fn test_get_substitution_bases() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(
+            get_substitution_bases(&variant),
+            Some(("A".to_string(), "G".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_get_substitution_bases_not_sub() {
+        let variant = parse_hgvs("NC_000001.11:g.12345del").unwrap();
+        assert_eq!(get_substitution_bases(&variant), None);
+    }
+
+    #[test]
+    fn test_is_identity_true() {
+        let variant = parse_hgvs("NM_000088.3:c.100=").unwrap();
+        assert!(is_identity(&variant));
+    }
+
+    #[test]
+    fn test_is_identity_false() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert!(!is_identity(&variant));
+    }
+
+    // ===== Indel Length Tests =====
+
+    #[test]
+    fn test_indel_length_substitution() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(0));
+    }
+
+    #[test]
+    fn test_indel_length_deletion_point() {
+        let variant = parse_hgvs("NC_000001.11:g.12345del").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(-1));
+    }
+
+    #[test]
+    fn test_indel_length_deletion_range() {
+        let variant = parse_hgvs("NC_000001.11:g.12345_12350del").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(-6));
+    }
+
+    #[test]
+    fn test_indel_length_insertion() {
+        let variant = parse_hgvs("NC_000001.11:g.12345_12346insATG").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(3));
+    }
+
+    #[test]
+    fn test_indel_length_delins() {
+        // delins replaces 6 bases with 4 bases → net -2
+        let variant = parse_hgvs("NC_000001.11:g.12345_12350delinsATTT").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(-2));
+    }
+
+    #[test]
+    fn test_indel_length_duplication_point() {
+        let variant = parse_hgvs("NC_000001.11:g.12345dup").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(1));
+    }
+
+    #[test]
+    fn test_indel_length_duplication_range() {
+        let variant = parse_hgvs("NC_000001.11:g.12345_12347dup").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(3));
+    }
+
+    #[test]
+    fn test_indel_length_inversion() {
+        let variant = parse_hgvs("NC_000001.11:g.12345_12350inv").unwrap();
+        assert_eq!(get_indel_length(&variant), Some(0));
+    }
+
+    // ===== Frameshift Tests =====
+
+    #[test]
+    fn test_is_frameshift_true() {
+        // 1bp deletion is frameshift
+        let variant = parse_hgvs("NC_000001.11:g.12345del").unwrap();
+        assert!(is_frameshift(&variant));
+    }
+
+    #[test]
+    fn test_is_frameshift_false_in_frame() {
+        // 3bp deletion is in-frame
+        let variant = parse_hgvs("NC_000001.11:g.12345_12347del").unwrap();
+        assert!(!is_frameshift(&variant));
+    }
+
+    #[test]
+    fn test_is_frameshift_false_substitution() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert!(!is_frameshift(&variant));
+    }
+
+    // ===== Num Variants Tests =====
+
+    #[test]
+    fn test_num_variants_simple() {
+        let variant = parse_hgvs("NC_000001.11:g.12345A>G").unwrap();
+        assert_eq!(get_num_variants(&variant), 1);
+    }
+
+    #[test]
+    fn test_num_variants_allele() {
+        let variant = parse_hgvs("NM_000088.3:c.[100A>G;200C>T]").unwrap();
+        assert_eq!(get_num_variants(&variant), 2);
     }
 }

--- a/tests/python/test_accessors.py
+++ b/tests/python/test_accessors.py
@@ -1,0 +1,152 @@
+"""Tests for Python variant accessor properties and methods."""
+
+import ferro_hgvs
+
+
+class TestPositionAccessors:
+    """Tests for start/end/offset properties."""
+
+    def test_genomic_substitution(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345A>G")
+        assert v.start == 12345
+        assert v.end == 12345
+        assert v.offset is None
+
+    def test_range_deletion(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345_12350del")
+        assert v.start == 12345
+        assert v.end == 12350
+
+    def test_coding_intronic_offset(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:c.93+1G>T")
+        assert v.start == 93
+        assert v.offset == 1
+
+    def test_noncoding_intronic_offset(self) -> None:
+        v = ferro_hgvs.parse("NR_046018.2:n.100+5A>G")
+        assert v.start == 100
+        assert v.offset == 5
+
+    def test_rna_intronic_offset(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:r.100+5a>g")
+        assert v.start == 100
+        assert v.offset == 5
+
+    def test_utr3_indistinguishable_from_cds(self) -> None:
+        # The `*` UTR marker is not exposed by start/end — both report the raw
+        # base value. This is documented behavior; callers needing to
+        # distinguish should inspect the variant string.
+        utr = ferro_hgvs.parse("NM_000088.3:c.*5A>G")
+        cds = ferro_hgvs.parse("NM_000088.3:c.5A>G")
+        assert utr.start == cds.start == 5
+
+    def test_protein_returns_none(self) -> None:
+        v = ferro_hgvs.parse("NP_000079.2:p.Glu6Val")
+        assert v.start is None
+        assert v.end is None
+        assert v.offset is None
+        assert v.indel_length is None
+
+
+class TestEditAccessors:
+    """Tests for substitution_bases, is_identity, indel_length, is_frameshift."""
+
+    def test_substitution_bases(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345A>G")
+        assert v.substitution_bases == ("A", "G")
+
+    def test_substitution_bases_none_for_deletion(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345del")
+        assert v.substitution_bases is None
+
+    def test_is_identity_true(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:c.100=")
+        assert v.is_identity()
+
+    def test_is_identity_false(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345A>G")
+        assert not v.is_identity()
+
+    def test_indel_length_substitution(self) -> None:
+        assert ferro_hgvs.parse("NC_000001.11:g.12345A>G").indel_length == 0
+
+    def test_indel_length_deletion(self) -> None:
+        assert ferro_hgvs.parse("NC_000001.11:g.12345_12350del").indel_length == -6
+
+    def test_indel_length_insertion(self) -> None:
+        assert ferro_hgvs.parse("NC_000001.11:g.12345_12346insATG").indel_length == 3
+
+    def test_indel_length_delins(self) -> None:
+        # Replaces 6 bases with 4 → net -2.
+        assert ferro_hgvs.parse("NC_000001.11:g.12345_12350delinsATTT").indel_length == -2
+
+    def test_indel_length_uncertain_insertion_is_none(self) -> None:
+        # ins(10_20) has unknown exact length.
+        v = ferro_hgvs.parse("NC_000001.11:g.12345_12346ins(10_20)")
+        assert v.indel_length is None
+
+    def test_is_frameshift_true(self) -> None:
+        assert ferro_hgvs.parse("NC_000001.11:g.12345del").is_frameshift()
+
+    def test_is_frameshift_in_frame(self) -> None:
+        assert not ferro_hgvs.parse("NC_000001.11:g.12345_12347del").is_frameshift()
+
+
+class TestAlleles:
+    """Tests for num_variants, variants(), and allele start/end behavior."""
+
+    def test_simple_variant_num_variants(self) -> None:
+        v = ferro_hgvs.parse("NC_000001.11:g.12345A>G")
+        assert v.num_variants == 1
+        assert len(v.variants()) == 1
+
+    def test_allele_num_variants(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:c.[100A>G;200C>T]")
+        assert v.num_variants == 2
+        subs = v.variants()
+        assert len(subs) == 2
+        assert subs[0].start == 100
+        assert subs[1].start == 200
+
+    def test_multi_allele_start_is_none(self) -> None:
+        # Multi-sub-variant alleles have ambiguous start; expose None.
+        v = ferro_hgvs.parse("NM_000088.3:c.[100A>G;200C>T]")
+        assert v.start is None
+        assert v.end is None
+
+    def test_single_allele_delegates(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:c.[100A>G]")
+        assert v.start == 100
+        assert v.end == 100
+
+
+class TestToDict:
+    """Tests for to_dict() including new accessor keys."""
+
+    def test_substitution_keys(self) -> None:
+        d = ferro_hgvs.parse("NC_000001.11:g.12345A>G").to_dict()
+        assert d["start"] == 12345
+        assert d["end"] == 12345
+        assert d["ref_base"] == "A"
+        assert d["alt_base"] == "G"
+        assert d["indel_length"] == 0
+        assert d["num_variants"] == 1
+
+    def test_deletion_omits_substitution_keys(self) -> None:
+        d = ferro_hgvs.parse("NC_000001.11:g.12345_12350del").to_dict()
+        assert d["start"] == 12345
+        assert d["end"] == 12350
+        assert d["indel_length"] == -6
+        assert "ref_base" not in d
+        assert "alt_base" not in d
+
+    def test_intronic_includes_offset(self) -> None:
+        d = ferro_hgvs.parse("NM_000088.3:c.93+1G>T").to_dict()
+        assert d["offset"] == 1
+
+    def test_protein_omits_position_keys(self) -> None:
+        d = ferro_hgvs.parse("NP_000079.2:p.Glu6Val").to_dict()
+        assert "start" not in d
+        assert "end" not in d
+        assert "offset" not in d
+        assert "indel_length" not in d


### PR DESCRIPTION
# PR: Add variant accessor properties to Python bindings

**Closes #45**

## Summary

Adds first-class Python properties for extracting positional and edit data from `HgvsVariant` without JSON parsing. These are the fields commonly needed by downstream consumers that previously required mutalyzer's `to_model()` in a downstream project.

## New API surface

### Properties

| Property | Type | Description |
|----------|------|-------------|
| `start` | `int \| None` | 1-based start position (base only, no offset) |
| `end` | `int \| None` | 1-based end position (inclusive) |
| `offset` | `int \| None` | Intronic offset for CDS variants (e.g., 1 for `c.93+1G>T`) |
| `substitution_bases` | `tuple[str, str] \| None` | `("A", "G")` for substitutions |
| `num_variants` | `int` | 1 for simple variants, N for alleles |
| `indel_length` | `int \| None` | Net bases gained/lost (negative for deletions) |

### Methods

| Method | Return | Description |
|--------|--------|-------------|
| `variants()` | `list[HgvsVariant]` | Sub-variants for alleles; `[self]` for simple variants |
| `is_identity()` | `bool` | True for `=` edits |
| `is_frameshift()` | `bool` | True if `indel_length % 3 != 0` |

### Enriched `to_dict()`

```python
>>> ferro_hgvs.parse("NC_000001.11:g.12345A>G").to_dict()
{
    'string': 'NC_000001.11:g.12345A>G',
    'variant_type': 'genomic',
    'reference': 'NC_000001.11',
    'edit_type': 'substitution',
    'start': 12345,
    'end': 12345,
    'ref_base': 'A',
    'alt_base': 'G',
    'indel_length': 0,
    'num_variants': 1
}
```

## Usage examples

```python
import ferro_hgvs

# Position extraction
v = ferro_hgvs.parse("NC_000001.11:g.12345_12350del")
v.start  # 12345
v.end    # 12350
v.indel_length  # -6
v.is_frameshift()  # False (6 % 3 == 0)

# CDS with intronic offset
v = ferro_hgvs.parse("NM_000088.3:c.93+1G>T")
v.start   # 93
v.offset  # 1
v.substitution_bases  # ("G", "T")

# Allele decomposition
v = ferro_hgvs.parse("NM_000088.3:c.[100A>G;200C>T]")
v.num_variants  # 2
for sub in v.variants():
    print(sub.start)  # 100, 200
```

## Implementation

The bulk of the logic lives in `src/python_helpers.rs` as pure Rust functions (testable without the Python runtime), then wired into PyO3 properties in `src/python.rs`.

Key design decisions:
- **`start`/`end` return base only** — offset is a separate property, keeping positional and intronic data orthogonal
- **`indel_length` is computed from the AST** — no reference lookup required. Returns `None` for unknowable cases (uncertain inserted sequences)
- **Allele `start`/`end` delegate to first sub-variant** — simple and matches the common case where all sub-variants share a reference
- **`to_dict()` is additive** — all old keys remain; new keys appear only when applicable (e.g., `ref_base`/`alt_base` only for substitutions)

## Testing

- 26 new unit tests in `python_helpers.rs` covering all accessors, edge cases, and indel length arithmetic
- All 1875 lib tests pass
- All 80 existing Python tests pass unchanged
- Type stubs updated in `__init__.pyi`

## Files changed

- `src/python_helpers.rs` — new helper functions (position extraction, edit accessors, indel length)
- `src/python.rs` — new `#[getter]` properties and methods on `PyHgvsVariant`
- `python/ferro_hgvs/__init__.pyi` — type stub updates
