### PR TITLE
fix(normalize): apply 3' rule to allele-merged del/dup/ins (#180)

### DIFF
--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -50,10 +50,16 @@ pub struct NormalizeConfig {
     /// Window size for reference sequence fetching
     pub window_size: u64,
 
-    /// Whether to prevent overlaps in compound variant normalization
+    /// Vestigial overlap-prevention flag retained for source compatibility.
     ///
-    /// When true, normalization will check if variants in an allele would overlap
-    /// after shifting and constrain the normalization to prevent collisions.
+    /// Overlap is now prevented structurally: `normalize_allele` merges
+    /// adjacent sub-variants before the per-variant pipeline runs, and
+    /// `merge_consecutive_edits` uses a strict `prev.end + 1 == next.start`
+    /// adjacency rule, so the normalizer cannot emit overlapping ranges
+    /// from non-overlapping inputs. Detection of input-time overlap is
+    /// handled unconditionally by `detect_overlap_conflicts`. This field
+    /// has no effect and is preserved only so existing callers (notably
+    /// `with_overlap_prevention`) keep compiling.
     pub prevent_overlap: bool,
 }
 
@@ -148,7 +154,13 @@ impl NormalizeConfig {
         self
     }
 
-    /// Enable overlap prevention in compound variants
+    /// Set the vestigial `prevent_overlap` flag.
+    ///
+    /// This builder is retained only for source compatibility with existing
+    /// callers. The flag has no runtime effect: overlap prevention is handled
+    /// structurally by `normalize_allele`, `merge_consecutive_edits`, and
+    /// `detect_overlap_conflicts`. See [`NormalizeConfig::prevent_overlap`]
+    /// for details.
     pub fn with_overlap_prevention(mut self, prevent: bool) -> Self {
         self.prevent_overlap = prevent;
         self

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -61,22 +61,6 @@ fn has_unknown_offset_cds(pos: &CdsPos) -> bool {
     )
 }
 
