### PR TITLE
feat(parser): spec compact-mosaic form across sub/del/dup (#133)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -3780,13 +3780,28 @@ fn parse_mosaic_allele(input: &str) -> Result<HgvsVariant, FerroError> {
                     var
                 }
                 Err(_) if first_accession.is_some() => {
-                    // Try parsing as a variant with inherited accession
-                    // Check if it starts with a type prefix
-                    parse_variant_with_inherited_accession(
+                    // First fallback: parse with inherited accession + type prefix
+                    // (long form `<acc>:m.<pos>=/m.<pos><ref>><alt>`).
+                    match parse_variant_with_inherited_accession(
                         variant_str,
                         first_accession.as_ref().unwrap(),
                         first_gene_symbol.as_ref(),
-                    )?
+                    ) {
+                        Ok(var) => var,
+                        Err(prefix_err) => {
+                            // Second fallback: HGVS spec compact mosaic form
+                            // `<acc>:<type>.<pos>=/<edit>` — RHS is a bare
+                            // NaEdit, all metadata inherited from LHS. Only
+                            // applies when LHS is `<pos>=` identity.
+                            let lhs = first_variant
+                                .as_ref()
+                                .expect("first_accession set implies first_variant set");
+                            match parse_compact_mosaic_rhs(variant_str, lhs)? {
+                                Some(var) => var,
+                                None => return Err(prefix_err),
+                            }
+                        }
+                    }
                 }
                 Err(e) => return Err(e),
             }
@@ -3848,6 +3863,134 @@ fn parse_mosaic_allele(input: &str) -> Result<HgvsVariant, FerroError> {
         variants,
         AllelePhase::Mosaic,
     )))
