### PR TITLE
fix(ci): drop redundant `#[allow(dead_code)]` on `mod common;`

### DIFF
--- a/tests/issue_132_cyclic_rotation_insertion.rs
+++ b/tests/issue_132_cyclic_rotation_insertion.rs
@@ -6,7 +6,6 @@
 //! handles this; this file pins the single-copy fix and the round-trip
 //! equivalence between rotation-mismatched alts and the matched alt.
 
-#[allow(dead_code)]
 mod common;
 
 use common::synthetic::{normalize_to_string, SyntheticBuilder};


### PR DESCRIPTION
## Summary

Clippy 1.95.0's `duplicated_attributes` lint is failing CI on `main` (and every PR that rebases on it). The offender is `tests/issue_132_cyclic_rotation_insertion.rs:9`, which carries `#[allow(dead_code)]` on its `mod common;` import — redundant because `tests/common/mod.rs` already applies `#![allow(dead_code)]` as an inner attribute.

```
error: duplicated attribute
  --> tests/common/mod.rs:16:10
   |
16 | #![allow(dead_code)]
   |          ^^^^^^^^^
   |
note: first defined here
  --> tests/issue_132_cyclic_rotation_insertion.rs:9:9
   |
 9 | #[allow(dead_code)]
   |         ^^^^^^^^^
```

All other integration tests that do `mod common;` (e.g. `clinvar_hgvs_tests.rs`, `cmrg_exhaustive_tests.rs`, `del_shift_matrix.rs`, `dup_shift_matrix.rs`, `ins_repeat_b1_matrix.rs`, `ins_shift_matrix.rs`, `paraphase_exhaustive_tests.rs`) rely on the inner attribute alone — this brings `issue_132_cyclic_rotation_insertion.rs` in line with them.

Verified locally with `cargo clippy --features dev --all-targets -- -D warnings`.

## Test plan

- [x] `cargo clippy --features dev --all-targets -- -D warnings` passes locally
- [ ] CI Clippy job passes on this PR