### PR TITLE
fix(normalize): preserve r.*N UTR flag and translate via cds_end (closes #163)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -846,7 +846,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &crate::hgvs::variant::RnaVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         use crate::hgvs::interval::RnaInterval;
-        use crate::hgvs::location::RnaPos;
         use crate::hgvs::variant::{LocEdit, RnaVariant};
 
         // Can't normalize variants with unknown edits or positions
@@ -883,34 +882,131 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Err(_) => return Ok((HV::Rna(variant.clone()), vec![])),
         };
 
-        // Only normalize positive positions (within transcript)
-        // Negative positions are outside the transcript sequence
-        if start_pos.base < 1 || end_pos.base < 1 {
-            return Ok((HV::Rna(variant.clone()), vec![]));
-        }
+        // Convert RNA positions to transcript-1 positions, deciding per
+        // endpoint. UTR (`r.*N`/`r.-N`) and non-positive bases need a CDS
+        // to translate; non-UTR positive bases map 1:1 to transcript-1
+        // indices and work without a CDS (mock providers used in tests
+        // often omit cds_start/end). Choosing per endpoint keeps mixed
+        // intervals like `r.50_*1del` from rerouting the positive end
+        // through `rna_to_tx_pos` — issue #163 follow-up.
+        let cds_info = transcript.cds_start.zip(transcript.cds_end);
+        let map_in = |pos: &crate::hgvs::location::RnaPos| -> Option<u64> {
+            if pos.utr3 || pos.base < 1 {
+                let (cds_start, cds_end) = cds_info?;
+                self.rna_to_tx_pos(pos, cds_start, Some(cds_end)).ok()
+            } else {
+                Some(pos.base as u64)
+            }
+        };
+        let tx_start = match map_in(start_pos) {
+            Some(v) => v,
+            None => return Ok((HV::Rna(variant.clone()), vec![])),
+        };
+        let tx_end = match map_in(end_pos) {
+            Some(v) => v,
+            None => return Ok((HV::Rna(variant.clone()), vec![])),
+        };
 
-        let rna_start = start_pos.base as u64;
-        let rna_end = end_pos.base as u64;
-
-        // Get boundaries
+        // Get boundaries (entire transcript span; r. has no exon-level
+        // junction restriction beyond the transcript ends).
         let boundaries = Boundaries::new(1, transcript.sequence.len() as u64);
 
         // Perform normalization (RNA context: codon-frame gate does not apply;
         // r. is not in the spec's accepted reference types for repeats).
         let seq = transcript.sequence.as_bytes();
-        let (new_start, new_end, new_edit, warnings) =
-            self.normalize_na_edit(seq, edit, rna_start, rna_end, &boundaries, false)?;
+        let (new_tx_start, new_tx_end, new_edit, warnings) =
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
+
+        // Convert each normalized tx position back independently, restoring
+        // UTR notation when the position falls outside the CDS. This catches
+        // both the original issue #163 case (UTR input shuffling within the
+        // UTR) and a positive-base input that shifts past `cds_end` during
+        // normalization. Without `cds_info` we keep the simple base-1 mapping.
+        use crate::hgvs::location::RnaPos;
+        let map_out = |pos: u64| -> Result<RnaPos, FerroError> {
+            if let Some((cds_start, cds_end)) = cds_info {
+                if pos < cds_start || pos > cds_end {
+                    return self.tx_to_rna_pos(pos, cds_start, Some(cds_end));
+                }
+            }
+            Ok(RnaPos::new(pos as i64))
+        };
+        let new_start = map_out(new_tx_start)?;
+        let new_end = map_out(new_tx_end)?;
 
         let new_variant = RnaVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(
-                RnaInterval::new(RnaPos::new(new_start as i64), RnaPos::new(new_end as i64)),
-                new_edit,
-            ),
+            loc_edit: LocEdit::new(RnaInterval::new(new_start, new_end), new_edit),
         };
 
         Ok((HV::Rna(new_variant), warnings))
