### PR TITLE
fix(normalize): apply 3'-rule to merged cis-allele deletions (closes #161)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -53,6 +53,22 @@ fn has_unknown_offset_cds(pos: &CdsPos) -> bool {
     )
 }
 
+/// Whether a variant carries a pure `Deletion` edit (no inserted sequence).
+///
+/// Used by the cis-allele post-merge step to decide whether to re-apply
+/// the 3'-rule to a freshly-merged anchor (issue #161).
+fn is_pure_deletion(v: &HgvsVariant) -> bool {
+    let edit = match v {
+        HV::Genome(g) => g.loc_edit.edit.inner(),
+        HV::Cds(c) => c.loc_edit.edit.inner(),
+        HV::Tx(t) => t.loc_edit.edit.inner(),
+        HV::Rna(r) => r.loc_edit.edit.inner(),
+        HV::Mt(m) => m.loc_edit.edit.inner(),
+        _ => None,
+    };
+    matches!(edit, Some(NaEdit::Deletion { .. }))
+}
+
 /// Check if a TxPos has an unknown (?) offset sentinel value
 fn has_unknown_offset_tx(pos: &TxPos) -> bool {
     matches!(
@@ -230,6 +246,32 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // (Display already renders singletons in bare form regardless).
         let original_len = normalized.len();
         let mut merged = merge::merge_consecutive_edits(normalized, allele.phase, &self.provider);
+
+        // The HGVS 3'-rule requires the most-3' position possible — and that
+        // applies to the post-merge form, not just the per-variant inputs.
+        // When merge collapses adjacent single-base deletions into one
+        // ranged Deletion, that fresh anchor must reach its rotation
+        // fixed point. (Issue #161.)
+        //
+        // We restrict the re-normalize to merged Deletions specifically.
+        // Other merged forms (delins from sub+sub, delins from sub+ins,
+        // pure ins, etc.) are produced by the merge layer in their
+        // intended form; sending them back through `normalize_with_warnings`
+        // would re-canonicalize delins and traverse coord-system paths
+        // that are out of scope for this issue.
+        if merged.len() < original_len {
+            let mut renormalized = Vec::with_capacity(merged.len());
+            for v in merged {
+                if is_pure_deletion(&v) {
+                    let r = self.normalize_with_warnings(&v)?;
+                    all_warnings.extend(r.warnings);
+                    renormalized.push(r.result);
+                } else {
+                    renormalized.push(v);
+                }
+            }
+            merged = renormalized;
+        }
 
         let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
             && original_len > 1

--- a/src/normalize/shuffle.rs
+++ b/src/normalize/shuffle.rs
@@ -64,7 +64,14 @@ pub fn shuffle(
 
     match direction {
         ShuffleDirection::ThreePrime => {
-            // Shuffle right (3')
+            // Shuffle right (3').
+            //
+            // HGVS rotation invariant for a deletion of length L over the
+            // 0-based half-open window [s, s+L): advance to (s+1, s+L+1) iff
+            // ref[s] == ref[s+L]. The deleted bases at (s+1, s+L+1) then
+            // equal a 1-position rotation of ref[s, s+L), so the haplotype
+            // is unchanged. Iterating to the fixed point yields the
+            // spec-canonical 3'-most representation.
             while new_end < boundaries.right {
                 let ref_idx = new_end as usize;
                 if ref_idx >= ref_seq.len() {
@@ -73,7 +80,8 @@ pub fn shuffle(
 
                 // For deletion: check if we can shift right
                 if alt_seq.is_empty() {
-                    // The base at the end of the deletion matches the base after
+                    // ref[del_start] == ref[del_end_exclusive] is the
+                    // rotation predicate above.
                     let del_start_idx = new_start as usize;
                     if del_start_idx < ref_seq.len() && ref_seq[del_start_idx] == ref_seq[ref_idx] {
                         new_start += 1;
@@ -92,6 +100,20 @@ pub fn shuffle(
                     }
                 }
             }
+            // Fixed-point invariant: on loop exit while still strictly
+            // inside the boundary and the reference, the rotation
+            // predicate must be false. A regression that under-shifts
+            // by one rotation trips this in debug builds.
+            debug_assert!(
+                new_end >= boundaries.right
+                    || (new_end as usize) >= ref_seq.len()
+                    || (alt_seq.is_empty()
+                        && ref_seq[new_start as usize] != ref_seq[new_end as usize])
+                    || (!alt_seq.is_empty()
+                        && ref_seq[new_end as usize]
+                            != alt_seq[((new_end - start) % alt_seq.len() as u64) as usize]),
+                "3'-shuffle terminated before reaching the rotation fixed point",
+            );
         }
         ShuffleDirection::FivePrime => {
             // Shuffle left (5')

--- a/tests/del_shift_matrix.rs
+++ b/tests/del_shift_matrix.rs
@@ -148,6 +148,53 @@ mod genomic {
         let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}del", &[6]));
         assert_eq!(result, hgvs("NC_TEST.1:g.{0}del", &[6]));
     }
+
+    // Issue #161: cis-allele bracket form whose merged 4-bp deletion is
+    // one rotation 5' of the spec-canonical 3'-most form. Per-variant
+    // shuffle does not move the individual delN bases; the 3'-rule must
+    // apply to the post-merge form.
+    //
+    // Core CCGTCTGAAGG: positions 3-6 (core) = G,T,C,T (the 4 bases the
+    // bracket allele deletes); core[7] = G matches core[3] = G, allowing
+    // exactly one 3' rotation of the merged window. core[8] = A then
+    // breaks the predicate and the loop terminates.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation() {
+        let p = provider("CCGTCTGAAGG");
+        let input = hgvs(
+            "NC_TEST.1:g.[{0}delG;{1}delT;{2}delC;{3}delT]",
+            &[3, 4, 5, 6],
+        );
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}del", &[4, 7]));
+    }
+
+    // Issue #161, second example: a 2-bp del in cis-allele form whose
+    // merged window can shift exactly one position 3'.
+    //
+    // Core CCTGTAAGG: positions 3-4 (core) = T,G (the bracket allele
+    // deletes these two). core[5] = T matches core[3] = T, so the merged
+    // window rotates once 3' to positions 4-5; core[6] = A then breaks
+    // the predicate.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_2bp_del_shifts_one_rotation() {
+        let p = provider("CCTGTAAGG");
+        let input = hgvs("NC_TEST.1:g.[{0}delT;{1}delG]", &[3, 4]);
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}del", &[4, 5]));
+    }
+
+    // Issue #161 sanity guard: the canonical (non-bracket) form of the
+    // same merged deletion already normalizes correctly today. Locking it
+    // here ensures the post-merge re-normalize produces the same answer
+    // as the direct-form path.
+    #[rstest]
+    fn issue_161_canonical_form_4bp_del_matches_bracket_form() {
+        let p = provider("CCGTCTGAAGG");
+        let input = hgvs("NC_TEST.1:g.{0}_{1}del", &[3, 6]);
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}del", &[4, 7]));
+    }
 }
 
 mod cds_plus {
@@ -278,6 +325,18 @@ mod cds_plus {
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}del", &[19]));
         assert_eq!(result, hgvs("NM_TEST.1:c.{0}del", &[19]));
     }
+
+    // Issue #161: post-merge re-normalize on the c. path.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation() {
+        let p = provider("CCGTCTGAAGGACGTACGT");
+        let input = hgvs(
+            "NM_TEST.1:c.[{0}delG;{1}delT;{2}delC;{3}delT]",
+            &[3, 4, 5, 6],
+        );
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}del", &[4, 7]));
+    }
 }
 
 mod cds_minus {
@@ -403,6 +462,18 @@ mod cds_minus {
         let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}del", &[19]));
         assert_eq!(result, hgvs("NM_TEST.1:c.{0}del", &[19]));
     }
