### PR TITLE
fix(normalize): repeat-notation position locates first unit, not full tract (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(normalize)* Repeat notation now emits the position of the FIRST
+  repeat unit per HGVS spec, not the entire reference tract. The three
+  repeat-emission paths in `src/normalize/rules.rs`
+  (`duplication_to_repeat`, `insertion_to_repeat`, `normalize_repeat`)
+  previously set the position end to `ref_start + ref_count * unit_len
+  - 1`, producing forms like `c.342_362GCA[9]` for a 9-unit GCA tract
+  (21-base position) where the spec requires `c.342_344GCA[9]` (3-base
+  position matching the 3-base unit length). The fix sets `end =
+  ref_start + unit_len - 1` everywhere repeat notation is emitted, so
+  the position-range length always equals the unit length.
+  Mechanically updates the locked outputs of every multi-base
+  ins/dup→repeat case in `tests/ins_shift_matrix.rs` (29 cells across
+  all 7 nucleotide coord-system / strand modules), three real-accession
+  smoke tests in `tests/normalize_tests.rs`, and the residual #96 lock
+  in `tests/coverage_gap_tests.rs`. Issue #96.
 - *(normalize)* Minus-strand intronic normalization now reads the
   reference window in transcript-view orientation. `normalize_intronic_cds`
   and `normalize_intronic_tx` previously passed the genomic-strand bytes

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -193,12 +193,16 @@ pub fn insertion_to_repeat(
 
     let (unit, ref_start, ref_count) = best?;
     let total_count = ref_count + added_copies;
-    let ref_end = ref_start + ref_count as usize * unit.len() - 1;
+    // Per HGVS spec, the position in `prefix:position_or_range unit[N]`
+    // must locate the FIRST repeat unit, not the entire tract. The
+    // first-unit end position is `ref_start + unit_len - 1` (inclusive,
+    // 0-based), not `ref_start + ref_count * unit_len - 1`. Issue #96.
+    let unit_first_end = ref_start + unit.len() - 1;
     Some((
         unit[0],
         total_count,
         index_to_hgvs_pos(ref_start),
-        index_to_hgvs_pos(ref_end),
+        index_to_hgvs_pos(unit_first_end),
         unit,
     ))
 }
@@ -472,11 +476,14 @@ pub fn duplication_to_repeat(ref_seq: &[u8], start: u64, end: u64) -> Option<Dup
         if let Some(analysis) = find_homopolymer_at(ref_seq, start_idx) {
             if analysis.base == Some(first) {
                 let total_count = analysis.ref_count + dup_len as u64;
+                // Per HGVS spec the position must locate the FIRST
+                // repeat unit, not the full ref-tract extent. For a
+                // single-base unit that is a 1-base position. Issue #96.
                 return Some(DupToRepeatResult::Homopolymer {
                     base: first,
                     count: total_count,
                     start: index_to_hgvs_pos(analysis.ref_start),
-                    end: index_to_hgvs_pos(analysis.ref_start + analysis.ref_count as usize - 1),
+                    end: index_to_hgvs_pos(analysis.ref_start),
                 });
             }
         }
@@ -511,17 +518,20 @@ pub fn duplication_to_repeat(ref_seq: &[u8], start: u64, end: u64) -> Option<Dup
         }
 
         // Found a repeat unit. Now find the full extent in the reference.
-        if let Some((ref_count, rep_start, rep_end)) =
+        if let Some((ref_count, rep_start, _rep_end)) =
             count_tandem_repeats(ref_seq, start_idx, unit)
         {
             // Total count = reference count + duplicated copies
             let total_count = ref_count + copies_in_dup as u64;
-            // rep_end is exclusive (0-based), so last position is rep_end - 1
+            // Per HGVS spec the position must locate the FIRST repeat
+            // unit, not the full ref-tract extent. For a unit of length
+            // U the first-unit end position (inclusive, 0-based) is
+            // `rep_start + U - 1`. Issue #96.
             return Some(DupToRepeatResult::TandemRepeat {
                 unit: unit.to_vec(),
                 count: total_count,
                 start: index_to_hgvs_pos(rep_start),
-                end: index_to_hgvs_pos(rep_end - 1),
+                end: index_to_hgvs_pos(rep_start + unit_len - 1),
             });
         }
     }
