### PR TITLE
test: drop ferro_version from HGVS spec fixture

### DIFF
--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -802,7 +802,6 @@ mod render {
     struct Document<'a> {
         description: &'a str,
         spec: SpecBlock<'a>,
-        ferro_version: &'a str,
         generated_utc: String,
         summary: Summary,
         rows: &'a [runner::Row],
@@ -865,7 +864,6 @@ mod render {
                 tag: "21.0.0",
                 commit_sha,
             },
-            ferro_version: env!("CARGO_PKG_VERSION"),
             generated_utc: "fixture-byte-stable".to_string(),
             summary,
             rows,

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -5,7 +5,6 @@
     "tag": "21.0.0",
     "commit_sha": "a32f970d1d2eb14248c97a50d32c0974e3bb1daf"
   },
-  "ferro_version": "0.4.1",
   "generated_utc": "fixture-byte-stable",
   "summary": {
     "total": 823,


### PR DESCRIPTION
## Summary

The HGVS v21.0 spec fixture (`tests/fixtures/grammar/hgvs_spec_normalization.json`) embeds a `ferro_version` field generated from `env!("CARGO_PKG_VERSION")`. Every Cargo.toml version bump therefore makes the on-disk fixture stale relative to a freshly regenerated one, and the CI step **Verify HGVS v21.0 fixture is up to date** fails on every release-plz PR (most recently [#112](https://github.com/fulcrumgenomics/ferro-hgvs/pull/112) for v0.5.0) even though no normalizer behavior has drifted.

The version metadata isn't part of the normalization contract the fixture pins — it's noise that turns the drift check into a footgun. Dropping it from both the generator and the JSON makes `--check` insensitive to version bumps. The spec submodule's tag/commit_sha (which *is* meaningful for what the fixture pins) is preserved.

Net change: 3 lines deleted.

- `examples/generate_spec_fixture.rs`: remove `ferro_version` from the `Document` struct and its initialization
- `tests/fixtures/grammar/hgvs_spec_normalization.json`: remove the `ferro_version: "0.4.1"` line (regenerated)

## Test plan

- [x] `cargo run --features dev --example generate_spec_fixture` regenerates the fixture without `ferro_version`
- [x] `cargo run --features dev --example generate_spec_fixture -- --check` passes (no drift)
- [x] `cargo test --features dev --test hgvs_spec_normalization_tests --test idempotency_tests --test mito_circular_audit --test protein_unknown_roundtrip --test protein_silent_eq` — all 47 tests across these suites pass
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --features dev --all-targets -- -D warnings` passes
- [ ] Once this lands, rebase #112 and confirm the `Test` job's fixture-drift step is green

## Followup

This fixes the symptom for release-plz PRs but not the broader class — any feature PR that changes normalizer output without regenerating the fixture will still land on main and only fail the *next* PR's check. Worth considering a pre-commit / pre-push hook that runs the `--check` locally, and verifying the CI step is configured as a required check on `main`.