### PR TITLE
fix(normalize): group consecutive sub-flanks of inv-split into delins (#182)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -33,7 +33,7 @@ pub mod validate;
 
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
-use crate::hgvs::edit::{InsertedSequence, NaEdit};
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
 use crate::hgvs::interval::Interval;
 use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
@@ -2938,6 +2938,18 @@ fn build_variant_at(
 /// subedits are 0-indexed into the (per-variant-sized) ref slice; absolute
 /// 1-based HGVS positions are recovered as `offset + hgvs_start`, where
 /// `hgvs_start` is the variant's HGVS start position.
+///
+/// Consecutive `Substitution` sub-edits whose positions are strictly
+/// adjacent (no gap, no `Inversion` or `IdentityAt` between them) are
+/// grouped into a single `delins` variant per HGVS spec — `substitution.md`:
+/// "changes involving two or more consecutive nucleotides are described as
+/// deletion/insertion (delins)" (issue #182). Singleton sub-runs stay as
+/// `Substitution`; an `Inversion` or `IdentityAt` always breaks a run and
+/// emits separately. `Inversion` therefore acts as a hard barrier — adjacent
+/// sub flanks on either side of an inv are NOT re-merged into the inv span,
+/// preserving the inv-priority decomposition introduced by #166 (which was
+/// adopted to align with the spec's edit-priority list `general.md:45`:
+/// sub > del > inv > dup > ins).
 fn build_split_variants(
     template: &HgvsVariant,
     subedits: Vec<DelinsSubedit>,
@@ -2945,32 +2957,33 @@ fn build_split_variants(
 ) -> Vec<HgvsVariant> {
     let abs = |idx: usize| -> u64 { idx as u64 + hgvs_start };
 
-    subedits
-        .into_iter()
-        .filter_map(|se| match se {
+    let mut output: Vec<HgvsVariant> = Vec::new();
+    // Pending run of strictly-adjacent Substitution sub-edits, in
+    // left-to-right order. Each entry is `(position, reference, alternative)`
+    // with `position` the 0-indexed offset into the variant's ref window.
+    let mut run: Vec<(usize, Base, Base)> = Vec::new();
+
+    for se in subedits {
+        match se {
             DelinsSubedit::Substitution {
                 position,
                 reference,
                 alternative,
             } => {
-                let p = abs(position);
-                Some(build_variant_at(
-                    template,
-                    p,
-                    p,
-                    NaEdit::Substitution {
-                        reference,
-                        alternative,
-                    },
-                ))
+                let breaks_run = matches!(run.last(), Some((prev, _, _)) if *prev + 1 != position);
+                if breaks_run {
+                    flush_substitution_run(&mut output, template, hgvs_start, &mut run);
+                }
+                run.push((position, reference, alternative));
             }
             DelinsSubedit::Inversion { start, end } => {
+                flush_substitution_run(&mut output, template, hgvs_start, &mut run);
                 // Half-open 0-indexed [start, end) of length L=end-start.
                 // HGVS inclusive interval covers L bases starting at
                 // abs(start) and ending at abs(start)+L-1 = abs(end-1).
                 let s = abs(start);
                 let e = abs(end) - 1;
-                Some(build_variant_at(
+                output.push(build_variant_at(
                     template,
                     s,
                     e,
@@ -2978,15 +2991,65 @@ fn build_split_variants(
                         sequence: None,
                         length: None,
                     },
-                ))
+                ));
             }
             // Drop IdentityAt: an unchanged base is not an edit, so emitting
             // a `pos=` sub-variant would clutter the split allele. Both the
             // codon-frame-merge interior identity (issue #79) and the outer
-            // bases absorbed by `shorten_inversion` map to IdentityAt.
-            DelinsSubedit::IdentityAt { .. } => None,
-        })
-        .collect()
+            // bases absorbed by `shorten_inversion` map to IdentityAt. An
+            // identity also ends any in-flight substitution run — the gap
+            // means the surrounding subs are no longer "consecutive".
+            DelinsSubedit::IdentityAt { .. } => {
+                flush_substitution_run(&mut output, template, hgvs_start, &mut run);
+            }
+        }
+    }
+    flush_substitution_run(&mut output, template, hgvs_start, &mut run);
+    output
+}
+
+/// Flush a pending run of consecutive substitution sub-edits into `output`.
+/// A length-1 run emits a `Substitution`; a length-2+ run emits a single
+/// `Delins` over `[run.first.position, run.last.position]` with `sequence`
+/// = concatenated `alternative` bases. See `build_split_variants` for the
+/// spec rationale (issue #182).
+fn flush_substitution_run(
+    output: &mut Vec<HgvsVariant>,
+    template: &HgvsVariant,
+    hgvs_start: u64,
+    run: &mut Vec<(usize, Base, Base)>,
+) {
+    if run.is_empty() {
+        return;
+    }
+    let abs = |idx: usize| -> u64 { idx as u64 + hgvs_start };
+    if run.len() == 1 {
+        let (position, reference, alternative) = run.pop().unwrap();
+        let p = abs(position);
+        output.push(build_variant_at(
+            template,
+            p,
+            p,
+            NaEdit::Substitution {
+                reference,
+                alternative,
+            },
+        ));
+        return;
+    }
+    let s = abs(run.first().unwrap().0);
+    let e = abs(run.last().unwrap().0);
+    let alt_bases: Vec<Base> = run.drain(..).map(|(_, _, a)| a).collect();
+    output.push(build_variant_at(
+        template,
+        s,
+        e,
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
+            deleted: None,
+            deleted_length: None,
+        },
+    ));
 }
 
 /// Normalize DNA `T` and RNA `U` to a single byte (`T`) so byte-wise

--- a/tests/issue_182_postcanon_adjacency.rs
+++ b/tests/issue_182_postcanon_adjacency.rs
@@ -1,0 +1,172 @@
+//! Issue #182: post-canonicalization adjacency of substitution flanks
+//! produced by the inv-split pass (#160 / #166).
+//!
+//! When `decompose_delins_inv` splits a merged delins into `[…; inv; …]`,
+//! the non-inv positions are emitted as per-position `Substitution`
+//! sub-edits. Two or more strictly-adjacent (no gap) Substitutions in that
+//! emission stream represent a multi-nucleotide substitution and must
+//! render as a single `delins` per HGVS spec — `substitution.md`: "changes
+//! involving two or more consecutive nucleotides are described as
+//! deletion/insertion (delins)" / `delins.md`: same rule.
+//!
+//! The fix is local to `build_split_variants` (in `src/normalize/mod.rs`):
+//! it now groups runs of strictly-adjacent `Substitution` sub-edits into a
+//! single `Delins` variant. `Inversion` sub-edits remain a hard barrier —
+//! sub flanks on either side of an inv stay split, preserving the
+//! sub > del > **inv** > dup > ins priority rule (`general.md:45`) and the
+//! mutalyzer-aligned position adopted in #166. `IdentityAt` also breaks a
+//! run (a position-gap means the flanking subs are no longer "consecutive"
+//! per the spec's wording).
+//!
+//! Scope (deliberately narrow): this fix does NOT re-merge across an `inv`
+//! to re-form a flat delins. The broader "should adjacency to inv force
+//! delins?" question is tracked separately, gated on what SVD-WG010
+//! settles — see the pushback comment on issue #182 for rationale.
+
+mod common;
+
+use common::synthetic::{normalize_to_string, SyntheticBuilder};
+
+const SEQID: &str = "NC_TEST.1";
+
+// ---------------------------------------------------------------------------
+// Two adjacent sub flanks AFTER an inv → group into one delins
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_subs_trailing_an_inv_merge_to_delins() {
+    // Core "GACTTTTGAAG" places:
+    //   pos 257 G  258 A  259 C  (first sub run, no inv)
+    //   pos 260-263 TTTT (gap of 4 — barrier between the two runs)
+    //   pos 264 G  265 A  266 A  267 G  (second run, with 264_265 inv-eligible)
+    //
+    // Input merges to two delins after #80:
+    //   257_259delinsCCT, 264_267delinsTCCC
+    //
+    // 264_267delins: ref GAAG, alt TCCC.
+    //   - 264_265 ref GA / alt TC: revcomp(GA)=TC ✓ INV.
+    //   - 266 A → C : SUB.
+    //   - 267 G → C : SUB.
+    // The two trailing subs are strictly adjacent (266→267, gap=0) and
+    // must render as a single delinsCC per spec. The inv stays between
+    // the leading delins and the new trailing delins.
+    let p = SyntheticBuilder::genomic("GACTTTTGAAG").build();
+    let result = normalize_to_string(
+        p,
+        &format!(
+            "{}:g.[257G>C;258A>C;259C>T;264G>T;265A>C;266A>C;267G>C]",
+            SEQID
+        ),
+    );
+    assert_eq!(
+        result,
+        format!("{}:g.[257_259delinsCCT;264_265inv;266_267delinsCC]", SEQID)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Two adjacent sub flanks BEFORE an inv → group into one delins
+// ---------------------------------------------------------------------------
+
+#[test]
+fn two_subs_leading_an_inv_merge_to_delins() {
+    // Core "TCGACG" places ref T C G A C G at 257-262.
+    //   257 T>A  258 C>G  : two-base sub flank to the left of the inv
+    //   259 G>T  260 A>C  : 259_260 inv (revcomp(GA)=TC)
+    //   261 C>X  262 G>X  : (omitted to keep this test focused on the leading flank)
+    //
+    // Inputs cover only 257-260 so the trailing positions are unedited.
+    // Step #80 merges to 257_260delinsAGTC. Decompose:
+    //   - 257_258 TC→AG: revcomp(TC)=GA, no.
+    //   - 259_260 GA→TC: revcomp(GA)=TC ✓ INV.
+    //   Sub(257 T→A); Sub(258 C→G); Inv(259_260).
+    // The two leading subs (257, 258) are strictly adjacent → delinsAG.
+    let p = SyntheticBuilder::genomic("TCGACG").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258C>G;259G>T;260A>C]", SEQID));
+    assert_eq!(result, format!("{}:g.[257_258delinsAG;259_260inv]", SEQID));
+}
+
+// ---------------------------------------------------------------------------
+// Inv flanked on BOTH sides by two-sub runs → both flanks group, inv stays
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inv_flanked_by_two_sub_runs_each_side_groups_both_flanks() {
+    // Core "TCGACG" places ref T C G A C G at 257-262.
+    //   257 T>A  258 C>G  : two-base leading flank
+    //   259 G>T  260 A>C  : 259_260 inv (revcomp(GA)=TC)
+    //   261 C>A  262 G>T  : two-base trailing flank
+    //
+    // Step #80 merges to 257_262delinsAGTCAT. Decompose:
+    //   - 259_260 GA→TC ✓ INV (longest, picked greedily at i=259).
+    //   - i=257: no inv → Sub(257 T→A).
+    //   - i=258: no inv → Sub(258 C→G).
+    //   - i=261: no inv → Sub(261 C→A).
+    //   - i=262: out of range for inv (i+2 > n) → Sub(262 G→T).
+    // Both flanks are length-2 strictly-adjacent runs → each becomes a delins.
+    // The inv stays between them (not re-merged across — see #166 / general.md:45).
+    let p = SyntheticBuilder::genomic("TCGACG").build();
+    let result = normalize_to_string(
+        p,
+        &format!("{}:g.[257T>A;258C>G;259G>T;260A>C;261C>A;262G>T]", SEQID),
+    );
+    assert_eq!(
+        result,
+        format!("{}:g.[257_258delinsAG;259_260inv;261_262delinsAT]", SEQID)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Single-sub flank (length-1 run) stays as Substitution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_sub_flank_stays_as_substitution() {
+    // Core "TGAGC" at 257-261:
+    //   257 T  258 G  259 A  260 G  261 C
+    //
+    // Inputs cover 257-260 only. Step #80 merges to 257_260delinsATCC.
+    // Decompose: Sub(257 T→A); Inv(258_259); Sub(260 G→C). Each flank is a
+    // length-1 run → emits as Substitution, not delins (the spec rule
+    // requires "two or more consecutive nucleotides").
+    //
+    // 258_259 is non-palindromic (GA, revcomp TC). Length-2 palindromic
+    // candidates (CG, AT, GC, TA) collapse under `shorten_inversion` and
+    // are not emitted as Inversion sub-edits.
+    let p = SyntheticBuilder::genomic("TGAGC").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258G>T;259A>C;260G>C]", SEQID));
+    assert_eq!(result, format!("{}:g.[257T>A;258_259inv;260G>C]", SEQID));
+}
+
+// ---------------------------------------------------------------------------
+// IdentityAt breaks a substitution run
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identity_at_in_decomposition_breaks_sub_run() {
+    // Core "TGAGCC" at 257-262 produces a delins where the decomposer
+    // emits an IdentityAt between two Substitution sub-edits. The IdentityAt
+    // both (a) drops cleanly (no `g.<pos>=` emission) and (b) breaks the
+    // sub run so the bracketing subs do NOT group into a delins.
+    //
+    //   pos 257 T  258 G  259 A  260 G  261 C  262 C
+    //
+    // Inputs:
+    //   257 T>A     : leading sub flank (length 1)
+    //   258 G>T     : start of inv 258_259 (alt T)
+    //   259 A>C     : end   of inv 258_259 (alt C; revcomp(GA)=TC ✓)
+    //   260 G>G     : alt = ref → IdentityAt at 260
+    //   261 C>A     : trailing sub at 261
+    //   262 C>T     : (omitted — keeping the trailing run length 1 isolates
+    //                  the identity-breaks-run case from the run-grouping case)
+    //
+    // Expected merged delins: 257_261delinsATCGA.
+    // Decompose: Sub(257 T→A); Inv(258_259); IdentityAt(260); Sub(261 C→A).
+    // Output: [257T>A; 258_259inv; 261C>A] — IdentityAt drops, no spurious
+    // `260=` emission, and 261 stays a singleton Substitution (no run to
+    // group with — it's bracketed by the inv on the left and end-of-allele
+    // on the right).
+    let p = SyntheticBuilder::genomic("TGAGCC").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258G>T;259A>C;261C>A]", SEQID));
+    assert_eq!(result, format!("{}:g.[257T>A;258_259inv;261C>A]", SEQID));
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -4476,11 +4476,14 @@ mod issue_160_revcomp_inv_subspans {
         // ref AGACC at 1300-1304, alt CTAGT decomposes to
         // [Inv(0,2); Identity(2); Sub(3 C>G); Sub(4 C>T)] inside
         // decompose_delins_inv. The IdentityAt sub-edit must NOT render as a
-        // spurious `g.1302=` variant — the split allele should contain
-        // exactly the 3 real edits, in order.
+        // spurious `g.1302=` variant. Per issue #182, the trailing two
+        // strictly-adjacent Substitutions group into a single delins
+        // (substitution.md: "changes involving two or more consecutive
+        // nucleotides are described as deletion/insertion"). The IdentityAt
+        // at position 1302 still drops cleanly.
         let provider = provider_with_genomic("NC_000001.11", 1300, "AGACC");
         let result = normalize_to_string(provider, "NC_000001.11:g.1300_1304delinsCTAGT");
-        assert_eq!(result, "NC_000001.11:g.[1300_1301inv;1303C>G;1304C>T]");
+        assert_eq!(result, "NC_000001.11:g.[1300_1301inv;1303_1304delinsGT]");
     }
 
     #[test]


### PR DESCRIPTION
Scope-down for #182 — see the [pushback comment](https://github.com/fulcrumgenomics/ferro-hgvs/issues/182#issuecomment-4437396360) for the spec analysis.

## Summary

When `decompose_delins_inv` (#160 / #166) splits a merged delins into `[…; inv; …]`, non-inv positions were being emitted as per-position `Substitution` sub-edits even when two or more were strictly adjacent. That violates the only piece of the HGVS spec that unambiguously mandates merging in this codepath:

- `substitution.md`: *"changes involving two or more consecutive nucleotides are described as deletion/insertion (delins)"*
- `delins.md`: same rule.

`build_split_variants` now groups runs of strictly-adjacent (no position gap) `Substitution` sub-edits into a single `Delins`. Length-1 runs still emit as `Substitution`. `Inversion` and `IdentityAt` sub-edits remain hard barriers.

## What this deliberately does NOT do

It does NOT re-merge across an `inv` to re-form a flat delins. The broader "should adjacency to inv force delins?" reading conflicts with `general.md:45` (sub > del > **inv** > dup > ins, with delins as the residual) and with the position adopted in #160/#166. That question is gated on what SVD-WG010 settles. Until then, priority wins:

| Issue example | Issue's "Expected" | This PR | Rationale |
|---|---|---|---|
| Ex 1 `[G>C; inv; A>G]` | `delinsCACCTG` (erases inv) | unchanged | inv is a barrier per `general.md:45` |
| Ex 2 `[delinsCCT; inv; A>C; G>C]` | `[delinsCCT; delinsTCCC]` (erases inv) | `[delinsCCT; inv; delinsCC]` | trailing two subs group; inv stays |
| Ex 3 `[…; inv; T>C]` | flat `delins` (erases inv) | unchanged | inv is a barrier |

The only example whose output changes is Ex 2's trailing two-sub flank — the genuine strict-compliance case.

## Stacking on #187

Based on `fix/issue-180-3prime-shift-allele-norm` (PR #187). #187's `merge-first → split → per-variant normalize` reorder produces *more* `[…; inv; …]` shapes (the PR already updates two UTR tests for this), which makes #182's pattern more visible — both PRs together arrive at the spec-canonical form. This PR will need to retarget to `main` once #187 lands.

## Test plan

- [x] `cargo nextest run --features dev` — 4244 passed (1 pre-existing test in `issue_160_revcomp_inv_subspans` updated for the grouped-delins shape; the `IdentityAt`-drops behavior it was originally asserting still holds)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `pytest tests/python/` — 134 passed
- [x] 5 new tests in `tests/issue_182_postcanon_adjacency.rs` covering: trailing two-sub flank groups; leading two-sub flank groups; both-side flanks group with inv preserved between; length-1 flanks stay as `Substitution`; `IdentityAt` breaks a sub run

## Files changed

- `src/normalize/mod.rs` — `build_split_variants` rewrites the per-subedit `filter_map` into a left-to-right walk that accumulates strictly-adjacent `Substitution` runs and flushes via a new helper `flush_substitution_run` (length-1 → Substitution, length-2+ → Delins).
- `tests/normalize_tests.rs` — `split_drops_identity_subedit_no_eq_emitted` expectation updated; the test still verifies IdentityAt is dropped.
- `tests/issue_182_postcanon_adjacency.rs` — new dedicated test file.