### PR TITLE
fix: Emit single-variant alleles in bare spec form

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -461,6 +461,12 @@ fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt:
 
 impl fmt::Display for AlleleVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Per HGVS spec, `[var]` denotes a multi-variant allele; a singleton
+        // is just the inner variant. (Mosaic/chimeric already emit bare via
+        // their separator-only loops; this unifies cis/trans/unknown.)
+        if self.variants.len() == 1 {
+            return self.variants[0].fmt(f);
+        }
         match self.phase {
             AllelePhase::Cis => {
                 if use_compact_form(&self.variants) {
@@ -1263,29 +1269,33 @@ mod tests {
     }
 
     #[test]
-    fn test_allele_unknown_phase_singleton_keeps_wrapper() {
+    fn test_allele_singleton_emits_bare_form() {
         use crate::hgvs::location::CdsPos;
 
-        // A singleton unknown-phase allele must keep the bracketed wrapper;
-        // the compact form `ACC:c.edit` would be indistinguishable from a
-        // bare variant and would not round-trip.
-        let var = HgvsVariant::Cds(CdsVariant {
-            accession: Accession::new("NM", "000088", Some(3)),
-            gene_symbol: None,
-            loc_edit: LocEdit::new(
-                CdsInterval::point(CdsPos::new(100)),
-                NaEdit::Substitution {
-                    reference: Base::A,
-                    alternative: Base::G,
-                },
-            ),
-        });
+        let make_var = || {
+            HgvsVariant::Cds(CdsVariant {
+                accession: Accession::new("NM", "000088", Some(3)),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(100)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::G,
+                    },
+                ),
+            })
+        };
+        let bare = "NM_000088.3:c.100A>G";
 
-        let allele = AlleleVariant::unknown_phase(vec![var]);
-        assert_eq!(
-            format!("{}", HgvsVariant::Allele(allele)),
-            "[NM_000088.3:c.100A>G]"
-        );
+        for allele in [
+            AlleleVariant::cis(vec![make_var()]),
+            AlleleVariant::trans(vec![make_var()]),
+            AlleleVariant::unknown_phase(vec![make_var()]),
+            AlleleVariant::mosaic(vec![make_var()]),
+            AlleleVariant::chimeric(vec![make_var()]),
+        ] {
+            assert_eq!(format!("{}", HgvsVariant::Allele(allele)), bare);
+        }
     }
 
     #[test]
@@ -1364,11 +1374,12 @@ mod tests {
     }
 
     #[test]
-    fn test_allele_null_variant_uses_expanded_form() {
-        // A single NullAllele has no accession — must not panic, must use expanded form
+    fn test_allele_null_variant_singleton_delegates() {
+        // NullAllele has no accession; the singleton path must not invoke
+        // `use_compact_form` (which would deref the missing accession).
         let null = HgvsVariant::NullAllele;
         let cis = AlleleVariant::cis(vec![null]);
-        assert_eq!(format!("{}", HgvsVariant::Allele(cis)), "[0]");
+        assert_eq!(format!("{}", HgvsVariant::Allele(cis)), "0");
     }
 
     #[test]

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -298,6 +298,9 @@ fn test_verified_roundtrip(#[case] input: &str) {
 #[case("NM_000350.2:c.[1622T>C;3113C>T]", "NM_000350.2:c.[1622T>C;3113C>T]")]
 #[case("NM_000350.3:c.[1531C>T;872C>T]", "NM_000350.3:c.[1531C>T;872C>T]")]
 #[case("NM_005157.6:c.[1516G>A;1531G>C]", "NM_005157.6:c.[1516G>A;1531G>C]")]
+// Singleton allele unwraps to bare form (HGVS spec: `[var]` denotes multi-variant)
+#[case("NM_000088.3:c.[10A>G]", "NM_000088.3:c.10A>G")]
+#[case("NC_000001.11:g.[100A>G]", "NC_000001.11:g.100A>G")]
 // Missing ref base substitution (ferro preserves as-is)
 #[case("NG_008029.2:g.5049>A", "NG_008029.2:g.5049>A")]
 #[case("NM_002055.4:c.1086>C", "NM_002055.4:c.1086>C")]


### PR DESCRIPTION
## Summary

Fixes #74

Per HGVS spec, `[var]` denotes an allele containing multiple variants. A
single-variant allele is just a regular variant. Before: `NM_000088.3:c.[10A>G]`
round-tripped to itself; after, it normalizes to the spec form
`NM_000088.3:c.10A>G`.

`AlleleVariant::Display` now delegates to the inner variant's `Display` when
`variants.len() == 1`. Mosaic/chimeric were already correct via their
separator-only loops; this unifies cis/trans/unknown to the same behavior.
Also covers the post-merge case where a consecutive-edit pass collapses an
allele to a single variant.

**Multi-variant alleles are unaffected** — the early-return only triggers on
exact length 1; all compact/expanded behavior introduced in #48 is preserved.

| Input | Before | After |
|---|---|---|
| `c.[10A>G]` | `c.[10A>G]` | `c.10A>G` |
| `c.[10A>G;20T>C]` | `c.[10A>G;20T>C]` | unchanged |
| `c.[10A>G];[20T>C]` | `c.[10A>G];[20T>C]` | unchanged |

Note: Python `__eq__`/`__hash__` (string-based) now treat
`parse("c.[10A>G]")` and `parse("c.10A>G")` as equal — they denote the same
variant.

## Test plan

- New `test_allele_singleton_emits_bare_form` exercises all five phases
  (cis, trans, unknown, mosaic, chimeric) emit the bare form.
- `test_allele_null_variant_singleton_delegates` retains the no-panic
  guarantee for accessionless singletons.
- Two parse→format rows added to `test_mismatch_parses` lock the spec-
  compliant output at the integration boundary.
- Full Rust + Python suite green; multi-variant Display behavior unchanged.