### PR TITLE
chore(python): migrate type stubs to PEP 604 unions and built-in generics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Native extension re-exports - star imports are intentional
 "python/ferro_hgvs/__init__.py" = ["F403", "F405"]
-# Type stubs use Optional/List for broad compatibility
-"python/ferro_hgvs/__init__.pyi" = ["UP006", "UP007"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["ferro_hgvs"]

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1,7 +1,7 @@
 """Type stubs for ferro-hgvs Python bindings."""
 
 from enum import IntEnum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable
 
 __version__: str
 
@@ -140,9 +140,7 @@ def is_mave_short_form_variant(hgvs_string: str) -> bool:
 # Error Handling Functions
 # ============================================================================
 
-def parse_lenient(
-    hgvs_string: str, config: Optional[ErrorConfig] = None
-) -> ParseResultWithWarnings:
+def parse_lenient(hgvs_string: str, config: ErrorConfig | None = None) -> ParseResultWithWarnings:
     """Parse an HGVS string with lenient error handling.
 
     Args:
@@ -269,7 +267,7 @@ class HgvsVariant:
         """Normalize this variant."""
         ...
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to a dictionary representation."""
         ...
 
@@ -329,7 +327,7 @@ class HgvsVariant:
 class Normalizer:
     """HGVS variant normalizer using a reference provider."""
 
-    def __init__(self, reference_json: Optional[str] = None, direction: str = "3prime") -> None:
+    def __init__(self, reference_json: str | None = None, direction: str = "3prime") -> None:
         """Create a new normalizer.
 
         Args:
@@ -420,7 +418,7 @@ class SpdiVariant:
         """Convert 0-based SPDI position to 1-based HGVS position."""
         ...
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to a dictionary representation."""
         ...
 
@@ -520,17 +518,17 @@ class EquivalenceResult:
         ...
 
     @property
-    def normalized_first(self) -> Optional[str]:
+    def normalized_first(self) -> str | None:
         """The normalized form of the first variant."""
         ...
 
     @property
-    def normalized_second(self) -> Optional[str]:
+    def normalized_second(self) -> str | None:
         """The normalized form of the second variant."""
         ...
 
     @property
-    def notes(self) -> List[str]:
+    def notes(self) -> list[str]:
         """Additional notes about the comparison."""
         ...
 
@@ -541,7 +539,7 @@ class EquivalenceResult:
 class EquivalenceChecker:
     """Equivalence checker for comparing HGVS variants."""
 
-    def __init__(self, reference_json: Optional[str] = None) -> None:
+    def __init__(self, reference_json: str | None = None) -> None:
         """Create a new equivalence checker.
 
         Args:
@@ -553,7 +551,7 @@ class EquivalenceChecker:
         """Check if two variants are equivalent."""
         ...
 
-    def all_equivalent(self, variants: List[HgvsVariant]) -> bool:
+    def all_equivalent(self, variants: list[HgvsVariant]) -> bool:
         """Check if multiple variants are all equivalent to each other."""
         ...
 
@@ -612,7 +610,7 @@ class ProteinEffect:
     """Protein effect prediction result."""
 
     @property
-    def consequences(self) -> List[Consequence]:
+    def consequences(self) -> list[Consequence]:
         """Get all applicable consequences."""
         ...
 
@@ -670,13 +668,13 @@ class MaveContext:
         ...
 
     @property
-    def protein_accession(self) -> Optional[str]: ...
+    def protein_accession(self) -> str | None: ...
     @property
-    def coding_accession(self) -> Optional[str]: ...
+    def coding_accession(self) -> str | None: ...
     @property
-    def genomic_accession(self) -> Optional[str]: ...
+    def genomic_accession(self) -> str | None: ...
     @property
-    def gene_symbol(self) -> Optional[str]: ...
+    def gene_symbol(self) -> str | None: ...
     def with_protein_accession(self, accession: str) -> MaveContext:
         """Set the protein sequence accession for p. variants."""
         ...
@@ -698,7 +696,7 @@ class MaveContext:
         ...
 
     @property
-    def noncoding_accession(self) -> Optional[str]: ...
+    def noncoding_accession(self) -> str | None: ...
     def has_accessions(self) -> bool:
         """Check if this context has any accessions defined."""
         ...
@@ -752,18 +750,18 @@ class BatchResult:
         """Success rate as a percentage."""
         ...
 
-    def successes(self) -> List[HgvsVariant]:
+    def successes(self) -> list[HgvsVariant]:
         """Get successfully parsed/normalized variants."""
         ...
 
-    def errors(self) -> List[tuple[int, str]]:
+    def errors(self) -> list[tuple[int, str]]:
         """Get errors as (index, error_message) tuples."""
         ...
 
 class BatchProcessor:
     """Batch processor for parsing and normalizing multiple variants."""
 
-    def __init__(self, reference_json: Optional[str] = None) -> None:
+    def __init__(self, reference_json: str | None = None) -> None:
         """Create a new batch processor.
 
         Args:
@@ -771,16 +769,16 @@ class BatchProcessor:
         """
         ...
 
-    def parse(self, variants: List[str]) -> BatchResult:
+    def parse(self, variants: list[str]) -> BatchResult:
         """Parse multiple HGVS strings."""
         ...
 
-    def parse_and_normalize(self, variants: List[str]) -> BatchResult:
+    def parse_and_normalize(self, variants: list[str]) -> BatchResult:
         """Parse and normalize multiple HGVS strings."""
         ...
 
     def parse_with_progress(
-        self, variants: List[str], callback: Callable[[BatchProgress], None]
+        self, variants: list[str], callback: Callable[[BatchProgress], None]
     ) -> BatchResult:
         """Parse multiple HGVS strings with progress callback."""
         ...
@@ -880,7 +878,7 @@ class ParseResultWithWarnings:
     @property
     def variant(self) -> HgvsVariant: ...
     @property
-    def warnings(self) -> List[CorrectionWarning]: ...
+    def warnings(self) -> list[CorrectionWarning]: ...
     @property
     def original_input(self) -> str: ...
     @property
@@ -911,7 +909,7 @@ class CodonChange:
         ...
 
     @property
-    def changed_positions(self) -> List[int]:
+    def changed_positions(self) -> list[int]:
         """Position(s) in codon that changed (1-indexed)."""
         ...
 
@@ -930,7 +928,7 @@ class CodonTable:
 class Backtranslator:
     """Backtranslation engine for converting protein changes to DNA changes."""
 
-    def __init__(self, codon_table: Optional[CodonTable] = None) -> None:
+    def __init__(self, codon_table: CodonTable | None = None) -> None:
         """Create a new backtranslator with the given codon table."""
         ...
 
@@ -939,15 +937,15 @@ class Backtranslator:
         """Create a backtranslator with the standard genetic code."""
         ...
 
-    def backtranslate_substitution(self, ref_aa: str, alt_aa: str) -> List[CodonChange]:
+    def backtranslate_substitution(self, ref_aa: str, alt_aa: str) -> list[CodonChange]:
         """Backtranslate an amino acid substitution."""
         ...
 
-    def backtranslate_to_stop(self, ref_aa: str) -> List[CodonChange]:
+    def backtranslate_to_stop(self, ref_aa: str) -> list[CodonChange]:
         """Backtranslate a nonsense mutation (amino acid to stop codon)."""
         ...
 
-    def backtranslate_stop_loss(self, alt_aa: str) -> List[CodonChange]:
+    def backtranslate_stop_loss(self, alt_aa: str) -> list[CodonChange]:
         """Backtranslate a stop loss (stop codon to amino acid)."""
         ...
 
@@ -969,11 +967,11 @@ class RsIdResult:
     @property
     def alternate(self) -> str: ...
     @property
-    def hgvs(self) -> Optional[str]: ...
+    def hgvs(self) -> str | None: ...
     @property
-    def allele_frequency(self) -> Optional[float]: ...
+    def allele_frequency(self) -> float | None: ...
     @property
-    def clinical_significance(self) -> Optional[str]: ...
+    def clinical_significance(self) -> str | None: ...
     def is_snv(self) -> bool:
         """Check if this is a substitution (SNV)."""
         ...
@@ -998,7 +996,7 @@ class InMemoryRsIdLookup:
         """Create with common test variants (BRAF V600E, BRCA1 185delAG)."""
         ...
 
-    def lookup(self, rsid: str) -> List[RsIdResult]:
+    def lookup(self, rsid: str) -> list[RsIdResult]:
         """Look up rsID and return matching variants."""
         ...
 
@@ -1014,7 +1012,7 @@ class VcfRecord:
     """A VCF record."""
 
     def __init__(
-        self, chrom: str, pos: int, reference: str, alternate: str, id: Optional[str] = None
+        self, chrom: str, pos: int, reference: str, alternate: str, id: str | None = None
     ) -> None:
         """Create a new VCF record.
 
@@ -1047,15 +1045,15 @@ class VcfRecord:
     @property
     def pos(self) -> int: ...
     @property
-    def id(self) -> Optional[str]: ...
+    def id(self) -> str | None: ...
     @property
     def reference(self) -> str: ...
     @property
-    def alternate(self) -> Optional[str]:
+    def alternate(self) -> str | None:
         """Get the first alternate allele (for simple variants)."""
         ...
     @property
-    def alternates(self) -> List[str]:
+    def alternates(self) -> list[str]:
         """Get all alternate alleles."""
         ...
 
@@ -1098,15 +1096,15 @@ class ReferenceManifest:
     @property
     def transcript_count(self) -> int: ...
     @property
-    def transcript_fastas(self) -> List[str]: ...
+    def transcript_fastas(self) -> list[str]: ...
     @property
-    def genome_fasta(self) -> Optional[str]: ...
+    def genome_fasta(self) -> str | None: ...
     @property
-    def cdot_json(self) -> Optional[str]: ...
+    def cdot_json(self) -> str | None: ...
     @property
-    def cdot_grch37_json(self) -> Optional[str]: ...
+    def cdot_grch37_json(self) -> str | None: ...
     @property
-    def available_prefixes(self) -> List[str]: ...
+    def available_prefixes(self) -> list[str]: ...
 
 # ============================================================================
 # Reference Classes
@@ -1136,7 +1134,7 @@ class CoordinateMapper:
     transcript (n.), and protein (p.) coordinate systems.
     """
 
-    def __init__(self, reference_json: Optional[str] = None) -> None:
+    def __init__(self, reference_json: str | None = None) -> None:
         """Create a new coordinate mapper.
 
         Args:
@@ -1146,8 +1144,8 @@ class CoordinateMapper:
         ...
 
     def c_to_g(
-        self, transcript_id: str, cds_position: int, offset: Optional[int] = None
-    ) -> Optional[tuple[str, int]]:
+        self, transcript_id: str, cds_position: int, offset: int | None = None
+    ) -> tuple[str, int] | None:
         """Convert a CDS position to genomic position.
 
         Args:
@@ -1165,7 +1163,7 @@ class CoordinateMapper:
         """
         ...
 