-/// Whether a variant carries a pure `Deletion` edit (no inserted sequence).
-///
-/// Used by the cis-allele post-merge step to decide whether to re-apply
-/// the 3'-rule to a freshly-merged anchor (issue #161).
-fn is_pure_deletion(v: &HgvsVariant) -> bool {
-    let edit = match v {
-        HV::Genome(g) => g.loc_edit.edit.inner(),
-        HV::Cds(c) => c.loc_edit.edit.inner(),
-        HV::Tx(t) => t.loc_edit.edit.inner(),
-        HV::Rna(r) => r.loc_edit.edit.inner(),
-        HV::Mt(m) => m.loc_edit.edit.inner(),
-        _ => None,
-    };
-    matches!(edit, Some(NaEdit::Deletion { .. }))
-}
-
 /// Check if a TxPos has an unknown (?) offset sentinel value
 fn has_unknown_offset_tx(pos: &TxPos) -> bool {
     matches!(
@@ -282,36 +266,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         allele: &crate::hgvs::variant::AlleleVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
-        // First pass: normalize each variant independently, collecting all warnings
+        // Merge first, then normalize each result through the full per-variant
+        // pipeline. Pre-normalizing each bracket entry would shift it
+        // independently of its siblings, which can collapse adjacent edits
+        // onto the same 3'-end position (e.g. `[260delA;261delA]` →
+        // `[264del;264del]`) and defeat the strict-adjacency merge. Issue #180.
+        //
+        // Order:
+        //   1. merge raw bracket entries by positional adjacency
+        //   2. cis-only: decompose merged delins into [..., inv, ...] (#160)
+        //   3. run the full per-variant pipeline on every result — this is
+        //      what applies the HGVS 3' rule to the merged anchor (#161, #180)
+        //   4. detect post-shift overlaps and emit warnings
         let mut all_warnings = Vec::new();
-        let mut normalized = Vec::new();
-
-        for v in &allele.variants {
-            let result = self.normalize_with_warnings(v)?;
-            all_warnings.extend(result.warnings);
-            normalized.push(result.result);
-        }
-
-        // Second pass: check for overlaps and resolve
-        if self.config.prevent_overlap {
-            normalized = self.resolve_overlaps(normalized)?;
-        }
-
-        // Detect coincident-bounds conflicts (issue #81 A8). Runs after per-variant
-        // normalization so post-shift collisions are caught the same as input-time
-        // ones; emits OVERLAP_CONFLICTING_EDITS warnings, leaves output unchanged.
-        all_warnings.extend(crate::normalize::overlap::detect_overlap_conflicts(
-            &normalized,
-            allele.phase,
-        ));
-
-        // HGVS requires consecutive edits in cis to render as a single delins.
-        // Track input length so we only unwrap when a merge actually collapsed
-        // multiple sub-variants — not for pre-existing singleton alleles, which
-        // must round-trip with the Allele wrapper intact for programmatic callers
-        // (Display already renders singletons in bare form regardless).
-        let original_len = normalized.len();
-        let merged_raw = merge::merge_consecutive_edits(normalized, allele.phase, &self.provider);
+        let original_len = allele.variants.len();
+        let merged_raw =
+            merge::merge_consecutive_edits(allele.variants.clone(), allele.phase, &self.provider);
 
         // Issue #160: any merged delins (or pre-existing delins that survived
         // merge unchanged) may decompose into [..., inv, ...] when an inv-
@@ -319,145 +289,56 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // helper is a no-op for non-Delins variants and for Delins without an
         // inv sub-span. Only applies in cis phase — trans alleles aren't
         // collapsible in the first place.
-        let mut merged: Vec<HgvsVariant> = Vec::with_capacity(merged_raw.len());
-        if allele.phase == crate::hgvs::variant::AllelePhase::Cis {
-            for v in merged_raw {
-                merged.extend(self.split_inv_for_variant(v));
-            }
-        } else {
-            merged = merged_raw;
+        let merged_split: Vec<HgvsVariant> =
+            if allele.phase == crate::hgvs::variant::AllelePhase::Cis {
+                merged_raw
+                    .into_iter()
+                    .flat_map(|v| self.split_inv_for_variant(v))
+                    .collect()
+            } else {
+                merged_raw
+            };
+
+        // Per-variant pipeline on every merged result. This is the single
+        // canonical place where the 3' rule, ins→dup canonicalization, ref
+        // validation, etc. apply — a merged variant is semantically a new
+        // variant and goes through the same pipeline as any direct input.
+        let mut normalized: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
+        for v in merged_split {
+            let r = self.normalize_with_warnings(&v)?;
+            all_warnings.extend(r.warnings);
+            normalized.push(r.result);
         }
 
-        // The HGVS 3'-rule requires the most-3' position possible — and that
-        // applies to the post-merge form, not just the per-variant inputs.
-        // When merge collapses adjacent single-base deletions into one
-        // ranged Deletion, that fresh anchor must reach its rotation
-        // fixed point. (Issue #161.)
-        //
-        // We restrict the re-normalize to merged Deletions specifically.
-        // Other merged forms (delins from sub+sub, delins from sub+ins,
-        // pure ins, etc.) are produced by the merge layer in their
-        // intended form; sending them back through `normalize_with_warnings`
-        // would re-canonicalize delins and traverse coord-system paths
-        // that are out of scope for this issue.
-        if merged.len() < original_len {
-            let mut renormalized = Vec::with_capacity(merged.len());
-            for v in merged {
-                if is_pure_deletion(&v) {
-                    let r = self.normalize_with_warnings(&v)?;
-                    all_warnings.extend(r.warnings);
-                    renormalized.push(r.result);
-                } else {
-                    renormalized.push(v);
-                }
-            }
-            merged = renormalized;
-        }
+        // Overlap detection runs post-shift so collisions caused by the
+        // 3' shift surface alongside input-time ones. Overlap *prevention*
+        // is structural — the merge-first ordering above plus the strict
+        // `prev.end + 1 == next.start` adjacency check in
+        // `merge_consecutive_edits` make it impossible for the normalizer
+        // to emit overlapping ranges from non-overlapping inputs.
+        all_warnings.extend(crate::normalize::overlap::detect_overlap_conflicts(
+            &normalized,
+            allele.phase,
+        ));
 
+        // HGVS requires consecutive edits in cis to render as a single edit.
+        // Only unwrap when a merge actually collapsed multiple sub-variants —
+        // pre-existing singleton alleles must round-trip with the Allele
+        // wrapper intact for programmatic callers (Display already renders
+        // singletons in bare form regardless).
         let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
             && original_len > 1
-            && merged.len() == 1
+            && normalized.len() == 1
         {
-            merged.pop().unwrap()
+            normalized.pop().unwrap()
         } else {
             HgvsVariant::Allele(crate::hgvs::variant::AlleleVariant::new(
-                merged,
+                normalized,
                 allele.phase,
             ))
         };
 
         Ok((result, all_warnings))
-    }
-
-    /// Resolve overlaps between normalized variants in a compound allele.
-    ///
-    /// When normalization shifts variants, they may end up overlapping. This function
-    /// detects overlaps and constrains the normalization to prevent collisions.
-    fn resolve_overlaps(&self, variants: Vec<HgvsVariant>) -> Result<Vec<HgvsVariant>, FerroError> {
-        if variants.len() < 2 {
-            return Ok(variants);
-        }
-
-        // Extract positions for comparison
-        let mut positions: Vec<(usize, Option<(u64, u64)>)> = variants
-            .iter()
-            .enumerate()
-            .map(|(i, v)| (i, self.extract_position_range(v)))
-            .collect();
-
-        // Sort by start position
-        positions.sort_by(|a, b| match (&a.1, &b.1) {
-            (Some((s1, _)), Some((s2, _))) => s1.cmp(s2),
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => std::cmp::Ordering::Equal,
-        });
-
-        // Check for overlaps and mark variants that need adjustment
-        let mut needs_adjustment = vec![false; variants.len()];
-
-        for i in 0..positions.len() - 1 {
-            let (_idx_a, pos_a) = &positions[i];
-            let (idx_b, pos_b) = &positions[i + 1];
-
-            if let (Some((_, end_a)), Some((start_b, _))) = (pos_a, pos_b) {
-                // Check for overlap: end of A >= start of B
-                if end_a >= start_b {
-                    // Mark the second variant for potential adjustment
-                    needs_adjustment[*idx_b] = true;
-                }
-            }
-        }
-
-        // For now, we report overlaps but don't modify the variants
-        // A more sophisticated implementation would re-normalize with constraints
-        // or report a warning
-        for (i, needs_adj) in needs_adjustment.iter().enumerate() {
-            if *needs_adj {
-                // In a complete implementation, we would constrain normalization
-                // For now, we preserve the variant as-is with a potential warning
-                // Future: add to a warnings collection
-                let _ = i; // Suppress unused variable warning
-            }
-        }
-
-        Ok(variants)
-    }
-
-    /// Extract the genomic/CDS position range from a variant.
-    fn extract_position_range(&self, variant: &HgvsVariant) -> Option<(u64, u64)> {
-        match variant {
-            HV::Genome(v) => {
-                let start = v.loc_edit.location.start.inner()?.base;
-                let end = v.loc_edit.location.end.inner()?.base;
-                Some((start, end))
-            }
-            HV::Cds(v) => {
-                let start_pos = v.loc_edit.location.start.inner()?;
-                let end_pos = v.loc_edit.location.end.inner()?;
-                // Only return positions for exonic, non-UTR variants
-                if start_pos.is_intronic()
-                    || end_pos.is_intronic()
-                    || start_pos.base < 1
-                    || end_pos.base < 1
-                {
-                    None
-                } else {
-                    Some((start_pos.base as u64, end_pos.base as u64))
-                }
-            }
-            HV::Tx(v) => {
-                let start = v.loc_edit.location.start.inner()?.base;
-                let end = v.loc_edit.location.end.inner()?.base;
-                // Only return positions for positive bases (within transcript)
-                if start < 1 || end < 1 {
-                    None
-                } else {
-                    Some((start as u64, end as u64))
-                }
-            }
-            _ => None,
-        }
     }
 
     /// Normalize a genomic variant
@@ -2207,35 +2088,72 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         }
                     }
 
