### PR TITLE
fix(normalize): enforce HGVS c. codon-frame exception for repeat notation (#81 B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(normalize)* rewrite degenerate substitutions (ref == alt, e.g. `c.100A>A`) to identity (`=`) per HGVS v21 spec, which marks `c.X>X` as "not allowed" (`docs/recommendations/DNA/other.md`). The rule is purely syntactic on the edit's stated bases, so it fires in both the full-normalization path and the no-reference canonicalization path — `c.123C>C` rewrites to `c.123=` regardless of provider availability. ([#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) A4)
 - *(normalize)* rewrite a `delins` whose inserted sequence is empty as a deletion, per the HGVS spec requirement that an empty insert is semantically a deletion and must be rendered as `del`. The rewritten deletion is then 3'-shifted under the standard del rule. Issue [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item A3.
+- *(normalize)* HGVS spec compliance ([#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) B1): repeat-notation rewrites in `c.` (coding DNA) context now enforce the spec's codon-frame exception — repeat notation requires `unit_len % 3 == 0`. Previously `insertion_to_repeat`, `deletion_to_repeat`, `duplication_to_repeat`, and `normalize_repeat` could emit `c.X_YA[N]`, `c.X_YAT[N]`, etc. for non-codon-aligned units, violating the spec (`docs/recommendations/DNA/repeated.md`). Variants in `c.` with non-codon-aligned units now retain the spec-prescribed alternative form: `dup` for 1 added copy, `ins<literal>` for ≥2 added copies, and plain `del` for contractions of ≥2 unit copies.
+
+### Changed (public API)
+
+- `insertion_to_repeat`, `duplication_to_repeat`, and `normalize_repeat` in `ferro_hgvs::normalize::rules` gain an `is_coding: bool` parameter to drive the codon-frame gate. (`deletion_to_repeat` is `pub(crate)` and gains the same parameter as an internal change.)
+- `RepeatNormResult::Insertion { start, end, sequence }` and `DupToRepeatResult::GatedInsertion { start, end, sequence }` variants added so the rule layer can route gated rewrites to the spec-canonical literal `ins` form.
 
 ## [0.4.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.4.0...v0.4.1) - 2026-05-04
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -404,6 +404,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             rel_start,
             rel_end,
             &Boundaries::new(1, ref_seq.len() as u64),
+            false, // genomic context: codon-frame gate does not apply
         )?;
 
         // Adjust back to genomic coordinates
@@ -504,10 +505,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         };
 
-        // Perform normalization on transcript sequence
+        // Perform normalization on transcript sequence (CDS context).
         let seq = transcript.sequence.as_bytes();
         let (new_tx_start, new_tx_end, new_edit, warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries)?;
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, true)?;
 
         // Convert back to CDS coordinates
         let new_start = self.tx_to_cds_pos(new_tx_start, cds_start, transcript.cds_end)?;
@@ -584,10 +585,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // Get boundaries
         let boundaries = Boundaries::new(1, transcript.sequence.len() as u64);
 
-        // Perform normalization
+        // Perform normalization (n. non-coding tx context).
         let seq = transcript.sequence.as_bytes();
         let (new_start, new_end, new_edit, warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries)?;
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
 
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
@@ -894,10 +895,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // Get boundaries
         let boundaries = Boundaries::new(1, transcript.sequence.len() as u64);
 
-        // Perform normalization
+        // Perform normalization (RNA context: codon-frame gate does not apply;
+        // r. is not in the spec's accepted reference types for repeats).
         let seq = transcript.sequence.as_bytes();
         let (new_start, new_end, new_edit, warnings) =
-            self.normalize_na_edit(seq, edit, rna_start, rna_end, &boundaries)?;
+            self.normalize_na_edit(seq, edit, rna_start, rna_end, &boundaries, false)?;
 
         let new_variant = RnaVariant {
             accession: variant.accession.clone(),
@@ -1032,7 +1034,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             &boundaries,
         );
 
-        // Perform normalization in transcript-view space
+        // Perform normalization in transcript-view space (CDS intronic context).
         let seq_bytes = work_seq.as_bytes();
         let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
             seq_bytes,
@@ -1040,6 +1042,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_start,
             work_rel_end,
             &work_boundaries,
+            true,
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -1173,7 +1176,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             &boundaries,
         );
 
-        // Perform normalization in transcript-view space
+        // Perform normalization in transcript-view space (n. non-coding intronic context).
         let seq_bytes = work_seq.as_bytes();
         let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
             seq_bytes,
@@ -1181,6 +1184,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_start,
             work_rel_end,
             &work_boundaries,
+            false,
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -1282,10 +1286,38 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let boundaries =
             self.get_boundary_spanning_limits(transcript, &mapper, start_pos, end_pos, seq_start)?;
 
-        // Normalize in genomic space
-        let seq_bytes = genomic_seq.as_bytes();
-        let (new_rel_start, new_rel_end, new_edit, warnings) =
-            self.normalize_na_edit(seq_bytes, edit, rel_start, rel_end, &boundaries)?;
+        // On minus-strand transcripts the genomic-strand window is the
+        // reverse complement of the transcript view, but the variant's edit
+        // alt is in transcript view. Running `normalize_na_edit` on raw
+        // genomic bytes therefore canonicalizes against the wrong alphabet
+        // (and the codon-frame repeat gate inspects ref context here too).
+        // Mirror the intronic flow: flip into transcript view before
+        // normalization, then unflip the result positions back to the
+        // genomic frame. (CDS boundary-spanning context.)
+        let (work_seq, work_rel_start, work_rel_end, work_boundaries) = flip_intronic_for_strand(
+            transcript.strand,
+            &genomic_seq,
+            rel_start,
+            rel_end,
+            &boundaries,
+        );
+
+        let seq_bytes = work_seq.as_bytes();
+        let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
+            seq_bytes,
+            edit,
+            work_rel_start,
+            work_rel_end,
+            &work_boundaries,
+            true,
+        )?;
+
+        let (new_rel_start, new_rel_end) = unflip_intronic_positions(
+            transcript.strand,
+            work_seq.len() as u64,
+            work_new_rel_start,
+            work_new_rel_end,
+        );
 
         // Convert back to absolute genomic
         let new_g_start = seq_start + new_rel_start - 1;
@@ -1427,6 +1459,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         start: u64,
         end: u64,
         boundaries: &Boundaries,
+        is_coding: bool,
     ) -> Result<(u64, u64, NaEdit, Vec<NormalizationWarning>), FerroError> {
         let mut warnings = Vec::new();
 
@@ -1496,7 +1529,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         sequence: None,
                         length: None,
                     };
-                    return self.normalize_na_edit(ref_seq, &del, start, end, boundaries);
+                    return self
+                        .normalize_na_edit(ref_seq, &del, start, end, boundaries, is_coding);
                 }
 
                 // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
@@ -1607,7 +1641,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 let pos_idx = hgvs_pos_to_index(start); // Convert 1-based to 0-based
 
                 // Normalize the repeat
