### PR TITLE
fix(normalize): 5'UTR CDS↔tx off-by-one collapsed UTR del to c.? (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for 3'UTR / downstream). Cross-region pairs (`c.[-1A>G;1A>T]` 5'UTR↔CDS,
   `c.[40C>T;*1A>G]` CDS↔3'UTR, …) still correctly do not merge.
   Issue #89.
+- *(normalize)* CDS ↔ transcript coordinate mappings now respect the
+  HGVS no-c.0 numbering rule for 5'UTR positions. The forward mapping
+  (`Normalizer::cds_to_tx_pos`, `convert::coding::cds_to_transcript_pos`)
+  previously computed `tx = cds_start + base - 1` for negative `base`,
+  which double-counted the gap between c.-1 and c.1 and emitted a tx
+  position one base 5' of the true location. The inverse mapping
+  (`Normalizer::tx_to_cds_pos`) had the mirror bug: tx positions one
+  base before `cds_start` mapped to `base = 0`, which `CdsPos::Display`
+  renders as `c.?` (`CDS_BASE_UNKNOWN`). The most visible symptom was a
+  5'UTR single-base deletion on a minus-strand transcript collapsing
+  to `c.?del` instead of resolving to a real position (e.g. `c.-1del`
+  after 3'-shifting within a UTR homopolymer). Forward and inverse are
+  now `tx = cds_start + base` and `base = tx - cds_start` for negative
+  / pre-cds_start positions, matching the spec's "c.-1 is one base 5'
+  of c.1" rule and the existing exon-aware mapper at
+  `convert::mapper::cds_to_tx` / `tx_to_cds`. Issue #97.
 - *(normalize)* Minus-strand intronic normalization now reads the
   reference window in transcript-view orientation. `normalize_intronic_cds`
   and `normalize_intronic_tx` previously passed the genomic-strand bytes

--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -83,8 +83,15 @@ pub fn cds_to_transcript_pos(pos: &CdsPos, transcript: &Transcript) -> Result<u6
 
     let tx_pos = if pos.utr3 {
         cds_end + pos.base as u64
-    } else if pos.base < 1 {
-        (cds_start as i64 + pos.base - 1) as u64
+    } else if pos.base < 0 {
+        // 5'UTR: HGVS numbering skips c.0 (c.-1 is the base immediately
+        // upstream of c.1), so c.-N maps to tx position cds_start - N.
+        // Issue #97.
+        (cds_start as i64 + pos.base) as u64
+    } else if pos.base == 0 {
+        // c.0 is not a valid HGVS position; preserve the legacy mapping
+        // (last 5'UTR base, equivalent to c.-1) rather than failing.
+        cds_start.saturating_sub(1)
     } else {
         cds_start + pos.base as u64 - 1
     };
@@ -147,5 +154,48 @@ mod tests {
         // 3' UTR is 6bp (positions *1 to *6)
         assert!(validate_cds_pos(&CdsPos::utr3(3), &tx).is_ok());
         assert!(validate_cds_pos(&CdsPos::utr3(10), &tx).is_err());
+    }
+
+    #[test]
+    fn test_cds_to_transcript_pos_5utr_and_legacy_c0() {
+        // Pin the issue #97 fix and the legacy c.0 mapping in the public
+        // helper, mirroring Normalizer::cds_to_tx_pos.
+        //
+        // 5'UTR (issue #97): HGVS skips c.0, so c.-N maps to tx position
+        // cds_start - N — i.e. (cds_start as i64 + pos.base) as u64.
+        let tx = make_test_transcript();
+        let cds_start = tx.cds_start.unwrap(); // 6
+
+        let result = cds_to_transcript_pos(&CdsPos::new(-1), &tx).unwrap();
+        assert_eq!(result, (cds_start as i64 + (-1)) as u64);
+
+        // Legacy c.0 mapping: treat as the last 5'UTR base (== c.-1) via
+        // cds_start.saturating_sub(1) rather than failing.
+        let result = cds_to_transcript_pos(&CdsPos::new(0), &tx).unwrap();
+        assert_eq!(result, cds_start.saturating_sub(1));
+
+        // Defensive: cds_start == 0 must not underflow. saturating_sub
+        // pins the result at 0 instead of wrapping to u64::MAX.
+        let tx_zero_cds = Transcript {
+            id: "NM_TEST_ZERO.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: "ATGCCCAAAGGG".to_string(),
+            cds_start: Some(0),
+            cds_end: Some(5),
+            exons: vec![Exon::new(1, 1, 12)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+        let result = cds_to_transcript_pos(&CdsPos::new(0), &tx_zero_cds).unwrap();
+        assert_eq!(result, tx_zero_cds.cds_start.unwrap().saturating_sub(1));
+        assert_eq!(result, 0);
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1904,14 +1904,23 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 msg: format!("Negative base {} in 3' UTR position", pos.base),
             })?;
             Ok(end + base)
-        } else if pos.base < 1 {
-            let tx_pos = cds_start as i64 + pos.base - 1;
+        } else if pos.base < 0 {
+            // 5'UTR: HGVS numbering skips c.0 (c.-1 is the base immediately
+            // upstream of c.1), so c.-N maps to tx position cds_start - N.
+            // Issue #97 — the previous formula `cds_start + base - 1`
+            // double-counted the gap and emitted the wrong tx position.
+            let tx_pos = cds_start as i64 + pos.base;
             u64::try_from(tx_pos).map_err(|_| FerroError::ConversionError {
                 msg: format!(
                     "CDS position c.{} maps before transcript start (cds_start={})",
                     pos.base, cds_start
                 ),
             })
+        } else if pos.base == 0 {
+            // c.0 is not a valid HGVS position, but historical inputs
+            // can land here. Preserve the legacy mapping (treat as the
+            // last 5'UTR base, equivalent to c.-1) rather than failing.
+            Ok(cds_start.saturating_sub(1))
         } else {
             Ok(cds_start + pos.base as u64 - 1)
         }
@@ -1929,10 +1938,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
         })?;
 
         if pos < cds_start {
-            // For 5'UTR: cds_to_tx_pos formula is tx = cds_start + base - 1
-            // So inverse is: base = tx - cds_start + 1
+            // 5'UTR: HGVS numbering skips c.0, so a tx position one
+            // base 5' of cds_start is c.-1 (not c.0). Inverse of the
+            // forward formula `tx = cds_start + base` for negative
+            // base: `base = tx - cds_start`. Issue #97 — the previous
+            // formula `tx - cds_start + 1` would emit base = 0 for
+            // tx = cds_start - 1, rendered by `CdsPos::Display` as
+            // `c.?` (`CDS_BASE_UNKNOWN`).
             Ok(CdsPos {
-                base: pos as i64 - cds_start as i64 + 1,
+                base: pos as i64 - cds_start as i64,
                 offset: None,
                 utr3: false,
             })
@@ -3419,7 +3433,10 @@ mod tests {
 
     #[test]
     fn test_cds_to_tx_pos_utr5_valid() {
-        // cds_start=5, base=-3 → 5 + (-3) - 1 = 1, valid position
+        // HGVS numbering skips c.0, so c.-N maps to tx position
+        // cds_start - N. For cds_start=5, c.-3 → tx = 5 + (-3) = 2.
+        // Issue #97 — the previous formula `cds_start + base - 1`
+        // double-counted the gap and returned tx 1 (the c.-4 base).
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
         let pos = CdsPos {
@@ -3428,7 +3445,7 @@ mod tests {
             utr3: false,
         };
         let result = normalizer.cds_to_tx_pos(&pos, 5, Some(38));
-        assert_eq!(result.unwrap(), 1);
+        assert_eq!(result.unwrap(), 2);
     }
 
     #[test]

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -16,13 +16,14 @@
 //!
 //! Issue #94: every gap test that previously asserted only `contains(...)`
 //! or `is_ok() || is_err()` is locked with `assert_eq!` against the
-//! exact normalizer output. Issue #98 (minus-strand intronic ref-base
-//! orientation) was identified as a common root cause behind several
-//! initially suspected-buggy lock points and has since been fixed; the
+//! exact normalizer output. Two root causes have since been fixed:
+//! #98 (minus-strand intronic ref-base orientation) and #97 (5'UTR
+//! CDS↔tx off-by-one that collapsed UTR del positions to `c.?`); the
 //! affected tests now lock spec-correct outputs (full-tract position
 //! with the transcript-view repeat unit, per the HGVS DNA repeat
-//! spec). Boundary-spanning panic-canary tests are intentionally left
-//! as `is_ok() || is_err()` per #94 scope.
+//! spec; UTR positions resolved per the HGVS no-c.0 numbering rule).
+//! Boundary-spanning panic-canary tests are intentionally left as
+//! `is_ok() || is_err()` per #94 scope.
 
 use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
@@ -564,14 +565,15 @@ mod utr_minus_strand {
 
     #[test]
     fn test_5prime_utr_deletion_minus_strand() {
-        // Single-base 5'UTR del on minus strand. The position is fully
-        // resolved on input and the local tract is unambiguous, but ferro
-        // collapses to `c.?del`, discarding positional information.
+        // Single-base 5'UTR del on minus strand. The 5'UTR is the
+        // homopolymer `AAAAA` at c.-5..c.-1 (transcript view); a
+        // single-A del at c.-3 3'-shifts to the rightmost A in the
+        // run, c.-1. Issue #97 closed the off-by-one in the CDS↔tx
+        // 5'UTR coordinate mapping that had previously caused the
+        // result to collapse to `c.?del`.
         let provider = make_provider_with_minus_utr();
         let result = normalize(provider, "NM_MUTR.1:c.-3del");
-        // FIXME(#97): expected canonical form preserves the position
-        // (and 3'-shifts within the 5'UTR run if applicable).
-        assert_eq!(result, "NM_MUTR.1:c.?del");
+        assert_eq!(result, "NM_MUTR.1:c.-1del");
     }
 
     #[test]

--- a/tests/issue_97_utr_del_position.rs
+++ b/tests/issue_97_utr_del_position.rs
@@ -1,0 +1,100 @@
+//! Regression test for issue #97: 5'UTR deletions on minus-strand
+//! transcripts collapsed to `c.?del`, discarding positional information.
+//!
+//! Root cause is an off-by-one in the CDS↔tx coordinate conversions
+//! (`cds_to_tx_pos` and `tx_to_cds_pos`) for 5'UTR positions: HGVS
+//! coordinates skip from `c.-1` directly to `c.1` (no `c.0`), but the
+//! conversion formulas treated the gap as if `c.0` existed. As a
+//! result, after 3'-shifting moved a single-base UTR deletion to the
+//! rightmost position in its homopolymer tract, the inverse mapping
+//! produced `base = 0` — which `CdsPos::Display` renders as `?`.
+//!
+//! These tests fail before the fix and pass after. Independent of the
+//! symptom-locked tests in `tests/coverage_gap_tests.rs`.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+const PAD_OFFSET: u64 = 256;
+
+/// Single-exon minus-strand transcript whose first 5 transcript bases
+/// are `AAAAA` (5'UTR; cds_start = 6 means `c.-5..c.-1` map to
+/// `tx 1..5`). The genomic sequence is the reverse complement of the
+/// transcript view: `TTTTT` at PAD..PAD+4 becomes `AAAAA` in
+/// transcript view at c.-5..c.-1.
+fn make_minus_strand_utr_fixture() -> MockProvider {
+    let core = "TTTTTGCATGCATGCATGCATTTTT";
+    let genomic_seq = format!("{}{}{}", PAD, core, PAD);
+
+    let tx_seq = "AAAAATGCATGCATGCATGCAAAAA";
+
+    let p = PAD_OFFSET;
+    let transcript = Transcript::new(
+        "NM_MUTR.1".to_string(),
+        Some("MUTRGENE".to_string()),
+        Strand::Minus,
+        tx_seq.to_string(),
+        Some(6),
+        Some(20),
+        vec![Exon::with_genomic(1, 1, 25, p, p + 24)],
+        Some("chr_mutr".to_string()),
+        Some(p),
+        Some(p + 24),
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    );
+
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr_mutr", genomic_seq);
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse should succeed");
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize should succeed");
+    format!("{}", normalized)
+}
+
+/// **Diagnostic 1 — 5'UTR del 3'-shift on minus strand.**
+///
+/// `c.-3del` (a single A in the c.-5..c.-1 homopolymer) must shift to
+/// the 3'-most A in the run, c.-1. Before the fix it collapsed to
+/// `c.?del`.
+#[test]
+fn five_prime_utr_del_shifts_to_minus_one() {
+    let provider = make_minus_strand_utr_fixture();
+    let result = normalize(provider, "NM_MUTR.1:c.-3del");
+    assert_eq!(result, "NM_MUTR.1:c.-1del");
+}
+
+/// **Diagnostic 2 — round-trip of c.-1del.**
+///
+/// Re-normalizing the canonical form must be a no-op. If the inverse
+/// `tx_to_cds_pos` mapping is correct, a second pass through normalize
+/// produces the same output.
+#[test]
+fn five_prime_utr_del_round_trip() {
+    let provider = make_minus_strand_utr_fixture();
+    let once = normalize(provider, "NM_MUTR.1:c.-1del");
+    assert_eq!(once, "NM_MUTR.1:c.-1del");
+}
+
+/// **Diagnostic 3 — substitution at c.-3 round-trip.**
+///
+/// Substitutions do not shift, so the round-trip must preserve the
+/// position exactly. The forward-direction off-by-one is invisible to
+/// substitutions on a homopolymer (every UTR base is the same letter),
+/// so this test explicitly pins both the forward and inverse mappings.
+#[test]
+fn five_prime_utr_substitution_round_trip() {
+    let provider = make_minus_strand_utr_fixture();
+    let result = normalize(provider, "NM_MUTR.1:c.-3A>G");
+    assert_eq!(result, "NM_MUTR.1:c.-3A>G");
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -992,9 +992,13 @@ mod clinvar_normalization {
     #[case("NM_000059.4:c.6275_6276del", "NM_000059.4:c.6275_6276del")]
     #[case("NM_001414398.1:c.*160_*163del", "NM_001414398.1:c.*160_*163del")]
     // Duplications
-    // 5'UTR dup shifts 3' (toward CDS) per HGVS normalization rules
-    // Mutalyzer: c.-56_-47dup (differs - we apply 3' shift in UTR, Mutalyzer doesn't)
-    #[case("NM_001394148.2:c.-56_-47dup", "NM_001394148.2:c.-55_-46dup")]
+    // 5'UTR dup — Mutalyzer: agrees. The duplicated 10-base region is
+    // already in its 3'-most equivalent representation in the local
+    // tract, so 3' shift is a no-op and the canonical form matches the
+    // input. (Pre-#97 ferro emitted a spurious 1-base shift to
+    // `c.-55_-46dup` as a side effect of the 5'UTR off-by-one in the
+    // CDS↔tx mapping; once that's fixed, ferro and Mutalyzer agree.)
+    #[case("NM_001394148.2:c.-56_-47dup", "NM_001394148.2:c.-56_-47dup")]
     // Mutalyzer: agrees
     #[case("NR_153405.1:n.3908_3910dup", "NR_153405.1:n.3908_3910dup")]
     // Delins - Mutalyzer: agrees


### PR DESCRIPTION
Closes #97. Stacked on #100 (will retarget through the chain as the upstream PRs merge).

## TL;DR

HGVS coordinate numbering skips `c.0` — `c.-1` is the base immediately 5' of `c.1`, not the base 5' of `c.0`. ferro had three coordinate-conversion implementations; one (`convert::mapper::cds_to_tx` / `tx_to_cds`) handled this correctly, and two (`Normalizer::cds_to_tx_pos` and `convert::coding::cds_to_transcript_pos`) used the formula `cds_start + base - 1` uniformly — which double-counts the missing-zero step for negative `base`. The inverse in `Normalizer::tx_to_cds_pos` had the mirror bug. The most visible symptom was a 5'UTR single-base deletion on a minus-strand transcript collapsing to `c.?del`.

## Root cause

For `pos.base = -1` (the base immediately upstream of c.1) with `cds_start = X`:

- Spec-correct: `tx = X - 1`.
- Buggy formula `tx = cds_start + base - 1` = `X + (-1) - 1` = `X - 2`. Off by one.

For the inverse, `pos = cds_start - 1` should map to `base = -1`:

- Spec-correct: `base = pos - cds_start = -1`.
- Buggy formula `base = pos - cds_start + 1` = `0`. `CdsPos::Display` renders `base == CDS_BASE_UNKNOWN (0)` as `?`.

The two formulas are internally consistent (round-trip works), so no test caught it until normalization shifted to a tx position whose buggy inverse landed on `base = 0`. This happened on a minus-strand 5'UTR fixture where the UTR is a homopolymer: the input `c.-3del` mapped to tx `cds_start - 4` (buggy), the 3'-shift walked through the homopolymer to `cds_start - 1`, and the buggy inverse mapped that to `base = 0` → `c.?del`.

## Fix

`src/normalize/mod.rs::cds_to_tx_pos`:

| `pos.base` | Old formula | New formula |
|---|---|---|
| `< 0` | `cds_start + base - 1` (buggy) | `cds_start + base` |
| `== 0` | `cds_start + 0 - 1 = cds_start - 1` | preserved as `cds_start - 1` (legacy; `c.0` isn't valid HGVS but historical inputs can land here) |
| `>= 1` | `cds_start + base - 1` | unchanged |

`src/normalize/mod.rs::tx_to_cds_pos`:

| `pos` | Old formula | New formula |
|---|---|---|
| `< cds_start` | `pos - cds_start + 1` (buggy) | `pos - cds_start` |
| `>= cds_start && <= cds_end` | `pos - cds_start + 1` | unchanged |

`src/convert/coding.rs::cds_to_transcript_pos` gets the same forward fix for parity. It currently has no callers in `src/` but is a public function and could be called externally.

`src/convert/mapper.rs::cds_to_tx` / `tx_to_cds` were already correct (they treat the CDS step as `pos.base - 1` and the 5'UTR step as `pos.base`, separately) — unchanged.

## Diagnostic suite

`tests/issue_97_utr_del_position.rs` (new) — three single-assertion tests on a minimal minus-strand UTR fixture (`AAAAA` 5'UTR at `c.-5..c.-1`):

| Test | Asserted |
|---|---|
| `five_prime_utr_del_shifts_to_minus_one` | `NM_MUTR.1:c.-3del → c.-1del` |
| `five_prime_utr_del_round_trip` | `c.-1del → c.-1del` |
| `five_prime_utr_substitution_round_trip` | `c.-3A>G → c.-3A>G` (sub doesn't shift; pinned to catch any mirror-bug regression) |

All three fail before the fix and pass after.

## Cascade

| Test | Old | New |
|---|---|---|
| `coverage_gap_tests::utr_minus_strand::test_5prime_utr_deletion_minus_strand` | `c.?del` (with `FIXME(#97)`) | `c.-1del` (FIXME removed) |
| `normalize::tests::test_cds_to_tx_pos_utr5_valid` | tx 1 (cds_start=5, c.-3) | tx 2 |
| `normalize_tests::clinvar_normalization::test_verified_normalization_indels_batch1::case_5` (`NM_001394148.2:c.-56_-47dup`) | `c.-55_-46dup` | `c.-56_-47dup` |

The clinvar case is worth flagging: ferro's pre-fix output `c.-55_-46dup` matched the test's documented "ferro-vs-Mutalyzer" expectation ("we apply 3' shift in UTR, Mutalyzer doesn't"). With the fix, ferro emits `c.-56_-47dup` — **matching Mutalyzer**. Tracing through the new formula: the 10-base region at the spec-correct tx range is already in its 3'-most equivalent representation in the local tract, so the 3'-shift is a no-op. The pre-fix "shift" was a side effect of the off-by-one (the buggy forward read a shifted 10-base region whose 3'-most form was the spec-correct tx range, then the buggy inverse mapped that back). The test comment is updated to "Mutalyzer: agrees" and the source-of-truth annotation explains the pre-fix vs post-fix delta.

## What this means for the related issues

- **#97** — closed by this PR.
- **#94** — together with #100, all `FIXME(#NN)` markers in `tests/coverage_gap_tests.rs` are now resolved (intronic-orientation symptoms via #100; UTR collapse symptom via this PR).
- **#81 J2** (n. UTR `*` and `-` markers) — separate; not addressed here. The `n.` coordinate path is in `convert/mapper.rs` which already handles the c.0 skip correctly. If a similar bug exists in another `n.`-flavored helper it would be its own follow-up; the grep on `cds_start as i64` patterns surfaced only the three locations fixed here.

## Verification

- [x] `cargo nextest run --features dev --test issue_97_utr_del_position` — 3/3 pass
- [x] `cargo nextest run --features dev` — full suite passes (3179/3179); the three previously-failing tests now pass with their updated locks; no unrelated regressions
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features dev --tests -- -D warnings` — no new findings (the 11 pre-existing errors in `src/` reproduce identically on `main`)
- [x] Pre-commit hooks pass