-                    // Check for cyclic-rotation single-copy duplication (issue #132).
-                    // When the inserted alt is a phase-mismatched cyclic rotation of an
-                    // adjacent reference repeat unit, shuffle's first-base check fails
-                    // (`alt[0] != ref[ins_point]`) and the variant never moves. The
-                    // 2+-copy path (`insertion_to_repeat`, above) already iterates
-                    // rotations; do the same for the single-copy case here so the
-                    // variant canonicalizes to the most-3' rotation-aligned dup slot.
+                    // Resolve insertion → duplication canonicalization. Three candidate
+                    // dup positions compete; we pick by the rules below in order.
                     //
-                    // Use the ORIGINAL position (start, 1-based HGVS), not the post-shuffle
-                    // result.start, because rotation iteration relies on the unmoved
-                    // insertion point. This is symmetric with the call to
-                    // `insertion_to_repeat` above.
+                    // (a) Tract-aligned dup via `insertion_to_duplication` (uses the
+                    //     ORIGINAL insertion point and finds the maximal tandem run
+                    //     under any cyclic rotation of the alt). When the tract has
+                    //     `ref_count >= 2` we prefer this regardless of how far
+                    //     shuffle walked: the multi-copy tract has a meaningful phase
+                    //     that the spec-canonical form preserves (issue #132).
+                    //
+                    // (b) Post-shuffle simple dup via `insertion_is_duplication`. When
+                    //     shuffle walked past a single-copy tract via partial-match
+                    //     extension (e.g. TGATC abutting TGAAG — first three bases
+                    //     match but the fourth does not), the post-shuffle position is
+                    //     more 3' than (a)'s tract-aligned position and is the canonical
+                    //     answer per the 3' rule (issue #180).
+                    //
+                    // (c) Single-copy tract fallback (`insertion_to_duplication` with
+                    //     `ref_count == 1`). Hit when shuffle stalled before completing
+                    //     one alt rotation (so (b) doesn't find a dup at the post-
+                    //     shuffle position) but the alt does match an adjacent ref unit
+                    //     at the ORIGINAL position. Example: ins AACA abutting AACA.
+                    //
+                    // If none match, fall through to ins (possibly rotated).
                     let original_pos_idx = hgvs_pos_to_index(start) as u64;
