### PR TITLE
fix(normalize): minus-strand intronic ref-base orientation (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(normalize)* Minus-strand intronic normalization now reads the
+  reference window in transcript-view orientation. `normalize_intronic_cds`
+  and `normalize_intronic_tx` previously passed the genomic-strand bytes
+  fetched from `get_genomic_sequence` directly into `normalize_na_edit`
+  alongside the variant's transcript-view edit alt; on minus-strand
+  transcripts the two were mis-oriented, defeating every rule that
+  compared the alt against the local reference window. The fix
+  reverse-complements the genomic window and flips the relative
+  positions / shuffle boundaries on minus strand before normalization,
+  then maps the resulting positions back to the genomic frame for the
+  CDS / tx coordinate conversion. As a single root-cause fix this
+  resurfaces #81 A1 / A5 / A6 canonicalization, the PR #78 delins-as-
+  identity rewrite, and the transcript-view repeat-unit letter on
+  minus-strand intronic positions — all of which had been observed to
+  misfire in #94's locking pass. Issue #98.
 - Insertions that add ≥2 copies of a multi-base tandem repeat unit now
   emit repeat notation (`unit[N+k]`) instead of a duplication of the
   inserted sequence, per HGVS spec ("when more than one additional copies

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -38,6 +38,7 @@ use crate::hgvs::location::{CdsPos, GenomePos, TxPos};
 use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
 use crate::hgvs::variant::{CdsVariant, GenomeVariant, HgvsVariant, LocEdit, TxVariant};
 use crate::hgvs::HgvsVariant as HV;
+use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use boundary::Boundaries;
 pub use config::{NormalizeConfig, ShuffleDirection};
@@ -1015,10 +1016,39 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let intron_rel_end = intron_g_end.saturating_sub(seq_start) + 1;
         let boundaries = Boundaries::new(intron_rel_start, intron_rel_end);
 
-        // Perform normalization in genomic space
-        let seq_bytes = genomic_seq.as_bytes();
-        let (new_rel_start, new_rel_end, new_edit, warnings) =
-            self.normalize_na_edit(seq_bytes, edit, rel_start, rel_end, &boundaries)?;
+        // On minus-strand transcripts the genomic-strand sequence is the
+        // reverse complement of the transcript view, but the variant's
+        // edit alt is in transcript view. Running `normalize_na_edit` on
+        // the genomic-strand bytes therefore defeats every rule that
+        // compares the alt against the local reference window. Flip the
+        // sequence and the relative positions / boundaries to transcript
+        // view here, run normalization, then map the result positions
+        // back to the genomic frame. (Issue #98.)
+        let (work_seq, work_rel_start, work_rel_end, work_boundaries) = flip_intronic_for_strand(
+            transcript.strand,
+            &genomic_seq,
+            rel_start,
+            rel_end,
+            &boundaries,
+        );
+
+        // Perform normalization in transcript-view space
+        let seq_bytes = work_seq.as_bytes();
+        let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
+            seq_bytes,
+            edit,
+            work_rel_start,
+            work_rel_end,
+            &work_boundaries,
+        )?;
+
+        // Map the result positions back to the genomic-strand frame
+        let (new_rel_start, new_rel_end) = unflip_intronic_positions(
+            transcript.strand,
+            work_seq.len() as u64,
+            work_new_rel_start,
+            work_new_rel_end,
+        );
 
         // Convert the normalized genomic position back to absolute genomic
         let new_g_start = seq_start + new_rel_start - 1;
@@ -1134,10 +1164,32 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let intron_rel_end = intron_g_end.saturating_sub(seq_start) + 1;
         let boundaries = Boundaries::new(intron_rel_start, intron_rel_end);
 
-        // Perform normalization in genomic space
-        let seq_bytes = genomic_seq.as_bytes();
-        let (new_rel_start, new_rel_end, new_edit, warnings) =
-            self.normalize_na_edit(seq_bytes, edit, rel_start, rel_end, &boundaries)?;
+        // See `normalize_intronic_cds`: same orientation fix for #98.
+        let (work_seq, work_rel_start, work_rel_end, work_boundaries) = flip_intronic_for_strand(
+            transcript.strand,
+            &genomic_seq,
+            rel_start,
+            rel_end,
+            &boundaries,
+        );
+
+        // Perform normalization in transcript-view space
+        let seq_bytes = work_seq.as_bytes();
+        let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
+            seq_bytes,
+            edit,
+            work_rel_start,
+            work_rel_end,
+            &work_boundaries,
+        )?;
+
+        // Map the result positions back to the genomic-strand frame
+        let (new_rel_start, new_rel_end) = unflip_intronic_positions(
+            transcript.strand,
+            work_seq.len() as u64,
+            work_new_rel_start,
+            work_new_rel_end,
+        );
 
         // Convert the normalized genomic position back to absolute genomic
         let new_g_start = seq_start + new_rel_start - 1;
