### PR TITLE
fix(parser): soft-warn embedded whitespace and zero-width chars (#128)

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -135,81 +135,70 @@ pub fn correct_quote_characters(input: &str) -> (String, Vec<DetectedCorrection>
     (result, corrections)
 }
 
+/// Return true if the character is whitespace per Rust's `char::is_whitespace`,
+/// or one of the common zero-width invisible characters that users frequently
+/// paste from PDFs and rich-text sources:
+/// - U+200B ZERO WIDTH SPACE
+/// - U+200C ZERO WIDTH NON-JOINER
+/// - U+200D ZERO WIDTH JOINER
+/// - U+FEFF ZERO WIDTH NO-BREAK SPACE (BOM)
+///
+/// HGVS expressions never contain any of these; we treat them all as
+/// `ExtraWhitespace` (W2003) and strip them under the same soft-warn contract.
+#[inline]
+fn is_invisible_whitespace(c: char) -> bool {
+    c.is_whitespace() || matches!(c, '\u{200B}' | '\u{200C}' | '\u{200D}' | '\u{FEFF}')
+}
+
 /// Normalize extra whitespace in the input.
 ///
-/// This removes leading/trailing whitespace and collapses internal
-/// whitespace around significant characters.
+/// HGVS expressions are not permitted to contain whitespace (the spec is
+/// explicit that the format `reference:description` has spaces "added for
+/// clarity only"). This function therefore removes all whitespace from the
+/// input — leading, trailing, and embedded — along with the zero-width
+/// invisible characters U+200B/U+200C/U+200D/U+FEFF that are functionally
+/// indistinguishable from whitespace. Each contiguous run of stripped
+/// characters is recorded as a single [`DetectedCorrection`] of type
+/// [`ErrorType::ExtraWhitespace`].
+///
+/// In strict mode the preprocessor will turn those corrections into a hard
+/// rejection; in lenient/silent modes they become warnings (or are applied
+/// silently). The function is idempotent on its own output. See issue #128.
 ///
 /// Returns the corrected string and a list of corrections made.
 pub fn correct_whitespace(input: &str) -> (String, Vec<DetectedCorrection>) {
     let mut corrections = Vec::new();
-    let trimmed = input.trim();
+    let mut result = String::with_capacity(input.len());
+    let mut run_start: Option<usize> = None;
 
-    // Track if we trimmed leading/trailing whitespace
-    if input != trimmed {
-        let leading = input.len() - input.trim_start().len();
-        let trailing = input.trim_end().len();
-        if leading > 0 || trailing < input.len() {
-            corrections.push(DetectedCorrection::new(
-                ErrorType::ExtraWhitespace,
-                input.to_string(),
-                trimmed.to_string(),
-                0,
-                input.len(),
-            ));
-        }
-    }
-
-    // Remove spaces around significant HGVS characters
-    let mut result = String::with_capacity(trimmed.len());
-    let mut prev_space = false;
-    let mut chars = trimmed.char_indices().peekable();
-
-    while let Some((i, c)) = chars.next() {
-        if c.is_whitespace() {
-            // Check if next char is a significant HGVS character
-            if let Some(&(_, next_c)) = chars.peek() {
-                // Don't add space before these characters
-                if matches!(
-                    next_c,
-                    '.' | ':' | '>' | '<' | '+' | '-' | '_' | '(' | ')' | '[' | ']'
-                ) {
-                    if corrections.is_empty()
-                        || corrections.last().unwrap().error_type != ErrorType::ExtraWhitespace
-                    {
-                        corrections.push(DetectedCorrection::new(
-                            ErrorType::ExtraWhitespace,
-                            " ".to_string(),
-                            "".to_string(),
-                            i,
-                            i + 1,
-                        ));
-                    }
-                    prev_space = false;
-                    continue;
-                }
+    for (i, c) in input.char_indices() {
+        if is_invisible_whitespace(c) {
+            if run_start.is_none() {
+                run_start = Some(i);
             }
-            prev_space = true;
         } else {
-            // Check if previous char was space and current is significant
-            if prev_space
-                && matches!(
-                    c,
-                    '.' | ':' | '>' | '<' | '+' | '-' | '_' | '(' | ')' | '[' | ']'
-                )
-            {
-                // Don't add space before this character
-                prev_space = false;
-                result.push(c);
-                continue;
-            }
-
-            if prev_space {
-                result.push(' ');
-                prev_space = false;
+            if let Some(start) = run_start.take() {
+                corrections.push(DetectedCorrection::new(
+                    ErrorType::ExtraWhitespace,
+                    input[start..i].to_string(),
+                    String::new(),
+                    start,
+                    i,
+                ));
             }
             result.push(c);
         }
+    }
+
+    // Trailing whitespace run, if any.
+    if let Some(start) = run_start {
+        corrections.push(DetectedCorrection::new(
+            ErrorType::ExtraWhitespace,
+            input[start..].to_string(),
+            String::new(),
+            start,
+            input.len(),
+        ));
     }
 
     (result, corrections)
@@ -1367,6 +1356,67 @@ mod tests {
         assert_eq!(corrected, "c.100A>G");
         // May have corrections detected but result should be same
         assert_eq!(corrected, "c.100A>G");
+    }
+
+    #[test]
+    fn test_correct_whitespace_strips_zero_width_chars() {
+        // U+200B ZERO WIDTH SPACE, U+FEFF ZWNBSP/BOM, U+200C ZWNJ, U+200D ZWJ
+        // are functionally invisible; users frequently paste them from PDFs/web.
+        // Treat them like whitespace under W2003.
+        let input = "NM_000088.3:c.100\u{200B}A>G";
+        let (corrected, corrections) = correct_whitespace(input);
+        assert_eq!(corrected, "NM_000088.3:c.100A>G");
+        assert_eq!(corrections.len(), 1, "should record one correction");
+        assert_eq!(corrections[0].error_type, ErrorType::ExtraWhitespace);
+
+        let input = "\u{FEFF}NM_000088.3:c.100A>G";
+        let (corrected, _) = correct_whitespace(input);
+        assert_eq!(corrected, "NM_000088.3:c.100A>G");
+
+        let input = "c.100\u{200C}A>G";
+        let (corrected, _) = correct_whitespace(input);
+        assert_eq!(corrected, "c.100A>G");
+
+        let input = "c.100\u{200D}A>G";
+        let (corrected, _) = correct_whitespace(input);
+        assert_eq!(corrected, "c.100A>G");
+    }
+
+    #[test]
+    fn test_correct_whitespace_embedded_single_run_one_warning() {
+        // Multiple whitespace chars in one contiguous run = ONE correction.
+        let (corrected, corrections) = correct_whitespace("c.100   A>G");
+        assert_eq!(corrected, "c.100A>G");
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].original, "   ");
+        assert_eq!(corrections[0].start, 5);
+        assert_eq!(corrections[0].end, 8);
+    }
+
+    #[test]
+    fn test_correct_whitespace_multiple_runs_count() {
+        // Three separate whitespace runs = THREE corrections.
+        let (corrected, corrections) = correct_whitespace(" c.100 A> G");
+        assert_eq!(corrected, "c.100A>G");
+        assert_eq!(corrections.len(), 3);
+    }
+
+    #[test]
+    fn test_correct_whitespace_idempotent() {
+        // Re-normalizing a corrected output produces zero corrections.
+        let (first, _) = correct_whitespace("  c. 100 A>G  ");
+        let (second, corrections) = correct_whitespace(&first);
+        assert_eq!(first, second);
+        assert!(corrections.is_empty());
+    }
+
+    #[test]
+    fn test_correct_whitespace_mixed_unicode_whitespace() {
+        // Tab, NBSP, em-space, vertical tab — all stripped, one run = one warning.
+        let input = "c.100\t\u{00A0}\u{2003}\u{000B}A>G";
+        let (corrected, corrections) = correct_whitespace(input);
+        assert_eq!(corrected, "c.100A>G");
+        assert_eq!(corrections.len(), 1);
     }
 
     // Position zero detection tests

--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -546,14 +546,23 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
             code: "W2003",
             name: "ExtraWhitespace",
             summary: "Extra whitespace in description.",
-            explanation: "HGVS expressions should not contain spaces (except in gene symbols). \
-                Extra spaces are removed in lenient/silent modes.",
+            explanation: "HGVS expressions should not contain spaces (the spec is explicit \
+                that the format `reference:description` has spaces \"added for clarity only\"). \
+                Leading, trailing, and embedded whitespace — and zero-width invisible \
+                characters (U+200B ZERO WIDTH SPACE, U+200C ZERO WIDTH NON-JOINER, \
+                U+200D ZERO WIDTH JOINER, U+FEFF BOM/ZWNBSP) — are stripped in \
+                lenient/silent modes.",
             category: CodeCategory::Character,
-            bad_examples: &["c.100 A>G", "NM_000088.3 : c.459A>G"],
+            bad_examples: &[
+                "c.100 A>G",
+                "NM_000088.3 : c.459A>G",
+                "c.[100A>G ; 200T>C]",
+                "NM_000088.3\u{200B}:c.100A>G",
+            ],
             good_examples: &["c.100A>G", "NM_000088.3:c.459A>G"],
             mode_behavior: Some(ModeBehavior::standard_correctable()),
-            hgvs_spec_url: None,
-            related_codes: &[],
+            hgvs_spec_url: Some("https://hgvs-nomenclature.org/stable/recommendations/general/"),
+            related_codes: &["W2001", "W2004"],
         },
     );
 

--- a/tests/error_mode_tests.rs
+++ b/tests/error_mode_tests.rs
@@ -171,16 +171,244 @@ mod w2003_extra_whitespace {
         assert!(!config.should_warn(ErrorType::ExtraWhitespace));
     }
 
-    // Note: Whitespace removal is not yet fully implemented in the preprocessor.
-    // This test is commented out until that feature is added.
-    // #[test]
-    // fn test_lenient_removes_whitespace() {
-    //     let config = ErrorConfig::lenient();
-    //     let preprocessor = config.preprocessor();
-    //     let result = preprocessor.preprocess("NM_000088.3: c.100A>G");
-    //     assert!(result.success);
-    //     assert_eq!(result.preprocessed, "NM_000088.3:c.100A>G");
-    // }
+    #[test]
+    fn test_lenient_removes_whitespace_around_colon() {
+        let config = ErrorConfig::lenient();
+        let preprocessor = config.preprocessor();
+        let result = preprocessor.preprocess("NM_000088.3: c.100A>G");
+        assert!(result.success);
+        assert_eq!(result.preprocessed, "NM_000088.3:c.100A>G");
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::ExtraWhitespace));
+    }
+
+    // Mid-expression whitespace (between digits and a base letter, between
+    // underscore and the second coordinate, around `;` in an allele list, etc.)
+    // is non-canonical per the HGVS spec but lenient mode should accept-and-warn
+    // rather than hard-reject. See #128.
+
+    #[test]
+    fn test_lenient_strips_whitespace_between_position_and_base() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.100 A>G");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept embedded whitespace: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert!(parsed
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::ExtraWhitespace));
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.100A>G");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_between_underscore_and_position() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.100_ 200del");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace after `_`: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.100_200del");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_around_allele_separator() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.[100A>G ; 200T>C]");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace around `;`: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.[100A>G;200T>C]");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_inside_brackets() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.[ 100A>G;200T>C ]");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace inside `[ ]`: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.[100A>G;200T>C]");
+    }
+
+    #[test]
+    fn test_silent_strips_embedded_whitespace_without_warning() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_silent;
+        let result = parse_hgvs_silent("NM_000088.3:c.100 A>G");
+        assert!(result.is_ok());
+        let parsed = result.unwrap();
+        assert!(!parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.100A>G");
+    }
+
+    #[test]
+    fn test_strict_still_rejects_embedded_whitespace() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+        let config = ErrorConfig::strict();
+        let result = parse_hgvs_with_config("NM_000088.3:c.100 A>G", config);
+        assert!(
+            result.is_err(),
+            "strict mode must continue to reject embedded whitespace"
+        );
+    }
+
+    // Coverage for additional HGVS contexts brainstormed alongside #128:
+    // protein, accession-internal, repeat, uncertain-position, compact allele,
+    // zero-width invisible characters, multi-run warning counts, idempotency.
+
+    #[test]
+    fn test_lenient_strips_whitespace_in_protein() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NP_000079.2:p.Arg 97 Trp");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace in protein: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NP_000079.2:p.Arg97Trp");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_around_accession_dot() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088 .3:c.459A>G");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace around accession dot: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.459A>G");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_in_repeat_block() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.123_125 CAG[10]");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace in repeat: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.123_125CAG[10]");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_inside_uncertain_position() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c.( 123 _ 127 )delA");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace inside uncertain position: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.(123_127)delA");
+    }
+
+    #[test]
+    fn test_lenient_strips_whitespace_in_compact_allele() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        let result = parse_hgvs_lenient("NM_000088.3:c. [ 100A>G ; 200T>C ]");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept whitespace in compact allele: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.[100A>G;200T>C]");
+    }
+
+    #[test]
+    fn test_lenient_strips_zero_width_space() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        // Zero-width space pasted between accession and colon.
+        let result = parse_hgvs_lenient("NM_000088.3\u{200B}:c.100A>G");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept zero-width space: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.100A>G");
+    }
+
+    #[test]
+    fn test_lenient_strips_byte_order_mark() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        // BOM/ZWNBSP at start of input — common when copy-pasting from a
+        // UTF-8-with-BOM file.
+        let result = parse_hgvs_lenient("\u{FEFF}NM_000088.3:c.100A>G");
+        assert!(
+            result.is_ok(),
+            "lenient parse should accept leading BOM: {:?}",
+            result
+        );
+        let parsed = result.unwrap();
+        assert!(parsed.has_warnings());
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.100A>G");
+    }
+
+    #[test]
+    fn test_lenient_one_warning_per_run_not_per_char() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        // Three runs of whitespace -> exactly three W2003 warnings.
+        let result = parse_hgvs_lenient(" NM_000088.3 :c.100 A>G").unwrap();
+        let ws_warnings: Vec<_> = result
+            .warnings
+            .iter()
+            .filter(|w| w.error_type == ErrorType::ExtraWhitespace)
+            .collect();
+        assert_eq!(
+            ws_warnings.len(),
+            3,
+            "expected one W2003 per run, got: {:?}",
+            result.warnings
+        );
+        assert_eq!(result.preprocessed_input, "NM_000088.3:c.100A>G");
+    }
+
+    #[test]
+    fn test_lenient_idempotent_on_canonical_form() {
+        use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+        // Canonical input -> no whitespace warnings emitted.
+        let result = parse_hgvs_lenient("NM_000088.3:c.100A>G").unwrap();
+        let ws_warnings: Vec<_> = result
+            .warnings
+            .iter()
+            .filter(|w| w.error_type == ErrorType::ExtraWhitespace)
+            .collect();
+        assert!(
+            ws_warnings.is_empty(),
+            "canonical input must not generate W2003"
+        );
+    }
 }
 
 mod w4002_position_zero {


### PR DESCRIPTION
Closes #128. Follow-up from #81 L2 audit (SVA-024).

## Summary

- Rewrite `correct_whitespace` in `src/error_handling/corrections.rs` to strip every contiguous run of whitespace AND zero-width invisible characters (U+200B, U+200C, U+200D, U+FEFF), recording each run as a single `W2003 ExtraWhitespace` correction. The preprocessor's per-mode action selection is unchanged: strict still rejects, lenient warns-and-corrects, silent corrects silently.
- Cite the HGVS spec page on the W2003 registry entry (`hgvs_spec_url`) and broaden `bad_examples` to include embedded and zero-width cases.
- Cover every HGVS context the issue called out plus the additional gaps surfaced during enhancement: protein (`p.Arg 97 Trp`), accession-internal (`NM_000088 .3:`), repeat block (`c.123_125 CAG[10]`), uncertain position (`c.( 123 _ 127 )delA`), compact allele (`c. [ 100A>G ; 200T>C ]`), zero-width space, byte-order mark, multi-run-count guarantee, and idempotency.

## HGVS spec rationale

The HGVS Nomenclature is explicit that descriptions should be written without spaces — the format `reference:description` has spaces "added for clarity only" (https://hgvs-nomenclature.org/stable/background/simple/). The principled lenient-mode behavior is "accept, strip, warn", matching the auto-correctable contract already used by W2001 (en-dash → hyphen) and W3002 (protein arrow). Zero-width invisible characters (U+200B/U+FEFF/U+200C/U+200D) are functionally indistinguishable from whitespace from a user perspective and are commonly pasted from PDFs and rich-text sources, so they are folded into the same W2003 contract.

## Test plan

- [x] cargo nextest run --features dev — 3419 tests pass (was 3405; +14 new tests), 51 skipped
- [x] cargo clippy --features dev --all-targets -- -D warnings — clean
- [x] cargo fmt --all -- --check — clean

### Coverage matrix

Unit tests (`src/error_handling/corrections.rs`):
- `test_correct_whitespace_strips_zero_width_chars` (U+200B, U+FEFF, U+200C, U+200D)
- `test_correct_whitespace_embedded_single_run_one_warning` (one warning per contiguous run, exact byte offsets)
- `test_correct_whitespace_multiple_runs_count` (three separate runs → three corrections)
- `test_correct_whitespace_idempotent` (re-normalize is a no-op)
- `test_correct_whitespace_mixed_unicode_whitespace` (tab + NBSP + em-space + vtab as one run)

Integration tests (`tests/error_mode_tests.rs::w2003_extra_whitespace`):
- `test_lenient_strips_whitespace_in_protein` — `p.Arg 97 Trp`
- `test_lenient_strips_whitespace_around_accession_dot` — `NM_000088 .3:c.459A>G`
- `test_lenient_strips_whitespace_in_repeat_block` — `c.123_125 CAG[10]`
- `test_lenient_strips_whitespace_inside_uncertain_position` — `c.( 123 _ 127 )delA`
- `test_lenient_strips_whitespace_in_compact_allele` — `c. [ 100A>G ; 200T>C ]`
- `test_lenient_strips_zero_width_space` — `NM_000088.3<ZWSP>:c.100A>G`
- `test_lenient_strips_byte_order_mark` — `<BOM>NM_000088.3:c.100A>G`
- `test_lenient_one_warning_per_run_not_per_char` — 3 runs ⇒ exactly 3 W2003
- `test_lenient_idempotent_on_canonical_form` — canonical input emits no W2003

Plus the original PR coverage (still passing): position/base, underscore/coord, allele separator, brackets, silent mode, strict-mode-still-rejects.