### PR TITLE
fix(parser): extend unknown-phase (;) support to g./n./m./o./p. coord systems (#123)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -881,13 +881,23 @@ fn parse_genome_variant(
             }
         }
 
-        // Try compound allele notation: g.[pos1edit1;pos2edit2;...]
+        // Try compound allele notation: g.[pos1edit1;pos2edit2;...] or g.[a(;)b]
         if input.starts_with('[') {
             if let Ok((remaining, allele)) =
                 parse_genome_compound_allele(input, accession.clone(), gene_symbol.clone())
             {
                 return Ok((remaining, HgvsVariant::Allele(allele)));
             }
+        }
+
+        // Bracketless unknown-phase shorthand: g.123G>A(;)345del (#123)
+        if input.contains("(;)") && !input.starts_with('[') {
+            return parse_genome_position_unknown_phase(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+                GenomeKind::Genome,
+            );
         }
 
         let (input, interval) = parse_genome_interval(input)?;
@@ -924,54 +934,172 @@ fn parse_genome_variant(
     }
 }
 
-/// Parse a compound allele with genomic variants: [pos1edit1;pos2edit2;...]
+/// Tag that selects which DNA variant constructor to use when the genome-style
+/// allele helpers are shared between `g.`, `m.`, and `o.`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GenomeKind {
+    Genome,
+    Mt,
+    Circular,
+}
+
+impl GenomeKind {
+    fn build_variant(
+        self,
+        accession: Accession,
+        gene_symbol: Option<String>,
+        interval: GenomeInterval,
+        edit: crate::hgvs::edit::NaEdit,
+    ) -> HgvsVariant {
+        match self {
+            GenomeKind::Genome => HgvsVariant::Genome(GenomeVariant {
+                accession,
+                gene_symbol,
+                loc_edit: LocEdit::new(interval, edit),
+            }),
+            GenomeKind::Mt => HgvsVariant::Mt(MtVariant {
+                accession,
+                gene_symbol,
+                loc_edit: LocEdit::new(interval, edit),
+            }),
+            GenomeKind::Circular => HgvsVariant::Circular(CircularVariant {
+                accession,
+                gene_symbol,
+                loc_edit: LocEdit::new(interval, edit),
+            }),
+        }
+    }
+}
+
+/// Find the index of the `]` that closes the leading `[` in `input`, scanning
+/// at bracket depth 0. Returns `None` if `input` does not start with `[` or if
+/// the bracket is unbalanced.
+///
+/// Plain `input.find(']')` would truncate at any inner edit bracket
+/// (`delins[ACC:g.x_y]`, `delins[A;T]`, etc.); plain `input.rfind(']')` would
+/// over-consume on trans-form `[a];[b]`. The depth-tracking scan handles both.
+fn find_top_level_close_bracket(input: &str) -> Option<usize> {
+    if !input.starts_with('[') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    for (i, b) in input.bytes().enumerate() {
+        match b {
+            b'[' => depth += 1,
+            b']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Parse a compound allele with genomic variants:
+///   `[pos1edit1;pos2edit2;...]`   (cis)
+///   `[pos1edit1(;)pos2edit2;...]` (unknown phase)
+///
+/// A single bracket pair must use exactly one separator type; mixed
+/// `;`/`(;)` inside one bracket pair is not spec-valid and is rejected.
 fn parse_genome_compound_allele(
     input: &str,
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, AlleleVariant> {
-    let (remaining, _) = char('[').parse(input)?;
+    parse_genome_kind_compound_allele(input, accession, gene_symbol, GenomeKind::Genome)
+}
 
-    let mut variants = Vec::new();
-    let mut current = remaining;
+fn parse_genome_kind_compound_allele(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+    kind: GenomeKind,
+) -> IResult<&str, AlleleVariant> {
+    if !input.starts_with('[') {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
 
-    loop {
-        // Parse interval and edit
-        let (rest, interval) = parse_genome_interval(current)?;
-        // Edit is optional - if not present, treat as identity (no change)
-        let (rest, edit) = if let Ok((r, e)) = parse_na_edit(rest) {
+    // Locate the `]` that closes the leading `[`, scanning at bracket depth 0
+    // so that members containing nested edit brackets (`delins[ACC:g.x_y]`,
+    // `delins[A;T]`, etc.) are not truncated at the inner `]`.
+    let close_bracket = find_top_level_close_bracket(input).ok_or_else(|| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
+    })?;
+
+    let content = &input[1..close_bracket];
+    let remaining = &input[close_bracket + 1..];
+
+    // Distinguish unknown phase from cis based on `(;)` presence.
+    let has_unknown_phase = content.contains("(;)");
+    let has_cis_separator = {
+        // Any `;` that isn't part of `(;)`.
+        let temp = content.replace("(;)", "\x00");
+        temp.contains(';')
+    };
+
+    // Mixed `;` and `(;)` inside a single bracket pair is not spec-valid
+    // (HGVS `recommendations/{DNA,protein}/alleles.md` only mixes `;`/`(;)` at
+    // the top level via `[a;b];[c](;)d`, not inside one `[...]`). Reject
+    // rather than silently flatten the cis subgroup boundary into a single
+    // `phase: Unknown` allele.
+    if has_unknown_phase && has_cis_separator {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    let phase = if has_unknown_phase {
+        AllelePhase::Unknown
+    } else {
+        AllelePhase::Cis
+    };
+
+    let separator = if has_unknown_phase { "(;)" } else { ";" };
+    let mut variants = Vec::with_capacity(4);
+
+    for part in content.split(separator) {
+        let part = part.trim();
+        if part.is_empty() {
+            // Empty parts (e.g. `[a;;b]`, `[a(;)(;)b]`, or trailing `[a(;)]`)
+            // are malformed; reject rather than silently dropping them.
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (edit_remaining, interval) = parse_genome_interval(part)?;
+        let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
             (r, e)
         } else {
-            // No edit found - use identity (reference)
             (
-                rest,
+                edit_remaining,
                 crate::hgvs::edit::NaEdit::Identity {
                     sequence: None,
                     whole_entity: false,
                 },
             )
         };
-
-        variants.push(HgvsVariant::Genome(GenomeVariant {
-            accession: accession.clone(),
-            gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
-        }));
-
-        // Check for more variants (semicolon separator) or end of allele
-        if let Some(after_semi) = rest.strip_prefix(';') {
-            current = after_semi;
-        } else if let Some(after_bracket) = rest.strip_prefix(']') {
-            current = after_bracket;
-            break;
-        } else {
+        if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
-                rest,
+                final_remaining,
                 nom::error::ErrorKind::Tag,
             )));
         }
+        variants.push(kind.build_variant(accession.clone(), gene_symbol.clone(), interval, edit));
     }
 
+    // Singletons (`[a]`) are intentionally accepted by ferro: the bracketed
+    // wrapper is preserved for upstream tooling rather than rejected, and a
+    // non-empty `remaining` (e.g. trans-form `[a];[b]`) is handled by the
+    // outer parser. See `test_singleton_cis_allele_preserves_wrapper` and
+    // `pinned_v21_normalization_behavior` for the pinned behavior.
     if variants.is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -979,7 +1107,54 @@ fn parse_genome_compound_allele(
         )));
     }
 
-    Ok((current, AlleleVariant::cis(variants)))
+    Ok((remaining, AlleleVariant::new(variants, phase)))
+}
+
+/// Parse position-based unknown-phase shorthand for genome-style coord systems:
+///   `123G>A(;)345del` (uses [`GenomeKind`] to select the wrapping variant kind)
+fn parse_genome_position_unknown_phase(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+    kind: GenomeKind,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(4);
+
+    for part in input.split("(;)") {
+        let part = part.trim();
+        if part.is_empty() {
+            // An empty `(;)` group (e.g. `a(;)(;)b` or trailing/leading
+            // `(;)`) is malformed; reject rather than silently dropping it.
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+
+        let (edit_remaining, interval) = parse_genome_interval(part)?;
+        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+
+        if !final_remaining.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                final_remaining,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+
+        variants.push(kind.build_variant(accession.clone(), gene_symbol.clone(), interval, edit));
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        "",
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Unknown)),
+    ))
 }
 
 /// Parse a genomic trans-allele compact-prefix shorthand: `[edit1];[edit2]`