@@ -1970,6 +2022,54 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 variant.loc_edit.edit.map_ref(|_| canonical_edit),
             ),
         }
+    }
+}
+
+/// Flip a fetched intronic genomic-strand window into transcript-view
+/// orientation when the host transcript is on the minus strand. Returns
+/// the input unchanged on plus strand. The relative positions and the
+/// shuffle boundaries are flipped so they index into the returned
+/// sequence consistently. Companion to [`unflip_intronic_positions`].
+fn flip_intronic_for_strand(
+    strand: Strand,
+    genomic_seq: &str,
+    rel_start: u64,
+    rel_end: u64,
+    boundaries: &Boundaries,
+) -> (String, u64, u64, Boundaries) {
+    if strand != Strand::Minus {
+        return (
+            genomic_seq.to_string(),
+            rel_start,
+            rel_end,
+            boundaries.clone(),
+        );
+    }
+    let seq_len = genomic_seq.len() as u64;
+    let rc = crate::cli::reverse_complement(genomic_seq);
+    let new_rel_start = seq_len - rel_end + 1;
+    let new_rel_end = seq_len - rel_start + 1;
+    let new_boundaries = Boundaries::new(
+        seq_len - boundaries.right + 1,
+        seq_len - boundaries.left + 1,
+    );
+    (rc, new_rel_start, new_rel_end, new_boundaries)
+}
+
+/// Inverse of [`flip_intronic_for_strand`] for the result positions
+/// emitted by `normalize_na_edit`. On plus strand returns the input
+/// unchanged; on minus strand maps from transcript-view back to the
+/// genomic-strand frame.
+fn unflip_intronic_positions(
+    strand: Strand,
+    seq_len: u64,
+    rel_start: u64,
+    rel_end: u64,
+) -> (u64, u64) {
+    if strand == Strand::Minus {
+        (seq_len - rel_end + 1, seq_len - rel_start + 1)
+    } else {
+        (rel_start, rel_end)
     }
 }
 

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -15,12 +15,14 @@
 //! Issue #11: NM_004119.3:c.1837+2_1837+3ins... position ordering bug
 //!
 //! Issue #94: every gap test that previously asserted only `contains(...)`
