### PR TITLE
ci: use poe tasks in Python lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Install dev dependencies
         run: uv sync --group dev --locked --no-install-project
       - name: Run ruff check
-        run: uv run ruff check python/ tests/python/
+        run: uv run poe check-lint
       - name: Run ruff format
-        run: uv run ruff format --check python/ tests/python/
+        run: uv run poe check-format
       - name: Run mypy
-        run: uv run mypy python/ferro_hgvs/
+        run: uv run poe check-typing
 
   clippy:
     name: Clippy
@@ -103,10 +103,8 @@ jobs:
         run: cargo nextest run --features dev
       - name: Install dev dependencies
         run: uv sync --group dev --locked --no-install-project
-      - name: Build and install Python wheel
-        run: uv run maturin develop --features python
       - name: Run Python tests
-        run: uv run pytest tests/python/ -v
+        run: uv run poe check-tests
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Closes #60.

Replace direct `ruff`/`mypy`/`maturin`/`pytest` invocations in `ci.yml` with the equivalent `poe` tasks added in #53. Single source of truth in `pyproject.toml` — path/flag changes propagate to both local and CI without touching the workflow.

Steps stay separate (not collapsed into `check-all`) so CI still emits per-check annotations. The `maturin develop` + `pytest` pair in the test job collapses into one `check-tests` step (the task's sequence runs the build first).

**Stacked on #55** — relies on `poethepoet` being unconditional in `pyproject.toml`. Rebase to `main` once #53/#55 land.

## Test plan

- [ ] CI Python Lint job runs the three poe tasks and emits per-check annotations
- [ ] CI Test job builds the native extension and runs pytest via `poe check-tests`
- [ ] Pytest verbosity preserved (still set in `[tool.pytest.ini_options].addopts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)