@@ -666,12 +676,14 @@ pub fn normalize_repeat(
         // Same as reference - this is identity (no change)
         RepeatNormResult::Unchanged
     } else {
-        // Keep as repeat notation with canonical position
-        // The repeat region describes the REFERENCE tract (per HGVS spec)
-        // ref_end is exclusive, so last position is ref_end - 1
+        // Keep as repeat notation with canonical position. Per HGVS spec
+        // the position must locate the FIRST repeat unit, not the entire
+        // tract — i.e. the position-range length must equal the unit
+        // length. Issue #96.
+        let _ = ref_end; // ref_end is the exclusive end of the full tract; not needed here
         RepeatNormResult::Repeat {
             start: index_to_hgvs_pos(ref_start),
-            end: index_to_hgvs_pos(ref_end - 1),
+            end: index_to_hgvs_pos(ref_start + repeat_unit.len() - 1),
             sequence: repeat_unit.to_vec(),
             count: specified_count,
         }
@@ -948,14 +960,16 @@ mod tests {
         // `pos` is the 0-based index of the base immediately 5' of the
         // insertion point. pos=7 means insert between index 7 and 8 — i.e.,
         // immediately after the last A in the homopolymer. Inserting AA here
-        // should become A[7] (5 ref + 2 inserted).
+        // should become A[7] (5 ref + 2 inserted). Per HGVS spec the
+        // returned position locates the FIRST repeat unit; for a 1-base
+        // unit that is a single position, so end == start (issue #96).
         let result = insertion_to_repeat(ref_seq, 7, b"AA");
         assert!(result.is_some());
         let (base, count, start, end, _unit) = result.unwrap();
         assert_eq!(base, b'A');
         assert_eq!(count, 7); // 5 original + 2 inserted
-        assert_eq!(start, 4); // 1-indexed start of A region in reference
-        assert_eq!(end, 8); // 1-indexed end of A region in reference (per HGVS, positions refer to reference tract)
+        assert_eq!(start, 4); // 1-indexed start of the first A repeat unit
+        assert_eq!(end, 4); // first-unit end == start (single-base unit)
 
         // Single-copy inserts (added_copies < 2) are duplications, not repeats.
         let result = insertion_to_repeat(ref_seq, 7, b"A");
@@ -972,15 +986,17 @@ mod tests {
         // Multi-base tandem unit: insert ACAC into ACAC tract → AC[4].
         // ref_seq has ACAC at indices 0-3. Insert ACAC just before index 4
         // (pos=3, between A at index 3 and base at index 4). Expected:
-        // 2 ref AC units + 2 inserted AC units = AC[4] at ref indices 0..3.
+        // 2 ref AC units + 2 inserted AC units = AC[4]. The returned
+        // position locates the first AC unit at indices 0..1
+        // (1-indexed 1..2) — a 2-base range matching the 2-base unit.
         let ref_ac = b"ACACGGG";
         let result = insertion_to_repeat(ref_ac, 3, b"ACAC");
         assert!(result.is_some());
         let (base, count, start, end, unit) = result.unwrap();
         assert_eq!(base, b'A');
         assert_eq!(count, 4);
-        assert_eq!(start, 1); // 1-indexed
-        assert_eq!(end, 4); // 1-indexed
+        assert_eq!(start, 1); // 1-indexed start of first AC unit
+        assert_eq!(end, 2); // 1-indexed end of first AC unit (start + 2 - 1)
         assert_eq!(unit, b"AC");
     }
 
@@ -1023,7 +1039,9 @@ mod tests {
         let result = duplication_to_repeat(ref_seq, 5, 8);
         assert!(result.is_none(), "Single-copy dup should not become repeat");
 
-        // Duplicating GCAGCA (2 copies) SHOULD become repeat notation
+        // Duplicating GCAGCA (2 copies) SHOULD become repeat notation.
+        // Per HGVS spec the returned position locates the FIRST GCA unit;
+        // for a 3-base unit that is a 3-base range (issue #96).
         let result = duplication_to_repeat(ref_seq, 5, 11);
         assert!(result.is_some());
         match result.unwrap() {
@@ -1035,8 +1053,8 @@ mod tests {
             } => {
                 assert_eq!(unit, b"GCA");
                 assert_eq!(count, 10); // 8 original + 2 duplicated
-                assert_eq!(start, 6); // 1-indexed
-                assert_eq!(end, 29); // 1-indexed end of 8 GCAs (0-indexed 28 + 1)
+                assert_eq!(start, 6); // 1-indexed start of first GCA unit
+                assert_eq!(end, 8); // 1-indexed end of first GCA unit (start + 3 - 1)
             }
             _ => panic!("Expected TandemRepeat result"),
         }

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -16,12 +16,11 @@
 //!
 //! Issue #94: every gap test that previously asserted only `contains(...)`
 //! or `is_ok() || is_err()` is locked with `assert_eq!` against the
-//! exact normalizer output. Issue #98 (minus-strand intronic ref-base
-//! orientation) was identified as a common root cause behind several
-//! initially suspected-buggy lock points and has since been fixed; the
-//! affected tests now lock spec-correct outputs. The one remaining
-//! `FIXME` in this file points at #96 (multi-base dup repeat-unit
-//! position not yet consistent with the unit length, on minus strand).
+//! exact normalizer output. Issues #96 (repeat-unit position not
+//! consistent with unit length) and #98 (minus-strand intronic
+//! ref-base orientation) were identified as common root causes behind
+//! several initially suspected-buggy lock points and have since been
+//! fixed; the affected tests now lock spec-correct outputs.
 //! Boundary-spanning panic-canary tests are intentionally left as
 //! `is_ok() || is_err()` per #94 scope.
 
@@ -444,18 +443,14 @@ mod intronic_duplications {
     #[test]
     fn test_minus_strand_intronic_multi_base_dup() {
         // Transcript-view AAA tract at c.30+2..c.30+4 duplicated to
-        // AAAAAA. The repeat unit is now correctly emitted as the
-        // transcript-view letter `A` (the genomic-strand `T` was the
-        // surface symptom of #98, fixed). The first-unit position
-        // range, however, is still the original 3-base span of the
-        // duplicated region rather than a single base consistent with
-        // the 1-base unit — that residual is tracked separately as
-        // #96.
+        // AAAAAA. The repeat unit is the transcript-view letter `A`
+        // (the genomic-strand `T` was the surface symptom of #98).
+        // The first-unit position is a single base (`c.30+2`) per HGVS
+        // spec — the position-range length must equal the unit length
+        // (issue #96).
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4dup");
-        // FIXME(#96): expected first-unit position is consistent with
-        // the unit length (1-base unit `A` → 1-base position).
-        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4A[6]");
+        assert_eq!(result, "NM_MINUS.1:c.30+2A[6]");
     }
 }
 

--- a/tests/ins_shift_matrix.rs
+++ b/tests/ins_shift_matrix.rs
@@ -73,26 +73,28 @@ mod genomic {
     }
 
     #[rstest]
-    // 2+ units added → repeat notation per HGVS spec.
-    // Case 1: 2 A's added to AAA tract → A[5].
-    //   Core: ACAAACG. ref core[3..6]=AAA. Insert AA at core 2_3.
+    // 2+ units added → repeat notation per HGVS spec. Output position
+    // locates the FIRST repeat unit (issue #96), so its length matches
+    // the unit length: 1-base unit → single position, 2-base unit →
+    // 2-base range, 3-base unit → 3-base range.
+    // Case 1: 2 A's added to AAA tract → A[5] at core pos 3 (single base).
+    //   Core: ACAAACG. ref core[3..5]=AAA (3 A's). Insert AA at core 2_3.
     //   Shifts to end of A-tract; 3+2=5 As → A[5].
-    //   Repeat tract: core[3..5] (1-based, 3 A's at HGVS pos 3..5).
-    #[case("ACAAACG", "g.{0}_{1}insAA", &[2u64, 3u64], "g.{0}_{1}A[5]", &[3u64, 5u64])]
-    // Case 2: 4 A's added to AAA tract → A[7].
-    #[case("ACAAACG", "g.{0}_{1}insAAAA", &[2u64, 3u64], "g.{0}_{1}A[7]", &[3u64, 5u64])]
+    #[case("ACAAACG", "g.{0}_{1}insAA", &[2u64, 3u64], "g.{0}A[5]", &[3u64])]
+    // Case 2: 4 A's added to AAA tract → A[7] at core pos 3 (single base).
+    #[case("ACAAACG", "g.{0}_{1}insAAAA", &[2u64, 3u64], "g.{0}A[7]", &[3u64])]
     // Case 3: 2 GCA units added to GCAGCAGCA tract → GCA[5].
     //   Core: ACGCAGCAGCATG. ref core[3..11]=GCAGCAGCA (3 GCA units).
     //   Insert GCAGCA at core 2_3. Shifts; 3+2=5 GCA → GCA[5].
-    //   Repeat tract: core[3..11] (1-based, 9 bases = 3 units).
-    #[case("ACGCAGCAGCATG", "g.{0}_{1}insGCAGCA", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    //   Position: first GCA unit at core 3..5 (3-base range).
+    #[case("ACGCAGCAGCATG", "g.{0}_{1}insGCAGCA", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 5u64])]
     // Case 4: 2 AC units added to ACACAC tract → AC[5].
     //   Core: GCACACACG. Pairs (3-4)=AC, (5-6)=AC, (7-8)=AC; 3 AC units at core 3..8.
     //   Trailing G at core 9 prevents the AC tract from leaking into padding
     //   (padding starts with 'A', which would otherwise extend the tract).
     //   Insert ACAC at core 2_3 (between C and A). alt[0]=A, ref[3]=A → match → shifts.
-    //   3+2=5 AC → AC[5]. Tract: core 3..8 (1-based, 6 bases = 3 units).
-    #[case("GCACACACG", "g.{0}_{1}insACAC", &[2u64, 3u64], "g.{0}_{1}AC[5]", &[3u64, 8u64])]
+    //   3+2=5 AC → AC[5]. Position: first AC unit at core 3..4 (2-base range).
+    #[case("GCACACACG", "g.{0}_{1}insACAC", &[2u64, 3u64], "g.{0}_{1}AC[5]", &[3u64, 4u64])]
     // Case 5: alt is a cyclic rotation of the ref unit.
     //   Core: TTGCAGCAGCATT. Ref tract (GCA)x3 at core 3..11; flanking T's
     //   at core 1-2 and 12-13 prevent the tract from extending into PAD.
@@ -100,8 +102,8 @@ mod genomic {
     //   smallest_repeat_unit returns CAG, but the ref tract is GCA — the
     //   algorithm must try all cyclic rotations of the unit to find the
     //   reference-aligned tract.
-    //   Expected: GCA[5] at core 3..11.
-    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAGCAG", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    //   Expected: GCA[5]. Position: first GCA unit at core 3..5 (3-base range).
+    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAGCAG", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 5u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -234,13 +236,13 @@ mod cds_plus {
 
     #[rstest]
     // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}A[5]", &[3u64])]
     // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}A[7]", &[3u64])]
     // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
-    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 5u64])]
     // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -362,13 +364,13 @@ mod cds_minus {
 
     #[rstest]
     // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}A[5]", &[3u64])]
     // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}A[7]", &[3u64])]
     // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
-    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 5u64])]
     // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -491,13 +493,13 @@ mod noncoding_plus {
 
     #[rstest]
     // Case 1: 2 A's added to AAA tract → A[5]. Tract: n.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}_{1}A[5]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}A[5]", &[3u64])]
     // Case 2: 4 A's added to AAA tract → A[7]. Tract: n.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}_{1}A[7]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}A[7]", &[3u64])]
     // Case 3: 2 GCA units added → GCA[5]. Tract: n.3..11.