-                    if let Some(rules::InsToDupResult {
-                        unit: _,
-                        start: dup_start,
-                        end: dup_end,
-                    }) = rules::insertion_to_duplication(ref_seq, original_pos_idx, &seq_bytes)
-                    {
-                        return Ok((
-                            dup_start,
-                            dup_end,
-                            NaEdit::Duplication {
-                                sequence: None,
-                                length: None,
-                                uncertain_extent: None,
-                            },
-                            warnings,
-                        ));
+                    let ins_to_dup =
+                        rules::insertion_to_duplication(ref_seq, original_pos_idx, &seq_bytes);
+
+                    // Codon-frame gate (repeated.md): in c., if the alt is
+                    // >=2 copies of a non-codon-aligned unit, the spec
+                    // mandates ins<literal>, not dup. The smallest-unit
+                    // length is rotation-invariant, so we can compute it
+                    // once from `seq_bytes` and apply the same gate at
+                    // every dup-emission site below. In practice the gate
+                    // never fires when `ins_to_dup` is `Some` (that helper
+                    // only returns for single-unit alts, where
+                    // `smallest_unit.len() == seq_bytes.len()`), but we
+                    // guard the (a) fast path and (c) single-copy fallback
+                    // anyway so the spec rule is explicit at each site and
+                    // survives future changes to `insertion_to_duplication`.
+                    let smallest_unit = rules::smallest_repeat_unit(&seq_bytes);
+                    let codon_blocks_dup = is_coding
+                        && smallest_unit.len() < seq_bytes.len()
+                        && !smallest_unit.len().is_multiple_of(3);
+
+                    if !codon_blocks_dup {
+                        if let Some(rules::InsToDupResult {
+                            start: dup_start,
+                            end: dup_end,
+                            ref_count,
+                            ..
+                        }) = ins_to_dup.as_ref()
+                        {
+                            if *ref_count >= 2 {
+                                return Ok((
+                                    *dup_start,
+                                    *dup_end,
+                                    NaEdit::Duplication {
+                                        sequence: None,
+                                        length: None,
+                                        uncertain_extent: None,
+                                    },
+                                    warnings,
+                                ));
+                            }
+                        }
                     }
 
                     // Check for simple duplication (single-base or matching adjacent)
@@ -2254,15 +2172,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         seq_bytes.clone()
                     };
 
-                    // Codon-frame gate (repeated.md): in c., if the rotated
-                    // insertion is >=2 copies of a non-codon-aligned unit, the
-                    // spec mandates ins<literal>, not dup. Skip dup conversion
-                    // in that case so the caller falls through to the literal
-                    // ins emission below.
-                    let smallest_unit = rules::smallest_repeat_unit(&rotated_seq);
-                    let codon_blocks_dup = is_coding
-                        && smallest_unit.len() < rotated_seq.len()
-                        && !smallest_unit.len().is_multiple_of(3);
                     if !codon_blocks_dup
                         && rules::insertion_is_duplication(ref_seq, result.start, &rotated_seq)
                     {
@@ -2281,6 +2190,27 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             dup_end,
                             NaEdit::Duplication {
                                 sequence: None, // Minimal notation - no explicit sequence
+                                length: None,
+                                uncertain_extent: None,
+                            },
+                        )
+                    } else if let Some(rules::InsToDupResult {
+                        start: dup_start,
+                        end: dup_end,
+                        ..
+                    }) = ins_to_dup.as_ref().filter(|_| !codon_blocks_dup)
+                    {
+                        // (c) Single-copy tract fallback. Reached when (a) declined
+                        // because `ref_count < 2` and (b) declined because the post-
+                        // shuffle rotated alt doesn't match adjacent reference. The
+                        // alt is a (possibly rotated) tandem unit abutting a single-
+                        // copy ref tract at the original insertion point — emit the
+                        // dup over that tract.
+                        (
+                            *dup_start,
+                            *dup_end,
+                            NaEdit::Duplication {
+                                sequence: None,
                                 length: None,
                                 uncertain_extent: None,
                             },
@@ -4620,19 +4550,6 @@ mod tests {
         };
         let result = normalizer.cds_to_tx_pos(&pos, 5, Some(38));
         assert_eq!(result.unwrap(), 2);
-    }
-
-    #[test]
-    fn test_variant_positions_negative_cds_base() {
-        // CDS variant with negative base should return None from variant_positions
-        let provider = MockProvider::with_test_data();
-        let normalizer = Normalizer::new(provider);
-        let variant = parse_hgvs("NM_001234.1:c.-3A>G").unwrap();
-        let positions = normalizer.extract_position_range(&variant);
-        assert_eq!(
-            positions, None,
-            "variant_positions should return None for 5' UTR CDS positions"
-        );
     }
 
     #[test]

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -239,6 +239,13 @@ pub(crate) struct InsToDupResult {
     /// 1-based HGVS end of the most-3' unit-aligned duplication position
     /// inside the rotation-aligned reference tract (inclusive).
     pub end: u64,
+    /// Number of full reference copies of `unit` in the chosen tract. The
+    /// caller uses this to decide whether the tract-aligned dup position
+    /// should win over a post-shuffle simple-dup candidate: a multi-copy
+    /// tract (`ref_count >= 2`) has a meaningful phase that must be
+    /// preserved; a single-copy tract is just one unit, and a longer
+    /// post-shuffle partial-match extension is more 3' (issue #180).
+    pub ref_count: u64,
 }
 
 /// Compute the canonical 3'-rule duplication position for a single-copy
@@ -307,6 +314,7 @@ pub(crate) fn insertion_to_duplication(
         unit,
         start: index_to_hgvs_pos(dup_start_idx),
         end: index_to_hgvs_pos(dup_end_idx),
+        ref_count,
     })
 }
 

