### PR TITLE
chore(ci): tighten workflow security (zizmor findings)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ferro-deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -22,6 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.94.0  # TODO(#35): unpin once new clippy lints are fixed
@@ -33,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: "3.12"
@@ -53,6 +59,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.94.0
@@ -79,6 +86,7 @@ jobs:
         with:
           lfs: true
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.94.0
@@ -113,8 +121,6 @@ jobs:
   python-wheel-test:
     name: Python Wheel Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -171,6 +177,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.94.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -17,6 +20,7 @@ jobs:
         with:
           lfs: true
           submodules: true
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: 1.94.0

--- a/.github/workflows/deploy-local.yml
+++ b/.github/workflows/deploy-local.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   BINARY_NAME: ferro-web
   CONFIG_FILE: /opt/ferro-web/service.toml
@@ -27,6 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -38,14 +42,14 @@ jobs:
           if ! command -v rustc &> /dev/null; then
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           fi
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Setup Pixi
         run: |
           if ! command -v pixi &> /dev/null; then
             curl -fsSL https://pixi.sh/install.sh | bash
           fi
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+          echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
 
       - name: Install Python dependencies via Pixi
         run: |

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -15,6 +15,9 @@ on:
         required: false
         default: '0'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -27,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -94,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download API fixtures
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -134,27 +141,29 @@ jobs:
 
       - name: Generate validation report
         run: |
-          echo "# External Validation Report" > validation_report.md
-          echo "" >> validation_report.md
-          echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> validation_report.md
-          echo "" >> validation_report.md
+          {
+            echo "# External Validation Report"
+            echo ""
+            echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+            echo ""
 
-          echo "## API Comparison Results" >> validation_report.md
-          echo '```' >> validation_report.md
-          tail -50 api_comparison_results.txt >> validation_report.md || echo "No results" >> validation_report.md
-          echo '```' >> validation_report.md
-          echo "" >> validation_report.md
+            echo "## API Comparison Results"
+            echo '```'
+            tail -50 api_comparison_results.txt || echo "No results"
+            echo '```'
+            echo ""
 
-          echo "## SPDI Test Results" >> validation_report.md
-          echo '```' >> validation_report.md
-          tail -50 spdi_results.txt >> validation_report.md || echo "No results" >> validation_report.md
-          echo '```' >> validation_report.md
-          echo "" >> validation_report.md
+            echo "## SPDI Test Results"
+            echo '```'
+            tail -50 spdi_results.txt || echo "No results"
+            echo '```'
+            echo ""
 
-          echo "## dbSNP Test Results" >> validation_report.md
-          echo '```' >> validation_report.md
-          tail -50 dbsnp_results.txt >> validation_report.md || echo "No results" >> validation_report.md
-          echo '```' >> validation_report.md
+            echo "## dbSNP Test Results"
+            echo '```'
+            tail -50 dbsnp_results.txt || echo "No results"
+            echo '```'
+          } > validation_report.md
 
       - name: Upload validation report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -175,6 +184,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
@@ -203,6 +213,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
@@ -265,10 +277,10 @@ jobs:
 
       - name: Post summary
         run: |
-          echo "## External Validation Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## External Validation Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -f validation_report.md ]; then
-            cat validation_report.md >> $GITHUB_STEP_SUMMARY
+            cat validation_report.md >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "Validation report not available" >> $GITHUB_STEP_SUMMARY
+            echo "Validation report not available" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: '300'
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -28,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2  # nightly
@@ -57,10 +62,12 @@ jobs:
             fuzz-corpus-${{ matrix.target }}-
 
       - name: Run fuzzer
+        env:
+          FUZZ_SECONDS: ${{ github.event.inputs.fuzz_seconds || '300' }}
+          FUZZ_TARGET: ${{ matrix.target }}
         run: |
           cd fuzz
