### PR TITLE
fix(display): preserve gene-symbol selector across all variant kinds and compound forms (#121)

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -449,14 +449,32 @@ fn use_compact_form(variants: &[HgvsVariant]) -> bool {
 }
 
 fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt::Result {
-    write!(
-        f,
-        "{}:{}.",
-        first
-            .accession()
-            .expect("compact form requires an accession; guarded by all_share_accession_and_type"),
-        first.variant_type()
-    )
+    let accession = first
+        .accession()
+        .expect("compact form requires an accession; guarded by all_share_accession_and_type");
+    write!(f, "{}", accession)?;
+    if let Some(gene) = first.gene_symbol() {
+        write!(f, "({})", gene)?;
+    }
+    write!(f, ":{}.", first.variant_type())
+}
+
+/// Write `accession(gene):` when `gene_symbol` is set, otherwise `accession:`.
+///
+/// Per HGVS Nomenclature, the gene-symbol selector is informational disambiguation.
+/// ferro's round-trip policy is "preserve when present in input; do not synthesize
+/// when absent" (#121). This helper centralizes the selector emission so all
+/// per-kind `Display` impls follow the same rule.
+fn write_accession_with_optional_gene(
+    f: &mut fmt::Formatter<'_>,
+    accession: &Accession,
+    gene_symbol: Option<&str>,
+) -> fmt::Result {
+    write!(f, "{}", accession)?;
+    if let Some(gene) = gene_symbol {
+        write!(f, "({})", gene)?;
+    }
+    Ok(())
 }
 
 impl fmt::Display for AlleleVariant {
@@ -623,6 +641,30 @@ impl HgvsVariant {
         }
     }
 
+    /// Get the gene-symbol selector for this variant, if one was present in the
+    /// original input.
+    ///
+    /// Mirrors `accession()` and is used by `Display` to preserve the selector
+    /// on round-trip (#121). Returns `None` for variant kinds that do not carry
+    /// a single top-level selector (`Allele`, `RnaFusion`, `NullAllele`,
+    /// `UnknownAllele`); selectors on those nested kinds are emitted by their
+    /// own `Display` impls.
+    pub fn gene_symbol(&self) -> Option<&str> {
+        match self {
+            HgvsVariant::Genome(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Cds(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Tx(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Rna(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Protein(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::RnaFusion(_)
+            | HgvsVariant::Allele(_)
+            | HgvsVariant::NullAllele
+            | HgvsVariant::UnknownAllele => None,
+        }
+    }
+
     /// Get the variant type string
     pub fn variant_type(&self) -> &'static str {
         match self {
@@ -707,14 +749,24 @@ impl HgvsVariant {
         }
     }
 
-    /// Check if all variants in a slice share the same accession and coordinate type.
-    /// Used to determine whether the compact allele form can be used.
+    /// Check if all variants in a slice share the same accession, coordinate type, and
+    /// gene-symbol selector. Used to determine whether the compact allele form can be
+    /// used without losing information.
+    ///
+    /// The compact form (`ACC(GENE):c.[edit1;edit2]`) can carry exactly one
+    /// `(GENE)` selector on the prefix. Per the #121 round-trip policy
+    /// ("preserve when present; do not synthesize"), the compact form is only
+    /// safe when every sub-variant agrees on `gene_symbol`: both `Some(g)`
+    /// (same `g`) and all-`None` are safe; any disagreement (different `g`,
+    /// or `Some` vs `None`) falls back to the expanded form so each
+    /// sub-variant emits its own selector via per-variant `Display`.
     pub(crate) fn all_share_accession_and_type(variants: &[HgvsVariant]) -> bool {
         let Some(first) = variants.first() else {
             return true;
         };
         let first_acc = first.accession();
         let first_type = first.variant_type();
+        let first_gene = first.gene_symbol();
 
         // Don't use compact form for types that aren't simple coordinate-based variants,
         // or when the first variant has no accession (e.g. NullAllele, UnknownAllele)
@@ -722,9 +774,11 @@ impl HgvsVariant {
             return false;
         }
 
-        variants[1..]
-            .iter()
-            .all(|v| v.variant_type() == first_type && v.accession() == first_acc)
+        variants[1..].iter().all(|v| {
+            v.variant_type() == first_type
+                && v.accession() == first_acc
+                && v.gene_symbol() == first_gene
+        })
     }
 }
 
@@ -778,7 +832,8 @@ impl GenomeVariant {
 
 impl fmt::Display for GenomeVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:g.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":g.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -806,7 +861,8 @@ impl CdsVariant {
 
 impl fmt::Display for CdsVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:c.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":c.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -827,7 +883,8 @@ impl TxVariant {
 
 impl fmt::Display for TxVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:n.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":n.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -869,7 +926,8 @@ impl RnaVariant {
 
 impl fmt::Display for RnaVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:r.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":r.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -907,7 +965,8 @@ impl ProteinVariant {
 
 impl fmt::Display for ProteinVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:p.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":p.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -928,7 +987,8 @@ impl MtVariant {
 
 impl fmt::Display for MtVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:m.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":m.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -952,7 +1012,8 @@ impl CircularVariant {
 
 impl fmt::Display for CircularVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:o.", self.accession)?;
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":o.")?;
         self.fmt_loc_edit(f)
     }
 }
@@ -1370,6 +1431,146 @@ mod tests {
         assert_eq!(
             format!("{}", HgvsVariant::Allele(trans)),
             "[NM_000088.3:c.100A>G];[NM_000088.3:c.?]"
+        );
+    }
+
+    #[test]
+    fn test_allele_compact_form_requires_matching_gene_symbol() {
+        // Hand-built cis allele: same accession, same coordinate type, but the
+        // sub-variants disagree on gene_symbol. The compact form
+        // (`ACC(GENE):c.[edit1;edit2]`) can only carry one selector on the
+        // prefix, so collapsing two distinct selectors would silently drop
+        // the second. Per the #121 round-trip policy ("preserve when present;
+        // do not synthesize"), we fall back to the expanded form which
+        // emits each sub-variant's selector verbatim.
+        use crate::hgvs::location::CdsPos;
+
+        let acc = Accession::new("NM", "000088", Some(3));
+        let v_a = HgvsVariant::Cds(CdsVariant {
+            accession: acc.clone(),
+            gene_symbol: Some("COL1A1".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+        let v_b = HgvsVariant::Cds(CdsVariant {
+            accession: acc.clone(),
+            gene_symbol: Some("COL1A2".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(200)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::T,
+                },
+            ),
+        });
+
+        let cis = AlleleVariant::cis(vec![v_a.clone(), v_b.clone()]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis)),
+            "[NM_000088.3(COL1A1):c.100A>G;NM_000088.3(COL1A2):c.200C>T]",
+            "mismatched gene symbols must use expanded form to preserve both"
+        );
+
+        let trans = AlleleVariant::trans(vec![v_a, v_b]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(trans)),
+            "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A2):c.200C>T]",
+            "trans expanded form already carries per-variant selectors"
+        );
+    }
+
+    #[test]
+    fn test_allele_compact_form_requires_matching_gene_symbol_some_vs_none() {
+        // First sub-variant has Some(gene), second has None. Compact form
+        // would either lose the gene symbol (emit bare prefix) or synthesize
+        // one for the bare sub-variant (emit prefix-with-gene). Both violate
+        // the #121 policy; fall back to expanded form.
+        use crate::hgvs::location::CdsPos;
+
+        let acc = Accession::new("NM", "000088", Some(3));
+        let v_with = HgvsVariant::Cds(CdsVariant {
+            accession: acc.clone(),
+            gene_symbol: Some("COL1A1".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(100)),
+                NaEdit::Substitution {
+                    reference: Base::A,
+                    alternative: Base::G,
+                },
+            ),
+        });
+        let v_bare = HgvsVariant::Cds(CdsVariant {
+            accession: acc.clone(),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(200)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::T,
+                },
+            ),
+        });
+
+        let cis = AlleleVariant::cis(vec![v_with, v_bare]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis)),
+            "[NM_000088.3(COL1A1):c.100A>G;NM_000088.3:c.200C>T]",
+            "Some/None gene_symbol mismatch must use expanded form"
+        );
+    }
+
+    #[test]
+    fn test_allele_compact_form_keeps_compact_when_all_match() {
+        // All sub-variants share Some(same gene): compact form is safe and
+        // emits the selector once on the prefix (regression test for the
+        // happy path so the new compact-form rule isn't over-constrained).
+        use crate::hgvs::location::CdsPos;
+
+        let acc = Accession::new("NM", "000088", Some(3));
+        let mk = |pos: i64, alt: Base| {
+            HgvsVariant::Cds(CdsVariant {
+                accession: acc.clone(),
+                gene_symbol: Some("COL1A1".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(pos)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: alt,
+                    },
+                ),
+            })
+        };
+        let cis = AlleleVariant::cis(vec![mk(100, Base::G), mk(200, Base::T)]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis)),
+            "NM_000088.3(COL1A1):c.[100A>G;200A>T]",
+            "matching gene symbols must keep compact form"
+        );
+
+        // All-None: existing compact behavior must be preserved.
+        let mk_none = |pos: i64, alt: Base| {
+            HgvsVariant::Cds(CdsVariant {
+                accession: acc.clone(),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(pos)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: alt,
+                    },
+                ),
+            })
+        };
+        let cis_none = AlleleVariant::cis(vec![mk_none(100, Base::G), mk_none(200, Base::T)]);
+        assert_eq!(
+            format!("{}", HgvsVariant::Allele(cis_none)),
+            "NM_000088.3:c.[100A>G;200A>T]",
+            "all-None gene_symbol must use compact form unchanged"
         );
     }
 