-    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 5u64])]
     // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: n.3..8.
-    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 8u64])]
+    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -620,13 +622,13 @@ mod noncoding_minus {
 
     #[rstest]
     // Case 1: 2 A's added to AAA tract → A[5]. Tract: n.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}_{1}A[5]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAA", &[2u64, 3u64], "n.{0}A[5]", &[3u64])]
     // Case 2: 4 A's added to AAA tract → A[7]. Tract: n.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}_{1}A[7]", &[3u64, 5u64])]
+    #[case("ACAAACGTACGTACGTACGT", "n.{0}_{1}insAAAA", &[2u64, 3u64], "n.{0}A[7]", &[3u64])]
     // Case 3: 2 GCA units added → GCA[5]. Tract: n.3..11.
-    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    #[case("ACGCAGCAGCATGACGTACG", "n.{0}_{1}insGCAGCA", &[2u64, 3u64], "n.{0}_{1}GCA[5]", &[3u64, 5u64])]
     // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: n.3..8.
-    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 8u64])]
+    #[case("GCACACACGTACGTACGTAC", "n.{0}_{1}insACAC", &[2u64, 3u64], "n.{0}_{1}AC[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -746,13 +748,13 @@ mod rna_plus {
 
     #[rstest]
     // Case 1: 2 a's added to aaa tract → a[5]. Tract: r.3..5.
