### PR TITLE
fix: accept gene selectors on non-RefSeq accessions

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -123,7 +123,10 @@ fn is_sam_refname_char(c: char) -> bool {
 /// Uses look-ahead to correctly identify the HGVS separator (`:` followed by type prefix).
 ///
 /// SAM spec: Reference names may contain printable ASCII `[!-~]` except `\ , " ' ( ) [ ] { } < >`
-/// and cannot start with `*` or `=`.
+/// and cannot start with `*` or `=`. Because `(` is forbidden in SAM refnames, a `(` before
+/// the type-prefix colon must be the start of an optional gene/transcript selector
+/// (e.g. `MYSEQ(GENE1):c.…`); the accession ends there and `parse_gene_symbol` consumes
+/// the selector next.
 fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
     // Check first character: cannot be empty, and cannot start with * or =
     let first_char = input.chars().next().ok_or_else(|| {
@@ -187,8 +190,7 @@ fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
         nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
     })?;
 
-    // SAM refnames forbid '(', so a '(' before the type-prefix colon must be
-    // the start of a gene/transcript selector consumed by parse_gene_symbol.
+    // See doc comment: '(' before the colon ends the accession (selector boundary).
     let accession_end = memchr(b'(', &input_bytes[..separator_pos]).unwrap_or(separator_pos);
 
     // Validate all characters in the accession name are SAM-compatible

--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -187,8 +187,12 @@ fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
         nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
     })?;
 
+    // SAM refnames forbid '(', so a '(' before the type-prefix colon must be
+    // the start of a gene/transcript selector consumed by parse_gene_symbol.
+    let accession_end = memchr(b'(', &input_bytes[..separator_pos]).unwrap_or(separator_pos);
+
     // Validate all characters in the accession name are SAM-compatible
-    let accession_str = &input[..separator_pos];
+    let accession_str = &input[..accession_end];
     if accession_str.is_empty() || !accession_str.chars().all(is_sam_refname_char) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -210,7 +214,7 @@ fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
     };
 
     Ok((
-        &input[separator_pos..],
+        &input[accession_end..],
         Accession::with_style(name.to_string(), String::new(), version, true),
     ))
 }
@@ -861,5 +865,67 @@ mod tests {
         );
         assert_eq!(&*acc.prefix, "NC");
         assert!(remaining.starts_with('('));