-                match rules::normalize_repeat(ref_seq, pos_idx, &repeat_unit, *specified_count) {
+                match rules::normalize_repeat(
+                    ref_seq,
+                    pos_idx,
+                    &repeat_unit,
+                    *specified_count,
+                    is_coding,
+                ) {
                     rules::RepeatNormResult::Deletion {
                         start: del_start,
                         end: del_end,
@@ -1632,6 +1672,30 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         };
                         return Ok((dup_start, dup_end, dup_edit, warnings));
                     }
+                    rules::RepeatNormResult::Insertion {
+                        start: ins_start,
+                        end: ins_end,
+                        sequence: ins_seq,
+                    } => {
+                        // Codon-frame gate routed an expansion to ins literal form
+                        // (e.g., c.1741_1742insTATATATA per spec).
+                        use crate::hgvs::edit::{Base, InsertedSequence, Sequence};
+                        let bases: Vec<Base> = ins_seq
+                            .iter()
+                            .filter_map(|&b| Base::from_char(b as char))
+                            .collect();
+                        if bases.len() == ins_seq.len() {
+                            let ins_edit = NaEdit::Insertion {
+                                sequence: InsertedSequence::Literal(Sequence::new(bases)),
+                            };
+                            return Ok((ins_start, ins_end, ins_edit, warnings));
+                        }
+                        // Defensive fallback: rule layer returned a base byte
+                        // that doesn't fit the Base alphabet (e.g. N). Don't
+                        // emit a truncated insertion — keep the original edit
+                        // and positions so downstream invariants hold.
+                        return Ok((start, end, edit.clone(), warnings));
+                    }
                     rules::RepeatNormResult::Repeat {
                         start: rep_start,
                         end: rep_end,
@@ -1643,13 +1707,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             .iter()
                             .filter_map(|&b| Base::from_char(b as char))
                             .collect();
-                        let rep_edit = NaEdit::Repeat {
-                            sequence: Some(Sequence::new(bases)),
-                            count: RepeatCount::Exact(rep_count),
-                            additional_counts: vec![],
-                            trailing: None,
-                        };
-                        return Ok((rep_start, rep_end, rep_edit, warnings));
+                        if bases.len() == rep_seq.len() {
+                            let rep_edit = NaEdit::Repeat {
+                                sequence: Some(Sequence::new(bases)),
+                                count: RepeatCount::Exact(rep_count),
+                                additional_counts: vec![],
+                                trailing: None,
+                            };
+                            return Ok((rep_start, rep_end, rep_edit, warnings));
+                        }
+                        // Defensive fallback: rule layer returned a repeat
+                        // unit byte that doesn't fit the Base alphabet (e.g.
+                        // a gap or non-IUPAC byte from the reference). Don't
+                        // emit a truncated repeat sequence — keep the
+                        // original edit and positions.
+                        return Ok((start, end, edit.clone(), warnings));
                     }
                     rules::RepeatNormResult::Unchanged => {
                         return Ok((start, end, edit.clone(), warnings.clone()));
@@ -1721,7 +1793,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     if seq_bytes.len() > 1 {
                         let original_pos_idx = hgvs_pos_to_index(start) as u64; // 0-based original position
                         if let Some((_first, count, rep_start, rep_end, unit_bytes)) =
-                            rules::insertion_to_repeat(ref_seq, original_pos_idx, &seq_bytes)
+                            rules::insertion_to_repeat(
+                                ref_seq,
+                                original_pos_idx,
+                                &seq_bytes,
+                                is_coding,
+                            )
                         {
                             use crate::hgvs::edit::Base;
                             let bases: Vec<Base> = unit_bytes
@@ -1757,7 +1834,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         seq_bytes.clone()
                     };
 
-                    if rules::insertion_is_duplication(ref_seq, result.start, &rotated_seq) {
+                    // Codon-frame gate (repeated.md): in c., if the rotated
+                    // insertion is >=2 copies of a non-codon-aligned unit, the
+                    // spec mandates ins<literal>, not dup. Skip dup conversion
+                    // in that case so the caller falls through to the literal
+                    // ins emission below.
+                    let smallest_unit = rules::smallest_repeat_unit(&rotated_seq);
+                    let codon_blocks_dup = is_coding
+                        && smallest_unit.len() < rotated_seq.len()
+                        && !smallest_unit.len().is_multiple_of(3);
+                    if !codon_blocks_dup
+                        && rules::insertion_is_duplication(ref_seq, result.start, &rotated_seq)
+                    {
                         // For duplication, use minimal notation without explicit sequence
                         // Position: for c.X_(X+1)ins that duplicates preceding sequence,
                         // the result is c.(X-len+1)_Xdup
@@ -1785,15 +1873,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 .iter()
                                 .filter_map(|&b| Base::from_char(b as char))
                                 .collect();
-                            let new_sequence =
-                                InsertedSequence::Literal(Sequence::new(rotated_bases));
-                            (
-                                new_start,
-                                new_end,
-                                NaEdit::Insertion {
-                                    sequence: new_sequence,
-                                },
-                            )
+                            // Mirror the gated-ins guard used by the
+                            // RepeatNormResult::Insertion / GatedInsertion
+                            // branches: if any byte fell outside the Base
+                            // alphabet, refuse to emit a truncated `ins`
+                            // and fall back to the original edit so
+                            // downstream invariants hold.
+                            if rotated_bases.len() == rotated_seq.len() {
+                                let new_sequence =
+                                    InsertedSequence::Literal(Sequence::new(rotated_bases));
+                                (
+                                    new_start,
+                                    new_end,
+                                    NaEdit::Insertion {
+                                        sequence: new_sequence,
+                                    },
+                                )
+                            } else {
+                                (new_start, new_end, edit.clone())
+                            }
                         } else {
                             (new_start, new_end, edit.clone())
                         }
@@ -1809,7 +1907,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 // Use the shuffled positions (result.start, result.end) which are 0-based
                 // This applies to both single-base dups in homopolymers and multi-base tandem dups
                 if let Some(dup_result) =
-                    rules::duplication_to_repeat(ref_seq, result.start, result.end)
+                    rules::duplication_to_repeat(ref_seq, result.start, result.end, is_coding)
                 {
                     match dup_result {
                         rules::DupToRepeatResult::Homopolymer {
@@ -1850,6 +1948,30 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 return Ok((rep_start, rep_end, repeat_edit, warnings));
                             }
                         }
+                        rules::DupToRepeatResult::GatedInsertion {
+                            start: ins_start,
+                            end: ins_end,
+                            sequence: ins_seq,
+                        } => {
+                            // Codon-frame gate routed a multi-copy dup to ins
+                            // literal form per HGVS spec.
+                            use crate::hgvs::edit::InsertedSequence;
+                            let bases: Vec<Base> = ins_seq
+                                .iter()
+                                .filter_map(|&b| Base::from_char(b as char))
+                                .collect();
+                            if bases.len() == ins_seq.len() {
+                                let ins_edit = NaEdit::Insertion {
+                                    sequence: InsertedSequence::Literal(Sequence::new(bases)),
+                                };
+                                return Ok((ins_start, ins_end, ins_edit, warnings));
+                            }
+                            // Defensive fallback: rule layer returned a base
+                            // byte that doesn't fit the Base alphabet (e.g.
+                            // N). Fall through to the generic dup minimal-
+                            // notation path below rather than emitting a
+                            // truncated insertion.
+                        }
                     }
                 }
                 // Keep as duplication but strip explicit sequence (minimal notation)
@@ -1881,17 +2003,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             .iter()
                             .filter_map(|&b| crate::hgvs::edit::Base::from_char(b as char))
                             .collect();
-                        let dup_seq = Sequence::new(dup_bases);
-
-                        (
-                            new_start,
-                            new_end,
-                            NaEdit::Duplication {
-                                sequence: Some(dup_seq),
-                                length: Some(dup_len as u64),
-                                uncertain_extent: None,
-                            },
-                        )
+                        if dup_bases.len() == dup_seq_bytes.len() {
+                            let dup_seq = Sequence::new(dup_bases);
+                            (
+                                new_start,
+                                new_end,
+                                NaEdit::Duplication {
+                                    sequence: Some(dup_seq),
+                                    length: Some(dup_len as u64),
+                                    uncertain_extent: None,
+                                },
+                            )
+                        } else {
+                            // Defensive fallback: ref slice contains a byte
+                            // outside the Base alphabet. Keep the original
+                            // delins rather than emitting a duplication with
+                            // a truncated sequence.
+                            (new_start, new_end, edit.clone())
+                        }
                     } else {
                         (new_start, new_end, edit.clone())
                     }
@@ -1917,6 +2046,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         ref_seq,
                         result.start as usize,
                         result.end as usize,
+                        is_coding,
                     ) {
                         let bases: Option<Vec<Base>> = rep
                             .unit
@@ -3152,6 +3282,73 @@ mod tests {
         provider
     }
 
+    /// Minus-strand mirror of `make_boundary_test_provider`.
+    ///
+    /// Same transcript sequence as the plus-strand fixture, so c.40_40+3
+    /// still spans the same poly-A region in transcript view. The genomic
+    /// content at the gene region is the reverse complement of each exon
+    /// (so RC of the genomic plus strand recovers `tx_seq`), and the
+    /// exon-to-genomic mapping is reversed: tx 1 maps to the high genomic
+    /// end (g.1077) and tx 58 to the low end (g.1000). Intron 2 is laid
+    /// out so that c.40+1..c.40+4 read as `A` in transcript view, putting
+    /// the boundary-spanning dup inside the same 5-A tract that the plus
+    /// fixture exercises.
+    fn make_boundary_test_provider_minus() -> MockProvider {
+        use crate::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+        use std::sync::OnceLock;
+
+        let mut provider = MockProvider::new();
+
+        let tx_seq = "ATGCCCAAAGGGTTTAGGCCAAAGGGTTTAGGCCCAAAAAGGGTTTAGGCCCAAATGA";
+
+        let mut genomic_seq = String::new();
+        for _ in 0..1000 {
+            genomic_seq.push('N');
+        }
+        // Exon 3 region (g.1000-1017): RC of tx[41..58] ("GGGTTTAGGCCCAAATGA").
+        genomic_seq.push_str("TCATTTGGGCCTAAACCC");
+        // Intron 2 (g.1018-1027): the last four bases (g.1024-1027) are 'T',
+        // so c.40+1..c.40+4 read as 'A' in transcript view, extending the
+        // exonic poly-A across the boundary.
+        genomic_seq.push_str("AAAGTATTTT");
+        // Exon 2 region (g.1028-1047): RC of tx[21..40] ("AAAGGGTTTAGGCCCAAAAA").
+        genomic_seq.push_str("TTTTTGGGCCTAAACCCTTT");
+        // Intron 1 (g.1048-1057): mirrors the plus fixture's intron 1 content.
+        genomic_seq.push_str("GTAAGCTAAA");
+        // Exon 1 region (g.1058-1077): RC of tx[1..20] ("ATGCCCAAAGGGTTTAGGCC").
+        genomic_seq.push_str("GGCCTAAACCCTTTGGGCAT");
+        for _ in 0..100 {
+            genomic_seq.push('N');
+        }
+
+        provider.add_genomic_sequence("chr1", genomic_seq);
+
+        provider.add_transcript(Transcript {
+            id: "NM_BOUNDARYM.1".to_string(),
+            gene_symbol: Some("BOUNDARY_M".to_string()),
+            strand: Strand::Minus,
+            sequence: tx_seq.to_string(),
+            cds_start: Some(1),
+            cds_end: Some(58),
+            exons: vec![
+                Exon::with_genomic(1, 1, 20, 1058, 1077),
+                Exon::with_genomic(2, 21, 40, 1028, 1047),
+                Exon::with_genomic(3, 41, 58, 1000, 1017),
+            ],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1077),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::None,
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+
+        provider
+    }
+
     #[test]
     fn test_boundary_spanning_exonic_to_intronic_del() {
         // Test: c.20_20+3del - deletion from last exon base into intron
@@ -3263,11 +3460,11 @@ mod tests {
 
     #[test]
     fn test_boundary_spanning_dup() {
-        // Test: c.40_40+3dup - duplication spanning exon-intron boundary
-        // c.40 = last base of exon 2 (A at g.1049)
-        // c.40+3 = 3rd intronic base of intron 2 (A at g.1052)
-        // Since intron 2 starts with AAA (and exon 2 ends with AAAAA), this creates a repeat pattern
-        // The normalizer correctly converts this to repeat notation (A[N])
+        // Test: c.40_40+3dup - duplication spanning exon-intron boundary.
+        // The dup is 4 A's in a poly-A region. Per HGVS spec (repeated.md
+        // codon-frame exception): in c. context, repeat notation requires
+        // unit_len % 3 == 0, so unit_len=1 routes the multi-copy dup to
+        // `ins<literal>` form rather than `A[N]` or a multi-base dup.
         let provider = make_boundary_test_provider();
         let normalizer = Normalizer::new(provider);
 
@@ -3281,10 +3478,38 @@ mod tests {
         );
 
         let output = format!("{}", result.unwrap());
-        // May remain as dup or be converted to repeat notation for poly-A
         assert!(
-            output.contains("dup") || output.contains("["),
-            "Should remain a duplication or become repeat notation, got: {}",
+            output.contains("ins") && !output.contains("A["),
+            "Boundary-spanning multi-copy dup in c. with unit_len=1 must emit \
+             ins<literal> per codon-frame gate, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_boundary_spanning_dup_minus_strand() {
+        // Minus-strand mirror of `test_boundary_spanning_dup`. Pins the
+        // strand-specific flip in `normalize_boundary_spanning_cds`: the
+        // genomic-strand window is RC of the transcript view, so without
+        // flipping, the codon-frame gate would inspect the wrong alphabet
+        // and the gated `ins<literal>` rewrite would not fire.
+        let provider = make_boundary_test_provider_minus();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_BOUNDARYM.1:c.40_40+3dup").unwrap();
+        let result = normalizer.normalize(&variant);
+
+        assert!(
+            result.is_ok(),
+            "Boundary-spanning duplication should normalize, got error: {:?}",
+            result.err()
+        );
+
+        let output = format!("{}", result.unwrap());
+        assert!(
+            output.contains("ins") && !output.contains("A["),
+            "Minus-strand boundary-spanning multi-copy dup in c. with \
+             unit_len=1 must emit ins<literal> per codon-frame gate, got: {}",
             output
         );
     }

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -163,6 +163,11 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// variant is expressed as repeat notation `unit[N+k]`. A single-copy
 /// addition is left as a duplication (handled by `insertion_is_duplication`).
 ///
+/// `is_coding` enables the spec's codon-frame exception (repeated.md): in
+/// c. context, repeat notation requires `unit_len % 3 == 0`. When the gate
+/// blocks the rewrite this returns `None` and the caller falls back to a
+/// literal `ins` description.
+///
 /// Returns `Some((first_byte, total_count, ref_start_1based,
 /// ref_end_1based, unit_bytes))` when repeat notation applies, `None`
 /// otherwise. `first_byte` is preserved for backwards-compat with the
@@ -171,6 +176,7 @@ pub fn insertion_to_repeat(
     ref_seq: &[u8],
     pos: u64,
     inserted_seq: &[u8],
+    is_coding: bool,
 ) -> Option<(u8, u64, u64, u64, Vec<u8>)> {
     if inserted_seq.is_empty() {
         return None;
@@ -180,6 +186,12 @@ pub fn insertion_to_repeat(
     let added_copies = (inserted_seq.len() / base_unit.len()) as u64;
     if added_copies < 2 {
         // Single-copy addition is a duplication, not repeat notation.
+        return None;
+    }
+
+    // HGVS spec (repeated.md): in c. context, repeat notation requires
+    // unit_len % 3 == 0. Falls back to literal `ins` when the gate blocks.
+    if is_coding && !base_unit.len().is_multiple_of(3) {
         return None;
     }
 
@@ -394,6 +406,7 @@ pub(crate) fn deletion_to_repeat(
     ref_seq: &[u8],
     del_start: usize,
     del_end: usize,
+    is_coding: bool,
 ) -> Option<DelToRepeatResult> {
     if del_start >= del_end || del_end > ref_seq.len() {
         return None;
@@ -402,6 +415,12 @@ pub(crate) fn deletion_to_repeat(
     let unit_slice = smallest_repeat_unit(del_slice);
     let p = unit_slice.len();
     if p == 0 || !(del_end - del_start).is_multiple_of(p) {
+        return None;
+    }
+
+    // HGVS spec (repeated.md): in c. context, repeat notation requires
+    // unit_len % 3 == 0. Falls back to plain del when the gate blocks.
+    if is_coding && !p.is_multiple_of(3) {
         return None;
     }
 
@@ -592,9 +611,24 @@ pub enum DupToRepeatResult {
         start: u64, // 1-based (HGVS), use index_to_hgvs_pos() for conversion
         end: u64,   // 1-based (HGVS), inclusive
     },
+    /// Codon-frame gate triggered: structural conditions for repeat
+    /// notation are met, but `unit_len % 3 != 0` in c. context, so the
+    /// canonical form is a literal `ins` of the duplicated sequence at
+    /// the 3' flanking position. `start` and `end` are the two flanking
+    /// 1-based HGVS positions (last tract base and the next base).
+    GatedInsertion {
+        start: u64,
+        end: u64,
+        sequence: Vec<u8>,
+    },
 }
 
-pub fn duplication_to_repeat(ref_seq: &[u8], start: u64, end: u64) -> Option<DupToRepeatResult> {
+pub fn duplication_to_repeat(
+    ref_seq: &[u8],
+    start: u64,
+    end: u64,
+    is_coding: bool,
+) -> Option<DupToRepeatResult> {
     let start_idx = start as usize;
     let end_idx = end as usize;
 
@@ -617,6 +651,18 @@ pub fn duplication_to_repeat(ref_seq: &[u8], start: u64, end: u64) -> Option<Dup
         // Find the full homopolymer extent
         if let Some(analysis) = find_homopolymer_at(ref_seq, start_idx) {
             if analysis.base == Some(first) {
+                // Codon-frame gate (repeated.md): homopolymer unit_len=1 is
+                // never codon-aligned, so c. context blocks repeat notation.
+                // Emit GatedInsertion so the caller renders as `ins<dup_seq>`
+                // at the 3' flanking position of the reference tract.
+                if is_coding {
+                    let last_tract_idx = analysis.ref_start + analysis.ref_count as usize - 1;
+                    return Some(DupToRepeatResult::GatedInsertion {
+                        start: index_to_hgvs_pos(last_tract_idx),
+                        end: index_to_hgvs_pos(last_tract_idx) + 1,
+                        sequence: dup_seq.to_vec(),
+                    });
+                }
                 let total_count = analysis.ref_count + dup_len as u64;
                 return Some(DupToRepeatResult::Homopolymer {
                     base: first,
@@ -660,6 +706,18 @@ pub fn duplication_to_repeat(ref_seq: &[u8], start: u64, end: u64) -> Option<Dup
         if let Some((ref_count, rep_start, rep_end)) =
             count_tandem_repeats(ref_seq, start_idx, unit)
         {
+            // Codon-frame gate (repeated.md): in c., repeat notation requires
+            // unit_len % 3 == 0. Structural conditions are met but the gate
+            // forces a literal `ins<dup_seq>` at the 3' tract flanking
+            // position instead.
+            if is_coding && !unit_len.is_multiple_of(3) {
+                let last_tract_idx = rep_end - 1;
+                return Some(DupToRepeatResult::GatedInsertion {
+                    start: index_to_hgvs_pos(last_tract_idx),
+                    end: index_to_hgvs_pos(last_tract_idx) + 1,
+                    sequence: dup_seq.to_vec(),
+                });
+            }
             // Total count = reference count + duplicated copies
             let total_count = ref_count + copies_in_dup as u64;
             // rep_end is exclusive (0-based), so last position is rep_end - 1
@@ -748,6 +806,16 @@ pub enum RepeatNormResult {
         end: u64,   // 1-based (HGVS), inclusive end of duplicated region
         sequence: Vec<u8>,
     },
+    /// Convert to insertion. Used when the codon-frame gate blocks repeat
+    /// notation in c. context for an expansion of >=2 unit copies. `start`
+    /// and `end` are the two flanking 1-based HGVS positions; `sequence` is
+    /// the literal inserted sequence (canonical unit repeated `specified -
+    /// ref_count` times).
+    Insertion {
+        start: u64,
+        end: u64,
+        sequence: Vec<u8>,
+    },
     /// Keep as repeat notation with canonical position
     Repeat {
         start: u64, // 1-based (HGVS), inclusive start
@@ -776,6 +844,7 @@ pub fn normalize_repeat(
     pos: usize,
     repeat_unit: &[u8],
     specified_count: u64,
+    is_coding: bool,
 ) -> RepeatNormResult {
     // Match `count_tandem_repeats`'s pre-refactor contract: an empty unit
     // is meaningless and falls through to `Unchanged`. Without this guard,
@@ -801,10 +870,14 @@ pub fn normalize_repeat(
     };
 
     let unit_len = canonical_unit.len() as u64;
+    // HGVS spec (repeated.md): in c. context, repeat notation requires
+    // unit_len % 3 == 0. When the gate blocks, contraction-with-survivors
+    // routes to Deletion and expansion-of->=2-copies routes to Insertion.
+    let codon_blocks_repeat = is_coding && !canonical_unit.len().is_multiple_of(3);
 
     if specified_count < ref_count {
         let k = ref_count - specified_count;
-        if k >= 2 && specified_count >= 1 {
+        if k >= 2 && specified_count >= 1 && !codon_blocks_repeat {
             // B2 (symmetric with A7): >=2 unit reduction with surviving units → repeat
             RepeatNormResult::Repeat {
                 start: index_to_hgvs_pos(ref_start),
@@ -813,7 +886,7 @@ pub fn normalize_repeat(
                 count: specified_count,
             }
         } else {
-            // 1-unit reduction or full tract removal → deletion
+            // 1-unit reduction, full tract removal, or codon-frame-gated → deletion
             // (HGVS prioritization: deletion outranks unranked repeat[0])
             let del_len = (k as usize) * unit_len as usize;
             let del_end_idx = ref_end - 1;
@@ -824,8 +897,9 @@ pub fn normalize_repeat(
             }
         }
     } else if specified_count == ref_count + 1 {
-        // Convert to duplication - we're adding exactly one copy
-        // The duplicated region is the last copy in the reference
+        // Convert to duplication - we're adding exactly one copy.
+        // dup is always permitted; the spec exception only forbids `[N]`.
+        // The duplicated region is the last copy in the reference.
         // ref_end is exclusive, so last position is ref_end - 1
         let dup_end_idx = ref_end - 1;
         let dup_start_idx = ref_end - canonical_unit.len();
@@ -837,8 +911,25 @@ pub fn normalize_repeat(
     } else if specified_count == ref_count {
         // Same as reference - this is identity (no change)
         RepeatNormResult::Unchanged
+    } else if codon_blocks_repeat {
+        // Expansion of >=2 copies in c. with non-codon-aligned unit: spec
+        // mandates `ins<literal>` form (e.g., c.1741_1742insTATATATA), not
+        // `[N]`. Insertion point is between the last base of the reference
+        // tract (ref_end - 1, 0-based) and the next base (ref_end).
+        let added_copies = specified_count - ref_count;
+        let mut inserted = Vec::with_capacity((added_copies as usize) * canonical_unit.len());
+        for _ in 0..added_copies {
+            inserted.extend_from_slice(canonical_unit);
+        }
+        let flank_left = index_to_hgvs_pos(ref_end - 1);
+        let flank_right = flank_left + 1;
+        RepeatNormResult::Insertion {
+            start: flank_left,
+            end: flank_right,
+            sequence: inserted,
+        }
     } else {
-        // Keep as repeat notation with canonical position
+        // Default expansion (>=2 copies, not gated): repeat notation.
         // The repeat region describes the REFERENCE tract (per HGVS spec)
         // ref_end is exclusive, so last position is ref_end - 1
         RepeatNormResult::Repeat {
@@ -1151,7 +1242,7 @@ mod tests {
         // insertion point. pos=7 means insert between index 7 and 8 — i.e.,
         // immediately after the last A in the homopolymer. Inserting AA here
         // should become A[7] (5 ref + 2 inserted).
-        let result = insertion_to_repeat(ref_seq, 7, b"AA");
+        let result = insertion_to_repeat(ref_seq, 7, b"AA", false);
         assert!(result.is_some());
         let (base, count, start, end, _unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -1160,15 +1251,15 @@ mod tests {
         assert_eq!(end, 8); // 1-indexed end of A region in reference (per HGVS, positions refer to reference tract)
 
         // Single-copy inserts (added_copies < 2) are duplications, not repeats.
-        let result = insertion_to_repeat(ref_seq, 7, b"A");
+        let result = insertion_to_repeat(ref_seq, 7, b"A", false);
         assert!(result.is_none());
 
         // Inserting T (non-matching) should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"T");
+        let result = insertion_to_repeat(ref_seq, 7, b"T", false);
         assert!(result.is_none());
 
         // Inserting mixed bases should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"AT");
+        let result = insertion_to_repeat(ref_seq, 7, b"AT", false);
         assert!(result.is_none());
 
         // Multi-base tandem unit: insert ACAC into ACAC tract → AC[4].
@@ -1176,7 +1267,7 @@ mod tests {
         // (pos=3, between A at index 3 and base at index 4). Expected:
         // 2 ref AC units + 2 inserted AC units = AC[4] at ref indices 0..3.
         let ref_ac = b"ACACGGG";
-        let result = insertion_to_repeat(ref_ac, 3, b"ACAC");
+        let result = insertion_to_repeat(ref_ac, 3, b"ACAC", false);
         assert!(result.is_some());
         let (base, count, start, end, unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -1192,7 +1283,7 @@ mod tests {
         let ref_seq = b"GGGAAAAAGGG";
 
         // Duplicating 2 A's (positions 3-5, 0-indexed) should become A[7]
-        let result = duplication_to_repeat(ref_seq, 3, 5);
+        let result = duplication_to_repeat(ref_seq, 3, 5, false);
         assert!(result.is_some());
         match result.unwrap() {
             DupToRepeatResult::Homopolymer {
@@ -1208,7 +1299,7 @@ mod tests {
         // Duplicating non-homopolymer region should return None (if not a tandem repeat)
         // ATGCXYZ has no repeats, so duplicating ATG should return None
         let non_repeat_seq = b"ATGCXYZ";
-        let result = duplication_to_repeat(non_repeat_seq, 0, 3);
+        let result = duplication_to_repeat(non_repeat_seq, 0, 3, false);
         assert!(result.is_none());
     }
 
@@ -1222,11 +1313,11 @@ mod tests {
 
         // Duplicating single GCA (one copy) should NOT become repeat notation
         // It should stay as a simple dup per HGVS rules
-        let result = duplication_to_repeat(ref_seq, 5, 8);
+        let result = duplication_to_repeat(ref_seq, 5, 8, false);
         assert!(result.is_none(), "Single-copy dup should not become repeat");
 
         // Duplicating GCAGCA (2 copies) SHOULD become repeat notation
-        let result = duplication_to_repeat(ref_seq, 5, 11);
+        let result = duplication_to_repeat(ref_seq, 5, 11, false);
         assert!(result.is_some());
         match result.unwrap() {
             DupToRepeatResult::TandemRepeat {
@@ -1300,7 +1391,7 @@ mod tests {
         // Specifying CAT[1]: ref_count=4, specified=1, k=3 >= 2, post=1 >= 1 → B2 → Repeat
         let ref_seq = b"GGGCATCATCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 1);
+        let result = normalize_repeat(ref_seq, 3, b"CAT", 1, false);
         match result {
             RepeatNormResult::Repeat {
                 sequence, count, ..
@@ -1318,7 +1409,7 @@ mod tests {
         // Specifying CAT[3] (ref is 2, so 2+1=3) should become duplication
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 3);
+        let result = normalize_repeat(ref_seq, 3, b"CAT", 3, false);
         match result {
             RepeatNormResult::Duplication {
                 start,
@@ -1338,7 +1429,7 @@ mod tests {
         // Specifying CAT[5] (ref is 2, 5 > 2+1) should stay as repeat
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 5);
+        let result = normalize_repeat(ref_seq, 3, b"CAT", 5, false);
         match result {
             RepeatNormResult::Repeat {
                 count, sequence, ..
@@ -1356,7 +1447,7 @@ mod tests {
         // Specifying CAT[2] (same as ref) should be unchanged
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 2);
+        let result = normalize_repeat(ref_seq, 3, b"CAT", 2, false);
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -1370,7 +1461,7 @@ mod tests {
         // canonical_unit.len()` unless we guard up front. This test pins the
         // pre-refactor contract.
         let ref_seq = b"GGGCATCATGGG";
-        let result = normalize_repeat(ref_seq, 3, b"", 1);
+        let result = normalize_repeat(ref_seq, 3, b"", 1, false);
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -1382,7 +1473,7 @@ mod tests {
         // this would fall to a 1-unit (ATAT) reduction → deletion (k<2).
         let ref_seq = b"GGGATATATATGGG"; // AT-tract at indices 3..11 (4 AT)
 
-        let result = normalize_repeat(ref_seq, 3, b"ATAT", 1);
+        let result = normalize_repeat(ref_seq, 3, b"ATAT", 1, false);
         match result {
             RepeatNormResult::Repeat {
                 start,
@@ -1542,7 +1633,7 @@ mod tests {
         // After 3' shift, del lands at [5..7). post-shift slice "AA", unit "A", k=2.
         // Tract [2..7), ref_count=5, post_count=3 → A[3] at HGVS [3..7] (1-based).
         let ref_seq = b"TTAAAAATT";
-        let r = deletion_to_repeat(ref_seq, 5, 7).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 5, 7, false).expect("should fire");
         assert_eq!(r.unit, b"A");
         assert_eq!(r.count, 3);
         assert_eq!(r.start, 3); // 1-based HGVS
@@ -1555,7 +1646,7 @@ mod tests {
         // post-shift slice "GCAGCA", unit "GCA", k=2. Tract [2..11), ref_count=3,
         // post_count=1 → GCA[1] at HGVS [3..11] (1-based).
         let ref_seq = b"TTGCAGCAGCATT";
-        let r = deletion_to_repeat(ref_seq, 5, 11).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 5, 11, false).expect("should fire");
         assert_eq!(r.unit, b"GCA");
         assert_eq!(r.count, 1);
         assert_eq!(r.start, 3);
@@ -1567,7 +1658,7 @@ mod tests {
         // k=1 → stays as del.
         // ref "TTAAAAATT", delete 1 A at [6..7).
         let ref_seq = b"TTAAAAATT";
-        assert!(deletion_to_repeat(ref_seq, 6, 7).is_none());
+        assert!(deletion_to_repeat(ref_seq, 6, 7, false).is_none());
     }
 
     #[test]
@@ -1575,7 +1666,7 @@ mod tests {
         // post_count == 0 → stays as del.
         // ref "TTAATT", delete both A's at [2..4). ref_count=2, k=2, post_count=0.
         let ref_seq = b"TTAATT";
-        assert!(deletion_to_repeat(ref_seq, 2, 4).is_none());
+        assert!(deletion_to_repeat(ref_seq, 2, 4, false).is_none());
     }
 
     #[test]
@@ -1584,7 +1675,7 @@ mod tests {
         // ref "TTGCATT", delete "GCA" at [2..5). smallest_repeat_unit("GCA")="GCA",
         // ref_count=1, returns None.
         let ref_seq = b"TTGCATT";
-        assert!(deletion_to_repeat(ref_seq, 2, 5).is_none());
+        assert!(deletion_to_repeat(ref_seq, 2, 5, false).is_none());
     }
 
     #[test]
@@ -1592,7 +1683,7 @@ mod tests {
         // ref "TTATATATATATT" (5 ATs at [2..12)). Delete "ATAT" at [8..12).
         // smallest_repeat_unit("ATAT")="AT", k=2, ref_count=5, post_count=3 → AT[3].
         let ref_seq = b"TTATATATATATT";
-        let r = deletion_to_repeat(ref_seq, 8, 12).expect("should fire");
+        let r = deletion_to_repeat(ref_seq, 8, 12, false).expect("should fire");
         assert_eq!(r.unit, b"AT");
         assert_eq!(r.count, 3);
         assert_eq!(r.start, 3); // 1-based HGVS [3..12]
@@ -1722,5 +1813,153 @@ mod tests {
             alternative: Base::G,
         };
         assert_eq!(canonicalize_edit(&real_sub), real_sub);
+    }
+
+    // =========================================================================
+    // Codon-frame gate tests (#81 B1)
+    //
+    // HGVS spec (docs/recommendations/DNA/repeated.md, §Notes):
+    // > using a coding DNA reference sequence ("c." description) a Repeated
+    // > sequence variant description can be used only for repeat units with
+    // > a length which is a multiple of 3, i.e. which can not affect the
+    // > reading frame.
+    // =========================================================================
+
+    #[test]
+    fn test_insertion_to_repeat_codon_frame_gate_blocks_a_in_coding() {
+        // Reference: 5-A homopolymer flanked by Cs. Insert AA → would normally
+        // emit A[7], but unit_len=1 is not a multiple of 3 in c. context,
+        // so the gate returns None.
+        let ref_seq = b"CAAAAAC";
+        let result = insertion_to_repeat(ref_seq, 5, b"AA", true);
+        assert!(
+            result.is_none(),
+            "is_coding=true + unit_len=1 must return None"
+        );
+    }
+
+    #[test]
+    fn test_insertion_to_repeat_codon_frame_gate_blocks_at_in_coding() {
+        // Reference: AT[3] tandem flanked by Cs. Insert ATAT → unit_len=2,
+        // gate blocks in coding context.
+        let ref_seq = b"CATATATC";
+        let result = insertion_to_repeat(ref_seq, 6, b"ATAT", true);
+        assert!(
+            result.is_none(),
+            "is_coding=true + unit_len=2 must return None"
+        );
+    }
+
+    #[test]
+    fn test_insertion_to_repeat_codon_frame_gate_passes_cag_in_coding() {
+        // Reference: CAG[3] tandem. Insert CAGCAG → unit_len=3, codon-aligned,
+        // gate passes; result is Some(...) carrying CAG[5].
+        let ref_seq = b"CCAGCAGCAGT";
+        let result = insertion_to_repeat(ref_seq, 9, b"CAGCAG", true);
+        assert!(
+            result.is_some(),
+            "is_coding=true + unit_len=3 must allow rewrite"
+        );
+        let (_first, count, _start, _end, unit) = result.unwrap();
+        assert_eq!(count, 5, "expected CAG[5]");
+        assert_eq!(unit, b"CAG");
+    }
+
+    #[test]
+    fn test_insertion_to_repeat_gate_no_op_in_genomic() {
+        // Same A-homopolymer case as the blocking test, but is_coding=false
+        // → gate is a no-op, repeat rewrite proceeds.
+        let ref_seq = b"CAAAAAC";
+        let result = insertion_to_repeat(ref_seq, 5, b"AA", false);
+        assert!(result.is_some(), "is_coding=false must not gate");
+    }
+
+    #[test]
+    fn test_deletion_to_repeat_codon_frame_gate_blocks_a_in_coding() {
+        // 5-A tract, delete 2 A's. Span 2..4 covers two of the As so that
+        // without the codon-frame gate the function would return Some(A[3]);
+        // with the gate (coding) it must return None. Span 2..3 would also
+        // return None via the unrelated `k < 2` early exit, so it would not
+        // discriminate the gate.
+        let ref_seq = b"CAAAAAC";
+        let result = deletion_to_repeat(ref_seq, 2, 4, true);
+        assert!(
+            result.is_none(),
+            "is_coding=true + unit_len=1 must return None"
+        );
+    }
+
+    #[test]
+    fn test_deletion_to_repeat_codon_frame_gate_passes_cag_in_coding() {
+        // ref "CCAGCAGCAGT": 3-CAG tract at indices 1..10. Delete 2 CAGs at
+        // [1..7) (6 bases CAGCAG). With codon-aligned unit, gate passes.
+        let ref_seq = b"CCAGCAGCAGT";
+        let result = deletion_to_repeat(ref_seq, 1, 7, true);
+        assert!(
+            result.is_some(),
+            "is_coding=true + unit_len=3 must allow rewrite"
+        );
+    }
+
+    #[test]
+    fn test_duplication_to_repeat_codon_frame_gate_routes_a_to_gated_insertion() {
+        // 4-A tract at indices 1..5 (0-based). Duplicate 2 A's at positions 1..3.
+        // Under the gate, structural conditions for repeat notation are met
+        // but unit_len=1 in c. is forbidden, so the result routes to a
+        // GatedInsertion that the caller renders as `ins<dup_seq>`.
+        let ref_seq = b"CAAAAC";
+        let result = duplication_to_repeat(ref_seq, 1, 3, true);
+        match result {
+            Some(DupToRepeatResult::GatedInsertion { sequence, .. }) => {
+                assert_eq!(sequence, b"AA", "sequence is the duplicated literal");
+            }
+            other => panic!("expected GatedInsertion, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_duplication_to_repeat_codon_frame_gate_passes_cag_in_coding() {
+        // 3-CAG tract. Duplicate 2 CAGs.
+        let ref_seq = b"CCAGCAGCAGT";
+        let result = duplication_to_repeat(ref_seq, 1, 7, true);
+        assert!(
+            result.is_some(),
+            "is_coding=true + unit_len=3 must allow rewrite"
+        );
+    }
+
+    #[test]
+    fn test_normalize_repeat_codon_frame_gate_routes_contraction_to_deletion() {
+        // 5-A tract, specified A[3] in coding → must NOT emit Repeat; emits Deletion.
+        let ref_seq = b"CAAAAAC";
+        let result = normalize_repeat(ref_seq, 1, b"A", 3, true);
+        match result {
+            RepeatNormResult::Deletion { .. } => {}
+            other => panic!("expected Deletion under gate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_repeat_codon_frame_gate_routes_expansion_to_insertion() {
+        // 5-A tract, specified A[8] in coding → must NOT emit Repeat; emits Insertion.
+        let ref_seq = b"CAAAAAC";
+        let result = normalize_repeat(ref_seq, 1, b"A", 8, true);
+        match result {
+            RepeatNormResult::Insertion { sequence, .. } => {
+                assert_eq!(sequence, b"AAA", "3 extra A's");
+            }
+            other => panic!("expected Insertion under gate, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_normalize_repeat_codon_frame_gate_passes_through_dup_branch() {
+        // 5-A tract, specified A[6] in coding → +1 copy = dup, gate doesn't change this.
+        let ref_seq = b"CAAAAAC";
+        let result = normalize_repeat(ref_seq, 1, b"A", 6, true);
+        match result {
+            RepeatNormResult::Duplication { .. } => {}
+            other => panic!("expected Duplication, got {:?}", other),
+        }
     }
 }

--- a/tests/common/synthetic.rs
+++ b/tests/common/synthetic.rs
@@ -32,6 +32,11 @@ pub struct SyntheticBuilder {
     inner: CoordSystem,
 }
 
+// Per-binary dead-code allowance: not every test binary that uses this
+// helper exercises every coord system (e.g., the B1 matrix has no r.
+// modules because r. is not in the spec's accepted reference types for
+// repeats), and clippy --tests evaluates each binary independently.
+#[allow(dead_code)]
 enum CoordSystem {
     Genomic {
         core: String,
@@ -95,6 +100,7 @@ impl SyntheticBuilder {
     /// Build an RNA provider with a transcript named `NR_TEST.1`. The
     /// transcript sequence should be lowercase RNA bases (a/c/g/u). The
     /// underlying genomic mapping is built from the DNA-equivalent.
+    #[allow(dead_code)] // not used by every test binary; see CoordSystem allow above
     pub fn rna(core: &str, strand: Strand) -> Self {
         Self {
             inner: CoordSystem::Rna {
@@ -204,6 +210,22 @@ impl SyntheticBuilder {
         }
         provider
     }
+}
+
+/// Substitute 1-based numeric positions into an HGVS template by index.
+///
+/// Replaces `{0}`, `{1}`, ... in `template` with `args[0]`, `args[1]`, ...
+/// Used by the c./n./r. matrix tests (cds, noncoding, rna) where the
+/// padding offset does NOT shift positions — the transcript itself is the
+/// reference, so positions are literal. The genomic matrix uses a
+/// per-module helper that adds `PAD_OFFSET` to each position.
+#[allow(dead_code)] // not used by every test binary; see CoordSystem allow above
+pub fn hgvs(template: &str, args: &[u64]) -> String {
+    let mut s = template.to_string();
+    for (i, p) in args.iter().enumerate() {
+        s = s.replace(&format!("{{{}}}", i), &p.to_string());
+    }
+    s
 }
 
 /// Normalize an HGVS variant string against a provider and return the

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -390,15 +390,14 @@ mod intronic_duplications {
     #[test]
     fn test_minus_strand_intronic_multi_base_dup() {
         // Transcript-view AAA tract at c.30+2..c.30+4 duplicated to
-        // AAAAAA. Spec-canonical form per the HGVS DNA repeat page is
-        // `c.30+2_30+4A[6]` — full-tract position, transcript-view
-        // unit, post-edit unit count. Issue #98 closed the
-        // minus-strand intronic ref-base orientation gap that had
-        // previously caused ferro to emit `T[6]` (the genomic-strand
-        // letter) instead of `A[6]`.
+        // AAAAAA. Per HGVS spec (repeated.md codon-frame exception): in c.
+        // context, repeat notation requires unit_len % 3 == 0. With unit_len=1
+        // the canonical form is `ins<literal>` at the 3' tract flanking
+        // position, not `A[6]`. Issue #98 ensured the minus-strand orientation
+        // produces transcript-view `A`s rather than genomic-view `T`s.
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4dup");
-        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4A[6]");
+        assert_eq!(result, "NM_MINUS.1:c.30+4_30+5insAAA");
     }
 }
 
@@ -484,6 +483,26 @@ mod boundary_spanning {
             result.is_ok() || result.is_err(),
             "Intron-exon boundary insertion should not panic"
         );
+    }
+
+    #[test]
+    fn test_minus_strand_boundary_spanning_delins_identity() {
+        // Minus-strand boundary-spanning delins discriminator:
+        // c.30 (last exonic base of exon 1, tx view) = T;
+        // c.30+1 (first intronic base in tx-3' direction, tx view) = C
+        // (RC of genomic 'G' at the high end of intron 1).
+        // Inserting "TC" therefore matches the tx-view reference and PR #78
+        // collapses it to identity.
+        //
+        // If `normalize_boundary_spanning_cds` failed to flip the genomic
+        // window into transcript view before calling the delins-identity
+        // rule, the rule would compare "TC" against the genomic-strand
+        // bytes (G,A) and the insertion would not collapse — the result
+        // would stay as `c.30_30+1delinsTC`. Asserting `c.30_30+1=` locks
+        // the strand-aware path.
+        let provider = make_provider_with_minus_strand();
+        let result = normalize(provider, "NM_MINUS.1:c.30_30+1delinsTC");
+        assert_eq!(result, "NM_MINUS.1:c.30_30+1=");
     }
 }
 

--- a/tests/del_shift_matrix.rs
+++ b/tests/del_shift_matrix.rs
@@ -201,12 +201,20 @@ mod cds_plus {
     }
 
     #[rstest]
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}A[3]", &[3u64, 7u64])]
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}A[2]", &[3u64, 6u64])]
+    // Case 1: 2 A's removed from 5-A homopolymer. unit_len=1; codon-frame
+    // gate forbids A[N] in c., so falls through to plain del at the
+    // canonical 3' end of the post-shift tract.
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}del", &[6u64, 7u64])]
+    // Case 2: 2 A's removed from 4-A homopolymer → del at 3' end.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}del", &[5u64, 6u64])]
+    // Case 3: 2 GCAs removed from 3-GCA tandem → GCA[1] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}del", &[3u64, 8u64], "c.{0}_{1}GCA[1]", &[3u64, 11u64])]
+    // Case 4: full tract removal → del.
     #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}del", &[3u64, 6u64])]
+    // Case 5: cyclic-rotation GCA tract (codon-aligned, gate passes).
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}del", &[4u64, 9u64], "c.{0}_{1}GCA[1]", &[3u64, 11u64])]
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}AT[3]", &[3u64, 12u64])]
+    // Case 6: AT periodicity. unit_len=2; gate forbids AT[N] in c. → plain del.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}del", &[9u64, 12u64])]
     fn multi_base_del_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -321,12 +329,20 @@ mod cds_minus {
     }
 
     #[rstest]
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}A[3]", &[3u64, 7u64])]
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}A[2]", &[3u64, 6u64])]
+    // Case 1: 2 A's removed from 5-A homopolymer. unit_len=1; codon-frame
+    // gate forbids A[N] in c., so falls through to plain del at the
+    // canonical 3' end of the post-shift tract.
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}del", &[6u64, 7u64])]
+    // Case 2: 2 A's removed from 4-A homopolymer → del at 3' end.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 4u64], "c.{0}_{1}del", &[5u64, 6u64])]
+    // Case 3: 2 GCAs removed from 3-GCA tandem → GCA[1] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}del", &[3u64, 8u64], "c.{0}_{1}GCA[1]", &[3u64, 11u64])]
+    // Case 4: full tract removal → del.
     #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}del", &[3u64, 6u64])]
+    // Case 5: cyclic-rotation GCA tract (codon-aligned, gate passes).
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}del", &[4u64, 9u64], "c.{0}_{1}GCA[1]", &[3u64, 11u64])]
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}AT[3]", &[3u64, 12u64])]
+    // Case 6: AT periodicity. unit_len=2; gate forbids AT[N] in c. → plain del.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}del", &[3u64, 6u64], "c.{0}_{1}del", &[9u64, 12u64])]
     fn multi_base_del_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/dup_shift_matrix.rs
+++ b/tests/dup_shift_matrix.rs
@@ -195,11 +195,18 @@ mod cds_plus {
     }
 
     #[rstest]
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}A[7]", &[3u64, 7u64])]
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}A[8]", &[3u64, 6u64])]
+    // Case 1: 2-A dup in 5-A homopolymer. unit_len=1; codon-frame gate forbids
+    // A[7] in c., so emits insAA at the 3' tract flanking position per spec
+    // (≥2 added unit copies → ins<literal>).
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}insAA", &[7u64, 8u64])]
+    // Case 2: 4-A dup in 4-A homopolymer (full tract dup) → insAAAA.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insAAAA", &[6u64, 7u64])]
+    // Case 3: 2 GCAs dup'd in 3-GCA tandem → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}dup", &[3u64, 8u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: cyclic GCA tract → GCA[5].
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}dup", &[4u64, 9u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}AT[7]", &[3u64, 12u64])]
+    // Case 5: AT periodicity. unit_len=2; gate forbids AT[7] in c. → insATAT.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insATAT", &[12u64, 13u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -312,11 +319,18 @@ mod cds_minus {
     }
 
     #[rstest]
-    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}A[7]", &[3u64, 7u64])]
-    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}A[8]", &[3u64, 6u64])]
+    // Case 1: 2-A dup in 5-A homopolymer. unit_len=1; codon-frame gate forbids
+    // A[7] in c., so emits insAA at the 3' tract flanking position per spec
+    // (≥2 added unit copies → ins<literal>).
+    #[case("ACAAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 4u64], "c.{0}_{1}insAA", &[7u64, 8u64])]
+    // Case 2: 4-A dup in 4-A homopolymer (full tract dup) → insAAAA.
+    #[case("ACAAAACGTACGTACGTAC", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insAAAA", &[6u64, 7u64])]
+    // Case 3: 2 GCAs dup'd in 3-GCA tandem → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}dup", &[3u64, 8u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    // Case 4: cyclic GCA tract → GCA[5].
     #[case("TTGCAGCAGCATTACGTACGT", "c.{0}_{1}dup", &[4u64, 9u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}AT[7]", &[3u64, 12u64])]
+    // Case 5: AT periodicity. unit_len=2; gate forbids AT[7] in c. → insATAT.
+    #[case("CCATATATATATCCACGTACGT", "c.{0}_{1}dup", &[3u64, 6u64], "c.{0}_{1}insATAT", &[12u64, 13u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/ins_repeat_b1_matrix.rs
+++ b/tests/ins_repeat_b1_matrix.rs
@@ -1,0 +1,228 @@
+//! B1: ins matching the adjacent repeat unit + c. codon-frame gate.
+//!
+//! Locks two HGVS spec rules across all coordinate systems:
+//!
+//! 1. 1 added copy of a unit = `dup`; ≥2 added copies = `[N]` repeat
+//!    notation (or, in c. with `unit_len % 3 != 0`, the spec's fallback
+//!    forms — see rule 2).
+//! 2. In c. context, repeat notation requires `unit_len % 3 == 0`
+//!    (codon-frame exception, `docs/recommendations/DNA/repeated.md`).
+//!    When the gate fires:
+//!      - contraction-with-survivors → plain `del`,
+//!      - 1-copy expansion → `dup` (always permitted),
+//!      - ≥2-copy expansion / dup → literal `ins<sequence>`.
+//!
+//! See spec at
+//! `docs/superpowers/specs/2026-05-05-b1-ins-repeat-unit-increment-design.md`.
+
+mod common;
+
+mod genomic {
+    use super::common::synthetic::{normalize_to_string, SyntheticBuilder, PAD_OFFSET};
+    use rstest::rstest;
+
+    /// 1-based HGVS position of the first base of the core region.
+    const C0: u64 = PAD_OFFSET + 1;
+
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::genomic(core).build()
+    }
+
+    fn hgvs(template: &str, args: &[u64]) -> String {
+        let mut s = template.to_string();
+        for (i, p) in args.iter().enumerate() {
+            s = s.replace(&format!("{{{}}}", i), &(C0 + p - 1).to_string());
+        }
+        s
+    }
+
+    #[rstest]
+    fn single_copy_ins_in_homopolymer_tract_emits_dup() {
+        // Core ACAAAACG: A-tract at core 3-6. insA at 2_3 → dup at the
+        // canonical 3' end (1 added copy = dup per spec).
+        let p = provider("ACAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_homopolymer_unit_emits_repeat_in_genomic() {
+        // Core ACAAAACG (4 A's). insAA at 2_3 → A[6] (gate is no-op in g.).
+        let p = provider("ACAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAA", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}A[6]", &[3, 6]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_dinucleotide_unit_emits_repeat_in_genomic() {
+        // Core CATATATC: 3 ATs at core 2-7. insATAT at 1_2 → AT[5].
+        let p = provider("CATATATC");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insATAT", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}AT[5]", &[2, 7]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_codon_unit_emits_repeat_in_genomic() {
+        // Core CCAGCAGCAGT: 3 CAGs at core 2-10. insCAGCAG at 1_2 → CAG[5].
+        let p = provider("CCAGCAGCAGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insCAGCAG", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}CAG[5]", &[2, 10]));
+    }
+
+    #[rstest]
+    fn single_copy_ins_into_single_ref_copy_emits_dup() {
+        // Core ACGTACGT. insAC at 4_5 → adjacent matches, single copy → dup.
+        let p = provider("ACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAC", &[4, 5]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}dup", &[5, 6]));
+    }
+}
+
+mod cds_plus {
+    use super::common::synthetic::{hgvs, normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Plus).build()
+    }
+
+    #[rstest]
+    fn single_copy_ins_in_homopolymer_tract_emits_dup() {
+        // 4-A tract; insA → dup at the canonical 3' end. 1 added copy is
+        // always `dup` per spec, regardless of coord system.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_homopolymer_unit_blocks_in_cds() {
+        // unit_len=1 in c. → codon-frame gate forbids A[N]. Caller emits
+        // ins literal at the 3' tract flanking position.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_dinucleotide_unit_blocks_in_cds() {
+        // unit_len=2 in c. → gate forbids AT[N]. Mirrors the spec's
+        // c.1741_1742insTATATATA example.
+        let p = provider("CATATATCACGTACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[7, 8]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_codon_unit_passes_in_cds() {
+        // unit_len=3, codon-aligned: gate is no-op, repeat notation fires.
+        let p = provider("CCAGCAGCAGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insCAGCAG", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}CAG[5]", &[2, 10]));
+    }
+
+    #[rstest]
+    fn round_trip_dup_form_and_repeat_form_in_cds() {
+        // Round-trip lock: dup-form and repeat-form of the same edit must
+        // canonicalize identically under the codon-frame gate. 4-A ref,
+        // c.3_4dup vs c.3_6A[6] both → `c.6_7insAA`.
+        let p1 = provider("ACAAAACGTACGTACGTAC");
+        let p2 = provider("ACAAAACGTACGTACGTAC");
+        let r1 = normalize_to_string(p1, &hgvs("NM_TEST.1:c.{0}_{1}dup", &[3, 4]));
+        let r2 = normalize_to_string(p2, &hgvs("NM_TEST.1:c.{0}_{1}A[6]", &[3, 6]));
+        assert_eq!(r1, r2, "dup-form and repeat-form must agree");
+        assert_eq!(r1, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+    }
+}
+
+mod cds_minus {
+    use super::common::synthetic::{hgvs, normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Minus).build()
+    }
+
+    #[rstest]
+    fn single_copy_ins_in_homopolymer_tract_emits_dup() {
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_homopolymer_unit_blocks_in_cds_minus() {
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAA", &[2, 3]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insAA", &[6, 7]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_dinucleotide_unit_blocks_in_cds_minus() {
+        // unit_len=2 in c. → gate forbids AT[N] regardless of strand.
+        // Mirrors cds_plus::multi_copy_ins_dinucleotide_unit_blocks_in_cds.
+        let p = provider("CATATATCACGTACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}insATAT", &[7, 8]));
+    }
+
+    #[rstest]
+    fn multi_copy_ins_codon_unit_passes_in_cds_minus() {
+        let p = provider("CCAGCAGCAGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insCAGCAG", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}CAG[5]", &[2, 10]));
+    }
+}
+
+mod noncoding_plus {
+    use super::common::synthetic::{hgvs, normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::noncoding(core, Strand::Plus).build()
+    }
+
+    #[rstest]
+    fn multi_copy_ins_homopolymer_unit_emits_repeat_in_noncoding() {
+        // n. is non-coding; codon-frame gate does not apply. A[N] permitted.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insAA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}A[6]", &[3, 6]));
+    }
+
+    #[rstest]
+    fn single_copy_ins_in_homopolymer_tract_emits_dup_in_noncoding() {
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[6]));
+    }
+}
+
+mod noncoding_minus {
+    use super::common::synthetic::{hgvs, normalize_to_string, SyntheticBuilder};
+    use ferro_hgvs::reference::transcript::Strand;
+    use rstest::rstest;
+
+    fn provider(core: &str) -> ferro_hgvs::MockProvider {
+        SyntheticBuilder::noncoding(core, Strand::Minus).build()
+    }
+
+    #[rstest]
+    fn multi_copy_ins_homopolymer_unit_emits_repeat_in_noncoding_minus() {
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insAA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}_{1}A[6]", &[3, 6]));
+    }
+
+    #[rstest]
+    fn single_copy_ins_in_homopolymer_tract_emits_dup_in_noncoding_minus() {
+        // Mirror of noncoding_plus single-copy case. 1 added copy is always
+        // `dup` per spec, regardless of coord system or strand.
+        let p = provider("ACAAAACGTACGTACGTAC");
+        let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}_{1}insA", &[2, 3]));
+        assert_eq!(result, hgvs("NR_TEST.1:n.{0}dup", &[6]));
+    }
+}

--- a/tests/ins_shift_matrix.rs
+++ b/tests/ins_shift_matrix.rs
@@ -233,14 +233,15 @@ mod cds_plus {
     }
 
     #[rstest]
-    // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
-    // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
-    // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
+    // Case 1: 2 A's added to AAA tract. unit_len=1; codon-frame gate forbids
+    // A[N] in c., emit insAA at the 3' tract flanking position per spec.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}insAA", &[5u64, 6u64])]
+    // Case 2: 4 A's added to AAA tract → insAAAA (gate blocks A[N], unit_len=1).
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}insAAAA", &[5u64, 6u64])]
+    // Case 3: 2 GCA units added → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    // Case 4: 2 AC units added → insACAC (gate blocks AC[N], unit_len=2).
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}insACAC", &[8u64, 9u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -361,14 +362,15 @@ mod cds_minus {
     }
 
     #[rstest]
-    // Case 1: 2 A's added to AAA tract → A[5]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}A[5]", &[3u64, 5u64])]
-    // Case 2: 4 A's added to AAA tract → A[7]. Tract: c.3..5.
-    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}A[7]", &[3u64, 5u64])]
-    // Case 3: 2 GCA units added → GCA[5]. Tract: c.3..11.
+    // Case 1: 2 A's added to AAA tract. unit_len=1; codon-frame gate forbids
+    // A[N] in c., emit insAA at the 3' tract flanking position per spec.
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAA", &[2u64, 3u64], "c.{0}_{1}insAA", &[5u64, 6u64])]
+    // Case 2: 4 A's added to AAA tract → insAAAA (gate blocks A[N], unit_len=1).
+    #[case("ACAAACGTACGTACGTACGT", "c.{0}_{1}insAAAA", &[2u64, 3u64], "c.{0}_{1}insAAAA", &[5u64, 6u64])]
+    // Case 3: 2 GCA units added → GCA[5] (codon-aligned, gate passes).
     #[case("ACGCAGCAGCATGACGTACG", "c.{0}_{1}insGCAGCA", &[2u64, 3u64], "c.{0}_{1}GCA[5]", &[3u64, 11u64])]
-    // Case 4: 2 AC units added to ACACAC tract → AC[5]. Tract: c.3..8.
-    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}AC[5]", &[3u64, 8u64])]
+    // Case 4: 2 AC units added → insACAC (gate blocks AC[N], unit_len=2).
+    #[case("GCACACACGTACGTACGTAC", "c.{0}_{1}insACAC", &[2u64, 3u64], "c.{0}_{1}insACAC", &[8u64, 9u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -427,29 +427,34 @@ mod output_tests {
     }
 
     #[test]
-    fn test_multi_base_deletion_in_homopolymer_becomes_repeat() {
-        // Per B2: delete 2 A's from an 8-A tract → A[6] at the canonical
-        // tract position (post-A5 behavior). ref_count=8, k=2, post=6.
+    fn test_multi_base_deletion_in_homopolymer_in_cds_stays_as_del() {
+        // Delete 2 A's from an 8-A tract in c. context. Per HGVS spec
+        // (repeated.md codon-frame exception), repeat notation requires
+        // unit_len % 3 == 0 in c.; unit_len=1 is gated, so the canonical
+        // form stays as plain `del` at the post-shift 3' position.
         //
-        // Sequence: GGGGGGGGGAAAAAAAAGGGGGGGGG. A-tract at positions 10-17
-        // (8 A's, 1-based).
+        // Sequence: GGGGGGGGGAAAAAAAAGGGGGGGGG. A-tract at positions 10-17.
         let seq = "GGGGGGGGGAAAAAAAAGGGGGGGGG";
         let provider = provider_with_transcript("NM_TEST.1", seq);
         let result = normalize_to_string(provider, "NM_TEST.1:c.10_11del");
-        assert_eq!(result, "NM_TEST.1:c.10_17A[6]");
+        assert_eq!(result, "NM_TEST.1:c.16_17del");
     }
 
     #[test]
-    fn test_b2_only_in_three_prime_mode() {
-        // B2 (`unit[N-k]` rewrite) is defined post-3'-shift. In FivePrime
-        // mode, the 5'-shifted deletion must not be re-anchored to the
-        // canonical 3' tract position; the result stays as a plain `del`
-        // at the 5'-most position.
+    fn test_direction_shift_under_codon_frame_gate() {
+        // In c. context with unit_len=1 the codon-frame gate (repeated.md)
+        // forbids `A[N]` repeat notation regardless of shuffle direction,
+        // so neither branch can rewrite to `unit[N-k]`. What this test
+        // locks is the direction-conditional shift behavior: ThreePrime
+        // shifts the deletion to the 3'-most position in the tract;
+        // FivePrime shifts to the 5'-most position. (For B2 in its native
+        // direction-conditional form — only firing in ThreePrime — see
+        // the matrix tests that use a codon-aligned unit.)
         //
         // Sequence: GGGGGGGGGAAAAAAAAGGGGGGGGG. 8-A tract at pos 10-17
         // (1-based). Input c.16_17del (last 2 A's of the tract):
-        //   - ThreePrime: B2 fires → c.10_17A[6]
-        //   - FivePrime:  shift to 5'-most position → c.10_11del
+        //   - ThreePrime: del shifted to canonical 3' end → c.16_17del.
+        //   - FivePrime:  shift to 5'-most position → c.10_11del.
         let seq = "GGGGGGGGGAAAAAAAAGGGGGGGGG";
 
         let provider = provider_with_transcript("NM_TEST.1", seq);
@@ -465,8 +470,8 @@ mod output_tests {
                 .expect("Normalization failed")
         );
         assert_eq!(
-            result_3p, "NM_TEST.1:c.10_17A[6]",
-            "ThreePrime mode should apply B2"
+            result_3p, "NM_TEST.1:c.16_17del",
+            "ThreePrime mode in c. with unit_len=1 must emit plain del per codon-frame gate"
         );
 
         let provider = provider_with_transcript("NM_TEST.1", seq);
@@ -482,7 +487,7 @@ mod output_tests {
         );
         assert_eq!(
             result_5p, "NM_TEST.1:c.10_11del",
-            "FivePrime mode must NOT apply B2 (no re-anchoring to canonical tract)"
+            "FivePrime mode shifts to 5'-most position"
         );
     }
 
@@ -575,6 +580,41 @@ mod output_tests {
         // ref[4]='A', ref[5]='T' → mismatch, no shift. Stays at c.5del.
         assert_eq!(result, "NM_TEST.1:c.5del");
     }
+
+    // =========================================================================
+    // CODON-FRAME GATE TESTS (B1) — c. context, repeated.md exception
+    // =========================================================================
+
+    #[test]
+    fn test_multi_insertion_in_homopolymer_codon_frame_blocks_repeat_in_cds() {
+        // Per HGVS spec (repeated.md codon-frame exception): in c. context,
+        // repeat notation requires unit_len % 3 == 0. unit_len=1 (A) is
+        // forbidden, so the canonical form stays as `ins<literal>`, not A[N].
+        let seq = "GGGGAAAAAAAGGGG"; // 7 A's
+        let provider = provider_with_transcript("NM_TEST.1", seq);
+        let result = normalize_to_string(provider, "NM_TEST.1:c.5_6insAA");
+        assert!(
+            result.contains("ins") && !result.contains("A["),
+            "c. + unit_len=1 must not emit A[N], got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_multi_dup_in_homopolymer_codon_frame_blocks_repeat_in_cds() {
+        // 2-base dup in 7-A tract: per spec the structurally-canonical form
+        // is repeat notation A[9], but the c. codon-frame exception forbids
+        // it (unit_len=1). Falls back to literal `ins<dup_seq>` per the
+        // GatedInsertion path in duplication_to_repeat.
+        let seq = "GGGGAAAAAAAGGGG"; // 7 A's at pos 5-11
+        let provider = provider_with_transcript("NM_TEST.1", seq);
+        let result = normalize_to_string(provider, "NM_TEST.1:c.5_6dup");
+        assert!(
+            result.contains("ins") && !result.contains("A["),
+            "c. + unit_len=1 dup must not emit A[N], got: {}",
+            result
+        );
+    }
 }
 
 // =============================================================================
@@ -622,42 +662,6 @@ mod expected_failures {
             .normalize(&variant)
             .expect("Normalization failed");
         format!("{}", normalized)
-    }
-
-    #[test]
-    fn test_multi_insertion_becomes_repeat_notation() {
-        // Mutalyzer: c.5067_5068insAA -> c.5067_5073A[9]
-        // When inserting multiple bases that extend an existing repeat,
-        // should convert to repeat notation
-        let seq = "GGGGAAAAAAAGGGG"; // 7 A's
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.5_6insAA");
-
-        // Should become repeat notation A[9] (7 original + 2 inserted)
-        assert!(
-            result.contains("[9]") || result.contains("A["),
-            "Multi-base insertion in repeat should become repeat notation, got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn test_multi_dup_becomes_repeat_notation() {
-        // Mutalyzer: c.5067_5068dup -> c.5067_5073A[9]
-        // When duplicating multiple bases in a repeat region,
-        // should convert to repeat notation
-        let seq = "GGGGAAAAAAAGGGG"; // 7 A's at pos 5-11
-        let provider = provider_with_transcript("NM_TEST.1", seq);
-
-        let result = normalize_to_string(provider, "NM_TEST.1:c.5_6dup");
-
-        // Should become repeat notation
-        assert!(
-            result.contains("["),
-            "Multi-base dup in repeat should become repeat notation, got: {}",
-            result
-        );
     }
 
     #[test]
@@ -884,13 +888,15 @@ mod mutalyzer_verified {
     }
 
     #[test]
-    fn test_single_base_repeat_to_repeat_decrement() {
-        // Per B2: input A[1] against 4-A ref → A[1] (k=3, post=1).
+    fn test_single_base_repeat_contraction_in_cds_routes_to_del() {
+        // Input A[1] against 4-A ref. In c. context with unit_len=1, the
+        // codon-frame gate forbids `[N]` repeat notation, so the contraction
+        // routes to a plain del of the surplus A's.
         let seq = "GGGAAAAGGG"; // 4 A's at positions 4-7
         let provider = provider_with_transcript("NM_TEST.1", seq, 1, seq.len() as u64);
 
         let result = normalize_to_string(provider, "NM_TEST.1:c.4A[1]");
-        assert_eq!(result, "NM_TEST.1:c.4_7A[1]");
+        assert_eq!(result, "NM_TEST.1:c.5_7del");
     }
 
     #[test]
@@ -1754,18 +1760,20 @@ mod normalization_transformations {
     // =========================================================================
 
     // Real-accession smoke; matrix-level coverage in tests/ins_shift_matrix.rs.
+    // Per HGVS spec (repeated.md codon-frame exception): in c. context,
+    // homopolymer expansions (unit_len=1) emit `ins<literal>`, not `[N]`.
     #[rstest]
-    // polyA expansion: inserting AAAA into A-tract becomes A[n] - Mutalyzer: agrees
-    #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.401_403A[7]")]
-    // polyT expansion - Mutalyzer: agrees
-    #[case("NM_000382.3:c.399_400insTTTT", "NM_000382.3:c.398_399T[6]")]
-    // polyG expansion - Mutalyzer: agrees
-    #[case("NM_015120.4:c.46_47insGGG", "NM_015120.4:c.45_46G[5]")]
+    // polyA expansion: inserting AAAA into A-tract → ins (not A[7]).
+    #[case("NM_001127687.1:c.400_401insAAAA", "NM_001127687.1:c.403_404insAAAA")]
+    // polyT expansion: inserting TTTT into T-tract → ins (not T[6]).
+    #[case("NM_000382.3:c.399_400insTTTT", "NM_000382.3:c.399_400insTTTT")]
+    // polyG expansion: inserting GGG into G-tract → ins (not G[5]).
+    #[case("NM_015120.4:c.46_47insGGG", "NM_015120.4:c.46_47insGGG")]
     fn test_insertion_becomes_repeat(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input);
         assert_eq!(
             result, expected,
-            "Insertion→repeat failed for '{}': got '{}', expected '{}'",
+            "Insertion→ins-literal failed for '{}': got '{}', expected '{}'",
             input, result, expected
         );
     }
@@ -1810,23 +1818,24 @@ mod normalization_transformations {
     }
 
     // =========================================================================
-    // DELETION → REPEAT NOTATION TESTS (B2; real RefSeq data)
-    // Multi-unit del of a real tandem reduces to unit[N-k] notation.
-    // Real-accession smoke; matrix-level coverage in tests/del_shift_matrix.rs.
-    // Note: these cases diverge from Mutalyzer (which doesn't apply B2).
+    // DELETION CANONICALIZATION (real RefSeq data; codon-frame gate)
+    // In c. context, the codon-frame gate (repeated.md) suppresses B2
+    // (`unit[N-k]` rewrite) when unit_len % 3 != 0, so multi-unit dels of
+    // non-codon-aligned tandems canonicalize to plain `del` rather than
+    // `unit[N-k]`. Real-accession smoke; matrix-level coverage in
+    // tests/del_shift_matrix.rs.
     // =========================================================================
 
     #[rstest]
-    // TP53 c.627-629 is an AAA tract; deleting 2 As (c.628_629del) leaves 1 A,
-    // emitted as A[1] per B2. (This case was previously locked as "no change"
-    // in test_no_change_verified — that lock was removed in the A5 PR since
-    // ferro now diverges from Mutalyzer here.)
-    #[case("NM_000546.6:c.628_629del", "NM_000546.6:c.627_629A[1]")]
+    // TP53 c.627-629 is an AAA tract; deleting 2 As (c.628_629del) leaves 1 A.
+    // In c. context with unit_len=1, the codon-frame gate (repeated.md) forbids
+    // A[1] repeat notation, so the canonical form is plain del.
+    #[case("NM_000546.6:c.628_629del", "NM_000546.6:c.628_629del")]
     fn test_deletion_becomes_repeat(#[case] input: &str, #[case] expected: &str) {
         let result = normalize_to_string(input);
         assert_eq!(
             result, expected,
-            "Deletion→repeat failed for '{}': got '{}', expected '{}'",
+            "Deletion→canonical-form failed for '{}': got '{}', expected '{}'",
             input, result, expected
         );
     }
@@ -2586,7 +2595,7 @@ mod repeat_position_tests {
         );
 
         // Test normalize_repeat - should return Unchanged
-        let result = normalize_repeat(ref_seq, 6, b"CA", 1);
+        let result = normalize_repeat(ref_seq, 6, b"CA", 1, false);
         assert!(
             matches!(result, RepeatNormResult::Unchanged),
             "Should return Unchanged when repeat unit not found at position. Got {:?}",
@@ -2610,7 +2619,7 @@ mod repeat_position_tests {
         );
 
         // normalize_repeat with count=1 should produce deletion
-        let result = normalize_repeat(ref_seq, 0, b"CA", 1);
+        let result = normalize_repeat(ref_seq, 0, b"CA", 1, false);
         match result {
             RepeatNormResult::Deletion { start, end } => {
                 // Should delete one copy (2 bases) from the 3' end
@@ -3197,47 +3206,47 @@ mod comprehensive_normalization_tests {
         use super::*;
 
         #[test]
-        fn test_single_a_insertion_into_a_tract_becomes_repeat() {
-            // Sequence: GGGAAAGGG (A's at positions 4-6)
-            // Inserting A extends tract from 3 to 4 A's
+        fn test_single_a_insertion_into_a_tract_becomes_dup() {
+            // Sequence: GGGAAAGGG (A's at positions 4-6).
+            // Per HGVS spec: 1 added copy of a unit = dup (never `[N]`).
+            // Plus the c. codon-frame exception explicitly forbids `A[4]`
+            // (unit_len=1, not a multiple of 3). So the only spec-compliant
+            // output here is `dup`.
             let seq = "GGGAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            // Inserting single A - may become dup or repeat depending on implementation
             let result = normalize_to_string(provider, "NM_TEST.1:c.4_5insA");
-            // Should be either A[4] repeat or dup
             assert!(
-                result.contains("A[4]") || result.contains("dup"),
-                "Expected repeat A[4] or dup, got: {}",
+                result.contains("dup"),
+                "Single-copy ins matching adjacent A must emit dup, got: {}",
                 result
             );
         }
 
         #[test]
-        fn test_multiple_a_insertion_into_tract_becomes_repeat() {
-            // Sequence: GGGAAAGGG (3 A's at positions 4-6)
-            // Inserting AAA extends tract from 3 to 6 A's
+        fn test_multiple_a_insertion_into_tract_in_cds_stays_as_ins() {
+            // Sequence: GGGAAAGGG (3 A's at positions 4-6).
+            // Per HGVS spec (repeated.md codon-frame exception): in c.
+            // context, repeat notation requires unit_len % 3 == 0. With
+            // unit_len=1 the canonical form is `ins<literal>`, not A[N].
             let seq = "GGGAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insAAA");
-            // Should become A[6] repeat notation
             assert!(
-                result.contains("A[6]"),
-                "Expected repeat A[6], got: {}",
+                result.contains("insAAA") && !result.contains("A["),
+                "c. + unit_len=1 must emit insAAA literal, got: {}",
                 result
             );
         }
 
         #[test]
-        fn test_t_insertion_in_t_tract() {
-            // Sequence: AAATTTAAA (T's at positions 4-6)
-            // Inserting TT extends tract from 3 to 5 T's
+        fn test_t_insertion_in_t_tract_in_cds_stays_as_ins() {
+            // Sequence: AAATTTAAA (T's at positions 4-6). c. + unit_len=1.
             let seq = "AAATTTAAA";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.6_7insTT");
-            // Should become T[5]
             assert!(
-                result.contains("T[5]"),
-                "Expected repeat T[5], got: {}",
+                result.contains("insTT") && !result.contains("T["),
+                "c. + unit_len=1 must emit insTT literal, got: {}",
                 result
             );
         }
@@ -3257,15 +3266,16 @@ mod comprehensive_normalization_tests {
         }
 
         #[test]
-        fn test_large_homopolymer_expansion() {
-            // Sequence: GGAAAAAGGG (5 A's at positions 3-7)
-            // Inserting 5 A's should become A[10]
+        fn test_large_homopolymer_expansion_in_cds_stays_as_ins() {
+            // Sequence: GGAAAAAGGG (5 A's at positions 3-7). Inserting 5 A's
+            // would normally produce A[10]; the c. codon-frame gate forbids
+            // A[N] (unit_len=1), so the canonical form is `ins<literal>`.
             let seq = "GGAAAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.7_8insAAAAA");
             assert!(
-                result.contains("A[10]"),
-                "Expected repeat A[10], got: {}",
+                result.contains("insAAAAA") && !result.contains("A["),
+                "c. + unit_len=1 must emit insAAAAA literal, got: {}",
                 result
             );
         }
@@ -3403,21 +3413,24 @@ mod comprehensive_normalization_tests {
         }
 
         #[test]
-        fn test_repeat_contraction_to_repeat_decrement_homopolymer() {
-            // Per B2: A[3] against 5-A ref → A[3] (k=2, post=3).
+        fn test_repeat_contraction_in_cds_homopolymer_routes_to_del() {
+            // 5-A ref, A[3] in c. context. unit_len=1 — codon-frame gate
+            // forbids A[N], routes the contraction-with-survivors branch to
+            // a plain deletion.
             let seq = "GGAAAAAGGG"; // 5 A's at positions 3-7
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.3A[3]");
-            assert_eq!(result, "NM_TEST.1:c.3_7A[3]");
+            assert_eq!(result, "NM_TEST.1:c.6_7del");
         }
 
         #[test]
-        fn test_repeat_contraction_to_repeat_decrement_multibase() {
-            // Per B2: CT[1] against 3-CT ref → CT[1] (k=2, post=1).
+        fn test_repeat_contraction_in_cds_multibase_routes_to_del() {
+            // 3-CT ref, CT[1] in c. context. unit_len=2 — codon-frame gate
+            // forbids CT[N], routes to plain del.
             let seq = "AACTCTCTAA"; // 3 CTs at positions 3-8
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.3_4CT[1]");
-            assert_eq!(result, "NM_TEST.1:c.3_8CT[1]");
+            assert_eq!(result, "NM_TEST.1:c.5_8del");
         }
 
         #[test]
@@ -3513,15 +3526,17 @@ mod comprehensive_normalization_tests {
         }
 
         #[test]
-        fn test_large_homopolymer_expansion_stays_repeat() {
-            // Sequence: GGAAAAAGGG (5 A's)
-            // A[20] = large expansion
+        fn test_large_homopolymer_expansion_in_cds_routes_to_ins() {
+            // Sequence: GGAAAAAGGG (5 A's). A[20] = +15 unit copies.
+            // Per HGVS spec (repeated.md codon-frame exception): repeat
+            // notation in c. requires unit_len % 3 == 0. unit_len=1 is gated;
+            // canonical form is `ins<literal>` of the added copies.
             let seq = "GGAAAAAGGG";
             let provider = provider_with_transcript("NM_TEST.1", seq);
             let result = normalize_to_string(provider, "NM_TEST.1:c.3A[20]");
             assert!(
-                result.contains("A[20]"),
-                "Large homopolymer expansion should stay as repeat, got: {}",
+                result.contains("ins") && !result.contains("A["),
+                "c. + unit_len=1 expansion must emit ins, got: {}",
                 result
             );
         }


### PR DESCRIPTION
## Summary

Closes item B1 of #81 and fixes a related production bug surfaced while reviewing the spec: ferro could emit `c.X_YA[N]`, `c.X_YAT[N]`, etc. for non-codon-aligned units, violating the codon-frame exception in [`docs/recommendations/DNA/repeated.md`](https://hgvs-nomenclature.org/stable/recommendations/DNA/repeated/):

> using a coding DNA reference sequence ("c." description) a Repeated sequence variant description can be used **only for repeat units with a length which is a multiple of 3**, i.e. which can not affect the reading frame. Consequently, use `NM_024312.4:c.2692_2693dup` and **not** `NM_024312.4:c.2686A[10]`, use `NM_024312.4:c.1741_1742insTATATATA` and **not** `NM_024312.4:c.1738TA[6]`.

In `c.` context with `unit_len % 3 != 0`, repeat notation is suppressed and the variant retains its spec-canonical alternative form: `dup` for 1 added copy, `ins<literal>` for ≥2 added copies, plain `del` for contractions of ≥2 unit copies.

## What changed

**Rule layer (`src/normalize/rules.rs`)**

- `insertion_to_repeat`, `deletion_to_repeat`, `duplication_to_repeat`, and `normalize_repeat` gain `is_coding: bool`. When the gate fires, each function refuses to emit repeat-notation output.
- New `RepeatNormResult::Insertion { start, end, sequence }` variant — `normalize_repeat` routes a ≥2-copy expansion to literal `ins` form rather than `[N]` (mirroring the spec example `c.1741_1742insTATATATA`).
- New `DupToRepeatResult::GatedInsertion { start, end, sequence }` variant — `duplication_to_repeat` routes a multi-unit-copy dup to literal `ins` form when the gate fires (e.g., `c.5_6dupAA` → `c.6_7insAA`).

**Dispatcher (`src/normalize/mod.rs`)**

- `normalize_na_edit` gains `is_coding: bool`. Each per-coord-system dispatcher passes the correct value: `normalize_cds`, `normalize_intronic_cds`, and `normalize_boundary_spanning_cds` pass `true`; `normalize_genome`, `normalize_tx`, `normalize_intronic_tx`, `normalize_rna` pass `false`.
- The ins→dup fallback path is also gated: a multi-unit-copy ins of a non-codon-aligned unit in `c.` no longer collapses to `dup` (which would be incorrect per spec); it stays as literal `ins`.

**Test coverage**

- `tests/ins_repeat_b1_matrix.rs` (new): 5 coord-system × strand modules × 16 cases, mirroring `tests/del_shift_matrix.rs` structure. Locks the two spec rules across genomic, cds (plus/minus), and noncoding (plus/minus).
- `tests/{del,dup,ins}_shift_matrix.rs`: `cds_plus`/`cds_minus` modules updated. A/AT/AC tract cases (`unit_len ∈ {1, 2}`) now assert plain `del`/`dup`/`ins<literal>`. Codon-aligned GCA cases and all genomic/non-coding modules unchanged.
- `tests/dup_shift_matrix.rs` round-trip equivalence for `c.` is now locked: dup-form and repeat-form inputs canonicalize identically under the gate.
- `tests/normalize_tests.rs`: ~15 weak/spec-violating assertions tightened. Real-RefSeq smoke tests (TP53, CFTR, FMR1) updated likewise.
- `src/normalize/rules.rs` co-located unit tests: 11 new gate tests covering all four rule functions across coding / non-coding / codon-aligned / non-codon-aligned scenarios.

## Test plan

- [x] `cargo nextest run --features dev` — 3439 tests run, 3439 passed, 51 skipped
- [x] `cargo clippy --features dev --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green