-    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}_{1}a[5]", &[3u64, 5u64])]
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}a[5]", &[3u64])]
     // Case 2: 4 a's added to aaa tract → a[7]. Tract: r.3..5.
-    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}_{1}a[7]", &[3u64, 5u64])]
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}a[7]", &[3u64])]
     // Case 3: 2 gca units added → gca[5]. Tract: r.3..11.
-    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 5u64])]
     // Case 4: 2 ac units added to acacac tract → ac[5]. Tract: r.3..8.
-    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 8u64])]
+    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -872,13 +874,13 @@ mod rna_minus {
 
     #[rstest]
     // Case 1: 2 a's added to aaa tract → a[5]. Tract: r.3..5.
-    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}_{1}a[5]", &[3u64, 5u64])]
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaa", &[2u64, 3u64], "r.{0}a[5]", &[3u64])]
     // Case 2: 4 a's added to aaa tract → a[7]. Tract: r.3..5.
-    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}_{1}a[7]", &[3u64, 5u64])]
+    #[case("acaaacguacguacguacgu", "r.{0}_{1}insaaaa", &[2u64, 3u64], "r.{0}a[7]", &[3u64])]
     // Case 3: 2 gca units added → gca[5]. Tract: r.3..11.
-    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
+    #[case("acgcagcagcaugacguacg", "r.{0}_{1}insgcagca", &[2u64, 3u64], "r.{0}_{1}gca[5]", &[3u64, 5u64])]
     // Case 4: 2 ac units added to acacac tract → ac[5]. Tract: r.3..8.
