### PR TITLE
fix(normalize): codon-frame exception for c. SNV pairs separated by one nucleotide (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / pre-cds_start positions, matching the spec's "c.-1 is one base 5'
   of c.1" rule and the existing exon-aware mapper at
   `convert::mapper::cds_to_tx` / `tx_to_cds`. Issue #97.
+- *(normalize)* Cis-allele consecutive-edit merging now also collapses
+  the codon-frame exception case: two `c.` exonic SNVs in the CDS
+  proper, separated by exactly one nucleotide, that fall within the
+  same codon merge into a single delins with the unchanged middle
+  reference base preserved verbatim — per HGVS spec
+  (`c.[145C>T;147C>G]` → `c.145_147delinsTGG`, where the middle base
+  is the reference at `c.146`). Eligibility is narrow: same accession,
+  both endpoints in `Region::Cds`, gap-of-one on the axis, both prev
+  and next are single-base SUB anchors, and `(prev-1)/3 == (next-1)/3`
+  (same codon). The unchanged middle base is fetched via the
+  `ReferenceProvider` threaded into `merge_consecutive_edits`; if no
+  transcript is registered or the position is out of range, the merge
+  is silently declined and the variants pass through unchanged.
+  Codon-frame–merged delins continue to participate in the
+  strictly-consecutive walk, so a third SNV one base 3' of the pair
+  (`c.[10A>G;12A>C;13A>T]`) still folds into the running delins.
+  Cross-codon (`c.[3G>T;5A>C]`), gap-of-two (`c.[10A>G;13A>C]`), and
+  non-CDS pairs (`g.`, UTR, `n.`, `r.`) all correctly do not merge.
+  Issue #79.
 - *(normalize)* Minus-strand intronic normalization now reads the
   reference window in transcript-view orientation. `normalize_intronic_cds`
   and `normalize_intronic_tx` previously passed the genomic-strand bytes

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -9,6 +9,7 @@ use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
     AllelePhase, CdsVariant, GenomeVariant, HgvsVariant, LocEdit, MtVariant, RnaVariant, TxVariant,
 };
+use crate::reference::ReferenceProvider;
 
 /// Coordinate-system region used as the merge-eligibility key.
 ///
