### PR TITLE
docs(error-handling): audit error codes against HGVS spec sections (#81 L1)

### DIFF
--- a/docs/spec/error_code_audit.md
+++ b/docs/spec/error_code_audit.md
@@ -1,0 +1,197 @@
+# Error code audit against the HGVS spec
+
+This document maps every error and warning code defined in
+[`src/error_handling/registry.rs`](../../src/error_handling/registry.rs) to the
+section of the [HGVS nomenclature spec](https://hgvs-nomenclature.org/stable/)
+it enforces, and identifies spec-mandated rules for which no code currently
+exists.
+
+Audited against the vendored spec at
+[`assets/hgvs-nomenclature/`](../../assets/hgvs-nomenclature/) (version 21.0,
+submodule pinned to `a32f970`).
+
+The companion fixture [`tests/fixtures/error_code_audit.json`](../../tests/fixtures/error_code_audit.json)
+mirrors this table machine-readably; the test
+[`tests/error_code_audit.rs`](../../tests/error_code_audit.rs) asserts the
+fixture and the registry stay in sync (every registry code must appear in the
+fixture; every fixture code must exist in the registry) and that any W-row
+classified `Enforced` corresponds to an `ErrorType::<Variant>` reference
+emitted from a non-bookkeeping file under `src/`.
+
+Tracking issue: [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81)
+item **L1**. Follow-up gaps (codes the spec implies but ferro doesn't emit)
+are tracked in [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115)
+and the soft-validation issues
+[#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124),
+[#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125),
+[#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127),
+[#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128) under #81 L2.
+
+## Status legend
+
+- **Enforced** — the code reliably surfaces every input that violates the
+  cited spec rule; no known false negatives at the boundary the code claims.
+- **Partial** — the code surfaces a subset of inputs that violate the cited
+  rule (e.g., one syntactic form but not all), or surfaces them only in some
+  modes / coordinate systems. Concrete gap noted in the row.
+- **Registered** — the code is present in `src/error_handling/registry.rs`
+  and the `ErrorType` enum, but no preprocessor or parser site emits it. The
+  spec rule is unenforced at runtime under this code (some Registered rows
+  *are* enforced under a different code — e.g. `c.0A>G` is rejected as
+  `E1003 InvalidPosition`, not as `W4002 PositionZero`; that overlap is
+  noted in the row). Distinct from **Missing** because the code already
+  exists in the registry; only the emission wiring is absent.
+- **Missing** — the code is documented in the audit but does not exist in
+  the registry yet. (Currently no rows use this status; reserved for future
+  audits where the registry should grow.)
+- **Infra** — the code covers an infrastructure failure (I/O, JSON, missing
+  reference data) rather than a spec rule; included for completeness, no spec
+  section applies.
+
+## Error codes (E-prefix)
+
+| Code | Description | Spec section | Status |
+|------|-------------|--------------|--------|
+| E1001 | InvalidAccession — accession does not match a recognized RefSeq/Ensembl/LRG prefix | [background/refseq.md — Reference sequence accession formats](https://hgvs-nomenclature.org/stable/background/refseq/) (lines 45–57: NC\_, NT\_, NW\_, NG\_, NM\_, NR\_, NP\_, LRG\_) | Enforced |
+| E1002 | UnknownVariantType — coordinate-type prefix (g./c./n./r./p./m./o.) missing or invalid | [background/refseq.md — Sequence types and prefixes](https://hgvs-nomenclature.org/stable/background/refseq/) (lines 64, 81–141: c., g., m., n., o., p., r.); [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) (lines 20–28) | Enforced |
+| E1003 | InvalidPosition — position is not a valid integer / offset position | [background/numbering.md — Position numbering](https://hgvs-nomenclature.org/stable/background/numbering/) (lines 16–28: c. numbering rules); [recommendations/DNA/](https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/) | Enforced |
+| E1004 | InvalidEdit — edit type or format is invalid | [recommendations/DNA/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/), [deletion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/), [insertion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/insertion/), [duplication.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/), [inversion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/inversion/), [delins.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/delins/) | Enforced |
+| E1005 | UnexpectedEnd — input ended before description was complete | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (full grammar rules) | Enforced |
+| E1006 | UnexpectedChar — invalid character at this parser position | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/); also catches retracted `c.IVS` notation per [background/numbering.md](https://hgvs-nomenclature.org/stable/background/numbering/) line 32 | Partial — generic `UnexpectedChar` is also raised for the retracted `c.IVS` notation, which the spec calls out specifically as "should not be used"; a dedicated code with an actionable hint is filed in [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 2 |
+| E1007 | InvalidBase — invalid nucleotide base (must be A/C/G/T/U or IUPAC code) | [background/standards.md — Nucleotide standards](https://hgvs-nomenclature.org/stable/background/standards/) (line 15: NC-IUB / IUBMB nucleotide codes) | Enforced |
+| E1008 | InvalidAminoAcid — invalid amino acid (must be valid 1- or 3-letter IUPAC code) | [background/standards.md — Amino Acid Descriptions](https://hgvs-nomenclature.org/stable/background/standards/) (lines 210–214: IUPAC-IUB amino acid table) | Enforced |
+| E2001 | ReferenceNotFound — accession not present in loaded reference data | n/a (infrastructure: depends on which reference set is loaded) | Infra |
+| E2002 | SequenceNotFound — sequence data unavailable for accession with metadata | n/a (infrastructure) | Infra |
+| E2003 | ChromosomeNotFound — chromosome / contig not in reference | n/a (infrastructure) | Infra |
+| E3001 | PositionOutOfBounds — position beyond the length of the reference sequence | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 15: "the reference sequence used must contain the residue(s) described to be changed" | Enforced |
+| E3002 | ReferenceMismatch — stated reference base does not match the actual reference | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 15 (residues must exist as described); [recommendations/DNA/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/) (substitution semantics) | Enforced |
+| E3003 | InvalidRange — start > end or otherwise invalid coordinate range | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 65: "`_` (underscore) is used to indicate a range" (range semantics imply start ≤ end) | Enforced |
+| E3004 | ExonIntronBoundary — variant spans an exon/intron junction | [background/numbering.md — Coding DNA numbering](https://hgvs-nomenclature.org/stable/background/numbering/) (lines 21–28: intronic offsets are reckoned per-side); [recommendations/DNA/deletion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/) (boundary cases) | Enforced |
+| E3005 | UtrCdsBoundary — variant spans the UTR/CDS boundary | [background/numbering.md](https://hgvs-nomenclature.org/stable/background/numbering/) (UTR uses `-`/`*` markers, CDS uses bare integers; boundary requires special handling) | Enforced |
+| E4001 | IntronicVariant — intronic variant cannot be normalized without genomic context | [background/numbering.md](https://hgvs-nomenclature.org/stable/background/numbering/) line 28: "a coding DNA reference sequence does not contain intron … sequences and can therefore not be used as a reference to describe variants in these regions"; [background/refseq.md](https://hgvs-nomenclature.org/stable/background/refseq/) (RNA/cDNA refs do not carry intronic sequence) | Enforced |
+| E4002 | UnsupportedVariant — variant type not supported for this operation | n/a (implementation limit; surfaces incomplete coverage rather than a spec rule) | Infra |
+| E5001 | ConversionFailed — coordinate conversion between reference systems failed | [background/refseq.md](https://hgvs-nomenclature.org/stable/background/refseq/) (cross-reference c./g./n./p. relations) | Enforced |
+| E5002 | NoOverlappingTranscript — no transcript overlaps the genomic position | n/a (infrastructure: depends on transcript set loaded) | Infra |
+| E9001 | IoError — file I/O failure | n/a (infrastructure) | Infra |
+| E9002 | JsonError — JSON parse failure | n/a (infrastructure) | Infra |
+
+## Warning codes (W-prefix)
+
+| Code | Description | Spec section | Status |
+|------|-------------|--------------|--------|
+| W1001 | LowercaseAminoAcid — `val` instead of `Val` | [recommendations/protein/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/protein/substitution/); [background/standards.md](https://hgvs-nomenclature.org/stable/background/standards/) (3-letter code preferred); [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) lines 41–43 | Registered — `correct_amino_acid_case` in `corrections.rs` returns this `ErrorType` but the preprocessor never invokes it; `NP_003997.1:p.val600glu` is auto-normalized in lenient mode with an empty corrections list. Tracked in [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124) (#81 L2 SVA-001) |
+| W1002 | SingleLetterAminoAcid — `V600E` instead of `Val600Glu` | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) lines 41–43: "three-letter amino acid code is preferred"; [recommendations/protein/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/protein/substitution/) | Registered — `NP_003997.1:p.V600E` is auto-expanded to `p.Val600Glu` in lenient mode with no W1002 in the corrections list. Tracked in [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124) (#81 L2 SVA-002) |
+| W1003 | LowercaseAccessionPrefix — `nm_000088.3` instead of `NM_000088.3` | [background/refseq.md](https://hgvs-nomenclature.org/stable/background/refseq/) lines 45–57 (accession prefixes shown in uppercase) | Enforced |
+| W1004 | MixedCaseEditType — `Del` / `INS` instead of `del` / `ins` | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) lines 87–104 (edit-type tokens shown in lowercase: `del`, `ins`, `dup`, `inv`, `delins`) | Registered — `correct_edit_type_case` in `corrections.rs` returns this `ErrorType` but no preprocessor phase calls it; `NM_000088.3:c.100Del` produces a generic parse error in lenient mode with no W1004 emission |
+| W2001 | WrongDashCharacter — en-dash / em-dash instead of ASCII `-` | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (ASCII grammar); [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 114 (minus sign semantics) | Enforced |
+| W2002 | WrongQuoteCharacter — smart quotes instead of ASCII `"` | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (ASCII grammar) | Partial — emitted by `correct_quote_characters` (preprocessor Phase 3), but standard HGVS does not use ASCII quotes inside any current production rule, so the catch-all parse failure shadows W2002 for most realistic inputs |
+| W2003 | ExtraWhitespace — extraneous spaces in expression | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (no whitespace in production rules) | Enforced |
+| W2004 | InvalidUnicodeCharacter — generic non-ASCII character | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (ASCII grammar) | Registered — real coverage of non-ASCII inputs is via W2001 (en/em-dash) and W2002 (smart quotes); the generic catch-all is registered but no preprocessor or parser site emits it on its own |
+| W3001 | MissingVersion — accession without `.N` version | [background/refseq.md](https://hgvs-nomenclature.org/stable/background/refseq/) line 20: "variant descriptions lacking a version number are **not** valid" | Registered — `NM_000088:c.100A>G` (no `.N` version) parses successfully in lenient mode with no W3001 warning. Tracked in [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124) (#81 L2 SVA-017) |
+| W3002 | ProteinSubstitutionArrow — `p.Val600>Glu` instead of `p.Val600Glu` | [recommendations/protein/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/protein/substitution/) (substitution syntax; no `>` at protein level) | Enforced |
+| W3003 | OldSubstitutionSyntax — `c.100_102>ATG` instead of `c.100_102delinsATG` | [recommendations/DNA/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/) line 16: "substitutions involving two or more consecutive nucleotides are described as deletion/insertion (delins) variants"; [recommendations/DNA/delins.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/delins/) | Registered — `c.100_102>ATG` (no ref bases) hits a generic parse error (no W3003); `c.79_80GC>TT` is silently rewritten to `c.79_80delinsTT` with no warning. The `ErrorType` variant exists but no parse-time hook emits it. Tracked in [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 3 |
+| W3004 | OldAlleleFormat — `[c.100A>G;c.200C>T]` instead of `c.[100A>G;200C>T]` | [recommendations/DNA/alleles.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/alleles/) (allele bracket placement) | Enforced |
+| W3005 | TrailingAnnotation — `c.459A>G (p.Lys153=)` annotations stripped | n/a (defensive against ClinVar-style trailing protein annotations; tolerant input handling, not a spec rule) | Infra |
+| W3006 | MissingCoordinatePrefix — `NC_000001.11:12345A>G` missing `g.` | [background/refseq.md](https://hgvs-nomenclature.org/stable/background/refseq/) line 64: "It is mandatory to indicate the type of reference sequence file using a prefix"; [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) lines 20–28 | Enforced |
+| W4001 | SwappedPositions — `c.200_100del` corrected to `c.100_200del` | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 65 (range semantics: start ≤ end implied by the underscore range syntax and reinforced throughout DNA/numbering examples) | Registered — `correct_swapped_positions` returns this `ErrorType` but the preprocessor's nine phases do not invoke it; `NM_000088.3:c.200_100del` produces a generic parse error in lenient mode with no W4001 emission |
+| W4002 | PositionZero — `c.0A>G` rejected (no auto-correct) | [background/numbering.md — Coding DNA numbering](https://hgvs-nomenclature.org/stable/background/numbering/) line 16: "numbering starts with c.1 at the A of the ATG translation initiation codon"; lines 19–28 confirm there is no `c.0` (numbering goes `c.-1` → `c.1`) | Registered — rejection happens (`detect_position_zero` runs in preprocessor Phase 1) but the diagnostic uses `ErrorCode::InvalidPosition` (E1003), not W4002. The spec rule is enforced under E1003; W4002 has no distinct emission path |
+| W5001 | RefSeqMismatch — stated reference base mismatches actual reference (warning sibling of `E3002`) | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 15: "the reference sequence used must contain the residue(s) described to be changed" | Registered — referenced from `src/normalize/config.rs` as a per-code policy override but no normalize/, reference/, or convert/ site emits the warning when a mismatch is observed. The spec rule is partially enforced by `E3002`; W5001 has no distinct emission path |
+
+## Spec rules without an error code (gaps)
+
+The audit identified spec rules that are either explicit prohibitions ("must
+not", "not allowed") or retracted notations ("should not be used") for which
+ferro-hgvs has no targeted error or warning code. The first four rows below
+expand the [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115)
+inventory; the remaining rows surfaced during the spot-check pass for this
+audit and overlap with the upcoming #81 L2 work tracked in
+[#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124),
+[#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125),
+[#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127),
+[#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128). Per the
+process for #81 item L1, **no new codes are added in this PR**; the table
+captures the gap and the follow-up.
+
+| Spec rule | Spec citation | Current ferro behavior | Follow-up |
+|-----------|---------------|------------------------|-----------|
+| Self-cancelling allele constructs ("removing part of a reference sequence replacing it with part of the same sequence are not allowed", e.g. `c.[762_768del;767_774dup]`) | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) line 47 | Parses silently | [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 1 |
+| Retracted `c.IVS` intronic notation (e.g. `c.IVS2+2T>G`) | [background/numbering.md](https://hgvs-nomenclature.org/stable/background/numbering/) line 32: "should not be used" | Generic `E1006 UnexpectedChar` parse error with no actionable hint | [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 2; also overlaps `deprecated::IVS_NOTATION` in `src/hgvs/version.rs` |
+| Multi-base substitution with explicit ref bases (e.g. `c.79_80GC>TT`, `c.79GC>TT`) | [recommendations/DNA/substitution.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/) line 58: "this change can not be described as a substitution like c.79_80GC>TT" | Silently rewritten to `delins` (no warning) or generic parse error | [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 3 (extends `W3003` coverage) |
+| `con` (sequence conversion) edits | [recommendations/general.md](https://hgvs-nomenclature.org/stable/recommendations/general/) (mentioned as a spec'd edit type) | Parses silently with no semantic validation; cannot distinguish "unrecognized syntax" from "recognized but unimplemented" | [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 4 |
+| Single-position range on `del` (e.g. `c.123_123del`) | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 27 | Silently collapsed to `c.123del` with no warning | [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) SVA-008 |
+| Single-position range on `dup` (e.g. `c.123_123dup`) | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 27 | Silently collapsed to `c.123dup` | [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) SVA-009 |
+| One-nucleotide inversion (e.g. `c.100_100inv`, `g.234inv`) | [recommendations/DNA/inversion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/inversion/) line 15: "the description g.234inv is therefore not allowed" | Silently collapsed (single-position form) or accepted (`g.234inv` form) | [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) SVA-014 |
+| Size suffix on deletion (e.g. `c.123del6`, `g.123del3`) | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 34; [recommendations/DNA/deletion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/) line 66: "not allowed" | Parses silently — the `6` is preserved as a size annotation | [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) SVA-007 |
+| Empty `delins` insert (e.g. `c.100_102delins`) | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 27 | Generic parse error | [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) SVA-010 |
+| Ambiguous insertion ("the format `c.52insT` is incomplete and not allowed") | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 26; [recommendations/DNA/insertion.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/insertion/) line 55 | Generic parse error; no targeted hint | New gap (file as #115 follow-up if not absorbed by L2) |
+| Insertion size-only (e.g. `c.5439_5430ins6`) | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 27 | Generic parse error | New gap |
+| Mixed-reference-types in allele (e.g. `c.[76A>C];g.[10091C>G]`) | [recommendations/DNA/alleles.md](https://hgvs-nomenclature.org/stable/recommendations/DNA/alleles/) line 22: "should not be used" | Parse error (current allele grammar lacks coverage) | Already partially in #81 item H2 |
+| `p.(Met1Val)` start-codon substitution | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 50: "the description p.(Met1Val) is not allowed" | Parses silently | New gap |
+| Embedded whitespace in lenient mode (e.g. `c.100 A>G`) | [recommendations/grammar.md](https://hgvs-nomenclature.org/stable/recommendations/grammar/) (no whitespace in production rules) | `correct_whitespace` strips outer whitespace but not embedded; lenient parse hard-rejects rather than soft-warning W2003 | [#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128) SVA-024 |
+
+## Cross-reference: deprecated features in `src/hgvs/version.rs`
+
+`src/hgvs/version.rs` already documents four deprecated HGVS notations under
+`deprecated::*`. Each maps to a spec rule this audit also surfaces, but none
+is wired to a warning code today. They are listed here so a future PR (likely
+under #81 L2) can wire them to existing or new codes:
+
+| Constant | Deprecated form | Spec citation | Audit row / follow-up |
+|----------|-----------------|---------------|-----------------------|
+| `STOP_AS_X` | `p.Arg97X` | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 48: "the X should not be used" | [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125) SVA-004 |
+| `STOP_AS_STAR` | `p.Arg97*` | [recommendations/checklist.md](https://hgvs-nomenclature.org/stable/recommendations/checklist/) line 48: "'Ter' or '\*' should be used to indicate a translation stop codon; the X should not be used" | [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125) SVA-003 |
+| `IVS_NOTATION` | `c.IVS2+2T>G` | [background/numbering.md](https://hgvs-nomenclature.org/stable/background/numbering/) line 32: "retracted and should not be used" | [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) item 2 |
+| `FS_X_NOTATION` | `p.Arg97fsX23` | [recommendations/protein/frameshift.md](https://hgvs-nomenclature.org/stable/recommendations/protein/frameshift/) | [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125) SVA-005 |
+
+## Coordination with #81 L2 (soft-validation)
+
+This audit (#81 L1) covers the **registry** of error and warning codes and
+maps each to the spec section it enforces. The companion #81 L2 audit covers
+the **soft-validation rules** the spec marks "should" or "should not"
+(distinct from the "must" / "not allowed" rules tracked here). Several rows
+in this audit are reclassified `Registered` — the code exists in the
+registry but is not emitted at runtime. Wiring these up is the work of:
+
+- [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124) — `W1001`,
+  `W1002`, `W3001` (registered-but-unused soft-validation warnings; existing
+  correctors in `corrections.rs` need wiring to the preprocessor).
+- [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125) —
+  deprecated stop-codon and frameshift forms (`p.Arg97X`, `p.Arg97*`,
+  `p.Arg97fsX23`, `p.Arg97fs*23`).
+- [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127) —
+  non-canonical input forms (size suffixes, single-position ranges,
+  1-nt inversions, redundant repeat labels).
+- [#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128) —
+  embedded-whitespace lenient-mode soft-warn.
+
+Boundary: `Enforced` rows in this audit are hard rejections (E-codes) or
+warnings already emitted in lenient/silent mode. `Registered` and `Partial`
+rows are exactly the surface where L2 work will land.
+
+## Normalization-output canonicalization gaps
+
+A separate, larger class of gaps — non-canonical inputs that ferro normalizes
+without rewriting into the spec's preferred form (e.g. `ins` that should
+collapse to `dup`, `delins` that should collapse to `inv`, `c.100A>A` that
+should canonicalize to `=`, single-variant alleles emitted with bracket
+wrapping) — is **out of scope** for this audit and is tracked under #81 items
+A1, A2, A3, A4, A8, B1–B5, C1–C5, D1–D8, E1–E3, F1–F2, G1–G3, H1–H2, I1–I4,
+J1–J3, K1–K2 and their downstream follow-up issues.
+
+## How to keep this document in sync
+
+1. Adding a code to `src/error_handling/registry.rs`: add a matching entry to
+   `tests/fixtures/error_code_audit.json` (mirror status, spec citation, and
+   any follow-up issues) and a row to this document.
+2. Removing or renaming a code: update the fixture and document in the same
+   commit.
+3. Reclassifying a status: update both the fixture row's `status` and the
+   markdown table row's status column. The drift-prevention test
+   (`tests/error_code_audit.rs`) asserts that any W-row classified
+   `Enforced` corresponds to an `ErrorType::<Variant>` substring in a
+   non-bookkeeping file under `src/`; if you reclassify *to* `Enforced`
+   without wiring an emission site, the test will fail. The inverse also
+   holds: a `Registered` row whose `ErrorType` variant is now referenced in
+   an emission-relevant file fails the symmetric drift check.
+4. The test suite enforces (1)–(3) at test time
+   (`cargo nextest run --features dev --test error_code_audit`).

--- a/tests/error_code_audit.rs
+++ b/tests/error_code_audit.rs
@@ -1,0 +1,328 @@
+//! Sync check between `src/error_handling/registry.rs` and the audit fixture
+//! `tests/fixtures/error_code_audit.json` (companion to
+//! `docs/spec/error_code_audit.md`).
+//!
+//! The audit document maps every error/warning code to the HGVS spec section
+//! it enforces. To prevent the document from drifting silently as codes are
+//! added, removed, or renamed, this test asserts that:
+//!
+//!   1. every code in the runtime registry has a matching audit entry, and
+//!   2. every audit entry refers to a code that exists in the runtime registry
+//!      (no stale rows).
+//!
+//! Tracking issue: fulcrumgenomics/ferro-hgvs#81 item L1.
+
+use ferro_hgvs::error_handling::list_all_codes;
+use serde::Deserialize;
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+
+/// One row from the audit fixture. Only fields that are validated here are
+/// modeled; other fields (descriptions, spec URLs, notes) are tolerated as
+/// pass-through metadata so the fixture stays human-friendly.
+#[derive(Debug, Deserialize)]
+struct AuditEntry {
+    code: String,
+    status: String,
+    #[serde(default)]
+    spec_section: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AuditFile {
+    codes: Vec<AuditEntry>,
+}
+
+/// Allowed values of the `status` field. Kept in lockstep with the legend in
+/// `docs/spec/error_code_audit.md`.
+const VALID_STATUSES: &[&str] = &["enforced", "partial", "registered", "missing", "infra"];
+
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/error_code_audit.json")
+}
+
+/// Source-tree subset where `ErrorType::<Variant>` references *should* count as
+/// "this variant is emitted as a warning at runtime."
+///
+/// Excluded files are bookkeeping shims that map every variant by definition
+/// (`config.rs`, `python.rs`, `bin/ferro.rs`, `error_handling/types.rs`,
+/// `error_handling/codes.rs`, `error_handling/registry.rs`) and the override
+/// surfaces (`error_handling/mod.rs`, `normalize/config.rs`) that only set
+/// per-code policy without raising the warning. The remaining set captures
+/// the real emission path: preprocessor invocations of correction functions
+/// that return `ErrorType::*` along with corrections, and any future emission
+/// site under `src/hgvs/`, `src/normalize/`, etc.
+const EMISSION_SCAN_PATHS: &[&str] = &[
+    "src/error_handling/preprocessor.rs",
+    "src/hgvs",
+    "src/normalize/rules.rs",
+    "src/normalize/shuffle.rs",
+    "src/convert",
+    "src/reference",
+    "src/spdi",
+    "src/vcf",
+];
+
+/// Scan [`EMISSION_SCAN_PATHS`] under `CARGO_MANIFEST_DIR` for distinct
+/// `ErrorType::<Variant>` variant names actually used to drive warning
+/// emission. The match is a substring scan; because the bookkeeping files
+/// are excluded the false-positive surface is small.
+///
+/// Returns variant names like `"WrongDashCharacter"` (without the
+/// `ErrorType::` prefix) for set-membership checks.
+fn emitted_error_type_variants() -> BTreeSet<String> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut found = BTreeSet::new();
+    for rel in EMISSION_SCAN_PATHS {
+        scan_for_variants(&manifest.join(rel), &mut found);
+    }
+    found
+}
+
+fn scan_for_variants(path: &std::path::Path, out: &mut BTreeSet<String>) {
+    if !path.exists() {
+        return;
+    }
+    if path.is_file() {
+        if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            if let Ok(text) = std::fs::read_to_string(path) {
+                extract_error_type_variants(&text, out);
+            }
+        }
+        return;
+    }
+    if let Ok(rd) = std::fs::read_dir(path) {
+        for entry in rd.flatten() {
+            scan_for_variants(&entry.path(), out);
+        }
+    }
+}
+
+fn extract_error_type_variants(text: &str, out: &mut BTreeSet<String>) {
+    // Match `ErrorType::<Variant>` where `<Variant>` starts with an ASCII
+    // uppercase letter and continues with alphanumerics or underscore.
+    let needle = "ErrorType::";
+    let mut i = 0;
+    while let Some(pos) = text[i..].find(needle) {
+        let start = i + pos + needle.len();
+        let rest = &text[start..];
+        let end = rest
+            .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .unwrap_or(rest.len());
+        if end > 0 {
+            let name = &rest[..end];
+            if name.chars().next().is_some_and(|c| c.is_ascii_uppercase()) {
+                out.insert(name.to_string());
+            }
+        }
+        i = start + end.max(1);
+    }
+}
+
+fn load_fixture() -> AuditFile {
+    let path = fixture_path();
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read audit fixture at {}: {}", path.display(), e));
+    serde_json::from_str(&raw).unwrap_or_else(|e| {
+        panic!(
+            "audit fixture at {} is not valid JSON matching the expected schema: {}",
+            path.display(),
+            e
+        )
+    })
+}
+
+#[test]
+fn audit_fixture_covers_every_registry_code() {
+    let registry_codes: BTreeSet<String> = list_all_codes()
+        .iter()
+        .map(|c| c.code.to_string())
+        .collect();
+    let audit = load_fixture();
+    let audit_codes: BTreeSet<String> = audit.codes.iter().map(|e| e.code.clone()).collect();
+
+    let missing_in_audit: Vec<&String> = registry_codes.difference(&audit_codes).collect();
+    assert!(
+        missing_in_audit.is_empty(),
+        "registry codes have no entry in tests/fixtures/error_code_audit.json (and therefore no \
+         row in docs/spec/error_code_audit.md). Add an audit row for each code listed below, \
+         then re-run this test:\n  {:?}",
+        missing_in_audit
+    );
+}
+
+#[test]
+fn audit_fixture_has_no_stale_codes() {
+    let registry_codes: BTreeSet<String> = list_all_codes()
+        .iter()
+        .map(|c| c.code.to_string())
+        .collect();
+    let audit = load_fixture();
+    let audit_codes: BTreeSet<String> = audit.codes.iter().map(|e| e.code.clone()).collect();
+
+    let stale_in_audit: Vec<&String> = audit_codes.difference(&registry_codes).collect();
+    assert!(
+        stale_in_audit.is_empty(),
+        "tests/fixtures/error_code_audit.json refers to codes that no longer exist in the \
+         registry (src/error_handling/registry.rs). Remove the stale rows from the fixture and \
+         from docs/spec/error_code_audit.md:\n  {:?}",
+        stale_in_audit
+    );
+}
+
+#[test]
+fn audit_fixture_codes_are_unique() {
+    let audit = load_fixture();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut duplicates: Vec<&str> = Vec::new();
+    for entry in &audit.codes {
+        if !seen.insert(entry.code.as_str()) {
+            duplicates.push(entry.code.as_str());
+        }
+    }
+    assert!(
+        duplicates.is_empty(),
+        "tests/fixtures/error_code_audit.json contains duplicate code entries: {:?}",
+        duplicates
+    );
+}
+
+#[test]
+fn audit_fixture_statuses_are_valid() {
+    let audit = load_fixture();
+    let mut bad: Vec<(String, String)> = Vec::new();
+    for entry in &audit.codes {
+        if !VALID_STATUSES.contains(&entry.status.as_str()) {
+            bad.push((entry.code.clone(), entry.status.clone()));
+        }
+    }
+    assert!(
+        bad.is_empty(),
+        "tests/fixtures/error_code_audit.json contains entries with invalid `status` values \
+         (allowed: {:?}). Update either the entry or the legend in \
+         docs/spec/error_code_audit.md:\n  {:?}",
+        VALID_STATUSES,
+        bad
+    );
+}
+
+#[test]
+fn audit_fixture_non_infra_entries_cite_a_spec_section() {
+    // `infra` rows are allowed to omit `spec_section` (they document I/O,
+    // missing reference data, and similar internal failures with no spec
+    // mapping). Every other status must cite a spec section so reviewers can
+    // verify the mapping without re-reading the registry.
+    let audit = load_fixture();
+    let mut missing_citation: Vec<String> = Vec::new();
+    for entry in &audit.codes {
+        if entry.status == "infra" {
+            continue;
+        }
+        let cited = entry
+            .spec_section
+            .as_ref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        if !cited {
+            missing_citation.push(entry.code.clone());
+        }
+    }
+    assert!(
+        missing_citation.is_empty(),
+        "audit entries with status enforced/partial/missing must cite a `spec_section`. \
+         Codes lacking a citation:\n  {:?}",
+        missing_citation
+    );
+}
+
+#[test]
+fn audit_enforced_warning_rows_have_emission_sites() {
+    // For every fixture row marked `enforced` for a W-code (warning), look up
+    // the `ErrorType::*` variant name from the registry's `name` field and
+    // assert that the variant is referenced from one of the emission-relevant
+    // files under `src/`. A failure here means either:
+    //
+    //   (a) an audit row was reclassified to `enforced` without wiring an
+    //       emission site, or
+    //   (b) an emission site was deleted but the audit row was not updated.
+    //
+    // E-codes use a different code path (`ErrorCode::*` raised via
+    // `Diagnostic`) and are not covered by this test; they are spot-checked
+    // by reviewer judgement and the existing parser/preprocessor unit tests.
+    let registry: HashMap<String, &'static str> = list_all_codes()
+        .iter()
+        .map(|c| (c.code.to_string(), c.name))
+        .collect();
+    let audit = load_fixture();
+    let emitted = emitted_error_type_variants();
+
+    let mut not_emitted: Vec<(String, &'static str)> = Vec::new();
+    for entry in &audit.codes {
+        if !entry.code.starts_with('W') {
+            continue;
+        }
+        if entry.status != "enforced" {
+            continue;
+        }
+        let Some(name) = registry.get(&entry.code) else {
+            // covered by audit_fixture_has_no_stale_codes
+            continue;
+        };
+        if !emitted.contains(*name) {
+            not_emitted.push((entry.code.clone(), *name));
+        }
+    }
+
+    assert!(
+        not_emitted.is_empty(),
+        "audit rows classified `enforced` for W-codes whose `ErrorType::<Variant>` \
+         is not referenced from any emission-relevant file under src/ \
+         (preprocessor, hgvs/, normalize/{{rules,shuffle}}.rs, convert/, \
+         reference/, spdi/, vcf/). Either wire an emission site, or reclassify \
+         the audit row to `registered` (no emission) or `partial` (some \
+         emission with a documented gap).\n  {:?}",
+        not_emitted
+    );
+}
+
+#[test]
+fn audit_registered_warning_rows_have_no_emission_site() {
+    // The companion to `audit_enforced_warning_rows_have_emission_sites`. A
+    // row classified `registered` declares "no preprocessor or parser site
+    // emits this code." If a future PR wires up emission, the row's status
+    // must move to `enforced` (or `partial`) — this test catches the case
+    // where someone wires emission but forgets to update the audit.
+    let registry: HashMap<String, &'static str> = list_all_codes()
+        .iter()
+        .map(|c| (c.code.to_string(), c.name))
+        .collect();
+    let audit = load_fixture();
+    let emitted = emitted_error_type_variants();
+
+    let mut should_upgrade: Vec<(String, &'static str)> = Vec::new();
+    for entry in &audit.codes {
+        if !entry.code.starts_with('W') {
+            continue;
+        }
+        if entry.status != "registered" {
+            continue;
+        }
+        let Some(name) = registry.get(&entry.code) else {
+            continue;
+        };
+        if emitted.contains(*name) {
+            should_upgrade.push((entry.code.clone(), *name));
+        }
+    }
+
+    assert!(
+        should_upgrade.is_empty(),
+        "audit rows classified `registered` for W-codes that *do* have an \
+         `ErrorType::<Variant>` reference in an emission-relevant file under \
+         src/. Either the code is now wired (promote to `enforced` / \
+         `partial` and remove the `registered` status), or the reference is a \
+         test/import — in which case extend EMISSION_SCAN_PATHS' exclusions \
+         instead.\n  {:?}",
+        should_upgrade
+    );
+}

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -1,0 +1,309 @@
+{
+  "_comment": "Machine-checkable companion to docs/spec/error_code_audit.md. Maps every code in src/error_handling/registry.rs to the HGVS spec section it enforces. Tracking issue: fulcrumgenomics/ferro-hgvs#81 item L1. Follow-up gaps: fulcrumgenomics/ferro-hgvs#115. Tests in tests/error_code_audit.rs assert registry and fixture stay in sync.",
+  "_status_legend": {
+    "enforced": "Code reliably surfaces every input that violates the cited spec rule.",
+    "partial": "Code surfaces a subset of violating inputs; gap noted in spec_section_notes.",
+    "registered": "Code is present in src/error_handling/registry.rs and the ErrorType enum but no preprocessor or parser site emits it. The spec rule is unenforced at runtime.",
+    "missing": "Code is documented in the audit but does not exist in the registry yet. (No rows currently use this status; reserved for audits where the registry should grow.)",
+    "infra": "Infrastructure code (I/O, missing reference data); no spec section applies."
+  },
+  "codes": [
+    {
+      "code": "E1001",
+      "description": "InvalidAccession — accession does not match a recognized RefSeq/Ensembl/LRG prefix.",
+      "spec_section": "background/refseq.md (lines 45-57: NC_, NT_, NW_, NG_, NM_, NR_, NP_, LRG_)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1002",
+      "description": "UnknownVariantType — coordinate-type prefix (g./c./n./r./p./m./o.) missing or invalid.",
+      "spec_section": "background/refseq.md (lines 64, 81-141); recommendations/general.md (lines 20-28)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1003",
+      "description": "InvalidPosition — position is not a valid integer or offset position.",
+      "spec_section": "background/numbering.md (lines 16-28: c. numbering rules)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/numbering/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1004",
+      "description": "InvalidEdit — edit type or format is invalid.",
+      "spec_section": "recommendations/DNA/{substitution,deletion,insertion,duplication,inversion,delins}.md",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1005",
+      "description": "UnexpectedEnd — input ended before description was complete.",
+      "spec_section": "recommendations/grammar.md (full grammar rules)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1006",
+      "description": "UnexpectedChar — invalid character at this parser position.",
+      "spec_section": "recommendations/grammar.md; also catches retracted c.IVS notation per background/numbering.md line 32",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "partial",
+      "spec_section_notes": "Generic UnexpectedChar is also raised for the retracted c.IVS notation; a dedicated code with an actionable hint is filed in #115 item 2.",
+      "follow_up_issues": [115]
+    },
+    {
+      "code": "E1007",
+      "description": "InvalidBase — invalid nucleotide base (must be A/C/G/T/U or IUPAC code).",
+      "spec_section": "background/standards.md (line 15: NC-IUB / IUBMB nucleotide codes)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/standards/",
+      "status": "enforced"
+    },
+    {
+      "code": "E1008",
+      "description": "InvalidAminoAcid — invalid amino acid (must be valid 1- or 3-letter IUPAC code).",
+      "spec_section": "background/standards.md — Amino Acid Descriptions (lines 210-214: IUPAC-IUB amino acid table)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/standards/",
+      "status": "enforced"
+    },
+    {
+      "code": "E2001",
+      "description": "ReferenceNotFound — accession not present in loaded reference data.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure: depends on which reference set is loaded."
+    },
+    {
+      "code": "E2002",
+      "description": "SequenceNotFound — sequence data unavailable for accession with metadata.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure."
+    },
+    {
+      "code": "E2003",
+      "description": "ChromosomeNotFound — chromosome / contig not in reference.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure."
+    },
+    {
+      "code": "E3001",
+      "description": "PositionOutOfBounds — position beyond the length of the reference sequence.",
+      "spec_section": "recommendations/general.md line 15: 'the reference sequence used must contain the residue(s) described to be changed'",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "enforced"
+    },
+    {
+      "code": "E3002",
+      "description": "ReferenceMismatch — stated reference base does not match the actual reference.",
+      "spec_section": "recommendations/general.md line 15; recommendations/DNA/substitution.md (substitution semantics)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "enforced"
+    },
+    {
+      "code": "E3003",
+      "description": "InvalidRange — start > end or otherwise invalid coordinate range.",
+      "spec_section": "recommendations/general.md line 65: '_ (underscore) is used to indicate a range' (range semantics imply start <= end)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "enforced"
+    },
+    {
+      "code": "E3004",
+      "description": "ExonIntronBoundary — variant spans an exon/intron junction.",
+      "spec_section": "background/numbering.md (lines 21-28: intronic offsets per-side); recommendations/DNA/deletion.md (boundary cases)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/numbering/",
+      "status": "enforced"
+    },
+    {
+      "code": "E3005",
+      "description": "UtrCdsBoundary — variant spans the UTR/CDS boundary.",
+      "spec_section": "background/numbering.md (UTR uses -/* markers, CDS uses bare integers; boundary requires special handling)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/numbering/",
+      "status": "enforced"
+    },
+    {
+      "code": "E4001",
+      "description": "IntronicVariant — intronic variant cannot be normalized without genomic context.",
+      "spec_section": "background/numbering.md line 28: 'a coding DNA reference sequence does not contain intron sequences and can therefore not be used as a reference'",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/numbering/",
+      "status": "enforced"
+    },
+    {
+      "code": "E4002",
+      "description": "UnsupportedVariant — variant type not supported for this operation.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Implementation limit; surfaces incomplete coverage rather than a spec rule."
+    },
+    {
+      "code": "E5001",
+      "description": "ConversionFailed — coordinate conversion between reference systems failed.",
+      "spec_section": "background/refseq.md (cross-reference c./g./n./p. relations)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "enforced"
+    },
+    {
+      "code": "E5002",
+      "description": "NoOverlappingTranscript — no transcript overlaps the genomic position.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure: depends on transcript set loaded."
+    },
+    {
+      "code": "E9001",
+      "description": "IoError — file I/O failure.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure."
+    },
+    {
+      "code": "E9002",
+      "description": "JsonError — JSON parse failure.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Infrastructure."
+    },
+    {
+      "code": "W1001",
+      "description": "LowercaseAminoAcid — 'val' instead of 'Val'.",
+      "spec_section": "recommendations/protein/substitution.md; background/standards.md (3-letter code preferred); recommendations/general.md lines 41-43",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/protein/substitution/",
+      "status": "registered",
+      "spec_section_notes": "correct_amino_acid_case in src/error_handling/corrections.rs returns ErrorType::LowercaseAminoAcid but is never invoked from the preprocessor or parser. Empirically, NP_003997.1:p.val600glu is auto-normalized to NP_003997.1:p.Val600Glu in lenient mode with an empty corrections list. Tracked in #124 (#81 L2 SVA-001).",
+      "follow_up_issues": [124]
+    },
+    {
+      "code": "W1002",
+      "description": "SingleLetterAminoAcid — 'V600E' instead of 'Val600Glu'.",
+      "spec_section": "recommendations/general.md lines 41-43: 'three-letter amino acid code is preferred'; recommendations/protein/substitution.md",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "registered",
+      "spec_section_notes": "Empirically, NP_003997.1:p.V600E is auto-expanded to NP_003997.1:p.Val600Glu in lenient mode with no W1002 in the corrections list (the preprocessor does not invoke a single-to-three-letter corrector). Tracked in #124 (#81 L2 SVA-002).",
+      "follow_up_issues": [124]
+    },
+    {
+      "code": "W1003",
+      "description": "LowercaseAccessionPrefix — 'nm_000088.3' instead of 'NM_000088.3'.",
+      "spec_section": "background/refseq.md lines 45-57 (accession prefixes shown in uppercase)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "enforced"
+    },
+    {
+      "code": "W1004",
+      "description": "MixedCaseEditType — 'Del' / 'INS' instead of 'del' / 'ins'.",
+      "spec_section": "recommendations/general.md lines 87-104 (edit-type tokens shown in lowercase: del, ins, dup, inv, delins)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "registered",
+      "spec_section_notes": "correct_edit_type_case in src/error_handling/corrections.rs returns ErrorType::MixedCaseEditType but the preprocessor never calls it. Empirically, NM_000088.3:c.100Del produces a generic parse error in lenient mode with no W1004 emission."
+    },
+    {
+      "code": "W2001",
+      "description": "WrongDashCharacter — en-dash / em-dash instead of ASCII '-'.",
+      "spec_section": "recommendations/grammar.md (ASCII grammar); recommendations/general.md line 114 (minus sign semantics)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "enforced"
+    },
+    {
+      "code": "W2002",
+      "description": "WrongQuoteCharacter — smart quotes instead of ASCII '\"'.",
+      "spec_section": "recommendations/grammar.md (ASCII grammar)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "partial",
+      "spec_section_notes": "Emitted by correct_quote_characters in preprocessor Phase 3, so the warning fires when the input also contains valid HGVS syntax around the quotes. Standard HGVS does not use ASCII quotes inside any current production rule, so in practice the catch-all parse failure shadows W2002 for most realistic inputs."
+    },
+    {
+      "code": "W2003",
+      "description": "ExtraWhitespace — extraneous spaces in expression.",
+      "spec_section": "recommendations/grammar.md (no whitespace in production rules)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "enforced"
+    },
+    {
+      "code": "W2004",
+      "description": "InvalidUnicodeCharacter — generic non-ASCII character.",
+      "spec_section": "recommendations/grammar.md (ASCII grammar)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/grammar/",
+      "status": "registered",
+      "spec_section_notes": "Real coverage of non-ASCII inputs is via W2001 (en/em-dash) and W2002 (smart quotes). The generic catch-all is registered as ErrorType::InvalidUnicodeCharacter but no preprocessor or parser site emits it on its own — non-ASCII characters not matching the dash or quote correctors fall through to a generic parse error."
+    },
+    {
+      "code": "W3001",
+      "description": "MissingVersion — accession without '.N' version.",
+      "spec_section": "background/refseq.md line 20: 'variant descriptions lacking a version number are not valid'",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "registered",
+      "spec_section_notes": "Empirically, NM_000088:c.100A>G (no .N version) parses successfully in lenient mode with an empty corrections list — no W3001 is emitted. Tracked in #124 (#81 L2 SVA-017).",
+      "follow_up_issues": [124]
+    },
+    {
+      "code": "W3002",
+      "description": "ProteinSubstitutionArrow — 'p.Val600>Glu' instead of 'p.Val600Glu'.",
+      "spec_section": "recommendations/protein/substitution.md (no '>' at protein level)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/protein/substitution/",
+      "status": "enforced"
+    },
+    {
+      "code": "W3003",
+      "description": "OldSubstitutionSyntax — 'c.100_102>ATG' instead of 'c.100_102delinsATG'.",
+      "spec_section": "recommendations/DNA/substitution.md line 16: 'substitutions involving two or more consecutive nucleotides are described as deletion/insertion (delins) variants'",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/substitution/",
+      "status": "registered",
+      "spec_section_notes": "Empirically, c.100_102>ATG (no ref bases) hits a generic 'unexpected trailing characters' parse error in lenient mode (no W3003); c.79_80GC>TT (with explicit ref bases) is silently rewritten as c.79_80delinsTT with no warning. The ErrorType variant exists but no parse-time hook emits it. Wiring the emission for both forms is tracked in #115 item 3.",
+      "follow_up_issues": [115]
+    },
+    {
+      "code": "W3004",
+      "description": "OldAlleleFormat — '[c.100A>G;c.200C>T]' instead of 'c.[100A>G;200C>T]'.",
+      "spec_section": "recommendations/DNA/alleles.md (allele bracket placement)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/alleles/",
+      "status": "enforced"
+    },
+    {
+      "code": "W3005",
+      "description": "TrailingAnnotation — 'c.459A>G (p.Lys153=)' annotations stripped.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "Defensive against ClinVar-style trailing protein annotations; tolerant input handling, not a spec rule."
+    },
+    {
+      "code": "W3006",
+      "description": "MissingCoordinatePrefix — 'NC_000001.11:12345A>G' missing 'g.'.",
+      "spec_section": "background/refseq.md line 64: 'It is mandatory to indicate the type of reference sequence file using a prefix'; recommendations/general.md lines 20-28",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "status": "enforced"
+    },
+    {
+      "code": "W4001",
+      "description": "SwappedPositions — 'c.200_100del' corrected to 'c.100_200del'.",
+      "spec_section": "recommendations/general.md line 65 (range semantics: start <= end implied by underscore range syntax)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "registered",
+      "spec_section_notes": "detect_swapped_positions and correct_swapped_positions in src/error_handling/corrections.rs return ErrorType::SwappedPositions, but the preprocessor's nine phases do not invoke them. Empirically, NM_000088.3:c.200_100del produces a generic parse error (nom Verify) in lenient mode with no W4001 emission."
+    },
+    {
+      "code": "W4002",
+      "description": "PositionZero — 'c.0A>G' rejected (no auto-correct).",
+      "spec_section": "background/numbering.md line 16: 'numbering starts with c.1 at the A of the ATG translation initiation codon'; lines 19-28 confirm there is no c.0",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/numbering/",
+      "status": "registered",
+      "spec_section_notes": "Position zero IS rejected at runtime — detect_position_zero runs in preprocessor Phase 1 and returns a failed PreprocessResult — but the diagnostic is raised under ErrorCode::InvalidPosition (E1003), not under W4002. The W4002 ErrorType variant is reachable only via the warning-code dispatch tables (config.rs, bin/ferro.rs); no emission path tags rejections with this specific code. The spec rule is enforced by E1003; W4002 is a duplicate identity that no caller emits."
+    },
+    {
+      "code": "W5001",
+      "description": "RefSeqMismatch — stated reference base mismatches actual reference (warning sibling of E3002).",
+      "spec_section": "recommendations/general.md line 15: 'the reference sequence used must contain the residue(s) described to be changed'",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
+      "status": "registered",
+      "spec_section_notes": "Referenced from src/normalize/config.rs as a per-code policy override (with_override(ErrorType::RefSeqMismatch, ...)) but no normalize/, reference/, or convert/ site emits this warning when a mismatch is observed. With no reference data loaded (the common CLI case) parsing succeeds and no warning fires; with reference data the sibling error E3002 is raised instead. The spec rule is partially enforced by E3002; W5001 has no distinct emission path."
+    }
+  ]
+}


### PR DESCRIPTION
Addresses [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item **L1**: map every error and warning code in `src/error_handling/registry.rs` to the spec section it enforces; identify codes the spec implies but ferro doesn't emit.

## Summary

Audit deliverable: `docs/spec/error_code_audit.md` (Markdown table), `tests/fixtures/error_code_audit.json` (machine-checkable fixture), `tests/error_code_audit.rs` (drift-prevention test).

The audit distinguishes five statuses:

- **Enforced** — emitted reliably; no known false negatives.
- **Partial** — emitted for some forms; gap noted in the row.
- **Registered** — present in the registry and `ErrorType` enum but no preprocessor or parser site emits it.
- **Missing** — documented in the audit but not yet in the registry.
- **Infra** — infrastructure failure (I/O, missing reference data); no spec rule applies.

Source-scanning under `src/` and empirical CLI checks confirmed several rows the original audit marked `Enforced` are actually `Registered` (`W1001`, `W1002`, `W1004`, `W2004`, `W3001`, `W3003`, `W4001`, `W4002`, `W5001`) or `Partial` (`W2002`). The reclassifications are documented per row with the specific reason — usually that an emission site exists in `src/error_handling/corrections.rs` but the preprocessor's nine phases never invoke it, or that the diagnostic uses a different code (e.g. `c.0A>G` is rejected as `E1003 InvalidPosition`, not as `W4002 PositionZero`).

## Drift-prevention

`tests/error_code_audit.rs` asserts:

- Every code in `list_all_codes()` (the runtime registry) has a fixture row.
- Every fixture row refers to a code that exists in the registry.
- Every fixture row uses one of the five allowed statuses.
- Non-`infra` rows cite a spec section.
- W-rows classified `enforced` must reference `ErrorType::<Variant>` in a non-bookkeeping file under `src/` (catches "labelled enforced but no emission").
- W-rows classified `registered` must *not* have such a reference (catches "wired emission but forgot to update the audit").

E-codes use a different code path (`ErrorCode::*` raised via `Diagnostic`); the emission tests are scoped to W-codes.

## Cross-links

- The "spec rules without an error code" section expands the [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) inventory from 4 items to 13 — adds single-position ranges (`c.123_123del`, `_123dup`, `_100inv`), size suffix on `del` (`c.123del6`), empty `delins`, ambiguous and size-only insertions, mixed-reference alleles, `p.(Met1Val)`, and embedded whitespace.
- A new section cross-references the `deprecated::*` constants in `src/hgvs/version.rs` (`STOP_AS_X`, `STOP_AS_STAR`, `IVS_NOTATION`, `FS_X_NOTATION`) so a future L2 PR can wire them up to warning codes.
- The L2 boundary is pinned: the audit explicitly defers `Registered` and `Partial` rows to [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124), [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125), [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127), [#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128).

## Why #115 stays open

[#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115)'s acceptance criteria require adding new `E`/`W` entries to the registry plus emission sites and tests across multiple files. That is genuinely architectural follow-up, not a small incidental fix to fold into a doc-only audit PR. This PR absorbs and extends #115's gap inventory inside the audit doc, but the registry and emission changes belong in their own PR.

## Test plan

- [x] `cargo nextest run --features dev` — 3405 tests pass, 51 skipped.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.

## Follow-up issues

- [#115](https://github.com/fulcrumgenomics/ferro-hgvs/issues/115) — Spec-mandated input rejections without error codes (gap inventory expanded here).
- [#124](https://github.com/fulcrumgenomics/ferro-hgvs/issues/124), [#125](https://github.com/fulcrumgenomics/ferro-hgvs/issues/125), [#127](https://github.com/fulcrumgenomics/ferro-hgvs/issues/127), [#128](https://github.com/fulcrumgenomics/ferro-hgvs/issues/128) — #81 L2 soft-validation work that owns the `Registered` and `Partial` rows.