### PR TITLE
test(allele): pin trans-phase round-trip across all coord systems and merge-barrier (#81 C1)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -870,6 +870,17 @@ fn parse_genome_variant(
             ));
         }
 
+        // Try trans-allele compact-prefix shorthand: g.[edit1];[edit2]
+        // Detection mirrors the CDS/RNA paths (parse_cds_allele_shorthand,
+        // parse_rna_allele_shorthand): starts with `[` and contains `];[`.
+        if input.starts_with('[') && input.contains("];[") {
+            if let Ok((remaining, variant)) =
+                parse_genome_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, variant));
+            }
+        }
+
         // Try compound allele notation: g.[pos1edit1;pos2edit2;...]
         if input.starts_with('[') {
             if let Ok((remaining, allele)) =
@@ -969,6 +980,86 @@ fn parse_genome_compound_allele(
     }
 
     Ok((current, AlleleVariant::cis(variants)))
+}
+
+/// Parse a genomic trans-allele compact-prefix shorthand: `[edit1];[edit2]`
+/// (with the `g.` already consumed by the caller). Each bracketed group holds
+/// a single sub-variant rendered with this allele's accession. Mirrors
+/// `parse_cds_trans_allele_shorthand` and `parse_rna_trans_allele_shorthand`.
+fn parse_genome_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(2);
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        if !remaining.starts_with('[') {
+            break;
+        }
+
+        let close_bracket = remaining.find(']').ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            ))
+        })?;
+
+        let content = remaining[1..close_bracket].trim();
+
+        let variant = if content == "0" {
+            HgvsVariant::NullAllele
+        } else if content == "?" {
+            HgvsVariant::UnknownAllele
+        } else {
+            let (edit_remaining, interval) = parse_genome_interval(content)?;
+            // Edit is optional - if not present, treat as identity (position-only).
+            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
+                (r, e)
+            } else {
+                (
+                    edit_remaining,
+                    crate::hgvs::edit::NaEdit::Identity {
+                        sequence: None,
+                        whole_entity: false,
+                    },
+                )
+            };
+
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+
+            HgvsVariant::Genome(GenomeVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            })
+        };
+
+        variants.push(variant);
+        remaining = &remaining[close_bracket + 1..];
+
+        if remaining.starts_with(';') {
+            remaining = &remaining[1..];
+        }
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        remaining,
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
 }
 
 /// Parse whole-genome identity: g.=
@@ -1432,6 +1523,18 @@ fn parse_tx_variant(
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("n.").parse(input)?;
+
+        // Compact-prefix trans-allele shorthand: n.[a];[b]. Mirrors
+        // parse_genome_variant's dispatch added in PR #146; the expanded
+        // form [ACC:n.a];[ACC:n.b] is handled by the top-level allele parser.
+        if input.starts_with('[') && input.contains("];[") {
+            if let Ok((remaining, variant)) =
+                parse_tx_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, variant));
+            }
+        }
+
         let (input, interval) = parse_tx_interval(input)?;
         let (input, edit) = parse_na_edit(input)?;
 
@@ -1446,6 +1549,87 @@ fn parse_tx_variant(
     }
 }
 
+/// Parse a non-coding transcript trans-allele compact-prefix shorthand:
+/// `[edit1];[edit2]` (with the `n.` already consumed by the caller). Each
+/// bracketed group holds a single sub-variant rendered with this allele's
+/// accession. Mirrors `parse_genome_trans_allele_shorthand`.
+fn parse_tx_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(2);
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        if !remaining.starts_with('[') {
+            break;
+        }
+
+        let close_bracket = remaining.find(']').ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            ))
+        })?;
+
+        let content = remaining[1..close_bracket].trim();
+
+        let variant = if content == "0" {
+            HgvsVariant::NullAllele
+        } else if content == "?" {
+            HgvsVariant::UnknownAllele
+        } else {
+            let (edit_remaining, interval) = parse_tx_interval(content)?;
+            // Edit is optional - if not present, treat as identity (position-only),
+            // matching parse_genome_trans_allele_shorthand.
+            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
+                (r, e)
+            } else {
+                (
+                    edit_remaining,
+                    crate::hgvs::edit::NaEdit::Identity {
+                        sequence: None,
+                        whole_entity: false,
+                    },
+                )
+            };
+
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+
+            HgvsVariant::Tx(TxVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            })
+        };
+
+        variants.push(variant);
+        remaining = &remaining[close_bracket + 1..];
+
+        if remaining.starts_with(';') {
+            remaining = &remaining[1..];
+        }
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        remaining,
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
+}
+
 /// Parse mitochondrial variant (m.)
 fn parse_mt_variant(
     accession: Accession,
@@ -1453,6 +1637,17 @@ fn parse_mt_variant(
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("m.").parse(input)?;
+
+        // Compact-prefix trans-allele shorthand: m.[a];[b]. Mirrors
+        // parse_genome_variant's dispatch added in PR #146.
+        if input.starts_with('[') && input.contains("];[") {
+            if let Ok((remaining, variant)) =
+                parse_mt_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, variant));
+            }
+        }
+
         let (input, interval) = parse_genome_interval(input)?;
         let (input, edit) = parse_na_edit(input)?;
 
@@ -1465,6 +1660,85 @@ fn parse_mt_variant(
             }),
         ))
     }
+}
+
+/// Parse a mitochondrial trans-allele compact-prefix shorthand:
+/// `[edit1];[edit2]` (with the `m.` already consumed). Mirrors
+/// `parse_genome_trans_allele_shorthand`; mitochondrial variants reuse
+/// `parse_genome_interval`.
+fn parse_mt_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(2);
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        if !remaining.starts_with('[') {
+            break;
+        }
+
+        let close_bracket = remaining.find(']').ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            ))
+        })?;
+
+        let content = remaining[1..close_bracket].trim();
+
+        let variant = if content == "0" {
+            HgvsVariant::NullAllele
+        } else if content == "?" {
+            HgvsVariant::UnknownAllele
+        } else {
+            let (edit_remaining, interval) = parse_genome_interval(content)?;
+            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
+                (r, e)
+            } else {
+                (
+                    edit_remaining,
+                    crate::hgvs::edit::NaEdit::Identity {
+                        sequence: None,
+                        whole_entity: false,
+                    },
+                )
+            };
+
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+
+            HgvsVariant::Mt(MtVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            })
+        };
+
+        variants.push(variant);
+        remaining = &remaining[close_bracket + 1..];
+
+        if remaining.starts_with(';') {
+            remaining = &remaining[1..];
+        }
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        remaining,
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
 }
 
 /// Parse whole-protein identity: p.= or p.(=)
@@ -1548,6 +1822,77 @@ fn parse_protein_allele_shorthand(
     }
 
     Ok((current, AlleleVariant::cis(variants)))
