### PR TITLE
feat(normalize): merge consecutive edits in cis alleles per HGVS spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(normalize)* Merge consecutive sub-variants in cis alleles into a single delins per HGVS spec. `g.[1000G>A;1001A>C]` now normalizes to `g.1000_1001delinsAC`; `g.[1000del;1001del]` to `g.1000_1001del`. Covers `g./c./n./r./m.` coordinate systems, sub/del/delins/ins edit combinations, chains, and same-boundary insertion pairs. Non-adjacent variants, intronic/UTR boundaries, uncertain edits, and non-`Literal` insertion payloads are barriers and pass through unchanged. The codon-frame exception (one-nt gap within a codon) is tracked separately in [#79](https://github.com/fulcrumgenomics/ferro-hgvs/issues/79). ([#80](https://github.com/fulcrumgenomics/ferro-hgvs/pull/80))
+
 ## [0.4.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.3.0...v0.4.0) - 2026-04-30
 
 ### Added

--- a/docs/superpowers/plans/2026-04-30-merge-consecutive-allele-edits.md
+++ b/docs/superpowers/plans/2026-04-30-merge-consecutive-allele-edits.md
@@ -1,0 +1,1422 @@
+# Merge consecutive allele edits — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After per-variant normalization in `normalize_allele`, merge sub-variants whose edits describe consecutive nucleotides into a single delins/del/ins per HGVS spec — bringing allele output into spec compliance for the strictly-consecutive case.
+
+**Architecture:** A new module `src/normalize/merge.rs` exposes `merge_consecutive_edits`, called from `normalize_allele` after `resolve_overlaps`. Each sub-variant is reduced to an `(start, end, alt)` *anchor*; pairs are merged when `A.end + 1 == B.start`. The merge result becomes a `Deletion`, `Insertion`, or `Delins` depending on which inputs contributed alt content. Phase scope (Cis only), variant types (g/c/n/r/m), edit-type allowlist, and exclusions (non-`Literal` `InsertedSequence`, intronic, UTR-boundary crossing, `Mu::Uncertain`, etc.) follow the spec doc.
+
+**Tech Stack:** Rust 2021, `cargo nextest` for tests, existing `parse_hgvs` / `Normalizer` / `MockProvider` test infrastructure.
+
+**Spec doc:** `docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md`
+
+**Issue:** [#72](https://github.com/fulcrumgenomics/ferro-hgvs/issues/72) (Phase 2 codon-frame exception tracked separately as #79)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/normalize/merge.rs` | Create | Anchor model, adjacency check, merge logic. Pure transformation — no reference-provider access. |
+| `src/normalize/mod.rs` | Modify | `pub mod merge;` declaration; call `merge::merge_consecutive_edits` at the end of `normalize_allele`. |
+| `tests/merge_consecutive_edits_tests.rs` | Create | Integration tests using `parse_hgvs → normalize → display` round-trip. |
+
+The new module is internal (`pub(crate)`); no public-API change.
+
+---
+
+## Conventions for all tasks
+
+- **Tests use `parse → normalize → display` round-trip** unless otherwise noted. Genomic (`g.`) tests use `MockProvider::new()` (no transcripts needed); CDS / RNA tests use `provider_with_transcript` patterns from the existing test suite.
+- **Run tests with:** `cargo nextest run --features dev -E 'test(merge_consecutive)'` (filters to the new module).
+- **Pre-commit hooks** run `cargo fmt`, `cargo clippy --features dev -- -D warnings`, and the test suite. If a hook fails, fix the issue and create a NEW commit (per the repo's commit safety protocol).
+- **Commit messages** follow the repo style: `feat:`, `fix:`, `test:`, `docs:`. Include a `Co-Authored-By:` trailer matching recent commits.
+
+---
+
+## Task 1: Module scaffold + sub+sub merging
+
+**Files:**
+- Create: `src/normalize/merge.rs`
+- Modify: `src/normalize/mod.rs:26-30` (add `pub mod merge;`) and `src/normalize/mod.rs:200-231` (call merge at end of `normalize_allele`)
+- Create: `tests/merge_consecutive_edits_tests.rs`
+
+### Step 1: Write the first failing test
+
+Create `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+//! Tests for HGVS-spec consecutive-edit merging in alleles.
+//! See docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn test_merge_consecutive_subs_genome() {
+    // Issue #72 example: two adjacent SNVs collapse to a single delins.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C]"),
+        "NC_000001.11:g.1000_1001delinsAC",
+    );
+}
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: FAIL with the assertion showing `NC_000001.11:g.[1000G>A;1001A>C]` (the unchanged input) on the left.
+
+- [ ] **Step 3: Create the merge module**
+
+Create `src/normalize/merge.rs`:
+
+```rust
+//! Merge consecutive sub-variants in a cis allele into a single edit per HGVS spec.
+//!
+//! See `docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md`.
+
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
+use crate::hgvs::interval::{Interval, UncertainBoundary};
+use crate::hgvs::location::GenomePos;
+use crate::hgvs::uncertainty::Mu;
+use crate::hgvs::variant::{
+    Accession, AllelePhase, GenomeVariant, HgvsVariant, LocEdit,
+};
+
+/// Anchor for a single sub-variant.
+///
+/// `start` and `end` are 1-based inclusive position bounds. For an `Insertion`
+/// between positions `p` and `p+1`, `start = p+1` and `end = p` (empty range
+/// at a boundary).
+#[derive(Debug, Clone)]
+struct Anchor {
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+}
+
+/// Merge consecutive sub-variants in an allele.
+///
+/// Returns the input unchanged unless `phase == Cis` and at least one merge
+/// is possible. Sub-variants that aren't merge-eligible (different accession,
+/// non-NaEdit, uncertain edit, disqualifying position, etc.) act as merge
+/// barriers — they pass through unchanged in their original input order.
+pub(crate) fn merge_consecutive_edits(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+) -> Vec<HgvsVariant> {
+    if phase != AllelePhase::Cis || variants.len() < 2 {
+        return variants.to_vec();
+    }
+
+    let mut output: Vec<HgvsVariant> = Vec::with_capacity(variants.len());
+    for next in variants {
+        if let Some(prev) = output.last() {
+            if let Some(merged) = try_merge_pair(prev, next) {
+                let last = output.last_mut().unwrap();
+                *last = merged;
+                continue;
+            }
+        }
+        output.push(next.clone());
+    }
+    output
+}
+
+fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
+    // Phase 1: only Genome-Genome same-accession sub+sub merging.
+    let (av, bv) = match (a, b) {
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => (av, bv),
+        _ => return None,
+    };
+    if av.accession != bv.accession {
+        return None;
+    }
+    let a_anchor = genome_anchor(av)?;
+    let b_anchor = genome_anchor(bv)?;
+    if a_anchor.end + 1 != b_anchor.start {
+        return None;
+    }
+    let mut alt = a_anchor.alt;
+    alt.extend(b_anchor.alt);
+    Some(HgvsVariant::Genome(build_genome_delins(
+        av,
+        a_anchor.start,
+        b_anchor.end,
+        alt,
+    )))
+}
+
+fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
+    let edit = v.loc_edit.edit.inner()?; // Mu::Certain only
+    let (start, end) = simple_genome_range(&v.loc_edit.location)?;
+    match edit {
+        NaEdit::Substitution { alternative, .. } => Some(Anchor {
+            start,
+            end,
+            alt: vec![*alternative],
+        }),
+        _ => None,
+    }
+}
+
+fn simple_genome_range(interval: &Interval<GenomePos>) -> Option<(u64, u64)> {
+    let start = simple_genome_pos(&interval.start)?;
+    let end = simple_genome_pos(&interval.end)?;
+    Some((start, end))
+}
+
+fn simple_genome_pos(boundary: &UncertainBoundary<GenomePos>) -> Option<u64> {
+    let mu = boundary.as_single()?;
+    let pos = match mu {
+        Mu::Certain(p) => p,
+        _ => return None,
+    };
+    if pos.is_special() || pos.offset.is_some() {
+        return None;
+    }
+    Some(pos.base)
+}
+
+fn build_genome_delins(
+    template: &GenomeVariant,
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+) -> GenomeVariant {
+    let location = Interval::new(GenomePos::new(start), GenomePos::new(end));
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::new(alt)),
+    };
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(merge_consecutive_edits(&[], AllelePhase::Cis).is_empty());
+    }
+
+    #[test]
+    fn single_input_passes_through() {
+        // Single-variant alleles are not Phase-1 mergeable.
+        let acc = Accession::new("NC", "000001", Some(11));
+        let v = HgvsVariant::Genome(GenomeVariant {
+            accession: acc,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                Interval::new(GenomePos::new(100), GenomePos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::G,
+                    alternative: Base::A,
+                },
+            ),
+        });
+        let out = merge_consecutive_edits(std::slice::from_ref(&v), AllelePhase::Cis);
+        assert_eq!(out.len(), 1);
+    }
+}
+```
+
+- [ ] **Step 4: Wire merge into `normalize_allele`**
+
+Edit `src/normalize/mod.rs`. Add `pub mod merge;` at the end of the existing `pub mod` block (after line 30). Then update `normalize_allele` (around line 219-231) so the final return passes the merged variants:
+
+Replace this block in `src/normalize/mod.rs:219-230`:
+
+```rust
+        // Second pass: check for overlaps and resolve
+        if self.config.prevent_overlap {
+            normalized = self.resolve_overlaps(normalized)?;
+        }
+
+        Ok((
+            HgvsVariant::Allele(crate::hgvs::variant::AlleleVariant::new(
+                normalized,
+                allele.phase,
+            )),
+            all_warnings,
+        ))
+```
+
+with:
+
+```rust
+        // Second pass: check for overlaps and resolve
+        if self.config.prevent_overlap {
+            normalized = self.resolve_overlaps(normalized)?;
+        }
+
+        // Third pass: merge consecutive edits per HGVS spec (issue #72)
+        let merged = merge::merge_consecutive_edits(&normalized, allele.phase);
+
+        Ok((
+            HgvsVariant::Allele(crate::hgvs::variant::AlleleVariant::new(
+                merged,
+                allele.phase,
+            )),
+            all_warnings,
+        ))
+```
+
+- [ ] **Step 5: Verify the test now passes**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: PASS for `test_merge_consecutive_subs_genome`.
+
+Also run the unit tests in the new module: `cargo nextest run --features dev -E 'test(merge::tests)'` — both `empty_input_returns_empty` and `single_input_passes_through` should PASS.
+
+- [ ] **Step 6: Run the full normalize test file to confirm no regressions**
+
+Run: `cargo nextest run --features dev -E 'test(normalize)'`
+
+Expected: all existing tests still PASS. In particular `test_allele_each_variant_normalized`, `test_allele_with_two_deletions_both_shift`, `test_allele_preserves_semicolon_separator`, `test_allele_with_dup_and_sub`, `test_compact_allele_notation`, `test_normalize_allele_normalizes_each_variant` should all still pass — they use inputs the merge pass should leave alone (different positions or non-mergeable edit combinations).
+
+If any pre-existing allele test fails because the merge pass changed its output, investigate whether the test's input is actually a case the spec says should merge. If yes, update the test's expected output. If no, the merge logic has a bug — fix it before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/normalize/merge.rs src/normalize/mod.rs tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+feat(normalize): merge consecutive substitutions in cis alleles (#72)
+
+Adds src/normalize/merge.rs and wires it into normalize_allele after
+resolve_overlaps. Currently handles the simplest case from the spec:
+two adjacent g. substitutions in a cis allele collapse to a single
+delins (e.g. g.[1000G>A;1001A>C] -> g.1000_1001delinsAC).
+
+Subsequent commits extend coverage to deletions, delins, insertions,
+all NaEdit-based variant types, and round-trip preservation of the
+non-mergeable cases.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `Deletion` support (incl. issue example for del+del)
+
+**Files:**
+- Modify: `src/normalize/merge.rs` (extend `genome_anchor` and `try_merge_pair`)
+- Modify: `tests/merge_consecutive_edits_tests.rs`
+
+- [ ] **Step 1: Write failing tests for `del` cases**
+
+Append to `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+#[test]
+fn test_merge_consecutive_dels_genome() {
+    // Issue #72 example: two adjacent single-nt deletions become a single ranged del.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000del;1001del]"),
+        "NC_000001.11:g.1000_1001del",
+    );
+}
+
+#[test]
+fn test_merge_sub_then_del() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001del]"),
+        "NC_000001.11:g.1000_1001delinsA",
+    );
+}
+
+#[test]
+fn test_merge_del_then_sub() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000del;1001A>C]"),
+        "NC_000001.11:g.1000_1001delinsC",
+    );
+}
+
+#[test]
+fn test_merge_dels_drops_explicit_sequence() {
+    // Per design doc: del+del with explicit ref sequences emits the no-sequence form.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000delA;1001delC]"),
+        "NC_000001.11:g.1000_1001del",
+    );
+}
+
+#[test]
+fn test_merge_dels_drops_length() {
+    // Per design doc: del+del with length specifiers emits no-sequence/no-length form.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1002del3;1003_1004del2]"),
+        "NC_000001.11:g.1000_1004del",
+    );
+}
+```
+
+- [ ] **Step 2: Verify the new tests fail**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: the four new tests FAIL (anchor extraction returns `None` for `Deletion`, so no merge happens). The Task-1 sub+sub test should still PASS.
+
+- [ ] **Step 3: Extend anchor extraction to handle `Deletion`**
+
+In `src/normalize/merge.rs`, replace the `genome_anchor` function with:
+
+```rust
+fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
+    let edit = v.loc_edit.edit.inner()?; // Mu::Certain only
+    let (start, end) = simple_genome_range(&v.loc_edit.location)?;
+    match edit {
+        NaEdit::Substitution { alternative, .. } => Some(Anchor {
+            start,
+            end,
+            alt: vec![*alternative],
+        }),
+        NaEdit::SubstitutionNoRef { alternative } => Some(Anchor {
+            start,
+            end,
+            alt: vec![*alternative],
+        }),
+        NaEdit::Deletion { .. } => Some(Anchor {
+            start,
+            end,
+            alt: Vec::new(),
+        }),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Generalize the merge result to choose `Deletion` vs `Delins`**
+
+Replace `build_genome_delins` and update `try_merge_pair` to use a new shared builder. In `src/normalize/merge.rs`:
+
+```rust
+fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
+    let (av, bv) = match (a, b) {
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => (av, bv),
+        _ => return None,
+    };
+    if av.accession != bv.accession {
+        return None;
+    }
+    let a_anchor = genome_anchor(av)?;
+    let b_anchor = genome_anchor(bv)?;
+    if a_anchor.end + 1 != b_anchor.start {
+        return None;
+    }
+    let mut alt = a_anchor.alt;
+    alt.extend(b_anchor.alt);
+    Some(HgvsVariant::Genome(build_genome_merged(
+        av,
+        a_anchor.start,
+        b_anchor.end,
+        alt,
+    )))
+}
+
+fn build_genome_merged(
+    template: &GenomeVariant,
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+) -> GenomeVariant {
+    let location = Interval::new(GenomePos::new(start), GenomePos::new(end));
+    let edit = if alt.is_empty() {
+        // Spec-recommended no-sequence/no-length form.
+        NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        }
+    } else {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+        }
+    };
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+```
+
+Delete the old `build_genome_delins` function.
+
+- [ ] **Step 5: Verify all tests pass**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: all six tests in `tests/merge_consecutive_edits_tests.rs` PASS.
+
+- [ ] **Step 6: Confirm no regressions**
+
+Run: `cargo nextest run --features dev -E 'test(normalize)'`
+
+Expected: all existing normalize tests still PASS. In particular `test_allele_with_two_deletions_both_shift` (which uses non-adjacent positions `c.4del` and `c.13del`) must still pass — the merge pass should leave it alone.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/normalize/merge.rs tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+feat(normalize): merge consecutive deletions and sub/del pairs (#72)
+
+Extends the consecutive-edit merge pass to handle Deletion-typed
+sub-variants. Two adjacent dels collapse to a single ranged del; a
+sub+del or del+sub pair becomes a delins. Per-input ref-sequence and
+length specifiers are dropped from the merged output to emit the
+spec-recommended no-sequence form.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `Delins` support (with non-`Literal` exclusion)
+
+**Files:**
+- Modify: `src/normalize/merge.rs` (extend `genome_anchor`)
+- Modify: `tests/merge_consecutive_edits_tests.rs`
+
+- [ ] **Step 1: Write failing tests for `delins` cases**
+
+Append to `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+#[test]
+fn test_merge_sub_then_delins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001_1002delinsTT]"),
+        "NC_000001.11:g.1000_1002delinsATT",
+    );
+}
+
+#[test]
+fn test_merge_delins_then_sub() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1001delinsTT;1002A>C]"),
+        "NC_000001.11:g.1000_1002delinsTTC",
+    );
+}
+
+#[test]
+fn test_merge_delins_then_delins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1001delinsTT;1002_1003delinsAA]"),
+        "NC_000001.11:g.1000_1003delinsTTAA",
+    );
+}
+
+#[test]
+fn test_merge_skips_non_literal_delins() {
+    // delins with a non-Literal payload (e.g., delins10) is not safely
+    // concatenable; the design doc requires the pair to pass through.
+    let input = "NC_000001.11:g.[1000G>A;1001_1010delins10]";
+    let result = normalize_to_string(input);
+    // The output must still contain both edits separately (unchanged).
+    assert!(result.contains("1000G>A"), "expected 1000G>A in {}", result);
+    assert!(result.contains("1001_1010delins"), "expected 1001_1010delins in {}", result);
+    assert!(result.contains(';'), "expected separator in {}", result);
+}
+```
+
+- [ ] **Step 2: Verify the new tests fail**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: the three positive tests FAIL (anchor extraction returns `None` for `Delins`); `test_merge_skips_non_literal_delins` may PASS by accident (no merge attempted) — that's fine, the assertion still holds.
+
+- [ ] **Step 3: Extend anchor extraction to handle `Delins`**
+
+In `src/normalize/merge.rs`, update `genome_anchor` to add a `NaEdit::Delins` arm. The arm extracts the literal alt sequence; non-`Literal` payloads return `None` (refusing the merge for that pair):
+
+```rust
+        NaEdit::Delins { sequence } => {
+            let bases = sequence.as_literal()?.bases().to_vec();
+            Some(Anchor { start, end, alt: bases })
+        }
+```
+
+Place the new arm after the `Deletion` arm, before the catch-all `_ => None`.
+
+- [ ] **Step 4: Verify all tests pass**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: all positive tests PASS; `test_merge_skips_non_literal_delins` PASSES.
+
+- [ ] **Step 5: Confirm no regressions**
+
+Run: `cargo nextest run --features dev -E 'test(normalize)'`
+
+Expected: all existing tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/normalize/merge.rs tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+feat(normalize): merge delins into consecutive-edit pass (#72)
+
+Adjacent Delins sub-variants (literal alt only) participate in the
+merge alongside Substitution and Deletion. Non-Literal InsertedSequence
+payloads (Count, Range, Repeat, etc.) are excluded — those pairs pass
+through unchanged because their alt content cannot be safely
+concatenated into a single merged delins.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `Insertion` support (incl. spec FAQ example, two-ins-same-boundary)
+
+**Files:**
+- Modify: `src/normalize/merge.rs` (extend `genome_anchor`, generalize merged-edit construction)
+- Modify: `tests/merge_consecutive_edits_tests.rs`
+
+- [ ] **Step 1: Write failing tests for `ins` cases**
+
+Append to `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+#[test]
+fn test_merge_sub_then_ins() {
+    // Spec FAQ analogue (in g. context):
+    // sub at 100 + ins between 100 and 101 -> delins at 100 with alt = sub.alt + ins.bases.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;100_101insTA]"),
+        "NC_000001.11:g.100delinsATA",
+    );
+}
+
+#[test]
+fn test_merge_ins_then_sub() {
+    // Mirror: ins between 100 and 101 + sub at 101 -> delins at 101 with alt = ins.bases + sub.alt.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insTA;101G>A]"),
+        "NC_000001.11:g.101delinsTAA",
+    );
+}
+
+#[test]
+fn test_merge_del_then_ins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100del;100_101insTA]"),
+        "NC_000001.11:g.100delinsTA",
+    );
+}
+
+#[test]
+fn test_merge_ins_then_del() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insTA;101del]"),
+        "NC_000001.11:g.101delinsTA",
+    );
+}
+
+#[test]
+fn test_merge_two_ins_same_boundary_preserves_input_order() {
+    // Two ins at the same boundary p|p+1 collapse into a single ins; bases
+    // are concatenated in input order (T then A -> TA).
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insT;100_101insA]"),
+        "NC_000001.11:g.100_101insTA",
+    );
+}
+
+#[test]
+fn test_merge_skips_non_literal_ins() {
+    // Ins with a non-Literal payload (e.g., ins10) is not safely
+    // concatenable; the pair passes through unchanged.
+    let input = "NC_000001.11:g.[100G>A;100_101ins10]";
+    let result = normalize_to_string(input);
+    assert!(result.contains("100G>A"), "expected 100G>A in {}", result);
+    assert!(result.contains("100_101ins10"), "expected 100_101ins10 in {}", result);
+    assert!(result.contains(';'), "expected separator in {}", result);
+}
+```
+
+- [ ] **Step 2: Verify the new tests fail**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: the five positive tests FAIL; `test_merge_skips_non_literal_ins` passes by accident.
+
+- [ ] **Step 3: Add `Insertion` to anchor extraction**
+
+In `src/normalize/merge.rs`, update `genome_anchor` to add an `Insertion` arm. For an insertion at interval `[p, p+1]`, the anchor is `start = p+1, end = p` (empty range at the boundary):
+
+```rust
+        NaEdit::Insertion { sequence } => {
+            // Insertion's interval is [p, p+1]; anchor is start=p+1, end=p (empty range).
+            let bases = sequence.as_literal()?.bases().to_vec();
+            // simple_genome_range gave us (p, p+1); convert to anchor form.
+            if end != start + 1 {
+                return None;
+            }
+            Some(Anchor {
+                start: end, // p+1
+                end: start, // p
+                alt: bases,
+            })
+        }
+```
+
+Place this arm after the `Delins` arm.
+
+- [ ] **Step 4: Generalize merged-edit construction to handle the empty-range case**
+
+Replace `build_genome_merged` in `src/normalize/merge.rs`:
+
+```rust
+fn build_genome_merged(
+    template: &GenomeVariant,
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+) -> GenomeVariant {
+    let edit = if start > end {
+        // Empty range -> emit Insertion at boundary [end, start] = [start-1, start].
+        debug_assert_eq!(start, end + 1, "invariant: anchor span <= 1 nt");
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+        }
+    } else if alt.is_empty() {
+        NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        }
+    } else {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+        }
+    };
+    let location = if start > end {
+        // Insertion uses the original [end, start] interval.
+        Interval::new(GenomePos::new(end), GenomePos::new(start))
+    } else {
+        Interval::new(GenomePos::new(start), GenomePos::new(end))
+    };
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+```
+
+- [ ] **Step 5: Verify all tests pass**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: all tests in `tests/merge_consecutive_edits_tests.rs` PASS, including the previous tasks' tests.
+
+- [ ] **Step 6: Confirm no regressions**
+
+Run: `cargo nextest run --features dev -E 'test(normalize)'`
+
+Expected: all existing normalize tests still PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/normalize/merge.rs tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+feat(normalize): merge insertions at boundaries into consecutive pass (#72)
+
+Insertions sit between positions, not at them, so they're modeled as
+empty-range anchors (start = end + 1) at the boundary. They merge with
+adjacent sub/del/delins via the same A.end+1 == B.start adjacency rule,
+producing a delins covering the union range. Two ins at the same
+boundary collapse to a single ins, bases concatenated in input order.
+
+Mirrors the HGVS spec FAQ:
+  c.[2077G>A;2077_2078insTA] -> c.2077delinsATA
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Multi-coordinate-system support + negative cases
+
+**Files:**
+- Modify: `src/normalize/merge.rs` (generalize across `Cds`, `Tx`, `Rna`, `Mt` variant types)
+- Modify: `tests/merge_consecutive_edits_tests.rs`
+
+This task generalizes the per-type matching in `try_merge_pair` so the same anchor / merge logic applies to `Cds`, `Tx`, `Rna`, and `Mt` variants — and also pins the negative cases that must round-trip unchanged.
+
+The CDS / TX / RNA position types differ from `GenomePos`: they are signed (`i64`), with offsets and UTR markers. The merge pass treats a position as merge-eligible only if it is positive (≥ 1), has no offset, has no special UTR/downstream marker, and is not unknown — matching the design doc's "simple position" rule. For these "simple" positions the adjacency rule reduces to the same `A.end + 1 == B.start` check on the integer base value.
+
+- [ ] **Step 1: Write tests for each coordinate system**
+
+Append to `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+fn provider_with_simple_transcript() -> MockProvider {
+    use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+    let mut provider = MockProvider::new();
+    let sequence: String = "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let exons = vec![Exon::new(1, 1, sequence.len() as u32)];
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with_provider(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn test_merge_cds_consecutive_subs() {
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:c.[10A>G;11A>C]",
+        ),
+        "NM_TEST.1:c.10_11delinsGC",
+    );
+}
+
+#[test]
+fn test_merge_tx_consecutive_subs() {
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:n.[10A>G;11A>C]",
+        ),
+        "NM_TEST.1:n.10_11delinsGC",
+    );
+}
+
+#[test]
+fn test_merge_rna_consecutive_subs_lowercase() {
+    // RNA uses lowercase nucleotides per HGVS spec; merged alt must preserve case.
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:r.[10a>g;11a>c]",
+        ),
+        "NM_TEST.1:r.10_11delinsgc",
+    );
+}
+
+#[test]
+fn test_merge_mt_consecutive_subs() {
+    assert_eq!(
+        normalize_to_string("NC_012920.1:m.[100G>A;101A>C]"),
+        "NC_012920.1:m.100_101delinsAC",
+    );
+}
+
+// =====================================================================
+// Negative cases — must round-trip unchanged.
+// =====================================================================
+
+#[test]
+fn test_no_merge_one_nt_gap() {
+    // One unchanged nucleotide between variants -> spec keeps them separate.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;102C>T]");
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("102C>T"), "got {}", result);
+    assert!(result.contains(';'), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_different_accessions() {
+    let result = normalize_to_string("[NC_000001.11:g.100G>A;NC_000002.11:g.101A>C]");
+    assert!(result.contains("NC_000001.11"), "got {}", result);
+    assert!(result.contains("NC_000002.11"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_different_variant_types() {
+    // Genome and Cds in the same allele bracket -> not mergeable.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "[NC_000001.11:g.100G>A;NM_TEST.1:c.10A>C]",
+    );
+    assert!(result.contains("g.100G>A"), "got {}", result);
+    assert!(result.contains("c.10A>C"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_trans_phase() {
+    // [a];[b] (semicolon between bracket pairs) is trans phase per HGVS.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A];[101A>C]");
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("101A>C"), "got {}", result);
+    // No delins should appear.
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_intronic_position() {
+    // Intronic positions (non-zero offset) are excluded from the merge pass.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:c.[10+1A>G;10+2T>G]",
+    );
+    assert!(result.contains("10+1A>G"), "got {}", result);
+    assert!(result.contains("10+2T>G"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_utr_boundary() {
+    // c.-1 and c.1 are physically adjacent but no valid HGVS range syntax
+    // spans the 5'UTR / CDS boundary (c.-1_1 doesn't exist).
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:c.[-1A>G;1A>T]",
+    );
+    assert!(result.contains("-1A>G"), "got {}", result);
+    assert!(result.contains("1A>T"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_uncertain_edit() {
+    // Mu::Uncertain (paren-wrapped edit) is not mergeable.
+    let result = normalize_to_string("NC_000001.11:g.[(100G>A);101A>C]");
+    assert!(result.contains("(100G>A)"), "got {}", result);
+    assert!(result.contains("101A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_duplication_adjacent_to_sub() {
+    let result = normalize_to_string("NC_000001.11:g.[100dup;101A>C]");
+    assert!(result.contains("100dup"), "got {}", result);
+    assert!(result.contains("101A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_inversion_adjacent_to_sub() {
+    let result = normalize_to_string("NC_000001.11:g.[100_102inv;103A>C]");
+    assert!(result.contains("100_102inv"), "got {}", result);
+    assert!(result.contains("103A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_two_ins_different_boundaries() {
+    // Two ins separated by an unchanged nucleotide at position 101 -> no merge.
+    let result = normalize_to_string("NC_000001.11:g.[100_101insT;101_102insA]");
+    assert!(result.contains("100_101insT"), "got {}", result);
+    assert!(result.contains("101_102insA"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_reverse_input_order() {
+    // Input listed in reverse position order; the walk preserves input order
+    // and checks input-order adjacency (1001's anchor end + 1 != 1000's start),
+    // so no merge happens. Pins the no-resort decision.
+    let result = normalize_to_string("NC_000001.11:g.[1001A>C;1000G>A]");
+    assert!(result.contains("1001A>C"), "got {}", result);
+    assert!(result.contains("1000G>A"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+```
+
+- [ ] **Step 2: Verify the new tests fail (positive ones) / pass (negative ones)**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: the four positive tests (`test_merge_cds_consecutive_subs`, `test_merge_tx_consecutive_subs`, `test_merge_rna_consecutive_subs_lowercase`, `test_merge_mt_consecutive_subs`) FAIL because `try_merge_pair` only matches `(Genome, Genome)`. The negative tests should already PASS — the merge pass leaves them alone today (no support for those edit types means no merge attempted).
+
+- [ ] **Step 3: Generalize the merge pass across coordinate types**
+
+Replace `try_merge_pair` and add per-type anchor helpers in `src/normalize/merge.rs`. The structure: each variant produces an `(Anchor, accession, type-tag)`; merging requires matching accession and type-tag; the anchor logic is identical across types because all use simple integer positions.
+
+Add these imports near the top of the file (replacing the existing import line):
+
+```rust
+use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
+use crate::hgvs::variant::{
+    Accession, AllelePhase, CdsVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant,
+    RnaVariant, TxVariant,
+};
+```
+
+Replace `try_merge_pair` and the helper functions with the generalized versions:
+
+```rust
+fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
+    match (a, b) {
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => {
+            try_merge_genome(av, bv).map(HgvsVariant::Genome)
+        }
+        (HgvsVariant::Cds(av), HgvsVariant::Cds(bv)) => {
+            try_merge_cds(av, bv).map(HgvsVariant::Cds)
+        }
+        (HgvsVariant::Tx(av), HgvsVariant::Tx(bv)) => try_merge_tx(av, bv).map(HgvsVariant::Tx),
+        (HgvsVariant::Rna(av), HgvsVariant::Rna(bv)) => {
+            try_merge_rna(av, bv).map(HgvsVariant::Rna)
+        }
+        (HgvsVariant::Mt(av), HgvsVariant::Mt(bv)) => try_merge_mt(av, bv).map(HgvsVariant::Mt),
+        _ => None,
+    }
+}
+
+fn try_merge_genome(a: &GenomeVariant, b: &GenomeVariant) -> Option<GenomeVariant> {
+    if a.accession != b.accession { return None; }
+    let aa = anchor_from_naedit(&a.loc_edit, simple_genome_range)?;
+    let ba = anchor_from_naedit(&b.loc_edit, simple_genome_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_genome_merged(a, merged))
+}
+
+fn try_merge_cds(a: &CdsVariant, b: &CdsVariant) -> Option<CdsVariant> {
+    if a.accession != b.accession { return None; }
+    let aa = anchor_from_naedit(&a.loc_edit, simple_cds_range)?;
+    let ba = anchor_from_naedit(&b.loc_edit, simple_cds_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_cds_merged(a, merged))
+}
+
+fn try_merge_tx(a: &TxVariant, b: &TxVariant) -> Option<TxVariant> {
+    if a.accession != b.accession { return None; }
+    let aa = anchor_from_naedit(&a.loc_edit, simple_tx_range)?;
+    let ba = anchor_from_naedit(&b.loc_edit, simple_tx_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_tx_merged(a, merged))
+}
+
+fn try_merge_rna(a: &RnaVariant, b: &RnaVariant) -> Option<RnaVariant> {
+    if a.accession != b.accession { return None; }
+    let aa = anchor_from_naedit(&a.loc_edit, simple_rna_range)?;
+    let ba = anchor_from_naedit(&b.loc_edit, simple_rna_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_rna_merged(a, merged))
+}
+
+fn try_merge_mt(a: &MtVariant, b: &MtVariant) -> Option<MtVariant> {
+    if a.accession != b.accession { return None; }
+    let aa = anchor_from_naedit(&a.loc_edit, simple_genome_range)?;
+    let ba = anchor_from_naedit(&b.loc_edit, simple_genome_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_mt_merged(a, merged))
+}
+
+/// Combine two adjacency-checked anchors into one merged anchor.
+/// Returns None if not adjacent.
+fn merge_anchors(a: Anchor, b: Anchor) -> Option<Anchor> {
+    if a.end.checked_add(1)? != b.start {
+        return None;
+    }
+    let mut alt = a.alt;
+    alt.extend(b.alt);
+    Some(Anchor {
+        start: a.start.min(b.start),
+        end: a.end.max(b.end),
+        alt,
+    })
+}
+
+/// Extract an anchor from a sub-variant's location+edit. The `range_fn`
+/// callback returns `(start, end)` for the location only when it is "simple"
+/// (no offsets, no UTR markers, certain). Returns None when the edit is
+/// not merge-eligible (uncertain, non-NaEdit handled at the caller).
+fn anchor_from_naedit<L>(
+    loc_edit: &LocEdit<Interval<L>, NaEdit>,
+    range_fn: impl Fn(&Interval<L>) -> Option<(u64, u64)>,
+) -> Option<Anchor> {
+    let edit = loc_edit.edit.inner()?; // Mu::Certain only
+    let (start, end) = range_fn(&loc_edit.location)?;
+    match edit {
+        NaEdit::Substitution { alternative, .. }
+        | NaEdit::SubstitutionNoRef { alternative } => Some(Anchor {
+            start,
+            end,
+            alt: vec![*alternative],
+        }),
+        NaEdit::Deletion { .. } => Some(Anchor {
+            start,
+            end,
+            alt: Vec::new(),
+        }),
+        NaEdit::Delins { sequence } => {
+            let bases = sequence.as_literal()?.bases().to_vec();
+            Some(Anchor { start, end, alt: bases })
+        }
+        NaEdit::Insertion { sequence } => {
+            // Insertion's interval is [p, p+1]; convert to anchor [p+1, p].
+            if end != start.checked_add(1)? {
+                return None;
+            }
+            let bases = sequence.as_literal()?.bases().to_vec();
+            Some(Anchor {
+                start: end,
+                end: start,
+                alt: bases,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn simple_cds_range(interval: &Interval<CdsPos>) -> Option<(u64, u64)> {
+    Some((simple_cds_pos(&interval.start)?, simple_cds_pos(&interval.end)?))
+}
+
+fn simple_cds_pos(boundary: &UncertainBoundary<CdsPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_unknown() || pos.is_intronic() || pos.is_5utr() || pos.is_3utr() || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+
+fn simple_tx_range(interval: &Interval<TxPos>) -> Option<(u64, u64)> {
+    Some((simple_tx_pos(&interval.start)?, simple_tx_pos(&interval.end)?))
+}
+
+fn simple_tx_pos(boundary: &UncertainBoundary<TxPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_intronic() || pos.is_upstream() || pos.is_downstream() || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+
+fn simple_rna_range(interval: &Interval<RnaPos>) -> Option<(u64, u64)> {
+    Some((simple_rna_pos(&interval.start)?, simple_rna_pos(&interval.end)?))
+}
+
+fn simple_rna_pos(boundary: &UncertainBoundary<RnaPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    // RnaPos has the same `is_intronic` / `is_3utr` / negative-base
+    // exclusions as CdsPos. Confirm method names against the impl in
+    // src/hgvs/location.rs (the impl block around line 332). If a method
+    // differs, replace the call with the equivalent predicate.
+    if pos.offset.unwrap_or(0) != 0 || pos.utr3 || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+```
+
+Replace the existing `simple_genome_range` and `simple_genome_pos` with these (unchanged behavior, signature kept):
+
+```rust
+fn simple_genome_range(interval: &Interval<GenomePos>) -> Option<(u64, u64)> {
+    Some((simple_genome_pos(&interval.start)?, simple_genome_pos(&interval.end)?))
+}
+
+fn simple_genome_pos(boundary: &UncertainBoundary<GenomePos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_special() || pos.offset.is_some() {
+        return None;
+    }
+    Some(pos.base)
+}
+```
+
+Add per-variant `build_*_merged` functions. They share structure; here is `build_cds_merged` as the canonical example, with the others differing only in position type and accession-prefix string:
+
+```rust
+fn build_genome_merged(template: &GenomeVariant, merged: Anchor) -> GenomeVariant {
+    let (location, edit) = build_naedit(merged, GenomePos::new);
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_cds_merged(template: &CdsVariant, merged: Anchor) -> CdsVariant {
+    let (location, edit) = build_naedit(merged, |b| CdsPos::new(b as i64));
+    CdsVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_tx_merged(template: &TxVariant, merged: Anchor) -> TxVariant {
+    let (location, edit) = build_naedit(merged, |b| TxPos::new(b as i64));
+    TxVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_rna_merged(template: &RnaVariant, merged: Anchor) -> RnaVariant {
+    let (location, edit) = build_naedit(merged, |b| RnaPos::new(b as i64));
+    RnaVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
+    let (location, edit) = build_naedit(merged, GenomePos::new);
+    MtVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_naedit<P>(merged: Anchor, mut to_pos: impl FnMut(u64) -> P) -> (Interval<P>, NaEdit) {
+    let edit = if merged.start > merged.end {
+        // Empty-range anchor -> Insertion at boundary.
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
+        }
+    } else if merged.alt.is_empty() {
+        NaEdit::Deletion { sequence: None, length: None }
+    } else {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
+        }
+    };
+    let (lo, hi) = if merged.start > merged.end {
+        (merged.end, merged.start) // Insertion: original [p, p+1] interval
+    } else {
+        (merged.start, merged.end)
+    };
+    (Interval::new(to_pos(lo), to_pos(hi)), edit)
+}
+```
+
+Delete the old non-generic helpers superseded by the new versions (`build_genome_merged` is replaced; `genome_anchor` is replaced by `anchor_from_naedit`).
+
+- [ ] **Step 4: Verify all tests pass**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: every test in `tests/merge_consecutive_edits_tests.rs` PASSES, including the previous tasks' tests, the four new positive multi-coord tests, and the negative tests.
+
+If `simple_rna_pos` fails to compile due to method-name differences on `RnaPos`, open `src/hgvs/location.rs` near the `RnaPos` impl block (around line 332) and adjust the predicate calls — the rule is "exonic CDS or transcript region only, no offsets, no UTR markers, base ≥ 1." Use the same set of predicates `RnaPos` actually exposes.
+
+- [ ] **Step 5: Confirm no regressions**
+
+Run: `cargo nextest run --features dev`
+
+Expected: the entire test suite still PASSES.
+
+- [ ] **Step 6: Run lint to catch dead code**
+
+Run: `cargo clippy --features dev -- -D warnings`
+
+Expected: no warnings. If clippy flags any unused imports left over from the refactor, remove them.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/normalize/merge.rs tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+feat(normalize): generalize consecutive-edit merge across c./n./r./m. (#72)
+
+Adds Cds, Tx, Rna, and Mt to the merge pass via per-type anchor helpers
+that share the core walk and merge logic. Position eligibility for c./
+n./r. excludes intronic offsets, UTR boundaries, and unknown positions
+per the design doc — there is no valid HGVS range syntax across UTR
+boundaries, so adjacency cannot be expressed even when positions are
+physically consecutive.
+
+Pins the negative-case round-trips: one-nt gap, different accessions,
+different variant types, trans phase, intronic positions, UTR boundary,
+uncertain edits, dup/inv adjacent to sub, two ins at different
+boundaries, and reverse-input-order pairs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Chains, mixed cases, and Phase-2 deferred test stub
+
+**Files:**
+- Modify: `tests/merge_consecutive_edits_tests.rs`
+
+This task adds tests that exercise the existing implementation rather than introducing new behavior. The walk's `for next in variants` loop already folds chains by repeatedly merging into `output.last()`, so 3+ chains should "just work."
+
+- [ ] **Step 1: Write tests for chains, defensive overlap, and the Phase-2 stub**
+
+Append to `tests/merge_consecutive_edits_tests.rs`:
+
+```rust
+#[test]
+fn test_merge_chain_three_consecutive_subs() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C;1002C>T]"),
+        "NC_000001.11:g.1000_1002delinsACT",
+    );
+}
+
+#[test]
+fn test_merge_chain_sub_ins_sub_at_shared_boundary() {
+    // Chain across one shared boundary: sub at 100 + ins between 100 and 101 + sub at 101.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;100_101insT;101A>C]"),
+        "NC_000001.11:g.100_101delinsATC",
+    );
+}
+
+#[test]
+fn test_merge_long_chain_mixed_types() {
+    // 4-element chain spanning sub, del, sub, sub at consecutive positions.
+    // Position 100 sub, 101 del, 102 sub, 103 sub -> single delins 100..=103 alt = A_AA = AAA.
+    // (The del at 101 contributes no alt, so the merged alt is "A" + "" + "A" + "A" = "AAA".)
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;101del;102C>A;103T>A]"),
+        "NC_000001.11:g.100_103delinsAAA",
+    );
+}
+
+#[test]
+fn test_merge_same_position_twice_no_merge() {
+    // Two edits at the SAME position (zero gap, but overlap not adjacency)
+    // must not collapse into a single delins.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;100A>C]");
+    // The output should still contain both — we don't synthesize a "double mutation" form.
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("100A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+#[ignore = "Codon-frame exception for c. — tracked in issue #79"]
+fn test_codon_frame_exception_deferred() {
+    // Per HGVS spec: c.[145C>T;147C>G] (positions 145-147 share codon 49)
+    // must be expressed as c.145_147delinsTGG. Implementing this needs
+    // reference-provider access for the unchanged middle nucleotide and
+    // codon-frame logic; deferred to issue #79.
+    let provider = provider_with_simple_transcript();
+    assert_eq!(
+        normalize_with_provider(provider, "NM_TEST.1:c.[10A>G;12A>C]"),
+        "NM_TEST.1:c.10_12delinsGAC",
+    );
+}
+```
+
+- [ ] **Step 2: Verify the tests pass (and the deferred one is skipped)**
+
+Run: `cargo nextest run --features dev -E 'test(merge_consecutive)'`
+
+Expected: the four positive chain tests and the same-position no-merge test PASS. The deferred test reports as IGNORED.
+
+If `test_merge_long_chain_mixed_types` fails because of a position assumption (e.g., the `del` at 101 doesn't actually have anchor end at 101), inspect the parsed variant's interval. `parse_hgvs("g.101del")` produces an interval `(101, 101)`, so the anchor is `(101, 101)` with empty alt — adjacency to the prior sub at 100 holds (`100 + 1 == 101`). The merged result then has anchor `(100, 101)` with alt `[A]`; the next sub at 102 gives `101 + 1 == 102`, merged anchor `(100, 102)` alt `[A, A]`; etc.
+
+- [ ] **Step 3: Run the full test suite and lint**
+
+Run: `cargo nextest run --features dev` and `cargo clippy --features dev -- -D warnings`
+
+Expected: all tests pass (with one ignored), no clippy warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/merge_consecutive_edits_tests.rs
+git commit -m "$(cat <<'EOF'
+test(normalize): cover merge chains and add deferred codon-rule stub (#72)
+
+Pins the chain behavior: 3+ consecutive substitutions, sub/ins/sub at a
+shared boundary, and a 4-element mixed sub/del/sub/sub chain all
+collapse into a single delins. Same-position-twice does not merge
+(overlap, not adjacency).
+
+Adds an #[ignore]-d test for the codon-frame exception (one-nt gap with
+both positions in the same codon), tracked in #79, so the spec gap is
+visible in the suite rather than only in the design doc.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Verification before opening the PR
+
+- [ ] Run the full test suite once more: `cargo nextest run --features dev`. Expected: all pass, one ignored (the deferred codon-rule stub).
+- [ ] Run lint: `cargo clippy --features dev -- -D warnings`. Expected: clean.
+- [ ] Run formatter: `cargo fmt --all --check`. Expected: no diff.
+- [ ] Run pre-commit: `pre-commit run --all-files`. Expected: clean.
+- [ ] Spot-check the rendered HGVS for each issue example by running locally:
+  ```bash
+  cargo run --release -- parse 'NC_000001.11:g.[1000G>A;1001A>C]' --normalize
+  cargo run --release -- parse 'NC_000001.11:g.[1000del;1001del]' --normalize
+  ```
+  Expected: `NC_000001.11:g.1000_1001delinsAC` and `NC_000001.11:g.1000_1001del` respectively. (If the CLI subcommand differs from `parse --normalize`, find the equivalent in `src/bin/ferro.rs` — but not having a CLI smoke test is fine; the integration tests already cover this.)
+
+---
+
+## Self-review notes
+
+- **Spec coverage.** Every section of the design doc has at least one task or test:
+  - Phase / variant types / edit types / certainty / position constraints / accession matching → enforced in `try_merge_pair` (Tasks 1, 5) and exercised by the negative-case tests (Task 5).
+  - Anchor model + adjacency rule → Tasks 1 (sub), 2 (del), 3 (delins), 4 (ins), 5 (multi-coord).
+  - Result-type rules (`Insertion` / `Deletion` / `Delins`) → Task 4 generalizes the builder; Tasks 2 and 4 cover the no-alt and empty-range branches.
+  - Two-ins-same-boundary input ordering → Task 4.
+  - Reverse-input-order no-resort decision → Task 5.
+  - Defensive `A.end >= B.start` overlap refusal → covered indirectly by `test_merge_same_position_twice_no_merge` (Task 6) and the strict `A.end + 1 == B.start` check.
+  - Phase-2 deferred test → Task 6.
+
+- **Type / signature consistency.** `Anchor`, `try_merge_pair`, `merge_anchors`, `anchor_from_naedit`, `simple_*_range`, `build_*_merged` all use consistent (`u64`, `Vec<Base>`) types throughout. The `Insertion` anchor invariant (`start = end + 1`) is asserted via `debug_assert_eq!` in `build_naedit` (Task 5 generalization implicitly carries the same logic).
+
+- **Pre-existing tests at risk.** The five pre-existing `mod allele_tests` tests in `tests/normalize_tests.rs` use inputs the merge pass should not touch (positions are not strictly adjacent, or mix dup with sub). Verified manually; if any of them turn out to be affected, the right move is to inspect whether the input is genuinely a spec-merge case and update the test, not to weaken the merge pass.

--- a/docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md
+++ b/docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md
@@ -1,0 +1,332 @@
+# Merge consecutive edits within alleles per HGVS spec
+
+Issue: [#72](https://github.com/fulcrumgenomics/ferro-hgvs/issues/72)
+
+## Problem
+
+`normalize()` currently preserves the input form for an `AlleleVariant` whose
+sub-variants describe changes to the same or nearby nucleotides. The HGVS
+spec requires such changes to be expressed as a single combined operation
+rather than as multiple bracketed edits. This document specifies a merging
+pass that runs as part of `normalize_allele` to bring allele output into
+spec compliance.
+
+## Spec basis
+
+From the HGVS recommendations on delins
+(<https://hgvs-nomenclature.org/stable/recommendations/DNA/delins/>):
+
+- **Consecutive nucleotide changes must collapse to a single delins.** Notes:
+  *"changes involving two or more consecutive nucleotides are described as
+  deletion/insertion (delins) variants."* The Discussion FAQ reinforces this
+  with: di-nucleotide substitutions don't exist — the change `GC` to `TG` at
+  positions 4-5 must be `g.4_5delinsTG`, not two adjacent SNVs.
+- **Non-adjacent variants are described separately, with one exception.**
+  Notes: *"two variants separated by one or more nucleotides should
+  preferably be described individually and not as a 'delins'. Exception:
+  two variants separated by one nucleotide, together affecting one amino
+  acid, should be described as a 'delins'."* The Examples section makes the
+  carve-out concrete: `c.[145C>T;147C>G]` is *not correct*; the required
+  form is `c.145_147delinsTGG` because positions 145–147 fall in a single
+  codon.
+- **An insertion at the boundary of an adjacent change participates in the
+  merge.** Discussion FAQ: `NM_007294.3:c.[2077G>A;2077_2078insTA]` is
+  incorrect; the correct form is `NM_007294.3:c.2077delinsATA`. The
+  substitution at 2077 and the insertion between 2077 and 2078 share the
+  boundary at position 2077.
+
+## Scope and phasing
+
+To keep development and review tractable, the work is split into two phases,
+each landing as a separate commit. Phase 1 covers strictly consecutive
+merging and is sufficient to make several long-standing examples spec-compliant.
+Phase 2 adds the codon-frame exception, which requires reference-provider
+access for the unchanged middle nucleotide.
+
+### Phase 1: strictly consecutive merging
+
+Two sub-variants merge iff their anchors (defined below) are exactly
+adjacent — `A.end + 1 == B.start` — with no intervening unchanged
+nucleotide. Applies to Genome (`g.`), Cds (`c.`), Tx (`n.`), Rna (`r.`),
+and Mt (`m.`) variants.
+
+### Phase 2: codon-frame exception for `c.` variants
+
+Two CDS sub-variants whose anchors are separated by exactly one nucleotide
+merge when their positions fall within a single codon. The unchanged middle
+nucleotide is fetched from the reference provider. If no reference provider
+is available or the lookup fails, the variants pass through unchanged (with
+a warning surfaced via the existing `NormalizationWarning` channel) — Phase
+1 behavior, not an error. Phase 2 applies only to `c.` variants in the
+exonic CDS region (positions ≥ 1, not in 5'UTR or 3'UTR, not intronic).
+
+Whether the same exception applies to `r.` is left for a follow-up; the
+spec example uses `c.` and `r.` codon framing aligns with `c.` only when
+the RNA region is coding. This is captured as a deferred test, not a
+deferred phase of the same issue.
+
+## Common scope (both phases)
+
+### Phase
+
+- **Cis only.** Trans, Mosaic, Chimeric, and Unknown phases never merge —
+  they encode distinct chromosomes or distinct cell populations rather than
+  a single contiguous coding sequence.
+
+### Variant types
+
+- Sub-variants whose edit is `NaEdit` participate: `Genome`, `Cds`, `Tx`,
+  `Rna`, `Mt`.
+- Other variant types (`Protein`, `Circular`, `RnaFusion`, `NullAllele`,
+  `UnknownAllele`) pass through unchanged.
+
+### Edit types
+
+| Edit | Participates? | Notes |
+| --- | --- | --- |
+| `Substitution`, `SubstitutionNoRef` | yes | Single-base anchor |
+| `Deletion` | yes | Contributes ref-range, empty alt |
+| `Delins` | yes | Ref-range + alt sequence; only when `InsertedSequence` is `Literal` |
+| `Insertion` | yes | Boundary-only edit; only when `InsertedSequence` is `Literal` |
+| `Duplication` | no | Spec describes duplications as a distinct event; this exclusion is a deliberate scope choice, not a spec mandate |
+| `Inversion` | no | Spec describes inversions as a distinct event; the merge pass also does *not* try to detect "this delins is actually an inversion" — that would be a separate canonicalization |
+| `Repeat`, `MultiRepeat`, `Identity`, `Conversion`, `Unknown`, `Methylation`, `CopyNumber`, `Splice`, `NoProduct`, `PositionOnly` | no | Don't fit the consecutive-nucleotide model |
+
+**Non-`Literal` `InsertedSequence` is a hard exclusion.**
+`InsertedSequence` admits non-literal forms (`Count`, `Range`, `Repeat`,
+`SequenceRepeat`, `Complex`, `Named`, `Reference`, `PositionRange`,
+`PositionRangeInv`, `Uncertain`). These cannot be safely concatenated into
+a single delins. If any participant `Insertion` or `Delins` carries a
+non-`Literal` payload, the merge for that pair is refused; both inputs
+pass through unchanged.
+
+### Edit certainty
+
+- Only `Mu::Certain` edits merge. `Mu::Uncertain` (parens-wrapped) and
+  `Mu::Unknown` sub-variants pass through.
+
+### Position constraints
+
+A position participates in merging only if it is:
+
+- not unknown (`?`),
+- not a special marker (`pter`/`qter`/`cen`),
+- not intronic (per the existing `is_intronic()` predicate on `CdsPos`,
+  `TxPos`, etc.),
+- not crossing a coordinate-system boundary. For `c.` this means 5'UTR
+  (`-N`), CDS (`1..=N`), and 3'UTR (`*N`) are mutually exclusive merge
+  regions — there is no valid HGVS range syntax that spans these (e.g.,
+  `c.-1_1` does not exist), so adjacency cannot be expressed even when
+  positions are physically consecutive. The same logic applies to `n.`
+  (upstream `-N` / transcript / downstream `*N`) and `r.` (UTR boundaries).
+
+### Accession and variant type
+
+Two sub-variants are merge-eligible only if they share both:
+
+- the same accession string (`Accession::full()` equality), and
+- the same `HgvsVariant` discriminant (`Cds` with `Cds`, `Genome` with
+  `Genome`, etc.).
+
+Gene symbol is not separately checked; in practice it is determined by the
+accession. The merged result inherits the accession, gene symbol, and
+discriminant of the first input.
+
+## Algorithm
+
+### Anchor model
+
+Each merge-eligible sub-variant has an *anchor*: an inclusive position
+range it occupies plus the alt content it contributes.
+
+| Edit | Anchor start | Anchor end | Alt |
+| --- | --- | --- | --- |
+| `sub` at `p` (`X>Y`) | `p` | `p` | `Y` |
+| `del` at `[p, q]` | `p` | `q` | `""` |
+| `delins` at `[p, q]` (alt `S`) | `p` | `q` | `S` |
+| `ins` between `p` and `p+1` (alt `S`) | `p+1` | `p` | `S` |
+
+For an insertion, `start = end + 1` — the range is empty but locates the
+boundary precisely. Two anchors `A` and `B` (in position order) are
+*Phase-1 adjacent* iff `A.end + 1 == B.start`. This produces the right
+answer for every combination:
+
+- sub/del/delins at `[…, p]` then sub/del/delins at `[p+1, …]` → adjacent
+- sub/del/delins at `[…, p]` then `ins` between `p` and `p+1` → adjacent
+- `ins` between `p` and `p+1` then sub/del/delins at `[p+1, …]` → adjacent
+- two `ins` at the same boundary `p|p+1` → adjacent
+- `ins` between `p` and `p+1` then `ins` between `p+1` and `p+2` → not
+  adjacent (one intervening unchanged nucleotide; spec rule keeps separate)
+
+Two anchors are *Phase-2 adjacent* iff they are CDS exonic SNVs (not
+ranges, not insertions, both `Substitution` or `SubstitutionNoRef`, both
+position ≥ 1 with no offset and no UTR), with `A.end + 2 == B.start`, and
+`(A.end - 1) / 3 == (B.start - 1) / 3` (same codon, 0-indexed). Phase 2
+extends only the SNV-pair case; broader forms (`sub`+`ins`+`sub` straddling
+a codon, etc.) are not in scope for issue #72.
+
+### Walk
+
+In `normalize_allele`, after the existing `resolve_overlaps` call:
+
+1. Return the input unchanged unless `phase == Cis` and `len() >= 2`.
+2. Walk left-to-right with a single output cursor, preserving input order
+   (input order should already match position order; no resort, so
+   ordering is stable for tie-cases like two insertions at the same
+   boundary).
+3. For each next variant, attempt to merge with the head of the output
+   under Phase-1 rules. If that fails and Phase 2 is in scope, attempt the
+   codon-frame merge. Otherwise push.
+4. Sub-variants that aren't merge-eligible (different accession, different
+   type, non-NaEdit, uncertain edit, disqualifying position, non-Literal
+   insertion payload, etc.) act as merge barriers — they're emitted in
+   place and reset the cursor.
+
+### Merge result
+
+For a merged group spanning anchor `[start, end]` with concatenated alt
+`alt_seq`:
+
+- If `start > end` (all inputs were insertions at one boundary) → emit
+  `Insertion` between `start - 1` and `start` with content `alt_seq`.
+- Else if `alt_seq.is_empty()` (only deletions contributed) → emit
+  `Deletion` at `[start, end]`. Drop any per-input ref-sequence; emit the
+  no-sequence form (`g.<start>_<end>del`), which is the spec-recommended
+  shape and avoids the ambiguity of partial ref-sequence info.
+- Else → emit `Delins` at `[start, end]` with
+  `InsertedSequence::Literal(alt_seq)`.
+
+Phase-2 codon-frame merges always produce the `Delins` branch. The middle
+nucleotide is fetched from the reference provider and embedded in
+`alt_seq` between the contributions of the two SNVs.
+
+### Two insertions at the same boundary
+
+`g.[100_101insT;100_101insA]` → `g.100_101insTA`. Order is the input order
+of the allele bracket. Two insertions at the *same* boundary merge into a
+single `Insertion`; the `Delins` branch is not used because there is no
+covered range.
+
+## Placement
+
+The merge pass lives in a new module `src/normalize/merge.rs`, called from
+`normalize_allele` in `src/normalize/mod.rs` after the existing
+`resolve_overlaps` call.
+
+Note that `resolve_overlaps` is currently a no-op for the variants
+themselves — it walks for overlap detection but does not modify the input
+(see the comment block in `mod.rs` near the end of `resolve_overlaps`).
+The merge pass therefore sees the post-individual-normalization positions
+directly. As a defensive measure, the merge pass refuses to merge any pair
+where `A.end >= B.start` (true overlap), so that an unresolved overlap
+silently degrades to "leave both inputs as-is" rather than producing a
+malformed merged variant.
+
+The new module exposes:
+
+```rust
+pub(super) fn merge_consecutive_edits(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+    provider: Option<&dyn ReferenceProvider>, // None disables Phase 2
+) -> Vec<HgvsVariant>;
+```
+
+Private helpers handle anchor extraction, adjacency checks, and merged-edit
+construction. The position-typed pieces (`GenomePos`, `CdsPos`, `TxPos`,
+`RnaPos`) are bridged via small per-type helpers; the core walk is shared.
+
+## Tests
+
+All assertions use `parse → normalize → display` round-trip and check the
+rendered HGVS string, which is the user-visible contract.
+
+### Phase 1 tests
+
+#### Issue examples
+
+- `g.[1000G>A;1001A>C]` → `g.1000_1001delinsAC`
+- `g.[1000del;1001del]` → `g.1000_1001del`
+
+#### Coordinate systems
+
+One sub+sub case per merge-eligible coordinate system (g/c/n/r/m). RNA
+case verifies lowercase nucleotide preservation in the merged alt
+sequence.
+
+#### Spec FAQ example (sub+ins)
+
+- `NM_007294.3:c.[2077G>A;2077_2078insTA]` → `NM_007294.3:c.2077delinsATA`
+- Mirror: `c.[2077_2078insTA;2078G>A]` (ins-then-sub at the shared
+  boundary `2077|2078`).
+
+#### Mixed mergeable types
+
+- `sub+del`, `del+sub` → delins
+- `sub+delins`, `delins+sub` → delins
+- `del+delins`, `delins+del`, `delins+delins`
+- `del+ins` and `ins+del` at a shared boundary
+
+#### Chains
+
+- Three consecutive substitutions → single delins
+- `sub`, `ins`, `sub` chained at a single shared boundary triple → single
+  delins
+- Long chain (≥ 4) of mixed sub/del/ins → single delins
+
+#### Two insertions at the same boundary
+
+- `g.[100_101insT;100_101insA]` → `g.100_101insTA` (preserve input order)
+
+#### Deletion ref-sequence handling
+
+- `g.[100delA;101delC]` → `g.100_101del` (sequence dropped)
+- `g.[100del;101del]` → `g.100_101del`
+- `g.[100del3;101del2]` → `g.100_101del` (length info dropped; emit
+  no-sequence form)
+
+#### Round-trips that must remain unchanged
+
+- One-nucleotide gap between variants in non-CDS context (`g.[100G>A;102C>T]`)
+- Same position twice (zero-gap but overlap, not adjacency)
+- Different accessions in the bracket
+- Different variant-type discriminants in the bracket
+- Trans, Mosaic, Chimeric, Unknown phase
+- Sub at intronic position (`c.79+1A>G` adjacent to `c.79+2T>G`)
+- Sub crossing 5'UTR/CDS boundary (`c.[-1A>G;1G>T]`)
+- `Mu::Uncertain` edit
+- Duplication adjacent to substitution
+- Inversion adjacent to substitution
+- Two insertions at *different* boundaries (`g.[100_101insT;101_102insA]`)
+- `Delins` with non-`Literal` `InsertedSequence` adjacent to `sub`
+- Reverse-input-order pair that would not be position-order-adjacent
+  (`g.[1001A>C;1000G>A]` — input order preserved, no merge in Phase 1
+  since the walk checks position-order adjacency; this pins the no-resort
+  decision)
+
+### Phase 2 tests
+
+- Spec example: `NM_…:c.[145C>T;147C>G]` (with a reference provider that
+  returns `G` at position 146) → `c.145_147delinsTGG`
+- Same-codon SNV pair, position 1+3 of a codon, exhaustive over the codon
+  positions (1+3, 2+? — Phase 2 only handles the 1+3 / 1-intervening case)
+- Cross-codon SNV pair (`c.[3C>T;5G>A]` straddles codon 1/codon 2) → no
+  merge
+- One-nt-gap pair in `g.` context → no merge (Phase 2 is `c.` only)
+- One-nt-gap pair with no reference provider → no merge, warning
+  surfaced
+- One-nt-gap pair with reference-provider failure → no merge, warning
+  surfaced
+- Phase-1 merge still wins for strictly consecutive `c.` SNVs (Phase 2
+  rule is only consulted when Phase 1 doesn't apply)
+
+### Deferred (follow-up issue, not in this PR)
+
+- Codon-frame exception for `r.` coding regions
+- Codon-frame exception for chains involving more than two SNVs (`sub`,
+  `ins`, `sub` straddling a codon)
+- Codon-frame exception for SNV+`del` pairs separated by one unchanged
+  nucleotide
+
+These get a single `#[ignore]`-d test each so the gap is visible in the
+test suite rather than only in this design doc.

--- a/docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md
+++ b/docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md
@@ -4,79 +4,52 @@ Issue: [#72](https://github.com/fulcrumgenomics/ferro-hgvs/issues/72)
 
 ## Problem
 
-`normalize()` currently preserves the input form for an `AlleleVariant` whose
-sub-variants describe changes to the same or nearby nucleotides. The HGVS
+`normalize()` currently preserves the input form for an `AlleleVariant`
+whose sub-variants describe changes to consecutive nucleotides. The HGVS
 spec requires such changes to be expressed as a single combined operation
 rather than as multiple bracketed edits. This document specifies a merging
 pass that runs as part of `normalize_allele` to bring allele output into
-spec compliance.
+spec compliance for the strictly-consecutive case.
 
 ## Spec basis
 
 From the HGVS recommendations on delins
 (<https://hgvs-nomenclature.org/stable/recommendations/DNA/delins/>):
 
-- **Consecutive nucleotide changes must collapse to a single delins.** Notes:
-  *"changes involving two or more consecutive nucleotides are described as
-  deletion/insertion (delins) variants."* The Discussion FAQ reinforces this
-  with: di-nucleotide substitutions don't exist — the change `GC` to `TG` at
-  positions 4-5 must be `g.4_5delinsTG`, not two adjacent SNVs.
-- **Non-adjacent variants are described separately, with one exception.**
-  Notes: *"two variants separated by one or more nucleotides should
-  preferably be described individually and not as a 'delins'. Exception:
-  two variants separated by one nucleotide, together affecting one amino
-  acid, should be described as a 'delins'."* The Examples section makes the
-  carve-out concrete: `c.[145C>T;147C>G]` is *not correct*; the required
-  form is `c.145_147delinsTGG` because positions 145–147 fall in a single
-  codon.
+- **Consecutive nucleotide changes must collapse to a single delins.**
+  Notes: *"changes involving two or more consecutive nucleotides are
+  described as deletion/insertion (delins) variants."* The Discussion FAQ
+  reinforces this with: di-nucleotide substitutions don't exist — the
+  change `GC` to `TG` at positions 4-5 must be `g.4_5delinsTG`, not two
+  adjacent SNVs.
 - **An insertion at the boundary of an adjacent change participates in the
   merge.** Discussion FAQ: `NM_007294.3:c.[2077G>A;2077_2078insTA]` is
   incorrect; the correct form is `NM_007294.3:c.2077delinsATA`. The
   substitution at 2077 and the insertion between 2077 and 2078 share the
   boundary at position 2077.
+- **Non-adjacent variants are described separately, with one
+  exception.** Notes: *"two variants separated by one or more nucleotides
+  should preferably be described individually and not as a 'delins'.
+  Exception: two variants separated by one nucleotide, together affecting
+  one amino acid, should be described as a 'delins'."* The codon-frame
+  exception (e.g., `c.[145C>T;147C>G]` → `c.145_147delinsTGG`) is **out of
+  scope for this design** and is tracked separately. Implementing the
+  exception requires reference-provider access for the unchanged middle
+  nucleotide and codon-frame logic that does not generalize across
+  coordinate systems.
 
-## Scope and phasing
-
-To keep development and review tractable, the work is split into two phases,
-each landing as a separate commit. Phase 1 covers strictly consecutive
-merging and is sufficient to make several long-standing examples spec-compliant.
-Phase 2 adds the codon-frame exception, which requires reference-provider
-access for the unchanged middle nucleotide.
-
-### Phase 1: strictly consecutive merging
-
-Two sub-variants merge iff their anchors (defined below) are exactly
-adjacent — `A.end + 1 == B.start` — with no intervening unchanged
-nucleotide. Applies to Genome (`g.`), Cds (`c.`), Tx (`n.`), Rna (`r.`),
-and Mt (`m.`) variants.
-
-### Phase 2: codon-frame exception for `c.` variants
-
-Two CDS sub-variants whose anchors are separated by exactly one nucleotide
-merge when their positions fall within a single codon. The unchanged middle
-nucleotide is fetched from the reference provider. If no reference provider
-is available or the lookup fails, the variants pass through unchanged (with
-a warning surfaced via the existing `NormalizationWarning` channel) — Phase
-1 behavior, not an error. Phase 2 applies only to `c.` variants in the
-exonic CDS region (positions ≥ 1, not in 5'UTR or 3'UTR, not intronic).
-
-Whether the same exception applies to `r.` is left for a follow-up; the
-spec example uses `c.` and `r.` codon framing aligns with `c.` only when
-the RNA region is coding. This is captured as a deferred test, not a
-deferred phase of the same issue.
-
-## Common scope (both phases)
+## Scope
 
 ### Phase
 
 - **Cis only.** Trans, Mosaic, Chimeric, and Unknown phases never merge —
-  they encode distinct chromosomes or distinct cell populations rather than
-  a single contiguous coding sequence.
+  they encode distinct chromosomes or distinct cell populations rather
+  than a single contiguous coding sequence.
 
 ### Variant types
 
-- Sub-variants whose edit is `NaEdit` participate: `Genome`, `Cds`, `Tx`,
-  `Rna`, `Mt`.
+- Sub-variants whose edit is `NaEdit` participate: `Genome` (`g.`),
+  `Cds` (`c.`), `Tx` (`n.`), `Rna` (`r.`), `Mt` (`m.`).
 - Other variant types (`Protein`, `Circular`, `RnaFusion`, `NullAllele`,
   `UnknownAllele`) pass through unchanged.
 
@@ -86,7 +59,7 @@ deferred phase of the same issue.
 | --- | --- | --- |
 | `Substitution`, `SubstitutionNoRef` | yes | Single-base anchor |
 | `Deletion` | yes | Contributes ref-range, empty alt |
-| `Delins` | yes | Ref-range + alt sequence; only when `InsertedSequence` is `Literal` |
+| `Delins` | yes | Ref-range + alt; only when `InsertedSequence` is `Literal` |
 | `Insertion` | yes | Boundary-only edit; only when `InsertedSequence` is `Literal` |
 | `Duplication` | no | Spec describes duplications as a distinct event; this exclusion is a deliberate scope choice, not a spec mandate |
 | `Inversion` | no | Spec describes inversions as a distinct event; the merge pass also does *not* try to detect "this delins is actually an inversion" — that would be a separate canonicalization |
@@ -95,9 +68,9 @@ deferred phase of the same issue.
 **Non-`Literal` `InsertedSequence` is a hard exclusion.**
 `InsertedSequence` admits non-literal forms (`Count`, `Range`, `Repeat`,
 `SequenceRepeat`, `Complex`, `Named`, `Reference`, `PositionRange`,
-`PositionRangeInv`, `Uncertain`). These cannot be safely concatenated into
-a single delins. If any participant `Insertion` or `Delins` carries a
-non-`Literal` payload, the merge for that pair is refused; both inputs
+`PositionRangeInv`, `Uncertain`). These cannot be safely concatenated
+into a single delins. If any participant `Insertion` or `Delins` carries
+a non-`Literal` payload, the merge for that pair is refused; both inputs
 pass through unchanged.
 
 ### Edit certainty
@@ -118,7 +91,8 @@ A position participates in merging only if it is:
   regions — there is no valid HGVS range syntax that spans these (e.g.,
   `c.-1_1` does not exist), so adjacency cannot be expressed even when
   positions are physically consecutive. The same logic applies to `n.`
-  (upstream `-N` / transcript / downstream `*N`) and `r.` (UTR boundaries).
+  (upstream `-N` / transcript / downstream `*N`) and `r.` (UTR
+  boundaries).
 
 ### Accession and variant type
 
@@ -128,9 +102,9 @@ Two sub-variants are merge-eligible only if they share both:
 - the same `HgvsVariant` discriminant (`Cds` with `Cds`, `Genome` with
   `Genome`, etc.).
 
-Gene symbol is not separately checked; in practice it is determined by the
-accession. The merged result inherits the accession, gene symbol, and
-discriminant of the first input.
+Gene symbol is not separately checked; in practice it is determined by
+the accession. The merged result inherits the accession, gene symbol,
+and discriminant of the first input.
 
 ## Algorithm
 
@@ -146,41 +120,37 @@ range it occupies plus the alt content it contributes.
 | `delins` at `[p, q]` (alt `S`) | `p` | `q` | `S` |
 | `ins` between `p` and `p+1` (alt `S`) | `p+1` | `p` | `S` |
 
-For an insertion, `start = end + 1` — the range is empty but locates the
-boundary precisely. Two anchors `A` and `B` (in position order) are
-*Phase-1 adjacent* iff `A.end + 1 == B.start`. This produces the right
-answer for every combination:
+For an insertion, `start = end + 1` — the range is empty but locates
+the boundary precisely. Two anchors `A` and `B` (in input order) are
+*adjacent* iff `A.end + 1 == B.start`. This produces the right answer
+for every combination:
 
-- sub/del/delins at `[…, p]` then sub/del/delins at `[p+1, …]` → adjacent
-- sub/del/delins at `[…, p]` then `ins` between `p` and `p+1` → adjacent
-- `ins` between `p` and `p+1` then sub/del/delins at `[p+1, …]` → adjacent
+- sub/del/delins at `[…, p]` then sub/del/delins at `[p+1, …]` →
+  adjacent
+- sub/del/delins at `[…, p]` then `ins` between `p` and `p+1` →
+  adjacent
+- `ins` between `p` and `p+1` then sub/del/delins at `[p+1, …]` →
+  adjacent
 - two `ins` at the same boundary `p|p+1` → adjacent
 - `ins` between `p` and `p+1` then `ins` between `p+1` and `p+2` → not
-  adjacent (one intervening unchanged nucleotide; spec rule keeps separate)
-
-Two anchors are *Phase-2 adjacent* iff they are CDS exonic SNVs (not
-ranges, not insertions, both `Substitution` or `SubstitutionNoRef`, both
-position ≥ 1 with no offset and no UTR), with `A.end + 2 == B.start`, and
-`(A.end - 1) / 3 == (B.start - 1) / 3` (same codon, 0-indexed). Phase 2
-extends only the SNV-pair case; broader forms (`sub`+`ins`+`sub` straddling
-a codon, etc.) are not in scope for issue #72.
+  adjacent (one intervening unchanged nucleotide; spec rule keeps
+  separate)
 
 ### Walk
 
 In `normalize_allele`, after the existing `resolve_overlaps` call:
 
 1. Return the input unchanged unless `phase == Cis` and `len() >= 2`.
-2. Walk left-to-right with a single output cursor, preserving input order
-   (input order should already match position order; no resort, so
-   ordering is stable for tie-cases like two insertions at the same
+2. Walk left-to-right with a single output cursor, preserving input
+   order (input order should already match position order; no resort,
+   so ordering is stable for tie-cases like two insertions at the same
    boundary).
-3. For each next variant, attempt to merge with the head of the output
-   under Phase-1 rules. If that fails and Phase 2 is in scope, attempt the
-   codon-frame merge. Otherwise push.
-4. Sub-variants that aren't merge-eligible (different accession, different
-   type, non-NaEdit, uncertain edit, disqualifying position, non-Literal
-   insertion payload, etc.) act as merge barriers — they're emitted in
-   place and reset the cursor.
+3. For each next variant, attempt to merge with the head of the output.
+   If merge succeeds, replace the head; otherwise push.
+4. Sub-variants that aren't merge-eligible (different accession,
+   different type, non-NaEdit, uncertain edit, disqualifying position,
+   non-Literal insertion payload, etc.) act as merge barriers — they're
+   emitted in place and reset the cursor.
 
 ### Merge result
 
@@ -190,35 +160,33 @@ For a merged group spanning anchor `[start, end]` with concatenated alt
 - If `start > end` (all inputs were insertions at one boundary) → emit
   `Insertion` between `start - 1` and `start` with content `alt_seq`.
 - Else if `alt_seq.is_empty()` (only deletions contributed) → emit
-  `Deletion` at `[start, end]`. Drop any per-input ref-sequence; emit the
-  no-sequence form (`g.<start>_<end>del`), which is the spec-recommended
-  shape and avoids the ambiguity of partial ref-sequence info.
+  `Deletion` at `[start, end]`. Drop any per-input ref-sequence; emit
+  the no-sequence form (`g.<start>_<end>del`), which is the
+  spec-recommended shape and avoids the ambiguity of partial
+  ref-sequence info.
 - Else → emit `Delins` at `[start, end]` with
   `InsertedSequence::Literal(alt_seq)`.
 
-Phase-2 codon-frame merges always produce the `Delins` branch. The middle
-nucleotide is fetched from the reference provider and embedded in
-`alt_seq` between the contributions of the two SNVs.
-
 ### Two insertions at the same boundary
 
-`g.[100_101insT;100_101insA]` → `g.100_101insTA`. Order is the input order
-of the allele bracket. Two insertions at the *same* boundary merge into a
-single `Insertion`; the `Delins` branch is not used because there is no
-covered range.
+`g.[100_101insT;100_101insA]` → `g.100_101insTA`. Order is the input
+order of the allele bracket. Two insertions at the *same* boundary
+merge into a single `Insertion`; the `Delins` branch is not used
+because there is no covered range.
 
 ## Placement
 
-The merge pass lives in a new module `src/normalize/merge.rs`, called from
-`normalize_allele` in `src/normalize/mod.rs` after the existing
+The merge pass lives in a new module `src/normalize/merge.rs`, called
+from `normalize_allele` in `src/normalize/mod.rs` after the existing
 `resolve_overlaps` call.
 
 Note that `resolve_overlaps` is currently a no-op for the variants
-themselves — it walks for overlap detection but does not modify the input
-(see the comment block in `mod.rs` near the end of `resolve_overlaps`).
-The merge pass therefore sees the post-individual-normalization positions
-directly. As a defensive measure, the merge pass refuses to merge any pair
-where `A.end >= B.start` (true overlap), so that an unresolved overlap
+themselves — it walks for overlap detection but does not modify the
+input (see the comment block in `mod.rs` near the end of
+`resolve_overlaps`). The merge pass therefore sees the
+post-individual-normalization positions directly. As a defensive
+measure, the merge pass refuses to merge any pair where
+`A.end >= B.start` (true overlap), so that an unresolved overlap
 silently degrades to "leave both inputs as-is" rather than producing a
 malformed merged variant.
 
@@ -228,66 +196,66 @@ The new module exposes:
 pub(super) fn merge_consecutive_edits(
     variants: &[HgvsVariant],
     phase: AllelePhase,
-    provider: Option<&dyn ReferenceProvider>, // None disables Phase 2
 ) -> Vec<HgvsVariant>;
 ```
 
-Private helpers handle anchor extraction, adjacency checks, and merged-edit
-construction. The position-typed pieces (`GenomePos`, `CdsPos`, `TxPos`,
-`RnaPos`) are bridged via small per-type helpers; the core walk is shared.
+Private helpers handle anchor extraction, adjacency checks, and
+merged-edit construction. The position-typed pieces (`GenomePos`,
+`CdsPos`, `TxPos`, `RnaPos`) are bridged via small per-type helpers;
+the core walk is shared.
 
 ## Tests
 
-All assertions use `parse → normalize → display` round-trip and check the
-rendered HGVS string, which is the user-visible contract.
+All assertions use `parse → normalize → display` round-trip and check
+the rendered HGVS string, which is the user-visible contract.
 
-### Phase 1 tests
-
-#### Issue examples
+### Issue examples
 
 - `g.[1000G>A;1001A>C]` → `g.1000_1001delinsAC`
 - `g.[1000del;1001del]` → `g.1000_1001del`
 
-#### Coordinate systems
+### Coordinate systems
 
 One sub+sub case per merge-eligible coordinate system (g/c/n/r/m). RNA
 case verifies lowercase nucleotide preservation in the merged alt
 sequence.
 
-#### Spec FAQ example (sub+ins)
+### Spec FAQ example (sub+ins)
 
-- `NM_007294.3:c.[2077G>A;2077_2078insTA]` → `NM_007294.3:c.2077delinsATA`
+- `NM_007294.3:c.[2077G>A;2077_2078insTA]` →
+  `NM_007294.3:c.2077delinsATA`
 - Mirror: `c.[2077_2078insTA;2078G>A]` (ins-then-sub at the shared
   boundary `2077|2078`).
 
-#### Mixed mergeable types
+### Mixed mergeable types
 
 - `sub+del`, `del+sub` → delins
 - `sub+delins`, `delins+sub` → delins
 - `del+delins`, `delins+del`, `delins+delins`
 - `del+ins` and `ins+del` at a shared boundary
 
-#### Chains
+### Chains
 
 - Three consecutive substitutions → single delins
-- `sub`, `ins`, `sub` chained at a single shared boundary triple → single
-  delins
+- `sub`, `ins`, `sub` chained at a single shared boundary triple →
+  single delins
 - Long chain (≥ 4) of mixed sub/del/ins → single delins
 
-#### Two insertions at the same boundary
+### Two insertions at the same boundary
 
-- `g.[100_101insT;100_101insA]` → `g.100_101insTA` (preserve input order)
+- `g.[100_101insT;100_101insA]` → `g.100_101insTA` (preserve input
+  order)
 
-#### Deletion ref-sequence handling
+### Deletion ref-sequence handling
 
 - `g.[100delA;101delC]` → `g.100_101del` (sequence dropped)
 - `g.[100del;101del]` → `g.100_101del`
 - `g.[100del3;101del2]` → `g.100_101del` (length info dropped; emit
   no-sequence form)
 
-#### Round-trips that must remain unchanged
+### Round-trips that must remain unchanged
 
-- One-nucleotide gap between variants in non-CDS context (`g.[100G>A;102C>T]`)
+- One-nucleotide gap between variants (`g.[100G>A;102C>T]`)
 - Same position twice (zero-gap but overlap, not adjacency)
 - Different accessions in the bracket
 - Different variant-type discriminants in the bracket
@@ -297,36 +265,17 @@ sequence.
 - `Mu::Uncertain` edit
 - Duplication adjacent to substitution
 - Inversion adjacent to substitution
-- Two insertions at *different* boundaries (`g.[100_101insT;101_102insA]`)
+- Two insertions at *different* boundaries
+  (`g.[100_101insT;101_102insA]`)
 - `Delins` with non-`Literal` `InsertedSequence` adjacent to `sub`
-- Reverse-input-order pair that would not be position-order-adjacent
-  (`g.[1001A>C;1000G>A]` — input order preserved, no merge in Phase 1
-  since the walk checks position-order adjacency; this pins the no-resort
-  decision)
+- Reverse-input-order pair (`g.[1001A>C;1000G>A]`) — input order
+  preserved, no merge since the walk checks input-order adjacency;
+  pins the no-resort decision
 
-### Phase 2 tests
+### Codon-frame exception (deferred to follow-up issue)
 
-- Spec example: `NM_…:c.[145C>T;147C>G]` (with a reference provider that
-  returns `G` at position 146) → `c.145_147delinsTGG`
-- Same-codon SNV pair, position 1+3 of a codon, exhaustive over the codon
-  positions (1+3, 2+? — Phase 2 only handles the 1+3 / 1-intervening case)
-- Cross-codon SNV pair (`c.[3C>T;5G>A]` straddles codon 1/codon 2) → no
-  merge
-- One-nt-gap pair in `g.` context → no merge (Phase 2 is `c.` only)
-- One-nt-gap pair with no reference provider → no merge, warning
-  surfaced
-- One-nt-gap pair with reference-provider failure → no merge, warning
-  surfaced
-- Phase-1 merge still wins for strictly consecutive `c.` SNVs (Phase 2
-  rule is only consulted when Phase 1 doesn't apply)
-
-### Deferred (follow-up issue, not in this PR)
-
-- Codon-frame exception for `r.` coding regions
-- Codon-frame exception for chains involving more than two SNVs (`sub`,
-  `ins`, `sub` straddling a codon)
-- Codon-frame exception for SNV+`del` pairs separated by one unchanged
-  nucleotide
-
-These get a single `#[ignore]`-d test each so the gap is visible in the
-test suite rather than only in this design doc.
+`c.[145C>T;147C>G]` and similar one-nucleotide-gap pairs that share a
+codon are tracked in the follow-up issue and excluded from this PR.
+A single `#[ignore]`-d test stub is included in this PR to make the
+gap visible in the test suite, with the follow-up issue number in the
+ignore reason.

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -49,7 +49,7 @@ pub(crate) fn merge_consecutive_edits(
 }
 
 fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
-    // Phase 1: only Genome-Genome same-accession sub+sub merging.
+    // Phase 1: only Genome-Genome same-accession merging.
     let (av, bv) = match (a, b) {
         (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => (av, bv),
         _ => return None,
@@ -64,7 +64,7 @@ fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
     }
     let mut alt = a_anchor.alt;
     alt.extend(b_anchor.alt);
-    Some(HgvsVariant::Genome(build_genome_delins(
+    Some(HgvsVariant::Genome(build_genome_merged(
         av,
         a_anchor.start,
         b_anchor.end,
@@ -73,16 +73,23 @@ fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
 }
 
 fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
-    let edit = v.loc_edit.edit.inner()?; // Mu::Certain or Mu::Uncertain; filter Uncertain below
+    let edit = v.loc_edit.edit.inner()?;
     if !v.loc_edit.edit.is_certain() {
         return None;
     }
     let (start, end) = simple_genome_range(&v.loc_edit.location)?;
     match edit {
-        NaEdit::Substitution { alternative, .. } => Some(Anchor {
+        NaEdit::Substitution { alternative, .. } | NaEdit::SubstitutionNoRef { alternative } => {
+            Some(Anchor {
+                start,
+                end,
+                alt: vec![*alternative],
+            })
+        }
+        NaEdit::Deletion { .. } => Some(Anchor {
             start,
             end,
-            alt: vec![*alternative],
+            alt: Vec::new(),
         }),
         _ => None,
     }
@@ -106,15 +113,23 @@ fn simple_genome_pos(boundary: &UncertainBoundary<GenomePos>) -> Option<u64> {
     Some(pos.base)
 }
 
-fn build_genome_delins(
+fn build_genome_merged(
     template: &GenomeVariant,
     start: u64,
     end: u64,
     alt: Vec<Base>,
 ) -> GenomeVariant {
     let location = Interval::new(GenomePos::new(start), GenomePos::new(end));
-    let edit = NaEdit::Delins {
-        sequence: InsertedSequence::Literal(Sequence::new(alt)),
+    let edit = if alt.is_empty() {
+        // Spec-recommended no-sequence/no-length form.
+        NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        }
+    } else {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+        }
     };
     GenomeVariant {
         accession: template.accession.clone(),

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -4,9 +4,11 @@
 
 use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
 use crate::hgvs::interval::{Interval, UncertainBoundary};
-use crate::hgvs::location::GenomePos;
+use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::uncertainty::Mu;
-use crate::hgvs::variant::{AllelePhase, GenomeVariant, HgvsVariant, LocEdit};
+use crate::hgvs::variant::{
+    AllelePhase, CdsVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant, RnaVariant, TxVariant,
+};
 
 /// Anchor for a single sub-variant.
 ///
@@ -49,35 +51,101 @@ pub(crate) fn merge_consecutive_edits(
 }
 
 fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
-    // Phase 1: only Genome-Genome same-accession merging.
-    let (av, bv) = match (a, b) {
-        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => (av, bv),
-        _ => return None,
-    };
-    if av.accession != bv.accession {
-        return None;
+    match (a, b) {
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => {
+            try_merge_genome(av, bv).map(HgvsVariant::Genome)
+        }
+        (HgvsVariant::Cds(av), HgvsVariant::Cds(bv)) => try_merge_cds(av, bv).map(HgvsVariant::Cds),
+        (HgvsVariant::Tx(av), HgvsVariant::Tx(bv)) => try_merge_tx(av, bv).map(HgvsVariant::Tx),
+        (HgvsVariant::Rna(av), HgvsVariant::Rna(bv)) => try_merge_rna(av, bv).map(HgvsVariant::Rna),
+        (HgvsVariant::Mt(av), HgvsVariant::Mt(bv)) => try_merge_mt(av, bv).map(HgvsVariant::Mt),
+        _ => None,
     }
-    let a_anchor = genome_anchor(av)?;
-    let b_anchor = genome_anchor(bv)?;
-    if a_anchor.end + 1 != b_anchor.start {
-        return None;
-    }
-    let mut alt = a_anchor.alt;
-    alt.extend(b_anchor.alt);
-    Some(HgvsVariant::Genome(build_genome_merged(
-        av,
-        a_anchor.start,
-        b_anchor.end,
-        alt,
-    )))
 }
 
-fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
-    let edit = v.loc_edit.edit.inner()?;
-    if !v.loc_edit.edit.is_certain() {
+fn try_merge_genome(a: &GenomeVariant, b: &GenomeVariant) -> Option<GenomeVariant> {
+    if a.accession != b.accession {
         return None;
     }
-    let (start, end) = simple_genome_range(&v.loc_edit.location)?;
+    let aa = anchor_from_loc_edit(&a.loc_edit, simple_genome_range)?;
+    let ba = anchor_from_loc_edit(&b.loc_edit, simple_genome_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_genome_merged(a, merged))
+}
+
+fn try_merge_cds(a: &CdsVariant, b: &CdsVariant) -> Option<CdsVariant> {
+    if a.accession != b.accession {
+        return None;
+    }
+    let aa = anchor_from_loc_edit(&a.loc_edit, simple_cds_range)?;
+    let ba = anchor_from_loc_edit(&b.loc_edit, simple_cds_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_cds_merged(a, merged))
+}
+
+fn try_merge_tx(a: &TxVariant, b: &TxVariant) -> Option<TxVariant> {
+    if a.accession != b.accession {
+        return None;
+    }
+    let aa = anchor_from_loc_edit(&a.loc_edit, simple_tx_range)?;
+    let ba = anchor_from_loc_edit(&b.loc_edit, simple_tx_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_tx_merged(a, merged))
+}
+
+fn try_merge_rna(a: &RnaVariant, b: &RnaVariant) -> Option<RnaVariant> {
+    if a.accession != b.accession {
+        return None;
+    }
+    let aa = anchor_from_loc_edit(&a.loc_edit, simple_rna_range)?;
+    let ba = anchor_from_loc_edit(&b.loc_edit, simple_rna_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_rna_merged(a, merged))
+}
+
+fn try_merge_mt(a: &MtVariant, b: &MtVariant) -> Option<MtVariant> {
+    if a.accession != b.accession {
+        return None;
+    }
+    let aa = anchor_from_loc_edit(&a.loc_edit, simple_genome_range)?;
+    let ba = anchor_from_loc_edit(&b.loc_edit, simple_genome_range)?;
+    let merged = merge_anchors(aa, ba)?;
+    Some(build_mt_merged(a, merged))
+}
+
+/// Combine two adjacency-checked anchors into one merged anchor.
+/// Returns None if the pair is not strictly adjacent (`a.end + 1 == b.start`).
+/// For two `Insertion` anchors at the same boundary `p|p+1` (both `start=p+1, end=p`),
+/// `a.end + 1 = p + 1 == b.start = p + 1`, so adjacency holds.
+fn merge_anchors(a: Anchor, b: Anchor) -> Option<Anchor> {
+    if a.end.checked_add(1)? != b.start {
+        return None;
+    }
+    let mut alt = a.alt;
+    alt.extend(b.alt);
+    // Use the earliest start and the latest end so that the merged range
+    // covers the union. For an Insertion-only merge, `start = a.start` (= p+1)
+    // and `end = b.end` (= p), preserving the empty-range invariant.
+    Some(Anchor {
+        start: a.start.min(b.start),
+        end: a.end.max(b.end),
+        alt,
+    })
+}
+
+/// Extract an anchor from a sub-variant's location+edit. The `range_fn`
+/// callback returns `(start, end)` for the location only when it is "simple"
+/// (no offsets, no UTR markers, certain). Returns None when the edit is
+/// uncertain, unknown, or not a merge-eligible NaEdit variant.
+fn anchor_from_loc_edit<L>(
+    loc_edit: &LocEdit<Interval<L>, NaEdit>,
+    range_fn: impl Fn(&Interval<L>) -> Option<(u64, u64)>,
+) -> Option<Anchor> {
+    if !loc_edit.edit.is_certain() {
+        return None;
+    }
+    let edit = loc_edit.edit.inner()?;
+    let (start, end) = range_fn(&loc_edit.location)?;
     match edit {
         NaEdit::Substitution { alternative, .. } | NaEdit::SubstitutionNoRef { alternative } => {
             Some(Anchor {
@@ -93,17 +161,21 @@ fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
         }),
         NaEdit::Delins { sequence } => {
             let bases = sequence.as_literal()?.bases().to_vec();
-            Some(Anchor { start, end, alt: bases })
+            Some(Anchor {
+                start,
+                end,
+                alt: bases,
+            })
         }
         NaEdit::Insertion { sequence } => {
-            // Insertion's interval is [p, p+1]; anchor is start=p+1, end=p (empty range).
-            if end != start + 1 {
+            // Insertion's interval is [p, p+1]; convert to anchor [p+1, p].
+            if end != start.checked_add(1)? {
                 return None;
             }
             let bases = sequence.as_literal()?.bases().to_vec();
             Some(Anchor {
-                start: end, // p+1
-                end: start, // p
+                start: end,
+                end: start,
                 alt: bases,
             })
         }
@@ -112,56 +184,149 @@ fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
 }
 
 fn simple_genome_range(interval: &Interval<GenomePos>) -> Option<(u64, u64)> {
-    let start = simple_genome_pos(&interval.start)?;
-    let end = simple_genome_pos(&interval.end)?;
-    Some((start, end))
+    Some((
+        simple_genome_pos(&interval.start)?,
+        simple_genome_pos(&interval.end)?,
+    ))
 }
 
 fn simple_genome_pos(boundary: &UncertainBoundary<GenomePos>) -> Option<u64> {
-    let mu = boundary.as_single()?;
-    let pos = match mu {
-        Mu::Certain(p) => p,
-        _ => return None,
-    };
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
     if pos.is_special() || pos.offset.is_some() {
         return None;
     }
     Some(pos.base)
 }
 
-fn build_genome_merged(
-    template: &GenomeVariant,
-    start: u64,
-    end: u64,
-    alt: Vec<Base>,
-) -> GenomeVariant {
-    let edit = if start > end {
-        // Empty range -> emit Insertion at boundary [end, start] = [start-1, start].
-        debug_assert_eq!(start, end + 1, "invariant: anchor span <= 1 nt");
+fn simple_cds_range(interval: &Interval<CdsPos>) -> Option<(u64, u64)> {
+    Some((
+        simple_cds_pos(&interval.start)?,
+        simple_cds_pos(&interval.end)?,
+    ))
+}
+
+fn simple_cds_pos(boundary: &UncertainBoundary<CdsPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_unknown() || pos.is_intronic() || pos.is_5utr() || pos.is_3utr() || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+
+fn simple_tx_range(interval: &Interval<TxPos>) -> Option<(u64, u64)> {
+    Some((
+        simple_tx_pos(&interval.start)?,
+        simple_tx_pos(&interval.end)?,
+    ))
+}
+
+fn simple_tx_pos(boundary: &UncertainBoundary<TxPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_intronic() || pos.is_upstream() || pos.is_downstream() || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+
+fn simple_rna_range(interval: &Interval<RnaPos>) -> Option<(u64, u64)> {
+    Some((
+        simple_rna_pos(&interval.start)?,
+        simple_rna_pos(&interval.end)?,
+    ))
+}
+
+fn simple_rna_pos(boundary: &UncertainBoundary<RnaPos>) -> Option<u64> {
+    let pos = boundary.as_single().and_then(|mu| match mu {
+        Mu::Certain(p) => Some(p),
+        _ => None,
+    })?;
+    if pos.is_intronic() || pos.is_3utr() || pos.is_5utr() || pos.base < 1 {
+        return None;
+    }
+    Some(pos.base as u64)
+}
+
+fn build_genome_merged(template: &GenomeVariant, merged: Anchor) -> GenomeVariant {
+    let (location, edit) = build_naedit(merged, GenomePos::new);
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_cds_merged(template: &CdsVariant, merged: Anchor) -> CdsVariant {
+    let (location, edit) = build_naedit(merged, |b| CdsPos::new(b as i64));
+    CdsVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_tx_merged(template: &TxVariant, merged: Anchor) -> TxVariant {
+    let (location, edit) = build_naedit(merged, |b| TxPos::new(b as i64));
+    TxVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_rna_merged(template: &RnaVariant, merged: Anchor) -> RnaVariant {
+    let (location, edit) = build_naedit(merged, |b| RnaPos::new(b as i64));
+    RnaVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
+    let (location, edit) = build_naedit(merged, GenomePos::new);
+    MtVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+fn build_naedit<P>(merged: Anchor, mut to_pos: impl FnMut(u64) -> P) -> (Interval<P>, NaEdit) {
+    let edit = if merged.start > merged.end {
+        // Empty-range anchor -> Insertion at boundary.
+        debug_assert_eq!(
+            merged.start,
+            merged.end + 1,
+            "invariant: insertion anchor span = 1 nt"
+        );
         NaEdit::Insertion {
-            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+            sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
         }
-    } else if alt.is_empty() {
+    } else if merged.alt.is_empty() {
         NaEdit::Deletion {
             sequence: None,
             length: None,
         }
     } else {
         NaEdit::Delins {
-            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+            sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
         }
     };
-    let location = if start > end {
-        // Insertion uses the original [end, start] interval.
-        Interval::new(GenomePos::new(end), GenomePos::new(start))
+    let (lo, hi) = if merged.start > merged.end {
+        (merged.end, merged.start) // Insertion: original [p, p+1] interval
     } else {
-        Interval::new(GenomePos::new(start), GenomePos::new(end))
+        (merged.start, merged.end)
     };
-    GenomeVariant {
-        accession: template.accession.clone(),
-        gene_symbol: template.gene_symbol.clone(),
-        loc_edit: LocEdit::new(location, edit),
-    }
+    (Interval::new(to_pos(lo), to_pos(hi)), edit)
 }
 
 #[cfg(test)]

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -29,23 +29,23 @@ struct Anchor {
 /// non-NaEdit, uncertain edit, disqualifying position, etc.) act as merge
 /// barriers — they pass through unchanged in their original input order.
 pub(crate) fn merge_consecutive_edits(
-    variants: &[HgvsVariant],
+    variants: Vec<HgvsVariant>,
     phase: AllelePhase,
 ) -> Vec<HgvsVariant> {
     if phase != AllelePhase::Cis || variants.len() < 2 {
-        return variants.to_vec();
+        return variants;
     }
 
     let mut output: Vec<HgvsVariant> = Vec::with_capacity(variants.len());
     for next in variants {
         if let Some(prev) = output.last() {
-            if let Some(merged) = try_merge_pair(prev, next) {
+            if let Some(merged) = try_merge_pair(prev, &next) {
                 let last = output.last_mut().unwrap();
                 *last = merged;
                 continue;
             }
         }
-        output.push(next.clone());
+        output.push(next);
     }
     output
 }
@@ -123,9 +123,6 @@ fn merge_anchors(a: Anchor, b: Anchor) -> Option<Anchor> {
     }
     let mut alt = a.alt;
     alt.extend(b.alt);
-    // Use the earliest start and the latest end so that the merged range
-    // covers the union. For an Insertion-only merge, `start = a.start` (= p+1)
-    // and `end = b.end` (= p), preserving the empty-range invariant.
     Some(Anchor {
         start: a.start.min(b.start),
         end: a.end.max(b.end),
@@ -160,7 +157,7 @@ fn anchor_from_loc_edit<L>(
             alt: Vec::new(),
         }),
         NaEdit::Delins { sequence } => {
-            let bases = sequence.as_literal()?.bases().to_vec();
+            let bases = sequence.bases()?.to_vec();
             Some(Anchor {
                 start,
                 end,
@@ -168,11 +165,10 @@ fn anchor_from_loc_edit<L>(
             })
         }
         NaEdit::Insertion { sequence } => {
-            // Insertion's interval is [p, p+1]; convert to anchor [p+1, p].
             if end != start.checked_add(1)? {
                 return None;
             }
-            let bases = sequence.as_literal()?.bases().to_vec();
+            let bases = sequence.bases()?.to_vec();
             Some(Anchor {
                 start: end,
                 end: start,
@@ -302,7 +298,6 @@ fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
 
 fn build_naedit<P>(merged: Anchor, mut to_pos: impl FnMut(u64) -> P) -> (Interval<P>, NaEdit) {
     let edit = if merged.start > merged.end {
-        // Empty-range anchor -> Insertion at boundary.
         debug_assert_eq!(
             merged.start,
             merged.end + 1,
@@ -322,7 +317,7 @@ fn build_naedit<P>(merged: Anchor, mut to_pos: impl FnMut(u64) -> P) -> (Interva
         }
     };
     let (lo, hi) = if merged.start > merged.end {
-        (merged.end, merged.start) // Insertion: original [p, p+1] interval
+        (merged.end, merged.start)
     } else {
         (merged.start, merged.end)
     };
@@ -336,12 +331,11 @@ mod tests {
 
     #[test]
     fn empty_input_returns_empty() {
-        assert!(merge_consecutive_edits(&[], AllelePhase::Cis).is_empty());
+        assert!(merge_consecutive_edits(vec![], AllelePhase::Cis).is_empty());
     }
 
     #[test]
     fn single_input_passes_through() {
-        // Single-variant alleles are not Phase-1 mergeable.
         let acc = Accession::new("NC", "000001", Some(11));
         let v = HgvsVariant::Genome(GenomeVariant {
             accession: acc,
@@ -354,7 +348,7 @@ mod tests {
                 },
             ),
         });
-        let out = merge_consecutive_edits(std::slice::from_ref(&v), AllelePhase::Cis);
+        let out = merge_consecutive_edits(vec![v], AllelePhase::Cis);
         assert_eq!(out.len(), 1);
     }
 }

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1,0 +1,154 @@
+//! Merge consecutive sub-variants in a cis allele into a single edit per HGVS spec.
+//!
+//! See `docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md`.
+
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
+use crate::hgvs::interval::{Interval, UncertainBoundary};
+use crate::hgvs::location::GenomePos;
+use crate::hgvs::uncertainty::Mu;
+use crate::hgvs::variant::{AllelePhase, GenomeVariant, HgvsVariant, LocEdit};
+
+/// Anchor for a single sub-variant.
+///
+/// `start` and `end` are 1-based inclusive position bounds. For an `Insertion`
+/// between positions `p` and `p+1`, `start = p+1` and `end = p` (empty range
+/// at a boundary).
+#[derive(Debug, Clone)]
+struct Anchor {
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+}
+
+/// Merge consecutive sub-variants in an allele.
+///
+/// Returns the input unchanged unless `phase == Cis` and at least one merge
+/// is possible. Sub-variants that aren't merge-eligible (different accession,
+/// non-NaEdit, uncertain edit, disqualifying position, etc.) act as merge
+/// barriers — they pass through unchanged in their original input order.
+pub(crate) fn merge_consecutive_edits(
+    variants: &[HgvsVariant],
+    phase: AllelePhase,
+) -> Vec<HgvsVariant> {
+    if phase != AllelePhase::Cis || variants.len() < 2 {
+        return variants.to_vec();
+    }
+
+    let mut output: Vec<HgvsVariant> = Vec::with_capacity(variants.len());
+    for next in variants {
+        if let Some(prev) = output.last() {
+            if let Some(merged) = try_merge_pair(prev, next) {
+                let last = output.last_mut().unwrap();
+                *last = merged;
+                continue;
+            }
+        }
+        output.push(next.clone());
+    }
+    output
+}
+
+fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
+    // Phase 1: only Genome-Genome same-accession sub+sub merging.
+    let (av, bv) = match (a, b) {
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => (av, bv),
+        _ => return None,
+    };
+    if av.accession != bv.accession {
+        return None;
+    }
+    let a_anchor = genome_anchor(av)?;
+    let b_anchor = genome_anchor(bv)?;
+    if a_anchor.end + 1 != b_anchor.start {
+        return None;
+    }
+    let mut alt = a_anchor.alt;
+    alt.extend(b_anchor.alt);
+    Some(HgvsVariant::Genome(build_genome_delins(
+        av,
+        a_anchor.start,
+        b_anchor.end,
+        alt,
+    )))
+}
+
+fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
+    let edit = v.loc_edit.edit.inner()?; // Mu::Certain or Mu::Uncertain; filter Uncertain below
+    if !v.loc_edit.edit.is_certain() {
+        return None;
+    }
+    let (start, end) = simple_genome_range(&v.loc_edit.location)?;
+    match edit {
+        NaEdit::Substitution { alternative, .. } => Some(Anchor {
+            start,
+            end,
+            alt: vec![*alternative],
+        }),
+        _ => None,
+    }
+}
+
+fn simple_genome_range(interval: &Interval<GenomePos>) -> Option<(u64, u64)> {
+    let start = simple_genome_pos(&interval.start)?;
+    let end = simple_genome_pos(&interval.end)?;
+    Some((start, end))
+}
+
+fn simple_genome_pos(boundary: &UncertainBoundary<GenomePos>) -> Option<u64> {
+    let mu = boundary.as_single()?;
+    let pos = match mu {
+        Mu::Certain(p) => p,
+        _ => return None,
+    };
+    if pos.is_special() || pos.offset.is_some() {
+        return None;
+    }
+    Some(pos.base)
+}
+
+fn build_genome_delins(
+    template: &GenomeVariant,
+    start: u64,
+    end: u64,
+    alt: Vec<Base>,
+) -> GenomeVariant {
+    let location = Interval::new(GenomePos::new(start), GenomePos::new(end));
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::new(alt)),
+    };
+    GenomeVariant {
+        accession: template.accession.clone(),
+        gene_symbol: template.gene_symbol.clone(),
+        loc_edit: LocEdit::new(location, edit),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::variant::Accession;
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(merge_consecutive_edits(&[], AllelePhase::Cis).is_empty());
+    }
+
+    #[test]
+    fn single_input_passes_through() {
+        // Single-variant alleles are not Phase-1 mergeable.
+        let acc = Accession::new("NC", "000001", Some(11));
+        let v = HgvsVariant::Genome(GenomeVariant {
+            accession: acc,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                Interval::new(GenomePos::new(100), GenomePos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::G,
+                    alternative: Base::A,
+                },
+            ),
+        });
+        let out = merge_consecutive_edits(std::slice::from_ref(&v), AllelePhase::Cis);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -91,6 +91,10 @@ fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
             end,
             alt: Vec::new(),
         }),
+        NaEdit::Delins { sequence } => {
+            let bases = sequence.as_literal()?.bases().to_vec();
+            Some(Anchor { start, end, alt: bases })
+        }
         _ => None,
     }
 }

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -95,6 +95,18 @@ fn genome_anchor(v: &GenomeVariant) -> Option<Anchor> {
             let bases = sequence.as_literal()?.bases().to_vec();
             Some(Anchor { start, end, alt: bases })
         }
+        NaEdit::Insertion { sequence } => {
+            // Insertion's interval is [p, p+1]; anchor is start=p+1, end=p (empty range).
+            if end != start + 1 {
+                return None;
+            }
+            let bases = sequence.as_literal()?.bases().to_vec();
+            Some(Anchor {
+                start: end, // p+1
+                end: start, // p
+                alt: bases,
+            })
+        }
         _ => None,
     }
 }
@@ -123,9 +135,13 @@ fn build_genome_merged(
     end: u64,
     alt: Vec<Base>,
 ) -> GenomeVariant {
-    let location = Interval::new(GenomePos::new(start), GenomePos::new(end));
-    let edit = if alt.is_empty() {
-        // Spec-recommended no-sequence/no-length form.
+    let edit = if start > end {
+        // Empty range -> emit Insertion at boundary [end, start] = [start-1, start].
+        debug_assert_eq!(start, end + 1, "invariant: anchor span <= 1 nt");
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::new(alt)),
+        }
+    } else if alt.is_empty() {
         NaEdit::Deletion {
             sequence: None,
             length: None,
@@ -134,6 +150,12 @@ fn build_genome_merged(
         NaEdit::Delins {
             sequence: InsertedSequence::Literal(Sequence::new(alt)),
         }
+    };
+    let location = if start > end {
+        // Insertion uses the original [end, start] interval.
+        Interval::new(GenomePos::new(end), GenomePos::new(start))
+    } else {
+        Interval::new(GenomePos::new(start), GenomePos::new(end))
     };
     GenomeVariant {
         accession: template.accession.clone(),

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -28,6 +28,10 @@ struct Anchor {
 /// is possible. Sub-variants that aren't merge-eligible (different accession,
 /// non-NaEdit, uncertain edit, disqualifying position, etc.) act as merge
 /// barriers — they pass through unchanged in their original input order.
+///
+/// The walk caches the head-of-output's anchor so it isn't re-extracted on
+/// every iteration, and uses a cheap position-only adjacency precheck so
+/// non-adjacent delins/ins pairs skip the alt-bases allocation.
 pub(crate) fn merge_consecutive_edits(
     variants: Vec<HgvsVariant>,
     phase: AllelePhase,
@@ -37,97 +41,129 @@ pub(crate) fn merge_consecutive_edits(
     }
 
     let mut output: Vec<HgvsVariant> = Vec::with_capacity(variants.len());
+    // Cached anchor of `output.last()`. None means either output is empty or
+    // the head isn't merge-eligible — in either case we cannot extend.
+    let mut prev_anchor: Option<Anchor> = None;
+
     for next in variants {
-        if let Some(prev) = output.last() {
-            if let Some(merged) = try_merge_pair(prev, &next) {
-                let last = output.last_mut().unwrap();
-                *last = merged;
-                continue;
+        if let Some(prev_a) = prev_anchor.as_ref() {
+            // Cheap adjacency precheck against next's positions only. This
+            // skips the alt-bases allocation when the pair won't merge.
+            if let Some((next_start, next_end)) = simple_range_for_variant(&next) {
+                if prev_a.end.checked_add(1) == Some(next_start)
+                    && same_accession_and_kind(output.last().unwrap(), &next)
+                {
+                    if let Some(next_anchor) = anchor_for_variant(&next) {
+                        debug_assert_eq!(next_anchor.start, next_start);
+                        debug_assert_eq!(next_anchor.end, next_end);
+                        let prev_a = prev_anchor.take().unwrap();
+                        let merged_anchor = merge_anchors(prev_a, next_anchor);
+                        let merged_v = build_merged(output.last().unwrap(), &merged_anchor);
+                        *output.last_mut().unwrap() = merged_v;
+                        prev_anchor = Some(merged_anchor);
+                        continue;
+                    }
+                }
             }
         }
+        // No merge — recompute prev_anchor for the new head.
+        prev_anchor = anchor_for_variant(&next);
         output.push(next);
     }
     output
 }
 
-fn try_merge_pair(a: &HgvsVariant, b: &HgvsVariant) -> Option<HgvsVariant> {
+/// Same accession and same `HgvsVariant` discriminant.
+fn same_accession_and_kind(a: &HgvsVariant, b: &HgvsVariant) -> bool {
     match (a, b) {
-        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => {
-            try_merge_genome(av, bv).map(HgvsVariant::Genome)
-        }
-        (HgvsVariant::Cds(av), HgvsVariant::Cds(bv)) => try_merge_cds(av, bv).map(HgvsVariant::Cds),
-        (HgvsVariant::Tx(av), HgvsVariant::Tx(bv)) => try_merge_tx(av, bv).map(HgvsVariant::Tx),
-        (HgvsVariant::Rna(av), HgvsVariant::Rna(bv)) => try_merge_rna(av, bv).map(HgvsVariant::Rna),
-        (HgvsVariant::Mt(av), HgvsVariant::Mt(bv)) => try_merge_mt(av, bv).map(HgvsVariant::Mt),
+        (HgvsVariant::Genome(av), HgvsVariant::Genome(bv)) => av.accession == bv.accession,
+        (HgvsVariant::Cds(av), HgvsVariant::Cds(bv)) => av.accession == bv.accession,
+        (HgvsVariant::Tx(av), HgvsVariant::Tx(bv)) => av.accession == bv.accession,
+        (HgvsVariant::Rna(av), HgvsVariant::Rna(bv)) => av.accession == bv.accession,
+        (HgvsVariant::Mt(av), HgvsVariant::Mt(bv)) => av.accession == bv.accession,
+        _ => false,
+    }
+}
+
+/// Position-only extraction for the cheap adjacency precheck. Returns the
+/// anchor's `(start, end)` tuple if the variant is merge-eligible by type
+/// and position, without allocating alt bases.
+fn simple_range_for_variant(v: &HgvsVariant) -> Option<(u64, u64)> {
+    match v {
+        HgvsVariant::Genome(g) => simple_range_for_loc_edit(&g.loc_edit, simple_genome_range),
+        HgvsVariant::Cds(c) => simple_range_for_loc_edit(&c.loc_edit, simple_cds_range),
+        HgvsVariant::Tx(t) => simple_range_for_loc_edit(&t.loc_edit, simple_tx_range),
+        HgvsVariant::Rna(r) => simple_range_for_loc_edit(&r.loc_edit, simple_rna_range),
+        HgvsVariant::Mt(m) => simple_range_for_loc_edit(&m.loc_edit, simple_genome_range),
         _ => None,
     }
 }
 
-fn try_merge_genome(a: &GenomeVariant, b: &GenomeVariant) -> Option<GenomeVariant> {
-    if a.accession != b.accession {
-        return None;
+/// Per-coordinate-system dispatch for full anchor extraction.
+fn anchor_for_variant(v: &HgvsVariant) -> Option<Anchor> {
+    match v {
+        HgvsVariant::Genome(g) => anchor_from_loc_edit(&g.loc_edit, simple_genome_range),
+        HgvsVariant::Cds(c) => anchor_from_loc_edit(&c.loc_edit, simple_cds_range),
+        HgvsVariant::Tx(t) => anchor_from_loc_edit(&t.loc_edit, simple_tx_range),
+        HgvsVariant::Rna(r) => anchor_from_loc_edit(&r.loc_edit, simple_rna_range),
+        HgvsVariant::Mt(m) => anchor_from_loc_edit(&m.loc_edit, simple_genome_range),
+        _ => None,
     }
-    let aa = anchor_from_loc_edit(&a.loc_edit, simple_genome_range)?;
-    let ba = anchor_from_loc_edit(&b.loc_edit, simple_genome_range)?;
-    let merged = merge_anchors(aa, ba)?;
-    Some(build_genome_merged(a, merged))
 }
 
-fn try_merge_cds(a: &CdsVariant, b: &CdsVariant) -> Option<CdsVariant> {
-    if a.accession != b.accession {
+/// Position-only counterpart of `anchor_from_loc_edit`. Mirrors its
+/// edit-kind and edit-certainty filters but does not touch alt bases.
+fn simple_range_for_loc_edit<L>(
+    loc_edit: &LocEdit<Interval<L>, NaEdit>,
+    range_fn: impl Fn(&Interval<L>) -> Option<(u64, u64)>,
+) -> Option<(u64, u64)> {
+    if !loc_edit.edit.is_certain() {
         return None;
     }
-    let aa = anchor_from_loc_edit(&a.loc_edit, simple_cds_range)?;
-    let ba = anchor_from_loc_edit(&b.loc_edit, simple_cds_range)?;
-    let merged = merge_anchors(aa, ba)?;
-    Some(build_cds_merged(a, merged))
+    let edit = loc_edit.edit.inner()?;
+    let (start, end) = range_fn(&loc_edit.location)?;
+    match edit {
+        NaEdit::Substitution { .. }
+        | NaEdit::SubstitutionNoRef { .. }
+        | NaEdit::Deletion { .. } => Some((start, end)),
+        NaEdit::Delins { sequence } => {
+            sequence.bases()?;
+            Some((start, end))
+        }
+        NaEdit::Insertion { sequence } => {
+            sequence.bases()?;
+            // Anchor for an insertion is [end, start] — empty range at boundary.
+            (end == start.checked_add(1)?).then_some((end, start))
+        }
+        _ => None,
+    }
 }
 
-fn try_merge_tx(a: &TxVariant, b: &TxVariant) -> Option<TxVariant> {
-    if a.accession != b.accession {
-        return None;
+/// Build the merged variant from the head of output and the merged anchor.
+/// Caller has already established that `head` and the partner are the same
+/// kind via `same_accession_and_kind`.
+fn build_merged(head: &HgvsVariant, merged: &Anchor) -> HgvsVariant {
+    match head {
+        HgvsVariant::Genome(g) => HgvsVariant::Genome(build_genome_merged(g, merged.clone())),
+        HgvsVariant::Cds(c) => HgvsVariant::Cds(build_cds_merged(c, merged.clone())),
+        HgvsVariant::Tx(t) => HgvsVariant::Tx(build_tx_merged(t, merged.clone())),
+        HgvsVariant::Rna(r) => HgvsVariant::Rna(build_rna_merged(r, merged.clone())),
+        HgvsVariant::Mt(m) => HgvsVariant::Mt(build_mt_merged(m, merged.clone())),
+        _ => unreachable!("build_merged called with non-NaEdit variant kind"),
     }
-    let aa = anchor_from_loc_edit(&a.loc_edit, simple_tx_range)?;
-    let ba = anchor_from_loc_edit(&b.loc_edit, simple_tx_range)?;
-    let merged = merge_anchors(aa, ba)?;
-    Some(build_tx_merged(a, merged))
-}
-
-fn try_merge_rna(a: &RnaVariant, b: &RnaVariant) -> Option<RnaVariant> {
-    if a.accession != b.accession {
-        return None;
-    }
-    let aa = anchor_from_loc_edit(&a.loc_edit, simple_rna_range)?;
-    let ba = anchor_from_loc_edit(&b.loc_edit, simple_rna_range)?;
-    let merged = merge_anchors(aa, ba)?;
-    Some(build_rna_merged(a, merged))
-}
-
-fn try_merge_mt(a: &MtVariant, b: &MtVariant) -> Option<MtVariant> {
-    if a.accession != b.accession {
-        return None;
-    }
-    let aa = anchor_from_loc_edit(&a.loc_edit, simple_genome_range)?;
-    let ba = anchor_from_loc_edit(&b.loc_edit, simple_genome_range)?;
-    let merged = merge_anchors(aa, ba)?;
-    Some(build_mt_merged(a, merged))
 }
 
 /// Combine two adjacency-checked anchors into one merged anchor.
-/// Returns None if the pair is not strictly adjacent (`a.end + 1 == b.start`).
-/// For two `Insertion` anchors at the same boundary `p|p+1` (both `start=p+1, end=p`),
-/// `a.end + 1 = p + 1 == b.start = p + 1`, so adjacency holds.
-fn merge_anchors(a: Anchor, b: Anchor) -> Option<Anchor> {
-    if a.end.checked_add(1)? != b.start {
-        return None;
-    }
+/// Caller has already verified `a.end + 1 == b.start`.
+fn merge_anchors(a: Anchor, b: Anchor) -> Anchor {
+    debug_assert_eq!(a.end.checked_add(1), Some(b.start));
     let mut alt = a.alt;
     alt.extend(b.alt);
-    Some(Anchor {
+    Anchor {
         start: a.start.min(b.start),
         end: a.end.max(b.end),
         alt,
-    })
+    }
 }
 
 /// Extract an anchor from a sub-variant's location+edit. The `range_fn`

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -29,9 +29,11 @@ struct Anchor {
 /// non-NaEdit, uncertain edit, disqualifying position, etc.) act as merge
 /// barriers — they pass through unchanged in their original input order.
 ///
-/// The walk caches the head-of-output's anchor so it isn't re-extracted on
-/// every iteration, and uses a cheap position-only adjacency precheck so
-/// non-adjacent delins/ins pairs skip the alt-bases allocation.
+/// Variants are pushed to `output` immediately on arrival. While a chain is
+/// growing, only the running anchor is updated (alt extended in place). At
+/// chain end the head of `output` is rebuilt once from the merged anchor.
+/// This keeps non-merging iterations as cheap as the no-merge baseline and
+/// makes a chain of N consecutive merges O(N) total instead of O(N^2).
 pub(crate) fn merge_consecutive_edits(
     variants: Vec<HgvsVariant>,
     phase: AllelePhase,
@@ -41,36 +43,63 @@ pub(crate) fn merge_consecutive_edits(
     }
 
     let mut output: Vec<HgvsVariant> = Vec::with_capacity(variants.len());
-    // Cached anchor of `output.last()`. None means either output is empty or
-    // the head isn't merge-eligible — in either case we cannot extend.
-    let mut prev_anchor: Option<Anchor> = None;
+    // Anchor of `output.last()` while the head is merge-eligible. None once
+    // the head is non-eligible (a Duplication, uncertain edit, etc.) or
+    // output is empty.
+    let mut head_anchor: Option<Anchor> = None;
+    // Whether at least one merge has folded into `head_anchor`. While true,
+    // `output.last()` is stale relative to `head_anchor` and must be
+    // rebuilt before any external observation.
+    let mut head_merged = false;
 
     for next in variants {
-        if let Some(prev_a) = prev_anchor.as_ref() {
-            // Cheap adjacency precheck against next's positions only. This
-            // skips the alt-bases allocation when the pair won't merge.
-            if let Some((next_start, next_end)) = simple_range_for_variant(&next) {
-                if prev_a.end.checked_add(1) == Some(next_start)
-                    && same_accession_and_kind(output.last().unwrap(), &next)
-                {
-                    if let Some(next_anchor) = anchor_for_variant(&next) {
-                        debug_assert_eq!(next_anchor.start, next_start);
-                        debug_assert_eq!(next_anchor.end, next_end);
-                        let prev_a = prev_anchor.take().unwrap();
-                        let merged_anchor = merge_anchors(prev_a, next_anchor);
-                        let merged_v = build_merged(output.last().unwrap(), &merged_anchor);
-                        *output.last_mut().unwrap() = merged_v;
-                        prev_anchor = Some(merged_anchor);
-                        continue;
-                    }
-                }
+        let merged = 'try_merge: {
+            let Some(prev_a) = head_anchor.as_mut() else {
+                break 'try_merge false;
+            };
+            let Some((next_start, _)) = simple_range_for_variant(&next) else {
+                break 'try_merge false;
+            };
+            if prev_a.end.checked_add(1) != Some(next_start) {
+                break 'try_merge false;
             }
+            if !same_accession_and_kind(output.last().unwrap(), &next) {
+                break 'try_merge false;
+            }
+            let Some(next_anchor) = anchor_for_variant(&next) else {
+                break 'try_merge false;
+            };
+            // Extend in place — amortized O(1) per base added.
+            prev_a.alt.extend(next_anchor.alt);
+            prev_a.start = prev_a.start.min(next_anchor.start);
+            prev_a.end = prev_a.end.max(next_anchor.end);
+            true
+        };
+        if merged {
+            head_merged = true;
+            continue;
         }
-        // No merge — recompute prev_anchor for the new head.
-        prev_anchor = anchor_for_variant(&next);
+        // Chain ends here. If we'd been growing one, rebuild the head once
+        // from the final merged anchor before moving on.
+        if head_merged {
+            reconcile_head(&mut output, head_anchor.take().unwrap());
+            head_merged = false;
+        }
+        head_anchor = anchor_for_variant(&next);
         output.push(next);
     }
+    if head_merged {
+        reconcile_head(&mut output, head_anchor.take().unwrap());
+    }
     output
+}
+
+/// Replace `output.last()` with a freshly-built variant from `anchor`.
+/// Caller has established that the head is merge-eligible (so kind dispatch
+/// in `build_merged` is safe).
+fn reconcile_head(output: &mut [HgvsVariant], anchor: Anchor) {
+    let last = output.last_mut().expect("head must exist when head_merged");
+    *last = build_merged(last, anchor);
 }
 
 /// Same accession and same `HgvsVariant` discriminant.
@@ -141,28 +170,16 @@ fn simple_range_for_loc_edit<L>(
 
 /// Build the merged variant from the head of output and the merged anchor.
 /// Caller has already established that `head` and the partner are the same
-/// kind via `same_accession_and_kind`.
-fn build_merged(head: &HgvsVariant, merged: &Anchor) -> HgvsVariant {
+/// kind via `same_accession_and_kind`. Takes `merged` by value so the alt
+/// vec moves into the new variant rather than being cloned.
+fn build_merged(head: &HgvsVariant, merged: Anchor) -> HgvsVariant {
     match head {
-        HgvsVariant::Genome(g) => HgvsVariant::Genome(build_genome_merged(g, merged.clone())),
-        HgvsVariant::Cds(c) => HgvsVariant::Cds(build_cds_merged(c, merged.clone())),
-        HgvsVariant::Tx(t) => HgvsVariant::Tx(build_tx_merged(t, merged.clone())),
-        HgvsVariant::Rna(r) => HgvsVariant::Rna(build_rna_merged(r, merged.clone())),
-        HgvsVariant::Mt(m) => HgvsVariant::Mt(build_mt_merged(m, merged.clone())),
+        HgvsVariant::Genome(g) => HgvsVariant::Genome(build_genome_merged(g, merged)),
+        HgvsVariant::Cds(c) => HgvsVariant::Cds(build_cds_merged(c, merged)),
+        HgvsVariant::Tx(t) => HgvsVariant::Tx(build_tx_merged(t, merged)),
+        HgvsVariant::Rna(r) => HgvsVariant::Rna(build_rna_merged(r, merged)),
+        HgvsVariant::Mt(m) => HgvsVariant::Mt(build_mt_merged(m, merged)),
         _ => unreachable!("build_merged called with non-NaEdit variant kind"),
-    }
-}
-
-/// Combine two adjacency-checked anchors into one merged anchor.
-/// Caller has already verified `a.end + 1 == b.start`.
-fn merge_anchors(a: Anchor, b: Anchor) -> Anchor {
-    debug_assert_eq!(a.end.checked_add(1), Some(b.start));
-    let mut alt = a.alt;
-    alt.extend(b.alt);
-    Anchor {
-        start: a.start.min(b.start),
-        end: a.end.max(b.end),
-        alt,
     }
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -228,8 +228,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // When merging collapses a Cis allele to a single sub-variant, unwrap
         // the Allele so the rendered output matches the HGVS spec's bracket-free
         // form (e.g., g.1000_1001delinsAC, not g.[1000_1001delinsAC]).
-        let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
-            && merged.len() == 1
+        let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis && merged.len() == 1
         {
             merged.pop().unwrap()
         } else {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -222,8 +222,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
             normalized = self.resolve_overlaps(normalized)?;
         }
 
-        // Third pass: merge consecutive edits per HGVS spec (issue #72)
-        let mut merged = merge::merge_consecutive_edits(&normalized, allele.phase);
+        // HGVS requires consecutive edits in cis to render as a single delins.
+        let mut merged = merge::merge_consecutive_edits(normalized, allele.phase);
 
         // When merging collapses a Cis allele to a single sub-variant, unwrap
         // the Allele so the rendered output matches the HGVS spec's bracket-free

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -25,6 +25,7 @@
 
 pub mod boundary;
 pub mod config;
+pub(crate) mod merge;
 pub mod rules;
 pub mod shuffle;
 pub mod validate;
@@ -221,13 +222,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
             normalized = self.resolve_overlaps(normalized)?;
         }
 
-        Ok((
+        // Third pass: merge consecutive edits per HGVS spec (issue #72)
+        let mut merged = merge::merge_consecutive_edits(&normalized, allele.phase);
+
+        // When merging collapses a Cis allele to a single sub-variant, unwrap
+        // the Allele so the rendered output matches the HGVS spec's bracket-free
+        // form (e.g., g.1000_1001delinsAC, not g.[1000_1001delinsAC]).
+        let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
+            && merged.len() == 1
+        {
+            merged.pop().unwrap()
+        } else {
             HgvsVariant::Allele(crate::hgvs::variant::AlleleVariant::new(
-                normalized,
+                merged,
                 allele.phase,
-            )),
-            all_warnings,
-        ))
+            ))
+        };
+
+        Ok((result, all_warnings))
     }
 
     /// Resolve overlaps between normalized variants in a compound allele.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -223,12 +223,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         // HGVS requires consecutive edits in cis to render as a single delins.
+        // Track input length so we only unwrap when a merge actually collapsed
+        // multiple sub-variants — not for pre-existing singleton alleles, which
+        // must round-trip with the Allele wrapper intact for programmatic callers
+        // (Display already renders singletons in bare form regardless).
+        let original_len = normalized.len();
         let mut merged = merge::merge_consecutive_edits(normalized, allele.phase);
 
-        // When merging collapses a Cis allele to a single sub-variant, unwrap
-        // the Allele so the rendered output matches the HGVS spec's bracket-free
-        // form (e.g., g.1000_1001delinsAC, not g.[1000_1001delinsAC]).
-        let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis && merged.len() == 1
+        let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
+            && original_len > 1
+            && merged.len() == 1
         {
             merged.pop().unwrap()
         } else {

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -61,3 +61,43 @@ fn test_merge_dels_drops_length() {
         "NC_000001.11:g.1000_1004del",
     );
 }
+
+#[test]
+fn test_merge_sub_then_delins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001_1002delinsTT]"),
+        "NC_000001.11:g.1000_1002delinsATT",
+    );
+}
+
+#[test]
+fn test_merge_delins_then_sub() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1001delinsTT;1002A>C]"),
+        "NC_000001.11:g.1000_1002delinsTTC",
+    );
+}
+
+#[test]
+fn test_merge_delins_then_delins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1001delinsTT;1002_1003delinsAA]"),
+        "NC_000001.11:g.1000_1003delinsTTAA",
+    );
+}
+
+#[test]
+fn test_merge_skips_non_literal_delins() {
+    // delins with a non-Literal payload (e.g., delins10) is not safely
+    // concatenable; the design doc requires the pair to pass through.
+    let input = "NC_000001.11:g.[1000G>A;1001_1010delins10]";
+    let result = normalize_to_string(input);
+    // The output must still contain both edits separately (unchanged).
+    assert!(result.contains("1000G>A"), "expected 1000G>A in {}", result);
+    assert!(
+        result.contains("1001_1010delins"),
+        "expected 1001_1010delins in {}",
+        result
+    );
+    assert!(result.contains(';'), "expected separator in {}", result);
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -356,3 +356,60 @@ fn test_no_merge_reverse_input_order() {
     assert!(result.contains("1000G>A"), "got {}", result);
     assert!(!result.contains("delins"), "got {}", result);
 }
+
+// =====================================================================
+// Chains and mixed-edit-type sequences.
+// =====================================================================
+
+#[test]
+fn test_merge_chain_three_consecutive_subs() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C;1002C>T]"),
+        "NC_000001.11:g.1000_1002delinsACT",
+    );
+}
+
+#[test]
+fn test_merge_chain_sub_ins_sub_at_shared_boundary() {
+    // Chain across one shared boundary: sub at 100 + ins between 100 and 101 + sub at 101.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;100_101insT;101A>C]"),
+        "NC_000001.11:g.100_101delinsATC",
+    );
+}
+
+#[test]
+fn test_merge_long_chain_mixed_types() {
+    // 4-element chain spanning sub, del, sub, sub at consecutive positions.
+    // Position 100 sub, 101 del, 102 sub, 103 sub -> single delins 100..=103 alt = A_AA = AAA.
+    // (The del at 101 contributes no alt, so the merged alt is "A" + "" + "A" + "A" = "AAA".)
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;101del;102C>A;103T>A]"),
+        "NC_000001.11:g.100_103delinsAAA",
+    );
+}
+
+#[test]
+fn test_merge_same_position_twice_no_merge() {
+    // Two edits at the SAME position (zero gap, but overlap not adjacency)
+    // must not collapse into a single delins.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;100A>C]");
+    // The output should still contain both — we don't synthesize a "double mutation" form.
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("100A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+#[ignore = "Codon-frame exception for c. — tracked in issue #79"]
+fn test_codon_frame_exception_deferred() {
+    // Per HGVS spec: c.[145C>T;147C>G] (positions 145-147 share codon 49)
+    // must be expressed as c.145_147delinsTGG. Implementing this needs
+    // reference-provider access for the unchanged middle nucleotide and
+    // codon-frame logic; deferred to issue #79.
+    let provider = provider_with_simple_transcript();
+    assert_eq!(
+        normalize_with_provider(provider, "NM_TEST.1:c.[10A>G;12A>C]"),
+        "NM_TEST.1:c.10_12delinsGAC",
+    );
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -161,3 +161,198 @@ fn test_merge_skips_non_literal_ins() {
     );
     assert!(result.contains(';'), "expected separator in {}", result);
 }
+
+fn provider_with_simple_transcript() -> MockProvider {
+    use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with_provider(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn test_merge_cds_consecutive_subs() {
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:c.[10A>G;11A>C]",
+        ),
+        "NM_TEST.1:c.10_11delinsGC",
+    );
+}
+
+#[test]
+fn test_merge_tx_consecutive_subs() {
+    // n. compact form isn't accepted by the parser; use expanded form.
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "[NM_TEST.1:n.10A>G;NM_TEST.1:n.11A>C]",
+        ),
+        "NM_TEST.1:n.10_11delinsGC",
+    );
+}
+
+#[test]
+fn test_merge_rna_consecutive_subs_lowercase() {
+    // RNA uses lowercase nucleotides per HGVS spec; merged alt must preserve case.
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:r.[10a>g;11a>c]",
+        ),
+        "NM_TEST.1:r.10_11delinsgc",
+    );
+}
+
+#[test]
+fn test_merge_mt_consecutive_subs() {
+    // m. compact form isn't accepted by the parser; use expanded form.
+    assert_eq!(
+        normalize_to_string("[NC_012920.1:m.100G>A;NC_012920.1:m.101A>C]"),
+        "NC_012920.1:m.100_101delinsAC",
+    );
+}
+
+// =====================================================================
+// Negative cases — must round-trip unchanged.
+// =====================================================================
+
+#[test]
+fn test_no_merge_one_nt_gap() {
+    // One unchanged nucleotide between variants -> spec keeps them separate.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;102C>T]");
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("102C>T"), "got {}", result);
+    assert!(result.contains(';'), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_different_accessions() {
+    let result = normalize_to_string("[NC_000001.11:g.100G>A;NC_000002.11:g.101A>C]");
+    assert!(result.contains("NC_000001.11"), "got {}", result);
+    assert!(result.contains("NC_000002.11"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_different_variant_types() {
+    // Genome and Cds in the same allele bracket -> not mergeable.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "[NC_000001.11:g.100G>A;NM_TEST.1:c.10A>C]",
+    );
+    assert!(result.contains("g.100G>A"), "got {}", result);
+    assert!(result.contains("c.10A>C"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_trans_phase() {
+    // [a];[b] (semicolon between bracket pairs) is trans phase per HGVS.
+    // The compact form g.[a];[b] isn't accepted by the parser; use expanded form.
+    let result = normalize_to_string("[NC_000001.11:g.100G>A];[NC_000001.11:g.101A>C]");
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("101A>C"), "got {}", result);
+    // No delins should appear.
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_intronic_position() {
+    // Intronic positions (non-zero offset) are excluded from the merge pass.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:c.[10+1A>G;10+2T>G]",
+    );
+    assert!(result.contains("10+1A>G"), "got {}", result);
+    assert!(result.contains("10+2T>G"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_utr_boundary() {
+    // c.-1 and c.1 are physically adjacent but no valid HGVS range syntax
+    // spans the 5'UTR / CDS boundary (c.-1_1 doesn't exist).
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:c.[-1A>G;1A>T]",
+    );
+    assert!(result.contains("-1A>G"), "got {}", result);
+    assert!(result.contains("1A>T"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_uncertain_edit() {
+    // Mu::Uncertain (paren-wrapped edit) is not mergeable.
+    // The g. uncertain-edit syntax isn't supported by the parser, but c.
+    // accepts it via the expanded allele form.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "[NM_TEST.1:c.(10A>G);NM_TEST.1:c.11A>C]",
+    );
+    assert!(result.contains("10(A>G)"), "got {}", result);
+    assert!(result.contains("11A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_duplication_adjacent_to_sub() {
+    let result = normalize_to_string("NC_000001.11:g.[100dup;101A>C]");
+    assert!(result.contains("100dup"), "got {}", result);
+    assert!(result.contains("101A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_inversion_adjacent_to_sub() {
+    let result = normalize_to_string("NC_000001.11:g.[100_102inv;103A>C]");
+    assert!(result.contains("100_102inv"), "got {}", result);
+    assert!(result.contains("103A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_two_ins_different_boundaries() {
+    // Two ins separated by an unchanged nucleotide at position 101 -> no merge.
+    let result = normalize_to_string("NC_000001.11:g.[100_101insT;101_102insA]");
+    assert!(result.contains("100_101insT"), "got {}", result);
+    assert!(result.contains("101_102insA"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_merge_reverse_input_order() {
+    // Input listed in reverse position order; the walk preserves input order
+    // and checks input-order adjacency (1001's anchor end + 1 != 1000's start),
+    // so no merge happens. Pins the no-resort decision.
+    let result = normalize_to_string("NC_000001.11:g.[1001A>C;1000G>A]");
+    assert!(result.contains("1001A>C"), "got {}", result);
+    assert!(result.contains("1000G>A"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -18,3 +18,46 @@ fn test_merge_consecutive_subs_genome() {
         "NC_000001.11:g.1000_1001delinsAC",
     );
 }
+
+#[test]
+fn test_merge_consecutive_dels_genome() {
+    // Issue #72 example: two adjacent single-nt deletions become a single ranged del.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000del;1001del]"),
+        "NC_000001.11:g.1000_1001del",
+    );
+}
+
+#[test]
+fn test_merge_sub_then_del() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001del]"),
+        "NC_000001.11:g.1000_1001delinsA",
+    );
+}
+
+#[test]
+fn test_merge_del_then_sub() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000del;1001A>C]"),
+        "NC_000001.11:g.1000_1001delinsC",
+    );
+}
+
+#[test]
+fn test_merge_dels_drops_explicit_sequence() {
+    // Per design doc: del+del with explicit ref sequences emits the no-sequence form.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000delA;1001delC]"),
+        "NC_000001.11:g.1000_1001del",
+    );
+}
+
+#[test]
+fn test_merge_dels_drops_length() {
+    // Per design doc: del+del with length specifiers emits no-sequence/no-length form.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000_1002del3;1003_1004del2]"),
+        "NC_000001.11:g.1000_1004del",
+    );
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -101,3 +101,63 @@ fn test_merge_skips_non_literal_delins() {
     );
     assert!(result.contains(';'), "expected separator in {}", result);
 }
+
+#[test]
+fn test_merge_sub_then_ins() {
+    // Spec FAQ analogue (in g. context):
+    // sub at 100 + ins between 100 and 101 -> delins at 100 with alt = sub.alt + ins.bases.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100G>A;100_101insTA]"),
+        "NC_000001.11:g.100delinsATA",
+    );
+}
+
+#[test]
+fn test_merge_ins_then_sub() {
+    // Mirror: ins between 100 and 101 + sub at 101 -> delins at 101 with alt = ins.bases + sub.alt.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insTA;101G>A]"),
+        "NC_000001.11:g.101delinsTAA",
+    );
+}
+
+#[test]
+fn test_merge_del_then_ins() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100del;100_101insTA]"),
+        "NC_000001.11:g.100delinsTA",
+    );
+}
+
+#[test]
+fn test_merge_ins_then_del() {
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insTA;101del]"),
+        "NC_000001.11:g.101delinsTA",
+    );
+}
+
+#[test]
+fn test_merge_two_ins_same_boundary_preserves_input_order() {
+    // Two ins at the same boundary p|p+1 collapse into a single ins; bases
+    // are concatenated in input order (T then A -> TA).
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[100_101insT;100_101insA]"),
+        "NC_000001.11:g.100_101insTA",
+    );
+}
+
+#[test]
+fn test_merge_skips_non_literal_ins() {
+    // Ins with a non-Literal payload (e.g., ins10) is not safely
+    // concatenable; the pair passes through unchanged.
+    let input = "NC_000001.11:g.[100G>A;100_101ins10]";
+    let result = normalize_to_string(input);
+    assert!(result.contains("100G>A"), "expected 100G>A in {}", result);
+    assert!(
+        result.contains("100_101ins10"),
+        "expected 100_101ins10 in {}",
+        result
+    );
+    assert!(result.contains(';'), "expected separator in {}", result);
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -1,0 +1,20 @@
+//! Tests for HGVS-spec consecutive-edit merging in alleles.
+//! See docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn test_merge_consecutive_subs_genome() {
+    // Issue #72 example: two adjacent SNVs collapse to a single delins.
+    assert_eq!(
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C]"),
+        "NC_000001.11:g.1000_1001delinsAC",
+    );
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -400,6 +400,60 @@ fn test_merge_same_position_twice_no_merge() {
     assert!(!result.contains("delins"), "got {}", result);
 }
 
+#[test]
+fn test_merge_chain_then_barrier_then_chain() {
+    // Three consecutive subs, then a duplication (a non-mergeable barrier),
+    // then two more consecutive subs. The expected output is two separate
+    // merged delins surrounding the dup. Pins the chain-flush-on-barrier
+    // and chain-restart-after-barrier paths used by deferred-materialization.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;101A>C;102C>T;103dup;104A>G;105G>T]");
+    assert!(result.contains("100_102delinsACT"), "got {}", result);
+    assert!(result.contains("103dup"), "got {}", result);
+    assert!(result.contains("104_105delinsGT"), "got {}", result);
+    // No spurious extra merges.
+    assert_eq!(
+        result.matches("delins").count(),
+        2,
+        "expected exactly two delins in {}",
+        result
+    );
+}
+
+#[test]
+fn test_merge_long_consecutive_chain_correctness() {
+    // 10-element chain of consecutive substitutions. The merged alt must be
+    // the concatenation of all alt bases in input order. Pins correctness
+    // for chains long enough that the deferred-materialization path
+    // dominates the work.
+    let result =
+        normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C;1002C>T;1003T>G;1004G>A;1005A>C;1006C>T;1007T>G;1008G>A;1009A>C]");
+    assert_eq!(result, "NC_000001.11:g.1000_1009delinsACTGACTGAC");
+}
+
+#[test]
+fn test_merge_chain_at_input_end() {
+    // Chain spans the last variants in the allele — the loop ends mid-chain
+    // and the deferred-materialization version must flush at loop end, not
+    // leave the last chain unemitted.
+    let result = normalize_to_string("NC_000001.11:g.[100dup;101G>A;102A>C]");
+    assert!(result.contains("100dup"), "got {}", result);
+    assert!(result.contains("101_102delinsAC"), "got {}", result);
+}
+
+#[test]
+fn test_unmerged_pending_passes_through_unchanged() {
+    // A merge-eligible variant followed by a non-mergeable barrier with no
+    // mergeable predecessor: the eligible variant must emit AS-IS (a
+    // substitution, not a delins). Pins the was_merged=false flush path.
+    let result = normalize_to_string("NC_000001.11:g.[100G>A;200dup]");
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("200dup"), "got {}", result);
+    // CRITICAL: the lone sub must NOT have been turned into a delins by
+    // building from its anchor — that's the pitfall the was_merged flag
+    // exists to prevent.
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
 // =====================================================================
 // SPDI/VCF interaction with merge.
 //

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -489,6 +489,26 @@ fn test_merged_allele_changes_variant_kind() {
 }
 
 #[test]
+fn test_singleton_cis_allele_preserves_wrapper() {
+    // The unwrap in normalize_allele must only fire when a merge actually
+    // collapsed multiple sub-variants — not for pre-existing singletons.
+    // Parsing `[1000G>A]` yields an AlleleVariant with one sub-variant; with
+    // no merge happening, the wrapper must round-trip so programmatic callers
+    // still see HgvsVariant::Allele. (Display already renders the bracket-free
+    // form via AlleleVariant::Display, so user-visible output is unchanged.)
+    use ferro_hgvs::HgvsVariant;
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed = parse_hgvs("NC_000001.11:g.[1000G>A]").expect("parse failed");
+    assert!(matches!(parsed, HgvsVariant::Allele(_)));
+    let normalized = normalizer.normalize(&parsed).expect("normalize failed");
+    assert!(
+        matches!(normalized, HgvsVariant::Allele(_)),
+        "expected Allele preserved (no merge happened), got {:?}",
+        normalized
+    );
+}
+
+#[test]
 fn test_merged_delins_spdi_needs_reference() {
     // Documents that hgvs_to_spdi_simple cannot encode a merged delins
     // without reference data: the merged form drops per-base ref info from

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for HGVS-spec consecutive-edit merging in alleles.
 //! See docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md.
 
-use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use ferro_hgvs::{hgvs_to_spdi_simple, parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
 
 fn normalize_to_string(input: &str) -> String {
     let normalizer = Normalizer::new(MockProvider::new());
@@ -395,6 +395,113 @@ fn test_merge_same_position_twice_no_merge() {
     // must not collapse into a single delins.
     let result = normalize_to_string("NC_000001.11:g.[100G>A;100A>C]");
     // The output should still contain both — we don't synthesize a "double mutation" form.
+    assert!(result.contains("100G>A"), "got {}", result);
+    assert!(result.contains("100A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+// =====================================================================
+// SPDI/VCF interaction with merge.
+//
+// Audit findings (recorded for future readers, not just tests):
+//   * Neither hgvs_to_spdi_simple nor any vcf::to_hgvs path *produces*
+//     HgvsVariant::Allele, so the merge pass cannot affect VCF/SPDI -> HGVS.
+//   * hgvs_to_spdi_simple accepts only HgvsVariant::Genome. Merge collapses
+//     a cis allele into a Genome (or Cds/etc.), changing which branch is
+//     taken downstream. For a sub-sub merge the result is a Delins, which
+//     SPDI cannot encode without the deleted reference sequence — that
+//     limitation is independent of merge and the test below pins it.
+//   * vcf::from_hgvs::HgvsToVcfConverter erred on multi-variant Cis
+//     alleles. Post-merge, those alleles become a single variant and now
+//     follow the single-variant convert path (success there is gated on
+//     reference availability for delins, which MockProvider lacks).
+// =====================================================================
+
+#[test]
+fn test_merged_allele_changes_variant_kind() {
+    // Before merge: HgvsVariant::Allele wrapping two Genome subs.
+    // After merge: a single Genome variant (no Allele wrapper) — so
+    // downstream code dispatching on variant kind hits the Genome branch.
+    use ferro_hgvs::HgvsVariant;
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed = parse_hgvs("NC_000001.11:g.[1000G>A;1001A>C]").expect("parse failed");
+    assert!(matches!(parsed, HgvsVariant::Allele(_)));
+    let normalized = normalizer.normalize(&parsed).expect("normalize failed");
+    assert!(
+        matches!(normalized, HgvsVariant::Genome(_)),
+        "expected Genome after merge, got {:?}",
+        normalized
+    );
+}
+
+#[test]
+fn test_merged_delins_spdi_needs_reference() {
+    // Documents that hgvs_to_spdi_simple cannot encode a merged delins
+    // without reference data: the merged form drops per-base ref info from
+    // the input subs, and SPDI requires the deleted bases. Pre-merge this
+    // call would have failed with UnsupportedVariantType (Allele); post-merge
+    // it fails with MissingReferenceData (Delins). The capability hasn't
+    // changed — just the failure mode.
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed = parse_hgvs("NC_000001.11:g.[1000G>A;1001A>C]").expect("parse failed");
+    let normalized = normalizer.normalize(&parsed).expect("normalize failed");
+    let err = hgvs_to_spdi_simple(&normalized).expect_err("delins requires ref data");
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("MissingReferenceData") || msg.contains("reference"),
+        "expected ref-data failure, got {}",
+        msg
+    );
+}
+
+#[test]
+fn test_unmerged_allele_still_unsupported_by_spdi() {
+    // Sanity check the non-merge path: hgvs_to_spdi_simple still refuses
+    // an Allele that didn't collapse (variants stay as separate sub-variants).
+    let normalizer = Normalizer::new(MockProvider::new());
+    // One nt gap -> no merge, still an Allele after normalize.
+    let parsed = parse_hgvs("NC_000001.11:g.[100G>A;102C>T]").expect("parse failed");
+    let normalized = normalizer.normalize(&parsed).expect("normalize failed");
+    let result = hgvs_to_spdi_simple(&normalized);
+    assert!(
+        result.is_err(),
+        "unmerged Allele should not convert to SPDI, got {:?}",
+        result
+    );
+}
+
+// =====================================================================
+// Merge runs even when overlap prevention is disabled.
+//
+// The merge pass uses a strict `a.end + 1 == b.start` adjacency check,
+// so an overlapping pair never merges regardless of the prevent_overlap
+// flag — but adjacent pairs still must merge.
+// =====================================================================
+
+fn normalize_to_string_no_overlap_check(input: &str) -> String {
+    let config = NormalizeConfig::default().with_overlap_prevention(false);
+    let normalizer = Normalizer::with_config(MockProvider::new(), config);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn test_merge_still_runs_with_prevent_overlap_disabled() {
+    // Adjacent pair must still collapse to a delins; merge is independent
+    // of the overlap-prevention pre-pass.
+    assert_eq!(
+        normalize_to_string_no_overlap_check("NC_000001.11:g.[1000G>A;1001A>C]"),
+        "NC_000001.11:g.1000_1001delinsAC",
+    );
+}
+
+#[test]
+fn test_overlap_pair_does_not_merge_with_prevent_overlap_disabled() {
+    // Same-position pair is an overlap, not adjacency. Even with the
+    // overlap-prevention pre-pass disabled, the strict adjacency check
+    // in merge_consecutive_edits refuses to combine them.
+    let result = normalize_to_string_no_overlap_check("NC_000001.11:g.[100G>A;100A>C]");
     assert!(result.contains("100G>A"), "got {}", result);
     assert!(result.contains("100A>C"), "got {}", result);
     assert!(!result.contains("delins"), "got {}", result);

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -103,3 +103,23 @@ class TestVersion:
         assert hasattr(ferro_hgvs, "__version__")
         assert isinstance(ferro_hgvs.__version__, str)
         assert len(ferro_hgvs.__version__) > 0
+
+
+class TestNormalizeMergeConsecutive:
+    """Smoke tests for HGVS-spec consecutive-edit merging via the Python binding."""
+
+    def test_consecutive_subs_collapse_to_delins(self) -> None:
+        # Issue #72: two adjacent SNVs in cis must collapse to one delins.
+        result = ferro_hgvs.normalize("NC_000001.11:g.[1000G>A;1001A>C]")
+        assert result == "NC_000001.11:g.1000_1001delinsAC"
+
+    def test_consecutive_dels_collapse_to_ranged_del(self) -> None:
+        result = ferro_hgvs.normalize("NC_000001.11:g.[1000del;1001del]")
+        assert result == "NC_000001.11:g.1000_1001del"
+
+    def test_non_adjacent_subs_stay_separate(self) -> None:
+        # One unchanged nt between variants -> spec keeps them separate.
+        result = ferro_hgvs.normalize("NC_000001.11:g.[100G>A;102C>T]")
+        assert "100G>A" in result
+        assert "102C>T" in result
+        assert ";" in result


### PR DESCRIPTION
## Summary

Adds a normalize pass that merges consecutive sub-variants in cis alleles into a single delins per the HGVS spec — `g.[1000G>A;1001A>C]` → `g.1000_1001delinsAC`, `g.[1000del;1001del]` → `g.1000_1001del`.

Closes #72.

## Scope

- Cis phase only (Trans/Mosaic/Chimeric/Unknown pass through unchanged)
- All NaEdit-bearing variant types: g./c./n./r./m.
- Edit combinations: sub, del, delins, ins (Literal-payload only); chains of any of the above; insertions at shared boundaries (two ins at the same boundary collapse to one)
- Barriers: dup, inv, repeat, uncertain edits, non-Literal payloads, intronic positions, UTR-boundary crossings, accession or variant-kind changes
- Codon-frame exception (`c.[145C>T;147C>G]` style) is deferred to #79 with an `#[ignore]`-d test stub

## Algorithm

Walk left-to-right with a cached anchor of `output.last()`. On adjacency + same-kind, extend the anchor's alt in place (amortized O(1) per base). When a chain ends, the head of `output` is rebuilt once from the merged anchor — total cost for an N-chain is O(N) instead of the natural O(N^2) "rebuild on every step". A `head_merged` flag also prevents a lone substitution from being rebuilt into a delins.

## Output behavior

When merge collapses 2+ sub-variants to one, the Allele wrapper is dropped: `g.[1000G>A;1001A>C]` → `g.1000_1001delinsAC`, not `[g.1000_1001delinsAC]`. Single-element bracket inputs (`g.[100G>A]`) stay wrapped to preserve user intent and parse→normalize round-trip identity.

## Testing

- 46 dedicated tests in `tests/merge_consecutive_edits_tests.rs` covering all coordinate systems, mixed-edit chains, same-boundary insertion pairs, all barrier categories, singleton-unwrap (both branches), SPDI/VCF interaction, and `prevent_overlap=false`
- 3 Python smoke tests in `tests/python/test_core.py`
- Full suite: 3082 Rust + 113 Python pass

## Performance

Allele normalize, release, 50k iters/op:

| workload                  | main   | this PR | Δ |
|---------------------------|--------|---------|---|
| consecutive_subs n=2      |  427ns |   423ns | parity |
| consecutive_subs n=16     | 2460ns |  2338ns | -5% |
| consecutive_subs n=32     | 3280ns |  4393ns | +34% |
| non_adjacent_subs n=16    | 2154ns |  2221ns | +3% |
| non_adjacent_subs n=32    | 3461ns |  4255ns | +23% |
| non_adjacent_delins n=32  | 8918ns |  9322ns | +5% |

Single-variant (non-allele) normalization is structurally untouched — the merge code is only reachable from `normalize_allele`.