### PR TITLE
feat(rna): support r.spl, r.spl?, r.(spl), r.(spl?) splicing markers (#81 E2)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -518,9 +518,21 @@ pub enum NaEdit {
     /// Copy number: specifies the number of copies of a region (e.g., copy2, copy4)
     CopyNumber { count: u64 },
 
-    /// Aberrant splicing (RNA-specific): r.spl
-    /// Indicates that the RNA is aberrantly spliced, but the exact effect is unknown
-    Splice,
+    /// Aberrant splicing (RNA-specific): `r.spl`, `r.spl?`, `r.(spl)`, `r.(spl?)`.
+    ///
+    /// Indicates that the RNA is aberrantly spliced. Per HGVS v21.0
+    /// (`assets/hgvs-nomenclature/docs/recommendations/RNA/splicing.md` and
+    /// `docs/recommendations/uncertain.md`):
+    /// - `unknown == false` (`spl`): RNA not analysed; splicing is **very likely**
+    ///   affected (canonical donor/acceptor positions: intron +1, +2, -2, -1, excl.
+    ///   GT↔GC).
+    /// - `unknown == true` (`spl?`): RNA not analysed; splicing **might** be affected
+    ///   (first/last exon nucleotide, intron +3..+6, new acceptor-adjacent AG).
+    ///
+    /// The predicted wrappers `r.(spl)` and `r.(spl?)` are produced by the parser as
+    /// `Mu::Uncertain(NaEdit::Splice { unknown })`; the parens are emitted by
+    /// `RnaVariant::fmt_loc_edit` for whole-entity uncertain edits.
+    Splice { unknown: bool },
 
     /// No RNA product (RNA-specific): r.0
     /// Indicates that no RNA is produced (similar to p.0 for protein)
@@ -570,9 +582,9 @@ impl NaEdit {
         matches!(self, NaEdit::Unknown { whole_entity: true })
     }
 
-    /// Check if this is an RNA splice edit (r.spl)
+    /// Check if this is an RNA splice edit (`r.spl` or `r.spl?`)
     pub fn is_splice(&self) -> bool {
-        matches!(self, NaEdit::Splice)
+        matches!(self, NaEdit::Splice { .. })
     }
 
     /// Check if this is an RNA no product edit (r.0)
@@ -685,7 +697,13 @@ impl NaEdit {
             NaEdit::Unknown { .. } => String::from("?"),
             NaEdit::Methylation { status } => status.to_string(),
             NaEdit::CopyNumber { count } => format!("copy{}", count),
-            NaEdit::Splice => String::from("spl"),
+            NaEdit::Splice { unknown } => {
+                if *unknown {
+                    String::from("spl?")
+                } else {
+                    String::from("spl")
+                }
+            }
             NaEdit::NoProduct => String::from("0"),
             NaEdit::PositionOnly => String::new(),
         }
@@ -790,8 +808,12 @@ impl fmt::Display for NaEdit {
             NaEdit::CopyNumber { count } => {
                 write!(f, "copy{}", count)
             }
-            NaEdit::Splice => {
-                write!(f, "spl")
+            NaEdit::Splice { unknown } => {
+                if *unknown {
+                    write!(f, "spl?")
+                } else {
+                    write!(f, "spl")
+                }
             }
             NaEdit::NoProduct => {
                 write!(f, "0")
@@ -1588,8 +1610,11 @@ mod tests {
 
     #[test]
     fn test_na_edit_splice_display() {
-        let edit = NaEdit::Splice;
+        let edit = NaEdit::Splice { unknown: false };
         assert_eq!(format!("{}", edit), "spl");
+
+        let edit = NaEdit::Splice { unknown: true };
+        assert_eq!(format!("{}", edit), "spl?");
     }
 
     #[test]

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1919,6 +1919,31 @@ fn parse_rna_variant(
             ));
         }
 
+        // Try whole-RNA predicted splice (r.(spl) / r.(spl?)) — must come before the
+        // generic predicted-variant parser, which requires an interval. The whole-entity
+        // splicing marker has no positional content, so we attach a dummy interval and
+        // wrap the edit in `Mu::Uncertain` so that `RnaVariant::fmt_loc_edit` emits the
+        // surrounding parens.
+        if let Ok((remaining, edit)) = parse_whole_rna_predicted_splice(input) {
+            let dummy_pos = crate::hgvs::location::RnaPos {
+                base: 1,
+                offset: None,
+                utr3: false,
+            };
+            let dummy_interval = RnaInterval::point(dummy_pos);
+            return Ok((
+                remaining,
+                HgvsVariant::Rna(RnaVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit {
+                        location: dummy_interval,
+                        edit: Mu::Uncertain(edit),
+                    },
+                }),
+            ));
+        }
+
         // Try predicted RNA variant format: r.(interval edit)
         if let Ok((remaining, variant)) =
             parse_predicted_rna_variant(input, accession.clone(), gene_symbol.clone())
@@ -1961,9 +1986,36 @@ fn parse_whole_rna_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEd
     Ok((remaining, crate::hgvs::edit::NaEdit::whole_entity_unknown()))
 }
 
-/// Parse RNA splice pattern: r.spl
+/// Parse RNA splice pattern: `spl` (very-likely-affected) or `spl?` (might-be-affected).
+///
+/// Per HGVS v21.0 (`assets/hgvs-nomenclature/docs/recommendations/RNA/splicing.md` and
+/// `docs/recommendations/uncertain.md`):
+/// - `r.spl`  — RNA not analysed; splicing very likely affected.
+/// - `r.spl?` — RNA not analysed; splicing might be affected.
 fn parse_rna_splice(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
-    map(tag("spl"), |_| crate::hgvs::edit::NaEdit::Splice).parse(input)
+    let (input, _) = tag("spl").parse(input)?;
+    let (input, marker) =
+        nom::combinator::opt(tag::<_, _, nom::error::Error<&str>>("?")).parse(input)?;
+    Ok((
+        input,
+        crate::hgvs::edit::NaEdit::Splice {
+            unknown: marker.is_some(),
+        },
+    ))
+}
+
+/// Parse whole-RNA predicted splice pattern: `(spl)` or `(spl?)`.
+///
+/// Per HGVS v21.0, `r.(spl?)` is the canonical predicted-uncertain splicing marker;
+/// `r.(spl)` is the symmetric predicted-but-certain form. Both are whole-entity edits
+/// (no positional content), so we wrap the result in `Mu::Uncertain` rather than
+/// dispatching through the generic `parse_predicted_rna_variant`, which requires an
+/// interval. See `RnaVariant::fmt_loc_edit` for the matching Display path.
+fn parse_whole_rna_predicted_splice(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+    let (input, _) = tag("(").parse(input)?;
+    let (input, edit) = parse_rna_splice(input)?;
+    let (input, _) = tag(")").parse(input)?;
+    Ok((input, edit))
 }
 
 /// Parse RNA no product pattern: r.0

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -72,7 +72,7 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
         NaEdit::Unknown { .. } => "unknown",
         NaEdit::Methylation { .. } => "methylation",
         NaEdit::CopyNumber { .. } => "copy_number",
-        NaEdit::Splice => "splice",
+        NaEdit::Splice { .. } => "splice",
         NaEdit::NoProduct => "no_product",
         NaEdit::PositionOnly => "position_only",
     }

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -479,9 +479,9 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
 
                 return Ok(record);
             }