+}
+
+/// Parse a protein trans-allele compact-prefix shorthand:
+/// `[edit1];[edit2]` (with `p.` already consumed by the caller). Each
+/// bracketed group holds a single sub-variant. Mirrors
+/// `parse_genome_trans_allele_shorthand`, but parses protein intervals +
+/// edits and does NOT allow a bare-position (Identity) fallback — the
+/// protein grammar requires an edit.
+fn parse_protein_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(2);
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        if !remaining.starts_with('[') {
+            break;
+        }
+
+        let close_bracket = remaining.find(']').ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            ))
+        })?;
+
+        let content = remaining[1..close_bracket].trim();
+
+        let variant = if content == "0" {
+            HgvsVariant::NullAllele
+        } else if content == "?" {
+            HgvsVariant::UnknownAllele
+        } else {
+            let (edit_remaining, interval) = parse_prot_interval(content)?;
+            let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
+
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+
+            HgvsVariant::Protein(ProteinVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            })
+        };
+
+        variants.push(variant);
+        remaining = &remaining[close_bracket + 1..];
+
+        if remaining.starts_with(';') {
+            remaining = &remaining[1..];
+        }
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        remaining,
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
 }
 
 /// Parse a numeric-only protein repeat (e.g., p.223PA[3], p.179_180AP[9])
@@ -1756,6 +2101,18 @@ fn parse_protein_variant(
                     loc_edit: LocEdit::new(dummy_interval, edit),
                 }),
             ));
+        }
+
+        // Try protein trans-allele compact-prefix shorthand: p.[edit1];[edit2]
+        // before the cis allele path, since trans is the more specific shape.
+        // Mirrors the DNA/RNA dispatches (parse_genome_variant,
+        // parse_cds_variant, parse_rna_variant) and PR #146's fix for `g.`.
+        if input.starts_with('[') && input.contains("];[") {
+            if let Ok((remaining, variant)) =
+                parse_protein_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, variant));
+            }
         }
 
         // Try protein allele: p.[edit1;edit2;...]
@@ -2281,6 +2638,18 @@ fn parse_circular_variant(
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("o.").parse(input)?;
+
+        // Compact-prefix trans-allele shorthand: o.[a];[b]. Mirrors
+        // parse_genome_variant's dispatch added in PR #146; SVD-WG006 says
+        // circular DNA inherits the DNA allele grammar.
+        if input.starts_with('[') && input.contains("];[") {
+            if let Ok((remaining, variant)) =
+                parse_circular_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, variant));
+            }
+        }
+
         let (input, interval) = parse_genome_interval(input)?;
         let (input, edit) = parse_na_edit(input)?;
 
@@ -2293,6 +2662,85 @@ fn parse_circular_variant(
             }),
         ))
     }
+}
+
+/// Parse a circular DNA trans-allele compact-prefix shorthand:
+/// `[edit1];[edit2]` (with the `o.` already consumed). Mirrors
+/// `parse_genome_trans_allele_shorthand`; circular variants reuse
+/// `parse_genome_interval`.
+fn parse_circular_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(2);
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        if !remaining.starts_with('[') {
+            break;
+        }
+
+        let close_bracket = remaining.find(']').ok_or_else(|| {
+            nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            ))
+        })?;
+
+        let content = remaining[1..close_bracket].trim();
+
+        let variant = if content == "0" {
+            HgvsVariant::NullAllele
+        } else if content == "?" {
+            HgvsVariant::UnknownAllele
+        } else {
+            let (edit_remaining, interval) = parse_genome_interval(content)?;
+            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
+                (r, e)
+            } else {
+                (
+                    edit_remaining,
+                    crate::hgvs::edit::NaEdit::Identity {
+                        sequence: None,
+                        whole_entity: false,
+                    },
+                )
+            };
+
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+
+            HgvsVariant::Circular(CircularVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            })
+        };
+
+        variants.push(variant);
+        remaining = &remaining[close_bracket + 1..];
+
+        if remaining.starts_with(';') {
+            remaining = &remaining[1..];
+        }
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        remaining,
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
 }
 
 /// Parse a single variant (not an allele) from input