-//! or `is_ok() || is_err()` is now locked with `assert_eq!` against the
-//! exact normalizer output. Several locked outputs are suspected-buggy
-//! and carry `FIXME(#NN)` comments pointing to the tracking issue (most
-//! converge on #98 — minus-strand intronic ref-base orientation as a
-//! likely common root cause). Boundary-spanning panic-canary tests are
-//! intentionally left as `is_ok() || is_err()` per #94 scope.
+//! or `is_ok() || is_err()` is locked with `assert_eq!` against the
+//! exact normalizer output. Issue #98 (minus-strand intronic ref-base
+//! orientation) was identified as a common root cause behind several
+//! initially suspected-buggy lock points and has since been fixed; the
+//! affected tests now lock spec-correct outputs (full-tract position
+//! with the transcript-view repeat unit, per the HGVS DNA repeat
+//! spec). Boundary-spanning panic-canary tests are intentionally left
+//! as `is_ok() || is_err()` per #94 scope.
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
@@ -337,16 +339,17 @@ mod position_ordering {
 
     #[test]
     fn test_minus_strand_intronic_insertion_position_order() {
-        // Issue #11: positions must stay in 5'-to-3' coding order (no swap).
-        // Transcript-view bases at c.30+1..c.30+4 are C, A, A, A — analogous
-        // to the plus-strand AAA tract — so ins A *should* canonicalize to
-        // c.30+4dup. It does not today: see #98 (minus-strand intronic
-        // ref-base orientation defeats #81 A1). This locks the no-swap
-        // invariant that issue #11 was originally about.
+        // Issue #11: positions must stay in 5'-to-3' coding order (no
+        // swap). Transcript-view bases at c.30+1..c.30+4 are C, A, A, A
+        // — analogous to the plus-strand AAA tract — so ins A
+        // canonicalizes to dup at the 3'-most A in the run (c.30+4) per
+        // #81 A1, with the issue-#11 no-swap invariant preserved.
+        // Issue #98 closed the minus-strand intronic ref-base
+        // orientation gap that had prevented this canonicalization
+        // from firing.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+3insA");
-        // FIXME(#98, #81 A1): expected canonical form is c.30+4dup.
-        assert_eq!(result, "NM_MINUS.1:c.30+2_30+3insA");
+        assert_eq!(result, "NM_MINUS.1:c.30+4dup");
     }
 
     #[test]
@@ -429,26 +432,26 @@ mod intronic_duplications {
     #[test]
     fn test_minus_strand_intronic_dup() {
         // Transcript-view AAA tract at c.30+2..c.30+4; dup of A at +2
-        // *should* shift to c.30+4dup. It does not today.
+        // shifts to c.30+4dup per #81 A6. Issue #98 closed the
+        // minus-strand intronic ref-base orientation gap that had
+        // prevented this shift from firing.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2dup");
-        // FIXME(#98, #81 A6): expected canonical form is c.30+4dup.
-        assert_eq!(result, "NM_MINUS.1:c.30+2dup");
+        assert_eq!(result, "NM_MINUS.1:c.30+4dup");
     }
 
     #[test]
     fn test_minus_strand_intronic_multi_base_dup() {
-        // Transcript-view AAA tract at c.30+2..c.30+4 duplicated to AAAAAA.
-        // Spec-canonical form is repeat notation with the transcript-view
-        // unit (`c.30+2_30+4A[6]` — full-tract position, post-edit count
-        // per the HGVS DNA repeat spec). Today ferro emits `T[6]` —
-        // the genomic-strand letter — instead of the transcript-view
-        // letter `A`.
+        // Transcript-view AAA tract at c.30+2..c.30+4 duplicated to
+        // AAAAAA. Spec-canonical form per the HGVS DNA repeat page is
+        // `c.30+2_30+4A[6]` — full-tract position, transcript-view
+        // unit, post-edit unit count. Issue #98 closed the
+        // minus-strand intronic ref-base orientation gap that had
+        // previously caused ferro to emit `T[6]` (the genomic-strand
+        // letter) instead of `A[6]`.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4dup");
-        // FIXME(#98, #81 A6): expected canonical form uses the
-        // transcript-view repeat unit (`A`).
-        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4T[6]");
+        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4A[6]");
     }
 }
 
@@ -461,12 +464,13 @@ mod intronic_deletions_minus {
 
     #[test]
     fn test_minus_strand_intronic_single_del() {
-        // Transcript-view AAA tract at c.30+2..c.30+4; single-A del at +2
-        // *should* shift to c.30+4del. It does not today.
+        // Transcript-view AAA tract at c.30+2..c.30+4; single-A del at
+        // +2 shifts to the 3'-most A (c.30+4) per #81 A5. Issue #98
+        // closed the minus-strand intronic ref-base orientation gap
+        // that had prevented this shift from firing.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2del");
-        // FIXME(#98, #81 A5): expected canonical form is c.30+4del.
-        assert_eq!(result, "NM_MINUS.1:c.30+2del");
+        assert_eq!(result, "NM_MINUS.1:c.30+4del");
     }
 
     #[test]
@@ -481,13 +485,17 @@ mod intronic_deletions_minus {
 
     #[test]
     fn test_minus_strand_intronic_del_3prime_shift() {
-        // Transcript-view GGG tract at c.30+5..c.30+7 (RC of genomic CCC at
-        // PAD+73..PAD+75); single-G del at +5 *should* shift to c.30+7del.
-        // It does not today.
+        // Transcript-view GGG tract at c.30+5..c.30+7 (RC of genomic
+        // CCC at PAD+73..PAD+75); single-G del at +5 shifts to the
+        // 3'-most G in the run per #81 A5. For this 10-base intron
+        // ferro renders the resulting position with acceptor-relative
+        // notation (positions past the midpoint use `c.31-N`); c.30+7
+        // and c.31-4 designate the same intronic base. Issue #98
+        // closed the orientation gap that had prevented this shift
+        // from firing.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+5del");
-        // FIXME(#98, #81 A5): expected canonical form is c.30+7del.
-        assert_eq!(result, "NM_MINUS.1:c.30+5del");
+        assert_eq!(result, "NM_MINUS.1:c.31-4del");
     }
 }
 
@@ -610,15 +618,13 @@ mod delins_boundary {
     #[test]
     fn test_intronic_delins_minus() {
         // Transcript-view bases at c.30+2..c.30+4 are A, A, A; insertion
-        // is also AAA — this is an identity delins and PR #78 *should*
-        // rewrite it to identity (`c.30+2_30+4=`). It does not today
-        // because the engine's reference lookup at minus-strand intronic
-        // positions returns the genomic-strand bases (TTT), so the
-        // identity check fails (see #98).
+        // is also AAA — this is an identity delins and PR #78 rewrites
+        // it to identity (`c.30+2_30+4=`). Issue #98 closed the
+        // minus-strand intronic ref-base orientation gap that had
+        // prevented PR #78's identity check from succeeding.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4delinsAAA");
-        // FIXME(#98, PR #78): expected rewrite to identity form.
-        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4delinsAAA");
+        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4=");
     }
 
     #[test]

--- a/tests/issue_98_minus_strand_intronic_orientation.rs
+++ b/tests/issue_98_minus_strand_intronic_orientation.rs
@@ -1,0 +1,135 @@
+//! Regression test for issue #98: minus-strand intronic reference-base
+//! lookup returned genomic-strand letters, defeating every rule that
+//! compared the input edit against the local reference window.
+//!
+//! These tests fail before the fix in `normalize_intronic_cds` /
+//! `normalize_intronic_tx` and pass after. Each one is a single,
+//! diagnostic assertion: it does not depend on the symptom-locked tests
+//! in `tests/coverage_gap_tests.rs`.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+const PAD_OFFSET: u64 = 256;
+
+/// Minus-strand transcript with intron 1 chosen so that the transcript-view
+/// bases at `c.30+1..c.30+10` are `C, A, A, A, G, G, G, C, C, C` — the
+/// reverse complement of the genomic-strand intron `GGGCCCTTTG`. Every
+/// orientation rule below asserts a behavior that is only achievable if
+/// the normalizer reads the *transcript-view* letters (A,A,A; G,G,G) when
+/// canonicalizing — not the genomic-strand letters (T,T,T; C,C,C).
+fn make_minus_strand_fixture() -> MockProvider {
+    let core = "CATGCATGCATGCATGCATGCATGCATGCA\
+                AAATTTAAAT\
+                GCATGCATGCATGCATGCATGCATGCATGC\
+                GGGCCCTTTG\
+                ATGCATGCATGCATGCATGCATGCATGCAT";
+    let genomic_seq = format!("{}{}{}", PAD, core, PAD);
+
+    let tx_seq = "ATGCATGCATGCATGCATGCATGCATGCAT\
+                   GCATGCATGCATGCATGCATGCATGCATGC\
+                   TGCATGCATGCATGCATGCATGCATGCATG";
+
+    let p = PAD_OFFSET;
+    let transcript = Transcript::new(
+        "NM_MINUS.1".to_string(),
+        Some("MINUSGENE".to_string()),
+        Strand::Minus,
+        tx_seq.to_string(),
+        Some(1),
+        Some(90),
+        vec![
+            Exon::with_genomic(1, 1, 30, p + 80, p + 109),
+            Exon::with_genomic(2, 31, 60, p + 40, p + 69),
+            Exon::with_genomic(3, 61, 90, p + 0, p + 29),
+        ],
+        Some("chr_minus".to_string()),
+        Some(p),
+        Some(p + 109),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr_minus", genomic_seq);
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse should succeed");
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize should succeed");
+    format!("{}", normalized)
+}
+
+/// **Diagnostic 1 — ins → dup canonicalization (#81 A1, intronic).**
+///
+/// Inserting `A` into the transcript-view `AAA` tract at `c.30+2..c.30+4`
+/// must canonicalize to `dup` at the 3'-most A (c.30+4). If the
+/// normalizer compares the inserted `A` against the *genomic-strand*
+/// letters at this region (`T,T,T`), the rule does not fire and the
+/// output is unchanged.
+#[test]
+fn ins_into_transcript_view_aaa_tract_canonicalizes_to_dup() {
+    let provider = make_minus_strand_fixture();
+    let result = normalize(provider, "NM_MINUS.1:c.30+2_30+3insA");
+    assert_eq!(result, "NM_MINUS.1:c.30+4dup");
+}
+
+/// **Diagnostic 2 — single-base dup 3'-shift (#81 A6, intronic).**
+///
+/// `c.30+2dup` (A in the transcript-view AAA tract) must shift to the
+/// 3'-most equivalent position, `c.30+4dup`.
+#[test]
+fn dup_in_transcript_view_aaa_tract_shifts_three_prime() {
+    let provider = make_minus_strand_fixture();
+    let result = normalize(provider, "NM_MINUS.1:c.30+2dup");
+    assert_eq!(result, "NM_MINUS.1:c.30+4dup");
+}
+
+/// **Diagnostic 3 — single-base del 3'-shift (#81 A5, intronic).**
+///
+/// `c.30+5del` (G in the transcript-view GGG tract at c.30+5..c.30+7)
+/// must shift to the 3'-most G in the run. For this 10-base intron
+/// ferro renders the resulting position with acceptor-relative notation
+/// (positions past the midpoint use `c.31-N`); `c.30+7` and `c.31-4`
+/// designate the same intronic base.
+#[test]
+fn del_in_transcript_view_ggg_tract_shifts_three_prime() {
+    let provider = make_minus_strand_fixture();
+    let result = normalize(provider, "NM_MINUS.1:c.30+5del");
+    assert_eq!(result, "NM_MINUS.1:c.31-4del");
+}
+
+/// **Diagnostic 4 — delins identity rewrite (PR #78, intronic).**
+///
+/// Replacing the transcript-view `AAA` at c.30+2..c.30+4 with `AAA` is
+/// an identity edit and PR #78 should rewrite it. If the engine sees
+/// the genomic-strand `TTT` as the reference, the identity check fails
+/// and the rewrite is skipped.
+#[test]
+fn delins_identity_on_transcript_view_aaa_tract_rewrites() {
+    let provider = make_minus_strand_fixture();
+    let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4delinsAAA");
+    assert_eq!(result, "NM_MINUS.1:c.30+2_30+4=");
+}
+
+/// **Diagnostic 5 — `n.` parity for ins → dup canonicalization.**
+///
+/// Mirror of `ins_into_transcript_view_aaa_tract_canonicalizes_to_dup` but
+/// using `n.` notation, which routes through `normalize_intronic_tx()`
+/// instead of `normalize_intronic_cds()`. Both functions share the
+/// `flip_intronic_for_strand` helper for the issue #98 orientation fix,
+/// so this test guards against regressions on the `n.` (TxVariant) path.
+#[test]
+fn ins_into_transcript_view_aaa_tract_canonicalizes_to_dup_n() {
+    let provider = make_minus_strand_fixture();
+    let result = normalize(provider, "NM_MINUS.1:n.30+2_30+3insA");
+    assert_eq!(result, "NM_MINUS.1:n.30+4dup");
+}


### PR DESCRIPTION
Closes #98. Stacked on #99 (will retarget to `main` automatically when #99 merges).

## TL;DR

A single defect — minus-strand intronic ref-base reads returning **genomic-strand** letters where the rule machinery expects **transcript-view** letters — was responsible for *all* of the suspected-buggy lock points #94 surfaced on minus-strand intronic positions, including the wrong-strand-letter symptom in #96. Fixing it where the genomic window is fetched (`normalize_intronic_cds` and `normalize_intronic_tx`) resurfaces #81 A1 / A5 / A6 canonicalization on minus-strand intronic input, plus PR #78's delins-as-identity rewrite, and corrects the repeat-unit letter for minus-strand multi-base dup. All seven locked-buggy tests in `tests/coverage_gap_tests.rs` flip to their spec-correct expected values.

## Root cause

The exonic CDS path (`normalize_cds`, line 506-509) feeds `transcript.sequence` (transcript-view, naturally strand-correct) and the variant's transcript-view alt into `normalize_na_edit` together — same orientation, rule fires correctly. The intronic paths (`normalize_intronic_cds` line 1019-1021 and `normalize_intronic_tx` line 1138-1140) instead feed the **genomic-strand** window from `get_genomic_sequence` alongside the same transcript-view alt. On a minus-strand transcript the two are reverse complements of each other, so every rule that compares the alt against the local reference window — `ins → dup`, `del/dup` 3'-shift, delins-as-identity, repeat-unit-derived-from-ref — silently misfires. Issue #98 spelled out the hypothesis with the suggested investigation order; that order is what this PR follows.

## Fix

In both `normalize_intronic_cds` and `normalize_intronic_tx`, after fetching `genomic_seq` and computing the relative positions / shuffle boundaries:

1. If `transcript.strand == Strand::Minus`, reverse-complement the genomic window and flip the relative positions / boundaries via `flip_intronic_for_strand`. The window now matches the transcript-view orientation that `normalize_na_edit` expects from the alt.
2. Run `normalize_na_edit` against the flipped window.
3. Map the result positions back to the genomic frame via `unflip_intronic_positions` before the existing `genomic_to_cds_intronic` / `genomic_to_tx_with_intron` conversion.

The two helpers are private to `src/normalize/mod.rs`. No public API change; no behavior change on plus-strand transcripts. The `swapped` position swap for genomic-frame coding-order restoration is unchanged — that only handles position order, not sequence orientation, so it remains orthogonal.

`normalize_boundary_spanning_cds` (which uses the same genomic window pattern) is intentionally **not** fixed here — boundary-spanning is in the panic-canary scope of #94, and changing it requires a careful rethink of how the union-of-exon-and-intron boundaries flip across the splice site. Filed as a follow-up if needed.

## Tests

**Diagnostic suite** — `tests/issue_98_minus_strand_intronic_orientation.rs` (new). Four single-assertion tests, one per symptom class:

| Symptom | Input | Asserted |
|---|---|---|
| ins → dup canonicalization | `c.30+2_30+3insA` | `c.30+4dup` |
| dup 3'-shift | `c.30+2dup` | `c.30+4dup` |
| del 3'-shift (acceptor-relative) | `c.30+5del` | `c.31-4del` |
| delins identity rewrite | `c.30+2_30+4delinsAAA` | `c.30+2_30+4=` |

All four fail before the fix (orientation mismatch → no rule fires) and pass after. They depend only on the fixture and the public `normalize` API.

**Cascade in `tests/coverage_gap_tests.rs`** — every `FIXME(#98, ...)` lock point flipped to its spec-correct value, including the `#96` multi-base dup whose locked form moves from `T[6]` (genomic-strand letter) to `A[6]` (transcript-view letter, full-tract position, post-edit unit count — matching the HGVS DNA repeat spec's example shape):

| Test | Old buggy locked | New spec-correct |
|---|---|---|
| `position_ordering::test_minus_strand_intronic_insertion_position_order` | `c.30+2_30+3insA` | `c.30+4dup` |
| `intronic_duplications::test_minus_strand_intronic_dup` | `c.30+2dup` | `c.30+4dup` |
| `intronic_duplications::test_minus_strand_intronic_multi_base_dup` | `c.30+2_30+4T[6]` | `c.30+2_30+4A[6]` |
| `intronic_deletions_minus::test_minus_strand_intronic_single_del` | `c.30+2del` | `c.30+4del` |
| `intronic_deletions_minus::test_minus_strand_intronic_del_3prime_shift` | `c.30+5del` | `c.31-4del` |
| `delins_boundary::test_intronic_delins_minus` | `c.30+2_30+4delinsAAA` | `c.30+2_30+4=` |

The header docstring is updated to reflect that all `FIXME` markers are resolved.

## What this means for the related issues

- **#81 A1 (intronic, minus strand)** — now passes the no-intronic-cell gap that PR #93's matrix didn't cover. A1 may want to be re-marked as more-fully-closed in #81's checklist; left to the reviewer.
- **#81 A5 (del 3'-shift, minus-strand intronic)** — fires correctly; the broader A5 matrix is still its own item.
- **#81 A6 (dup 3'-shift, minus-strand intronic)** — same.
- **PR #78 (delins-as-identity rewrite)** — now fires on minus-strand intronic input.
- **#96 (multi-base dup repeat-unit)** — wrong-strand-letter symptom is fully fixed by this PR. The other concern in that issue's body — about position-vs-unit-length consistency — was based on a misreading of the HGVS DNA repeat spec; the spec uses full-tract position with the explicit unit and post-edit count uniformly (e.g., `g.101179660_101179695TG[14]`, `c.89_118AGC[13]`). #96 will be closed.
- **#97 (`c.?del` collapse on minus-strand 5'UTR del)** — untouched here; that path is exonic-UTR rather than intronic and needs a separate fix.

## Verification

- [x] `cargo nextest run --features dev` — full suite passes; seven previously-failing FIXME-tagged tests now pass with their updated locks; no unrelated regressions
- [x] `cargo nextest run --features dev --test issue_98_minus_strand_intronic_orientation` — 4/4 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features dev --tests -- -D warnings` — no new findings (the 11 pre-existing errors in `src/` reproduce identically on `main`)
- [x] Pre-commit hooks pass