+
+    // Issue #161: post-merge re-normalize on the c. minus-strand path.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation() {
+        let p = provider("CCGTCTGAAGGACGTACGT");
+        let input = hgvs(
+            "NM_TEST.1:c.[{0}delG;{1}delT;{2}delC;{3}delT]",
+            &[3, 4, 5, 6],
+        );
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}del", &[4, 7]));
+    }
 }
 
 mod noncoding_plus {
@@ -520,6 +591,14 @@ mod noncoding_plus {
         let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}del", &[19]));
         assert_eq!(result, hgvs("NR_TEST.1:n.{0}del", &[19]));
     }
+
+    // Note on issue #161 coverage on the n. path: the parser does not
+    // (yet) accept `n.[...]` cis-allele bracket shorthand, so the
+    // bracket-then-merge code path can't be exercised through the parser
+    // here. The post-merge re-normalize fix lives at the allele dispatch
+    // and applies uniformly across coord systems; coverage for the
+    // bracket-form bug is locked on the g., c., and r. paths in this
+    // file.
 }
 
 mod noncoding_minus {
@@ -637,6 +716,8 @@ mod noncoding_minus {
         let result = normalize_to_string(p, &hgvs("NR_TEST.1:n.{0}del", &[19]));
         assert_eq!(result, hgvs("NR_TEST.1:n.{0}del", &[19]));
     }
+
+    // See comment in `noncoding_plus` on n.-path issue #161 coverage.
 }
 
 mod rna_plus {
@@ -759,6 +840,18 @@ mod rna_plus {
         let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}del", &[18]));
         assert_eq!(result, hgvs("NR_TEST.1:r.{0}del", &[18]));
     }
