### PR TITLE
refactor(normalize): tag r. positive bases as Region::Rna (closes #168)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -28,8 +28,10 @@ enum Region {
     /// `g.` (genomic) and `m.` (mitochondrial) — single axis, no
     /// sub-regions.
     Genome,
-    /// `c.` / `r.` CDS proper (positive non-UTR base).
+    /// `c.` CDS proper (positive non-UTR base).
     Cds,
+    /// `r.` CDS proper (positive non-UTR base on a transcript).
+    Rna,
     /// `c.` / `r.` 5'UTR (negative base, e.g. `c.-3`).
     FivePrimeUtr,
     /// `c.` / `r.` 3'UTR (`utr3` flag, e.g. `c.*1`).
@@ -441,7 +443,7 @@ fn simple_rna_pos(boundary: &UncertainBoundary<RnaPos>) -> Option<(Region, i64)>
         return Some((Region::FivePrimeUtr, pos.base));
     }
     if pos.base > 0 {
-        return Some((Region::Cds, pos.base));
+        return Some((Region::Rna, pos.base));
     }
     None
 }
@@ -490,7 +492,7 @@ fn build_tx_merged(template: &TxVariant, merged: Anchor) -> TxVariant {
 
 fn build_rna_merged(template: &RnaVariant, merged: Anchor) -> RnaVariant {
     let (location, edit) = build_naedit(merged, |region, b| match region {
-        Region::Cds | Region::FivePrimeUtr => RnaPos::new(b),
+        Region::Rna | Region::FivePrimeUtr => RnaPos::new(b),
         Region::ThreePrimeUtr => RnaPos::utr3(b),
         _ => unreachable!("non-r. region {:?} on RnaVariant", region),
     });


### PR DESCRIPTION
## Summary

- `simple_rna_pos` returned `Region::Cds` for `r.` positive bases. The label was misleading — RNA isn't CDS-keyed — and `Region` is shared by `merge.rs` and (after #147) `overlap.rs` as a grouping key, so a label that hides which coord-system produced it invites confusion the moment the enum is reused outside the merge path.
- Add a dedicated `Region::Rna` variant. `simple_rna_pos` returns it for `pos.base > 0`; `build_rna_merged` accepts `Region::Rna | Region::FivePrimeUtr` to construct `RnaPos::new(b)`. The `c.` CDS-proper path is unchanged (still `Region::Cds`).
- Codon-frame check at line 120 stays `Region::Cds`-only. `same_accession_and_kind` already keeps `c.` and `r.` anchors in disjoint chains, so the variant addition is purely a labeling improvement with no behavioral change.

Closes #168.

## Test plan

- [x] `cargo nextest run --features dev` — 3818 passed, 51 skipped, 0 failed
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Targeted: `binary(merge_consecutive_edits_tests)` — 56 passed (covers both `c.` and `r.` merge paths, including the codon-frame exception that still keys on `Region::Cds`)