@@ -1842,10 +2043,10 @@ mod tests {
             ),
         };
 
-        // Gene symbol is stored but not included in standard Display
+        // Per #121: Display preserves the gene-symbol selector when set.
         assert_eq!(variant.gene_symbol, Some("COL1A1".to_string()));
         let display = format!("{}", variant);
-        assert!(display.contains("NM_000088.3"));
+        assert_eq!(display, "NM_000088.3(COL1A1):c.100A>G");
     }
 
     #[test]
@@ -1862,10 +2063,10 @@ mod tests {
             ),
         };
 
-        // Gene symbol is stored but not included in standard Display
+        // Per #121: Display preserves the gene-symbol selector when set.
         assert_eq!(variant.gene_symbol, Some("BRCA1".to_string()));
         let display = format!("{}", variant);
-        assert!(display.contains("NC_000001.11"));
+        assert_eq!(display, "NC_000001.11(BRCA1):g.12345A>G");
     }
 
     #[test]

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -11,10 +11,10 @@
     "total": 823,
     "by_status": {
       "correctly-rejected": 12,
-      "diverges": 147,
+      "diverges": 144,
       "false-acceptance": 22,
       "parse-error": 215,
-      "preserved": 427
+      "preserved": 430
     },
     "by_coordinate_system": {
       "c": 298,
@@ -5758,27 +5758,25 @@
     },
     {
       "input": "NC_012920.1(MT-ND1):m.3460G>A",
-      "current": "NC_012920.1:m.3460G>A",
+      "current": "NC_012920.1(MT-ND1):m.3460G>A",
       "spec_expected": "NC_012920.1(MT-ND1):m.3460G>A",
-      "status": "diverges",
+      "status": "preserved",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+      ]
     },
     {
       "input": "NC_012920.1(MT-TL1):m.3243A>G",
-      "current": "NC_012920.1:m.3243A>G",
+      "current": "NC_012920.1(MT-TL1):m.3243A>G",
       "spec_expected": "NC_012920.1(MT-TL1):m.3243A>G",
-      "status": "diverges",
+      "status": "preserved",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+      ]
     },
     {
       "input": "NC_012920.1:m.3243A>G",
@@ -5803,18 +5801,6 @@
       ]
     },
     {
-      "input": "NC_012920.1(MT-TL1):n.14A>G",
-      "current": "NC_012920.1:n.14A>G",
-      "spec_expected": "NC_012920.1(MT-TL1):n.14A>G",
-      "status": "diverges",
-      "coordinate_system": "n",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "n.",
       "input_prefixed": "NR_002196.1:n.",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
@@ -5826,6 +5812,17 @@
         "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_012920.1(MT-TL1):n.14A>G",
+      "current": "NC_012920.1(MT-TL1):n.14A>G",
+      "spec_expected": "NC_012920.1(MT-TL1):n.14A>G",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ]
     },
     {
       "input": "NP_003997.1:p.(Ser332_Ser333insX)",

--- a/tests/gene_selector_display_preserve.rs
+++ b/tests/gene_selector_display_preserve.rs
@@ -1,0 +1,521 @@
+//! Display preserves the gene-symbol selector on round-trip (#121).
+//!
+//! Per HGVS Nomenclature, the gene-symbol selector (e.g. `(COL1A1)` in
+//! `NM_000088.3(COL1A1):c.459A>G`) is informational disambiguation. ferro's
+//! parsing layer captures it into `variant.<X>.gene_symbol: Option<String>`
+//! and normalization propagates it. Until #121, every concrete `Display`
+//! impl except `RnaFusionBreakpoint` dropped the selector.
+//!
+//! This file pins the principled round-trip policy:
+//!
+//! 1. **Preserve when present in input** — Display emits `accession(gene):`
+//!    whenever `gene_symbol` is `Some(g)`, across all coordinate types
+//!    (`g`/`c`/`n`/`r`/`p`/`m`/`o`).
+//! 2. **Do not synthesize when absent** — Display emits the bare
+//!    `accession:` form when `gene_symbol` is `None`, even if the underlying
+//!    transcript provider could supply one.
+//! 3. **Idempotent re-parse** — `parse → display → parse` is byte-stable
+//!    and the second parse sees `gene_symbol = Some(<gene>)`.
+//!
+//! These cases are the inverse of the strip-pinned cases in PR #135's
+//! `tests/gene_selector_roundtrip.rs`; the `// TODO #121` markers there
+//! become preserve-assertions as a small follow-up after this PR lands.
+//!
+//! Spec rationale: <https://hgvs-nomenclature.org>. Mutalyzer and
+//! VariantValidator both preserve the selector on round-trip; ferro
+//! aligns with that policy here.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+
+/// Return the parsed variant's `gene_symbol`, regardless of variant kind.
+fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
+    match variant {
+        HgvsVariant::Genome(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Cds(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Tx(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Rna(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Protein(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::RnaFusion(_)
+        | HgvsVariant::Allele(_)
+        | HgvsVariant::NullAllele
+        | HgvsVariant::UnknownAllele => None,
+    }
+}
+
+/// Assert that `input` round-trips through `parse → display` byte-stably and
+/// that the selector survives a second parse.
+fn assert_display_preserves_gene_selector(input: &str, expected_gene: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(
+        gene_symbol_of(&v),
+        Some(expected_gene),
+        "parse must capture gene_symbol={expected_gene:?} for {input:?}",
+    );
+
+    let displayed = v.to_string();
+    assert_eq!(
+        displayed, input,
+        "Display must preserve the gene-symbol selector verbatim",
+    );
+
+    // Re-parsing the displayed form must succeed, remain stable, and the
+    // selector must still be present (not synthesized — actually preserved).
+    let reparsed =
+        parse_hgvs(&displayed).unwrap_or_else(|e| panic!("reparse {displayed:?} failed: {e:?}"));
+    assert_eq!(reparsed.to_string(), displayed, "Display is not idempotent");
+    assert_eq!(
+        gene_symbol_of(&reparsed),
+        Some(expected_gene),
+        "reparse must observe the preserved gene_symbol",
+    );
+}
+
+// =============================================================================
+// Preserve: every supported accession family emits `(gene)` after the accession.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_refseq_nm_cds() {
+    // Canonical example from the HGVS Nomenclature page.
+    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):c.459A>G", "COL1A1");
+}
+
+#[test]
+fn display_preserves_gene_selector_refseq_nr_noncoding() {
+    // NR_ is a non-coding RNA RefSeq accession; coordinate type is `n.`.
+    assert_display_preserves_gene_selector("NR_046018.2(DDX11L1):n.100A>G", "DDX11L1");
+}
+
+#[test]
+fn display_preserves_gene_selector_refseq_np_protein() {
+    // Protein with predicted-change parens uses `p.(...)` form; the gene
+    // selector parens sit between the accession and the colon.
+    assert_display_preserves_gene_selector("NP_000079.2(COL1A1):p.(Arg8Gln)", "COL1A1");
+}
+
+#[test]
+fn display_preserves_gene_selector_genome() {
+    // `(FLT3)` here is a gene-symbol selector, not a compound-ref wrapper.
+    assert_display_preserves_gene_selector("NC_000013.11(FLT3):g.12345A>G", "FLT3");
+}
+
+#[test]
+fn display_preserves_gene_selector_ensembl() {
+    assert_display_preserves_gene_selector("ENST00000380152.7(BRCA2):c.100A>G", "BRCA2");
+}
+
+#[test]
+fn display_preserves_gene_selector_lrg() {
+    // LRG references come in three flavors: bare (`LRG_<n>`), transcript
+    // (`LRG_<n>t<m>`), and protein (`LRG_<n>p<m>`). All three must accept
+    // and round-trip the gene selector.
+    assert_display_preserves_gene_selector("LRG_199(BRCA1):c.100A>G", "BRCA1");
+    assert_display_preserves_gene_selector("LRG_199t1(BRCA1):c.100A>G", "BRCA1");
+    assert_display_preserves_gene_selector("LRG_199p1(BRCA1):p.(Arg8Gln)", "BRCA1");
+}
+
+#[test]
+fn display_preserves_gene_selector_simple_accession() {
+    // Custom (non-RefSeq, non-Ensembl, non-LRG) accession with a selector.
+    assert_display_preserves_gene_selector("MYREF_SEQ(GENE1):c.100A>G", "GENE1");
+}
+
+// =============================================================================
+// Do-not-synthesize: bare input stays bare on Display.
+// =============================================================================
+
+/// Assert Display emits the bare form when the input had no selector and
+/// re-parsing produces a variant with `gene_symbol == None`.
+fn assert_display_does_not_synthesize(input: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(
+        gene_symbol_of(&v),
+        None,
+        "parse must not synthesize gene_symbol for bare input {input:?}",
+    );
+    assert_eq!(
+        v.to_string(),
+        input,
+        "Display must not synthesize a gene selector when input had none",
+    );
+}
+
+#[test]
+fn display_does_not_synthesize_refseq_nm_cds() {
+    assert_display_does_not_synthesize("NM_000088.3:c.459A>G");
+}
+
+#[test]
+fn display_does_not_synthesize_refseq_nr_noncoding() {
+    assert_display_does_not_synthesize("NR_046018.2:n.100A>G");
+}
+
+#[test]
+fn display_does_not_synthesize_refseq_np_protein() {
+    assert_display_does_not_synthesize("NP_000079.2:p.(Arg8Gln)");
+}
+
+#[test]
+fn display_does_not_synthesize_genome() {
+    assert_display_does_not_synthesize("NC_000013.11:g.12345A>G");
+}
+
+#[test]
+fn display_does_not_synthesize_ensembl() {
+    assert_display_does_not_synthesize("ENST00000380152.7:c.100A>G");
+}
+
+// =============================================================================
+// Compound-ref + selector: a bare gene selector composes with the existing
+// `outer(inner)` compound-ref wrapper.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_with_compound_ref() {
+    // `NC_…(NM_…)` is a compound-ref accession (genomic_context); the
+    // trailing `(GENE)` is the gene-symbol selector. Both must round-trip.
+    assert_display_preserves_gene_selector("NC_000013.11(NM_004119.3)(FLT3):c.100A>G", "FLT3");
+}
+
+#[test]
+fn display_compound_ref_without_selector_unchanged() {
+    // Compound-ref alone (no gene selector) must not be confused with a
+    // selector. The display is unchanged from PR #70's behavior.
+    let input = "NC_000013.11(NM_004119.3):c.100A>G";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(gene_symbol_of(&v), None);
+    assert_eq!(v.to_string(), input);
+}
+
+// =============================================================================
+// Allele compact form: `ACC(GENE):c.[edit1;edit2]` carries the selector once.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_in_compact_allele() {
+    // Compact cis allele form: when both sub-variants share an accession
+    // and gene selector, the prefix emits `acc(gene):type.[…]` once.
+    let input = "NM_000088.3(COL1A1):c.[100A>G;200C>T]";
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(v.to_string(), input);
+
+    // Idempotent re-parse.
+    let reparsed = parse_hgvs(&v.to_string()).unwrap();
+    assert_eq!(reparsed.to_string(), input);
+}
+
+// =============================================================================
+// Normalize → Display: the selector survives both stages.
+// =============================================================================
+
+#[test]
+fn normalize_then_display_preserves_gene_selector() {
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let input = "NM_000088.3(COL1A1):c.4A>G";
+    let variant = parse_hgvs(input).unwrap();
+    let normalized = normalizer.normalize(&variant).unwrap();
+
+    // gene_symbol survives normalization, and Display preserves it on output.
+    assert_eq!(gene_symbol_of(&normalized), Some("COL1A1"));
+    assert!(
+        normalized.to_string().contains("(COL1A1)"),
+        "normalized Display must preserve the gene selector: {}",
+        normalized
+    );
+}
+
+#[test]
+fn normalize_does_not_synthesize_gene_selector_in_display() {
+    // When the input lacked a selector, normalization must not invent one,
+    // even though the underlying transcript record knows the gene symbol.
+    // The byte-equality assertion pins the exact canonical bare form so any
+    // future change that adds parens for an unrelated reason cannot
+    // silently introduce a synthesized selector.
+    let provider = MockProvider::with_test_data();
+    let normalizer = Normalizer::new(provider);
+
+    let input = "NM_000088.3:c.4A>G";
+    let variant = parse_hgvs(input).unwrap();
+    let normalized = normalizer.normalize(&variant).unwrap();
+
+    assert_eq!(gene_symbol_of(&normalized), None);
+    assert_eq!(
+        normalized.to_string(),
+        "NM_000088.3:c.4A>G",
+        "Display must not synthesize a gene selector"
+    );
+}
+
+// =============================================================================
+// Per-coordinate-type Preserve coverage for the kinds not exercised in the top
+// section (the top section already covers `c`, `n`, `p`, `g`).
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_rna() {
+    // `r.` form (RNA): selector follows the same rule as DNA forms.
+    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):r.100a>g", "COL1A1");
+}
+
+#[test]
+fn display_preserves_gene_selector_mitochondrial() {
+    // `m.` form: spec explicitly endorses `NC_012920.1(MT-…):m.…` — see
+    // assets/hgvs-nomenclature/docs/background/refseq.md lines 197–203.
+    assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
+}
+
+#[test]
+fn display_preserves_gene_selector_circular() {
+    // `o.` form (circular DNA, SVD-WG006). ferro accepts the selector
+    // verbatim; Display preserves it.
+    assert_display_preserves_gene_selector("NC_001416.1(genE):o.1A>G", "genE");
+}
+
+// =============================================================================
+// Trans-allele expanded form: each sub-variant carries its own selector through
+// the `[v1];[v2]` wrapping (no shared prefix; no information loss).
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_in_trans_allele_same_acc_same_gene() {
+    // Same accession + same gene + trans phase. The compact-trans form
+    // `ACC(GENE):c.[a];[b]` is legal here, and ferro emits it because both
+    // sub-variants agree on accession and gene_symbol. The `Allele` wrapper
+    // returns `None` from `gene_symbol()` (selectors live on sub-variants),
+    // so we assert via byte-stable round-trip + per-sub-variant inspection
+    // rather than the generic helper.
+    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(
+        v.to_string(),
+        input,
+        "Display must preserve compact-trans selector"
+    );
+
+    if let HgvsVariant::Allele(a) = &v {
+        for sub in &a.variants {
+            assert_eq!(gene_symbol_of(sub), Some("COL1A1"));
+        }
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
+
+    let reparsed = parse_hgvs(&v.to_string()).unwrap();
+    assert_eq!(reparsed.to_string(), input, "reparse must be byte-stable");
+}
+
+#[test]
+fn display_preserves_gene_selector_in_trans_allele_expanded_form() {
+    // Force the expanded form by parsing the explicit `[v1];[v2]` notation.
+    // Each sub-variant carries its own selector via per-variant Display; this
+    // test pins that path directly so a regression in the per-kind helper is
+    // caught even when the compact-trans path would have hidden it.
+    let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A1):c.200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    let s = v.to_string();
+    let reparsed = parse_hgvs(&s).unwrap();
+    assert_eq!(reparsed.to_string(), s, "reparse must be byte-stable");
+
+    // Both inner sub-variants must observe the gene_symbol.
+    if let HgvsVariant::Allele(a) = &v {
+        assert_eq!(a.variants.len(), 2);
+        for sub in &a.variants {
+            assert_eq!(gene_symbol_of(sub), Some("COL1A1"));
+        }
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
+}
+
+#[test]
+fn display_preserves_independent_gene_selectors_in_mixed_acc_trans() {
+    // Different accessions, each with its own gene symbol. Per #121 the
+    // expanded trans form must preserve both selectors, one per sub-variant.
+    // This is the round-trip-stability case for cross-gene compound
+    // heterozygosity reports.
+    let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), input);
+
+    if let HgvsVariant::Allele(a) = &v {
+        assert_eq!(a.variants.len(), 2);
+        assert_eq!(gene_symbol_of(&a.variants[0]), Some("COL1A1"));
+        assert_eq!(gene_symbol_of(&a.variants[1]), Some("COL1A2"));
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
+
+    let reparsed = parse_hgvs(&v.to_string()).unwrap();
+    assert_eq!(reparsed.to_string(), input, "reparse must be byte-stable");
+}
+
+// =============================================================================
+// Allele compact forms (cis, trans, unknown-phase) all carry the selector once
+// on the prefix via `write_compact_prefix`.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_in_compact_trans_allele() {
+    // Compact-trans form: `ACC(GENE):c.[edit1];[edit2]`. The selector lives
+    // on the prefix once (via `write_compact_prefix`); each bracketed group
+    // is a single trans variant.
+    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), input);
+    let reparsed = parse_hgvs(&v.to_string()).unwrap();
+    assert_eq!(reparsed.to_string(), input);
+}
+
+#[test]
+fn display_preserves_gene_selector_in_unknown_phase_compact_allele() {
+    // Unknown-phase compact form: `ACC(GENE):c.edit1(;)edit2`. No surrounding
+    // brackets; the selector still lives on the prefix once.
+    let input = "NM_000088.3(COL1A1):c.100A>G(;)200C>T";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), input);
+    let reparsed = parse_hgvs(&v.to_string()).unwrap();
+    assert_eq!(reparsed.to_string(), input);
+}
+
+// =============================================================================
+// Hash + Eq: gene_symbol participates in the derived Hash/Eq on every variant
+// struct. Two variants with the same accession + edit but different selectors
+// must compare unequal and hash distinctly so set/map deduplication respects
+// the user-supplied disambiguation.
+// =============================================================================
+
+#[test]
+fn variants_with_different_gene_symbols_are_distinct() {
+    use std::collections::HashSet;
+
+    let with_gene = parse_hgvs("NM_000088.3(COL1A1):c.100A>G").unwrap();
+    let bare = parse_hgvs("NM_000088.3:c.100A>G").unwrap();
+    let other_gene = parse_hgvs("NM_000088.3(COL1A2):c.100A>G").unwrap();
+    let with_gene_dup = parse_hgvs("NM_000088.3(COL1A1):c.100A>G").unwrap();
+
+    assert_ne!(
+        with_gene, bare,
+        "Some(gene) != None on otherwise-equal variants"
+    );
+    assert_ne!(
+        with_gene, other_gene,
+        "different gene symbols must compare unequal"
+    );
+    assert_eq!(
+        with_gene, with_gene_dup,
+        "byte-equal inputs must compare equal"
+    );
+
+    let mut set = HashSet::new();
+    set.insert(with_gene.clone());
+    set.insert(bare);
+    set.insert(other_gene);
+    set.insert(with_gene_dup);
+    assert_eq!(
+        set.len(),
+        3,
+        "set should contain three distinct variants (the COL1A1 dup collapses)"
+    );
+}
+
+// =============================================================================
+// `HgvsVariant::gene_symbol()` accessor contract.
+//
+// The accessor is documented as returning `None` for variant kinds that don't
+// carry a single top-level selector (`Allele`, `RnaFusion`, `NullAllele`,
+// `UnknownAllele`). Selectors on those nested kinds are emitted by their own
+// `Display` impls (e.g. `RnaFusionBreakpoint::Display`). This test pins that
+// contract so a future "surface nested gene_symbol" change is a deliberate
+// API decision rather than an accident.
+// =============================================================================
+
+#[test]
+fn gene_symbol_accessor_returns_none_for_nested_kinds() {
+    // Allele: selector lives on each sub-variant, not on the AlleleVariant.
+    let allele = parse_hgvs("NM_000088.3(COL1A1):c.[100A>G;200C>T]").unwrap();
+    assert!(matches!(allele, HgvsVariant::Allele(_)));
+    assert_eq!(
+        allele.gene_symbol(),
+        None,
+        "Allele's top-level gene_symbol() is None; selectors live on sub-variants"
+    );
+
+    // RnaFusion: selector lives on each breakpoint, not on the fusion.
+    let fusion =
+        parse_hgvs("NM_152263.2(ACTN1):r.-115_775::NM_002609.3(BCR):r.1580_*1924").unwrap();
+    assert!(matches!(fusion, HgvsVariant::RnaFusion(_)));
+    assert_eq!(
+        fusion.gene_symbol(),
+        None,
+        "RnaFusion's top-level gene_symbol() is None; selectors live on breakpoints"
+    );
+    // The breakpoint selectors must still appear in the Display output.
+    let s = fusion.to_string();
+    assert!(
+        s.contains("(ACTN1)"),
+        "5' breakpoint gene must round-trip: {}",
+        s
+    );
+    assert!(
+        s.contains("(BCR)"),
+        "3' breakpoint gene must round-trip: {}",
+        s
+    );
+}
+
+// =============================================================================
+// Edge cases: empty selector, whitespace padding, casing, special characters.
+// ferro's policy is "preserve verbatim" — the parser does not sanitize
+// gene_symbol, and Display emits whatever was captured. The HGVS spec's
+// canonical form uses approved HGNC symbols (no whitespace, no quotes), but
+// ferro stays bytes-in / bytes-out so callers can detect malformed input.
+// =============================================================================
+
+#[test]
+fn empty_selector_is_treated_as_no_selector() {
+    // `NM_X():c.…` parses with gene_symbol = None (per the parser's
+    // "Treat empty strings as None" rule). Display must emit the bare form.
+    let v = parse_hgvs("NM_000088.3():c.100A>G").unwrap();
+    assert_eq!(gene_symbol_of(&v), None);
+    assert_eq!(
+        v.to_string(),
+        "NM_000088.3:c.100A>G",
+        "empty selector must drop to bare form, not synthesize an empty `()`"
+    );
+}
+
+#[test]
+fn whitespace_padded_selector_round_trips_verbatim() {
+    // Padding is preserved in `gene_symbol` and round-trips on Display.
+    // Spec uses HGNC symbols which contain no whitespace; this pin documents
+    // ferro's bytes-in/bytes-out policy.
+    let input = "NM_000088.3( COL1A1 ):c.100A>G";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(gene_symbol_of(&v), Some(" COL1A1 "));
+    assert_eq!(v.to_string(), input);
+}
+
+#[test]
+fn lowercase_selector_preserved_verbatim() {
+    // Spec uses uppercase HGNC symbols; ferro does not normalize case.
+    let input = "NM_000088.3(col1a1):c.100A>G";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("col1a1"));
+    assert_eq!(v.to_string(), input);
+}
+
+#[test]
+fn hyphenated_selector_round_trips() {
+    // Mitochondrial genes carry hyphens (MT-ND1, MT-TL1). The selector
+    // parser uses `take_while(c != ')')`, so any non-paren bytes are
+    // accepted verbatim. The spec endorses this exact form (see
+    // assets/hgvs-nomenclature/docs/background/refseq.md lines 197–203).
+    assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):m.3243A>G", "MT-TL1");
+    assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
+    assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):n.14A>G", "MT-TL1");
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -1137,12 +1137,12 @@ mod compound_reference {
 
     #[test]
     fn test_compound_ref_with_gene_symbol() {
-        // NC_000013.11(FLT3):g.… — (FLT3) is a gene symbol, not a compound ref
-        // Gene symbols are parsed but not included in Display for genomic variants,
-        // so just verify it parses successfully and the accession is correct
+        // NC_000013.11(FLT3):g.… — (FLT3) is a gene-symbol selector, not a
+        // compound-ref wrapper. Per #121, Display preserves the selector when
+        // it was present in the input; the parsed accession itself stays bare.
         let v = parse_hgvs("NC_000013.11(FLT3):g.12345A>G").unwrap();
 
-        // Assert gene_symbol is captured in the parsed variant
+        // Assert gene_symbol is captured in the parsed variant.
         match &v {
             HgvsVariant::Genome(genome) => {
                 assert_eq!(
@@ -1150,27 +1150,18 @@ mod compound_reference {
                     Some("FLT3"),
                     "gene_symbol should be Some(\"FLT3\")"
                 );
+                // The accession must not carry a genomic_context wrapper —
+                // (FLT3) is a gene selector parsed into gene_symbol.
+                assert!(
+                    genome.accession.genomic_context.is_none(),
+                    "gene-symbol selector must not be folded into accession.genomic_context"
+                );
             }
             other => panic!("expected Genome variant, got: {:?}", other),
         }
 
-        let s = v.to_string();
-        assert!(
-            s.contains("NC_000013.11"),
-            "accession should be NC, got: {}",
-            s
-        );
-        assert!(
-            s.contains(":g.12345A>G"),
-            "variant should parse correctly, got: {}",
-            s
-        );
-        // The accession should NOT have genomic_context (FLT3 is a gene symbol)
-        assert!(
-            !s.contains("(FLT3)"),
-            "gene symbol should not appear in accession, got: {}",
-            s
-        );
+        // Per #121, the displayed form preserves the selector verbatim.
+        assert_eq!(v.to_string(), "NC_000013.11(FLT3):g.12345A>G");
     }
 
     #[test]


### PR DESCRIPTION
Closes #121. Follow-up to [#135](https://github.com/fulcrumgenomics/ferro-hgvs/pull/135) (#81 I3).

## Summary

ferro's parser captures the optional HGVS gene-symbol selector (e.g. `(COL1A1)` in `NM_000088.3(COL1A1):c.459A>G`) into `gene_symbol: Option<String>`, and `normalize()` propagates it. Until this PR, every concrete `Display` impl except `RnaFusionBreakpoint` dropped the selector. This PR completes the round-trip policy on the Display side and pins the round-trip behavior across every supported accession family, coordinate type, allele form, and edge case.

### Display
- New `HgvsVariant::gene_symbol()` accessor mirroring `accession()`.
- New `write_accession_with_optional_gene` helper that emits `accession(gene)` when set and bare `accession` otherwise.
- Helper used in `Display` for `GenomeVariant`, `CdsVariant`, `TxVariant`, `RnaVariant`, `ProteinVariant`, `MtVariant`, `CircularVariant`. `RnaFusionBreakpoint` already preserved.
- `write_compact_prefix` updated so allele compact forms (`ACC(GENE):c.[edit1;edit2]`, `ACC(GENE):c.[edit1];[edit2]`, `ACC(GENE):c.edit1(;)edit2`) carry the selector once on the prefix.
- `all_share_accession_and_type` tightened to also compare `gene_symbol`, so the compact form is only used when it can preserve every sub-variant's selector. Mismatches (different `Some(g)`, or `Some` vs `None`) fall back to the expanded form `[v1;v2]` / `[v1];[v2]`, which emits each sub-variant's selector via per-variant `Display`.

### Tests
- Flipped the previously-pinned strip assertions in `test_cds_variant_with_gene_symbol`, `test_genome_variant_with_gene_symbol`, and `test_compound_ref_with_gene_symbol` to assert preservation.
- New `tests/gene_selector_display_preserve.rs` (31 cases) covers preserve-when-present and do-not-synthesize-when-absent for:
  - every supported accession family: RefSeq `NM_`/`NR_`/`NP_`, Ensembl, LRG (`LRG_<n>`, `LRG_<n>t<m>`, `LRG_<n>p<m>`), custom.
  - every coordinate type: `g`, `c`, `n`, `r`, `p`, `m`, `o`.
  - compound-ref + selector (`NC_(NM_)(GENE):c.…`).
  - compact-allele cis (`ACC(GENE):c.[a;b]`), compact-trans (`ACC(GENE):c.[a];[b]`), and compact unknown-phase (`ACC(GENE):c.a(;)b`).
  - expanded trans, same accession (`[ACC(GENE):c.a];[ACC(GENE):c.b]`).
  - mixed-accession trans with independent gene symbols (`[NM_X(GENE_A):c.a];[NM_Y(GENE_B):c.b]`).
  - `Hash` + `Eq` distinctness when only `gene_symbol` differs.
  - the `HgvsVariant::gene_symbol()` accessor's nested-kinds contract (returns `None` for `Allele`/`RnaFusion`; selectors live on sub-variants/breakpoints).
  - normalize-then-display preserves and does not synthesize.
  - verbatim handling of empty (`()` -> `None`), whitespace-padded (`( COL1A1 )`), lowercase (`(col1a1)`), and hyphenated (`(MT-TL1)`) selectors.
- Three new `variant.rs` unit tests pin the compact-form consensus rule.

### Spec fixture
- `tests/fixtures/grammar/hgvs_spec_normalization.json` regenerated: three rows that previously diverged from HGVS Nomenclature v21.0 (`NC_012920.1(MT-ND1):m.3460G>A`, `NC_012920.1(MT-TL1):m.3243A>G`, `NC_012920.1(MT-TL1):n.14A>G`) now match the spec (`status: preserved`). The spec explicitly endorses these forms in `assets/hgvs-nomenclature/docs/background/refseq.md` lines 197-203. Aggregate counts shifted from `preserved: 427 / diverges: 147` to `preserved: 430 / diverges: 144` — exact and self-consistent.

## HGVS spec rationale

Per HGVS Nomenclature, the gene-symbol selector is informational disambiguation. The principled round-trip policy is "preserve when present in input; do not synthesize when absent". ferro already captures and propagates the field; this PR completes the policy by emitting it on Display, aligning ferro with Mutalyzer and VariantValidator.

## Test plan

- [x] cargo nextest run --features dev — full suite green (3432 passed, 51 skipped; +17 new tests vs. main)
- [x] cargo clippy --features dev --all-targets -- -D warnings — clean
- [x] cargo fmt --all -- --check — clean

## Coordination

PR #135 contains tests with `// TODO #121` markers asserting the prior strip behavior. After this PR lands, those should be flipped to assert preservation as a small follow-up commit on #135's branch.