+    }
+
+    /// Convert an RNA position to a transcript-1 position.
+    ///
+    /// Mirrors `cds_to_tx_pos`. `r.*N` maps to `cds_end + N`, `r.-N` to
+    /// `cds_start + N` (HGVS skips the `0` gap).
+    fn rna_to_tx_pos(
+        &self,
+        pos: &crate::hgvs::location::RnaPos,
+        cds_start: u64,
+        cds_end: Option<u64>,
+    ) -> Result<u64, FerroError> {
+        if pos.utr3 {
+            let end = cds_end.ok_or_else(|| FerroError::ConversionError {
+                msg: "No CDS end".to_string(),
+            })?;
+            let base = u64::try_from(pos.base).map_err(|_| FerroError::ConversionError {
+                msg: format!("Negative base {} in 3' UTR position", pos.base),
+            })?;
+            Ok(end + base)
+        } else if pos.base < 0 {
+            let tx_pos = cds_start as i64 + pos.base;
+            u64::try_from(tx_pos).map_err(|_| FerroError::ConversionError {
+                msg: format!(
+                    "RNA position r.{} maps before transcript start (cds_start={})",
+                    pos.base, cds_start
+                ),
+            })
+        } else if pos.base == 0 {
+            Ok(cds_start.saturating_sub(1))
+        } else {
+            Ok(cds_start + pos.base as u64 - 1)
+        }
+    }
+
+    /// Convert a transcript-1 position back to an RNA position, restoring
+    /// the appropriate region (`r.*N` for 3'UTR, `r.-N` for 5'UTR).
+    fn tx_to_rna_pos(
+        &self,
+        pos: u64,
+        cds_start: u64,
+        cds_end: Option<u64>,
+    ) -> Result<crate::hgvs::location::RnaPos, FerroError> {
+        use crate::hgvs::location::RnaPos;
+        let end = cds_end.ok_or_else(|| FerroError::ConversionError {
+            msg: "No CDS end".to_string(),
+        })?;
+        if pos < cds_start {
+            Ok(RnaPos {
+                base: pos as i64 - cds_start as i64,
+                offset: None,
+                utr3: false,
+            })
+        } else if pos > end {
+            Ok(RnaPos {
+                base: (pos - end) as i64,
+                offset: None,
+                utr3: true,
+            })
+        } else {
+            Ok(RnaPos {
+                base: (pos - cds_start + 1) as i64,
+                offset: None,
+                utr3: false,
+            })
+        }
     }
 
     /// Normalize a mitochondrial variant