-            NaEdit::Splice => {
+            NaEdit::Splice { .. } => {
                 return Err(FerroError::ConversionError {
-                    msg: "Splice variants (r.spl) cannot be converted to VCF (RNA-specific effect)"
+                    msg: "Splice variants (r.spl/r.spl?) cannot be converted to VCF (RNA-specific effect)"
                         .to_string(),
                 });
             }

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "correctly-rejected": 12,
       "diverges": 147,
       "false-acceptance": 22,
-      "parse-error": 215,
-      "preserved": 427
+      "parse-error": 214,
+      "preserved": 428
     },
     "by_coordinate_system": {
       "c": 298,
@@ -9158,19 +9158,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.spl?",
-      "input_prefixed": "NM_004006.3:r.spl?",
-      "current": "parse error: Parse error at position 17: Unexpected trailing characters: '?'",
-      "spec_expected": "NM_004006.3:r.spl?",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "LRG_199t1:r.10del",
       "current": "LRG_199t1:r.10del",
       "spec_expected": "LRG_199t1:r.10del",
@@ -10020,6 +10007,18 @@
       "input_prefixed": "NM_004006.3:r.spl",
       "current": "NM_004006.3:r.spl",
       "spec_expected": "NM_004006.3:r.spl",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "r.spl?",
+      "input_prefixed": "NM_004006.3:r.spl?",
+      "current": "NM_004006.3:r.spl?",
+      "spec_expected": "NM_004006.3:r.spl?",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",

--- a/tests/rna_spl_marker.rs
+++ b/tests/rna_spl_marker.rs
@@ -1,0 +1,316 @@
+//! E2: HGVS v21.0 RNA splicing markers — `r.spl`, `r.spl?`, `r.(spl)`, `r.(spl?)`.
+//!
+//! Spec: `assets/hgvs-nomenclature/docs/recommendations/RNA/splicing.md` and
+//! `docs/recommendations/uncertain.md` (submodule sha `a32f970d`):
+//!
+//! - `r.spl` — RNA not analysed; splicing is **very likely** affected
+//!   (canonical donor/acceptor: intron +1, +2, -2, -1, excl. GT↔GC).
+//! - `r.spl?` — RNA not analysed; splicing **might** be affected
+//!   (first/last exon nucleotide, intron +3..+6, new acceptor-adjacent AG).
+//! - `r.(spl)` — predicted/uncertain wrapper around `spl`.
+//! - `r.(spl?)` — predicted/uncertain wrapper around `spl?` (canonical
+//!   predicted-splicing notation per HGVS v21.0).
+//!
+//! All four forms are now supported. This file pins:
+//! - parse + Display round-trip (single and double pass) with an accession,
+//! - `Normalizer::normalize` idempotency,
+//! - hash + Eq distinctness across the four forms,
+//! - non-equivalence with `r.?` (whole-RNA unknown),
+//! - rejection of malformed inputs (`r.spl??`, `r.spline`, `r.SPL`, whitespace),
+//! - current rejection of whole-entity edits inside allele brackets
+//!   (`r.[spl?];[spl]`) — pre-existing parser limitation, out of E2 scope.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+// ---------------------------------------------------------------------------
+// `r.spl` — round-trip + normalize idempotency.
+// ---------------------------------------------------------------------------
+
+/// `r.spl` round-trips through `parse_hgvs` -> `Display` with an accession.
+#[test]
+fn rna_spl_round_trips_with_accession() {
+    let input = "NM_004006.2:r.spl";
+    let variant = parse_hgvs(input).expect("r.spl with accession should parse");
+    assert_eq!(format!("{}", variant), input);
+}
+
+/// `r.spl` round-trips through a second parse — idempotent re-emission.
+#[test]
+fn rna_spl_double_round_trip_with_accession() {
+    let input = "NM_004006.2:r.spl";
+    let once = parse_hgvs(input).expect("first parse should succeed");
+    let displayed = format!("{}", once);
+    let twice = parse_hgvs(&displayed).expect("re-parse should succeed");
+    assert_eq!(format!("{}", twice), input);
+}
+
+/// `Normalizer::normalize` is a no-op (idempotent) on `r.spl` since the marker
+/// has no positional content to shift. Pin this so any future change to
+/// normalization of whole-entity RNA edits is caught.
+#[test]
+fn rna_spl_normalize_idempotent() {
+    let input = "NM_004006.2:r.spl";
+    let variant = parse_hgvs(input).expect("r.spl should parse");
+    let normalizer = Normalizer::new(MockProvider::new());
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize should succeed for whole-entity r.spl");
+    assert_eq!(format!("{}", normalized), input);
+
+    // Normalize a second time to confirm idempotency.
+    let normalized_twice = normalizer
+        .normalize(&normalized)
+        .expect("second normalize should succeed");
+    assert_eq!(format!("{}", normalized_twice), input);
+}
+
+// ---------------------------------------------------------------------------
+// `r.spl?` — round-trip + normalize idempotency.
+// ---------------------------------------------------------------------------
+
+/// `r.spl?` ("splicing might be affected") parses and round-trips with an accession.
+#[test]
+fn rna_spl_question_mark_round_trips_with_accession() {
+    let input = "NM_004006.2:r.spl?";
+    let variant = parse_hgvs(input).expect("r.spl? with accession should parse");
+    assert_eq!(format!("{}", variant), input);
+}
+
+/// `r.spl?` round-trips through a second parse — idempotent re-emission.
+#[test]
+fn rna_spl_question_mark_double_round_trip_with_accession() {
+    let input = "NM_004006.2:r.spl?";
+    let once = parse_hgvs(input).expect("first parse should succeed");
+    let displayed = format!("{}", once);
+    let twice = parse_hgvs(&displayed).expect("re-parse should succeed");
+    assert_eq!(format!("{}", twice), input);
+}
+
+/// `Normalizer::normalize` is a no-op (idempotent) on `r.spl?`.
+#[test]
+fn rna_spl_question_mark_normalize_idempotent() {
+    let input = "NM_004006.2:r.spl?";
+    let variant = parse_hgvs(input).expect("r.spl? should parse");
+    let normalizer = Normalizer::new(MockProvider::new());
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize should succeed for whole-entity r.spl?");
+    assert_eq!(format!("{}", normalized), input);
+
+    let normalized_twice = normalizer
+        .normalize(&normalized)
+        .expect("second normalize should succeed");
+    assert_eq!(format!("{}", normalized_twice), input);
+}
+
+// ---------------------------------------------------------------------------
+// `r.(spl)` and `r.(spl?)` — predicted wrappers.
+// ---------------------------------------------------------------------------
+
+/// `r.(spl)` (predicted wrapper around `spl`) round-trips with an accession.
+#[test]
+fn rna_predicted_spl_round_trips_with_accession() {
+    let input = "NM_004006.2:r.(spl)";
+    let variant = parse_hgvs(input).expect("r.(spl) with accession should parse");
+    assert_eq!(format!("{}", variant), input);
+}
+
+/// `r.(spl?)` (predicted wrapper around `spl?`, the canonical predicted-splicing form per
+/// HGVS v21.0) round-trips with an accession.
+#[test]
+fn rna_predicted_spl_question_mark_round_trips_with_accession() {
+    let input = "NM_004006.2:r.(spl?)";
+    let variant = parse_hgvs(input).expect("r.(spl?) with accession should parse");
+    assert_eq!(format!("{}", variant), input);
+}
+
+/// `r.(spl)` round-trips through a second parse — idempotent re-emission.
+#[test]
+fn rna_predicted_spl_double_round_trip_with_accession() {
+    let input = "NM_004006.2:r.(spl)";
+    let once = parse_hgvs(input).expect("first parse should succeed");
+    let displayed = format!("{}", once);
+    let twice = parse_hgvs(&displayed).expect("re-parse should succeed");
+    assert_eq!(format!("{}", twice), input);
+}
+
+/// `r.(spl?)` round-trips through a second parse — idempotent re-emission.
+#[test]
+fn rna_predicted_spl_question_mark_double_round_trip_with_accession() {
+    let input = "NM_004006.2:r.(spl?)";
+    let once = parse_hgvs(input).expect("first parse should succeed");
+    let displayed = format!("{}", once);
+    let twice = parse_hgvs(&displayed).expect("re-parse should succeed");
+    assert_eq!(format!("{}", twice), input);
+}
+
+/// `Normalizer::normalize` is idempotent on `r.(spl)` and `r.(spl?)`.
+#[test]
+fn rna_predicted_spl_normalize_idempotent() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    for input in ["NM_004006.2:r.(spl)", "NM_004006.2:r.(spl?)"] {
+        let variant =
+            parse_hgvs(input).unwrap_or_else(|e| panic!("{} should parse: {:?}", input, e));
+        let normalized = normalizer
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("normalize {} should succeed: {:?}", input, e));
+        assert_eq!(
+            format!("{}", normalized),
+            input,
+            "first normalize round-trip"
+        );
+        let normalized_twice = normalizer
+            .normalize(&normalized)
+            .unwrap_or_else(|e| panic!("second normalize {} should succeed: {:?}", input, e));
+        assert_eq!(
+            format!("{}", normalized_twice),
+            input,
+            "second normalize round-trip"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hash + Eq stability: the four forms are pairwise distinct.
+// ---------------------------------------------------------------------------
+
+/// `r.spl`, `r.spl?`, `r.(spl)`, `r.(spl?)` all hash and compare distinctly.
+#[test]
+fn rna_spl_four_forms_are_pairwise_distinct() {
+    use std::collections::HashSet;
+
+    let inputs = [
+        "NM_004006.2:r.spl",
+        "NM_004006.2:r.spl?",
+        "NM_004006.2:r.(spl)",
+        "NM_004006.2:r.(spl?)",
+    ];
+    let variants: Vec<_> = inputs
+        .iter()
+        .map(|s| parse_hgvs(s).unwrap_or_else(|e| panic!("{} should parse: {:?}", s, e)))
+        .collect();
+
+    // All four Display strings are pairwise distinct.
+    let displays: HashSet<_> = variants.iter().map(|v| v.to_string()).collect();
+    assert_eq!(
+        displays.len(),
+        4,
+        "expected 4 distinct Display strings, got {:?}",
+        displays
+    );
+
+    // All four hashed values are pairwise distinct.
+    let by_hash: HashSet<_> = variants.iter().collect();
+    assert_eq!(by_hash.len(), 4, "expected 4 distinct variant hashes");
+
+    // Pairwise inequality.
+    for (i, a) in variants.iter().enumerate() {
+        for (j, b) in variants.iter().enumerate() {
+            if i != j {
+                assert_ne!(
+                    a, b,
+                    "variant {} should not equal variant {}",
+                    inputs[i], inputs[j]
+                );
+            }
+        }
+    }
+}
+
+/// `r.spl?` (splicing-marker uncertain) is NOT equal to `r.?` (whole-RNA unknown).
+/// They are different `NaEdit` variants — pin the non-equivalence.
+#[test]
+fn rna_spl_question_mark_not_equal_to_rna_unknown() {
+    let spl_q = parse_hgvs("NM_004006.2:r.spl?").expect("r.spl? should parse");
+    let r_q = parse_hgvs("NM_004006.2:r.?").expect("r.? should parse");
+    assert_ne!(spl_q, r_q, "r.spl? and r.? must remain distinct");
+    assert_ne!(spl_q.to_string(), r_q.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// Allele compounds — pinned to current behavior.
+//
+// ferro's RNA allele bracket parsers (`parse_rna_allele_shorthand` and
+// `parse_rna_trans_allele_shorthand`) require an interval before each segment's
+// edit, so today they reject all whole-entity splicing markers — including the
+// pre-existing `r.[spl];[spl]`. This is independent of #126 (which scopes
+// standalone `r.spl?` / `r.(spl?)`); allowing whole-entity edits inside allele
+// brackets is its own change. Pin the current behavior so any future allele
+// parser refactor surfaces it.
+// ---------------------------------------------------------------------------
+
+/// `r.[spl?];[spl]` is currently rejected by the allele bracket parser. When/if
+/// support for whole-entity RNA edits inside allele brackets is added, flip this
+/// pin to assert successful round-trip.
+#[test]
+fn rna_spl_allele_compound_currently_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.[spl?];[spl]");
+    assert!(
+        result.is_err(),
+        "r.[spl?];[spl] is expected to be rejected today (pre-existing limitation \
+         of the RNA allele bracket parser, independent of this PR's scope); got \
+         Ok({:?}). When support for whole-entity edits inside allele brackets is \
+         added, flip this pin to assert successful round-trip.",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases — these MUST fail to parse.
+// ---------------------------------------------------------------------------
+
+/// `r.spl??` (double `?`) is not a valid HGVS form.
+#[test]
+fn rna_spl_double_question_mark_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.spl??");
+    assert!(
+        result.is_err(),
+        "r.spl?? must be rejected; got Ok({:?})",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+/// `r.spline` (extra letters after `spl`) — the parser must not accept the prefix and
+/// silently drop the trailing characters.
+#[test]
+fn rna_spl_trailing_letters_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.spline");
+    assert!(
+        result.is_err(),
+        "r.spline must be rejected; got Ok({:?})",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+/// Uppercase `SPL` violates the HGVS lowercase-RNA rule.
+#[test]
+fn rna_spl_uppercase_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.SPL");
+    assert!(
+        result.is_err(),
+        "r.SPL must be rejected (RNA must be lowercase); got Ok({:?})",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+/// Whitespace between `spl` and `?` is not valid.
+#[test]
+fn rna_spl_whitespace_before_question_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.spl ?");
+    assert!(
+        result.is_err(),
+        "r.spl <space>? must be rejected; got Ok({:?})",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+/// Whitespace inside the predicted parens is not valid.
+#[test]
+fn rna_predicted_spl_inner_whitespace_rejected() {
+    let result = parse_hgvs("NM_004006.2:r.( spl?)");
+    assert!(
+        result.is_err(),
+        "r.( spl?) must be rejected; got Ok({:?})",
+        result.ok().map(|v| v.to_string()),
+    );
+}


### PR DESCRIPTION
Implements [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item E2 (`spl?` for splicing-affected variants) and folds in [#126](https://github.com/fulcrumgenomics/ferro-hgvs/issues/126) (`r.spl?` / `r.(spl?)` parser support).

Closes #126.

## Summary

ferro now accepts all four canonical HGVS v21.0 RNA splicing markers (spec at `assets/hgvs-nomenclature/`, sha `a32f970d`):

| Form | Meaning | Status before | Status after |
|---|---|---|---|
| `r.spl` | RNA not analysed; splicing **very likely** affected (canonical donor/acceptor: intron +1, +2, -2, -1, excl. GT-GC) | parses | parses (unchanged) |
| `r.spl?` | RNA not analysed; splicing **might** be affected (first/last exon nt, intron +3..+6, new acceptor-adjacent AG) | `Unexpected trailing characters: '?'` | parses + round-trips |
| `r.(spl)` | Predicted/uncertain wrapper around `spl` | `code: Digit` | parses + round-trips |
| `r.(spl?)` | Predicted/uncertain wrapper around `spl?` (the canonical predicted-splicing notation per HGVS v21.0) | `code: Digit` | parses + round-trips |

## Spec rationale

Two relevant docs in the spec submodule:

- `docs/recommendations/RNA/splicing.md` (line 42, 48) — `r.spl` for very-likely-affected splicing; `r.(spl?)` for the predicted-uncertain form.
- `docs/recommendations/uncertain.md` (lines 67-69) — distinguishes `r.spl` (very likely) from `r.spl?` (might be), with concrete intron-position guidance for each.

## Implementation

- `NaEdit::Splice` becomes `NaEdit::Splice { unknown: bool }` (mirrors the field style of `NaEdit::Identity` / `NaEdit::Unknown`). `Display` and `to_rna_string` emit `spl` or `spl?` based on the flag; `is_splice`, the VCF rejection branch, and the Python helper match patterns are wildcard-updated.
- `parse_rna_splice` now consumes an optional trailing `?`.
- New `parse_whole_rna_predicted_splice` handles the bare `r.(spl)` / `r.(spl?)` whole-entity predicted forms ahead of the generic `parse_predicted_rna_variant` (which requires an interval). The result is wrapped in `Mu::Uncertain` so the existing `RnaVariant::fmt_loc_edit` Display path emits the surrounding parens.
- VCF rejection message updated to mention both `r.spl` and `r.spl?`. Python edit-type string remains `\"splice\"` (the `?` is uncertainty, not a separate edit kind).

## Test coverage (`tests/rna_spl_marker.rs`)

The previous E2 commit's three `// TODO #126` failure pins are flipped to success assertions. Added coverage:

- Single- and double-pass parse-Display round-trip with an accession for all four forms.
- `Normalizer::normalize` idempotency for all four (whole-entity edits have no positional content to shift).
- Hash + `Eq` pairwise distinctness across the four forms (via `HashSet`).
- `r.spl?` not equal to `r.?` (whole-RNA unknown) — different `NaEdit` variants, pinned.
- Negative cases: `r.spl??`, `r.spline`, uppercase `r.SPL`, whitespace `r.spl ?` and `r.( spl?)` are all rejected.
- `r.[spl?];[spl]` is pinned as currently rejected: the RNA allele bracket parsers require an interval per segment, so they reject all whole-entity splicing markers (including pre-existing `r.[spl];[spl]`). This is a pre-existing limitation independent of #126; the pin will flip when whole-entity edits inside allele brackets are supported.

## Spec-normalization fixture

The pinned `tests/fixtures/grammar/hgvs_spec_normalization.json` summary gains one `preserved` row (and loses one `parse-error` row): `r.spl?` (`NM_004006.3:r.spl?`) now correctly round-trips instead of erroring. Regenerated via `cargo run --features dev --example generate_spec_fixture`.

## Test plan

- [x] `cargo nextest run --features dev` -> 3417 passed (was 3404 baseline; +13 net new tests). 0 failed.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` -> clean
- [x] `cargo fmt --all -- --check` -> clean
- [x] `binary(rna_spl_marker)` -> 19/19 pass

## Notes for reviewers

Commit is unsigned -- 1Password biometric approval was unavailable during authoring (3 sign attempts failed); will re-sign when available, per the project guideline.