+
+    // Issue #161: post-merge re-normalize on the r. path.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation() {
+        let p = provider("ccgucugaaggacguacgu");
+        let input = hgvs(
+            "NR_TEST.1:r.[{0}delg;{1}delu;{2}delc;{3}delu]",
+            &[3, 4, 5, 6],
+        );
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}del", &[4, 7]));
+    }
 }
 
 mod rna_minus {
@@ -876,5 +969,17 @@ mod rna_minus {
         let p = provider("cguacguacguacgaaaa");
         let result = normalize_to_string(p, &hgvs("NR_TEST.1:r.{0}del", &[18]));
         assert_eq!(result, hgvs("NR_TEST.1:r.{0}del", &[18]));
+    }
+
+    // Issue #161: post-merge re-normalize on the r. minus-strand path.
+    #[rstest]
+    fn issue_161_bracket_cis_allele_4bp_del_shifts_one_rotation() {
+        let p = provider("ccgucugaaggacguacgu");
+        let input = hgvs(
+            "NR_TEST.1:r.[{0}delg;{1}delu;{2}delc;{3}delu]",
+            &[3, 4, 5, 6],
+        );
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, hgvs("NR_TEST.1:r.{0}_{1}del", &[4, 7]));
     }
 }


### PR DESCRIPTION
## Summary

Fixes [#161](https://github.com/fulcrumgenomics/ferro-hgvs/issues/161). Cis-allele bracket inputs whose adjacent single-base deletions collapse into a single ranged deletion were emitted at the merge anchor without the HGVS 3′-rule applied. The per-variant shuffle that runs before the merge sees one base at a time and can't move; the merge step itself does not normalize. The merged form must reach the rotation fixed point on its own.

### Repro

| Input | Mutalyzer (canonical) | Ferro (before) | Ferro (after) |
|---|---|---|---|
| `g.[1008delG;1009delT;1010delC;1011delT]` | `g.1009_1012del` | `g.1008_1011del` | `g.1009_1012del` |
| `g.[1034delT;1035delG]` | `g.1035_1036del` | `g.1034_1035del` | `g.1035_1036del` |

### Change

- `src/normalize/mod.rs`: after `merge::merge_consecutive_edits`, when sub-variants actually collapsed (`merged.len() < original_len`), re-run the normalize pipeline on each merged variant whose edit is a pure `Deletion`. Scoped to deletions because that is the spec-shift class that produced the under-shift; other merged forms (delins from sub+sub, ins+sub, etc.) are produced by the merge layer in their intended form and should not be re-canonicalized here.
- `src/normalize/shuffle.rs`: inline doc-comment naming the HGVS rotation invariant `ref[del_start] == ref[del_end_exclusive]`, plus a `debug_assert!` at the 3′-shuffle exit that trips if the rotation predicate is still satisfied while strictly inside the boundary. Self-locks against any future regression that re-introduces a one-rotation-short termination.
- `tests/del_shift_matrix.rs`: 7 new cases — both literal issue examples plus a canonical-form sanity guard, replicated across `genomic`, `cds_plus`, `cds_minus`, `rna_plus`, `rna_minus`. n. is omitted because the parser does not yet accept `n.[…]` cis-allele shorthand.

### Spec reference

HGVS 3′-rule (`general.md:41-44`) requires "the most 3′ position possible of the reference sequence" for all description types except the c./r./n. exon-junction exception (preserved by `boundary::get_cds_boundaries`).

## Test plan

- [x] `cargo nextest run --features dev` — 3559/3559 pass
- [x] `cargo clippy --features dev -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Failing-then-green issue-161 test cases on `g.`, `c.+`, `c.-`, `r.+`, `r.-`
- [ ] Mutalyzer comparison re-run; confirm 3′-shift mismatch category drops to ~0 (tracked separately)

## Out of scope

Diagnosis surfaced a separate latent bug in `normalize_rna`: when the merged delins re-normalize traverses an `r.*N` (3′UTR) position, the `*` flag is dropped because `RnaPos::new(...)` ignores the `utr3` field. This PR sidesteps that path by scoping re-normalize to pure deletions; the rna-path bug will be filed separately.