@@ -68,9 +69,10 @@ struct Anchor {
 /// chain end the head of `output` is rebuilt once from the merged anchor.
 /// This keeps non-merging iterations as cheap as the no-merge baseline and
 /// makes a chain of N consecutive merges O(N) total instead of O(N^2).
-pub(crate) fn merge_consecutive_edits(
+pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
     variants: Vec<HgvsVariant>,
     phase: AllelePhase,
+    provider: &P,
 ) -> Vec<HgvsVariant> {
     if phase != AllelePhase::Cis || variants.len() < 2 {
         return variants;
@@ -94,14 +96,34 @@ pub(crate) fn merge_consecutive_edits(
             let Some((next_region, next_start, _)) = simple_range_for_variant(&next) else {
                 break 'try_merge false;
             };
-            // Same-region adjacency: regions must match (no merge across
-            // the 5'UTR/CDS, CDS/3'UTR, upstream/transcript, or
-            // transcript/downstream boundaries) AND the integer axis
-            // must satisfy `prev.end + 1 == next.start`.
+            // Region match is required for both adjacency rules below.
             if prev_a.region != next_region {
                 break 'try_merge false;
             }
-            if prev_a.end.checked_add(1) != Some(next_start) {
+
+            // Strictly-consecutive adjacency: `prev.end + 1 == next.start`
+            // on the region's signed integer axis. Works uniformly for
+            // every region (5'UTR / upstream use negative axis values, so
+            // `c.-3 + 1 == c.-2` is `-3 + 1 == -2`).
+            let strict_adjacent = prev_a.end.checked_add(1) == Some(next_start);
+
+            // Codon-frame exception (issue #79): two `c.` exonic SNVs in
+            // the CDS proper, separated by exactly one nucleotide, that
+            // fall within the same codon merge into a delins with the
+            // unchanged middle reference base preserved. Eligibility is
+            // narrow: same accession+region (`Cds`), gap of exactly 1 on
+            // the axis, both endpoints in the same codon, and a
+            // `prev_a` that is still a single-base SUB anchor (so this
+            // doesn't fire on a delins that's already grown via an
+            // earlier merge).
+            let codon_frame_eligible = !strict_adjacent
+                && prev_a.region == Region::Cds
+                && prev_a.end.checked_add(2) == Some(next_start)
+                && prev_a.alt.len() == 1
+                && prev_a.start == prev_a.end
+                && same_codon(prev_a.end, next_start);
+
+            if !strict_adjacent && !codon_frame_eligible {
                 break 'try_merge false;
             }
             if !same_accession_and_kind(output.last().unwrap(), &next) {
@@ -110,6 +132,22 @@ pub(crate) fn merge_consecutive_edits(
             let Some(next_anchor) = anchor_for_variant(&next) else {
                 break 'try_merge false;
             };
+            if codon_frame_eligible {
+                // Next must also be a single-base SUB anchor.
+                if next_anchor.alt.len() != 1 || next_anchor.start != next_anchor.end {
+                    break 'try_merge false;
+                }
+                // Look up the unchanged middle reference base. If the
+                // provider has no transcript or no sequence covering the
+                // gap position, gracefully decline the codon-frame merge
+                // rather than erroring.
+                let Some(middle_ref) =
+                    lookup_cds_middle_ref(provider, output.last().unwrap(), prev_a.end + 1)
+                else {
+                    break 'try_merge false;
+                };
+                prev_a.alt.push(middle_ref);
+            }
             // Extend in place — amortized O(1) per base added.
             prev_a.alt.extend(next_anchor.alt);
             prev_a.start = prev_a.start.min(next_anchor.start);
@@ -475,6 +513,48 @@ fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
     }
 }
 
+/// Two CDS positions share a codon if they fall in the same 1-indexed
+/// triplet: `c.1..3` is codon 1, `c.4..6` is codon 2, etc. The standard
+/// codon-number formula is `(base - 1) / 3` (integer division).
+fn same_codon(a: i64, b: i64) -> bool {
+    if a < 1 || b < 1 {
+        return false;
+    }
+    (a - 1) / 3 == (b - 1) / 3
+}
+
+/// Look up the reference base at a CDS position on the head variant's
+/// transcript. Returns `None` if the head is not a `CdsVariant`, the
+/// provider has no transcript for the accession, the transcript has no
+/// `cds_start`, or the indexed position falls outside the transcript
+/// sequence. Used by the codon-frame merge to insert the unchanged
+/// middle nucleotide between two SUBs separated by one base; failure
+/// to look it up means the codon-frame merge is silently declined and
+/// the variants pass through unmerged.
+fn lookup_cds_middle_ref<P: ReferenceProvider>(
+    provider: &P,
+    head: &HgvsVariant,
+    cds_axis: i64,
+) -> Option<Base> {
+    let cds_var = match head {
+        HgvsVariant::Cds(v) => v,
+        _ => return None,
+    };
+    if cds_axis < 1 {
+        return None;
+    }
+    let tx = provider
+        .get_transcript(&cds_var.accession.transcript_accession())
+        .ok()?;
+    let cds_start = tx.cds_start?;
+    let tx_idx_1based = cds_start.checked_add(cds_axis as u64)?.checked_sub(1)?;
+    let byte = *tx
+        .sequence
+        .as_bytes()
+        .get(tx_idx_1based.checked_sub(1)? as usize)?;
+    Base::from_char(byte as char)
+}
+
 fn build_naedit<P>(
     merged: Anchor,
     mut to_pos: impl FnMut(Region, i64) -> P,
@@ -513,10 +593,11 @@ fn build_naedit<P>(
 mod tests {
     use super::*;
     use crate::hgvs::variant::Accession;
+    use crate::reference::MockProvider;
 
     #[test]
     fn empty_input_returns_empty() {
-        assert!(merge_consecutive_edits(vec![], AllelePhase::Cis).is_empty());
+        assert!(merge_consecutive_edits(vec![], AllelePhase::Cis, &MockProvider::new()).is_empty());
     }
 
     #[test]
@@ -533,7 +614,17 @@ mod tests {
                 },
             ),
         });
-        let out = merge_consecutive_edits(vec![v], AllelePhase::Cis);
+        let out = merge_consecutive_edits(vec![v], AllelePhase::Cis, &MockProvider::new());
         assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn same_codon_classifies_correctly() {
+        assert!(same_codon(1, 3));
+        assert!(same_codon(4, 6));
+        assert!(same_codon(145, 147));
+        assert!(!same_codon(3, 5)); // codon 1 vs codon 2
+        assert!(!same_codon(0, 2)); // 0 invalid
+        assert!(!same_codon(-3, -1));
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -229,7 +229,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // must round-trip with the Allele wrapper intact for programmatic callers
         // (Display already renders singletons in bare form regardless).
         let original_len = normalized.len();
-        let mut merged = merge::merge_consecutive_edits(normalized, allele.phase);
+        let mut merged = merge::merge_consecutive_edits(normalized, allele.phase, &self.provider);
 
         let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
             && original_len > 1

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -581,18 +581,98 @@ fn test_overlap_pair_does_not_merge_with_prevent_overlap_disabled() {
     assert!(!result.contains("delins"), "got {}", result);
 }
 
+// =====================================================================
+// Codon-frame exception (issue #79).
+//
+// HGVS spec carves out a single exception to the strictly-consecutive
+// rule: two `c.` exonic SNVs separated by exactly one nucleotide that
+// fall within the same codon must merge into a single delins, with
+// the unchanged middle nucleotide preserved verbatim. Spec example:
+//
+//   `c.[145C>T;147C>G]`  →  `c.145_147delinsTGG`
+//
+// Applies only to the CDS proper. UTR / `n.` / `r.` / `g.` have no
+// codon frame and continue to round-trip unchanged for gap-of-1 inputs.
+// =====================================================================
+
 #[test]
-#[ignore = "Codon-frame exception for c. — tracked in issue #79"]
-fn test_codon_frame_exception_deferred() {
-    // Per HGVS spec: c.[145C>T;147C>G] (positions 145-147 share codon 49)
-    // must be expressed as c.145_147delinsTGG. Implementing this needs
-    // reference-provider access for the unchanged middle nucleotide and
-    // codon-frame logic; deferred to issue #79.
-    let provider = provider_with_simple_transcript();
+fn test_codon_frame_two_subs_one_codon() {
+    // Tx sequence: ATGCAAAAACCCCCGGGGG... (cds_start = 1).
+    //   c.10 = C, c.11 = C, c.12 = C.
+    // Codon for c.10 is `(10-1)/3 = 3`; codon for c.12 is `(12-1)/3 = 3`.
+    // Same codon. The unchanged middle base is the actual reference at
+    // c.11 = C, so the merged delins alt is
+    // `G(c.10) + C(ref c.11) + C(c.12) = "GCC"`.
     assert_eq!(
-        normalize_with_provider(provider, "NM_TEST.1:c.[10A>G;12A>C]"),
-        "NM_TEST.1:c.10_12delinsGAC",
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:c.[10A>G;12A>C]",
+        ),
+        "NM_TEST.1:c.10_12delinsGCC",
     );
+}
+
+#[test]
+fn test_no_codon_frame_pair_straddles_codon_boundary() {
+    // c.3 sits in codon 0 (positions 1-3); c.5 sits in codon 1
+    // (positions 4-6). Different codons → no merge.
+    let result =
+        normalize_with_provider(provider_with_simple_transcript(), "NM_TEST.1:c.[3G>T;5A>C]");
+    assert!(result.contains("3G>T"), "got {}", result);
+    assert!(result.contains("5A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_codon_frame_gap_of_two() {
+    // Gap of 2 nt is beyond the spec carve-out, which is exactly one.
+    let result = normalize_with_provider(
+        provider_with_simple_transcript(),
+        "NM_TEST.1:c.[10A>G;13A>C]",
+    );
+    assert!(result.contains("10A>G"), "got {}", result);
+    assert!(result.contains("13A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_no_codon_frame_genomic() {
+    // `g.` has no codon frame — gap-of-1 must round-trip unchanged.
+    let result = normalize_to_string("NC_000001.11:g.[145G>A;147C>T]");
+    assert!(result.contains("145G>A"), "got {}", result);
+    assert!(result.contains("147C>T"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
+}
+
+#[test]
+fn test_codon_frame_then_strict_chain() {
+    // Issue #79 specifies that the codon-frame merge feeds back into
+    // the strictly-consecutive walk so a third SNV one base 3' of the
+    // pair still merges. Here: c.10 + c.12 codon-frame-merge into a
+    // delins at [10, 12], then c.13 is strictly-adjacent and folds
+    // into it.
+    //   Sequence: ATGCAAAAACCCCC... → c.10=C, c.11=C, c.12=C, c.13=C.
+    //   First merge alt = G + ref(c.11)=C + C = "GCC" at [10, 12].
+    //   Strict-merge with c.13A>T extends end to 13 and appends T →
+    //   "GCCT" at [10, 13].
+    assert_eq!(
+        normalize_with_provider(
+            provider_with_simple_transcript(),
+            "NM_TEST.1:c.[10A>G;12A>C;13A>T]",
+        ),
+        "NM_TEST.1:c.10_13delinsGCCT",
+    );
+}
+
+#[test]
+fn test_no_codon_frame_without_provider_transcript() {
+    // Without a transcript registered on the provider, the middle-base
+    // reference lookup fails and the merge passes through unchanged
+    // (no error). Demonstrates the graceful-fallback contract.
+    let result = normalize_to_string("NM_NOSEQ.99:c.[10A>G;12A>C]");
+    assert!(result.contains("10A>G"), "got {}", result);
+    assert!(result.contains("12A>C"), "got {}", result);
+    assert!(!result.contains("delins"), "got {}", result);
 }
 
 // =====================================================================


### PR DESCRIPTION
Closes #79. Stacked on #103 (issue #89 — region-tagged merge keys).

## TL;DR

The HGVS delins spec carves out a single exception to the strictly-consecutive merge rule: two `c.` exonic SNVs separated by exactly one nucleotide that fall in the same codon merge into a single delins, with the unchanged middle reference base preserved verbatim. PR #80 (issue #72) deferred this to #79. This PR adds the codon-frame branch to `merge_consecutive_edits`, threading a `ReferenceProvider` through the merge pass to look up the unchanged middle base.

Spec source (`hgvs-nomenclature.org/stable/recommendations/DNA/delins/`):

> Notes: "two variants separated by one or more nucleotides should preferably be described individually and not as a 'delins'. Exception: two variants separated by one nucleotide, together affecting one amino acid, should be described as a 'delins'."

Concrete spec example: `c.[145C>T;147C>G]` → `c.145_147delinsTGG`.

## Eligibility

After the strictly-consecutive check fails, the chain logic tries codon-frame merge. Both endpoints must satisfy:

| Constraint | Why |
|---|---|
| Same accession + same `HgvsVariant` discriminant | Existing rule from #72; reused. |
| `prev_a.region == Region::Cds` and `next_region == Region::Cds` | The carve-out is c.-only and CDS-only. UTR / `n.` / `r.` / `g.` all decline. |
| `prev_a.end + 2 == next_start` on the signed axis | Gap of exactly one nucleotide. |
| `(prev_a.end - 1) / 3 == (next_start - 1) / 3` | Same 1-indexed codon. |
| `prev_a.alt.len() == 1 && prev_a.start == prev_a.end` | `prev_a` is still a single-base SUB anchor — the carve-out is for SUB pairs, not for absorbing a third SUB onto a delins that's already grown via earlier merging. |
| `next_anchor.alt.len() == 1 && next_anchor.start == next_anchor.end` | Same constraint on the right side of the pair. |

When all match, `lookup_cds_middle_ref(provider, head, prev_a.end + 1)` fetches the unchanged middle base from the head variant's transcript sequence. The merged alt is `<altA> + <middle ref> + <altC>` and the anchor's range extends to `[prev_a.start, next_anchor.end]`.

If the provider has no transcript registered for the accession, the transcript has no `cds_start`, or the position falls outside the sequence, `lookup_cds_middle_ref` returns `None` and the codon-frame merge is silently declined — the pair passes through unchanged with no error.

## Chain interaction

Codon-frame–merged delins continue to participate in the strictly-consecutive walk: `prev_a.end` advances to the merged right edge and the chain continues. So `c.[10A>G;12A>C;13A>T]` produces:

1. 10 + 12: gap=1, same codon → codon-frame merge → `prev_a` = delins at `[10, 12]`, alt = `G + ref(11)=C + C = "GCC"`.
2. 12 + 13: strictly adjacent → strict merge → `prev_a` = delins at `[10, 13]`, alt = `"GCCT"`.
3. Output: `c.10_13delinsGCCT`.

The codon-frame check itself does not fire on a delins anchor (the `alt.len() == 1` guard), preventing the rule from inappropriately absorbing a third SUB across a codon boundary into an existing delins.

## Signature change

`merge_consecutive_edits` becomes generic over `P: ReferenceProvider`:

```rust
pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
    variants: Vec<HgvsVariant>,
    phase: AllelePhase,
    provider: &P,
) -> Vec<HgvsVariant>
```

Caller in `Normalizer::normalize_allele` passes `&self.provider`. The two existing in-module unit tests get a no-op `MockProvider::new()` (codon-frame can't fire without a registered transcript anyway).

## Tests

Six new tests in `tests/merge_consecutive_edits_tests.rs`:

| Test | Asserted |
|---|---|
| `test_codon_frame_two_subs_one_codon` | `c.[10A>G;12A>C]` → `c.10_12delinsGCC` (positive case; middle base from the actual fixture sequence) |
| `test_no_codon_frame_pair_straddles_codon_boundary` | `c.[3G>T;5A>C]` round-trips (different codons) |
| `test_no_codon_frame_gap_of_two` | `c.[10A>G;13A>C]` round-trips (gap of 2 nt) |
| `test_no_codon_frame_genomic` | `g.[145G>A;147C>T]` round-trips (no codon frame in `g.`) |
| `test_codon_frame_then_strict_chain` | `c.[10A>G;12A>C;13A>T]` → `c.10_13delinsGCCT` (codon-frame followed by strict adjacency) |
| `test_no_codon_frame_without_provider_transcript` | `c.[10A>G;12A>C]` against a `MockProvider::new()` (no transcript registered) round-trips — graceful fallback |

The previously `#[ignore]`d `test_codon_frame_exception_deferred` is replaced by `test_codon_frame_two_subs_one_codon` (with the expected delins corrected to match the actual reference at `c.11`: the fixture sequence's c.11 base is `C`, not the guessed `A`, so the merged alt is `GCC` and not `GAC`).

A new in-module unit test `same_codon_classifies_correctly` pins the codon-number formula edge cases.

## Verification

- [x] `cargo nextest run --features dev --test merge_consecutive_edits_tests` — 56/56 pass (+6 over #103's 50/50)
- [x] `cargo nextest run --features dev` — full suite 3184/3184 pass; no unrelated regressions
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features dev --tests -- -D warnings` — no new findings (the 11 pre-existing errors in `src/` reproduce identically on `main`)
- [x] Pre-commit hooks pass

## Out of scope (per #79)

- Codon-frame exception for `r.` coding regions
- Chains involving more than two SNVs across a codon (`sub`, `ins`, `sub` straddling a codon)
- `sub`+`del` pairs separated by one unchanged nucleotide