### PR TITLE
fix(parser): preserve explicit deleted sequence in delins round-trip

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -446,8 +446,21 @@ pub enum NaEdit {
     /// Insertion: addition of bases between two positions (e.g., insATG, ins10, insA[10])
     Insertion { sequence: InsertedSequence },
 
-    /// Deletion-insertion: replacement of bases (e.g., delinsATG, delinsA[10])
-    Delins { sequence: InsertedSequence },
+    /// Deletion-insertion: replacement of bases (e.g., delinsATG, delinsA[10],
+    /// delATGinsTTCC, del3insTA).
+    ///
+    /// `deleted` and `deleted_length` preserve an explicit deleted sequence or
+    /// length when the input notation provided one (e.g., `delATGinsTTCC`
+    /// parses to `deleted: Some("ATG")`). At most one of `deleted` /
+    /// `deleted_length` is `Some`; both are `None` for the recommended short
+    /// form `delinsXXX`. `Display` preserves on round-trip; `canonicalize_edit`
+    /// strips them back to the short form per the HGVS spec recommendation
+    /// (`recommendations/DNA/delins.md`).
+    Delins {
+        sequence: InsertedSequence,
+        deleted: Option<Sequence>,
+        deleted_length: Option<u64>,
+    },
 
     /// Duplication: copy of bases (e.g., dup, dupATG, dup101, dup(731_741), dup?)
     Duplication {
@@ -629,8 +642,20 @@ impl NaEdit {
             NaEdit::Insertion { sequence } => {
                 format!("ins{}", sequence.to_rna_string())
             }
-            NaEdit::Delins { sequence } => {
-                format!("delins{}", sequence.to_rna_string())
+            NaEdit::Delins {
+                sequence,
+                deleted,
+                deleted_length,
+            } => {
+                let mut s = String::from("del");
+                if let Some(seq) = deleted {
+                    s.push_str(&seq.to_lowercase_string());
+                } else if let Some(len) = deleted_length {
+                    s.push_str(&len.to_string());
+                }
+                s.push_str("ins");
+                s.push_str(&sequence.to_rna_string());
+                s
             }
             NaEdit::Duplication {
                 sequence,
@@ -734,8 +759,18 @@ impl fmt::Display for NaEdit {
             NaEdit::Insertion { sequence } => {
                 write!(f, "ins{}", sequence)
             }
-            NaEdit::Delins { sequence } => {
-                write!(f, "delins{}", sequence)
+            NaEdit::Delins {
+                sequence,
+                deleted,
+                deleted_length,
+            } => {
+                write!(f, "del")?;
+                if let Some(seq) = deleted {
+                    write!(f, "{}", seq)?;
+                } else if let Some(len) = deleted_length {
+                    write!(f, "{}", len)?;
+                }
+                write!(f, "ins{}", sequence)
             }
             NaEdit::Duplication {
                 sequence,
@@ -1154,8 +1189,55 @@ mod tests {
     fn test_delins_display() {
         let edit = NaEdit::Delins {
             sequence: InsertedSequence::Literal(Sequence::from_str("ATG").unwrap()),
+            deleted: None,
+            deleted_length: None,
         };
         assert_eq!(format!("{}", edit), "delinsATG");
+    }
+
+    #[test]
+    fn test_delins_display_with_explicit_deleted_seq() {
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
+            deleted: Some(Sequence::from_str("ATG").unwrap()),
+            deleted_length: None,
+        };
+        assert_eq!(format!("{}", edit), "delATGinsTTCC");
+    }
+
+    #[test]
+    fn test_delins_display_with_explicit_deleted_count() {
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TA").unwrap()),
+            deleted: None,
+            deleted_length: Some(3),
+        };
+        assert_eq!(format!("{}", edit), "del3insTA");
+    }
+
+    #[test]
+    fn test_delins_to_rna_string_with_explicit_deleted_seq() {
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("UUCC").unwrap()),
+            deleted: Some(Sequence::from_str("AUG").unwrap()),
+            deleted_length: None,
+        };
+        assert_eq!(edit.to_rna_string(), "delauginsuucc");
+    }
+
+    #[test]
+    fn test_delins_eq_distinguishes_explicit_vs_short_form() {
+        let short = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
+            deleted: None,
+            deleted_length: None,
+        };
+        let explicit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
+            deleted: Some(Sequence::from_str("ATG").unwrap()),
+            deleted_length: None,
+        };
+        assert_ne!(short, explicit);
     }
 
     #[test]
@@ -1684,6 +1766,8 @@ mod tests {
                 base: Base::A,
                 count: RepeatCount::Exact(10),
             },
+            deleted: None,
+            deleted_length: None,
         };
         assert_eq!(format!("{}", edit), "delinsA[10]");
     }

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -200,11 +200,14 @@ fn parse_multibase_substitution(input: &str) -> IResult<&str, NaEdit> {
         )));
     }
 
