### PR TITLE
fix: rewrite delins as identity when insert matches reference

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1408,14 +1408,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
                 // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
                 // but the edit-type priority (sub > del > inv > dup > ins) means
-                // we may need to rewrite it as a higher-priority form.
+                // we may need to rewrite it as a higher-priority form: identity
+                // (insert == ref), substitution (1->1 ref!=alt), or duplication.
                 if let InsertedSequence::Literal(seq) = sequence {
                     let seq_bytes: Vec<u8> = seq.bases().iter().map(|b| *b as u8).collect();
                     let start_idx = hgvs_pos_to_index(start);
                     let end_idx = end as usize;
 
-                    // Single-base delins with a different alt base is a substitution
-                    // (e.g., g.1000delinsA where ref[1000]=G → g.1000G>A).
+                    // Identity (highest priority): insert == deleted reference.
+                    // Example: c.10delinsG where ref[10]=G → c.10=.
+                    if rules::delins_is_identity(ref_seq, start_idx, end_idx, &seq_bytes) {
+                        return Ok((start, end, NaEdit::position_identity(), warnings.clone()));
+                    }
+
+                    // Substitution: 1-base delins with a different alt base.
+                    // Example: g.1000delinsA where ref[1000]=G → g.1000G>A.
                     if let Some((reference, alternative)) =
                         rules::delins_is_substitution(ref_seq, start_idx, end_idx, &seq_bytes)
                     {
@@ -1430,7 +1437,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         ));
                     }
 
