### PR TITLE
fix(normalize): rewrite empty-insert delins as del (#81 A3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - *(normalize)* rewrite degenerate substitutions (ref == alt, e.g. `c.100A>A`) to identity (`=`) per HGVS v21 spec, which marks `c.X>X` as "not allowed" (`docs/recommendations/DNA/other.md`). The rule is purely syntactic on the edit's stated bases, so it fires in both the full-normalization path and the no-reference canonicalization path — `c.123C>C` rewrites to `c.123=` regardless of provider availability. ([#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) A4)
+- *(normalize)* rewrite a `delins` whose inserted sequence is empty as a deletion, per the HGVS spec requirement that an empty insert is semantically a deletion and must be rendered as `del`. The rewritten deletion is then 3'-shifted under the standard del rule. Issue [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item A3.
 
 ## [0.4.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.4.0...v0.4.1) - 2026-05-04
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1487,6 +1487,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
             NaEdit::Delins { sequence } => {
                 use crate::hgvs::edit::InsertedSequence;
 
+                // HGVS spec (issue #81 A3): a delins with an empty inserted
+                // sequence is semantically a deletion and must be rendered as
+                // `del`. Rewrite up-front so the result picks up del 3'-shift
+                // and validation in the Deletion arm.
+                if matches!(sequence, InsertedSequence::Empty) {
+                    let del = NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    };
+                    return self.normalize_na_edit(ref_seq, &del, start, end, boundaries);
+                }
+
                 // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
                 // but the edit-type priority (sub > del > inv > dup > ins) means
                 // we may need to rewrite it as a higher-priority form: identity
@@ -2325,6 +2337,33 @@ mod tests {
             "Multi-base delete delins must not become a substitution, got: {}",
             output
         );
+    }
+
+    #[test]
+    fn test_normalize_empty_insert_delins_becomes_deletion() {
+        // HGVS spec: a delins whose inserted sequence is empty is semantically
+        // a deletion and must be rendered as `del`. Issue #81 item A3.
+        // Transcript NM_000088.3 starts ATGCCCAAGG…; c.10delins (empty insert)
+        // is a deletion of position 10 → c.10del.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10delins").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.10del");
+    }
+
+    #[test]
+    fn test_normalize_empty_insert_multi_base_delins_becomes_deletion() {
+        // Multi-base form: c.10_11delins (deletes "GT" at positions 10-11,
+        // inserts nothing) → del, then the spec's 3'-rule shifts the deletion
+        // to c.11_12del because ref[10]=G == ref[12]=G. Issue #81 item A3.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10_11delins").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:c.11_12del");
     }
 
     #[test]

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -123,3 +123,18 @@ class TestNormalizeMergeConsecutive:
         assert "100G>A" in result
         assert "102C>T" in result
         assert ";" in result
+
+
+class TestNormalizeEmptyInsertDelinsToDel:
+    """Issue #81 item A3: a delins with an empty inserted sequence -> del."""
+
+    def test_single_position_empty_delins(self) -> None:
+        # NM_000088.3 c.10 = G; c.10delins is semantically a deletion of G.
+        result = ferro_hgvs.normalize("NM_000088.3:c.10delins")
+        assert result == "NM_000088.3:c.10del"
+
+    def test_multi_position_empty_delins_with_3prime_shift(self) -> None:
+        # NM_000088.3 c.10_11 = GT; rewriting to del then applying the spec's
+        # 3'-rule shifts to c.11_12 because ref[10]=G == ref[12]=G.
+        result = ferro_hgvs.normalize("NM_000088.3:c.10_11delins")
+        assert result == "NM_000088.3:c.11_12del"


### PR DESCRIPTION
## Summary

- A `delins` whose inserted sequence is empty is semantically a deletion and per the HGVS spec must be rendered as `del`. Today ferro round-trips `c.10delins` as `c.10delins`; this PR rewrites it to `c.10del`.
- The rewrite is added at the top of the `NaEdit::Delins` arm in `normalize_na_edit` and recurses through the `NaEdit::Deletion` path, so the result picks up the standard del 3'-shift and reference validation instead of the delins arm's no-shift policy.

## Why normalize-time, not parse-time

ferro's posture is *lenient at parse, canonical at normalize*. The spec mandate is on output form, not input rejection — sitting at the same layer as the existing `delins → identity / sub / dup` rewrites in this same arm. The check is `O(1)` (`InsertedSequence::Empty` match) and short-circuits before any reference reads or other rule probes.

## Spec / tracking

Addresses **issue #81 item A3** ("`delins` with empty inserted sequence must render as `del` (or be rejected at parse). Edge case; needs a confirming test.").

The HGVS v21.0 spec fixture added in #84 / PR #105 has zero rows whose `input` or `current` is a bare empty-`delins` — the spec doesn't list this as a canonical example — so coverage belongs in `tests/normalize_tests.rs` as a synthetic-input regression, exactly as #81's "How to use this issue" prescribes. Verified the fixture is byte-identical post-fix (`generate_spec_fixture --check` passes).

## Test plan

- [x] Rust: two new unit tests in `src/normalize/mod.rs` covering single-position (`c.10delins` → `c.10del`) and multi-position with 3'-shift (`c.10_11delins` → `c.11_12del`, since `ref[10]=G == ref[12]=G`)
- [x] Python: matching integration tests in `tests/python/test_core.py::TestNormalizeEmptyInsertDelinsToDel`
- [x] Red-green-revert: confirmed both Rust tests fail without the fix and pass with it
- [x] Full Rust test suite: 3400 tests pass
- [x] All Python tests (uv run poe check-tests): 121 passed
- [x] cargo fmt --all -- --check: clean
- [x] cargo clippy --features dev --lib --tests --examples -- -D warnings: clean
- [x] uv run poe check-lint / check-format / check-typing: clean
- [x] Spec fixture byte-identical: `generate_spec_fixture --check` passes