-    // Convert to delins
+    // Convert to delins. Multi-base ">" notation does not carry an explicit
+    // deleted sequence/length, so leave both as None.
     Ok((
         input,
         NaEdit::Delins {
             sequence: InsertedSequence::Literal(alt_seq),
+            deleted: None,
+            deleted_length: None,
         },
     ))
 }
@@ -840,32 +843,26 @@ fn parse_simple_count(input: &str) -> IResult<&str, InsertedSequence> {
 fn parse_delins(input: &str) -> IResult<&str, NaEdit> {
     let (input, _) = tag("delins").parse(input)?;
     let (input, sequence) = parse_inserted_sequence(input)?;
-    Ok((input, NaEdit::Delins { sequence }))
-}
-
-/// Parse a delins with explicit deleted sequence (e.g., delAinsT, delATGinsCCC)
-/// This is a legacy/redundant format but appears in some databases.
-/// The deleted sequence is parsed and then discarded (normalized to delinsXXX format).
-fn parse_delins_with_deleted_seq(input: &str) -> IResult<&str, NaEdit> {
-    let (input, _) = tag("del").parse(input)?;
-    let (input, _deleted_seq) = parse_sequence(input)?;
-    let (input, _) = tag("ins").parse(input)?;
-    let (input, inserted_seq) = parse_inserted_sequence(input)?;
-
     Ok((
         input,
         NaEdit::Delins {
-            sequence: inserted_seq,
+            sequence,
+            deleted: None,
+            deleted_length: None,
         },
     ))
 }
 
-/// Parse a delins with explicit deleted count (e.g., del35insTA, del17insTA)
-/// This is a legacy/redundant format but appears in some databases.
-/// The deleted count is parsed and then discarded (normalized to delinsXXX format).
-fn parse_delins_with_deleted_count(input: &str) -> IResult<&str, NaEdit> {
+/// Parse a delins with explicit deleted sequence (e.g., delAinsT, delATGinsCCC).
+///
+/// The HGVS spec actively recommends the short form `delinsXXX` (see
+/// `recommendations/DNA/delins.md`), but the explicit form is allowed and
+/// appears in databases. ferro preserves the explicit deleted sequence so
+/// `parse → Display` round-trips faithfully; `canonicalize_edit` strips it
+/// back to the short form when canonicalization is requested.
+fn parse_delins_with_deleted_seq(input: &str) -> IResult<&str, NaEdit> {
     let (input, _) = tag("del").parse(input)?;
-    let (input, _deleted_count) = digit1.parse(input)?;
+    let (input, deleted_seq) = parse_sequence(input)?;
     let (input, _) = tag("ins").parse(input)?;
     let (input, inserted_seq) = parse_inserted_sequence(input)?;
 
@@ -873,6 +870,30 @@ fn parse_delins_with_deleted_count(input: &str) -> IResult<&str, NaEdit> {
         input,
         NaEdit::Delins {
             sequence: inserted_seq,
+            deleted: Some(deleted_seq),
+            deleted_length: None,
+        },
+    ))
+}
+
+/// Parse a delins with explicit deleted count (e.g., del35insTA, del17insTA).
+///
+/// As with explicit deleted sequence, the spec prefers the short form but
+/// ferro preserves the count for round-trip fidelity.
+fn parse_delins_with_deleted_count(input: &str) -> IResult<&str, NaEdit> {
+    let (input, _) = tag("del").parse(input)?;
+    let (input, deleted_count_str) = digit1.parse(input)?;
+    let (input, _) = tag("ins").parse(input)?;
+    let (input, inserted_seq) = parse_inserted_sequence(input)?;
+
+    let deleted_count: u64 = deleted_count_str.parse().unwrap_or(0);
+
+    Ok((
+        input,
+        NaEdit::Delins {
+            sequence: inserted_seq,
+            deleted: None,
+            deleted_length: Some(deleted_count),
         },
     ))
 }
@@ -2082,6 +2103,130 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_delins_with_explicit_deleted_seq_preserved() {
+        use crate::hgvs::edit::Sequence;
+        use std::str::FromStr;
+        let (remaining, edit) = parse_na_edit("delATGinsTTCC").unwrap();
+        assert_eq!(remaining, "");
+        if let NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } = edit
+        {
+            assert_eq!(deleted, Some(Sequence::from_str("ATG").unwrap()));
+            assert_eq!(deleted_length, None);
+            if let InsertedSequence::Literal(seq) = sequence {
+                assert_eq!(seq.to_string(), "TTCC");
+            } else {
+                panic!("expected literal inserted sequence");
+            }
+        } else {
+            panic!("expected NaEdit::Delins");
+        }
+    }
+
+    #[test]
+    fn test_parse_delins_with_explicit_deleted_count_preserved() {
+        let (remaining, edit) = parse_na_edit("del3insTA").unwrap();
+        assert_eq!(remaining, "");
+        if let NaEdit::Delins {
+            sequence: _,
+            deleted,
+            deleted_length,
+        } = edit
+        {
+            assert_eq!(deleted, None);
+            assert_eq!(deleted_length, Some(3));
+        } else {
+            panic!("expected NaEdit::Delins");
+        }
+    }
+
+    #[test]
+    fn test_parse_delins_short_form_has_no_explicit_deleted() {
+        let (remaining, edit) = parse_na_edit("delinsTTCC").unwrap();
+        assert_eq!(remaining, "");
+        if let NaEdit::Delins {
+            sequence: _,
+            deleted,
+            deleted_length,
+        } = edit
+        {
+            assert_eq!(deleted, None);
+            assert_eq!(deleted_length, None);
+        } else {
+            panic!("expected NaEdit::Delins");
+        }
+    }
+
+    #[test]
+    fn test_parse_multibase_substitution_does_not_set_explicit_deleted() {
+        let (remaining, edit) = parse_na_edit("GG>G").unwrap();
+        assert_eq!(remaining, "");
+        if let NaEdit::Delins {
+            sequence: _,
+            deleted,
+            deleted_length,
+        } = edit
+        {
+            assert_eq!(deleted, None);
+            assert_eq!(deleted_length, None);
+        } else {
+            panic!("expected NaEdit::Delins");
+        }
+    }
+
+    #[test]
+    fn test_full_hgvs_round_trip_delins_with_explicit_deleted_seq() {
+        use crate::parse_hgvs;
+        // Cover g./c./n./m. coordinate systems that share the parser.
+        let inputs = [
+            "NC_000001.11:g.100_102delATGinsTTCC",
+            "NC_000008.10:g.24814007_24814008delGGinsCT",
+            "NM_006158.3:c.22_23delCCinsAG",
+            "NR_046018.2:n.50_51delAGinsTC",
+            "NC_012920.1:m.1000_1001delAGinsTC",
+        ];
+        for input in inputs {
+            let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e:?}"));
+            assert_eq!(v.to_string(), input, "round-trip mismatch for {input}");
+        }
+    }
+
+    #[test]
+    fn test_full_hgvs_round_trip_delins_with_explicit_deleted_count() {
+        use crate::parse_hgvs;
+        let input = "NC_000001.11:g.100_102del3insTTCC";
+        let v = parse_hgvs(input).unwrap();
+        assert_eq!(v.to_string(), input);
+    }
+
+    #[test]
+    fn test_full_hgvs_round_trip_delins_short_form_unchanged() {
+        use crate::parse_hgvs;
+        let inputs = [
+            "NC_000001.11:g.100_102delinsTTCC",
+            "NM_006158.3:c.22_23delinsAG",
+        ];
+        for input in inputs {
+            let v = parse_hgvs(input).unwrap();
+            assert_eq!(v.to_string(), input);
+        }
+    }
+
+    #[test]
+    fn test_delins_parse_display_reparse_idempotent() {
+        use crate::parse_hgvs;
+        let input = "NC_000001.11:g.100_102delATGinsTTCC";
+        let v1 = parse_hgvs(input).unwrap();
+        let s1 = v1.to_string();
+        let v2 = parse_hgvs(&s1).unwrap();
+        assert_eq!(v1, v2);
+        assert_eq!(s1, v2.to_string());
+    }
+
+    #[test]
     fn test_parse_duplication() {
         let (remaining, edit) = parse_na_edit("dup").unwrap();
         assert_eq!(remaining, "");
@@ -2524,7 +2669,7 @@ mod tests {
         // Delins with count: delins10
         let (remaining, edit) = parse_na_edit("delins10").unwrap();
         assert_eq!(remaining, "");
-        if let NaEdit::Delins { sequence } = edit {
+        if let NaEdit::Delins { sequence, .. } = edit {
             assert!(matches!(sequence, InsertedSequence::Count(10)));
         } else {
             panic!("Expected delins");
@@ -2536,7 +2681,7 @@ mod tests {
         // Delins with N[count]: delinsN[12]
         let (remaining, edit) = parse_na_edit("delinsN[12]").unwrap();
         assert_eq!(remaining, "");
-        if let NaEdit::Delins { sequence } = edit {
+        if let NaEdit::Delins { sequence, .. } = edit {
             if let InsertedSequence::Repeat { base, count } = sequence {
                 assert_eq!(base, Base::N);
                 assert!(matches!(count, RepeatCount::Exact(12)));
@@ -2684,7 +2829,7 @@ mod tests {
         let (remaining, edit) =
             parse_na_edit("delins[AGAAGGAAATTT;45310743_46521014;45043709_45310738inv]").unwrap();
         assert_eq!(remaining, "");
-        if let NaEdit::Delins { sequence } = edit {
+        if let NaEdit::Delins { sequence, .. } = edit {
             if let InsertedSequence::Complex(parts) = sequence {
                 assert_eq!(parts.len(), 3);
                 assert!(matches!(&parts[0], InsertedPart::Literal(_)));
@@ -2782,7 +2927,7 @@ mod tests {
         // Delins with sequence repeat count: delinsTCGGCAGCGGCACAGCGAGG[13]
         let (remaining, edit) = parse_na_edit("delinsTCGGCAGCGGCACAGCGAGG[13]").unwrap();
         assert_eq!(remaining, "");
-        if let NaEdit::Delins { sequence } = edit {
+        if let NaEdit::Delins { sequence, .. } = edit {
             if let InsertedSequence::SequenceRepeat {
                 sequence: seq,
                 count,
@@ -2800,7 +2945,7 @@ mod tests {
         // Delins with sequence repeat range: delinsAAAGG[400_2000]
         let (remaining, edit) = parse_na_edit("delinsAAAGG[400_2000]").unwrap();
         assert_eq!(remaining, "");
-        if let NaEdit::Delins { sequence } = edit {
+        if let NaEdit::Delins { sequence, .. } = edit {
             if let InsertedSequence::SequenceRepeat {
                 sequence: seq,
                 count,

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -4603,10 +4603,15 @@ mod tests {
         assert!(matches!(variant, HgvsVariant::Cds(_)));
         assert_eq!(format!("{}", variant), "NM_000088.3:c.86-46_85+47insA");
 
-        // Delins with explicit deleted sequence (normalizes to delins)
+        // Delins with explicit deleted sequence is preserved on round-trip
+        // (issue #120). Use canonicalize_edit / canonicalization to strip
+        // the explicit deleted form when desired.
         let variant = parse_variant("NM_000088.3:c.85-47_84+48delGCCAinsG").unwrap();
         assert!(matches!(variant, HgvsVariant::Cds(_)));
-        assert_eq!(format!("{}", variant), "NM_000088.3:c.85-47_84+48delinsG");
+        assert_eq!(
+            format!("{}", variant),
+            "NM_000088.3:c.85-47_84+48delGCCAinsG"
+        );
     }
 
     #[test]

--- a/src/hgvs/validation.rs
+++ b/src/hgvs/validation.rs
@@ -306,7 +306,7 @@ pub mod rules {
                     "Insertion must have at least one base",
                 ));
             }
-            NaEdit::Delins { sequence } if sequence.is_empty() => {
+            NaEdit::Delins { sequence, .. } if sequence.is_empty() => {
                 result = result.with_error(ValidationError::new(
                     "E003",
                     "Deletion-insertion must have at least one inserted base",
@@ -579,6 +579,8 @@ mod tests {
         fn test_validate_delins_empty_error() {
             let edit = NaEdit::Delins {
                 sequence: InsertedSequence::Literal(Sequence::new(vec![])),
+                deleted: None,
+                deleted_length: None,
             };
             let result = rules::validate_na_edit(&edit);
             assert!(!result.valid);

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -236,7 +236,7 @@ fn simple_range_for_loc_edit<L>(
         NaEdit::Substitution { .. }
         | NaEdit::SubstitutionNoRef { .. }
         | NaEdit::Deletion { .. } => Some((region, start, end)),
-        NaEdit::Delins { sequence } => {
+        NaEdit::Delins { sequence, .. } => {
             sequence.bases()?;
             Some((region, start, end))
         }
@@ -296,7 +296,7 @@ fn anchor_from_loc_edit<L>(
             end,
             alt: Vec::new(),
         }),
-        NaEdit::Delins { sequence } => {
+        NaEdit::Delins { sequence, .. } => {
             let bases = sequence.bases()?.to_vec();
             Some(Anchor {
                 region,
@@ -578,6 +578,8 @@ fn build_naedit<P>(
     } else {
         NaEdit::Delins {
             sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
+            deleted: None,
+            deleted_length: None,
         }
     };
     let (lo, hi) = if merged.start > merged.end {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1819,7 +1819,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     }
                 }
             }
-            NaEdit::Delins { sequence } => {
+            NaEdit::Delins { sequence, .. } => {
                 use crate::hgvs::edit::InsertedSequence;
 
                 // HGVS spec (issue #81 A3): a delins with an empty inserted
@@ -1964,6 +1964,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 e0 as u64,
                                 NaEdit::Delins {
                                     sequence: bytes_to_inserted_seq(&trimmed_bytes),
+                                    deleted: None,
+                                    deleted_length: None,
                                 },
                                 warnings.clone(),
                             ));
@@ -2867,7 +2869,7 @@ fn extract_simple_delins(variant: &HgvsVariant) -> Option<(u64, u64, Vec<u8>)> {
         HgvsVariant::Mt(v) => simple_genome_loc_edit(&v.loc_edit)?,
         _ => return None,
     };
-    let NaEdit::Delins { sequence } = edit else {
+    let NaEdit::Delins { sequence, .. } = edit else {
         return None;
     };
     let InsertedSequence::Literal(seq) = sequence else {

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1353,11 +1353,14 @@ pub fn canonicalize_edit(edit: &NaEdit) -> NaEdit {
             length: None,
             uncertain_extent: uncertain_extent.clone(),
         },
-        NaEdit::Delins { sequence } => {
-            // Keep the inserted sequence but remove any explicit deletion info
-            // that might be embedded in the sequence description
+        NaEdit::Delins { sequence, .. } => {
+            // Keep only the inserted sequence; strip the explicit deleted
+            // sequence/length per the HGVS spec recommendation that the
+            // short form `delinsXXX` is preferred.
             NaEdit::Delins {
                 sequence: sequence.clone(),
+                deleted: None,
+                deleted_length: None,
             }
         }
         // A4: a substitution where ref == alt (e.g. `c.100A>A`) is degenerate;
@@ -1438,6 +1441,8 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
                 if start >= 1 && end >= 1 && start <= end {
                     return Some(NaEdit::Delins {
                         sequence: InsertedSequence::PositionRange { start, end },
+                        deleted: None,
+                        deleted_length: None,
                     });
                 }
             }
@@ -1448,6 +1453,8 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
     // wrap in `Reference`, which displays as `[<source>]`.
     Some(NaEdit::Delins {
         sequence: InsertedSequence::Reference(source.clone()),
+        deleted: None,
+        deleted_length: None,
     })
 }
 
@@ -2709,6 +2716,7 @@ mod tests {
         match got {
             NaEdit::Delins {
                 sequence: InsertedSequence::PositionRange { start, end },
+                ..
             } => {
                 assert_eq!(start, 42536337);
                 assert_eq!(end, 42536382);
@@ -2727,6 +2735,7 @@ mod tests {
         match &got {
             NaEdit::Delins {
                 sequence: InsertedSequence::Reference(s),
+                ..
             } => {
                 assert_eq!(s, "NM_000089.1:c.789_1011");
             }
@@ -2756,7 +2765,8 @@ mod tests {
         assert!(matches!(
             got,
             NaEdit::Delins {
-                sequence: InsertedSequence::Reference(_)
+                sequence: InsertedSequence::Reference(_),
+                ..
             }
         ));
     }
@@ -2774,6 +2784,7 @@ mod tests {
         match got {
             NaEdit::Delins {
                 sequence: InsertedSequence::Reference(s),
+                ..
             } => assert_eq!(s, "0_0"),
             other => panic!("expected Delins{{Reference}} for 0_0, got {:?}", other),
         }
@@ -2790,6 +2801,7 @@ mod tests {
         match got {
             NaEdit::Delins {
                 sequence: InsertedSequence::Reference(s),
+                ..
             } => assert_eq!(s, "10_2"),
             other => panic!("expected Delins{{Reference}} for 10_2, got {:?}", other),
         }
@@ -2807,7 +2819,8 @@ mod tests {
             matches!(
                 got,
                 NaEdit::Delins {
-                    sequence: InsertedSequence::Reference(_)
+                    sequence: InsertedSequence::Reference(_),
+                    ..
                 }
             ),
             "expected Delins{{Reference}} fallback for 0_5"
@@ -2887,5 +2900,51 @@ mod tests {
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);
+    }
+
+    #[test]
+    fn test_canonicalize_edit_delins_strips_explicit_deleted_seq() {
+        use crate::hgvs::edit::{InsertedSequence, Sequence};
+        use std::str::FromStr;
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
+            deleted: Some(Sequence::from_str("ATG").unwrap()),
+            deleted_length: None,
+        };
+        let canonical = canonicalize_edit(&edit);
+        match canonical {
+            NaEdit::Delins {
+                sequence: _,
+                deleted,
+                deleted_length,
+            } => {
+                assert_eq!(deleted, None);
+                assert_eq!(deleted_length, None);
+            }
+            other => panic!("expected NaEdit::Delins, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_canonicalize_edit_delins_strips_explicit_deleted_count() {
+        use crate::hgvs::edit::{InsertedSequence, Sequence};
+        use std::str::FromStr;
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("TA").unwrap()),
+            deleted: None,
+            deleted_length: Some(3),
+        };
+        let canonical = canonicalize_edit(&edit);
+        match canonical {
+            NaEdit::Delins {
+                sequence: _,
+                deleted,
+                deleted_length,
+            } => {
+                assert_eq!(deleted, None);
+                assert_eq!(deleted_length, None);
+            }
+            other => panic!("expected NaEdit::Delins, got {other:?}"),
+        }
     }
 }

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -385,7 +385,7 @@ pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
         NaEdit::Deletion { .. } => Some(-compute_span(variant)?),
         NaEdit::Duplication { .. } => Some(compute_span(variant)?),
         NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
-        NaEdit::Delins { sequence } => {
+        NaEdit::Delins { sequence, .. } => {
             Some(inserted_sequence_len(sequence)? - compute_span(variant)?)
         }
         _ => None,
@@ -523,6 +523,8 @@ mod tests {
         use std::str::FromStr;
         let edit = NaEdit::Delins {
             sequence: InsertedSequence::Literal(Sequence::from_str("ATG").unwrap()),
+            deleted: None,
+            deleted_length: None,
         };
         assert_eq!(na_edit_type_str(&edit), "delins");
     }

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -213,7 +213,7 @@ fn analyze_na_edit(edit: &crate::hgvs::edit::NaEdit) -> (&'static str, bool, usi
             let len = sequence.to_string().len();
             ("insertion", len % 3 != 0, 0, len)
         }
-        NaEdit::Delins { sequence } => {
+        NaEdit::Delins { sequence, .. } => {
             let alt_len = sequence.to_string().len();
             // Delins is frameshift if net change not divisible by 3
             ("delins", true, 0, alt_len) // Can't determine ref length easily

--- a/src/service/handlers/validate.rs
+++ b/src/service/handlers/validate.rs
@@ -223,7 +223,17 @@ fn extract_na_edit_info(
         NaEdit::Insertion { sequence } => {
             ("insertion".to_string(), None, Some(sequence.to_string()))
         }
-        NaEdit::Delins { sequence } => ("delins".to_string(), None, Some(sequence.to_string())),
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => {
+            let deleted = deleted
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| deleted_length.map(|l| format!("{} bp", l)));
+            ("delins".to_string(), deleted, Some(sequence.to_string()))
+        }
         NaEdit::Duplication {
             sequence, length, ..
         } => {
@@ -356,9 +366,38 @@ mod tests {
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350delinsATG").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, _deleted, inserted) = extract_na_edit_info(edit);
+                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
                 assert_eq!(vtype, "delins");
+                assert_eq!(deleted, None, "short form has no explicit deleted");
                 assert_eq!(inserted, Some("ATG".to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_delins_with_explicit_deleted_seq() {
+        let result =
+            crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_352delATGinsTTCC").unwrap();
+        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
+            if let Some(edit) = v.loc_edit.edit.inner() {
+                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
+                assert_eq!(vtype, "delins");
+                assert_eq!(deleted, Some("ATG".to_string()));
+                assert_eq!(inserted, Some("TTCC".to_string()));
+            }
+        }
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_delins_with_explicit_deleted_length() {
+        let result =
+            crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_352del3insTA").unwrap();
+        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
+            if let Some(edit) = v.loc_edit.edit.inner() {
+                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
+                assert_eq!(vtype, "delins");
+                assert_eq!(deleted, Some("3 bp".to_string()));
+                assert_eq!(inserted, Some("TA".to_string()));
             }
         }
     }

--- a/src/service/handlers/vcf_convert.rs
+++ b/src/service/handlers/vcf_convert.rs
@@ -632,7 +632,7 @@ fn extract_alleles_from_edit(edit: &crate::hgvs::edit::NaEdit) -> (Option<String
             // "N" is placeholder - accurate VCF needs reference lookup
             (Some("N".to_string()), Some(format!("N{}", sequence)))
         }
-        NaEdit::Delins { sequence } => {
+        NaEdit::Delins { sequence, .. } => {
             // Delins without original sequence - use "N" placeholder for ref
             (Some("N".to_string()), Some(sequence.to_string()))
         }

--- a/src/service/tools/ferro.rs
+++ b/src/service/tools/ferro.rs
@@ -128,7 +128,17 @@ fn extract_na_edit_info(edit: &NaEdit) -> (String, Option<String>, Option<String
         NaEdit::Insertion { sequence } => {
             ("insertion".to_string(), None, Some(sequence.to_string()))
         }
-        NaEdit::Delins { sequence } => ("delins".to_string(), None, Some(sequence.to_string())),
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => {
+            let deleted = deleted
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| deleted_length.map(|l| format!("{} bp", l)));
+            ("delins".to_string(), deleted, Some(sequence.to_string()))
+        }
         NaEdit::Duplication {
             sequence, length, ..
         } => {

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -849,7 +849,27 @@ fn emit_spdi_for_edit(
                 })
             }
         }
-        NaEdit::Delins { sequence: _ins_seq } => {
+        NaEdit::Delins {
+            sequence: ins_seq,
+            deleted,
+            deleted_length: _,
+        } => {
+            // Delins: g.100_102delinsATG -> seq:99:XYZ:ATG
+            //
+            // If the input carried an explicit deleted sequence
+            // (e.g. `delATGinsTTCC`, see issue #120) we can build the SPDI
+            // without consulting the reference. Otherwise we still need
+            // reference data.
+            if let Some(del_seq) = deleted.as_ref() {
+                if let Some(ins_str) = inserted_sequence_to_string(ins_seq) {
+                    return Ok(SpdiVariant::new(
+                        sequence,
+                        spdi_pos,
+                        sequence_to_string(del_seq),
+                        ins_str,
+                    ));
+                }
+            }
             let del_len = end_one_based
                 .saturating_sub(start_one_based)
                 .saturating_add(1) as usize;
@@ -1016,6 +1036,8 @@ pub fn spdi_to_hgvs(spdi: &SpdiVariant) -> Result<HgvsVariant, ConversionError> 
             interval,
             NaEdit::Delins {
                 sequence: InsertedSequence::Literal(ins_seq),
+                deleted: None,
+                deleted_length: None,
             },
         )
     };
@@ -1271,6 +1293,18 @@ mod tests {
     }
 
     #[test]
+    fn test_hgvs_to_spdi_delins_with_explicit_deleted_no_ref() {
+        // Issue #120: when the input carries an explicit deleted sequence, the
+        // SPDI conversion can succeed without reference data.
+        let hgvs = parse_hgvs("NC_000001.11:g.100_102delATGinsTTCC").unwrap();
+        let spdi = hgvs_to_spdi_simple(&hgvs)
+            .expect("explicit deleted sequence should not require reference data");
+        assert_eq!(spdi.position, 99);
+        assert_eq!(spdi.deletion, "ATG");
+        assert_eq!(spdi.insertion, "TTCC");
+    }
+
+    #[test]
     fn test_hgvs_to_spdi_duplication_with_seq() {
         let hgvs = parse_hgvs("NC_000001.11:g.100_102dupATG").unwrap();
         let spdi = hgvs_to_spdi_simple(&hgvs).unwrap();
@@ -1486,7 +1520,9 @@ mod tests {
                             })?;
                         Ok(SpdiVariant::new(sequence, spdi_pos, del_seq, ""))
                     }
-                    NaEdit::Delins { sequence: ins_seq } => {
+                    NaEdit::Delins {
+                        sequence: ins_seq, ..
+                    } => {
                         // Fetch deleted sequence from reference
                         let del_seq = reference
                             .get_sequence(&sequence, spdi_pos, end_pos)

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -304,7 +304,7 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
 
                 (anchor_pos, ref_allele, vec![alt_allele])
             }
-            NaEdit::Delins { sequence } => {
+            NaEdit::Delins { sequence, .. } => {
                 // Deletion-insertion: REF is deleted sequence, ALT is replacement
                 let deleted_seq = self.get_reference_sequence(chrom, start, end)?;
                 let alt_seq = sequence.to_string();
@@ -1212,6 +1212,8 @@ mod tests {
                 CdsInterval::new(CdsPos::new(1), CdsPos::new(3)),
                 NaEdit::Delins {
                     sequence: InsertedSequence::Literal(Sequence::from_str("TTT").unwrap()),
+                    deleted: None,
+                    deleted_length: None,
                 },
             ),
         });

--- a/src/vcf/to_hgvs.rs
+++ b/src/vcf/to_hgvs.rs
@@ -433,6 +433,8 @@ impl<'a> VcfToHgvsConverter<'a> {
             })?;
             NaEdit::Delins {
                 sequence: InsertedSequence::Literal(seq),
+                deleted: None,
+                deleted_length: None,
             }
         };
 
@@ -572,6 +574,8 @@ pub fn vcf_to_genomic_hgvs(vcf: &VcfRecord, alt_index: usize) -> Result<GenomeVa
         })?;
         NaEdit::Delins {
             sequence: InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
         }
     };
 

--- a/tests/comprehensive_edge_case_tests.rs
+++ b/tests/comprehensive_edge_case_tests.rs
@@ -172,6 +172,25 @@ fn test_delins_with_explicit_deleted() {
 }
 
 #[test]
+fn test_delins_with_explicit_deleted_round_trips() {
+    // Issue #120: parse → Display must preserve the explicit deleted sequence
+    // for inputs like c.22_23delCCinsAG so users don't lose information.
+    let fixtures = load_fixtures();
+    for test in &fixtures.delins_with_explicit_deleted.tests {
+        if !test.valid {
+            continue;
+        }
+        let v = parse_hgvs(&test.input).unwrap_or_else(|e| panic!("parse {}: {e:?}", test.input));
+        assert_eq!(
+            v.to_string(),
+            test.input,
+            "round-trip mismatch for {}",
+            test.input
+        );
+    }
+}
+
+#[test]
 fn test_intronic_and_utr_ranges() {
     let fixtures = load_fixtures();
     run_test_category(&fixtures.intronic_and_utr_ranges, "Intronic and UTR Ranges");

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,10 +10,10 @@
     "total": 823,
     "by_status": {
       "correctly-rejected": 12,
-      "diverges": 146,
+      "diverges": 142,
       "false-acceptance": 22,
       "parse-error": 196,
-      "preserved": 447
+      "preserved": 451
     },
     "by_coordinate_system": {
       "c": 298,
@@ -184,30 +184,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:c.6775_6777delGAGinsC",
-      "current": "NM_004006.2:c.6775_6777delinsC",
-      "spec_expected": "NM_004006.2:c.6775_6777delGAGinsC",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:c.6775_6777delGTGinsC",
-      "current": "NM_004006.2:c.6775_6777delinsC",
-      "spec_expected": "NM_004006.2:c.6775_6777delGTGinsC",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -2524,6 +2500,28 @@
       ]
     },
     {
+      "input": "NM_004006.2:c.6775_6777delGAGinsC",
+      "current": "NM_004006.2:c.6775_6777delGAGinsC",
+      "spec_expected": "NM_004006.2:c.6775_6777delGAGinsC",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:c.6775_6777delGTGinsC",
+      "current": "NM_004006.2:c.6775_6777delGTGinsC",
+      "spec_expected": "NM_004006.2:c.6775_6777delGTGinsC",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
       "input": "NM_004006.2:c.6775_6777delinsC",
       "current": "NM_004006.2:c.6775_6777delinsC",
       "spec_expected": "NM_004006.2:c.6775_6777delinsC",
@@ -3743,30 +3741,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11:g.32386323delCinsGA",
-      "current": "NC_000023.11:g.32386323delinsGA",
-      "spec_expected": "NC_000023.11:g.32386323delCinsGA",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11:g.32386323delTinsGA",
-      "current": "NC_000023.11:g.32386323delinsGA",
-      "spec_expected": "NC_000023.11:g.32386323delTinsGA",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -5431,6 +5405,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.32386323delCinsGA",
+      "current": "NC_000023.11:g.32386323delCinsGA",
+      "spec_expected": "NC_000023.11:g.32386323delCinsGA",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.32386323delTinsGA",
+      "current": "NC_000023.11:g.32386323delTinsGA",
+      "spec_expected": "NC_000023.11:g.32386323delTinsGA",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
       ]
     },
     {

--- a/tests/web_service_tests.rs
+++ b/tests/web_service_tests.rs
@@ -699,7 +699,7 @@ fn test_validate_na_edit_info_delins() {
     if let ferro_hgvs::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
         if let Some(edit) = v.loc_edit.edit.inner() {
             match edit {
-                NaEdit::Delins { sequence } => {
+                NaEdit::Delins { sequence, .. } => {
                     assert_eq!(sequence.to_string(), "ATG");
                 }
                 _ => panic!("Expected delins"),


### PR DESCRIPTION
Closes #120. Follow-up from #81 K1 audit.

## Summary

- Extended `NaEdit::Delins` with `deleted: Option<Sequence>` and `deleted_length: Option<u64>` fields so the parser can preserve the explicit deleted sequence/count from notations like `delATGinsTTCC` and `del3insTA`. Previously these were silently discarded, so `c.100_102delATGinsTTCC` parsed and displayed as `c.100_102delinsTTCC`.
- Updated parser sites: `parse_delins` (short form) sets both `None`; `parse_delins_with_deleted_seq` populates `deleted`; `parse_delins_with_deleted_count` populates `deleted_length`. The multi-base substitution path (`GG>G` -> delins) keeps both `None` because the `>`-form does not carry an explicit deleted sequence.
- Updated `Display` and `to_rna_string` to emit `del<XX>ins<YY>` only when those fields are set; short-form output is unchanged for short-form input. Synthesis-not-allowed: ferro never invents a `delXXX` part if the user did not supply one.
- `canonicalize_edit` continues to strip the explicit form back to `delins<YY>` per the HGVS spec recommendation that the short form is preferred. The new tests pin both directions.
- All other call sites (SPDI/VCF conversion, normalization, validation, python helpers, service handlers) updated to the new shape: construction passes `None`, destructuring uses `..` to ignore the new fields. Behavior is preserved at those sites.
- Opportunistic SPDI improvement: when the input carries an explicit deleted sequence, `hgvs_to_spdi_simple` can now succeed without consulting a reference provider (`NC_000001.11:g.100_102delATGinsTTCC` -> `NC_000001.11:99:ATG:TTCC`).
- Regenerated `tests/fixtures/grammar/hgvs_spec_normalization.json`: 4 rows transitioned from `diverges` to `preserved` (the previous \"current\" pinned the bug). The fixture is byte-identical under `cargo run --features dev --example generate_spec_fixture -- --check`.
- Added unit tests for parser preservation (explicit seq, explicit count, short form unchanged, multi-base substitution untouched), Display, RNA lowercase Display, equality (explicit vs short form are not equal), full HGVS round-trip across `g.`/`c.`/`n.`/`m.` coordinate systems, parse-display-reparse idempotency, and `canonicalize_edit` strips both forms.
- Strengthened `tests/comprehensive_edge_case_tests.rs` to assert each fixture entry under `delins_with_explicit_deleted` round-trips its input verbatim.

## HGVS spec rationale

`assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md` allows the explicit form `<pos>del<XX>ins<YY>` while the spec actively recommends the short form `<pos>delins<YY>` ("the recommendation is not to describe the variant as `NC_000023.11:g.32386323delTinsGA`, i.e. describe the deleted nucleotide sequence. This description is longer, it contains redundant information and chances to make an error increase"). That note tells implementations how to recommend writing variants but does not say tools should silently discard user input. ferro now treats explicit-form input as carrying meaningful round-trip information: parse preserves it, Display emits it back, and `canonicalize_edit` is the explicit way to drop it.

## Test plan

- [x] `cargo nextest run --features dev` - 3414 tests pass (full suite)
- [x] `cargo clippy --features dev --all-targets -- -D warnings` - clean
- [x] `cargo fmt --all -- --check` - clean
- [x] `cargo run --features dev --example generate_spec_fixture -- --check` - byte-identical