### PR TITLE
chore: unpin CI Rust toolchain and fix 1.95 clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0  # TODO(#35): unpin once new clippy lints are fixed
+          toolchain: stable
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -55,7 +55,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
           components: clippy
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
@@ -69,7 +69,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-
-      - run: cargo clippy --features dev -- -D warnings
+      - run: cargo clippy --features dev --all-targets -- -D warnings
 
   test:
     name: Test
@@ -81,7 +81,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
@@ -122,7 +122,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
@@ -173,7 +173,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
       - uses: taiki-e/install-action@3f7f2bd74f95d407a45d96b106f26d4f6c238fab  # cargo-llvm-cov
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:

--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -105,8 +105,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
-          components: clippy
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
@@ -179,7 +178,8 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
+          components: clippy
 
       - name: Cache cargo registry
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
-          toolchain: 1.94.0
+          toolchain: stable
       - name: Run release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11  # v0.5.128
         env:

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -3677,7 +3677,7 @@ fn print_multiway_overlap_tables(
     }
 
     // Sort by count descending
-    upset_success.sort_by(|a, b| b.1.cmp(&a.1));
+    upset_success.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (combo, count) in &upset_success {
         let label = if combo.is_empty() {
@@ -3730,7 +3730,7 @@ fn print_multiway_overlap_tables(
         upset_fail.push((vec![], none_failed.len()));
     }
 
-    upset_fail.sort_by(|a, b| b.1.cmp(&a.1));
+    upset_fail.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (combo, count) in &upset_fail {
         let label = if combo.is_empty() {

--- a/src/hgvs/interval.rs
+++ b/src/hgvs/interval.rs
@@ -217,15 +217,12 @@ impl GenomeInterval {
     /// Get the length of this interval (returns 0 if either position is unknown)
     pub fn len(&self) -> u64 {
         match (self.start.inner(), self.end.inner()) {
-            (Some(start), Some(end)) => {
-                if end.base >= start.base {
-                    // Use saturating_add to prevent overflow at u64::MAX
-                    (end.base - start.base).saturating_add(1)
-                } else {
-                    0
-                }
+            // Use saturating_add to prevent overflow at u64::MAX
+            (Some(start), Some(end)) if end.base >= start.base => {
+                (end.base - start.base).saturating_add(1)
             }
-            _ => 0, // Unknown positions result in length 0
+            // Unknown positions or end < start result in length 0
+            _ => 0,
         }
     }
 

--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -781,7 +781,7 @@ mod tests {
         let (remaining, acc) = parse_accession("NC_000013.11(NP_004110.2):p.Val600Glu").unwrap();
         assert_eq!(remaining, ":p.Val600Glu");
         assert_eq!(&*acc.prefix, "NP");
-        assert_eq!(acc.genomic_context.is_some(), true);
+        assert!(acc.genomic_context.is_some());
     }
 
     #[test]

--- a/src/hgvs/validation.rs
+++ b/src/hgvs/validation.rs
@@ -282,44 +282,35 @@ pub mod rules {
             NaEdit::Substitution {
                 reference,
                 alternative,
-            } => {
-                if reference == alternative {
-                    result = result.with_warning(ValidationWarning::new(
-                        "W001",
-                        format!(
-                            "Reference and alternative are the same: {} = {}",
-                            reference, alternative
-                        ),
-                    ));
-                }
+            } if reference == alternative => {
+                result = result.with_warning(ValidationWarning::new(
+                    "W001",
+                    format!(
+                        "Reference and alternative are the same: {} = {}",
+                        reference, alternative
+                    ),
+                ));
             }
             NaEdit::Deletion {
                 sequence: Some(seq),
                 ..
-            } => {
-                if seq.is_empty() {
-                    result = result.with_warning(ValidationWarning::new(
-                        "W002",
-                        "Deletion has empty sequence specified",
-                    ));
-                }
+            } if seq.is_empty() => {
+                result = result.with_warning(ValidationWarning::new(
+                    "W002",
+                    "Deletion has empty sequence specified",
+                ));
             }
-            NaEdit::Deletion { sequence: None, .. } => {}
-            NaEdit::Insertion { sequence } => {
-                if sequence.is_empty() {
-                    result = result.with_error(ValidationError::new(
-                        "E002",
-                        "Insertion must have at least one base",
-                    ));
-                }
+            NaEdit::Insertion { sequence } if sequence.is_empty() => {
+                result = result.with_error(ValidationError::new(
+                    "E002",
+                    "Insertion must have at least one base",
+                ));
             }
-            NaEdit::Delins { sequence } => {
-                if sequence.is_empty() {
-                    result = result.with_error(ValidationError::new(
-                        "E003",
-                        "Deletion-insertion must have at least one inserted base",
-                    ));
-                }
+            NaEdit::Delins { sequence } if sequence.is_empty() => {
+                result = result.with_error(ValidationError::new(
+                    "E003",
+                    "Deletion-insertion must have at least one inserted base",
+                ));
             }
             _ => {}
         }

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -321,10 +321,12 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let ref_path = temp_dir.path().to_path_buf();
 
-        let mut manifest = ReferenceManifest::default();
-        manifest.reference_dir = ref_path.clone();
-        manifest.transcript_fastas = vec![ref_path.join("transcripts.fa")];
-        manifest.cdot_json = Some(ref_path.join("cdot.json"));
+        let mut manifest = ReferenceManifest {
+            reference_dir: ref_path.clone(),
+            transcript_fastas: vec![ref_path.join("transcripts.fa")],
+            cdot_json: Some(ref_path.join("cdot.json")),
+            ..Default::default()
+        };
 
         manifest.make_paths_relative();
 
@@ -342,10 +344,12 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let ref_path = temp_dir.path().to_path_buf();
 
-        let mut manifest = ReferenceManifest::default();
-        manifest.reference_dir = ref_path.clone();
-        manifest.transcript_fastas = vec![PathBuf::from("transcripts.fa")];
-        manifest.cdot_json = Some(PathBuf::from("cdot.json"));
+        let mut manifest = ReferenceManifest {
+            reference_dir: ref_path.clone(),
+            transcript_fastas: vec![PathBuf::from("transcripts.fa")],
+            cdot_json: Some(PathBuf::from("cdot.json")),
+            ..Default::default()
+        };
 
         manifest.make_paths_absolute();
 
@@ -358,13 +362,15 @@ mod tests {
 
     #[test]
     fn test_deduplicate_paths() {
-        let mut manifest = ReferenceManifest::default();
-        manifest.transcript_fastas = vec![
-            PathBuf::from("b.fa"),
-            PathBuf::from("a.fa"),
-            PathBuf::from("b.fa"),
-        ];
-        manifest.lrg_fastas = vec![PathBuf::from("lrg.fa"), PathBuf::from("lrg.fa")];
+        let mut manifest = ReferenceManifest {
+            transcript_fastas: vec![
+                PathBuf::from("b.fa"),
+                PathBuf::from("a.fa"),
+                PathBuf::from("b.fa"),
+            ],
+            lrg_fastas: vec![PathBuf::from("lrg.fa"), PathBuf::from("lrg.fa")],
+            ..Default::default()
+        };
 
         manifest.deduplicate_paths();
 

--- a/tests/bulk_fixture_tests.rs
+++ b/tests/bulk_fixture_tests.rs
@@ -315,7 +315,7 @@ fn test_gnomad_constrained_by_gene() {
 
     eprintln!("\ngnomAD Constrained - By Gene (top 10):");
     let mut genes: Vec<_> = by_gene.iter().collect();
-    genes.sort_by(|a, b| (b.1 .0 + b.1 .1).cmp(&(a.1 .0 + a.1 .1)));
+    genes.sort_by_key(|b| std::cmp::Reverse(b.1 .0 + b.1 .1));
 
     for (gene, (passed, failed)) in genes.iter().take(10) {
         let total = passed + failed;

--- a/tests/civic_validation.rs
+++ b/tests/civic_validation.rs
@@ -66,7 +66,7 @@ fn test_civic_validation() {
     if !failure_categories.is_empty() {
         println!("\nTop failure categories:");
         let mut sorted: Vec<_> = failure_categories.iter().collect();
-        sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
         for (category, examples) in sorted.iter().take(15) {
             println!("  [{}x] {}", examples.len(), category);

--- a/tests/clinical_genes_tests.rs
+++ b/tests/clinical_genes_tests.rs
@@ -155,7 +155,7 @@ fn test_clinical_genes_by_gene() {
 
     eprintln!("\nClinical Genes - By Gene:");
     let mut genes: Vec<_> = by_gene.iter().collect();
-    genes.sort_by(|a, b| (b.1 .0 + b.1 .1).cmp(&(a.1 .0 + a.1 .1)));
+    genes.sort_by_key(|b| std::cmp::Reverse(b.1 .0 + b.1 .1));
 
     for (gene, (passed, failed)) in genes.iter().take(15) {
         let total = passed + failed;

--- a/tests/clinvar_hgvs_tests.rs
+++ b/tests/clinvar_hgvs_tests.rs
@@ -153,7 +153,7 @@ fn test_clinvar_hgvs_500k_by_hgvs_type() {
 
     eprintln!("\nClinVar HGVS 500K - By HGVS Type:");
     let mut types: Vec<_> = by_hgvs_type.iter().collect();
-    types.sort_by(|a, b| (b.1 .0 + b.1 .1).cmp(&(a.1 .0 + a.1 .1)));
+    types.sort_by_key(|b| std::cmp::Reverse(b.1 .0 + b.1 .1));
 
     for (hgvs_type, (passed, failed)) in types.iter() {
         let total = passed + failed;

--- a/tests/clinvar_validation.rs
+++ b/tests/clinvar_validation.rs
@@ -79,7 +79,7 @@ fn test_clinvar_validation() {
 
     println!("\nTop failure categories:");
     let mut sorted_failures: Vec<_> = failures.iter().collect();
-    sorted_failures.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    sorted_failures.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     for (error, examples) in sorted_failures.iter().take(20) {
         println!("  [{}x] {}", examples.len(), error);

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -84,7 +84,7 @@ fn make_minus_strand_transcript() -> (Transcript, String) {
         vec![
             Exon::with_genomic(1, 1, 30, p + 80, p + 109),
             Exon::with_genomic(2, 31, 60, p + 40, p + 69),
-            Exon::with_genomic(3, 61, 90, p + 0, p + 29),
+            Exon::with_genomic(3, 61, 90, p, p + 29),
         ],
         Some("chr_minus".to_string()),
         Some(p),
@@ -127,59 +127,13 @@ fn make_plus_strand_transcript() -> (Transcript, String) {
         Some(1),
         Some(90),
         vec![
-            Exon::with_genomic(1, 1, 30, p + 0, p + 29),
+            Exon::with_genomic(1, 1, 30, p, p + 29),
             Exon::with_genomic(2, 31, 60, p + 40, p + 69),
             Exon::with_genomic(3, 61, 90, p + 80, p + 109),
         ],
         Some("chr_plus".to_string()),
         Some(p),
         Some(p + 109),
-        GenomeBuild::GRCh38,
-        ManeStatus::None,
-        None,
-        None,
-    );
-
-    (transcript, genomic_seq)
-}
-
-/// Build a plus-strand transcript with UTR regions and genomic mapping.
-///
-/// Layout: 5'UTR (5bp) + CDS (60bp) + 3'UTR (5bp) = 70bp total transcript
-///   Exon 1: tx 1-25   genomic (PAD+0)–(PAD+24)
-///   Intron 1:          genomic (PAD+25)–(PAD+34)  AAAAAAAAAA
-///   Exon 2: tx 26-50  genomic (PAD+35)–(PAD+59)
-///   Intron 2:          genomic (PAD+60)–(PAD+69)  CCCCCCCCCC
-///   Exon 3: tx 51-70  genomic (PAD+70)–(PAD+89)
-///   CDS: tx 6-65
-fn make_plus_strand_utr_transcript() -> (Transcript, String) {
-    let core = "AAAAATGCATGCATGCATGCATGCAT\
-                AAAAAAAAAA\
-                GCATGCATGCATGCATGCATGCATGC\
-                CCCCCCCCCC\
-                ATGCATGCATGCATGCATGCAAAAA";
-    let genomic_seq = padded_genomic(core);
-
-    let tx_seq = "AAAAATGCATGCATGCATGCATGCAT\
-                   GCATGCATGCATGCATGCATGCATGC\
-                   ATGCATGCATGCATGCATGCAAAAA";
-
-    let p = PAD_OFFSET;
-    let transcript = Transcript::new(
-        "NM_UTR.1".to_string(),
-        Some("UTRGENE".to_string()),
-        Strand::Plus,
-        tx_seq.to_string(),
-        Some(6),
-        Some(65),
-        vec![
-            Exon::with_genomic(1, 1, 25, p + 0, p + 24),
-            Exon::with_genomic(2, 26, 50, p + 35, p + 59),
-            Exon::with_genomic(3, 51, 70, p + 70, p + 89),
-        ],
-        Some("chr_utr".to_string()),
-        Some(p),
-        Some(p + 89),
         GenomeBuild::GRCh38,
         ManeStatus::None,
         None,
@@ -222,7 +176,7 @@ fn make_minus_strand_utr_transcript() -> (Transcript, String) {
         vec![
             Exon::with_genomic(1, 1, 25, p + 65, p + 89),
             Exon::with_genomic(2, 26, 50, p + 30, p + 54),
-            Exon::with_genomic(3, 51, 70, p + 0, p + 19),
+            Exon::with_genomic(3, 51, 70, p, p + 19),
         ],
         Some("chr_mutr".to_string()),
         Some(p),
@@ -248,14 +202,6 @@ fn make_provider_with_plus_strand() -> MockProvider {
     let mut provider = MockProvider::new();
     let (tx, genomic) = make_plus_strand_transcript();
     provider.add_genomic_sequence("chr_plus", genomic);
-    provider.add_transcript(tx);
-    provider
-}
-
-fn make_provider_with_plus_utr() -> MockProvider {
-    let mut provider = MockProvider::new();
-    let (tx, genomic) = make_plus_strand_utr_transcript();
-    provider.add_genomic_sequence("chr_utr", genomic);
     provider.add_transcript(tx);
     provider
 }

--- a/tests/dbsnp_tests.rs
+++ b/tests/dbsnp_tests.rs
@@ -169,7 +169,7 @@ fn test_dbsnp_rsid_parsing() {
     // By gene
     println!("\nBy gene (top 10):");
     let mut genes: Vec<_> = report.by_gene.iter().collect();
-    genes.sort_by(|a, b| b.1 .1.cmp(&a.1 .1));
+    genes.sort_by_key(|b| std::cmp::Reverse(b.1 .1));
     for (gene, (parsed, total)) in genes.iter().take(10) {
         println!("  {}: {}/{}", gene, parsed, total);
     }
@@ -463,7 +463,7 @@ fn test_coverage_statistics() {
 
     println!("\nTop genes:");
     let mut gene_list: Vec<_> = genes.iter().collect();
-    gene_list.sort_by(|a, b| b.1.cmp(a.1));
+    gene_list.sort_by_key(|b| std::cmp::Reverse(*b.1));
     for (gene, count) in gene_list.iter().take(10) {
         println!("  {}: {}", gene, count);
     }

--- a/tests/exac_validation.rs
+++ b/tests/exac_validation.rs
@@ -62,7 +62,7 @@ fn test_exac_validation() {
     if !failure_categories.is_empty() {
         println!("\nTop failure categories:");
         let mut sorted: Vec<_> = failure_categories.iter().collect();
-        sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
         for (category, examples) in sorted.iter().take(15) {
             println!("  [{}x] {}", examples.len(), category);

--- a/tests/gnomad_validation.rs
+++ b/tests/gnomad_validation.rs
@@ -47,7 +47,7 @@ fn test_gnomad_validation() {
 
     println!("\nTop failure categories:");
     let mut sorted_failures: Vec<_> = failures.iter().collect();
-    sorted_failures.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    sorted_failures.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
 
     for (error, examples) in sorted_failures.iter().take(15) {
         println!("  [{}x] {}", examples.len(), error);

--- a/tests/handler_integration_tests.rs
+++ b/tests/handler_integration_tests.rs
@@ -434,5 +434,8 @@ async fn test_response_includes_processing_time() {
 
     assert!(result.is_ok());
     let response = result.unwrap().0;
-    assert!(response.processing_time_ms > 0 || response.processing_time_ms == 0);
+    // `processing_time_ms` is `u64` and structurally always present, so no
+    // range assertion is meaningful — touching the field is enough to make
+    // any rename/removal a compile error.
+    let _ = response.processing_time_ms;
 }

--- a/tests/issue_98_minus_strand_intronic_orientation.rs
+++ b/tests/issue_98_minus_strand_intronic_orientation.rs
@@ -42,7 +42,7 @@ fn make_minus_strand_fixture() -> MockProvider {
         vec![
             Exon::with_genomic(1, 1, 30, p + 80, p + 109),
             Exon::with_genomic(2, 31, 60, p + 40, p + 69),
-            Exon::with_genomic(3, 61, 90, p + 0, p + 29),
+            Exon::with_genomic(3, 61, 90, p, p + 29),
         ],
         Some("chr_minus".to_string()),
         Some(p),

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -4080,7 +4080,7 @@ mod cigar_cds_mapping {
     #[ignore] // Until CIGAR-aware CDS mapping is implemented
     fn test_cds_to_tx_with_cigar_insertion() {
         let tx = transcript_with_cigar_insertion();
-        let _cigar = vec![
+        let _cigar = [
             CigarOp::Match(185),
             CigarOp::Insertion(3),
             CigarOp::Match(250),
@@ -4113,7 +4113,7 @@ mod cigar_cds_mapping {
     #[ignore] // Until CIGAR-aware CDS mapping is implemented
     fn test_cds_to_tx_with_cigar_deletion() {
         let tx = transcript_with_cigar_deletion();
-        let _cigar = vec![
+        let _cigar = [
             CigarOp::Match(504),
             CigarOp::Deletion(2),
             CigarOp::Match(123),

--- a/tests/paraphase_exhaustive_tests.rs
+++ b/tests/paraphase_exhaustive_tests.rs
@@ -116,7 +116,7 @@ fn test_paraphase_exhaustive_benchmark() {
 
     eprintln!("\nBy coordinate type:");
     let mut types: Vec<_> = by_type.iter().collect();
-    types.sort_by(|a, b| (b.1 .0 + b.1 .1).cmp(&(a.1 .0 + a.1 .1)));
+    types.sort_by_key(|b| std::cmp::Reverse(b.1 .0 + b.1 .1));
     for (t, (p, f)) in types.iter() {
         let tot = p + f;
         let r = (*p as f64 / tot as f64) * 100.0;
@@ -125,7 +125,7 @@ fn test_paraphase_exhaustive_benchmark() {
 
     eprintln!("\nTop 10 genes by variant count:");
     let mut genes: Vec<_> = by_gene.iter().collect();
-    genes.sort_by(|a, b| (b.1 .0 + b.1 .1).cmp(&(a.1 .0 + a.1 .1)));
+    genes.sort_by_key(|b| std::cmp::Reverse(b.1 .0 + b.1 .1));
     for (gene, (p, f)) in genes.iter().take(10) {
         let tot = p + f;
         let r = (*p as f64 / tot as f64) * 100.0;

--- a/tests/service_tools_tests.rs
+++ b/tests/service_tools_tests.rs
@@ -316,32 +316,6 @@ fn test_tool_filtering_empty_request_returns_empty() {
     assert!(filtered.is_empty());
 }
 
-#[test]
-fn test_timeout_duration_calculation() {
-    // Test default timeout
-    let timeout_seconds: Option<u32> = None;
-    let timeout_duration = Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
-    assert_eq!(timeout_duration.as_secs(), 30);
-
-    // Test custom timeout
-    let timeout_seconds: Option<u32> = Some(60);
-    let timeout_duration = Duration::from_secs(timeout_seconds.unwrap_or(30) as u64);
-    assert_eq!(timeout_duration.as_secs(), 60);
-}
-
-#[test]
-fn test_concurrent_limit_configuration() {
-    // Test default concurrent limit
-    let config_limit: Option<usize> = None;
-    let concurrent_limit = config_limit.unwrap_or(10);
-    assert_eq!(concurrent_limit, 10);
-
-    // Test custom limit
-    let config_limit: Option<usize> = Some(5);
-    let concurrent_limit = config_limit.unwrap_or(10);
-    assert_eq!(concurrent_limit, 5);
-}
-
 // ==================== Tool Mode Tests ====================
 
 #[test]
@@ -443,10 +417,8 @@ fn test_tool_initialization_fails_when_all_fail() {
         Err("Biocommons failed"),
     ];
 
-    for result in init_results {
-        if let Ok(tool) = result {
-            tools_initialized.push(tool);
-        }
+    for tool in init_results.into_iter().flatten() {
+        tools_initialized.push(tool);
     }
 
     // Should fail when no tools initialized
@@ -478,7 +450,7 @@ fn test_processing_time_calculation() {
 
 #[test]
 fn test_agreement_calculation_all_agree() {
-    let results = vec![
+    let results = [
         ("ferro", Some("NM_000249.4:c.350C>T")),
         ("mutalyzer", Some("NM_000249.4:c.350C>T")),
         ("biocommons", Some("NM_000249.4:c.350C>T")),
@@ -494,7 +466,7 @@ fn test_agreement_calculation_all_agree() {
 
 #[test]
 fn test_agreement_calculation_some_disagree() {
-    let results = vec![
+    let results = [
         ("ferro", Some("NM_000249.4:c.350C>T")),
         ("mutalyzer", Some("NM_000249.4:c.350C>T")),
         ("biocommons", Some("NM_000249.4:c.351C>T")), // Different!

--- a/tests/web_service_tests.rs
+++ b/tests/web_service_tests.rs
@@ -680,11 +680,9 @@ fn test_validate_na_edit_info_deletion() {
     if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
         if let Some(edit) = v.loc_edit.edit.inner() {
             match edit {
-                NaEdit::Deletion { sequence, length } => {
-                    // Verify deletion info is extractable
-                    // (may have sequence, length, or both)
-                    assert!(sequence.is_some() || length.is_some() || true);
-                }
+                // Deletion info may have sequence, length, or both — the
+                // test exists to lock in that we land in this arm.
+                NaEdit::Deletion { .. } => {}
                 _ => panic!("Expected deletion"),
             }
         }
@@ -829,15 +827,18 @@ fn test_effect_frameshift_detection_single_base_del() {
     let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
 
     if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-        if let Some(edit) = v.loc_edit.edit.inner() {
-            match edit {
-                ferro_hgvs::hgvs::edit::NaEdit::Deletion { length, .. } => {
-                    // Default length for unspecified deletion is 1
-                    let len = length.unwrap_or(1) as usize;
-                    assert!(len % 3 != 0, "Single base deletion should cause frameshift");
-                }
-                _ => {}
-            }
+        if let Some(ferro_hgvs::hgvs::edit::NaEdit::Deletion { length, .. }) =
+            v.loc_edit.edit.inner()
+        {
+            // `c.350del` is a point-position deletion, so the parsed `length`
+            // is None and 1 is the correct default. Range deletions (e.g.
+            // `c.350_352del`) also yield None but their length must instead
+            // be derived from the position range — do not copy this default.
+            let len = length.unwrap_or(1) as usize;
+            assert!(
+                !len.is_multiple_of(3),
+                "Single base deletion should cause frameshift"
+            );
         }
     }
 }
@@ -845,8 +846,21 @@ fn test_effect_frameshift_detection_single_base_del() {
 #[test]
 fn test_effect_inframe_deletion_three_bases() {
     // Three base deletion is in-frame (3 % 3 == 0)
-    let len = 3;
-    assert!(len % 3 == 0, "Three base deletion should be in-frame");
+    let input = "NM_000249.4:c.350_352del";
+    let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
+
+    if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
+        if let Some(ferro_hgvs::hgvs::edit::NaEdit::Deletion { .. }) = v.loc_edit.edit.inner() {
+            let start = v.loc_edit.location.start.inner().expect("start position");
+            let end = v.loc_edit.location.end.inner().expect("end position");
+            let len = (end.base - start.base + 1) as usize;
+            assert_eq!(len, 3);
+            assert!(
+                len.is_multiple_of(3),
+                "Three base deletion should be in-frame"
+            );
+        }
+    }
 }
 
 #[test]
@@ -856,15 +870,15 @@ fn test_effect_frameshift_insertion() {
     let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
 
     if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-        if let Some(edit) = v.loc_edit.edit.inner() {
-            match edit {
-                ferro_hgvs::hgvs::edit::NaEdit::Insertion { sequence } => {
-                    let len = sequence.to_string().len();
-                    assert_eq!(len, 2);
-                    assert!(len % 3 != 0, "Two base insertion should cause frameshift");
-                }
-                _ => {}
-            }
+        if let Some(ferro_hgvs::hgvs::edit::NaEdit::Insertion { sequence }) =
+            v.loc_edit.edit.inner()
+        {
+            let len = sequence.to_string().len();
+            assert_eq!(len, 2);
+            assert!(
+                !len.is_multiple_of(3),
+                "Two base insertion should cause frameshift"
+            );
         }
     }
 }
@@ -875,15 +889,15 @@ fn test_effect_inframe_insertion_three_bases() {
     let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
 
     if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-        if let Some(edit) = v.loc_edit.edit.inner() {
-            match edit {
-                ferro_hgvs::hgvs::edit::NaEdit::Insertion { sequence } => {
-                    let len = sequence.to_string().len();
-                    assert_eq!(len, 3);
-                    assert!(len % 3 == 0, "Three base insertion should be in-frame");
-                }
-                _ => {}
-            }
+        if let Some(ferro_hgvs::hgvs::edit::NaEdit::Insertion { sequence }) =
+            v.loc_edit.edit.inner()
+        {
+            let len = sequence.to_string().len();
+            assert_eq!(len, 3);
+            assert!(
+                len.is_multiple_of(3),
+                "Three base insertion should be in-frame"
+            );
         }
     }
 }
@@ -915,10 +929,13 @@ fn test_effect_codon_phase_calculation() {
     // Phase 1 = second position
     // Phase 2 = third position
 
-    assert_eq!((1 - 1) % 3, 0, "Position 1 is first in codon");
-    assert_eq!((2 - 1) % 3, 1, "Position 2 is second in codon");
-    assert_eq!((3 - 1) % 3, 2, "Position 3 is third in codon");
-    assert_eq!((4 - 1) % 3, 0, "Position 4 is first in codon");
+    for (cds_pos, expected_phase) in [(1i32, 0), (2, 1), (3, 2), (4, 0)] {
+        assert_eq!(
+            (cds_pos - 1) % 3,
+            expected_phase,
+            "Position {cds_pos} should have phase {expected_phase}"
+        );
+    }
 }
 
 // ==================== Convert Handler Error Path Tests ====================


### PR DESCRIPTION
Closes #35.

## Summary

- Drop the temporary `toolchain: 1.94.0` pin from #34 across `ci.yml`, `coverage.yml`, `external-validation.yml`, and `publish.yml`. CI now tracks current stable Rust; `fuzz.yml` stays on `nightly` (cargo-fuzz requirement).
- Fix every clippy lint that Rust 1.95 newly fires under `-D warnings`. Beyond the five `collapsible_match` sites named in the issue (`hgvs/interval.rs`, `hgvs/validation.rs`), 1.95 also tightens / introduces: `unnecessary_sort_by`, `field_reassign_with_default`, `bool_assert_comparison`, `absurd_extreme_comparisons`, `identity_op`, `single_match` (when paired with `collapsible_match`), `manual_is_multiple_of`, `useless_vec`, and the iterator-of-`Result` `unnecessary_filter_map` form. All addressed without `#[allow(...)]` escapes.
- Remove two tautological tests in `service_tools_tests.rs` (`test_timeout_duration_calculation`, `test_concurrent_limit_configuration`) — they constructed literal `Option<u32>` values and asserted that `Option::unwrap_or` returns the right thing. They tested stdlib, not application code, and would not catch a regression in the `unwrap_or(30)` / `unwrap_or(10)` defaults in `src/service/tools/manager.rs` because they didn't reference those sites.
- Remove unused plus-strand UTR helpers (`make_plus_strand_utr_transcript`, `make_provider_with_plus_utr`) in `coverage_gap_tests.rs`. They were speculative scaffolding added in `3df8ca5`; only their minus-strand counterparts were ever called.

## Test plan

- [x] `cargo clippy --features dev --all-targets -- -D warnings` is clean on stable 1.95 (rc=0 from a fresh `cargo clean`)
- [x] `cargo nextest run --features dev` — 3182 passed, 52 skipped, 0 failed
- [x] `cargo fmt` clean (pre-commit hook ran)
- [ ] CI passes once unpinned (fmt / clippy / build / test / coverage / external-validation jobs all need to be green on `stable`)