-          FUZZ_SECONDS="${{ github.event.inputs.fuzz_seconds || '300' }}"
-          timeout "${FUZZ_SECONDS}s" cargo +nightly fuzz run ${{ matrix.target }} -- -max_len=1024 || true
+          timeout "${FUZZ_SECONDS}s" cargo +nightly fuzz run "${FUZZ_TARGET}" -- -max_len=1024 || true
 
       - name: Save corpus
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -67,6 +67,10 @@ jobs:
           FUZZ_TARGET: ${{ matrix.target }}
         run: |
           cd fuzz
+          if ! [[ "$FUZZ_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid fuzz_seconds='$FUZZ_SECONDS' (must be a positive integer)" >&2
+            exit 1
+          fi
           timeout "${FUZZ_SECONDS}s" cargo +nightly fuzz run "${FUZZ_TARGET}" -- -max_len=1024 || true
 
       - name: Save corpus

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Run zizmor
         run: zizmor .github/workflows/
       - name: Run actionlint
-        run: actionlint .github/workflows/*.yml
+        run: actionlint

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/actionlint.yaml'
   pull_request:
     branches: [main]
     paths:
       - '.github/workflows/**'
+      - '.github/actionlint.yaml'
 
 permissions:
   contents: read
@@ -28,12 +30,18 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: .github/workflows/lint-workflows.yml
       - name: Install zizmor
         run: pip install 'zizmor==1.24.1'
       - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
         run: |
           curl -sSL -o /tmp/actionlint.tgz \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tgz" | sha256sum -c -
           tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint
       - name: Run zizmor
         run: zizmor .github/workflows/

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install actionlint
         run: |
           curl -sSL -o /tmp/actionlint.tgz \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
           tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint
       - name: Run zizmor
         run: zizmor .github/workflows/

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,41 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: zizmor + actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install zizmor
+        run: pip install 'zizmor==1.24.1'
+      - name: Install actionlint
+        run: |
+          curl -sSL -o /tmp/actionlint.tgz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          tar -xzf /tmp/actionlint.tgz -C /usr/local/bin actionlint
+      - name: Run zizmor
+        run: zizmor .github/workflows/
+      - name: Run actionlint
+        run: actionlint .github/workflows/*.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          # release-plz pushes tags/commits via the persisted token; do not disable.
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }} # zizmor: ignore[artipacked]
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:


### PR DESCRIPTION
Fixes #67

zizmor flagged 62 findings across the workflows: one High-severity
template-injection in `fuzz.yml` plus widespread `artipacked` (token
persistence) and `excessive-permissions` (no `permissions:` block)
warnings. This PR resolves all of them and adds a `lint-workflows` job
to catch regressions on future workflow edits.

**Existing CI behavior is unchanged.** Every workflow gets
`permissions: contents: read` at the top, which matches the *effective*
permissions every existing job already needed (none push, comment, or
write releases — `publish.yml` already had its own write block and
keeps it). Checkouts get `persist-credentials: false` everywhere except
`publish.yml`, which intentionally persists `RELEASE_PLZ_TOKEN` for
release-plz's git push.

Two cleanups landed alongside so the new lint job actually passes on
existing code:
- Quoted `$GITHUB_PATH` / `$GITHUB_STEP_SUMMARY` in two run blocks
  (real word-splitting bugs flagged by shellcheck).
- Refactored the validation-report generator in
  `external-validation.yml` from ~20 sequential `>>` redirects to one
  `{ … } > file` group — output is byte-identical, just readable.

## Test plan

- [ ] `zizmor .github/workflows/` clean (was 62 findings).
- [ ] `actionlint .github/workflows/*.yml` clean (was 13).
- [ ] New `lint-workflows` job runs on this PR and passes.
- [ ] Other CI jobs (format, python-lint, clippy, test, python-wheel-test, build) all green — confirms least-privilege `permissions:` doesn't break anything.
- [ ] `fuzz.yml` `workflow_dispatch` with custom `fuzz_seconds` still honors the input (env-var refactor is behavior-equivalent; manual check).