--- a/tests/allele_trans_phase.rs
+++ b/tests/allele_trans_phase.rs
@@ -1,0 +1,572 @@
+//! Tests for trans-phase allele canonicalization.
+//!
+//! Tracking: issue #81 item C1 — "Trans-phase canonicalization — `[a];[b]` shape
+//! vs malformed inputs. Round-trip fidelity unverified."
+//!
+//! Per the HGVS DNA alleles recommendation
+//! (`assets/hgvs-nomenclature/docs/recommendations/DNA/alleles.md`), trans phase
+//! is written as `[variant1];[variant2]` (each variant in its own bracket pair,
+//! separated by `;`). Cis phase, by contrast, is `[variant1;variant2]` (a
+//! single bracket pair containing semicolon-separated variants). The two shapes
+//! describe biologically distinct genotypes and must not be confused by parser
+//! or display.
+//!
+//! These tests pin:
+//! 1. Round-trip fidelity for `[a];[b]` (both expanded and compact-prefix forms).
+//! 2. That `[a;b]` (cis) does not collapse onto, nor parse as, `[a];[b]` (trans).
+//! 3. That the `Cis`-only consecutive-edit merge pass (issue #72 / PR #80) is
+//!    correctly excluded for trans alleles, even when the sub-variant positions
+//!    are strictly adjacent (the case that would merge under cis).
+//! 4. Mixed-accession trans round-trip (related to C4: mixed-accession alleles).
+//!
+//! See also: C2 (mosaic / chimeric), C3 (unknown-phase `[a(;)b]`),
+//! C4 (mixed-accession alleles), C5 (3+ variants per allele).
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+fn parse_to_string(input: &str) -> String {
+    let variant = parse_hgvs(input).expect("parse failed");
+    format!("{}", variant)
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+fn parse_phase(input: &str) -> AllelePhase {
+    match parse_hgvs(input).expect("parse failed") {
+        HgvsVariant::Allele(a) => a.phase,
+        other => panic!("expected Allele variant, got {:?}", other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip fidelity for `[a];[b]`
+// ---------------------------------------------------------------------------
+
+/// `[ACC:c.a];[ACC:c.b]` (expanded form) round-trips through parse + display.
+///
+/// Same-accession trans alleles render in the spec's compact-prefix form
+/// `ACC:c.[a];[b]`, so the second-pass round-trip is bit-identical.
+#[test]
+fn test_trans_expanded_form_round_trips_via_compact() {
+    // First pass: expanded → compact (same accession, so compact-prefix form).
+    assert_eq!(
+        parse_to_string("[NM_000088.3:c.100A>G];[NM_000088.3:c.200T>C]"),
+        "NM_000088.3:c.[100A>G];[200T>C]",
+    );
+    // Second pass: compact → compact (bit-identical, idempotent).
+    assert_eq!(
+        parse_to_string("NM_000088.3:c.[100A>G];[200T>C]"),
+        "NM_000088.3:c.[100A>G];[200T>C]",
+    );
+    // Phase is Trans for both.
+    assert_eq!(
+        parse_phase("[NM_000088.3:c.100A>G];[NM_000088.3:c.200T>C]"),
+        AllelePhase::Trans,
+    );
+    assert_eq!(
+        parse_phase("NM_000088.3:c.[100A>G];[200T>C]"),
+        AllelePhase::Trans,
+    );
+}
+
+/// Trans round-trip for the spec's `LRG_199t1:c.[2376G>C];[3103del]` example.
+///
+/// Source: `assets/hgvs-nomenclature/docs/recommendations/DNA/alleles.md`,
+/// "Variants in trans" section.
+#[test]
+fn test_trans_spec_example_round_trip() {
+    assert_eq!(
+        parse_to_string("NM_004006.2:c.[2376G>C];[3103del]"),
+        "NM_004006.2:c.[2376G>C];[3103del]",
+    );
+    assert_eq!(
+        parse_phase("NM_004006.2:c.[2376G>C];[3103del]"),
+        AllelePhase::Trans,
+    );
+}
+
+/// Genomic trans round-trip — exercises the `g.` parser path.
+#[test]
+fn test_trans_genomic_round_trip() {
+    assert_eq!(
+        parse_to_string("[NC_000001.11:g.1000G>A];[NC_000001.11:g.2000T>C]"),
+        "NC_000001.11:g.[1000G>A];[2000T>C]",
+    );
+    assert_eq!(
+        parse_to_string("NC_000001.11:g.[1000G>A];[2000T>C]"),
+        "NC_000001.11:g.[1000G>A];[2000T>C]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cis vs trans: distinct shapes, distinct phases
+// ---------------------------------------------------------------------------
+
+/// `[a;b]` (cis) and `[a];[b]` (trans) must not be confused.
+///
+/// They describe biologically distinct genotypes — cis = both variants on the
+/// same chromosome, trans = one variant per chromosome (compound heterozygote).
+/// The parser must classify them by shape, and the round-trip must preserve
+/// the shape.
+#[test]
+fn test_cis_and_trans_are_not_confused() {
+    let cis_input = "[NM_000088.3:c.100A>G;NM_000088.3:c.200T>C]";
+    let trans_input = "[NM_000088.3:c.100A>G];[NM_000088.3:c.200T>C]";
+
+    // Phase is correctly distinguished.
+    assert_eq!(parse_phase(cis_input), AllelePhase::Cis);
+    assert_eq!(parse_phase(trans_input), AllelePhase::Trans);
+
+    // The two parse to non-equal HgvsVariant values.
+    let cis_parsed = parse_hgvs(cis_input).expect("parse cis");
+    let trans_parsed = parse_hgvs(trans_input).expect("parse trans");
+    assert_ne!(
+        cis_parsed, trans_parsed,
+        "cis [a;b] and trans [a];[b] must not compare equal",
+    );
+
+    // Display preserves the shape: cis collapses inside one bracket pair,
+    // trans keeps the bracket pair around each sub-variant.
+    assert_eq!(
+        format!("{}", cis_parsed),
+        "NM_000088.3:c.[100A>G;200T>C]",
+        "cis must render as [a;b]",
+    );
+    assert_eq!(
+        format!("{}", trans_parsed),
+        "NM_000088.3:c.[100A>G];[200T>C]",
+        "trans must render as [a];[b]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Trans is excluded from the Cis-only consecutive-edit merge (PR #80)
+// ---------------------------------------------------------------------------
+
+/// PR #80 / issue #72 introduced consecutive-edit merging for cis alleles
+/// (e.g. `g.[1000G>A;1001A>C]` → `g.1000_1001delinsAC`). The merge is gated on
+/// `AllelePhase::Cis` in `src/normalize/merge.rs`. This test pins that gating:
+/// strictly adjacent variants in trans must NOT merge — they describe two
+/// independent single-nucleotide events on opposite chromosomes, not one
+/// dinucleotide event.
+#[test]
+fn test_trans_does_not_trigger_consecutive_edit_merge() {
+    // Adjacent g. SNVs in trans — under cis these would merge to delins.
+    let normalized = normalize_to_string("[NC_000001.11:g.1000G>A];[NC_000001.11:g.1001A>C]");
+    assert!(
+        !normalized.contains("delins"),
+        "trans [1000G>A];[1001A>C] must not merge to delins, got: {}",
+        normalized,
+    );
+    assert!(
+        normalized.contains("1000G>A"),
+        "first sub-variant must survive, got: {}",
+        normalized,
+    );
+    assert!(
+        normalized.contains("1001A>C"),
+        "second sub-variant must survive, got: {}",
+        normalized,
+    );
+
+    // Phase remains Trans after normalization (no unwrap to a single Genome).
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed = parse_hgvs("[NC_000001.11:g.1000G>A];[NC_000001.11:g.1001A>C]").unwrap();
+    let normalized_variant = normalizer.normalize(&parsed).unwrap();
+    match normalized_variant {
+        HgvsVariant::Allele(a) => assert_eq!(
+            a.phase,
+            AllelePhase::Trans,
+            "phase must remain Trans after normalize",
+        ),
+        other => panic!("expected Allele after normalize, got {:?}", other),
+    }
+}
+
+/// Sanity-paired with the test above: the same adjacent positions in cis DO
+/// merge to delins under PR #80. If this assertion ever fails, the cross-check
+/// in `test_trans_does_not_trigger_consecutive_edit_merge` becomes vacuous and
+/// must be re-examined.
+#[test]
+fn test_cis_counterpart_does_merge_to_delins() {
+    let normalized = normalize_to_string("NC_000001.11:g.[1000G>A;1001A>C]");
+    assert_eq!(
+        normalized, "NC_000001.11:g.1000_1001delinsAC",
+        "cis adjacent SNVs must merge under PR #80; if not, the trans \
+         exclusion test is vacuous",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-accession trans (related to C4)
+// ---------------------------------------------------------------------------
+
+/// A trans allele whose sub-variants share an accession renders in compact-
+/// prefix form `ACC:c.[a];[b]`. Synthetic short accession exercises that path.
+/// (See also C4 — mixed-accession alleles — for the cross-accession case.)
+#[test]
+fn test_mixed_accession_trans_same_accession_compact_round_trip() {
+    // Both sub-variants share the synthetic accession `NM_X.1`, so the parser
+    // accepts the expanded form and the display emits the compact-prefix form.
+    let expanded = "[NM_X.1:c.1A>G];[NM_X.1:c.2T>C]";
+    let compact = "NM_X.1:c.[1A>G];[2T>C]";
+    assert_eq!(parse_to_string(expanded), compact);
+    assert_eq!(parse_to_string(compact), compact);
+    assert_eq!(parse_phase(expanded), AllelePhase::Trans);
+}
+
+/// When sub-variants come from different accessions or different coordinate
+/// systems, the compact-prefix form does not apply: the expanded form
+/// `[ACC1:...];[ACC2:...]` must round-trip bit-identically.
+#[test]
+fn test_mixed_accession_trans_distinct_accessions_round_trip() {
+    let input = "[NC_000001.11:g.100A>G];[NM_000088.3:c.200T>C]";
+    assert_eq!(parse_to_string(input), input);
+    assert_eq!(parse_phase(input), AllelePhase::Trans);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed inputs — pin current rejection behavior
+// ---------------------------------------------------------------------------
+
+/// Whitespace inside the trans separator (`[a]; [b]`, `[a] ;[b]`,
+/// `[a] ; [b]`) is currently REJECTED by the parser. The HGVS spec is silent
+/// on whether human-readable whitespace should be tolerated, but pragmatic
+/// implementations typically trim. This test pins ferro's current strict
+/// behavior so any future relaxation is an explicit, reviewed change rather
+/// than an accidental regression in either direction.
+///
+/// TODO(#81 C1 follow-up): consider tolerating cosmetic whitespace around the
+/// `];` and `;[` separators in trans-allele inputs (the spec answer per the
+/// issue description is "trim whitespace, accept"). Filing a follow-up issue
+/// requires user approval for the title/body, so this is left as a TODO here.
+#[test]
+fn test_trans_with_whitespace_around_separator_is_rejected() {
+    let cases = [
+        "[NM_000088.3:c.100A>G]; [NM_000088.3:c.200T>C]",
+        "[NM_000088.3:c.100A>G] ;[NM_000088.3:c.200T>C]",
+        "[NM_000088.3:c.100A>G] ; [NM_000088.3:c.200T>C]",
+        "NM_000088.3:c.[100A>G]; [200T>C]",
+        "NM_000088.3:c.[100A>G] ;[200T>C]",
+        "NM_000088.3:c.[100A>G] ; [200T>C]",
+    ];
+    for input in cases {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "expected parse error for whitespace-padded trans separator, \
+             but parse succeeded: {:?}",
+            input,
+        );
+    }
+}
+
+/// Unbalanced brackets and obviously-malformed shapes must be rejected.
+#[test]
+fn test_trans_obvious_malformed_shapes_rejected() {
+    let cases = [
+        // Missing closing bracket on second variant.
+        "[NM_000088.3:c.100A>G];[NM_000088.3:c.200T>C",
+        // Missing opening bracket on second variant.
+        "[NM_000088.3:c.100A>G];NM_000088.3:c.200T>C]",
+        // Empty trans bracket pair.
+        "[];[NM_000088.3:c.100A>G]",
+        // Trailing garbage after the trans allele.
+        "[NM_000088.3:c.100A>G];[NM_000088.3:c.200T>C]xyz",
+    ];
+    for input in cases {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "expected parse error for malformed trans input, but parse \
+             succeeded: {:?}",
+            input,
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// n. (non-coding transcript) — compact-prefix trans round-trip
+// ---------------------------------------------------------------------------
+
+/// Compact-prefix `n.[a];[b]` round-trips through parse + display.
+///
+/// Asymmetry fix paralleling PR #146's genomic case: the expanded form
+/// `[ACC:n.a];[ACC:n.b]` already parsed via the top-level allele path, but
+/// `Display` emits the compact form `ACC:n.[a];[b]` for same-accession
+/// alleles, so without a compact-form parser path the `Display` → parse
+/// round-trip was broken for `n.`.
+#[test]
+fn test_trans_n_compact_round_trip() {
+    // First pass: expanded → compact (Display canonicalises same-acc trans).
+    assert_eq!(
+        parse_to_string("[NR_X.1:n.100A>G];[NR_X.1:n.200T>C]"),
+        "NR_X.1:n.[100A>G];[200T>C]",
+    );
+    // Second pass: compact → compact (idempotent; was a parse error pre-fix).
+    assert_eq!(
+        parse_to_string("NR_X.1:n.[100A>G];[200T>C]"),
+        "NR_X.1:n.[100A>G];[200T>C]",
+    );
+    assert_eq!(
+        parse_phase("NR_X.1:n.[100A>G];[200T>C]"),
+        AllelePhase::Trans,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// m. (mitochondrial) — compact-prefix trans round-trip
+// ---------------------------------------------------------------------------
+
+/// Compact-prefix `m.[a];[b]` round-trips through parse + display.
+///
+/// Mitochondrial heteroplasmy is a canonical use case for trans (different
+/// alleles in different mtDNA copies). Same Display → parse asymmetry as
+/// `g.`/`n.`: fixed by paralleling `parse_genome_trans_allele_shorthand`
+/// for `m.`.
+#[test]
+fn test_trans_m_compact_round_trip() {
+    assert_eq!(
+        parse_to_string("[NC_012920.1:m.100A>G];[NC_012920.1:m.200T>C]"),
+        "NC_012920.1:m.[100A>G];[200T>C]",
+    );
+    assert_eq!(
+        parse_to_string("NC_012920.1:m.[100A>G];[200T>C]"),
+        "NC_012920.1:m.[100A>G];[200T>C]",
+    );
+    assert_eq!(
+        parse_phase("NC_012920.1:m.[100A>G];[200T>C]"),
+        AllelePhase::Trans,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// o. (circular DNA, SVD-WG006) — compact-prefix trans round-trip
+// ---------------------------------------------------------------------------
+
+/// Compact-prefix `o.[a];[b]` round-trips through parse + display.
+///
+/// Circular DNA inherits the DNA allele grammar per SVD-WG006. Same
+/// Display → parse asymmetry as `g.`/`n.`/`m.` fixed here.
+#[test]
+fn test_trans_o_compact_round_trip() {
+    assert_eq!(
+        parse_to_string("[AC_X.1:o.100A>G];[AC_X.1:o.200T>C]"),
+        "AC_X.1:o.[100A>G];[200T>C]",
+    );
+    assert_eq!(
+        parse_to_string("AC_X.1:o.[100A>G];[200T>C]"),
+        "AC_X.1:o.[100A>G];[200T>C]",
+    );
+    assert_eq!(
+        parse_phase("AC_X.1:o.[100A>G];[200T>C]"),
+        AllelePhase::Trans,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// p. (protein) — compact-prefix trans round-trip
+// ---------------------------------------------------------------------------
+
+/// Compact-prefix `p.[a];[b]` round-trips through parse + display.
+///
+/// Protein trans alleles use the same shape per
+/// `assets/hgvs-nomenclature/docs/recommendations/protein/alleles.md`
+/// (compound heterozygote). Pre-fix the parser only handled the cis form
+/// `p.[a;b]`; the corresponding `parse_protein_trans_allele_shorthand`
+/// added here parallels the DNA helpers.
+#[test]
+fn test_trans_p_compact_round_trip() {
+    assert_eq!(
+        parse_to_string("NP_003997.1:p.[Ser68Arg];[Asn594del]"),
+        "NP_003997.1:p.[Ser68Arg];[Asn594del]",
+    );
+    assert_eq!(
+        parse_to_string("[NP_003997.1:p.Ser68Arg];[NP_003997.1:p.Asn594del]"),
+        "NP_003997.1:p.[Ser68Arg];[Asn594del]",
+    );
+    assert_eq!(
+        parse_phase("NP_003997.1:p.[Ser68Arg];[Asn594del]"),
+        AllelePhase::Trans,
+    );
+}
+
+/// Spec line 38 (DNA alleles, applied to protein per the analogous protein
+/// alleles section): homozygous trans (same variant on both alleles); both
+/// chromosomes carry the same change. Phase still distinguishes from cis.
+#[test]
+fn test_trans_p_homozygous_round_trip() {
+    assert_eq!(
+        parse_to_string("NP_003997.1:p.[Ser68Arg];[Ser68Arg]"),
+        "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
+    );
+    assert_eq!(
+        parse_phase("NP_003997.1:p.[Ser68Arg];[Ser68Arg]"),
+        AllelePhase::Trans,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Trans with special second-allele tokens: [?] (unknown), [0] (null),
+// [pos=] (wild-type / no-change). All are spec-mandated forms.
+// ---------------------------------------------------------------------------
+
+/// `c.[a];[?]`: one allele has a variant, the other allele is unknown.
+/// Spec: `assets/hgvs-nomenclature/docs/recommendations/DNA/alleles.md`,
+/// "Variants in trans" section. Pre-existing functionality; pinned to catch
+/// regressions and to confirm `[?]` lowers to the dedicated `UnknownAllele`
+/// sentinel rather than to a coord-system variant (which would lose the
+/// "second allele unknown" semantics).
+#[test]
+fn test_trans_c_with_unknown_allele_round_trip() {
+    let input = "[NM_000088.3:c.100A>G];[?]";
+    assert_eq!(parse_to_string(input), input);
+    assert_eq!(parse_phase(input), AllelePhase::Trans);
+    let parsed = parse_hgvs(input).expect("parse failed");
+    if let HgvsVariant::Allele(a) = parsed {
+        assert_eq!(a.variants.len(), 2);
+        assert!(matches!(a.variants[1], HgvsVariant::UnknownAllele));
+    } else {
+        panic!("expected Allele");
+    }
+}
+
+/// `c.[a];[0]`: one allele has a variant, the other allele is absent
+/// (canonically used for hemizygous males on X-chromosome variants per
+/// the "X-chromosome" Discussion note in
+/// `recommendations/DNA/alleles.md`). Lowers to `NullAllele`.
+#[test]
+fn test_trans_c_with_null_allele_round_trip() {
+    let input = "[NM_000088.3:c.100A>G];[0]";
+    assert_eq!(parse_to_string(input), input);
+    assert_eq!(parse_phase(input), AllelePhase::Trans);
+    let parsed = parse_hgvs(input).expect("parse failed");
+    if let HgvsVariant::Allele(a) = parsed {
+        assert_eq!(a.variants.len(), 2);
+        assert!(matches!(a.variants[1], HgvsVariant::NullAllele));
+    } else {
+        panic!("expected Allele");
+    }
+}
+
+/// `c.[a];[pos=]`: one allele has a variant, the other is wild-type at the
+/// SAME position. Spec line 41: `LRG_199t1:c.[2376G>C];[2376=]`. The note
+/// on line 43 calls this out as the canonical pattern across edit types
+/// (substitution, deletion, duplication, insertion).
+#[test]
+fn test_trans_c_with_wildtype_second_allele_round_trip() {
+    // Same-accession, so Display emits compact form.
+    assert_eq!(
+        parse_to_string("NM_004006.2:c.[2376G>C];[2376=]"),
+        "NM_004006.2:c.[2376G>C];[2376=]",
+    );
+    assert_eq!(
+        parse_phase("NM_004006.2:c.[2376G>C];[2376=]"),
+        AllelePhase::Trans,
+    );
+    // Spec note line 43 — same pattern for deletion.
+    assert_eq!(
+        parse_to_string("NM_004006.2:c.[2376del];[2376=]"),
+        "NM_004006.2:c.[2376del];[2376=]",
+    );
+}
+
+/// `g.[a];[?]` and `g.[a];[0]`: the same special tokens for the genomic
+/// path. PR #146 added `parse_genome_trans_allele_shorthand`; this pin
+/// asserts both special-token branches in that helper.
+#[test]
+fn test_trans_g_with_special_tokens_round_trip() {
+    let unknown = "[NC_000001.11:g.100G>A];[?]";
+    assert_eq!(parse_to_string(unknown), unknown);
+    assert_eq!(parse_phase(unknown), AllelePhase::Trans);
+
+    let null = "[NC_000001.11:g.100G>A];[0]";
+    assert_eq!(parse_to_string(null), null);
+    assert_eq!(parse_phase(null), AllelePhase::Trans);
+}
+
+/// `n.[a];[?]`: special tokens reach the new n.-trans helper added above.
+/// The compact form parses; Display emits the expanded form for the [?]
+/// branch (the Allele Display logic detects mixed-variant-kinds and falls
+/// back). The Display→parse round-trip closes the loop.
+#[test]
+fn test_trans_n_with_unknown_allele_round_trip() {
+    let parsed = parse_hgvs("NR_X.1:n.[100A>G];[?]").expect("parse failed");
+    let displayed = format!("{}", parsed);
+    assert_eq!(parse_to_string(&displayed), displayed);
+    if let HgvsVariant::Allele(a) = parsed {
+        assert_eq!(a.variants.len(), 2);
+        assert!(matches!(a.variants[1], HgvsVariant::UnknownAllele));
+        assert_eq!(a.phase, AllelePhase::Trans);
+    } else {
+        panic!("expected Allele");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Homozygous trans: same variant on both alleles. Distinct from cis-with-
+// duplicate-sub-variants because the bracket shape encodes phase.
+// ---------------------------------------------------------------------------
+
+/// Spec line 38: `c.[2376G>C];[2376G>C]` — homozygous compound heterozygote.
+/// Pre-existing in the c. trans-shorthand path; pinned for regression
+/// coverage so a future parser change can't silently collapse a homozygous
+/// trans into a cis duplicate.
+#[test]
+fn test_trans_c_homozygous_round_trip() {
+    assert_eq!(
+        parse_to_string("NM_004006.2:c.[2376G>C];[2376G>C]"),
+        "NM_004006.2:c.[2376G>C];[2376G>C]",
+    );
+    assert_eq!(
+        parse_phase("NM_004006.2:c.[2376G>C];[2376G>C]"),
+        AllelePhase::Trans,
+    );
+}
+
+/// Genomic homozygous trans — the `g.` counterpart of the c. case above,
+/// exercising the `parse_genome_trans_allele_shorthand` path added in
+/// PR #146.
+#[test]
+fn test_trans_g_homozygous_round_trip() {
+    assert_eq!(
+        parse_to_string("NC_000001.11:g.[100G>A];[100G>A]"),
+        "NC_000001.11:g.[100G>A];[100G>A]",
+    );
+    assert_eq!(
+        parse_phase("NC_000001.11:g.[100G>A];[100G>A]"),
+        AllelePhase::Trans,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Normalize idempotency: normalize(normalize(x)) == normalize(x).
+// ---------------------------------------------------------------------------
+
+/// Trans alleles must be idempotent under repeated `normalize`. PR #146
+/// asserted only that one-pass normalize doesn't break the trans
+/// merge-barrier; this guards against rules that accidentally re-shuffle
+/// trans on a second pass (e.g. by re-parsing through a path that drops
+/// the phase wrapper).
+#[test]
+fn test_trans_normalize_is_idempotent() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed =
+        parse_hgvs("[NC_000001.11:g.1000G>A];[NC_000001.11:g.2000T>C]").expect("parse failed");
+    let pass1 = normalizer.normalize(&parsed).expect("normalize pass1");
+    let pass2 = normalizer.normalize(&pass1).expect("normalize pass2");
+    assert_eq!(
+        format!("{}", pass1),
+        format!("{}", pass2),
+        "normalize must be idempotent on trans alleles",
+    );
+    if let HgvsVariant::Allele(a) = pass2 {
+        assert_eq!(a.phase, AllelePhase::Trans);
+    } else {
+        panic!("expected Allele after second normalize");
+    }
+}

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "correctly-rejected": 12,
       "diverges": 144,
       "false-acceptance": 22,
-      "parse-error": 214,
-      "preserved": 431
+      "parse-error": 209,
+      "preserved": 436
     },
     "by_coordinate_system": {
       "c": 298,
@@ -4563,18 +4563,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000001.11:g.[123G>A];[345del]",
-      "current": "parse error: Parse error at position 23: Unexpected trailing characters: ';[345del]'",
-      "spec_expected": "NC_000001.11:g.[123G>A];[345del]",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
       "current": "parse error: Parse error at position 13: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found ':g.'",
       "spec_expected": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
@@ -4861,19 +4849,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.[123456A>G];[345678G>C]",
-      "input_prefixed": "NC_000023.11:g.[123456A>G];[345678G>C]",
-      "current": "parse error: Parse error at position 26: Unexpected trailing characters: ';[345678G>C]'",
-      "spec_expected": "NC_000023.11:g.[123456A>G];[345678G>C]",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/general.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "current": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "spec_expected": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
@@ -5018,6 +4993,17 @@
       "input": "NC_000001.11:g.[123G>A;345del]",
       "current": "NC_000001.11:g.[123G>A;345del]",
       "spec_expected": "NC_000001.11:g.[123G>A;345del]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NC_000001.11:g.[123G>A];[345del]",
+      "current": "NC_000001.11:g.[123G>A];[345del]",
+      "spec_expected": "NC_000001.11:g.[123G>A];[345del]",
       "status": "preserved",
       "coordinate_system": "g",
       "source_kind": "syntax_yaml",
@@ -5745,6 +5731,18 @@
       ]
     },
     {
+      "input": "g.[123456A>G];[345678G>C]",
+      "input_prefixed": "NC_000023.11:g.[123456A>G];[345678G>C]",
+      "current": "NC_000023.11:g.[123456A>G];[345678G>C]",
+      "spec_expected": "NC_000023.11:g.[123456A>G];[345678G>C]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
       "input": "r.415_1655delins[AC096506.5:g.409_1649]",
       "input_prefixed": "NM_004006.3:r.415_1655delins[AC096506.5:g.409_1649]",
       "current": "NM_004006.3:r.415_1655delins[AC096506.5:g.409_1649]",
@@ -6456,42 +6454,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.[Ser68Arg];[Asn594del]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[Asn594del]'",
-      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Asn594del]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.[Ser68Arg];[Ser68=]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[Ser68=]'",
-      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Ser68=]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[Ser68Arg]'",
-      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]\", code: Tag })",
       "spec_expected": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
@@ -6987,6 +6949,39 @@
       "input": "NP_003997.1:p.[Ser68Arg;Asn594del]",
       "current": "NP_003997.1:p.[Ser68Arg;Asn594del]",
       "spec_expected": "NP_003997.1:p.[Ser68Arg;Asn594del]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[Ser68Arg];[Asn594del]",
+      "current": "NP_003997.1:p.[Ser68Arg];[Asn594del]",
+      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Asn594del]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[Ser68Arg];[Ser68=]",
+      "current": "NP_003997.1:p.[Ser68Arg];[Ser68=]",
+      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Ser68=]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
+      "current": "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
+      "spec_expected": "NP_003997.1:p.[Ser68Arg];[Ser68Arg]",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -281,7 +281,6 @@ fn test_no_merge_different_variant_types() {
 #[test]
 fn test_no_merge_trans_phase() {
     // [a];[b] (semicolon between bracket pairs) is trans phase per HGVS.
-    // The compact form g.[a];[b] isn't accepted by the parser; use expanded form.
     let result = normalize_to_string("[NC_000001.11:g.100G>A];[NC_000001.11:g.101A>C]");
     assert!(result.contains("100G>A"), "got {}", result);
     assert!(result.contains("101A>C"), "got {}", result);

--- a/tests/mito_circular_audit.rs
+++ b/tests/mito_circular_audit.rs
@@ -84,6 +84,7 @@
 //! that pin "this fails today" must flip to "this succeeds with the
 //! expected canonical form" — that diff is the audit trail.
 
+use ferro_hgvs::hgvs::AllelePhase;
 use ferro_hgvs::python_helpers::get_indel_length;
 use ferro_hgvs::{hgvs_to_spdi_simple, parse_hgvs, HgvsVariant, MockProvider, Normalizer};
 
@@ -382,11 +383,11 @@ fn audit_mt_negative_position_rejected_today() {
 //
 // Spec permits compound HGVS allele descriptions in cis (`[a;b]`),
 // trans (`[a];[b]`), and the homozygous shorthand `[a](;)`. Ferro's
-// parser today rejects all three for the `m.` coordinate system.
-// This is unrelated to wraparound but is part of the F1 architectural
-// surface: any plan to support trans-heteroplasmy or to render a pair
-// of m. variants as a single allele has to clear this rejection.
-// (Sibling F2 / PR #139 / #133 is aware.)
+// parser accepts trans (`[a];[b]`) on `m.` (PR #146 / sibling C1);
+// cis and homozygous shorthand are still rejected. This is unrelated
+// to wraparound but is part of the F1 architectural surface: any plan
+// to render a pair of m. variants as a single cis allele still has to
+// clear this rejection. (Sibling F2 / PR #139 / #133 is aware.)
 // -----------------------------------------------------------------------------
 
 /// Compound `m.[…;…]` (cis) is rejected today.
@@ -400,14 +401,21 @@ fn audit_mt_compound_cis_allele_rejected_today() {
     );
 }
 
-/// Compound `m.[…];[…]` (trans) is rejected today.
+/// Compound `m.[…];[…]` (trans) parses today as an `AlleleVariant` in
+/// `Trans` phase. PR #146 (sibling C1) added the compact-prefix trans
+/// shorthand for `m.` to parallel `g.`/`n.`. Heteroplasmy is the
+/// canonical use case (different alleles on different mtDNA copies).
 #[test]
-fn audit_mt_compound_trans_allele_rejected_today() {
+fn audit_mt_compound_trans_allele_accepted_today() {
     let input = "NC_012920.1:m.[100A>G];[200T>C]";
-    assert!(
-        parse_hgvs(input).is_err(),
-        "PINNED: compound m. trans allele rejected today."
-    );
+    let variant = parse_hgvs(input).expect("compound m. trans allele should parse");
+    let HgvsVariant::Allele(allele) = &variant else {
+        panic!("expected HgvsVariant::Allele, got {variant:?}");
+    };
+    assert_eq!(allele.phase, AllelePhase::Trans);
+    assert_eq!(allele.variants.len(), 2);
+    assert!(matches!(allele.variants[0], HgvsVariant::Mt(_)));
+    assert!(matches!(allele.variants[1], HgvsVariant::Mt(_)));
 }
 
 /// `m.[…](;)` (homozygous shorthand) is rejected today.

--- a/tests/protein_silent_eq.rs
+++ b/tests/protein_silent_eq.rs
@@ -546,30 +546,17 @@ fn silent_eq_fast_path_matches_full_path() {
 }
 
 #[test]
-fn silent_eq_trans_allele_compact_form_drift_pinned_to_current_behavior() {
-    // CURRENT BEHAVIOR (drift; tracked by issue #83 in the v21.0 spec fixture
-    // at tests/fixtures/grammar/hgvs_spec_normalization.json:6390-6399 with
-    // `status: parse-error`):
+fn silent_eq_trans_allele_compact_form_round_trips() {
+    // PR #146 (sibling C1) added the compact-prefix protein trans-allele
+    // shorthand `ACC:p.[a];[b]`, fixing the parse-error drift previously
+    // tracked under issue #83.  Both expanded and compact forms now parse
+    // and the AST round-trips structurally:
     //
-    // The expanded trans-allele form `[ACC:p.Leu54=];[ACC:p.Arg97Trp]` parses
-    // and the resulting `AlleleVariant` Displays in the compact form
-    // `ACC:p.[Leu54=];[Arg97Trp]` — but ferro's own protein parser cannot
-    // re-parse that compact form today: it bails with "Unexpected trailing
-    // characters: ';[Arg97Trp]'".  This is not specific to silent `=`; the
-    // same drift hits any same-accession protein trans allele (e.g.
-    // `p.[Arg97Trp];[Leu54Pro]`), which is why the v21.0 fixture rows for
-    // `p.[(Ser68Arg)];[(Ser68Arg)]` and `p.[(Ser68Arg)];[?]` are also marked
-    // `parse-error`.
+    //   parse("[ACC:p.Leu54=];[ACC:p.Arg97Trp]")
+    //     == parse("ACC:p.[Leu54=];[Arg97Trp]")
     //
-    // We pin the drift here (rather than asserting the round-trip) so that:
-    //   1. D5's contract is locked in factually (no false-positive failure on
-    //      an existing #83 gap), and
-    //   2. when #83 is fixed and the compact form re-parses, this test fails
-    //      loudly and forces an update to assert structural round-trip.
-    //
-    // The cis form `ACC:p.[Leu54=;Arg97Trp]` (single bracket pair, semicolons
-    // inside) DOES round-trip cleanly today, and we pin that as the
-    // already-working contract below.
+    // The cis form `ACC:p.[Leu54=;Arg97Trp]` (single bracket pair,
+    // semicolons inside) was already working and is pinned alongside.
     let expanded = "[NP_000079.2:p.Leu54=];[NP_000079.2:p.Arg97Trp]";
     let parsed = parse_hgvs(expanded).unwrap_or_else(|e| panic!("parse({expanded:?}) failed: {e}"));
 
@@ -580,14 +567,16 @@ fn silent_eq_trans_allele_compact_form_drift_pinned_to_current_behavior() {
         "expanded trans allele did not Display as the compact form"
     );
 
-    // CURRENT BEHAVIOR: compact-form re-parse fails (issue #83).  When that
-    // is fixed, flip this to assert_eq!(parsed, reparse).
-    let reparse = parse_hgvs(compact);
-    assert!(
-        reparse.is_err(),
-        "compact-form trans allele unexpectedly re-parsed (issue #83 may be fixed; flip this \
-         assertion to round-trip): {:?}",
-        reparse.ok()
+    let reparsed = parse_hgvs(compact)
+        .unwrap_or_else(|e| panic!("parse({compact:?}) failed after PR #146: {e}"));
+    assert_eq!(
+        parsed, reparsed,
+        "compact-form trans allele AST drifted on re-parse"
+    );
+    assert_eq!(
+        format!("{}", reparsed),
+        compact,
+        "compact-form trans allele Display did not round-trip"
     );
 
     // Cis compact form does round-trip cleanly today; pin that contract too.

--- a/tests/protein_unknown_roundtrip.rs
+++ b/tests/protein_unknown_roundtrip.rs
@@ -732,68 +732,122 @@ fn protein_unknown_trans_compound_with_whole_protein_unknown_arm_round_trips() {
 
 // =====================================================================
 // Trans-allele compound: when an arm is a POSITION-SPECIFIC unknown
-// (`p.Met1?` or `p.(Met1?)`), `is_whole_protein_unknown()` returns
-// false, so compact-form suppression does NOT trigger — Display
-// produces the compact form `ACC:p.[X];[Met1?]`, which today's parser
-// cannot re-parse (matches the same-accession trans compact-form drift
-// pinned by D5 against issue #83).
+// (`p.Met1?`), `is_whole_protein_unknown()` returns false, so
+// compact-form suppression does NOT trigger — Display produces the
+// compact form `ACC:p.[Arg97Trp];[Met1?]`.
 //
-// We pin this as CURRENT behavior with `is_err()`. Flip to a clean
-// round-trip when #83 lands.
+// PR #146 (sibling C1) added the compact-prefix protein trans-allele
+// shorthand parser, so the compact form now round-trips structurally
+// (previously this was tracked under issue #83 as a parse-error drift).
 // =====================================================================
 
 #[test]
-fn protein_unknown_trans_compound_with_position_unknown_arm_drifts() {
-    let inputs = [
-        "[NP_000079.2:p.Arg97Trp];[NP_000079.2:p.Met1?]",
-        "[NP_000079.2:p.Arg97Trp];[NP_000079.2:p.(Met1?)]",
-    ];
-    for input in inputs {
-        let parsed = parse_hgvs(input).unwrap();
+fn protein_unknown_trans_compound_with_position_unknown_arm_round_trips() {
+    let input = "[NP_000079.2:p.Arg97Trp];[NP_000079.2:p.Met1?]";
+    let parsed = parse_hgvs(input).unwrap();
 
-        // Phase = Trans, arm 1 is position-specific Unknown.
-        let allele = match &parsed {
-            HgvsVariant::Allele(a) => a,
-            other => panic!("{input:?}: expected HgvsVariant::Allele, got {other:?}"),
-        };
-        assert_eq!(
-            allele.phase,
-            AllelePhase::Trans,
-            "{input:?}: phase mismatch"
-        );
+    // Phase = Trans, arm 1 is position-specific Unknown.
+    let allele = match &parsed {
+        HgvsVariant::Allele(a) => a,
+        other => panic!("{input:?}: expected HgvsVariant::Allele, got {other:?}"),
+    };
+    assert_eq!(
+        allele.phase,
+        AllelePhase::Trans,
+        "{input:?}: phase mismatch"
+    );
 
-        let arm1 = match &allele.variants[1] {
-            HgvsVariant::Protein(v) => v,
-            other => panic!("{input:?}: arm 1 expected Protein, got {other:?}"),
-        };
-        match arm1.loc_edit.edit.inner() {
-            Some(ProteinEdit::Unknown {
-                whole_protein: false,
-                ..
-            }) => {} // expected
-            other => panic!(
-                "{input:?}: arm 1 inner edit expected Unknown(whole_protein=false), got {other:?}"
-            ),
-        }
-
-        // Display compacts to ACC:p.[X];[...].  The parser today cannot
-        // reparse the compact same-accession trans form (issue #83). Pin
-        // current behavior so a future fix that lands #83 fails this
-        // assertion and forces the test to flip to round-trip equality.
-        let displayed = format!("{}", parsed);
-        assert!(
-            displayed.starts_with("NP_000079.2:p.["),
-            "{input:?}: expected compact same-accession Display, got {displayed:?}"
-        );
-
-        let reparsed = parse_hgvs(&displayed);
-        assert!(
-            reparsed.is_err(),
-            "{input:?}: compact-form Display {displayed:?} unexpectedly re-parsed; \
-             this means issue #83 is fixed and this assertion should flip to \
-             `assert_eq!(reparsed.unwrap(), parsed)`. \
-             Got: {:?}",
-            reparsed.ok()
-        );
+    let arm1 = match &allele.variants[1] {
+        HgvsVariant::Protein(v) => v,
+        other => panic!("{input:?}: arm 1 expected Protein, got {other:?}"),
+    };
+    match arm1.loc_edit.edit.inner() {
+        Some(ProteinEdit::Unknown {
+            whole_protein: false,
+            ..
+        }) => {} // expected
+        other => panic!(
+            "{input:?}: arm 1 inner edit expected Unknown(whole_protein=false), got {other:?}"
+        ),
     }
+
+    // Display compacts to ACC:p.[X];[...] and round-trips structurally.
+    let displayed = format!("{}", parsed);
+    assert!(
+        displayed.starts_with("NP_000079.2:p.["),
+        "{input:?}: expected compact same-accession Display, got {displayed:?}"
+    );
+
+    let reparsed = parse_hgvs(&displayed)
+        .unwrap_or_else(|e| panic!("{input:?}: parse({displayed:?}) failed after PR #146: {e}"));
+    assert_eq!(
+        reparsed, parsed,
+        "{input:?}: compact-form Display {displayed:?} did not round-trip"
+    );
+}
+
+// =====================================================================
+// Trans-allele compound, predicted-uncertainty arm `(Met1?)`: the
+// predicted-uncertainty wrapper `(...)` is NOT recognized inside any
+// allele-shorthand bracket today (cis `p.[(Met1?);...]` and trans
+// `p.[X];[(Met1?)]` both fail to re-parse). PR #146 explicitly scoped
+// out predicted-form arms; this gap is independent of the same-accession
+// trans compact-form fix and remains tracked under issue #83 alongside
+// the cis bracket path.
+//
+// We pin the drift here so a future fix (extending the bracket parsers
+// to dispatch on `(`) lights this up and forces a flip to round-trip.
+// =====================================================================
+
+#[test]
+fn protein_unknown_trans_compound_with_predicted_arm_drifts() {
+    let input = "[NP_000079.2:p.Arg97Trp];[NP_000079.2:p.(Met1?)]";
+    let parsed = parse_hgvs(input).unwrap();
+
+    // Phase = Trans, arm 1 is position-specific Unknown (uncertainty
+    // wrapper is preserved on the loc_edit, not the inner edit).
+    let allele = match &parsed {
+        HgvsVariant::Allele(a) => a,
+        other => panic!("{input:?}: expected HgvsVariant::Allele, got {other:?}"),
+    };
+    assert_eq!(
+        allele.phase,
+        AllelePhase::Trans,
+        "{input:?}: phase mismatch"
+    );
+
+    let arm1 = match &allele.variants[1] {
+        HgvsVariant::Protein(v) => v,
+        other => panic!("{input:?}: arm 1 expected Protein, got {other:?}"),
+    };
+    match arm1.loc_edit.edit.inner() {
+        Some(ProteinEdit::Unknown {
+            whole_protein: false,
+            ..
+        }) => {} // expected
+        other => panic!(
+            "{input:?}: arm 1 inner edit expected Unknown(whole_protein=false), got {other:?}"
+        ),
+    }
+
+    // Display compacts to ACC:p.[Arg97Trp];[(Met1?)]. The bracket parsers
+    // don't dispatch on `(` today, so re-parsing the compact form fails.
+    let displayed = format!("{}", parsed);
+    assert!(
+        displayed.starts_with("NP_000079.2:p.["),
+        "{input:?}: expected compact same-accession Display, got {displayed:?}"
+    );
+    assert!(
+        displayed.contains("[(Met1?)]"),
+        "{input:?}: expected predicted-form arm in compact Display, got {displayed:?}"
+    );
+
+    let reparsed = parse_hgvs(&displayed);
+    assert!(
+        reparsed.is_err(),
+        "{input:?}: compact-form Display {displayed:?} unexpectedly re-parsed; \
+         this means the predicted-form bracket gap is fixed and this assertion \
+         should flip to `assert_eq!(reparsed.unwrap(), parsed)`. Got: {:?}",
+        reparsed.ok()
+    );
 }


### PR DESCRIPTION
Addresses [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item **C1**: trans-phase canonicalization — `[a];[b]` shape vs malformed inputs, round-trip fidelity.

## Summary

Pins HGVS trans-allele compound canonicalization (`[a];[b]`) end-to-end for every coordinate system ferro supports, and locks the cis-only consecutive-edit merge barrier from #72 / #80 against regressions. Adds five symmetrical parser helpers to bring trans-allele compact-prefix shorthand (`<kind>.[a];[b]`) to uniform coverage across `c.`, `g.`, `r.`, `n.`, `m.`, `o.`, `p.` (the prior `c.`/`r.` already handled trans; `g.` and the four kinds added in this PR were not). All existing variant types accept the cis form `[a;b]`; this PR brings the trans form to parity for the kinds that previously rejected it.

The new helpers are gated behind `starts_with('[') && contains("];[")` and dispatch *before* the cis allele path inside each per-kind entry point, so existing cis and single-variant inputs are untouched. There is no production behavior change for any input that already parsed.

### Parser additions (`src/hgvs/parser/variant.rs`)

- `parse_genome_trans_allele_shorthand` — `g.[a];[b]`
- `parse_tx_trans_allele_shorthand` — `n.[a];[b]` (non-coding transcript)
- `parse_mt_trans_allele_shorthand` — `m.[a];[b]` (mitochondrial)
- `parse_circular_trans_allele_shorthand` — `o.[a];[b]` (circular DNA, per SVD-WG006)
- `parse_protein_trans_allele_shorthand` — `p.[a];[b]`

All five share the same shape: split on `];[`, parse each group as a self-contained interval+edit, and special-case `[0]` → `NullAllele`, `[?]` → `UnknownAllele`. DNA/RNA helpers fall back to identity (position-only) when the edit is omitted; the protein helper requires an explicit edit (consistent with the protein grammar).

### Stale comment removal

`tests/merge_consecutive_edits_tests.rs` had a comment claiming `g.[a];[b]` "isn't accepted by the parser" — removed since it now is.

### Spec fixture (`tests/fixtures/grammar/hgvs_spec_normalization.json`)

Five inputs flip `parse-error` → `preserved` against the v21.0 corpus (regenerated via `cargo run --features dev --example generate_spec_fixture`):

- `NC_000001.11:g.[123G>A];[345del]`
- `NC_000023.11:g.[123456A>G];[345678G>C]`
- `NP_003997.1:p.[Ser68Arg];[Asn594del]`
- `NP_003997.1:p.[Ser68Arg];[Ser68=]`
- `NP_003997.1:p.[Ser68Arg];[Ser68Arg]`

## Coverage matrix

`tests/allele_trans_phase.rs` (23 tests):

| Coord system | Compact round-trip | Special tokens | Homozygous | Other |
|---|---|---|---|---|
| `c.` | yes (LRG_199t1 spec example + generic) | `?`, `0`, `=` | yes | cis-vs-trans equality, expanded form, mixed accession (same + distinct), merge-barrier (cis-pair sanity) |
| `g.` | yes | `?`, `0`, `=` | yes | |
| `r.` | (covered by prior pass; mixed-accession exercises r.) | | | |
| `n.` | yes | `?` | | |
| `m.` | yes | | | |
| `o.` | yes | | | |
| `p.` | yes | | yes | |

Plus: idempotency under two normalize passes (`normalize(parse(s)) == normalize(normalize(parse(s)))` for trans), whitespace-around-separator rejection, obviously-malformed shape rejection (unbalanced brackets, empty group, trailing garbage), and the cis-counterpart merge sanity assertion so the trans merge-barrier assertion cannot become vacuous.

## HGVS spec rationale

HGVS `recommendations/DNA/variant/alleles.md` and `recommendations/protein/alleles.md` distinguish cis `[a;b]` from trans `[a];[b]`. The trans-allele shape is symmetrical across every coordinate system that supports compound alleles. SVD-WG006 specifies that circular DNA (`o.`) inherits the DNA allele grammar. This PR brings ferro's parser into uniform shape across all of them.

## Test plan

- [x] `cargo nextest run --features dev` — full suite green (3421 tests pass; 1 failure was the `pinned_v21_normalization_behavior` fixture pin, expected and resolved by regenerating the fixture as the test instructs)
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] All 23 tests in `tests/allele_trans_phase.rs` pass (10 from prior pass + 13 new for this enhancement)