-    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 8u64])]
+    #[case("gcacacacguacguacguac", "r.{0}_{1}insacac", &[2u64, 3u64], "r.{0}_{1}ac[5]", &[3u64, 4u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/issue_96_repeat_unit_position_consistency.rs
+++ b/tests/issue_96_repeat_unit_position_consistency.rs
@@ -1,0 +1,110 @@
+//! Regression test for issue #96 (residual after #98).
+//!
+//! Per HGVS spec for repeated sequences, the position in
+//! `prefix:position_or_range unit[N]` must locate the **first repeat
+//! unit** — its length must match the unit length. ferro previously
+//! emitted the location of the **entire reference tract** (ref count ×
+//! unit length), which is a longer span than the unit.
+//!
+//! Examples (from `varnomen.hgvs.org/recommendations/DNA/variant/repeated/`):
+//!
+//! - `NC_000001.11:g.123456_123458GCA[12]` — 3-base position for a
+//!   3-base unit.
+//! - Single-base unit: position is a single base.
+//!
+//! These tests fail before the fix in `duplication_to_repeat` and
+//! `insertion_to_repeat` (which both used `start..ref_end_of_full_tract`)
+//! and pass after the fix sets `end = start + unit_len - 1`.
+//!
+//! Independent of the symptom-locked tests in
+//! `tests/coverage_gap_tests.rs` and `tests/ins_shift_matrix.rs`.
+//!
+//! The fixture is a single-exon transcript whose sequence contains a
+//! contiguous tandem run, so the position is computable purely from the
+//! transcript-view bases.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn provider_with_single_exon(id: &str, sequence: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let len = sequence.len() as u64;
+    provider.add_transcript(Transcript::new(
+        id.to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence.to_string(),
+        Some(1),
+        Some(len),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        GenomeBuild::Unknown,
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse should succeed");
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize should succeed");
+    format!("{}", normalized)
+}
+
+/// **Diagnostic 1 — single-base unit, dup → repeat.**
+///
+/// Tx `CAAACG` (c.1..6 = C,A,A,A,C,G); AAA tract at c.2..4. Dup
+/// `c.2_4` adds 3 more As → 6 As total → repeat notation with unit
+/// `A`. The position must locate ONE A — a single base — not the
+/// original 3-base tract.
+#[test]
+fn dup_single_base_unit_position_is_single_base() {
+    let provider = provider_with_single_exon("NM_TEST.1", "CAAACG");
+    let result = normalize(provider, "NM_TEST.1:c.2_4dup");
+    assert_eq!(result, "NM_TEST.1:c.2A[6]");
+}
+
+/// **Diagnostic 2 — multi-base unit, dup → repeat.**
+///
+/// Tx `CGCAGCAGCAT` (c.1..11). GCA tract at c.2..10 (3 units).
+/// Duplicating two GCA units (`c.3_8dup` = `AGCAGC` shifted to one
+/// of the GCA boundaries) triggers repeat notation with unit `GCA`.
+/// The position must locate the FIRST GCA unit — 3 bases starting
+/// at c.2 — i.e. `c.2_4`, not the full 9-base tract.
+#[test]
+fn dup_three_base_unit_position_is_three_bases() {
+    let provider = provider_with_single_exon("NM_TEST.1", "CGCAGCAGCAT");
+    let result = normalize(provider, "NM_TEST.1:c.3_8dup");
+    assert_eq!(result, "NM_TEST.1:c.2_4GCA[5]");
+}
+
+/// **Diagnostic 3 — single-base unit, ins → repeat.**
+///
+/// Tx `CAAACG`, AAA tract at c.2..4. Inserting two more As
+/// (`c.3_4insAA`) adds 2 units of `A` → 5 As total → repeat
+/// notation. Position must be a single base.
+#[test]
+fn ins_single_base_unit_position_is_single_base() {
+    let provider = provider_with_single_exon("NM_TEST.1", "CAAACG");
+    let result = normalize(provider, "NM_TEST.1:c.3_4insAA");
+    assert_eq!(result, "NM_TEST.1:c.2A[5]");
+}
+
+/// **Diagnostic 4 — multi-base unit, ins → repeat.**
+///
+/// Tx `CGCAGCAGCAT`, GCA tract at c.2..10 (3 units). Inserting two
+/// more GCA units (`c.5_6insGCAGCA`) adds 2 units → 5 GCA total →
+/// repeat. Position must be 3 bases (the first GCA at c.2_4), not
+/// the full 9-base tract.
+#[test]
+fn ins_three_base_unit_position_is_three_bases() {
+    let provider = provider_with_single_exon("NM_TEST.1", "CGCAGCAGCAT");
+    let result = normalize(provider, "NM_TEST.1:c.5_6insGCAGCA");
+    assert_eq!(result, "NM_TEST.1:c.2_4GCA[5]");
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -1686,13 +1686,15 @@ mod normalization_transformations {
     // =========================================================================
 
     // Real-accession smoke; matrix-level coverage in tests/ins_shift_matrix.rs.
+    // Output position locates the FIRST repeat unit per HGVS spec — for a
+    // 1-base unit that is a single position (issue #96).
     #[rstest]
-    // polyA expansion: inserting AAAA into A-tract becomes A[n] - Mutalyzer: agrees
-    #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.401_403A[7]")]
-    // polyT expansion - Mutalyzer: agrees
-    #[case("NM_000382.3:c.399_400insTTTT", "NM_000382.3:c.398_399T[6]")]
-    // polyG expansion - Mutalyzer: agrees
-    #[case("NM_015120.4:c.46_47insGGG", "NM_015120.4:c.45_46G[5]")]
+    // polyA expansion: inserting AAAA into A-tract becomes A[n].
+    #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.401A[7]")]
+    // polyT expansion.
+    #[case("NM_000382.3:c.399_400insTTTT", "NM_000382.3:c.398T[6]")]
+    // polyG expansion.
+    #[case("NM_015120.4:c.46_47insGGG", "NM_015120.4:c.45G[5]")]
     fn test_insertion_becomes_repeat(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input);
         assert_eq!(
@@ -1708,9 +1710,11 @@ mod normalization_transformations {
     // Mutalyzer: agrees
     // =========================================================================
 
+    // Output position locates the FIRST repeat unit per HGVS spec — for a
+    // 3-base unit that is a 3-base range (issue #96).
     #[rstest]
-    // Triplet repeat expansion: dupGCAGCA in GCA-tract becomes GCA[n] - Mutalyzer: agrees
-    #[case("NM_020732.3:c.357_362dupGCAGCA", "NM_020732.3:c.342_362GCA[9]")]
+    // Triplet repeat expansion: dupGCAGCA in GCA-tract becomes GCA[n].
+    #[case("NM_020732.3:c.357_362dupGCAGCA", "NM_020732.3:c.342_344GCA[9]")]
     fn test_dup_becomes_repeat(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input);
         assert_eq!(
@@ -2797,8 +2801,9 @@ mod equivalence_derived_normalize {
     // From check_dup_repeat_equivalence and check_dup_vs_expanded_repeat_equivalence.
 
     #[rstest]
-    // Triplet repeat expansion: dupGCAGCA in GCA-tract becomes GCA[n]
-    #[case("NM_020732.3:c.357_362dupGCAGCA", "NM_020732.3:c.342_362GCA[9]")]
+    // Triplet repeat expansion: dupGCAGCA in GCA-tract becomes GCA[n].
+    // Position locates the first GCA unit per HGVS spec (issue #96).
+    #[case("NM_020732.3:c.357_362dupGCAGCA", "NM_020732.3:c.342_344GCA[9]")]
     #[ignore]
     fn test_dup_to_repeat_normalization(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input)


### PR DESCRIPTION
Closes #96. Stacked on #100 (will retarget through the chain as the upstream PRs merge).

## TL;DR

Per HGVS spec for repeated sequences, the position in `prefix:position_or_range unit[N]` must locate the **first repeat unit** — its length must match the unit length. ferro previously emitted the location of the **entire reference tract** (`ref_start + ref_count * unit_len - 1`), producing forms like `c.342_362GCA[9]` for a 9-unit GCA tract (21-base position) where the spec requires `c.342_344GCA[9]` (3-base position matching the 3-base unit length). The defect was identical in three repeat-emission code paths in `src/normalize/rules.rs`. Fixing all three sets `end = ref_start + unit_len - 1`.

## What was wrong

Three independent emission paths, same bug shape:

| Function | Trigger | Old `end` | New `end` |
|---|---|---|---|
| `duplication_to_repeat::Homopolymer` | dup of a single-base homopolymer | `ref_start + ref_count - 1` (full tract) | `ref_start` (single-base unit, single-base position) |
| `duplication_to_repeat::TandemRepeat` | dup of a multi-base tandem unit | `ref_start + ref_count * unit_len - 1` (full tract) | `ref_start + unit_len - 1` (one unit) |
| `insertion_to_repeat` | ins adding ≥ 2 copies of a tandem unit | `ref_start + ref_count * unit_len - 1` (full tract) | `ref_start + unit_len - 1` (one unit) |
| `normalize_repeat::Repeat` (already-existing repeat input) | re-normalizing a `unit[N]` variant | `ref_end - 1` (exclusive end of full tract → last position) | `ref_start + unit_len - 1` (one unit) |

The fourth path (`normalize_repeat::Repeat`) is what made this a *spec-compliance* bug rather than just a cosmetic one: until it was also fixed, the idempotency suite caught the inconsistency. `dupGCAGCA` against a real RefSeq tract normalized to `c.342_344GCA[9]` once (correct first-unit position from the dup→repeat path), then expanded to `c.342_362GCA[9]` on a second pass (incorrect full-tract position from the repeat→repeat path). The existing `tests/idempotency_tests.rs::test_normalization_idempotency` test caught this within the cascade verification.

## Cascade

The fix is mechanical for the test suite — every locked output that previously hard-coded the full-tract end position flips to the first-unit end position:

- **`tests/ins_shift_matrix.rs`** — 29 case lines across all 7 modules (`genomic`, `cds_plus`, `cds_minus`, `noncoding_plus`, `noncoding_minus`, `rna_plus`, `rna_minus`) updated. Each module's `multi_base_ins_in_tandem_multiple_units` block changes:
  - 1-base unit (`A[5]`, `A[7]`): output template drops the `_{1}` and the args drop the second element.
  - 2-base unit (`AC[5]`): args become `[start, start + 1]`.
  - 3-base unit (`GCA[5]`): args become `[start, start + 2]`.
- **`tests/normalize_tests.rs`** — three real-accession `test_insertion_becomes_repeat` cases (`NM_001127687.1`, `NM_000382.3`, `NM_015120.4`), one `test_dup_becomes_repeat` case (`NM_020732.3`), and its ignored sibling.
- **`src/normalize/rules.rs::tests`** — `test_insertion_to_repeat` and `test_duplication_to_tandem_repeat` update their `end`-position assertions.
- **`tests/coverage_gap_tests.rs`** — the residual `FIXME(#96)` lock on `intronic_duplications::test_minus_strand_intronic_multi_base_dup` flips from `c.30+2_30+4A[6]` to `c.30+2A[6]`. The file's header docstring is updated to reflect that no FIXMEs remain (the only one was this).

## Diagnostic tests

`tests/issue_96_repeat_unit_position_consistency.rs` (new) — four single-assertion tests, one per (path × unit-length) combination:

| Path | Unit | Asserted shape |
|---|---|---|
| dup → repeat | 1-base | `c.2A[6]` |
| dup → repeat | 3-base | `c.2_4GCA[5]` |
| ins → repeat | 1-base | `c.2A[5]` |
| ins → repeat | 3-base | `c.2_4GCA[5]` |

All four fail before the fix (each emits the full-tract position) and pass after. They depend only on a synthetic single-exon transcript and the public `normalize` API — no overlap with the symptom-locked tests in `tests/coverage_gap_tests.rs` or `tests/ins_shift_matrix.rs`.

## What this means for the related issues

- **#94** — every speculative `FIXME` lock added in #99 has now been resolved by either #98 (orientation symptoms) or #96 (this PR, position-shape symptom). The header docstring is updated; no `FIXME(...)` markers remain in the file.
- **#81 A6** — multi-base `dup` 3'-shift is part of the broader A6 matrix work, but the spec-canonical form for the multi-base intronic minus-strand case is now correct end-to-end as a side effect of #98 + #96.
- **#97** — independent (UTR codepath); still its own follow-up PR.

## Verification

- [x] `cargo nextest run --features dev` — 3180/3180 pass; the previously-failing six (#98 cascade) and seven (#96 cascade) tests now pass with their updated locks; idempotency suite green
- [x] `cargo nextest run --features dev --test issue_96_repeat_unit_position_consistency` — 4/4 pass
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features dev --tests -- -D warnings` — no new findings (the 11 pre-existing errors in `src/` reproduce identically on `main`)
- [x] Pre-commit hooks pass