@@ -1271,7 +1446,10 @@ fn parse_cds_position_unknown_phase(
     for part in input.split("(;)") {
         let part = part.trim();
         if part.is_empty() {
-            continue;
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
         }
 
         // Parse interval + edit
@@ -1360,7 +1538,10 @@ fn parse_cds_allele_shorthand(
             for part in unknown_group.split(';') {
                 let part = part.trim();
                 if part.is_empty() {
-                    continue;
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        input,
+                        nom::error::ErrorKind::Verify,
+                    )));
                 }
 
                 let (edit_remaining, interval) = parse_cds_interval(part)?;
@@ -1398,7 +1579,10 @@ fn parse_cds_allele_shorthand(
         for part in content.split(separator) {
             let part = part.trim();
             if part.is_empty() {
-                continue;
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
             }
 
             // Parse interval + edit (e.g., "145C>T" or "100_200del")
@@ -1535,6 +1719,20 @@ fn parse_tx_variant(
             }
         }
 
+        // Bracketed compound allele: n.[var;var;...] or n.[var(;)var]
+        if input.starts_with('[') {
+            if let Ok((remaining, allele)) =
+                parse_tx_compound_allele(input, accession.clone(), gene_symbol.clone())
+            {
+                return Ok((remaining, HgvsVariant::Allele(allele)));
+            }
+        }
+
+        // Bracketless unknown-phase shorthand: n.100A>G(;)200T>C (#123)
+        if input.contains("(;)") && !input.starts_with('[') {
+            return parse_tx_position_unknown_phase(input, accession.clone(), gene_symbol.clone());
+        }
+
         let (input, interval) = parse_tx_interval(input)?;
         let (input, edit) = parse_na_edit(input)?;
 
@@ -1630,6 +1828,142 @@ fn parse_tx_trans_allele_shorthand(
     ))
 }
 
