### PR TITLE
docs(test): correct misleading comment on trans-allele expanded-form test

### DIFF
--- a/tests/gene_selector_display_preserve.rs
+++ b/tests/gene_selector_display_preserve.rs
@@ -311,10 +311,15 @@ fn display_preserves_gene_selector_in_trans_allele_same_acc_same_gene() {
 
 #[test]
 fn display_preserves_gene_selector_in_trans_allele_expanded_form() {
-    // Force the expanded form by parsing the explicit `[v1];[v2]` notation.
-    // Each sub-variant carries its own selector via per-variant Display; this
-    // test pins that path directly so a regression in the per-kind helper is
-    // caught even when the compact-trans path would have hidden it.
+    // Parse the expanded `[v1];[v2]` notation; each sub-variant captures the
+    // gene_symbol independently. Because both sub-variants share accession and
+    // gene_symbol, `all_share_accession_and_type` permits the compact-trans
+    // output `ACC(GENE):c.[a];[b]`, so this test does NOT exercise the
+    // per-kind expanded-form Display path (that case lives in
+    // `display_preserves_independent_gene_selectors_in_mixed_acc_trans`, where
+    // mismatched accessions force the expanded path). What this test pins is
+    // sub-variant `gene_symbol` capture under the expanded-input → compact-
+    // trans-output normalization, plus byte-stable re-parse of the output.
     let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A1):c.200C>T]";
     let v = parse_hgvs(input).unwrap();
     let s = v.to_string();


### PR DESCRIPTION
## Summary

- The doc-comment on `display_preserves_gene_selector_in_trans_allele_expanded_form` claimed the test pins the per-kind expanded-form `Display` path. It does not: both sub-variants share accession and `gene_symbol`, so `all_share_accession_and_type` returns true and ferro emits compact-trans `ACC(GENE):c.[a];[b]` — never reaching per-kind expanded `Display`.
- Replace the comment with one that accurately describes what the test pins (sub-variant `gene_symbol` capture under the expanded-input → compact-trans-output normalization, plus byte-stable round-trip), and point to `display_preserves_independent_gene_selectors_in_mixed_acc_trans` as the test that actually exercises the per-kind expanded path (via mismatched accessions).
- No code change; test body is unchanged and still passes.

This closes out a CodeRabbit review observation from PR #144 (which is being closed as superseded by PR #135 — the work landed via a different PR).

## Test plan

- [x] `cargo nextest run --features dev -E 'test(/gene_selector/)'` — all 40 gene-selector tests pass
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI lint + format + test pass on PR