+    }
+
+    // =========================================================================
+    // Gene selectors on non-RefSeq accessions (issue #69)
+    // =========================================================================
+
+    #[test]
+    fn test_parse_simple_accession_with_gene_selector() {
+        // Bare accession not matching the RefSeq XX_digits pattern should still
+        // accept an optional gene/transcript selector in parentheses.
+        let (remaining, acc) = parse_accession("MYSEQ(1):c.100A>G").unwrap();
+        assert_eq!(remaining, "(1):c.100A>G");
+        assert_eq!(&*acc.prefix, "MYSEQ");
+        assert_eq!(acc.version, None);
+    }
+
+    #[test]
+    fn test_parse_simple_accession_with_gene_selector_dashed() {
+        let (remaining, acc) = parse_accession("MY-SEQ(GENE1):c.100A>G").unwrap();
+        assert_eq!(remaining, "(GENE1):c.100A>G");
+        assert_eq!(&*acc.prefix, "MY-SEQ");
+    }
+
+    #[test]
+    fn test_parse_simple_accession_with_underscore_and_selector() {
+        // An accession with an underscore that does not match the strict RefSeq
+        // 2-letter prefix shape (e.g. MYREF_SEQ vs NM_…). Falls through to the
+        // simple-accession path and must still accept a selector.
+        let (remaining, acc) = parse_accession("MYREF_SEQ(1):c.100A>G").unwrap();
+        assert_eq!(remaining, "(1):c.100A>G");
+        assert_eq!(&*acc.prefix, "MYREF_SEQ");
+    }
+
+    #[test]
+    fn test_parse_hgvs_simple_accession_with_selector_end_to_end() {
+        // End-to-end via the public parser: a non-RefSeq accession with a gene
+        // selector should parse, retain the bare accession, and capture the
+        // selector as gene_symbol. (Display does not currently re-emit the
+        // selector for any accession kind, matching existing RefSeq behavior.)
+        use crate::hgvs::parser::parse_hgvs;
+        use crate::hgvs::variant::HgvsVariant;
+        let variant = parse_hgvs("MYREF_SEQ(1):c.100A>G").unwrap();
+        let cds = match variant {
+            HgvsVariant::Cds(v) => v,
+            other => panic!("expected CdsVariant, got {other:?}"),
+        };
+        assert_eq!(&*cds.accession.prefix, "MYREF_SEQ");
+        assert_eq!(cds.gene_symbol.as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn test_parse_hgvs_simple_accession_with_selector_protein() {
+        // Outer parens are the selector; the inner :p.(...) is the predicted form.
+        use crate::hgvs::parser::parse_hgvs;
+        use crate::hgvs::variant::HgvsVariant;
+        let variant = parse_hgvs("MYREF_SEQ(1):p.(Arg8Gln)").unwrap();
+        let prot = match variant {
+            HgvsVariant::Protein(v) => v,
+            other => panic!("expected ProteinVariant, got {other:?}"),
+        };
+        assert_eq!(&*prot.accession.prefix, "MYREF_SEQ");
+        assert_eq!(prot.gene_symbol.as_deref(), Some("1"));
     }
 }

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -46,18 +46,19 @@ class TestParsing:
         assert "dup" in str(variant)
 
     @pytest.mark.parametrize(
-        "hgvs",
+        ("hgvs", "selector"),
         [
-            "MYSEQ(1):c.100A>G",
-            "MY-SEQ(GENE1):c.100A>G",
-            "MYREF_SEQ(1):c.100A>G",
-            "MYREF_SEQ(1):p.(Arg8Gln)",
+            ("MYSEQ(1):c.100A>G", "1"),
+            ("MY-SEQ(GENE1):c.100A>G", "GENE1"),
+            ("MYREF_SEQ(1):c.100A>G", "1"),
+            ("MYREF_SEQ(1):p.(Arg8Gln)", "1"),
         ],
     )
-    def test_parse_accepts_gene_selector_on_non_refseq(self, hgvs: str) -> None:
-        # Issue #69: gene selectors must parse on any valid accession.
+    def test_parse_accepts_gene_selector_on_non_refseq(self, hgvs: str, selector: str) -> None:
+        # Issue #69: gene selectors must parse on any valid accession AND be
+        # captured on the variant — not silently dropped.
         variant = ferro_hgvs.parse(hgvs)
-        assert variant is not None
+        assert f'"gene_symbol":"{selector}"' in variant.to_json()
 
 
 class TestHgvsVariant:

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -45,6 +45,20 @@ class TestParsing:
         variant = ferro_hgvs.parse("NM_000088.3:c.100dup")
         assert "dup" in str(variant)
 
+    @pytest.mark.parametrize(
+        "hgvs",
+        [
+            "MYSEQ(1):c.100A>G",
+            "MY-SEQ(GENE1):c.100A>G",
+            "MYREF_SEQ(1):c.100A>G",
+            "MYREF_SEQ(1):p.(Arg8Gln)",
+        ],
+    )
+    def test_parse_accepts_gene_selector_on_non_refseq(self, hgvs: str) -> None:
+        # Issue #69: gene selectors must parse on any valid accession.
+        variant = ferro_hgvs.parse(hgvs)
+        assert variant is not None
+
 
 class TestHgvsVariant:
     """Tests for HgvsVariant class."""

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -1,5 +1,7 @@
 """Tests for core ferro-hgvs functionality."""
 
+import json
+
 import pytest
 
 import ferro_hgvs
@@ -58,7 +60,9 @@ class TestParsing:
         # Issue #69: gene selectors must parse on any valid accession AND be
         # captured on the variant — not silently dropped.
         variant = ferro_hgvs.parse(hgvs)
-        assert f'"gene_symbol":"{selector}"' in variant.to_json()
+        # to_json() wraps the variant body under its discriminator key (e.g. "Cds").
+        body = next(iter(json.loads(variant.to_json()).values()))
+        assert body["gene_symbol"] == selector
 
 
 class TestHgvsVariant:


### PR DESCRIPTION
Fixes #69

`parse()` raised `ValueError` on inputs like `MYREF_SEQ(1):c.100A>G` — any
gene/transcript selector after a non-RefSeq-shaped accession. The simple-
accession fallback in `parse_simple_accession` consumed everything up to the
type-prefix colon as the accession name, then rejected it because `(`/`)` are
not valid SAM refname characters.

Per the [HGVS nomenclature](https://hgvs-nomenclature.org/stable/background/refseq/#DNAg),
the selector is optional metadata and should not constrain the accession
format, so tools like mutalyzer that emit selectors on custom accessions
(`CUSTOM_ACC(1):c.100A>G`) now round-trip.

The fix terminates the simple accession at the first `(` before the colon.
SAM refnames cannot contain `(`, so it cleanly marks the boundary;
`parse_gene_symbol` (already invoked immediately after `parse_accession`) then
consumes the selector exactly as it does for RefSeq accessions today.

**Existing accession paths are unaffected.** RefSeq (`NM_…`), Ensembl, LRG,
UniProt, assembly (`GRCh38(chr1)`), and compound-ref (`NC_…(NM_…)`) parsing
all dispatch before the simple-accession fallback. Inputs without a `(` in
the accession portion hit the same code path as before.

## Test plan

- New unit tests in `accession.rs` cover `MYSEQ(1)`, `MY-SEQ(GENE1)`,
  `MYREF_SEQ(1)`, and the protein-form `MYREF_SEQ(1):p.(Arg8Gln)`; selector
  is captured into `gene_symbol`.
- New parametrized Python test mirrors the four issue repro cases.
- Full Rust parser suite (225 tests) and full Python suite (112 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)