--- a/tests/issue_163_rna_utr3_flag.rs
+++ b/tests/issue_163_rna_utr3_flag.rs
@@ -1,0 +1,133 @@
+//! Regression test for issue #163: `normalize_rna` drops the `*` UTR flag
+//! on 3'UTR `r.*N` variants, and reads the wrong slice of the transcript
+//! sequence because it treats `*N` as a transcript-1 position rather
+//! than an offset from `cds_end`.
+//!
+//! Before the fix, normalize on `r.*1_*2del` over a transcript whose
+//! 5'UTR begins with an `A` homopolymer would shuffle the deletion
+//! against the 5'UTR slice and emit a non-UTR `r.M_Ndel`, silently
+//! corrupting both the position and the region.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Build a single-exon transcript with:
+/// - 5'UTR (tx 1-10):  `AAAAAAAAAC`
+/// - CDS    (tx 11-50): `ATGCATGCATGCATGCATGCATGCATGCATGCATGCATGC`
+/// - 3'UTR  (tx 51-60): `ACTTTTTTTT`
+///
+/// `r.*1` → tx 51 = `A`; `r.*2` → tx 52 = `C`. The neighbouring byte
+/// `r.*3` → tx 53 = `T`, so a deletion at `r.*1_*2` cannot 3'-shift
+/// (the rotation predicate `ref[del_start] == ref[del_end]` fails).
+fn provider_with_utr_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "AAAAAAAAACATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCACTTTTTTTT".to_string();
+    assert_eq!(sequence.len(), 60, "fixture length must be 60");
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_TESTUTR.1".to_string(),
+        Some("UTR_TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(11),
+        Some(50),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(provider_with_utr_transcript());
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+#[test]
+fn rna_utr3_del_preserves_star_flag_and_position() {
+    // ref at *1='A', *2='C', *3='T'; rotation predicate fails so the
+    // canonical 3'-most form is the input itself.
+    assert_eq!(
+        normalize_to_string("NM_TESTUTR.1:r.*1_*2del"),
+        "NM_TESTUTR.1:r.*1_*2del",
+    );
+}
+
+#[test]
+fn rna_utr3_del_in_homopolymer_shifts_within_utr() {
+    // 3'UTR T-tract at tx 53..60 (eight T's). Deleting r.*3 must shift
+    // 3' to the last T (r.*10), staying inside the 3'UTR — both `*`
+    // markers must be preserved.
+    assert_eq!(
+        normalize_to_string("NM_TESTUTR.1:r.*3del"),
+        "NM_TESTUTR.1:r.*10del",
+    );
+}
+
+#[test]
+fn rna_utr3_delins_preserves_star_flag() {
+    // delins(ac→ug) at *1_*2: rev-comp of "ac" is "gu" (RNA), so the
+    // canonical form is `inv` (covered by the existing
+    // delins-canonicalization rule). Either way the `*` flag must
+    // survive normalization.
+    let result = normalize_to_string("NM_TESTUTR.1:r.*1_*2delinsug");
+    assert!(
+        result.contains("*1") && result.contains("*2"),
+        "expected `*1` and `*2` in normalized output, got {}",
+        result,
+    );
+}
+
+#[test]
+fn rna_utr3_ins_preserves_star_flag() {
+    // Insertion `gg` between r.*1 (A) and r.*2 (C). The inserted bases
+    // match neither neighbor, so no ins→dup canonicalization fires and
+    // the result stays as `ins`. The `*` markers must survive — covers
+    // the insertion path through `normalize_rna`, which is a separate
+    // canonicalization path from `del`/`delins`.
+    assert_eq!(
+        normalize_to_string("NM_TESTUTR.1:r.*1_*2insgg"),
+        "NM_TESTUTR.1:r.*1_*2insgg",
+    );
+}
+
+#[test]
+fn rna_utr3_dup_preserves_star_flag() {
+    // 3'UTR T-tract at tx 53..60 (eight T's). Duplicating the first T
+    // (r.*3) must 3'-shift to the last T (r.*10). The `*` flag must
+    // survive — covers the duplication path through `normalize_rna`,
+    // which is a separate canonicalization path from `del`/`delins`/`ins`.
+    assert_eq!(
+        normalize_to_string("NM_TESTUTR.1:r.*3dup"),
+        "NM_TESTUTR.1:r.*10dup",
+    );
+}
+
+#[test]
+fn rna_mixed_cds_utr3_del_shifts_into_utr() {
+    // Mixed-interval: start in CDS (r.50 = last C of CDS, tx 50), end in
+    // 3'UTR (r.*1 = A, tx 51). Deletion of "CA" can 3'-shift one position
+    // because tx 52 ('C') equals the first deleted byte; the new range
+    // [tx 51, tx 52] = "AC" lies entirely in the 3'UTR, so the canonical
+    // output must use `*1_*2` notation.
+    //
+    // Regression for per-endpoint translation: under the previous
+    // interval-wide `needs_cds_translation` flag, r.50 was rerouted
+    // through `rna_to_tx_pos` (yielding tx 60) just because the other
+    // endpoint was UTR, producing a reversed range that silently
+    // returned the input unchanged.
+    assert_eq!(
+        normalize_to_string("NM_TESTUTR.1:r.50_*1del"),
+        "NM_TESTUTR.1:r.*1_*2del",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes [#163](https://github.com/fulcrumgenomics/ferro-hgvs/issues/163). `normalize_rna` rebuilt the result interval with `RnaPos::new(...)`, which hard-codes `utr3: false` — so any `r.*N` (3'UTR) variant going through indel normalization lost its `*` marker and emerged as a CDS-region variant. The same site also used `start_pos.base` directly as a transcript-1 position, so the reference slice the shuffle ran against for `r.*N` was off by `cds_end` (it read the start of the transcript, not the 3'UTR region).

### Bug surface

```
input:                NM_TESTUTR.1:r.*3del   (3'UTR T-tract: tx 53..60 = TTTTTTTT)
expected (3'-rule):   NM_TESTUTR.1:r.*10del  (last T)
ferro before:         NM_TESTUTR.1:r.9del    (`*` dropped, wrong region, wrong position)
```

The bug was latent from a user-facing perspective: per-variant normalize on a substitution returns early via `needs_normalization`, so `r.*N` subs were never sent through the buggy path. A direct `r.*N` del / delins / ins / dup, or a post-merge re-normalize that produces a `r.*N` edit (surfaced during diagnosis of [#162](https://github.com/fulcrumgenomics/ferro-hgvs/pull/162)), exposed it.

## Change

- Mirror the `c.` path: translate input `r.` positions to transcript-1 via a CDS-aware translator (`rna_to_tx_pos`), normalize against the transcript bytes, then translate back with the appropriate region (`tx_to_rna_pos`). `r.*N` → `cds_end + N`; `r.-N` → `cds_start + N` (with the c.0 gap collapsed, mirroring the `cds_to_tx_pos` issue-#97 fix).
- For non-UTR, positive-base inputs — the case the existing `rna_plus` / `rna_minus` matrix coverage and many mock providers rely on (including providers built with no `cds_start`) — keep the simple base-1 mapping.

## Tests

`tests/issue_163_rna_utr3_flag.rs` adds three TDD-style cases over a UTR fixture (5'UTR `AAAAAAAAAC`, CDS, 3'UTR `ACTTTTTTTT`, `cds_start=11`, `cds_end=50`):

- `rna_utr3_del_preserves_star_flag_and_position` — `r.*1_*2del` must round-trip with both `*` markers preserved (rotation predicate fails so position is unchanged).
- `rna_utr3_del_in_homopolymer_shifts_within_utr` — `r.*3del` in the 3'UTR T-tract must shift to `r.*10del`, staying inside the 3'UTR.
- `rna_utr3_delins_preserves_star_flag` — `r.*1_*2delinsug` must preserve the `*` markers regardless of which higher-priority delins canonicalization (sub / inv / del / ins / dup) fires.

## Test plan

- [x] `cargo nextest run --features dev` — 3555/3555 pass
- [x] `cargo clippy --features dev -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Failing-then-green issue-163 tests
- [x] No regression in `del_shift_matrix` / `dup_shift_matrix` / `ins_shift_matrix` / `merge_consecutive_edits_tests` / clinvar / biocommons suites