### PR TITLE
test(normalize): pin RNA path + edge cases for A9 substitution-after-trim

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2565,6 +2565,17 @@ mod tests {
         let variant = parse_hgvs("NM_000088.3:c.1_3delinsACG").unwrap();
         let result = normalizer.normalize(&variant).unwrap();
         assert_eq!(format!("{}", result), "NM_000088.3:c.2T>C");
+
+        // r. twin: same collapse on the RNA path. NM_000088.3 has cds_start = 1,
+        // so r.1_3 maps to the same ATG run and the residual is at r.2.
+        // The substitution edit Display lowercases the reference byte but does
+        // not map T -> u for r. variants synthesized by canonicalize_delins,
+        // so the locked form is `r.2t>c` rather than the spec-ideal `r.2u>c`.
+        // RNA U/T mapping for synthesized substitutions is a separate display-
+        // layer concern (see `NaEdit::Substitution` in src/hgvs/edit.rs).
+        let variant = parse_hgvs("NM_000088.3:r.1_3delinsacg").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+        assert_eq!(format!("{}", result), "NM_000088.3:r.2t>c");
     }
 
     #[test]

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1308,6 +1308,46 @@ mod tests {
             }
         ));
 
+        // Substitution after both-side trim leaving exactly 1 residual base.
+        // ref window NACGN[1..4] = ACG, ins = ATG. Prefix `A` and suffix `G`
+        // shared; trimmed range idx 2..3 (C) -> T. The both-ends control flow
+        // is distinct from the prefix-only and suffix-only paths above.
+        assert!(matches!(
+            canonicalize_delins(b"NACGN", 1, 4, b"ATG"),
+            DelinsCanonical::Substitution {
+                position: 2,
+                reference: Base::C,
+                alternative: Base::T,
+            }
+        ));
+
+        // Mutalyzer A9 canonical example. ref window NGTAN[1..4] = GTA, ins = GTT.
+        // Greedy prefix `GT` matches; the residual A>T lands at the last
+        // position of the input window (the 3'-most index when no suffix
+        // shares). This is the byte-level analogue of the original report's
+        // `c.5948_5950delinsGTT over GTA -> c.5950A>T`.
+        assert!(matches!(
+            canonicalize_delins(b"NGTAN", 1, 4, b"GTT"),
+            DelinsCanonical::Substitution {
+                position: 3,
+                reference: Base::A,
+                alternative: Base::T,
+            }
+        ));
+
+        // Homopolymer residual: ref AAAA, ins AAAT. Multiple positions are
+        // semantically equivalent (any A could be the one that mutated to T);
+        // greedy prefix-trim consumes 3 As, locking the residual to the
+        // 3'-most position. This pins the tie-breaking convention.
+        assert!(matches!(
+            canonicalize_delins(b"AAAA", 0, 4, b"AAAT"),
+            DelinsCanonical::Substitution {
+                position: 3,
+                reference: Base::A,
+                alternative: Base::T,
+            }
+        ));
+
         // Pure deletion after both-side trim: ref ACGT (idx 0..4) -> AT.
         // Prefix A and suffix T shared; deleted CG remains at idx 1..3.
         assert!(matches!(


### PR DESCRIPTION
## Summary

#109 introduced the unified `canonicalize_delins` / `DelinsCanonical` pipeline. Its step 4c (substitution after shared-affix trimming) already implements the #81 A9 behavior, so no production-code change is required to satisfy A9. This PR is now purely additive test coverage on top of that pipeline.

## What changed

`src/normalize/mod.rs` — extend `test_normalize_delins_different_bases_becomes_substitution` with an r. twin so the RNA path through `canonicalize_delins` is pinned end-to-end, not just the c. path:

- `NM_000088.3:r.1_3delinsacg` → `NM_000088.3:r.2t>c`

The locked output is `r.2t>c`, not the spec-ideal `r.2u>c`. `NaEdit::Substitution`'s Display lowercases the reference byte but does not map T → u for r. variants synthesized inside the normalizer. This is a pre-existing display-layer behavior, not in scope here; the test comment cross-references `src/hgvs/edit.rs` for any follow-up.

`src/normalize/rules.rs` — add three byte-level asserts to `test_canonicalize_delins`. Existing cases cover prefix-only-trim and suffix-only-trim sub paths; these fill in the gaps:

1. Both-side trim leaving exactly 1 residual (`NACGN[1..4]` / `ATG` → C>T at idx 2). Distinct control flow from the prefix-only and suffix-only cases.
2. Mutalyzer A9 canonical example (`NGTAN[1..4]` / `GTT` → A>T at idx 3) — byte-level analogue of `c.5948_5950delinsGTT over GTA → c.5950A>T`.
3. Homopolymer residual greedy 3'-tie-breaking (`AAAA` / `AAAT` → A>T at idx 3). Multiple positions are semantically equivalent; pins greedy prefix-trim's tie-break to the 3'-most index.

## What was dropped

This branch originally added a standalone `delins_collapse_to_substitution` predicate plus a corresponding branch in the delins cascade in `mod.rs`. After rebasing onto main, both became redundant with #109's `canonicalize_delins`. Main's design is the more principled long-term solution — single-pass shared-affix trim, exhaustive enum dispatch, priority order encoded in one place — so this PR yields the implementation to main and keeps only the additive coverage above.

## Test plan

- [x] `cargo nextest run --features dev` (3537 passed)
- [x] `cargo clippy --features dev --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`