### PR TITLE
feat(normalize): canonicalize con to delins per SVD-WG009 (#81 H1)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -46,7 +46,10 @@ use crate::reference::transcript::Strand;
 use crate::reference::ReferenceProvider;
 use boundary::Boundaries;
 pub use config::{NormalizeConfig, ShuffleDirection};
-use rules::{canonicalize_edit, needs_normalization, should_canonicalize, DelinsSubedit};
+use rules::{
+    canonicalize_conversion_to_delins, canonicalize_edit, needs_normalization, should_canonicalize,
+    DelinsSubedit,
+};
 use shuffle::shuffle;
 
 /// Check if a CDS position has an unknown (?) offset sentinel value
@@ -409,6 +412,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => return Ok((HV::Genome(variant.clone()), vec![])),
         };
 
+        // SVD-WG009: rewrite `con` to `delins` before any further work.
+        // Pure-syntax; no reference data needed.
+        if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
+            let new_variant = GenomeVariant {
+                accession: variant.accession.clone(),
+                gene_symbol: variant.gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    variant.loc_edit.location.clone(),
+                    variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+                ),
+            };
+            return Ok((HV::Genome(new_variant), vec![]));
+        }
+
         // Only normalize indels
         if !needs_normalization(edit) {
             return Ok((HV::Genome(variant.clone()), vec![]));
@@ -499,6 +516,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(e) => e,
             None => return Ok((HV::Cds(variant.clone()), vec![])),
         };
+
+        // SVD-WG009: rewrite `con` to `delins`.
+        if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
+            let new_variant = CdsVariant {
+                accession: variant.accession.clone(),
+                gene_symbol: variant.gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    variant.loc_edit.location.clone(),
+                    variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+                ),
+            };
+            return Ok((HV::Cds(new_variant), vec![]));
+        }
 
         // Only normalize indels
         if !needs_normalization(edit) {
@@ -600,6 +630,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(e) => e,
             None => return Ok((HV::Tx(variant.clone()), vec![])),
         };
+
+        // SVD-WG009: rewrite `con` to `delins`.
+        if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
+            let new_variant = TxVariant {
+                accession: variant.accession.clone(),
+                gene_symbol: variant.gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    variant.loc_edit.location.clone(),
+                    variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+                ),
+            };
+            return Ok((HV::Tx(new_variant), vec![]));
+        }
 
         // Only normalize indels
         if !needs_normalization(edit) {
@@ -923,6 +966,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => return Ok((HV::Rna(variant.clone()), vec![])),
         };
 
+        // SVD-WG009: rewrite `con` to `delins`.
+        if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
+            let new_variant = RnaVariant {
+                accession: variant.accession.clone(),
+                gene_symbol: variant.gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    variant.loc_edit.location.clone(),
+                    variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+                ),
+            };
+            return Ok((HV::Rna(new_variant), vec![]));
+        }
+
         // Only normalize indels
         if !needs_normalization(edit) {
             return Ok((HV::Rna(variant.clone()), vec![]));
@@ -1085,14 +1141,28 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         variant: &crate::hgvs::variant::MtVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
-        // MT variants are similar to genomic. Full window-based normalization
-        // and the per-edit canonicalization that runs inside normalize_na_edit
-        // for g./c./n./r. is not yet wired up for m. (would also need circular
-        // genome handling) — that gap is pre-existing and out of scope here.
-        // Issue #160 only requires that a delins whose ref/alt span contains
-        // an inv-eligible sub-span decomposes for m. the same way it does for
-        // g.; route through apply_inv_split so user-typed and merged Mt
-        // delins both reach the split path.
+        // MT variants are similar to genomic. We canonicalize `con` -> `delins`
+        // (SVD-WG009) up front, then route through apply_inv_split so any
+        // delins whose ref/alt span contains an inv-eligible sub-span
+        // decomposes the same way it does for g. (issue #160). Full
+        // window-based normalization and the per-edit canonicalization that
+        // runs inside normalize_na_edit for g./c./n./r. is not yet wired up
+        // for m. (would also need circular genome handling) — that gap is
+        // pre-existing and out of scope here.
+        if let Some(edit) = variant.loc_edit.edit.inner() {
+            if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
+                let new_variant = MtVariant {
+                    accession: variant.accession.clone(),
+                    gene_symbol: variant.gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(
+                        variant.loc_edit.location.clone(),
+                        variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+                    ),
+                };
+                let split = self.apply_inv_split(HV::Mt(new_variant));
+                return Ok((wrap_allele_if_split(split), vec![]));
+            }
+        }
         let split = self.apply_inv_split(HV::Mt(variant.clone()));
         Ok((wrap_allele_if_split(split), vec![]))
     }

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1309,6 +1309,63 @@ pub fn should_canonicalize(edit: &NaEdit) -> bool {
     }
 }
 