-    def g_to_c(self, transcript_id: str, genomic_position: int) -> tuple[int, Optional[int], bool]:
+    def g_to_c(self, transcript_id: str, genomic_position: int) -> tuple[int, int | None, bool]:
         """Convert a genomic position to CDS position.
 
         Args:
@@ -1202,9 +1200,9 @@ class CoordinateMapper:
         self,
         transcript_id: str,
         cds_position: int,
-        offset: Optional[int] = None,
+        offset: int | None = None,
         utr3: bool = False,
-    ) -> tuple[int, Optional[int]]:
+    ) -> tuple[int, int | None]:
         """Convert a CDS position to transcript position.
 
         Args:
@@ -1225,9 +1223,9 @@ class CoordinateMapper:
         self,
         transcript_id: str,
         tx_position: int,
-        offset: Optional[int] = None,
+        offset: int | None = None,
         downstream: bool = False,
-    ) -> tuple[int, Optional[int], bool]:
+    ) -> tuple[int, int | None, bool]:
         """Convert a transcript position to CDS position.
 
         Args:
@@ -1256,7 +1254,7 @@ class CoordinateMapper:
         """
         ...
 
-    def get_chromosome(self, transcript_id: str) -> Optional[str]:
+    def get_chromosome(self, transcript_id: str) -> str | None:
         """Get the chromosome of a transcript.
 
         Args:


### PR DESCRIPTION
Fixes #61

Stacked on #55.

Now that the minimum supported Python is 3.10, the stub at `python/ferro_hgvs/__init__.pyi` no longer needs `typing.Optional` / `typing.List` / `typing.Dict`:

- `Optional[T]` → `T | None`
- `List[T]` → `list[T]`
- `Dict[K, V]` → `dict[K, V]`

Also drops the `UP006`/`UP007` per-file ignore for the stub in `pyproject.toml` so ruff enforces the new style going forward.

**Pure cosmetic — no runtime behavior change.** Stubs are not executed; this only affects how IDEs and `mypy` read the annotations.

## Test plan

- `ruff check python/ tests/python/` clean
- `ruff format --check python/ tests/python/` clean
- `mypy python/ferro_hgvs/` clean