### PR TITLE
fix(normalize): degenerate substitution (ref==alt) -> identity (#81 A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(normalize)* rewrite degenerate substitutions (ref == alt, e.g. `c.100A>A`) to identity (`=`) per HGVS v21 spec, which marks `c.X>X` as "not allowed" (`docs/recommendations/DNA/other.md`). The rule is purely syntactic on the edit's stated bases, so it fires in both the full-normalization path and the no-reference canonicalization path — `c.123C>C` rewrites to `c.123=` regardless of provider availability. ([#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) A4)
+
 ## [0.4.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.4.0...v0.4.1) - 2026-05-04
 
 ### Added

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1443,6 +1443,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
             });
         }
 
+        // Substitution with ref == alt is identity (e.g. c.100A>A → c.100=).
+        // This is the SNV companion to the same-base delins → identity rule;
+        // the rewrite is purely syntactic on the edit's stated bases, so it
+        // applies across coordinate systems and runs before shuffling.
+        if let NaEdit::Substitution {
+            reference,
+            alternative,
+        } = edit
+        {
+            if reference == alternative {
+                return Ok((start, end, NaEdit::position_identity(), warnings));
+            }
+        }
+
         // Get the alternate sequence for the edit
         let alt_seq = match edit {
             NaEdit::Deletion { .. } => vec![],
@@ -2347,6 +2361,58 @@ mod tests {
         let variant = parse_hgvs("NM_000088.3:c.1_3delinsACG").unwrap();
         let result = normalizer.normalize(&variant).unwrap();
         assert_eq!(format!("{}", result), "NM_000088.3:c.1_3delinsACG");
+    }
+
+    #[test]
+    fn test_normalize_substitution_ref_equals_alt_becomes_identity() {
+        // Per HGVS, a substitution where the reference and alternative bases
+        // are identical produces no change and must be expressed using
+        // identity notation (`=`). SNV companion to the same-base delins rule.
+        // Transcript NM_000088.3 starts ATGCCCAAGG...; position 10 is G.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10G>G").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10=");
+    }
+
+    #[test]
+    fn test_normalize_substitution_ref_equals_alt_first_position() {
+        // Boundary check: the rule must fire at position 1 (first base).
+        // Transcript NM_000088.3 starts ATG...; position 1 is A.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.1A>A").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.1=");
+    }
+
+    #[test]
+    fn test_normalize_substitution_ref_not_equal_alt_unchanged() {
+        // Regression guard: a real SNV must not be rewritten to identity.
+        // c.10G>T at position 10 (G) is a valid substitution.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10G>T").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10G>T");
+    }
+
+    #[test]
+    fn test_normalize_substitution_ref_equals_alt_without_provider_data() {
+        // The A4 rule is purely syntactic, so it must fire even when the
+        // provider has no transcript loaded — matching the spec's stance that
+        // `c.123C>C` is "not allowed" regardless of reference availability.
+        // Spec example: docs/recommendations/DNA/other.md (HGVS v21.0).
+        let provider = MockProvider::new(); // empty — no transcripts
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_004006.2:c.123C>C").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_004006.2:c.123=");
     }
 
     #[test]

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -22,13 +22,22 @@ use crate::hgvs::edit::NaEdit;
 
 /// Check if an edit type needs normalization
 pub fn needs_normalization(edit: &NaEdit) -> bool {
-    matches!(
+    if matches!(
         edit,
         NaEdit::Deletion { .. }
             | NaEdit::Insertion { .. }
             | NaEdit::Duplication { .. }
             | NaEdit::Delins { .. }
             | NaEdit::Repeat { .. }
+    ) {
+        return true;
+    }
+    // A substitution with ref == alt is degenerate and must be rewritten to
+    // identity (`=`); route it through normalization so the rule fires.
+    // Real substitutions (ref != alt) keep the fast no-op path.
+    matches!(
+        edit,
+        NaEdit::Substitution { reference, alternative } if reference == alternative
     )
 }
 
@@ -904,6 +913,16 @@ pub fn canonicalize_edit(edit: &NaEdit) -> NaEdit {
                 sequence: sequence.clone(),
             }
         }
+        // A4: a substitution where ref == alt (e.g. `c.100A>A`) is degenerate;
+        // the HGVS v21 spec calls the form "not allowed" (recommendations/DNA/
+        // other.md) and gives `c.100=` as the canonical alternative. The rule
+        // is purely syntactic on the edit's stated bases, so it lives here in
+        // the no-reference canonicalization path alongside the other minimal-
+        // notation rewrites — it must fire regardless of provider availability.
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } if reference == alternative => NaEdit::position_identity(),
         // Other edits pass through unchanged
         _ => edit.clone(),
     }
@@ -917,6 +936,13 @@ pub fn should_canonicalize(edit: &NaEdit) -> bool {
         NaEdit::Duplication {
             sequence, length, ..
         } => sequence.is_some() || length.is_some(),
+        // Companion to the A4 arm in `canonicalize_edit`: route degenerate
+        // substitutions through the no-reference canonicalize path so the
+        // rewrite fires even when the provider is empty.
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => reference == alternative,
         _ => false,
     }
 }