--- a/tests/ins_repeat_b1_matrix.rs
+++ b/tests/ins_repeat_b1_matrix.rs
@@ -115,6 +115,20 @@ mod cds_plus {
     }
 
     #[rstest]
+    fn single_copy_ins_dinucleotide_unit_in_multi_copy_tract_emits_dup() {
+        // Single-copy alt of a codon-misaligned unit (len=2) abutting a
+        // multi-copy AT tract. The 3'-rule fast path (`ref_count >= 2` in
+        // `insertion_to_duplication`) emits `dup` at the tract-aligned 3'-most
+        // position; the codon-frame gate does NOT block single-copy
+        // additions, since the gate fires only when the alt itself is >=2
+        // copies of a non-codon-aligned unit. Regression lock-in for the
+        // codon_blocks_dup guard applied to the fast path.
+        let p = provider("CATATATCACGTACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NM_TEST.1:c.{0}_{1}insAT", &[1, 2]));
+        assert_eq!(result, hgvs("NM_TEST.1:c.{0}_{1}dup", &[6, 7]));
+    }
+
+    #[rstest]
     fn multi_copy_ins_codon_unit_passes_in_cds() {
         // unit_len=3, codon-aligned: gate is no-op, repeat notation fires.
         let p = provider("CCAGCAGCAGTACGTACGTAC");

--- a/tests/issue_180_allele_3prime_shift.rs
+++ b/tests/issue_180_allele_3prime_shift.rs
@@ -1,0 +1,275 @@
+//! Issue #180 / #181: 3' shifting of del/dup/ins produced by allele-bracket merge.
+//!
+//! When consecutive edits inside an allele bracket merge into a `del`, `dup`,
+//! or `ins`, the HGVS 3' rule still applies to the merged form. Before this
+//! fix, only merged pure deletions were re-shifted; merged insertions (and
+//! merged delins that canonicalize into a shiftable form) skipped the shift.
+//!
+//! The pre-fix code also ran the per-element 3' shift *before* merge, which
+//! could collapse adjacent edits onto the same shifted position and emit
+//! outputs with duplicate or overlapping positions — invalid HGVS. Issue
+//! #181 documented that failure mode; the fix here (merge first, then run
+//! the per-variant pipeline on every merged result) resolves both #180 and
+//! #181 with one ordering change.
+//!
+//! Examples below use synthetic genomic providers via `SyntheticBuilder`,
+//! which pads the core with 256 bases so HGVS pos 257 maps to core base 1.
+
+mod common;
+
+use common::synthetic::{normalize_to_string, SyntheticBuilder};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// HGVS sequence-id used by `SyntheticBuilder::genomic`.
+const SEQID: &str = "NC_TEST.1";
+
+/// Core from issue #180's deletion examples (positions 1337..1351 in the
+/// issue map to HGVS pos 257..271 here): `CCCAAAAATAAACGC` — a 5-A
+/// homopolymer at HGVS 260..264, a T at 265, then AAA at 266..268.
+const CORE_DEL: &str = "CCCAAAAATAAACGC";
+
+/// Core from issue #180's duplication example (positions 1048..1065 in the
+/// issue map to HGVS pos 257..274 here): `ACCTATGATCTGAAGAGC`. The inserted
+/// `TGATC` between 261 and 262 matches the reference at 262..266, then
+/// shifts right through TGATC|TGAAG until 265..269.
+const CORE_DUP: &str = "ACCTATGATCTGAAGAGC";
+
+// ---------------------------------------------------------------------------
+// Deletions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allele_two_single_dels_shift_to_3prime_end_of_homopolymer() {
+    // Issue example 1: [260delA;261delA] merges to 260_261del. The 3' shift
+    // through the A-run then composes with the homopolymer-repeat
+    // canonicalization (matching del_shift_matrix's "k>1 in homopolymer →
+    // repeat" rule) to produce 260_264A[3] — the 5-A tract at HGVS 260..264
+    // becomes A[3] (3 A's remaining after deletion of 2).
+    let p = SyntheticBuilder::genomic(CORE_DEL).build();
+    let result = normalize_to_string(p, &format!("{}:g.[260delA;261delA]", SEQID));
+    assert_eq!(result, format!("{}:g.260_264A[3]", SEQID));
+}
+
+#[test]
+fn allele_seven_single_dels_spanning_run_boundary_shift_3prime() {
+    // Issue example 2: 7-base deletion spanning the A-run, the T, and one A
+    // of the AAA run. Merges to 260_266del, then 3'-shifts to 262_268del.
+    let p = SyntheticBuilder::genomic(CORE_DEL).build();
+    let result = normalize_to_string(
+        p,
+        &format!(
+            "{}:g.[260delA;261delA;262delA;263delA;264delA;265delT;266delA]",
+            SEQID
+        ),
+    );
+    assert_eq!(result, format!("{}:g.262_268del", SEQID));
+}
+
+#[test]
+fn allele_single_del_in_bracket_shifts_to_3prime_end_of_run() {
+    // Issue example 3: a singleton allele [260delA] currently emits 260del.
+    // Per the 3' rule it must shift to 264del (last A of the 5-A run).
+    let p = SyntheticBuilder::genomic(CORE_DEL).build();
+    let result = normalize_to_string(p, &format!("{}:g.[260delA]", SEQID));
+    assert_eq!(result, format!("{}:g.264del", SEQID));
+}
+
+// ---------------------------------------------------------------------------
+// Duplications (canonicalized from insertion)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allele_ins_canonicalized_to_dup_then_shifted_3prime() {
+    // Issue dup example: [261_262insTGATC] canonicalizes to 262_266dup, then
+    // 3'-shifts through TGATC|TGAAG until ref[265]=T != ref[270]=A, leaving
+    // 265_269dup.
+    let p = SyntheticBuilder::genomic(CORE_DUP).build();
+    let result = normalize_to_string(p, &format!("{}:g.[261_262insTGATC]", SEQID));
+    assert_eq!(result, format!("{}:g.265_269dup", SEQID));
+}
+
+// ---------------------------------------------------------------------------
+// Issue #181: no duplicate / overlapping positions in cis output.
+//
+// Same root cause as #180 (per-element 3' shift running before merge), but
+// surfaces as *invalid HGVS output* — duplicate positions, overlapping
+// ranges — rather than as a missed canonical form. The patterns below
+// reproduce #181's three examples at the literal positions cited there.
+// Cores are padded so HGVS pos N maps to core idx (N - 257); we use
+// non-homopolymer filler (alternating CGCT) so the only shiftable run is
+// the homopolymer we plant at the target positions.
+// ---------------------------------------------------------------------------
+
+/// Build a core where `snippet` lands at the requested HGVS position.
+///
+/// Prefix and trailing filler use a non-shiftable alternating pattern
+/// (CGCT) so the only run available to the 3' shift is the snippet itself.
+/// `hgvs_pos` is the 1-based HGVS coordinate where the first base of
+/// `snippet` should sit; the helper computes the prefix length as
+/// `hgvs_pos - 257` (since PAD_OFFSET=256 places core base 1 at HGVS 257).
+fn core_with_snippet_at(hgvs_pos: u64, snippet: &str, trail: usize) -> String {
+    let prefix_len = (hgvs_pos - 257) as usize;
+    let mut s = String::with_capacity(prefix_len + snippet.len() + trail);
+    for i in 0..prefix_len {
+        s.push(['C', 'G', 'C', 'T'][i % 4]);
+    }
+    s.push_str(snippet);
+    for i in 0..trail {
+        s.push(['C', 'G', 'C', 'T'][i % 4]);
+    }
+    s
+}
+
+/// Assert that no sub-variant repeats or overlaps another in a cis allele
+/// rendering. Catches the #181 anti-pattern (`[1220del;1220del]`,
+/// `[1054_1059del;1061del;1061del]`) regardless of which canonical form
+/// the normalizer happens to emit.
+fn assert_no_duplicate_or_overlap(rendered: &str) {
+    if !rendered.contains(";") {
+        return; // not a multi-element allele
+    }
+    // Extract the body between the first '[' and the last ']'.
+    let Some(open) = rendered.find('[') else {
+        return;
+    };
+    let Some(close) = rendered.rfind(']') else {
+        return;
+    };
+    let body = &rendered[open + 1..close];
+    // Parse `<start>(_<end>)?<op>...` from each `;`-separated element and
+    // collect inclusive position ranges. Anything that doesn't parse as a
+    // numeric range (e.g. `delins` strings) is ignored — sub-variants in
+    // a cis allele always lead with a positional anchor.
+    let mut ranges: Vec<(u64, u64)> = Vec::new();
+    for elt in body.split(';') {
+        let digits: String = elt.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if digits.is_empty() {
+            continue;
+        }
+        let start: u64 = digits.parse().unwrap();
+        let rest = &elt[digits.len()..];
+        let end = if let Some(stripped) = rest.strip_prefix('_') {
+            let d2: String = stripped
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            d2.parse().unwrap_or(start)
+        } else {
+            start
+        };
+        ranges.push((start, end));
+    }
+    ranges.sort();
+    for w in ranges.windows(2) {
+        let (_, end_a) = w[0];
+        let (start_b, _) = w[1];
+        assert!(
+            end_a < start_b,
+            "overlap or duplicate in cis allele output: {} (ranges {:?})",
+            rendered,
+            ranges
+        );
+    }
+}
+
+#[test]
+fn issue_181_example_1_adjacent_dels_no_duplicate_position() {
+    // Before the fix, ferro emitted `g.[1220del;1220del]` — same position
+    // twice, invalid HGVS. With merge-first ordering the two dels collapse
+    // to `1216_1217del` over the A-run at 1216..1220 and then 3'-shift,
+    // canonicalizing into the repeat form `1216_1220A[3]` (5 A's → 3 A's
+    // after deleting 2). The validity invariant: no sub-variant repeats.
+    let core = core_with_snippet_at(1216, "AAAAA", 100);
+    let p = SyntheticBuilder::genomic(&core).build();
+    let result = normalize_to_string(p, &format!("{}:g.[1216del;1217del]", SEQID));
+    assert_eq!(result, format!("{}:g.1216_1220A[3]", SEQID));
+    assert_no_duplicate_or_overlap(&result);
+}
+
+#[test]
+fn issue_181_example_2_eight_adjacent_dels_no_overlap() {
+    // Before the fix, ferro emitted `g.[1054_1059del;1061del;1061del]` —
+    // both a duplicate (`1061del` twice) and overlap between the merged
+    // 1054_1059 range and the subsequent 1061del. With merge-first
+    // ordering all 8 dels collapse into `1054_1061del` over the 10-A run
+    // and 3'-shift / repeat-canonicalize into `1054_1063A[2]`.
+    let core = core_with_snippet_at(1054, "AAAAAAAAAA", 100);
+    let p = SyntheticBuilder::genomic(&core).build();
+    let result = normalize_to_string(
+        p,
+        &format!(
+            "{}:g.[1054del;1055del;1056del;1057del;1058del;1059del;1060del;1061del]",
+            SEQID
+        ),
+    );
+    assert_eq!(result, format!("{}:g.1054_1063A[2]", SEQID));
+    assert_no_duplicate_or_overlap(&result);
+}
+
+#[test]
+fn issue_181_example_3_mixed_dels_and_ins_no_duplicate_position() {
+    // Before the fix, ferro emitted `g.[1006del;1008del;1008del;1010C[4]]`
+    // — `1008del` twice. With merge-first ordering the three adjacent
+    // dels collapse to `1006_1008del`; the trailing `1009_1010insCCC`
+    // does not fold into the del because the merge step's strict
+    // adjacency rule (`prev.end + 1 == next.start`) requires the
+    // insertion's anchored start (`p+1 = 1010`) to equal `prev.end + 1`,
+    // not `prev.end + 2`. Fully collapsing del+ins chains into a single
+    // delins is a separate improvement; here we pin the validity
+    // invariant — no duplicate or overlapping positions — which is what
+    // #181 was actually filed about.
+    let core = core_with_snippet_at(1006, "AGGTACGT", 100);
+    let p = SyntheticBuilder::genomic(&core).build();
+    let result = normalize_to_string(
+        p,
+        &format!("{}:g.[1006delA;1007delG;1008delG;1009_1010insCCC]", SEQID),
+    );
+    assert_eq!(
+        result,
+        format!("{}:g.[1006_1008del;1009_1010insCCC]", SEQID)
+    );
+    assert_no_duplicate_or_overlap(&result);
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency: a second normalization round must be a no-op.
+// ---------------------------------------------------------------------------
+
+fn normalize_twice(provider: MockProvider, input: &str) -> (String, String) {
+    let normalizer = Normalizer::new(provider);
+    let parsed = parse_hgvs(input).expect("parse");
+    let once = normalizer.normalize(&parsed).expect("normalize 1");
+    let twice = normalizer.normalize(&once).expect("normalize 2");
+    (once.to_string(), twice.to_string())
+}
+
+#[test]
+fn allele_norm_3prime_shift_is_idempotent() {
+    let cases: &[(String, String)] = &[
+        (CORE_DEL.to_string(), "g.[260delA;261delA]".to_string()),
+        (
+            CORE_DEL.to_string(),
+            "g.[260delA;261delA;262delA;263delA;264delA;265delT;266delA]".to_string(),
+        ),
+        (CORE_DEL.to_string(), "g.[260delA]".to_string()),
+        (CORE_DUP.to_string(), "g.[261_262insTGATC]".to_string()),
+        (
+            core_with_snippet_at(1216, "AAAAA", 100),
+            "g.[1216del;1217del]".to_string(),
+        ),
+        (
+            core_with_snippet_at(1054, "AAAAAAAAAA", 100),
+            "g.[1054del;1055del;1056del;1057del;1058del;1059del;1060del;1061del]".to_string(),
+        ),
+        (
+            core_with_snippet_at(1006, "AGGTACGT", 100),
+            "g.[1006delA;1007delG;1008delG;1009_1010insCCC]".to_string(),
+        ),
+    ];
+    for (core, tail) in cases {
+        let p = SyntheticBuilder::genomic(core).build();
+        let input = format!("{}:{}", SEQID, tail);
+        let (once, twice) = normalize_twice(p, &input);
+        assert_eq!(once, twice, "not idempotent for {}", input);
+    }
+}

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -764,25 +764,27 @@ fn provider_with_utr_transcript() -> MockProvider {
 fn test_merge_5utr_consecutive_subs_cds() {
     // `c.-2A>G;c.-1C>T` are physically adjacent within the 5'UTR.
     // No HGVS range crosses the 5'UTR/CDS boundary, but a range *within*
-    // the 5'UTR is valid (`c.-2_-1`); the merged form is a single delins.
+    // the 5'UTR is valid (`c.-2_-1`); the merged form is delinsGT, which
+    // is the reverse complement of the deleted AC → canonicalized to inv.
     assert_eq!(
         normalize_with_provider(
             provider_with_utr_transcript(),
             "NM_TESTUTR.1:c.[-2A>G;-1C>T]",
         ),
-        "NM_TESTUTR.1:c.-2_-1delinsGT",
+        "NM_TESTUTR.1:c.-2_-1inv",
     );
 }
 
 #[test]
 fn test_merge_3utr_consecutive_subs_cds() {
-    // `c.*1A>G;c.*2C>T` are physically adjacent within the 3'UTR.
+    // `c.*1A>G;c.*2C>T` are physically adjacent within the 3'UTR. Merged
+    // form `delinsGT` over deleted `AC` canonicalizes to inv (rev-comp).
     assert_eq!(
         normalize_with_provider(
             provider_with_utr_transcript(),
             "NM_TESTUTR.1:c.[*1A>G;*2C>T]",
         ),
-        "NM_TESTUTR.1:c.*1_*2delinsGT",
+        "NM_TESTUTR.1:c.*1_*2inv",
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #180.

Two related fixes so that del/dup/ins variants produced by allele-bracket merge get the same HGVS 3' canonicalization as direct inputs.

**1. Reorder `normalize_allele`: merge-first, then per-variant normalize.** The previous order pre-normalized each bracket entry first, which shifted singletons independently to their 3' ends (e.g. `[260delA;261delA]` → `[264del;264del]`) and broke the strict-adjacency merge. The deletion-only post-merge re-entry gate (introduced in #161 as a scope-limited fix) is removed: a merged variant is semantically a new variant and goes through the same per-variant canonicalization pipeline — `canonicalize_delins` → `shuffle` → `ins→dup` → `dup→repeat` — as any direct input. One pass suffices because that pipeline is already terminal.

**2. Fix per-variant `ins → dup` canonicalization in partial-match tracts.** When shuffle walks past a single-copy reference tract via partial-match extension (e.g. inserting `TGATC` next to `TGAAG` — first three bases of the alt match the ref, the fourth doesn't, so shuffle advances three extra positions past the 1-copy tract), the post-shuffle position is the canonical 3'-most dup, not the unshifted tract-aligned position that `insertion_to_duplication` returns. Multi-copy tracts (`ref_count >= 2`) still prefer the tract-aligned phase per #132. `InsToDupResult` now carries `ref_count` so the caller can pick:
1. tract-aligned dup when `ref_count >= 2` (multi-copy phase wins);
2. post-shuffle simple dup when (1) declines and the rotated alt matches adjacent ref (issue 180 case);
3. 1-copy tract fallback when (2) also declines (covers the `AACA`-abutting-`AACA` style cases and #132 cyclic rotations).

Two pre-existing UTR merge tests now legitimately get `inv` instead of `delinsGT` (the direct-delins → inv canonicalization rule, which already runs for direct inputs, now applies post-merge); expectations updated.

## Test plan

- [x] `cargo nextest run --features dev` — 4235 passed, 51 skipped, 0 failed
- [x] `cargo clippy --features dev -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] New file `tests/issue_180_allele_3prime_shift.rs` covers all three deletion examples and the duplication example from the issue body, plus an idempotency assertion that `normalize(normalize(v)) == normalize(v)` for the issue 180 inputs.