### PR TITLE
fix: rewrite single-base delins as substitution per HGVS priority

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1406,14 +1406,31 @@ impl<P: ReferenceProvider> Normalizer<P> {
             NaEdit::Delins { sequence } => {
                 use crate::hgvs::edit::InsertedSequence;
 
-                // HGVS spec: delins should NOT be 3' shifted like del/dup/ins
-                // But we should check if delins should become a duplication first
-                // Example: c.5delinsGG where position 5 is G → dup
+                // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
+                // but the edit-type priority (sub > del > inv > dup > ins) means
+                // we may need to rewrite it as a higher-priority form.
                 if let InsertedSequence::Literal(seq) = sequence {
                     let seq_bytes: Vec<u8> = seq.bases().iter().map(|b| *b as u8).collect();
                     let start_idx = hgvs_pos_to_index(start);
                     let end_idx = end as usize;
 
+                    // Single-base delins with a different alt base is a substitution
+                    // (e.g., g.1000delinsA where ref[1000]=G → g.1000G>A).
+                    if let Some((reference, alternative)) =
+                        rules::delins_is_substitution(ref_seq, start_idx, end_idx, &seq_bytes)
+                    {
+                        return Ok((
+                            start,
+                            start,
+                            NaEdit::Substitution {
+                                reference,
+                                alternative,
+                            },
+                            warnings.clone(),
+                        ));
+                    }
+
+                    // Example: c.5delinsGG where position 5 is G → dup
                     if rules::delins_is_duplication(ref_seq, start_idx, end_idx, &seq_bytes) {
                         // Convert to duplication with minimal notation
                         return Ok((
@@ -2058,6 +2075,53 @@ mod tests {
         assert!(
             output.contains("delinsAT"),
             "Delins should remain unchanged, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_normalize_single_base_delins_becomes_substitution() {
+        // HGVS edit-type priority: a 1→1 delins must be expressed as a substitution.
+        // Transcript NM_000088.3 starts ATGCCCAAGG...; position 10 is G.
+        // c.10delinsT replaces G with T → c.10G>T.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10delinsT").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10G>T");
+    }
+
+    #[test]
+    fn test_normalize_single_base_delins_same_base_unchanged() {
+        // c.10delinsG with ref=G is not a substitution (no change at the base).
+        // The conversion to substitution should not fire; delins is preserved.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10delinsG").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10delinsG");
+    }
+
+    #[test]
+    fn test_normalize_multi_base_delete_delins_unchanged() {
+        // 2→1 delins is not a single-base substitution and must not be rewritten.
+        // c.10_11delinsT (deletes GG, inserts T) stays as delins.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10_11delinsT").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        let output = format!("{}", result);
+        assert!(
+            output.contains("delinsT"),
+            "Multi-base delete delins should remain delins, got: {}",
+            output
+        );
+        assert!(
+            !output.contains(">"),
+            "Multi-base delete delins must not become a substitution, got: {}",
             output
         );
     }

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -281,6 +281,39 @@ pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(us
     Some((s, e))
 }
 
+/// Check if a delins should be represented as a substitution
+///
+/// Per the HGVS edit-type priority (substitution > deletion > inversion >
+/// duplication > insertion), a delins that replaces a single base with a
+/// *different* single base must be expressed as a substitution.
+///
+/// Example: g.1000delinsA where ref[1000] is G → g.1000G>A
+///
+/// Returns `None` for the same-base case (e.g. `g.1000delinsG` where ref=G),
+/// which is identity rather than substitution; that rewrite is tracked by a
+/// separate normalization rule.
+pub fn delins_is_substitution(
+    ref_seq: &[u8],
+    start: usize,
+    end: usize,
+    inserted_seq: &[u8],
+) -> Option<(crate::hgvs::edit::Base, crate::hgvs::edit::Base)> {
+    use crate::hgvs::edit::Base;
+
+    if end != start + 1 || end > ref_seq.len() || inserted_seq.len() != 1 {
+        return None;
+    }
+    let ref_byte = ref_seq[start];
+    let alt_byte = inserted_seq[0];
+    if ref_byte == alt_byte {
+        return None;
+    }
+    Some((
+        Base::from_char(ref_byte as char)?,
+        Base::from_char(alt_byte as char)?,
+    ))
+}
+
 /// Check if a delins should be represented as a duplication
 ///
 /// In HGVS, if a delins deletes N bases and inserts 2N bases where the
@@ -715,6 +748,34 @@ mod tests {
             get_canonical_form(&del_edit, ref_seq, 3, 6),
             CanonicalForm::Deletion
         );
+    }
+
+    #[test]
+    fn test_delins_is_substitution() {
+        use crate::hgvs::edit::Base;
+
+        let ref_seq = b"ACGTACGT";
+        // ref[3] = T, insert A → T>A
+        assert_eq!(
+            delins_is_substitution(ref_seq, 3, 4, b"A"),
+            Some((Base::T, Base::A))
+        );
+
+        // Single-base delins where ref == alt → not a substitution
+        // (would be identity, handled separately)
+        assert_eq!(delins_is_substitution(ref_seq, 3, 4, b"T"), None);
+
+        // Multi-base delete → not a single-base substitution
+        assert_eq!(delins_is_substitution(ref_seq, 3, 5, b"A"), None);
+
+        // Single-base delete with multi-base insert → not a substitution
+        assert_eq!(delins_is_substitution(ref_seq, 3, 4, b"AT"), None);
+
+        // Bounds: end past reference → None (no panic)
+        assert_eq!(delins_is_substitution(ref_seq, 8, 9, b"A"), None);
+
+        // Empty insert → None
+        assert_eq!(delins_is_substitution(ref_seq, 3, 4, b""), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #73

The HGVS spec defines an edit-type priority — substitution > deletion > inversion > duplication > insertion — and a 1→1 delins must be expressed as a substitution. `normalize()` previously preserved the delins form, so `g.1000delinsA` (ref=G) round-tripped instead of producing `g.1000G>A`.

`normalize_na_edit` now checks for the substitution case in the `Delins` arm before the existing duplication check, and emits `NaEdit::Substitution` at the original single-position interval.

**Only the 1→1, ref≠alt case is converted.** Other delins shapes are unchanged:

| Input (ref shown in `[]`) | Before | After |
|---|---|---|
| `c.10delinsT` (ref=`[G]`) | `c.10delinsT` | `c.10G>T` |
| `c.10delinsG` (ref=`[G]`) | unchanged | unchanged (#75) |
| `c.10delinsAT` (ref=`[G]`) | unchanged | unchanged |
| `c.10_11delinsA` (ref=`[GT]`) | unchanged | unchanged |
| `c.5delinsGG` (ref=`[G]`, dup pattern) | `c.5dup` | unchanged |

The same-base identity case (`c.10delinsG` → `c.10=`) is tracked separately in #75.

## Test plan

- New unit test for `delins_is_substitution` covers the substitution case, same-base, multi-base delete, multi-base insert, empty insert, and out-of-bounds.
- New integration tests verify `c.10delinsT` → `c.10G>T`, `c.10delinsG` round-trips as delins, and `c.10_11delinsT` (2→1) is preserved as delins.
- Full `normalize` suite (129 tests) and clippy/fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)