+/// Canonicalize a `con` (conversion) edit to its SVD-WG009 `delins` equivalent.
+///
+/// Per HGVS Nomenclature DNA delins recommendations and Community
+/// Consultation SVD-WG009 (accepted Nov 2020), the `con` form is "no longer
+/// used" and should be described as `delins`. This helper performs the
+/// purely-syntactic rewrite:
+///
+/// - Same-reference position-only source (e.g. `42536337_42536382`):
+///   emits `Delins{PositionRange{start, end}}`, displayed as
+///   `delins42536337_42536382`.
+/// - Cross-reference source (anything else, e.g. `NM_000089.1:c.789_1011`):
+///   emits `Delins{Reference(source)}`, displayed as
+///   `delins[NM_000089.1:c.789_1011]`. The square brackets and source
+///   reference-type prefix are required by SVD-WG009.
+///
+/// Returns `None` for any non-`Conversion` edit so callers can use it as
+/// an early-return probe.
+///
+/// This is a pure transformation; it does not require reference data and
+/// does not validate the source. Validation is delegated to the existing
+/// `delins`-source parser on any subsequent round-trip.
+pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
+    use crate::hgvs::edit::InsertedSequence;
+
+    let source = match edit {
+        NaEdit::Conversion { source } => source,
+        _ => return None,
+    };
+
+    // Try same-reference position-only form: `<digits>_<digits>`.
+    // HGVS positions are 1-based and ordered, so only emit a PositionRange
+    // when both endpoints are >= 1 and start <= end. Anything else falls
+    // through to Reference so we don't fabricate a structurally-invalid
+    // delins range (e.g. `0_0`, reversed `10_2`).
+    if let Some((s, e)) = source.split_once('_') {
+        if !s.is_empty()
+            && !e.is_empty()
+            && s.bytes().all(|b| b.is_ascii_digit())
+            && e.bytes().all(|b| b.is_ascii_digit())
+        {
+            if let (Ok(start), Ok(end)) = (s.parse::<u64>(), e.parse::<u64>()) {
+                if start >= 1 && end >= 1 && start <= end {
+                    return Some(NaEdit::Delins {
+                        sequence: InsertedSequence::PositionRange { start, end },
+                    });
+                }
+            }
+        }
+    }
+
+    // Cross-reference source (or anything that isn't a clean integer pair):
+    // wrap in `Reference`, which displays as `[<source>]`.
+    Some(NaEdit::Delins {
+        sequence: InsertedSequence::Reference(source.clone()),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2554,6 +2611,121 @@ mod tests {
                 sub_at(3, 'C', 'G'),
                 sub_at(4, 'C', 'T'),
             ])
+        );
+    }
+
+    #[test]
+    fn canonicalize_conversion_same_reference_emits_position_range() {
+        use crate::hgvs::edit::InsertedSequence;
+        let edit = NaEdit::Conversion {
+            source: "42536337_42536382".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        match got {
+            NaEdit::Delins {
+                sequence: InsertedSequence::PositionRange { start, end },
+            } => {
+                assert_eq!(start, 42536337);
+                assert_eq!(end, 42536382);
+            }
+            other => panic!("expected Delins{{PositionRange}}, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn canonicalize_conversion_cross_reference_emits_bracketed_reference() {
+        use crate::hgvs::edit::InsertedSequence;
+        let edit = NaEdit::Conversion {
+            source: "NM_000089.1:c.789_1011".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        match &got {
+            NaEdit::Delins {
+                sequence: InsertedSequence::Reference(s),
+            } => {
+                assert_eq!(s, "NM_000089.1:c.789_1011");
+            }
+            other => panic!("expected Delins{{Reference}}, got {:?}", other),
+        }
+        // Display of Reference adds the SVD-WG009 brackets.
+        assert_eq!(format!("{}", got), "delins[NM_000089.1:c.789_1011]");
+    }
+
+    #[test]
+    fn canonicalize_conversion_returns_none_for_non_conversion() {
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        assert!(canonicalize_conversion_to_delins(&edit).is_none());
+    }
+
+    #[test]
+    fn canonicalize_conversion_overflow_falls_back_to_reference() {
+        use crate::hgvs::edit::InsertedSequence;
+        // 21-digit number overflows u64. Falls back to Reference.
+        let edit = NaEdit::Conversion {
+            source: "123456789012345678901_2".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        assert!(matches!(
+            got,
+            NaEdit::Delins {
+                sequence: InsertedSequence::Reference(_)
+            }
+        ));
+    }
+
+    #[test]
+    fn canonicalize_conversion_zero_position_falls_back_to_reference() {
+        use crate::hgvs::edit::InsertedSequence;
+        // HGVS positions are 1-based; `0_0` is not a valid range, so we must
+        // not emit a `PositionRange`. Preserve the original numeric source as
+        // a `Reference` so the parser sees the same string on round-trip.
+        let edit = NaEdit::Conversion {
+            source: "0_0".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        match got {
+            NaEdit::Delins {
+                sequence: InsertedSequence::Reference(s),
+            } => assert_eq!(s, "0_0"),
+            other => panic!("expected Delins{{Reference}} for 0_0, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn canonicalize_conversion_reversed_range_falls_back_to_reference() {
+        use crate::hgvs::edit::InsertedSequence;
+        // `10_2` violates `start <= end`. Don't promote it to PositionRange.
+        let edit = NaEdit::Conversion {
+            source: "10_2".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        match got {
+            NaEdit::Delins {
+                sequence: InsertedSequence::Reference(s),
+            } => assert_eq!(s, "10_2"),
+            other => panic!("expected Delins{{Reference}} for 10_2, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn canonicalize_conversion_zero_start_falls_back_to_reference() {
+        use crate::hgvs::edit::InsertedSequence;
+        // `0_5`: start < 1 violates HGVS 1-based position rule.
+        let edit = NaEdit::Conversion {
+            source: "0_5".to_string(),
+        };
+        let got = canonicalize_conversion_to_delins(&edit).expect("expected Some");
+        assert!(
+            matches!(
+                got,
+                NaEdit::Delins {
+                    sequence: InsertedSequence::Reference(_)
+                }
+            ),
+            "expected Delins{{Reference}} fallback for 0_5"
         );
     }
 }

--- a/tests/con_conversion_audit.rs
+++ b/tests/con_conversion_audit.rs
@@ -1,0 +1,508 @@
+//! Audit of `con` (sequence-conversion) edit notation acceptance.
+//!
+//! Tracks issue #81 item H1: "`con` (sequence conversion) — rare but
+//! spec'd: `c.123_456conNM_X.1:c.789_1011`."
+//!
+//! ## Background
+//!
+//! Sequence conversion replaces a range of the current reference with a
+//! range from another (or the same) reference, e.g. `c.123_456conNM_X.1:c.789_1011`.
+//! The HGVS Nomenclature page on DNA delins (`assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md`)
+//! says the `con` form is "no longer used" in favor of `delins`, citing
+//! Community Consultation SVD-WG009. The form remains spec'd but
+//! deprecated, and it still appears in real-world inputs (Mutalyzer
+//! corpus, biocommons grammar tests, ClinVar legacy records).
+//!
+//! ## Audit goals
+//!
+//! The tests below pin parse, AST, normalize, and lowering behavior for
+//! `con`, including the SVD-WG009 canonicalization implemented in this
+//! PR. Any future change to any of these invariants must be intentional
+//! and visible in code review.
+//!
+//! 1. The exact spec form from issue #81 (cross-reference c. → c.) —
+//!    parse + display round-trip.
+//! 2. Cross-reference genomic conversion (NC → NC) — round-trip.
+//! 3. Same-reference position-only conversion (no second accession) —
+//!    round-trip.
+//! 4. Same-reference c. → c. position-only conversion — round-trip.
+//! 5. Internal AST shape: edit type is `NaEdit::Conversion` with the
+//!    full source string (including any `accession:` prefix) preserved
+//!    verbatim.
+//! 6. `normalize()` canonicalizes `con` edits to SVD-WG009 `delins`
+//!    (cross-reference -> `delins[...]`, same-reference -> `delins<a>_<b>`).
+//! 7. Downstream conversion to SPDI is an explicit
+//!    `UnsupportedEditType` error whose message references "conversion"
+//!    so callers know what's not supported.
+//! 8. Downstream conversion to VCF is an explicit `ConversionError`
+//!    — not a silent drop.
+//! 9. The `gene_conversion` versioned-feature flag is registered and
+//!    reports as supported in the current HGVS version.
+//! 10. Coordinate-system breadth: `n.` and `m.` accept `con`.
+//! 11. `Hash` + `Eq` stability: two parses of the same `con` input
+//!     compare equal and hash to the same bucket.
+//! 12. Idempotency: `normalize(normalize(x)) == normalize(x)`.
+//! 13. Allele compound containing `con` — member is canonicalized.
+//! 14. Empty-source parser rejection.
+//! 15. Cross-reference accession + coord prefix survive canonicalization
+//!     verbatim inside the `delins[...]` brackets.
+//!
+//! ## Closes #140
+//!
+//! - SVD-WG009 canonicalization: implemented (test 6). `parse → Display`
+//!   continues to round-trip `con` verbatim (tests 1-4); the rewrite
+//!   only happens on explicit `normalize()`.
+//! - Sequence-aware source validation at parse time: declined.
+//!   Superseded by canonicalization: the rewritten `delins` source is
+//!   parsed by ferro's existing structured `delins`-source parser on
+//!   any subsequent round-trip.
+//! - SPDI / VCF expansion of `con`: declined. Both surfaces stay as
+//!   explicit errors (tests 7, 8). Expansion would require lowering
+//!   support for `delins[ACC:...]`, which is a separate, larger feature.
+
+use ferro_hgvs::hgvs::edit::NaEdit;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::hgvs::version::{features, is_feature_supported};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Extract the `NaEdit` from a c./g./n./r./m. variant, panicking on
+/// any other shape. Convenience wrapper for the audit assertions
+/// below — keeps each test focused on the audit invariant.
+fn na_edit_of(variant: &HgvsVariant) -> &NaEdit {
+    match variant {
+        HgvsVariant::Cds(v) => v
+            .loc_edit
+            .edit
+            .inner()
+            .expect("Cds variant must carry an edit"),
+        HgvsVariant::Genome(v) => v
+            .loc_edit
+            .edit
+            .inner()
+            .expect("Genome variant must carry an edit"),
+        HgvsVariant::Tx(v) => v
+            .loc_edit
+            .edit
+            .inner()
+            .expect("Tx variant must carry an edit"),
+        HgvsVariant::Rna(v) => v
+            .loc_edit
+            .edit
+            .inner()
+            .expect("Rna variant must carry an edit"),
+        HgvsVariant::Mt(v) => v
+            .loc_edit
+            .edit
+            .inner()
+            .expect("Mt variant must carry an edit"),
+        other => panic!(
+            "expected nucleotide variant carrying NaEdit, got {:?}",
+            other
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------
+// 1. Exact spec form from issue #81: cross-reference c. → c.
+// ---------------------------------------------------------------------
+
+/// Pins parse + display round-trip for the canonical issue #81 H1
+/// example: a CDS interval on one transcript replaced by a CDS
+/// interval from another transcript.
+///
+/// If this regresses, ferro has either lost `con` parsing or changed
+/// its display form (e.g. rewriting to `delins`). Either is a
+/// behavior change that should be intentional and tracked.
+#[test]
+fn cross_reference_cds_conversion_round_trips() {
+    let input = "NM_000088.3:c.123_456conNM_000089.1:c.789_1011";
+    let variant = parse_hgvs(input).expect("issue #81 H1 canonical form must parse");
+    assert!(matches!(variant, HgvsVariant::Cds(_)));
+    assert_eq!(format!("{}", variant), input);
+}
+
+// ---------------------------------------------------------------------
+// 2. Cross-reference genomic conversion.
+// ---------------------------------------------------------------------
+
+/// Pins parse + display round-trip for a genomic-to-genomic
+/// cross-reference conversion. Matches the form found in the
+/// biocommons gauntlet and Mutalyzer grammar fixtures.
+#[test]
+fn cross_reference_genomic_conversion_round_trips() {
+    let input = "NC_000001.11:g.12345_12400conNC_000002.12:g.100_155";
+    let variant = parse_hgvs(input).expect("genomic cross-reference con must parse");
+    assert!(matches!(variant, HgvsVariant::Genome(_)));
+    assert_eq!(format!("{}", variant), input);
+}
+
+// ---------------------------------------------------------------------
+// 3. Same-reference position-only conversion (genomic).
+// ---------------------------------------------------------------------
+
+/// Pins the spec example from
+/// `assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md`
+/// (CYP2D6 exon-9 conversion to CYP2D7P1 flanking sequence on the
+/// same NC_ accession). Source has no `accession:` prefix; just
+/// numeric positions.
+#[test]
+fn same_reference_genomic_position_conversion_round_trips() {
+    let input = "NC_000017.11:g.42522624_42522669con42536337_42536382";
+    let variant = parse_hgvs(input).expect("same-reference position con must parse");
+    assert!(matches!(variant, HgvsVariant::Genome(_)));
+    assert_eq!(format!("{}", variant), input);
+}
+
+// ---------------------------------------------------------------------
+// 4. Same-reference position-only conversion (CDS).
+// ---------------------------------------------------------------------
+
+/// Pins the spec DRD4 example: `c.812_829con908_925` — same
+/// reference, CDS coordinates on both sides, no second accession.
+/// Note that the parser preserves the source string verbatim, so
+/// `908_925` (without a `c.` prefix) round-trips as-is.
+#[test]
+fn same_reference_cds_position_conversion_round_trips() {
+    let input = "NM_000797.3:c.812_829con908_925";
+    let variant = parse_hgvs(input).expect("same-reference CDS position con must parse");
+    assert!(matches!(variant, HgvsVariant::Cds(_)));
+    assert_eq!(format!("{}", variant), input);
+}
+
+// ---------------------------------------------------------------------
+// 5. Internal AST shape.
+// ---------------------------------------------------------------------
+
+/// Pins the AST shape: every accepted `con` form lands in
+/// `NaEdit::Conversion { source }` with `source` capturing
+/// everything after the literal `con` token verbatim. Pinning this
+/// is what catches a future refactor that, for example, splits
+/// `source` into structured `(Option<Accession>, Location)` — such
+/// a change would break this test loudly and force a deliberate
+/// migration.
+#[test]
+fn conversion_edit_preserves_source_string_verbatim() {
+    let cases = [
+        // (input HGVS, expected source string after the `con` token)
+        (
+            "NM_000088.3:c.123_456conNM_000089.1:c.789_1011",
+            "NM_000089.1:c.789_1011",
+        ),
+        (
+            "NC_000017.11:g.42522624_42522669con42536337_42536382",
+            "42536337_42536382",
+        ),
+        ("NM_000797.3:c.812_829con908_925", "908_925"),
+    ];
+
+    for (input, expected_source) in cases {
+        let variant =
+            parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {}: {}", input, e));
+        let edit = na_edit_of(&variant);
+        match edit {
+            NaEdit::Conversion { source } => {
+                assert_eq!(
+                    source, expected_source,
+                    "source mismatch for input {}",
+                    input
+                );
+            }
+            other => panic!("expected NaEdit::Conversion for {}, got {:?}", input, other),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// 6. `normalize()` canonicalizes `con` to SVD-WG009 `delins`.
+// ---------------------------------------------------------------------
+
+/// Pins SVD-WG009 canonicalization: every accepted `con` form is
+/// rewritten to its `delins` equivalent inside `Normalizer::normalize`.
+///
+/// - Same-reference position source -> bare `delins<start>_<end>`.
+/// - Cross-reference source -> `delins[<source>]` (square brackets per
+///   the spec: the reference type prefix on the source must survive).
+///
+/// `parse_hgvs` + `Display` continue to round-trip the legacy `con`
+/// form (pinned by tests 1-4); canonicalization happens only when
+/// callers explicitly invoke `normalize`.
+#[test]
+fn normalize_canonicalizes_conversion_to_delins() {
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let cases = [
+        // (input, expected normalized output)
+        (
+            "NM_000088.3:c.123_456conNM_000089.1:c.789_1011",
+            "NM_000088.3:c.123_456delins[NM_000089.1:c.789_1011]",
+        ),
+        (
+            "NC_000001.11:g.12345_12400conNC_000002.12:g.100_155",
+            "NC_000001.11:g.12345_12400delins[NC_000002.12:g.100_155]",
+        ),
+        (
+            "NC_000017.11:g.42522624_42522669con42536337_42536382",
+            "NC_000017.11:g.42522624_42522669delins42536337_42536382",
+        ),
+        (
+            "NM_000797.3:c.812_829con908_925",
+            "NM_000797.3:c.812_829delins908_925",
+        ),
+    ];
+    for (input, expected) in cases {
+        let variant = parse_hgvs(input).expect("input must parse");
+        let result = normalizer
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("normalize failed for {}: {}", input, e));
+        assert_eq!(
+            format!("{}", result),
+            expected,
+            "normalize() must canonicalize con to delins (input: {})",
+            input
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// 7. SPDI lowering rejects `con` explicitly.
+// ---------------------------------------------------------------------
+
+/// Pins that converting a `con` HGVS to SPDI fails with an explicit
+/// `UnsupportedEditType` error rather than silently dropping or
+/// emitting a wrong record. Behavior lives at
+/// `src/spdi/convert.rs:301` today.
+#[test]
+fn conversion_to_spdi_is_explicit_unsupported_error() {
+    use ferro_hgvs::spdi::ConversionError;
+
+    let variant =
+        parse_hgvs("NC_000017.11:g.42522624_42522669con42536337_42536382").expect("parse");
+    let err = ferro_hgvs::hgvs_to_spdi_simple(&variant).expect_err("SPDI lowering must error");
+    assert!(
+        matches!(err, ConversionError::UnsupportedEditType { .. }),
+        "expected UnsupportedEditType, got {:?}",
+        err
+    );
+    let msg = format!("{}", err);
+    assert!(
+        msg.to_lowercase().contains("conversion"),
+        "SPDI error message must mention 'conversion' for callers, got: {}",
+        msg
+    );
+}
+
+// ---------------------------------------------------------------------
+// 8. VCF lowering rejects `con` explicitly.
+// ---------------------------------------------------------------------
+
+/// Pins that converting a `con` HGVS to VCF returns an explicit
+/// error. The match arm at `src/vcf/from_hgvs.rs:430` is exercised
+/// via `genomic_hgvs_to_vcf` (the provider-less, genome-only entry
+/// point). We do not pin the human-readable message — only that it
+/// is an error and not silent success.
+#[test]
+fn conversion_to_vcf_is_explicit_error() {
+    use ferro_hgvs::vcf::genomic_hgvs_to_vcf;
+
+    let variant =
+        parse_hgvs("NC_000017.11:g.42522624_42522669con42536337_42536382").expect("parse");
+    let genome = match variant {
+        HgvsVariant::Genome(g) => g,
+        other => panic!("expected Genome variant, got {:?}", other),
+    };
+    let result = genomic_hgvs_to_vcf(&genome);
+    assert!(
+        result.is_err(),
+        "VCF lowering of a con edit should error, got Ok({:?})",
+        result.ok()
+    );
+}
+
+// ---------------------------------------------------------------------
+// 9. `gene_conversion` is a registered, supported feature.
+// ---------------------------------------------------------------------
+
+/// Pins that the version registry advertises `gene_conversion` as
+/// supported in the current HGVS version. If a future refactor
+/// removes the flag, this test catches the regression. The flag
+/// itself is purely informational today (no code reads it to
+/// decide whether to parse `con`); making it gate parsing is a
+/// separate audit follow-up.
+#[test]
+fn gene_conversion_feature_is_registered_and_supported() {
+    let feature = &features::GENE_CONVERSION;
+    assert_eq!(feature.name, "gene_conversion");
+    assert!(
+        is_feature_supported(feature),
+        "gene_conversion must be reported as supported in CURRENT version"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 10. Coordinate-system breadth: n. and m. accept `con`.
+// ---------------------------------------------------------------------
+
+/// Pins that `con` is accepted in non-coding (`n.`) and mitochondrial
+/// (`m.`) coord systems, not just `c.` and `g.`. The HGVS spec is
+/// coord-system-agnostic for `con`; this guards against a future parser
+/// refactor that accidentally narrows the accepted prefixes.
+///
+/// Round-trip parse + Display only — `normalize` canonicalization for
+/// `n.` and `m.` is exercised separately via the per-system normalizers
+/// (Tx and Mt) wired in this PR.
+#[test]
+fn conversion_round_trips_for_n_and_m_coords() {
+    let n_input = "NR_000001.1:n.10_20conNR_000002.1:n.30_40";
+    let variant = parse_hgvs(n_input).expect("n. con must parse");
+    assert!(matches!(variant, HgvsVariant::Tx(_)));
+    assert_eq!(format!("{}", variant), n_input);
+
+    let m_input = "NC_012920.1:m.100_200conNC_012920.1:m.300_400";
+    let variant = parse_hgvs(m_input).expect("m. con must parse");
+    assert!(matches!(variant, HgvsVariant::Mt(_)));
+    assert_eq!(format!("{}", variant), m_input);
+}
+
+// ---------------------------------------------------------------------
+// 11. `Hash` + `Eq` stability for `NaEdit::Conversion`.
+// ---------------------------------------------------------------------
+
+/// Pins that two parses of the same `con` input produce structurally
+/// equal variants that hash to the same bucket. A future refactor that
+/// changes `source: String` to a structured payload must keep this
+/// invariant -- otherwise `HashSet<HgvsVariant>` and friends silently
+/// break.
+#[test]
+fn conversion_hash_and_eq_are_stable_across_parses() {
+    use std::collections::HashSet;
+
+    let input = "NM_000088.3:c.123_456conNM_000089.1:c.789_1011";
+    let a = parse_hgvs(input).expect("first parse");
+    let b = parse_hgvs(input).expect("second parse");
+    assert_eq!(a, b, "two parses of the same input must be equal");
+
+    let mut set = HashSet::new();
+    set.insert(a);
+    set.insert(b);
+    assert_eq!(
+        set.len(),
+        1,
+        "two parses of the same input must hash to the same bucket"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 12. Idempotency: normalize(normalize(con)) == normalize(con).
+// ---------------------------------------------------------------------
+
+/// Pins that running `normalize` twice yields the same result as
+/// running it once. After the first pass, `con` becomes `delins`; the
+/// second pass must be a no-op (the resulting `delins{Reference|
+/// PositionRange}` has no literal sequence to shuffle and isn't
+/// re-canonicalized).
+#[test]
+fn normalize_is_idempotent_for_conversion() {
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let inputs = [
+        "NM_000088.3:c.123_456conNM_000089.1:c.789_1011",
+        "NC_000017.11:g.42522624_42522669con42536337_42536382",
+    ];
+    for input in inputs {
+        let variant = parse_hgvs(input).expect("parse");
+        let once = normalizer.normalize(&variant).expect("first normalize");
+        let twice = normalizer.normalize(&once).expect("second normalize");
+        assert_eq!(
+            format!("{}", once),
+            format!("{}", twice),
+            "normalize must be idempotent (input: {})",
+            input
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// 13. Allele compound containing `con`.
+// ---------------------------------------------------------------------
+
+/// Pins that `con` survives inside a bracketed compound allele
+/// alongside other edit types: the `con` member is canonicalized to
+/// `delins` while the substitution member is unchanged.
+#[test]
+fn allele_compound_with_conversion_canonicalizes_member() {
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let input = "NM_000088.3:c.[123_456conNM_000089.1:c.789_1011;500A>G]";
+    let variant = parse_hgvs(input).expect("compound con+sub must parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize compound");
+    let out = format!("{}", normalized);
+    assert!(
+        out.contains("delins[NM_000089.1:c.789_1011]"),
+        "con member must be canonicalized to delins[...] in compound; got {}",
+        out
+    );
+    assert!(
+        out.contains("500A>G"),
+        "substitution member must be untouched in compound; got {}",
+        out
+    );
+}
+
+// ---------------------------------------------------------------------
+// 14. Empty-source parser rejection.
+// ---------------------------------------------------------------------
+
+/// Pins that `con` followed by an empty source is rejected by the
+/// parser. Today this is enforced by `take_while1(!whitespace)` in
+/// `parse_conversion`; this test fences the invariant against a future
+/// switch to `take_while0`.
+#[test]
+fn empty_source_after_con_is_rejected() {
+    let result = parse_hgvs("NM_000088.3:c.1_2con");
+    assert!(
+        result.is_err(),
+        "empty source after `con` must be rejected, got Ok({:?})",
+        result.ok()
+    );
+}
+
+// ---------------------------------------------------------------------
+// 15. Cross-reference accession survives canonicalization verbatim.
+// ---------------------------------------------------------------------
+
+/// Pins that the accession + coord-system + interval payload of the
+/// `con` source is preserved character-for-character inside the
+/// resulting `delins[...]` brackets. This is the key SVD-WG009
+/// invariant: "for inserted sequences derived from another reference
+/// sequence the prefix of the reference sequence type ('g.' in the
+/// example) needs to be provided."
+#[test]
+fn cross_reference_canonicalization_preserves_source_payload() {
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let cases = [
+        (
+            "NM_000088.3:c.123_456conNM_000089.1:c.789_1011",
+            "NM_000089.1:c.789_1011",
+        ),
+        (
+            "NC_000001.11:g.12345_12400conNC_000002.12:g.100_155",
+            "NC_000002.12:g.100_155",
+        ),
+    ];
+    for (input, expected_inside_brackets) in cases {
+        let variant = parse_hgvs(input).expect("parse");
+        let out = format!("{}", normalizer.normalize(&variant).expect("normalize"));
+        let needle = format!("delins[{}]", expected_inside_brackets);
+        assert!(
+            out.contains(&needle),
+            "expected {} in normalized output, got {}",
+            needle,
+            out
+        );
+    }
+}


### PR DESCRIPTION
Addresses [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item **H1**: `con` (sequence conversion) notation. Closes [#140](https://github.com/fulcrumgenomics/ferro-hgvs/issues/140).

## Summary

`Normalizer::normalize` now rewrites the HGVS `con` (sequence-conversion) edit to the SVD-WG009-recommended `delins` form. `parse → Display` continues to round-trip `con` verbatim; the rewrite only happens when callers explicitly call `normalize`.

- Same-reference position source: `g.A_BconC_D` → `g.A_BdelinsC_D`
- Cross-reference source: `c.A_BconACC:type.X_Y` → `c.A_Bdelins[ACC:type.X_Y]`

The bracketed cross-reference form preserves the source's reference-type prefix per SVD-WG009.

## Why this shape

The HGVS Nomenclature DNA delins page (`assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md`) states: "**conversions** ... are described as a 'delins'. The previous format 'con' is no longer used (see Community Consultation SVD-WG009)." The rewrite is purely syntactic — no reference data needed — because the existing `InsertedSequence::Reference` and `InsertedSequence::PositionRange` variants of `Delins` already display in the SVD-WG009 shapes.

## What's in this PR

- `src/normalize/rules.rs`: new pure helper `canonicalize_conversion_to_delins(&NaEdit) -> Option<NaEdit>` plus unit tests for same-ref, cross-ref, non-conversion, and integer overflow.
- `src/normalize/mod.rs`: helper wired into `normalize_genome`, `normalize_cds`, `normalize_tx`, `normalize_rna`, and `normalize_mt` before the existing `needs_normalization` early-return.
- `tests/con_conversion_audit.rs`: 15 audit tests pinning parse/display round-trip, AST shape, canonicalization, n./m. acceptance, Hash/Eq stability, idempotency, allele compound, empty-source rejection, cross-ref payload preservation, SPDI/VCF lowering errors with caller-guidance text, and the `gene_conversion` versioned-feature flag.

## Closes #140

Three deferred decisions from the original audit:

1. SVD-WG009 canonicalization — implemented.
2. Sequence-aware source validation at parse time — declined: post-canonicalization, the structured `delins` source parser handles validation on any subsequent round-trip.
3. SPDI / VCF expansion of `con` — declined: explicit error retained; expansion would require new `delins[ACC:...]` lowering support, a separate feature.

## Test plan

- [x] cargo nextest run --features dev — 3417 passed
- [x] cargo clippy --features dev --all-targets -- -D warnings — clean
- [x] cargo fmt --all -- --check — clean