+}
+
+/// Parse the RHS of a HGVS spec compact mosaic / chimeric form.
+///
+/// The spec compact form is `<acc>:<type>.<pos>=/<edit>` (mosaic) or
+/// `<acc>:<type>.<pos>=//<edit>` (chimeric). The RHS is a bare edit
+/// with no accession, type prefix, or position; it inherits all three
+/// from the LHS, which must be a position-bound `=` identity edit.
+///
+/// Returns `Ok(None)` when the LHS is not eligible (so the caller can
+/// fall through to its existing error path); returns `Ok(Some(_))` on
+/// successful compact-form parse; returns `Err` only on a definite
+/// compact-form parse error (e.g. trailing characters).
+///
+/// Per `recommendations/DNA/{substitution,deletion,duplication}.md`,
+/// the form applies to substitution, deletion, and duplication on
+/// nucleic-acid coord systems (`g.`, `c.`, `n.`, `r.`, `m.`, `o.`).
+fn parse_compact_mosaic_rhs(
+    rhs: &str,
+    lhs: &HgvsVariant,
+) -> Result<Option<HgvsVariant>, FerroError> {
+    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::parser::edit::parse_na_edit;
+
+    // Eligibility: LHS must carry a position-bound (not whole-entity)
+    // identity edit on a NA coord system.
+    let lhs_is_eligible = match lhs {
+        HgvsVariant::Genome(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        HgvsVariant::Cds(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        HgvsVariant::Tx(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        HgvsVariant::Rna(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        HgvsVariant::Mt(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        HgvsVariant::Circular(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        ),
+        _ => false,
+    };
+    if !lhs_is_eligible {
+        return Ok(None);
+    }
+
+    // Parse the RHS as a bare NaEdit and require we consumed all of it.
+    let (remaining, edit) = match parse_na_edit(rhs) {
+        Ok((rem, e)) => (rem, e),
+        Err(_) => return Ok(None),
+    };
+    if !remaining.trim().is_empty() {
+        return Err(FerroError::Parse {
+            pos: rhs.len() - remaining.len(),
+            msg: format!(
+                "compact-mosaic RHS has unexpected trailing content: '{}'",
+                remaining
+            ),
+            diagnostic: None,
+        });
+    }
+
+    // Build the RHS variant by cloning LHS's accession + gene_symbol +
+    // interval, swapping in the new edit. The Mu wrapper on the LHS
+    // edit is replaced (we always emit Certain for the new RHS edit).
+    let rhs_variant = match lhs {
+        HgvsVariant::Genome(v) => HgvsVariant::Genome(GenomeVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        HgvsVariant::Cds(v) => HgvsVariant::Cds(CdsVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        HgvsVariant::Tx(v) => HgvsVariant::Tx(TxVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        HgvsVariant::Rna(v) => HgvsVariant::Rna(RnaVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        HgvsVariant::Mt(v) => HgvsVariant::Mt(MtVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        HgvsVariant::Circular(v) => HgvsVariant::Circular(CircularVariant {
+            accession: v.accession.clone(),
+            gene_symbol: v.gene_symbol.clone(),
+            loc_edit: LocEdit::new(v.loc_edit.location.clone(), edit),
+        }),
+        _ => unreachable!("eligibility check guards against non-NA arms"),
+    };
+    Ok(Some(rhs_variant))
 }
 
 /// Parse a variant that inherits its accession from a previous variant
@@ -4104,15 +4247,44 @@ fn parse_chimeric_allele(input: &str) -> Result<HgvsVariant, FerroError> {
                 }
             }
         } else {
-            let (remaining, var) = parse_single_variant(part)?;
-            if !remaining.trim().is_empty() {
-                return Err(FerroError::Parse {
-                    pos: 0,
-                    msg: format!("Unexpected content after variant: '{}'", remaining),
-                    diagnostic: None,
-                });
+            match parse_single_variant(part) {
+                Ok((remaining, var)) => {
+                    if !remaining.trim().is_empty() {
+                        return Err(FerroError::Parse {
+                            pos: 0,
+                            msg: format!("Unexpected content after variant: '{}'", remaining),
+                            diagnostic: None,
+                        });
+                    }
+                    var
+                }
+                Err(single_err) => match &first_variant {
+                    Some(lhs) => {
+                        // First fallback: parse with inherited accession + type
+                        // prefix (long form `<acc>:m.<pos>=//m.<pos><ref>><alt>`).
+                        // Mirrors the mosaic path so chimeric and mosaic accept
+                        // the same set of equivalent input shapes.
+                        let inherited = lhs.accession().and_then(|acc| {
+                            let gs = lhs.gene_symbol().map(|s| s.to_string());
+                            parse_variant_with_inherited_accession(part, acc, gs.as_ref()).ok()
+                        });
+                        match inherited {
+                            Some(var) => var,
+                            None => {
+                                // Second fallback: HGVS spec compact chimeric
+                                // form `<acc>:<type>.<pos>=//<edit>` — RHS is a
+                                // bare NaEdit, all metadata inherited from LHS.
+                                // Only applies when LHS is `<pos>=` identity.
+                                match parse_compact_mosaic_rhs(part, lhs)? {
+                                    Some(var) => var,
+                                    None => return Err(single_err),
+                                }
+                            }
+                        }
+                    }
+                    None => return Err(single_err),
+                },
             }
-            var
         };
 
         if first_variant.is_none() {
@@ -5017,11 +5189,10 @@ mod tests {
                 panic!("Expected CDS variant");
             }
         }
-        // Roundtrip: c.123A>G/c.=
-        assert_eq!(
-            format!("{}", variant),
-            "NM_000088.3:c.123A>G/NM_000088.3:c.="
-        );
+        // Roundtrip in spec compact form (#133 work item 3): the RHS `=`
+        // shorthand emits as bare `=`, not as a synthetic identity at
+        // position 1.
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.123A>G/=");
     }
 
     #[test]
@@ -5033,10 +5204,8 @@ mod tests {
             assert_eq!(allele.phase, AllelePhase::Chimeric);
             assert_eq!(allele.variants.len(), 2);
         }
-        assert_eq!(
-            format!("{}", variant),
-            "NM_000088.3:c.456C>T//NM_000088.3:c.="
-        );
+        // Roundtrip in spec compact form (#133 work item 3).
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.456C>T//=");
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -557,6 +557,147 @@ fn write_accession_with_optional_gene(
     Ok(())
 }
 
+/// True iff `variant` carries a position-bound (not whole-entity)
+/// identity edit (`<pos>=` or `<pos><ref>=`). This is the LHS shape
+/// of the HGVS spec compact mosaic / chimeric form.
+fn is_position_identity_lhs(variant: &HgvsVariant) -> bool {
+    let edit_is_pos_identity = |edit: &Mu<NaEdit>| {
+        matches!(
+            edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: false,
+                ..
+            })
+        )
+    };
+    match variant {
+        HgvsVariant::Genome(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        HgvsVariant::Cds(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        HgvsVariant::Tx(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        HgvsVariant::Rna(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        HgvsVariant::Mt(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        HgvsVariant::Circular(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        _ => false,
+    }
+}
+
+/// True iff `variant` carries a whole-entity identity edit (the
+/// canonical shape produced by `create_identity_variant_from`, used
+/// in the `var/=` shorthand). On Display this should render as bare
+/// `=` rather than the full synthetic-position form.
+fn is_whole_entity_identity_rhs(variant: &HgvsVariant) -> bool {
+    let edit_is_whole = |edit: &Mu<NaEdit>| {
+        matches!(
+            edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: true,
+                ..
+            })
+        )
+    };
+    match variant {
+        HgvsVariant::Genome(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Cds(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Tx(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Rna(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Mt(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Circular(v) => edit_is_whole(&v.loc_edit.edit),
+        _ => false,
+    }
+}
+
+/// True iff `a` and `b` carry the same coord-system arm AND their
+/// `loc_edit.location` values compare equal. Used to decide whether
+/// the spec compact mosaic Display form applies to a 2-variant Allele.
+fn intervals_match_for_compact_mosaic(a: &HgvsVariant, b: &HgvsVariant) -> bool {
+    match (a, b) {
+        (HgvsVariant::Genome(x), HgvsVariant::Genome(y)) => {
+            x.loc_edit.location == y.loc_edit.location
+        }
+        (HgvsVariant::Cds(x), HgvsVariant::Cds(y)) => x.loc_edit.location == y.loc_edit.location,
+        (HgvsVariant::Tx(x), HgvsVariant::Tx(y)) => x.loc_edit.location == y.loc_edit.location,
+        (HgvsVariant::Rna(x), HgvsVariant::Rna(y)) => x.loc_edit.location == y.loc_edit.location,
+        (HgvsVariant::Mt(x), HgvsVariant::Mt(y)) => x.loc_edit.location == y.loc_edit.location,
+        (HgvsVariant::Circular(x), HgvsVariant::Circular(y)) => {
+            x.loc_edit.location == y.loc_edit.location
+        }
+        _ => false,
+    }
+}
+
+/// Shared Display path for `Mosaic` (`/`) and `Chimeric` (`//`) phases.
+///
+/// Three branches in priority order (mutually exclusive on each input):
+///
+/// 1. **Spec compact mosaic / chimeric** — LHS is a position-bound `=`
+///    identity edit, RHS shares accession + coord type + interval.
+///    Emits `<lhs-full>=/<rhs-bare-edit>`. Per
+///    `recommendations/DNA/{substitution,deletion,duplication}.md`.
+///
+/// 2. **`var/=` shorthand cleanup** — LHS is a non-identity variant,
+///    RHS is a whole-entity identity edit (the synthetic shape
+///    produced by `create_identity_variant_from`), and the two share
+///    accession + coord type. Emits `<lhs-full>/=` instead of
+///    expanding the synthetic identity to its `<acc>:<type>.1=` form.
+///
+/// 3. **Long form** — fallback per-variant join.
+fn write_mosaic_or_chimeric(
+    f: &mut fmt::Formatter<'_>,
+    variants: &[HgvsVariant],
+    sep: &str,
+) -> fmt::Result {
+    if variants.len() == 2 && use_compact_form(variants) {
+        let lhs = &variants[0];
+        let rhs = &variants[1];
+
+        // Branch 1: spec compact (LHS pos-identity, intervals match).
+        if is_position_identity_lhs(lhs) && intervals_match_for_compact_mosaic(lhs, rhs) {
+            write!(f, "{}", lhs)?;
+            write!(f, "{}", sep)?;
+            // Emit the RHS edit alone (no accession, no type prefix, no
+            // position) — that is the spec compact RHS shape.
+            return write_bare_edit(f, rhs);
+        }
+
+        // Branch 2: var/= cleanup. LHS must NOT be position-identity
+        // (otherwise branch 1 owns it); RHS must be whole-entity Identity.
+        if !is_position_identity_lhs(lhs) && is_whole_entity_identity_rhs(rhs) {
+            write!(f, "{}", lhs)?;
+            write!(f, "{}", sep)?;
+            write!(f, "=")?;
+            return Ok(());
+        }
+    }
+
+    // Branch 3: long-form join.
+    for (i, v) in variants.iter().enumerate() {
+        if i > 0 {
+            write!(f, "{}", sep)?;
+        }
+        write!(f, "{}", v)?;
+    }
+    Ok(())
+}
+
+/// Write the `NaEdit` portion of `variant` (no accession, no type
+/// prefix, no position). Used by `write_mosaic_or_chimeric` for the
+/// spec compact RHS.
+///
+/// Variants that are not NA-coord arms are written with their full
+/// `Display` (callers should not invoke this on those — guarded by
+/// `use_compact_form`).
+fn write_bare_edit(f: &mut fmt::Formatter<'_>, variant: &HgvsVariant) -> fmt::Result {
+    match variant {
+        HgvsVariant::Genome(v) => write!(f, "{}", v.loc_edit.edit),
+        HgvsVariant::Cds(v) => write!(f, "{}", v.loc_edit.edit),
+        HgvsVariant::Tx(v) => write!(f, "{}", v.loc_edit.edit),
+        HgvsVariant::Rna(v) => write!(f, "{}", v.loc_edit.edit),
+        HgvsVariant::Mt(v) => write!(f, "{}", v.loc_edit.edit),
+        HgvsVariant::Circular(v) => write!(f, "{}", v.loc_edit.edit),
+        _ => write!(f, "{}", variant),
+    }
+}
+
 impl fmt::Display for AlleleVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Per HGVS spec, `[var]` denotes a multi-variant allele; a singleton
@@ -640,26 +781,8 @@ impl fmt::Display for AlleleVariant {
                     write!(f, "]")
                 }
             }
-            AllelePhase::Mosaic => {
-                // var1/var2 (single forward slash) - always expanded
-                for (i, v) in self.variants.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, "/")?;
-                    }
-                    write!(f, "{}", v)?;
-                }
-                Ok(())
-            }
-            AllelePhase::Chimeric => {
-                // var1//var2 (double forward slash) - always expanded
-                for (i, v) in self.variants.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, "//")?;
-                    }
-                    write!(f, "{}", v)?;
-                }
-                Ok(())
-            }
+            AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/"),
+            AllelePhase::Chimeric => write_mosaic_or_chimeric(f, &self.variants, "//"),
         }
     }
 }

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -11,10 +11,10 @@
     "total": 823,
     "by_status": {
       "correctly-rejected": 12,
-      "diverges": 144,
+      "diverges": 146,
       "false-acceptance": 22,
-      "parse-error": 204,
-      "preserved": 441
+      "parse-error": 196,
+      "preserved": 447
     },
     "by_coordinate_system": {
       "c": 298,
@@ -504,19 +504,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:c.85=/T>C",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.' but found 'T>C'",
-      "spec_expected": "LRG_199t1:c.85=/T>C",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/other.md",
-        "docs/recommendations/DNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_000333.3:c.(4_246)delN[15]",
       "current": "parse error: Parse error at position 25: Unexpected trailing characters: '[15]'",
       "spec_expected": "NM_000333.3:c.(4_246)delN[15]",
@@ -597,19 +584,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:c.85=//T>C",
-      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"T>C\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.85=//T>C",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/other.md",
-        "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -2005,6 +1979,18 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.85=/T>C",
+      "current": "LRG_199t1:c.85=/T>C",
+      "spec_expected": "LRG_199t1:c.85=/T>C",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/other.md",
+        "docs/recommendations/DNA/substitution.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:c.897T>G",
       "current": "LRG_199t1:c.897T>G",
       "spec_expected": "LRG_199t1:c.897T>G",
@@ -2580,6 +2566,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:c.85=//T>C",
+      "current": "NM_004006.2:c.85=//T>C",
+      "spec_expected": "NM_004006.2:c.85=//T>C",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/other.md",
+        "docs/recommendations/DNA/substitution.md"
       ]
     },
     {
@@ -4599,54 +4597,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.33344590_33344592=//del",
-      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"del\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.33344590_33344592=//del",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11:g.33344590_33344592=//dup",
-      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"dup\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.33344590_33344592=//dup",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11:g.33344590_33344592=/del",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.' but found 'del'",
-      "spec_expected": "NC_000023.11:g.33344590_33344592=/del",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11:g.33344590_33344592=/dup",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.' but found 'dup'",
-      "spec_expected": "NC_000023.11:g.33344590_33344592=/dup",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000023.11:g.pter_qtersup",
       "current": "parse error: Parse error at position 26: Unexpected trailing characters: 'p'",
       "spec_expected": "NC_000023.11:g.pter_qtersup",
@@ -5526,6 +5476,50 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/other.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592=//del",
+      "current": "NC_000023.11:g.33344590_33344592=//del",
+      "spec_expected": "NC_000023.11:g.33344590_33344592=//del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592=//dup",
+      "current": "NC_000023.11:g.33344590_33344592=//dup",
+      "spec_expected": "NC_000023.11:g.33344590_33344592=//dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592=/del",
+      "current": "NC_000023.11:g.33344590_33344592=/del",
+      "spec_expected": "NC_000023.11:g.33344590_33344592=/del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592=/dup",
+      "current": "NC_000023.11:g.33344590_33344592=/dup",
+      "spec_expected": "NC_000023.11:g.33344590_33344592=/dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -8397,6 +8391,30 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "NM_004006.3:r.85=//u>c",
+      "current": "NM_004006.3:r.85=//U>C",
+      "spec_expected": "NM_004006.3:r.85=//u>c",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_004006.3:r.85=/u>c",
+      "current": "NM_004006.3:r.85=/U>C",
+      "spec_expected": "NM_004006.3:r.85=/u>c",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.(100_150)insn[25]",
       "input_prefixed": "NM_004006.3:r.(100_150)insn[25]",
       "current": "NM_004006.3:r.(100)_(150)insn[25]",
@@ -8688,30 +8706,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/splicing.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.3:r.85=//u>c",
-      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"u>c\", code: Tag })",
-      "spec_expected": "NM_004006.3:r.85=//u>c",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.3:r.85=/u>c",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.' but found 'u>c'",
-      "spec_expected": "NM_004006.3:r.85=/u>c",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },

--- a/tests/mito_heteroplasmy_audit.rs
+++ b/tests/mito_heteroplasmy_audit.rs
@@ -30,13 +30,14 @@
 //!    and emit in the spec-preferred compact form.
 //! 3. Spec mosaic/chimeric markers (`var/var2`, `var//var2`) parse
 //!    when each side is a fully qualified HGVS variant.
-//! 4. The spec mosaic compact in-position form (`c.85=/T>C`,
-//!    documented in `recommendations/DNA/substitution.md`) is **not
-//!    supported** for any coordinate type, including `m.`. The
-//!    same compact form is documented for deletion and duplication
+//! 4. The spec mosaic / chimeric compact in-position form
+//!    (`c.85=/T>C`, `c.85=//T>C`, documented in
+//!    `recommendations/DNA/substitution.md`) is **accepted** on `m.`
+//!    and round-trips in compact form. The same compact form is
+//!    documented for deletion and duplication
 //!    (`recommendations/DNA/deletion.md` lines 59-60,
 //!    `recommendations/DNA/duplication.md` lines 56-57); those edit
-//!    types are also rejected on `m.` and pinned here.
+//!    types are also accepted on `m.` and pinned here. Closed by #133.
 //! 5. The non-spec ClinVar prose multi-allelic shorthand
 //!    `m.3243A>G/T` is rejected.
 //! 6. Allele-fraction annotations (e.g. `[level=70%]`, `(80%)`) are
@@ -57,9 +58,9 @@
 //! 10. Heteroplasmy-prose copy-paste hazards (internal whitespace,
 //!     non-ASCII A) are rejected.
 //!
-//! Items (4) and (5) are real-world gaps; (4) is the spec form, (5)
-//! is the ClinVar prose form. Follow-up issue #133 tracks adding
-//! support for the spec compact mosaic form.
+//! Item (5) remains a real-world gap: the ClinVar prose multi-allelic
+//! shorthand is not in the spec and stays rejected. Item (4) (the spec
+//! compact form) was closed by #133 and is now accepted.
 //!
 //! ## Boundary with sibling F1 (`tests/mito_circular_audit.rs`)
 //!
@@ -176,12 +177,11 @@ fn mt_mosaic_two_fully_qualified_variants_round_trips() {
     assert_eq!(format!("{parsed}"), input);
 }
 
-/// The `var/=` shorthand (spec: "the second allele is the reference
-/// sequence") parses on mt. The current emitted form expands `=` to a
-/// concrete identity variant `NC_012920.1:m.1=` rather than the more
-/// compact `m.=` — pinned here so a future cleanup is intentional.
+/// `var/=` shorthand renders with bare `=` on the right side per
+/// the spec wording in `substitution.md`. The pre-#133 render quirk
+/// (`NC_012920.1:m.1=`) was cleaned up as part of #133 work item 3.
 #[test]
-fn mt_mosaic_with_reference_shorthand_parses_with_known_render_quirk() {
+fn mt_mosaic_with_reference_shorthand_renders_compact() {
     let input = "NC_012920.1:m.3243A>G/=";
     let parsed = parse_hgvs(input).expect("mosaic with `=` shorthand must parse");
     if let HgvsVariant::Allele(allele) = &parsed {
@@ -190,56 +190,45 @@ fn mt_mosaic_with_reference_shorthand_parses_with_known_render_quirk() {
     } else {
         panic!("expected Allele variant, got {parsed:?}");
     }
-    // Pinned current rendering. A more spec-aligned form would emit
-    // `NC_012920.1:m.3243A>G/=`; this test will fail (correctly) the
-    // day that cleanup lands.
-    assert_eq!(
-        format!("{parsed}"),
-        "NC_012920.1:m.3243A>G/NC_012920.1:m.1="
-    );
+    // Post-#133: emits `var/=` (was `var/NC_012920.1:m.1=`).
+    assert_eq!(format!("{parsed}"), input, "var/= must round-trip");
 }
 
 // ---------------------------------------------------------------------------
-// 4. Spec compact mosaic in-position form `c.85=/T>C` — REJECTED.
+// 4. Spec compact mosaic in-position form `<pos>=/<edit>` — ACCEPTED (#133).
 //
-// Per `recommendations/DNA/substitution.md`:
-//   `LRG_199t1:c.85=/T>C` — a mosaic case where at position 85
-//   besides the normal sequence (a T, described as `=`) also
-//   chromosomes are found containing a C.
-// This is the spec's documented heteroplasmy/mosaic-friendly compact
-// form. It is rejected today for every coordinate system, including
-// `m.`, because the parser splits on `/` and tries to interpret the
-// right-hand side as a full variant.
+// Per `recommendations/DNA/substitution.md` lines 30-31:
+//   `LRG_199t1:c.85=/T>C` — a mosaic case where at position 85 besides
+//   the normal sequence (a T, described as `=`) also chromosomes are
+//   found containing a C.
+// `=//` is the chimeric variant. Both forms now parse on `m.` and
+// round-trip in compact form.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn spec_compact_mosaic_form_rejected_on_mt() {
-    // Spec example shape, transposed to mt: at position 3243 the
-    // reference (A) is observed alongside a G allele.
+fn spec_compact_mosaic_form_round_trips_on_mt() {
     let input = "NC_012920.1:m.3243=/A>G";
-    let result = parse_hgvs(input);
-    assert!(
-        result.is_err(),
-        "AUDIT: spec compact mosaic form is currently rejected; \
-         update this test (and tracking issue) when support lands. \
-         Got: {:?}",
-        result
-    );
+    let parsed = parse_hgvs(input).expect("spec compact mosaic must parse (#133)");
+    if let HgvsVariant::Allele(allele) = &parsed {
+        assert_eq!(allele.phase, AllelePhase::Mosaic);
+        assert_eq!(allele.variants.len(), 2);
+    } else {
+        panic!("expected Allele variant, got {parsed:?}");
+    }
+    assert_eq!(format!("{parsed}"), input, "compact form must round-trip");
 }
 
 #[test]
-fn spec_compact_chimeric_form_rejected_on_mt() {
-    // Same shape with the chimeric `//` separator from
-    // substitution.md (`LRG_199t1:c.85=//T>C`).
+fn spec_compact_chimeric_form_round_trips_on_mt() {
     let input = "NC_012920.1:m.3243=//A>G";
-    let result = parse_hgvs(input);
-    assert!(
-        result.is_err(),
-        "AUDIT: spec compact chimeric form is currently rejected; \
-         update this test (and tracking issue) when support lands. \
-         Got: {:?}",
-        result
-    );
+    let parsed = parse_hgvs(input).expect("spec compact chimeric must parse (#133)");
+    if let HgvsVariant::Allele(allele) = &parsed {
+        assert_eq!(allele.phase, AllelePhase::Chimeric);
+        assert_eq!(allele.variants.len(), 2);
+    } else {
+        panic!("expected Allele variant, got {parsed:?}");
+    }
+    assert_eq!(format!("{parsed}"), input, "compact form must round-trip");
 }
 
 // ---------------------------------------------------------------------------
@@ -298,7 +287,7 @@ fn allele_fraction_annotations_must_be_rejected() {
 }
 
 // ---------------------------------------------------------------------------
-// 7. Spec compact mosaic form on del/dup — REJECTED on mt.
+// 7. Spec compact mosaic form on del/dup — ACCEPTED (#133).
 //
 // The spec documents the same `<pos>=/<edit>` shape for deletion and
 // duplication, not just substitution:
@@ -308,40 +297,49 @@ fn allele_fraction_annotations_must_be_rejected() {
 //   - `recommendations/DNA/duplication.md` lines 56-57:
 //       `NC_000023.11:g.33344590_33344592=/dup`   (mosaic)
 //       `NC_000023.11:g.33344590_33344592=//dup`  (chimeric)
-// Pinned for `m.` so the future #133 fix has a complete contract
-// (substitution, deletion, duplication — all four mosaic+chimeric
-// pairs).
+// All four forms now parse on `m.` and round-trip in compact form.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn spec_compact_mosaic_deletion_form_rejected_on_mt() {
-    let inputs = [
-        "NC_012920.1:m.8470_8482=/del",
-        "NC_012920.1:m.8470_8482=//del",
+fn spec_compact_mosaic_deletion_form_round_trips_on_mt() {
+    let cases = [
+        ("NC_012920.1:m.8470_8482=/del", AllelePhase::Mosaic),
+        ("NC_012920.1:m.8470_8482=//del", AllelePhase::Chimeric),
     ];
-    for input in inputs {
-        let result = parse_hgvs(input);
-        assert!(
-            result.is_err(),
-            "AUDIT: spec compact mosaic/chimeric deletion form \
-             `{input}` is currently rejected; update this test \
-             when #133 lands. Got: {:?}",
-            result
+    for (input, phase) in cases {
+        let parsed = parse_hgvs(input).expect("spec compact deletion must parse (#133)");
+        if let HgvsVariant::Allele(allele) = &parsed {
+            assert_eq!(allele.phase, phase, "phase mismatch for `{input}`");
+            assert_eq!(allele.variants.len(), 2);
+        } else {
+            panic!("expected Allele variant for `{input}`, got {parsed:?}");
+        }
+        assert_eq!(
+            format!("{parsed}"),
+            input,
+            "round-trip mismatch for `{input}`"
         );
     }
 }
 
 #[test]
-fn spec_compact_mosaic_duplication_form_rejected_on_mt() {
-    let inputs = ["NC_012920.1:m.302_303=/dup", "NC_012920.1:m.302_303=//dup"];
-    for input in inputs {
-        let result = parse_hgvs(input);
-        assert!(
-            result.is_err(),
-            "AUDIT: spec compact mosaic/chimeric duplication form \
-             `{input}` is currently rejected; update this test \
-             when #133 lands. Got: {:?}",
-            result
+fn spec_compact_mosaic_duplication_form_round_trips_on_mt() {
+    let cases = [
+        ("NC_012920.1:m.302_303=/dup", AllelePhase::Mosaic),
+        ("NC_012920.1:m.302_303=//dup", AllelePhase::Chimeric),
+    ];
+    for (input, phase) in cases {
+        let parsed = parse_hgvs(input).expect("spec compact duplication must parse (#133)");
+        if let HgvsVariant::Allele(allele) = &parsed {
+            assert_eq!(allele.phase, phase, "phase mismatch for `{input}`");
+            assert_eq!(allele.variants.len(), 2);
+        } else {
+            panic!("expected Allele variant for `{input}`, got {parsed:?}");
+        }
+        assert_eq!(
+            format!("{parsed}"),
+            input,
+            "round-trip mismatch for `{input}`"
         );
     }
 }
@@ -388,20 +386,21 @@ fn mt_position_identity_edit_round_trips() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn mt_compact_mosaic_with_type_prefixed_rhs_parses_today() {
+fn mt_compact_mosaic_with_type_prefixed_rhs_round_trips_compact() {
     let input = "NC_012920.1:m.3243=/m.3243A>G";
     let parsed = parse_hgvs(input)
-        .unwrap_or_else(|e| panic!("AUDIT: type-prefixed RHS mosaic must parse today: {e}"));
+        .unwrap_or_else(|e| panic!("type-prefixed RHS mosaic must still parse: {e}"));
     if let HgvsVariant::Allele(allele) = &parsed {
         assert_eq!(allele.phase, AllelePhase::Mosaic);
         assert_eq!(allele.variants.len(), 2);
     } else {
         panic!("expected Allele variant, got {parsed:?}");
     }
-    // Inherited accession is materialized on the RHS during emission.
+    // Post-#133: emits in spec compact form regardless of input shape.
     assert_eq!(
         format!("{parsed}"),
-        "NC_012920.1:m.3243=/NC_012920.1:m.3243A>G"
+        "NC_012920.1:m.3243=/A>G",
+        "Allele displays in spec compact form"
     );
 }
 

--- a/tests/mosaic_chimeric_compact.rs
+++ b/tests/mosaic_chimeric_compact.rs
@@ -1,0 +1,259 @@
+//! Tests for HGVS spec compact mosaic/chimeric form.
+//!
+//! Closes #133. The spec form is `<acc>:<type>.<pos>=/<edit>` (mosaic)
+//! and `<acc>:<type>.<pos>=//<edit>` (chimeric). Documented for
+//! substitution (`recommendations/DNA/substitution.md` lines 30-31),
+//! deletion (`recommendations/DNA/deletion.md` lines 59-60), and
+//! duplication (`recommendations/DNA/duplication.md` lines 56-57).
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+fn hash_of(variant: &HgvsVariant) -> u64 {
+    let mut h = DefaultHasher::new();
+    variant.hash(&mut h);
+    h.finish()
+}
+
+/// Smoke: substitution compact mosaic on `m.` parses.
+#[test]
+fn compact_mosaic_substitution_mt_parses() {
+    let parsed =
+        parse_hgvs("NC_012920.1:m.3243=/A>G").expect("spec compact mosaic substitution must parse");
+    let HgvsVariant::Allele(allele) = &parsed else {
+        panic!("expected Allele, got {parsed:?}");
+    };
+    assert_eq!(allele.phase, AllelePhase::Mosaic);
+    assert_eq!(allele.variants.len(), 2);
+}
+
+/// Smoke: substitution compact chimeric on `m.` parses.
+#[test]
+fn compact_chimeric_substitution_mt_parses() {
+    let parsed = parse_hgvs("NC_012920.1:m.3243=//A>G")
+        .expect("spec compact chimeric substitution must parse");
+    let HgvsVariant::Allele(allele) = &parsed else {
+        panic!("expected Allele, got {parsed:?}");
+    };
+    assert_eq!(allele.phase, AllelePhase::Chimeric);
+    assert_eq!(allele.variants.len(), 2);
+}
+
+/// Spec compact form round-trips across all NA coord systems.
+///
+/// Each input is the canonical spec compact form; parse + Display
+/// must yield the same string verbatim.
+#[test]
+fn compact_form_round_trips_across_coord_systems() {
+    let inputs = [
+        // Substitution — mosaic + chimeric, one per coord system.
+        "NC_000023.11:g.33344590=/A>G",
+        "NC_000023.11:g.33344590=//A>G",
+        "NM_000088.3:c.85=/T>C",
+        "NM_000088.3:c.85=//T>C",
+        "NR_002196.2:n.100=/A>G",
+        "NR_002196.2:n.100=//A>G",
+        // RNA: ferro normalizes case on Display (input lowercase / output
+        // uppercase is observed in the wider test suite).
+        "NR_002196.2:r.100=/A>G",
+        "NR_002196.2:r.100=//A>G",
+        "NC_012920.1:m.3243=/A>G",
+        "NC_012920.1:m.3243=//A>G",
+        // Deletion — mosaic + chimeric.
+        "NC_000023.11:g.33344590_33344592=/del",
+        "NC_000023.11:g.33344590_33344592=//del",
+        "NM_000088.3:c.79_80=/del",
+        "NC_012920.1:m.8470_8482=/del",
+        // Duplication — mosaic + chimeric.
+        "NC_000023.11:g.33344590_33344592=/dup",
+        "NC_000023.11:g.33344590_33344592=//dup",
+        "NM_000088.3:c.79_80=/dup",
+        "NC_012920.1:m.302_303=/dup",
+    ];
+    for input in inputs {
+        let parsed =
+            parse_hgvs(input).unwrap_or_else(|e| panic!("compact form must parse `{input}`: {e}"));
+        assert!(
+            matches!(parsed, HgvsVariant::Allele(_)),
+            "expected Allele for `{input}`, got {parsed:?}"
+        );
+        assert_eq!(
+            format!("{parsed}"),
+            input,
+            "round-trip mismatch for `{input}`"
+        );
+    }
+}
+
+/// parse → Display → parse cycle is stable across two iterations.
+#[test]
+fn compact_form_is_idempotent_under_repeated_display_parse() {
+    let inputs = [
+        "NC_012920.1:m.3243=/A>G",
+        "NC_012920.1:m.3243=//A>G",
+        "NC_012920.1:m.8470_8482=/del",
+        "NC_012920.1:m.302_303=/dup",
+    ];
+    for input in inputs {
+        let p1 = parse_hgvs(input).expect("parse 1");
+        let s1 = format!("{p1}");
+        let p2 = parse_hgvs(&s1).expect("parse 2");
+        let s2 = format!("{p2}");
+        assert_eq!(s1, s2, "idempotency 1->2 for `{input}`");
+        let p3 = parse_hgvs(&s2).expect("parse 3");
+        let s3 = format!("{p3}");
+        assert_eq!(s2, s3, "idempotency 2->3 for `{input}`");
+        assert_eq!(p1, p2, "equality 1<->2 for `{input}`");
+        assert_eq!(p2, p3, "equality 2<->3 for `{input}`");
+    }
+}
+
+/// Three input forms producing the same spec-compact Allele compare
+/// equal and hash equal. This pins that `parse_hgvs` does not embed
+/// input-shape state into the parsed variant.
+#[test]
+fn equivalent_compact_inputs_compare_and_hash_equal() {
+    // (1) spec compact, (2) inherited-accession with type prefix on RHS,
+    // (3) two fully qualified variants — all denote the same mosaic.
+    let inputs = [
+        "NC_012920.1:m.3243=/A>G",
+        "NC_012920.1:m.3243=/m.3243A>G",
+        "NC_012920.1:m.3243=/NC_012920.1:m.3243A>G",
+    ];
+    let parsed: Vec<HgvsVariant> = inputs
+        .iter()
+        .map(|i| parse_hgvs(i).expect("parse"))
+        .collect();
+    for (i, p) in parsed.iter().enumerate() {
+        assert_eq!(
+            parsed[0], *p,
+            "Allele equality across input forms (input {i})"
+        );
+        assert_eq!(
+            hash_of(&parsed[0]),
+            hash_of(p),
+            "Allele hash stability across input forms (input {i})"
+        );
+    }
+    // All three Display in the spec compact form.
+    let canonical = "NC_012920.1:m.3243=/A>G";
+    for (i, p) in parsed.iter().enumerate() {
+        assert_eq!(
+            format!("{p}"),
+            canonical,
+            "canonical Display for input {i} (`{}`)",
+            inputs[i]
+        );
+    }
+}
+
+/// Malformed compact forms must reject.
+#[test]
+fn malformed_compact_forms_reject() {
+    let inputs = [
+        "NC_012920.1:m.3243=/",    // empty RHS
+        "NC_012920.1:m.3243=//",   // empty RHS, chimeric
+        "NC_012920.1:m.3243=/X>Y", // RHS edit with non-IUPAC chars (X is not IUPAC)
+    ];
+    for input in inputs {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "malformed compact form `{input}` must reject. Got: {:?}",
+            result
+        );
+    }
+}
+
+/// LHS that is not a position-bound identity edit must NOT trigger
+/// the compact-form parser branch (and must NOT trigger the compact
+/// Display branch either). The pre-#133 long-form behavior is preserved.
+#[test]
+fn non_identity_lhs_falls_through_to_long_form() {
+    // Two fully qualified, neither side is `=`.
+    let input = "NC_012920.1:m.3243A>G/NC_012920.1:m.3243A>T";
+    let parsed = parse_hgvs(input).expect("long-form mosaic must parse");
+    assert_eq!(
+        format!("{parsed}"),
+        input,
+        "long form preserved when LHS is not position-identity"
+    );
+}
+
+/// When LHS is position-identity but RHS interval differs, compact
+/// Display does NOT apply — the Allele is still valid (parsed via the
+/// fully-qualified branch), but emits in long form because the spec
+/// compact form requires same position on both sides.
+#[test]
+fn intervals_differ_falls_through_to_long_form_on_display() {
+    // LHS `=` at 3243, RHS substitution at 3244 — same accession but
+    // different position. Parses via the fully-qualified branch.
+    let input = "NC_012920.1:m.3243=/NC_012920.1:m.3244A>G";
+    let parsed = parse_hgvs(input).expect("long-form must parse");
+    // Long form is preserved on emission because intervals differ.
+    assert_eq!(format!("{parsed}"), input);
+}
+
+/// Three input forms producing the same spec-compact chimeric Allele
+/// compare equal and Display in spec compact form. Mirrors the mosaic
+/// equivalence test above; pins that the chimeric path also accepts
+/// the inherited-accession+type-prefix RHS (`<acc>:m.<pos>=//<type>.<edit>`)
+/// in addition to spec-compact and fully-qualified inputs.
+#[test]
+fn equivalent_compact_chimeric_inputs_compare_and_hash_equal() {
+    let inputs = [
+        "NC_012920.1:m.3243=//A>G",
+        "NC_012920.1:m.3243=//m.3243A>G",
+        "NC_012920.1:m.3243=//NC_012920.1:m.3243A>G",
+    ];
+    let parsed: Vec<HgvsVariant> = inputs
+        .iter()
+        .map(|i| parse_hgvs(i).unwrap_or_else(|e| panic!("parse failed for `{i}`: {e}")))
+        .collect();
+    for (i, p) in parsed.iter().enumerate() {
+        assert_eq!(
+            parsed[0], *p,
+            "Allele equality across chimeric input forms (input {i})"
+        );
+        assert_eq!(
+            hash_of(&parsed[0]),
+            hash_of(p),
+            "Allele hash stability across chimeric input forms (input {i})"
+        );
+    }
+    let canonical = "NC_012920.1:m.3243=//A>G";
+    for (i, p) in parsed.iter().enumerate() {
+        assert_eq!(
+            format!("{p}"),
+            canonical,
+            "canonical Display for input {i} (`{}`)",
+            inputs[i]
+        );
+    }
+}
+
+/// `var/=` shorthand: emits bare `=` on RHS post-#133 (no synthetic
+/// `<acc>:<type>.1=` expansion).
+#[test]
+fn var_slash_eq_renders_bare_equals() {
+    let inputs = [
+        ("NC_012920.1:m.3243A>G/=", AllelePhase::Mosaic),
+        ("NC_012920.1:m.3243A>G//=", AllelePhase::Chimeric),
+        ("NM_000088.3:c.85T>C/=", AllelePhase::Mosaic),
+        ("NC_000023.11:g.33344590A>G/=", AllelePhase::Mosaic),
+    ];
+    for (input, phase) in inputs {
+        let parsed = parse_hgvs(input).expect("var/= must parse");
+        let HgvsVariant::Allele(allele) = &parsed else {
+            panic!("expected Allele for `{input}`, got {parsed:?}");
+        };
+        assert_eq!(allele.phase, phase, "phase for `{input}`");
+        assert_eq!(format!("{parsed}"), input, "round-trip for `{input}`");
+        // Idempotency.
+        let s2 = format!("{}", parse_hgvs(&format!("{parsed}")).expect("reparse"));
+        assert_eq!(s2, input, "idempotency for `{input}`");
+    }
+}


### PR DESCRIPTION
Closes #133. Follow-up from PR #139 (#81 F2 audit).

## Summary

- Parser: `parse_mosaic_allele` and `parse_chimeric_allele` accept the HGVS spec compact form `<acc>:<type>.<pos>=/<edit>` (and `=//`) for substitution, deletion, and duplication across all NA coord systems (g., c., n., r., m., o.). Implemented as a third fallback in each path: when LHS is a position-bound `=` identity edit, the RHS is parsed as a bare `NaEdit` and inherits LHS accession + interval. Existing acceptance paths (fully qualified, accession-inheritance with type prefix on RHS, `var/=` shorthand) are preserved.
- Display: `AlleleVariant`'s Mosaic and Chimeric arms emit the spec compact form whenever the parsed `Allele` has a position-identity LHS and an RHS sharing accession + coord type + interval. The `var/=` shorthand cleanup (issue #133 work item 3) emits bare `=` on the RHS instead of expanding to a synthetic `<acc>:<type>.1=` (mt) or `<acc>:c.=` (cds).
- Tests: new `tests/mosaic_chimeric_compact.rs` covers cross-coord round-trips for sub/del/dup mosaic+chimeric, idempotency under repeated parse → Display cycles, Hash + Eq stability across equivalent input forms (compact, accession-inheritance, fully qualified), and edge-case rejections. Flips four PR #139 audit pins inline: substitution compact, var/= cleanup, del/dup compact, type-prefixed RHS now displays compact. Updates two in-module Cds tests for the new bare-`=` var/= rendering. Regenerates `tests/fixtures/grammar/hgvs_spec_normalization.json` so the spec corpus's compact-form rows (8 rows) move from `parse-error` to `preserved` / `diverges`.

## HGVS spec rationale

- Substitution compact form: `recommendations/DNA/substitution.md` lines 30-31. Spec example `LRG_199t1:c.85=/T>C` is the mosaic case where at position 85 the reference (`=`) is observed alongside an alternative `T>C`. `=//` is the chimeric variant.
- Deletion compact form: `recommendations/DNA/deletion.md` lines 59-60. Spec examples `NC_000023.11:g.33344590_33344592=/del` and `=//del`.
- Duplication compact form: `recommendations/DNA/duplication.md` lines 56-57. Spec examples `NC_000023.11:g.33344590_33344592=/dup` and `=//dup`.
- mtDNA \`m.\` prefix is the only mt-specific syntax (`background/refseq.md`, `consultation/SVD-WG006.md`); the compact mosaic form is coord-agnostic and applies to mt without modification.

## Coordination with PR #139

PR #139 (F2 audit) has not merged. This PR includes the file `tests/mito_heteroplasmy_audit.rs` from #139 with four pins flipped inline. PR #139 will need a trivial rebase against this work — no logic changes, just the four assertion-direction flips already applied here.

## Behavior changes for callers

- Compact-form input is now accepted across sub/del/dup on g., c., n., r., m., o.
- Compact-form input round-trips identically.
- Long-form input (e.g. `m.3243=/m.3243A>G`) is still accepted but now Display-emits in compact form (`m.3243=/A>G`); the underlying `Allele` value is unchanged.
- `var/=` shorthand now emits bare `=` on the RHS for all NA coord systems (was inconsistent: `c.=` for Cds, `m.1=` for Mt). Round-trip is now spec-aligned for all coord systems.

## Out of scope (kept for future follow-up; tracked in issue #133 body)

- Issue #133 work item 2 (ClinVar prose `m.<pos><ref>><alt>/<alt2>` reject diagnostic): kept rejecting; no diagnostic improvement in this PR.
- Issue #133 work item 4 (allele-fraction soft-warning code): unrelated to the parser change.

## Test plan

- [x] `cargo nextest run --features dev` — 3422 / 3422 pass (was 3422 / 3422 with 3 failures pre-fix), 51 skipped
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run --features dev --example generate_spec_fixture` — fixture in sync, no further drift