@@ -927,6 +953,8 @@ mod tests {
 
     #[test]
     fn test_needs_normalization() {
+        use crate::hgvs::edit::Base;
+
         assert!(needs_normalization(&NaEdit::Deletion {
             sequence: None,
             length: None,
@@ -939,6 +967,17 @@ mod tests {
         assert!(!needs_normalization(&NaEdit::Inversion {
             sequence: None,
             length: None,
+        }));
+        // Real substitutions stay on the no-op fast path.
+        assert!(!needs_normalization(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        }));
+        // Degenerate `A>A` substitutions must enter normalization so they
+        // can be rewritten to identity (`=`).
+        assert!(needs_normalization(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::A,
         }));
     }
 
@@ -1650,11 +1689,38 @@ mod tests {
             length: None
         }));
 
-        // Substitution shouldn't be canonicalized
+        // Real substitutions stay on the no-op fast path
         use crate::hgvs::edit::Base;
         assert!(!should_canonicalize(&NaEdit::Substitution {
             reference: Base::A,
             alternative: Base::G
         }));
+
+        // Degenerate `A>A` substitutions enter the no-reference canonicalize
+        // path so they can be rewritten to identity (`=`) even when the
+        // provider has no transcript / genomic sequence loaded.
+        assert!(should_canonicalize(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::A
+        }));
+    }
+
+    #[test]
+    fn test_canonicalize_edit_degenerate_substitution_to_identity() {
+        // A4: c.100A>A is "not allowed" per HGVS v21 spec; canonicalize to `=`.
+        use crate::hgvs::edit::Base;
+
+        let degenerate = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::A,
+        };
+        assert_eq!(canonicalize_edit(&degenerate), NaEdit::position_identity());
+
+        // Real SNVs pass through unchanged.
+        let real_sub = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        };
+        assert_eq!(canonicalize_edit(&real_sub), real_sub);
     }
 }

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -3110,8 +3110,8 @@
     {
       "input": "c.123C>C",
       "input_prefixed": "NM_004006.2:c.123C>C",
-      "current": "NM_004006.2:c.123C>C",
-      "spec_expected": "NM_004006.2:c.123C>C",
+      "current": "NM_004006.2:c.123=",
+      "spec_expected": "NM_004006.2:c.123=",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -1,3 +1,7 @@
 {
-  "by_input": {}
+  "by_input": {
+    "c.123C>C": {
+      "spec_expected": "NM_004006.2:c.123="
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Addresses tracking #81 item A4: substitution edits where `reference == alternative` (e.g. `c.100A>A`) now canonicalize to identity (`=`) per the HGVS v21 spec. The spec marks `c.X>X` as "not allowed" (`docs/recommendations/DNA/other.md`) and gives `c.123=` as the canonical alternative — so this is the spec-correct rewrite, and is the SNV companion to the same-base delins → identity rule already implemented for #75 / PR #78.

## Design

The rule is purely syntactic on the edit's stated bases, so it must fire regardless of coordinate system, strand, or provider availability. Two paths handle it:

- `normalize_na_edit` (full normalization with reference data): early return after reference validation, before shuffling. `needs_normalization` now returns `true` for the degenerate-sub case so this path is reached; real substitutions (`ref != alt`) keep the existing no-op fast path.
- `canonicalize_edit` / `should_canonicalize` (no-reference fallback): used by `canonicalize_*_variant` when the provider has no transcript / genomic sequence loaded. The rewrite fires even with an empty `MockProvider`.

This second path was added after rebasing on `main` and noticing that the new HGVS v21 spec fixture (PR #105) generates with `MockProvider::new()` — a path that bypasses `normalize_na_edit` entirely. Without the no-reference fallback, the spec fixture row for `c.123C>C` did not flip; with it, ferro now produces `c.123=` from any provider state.

## Tests

Unit tests in `src/normalize/rules.rs`:
- `test_needs_normalization` extended for both Substitution branches
- `test_should_canonicalize` extended for both Substitution branches
- `test_canonicalize_edit_degenerate_substitution_to_identity` (new)

Integration tests in `src/normalize/mod.rs`:
- `c.10G>G` (ref matches actual) → `c.10=` — full normalize path
- `c.1A>A` (position-1 boundary) → `c.1=`
- `c.10G>T` (real SNV) stays unchanged — regression guard
- `NM_004006.2:c.123C>C` with `MockProvider::new()` → `c.123=` — no-reference path

Spec fixture (`tests/fixtures/grammar/hgvs_spec_normalization.json`):
- `c.123C>C` row's `current` flips from `c.123C>C` to `c.123=`
- Override file pins `spec_expected: "NM_004006.2:c.123="` per the v21 spec text, classifying the row as `preserved` with no audit todo

## Test plan

- [x] `cargo nextest run --features dev` (3403 tests passed)
- [x] `cargo run --features dev --example generate_spec_fixture -- --check`
- [x] `cargo clippy --features dev -- -D warnings`
- [x] `cargo fmt --all -- --check`