-                    // Example: c.5delinsGG where position 5 is G → dup
+                    // Duplication: c.5delinsGG where position 5 is G → dup.
                     if rules::delins_is_duplication(ref_seq, start_idx, end_idx, &seq_bytes) {
                         // Convert to duplication with minimal notation
                         return Ok((
@@ -2081,9 +2088,9 @@ mod tests {
 
     #[test]
     fn test_normalize_single_base_delins_becomes_substitution() {
-        // HGVS edit-type priority: a 1→1 delins must be expressed as a substitution.
-        // Transcript NM_000088.3 starts ATGCCCAAGG...; position 10 is G.
-        // c.10delinsT replaces G with T → c.10G>T.
+        // HGVS edit-type priority: a 1→1 delins with ref!=alt must be expressed
+        // as a substitution. Transcript NM_000088.3 starts ATGCCCAAGG...; position
+        // 10 is G. c.10delinsT replaces G with T → c.10G>T.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
@@ -2093,15 +2100,28 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_single_base_delins_same_base_unchanged() {
-        // c.10delinsG with ref=G is not a substitution (no change at the base).
-        // The conversion to substitution should not fire; delins is preserved.
+    fn test_normalize_single_base_delins_same_base_becomes_identity() {
+        // Per HGVS, a delins whose insert equals the reference is identity (=).
+        // Transcript NM_000088.3 starts ATGCCCAAGG...; position 10 is G.
+        // c.10delinsG produces no change → c.10=.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
         let variant = parse_hgvs("NM_000088.3:c.10delinsG").unwrap();
         let result = normalizer.normalize(&variant).unwrap();
-        assert_eq!(format!("{}", result), "NM_000088.3:c.10delinsG");
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10=");
+    }
+
+    #[test]
+    fn test_normalize_multi_base_delins_same_seq_becomes_identity() {
+        // Transcript NM_000088.3 starts ATG at positions 1-3.
+        // c.1_3delinsATG produces no change → c.1_3=.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.1_3delinsATG").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.1_3=");
     }
 
     #[test]
@@ -2124,6 +2144,42 @@ mod tests {
             "Multi-base delete delins must not become a substitution, got: {}",
             output
         );
+    }
+
+    #[test]
+    fn test_normalize_delins_to_dup_still_works() {
+        // Regression guard: adding identity/substitution checks before the dup
+        // check must not block legitimate dup conversions. ref[5] = C;
+        // c.5delinsCC matches the dup pattern (insert == deleted twice) and
+        // must still normalize to dup.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.5delinsCC").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        let output = format!("{}", result);
+        assert!(
+            output.contains("dup"),
+            "delins matching dup pattern should normalize to dup, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("delins"),
+            "delins should not survive the dup conversion, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_normalize_delins_different_bases_unchanged() {
+        // c.1_3delinsACG (ref=ATG) differs at the middle base — not identity,
+        // not a dup pattern, so it stays as delins.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.1_3delinsACG").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.1_3delinsACG");
     }
 
     #[test]

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -281,6 +281,26 @@ pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(us
     Some((s, e))
 }
 
+/// Check if a delins should be represented as identity
+///
+/// Per the HGVS spec, a delins whose inserted sequence equals the deleted
+/// reference produces no change and must be expressed using identity
+/// notation (`=`). The rule applies for any matching length.
+///
+/// Examples:
+/// - g.1000delinsG where ref[1000] = G → g.1000=
+/// - g.1000_1002delinsGCA where ref[1000..1002] = GCA → g.1000_1002=
+pub fn delins_is_identity(ref_seq: &[u8], start: usize, end: usize, inserted_seq: &[u8]) -> bool {
+    if start >= end || end > ref_seq.len() {
+        return false;
+    }
+    let deleted_len = end - start;
+    if inserted_seq.len() != deleted_len {
+        return false;
+    }
+    &ref_seq[start..end] == inserted_seq
+}
+
 /// Check if a delins should be represented as a substitution
 ///
 /// Per the HGVS edit-type priority (substitution > deletion > inversion >
@@ -290,8 +310,8 @@ pub fn shorten_inversion(ref_seq: &[u8], start: usize, end: usize) -> Option<(us
 /// Example: g.1000delinsA where ref[1000] is G → g.1000G>A
 ///
 /// Returns `None` for the same-base case (e.g. `g.1000delinsG` where ref=G),
-/// which is identity rather than substitution; that rewrite is tracked by a
-/// separate normalization rule.
+/// which is identity rather than substitution; that rewrite is handled by
+/// `delins_is_identity`.
 pub fn delins_is_substitution(
     ref_seq: &[u8],
     start: usize,
@@ -748,6 +768,41 @@ mod tests {
             get_canonical_form(&del_edit, ref_seq, 3, 6),
             CanonicalForm::Deletion
         );
+    }
+
+    #[test]
+    fn test_delins_is_identity() {
+        let ref_seq = b"ACGTACGT";
+
+        // Single-base same → identity
+        assert!(delins_is_identity(ref_seq, 3, 4, b"T"));
+
+        // Multi-base same → identity
+        assert!(delins_is_identity(ref_seq, 1, 4, b"CGT"));
+
+        // Whole region, full match → identity
+        assert!(delins_is_identity(ref_seq, 0, 8, b"ACGTACGT"));
+
+        // Single-base differ → not identity
+        assert!(!delins_is_identity(ref_seq, 3, 4, b"A"));
+
+        // Multi-base differ at one position → not identity
+        assert!(!delins_is_identity(ref_seq, 1, 4, b"CGA"));
+
+        // Length mismatch (1→2) → not identity
+        assert!(!delins_is_identity(ref_seq, 3, 4, b"TT"));
+
+        // Length mismatch (2→1) → not identity
+        assert!(!delins_is_identity(ref_seq, 1, 3, b"C"));
+
+        // Empty insert → not identity
+        assert!(!delins_is_identity(ref_seq, 3, 4, b""));
+
+        // OOB end → false (no panic)
+        assert!(!delins_is_identity(ref_seq, 7, 9, b"TT"));
+
+        // Inverted range → false
+        assert!(!delins_is_identity(ref_seq, 5, 3, b"CG"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #75

Per the HGVS spec, a delins whose inserted sequence equals the deleted reference produces no change and must be expressed using identity notation (`=`). `normalize()` previously preserved the delins form, so `g.1000delinsG` (ref=G) round-tripped instead of producing `g.1000=`. The rule applies for any matching length, not just single bases.

`normalize_na_edit` now checks for the identity case in the `Delins` arm before the existing duplication check, and emits `NaEdit::position_identity()` preserving the original interval.

**Only the insert==ref case is converted.** Other delins shapes are unchanged:

| Input (ref shown in `[]`) | Before | After |
|---|---|---|
| `c.10delinsG` (ref=`[G]`) | `c.10delinsG` | `c.10=` |
| `c.1_3delinsATG` (ref=`[ATG]`) | `c.1_3delinsATG` | `c.1_3=` |
| `c.1_3delinsACG` (ref=`[ATG]`) | unchanged | unchanged |
| `c.10delinsAT` (ref=`[G]`) | unchanged | unchanged |
| `c.5delinsCC` (ref=`[C]`, dup pattern) | `c.5dup`-equivalent | `c.5dup`-equivalent |

Companion to #73 (substitution priority for the 1→1 ref≠alt case). The two PRs touch the same arm; merge order doesn't affect logic since the rules are length-disjoint, but the second to merge will need a one-line rebase to slot its check in.

## Test plan

- New unit test for `delins_is_identity` covers single-base same, multi-base same, full-region match, single/multi-base differ, both length mismatches, empty insert, OOB, and inverted range.
- New integration tests verify `c.10delinsG` → `c.10=`, `c.1_3delinsATG` → `c.1_3=`, `c.1_3delinsACG` (different bases) preserved as delins, and `c.5delinsCC` (dup pattern) still normalizes to dup.
- Full `normalize` suite (130 tests) and clippy/fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)