+/// Parse a compound allele with `n.` (transcript) variants:
+///   `[100A>G;200T>C]` (cis) or `[100A>G(;)200T>C]` (unknown phase)
+fn parse_tx_compound_allele(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, AlleleVariant> {
+    if !input.starts_with('[') {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    // See `find_top_level_close_bracket` for why a depth-aware scan is used.
+    let close_bracket = find_top_level_close_bracket(input).ok_or_else(|| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
+    })?;
+
+    let content = &input[1..close_bracket];
+    let remaining = &input[close_bracket + 1..];
+
+    let has_unknown_phase = content.contains("(;)");
+    let has_cis_separator = {
+        let temp = content.replace("(;)", "\x00");
+        temp.contains(';')
+    };
+
+    // Mixed `;`/`(;)` inside one bracket pair is not spec-valid — see
+    // `parse_genome_kind_compound_allele` for the spec citation.
+    if has_unknown_phase && has_cis_separator {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    let phase = if has_unknown_phase {
+        AllelePhase::Unknown
+    } else {
+        AllelePhase::Cis
+    };
+
+    let separator = if has_unknown_phase { "(;)" } else { ";" };
+
+    let mut variants = Vec::with_capacity(4);
+    for part in content.split(separator) {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (edit_remaining, interval) = parse_tx_interval(part)?;
+        let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
+            (r, e)
+        } else {
+            (
+                edit_remaining,
+                crate::hgvs::edit::NaEdit::Identity {
+                    sequence: None,
+                    whole_entity: false,
+                },
+            )
+        };
+        if !final_remaining.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                final_remaining,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+        variants.push(HgvsVariant::Tx(TxVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit: LocEdit::new(interval, edit),
+        }));
+    }
+
+    // Singletons are intentionally accepted — see
+    // `parse_genome_kind_compound_allele` for the rationale.
+    if variants.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    Ok((remaining, AlleleVariant::new(variants, phase)))
+}
+
+/// Parse position-based unknown-phase shorthand for `n.`:
+///   `100A>G(;)200T>C`
+fn parse_tx_position_unknown_phase(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(4);
+
+    for part in input.split("(;)") {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (edit_remaining, interval) = parse_tx_interval(part)?;
+        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+        if !final_remaining.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                final_remaining,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+        variants.push(HgvsVariant::Tx(TxVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit: LocEdit::new(interval, edit),
+        }));
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        "",
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Unknown)),
+    ))
+}
+
 /// Parse mitochondrial variant (m.)
 fn parse_mt_variant(
     accession: Accession,
@@ -1646,6 +1980,28 @@ fn parse_mt_variant(
             {
                 return Ok((remaining, variant));
             }
+        }
+
+        // Bracketed compound allele: m.[var;var] or m.[var(;)var]
+        if input.starts_with('[') {
+            if let Ok((remaining, allele)) = parse_genome_kind_compound_allele(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+                GenomeKind::Mt,
+            ) {
+                return Ok((remaining, HgvsVariant::Allele(allele)));
+            }
+        }
+
+        // Bracketless unknown-phase shorthand: m.100A>G(;)200T>C (#123)
+        if input.contains("(;)") && !input.starts_with('[') {
+            return parse_genome_position_unknown_phase(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+                GenomeKind::Mt,
+            );
         }
 
         let (input, interval) = parse_genome_interval(input)?;
@@ -1778,12 +2134,91 @@ fn parse_whole_protein_unknown(input: &str) -> IResult<&str, ProteinEdit> {
     .parse(input)
 }
 
-/// Parse a protein allele shorthand: p.[edit1;edit2;...]
+/// Parse a protein allele shorthand:
+///   `p.[edit1;edit2;...]`     (cis)
+///   `p.[edit1(;)edit2;...]`   (unknown phase)
+///
+/// A single bracket pair must use exactly one separator type; mixed
+/// `;`/`(;)` inside one bracket pair is not spec-valid and is rejected.
 fn parse_protein_allele_shorthand(
     input: &str,
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, AlleleVariant> {
+    if !input.starts_with('[') {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    // Fast path: any `(;)` inside the brackets means unknown phase. Slice the
+    // bracketed content, split on `(;)`, and parse each sub-variant as
+    // `interval+edit`. Use a depth-aware scan for the closing `]` so members
+    // containing nested edit brackets are not truncated — see
+    // `find_top_level_close_bracket`.
+    let close_bracket = find_top_level_close_bracket(input).ok_or_else(|| {
+        nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Tag))
+    })?;
+    let content = &input[1..close_bracket];
+    let after_bracket = &input[close_bracket + 1..];
+
+    let has_unknown_phase = content.contains("(;)");
+
+    if has_unknown_phase {
+        let has_cis_separator = {
+            let temp = content.replace("(;)", "\x00");
+            temp.contains(';')
+        };
+        // Mixed `;`/`(;)` inside one bracket pair is not spec-valid — see
+        // `parse_genome_kind_compound_allele` for the spec citation.
+        if has_cis_separator {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+
+        let mut variants = Vec::with_capacity(4);
+        for part in content.split("(;)") {
+            let part = part.trim();
+            if part.is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
+            }
+            let (edit_remaining, interval) = parse_prot_interval(part)?;
+            let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
+            if !final_remaining.trim().is_empty() {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    final_remaining,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+            variants.push(HgvsVariant::Protein(ProteinVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, edit),
+            }));
+        }
+
+        // Singletons are intentionally accepted — see
+        // `parse_genome_kind_compound_allele` for the rationale.
+        if variants.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+
+        return Ok((
+            after_bracket,
+            AlleleVariant::new(variants, AllelePhase::Unknown),
+        ));
+    }
+
+    // Cis path (existing behavior).
     let (remaining, _) = char('[').parse(input)?;
 
     let mut variants = Vec::new();
@@ -1814,6 +2249,8 @@ fn parse_protein_allele_shorthand(
         }
     }
 
+    // Singletons are intentionally accepted — see
+    // `parse_genome_kind_compound_allele` for the rationale.
     if variants.is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
@@ -1892,6 +2329,63 @@ fn parse_protein_trans_allele_shorthand(
     Ok((
         remaining,
         HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
+    ))
+}
+
+/// Parse position-based unknown-phase shorthand for protein (#123):
+///   `(Ser68Arg)(;)(Asn594del)`
+///
+/// Per `recommendations/protein/alleles.md` line 48, the protein unknown-phase
+/// form does NOT use surrounding square brackets and each sub-variant is a
+/// predicted change wrapped in `()`.
+fn parse_protein_position_unknown_phase(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    let mut variants = Vec::with_capacity(4);
+
+    for part in input.split("(;)") {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+
+        // Each part must be a parenthesized predicted change `(interval+edit)`.
+        let (rest, (interval, edit)) = delimited(
+            char('('),
+            (parse_prot_interval, parse_protein_edit),
+            char(')'),
+        )
+        .parse(part)?;
+
+        if !rest.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                rest,
+                nom::error::ErrorKind::Tag,
+            )));
+        }
+
+        variants.push(HgvsVariant::Protein(ProteinVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(interval, Mu::Uncertain(edit)),
+        }));
+    }
+
+    if variants.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+
+    Ok((
+        "",
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Unknown)),
     ))
 }
 
@@ -2115,13 +2609,25 @@ fn parse_protein_variant(
             }
         }
 
-        // Try protein allele: p.[edit1;edit2;...]
+        // Try protein allele: p.[edit1;edit2;...] or p.[edit1(;)edit2]
         if input.starts_with('[') {
             if let Ok((remaining, allele)) =
                 parse_protein_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {
                 return Ok((remaining, HgvsVariant::Allele(allele)));
             }
+        }
+
+        // Bracketless unknown-phase shorthand for protein (#123):
+        //   p.(Ser68Arg)(;)(Asn594del)
+        // Per spec the protein form is bare (no surrounding `[]`). Each
+        // sub-variant is a predicted change in parentheses.
+        if input.starts_with('(') && input.contains(")(;)(") {
+            return parse_protein_position_unknown_phase(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+            );
         }
 
         // Try predicted protein change: p.(position+edit) - wrapped in parentheses
