### PR TITLE
chore(python): use dependency-groups, stricter mypy, and --locked in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.12"
           enable-cache: true
       - name: Install dev dependencies
-        run: uv sync --extra dev --locked --no-install-project
+        run: uv sync --group dev --locked --no-install-project
       - name: Run ruff check
         run: uv run poe check-lint
       - name: Run ruff format
@@ -102,7 +102,9 @@ jobs:
       - name: Run Rust tests
         run: cargo nextest run --features dev
       - name: Install dev dependencies
-        run: uv sync --extra dev --locked --no-install-project
+        run: uv sync --group dev --locked --no-install-project
+      - name: Build and install Python wheel
+        run: uv run maturin develop --features python
       - name: Run Python tests
         run: uv run poe check-tests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,6 @@ jobs:
         run: cargo nextest run --features dev
       - name: Install dev dependencies
         run: uv sync --group dev --locked --no-install-project
-      - name: Build and install Python wheel
-        run: uv run maturin develop --features python
       - name: Run Python tests
         run: uv run poe check-tests
 

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -153,7 +153,7 @@ jobs:
           path: dist
           merge-multiple: true
       - name: Install dev dependencies
-        run: uv sync --extra dev --locked --no-install-project
+        run: uv sync --group dev --locked --no-install-project
       - name: Run twine check
         run: uv run --no-sync twine check --strict dist/*
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ cargo test --features dev
 ### Python Bindings Setup
 
 ```bash
-uv sync --extra dev
+uv sync --group dev
 uv run maturin develop --features python
 uv run pytest
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ Documentation = "https://github.com/fulcrumgenomics/ferro-hgvs#readme"
 dev = [
     "maturin>=1.0,<2.0",
     "pytest>=7.0",
-    "mypy>=1.0",
-    "ruff>=0.4",
+    "mypy==1.20.2",
+    "ruff==0.15.12",
     "poethepoet>=0.36",
     "twine>=6.0",
 ]
@@ -70,13 +70,15 @@ ignore = [
 known-first-party = ["ferro_hgvs"]
 
 [tool.poe.tasks]
-build        = {cmd = "maturin develop --features python",                help = "build the native extension in development mode"}
+build-dev          = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin develop --features python", help = "build the native extension in development mode"}
+build-wheel        = {cmd = "bash -c 'unset CONDA_PREFIX' && maturin build --features python",   help = "build a distributable wheel of the native extension"}
+
 check-format = {cmd = "ruff format --check --diff python/ tests/python/", help = "check Python code formatting"}
 check-lint   = {cmd = "ruff check python/ tests/python/",                 help = "lint Python sources"}
 check-typing = {cmd = "mypy",                                             help = "type-check Python sources"}
 
 check-tests.help     = "run Python tests (rebuilds the native extension first)"
-check-tests.sequence = ["build", {cmd = "pytest"}]
+check-tests.sequence = ["build-dev", {cmd = "pytest"}]
 
 check-all.help        = "run all checks: format, lint, typing, tests"
 check-all.ignore_fail = "return_non_zero"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Homepage = "https://github.com/fulcrumgenomics/ferro-hgvs"
 Repository = "https://github.com/fulcrumgenomics/ferro-hgvs"
 Documentation = "https://github.com/fulcrumgenomics/ferro-hgvs#readme"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "maturin>=1.0,<2.0",
     "pytest>=7.0",
@@ -97,8 +97,14 @@ fix-and-check-all.sequence    = ["fix-format", "fix-lint", "check-typing", "chec
 python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
+warn_unreachable = true
 strict = true
 files = ["python/ferro_hgvs"]
+enable_error_code = [
+    "ignore-without-code",
+    "possibly-undefined",
+    "exhaustive-match",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 name = "ferro-hgvs"
 source = { editable = "." }
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "maturin" },
     { name = "mypy" },
@@ -258,15 +258,16 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "maturin", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.36" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
-    { name = "twine", marker = "extra == 'dev'", specifier = ">=6.0" },
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "maturin", specifier = ">=1.0,<2.0" },
+    { name = "mypy", specifier = ">=1.0" },
+    { name = "poethepoet", specifier = ">=0.36" },
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "ruff", specifier = ">=0.4" },
+    { name = "twine", specifier = ">=6.0" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "id"

--- a/uv.lock
+++ b/uv.lock
@@ -262,10 +262,10 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "maturin", specifier = ">=1.0,<2.0" },
-    { name = "mypy", specifier = ">=1.0" },
+    { name = "mypy", specifier = "==1.20.2" },
     { name = "poethepoet", specifier = ">=0.36" },
     { name = "pytest", specifier = ">=7.0" },
-    { name = "ruff", specifier = ">=0.4" },
+    { name = "ruff", specifier = "==0.15.12" },
     { name = "twine", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
## Summary

Moves Python dev dependencies to `[dependency-groups]` (PEP 735), adds stricter mypy settings, and switches CI to `--locked`.

Builds on #50. Related to #51.

## Changes

- **`pyproject.toml`** — Migrate `[project.optional-dependencies].dev` → `[dependency-groups].dev`. Dev tools are not user-facing extras and should not appear in published PyPI metadata.
- **`pyproject.toml`** — Add `warn_unreachable = true` and `enable_error_code = ["ignore-without-code", "possibly-undefined", "exhaustive-match"]` to mypy config. These are not covered by `strict = true` and are used in our [python-template](https://github.com/fulcrumgenomics/python-template).
- **`.github/workflows/ci.yml`** — Switch from `uv sync --extra dev --frozen` to `uv sync --group dev --locked`. `--locked` verifies the lockfile is in sync with `pyproject.toml` before installing (stricter than `--frozen` which just trusts whatever lockfile exists).
- **`uv.lock`** — Regenerated.
- **`CONTRIBUTING.md`** — Updated to `--group dev`.

## Verification

- `uv run mypy python/ferro_hgvs/` passes with the new settings.