### PR TITLE
ins 3'-shift coverage matrix + tandem-repeat ins canonical-form fix (#81 A1, A7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 3'-shift coverage matrix for insertion variants
+  (`tests/ins_shift_matrix.rs`): 84 rstest cases across all 7 nucleotide
+  coord-system / strand combinations × 8 shuffle scenarios, with a
+  shared `SyntheticBuilder` fixture helper at `tests/common/synthetic.rs`
+  (reusable by future del / dup / repeat-notation matrices). Issue #81
+  item A7.
 - *(normalize)* Merge consecutive sub-variants in cis alleles into a single delins per HGVS spec. `g.[1000G>A;1001A>C]` now normalizes to `g.1000_1001delinsAC`; `g.[1000del;1001del]` to `g.1000_1001del`. Covers `g./c./n./r./m.` coordinate systems, sub/del/delins/ins edit combinations, chains, and same-boundary insertion pairs. Non-adjacent variants, intronic/UTR boundaries, uncertain edits, and non-`Literal` insertion payloads are barriers and pass through unchanged. The codon-frame exception (one-nt gap within a codon) is tracked separately in [#79](https://github.com/fulcrumgenomics/ferro-hgvs/issues/79). ([#80](https://github.com/fulcrumgenomics/ferro-hgvs/pull/80))
+
+### Fixed
+
+- Insertions that add ≥2 copies of a multi-base tandem repeat unit now
+  emit repeat notation (`unit[N+k]`) instead of a duplication of the
+  inserted sequence, per HGVS spec ("when more than one additional copies
+  are inserted directly 3' of the original copy, the change is indicated
+  using the format for Repeated sequences"). Single-unit additions remain
+  `dup`. Issue #81 item A7.
+- `MockProvider::get_sequence` now falls through to genomic contig
+  lookup when the id is not a transcript, matching `FastaProvider`'s
+  behavior. This unblocks 3'-shift normalization for genomic test
+  fixtures that register only `add_genomic_sequence`. Issue #81 item A7.
 
 ## [0.4.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.3.0...v0.4.0) - 2026-04-30
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1642,13 +1642,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     // because repeat notation refers to the reference tract position
                     if seq_bytes.len() > 1 {
                         let original_pos_idx = hgvs_pos_to_index(start) as u64; // 0-based original position
-                        if let Some((base, count, rep_start, rep_end)) =
+                        if let Some((_first, count, rep_start, rep_end, unit_bytes)) =
                             rules::insertion_to_repeat(ref_seq, original_pos_idx, &seq_bytes)
                         {
-                            // Convert to repeat notation: BASE[count]
                             use crate::hgvs::edit::Base;
-                            if let Some(base_enum) = Base::from_char(base as char) {
-                                let repeat_seq = Sequence::new(vec![base_enum]);
+                            let bases: Vec<Base> = unit_bytes
+                                .iter()
+                                .filter_map(|&b| Base::from_char(b as char))
+                                .collect();
+                            if bases.len() == unit_bytes.len() {
+                                let repeat_seq = Sequence::new(bases);
                                 let repeat_edit = NaEdit::Repeat {
                                     sequence: Some(repeat_seq),
                                     count: RepeatCount::Exact(count),

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -147,88 +147,139 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
     })
 }
 
-/// Check if an insertion in a homopolymer should become repeat notation
+/// Check if an insertion in a tandem repeat should become repeat notation.
 ///
-/// When inserting bases that are identical to an existing homopolymer repeat,
-/// the result should be expressed as repeat notation (e.g., A[9]).
+/// Per HGVS spec: when an insertion adds 2 or more copies of a tandem
+/// repeat unit already present adjacent to the insertion point, the
+/// variant is expressed as repeat notation `unit[N+k]`. A single-copy
+/// addition is left as a duplication (handled by `insertion_is_duplication`).
 ///
-/// Returns the total count if this should be repeat notation, None otherwise.
+/// Returns `Some((first_byte, total_count, ref_start_1based,
+/// ref_end_1based, unit_bytes))` when repeat notation applies, `None`
+/// otherwise. `first_byte` is preserved for backwards-compat with the
+/// homopolymer caller; `unit_bytes` is the full tandem unit.
 pub fn insertion_to_repeat(
     ref_seq: &[u8],
     pos: u64,
     inserted_seq: &[u8],
-) -> Option<(u8, u64, u64, u64)> {
-    // Only handle single-base insertions for now
-    // (multi-base tandem repeats are more complex)
+) -> Option<(u8, u64, u64, u64, Vec<u8>)> {
     if inserted_seq.is_empty() {
         return None;
     }
 
-    // Check if all inserted bases are the same
-    let first = inserted_seq[0];
-    if !inserted_seq.iter().all(|&b| b == first) {
+    let base_unit = smallest_repeat_unit(inserted_seq);
+    let added_copies = (inserted_seq.len() / base_unit.len()) as u64;
+    if added_copies < 2 {
+        // Single-copy addition is a duplication, not repeat notation.
         return None;
     }
 
-    let pos_idx = pos as usize;
-
-    // Find the homopolymer at or near this insertion position
-    // For an insertion between positions X and X+1, we need to find any adjacent
-    // homopolymer of the same base and pick the largest one.
-    // Check multiple positions and pick the best (largest) homopolymer
-    let mut best_analysis: Option<RepeatAnalysis> = None;
-
-    // Check position before insertion (X-1)
-    if pos_idx > 0 && ref_seq.get(pos_idx - 1) == Some(&first) {
-        if let Some(analysis) = find_homopolymer_at(ref_seq, pos_idx - 1) {
-            if analysis.base == Some(first) {
-                best_analysis = Some(analysis);
+    // The inserted sequence may be written as any cyclic rotation of the
+    // reference repeat unit (e.g. `insCAGCAG` against a `GCA` tract). Try
+    // every rotation of `base_unit` and pick the one that yields the
+    // largest contiguous tandem run anchored at the insertion point.
+    let u_len = base_unit.len();
+    let mut best: Option<(Vec<u8>, usize, u64)> = None;
+    for r in 0..u_len {
+        let mut rotated = Vec::with_capacity(u_len);
+        rotated.extend_from_slice(&base_unit[r..]);
+        rotated.extend_from_slice(&base_unit[..r]);
+        if let Some((ref_start, ref_count)) = find_tandem_extent(ref_seq, pos as usize, &rotated) {
+            if ref_count > 0 && best.as_ref().is_none_or(|(_, _, bc)| ref_count > *bc) {
+                best = Some((rotated, ref_start, ref_count));
             }
         }
     }
 
-    // Check position at insertion (X)
-    if ref_seq.get(pos_idx) == Some(&first) {
-        if let Some(analysis) = find_homopolymer_at(ref_seq, pos_idx) {
-            if analysis.base == Some(first)
-                && (best_analysis.is_none()
-                    || analysis.ref_count > best_analysis.as_ref().unwrap().ref_count)
-            {
-                best_analysis = Some(analysis);
-            }
+    let (unit, ref_start, ref_count) = best?;
+    let total_count = ref_count + added_copies;
+    let ref_end = ref_start + ref_count as usize * unit.len() - 1;
+    Some((
+        unit[0],
+        total_count,
+        index_to_hgvs_pos(ref_start),
+        index_to_hgvs_pos(ref_end),
+        unit,
+    ))
+}
+
+/// Smallest unit `U` such that `seq = U * k` for some integer k ≥ 1.
+fn smallest_repeat_unit(seq: &[u8]) -> &[u8] {
+    let n = seq.len();
+    for u in 1..=n {
+        if !n.is_multiple_of(u) {
+            continue;
+        }
+        let unit = &seq[..u];
+        if seq.chunks_exact(u).all(|c| c == unit) {
+            return unit;
+        }
+    }
+    seq // fallback (unreachable for n>0)
+}
+
+/// Find the maximal tandem run of `unit` near position `pos` in
+/// `ref_seq`. `pos` is the 0-based index of the base immediately 5' of
+/// the insertion point — i.e., the insertion is between `pos` and
+/// `pos+1`. The tract may not be unit-aligned with `pos`, so we probe
+/// anchor offsets in a window around `pos` and pick the run that
+/// abuts/contains the insertion point.
+///
+/// Returns `(ref_start_0based, count)` of the chosen tandem run.
+fn find_tandem_extent(ref_seq: &[u8], pos: usize, unit: &[u8]) -> Option<(usize, u64)> {
+    let u = unit.len();
+    if u == 0 {
+        return None;
+    }
+
+    // Insertion point in "between-bases" coords: between pos and pos+1.
+    let ins_point = pos + 1;
+
+    // Probe candidate anchor offsets within [ins_point - u, ins_point].
+    // For each anchor `a`, compute the maximal tandem run that includes
+    // anchor `a` (walk left and right in steps of `u`). Accept runs that
+    // abut or span the insertion point. Among accepted runs, pick the
+    // largest count.
+    let lo = ins_point.saturating_sub(u);
+    let hi = ins_point.min(ref_seq.len());
+
+    let mut best: Option<(usize, u64)> = None;
+
+    for anchor in lo..=hi {
+        if anchor + u > ref_seq.len() {
+            continue;
+        }
+        if &ref_seq[anchor..anchor + u] != unit {
+            continue;
+        }
+
+        // Walk left from anchor in steps of u.
+        let mut start = anchor;
+        while start >= u && &ref_seq[start - u..start] == unit {
+            start -= u;
+        }
+        // Walk right from anchor in steps of u.
+        let mut end = anchor + u;
+        while end + u <= ref_seq.len() && &ref_seq[end..end + u] == unit {
+            end += u;
+        }
+
+        let count = ((end - start) / u) as u64;
+
+        // Require the run [start, end) to abut/span ins_point: the
+        // insertion point must lie within [start, end].
+        if ins_point < start || ins_point > end {
+            continue;
+        }
+
+        match best {
+            None => best = Some((start, count)),
+            Some((_, bc)) if count > bc => best = Some((start, count)),
+            _ => {}
         }
     }
 
-    // Check position after insertion (X+1) - for cases where insertion extends a following tract
-    if ref_seq.get(pos_idx + 1) == Some(&first) {
-        if let Some(analysis) = find_homopolymer_at(ref_seq, pos_idx + 1) {
-            if analysis.base == Some(first)
-                && (best_analysis.is_none()
-                    || analysis.ref_count > best_analysis.as_ref().unwrap().ref_count)
-            {
-                best_analysis = Some(analysis);
-            }
-        }
-    }
-
-    let analysis = best_analysis;
-
-    if let Some(analysis) = analysis {
-        if analysis.base == Some(first) {
-            // Total count = reference count + inserted count
-            let total_count = analysis.ref_count + inserted_seq.len() as u64;
-            // Return (base, count, start, end) where start/end are 1-based
-            // Per HGVS, positions refer to the reference repeat tract, not expanded
-            return Some((
-                first,
-                total_count,
-                index_to_hgvs_pos(analysis.ref_start),
-                index_to_hgvs_pos(analysis.ref_start + analysis.ref_count as usize - 1),
-            ));
-        }
-    }
-
-    None
+    best
 }
 
 /// Get the complement of a DNA base
@@ -891,26 +942,46 @@ mod tests {
 
     #[test]
     fn test_insertion_to_repeat() {
-        // Sequence: GGGAAAAAGGG (5 A's at positions 3-7, 0-indexed)
+        // Sequence: GGGAAAAAGGG (5 A's at positions 3-7, 0-indexed inclusive)
         let ref_seq = b"GGGAAAAAGGG";
 
-        // Inserting AA at position 8 (after the A's) should become A[7]
-        // Position 8 is 0-indexed, which is after the last A
-        let result = insertion_to_repeat(ref_seq, 8, b"AA");
+        // `pos` is the 0-based index of the base immediately 5' of the
+        // insertion point. pos=7 means insert between index 7 and 8 — i.e.,
+        // immediately after the last A in the homopolymer. Inserting AA here
+        // should become A[7] (5 ref + 2 inserted).
+        let result = insertion_to_repeat(ref_seq, 7, b"AA");
         assert!(result.is_some());
-        let (base, count, start, end) = result.unwrap();
+        let (base, count, start, end, _unit) = result.unwrap();
         assert_eq!(base, b'A');
         assert_eq!(count, 7); // 5 original + 2 inserted
         assert_eq!(start, 4); // 1-indexed start of A region in reference
         assert_eq!(end, 8); // 1-indexed end of A region in reference (per HGVS, positions refer to reference tract)
 
+        // Single-copy inserts (added_copies < 2) are duplications, not repeats.
+        let result = insertion_to_repeat(ref_seq, 7, b"A");
+        assert!(result.is_none());
+
         // Inserting T (non-matching) should return None
-        let result = insertion_to_repeat(ref_seq, 8, b"T");
+        let result = insertion_to_repeat(ref_seq, 7, b"T");
         assert!(result.is_none());
 
         // Inserting mixed bases should return None
-        let result = insertion_to_repeat(ref_seq, 8, b"AT");
+        let result = insertion_to_repeat(ref_seq, 7, b"AT");
         assert!(result.is_none());
+
+        // Multi-base tandem unit: insert ACAC into ACAC tract → AC[4].
+        // ref_seq has ACAC at indices 0-3. Insert ACAC just before index 4
+        // (pos=3, between A at index 3 and base at index 4). Expected:
+        // 2 ref AC units + 2 inserted AC units = AC[4] at ref indices 0..3.
+        let ref_ac = b"ACACGGG";
+        let result = insertion_to_repeat(ref_ac, 3, b"ACAC");
+        assert!(result.is_some());
+        let (base, count, start, end, unit) = result.unwrap();
+        assert_eq!(base, b'A');
+        assert_eq!(count, 4);
+        assert_eq!(start, 1); // 1-indexed
+        assert_eq!(end, 4); // 1-indexed
+        assert_eq!(unit, b"AC");
     }
 
     #[test]

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -269,14 +269,20 @@ impl ReferenceProvider for MockProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
-        let transcript = self.get_transcript(id)?;
+        // Try as transcript ID first (matches FastaProvider behavior).
+        if let Ok(transcript) = self.get_transcript(id) {
+            return transcript
+                .get_sequence(start, end)
+                .map(|s| s.to_string())
+                .ok_or_else(|| FerroError::InvalidCoordinates {
+                    msg: format!("Position {}-{} out of range for {}", start, end, id),
+                });
+        }
 
-        transcript
-            .get_sequence(start, end)
-            .map(|s| s.to_string())
-            .ok_or_else(|| FerroError::InvalidCoordinates {
-                msg: format!("Position {}-{} out of range for {}", start, end, id),
-            })
+        // Fall through to contig/chromosome lookup so genomic accessions
+        // resolve against `genomic_sequences` instead of returning
+        // ReferenceNotFound.
+        self.get_genomic_sequence(id, start, end)
     }
 
     fn get_protein_sequence(
@@ -394,6 +400,16 @@ mod tests {
         let provider = MockProvider::with_test_data();
         let seq = provider.get_sequence("NM_000088.3", 0, 3).unwrap();
         assert_eq!(seq, "ATG");
+    }
+
+    #[test]
+    fn test_get_sequence_falls_through_to_contig() {
+        // Regression: get_sequence should fall through to contig lookup
+        // when the id is not a transcript, matching FastaProvider behavior.
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr1", "ACGTACGT");
+        let seq = provider.get_sequence("chr1", 0, 4).unwrap();
+        assert_eq!(seq, "ACGT");
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,7 @@
+//! Shared test infrastructure for ferro-hgvs integration tests.
+//!
+//! Exposed sub-modules:
+//! - `synthetic`: builders for synthetic `MockProvider` fixtures across
+//!   coordinate systems, used by the ins/del/dup shift coverage matrices.
+
+pub mod synthetic;

--- a/tests/common/synthetic.rs
+++ b/tests/common/synthetic.rs
@@ -1,0 +1,247 @@
+//! Synthetic `MockProvider` builders for nucleotide-shift coverage matrices.
+//!
+//! See `docs/superpowers/specs/2026-05-01-A7-ins-shift-coverage-matrix-design.md`.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// 256 bases of padding to ensure the normalizer's 100bp window stays in
+/// bounds on either side of any test variant.
+const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+
+/// The 0-based offset added by padding — used by cds/noncoding/rna builders.
+pub const PAD_OFFSET: u64 = 256;
+const GENOMIC_CONTIG: &str = "NC_TEST.1";
+const TX_ACCESSION: &str = "NM_TEST.1";
+const NR_ACCESSION: &str = "NR_TEST.1";
+const TX_CONTIG: &str = "chr_synth";
+
+fn padded(core: &str) -> String {
+    format!("{}{}{}", PAD, core, PAD)
+}
+
+/// Builder for synthetic `MockProvider` fixtures across HGVS coord systems.
+///
+/// All builders pad the input core sequence with 256 bases on each side so
+/// the normalizer's 100bp lookahead window stays in range. The first 1-based
+/// HGVS position of the core region is `PAD_OFFSET + 1` (= 257).
+pub struct SyntheticBuilder {
+    inner: CoordSystem,
+}
+
+enum CoordSystem {
+    Genomic {
+        core: String,
+    },
+    Cds {
+        core: String,
+        cds_start: u64,
+        cds_end: u64,
+        strand: Strand,
+    },
+    Noncoding {
+        core: String,
+        strand: Strand,
+    },
+    Rna {
+        core: String,
+        strand: Strand,
+    },
+}
+
+impl SyntheticBuilder {
+    /// Build a genomic provider over the contig `NC_TEST.1` with the given
+    /// core sequence. The core's first base is at 1-based HGVS position 257.
+    pub fn genomic(core: &str) -> Self {
+        Self {
+            inner: CoordSystem::Genomic {
+                core: core.to_string(),
+            },
+        }
+    }
+
+    /// Build a CDS provider with a transcript named `NM_TEST.1`.
+    ///
+    /// `core` is the transcript sequence (no padding needed — the transcript
+    /// is treated as the full reference for c. coordinates). `cds_start` and
+    /// `cds_end` are 1-based inclusive transcript positions delimiting the
+    /// CDS region. The transcript is mapped to a genomic contig `chr_synth`
+    /// at offset `PAD_OFFSET` for plus strand, or reverse-complemented at
+    /// the same offset for minus strand.
+    pub fn cds(core: &str, cds_start: u64, cds_end: u64, strand: Strand) -> Self {
+        Self {
+            inner: CoordSystem::Cds {
+                core: core.to_string(),
+                cds_start,
+                cds_end,
+                strand,
+            },
+        }
+    }
+
+    /// Build a non-coding RNA provider with a transcript named `NR_TEST.1`.
+    pub fn noncoding(core: &str, strand: Strand) -> Self {
+        Self {
+            inner: CoordSystem::Noncoding {
+                core: core.to_string(),
+                strand,
+            },
+        }
+    }
+
+    /// Build an RNA provider with a transcript named `NR_TEST.1`. The
+    /// transcript sequence should be lowercase RNA bases (a/c/g/u). The
+    /// underlying genomic mapping is built from the DNA-equivalent.
+    pub fn rna(core: &str, strand: Strand) -> Self {
+        Self {
+            inner: CoordSystem::Rna {
+                core: core.to_string(),
+                strand,
+            },
+        }
+    }
+
+    /// Materialize the configured `MockProvider` ready for use in a test.
+    pub fn build(self) -> MockProvider {
+        let mut provider = MockProvider::new();
+        match self.inner {
+            CoordSystem::Genomic { core } => {
+                provider.add_genomic_sequence(GENOMIC_CONTIG, padded(&core));
+            }
+            CoordSystem::Cds {
+                core,
+                cds_start,
+                cds_end,
+                strand,
+            } => {
+                let tx_len = core.len() as u64;
+                let genomic = padded(&match strand {
+                    Strand::Plus => core.clone(),
+                    Strand::Minus => reverse_complement(&core),
+                });
+                let g_start = PAD_OFFSET + 1;
+                let g_end = PAD_OFFSET + tx_len;
+                let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+                let transcript = Transcript::new(
+                    TX_ACCESSION.to_string(),
+                    Some("SYNTH".to_string()),
+                    strand,
+                    core,
+                    Some(cds_start),
+                    Some(cds_end),
+                    vec![exon],
+                    Some(TX_CONTIG.to_string()),
+                    Some(g_start),
+                    Some(g_end),
+                    GenomeBuild::GRCh38,
+                    ManeStatus::None,
+                    None,
+                    None,
+                );
+                provider.add_genomic_sequence(TX_CONTIG, genomic);
+                provider.add_transcript(transcript);
+            }
+            CoordSystem::Noncoding { core, strand } => {
+                let tx_len = core.len() as u64;
+                let genomic = padded(&match strand {
+                    Strand::Minus => reverse_complement(&core),
+                    _ => core.clone(),
+                });
+                let g_start = PAD_OFFSET + 1;
+                let g_end = PAD_OFFSET + tx_len;
+                let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+                let transcript = Transcript::new(
+                    NR_ACCESSION.to_string(),
+                    Some("SYNTH_NR".to_string()),
+                    strand,
+                    core,
+                    None,
+                    None,
+                    vec![exon],
+                    Some(TX_CONTIG.to_string()),
+                    Some(g_start),
+                    Some(g_end),
+                    GenomeBuild::GRCh38,
+                    ManeStatus::None,
+                    None,
+                    None,
+                );
+                provider.add_genomic_sequence(TX_CONTIG, genomic);
+                provider.add_transcript(transcript);
+            }
+            CoordSystem::Rna { core, strand } => {
+                let tx_len = core.len() as u64;
+                let dna_core = rna_to_dna(&core);
+                let genomic = padded(&match strand {
+                    Strand::Minus => reverse_complement(&dna_core),
+                    _ => dna_core.clone(),
+                });
+                let g_start = PAD_OFFSET + 1;
+                let g_end = PAD_OFFSET + tx_len;
+                let exon = Exon::with_genomic(1, 1, tx_len, g_start, g_end);
+                let transcript = Transcript::new(
+                    NR_ACCESSION.to_string(),
+                    Some("SYNTH_RNA".to_string()),
+                    strand,
+                    dna_core,
+                    None,
+                    None,
+                    vec![exon],
+                    Some(TX_CONTIG.to_string()),
+                    Some(g_start),
+                    Some(g_end),
+                    GenomeBuild::GRCh38,
+                    ManeStatus::None,
+                    None,
+                    None,
+                );
+                provider.add_genomic_sequence(TX_CONTIG, genomic);
+                provider.add_transcript(transcript);
+            }
+        }
+        provider
+    }
+}
+
+/// Normalize an HGVS variant string against a provider and return the
+/// formatted output. Panics on parse or normalize failure.
+pub fn normalize_to_string(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("Failed to parse '{}': {}", input, e));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("Normalization failed for '{}': {}", input, e));
+    format!("{}", normalized)
+}
+
+fn reverse_complement(seq: &str) -> String {
+    seq.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'G' => 'C',
+            'C' => 'G',
+            'a' => 't',
+            't' => 'a',
+            'g' => 'c',
+            'c' => 'g',
+            other => other,
+        })
+        .collect()
+}
+
+fn rna_to_dna(seq: &str) -> String {
+    seq.chars()
+        .map(|c| match c {
+            'u' => 't',
+            'U' => 'T',
+            other => other,
+        })
+        .collect::<String>()
+        .to_uppercase()
+}

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -364,54 +364,6 @@ mod position_ordering {
 }
 
 // =============================================================================
-// GAP 3: Intronic insertions
-// =============================================================================
-
-mod intronic_insertions {
-    use super::*;
-
-    #[test]
-    fn test_plus_strand_intronic_insertion() {
-        // Basic intronic insertion on plus strand
-        let provider = make_provider_with_plus_strand();
-        let result = normalize(provider, "NM_PLUS.1:c.30+3_30+4insGGG");
-        assert!(
-            result.contains("ins"),
-            "Should remain an insertion, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_minus_strand_intronic_insertion() {
-        // Basic intronic insertion on minus strand — the core issue #11 scenario
-        let provider = make_provider_with_minus_strand();
-        let result = normalize(provider, "NM_MINUS.1:c.30+3_30+4insGGG");
-        assert!(
-            result.contains("ins"),
-            "Should remain an insertion, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_intronic_insertion_to_dup_plus_strand() {
-        // If inserted sequence matches the preceding intronic sequence, should become dup.
-        // Intron 1 genomic (1031-1040): AAACCCAAAT
-        // c.30+1 = genomic 1031 = A, c.30+2 = 1032 = A, c.30+3 = 1033 = A
-        // Inserting A at c.30+3_30+4 into AAA tract could become dup
-        let provider = make_provider_with_plus_strand();
-        let result = normalize(provider, "NM_PLUS.1:c.30+1_30+2insA");
-        // In an AAA tract, inserting A should become dup after 3' shift
-        assert!(
-            result.contains("dup") || result.contains("ins"),
-            "Should be dup or ins, got: {}",
-            result
-        );
-    }
-}
-
-// =============================================================================
 // GAP 4: Intronic duplications
 // =============================================================================
 

--- a/tests/ins_shift_matrix.rs
+++ b/tests/ins_shift_matrix.rs
@@ -1,0 +1,938 @@
+//! A7: 3' shift coverage matrix for ins
+//!
+//! 56 rstest functions across 7 coord-system / strand modules × 8 shuffle
+//! scenarios. See spec at:
+//! docs/superpowers/specs/2026-05-01-A7-ins-shift-coverage-matrix-design.md.
+
+mod common;
+
+mod genomic {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder, PAD_OFFSET};
+    use rstest::rstest;
+
+    /// 1-based HGVS position of the first base of the core region —
+    /// derived from the synthetic builder's padding contract.
+    const C0: u64 = PAD_OFFSET + 1;
+
+    /// Build a genomic provider over the contig `NC_TEST.1` with the given
+    /// core sequence.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::genomic(core).build()
+    }
+
+    /// Format an HGVS string by substituting `{n}` placeholders with positions
+    /// computed as `C0 + p - 1` (so the caller can reason in core-local coords).
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &(C0 + p - 1).to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: ACGTACGT. Insert C between core pos 4 (T) and 5 (A).
+        //   ref[5] = 'A' ≠ 'C' (alt[0])    → no 3' shift
+        //   ref[4] = 'T' ≠ 'C' (alt[last]) → no preceding-base dup
+        // Output: unchanged ins.
+        let p = provider("ACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insC", &[4, 5]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}insC", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: ACAAAACG. A-tract at core pos 3-6. Insert A at core pos 2_3.
+        // 3'-shifts to end of A-tract (core pos 6), becomes dup.
+        let p = provider("ACAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Multi-base ins in tandem repeat, ONE unit added → dup.
+    // Case 1: AC tandem (ACAC at core pos 3-6), insert AC at core pos 2_3.
+    //   Shifts to 3' end; dup at the most-3' AC = core pos 5_6.
+    #[case("ACACACGT", "g.{0}_{1}insAC", &[2u64, 3u64], "g.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: GCA tandem (GCAGCAGCA at core pos 3-11), insert GCA at core pos 2_3.
+    //   Shifts to 3' end; dup at the most-3' GCA = core pos 9_11.
+    #[case("ACGCAGCAGCATG", "g.{0}_{1}insGCA", &[2u64, 3u64], "g.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NC_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NC_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // 2+ units added → repeat notation per HGVS spec.
+    // Case 1: 2 A's added to AAA tract → A[5].
+    //   Core: ACAAACG. ref core[3..6]=AAA. Insert AA at core 2_3.
+    //   Shifts to end of A-tract; 3+2=5 As → A[5].
+    //   Repeat tract: core[3..5] (1-based, 3 A's at HGVS pos 3..5).
+    #[case("ACAAACG", "g.{0}_{1}insAA", &[2u64, 3u64], "g.{0}_{1}A[5]", &[3u64, 5u64])]
+    // Case 2: 4 A's added to AAA tract → A[7].
+    #[case("ACAAACG", "g.{0}_{1}insAAAA", &[2u64, 3u64], "g.{0}_{1}A[7]", &[3u64, 5u64])]
+    // Case 3: 2 GCA units added to GCAGCAGCA tract → GCA[5].
+    //   Core: ACGCAGCAGCATG. ref core[3..11]=GCAGCAGCA (3 GCA units).
+    //   Insert GCAGCA at core 2_3. Shifts; 3+2=5 GCA → GCA[5].
+    //   Repeat tract: core[3..11] (1-based, 9 bases = 3 units).
+    #[case("ACGCAGCAGCATG", "g.{0}_{1}insGCAGCA", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: 2 AC units added to ACACAC tract → AC[5].
+    //   Core: GCACACACG. Pairs (3-4)=AC, (5-6)=AC, (7-8)=AC; 3 AC units at core 3..8.
+    //   Trailing G at core 9 prevents the AC tract from leaking into padding
+    //   (padding starts with 'A', which would otherwise extend the tract).
+    //   Insert ACAC at core 2_3 (between C and A). alt[0]=A, ref[3]=A → match → shifts.
+    //   3+2=5 AC → AC[5]. Tract: core 3..8 (1-based, 6 bases = 3 units).
+    #[case("GCACACACG", "g.{0}_{1}insACAC", &[2u64, 3u64], "g.{0}_{1}AC[5]", &[3u64, 8u64])]
+    // Case 5: alt is a cyclic rotation of the ref unit.
+    //   Core: TTGCAGCAGCATT. Ref tract (GCA)x3 at core 3..11; flanking T's
+    //   at core 1-2 and 12-13 prevent the tract from extending into PAD.
+    //   Insert CAGCAG at core 2_3 (between T and the start of the tract).
+    //   smallest_repeat_unit returns CAG, but the ref tract is GCA — the
+    //   algorithm must try all cyclic rotations of the unit to find the
+    //   reference-aligned tract.
+    //   Expected: GCA[5] at core 3..11.
+    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAGCAG", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NC_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NC_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Multi-base ins shifts by 1 (rotation = 1, len = 2). Rotated alt
+        // doesn't match adjacent ref, so output is rotated ins, not dup.
+        //
+        // Layout: core "ACGTAC". Insert GA at core 2_3:
+        //   ref[3]=G=alt[0]            → shift, alt rotates to "AG"
+        //   ref[4]=T, alt[1]=A         → mismatch, stop
+        // Final position: core 3_4, alt rotated to "AG".
+        // Preceding ref bytes (core[1..3]="CG") ≠ "AG" → not dup.
+        let p = provider("ACGTAC");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insGA", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}insAG", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Genomic-only "boundary" is the end of a homopolymer tract — once
+        // the run-of-A's ends, shuffling stops. (Pure end-of-ref clamping
+        // is exercised in Task 8 onward via transcript boundaries.)
+        //
+        // Core: CAAAACG. A-tract at core pos 2..5 (1-based), bordered by
+        // C at pos 1 and C at pos 6. Insert A at core 2_3 — shifts to end
+        // of A-tract. With a 1-unit insertion (single A), output is dup
+        // at core pos 5 (last A before boundary).
+        let p = provider("CAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at very start of core: pos 1_2. Verify shuffle behavior
+        // doesn't underflow on the 5' boundary.
+        //
+        // Core: AAAACG. A-tract at core 1..4. Insert A at core 1_2.
+        // Shifts to end of A-tract; dup at core pos 4.
+        let p = provider("AAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion near the 3' edge of the A-tract.
+        //
+        // Core: CGAAAAC. A-tract at core 3..6, bordered by G at pos 2 and
+        // C at pos 7. Insert A at core 5_6 (within the tract). Shifts to
+        // end (core pos 6); dup at core pos 6.
+        let p = provider("CGAAAAC");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA", &[5, 6]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[6]));
+    }
+}
+mod cds_plus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a plus-strand CDS provider whose CDS spans the entire transcript.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Plus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. CDS positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: ACGTACGTACGTACGTACGTACGTACGTAC (30 bases). c.10=C, c.11=A.
+        // Insert C between c.10 and c.11 — alt[0]='C' ≠ ref[c.11]='A' (no shift)
+        // and alt[last]='C' ≠ ref[c.10]='C'... wait that's equal, would dup.
+        // Pick a different position: c.4_5. c.4=T, c.5=A. Insert C.
+        //   alt[0]='C' ≠ ref[c.5]='A' → no shift
+        //   alt[last]='C' ≠ ref[c.4]='T' → no preceding-base dup
+        let p = provider("ACGTACGTACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insC", &[4, 5]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insC", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: ACAAAACGTACGTACGTAC (19 bases). A-tract at c.3..6.
+        // Insert A at c.2_3. Shifts to end of A-tract; dup at c.6.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: AC tandem at c.3-6 (ACAC). Insert AC at c.2_3 → dup at c.5_6.
+    #[case("ACACACGTACGTACGTACGTAC", "c.{0}_{1}insAC", &[2u64, 3u64], "c.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: GCA tandem at c.3-11 (GCAGCAGCA). Insert GCA at c.2_3 → dup at c.9_11.
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCA", &[2u64, 3u64], "c.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NM_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NM_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
+    // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
+    // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NM_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NM_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: ACGTACGTACGTACGTACGTAC. Insert GA at c.2_3.
+        //   ref[c.3]=G=alt[0] → shift, alt rotates to "AG"
+        //   ref[c.4]=T, alt[1]=A → mismatch, stop.
+        // Output: c.3_4insAG.
+        let p = provider("ACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insGA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAG", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: A-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: CAAAA (5 bases — entire transcript). A-tract c.2..5; the
+        // transcript ENDS at c.5 (end-of-ref boundary). Insert A at c.2_3.
+        // Should clamp to c.5 — dup at c.5.
+        let p = provider("CAAAA");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at c.1_2. Core: AAAACGTACGTACGTACGTAC.
+        // A-tract at c.1..4. Shifts to dup at c.4.
+        let p = provider("AAAACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an A-tract near transcript end.
+        // Core: CGTACGTACGTACGAAAAC (19 bases). A-tract at c.15..18.
+        // Insert A at c.16_17 (within tract); shifts to c.18, dup at c.18.
+        let p = provider("CGTACGTACGTACGAAAAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[16, 17]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[18]));
+    }
+}
+mod cds_minus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a minus-strand CDS provider whose CDS spans the entire transcript.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Minus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. CDS positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: ACGTACGTACGTACGTACGTACGTACGTAC (30 bases). c.10=C, c.11=A.
+        // Insert C between c.10 and c.11 — alt[0]='C' ≠ ref[c.11]='A' (no shift)
+        // and alt[last]='C' ≠ ref[c.10]='C'... wait that's equal, would dup.
+        // Pick a different position: c.4_5. c.4=T, c.5=A. Insert C.
+        //   alt[0]='C' ≠ ref[c.5]='A' → no shift
+        //   alt[last]='C' ≠ ref[c.4]='T' → no preceding-base dup
+        let p = provider("ACGTACGTACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insC", &[4, 5]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insC", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: ACAAAACGTACGTACGTAC (19 bases). A-tract at c.3..6.
+        // Insert A at c.2_3. Shifts to end of A-tract; dup at c.6.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: AC tandem at c.3-6 (ACAC). Insert AC at c.2_3 → dup at c.5_6.
+    #[case("ACACACGTACGTACGTACGTAC", "c.{0}_{1}insAC", &[2u64, 3u64], "c.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: GCA tandem at c.3-11 (GCAGCAGCA). Insert GCA at c.2_3 → dup at c.9_11.
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCA", &[2u64, 3u64], "c.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NM_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NM_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
+    // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
+    // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NM_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NM_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: ACGTACGTACGTACGTACGTAC. Insert GA at c.2_3.
+        //   ref[c.3]=G=alt[0] → shift, alt rotates to "AG"
+        //   ref[c.4]=T, alt[1]=A → mismatch, stop.
+        // Output: c.3_4insAG.
+        let p = provider("ACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insGA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAG", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: A-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: CAAAA (5 bases — entire transcript). A-tract c.2..5; the
+        // transcript ENDS at c.5 (end-of-ref boundary). Insert A at c.2_3.
+        // Should clamp to c.5 — dup at c.5.
+        let p = provider("CAAAA");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at c.1_2. Core: AAAACGTACGTACGTACGTAC.
+        // A-tract at c.1..4. Shifts to dup at c.4.
+        let p = provider("AAAACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an A-tract near transcript end.
+        // Core: CGTACGTACGTACGAAAAC (19 bases). A-tract at c.15..18.
+        // Insert A at c.16_17 (within tract); shifts to c.18, dup at c.18.
+        let p = provider("CGTACGTACGTACGAAAAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[16, 17]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[18]));
+    }
+}
+mod noncoding_plus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a plus-strand noncoding provider whose transcript spans the entire
+    /// core sequence.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::noncoding(core, Strand::Plus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. Noncoding positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: ACGTACGTACGTACGTACGTACGTACGTAC (30 bases). n.10=C, n.11=A.
+        // Insert C between n.10 and n.11 — alt[0]='C' ≠ ref[n.11]='A' (no shift)
+        // and alt[last]='C' ≠ ref[n.10]='C'... wait that's equal, would dup.
+        // Pick a different position: n.4_5. n.4=T, n.5=A. Insert C.
+        //   alt[0]='C' ≠ ref[n.5]='A' → no shift
+        //   alt[last]='C' ≠ ref[n.4]='T' → no preceding-base dup
+        let p = provider("ACGTACGTACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insC", &[4, 5]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}insC", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: ACAAAACGTACGTACGTAC (19 bases). A-tract at n.3..6.
+        // Insert A at n.2_3. Shifts to end of A-tract; dup at n.6.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: AC tandem at n.3-6 (ACAC). Insert AC at n.2_3 → dup at n.5_6.
+    #[case("ACACACGTACGTACGTACGTAC", "n.{0}_{1}insAC", &[2u64, 3u64], "n.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: GCA tandem at n.3-11 (GCAGCAGCA). Insert GCA at n.2_3 → dup at n.9_11.
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCA", &[2u64, 3u64], "n.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 A's added to AAA tract → A[5]. Tract: n.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}_{1}A[5]", &[3u64, 5u64])]
+    // Case 2: 4 A's added to AAA tract → A[7]. Tract: n.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}_{1}A[7]", &[3u64, 5u64])]
+    // Case 3: 2 GCA units added → GCA[5]. Tract: n.3..11.
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: n.3..8.
+    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: ACGTACGTACGTACGTACGTAC. Insert GA at n.2_3.
+        //   ref[n.3]=G=alt[0] → shift, alt rotates to "AG"
+        //   ref[n.4]=T, alt[1]=A → mismatch, stop.
+        // Output: n.3_4insAG.
+        let p = provider("ACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insGA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}insAG", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: A-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: CAAAA (5 bases — entire transcript). A-tract n.2..5; the
+        // transcript ENDS at n.5 (end-of-ref boundary). Insert A at n.2_3.
+        // Should clamp to n.5 — dup at n.5.
+        let p = provider("CAAAA");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at n.1_2. Core: AAAACGTACGTACGTACGTAC.
+        // A-tract at n.1..4. Shifts to dup at n.4.
+        let p = provider("AAAACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[1, 2]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an A-tract near transcript end.
+        // Core: CGTACGTACGTACGAAAAC (19 bases). A-tract at n.15..18.
+        // Insert A at n.16_17 (within tract); shifts to n.18, dup at n.18.
+        let p = provider("CGTACGTACGTACGAAAAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[16, 17]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[18]));
+    }
+}
+mod noncoding_minus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a minus-strand noncoding provider whose transcript spans the entire
+    /// core sequence.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::noncoding(core, Strand::Minus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. Noncoding positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: ACGTACGTACGTACGTACGTACGTACGTAC (30 bases). n.10=C, n.11=A.
+        // Insert C between n.10 and n.11 — alt[0]='C' ≠ ref[n.11]='A' (no shift)
+        // and alt[last]='C' ≠ ref[n.10]='C'... wait that's equal, would dup.
+        // Pick a different position: n.4_5. n.4=T, n.5=A. Insert C.
+        //   alt[0]='C' ≠ ref[n.5]='A' → no shift
+        //   alt[last]='C' ≠ ref[n.4]='T' → no preceding-base dup
+        let p = provider("ACGTACGTACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insC", &[4, 5]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}insC", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: ACAAAACGTACGTACGTAC (19 bases). A-tract at n.3..6.
+        // Insert A at n.2_3. Shifts to end of A-tract; dup at n.6.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: AC tandem at n.3-6 (ACAC). Insert AC at n.2_3 → dup at n.5_6.
+    #[case("ACACACGTACGTACGTACGTAC", "n.{0}_{1}insAC", &[2u64, 3u64], "n.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: GCA tandem at n.3-11 (GCAGCAGCA). Insert GCA at n.2_3 → dup at n.9_11.
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCA", &[2u64, 3u64], "n.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 A's added to AAA tract → A[5]. Tract: n.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}_{1}A[5]", &[3u64, 5u64])]
+    // Case 2: 4 A's added to AAA tract → A[7]. Tract: n.3..5.
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}_{1}A[7]", &[3u64, 5u64])]
+    // Case 3: 2 GCA units added → GCA[5]. Tract: n.3..11.
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: n.3..8.
+    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: ACGTACGTACGTACGTACGTAC. Insert GA at n.2_3.
+        //   ref[n.3]=G=alt[0] → shift, alt rotates to "AG"
+        //   ref[n.4]=T, alt[1]=A → mismatch, stop.
+        // Output: n.3_4insAG.
+        let p = provider("ACGTACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insGA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}insAG", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: A-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: CAAAA (5 bases — entire transcript). A-tract n.2..5; the
+        // transcript ENDS at n.5 (end-of-ref boundary). Insert A at n.2_3.
+        // Should clamp to n.5 — dup at n.5.
+        let p = provider("CAAAA");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at n.1_2. Core: AAAACGTACGTACGTACGTAC.
+        // A-tract at n.1..4. Shifts to dup at n.4.
+        let p = provider("AAAACGTACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[1, 2]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an A-tract near transcript end.
+        // Core: CGTACGTACGTACGAAAAC (19 bases). A-tract at n.15..18.
+        // Insert A at n.16_17 (within tract); shifts to n.18, dup at n.18.
+        let p = provider("CGTACGTACGTACGAAAAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[16, 17]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[18]));
+    }
+}
+mod rna_plus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a plus-strand RNA provider whose transcript spans the entire
+    /// core sequence.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::rna(core, Strand::Plus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. RNA positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: acguacguacguacguacguacguacguac (30 bases, RNA). r.4=u, r.5=a.
+        // Insert c between r.4 and r.5 — alt[0]='c' ≠ ref[r.5]='a' (no shift)
+        // and alt[last]='c' ≠ ref[r.4]='u' → no preceding-base dup.
+        let p = provider("acguacguacguacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insc", &[4, 5]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}insc", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: acaaaacguacguacguac (19 bases, RNA). A-tract at r.3..6.
+        // Insert a at r.2_3. Shifts to end of A-tract; dup at r.6.
+        let p = provider("acaaaacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: ac tandem at r.3-6 (acac). Insert ac at r.2_3 → dup at r.5_6.
+    #[case("acacacguacguacguacguac", "r.{0}_{1}insac", &[2u64, 3u64], "r.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: gca tandem at r.3-11 (gcagcagca). Insert gca at r.2_3 → dup at r.9_11.
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgca", &[2u64, 3u64], "r.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 a's added to aaa tract → a[5]. Tract: r.3..5.
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}_{1}a[5]", &[3u64, 5u64])]
+    // Case 2: 4 a's added to aaa tract → a[7]. Tract: r.3..5.
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}_{1}a[7]", &[3u64, 5u64])]
+    // Case 3: 2 gca units added → gca[5]. Tract: r.3..11.
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
+    // Case 4: 2 ac units added to acacac tract → ac[5]. Tract: r.3..8.
+    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: acguacguacguacguacguac (RNA). Insert ga at r.2_3.
+        //   ref[r.3]=g=alt[0] → shift, alt rotates to "ag"
+        //   ref[r.4]=u, alt[1]=a → mismatch, stop.
+        // Output: r.3_4insag.
+        let p = provider("acguacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insga", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}insag", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: a-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: caaaa (5 bases, RNA). a-tract r.2..5; the
+        // transcript ENDS at r.5 (end-of-ref boundary). Insert a at r.2_3.
+        // Should clamp to r.5 — dup at r.5.
+        let p = provider("caaaa");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at r.1_2. Core: aaaacguacguacguacguac (RNA).
+        // a-tract at r.1..4. Shifts to dup at r.4.
+        let p = provider("aaaacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[1, 2]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an a-tract near transcript end.
+        // Core: cguacguacguacgaaaac (19 bases, RNA). a-tract at r.15..18.
+        // Insert a at r.16_17 (within tract); shifts to r.18, dup at r.18.
+        let p = provider("cguacguacguacgaaaac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[16, 17]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[18]));
+    }
+}
+mod rna_minus {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    /// Build a minus-strand RNA provider whose transcript spans the entire
+    /// core sequence.
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::rna(core, Strand::Minus).build()
+    }
+
+    /// Format an HGVS string with `{n}` placeholders. RNA positions are
+    /// 1-based transcript-relative, no PAD_OFFSET — the caller passes raw
+    /// 1-based positions.
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &p.to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn no_shift_first_base_mismatch() {
+        // Core: acguacguacguacguacguacguacguac (30 bases, RNA). r.4=u, r.5=a.
+        // Insert c between r.4 and r.5 — alt[0]='c' ≠ ref[r.5]='a' (no shift)
+        // and alt[last]='c' ≠ ref[r.4]='u' → no preceding-base dup.
+        let p = provider("acguacguacguacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insc", &[4, 5]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}insc", &[4, 5]));
+    }
+
+    #[rstest]
+    fn single_base_ins_in_homopolymer_one_unit() {
+        // Core: acaaaacguacguacguac (19 bases, RNA). a-tract at r.3..6.
+        // Insert a at r.2_3. Shifts to end of a-tract; dup at r.6.
+        let p = provider("acaaaacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    // Case 1: ac tandem at r.3-6 (acac). Insert ac at r.2_3 → dup at r.5_6.
+    #[case("acacacguacguacguacguac", "r.{0}_{1}insac", &[2u64, 3u64], "r.{0}_{1}dup", &[5u64, 6u64])]
+    // Case 2: gca tandem at r.3-11 (gcagcagca). Insert gca at r.2_3 → dup at r.9_11.
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgca", &[2u64, 3u64], "r.{0}_{1}dup", &[9u64, 11u64])]
+    fn multi_base_ins_in_tandem_one_unit(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    // Case 1: 2 a's added to aaa tract → a[5]. Tract: r.3..5.
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}_{1}a[5]", &[3u64, 5u64])]
+    // Case 2: 4 a's added to aaa tract → a[7]. Tract: r.3..5.
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}_{1}a[7]", &[3u64, 5u64])]
+    // Case 3: 2 gca units added → gca[5]. Tract: r.3..11.
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
+    // Case 4: 2 ac units added to acacac tract → ac[5]. Tract: r.3..8.
+    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 8u64])]
+    fn multi_base_ins_in_tandem_multiple_units(
+        #[case] core: &str,
+        #[case] in_template: &str,
+        #[case] in_args: &[u64],
+        #[case] out_template: &str,
+        #[case] out_args: &[u64],
+    ) {
+        let p = provider(core);
+        let input = format!("NR_TEST.1:{}", hgvs(in_template, in_args));
+        let expected = format!("NR_TEST.1:{}", hgvs(out_template, out_args));
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, expected);
+    }
+
+    #[rstest]
+    fn partial_rotation_no_full_match() {
+        // Core: acguacguacguacguacguac (RNA). Insert ga at r.2_3.
+        //   ref[r.3]=g=alt[0] → shift, alt rotates to "ag"
+        //   ref[r.4]=u, alt[1]=a → mismatch, stop.
+        // Output: r.3_4insag.
+        let p = provider("acguacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insga", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}insag", &[3, 4]));
+    }
+
+    #[rstest]
+    fn shift_clamped_by_boundary() {
+        // Boundary clamp via end-of-transcript: a-tract runs into the last
+        // position of the transcript. Shuffling stops at the transcript end.
+        //
+        // Core: caaaa (5 bases, RNA). a-tract r.2..5; the
+        // transcript ENDS at r.5 (end-of-ref boundary). Insert a at r.2_3.
+        // Should clamp to r.5 — dup at r.5.
+        let p = provider("caaaa");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[5]));
+    }
+
+    #[rstest]
+    fn insertion_at_5prime_edge() {
+        // Insertion at r.1_2. Core: aaaacguacguacguacguac (RNA).
+        // a-tract at r.1..4. Shifts to dup at r.4.
+        let p = provider("aaaacguacguacguacguac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[1, 2]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[4]));
+    }
+
+    #[rstest]
+    fn insertion_at_3prime_edge() {
+        // Insertion within an a-tract near transcript end.
+        // Core: cguacguacguacgaaaac (19 bases, RNA). a-tract at r.15..18.
+        // Insert a at r.16_17 (within tract); shifts to r.18, dup at r.18.
+        let p = provider("cguacguacguacgaaaac");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}_{1}insa", &[16, 17]));
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}dup", &[18]));
+    }
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -423,94 +423,6 @@ mod output_tests {
     }
 
     // =========================================================================
-    // INSERTION TESTS - Insertions shift 3' and may become duplications
-    // =========================================================================
-
-    #[test]
-    fn test_insertion_becomes_dup_when_matches_preceding() {
-        // Sequence: GGGGGAAAAAGGGGG
-        // Inserting A after the A repeat should become a dup
-        // Position 10 is the last A, inserting A at 10_11 matches preceding A
-        let seq = "GGGGGAAAAAGGGGG"; // A's at pos 6-10
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insA");
-
-        // Should shift 3' and become dup
-        assert!(
-            result.contains("dup"),
-            "Insertion of A in A-repeat should become dup, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_insertion_stays_insertion_when_no_match() {
-        // Sequence: GGGGGAAAAAGGGGG
-        // Inserting T (which doesn't match A's or G's adjacent) stays as insertion
-        let seq = "GGGGGAAAAAGGGGG";
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insT");
-
-        // T doesn't match adjacent sequence, should stay as insertion
-        assert!(
-            result.contains("ins"),
-            "Insertion of non-matching base should stay ins, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_insertion_no_shift_when_first_base_differs() {
-        // This tests the fix for the insertion 3' shift bug.
-        // Sequence: ATGCGATGAGATGAGAT (positions 1-17)
-        //                ^pos5=G
-        //                  ^pos6=A
-        //                    ^pos7=T
-        // Inserting CAG between positions 5 and 6 should NOT shift because:
-        // - First base after insertion (pos 6 = 'A') != first base of insertion ('C')
-        // Before the fix, ferro would incorrectly shift because it checked
-        // the SECOND base of the insertion against the first reference base.
-        let seq = "ATGCGATGAGATGAGAT";
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.5_6insCAG");
-
-        // Should NOT shift - stays at c.5_6insCAG
-        assert_eq!(
-            result, "NM_TEST.1:c.5_6insCAG",
-            "Insertion should NOT shift when first base doesn't match, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_insertion_shifts_when_all_bases_match() {
-        // Sequence: ...AGAGAGAG...
-        // Inserting AG at the start of the repeat should shift 3'
-        // Positions: GGGAGAGAGAGGGG
-        //               ^4=A
-        //                ^5=G
-        //                 ^6=A
-        // Inserting AG between 3 and 4:
-        // - ref[4] = 'A' matches ins[0] = 'A' -> can shift
-        // - ref[5] = 'G' matches ins[1] = 'G' -> can shift again
-        // ... continues until end of repeat
-        let seq = "GGGAGAGAGAGGGG"; // AG repeat from pos 4-11
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.3_4insAG");
-
-        // Should shift 3' and become a dup at the end of the repeat
-        assert!(
-            result.contains("dup"),
-            "Insertion matching repeat should become dup after 3' shift, got: {}",
-            result
-        );
-    }
-
-    // =========================================================================
     // DUPLICATION TESTS - Duplications should shift 3'
     // =========================================================================
 
@@ -1754,6 +1666,7 @@ mod normalization_transformations {
     // Mutalyzer: agrees
     // =========================================================================
 
+    // Real-accession smoke; matrix-level coverage in tests/ins_shift_matrix.rs.
     #[rstest]
     // Single T inserted after T becomes dup - Mutalyzer: agrees
     #[case("NM_001089.2:c.3057_3058insT", "NM_001089.2:c.3057dup")]
@@ -1772,6 +1685,7 @@ mod normalization_transformations {
     // All cases: Mutalyzer agrees
     // =========================================================================
 
+    // Real-accession smoke; matrix-level coverage in tests/ins_shift_matrix.rs.
     #[rstest]
     // polyA expansion: inserting AAAA into A-tract becomes A[n] - Mutalyzer: agrees
     #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.401_403A[7]")]
@@ -2877,29 +2791,6 @@ mod equivalence_derived_normalize {
     }
 
     // =========================================================================
-    // PATTERN 2: Insertion → Duplication
-    // =========================================================================
-    // When inserted sequence matches the preceding sequence, it becomes dup.
-    // From check_dup_vs_ins_equivalence.
-
-    #[rstest]
-    // Single base insertion matching preceding base
-    #[case("NM_001089.2:c.3057_3058insT", "NM_001089.2:c.3057dup")]
-    #[ignore]
-    fn test_insertion_to_dup_normalization(#[case] input: &str, #[case] expected: &str) {
-        let result = normalize_to_string(input)
-            .expect("Normalization failed - is benchmark-output present?");
-        assert_eq!(
-            result, expected,
-            "Insertion matching preceding sequence should become dup.\n\
-             Input: {}\n\
-             Expected: {}\n\
-             Got: {}",
-            input, expected, result
-        );
-    }
-
-    // =========================================================================
     // PATTERN 3: Duplication → Repeat Notation
     // =========================================================================
     // Tandem duplications in existing repeat regions become repeat notation.
@@ -2963,33 +2854,6 @@ mod equivalence_derived_normalize {
         assert_eq!(
             result, expected,
             "Explicit bases in dup notation should be removed.\n\
-             Input: {}\n\
-             Expected: {}\n\
-             Got: {}",
-            input, expected, result
-        );
-    }
-
-    // =========================================================================
-    // PATTERN 6: Insertion → Repeat
-    // =========================================================================
-    // Homopolymer insertions become repeat notation when in existing repeat tract.
-    // From check_ins_vs_repeat_equivalence.
-    // Note: Only works when insertion position is in an existing repeat tract.
-
-    #[rstest]
-    // polyA expansion: inserting AAAA into A-tract becomes A[n]
-    #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.401_403A[7]")]
-    // polyT expansion
-    #[case("NM_000382.3:c.399_400insTTTT", "NM_000382.3:c.398_399T[6]")]
-    // Note: Some insertions don't become repeats if not in existing tract
-    #[ignore]
-    fn test_homopolymer_insertion_to_repeat(#[case] input: &str, #[case] expected: &str) {
-        let result = normalize_to_string(input)
-            .expect("Normalization failed - is benchmark-output present?");
-        assert_eq!(
-            result, expected,
-            "Homopolymer insertion should become repeat notation.\n\
              Input: {}\n\
              Expected: {}\n\
              Got: {}",
@@ -3208,75 +3072,6 @@ mod comprehensive_normalization_tests {
             let provider = provider_with_transcript("NM_TEST.1", seq);
             // Inserting GC at start of repeat - should shift and possibly become dup
             assert_normalizes_to("NM_TEST.1:c.3_4insGC", "NM_TEST.1:c.10_11dup", provider);
-        }
-
-        #[test]
-        fn test_insertion_at_homopolymer_end_becomes_dup() {
-            // Sequence: GGGAAAGGG (A's at 4-6)
-            // Inserting A at end of A-tract (c.6_7insA) becomes duplication
-            let seq = "GGGAAAGGG";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            assert_normalizes_to("NM_TEST.1:c.6_7insA", "NM_TEST.1:c.6dup", provider);
-        }
-    }
-
-    // =========================================================================
-    // RULE 3: Insertion → Duplication
-    // =========================================================================
-    // When inserted sequence matches preceding sequence, it becomes duplication.
-    // Function: insertion_is_duplication() in src/normalize/rules.rs
-
-    mod insertion_to_dup_tests {
-        use super::*;
-
-        #[test]
-        fn test_single_base_insertion_matches_preceding_becomes_dup() {
-            // Sequence: ATGCATGCAT
-            //           1234567890
-            // Inserting A after position 5 (A) becomes dup
-            let seq = "ATGCATGCAT";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            // c.5_6insA where ref[5]=A → c.5dup
-            assert_normalizes_to("NM_TEST.1:c.5_6insA", "NM_TEST.1:c.5dup", provider);
-        }
-
-        #[test]
-        fn test_multi_base_insertion_matches_preceding_becomes_dup() {
-            // Sequence: NNATGCNNNNN (ATG at positions 3-5)
-            //           12345678901
-            // Inserting ATG after position 5 becomes dup
-            let seq = "NNATGCNNNNN";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            // c.5_6insATG where ref[3-5]=ATG → c.3_5dup
-            assert_normalizes_to("NM_TEST.1:c.5_6insATG", "NM_TEST.1:c.3_5dup", provider);
-        }
-
-        #[test]
-        fn test_insertion_no_match_stays_insertion() {
-            // Sequence: ATGCATGCAT
-            // Inserting GGG doesn't match anything
-            let seq = "ATGCATGCAT";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            assert_normalizes_to("NM_TEST.1:c.5_6insGGG", "NM_TEST.1:c.5_6insGGG", provider);
-        }
-
-        #[test]
-        fn test_insertion_partial_match_stays_insertion() {
-            // Sequence: ATGCATGCAT
-            // Inserting ATT where preceding is ATG - partial match, stays insertion
-            let seq = "NNATGCNNNNN";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            assert_normalizes_to("NM_TEST.1:c.5_6insATT", "NM_TEST.1:c.5_6insATT", provider);
-        }
-
-        #[test]
-        fn test_insertion_in_repeat_becomes_dup_at_3prime_position() {
-            // Sequence with repeat: AAACCCAAAA
-            // Inserting CCC in C-tract should become dup at 3' position
-            let seq = "AAACCCAAAA";
-            let provider = provider_with_transcript("NM_TEST.1", seq);
-            // Inserting C in CCC tract
-            assert_normalizes_to("NM_TEST.1:c.4_5insC", "NM_TEST.1:c.6dup", provider);
         }
     }
 


### PR DESCRIPTION
Addresses #81 items A1 (`ins` → `dup` canonical form) and A7 (3'-shift coverage matrix for `ins`). The matrix scenarios (`single_base_ins_in_homopolymer_one_unit`, `multi_base_ins_in_tandem_one_unit`) lock the A1 rule with strict string equality across all 7 coord-system / strand combinations, so A1 is de-facto closed by this PR.

## Summary

Locks ferro's 3'-shift behavior for insertion variants across every nucleotide coord-system / strand combination, in a single audit-shaped matrix file. Surfaces and fixes two production bugs along the way.

### What's new

**Test infrastructure**
- New file `tests/ins_shift_matrix.rs`: 84 rstest cases organized into 7 modules (`genomic`, `cds_plus`, `cds_minus`, `noncoding_plus`, `noncoding_minus`, `rna_plus`, `rna_minus`), each exercising the same 8 shuffle scenarios.
- New shared helper module `tests/common/synthetic.rs`: `SyntheticBuilder` for constructing `MockProvider` fixtures across coord systems, reusable by future del / dup / repeat-notation matrices (sibling roadmap items A5, A6, B1, B2).

**Production-code fixes (surfaced by the matrix)**
- `MockProvider::get_sequence` now falls through to genomic contig lookup when the id is not a transcript, matching `FastaProvider` behavior. Without this, `add_genomic_sequence(...)` silently took the canonicalize-only fallback in `normalize_genome`, skipping 3'-shifting entirely.
- `insertion_to_repeat` extended to handle multi-base tandem units. An insertion adding ≥2 copies of a tandem unit already present adjacent to the insertion point now emits `unit[N+k]` repeat notation per HGVS spec, instead of `dup` of the inserted bases. Single-unit additions remain `dup`.

**Migration**
- 16 ins-shuffle tests removed from `tests/normalize_tests.rs` and `tests/coverage_gap_tests.rs` that overlap with matrix cells. Two real-accession smoke tests (`test_insertion_becomes_dup`, `test_insertion_becomes_repeat`) preserved as canonical-form sanity checks against real RefSeq data.

### Scenario matrix

| # | Scenario | Expected canonical form |
|---|---|---|
| 1 | No-shift (first-base mismatch) | unchanged `ins` |
| 2 | Single-base ins in homopolymer (1 unit added) | `dup` at 3' end |
| 3 | Multi-base ins in tandem, **1 unit added** | `dup` at 3' end |
| 4 | Multi-base ins in tandem, **2+ units added** | repeat notation `unit[N+k]` |
| 5 | Multi-base ins, partial rotation, no full match | rotated `ins` at most-3' position |
| 6 | Shift clamped by boundary | stops at boundary |
| 7 | Insertion at 5' edge of ref / transcript start | shifts cleanly; no underflow |
| 8 | Insertion at 3' edge of ref / transcript end | clamps to last position |

### Out of scope (filed as follow-ups)

- **Mitochondrial (m.)**: circular wraparound is its own design (#81 item F1). The matrix has no m. cells.
- **Protein (p.)**: ferro currently does not 3'-shift protein variants. Filed as #91 (protein 3' shifting) and #92 (`p.ins` → `p.dup` canonicalization).
- Other variant types (del, dup, delins, sub, inv): covered by sibling #81 items.

## Test plan

- [x] `cargo nextest run --features dev` — 3158/3158 tests pass; +84 matrix cases, −16 deleted duplicates net
- [x] `cargo clippy --features dev -- -D warnings` — no new warnings (5 pre-existing `collapsible_match` errors in `src/hgvs/` are not introduced by this PR)
- [x] `cargo fmt --all` clean
- [x] Pre-commit hooks pass on every commit

## Commits

1. `fix(reference)`: MockProvider::get_sequence falls through to genomic
2. `fix(normalize)`: emit repeat notation for ins of ≥2 tandem units (#81 A7)
3. `test`: ins 3'-shift coverage matrix across coord systems × strands (#81 A7)
4. `docs(changelog)`: A7 ins-shift coverage matrix and tandem-repeat ins fix
