### PR TITLE
test(coverage): restore intronic insertion tests dropped in #93

### DIFF
--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -364,6 +364,45 @@ mod position_ordering {
 }
 
 // =============================================================================
+// GAP 3: Intronic insertions
+// =============================================================================
+
+mod intronic_insertions {
+    use super::*;
+
+    #[test]
+    fn test_plus_strand_intronic_insertion() {
+        // Plus-strand intron 1 genomic sequence is AAACCCAAAT at c.30+1..c.30+10.
+        // Inserting GGG at c.30+3_30+4 sits between c.30+3=A and c.30+4=C; ins[0]=G
+        // matches neither side, so no 3'-shift and no dup canonicalization.
+        let provider = make_provider_with_plus_strand();
+        let result = normalize(provider, "NM_PLUS.1:c.30+3_30+4insGGG");
+        assert_eq!(result, "NM_PLUS.1:c.30+3_30+4insGGG");
+    }
+
+    #[test]
+    fn test_minus_strand_intronic_insertion() {
+        // Issue #11 scenario. Minus-strand intron 1 reads as CAAAGGGCCC in transcript
+        // orientation at c.30+1..c.30+10 (RC of genomic GGGCCCTTTG). Inserting GGG
+        // at c.30+3_30+4 sits between c.30+3=A and c.30+4=A; ins[0]=G doesn't match,
+        // so the variant stays put and positions remain in coding (5'→3') order.
+        let provider = make_provider_with_minus_strand();
+        let result = normalize(provider, "NM_MINUS.1:c.30+3_30+4insGGG");
+        assert_eq!(result, "NM_MINUS.1:c.30+3_30+4insGGG");
+    }
+
+    #[test]
+    fn test_intronic_insertion_to_dup_plus_strand() {
+        // Plus-strand intron 1: AAACCCAAAT. Inserting A at c.30+1_30+2 falls inside
+        // the leading AAA tract; 3'-shift walks the insertion through positions
+        // 30+2_30+3 → 30+3_30+4, then canonicalizes to a dup of the preceding base.
+        let provider = make_provider_with_plus_strand();
+        let result = normalize(provider, "NM_PLUS.1:c.30+1_30+2insA");
+        assert_eq!(result, "NM_PLUS.1:c.30+3dup");
+    }
+}
+
+// =============================================================================
 // GAP 4: Intronic duplications
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Restores 3 intronic insertion tests in `tests/coverage_gap_tests.rs::intronic_insertions` that were removed in #93. Coverage audit of #93:

- 12 of the 16 removed ins-shuffle tests were synthetic 3'-shift cases now covered by `tests/ins_shift_matrix.rs` across 7 coord-system / strand modules — genuinely redundant
- 1 removed rstest case was `#[ignore]`'d (didn't run in CI); active cases survived as `test_insertion_becomes_dup` / `test_insertion_becomes_repeat`
- 3 intronic-insertion tests were the only genuine coverage loss — the matrix has zero `c.N+M` intronic cells

Original tests asserted only `contains("ins")` / `contains("dup")` ("did it crash" coverage). Restored versions use strict `assert_eq!` against the current normalizer output:

| Input | Expected |
|---|---|
| `NM_PLUS.1:c.30+3_30+4insGGG` | `NM_PLUS.1:c.30+3_30+4insGGG` (no shift) |
| `NM_MINUS.1:c.30+3_30+4insGGG` | `NM_MINUS.1:c.30+3_30+4insGGG` (no shift, positions stay coding-ordered — issue #11) |
| `NM_PLUS.1:c.30+1_30+2insA` | `NM_PLUS.1:c.30+3dup` (3'-shift through AAA tract → dup) |

## Test plan
- [x] `cargo nextest run --features dev` — 3172/3172 pass
- [x] `cargo fmt --all -- --check` clean
- [x] No new clippy warnings in `tests/coverage_gap_tests.rs` (5 pre-existing `collapsible_match` errors in `src/hgvs/` unrelated)