### PR TITLE
build: bump pyo3 0.23 → 0.28 and add Python 3.14 wheels

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --features python -i python3.10 python3.11 python3.12 python3.13
+          args: --release --out dist --features python -i python3.10 python3.11 python3.12 python3.13 python3.14
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [macos-15-intel, macos-14]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - runner: macos-15-intel
             target: x86_64
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,15 +1594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,15 +1799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2413,37 +2395,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2451,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2 1.0.103",
  "pyo3-macros-backend",
@@ -2463,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2 1.0.103",
@@ -2544,7 +2521,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3260,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -3718,12 +3695,6 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ clap = { version = "4", features = ["derive"] }
 noodles-vcf = "0.73"
 flate2 = "1.0"
 ahash = { version = "0.8", optional = true }
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
 memmap2 = { version = "0.9", optional = true }
 memchr = "2.7"
 ureq = { version = "2.9", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]

--- a/src/python.rs
+++ b/src/python.rs
@@ -86,7 +86,7 @@ fn normalize(hgvs_string: &str, direction: &str) -> PyResult<String> {
 }
 
 /// Python wrapper for HgvsVariant
-#[pyclass(name = "HgvsVariant")]
+#[pyclass(name = "HgvsVariant", from_py_object)]
 #[derive(Clone)]
 pub struct PyHgvsVariant {
     pub(crate) inner: HgvsVariant,
@@ -315,7 +315,7 @@ impl PyHgvsVariant {
     }
 
     /// Convert to a dictionary representation
-    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
         dict.set_item("string", self.inner.to_string())?;
         dict.set_item("variant_type", self.variant_type())?;
@@ -347,7 +347,7 @@ impl PyHgvsVariant {
         // Allele info
         dict.set_item("num_variants", get_num_variants(&self.inner))?;
 
-        Ok(dict.into())
+        Ok(dict)
     }
 
     /// Convert to JSON string
@@ -480,7 +480,7 @@ fn spdi_to_hgvs_variant(spdi: &PySpdiVariant) -> PyResult<PyHgvsVariant> {
 }
 
 /// Python wrapper for SpdiVariant
-#[pyclass(name = "SpdiVariant")]
+#[pyclass(name = "SpdiVariant", from_py_object)]
 #[derive(Clone)]
 pub struct PySpdiVariant {
     inner: SpdiVariant,
@@ -589,14 +589,14 @@ impl PySpdiVariant {
     }
 
     /// Convert to a dictionary representation
-    fn to_dict(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_dict<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let dict = PyDict::new(py);
         dict.set_item("sequence", &self.inner.sequence)?;
         dict.set_item("position", self.inner.position)?;
         dict.set_item("deletion", &self.inner.deletion)?;
         dict.set_item("insertion", &self.inner.insertion)?;
         dict.set_item("variant_type", self.inner.variant_type())?;
-        Ok(dict.into())
+        Ok(dict)
     }
 }
 
@@ -605,7 +605,7 @@ impl PySpdiVariant {
 // ============================================================================
 
 /// Python wrapper for ZeroBasedPos
-#[pyclass(name = "ZeroBasedPos")]
+#[pyclass(name = "ZeroBasedPos", from_py_object)]
 #[derive(Clone)]
 pub struct PyZeroBasedPos {
     inner: ZeroBasedPos,
@@ -675,7 +675,7 @@ impl PyZeroBasedPos {
 }
 
 /// Python wrapper for OneBasedPos
-#[pyclass(name = "OneBasedPos")]
+#[pyclass(name = "OneBasedPos", from_py_object)]
 #[derive(Clone)]
 pub struct PyOneBasedPos {
     inner: OneBasedPos,
@@ -762,7 +762,7 @@ fn index_to_hgvs_pos(idx: usize) -> u64 {
 // ============================================================================
 
 /// Equivalence level between two variants
-#[pyclass(name = "EquivalenceLevel", eq, eq_int)]
+#[pyclass(name = "EquivalenceLevel", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyEquivalenceLevel {
     /// Exactly identical (same string representation)
@@ -818,7 +818,7 @@ impl PyEquivalenceLevel {
 }
 
 /// Result of an equivalence check
-#[pyclass(name = "EquivalenceResult")]
+#[pyclass(name = "EquivalenceResult", from_py_object)]
 #[derive(Clone)]
 pub struct PyEquivalenceResult {
     /// The determined equivalence level
@@ -924,7 +924,7 @@ impl PyEquivalenceChecker {
 // ============================================================================
 
 /// Sequence Ontology consequence term
-#[pyclass(name = "Consequence", eq, eq_int)]
+#[pyclass(name = "Consequence", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyConsequence {
     TranscriptAblation = 0,
@@ -1028,7 +1028,7 @@ impl PyConsequence {
 }
 
 /// Variant impact level (VEP-style)
-#[pyclass(name = "Impact", eq, eq_int)]
+#[pyclass(name = "Impact", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PyImpact {
     Modifier = 0,
@@ -1061,7 +1061,7 @@ impl PyImpact {
 }
 
 /// Protein effect prediction result
-#[pyclass(name = "ProteinEffect")]
+#[pyclass(name = "ProteinEffect", from_py_object)]
 #[derive(Clone)]
 pub struct PyProteinEffect {
     inner: ProteinEffect,
@@ -1226,7 +1226,7 @@ fn parse_amino_acid(code: &str) -> PyResult<AminoAcid> {
 // ============================================================================
 
 /// Context for parsing MAVE-HGVS short-form notation
-#[pyclass(name = "MaveContext")]
+#[pyclass(name = "MaveContext", from_py_object)]
 #[derive(Clone)]
 pub struct PyMaveContext {
     inner: MaveContext,
@@ -1356,7 +1356,7 @@ fn is_mave_short_form_variant(hgvs_string: &str) -> bool {
 // ============================================================================
 
 /// Progress information for batch processing
-#[pyclass(name = "BatchProgress")]
+#[pyclass(name = "BatchProgress", from_py_object)]
 #[derive(Clone)]
 pub struct PyBatchProgress {
     #[pyo3(get)]
@@ -1535,7 +1535,7 @@ impl PyBatchProcessor {
 // ============================================================================
 
 /// Error handling mode
-#[pyclass(name = "ErrorMode", eq, eq_int)]
+#[pyclass(name = "ErrorMode", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyErrorMode {
     /// Strict mode - reject all non-standard input
@@ -1567,7 +1567,7 @@ impl From<PyErrorMode> for ErrorMode {
 }
 
 /// Error type for configurable error handling
-#[pyclass(name = "ErrorType", eq, eq_int)]
+#[pyclass(name = "ErrorType", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum PyErrorType {
     LowercaseAminoAcid = 0,
@@ -1638,7 +1638,7 @@ impl From<PyErrorType> for ErrorType {
 }
 
 /// Override behavior for a specific error type
-#[pyclass(name = "ErrorOverride", eq, eq_int)]
+#[pyclass(name = "ErrorOverride", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyErrorOverride {
     /// Use the base mode's behavior
@@ -1678,7 +1678,7 @@ impl From<PyErrorOverride> for ErrorOverride {
 }
 
 /// Warning generated during preprocessing
-#[pyclass(name = "CorrectionWarning")]
+#[pyclass(name = "CorrectionWarning", from_py_object)]
 #[derive(Clone)]
 pub struct PyCorrectionWarning {
     #[pyo3(get)]
@@ -1713,7 +1713,7 @@ impl PyCorrectionWarning {
 }
 
 /// Error handling configuration
-#[pyclass(name = "ErrorConfig")]
+#[pyclass(name = "ErrorConfig", from_py_object)]
 #[derive(Clone)]
 pub struct PyErrorConfig {
     inner: ErrorConfig,
@@ -1854,7 +1854,7 @@ fn parse_lenient(
 // ============================================================================
 
 /// A codon change representing a DNA variant
-#[pyclass(name = "CodonChange")]
+#[pyclass(name = "CodonChange", from_py_object)]
 #[derive(Clone)]
 pub struct PyCodonChange {
     inner: CodonChange,
@@ -1898,7 +1898,7 @@ impl PyCodonChange {
 }
 
 /// Codon table (genetic code)
-#[pyclass(name = "CodonTable")]
+#[pyclass(name = "CodonTable", from_py_object)]
 #[derive(Clone)]
 pub struct PyCodonTable {
     inner: CodonTable,
@@ -2033,7 +2033,7 @@ fn format_rsid_value(rsid_num: u64) -> String {
 }
 
 /// Result of rsID lookup
-#[pyclass(name = "RsIdResult")]
+#[pyclass(name = "RsIdResult", from_py_object)]
 #[derive(Clone)]
 pub struct PyRsIdResult {
     inner: RsIdResult,
@@ -2164,7 +2164,7 @@ impl PyInMemoryRsIdLookup {
 // ============================================================================
 
 /// A VCF record
-#[pyclass(name = "VcfRecord")]
+#[pyclass(name = "VcfRecord", from_py_object)]
 #[derive(Clone)]
 pub struct PyVcfRecord {
     inner: VcfRecord,
@@ -2292,7 +2292,7 @@ fn vcf_to_genomic_hgvs(record: &PyVcfRecord, alt_index: usize) -> PyResult<PyHgv
 // ============================================================================
 
 /// Configuration for reference data preparation
-#[pyclass(name = "PrepareConfig")]
+#[pyclass(name = "PrepareConfig", from_py_object)]
 #[derive(Clone)]
 pub struct PyPrepareConfig {
     inner: PrepareConfig,
@@ -2314,6 +2314,7 @@ impl PyPrepareConfig {
         dry_run=false,
         download_cdot_grch37=false
     ))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         output_dir: &str,
         download_transcripts: bool,
@@ -2371,7 +2372,7 @@ impl PyPrepareConfig {
 }
 
 /// Manifest of prepared reference data
-#[pyclass(name = "ReferenceManifest")]
+#[pyclass(name = "ReferenceManifest", from_py_object)]
 #[derive(Clone)]
 pub struct PyReferenceManifest {
     inner: ReferenceManifest,
@@ -2474,7 +2475,7 @@ fn check_reference_data(directory: &str) -> PyResult<PyReferenceManifest> {
 // ============================================================================
 
 /// Genome build (GRCh37 or GRCh38)
-#[pyclass(name = "GenomeBuild", eq, eq_int)]
+#[pyclass(name = "GenomeBuild", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyGenomeBuild {
     GRCh37 = 0,
@@ -2504,7 +2505,7 @@ impl PyGenomeBuild {
 }
 
 /// Strand direction
-#[pyclass(name = "Strand", eq, eq_int)]
+#[pyclass(name = "Strand", eq, eq_int, from_py_object)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum PyStrand {
     Plus = 0,


### PR DESCRIPTION
Closes #56. Follow-up to review feedback on #43.

## Summary

- **Bump pyo3 0.23 → 0.28.3.** Required for Python 3.14 (3.14 support landed in pyo3 0.27).
- **Add Python 3.14 to the wheel matrix** in `.github/workflows/release-wheels.yml` (Linux `-i` list, macOS matrix, Windows matrix). Also update `pyproject.toml` classifiers to list 3.14. After this change the matrix is Linux × 4, macOS × 10, Windows × 5, sdist × 1 = **20 cells** (3.10–3.14; 3.8/3.9 were dropped on `main` in #55).

## Source changes (`src/python.rs`)

- **Two `to_dict` functions** now return `Bound<'py, PyDict>` instead of `PyResult<PyObject>`. `PyObject` is no longer in `pyo3::prelude` in 0.28.
- **24 `#[pyclass]` types with `derive(Clone)`** opt in to the auto-derived `FromPyObject` impl via `from_py_object`. In 0.28 the auto-derive is deprecated and you must opt in or out; opting in preserves prior behavior.
- **`PyPrepareConfig::new`** gets `#[allow(clippy::too_many_arguments)]` to match the existing pattern in `src/bin/{ferro,benchmark}.rs`.

## Test plan

- [x] `cargo clippy --features dev -- -D warnings` clean
- [x] `maturin develop --features python && pytest tests/python/` — 106/106 passing on Python 3.14
- [x] `workflow_dispatch` (blank tag) on `release-wheels.yml` from `nh/56_bump-pyo3` — all 20 matrix cells + smoke tests built clean ([run 25067268092](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/25067268092))

## Note for reviewer

The `smoke-test` matrix in `release-wheels.yml` covers Python 3.10–3.13. After this PR, 3.14 wheels are built but not exercised by smoke tests. Consider adding `"3.14"` to that matrix here or as a follow-up.