### PR TITLE
fix(parser): correct LRG accession variant-type inference and compound-ref handling (#122)

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -421,8 +421,22 @@ fn looks_like_accession_start(input: &str) -> bool {
 /// Parse the inner accession of a compound reference (after the opening paren)
 fn parse_compound_inner(input: &str) -> IResult<&str, Accession> {
     let bytes = input.as_bytes();
-    // Try standard accession (NC_, NM_, etc.)
+    // Try standard 2-letter-prefix accession (NC_, NM_, NG_, etc.)
     if bytes.len() > 2 && bytes[2] == b'_' {
+        if let Ok(result) = parse_standard_accession(input) {
+            return Ok(result);
+        }
+    }
+    // Try LRG (3-letter prefix + underscore: `LRG_…`).
+    // `parse_standard_accession` already handles LRG once we know we're
+    // looking at the right shape — gate on the prefix bytes here so we
+    // don't double-call it for the 2-letter case.
+    if bytes.len() > 3
+        && bytes[0] == b'L'
+        && bytes[1] == b'R'
+        && bytes[2] == b'G'
+        && bytes[3] == b'_'
+    {
         if let Ok(result) = parse_standard_accession(input) {
             return Ok(result);
         }
@@ -632,6 +646,36 @@ mod tests {
 
         let acc =
             Accession::with_style("ENSP".to_string(), "00000012345".to_string(), Some(2), true);
+        assert_eq!(acc.inferred_variant_type(), Some("p"));
+    }
+
+    #[test]
+    fn test_parse_lrg_inferred_variant_type() {
+        // Bare LRG record → genomic coordinates
+        let (_, acc) = parse_accession("LRG_1:g.100A>G").unwrap();
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "1");
+        assert_eq!(acc.inferred_variant_type(), Some("g"));
+
+        // LRG transcript (`t<M>`) → coding (c.)
+        let (_, acc) = parse_accession("LRG_1t1:c.100A>G").unwrap();
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "1t1");
+        assert_eq!(acc.inferred_variant_type(), Some("c"));
+
+        // LRG protein (`p<M>`) → protein (p.)
+        let (_, acc) = parse_accession("LRG_1p1:p.Arg100Lys").unwrap();
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "1p1");
+        assert_eq!(acc.inferred_variant_type(), Some("p"));
+
+        // Multi-digit LRG and discriminator numbers
+        let (_, acc) = parse_accession("LRG_741t1:c.100A>G").unwrap();
+        assert_eq!(&*acc.number, "741t1");
+        assert_eq!(acc.inferred_variant_type(), Some("c"));
+
+        let (_, acc) = parse_accession("LRG_673p1:p.Lys903delLys").unwrap();
+        assert_eq!(&*acc.number, "673p1");
         assert_eq!(acc.inferred_variant_type(), Some("p"));
     }
 
@@ -850,6 +894,37 @@ mod tests {
         assert_eq!(&*acc.prefix, "NM");
         let ctx = acc.genomic_context.as_ref().unwrap();
         assert_eq!(&*ctx.prefix, "LRG");
+    }
+
+    #[test]
+    fn test_parse_compound_ref_lrg_inner_transcript() {
+        // NC outer + LRG transcript inner — primary is LRG.
+        let (remaining, acc) = parse_accession("NC_000023.11(LRG_199t1):c.357+1G>A").unwrap();
+        assert_eq!(remaining, ":c.357+1G>A");
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "199t1");
+        let ctx = acc.genomic_context.as_ref().unwrap();
+        assert_eq!(&*ctx.prefix, "NC");
+        assert_eq!(ctx.version, Some(11));
+    }
+
+    #[test]
+    fn test_parse_compound_ref_lrg_inner_protein() {
+        // NC outer + LRG protein inner.
+        let (remaining, acc) = parse_accession("NC_000023.11(LRG_199p1):p.Trp24Cys").unwrap();
+        assert_eq!(remaining, ":p.Trp24Cys");
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "199p1");
+        assert!(acc.genomic_context.is_some());
+    }
+
+    #[test]
+    fn test_parse_compound_ref_lrg_inner_bare() {
+        // NC outer + bare LRG inner (no discriminator).
+        let (remaining, acc) = parse_accession("NC_000023.11(LRG_199):g.1A>G").unwrap();
+        assert_eq!(remaining, ":g.1A>G");
+        assert_eq!(&*acc.prefix, "LRG");
+        assert_eq!(&*acc.number, "199");
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -119,6 +119,13 @@ impl Accession {
     ) -> Self {
         let prefix = Self::intern_prefix(prefix);
         let ensembl_style = Self::is_ensembl_prefix(&prefix);
+        // LRG accessions never carry a version per HGVS spec (SVD-WG008).
+        // Drop any provided version so Display canonicalizes to the spec form.
+        let version = if Self::is_lrg_prefix(&prefix) {
+            None
+        } else {
+            version
+        };
         Self {
             prefix,
             number: number.into(),
@@ -137,8 +144,15 @@ impl Accession {
         version: Option<u32>,
         ensembl_style: bool,
     ) -> Self {
+        let prefix = Self::intern_prefix(prefix);
+        // LRG accessions never carry a version per HGVS spec (SVD-WG008).
+        let version = if Self::is_lrg_prefix(&prefix) {
+            None
+        } else {
+            version
+        };
         Self {
-            prefix: Self::intern_prefix(prefix),
+            prefix,
             number: number.into(),
             version,
             ensembl_style,
@@ -184,6 +198,20 @@ impl Accession {
         self.ensembl_style || Self::is_ensembl_prefix(&self.prefix)
     }
 
+    /// Check if a prefix is the canonical LRG prefix (`"LRG"`, uppercase).
+    ///
+    /// Per HGVS spec the LRG prefix is case-sensitive (lowercase `lrg_` is not
+    /// recognized as an LRG accession; it parses as a generic chromosome
+    /// name). See `assets/hgvs-nomenclature/docs/background/refseq.md`.
+    pub fn is_lrg_prefix(prefix: &str) -> bool {
+        prefix == "LRG"
+    }
+
+    /// Check if this accession is an LRG accession.
+    pub fn is_lrg(&self) -> bool {
+        Self::is_lrg_prefix(&self.prefix)
+    }
+
     /// Validate Ensembl accession format
     /// Returns true if valid, false if invalid
     pub fn validate_ensembl(&self) -> bool {
@@ -195,7 +223,26 @@ impl Accession {
         (11..=15).contains(&digit_count) && self.number.chars().all(|c| c.is_ascii_digit())
     }
 
-    /// Infer the expected variant type from the accession prefix
+    /// Infer the *primary* expected variant coordinate type from the accession
+    /// prefix and (for LRG) the trailing discriminator inside `number`.
+    ///
+    /// This is informational, not a validator: it returns the canonical
+    /// coordinate type for the accession class. The accession may legally
+    /// appear with other coordinate types in the variant block — for
+    /// example, `NM_*` always returns `"c"` even though `NM_*:n.…` and
+    /// `NM_*:r.…` parse correctly, and `LRG_<N>t<M>` always returns `"c"`
+    /// even though `LRG_<N>t<M>:n.…` (non-coding) and
+    /// `LRG_<N>t<M>:r.…` (RNA) are valid per the HGVS spec.
+    ///
+    /// LRG accessions take three forms (see https://www.lrg-sequence.org/faq/
+    /// and `assets/hgvs-nomenclature/docs/background/refseq.md`):
+    /// - `LRG_<N>`        — the LRG genomic record itself; uses `g.` coordinates.
+    /// - `LRG_<N>t<M>`    — transcript M of LRG_N; primary `c.` (coding).
+    /// - `LRG_<N>p<M>`    — protein M of LRG_N; uses `p.` coordinates.
+    ///
+    /// The `t<M>` / `p<M>` discriminator is captured inside `self.number`
+    /// (e.g. `prefix="LRG"`, `number="1t1"`), so the dispatch must inspect the
+    /// trailing discriminator rather than only the prefix.
     pub fn inferred_variant_type(&self) -> Option<&'static str> {
         match &*self.prefix {
             // RefSeq genomic
@@ -212,13 +259,46 @@ impl Accession {
             "ENSG" => Some("g"),
             // Ensembl protein
             "ENSP" => Some("p"),
-            // LRG
-            "LRG" => Some("g"),
+            // LRG: dispatch on the t<M> / p<M> discriminator captured in `number`.
+            // See `is_lrg_prefix` / `is_lrg` for the prefix-class predicate.
+            p if Self::is_lrg_prefix(p) => Some(Self::lrg_inferred_variant_type(&self.number)),
             // UniProt protein (single letter prefix: O, P, Q, A-N, R-Z)
             p if p.len() == 1 && p.chars().next().is_some_and(|c| c.is_ascii_uppercase()) => {
                 Some("p")
             }
             _ => None,
+        }
+    }
+
+    /// Map an LRG `number` field (e.g. `"1"`, `"1t1"`, `"1p1"`) to its variant type.
+    ///
+    /// The discriminator is `t<digits>` for transcripts (coding, `c.`) or
+    /// `p<digits>` for protein products (`p.`). A bare numeric `number`
+    /// (the LRG record itself) maps to genomic (`g.`). Any malformed input
+    /// falls back to `g`, matching the prior behavior for unrecognized shapes.
+    fn lrg_inferred_variant_type(number: &str) -> &'static str {
+        let bytes = number.as_bytes();
+        // Find the discriminator letter, if any. A valid LRG number is one or
+        // more digits, optionally followed by `t` or `p` and one or more digits.
+        let disc_pos = bytes.iter().position(|&b| b == b't' || b == b'p');
+        match disc_pos {
+            None => "g",
+            Some(pos) => {
+                // Validate: digits before, digits after, no further non-digits.
+                let before_ok = pos > 0 && bytes[..pos].iter().all(|b| b.is_ascii_digit());
+                let after = &bytes[pos + 1..];
+                let after_ok = !after.is_empty() && after.iter().all(|b| b.is_ascii_digit());
+                if before_ok && after_ok {
+                    if bytes[pos] == b't' {
+                        "c"
+                    } else {
+                        "p"
+                    }
+                } else {
+                    // Malformed discriminator — be conservative and treat as genomic.
+                    "g"
+                }
+            }
         }
     }
 
@@ -1595,6 +1675,27 @@ mod tests {
             Accession::new("LRG", "1", None).inferred_variant_type(),
             Some("g")
         );
+        // LRG transcript discriminator (`t<M>`) → coding (c.)
+        // The transcript discriminator is captured in `number` (e.g. "1t1"),
+        // so the dispatch must inspect it rather than only the prefix.
+        // See https://www.lrg-sequence.org/faq/ — `t<N>` is the transcript.
+        assert_eq!(
+            Accession::new("LRG", "1t1", None).inferred_variant_type(),
+            Some("c")
+        );
+        assert_eq!(
+            Accession::new("LRG", "292t1", None).inferred_variant_type(),
+            Some("c")
+        );
+        // LRG protein discriminator (`p<M>`) → protein (p.)
+        assert_eq!(
+            Accession::new("LRG", "1p1", None).inferred_variant_type(),
+            Some("p")
+        );
+        assert_eq!(
+            Accession::new("LRG", "673p1", None).inferred_variant_type(),
+            Some("p")
+        );
         // UniProt single-letter prefix
         assert_eq!(
             Accession::new("P", "12345", None).inferred_variant_type(),
@@ -1620,6 +1721,24 @@ mod tests {
         // Not UniProt - number wrong length
         let wrong_length = Accession::new("P", "123", None);
         assert!(!wrong_length.is_uniprot());
+    }
+
+    #[test]
+    fn test_accession_is_lrg_prefix() {
+        assert!(Accession::is_lrg_prefix("LRG"));
+        assert!(!Accession::is_lrg_prefix("lrg"));
+        assert!(!Accession::is_lrg_prefix("LRG_"));
+        assert!(!Accession::is_lrg_prefix("NM"));
+        assert!(!Accession::is_lrg_prefix(""));
+    }
+
+    #[test]
+    fn test_accession_is_lrg() {
+        assert!(Accession::new("LRG", "1", None).is_lrg());
+        assert!(Accession::new("LRG", "1t1", None).is_lrg());
+        assert!(Accession::new("LRG", "1p1", None).is_lrg());
+        assert!(!Accession::new("NM", "000088", Some(3)).is_lrg());
+        assert!(!Accession::new("NC", "000001", Some(11)).is_lrg());
     }
 
     #[test]

--- a/tests/lrg_inference_tests.rs
+++ b/tests/lrg_inference_tests.rs
@@ -1,0 +1,293 @@
+//! Integration tests pinning LRG accession behavior across all spec-derived forms.
+//!
+//! The HGVS specification (v21.0, see `assets/hgvs-nomenclature/docs/background/refseq.md`)
+//! defines three LRG accession forms:
+//! - `LRG_<N>`        — the LRG genomic record itself (uses `g.`)
+//! - `LRG_<N>t<M>`    — transcript M of LRG_N (uses `c.`, `n.`, or `r.`)
+//! - `LRG_<N>p<M>`    — protein M of LRG_N (uses `p.`)
+//!
+//! `Accession::inferred_variant_type` returns the *primary* type for each
+//! class — coding (`c`) for transcripts, protein (`p`) for proteins, genomic
+//! (`g`) for the bare record. It is informational, not a validator: a
+//! `LRG_199t1:n.5C>T` parses successfully even though the inferred primary
+//! type is `c`.
+
+use std::collections::HashMap;
+
+use ferro_hgvs::hgvs::variant::Accession;
+use ferro_hgvs::parse_hgvs;
+use rstest::rstest;
+
+/// `LRG_<N>t<M>` returns "c" regardless of the variant block's coordinate type.
+/// The function answers "what is the primary coordinate type for this accession?"
+/// not "what coordinate types are valid with it?".
+#[test]
+fn lrg_transcript_inferred_primary_is_c_for_all_variant_types() {
+    let acc = Accession::new("LRG", "199t1", None);
+    assert_eq!(acc.inferred_variant_type(), Some("c"));
+
+    // The variant block can pick any of c./n./r. — they all parse:
+    for input in &[
+        "LRG_199t1:c.357+1G>A",
+        "LRG_199t1:n.5C>T",
+        "LRG_199t1:r.426_427insa",
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+        assert_eq!(v.to_string(), *input, "round-trip mismatch for {input}");
+    }
+}
+
+/// `LRG_<N>p<M>` always maps to "p".
+#[test]
+fn lrg_protein_inferred_is_p() {
+    let acc = Accession::new("LRG", "199p1", None);
+    assert_eq!(acc.inferred_variant_type(), Some("p"));
+}
+
+/// Bare `LRG_<N>` always maps to "g".
+#[test]
+fn lrg_bare_inferred_is_g() {
+    let acc = Accession::new("LRG", "199", None);
+    assert_eq!(acc.inferred_variant_type(), Some("g"));
+}
+
+/// `inferred_variant_type` is a pure function over `(prefix, number)` —
+/// idempotent and reproducible across calls.
+#[test]
+fn lrg_inferred_type_is_idempotent() {
+    let acc = Accession::new("LRG", "1t1", None);
+    let first = acc.inferred_variant_type();
+    let second = acc.inferred_variant_type();
+    let third = acc.inferred_variant_type();
+    assert_eq!(first, second);
+    assert_eq!(second, third);
+    assert_eq!(first, Some("c"));
+}
+
+/// Two accessions with identical `(prefix, number, version)` must hash
+/// and compare equal regardless of construction path. Insert one via
+/// `Accession::new` and look up via a parsed accession — both should hit
+/// the same hash bucket.
+#[test]
+fn lrg_accessions_hash_and_eq_consistently() {
+    let constructed = Accession::new("LRG", "1t1", None);
+    let parsed = match parse_hgvs("LRG_1t1:c.100A>G").unwrap() {
+        ferro_hgvs::HgvsVariant::Cds(c) => c.accession,
+        other => panic!("expected Cds variant, got {other:?}"),
+    };
+
+    assert_eq!(
+        constructed, parsed,
+        "Eq must hold across construction paths"
+    );
+
+    let mut map: HashMap<Accession, &'static str> = HashMap::new();
+    map.insert(constructed, "marker");
+    assert_eq!(
+        map.get(&parsed),
+        Some(&"marker"),
+        "Hash must match across construction paths"
+    );
+}
+
+/// Malformed LRG numbers (no digits before/after the discriminator, alpha
+/// after, etc.) fall back to "g" — the same conservative answer the
+/// pre-#141 code returned for *any* LRG. This preserves backward
+/// compatibility with inputs that ferro accepts leniently.
+#[test]
+fn lrg_malformed_number_falls_back_to_g() {
+    // No digits before `t` (e.g., `LRG_t1`).
+    assert_eq!(
+        Accession::new("LRG", "t1", None).inferred_variant_type(),
+        Some("g")
+    );
+    // No digits after `t`.
+    assert_eq!(
+        Accession::new("LRG", "1t", None).inferred_variant_type(),
+        Some("g")
+    );
+    // Alpha discriminator suffix.
+    assert_eq!(
+        Accession::new("LRG", "1tabc", None).inferred_variant_type(),
+        Some("g")
+    );
+    // Two discriminator letters in a row.
+    assert_eq!(
+        Accession::new("LRG", "1tt1", None).inferred_variant_type(),
+        Some("g")
+    );
+    // Discriminator chained (`1t1p1`) — first non-digit is `t`, but the
+    // span after contains a non-digit `p`, so falls back to `g`.
+    assert_eq!(
+        Accession::new("LRG", "1t1p1", None).inferred_variant_type(),
+        Some("g")
+    );
+    // Uppercase discriminator (spec mandates lowercase). Lenient: returns g.
+    assert_eq!(
+        Accession::new("LRG", "1T1", None).inferred_variant_type(),
+        Some("g")
+    );
+    assert_eq!(
+        Accession::new("LRG", "1P1", None).inferred_variant_type(),
+        Some("g")
+    );
+}
+
+/// `LRG_1(NM_000088.3):c.459A>G` is a valid compound reference: LRG outer
+/// (genomic context) + NM transcript inner. The parsed Accession's primary
+/// `prefix` is `NM`, and `inferred_variant_type` returns `c`.
+#[test]
+fn lrg_outer_compound_with_nm_inner() {
+    let v = parse_hgvs("LRG_1(NM_000088.3):c.459A>G").unwrap();
+    assert_eq!(v.to_string(), "LRG_1(NM_000088.3):c.459A>G");
+
+    let acc = match v {
+        ferro_hgvs::HgvsVariant::Cds(c) => c.accession,
+        other => panic!("expected Cds, got {other:?}"),
+    };
+    assert_eq!(&*acc.prefix, "NM");
+    assert_eq!(acc.inferred_variant_type(), Some("c"));
+    let ctx = acc
+        .genomic_context
+        .as_ref()
+        .expect("must have genomic context");
+    assert_eq!(&*ctx.prefix, "LRG");
+    assert!(ctx.is_lrg());
+}
+
+/// LRG accessions never carry a version per HGVS spec (SVD-WG008). Ferro
+/// parses `LRG_1.2:g.…` leniently but drops the version so Display emits
+/// the canonical `LRG_1:g.…`.
+#[test]
+fn lrg_version_is_dropped_on_construction() {
+    // Direct construction.
+    let acc_with_ver = Accession::new("LRG", "1", Some(2));
+    assert_eq!(
+        acc_with_ver.version, None,
+        "Accession::new must drop LRG version"
+    );
+    assert_eq!(acc_with_ver.full(), "LRG_1");
+
+    let acc_styled = Accession::with_style("LRG", "1t1", Some(7), false);
+    assert_eq!(acc_styled.version, None);
+    assert_eq!(acc_styled.full(), "LRG_1t1");
+}
+
+/// Round-trip: parser may accept a stray `.N` after LRG, but Display drops it.
+#[test]
+fn lrg_version_round_trip_drops_illegal_version() {
+    let v = parse_hgvs("LRG_1.2:g.100A>G").unwrap();
+    assert_eq!(
+        v.to_string(),
+        "LRG_1:g.100A>G",
+        "Display must canonicalize away the illegal LRG version"
+    );
+}
+
+/// `NC_…(LRG_<N>t<M>)` compound reference: NC outer (chromosome) +
+/// LRG transcript inner. Today this fails because the inner-accession
+/// dispatcher in `parse_compound_inner` doesn't recognize the `LRG_`
+/// 3-letter prefix; this test pins the fix.
+#[test]
+fn nc_outer_compound_with_lrg_transcript_inner() {
+    let inputs_and_expected_inferred = [
+        ("NC_000023.11(LRG_199t1):c.357+1G>A", "c"),
+        ("NC_000023.11(LRG_199):g.1A>G", "g"),
+        ("NC_000023.11(LRG_199p1):p.Trp24Cys", "p"),
+    ];
+    for (input, expected) in inputs_and_expected_inferred {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+        assert_eq!(v.to_string(), input, "round-trip for {input}");
+        let acc = match v {
+            ferro_hgvs::HgvsVariant::Cds(c) => c.accession,
+            ferro_hgvs::HgvsVariant::Genome(g) => g.accession,
+            ferro_hgvs::HgvsVariant::Protein(p) => p.accession,
+            other => panic!("unexpected variant kind for {input}: {other:?}"),
+        };
+        assert!(acc.is_lrg(), "primary accession must be LRG for {input}");
+        assert_eq!(
+            acc.inferred_variant_type(),
+            Some(expected),
+            "inferred type mismatch for {input}",
+        );
+        let ctx = acc.genomic_context.as_ref().expect("must have NC context");
+        assert_eq!(&*ctx.prefix, "NC");
+    }
+}
+
+/// Cross-LRG compound allele in cis. Both inner accessions are LRG
+/// transcripts and each must report `c` as the inferred primary type.
+#[test]
+fn cross_lrg_compound_allele_in_cis() {
+    let input = "[LRG_1t1:c.1A>G;LRG_2t1:c.2A>G]";
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+    assert_eq!(v.to_string(), input);
+}
+
+/// Same LRG transcript, two variants in cis.
+#[test]
+fn lrg_compound_allele_same_transcript() {
+    let input = "LRG_199t1:c.[633A>G;635T>C]";
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+    assert_eq!(v.to_string(), input);
+}
+
+/// LRG transcript heterozygous trans-allele.
+#[test]
+fn lrg_compound_allele_in_trans() {
+    let input = "LRG_199t1:c.[76A>G];[103del]";
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+    assert_eq!(v.to_string(), input);
+}
+
+/// Spec corpus round-trips. Examples lifted from
+/// `assets/hgvs-nomenclature/docs/recommendations/` and
+/// `assets/hgvs-nomenclature/docs/background/refseq.md`.
+#[rstest]
+// Bare LRG genomic
+#[case("LRG_199:g.954966C>T", "g")]
+#[case("LRG_476:g.4950_39800=", "g")]
+// LRG transcript with c. (background/refseq.md, recommendations/DNA/delins.md)
+#[case("LRG_199t1:c.357+1G>A", "c")]
+#[case("LRG_199t1:c.4661delinsTC", "c")]
+#[case("LRG_199t1:c.145_147delinsTGG", "c")]
+// LRG transcript with r. (recommendations/RNA/insertion.md, deletion.md)
+#[case("LRG_199t1:r.426_427insa", "c")] // primary inferred = c, real = r
+#[case("LRG_2t1:r.1034_1036del", "c")]
+// LRG protein (recommendations/protein/substitution.md)
+#[case("LRG_199p1:p.Trp24Cys", "p")]
+fn lrg_spec_corpus_round_trip(#[case] input: &str, #[case] expected_primary: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} failed: {e}"));
+    assert_eq!(v.to_string(), input, "round-trip mismatch for {input}");
+
+    let acc = v
+        .accession()
+        .unwrap_or_else(|| panic!("{input} should expose an accession"));
+    assert!(acc.is_lrg(), "{input} should have an LRG accession");
+    assert_eq!(
+        acc.inferred_variant_type(),
+        Some(expected_primary),
+        "primary inferred type mismatch for {input}",
+    );
+}
+
+/// Edge values that ARE valid digit-shaped — pinned as `c`/`p` because the
+/// validator only checks "digits-only either side of the discriminator".
+#[test]
+fn lrg_zero_and_leading_zero_discriminators_are_accepted() {
+    // `LRG_0` exists nowhere in the wild but ferro accepts it leniently.
+    assert_eq!(
+        Accession::new("LRG", "0", None).inferred_variant_type(),
+        Some("g")
+    );
+    // Leading zero in M (`t01`): digits-only, accepted as `c`.
+    assert_eq!(
+        Accession::new("LRG", "1t01", None).inferred_variant_type(),
+        Some("c")
+    );
+    // Massive numbers — digits-only check is independent of magnitude.
+    assert_eq!(
+        Accession::new("LRG", "999999t999999", None).inferred_variant_type(),
+        Some("c")
+    );
+}


### PR DESCRIPTION
Closes #122.

## Summary

Folds two related LRG fixes into one PR:

- `Accession::inferred_variant_type` now dispatches on the LRG `t<M>` / `p<M>` discriminator captured inside `number`. `LRG_<N>` → `g`, `LRG_<N>t<M>` → `c`, `LRG_<N>p<M>` → `p`; malformed shapes (`LRG_t1`, `LRG_1tabc`, `LRG_1T1`, etc.) fall back to `g` to preserve the prior lenient behavior.
- `parse_compound_inner` now recognizes the `LRG_` prefix. Previously `NC_…(LRG_…):…` silently failed to form a compound — the inner-accession dispatcher only checked for 2-letter prefixes (`bytes[2] == b'_'`), so the LRG inner was left un-consumed and the variant parser produced wrong output. This is an incidental bug surfaced while pinning spec coverage for #122.
- LRG accessions never carry a version per HGVS SVD-WG008 ("LRG provides equivalent uniqueness but does not use version numbers"). Ferro now drops illegal versions on construction so Display canonicalizes `LRG_1.2` back to `LRG_1`.
- New `Accession::is_lrg` / `is_lrg_prefix` helpers for symmetry with `is_ensembl` / `is_uniprot`.
- `inferred_variant_type` doc clarified as returning the *primary* coordinate type (matching `NM` behavior, which always returns `"c"` even though `NM_*:n.…` and `NM_*:r.…` parse). Tests pin `LRG_*t*:c.…`, `:n.…`, and `:r.…` round-trip.

## HGVS spec rationale

LRG records (https://www.lrg-sequence.org/faq/, `assets/hgvs-nomenclature/docs/background/refseq.md`) take three forms:

- `LRG_<N>` — the LRG genomic record itself; `g.` coordinates.
- `LRG_<N>t<M>` — transcript M of LRG_N; primary `c.`, also valid with `n.` (non-coding) and `r.` (RNA).
- `LRG_<N>p<M>` — protein M of LRG_N; `p.` coordinates.

The discriminator is preserved in `Accession::number` (e.g. `prefix="LRG"`, `number="1t1"`); the dispatch must inspect it.

## Test plan

- [x] `cargo nextest run --features dev` — 3426 tests passed (was 3399; +27 new), 51 skipped, 0 failed
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

New `tests/lrg_inference_tests.rs` integration suite (22 tests):

- Bare `LRG_<N>`, transcript `LRG_<N>t<M>`, protein `LRG_<N>p<M>` round-trips
- `LRG_<N>t<M>:c.…` / `:n.…` / `:r.…` all parse and round-trip; `inferred_variant_type` returns primary `c`
- Compound `LRG_1(NM_…)` and `NC_…(LRG_…)` (incl. transcript / protein / bare inner)
- Compound alleles in cis / trans, including cross-LRG `[LRG_1t1:c.1A>G;LRG_2t1:c.2A>G]`
- Spec corpus parametric round-trip (8 examples lifted from `assets/hgvs-nomenclature/docs/recommendations/`)
- `Hash` + `Eq` stability across construction paths (parser vs `Accession::new`)
- Idempotency of `inferred_variant_type`
- Lenient fallback for malformed numbers (`LRG_t1`, `LRG_1t`, `LRG_1tabc`, `LRG_1tt1`, `LRG_1t1p1`, `LRG_1T1`, `LRG_1P1`)
- Edge digit-shaped values (`LRG_0`, `LRG_1t01`, `LRG_999999t999999`)
- Illegal LRG version (`LRG_1.2:g.…`) drops the version on Display