@@ -2426,7 +2932,10 @@ fn parse_rna_position_unknown_phase(
     for part in input.split("(;)") {
         let part = part.trim();
         if part.is_empty() {
-            continue;
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
         }
 
         let (edit_remaining, interval) = parse_rna_interval(part)?;
@@ -2505,7 +3014,10 @@ fn parse_rna_allele_shorthand(
             for part in unknown_group.split(';') {
                 let part = part.trim();
                 if part.is_empty() {
-                    continue;
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        input,
+                        nom::error::ErrorKind::Verify,
+                    )));
                 }
 
                 let (edit_remaining, interval) = parse_rna_interval(part)?;
@@ -2531,7 +3043,10 @@ fn parse_rna_allele_shorthand(
         for part in content.split(separator) {
             let part = part.trim();
             if part.is_empty() {
-                continue;
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
             }
 
             let (edit_remaining, interval) = parse_rna_interval(part)?;
@@ -2648,6 +3163,28 @@ fn parse_circular_variant(
             {
                 return Ok((remaining, variant));
             }
+        }
+
+        // Bracketed compound allele: o.[var;var] or o.[var(;)var]
+        if input.starts_with('[') {
+            if let Ok((remaining, allele)) = parse_genome_kind_compound_allele(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+                GenomeKind::Circular,
+            ) {
+                return Ok((remaining, HgvsVariant::Allele(allele)));
+            }
+        }
+
+        // Bracketless unknown-phase shorthand: o.100A>G(;)200T>C (#123)
+        if input.contains("(;)") && !input.starts_with('[') {
+            return parse_genome_position_unknown_phase(
+                input,
+                accession.clone(),
+                gene_symbol.clone(),
+                GenomeKind::Circular,
+            );
         }
 
         let (input, interval) = parse_genome_interval(input)?;
@@ -3606,12 +4143,19 @@ fn parse_unknown_phase_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     // Extract content inside brackets
     let content = &input[1..input.len() - 1];
 
-    // Split by (;) and parse each variant
+    // Split by (;) and parse each variant. Empty groups (e.g.
+    // `[A:c.x(;)(;)B:c.y]`, leading/trailing `(;)`) are malformed; reject
+    // rather than silently dropping them — matches the per-coord helpers
+    // (`parse_genome_kind_compound_allele` etc.) introduced for #123.
     let mut variants = Vec::with_capacity(2);
     for part in content.split("(;)") {
         let part = part.trim();
         if part.is_empty() {
-            continue;
+            return Err(FerroError::Parse {
+                pos: 0,
+                msg: "Empty `(;)` group in unknown-phase allele".to_string(),
+                diagnostic: None,
+            });
         }
         let (remaining, variant) = parse_single_variant(part)?;
         if !remaining.trim().is_empty() {

--- a/tests/allele_unknown_phase.rs
+++ b/tests/allele_unknown_phase.rs
@@ -1,0 +1,509 @@
+//! Tests for HGVS unknown-phase compound `(;)` separator across every
+//! coordinate system. Closes #123 / #81 C3.
+//!
+//! Per `assets/hgvs-nomenclature/docs/recommendations/DNA/alleles.md` and
+//! `recommendations/protein/alleles.md`, the unknown-phase compound
+//! `[a(;)b]` (parens around `;`) is symmetric across coordinate systems.
+//! Prior to this PR ferro accepted it only for `c.` and `r.`; this file
+//! pins parity across `g.`, `n.`, `m.`, `o.`, `p.`.
+//!
+//! See: docs/superpowers/plans/2026-05-06-issue-123.md
+
+use ferro_hgvs::hgvs::variant::{AllelePhase, HgvsVariant};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse and assert the result is an unknown-phase compound allele with the
+/// expected number of sub-variants.
+fn assert_unknown_phase(input: &str, expected_n_variants: usize) -> HgvsVariant {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("failed to parse {input:?}: {e}"));
+    match &v {
+        HgvsVariant::Allele(allele) => {
+            assert_eq!(
+                allele.phase,
+                AllelePhase::Unknown,
+                "expected unknown phase for {input:?}, got {:?}",
+                allele.phase
+            );
+            assert_eq!(
+                allele.variants.len(),
+                expected_n_variants,
+                "wrong sub-variant count for {input:?}",
+            );
+        }
+        other => panic!("expected Allele variant for {input:?}, got {other:?}"),
+    }
+    v
+}
+
+/// Round-trip parse → Display → parse and assert the second parse equals
+/// the first.
+fn assert_round_trip(input: &str) {
+    let v1 = parse_hgvs(input).unwrap_or_else(|e| panic!("first parse of {input:?} failed: {e}"));
+    let display = format!("{v1}");
+    let v2 = parse_hgvs(&display)
+        .unwrap_or_else(|e| panic!("re-parse of display {display:?} failed: {e}"));
+    assert_eq!(
+        v1, v2,
+        "round-trip mismatch: input={input:?} display={display:?}",
+    );
+}
+
+fn hash_of<T: Hash>(t: &T) -> u64 {
+    let mut h = DefaultHasher::new();
+    t.hash(&mut h);
+    h.finish()
+}
+
+// ---------------------------------------------------------------------------
+// Bracketless compact form across all coord systems
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cds_bracketless_unknown_phase() {
+    // c. is already supported; pin it as a parity baseline.
+    assert_unknown_phase("NM_004006.2:c.2376G>C(;)3103del", 2);
+    assert_round_trip("NM_004006.2:c.2376G>C(;)3103del");
+}
+
+#[test]
+fn rna_bracketless_unknown_phase() {
+    // r. is already supported; baseline.
+    assert_unknown_phase("NM_004006.3:r.123c>a(;)345del", 2);
+    assert_round_trip("NM_004006.3:r.123c>a(;)345del");
+}
+
+#[test]
+fn genome_bracketless_unknown_phase() {
+    // Spec example (syntax.yaml line 145).
+    assert_unknown_phase("NC_000001.11:g.123G>A(;)345del", 2);
+    assert_round_trip("NC_000001.11:g.123G>A(;)345del");
+}
+
+#[test]
+fn tx_bracketless_unknown_phase() {
+    // Non-coding transcript.
+    assert_unknown_phase("NM_000088.3:n.100A>G(;)200T>C", 2);
+    assert_round_trip("NM_000088.3:n.100A>G(;)200T>C");
+}
+
+#[test]
+fn mt_bracketless_unknown_phase() {
+    // Mitochondrial.
+    assert_unknown_phase("NC_012920.1:m.100A>G(;)200T>C", 2);
+    assert_round_trip("NC_012920.1:m.100A>G(;)200T>C");
+}
+
+#[test]
+fn circular_bracketless_unknown_phase() {
+    // Circular DNA (SVD-WG006).
+    assert_unknown_phase("NC_001416.1:o.100A>G(;)200T>C", 2);
+    assert_round_trip("NC_001416.1:o.100A>G(;)200T>C");
+}
+
+#[test]
+fn protein_bracketless_unknown_phase() {
+    // Spec example (recommendations/protein/alleles.md line 48).
+    // NOTE: per spec, brackets are NOT used for unknown-phase protein.
+    assert_unknown_phase("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)", 2);
+    assert_round_trip("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)");
+}
+
+#[test]
+fn protein_bracketless_unknown_phase_homozygous_predicted() {
+    // Homozygous predicted form with same variant on both sides.
+    assert_unknown_phase("NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)", 2);
+    assert_round_trip("NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)");
+}
+
+// ---------------------------------------------------------------------------
+// Bracketed form `[a(;)b]` per coord system (DNA/RNA only — protein uses
+// the bare bracketless shape per spec).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cds_bracketed_unknown_phase() {
+    // Baseline; already supported.
+    assert_unknown_phase("NM_004006.2:c.[2376G>C(;)3103del]", 2);
+    assert_round_trip("NM_004006.2:c.[2376G>C(;)3103del]");
+}
+
+#[test]
+fn rna_bracketed_unknown_phase() {
+    assert_unknown_phase("NM_004006.3:r.[123c>a(;)345del]", 2);
+    assert_round_trip("NM_004006.3:r.[123c>a(;)345del]");
+}
+
+#[test]
+fn genome_bracketed_unknown_phase() {
+    assert_unknown_phase("NC_000001.11:g.[123G>A(;)345del]", 2);
+    assert_round_trip("NC_000001.11:g.[123G>A(;)345del]");
+}
+
+#[test]
+fn tx_bracketed_unknown_phase() {
+    assert_unknown_phase("NM_000088.3:n.[100A>G(;)200T>C]", 2);
+    assert_round_trip("NM_000088.3:n.[100A>G(;)200T>C]");
+}
+
+#[test]
+fn mt_bracketed_unknown_phase() {
+    assert_unknown_phase("NC_012920.1:m.[100A>G(;)200T>C]", 2);
+    assert_round_trip("NC_012920.1:m.[100A>G(;)200T>C]");
+}
+
+#[test]
+fn circular_bracketed_unknown_phase() {
+    assert_unknown_phase("NC_001416.1:o.[100A>G(;)200T>C]", 2);
+    assert_round_trip("NC_001416.1:o.[100A>G(;)200T>C]");
+}
+
+// ---------------------------------------------------------------------------
+// 3+ variant compounds
+// ---------------------------------------------------------------------------
+
+#[test]
+fn three_variant_unknown_phase_genome() {
+    assert_unknown_phase("NC_000001.11:g.100A>G(;)200T>C(;)300del", 3);
+    assert_round_trip("NC_000001.11:g.100A>G(;)200T>C(;)300del");
+}
+
+#[test]
+fn three_variant_unknown_phase_protein() {
+    assert_unknown_phase("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)(;)(Pro100Leu)", 3);
+    assert_round_trip("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)(;)(Pro100Leu)");
+}
+
+#[test]
+fn three_variant_unknown_phase_bracketed_genome() {
+    assert_unknown_phase("NC_000001.11:g.[100A>G(;)200T>C(;)300del]", 3);
+    assert_round_trip("NC_000001.11:g.[100A>G(;)200T>C(;)300del]");
+}
+
+// ---------------------------------------------------------------------------
+// Phase distinctness: Cis vs Trans vs Unknown all hash and compare distinctly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_phase_distinct_from_cis_genome() {
+    let cis = parse_hgvs("NC_000001.11:g.[100A>G;200T>C]").unwrap();
+    let unknown = parse_hgvs("NC_000001.11:g.[100A>G(;)200T>C]").unwrap();
+    assert_ne!(cis, unknown, "cis and unknown phase must be distinct");
+    assert_ne!(
+        hash_of(&cis),
+        hash_of(&unknown),
+        "cis and unknown phase must hash distinctly"
+    );
+}
+
+#[test]
+fn unknown_phase_distinct_from_trans_cds() {
+    // Trans-form (`[a];[b]`) parser support across all coord systems is the
+    // sister effort tracked in #81 C1 / PR #146 — landed for `c.` and `r.`,
+    // pending for `g./n./m./o./p.`. Pin distinctness against `c.` to keep
+    // this test orthogonal to the other PR.
+    let trans = parse_hgvs("NM_004006.2:c.[2376G>C];[3103del]").unwrap();
+    let unknown = parse_hgvs("NM_004006.2:c.[2376G>C(;)3103del]").unwrap();
+    assert_ne!(trans, unknown, "trans and unknown phase must be distinct");
+    assert_ne!(
+        hash_of(&trans),
+        hash_of(&unknown),
+        "trans and unknown phase must hash distinctly"
+    );
+}
+
+#[test]
+fn unknown_phase_distinct_from_cis_protein() {
+    let cis = parse_hgvs("NP_003997.1:p.[Ser68Arg;Asn594del]").unwrap();
+    let unknown = parse_hgvs("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)").unwrap();
+    assert_ne!(cis, unknown);
+    assert_ne!(hash_of(&cis), hash_of(&unknown));
+}
+
+#[test]
+fn unknown_phase_eq_self_genome() {
+    // Eq + Hash stability: two parses of the same string compare and hash equal.
+    let a = parse_hgvs("NC_000001.11:g.[100A>G(;)200T>C]").unwrap();
+    let b = parse_hgvs("NC_000001.11:g.[100A>G(;)200T>C]").unwrap();
+    assert_eq!(a, b);
+    assert_eq!(hash_of(&a), hash_of(&b));
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency under multi-pass normalize.
+// ---------------------------------------------------------------------------
+
+fn idempotent_normalize(input: &str) {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {input:?}: {e}"));
+    let n1 = normalizer.normalize(&v).expect("first normalize");
+    let n2 = normalizer.normalize(&n1).expect("second normalize");
+    assert_eq!(
+        format!("{n1}"),
+        format!("{n2}"),
+        "normalize is not idempotent for {input:?}",
+    );
+}
+
+#[test]
+fn normalize_idempotent_unknown_phase_genome() {
+    idempotent_normalize("NC_000001.11:g.123G>A(;)345del");
+    idempotent_normalize("NC_000001.11:g.[123G>A(;)345del]");
+}
+
+#[test]
+fn normalize_idempotent_unknown_phase_tx() {
+    idempotent_normalize("NM_000088.3:n.100A>G(;)200T>C");
+    idempotent_normalize("NM_000088.3:n.[100A>G(;)200T>C]");
+}
+
+#[test]
+fn normalize_idempotent_unknown_phase_mt() {
+    idempotent_normalize("NC_012920.1:m.100A>G(;)200T>C");
+}
+
+#[test]
+fn normalize_idempotent_unknown_phase_circular() {
+    idempotent_normalize("NC_001416.1:o.100A>G(;)200T>C");
+}
+
+#[test]
+fn normalize_idempotent_unknown_phase_protein() {
+    idempotent_normalize("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)");
+}
+
+// ---------------------------------------------------------------------------
+// No-merge contract: an unknown-phase compound of *adjacent* edits MUST NOT
+// be merged into a single delins (cis-only contract from #80).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_phase_does_not_merge_adjacent_subs_genome() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    // Cis baseline merges to delins — proves the merge path is wired.
+    let cis = parse_hgvs("NC_000001.11:g.[1000G>A;1001A>C]").unwrap();
+    let cis_norm = normalizer.normalize(&cis).expect("normalize cis");
+    assert_eq!(
+        format!("{cis_norm}"),
+        "NC_000001.11:g.1000_1001delinsAC",
+        "cis-pair sanity (must merge so the unknown-phase assertion is not vacuous)",
+    );
+
+    // Unknown-phase parallel input MUST NOT merge.
+    let unk = parse_hgvs("NC_000001.11:g.[1000G>A(;)1001A>C]").unwrap();
+    let unk_norm = normalizer.normalize(&unk).expect("normalize unknown");
+    let s = format!("{unk_norm}");
+    assert!(
+        s.contains("(;)"),
+        "unknown-phase compound must preserve `(;)` (got {s:?})",
+    );
+    assert!(
+        !s.contains("delinsAC"),
+        "unknown-phase compound must NOT merge into delins (got {s:?})",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-accession compound (ClinVar-style) accepts unknown phase.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_accession_unknown_phase() {
+    // Two coding variants on different transcripts under unknown-phase. The
+    // top-level bracketed form `[A:c.x(;)B:c.y]` is dispatched through
+    // `parse_unknown_phase_allele` (no leading shared accession).
+    let v = parse_hgvs("[NM_000088.3:c.100A>G(;)NM_000089.4:c.200T>C]").unwrap_or_else(|e| {
+        panic!("mixed-accession unknown-phase parse failed: {e}");
+    });
+    match v {
+        HgvsVariant::Allele(allele) => {
+            assert_eq!(allele.phase, AllelePhase::Unknown);
+            assert_eq!(allele.variants.len(), 2);
+        }
+        other => panic!("expected Allele, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Malformed rejection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_unbalanced_bracket_genome_rejected() {
+    // missing closing bracket
+    assert!(parse_hgvs("NC_000001.11:g.[100A>G(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_trailing_garbage_protein_rejected() {
+    assert!(parse_hgvs("NP_003997.1:p.(Ser68Arg)(;)(Asn594del)garbage").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_unknown_phase_rejected() {
+    // Empty `(;)` group inside brackets must hard-fail. Previously the
+    // parser silently dropped empty parts and accepted this as a valid
+    // 2-variant allele.
+    assert!(parse_hgvs("NC_000001.11:g.[100A>G(;)(;)200T>C]").is_err());
+}
+
+// Empty `(;)` segments must hard-fail across every coord system, both for
+// the bracketed (`[a(;)(;)b]`) and bracketless (`a(;)(;)b`) forms. CodeRabbit
+// (PR #148) noted that previously empty parts were silently dropped, so a
+// malformed input like `(;)(;)` between two real entries still parsed as a
+// valid 2-variant allele.
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_genome() {
+    assert!(parse_hgvs("NC_000001.11:g.100A>G(;)(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_tx() {
+    assert!(parse_hgvs("NR_004430.2:n.100A>G(;)(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_mt() {
+    assert!(parse_hgvs("NC_012920.1:m.100A>G(;)(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_circular() {
+    assert!(parse_hgvs("NC_000913.3:o.100A>G(;)(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_cds() {
+    assert!(parse_hgvs("NM_004006.2:c.100A>G(;)(;)200T>C").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_rna() {
+    assert!(parse_hgvs("NM_004006.3:r.100a>g(;)(;)200u>c").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketless_rejected_protein() {
+    // Bracketless protein form: each sub-variant is `(...)`; empty `(;)`
+    // group between them must error.
+    assert!(parse_hgvs("NP_003997.1:p.(Ser68Arg)(;)(;)(Asn594del)").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketed_rejected_tx() {
+    assert!(parse_hgvs("NR_004430.2:n.[100A>G(;)(;)200T>C]").is_err());
+}
+
+#[test]
+fn malformed_empty_segment_bracketed_rejected_protein() {
+    assert!(parse_hgvs("NP_003997.1:p.[Ser68Arg(;)(;)Asn594del]").is_err());
+}
+
+// Trailing/leading empty `(;)` groups inside brackets (e.g. `[a(;)]`) must
+// error rather than silently produce a phantom 1-variant unknown-phase allele.
+// Note: bare singletons like `[a]` are intentionally accepted by ferro and
+// expanded upstream — see test_singleton_cis_allele_preserves_wrapper.
+
+#[test]
+fn malformed_trailing_empty_unknown_group_rejected_genome() {
+    assert!(parse_hgvs("NC_000001.11:g.[100A>G(;)]").is_err());
+}
+
+#[test]
+fn malformed_trailing_empty_unknown_group_rejected_tx() {
+    assert!(parse_hgvs("NR_004430.2:n.[100A>G(;)]").is_err());
+}
+
+#[test]
+fn malformed_trailing_empty_unknown_group_rejected_protein() {
+    assert!(parse_hgvs("NP_003997.1:p.[Ser68Arg(;)]").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Empty `(;)` segments must be rejected on the mixed-accession path too
+// (CodeRabbit PR #148): `parse_unknown_phase_allele` previously skipped empty
+// splits, so `[A:c.x(;)(;)B:c.y]` parsed as a valid 2-variant allele.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_empty_segment_mixed_accession_rejected() {
+    assert!(
+        parse_hgvs("[NM_000088.3:c.100A>G(;)(;)NM_000089.4:c.200T>C]").is_err(),
+        "double `(;)` in a mixed-accession unknown-phase compound must be rejected",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed `;`/`(;)` inside one bracket pair (CodeRabbit PR #148): per HGVS spec
+// (`recommendations/{DNA,protein}/alleles.md`), a single `[...]` carries either
+// all-cis (`;`) or all-unknown-phase (`(;)`) members. Top-level mixing
+// (`[a;b];[c](;)d`) uses the trans + bracketless paths separately. Mixing
+// inside one bracket is not spec-valid — must be rejected, not flattened.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_mixed_separators_rejected_genome() {
+    assert!(parse_hgvs("NC_000001.11:g.[100A>G;200T>C(;)300del]").is_err());
+}
+
+#[test]
+fn malformed_mixed_separators_rejected_tx() {
+    assert!(parse_hgvs("NM_000088.3:n.[100A>G;200T>C(;)300del]").is_err());
+}
+
+#[test]
+fn malformed_mixed_separators_rejected_protein() {
+    assert!(parse_hgvs("NP_003997.1:p.[Ser68Arg;Asn594del(;)Pro100Leu]").is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Compound allele members containing nested bracketed edits (CodeRabbit
+// PR #148): the compound parser must locate the FIRST TOP-LEVEL `]`, not the
+// first byte match — otherwise valid members like `delins[ACC:g.x_y]`,
+// `delins[A;T]`, etc. are truncated mid-edit and the whole compound rejects.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_member_with_xref_delins_genome() {
+    let v = parse_hgvs("NC_000008.11:g.[86587460_86650711delins[KY923049.1:g.1_466];86660000A>G]")
+        .expect("compound with delins[xref] member must parse");
+    match v {
+        HgvsVariant::Allele(allele) => {
+            assert_eq!(allele.variants.len(), 2);
+        }
+        other => panic!("expected Allele, got {other:?}"),
+    }
+}
+
+#[test]
+fn compound_member_with_inner_bracket_delins_tx() {
+    let v = parse_hgvs("NM_002001.2:c.[12_17delins[28_39];100A>G]")
+        .expect("tx compound with delins[range] member must parse");
+    match v {
+        HgvsVariant::Allele(allele) => {
+            assert_eq!(allele.variants.len(), 2);
+        }
+        other => panic!("expected Allele, got {other:?}"),
+    }
+}
+
+#[test]
+fn compound_member_with_inner_bracket_unknown_phase_genome() {
+    // Same nested-bracket hazard but with `(;)` separator.
+    let v =
+        parse_hgvs("NC_000008.11:g.[86587460_86650711delins[KY923049.1:g.1_466](;)86660000A>G]")
+            .expect("unknown-phase compound with delins[xref] member must parse");
+    match v {
+        HgvsVariant::Allele(allele) => {
+            assert_eq!(allele.phase, AllelePhase::Unknown);
+            assert_eq!(allele.variants.len(), 2);
+        }
+        other => panic!("expected Allele, got {other:?}"),
+    }
+}

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "correctly-rejected": 12,
       "diverges": 144,
       "false-acceptance": 22,
-      "parse-error": 209,
-      "preserved": 436
+      "parse-error": 204,
+      "preserved": 441
     },
     "by_coordinate_system": {
       "c": 298,
@@ -4551,18 +4551,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000001.11:g.123G>A(;)345del",
-      "current": "parse error: Parse error at position 21: Unexpected trailing characters: '(;)345del'",
-      "spec_expected": "NC_000001.11:g.123G>A(;)345del",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
       "current": "parse error: Parse error at position 13: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found ':g.'",
       "spec_expected": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
@@ -4667,18 +4655,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/duplication.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NG_012232.1:g.12G>T(;)13C>G",
-      "current": "parse error: Parse error at position 19: Unexpected trailing characters: '(;)13C>G'",
-      "spec_expected": "NG_012232.1:g.12G>T(;)13C>G",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4952,6 +4928,17 @@
       "source_paths": [
         "docs/syntax.yaml",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
+      ]
+    },
+    {
+      "input": "NC_000001.11:g.123G>A(;)345del",
+      "current": "NC_000001.11:g.123G>A(;)345del",
+      "spec_expected": "NC_000001.11:g.123G>A(;)345del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
       ]
     },
     {
@@ -5583,6 +5570,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1:g.12G>T(;)13C>G",
+      "current": "NG_012232.1:g.12G>T(;)13C>G",
+      "spec_expected": "NG_012232.1:g.12G>T(;)13C>G",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
       ]
     },
     {
@@ -6286,30 +6284,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '(;)(Asn594del)'",
-      "spec_expected": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '(;)(Ser68Arg)'",
-      "spec_expected": "NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.1:p.(Ser73Arg)](;)[(Asn103del)",
       "current": "parse error: Parse error at position 24: Unexpected trailing characters: '](;)[(Asn103del)'",
       "spec_expected": "NP_003997.1:p.(Ser73Arg)](;)[(Asn103del)",
@@ -6536,19 +6510,6 @@
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Asn158Asp)(;)(Asn158Ile)",
-      "input_prefixed": "NP_003997.1:p.(Asn158Asp)(;)(Asn158Ile)",
-      "current": "parse error: Parse error at position 25: Unexpected trailing characters: '(;)(Asn158Ile)'",
-      "spec_expected": "NP_003997.1:p.(Asn158Asp)(;)(Asn158Ile)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -6874,6 +6835,28 @@
       "source_kind": "syntax_yaml",
       "source_paths": [
         "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
+      "current": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
+      "spec_expected": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)",
+      "current": "NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)",
+      "spec_expected": "NP_003997.1:p.(Ser68Arg)(;)(Ser68Arg)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
       ]
     },
     {
@@ -7383,6 +7366,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/duplication.md"
+      ]
+    },
+    {
+      "input": "p.(Asn158Asp)(;)(Asn158Ile)",
+      "input_prefixed": "NP_003997.1:p.(Asn158Asp)(;)(Asn158Ile)",
+      "current": "NP_003997.1:p.(Asn158Asp)(;)(Asn158Ile)",
+      "spec_expected": "NP_003997.1:p.(Asn158Asp)(;)(Asn158Ile)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
       ]
     },
     {

--- a/tests/mito_circular_audit.rs
+++ b/tests/mito_circular_audit.rs
@@ -383,22 +383,26 @@ fn audit_mt_negative_position_rejected_today() {
 //
 // Spec permits compound HGVS allele descriptions in cis (`[a;b]`),
 // trans (`[a];[b]`), and the homozygous shorthand `[a](;)`. Ferro's
-// parser accepts trans (`[a];[b]`) on `m.` (PR #146 / sibling C1);
-// cis and homozygous shorthand are still rejected. This is unrelated
-// to wraparound but is part of the F1 architectural surface: any plan
-// to render a pair of m. variants as a single cis allele still has to
-// clear this rejection. (Sibling F2 / PR #139 / #133 is aware.)
+// parser accepts trans (`[a];[b]`) on `m.` (PR #146 / sibling C1) and
+// cis (`[a;b]`) plus unknown-phase (`[a(;)b]`) on `m.` (PR #148 /
+// sibling C3, issue #123). The bracket-suffix homozygous shorthand
+// (`[a](;)`) is still rejected — it is a separate construct from the
+// bracketless unknown-phase form covered by #123.
 // -----------------------------------------------------------------------------
 
-/// Compound `m.[…;…]` (cis) is rejected today.
+/// Compound `m.[…;…]` (cis) parses today (PR #148 / issue #123) as an
+/// `AlleleVariant` in `Cis` phase.
 #[test]
-fn audit_mt_compound_cis_allele_rejected_today() {
+fn audit_mt_compound_cis_allele_accepted_today() {
     let input = "NC_012920.1:m.[100A>G;200T>C]";
-    assert!(
-        parse_hgvs(input).is_err(),
-        "PINNED: compound m. cis allele rejected today; F1 should \
-         reconsider as part of the m.-grammar surface."
-    );
+    let variant = parse_hgvs(input).expect("compound m. cis allele should parse");
+    let HgvsVariant::Allele(allele) = &variant else {
+        panic!("expected HgvsVariant::Allele, got {variant:?}");
+    };
+    assert_eq!(allele.phase, AllelePhase::Cis);
+    assert_eq!(allele.variants.len(), 2);
+    assert!(matches!(allele.variants[0], HgvsVariant::Mt(_)));
+    assert!(matches!(allele.variants[1], HgvsVariant::Mt(_)));
 }
 
 /// Compound `m.[…];[…]` (trans) parses today as an `AlleleVariant` in


### PR DESCRIPTION
Closes #123. Follow-up from #81 C3.

## Summary

Extends the HGVS unknown-phase compound `(;)` separator (previously accepted only on `c.` and `r.`) to every other coordinate system. The grammar is symmetric per the HGVS recommendations, and ferro now accepts both shapes uniformly:

- `g.`/`n.`/`m.`/`o.`: bracketless `g.123G>A(;)345del` and bracketed `g.[123G>A(;)345del]` (plus mixed `(;)`/`;` compounds).
- `p.`: the spec-canonical bare form `p.(Ser68Arg)(;)(Asn594del)` (no surrounding `[]`; each sub-variant is a predicted change in parentheses), and the bracketed `p.[edit1(;)edit2]` shorthand.

Implementation in `src/hgvs/parser/variant.rs`:

- New `GenomeKind` tag (Genome / Mt / Circular) lets the bracketed and bracketless helpers be shared between `g.`, `m.`, `o.` while still constructing the correct `HgvsVariant` wrapper.
- `parse_genome_compound_allele` is refactored into `parse_genome_kind_compound_allele`, distinguishing Cis vs Unknown by whether `(;)` appears inside the brackets and supporting mixed compounds.
- New helpers: `parse_genome_position_unknown_phase`, `parse_tx_compound_allele`, `parse_tx_position_unknown_phase`, `parse_protein_position_unknown_phase`. `parse_protein_allele_shorthand` grows an unknown-phase fast path.
- Bracketed slicing uses the FIRST `]` so that trans-form continuations like `[a];[b]` still surface the historical "Unexpected trailing characters" wrapper error rather than getting eaten as one giant content span.

Tests:

- `tests/allele_unknown_phase.rs` (new, 31 cases): pins parse + Display round-trip across every coord system in both bracketed and bracketless shapes; 3+-variant compounds; Eq/Hash distinctness vs Cis and Trans; multi-pass normalize idempotency; the no-merge contract for adjacent unknown-phase subs (cis-baseline asserts the merge path is wired so the unknown-phase assertion is non-vacuous); mixed-accession compounds; malformed-input rejection.
- `tests/fixtures/grammar/hgvs_spec_normalization.json` regenerated: five v21.0-spec rows for `g.` and `p.` `(;)` examples flip from `parse-error` to `preserved` and drop their `#83` todo links.

## HGVS spec rationale

HGVS `recommendations/DNA/variant/alleles.md` (and FAQ) describe `[a(;)b]` for compound alleles when phase is unknown. `recommendations/protein/alleles.md` describes the bare `p.(a)(;)(b)` shape. The notation is symmetrical across coordinate systems; ferro now recognizes it uniformly.

## Test plan

- [x] `cargo nextest run --features dev` — full suite green (3429 passed, 51 skipped)
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean