### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
+
+### Added
+
+- *(project)* compound alleles + project_all + project_normalized (PR 3: closes #200) ([#204](https://github.com/fulcrumgenomics/ferro-hgvs/pull/204))
+- *(cli)* add build-transcript subcommand for FASTA + CDS construction (closes #184) ([#199](https://github.com/fulcrumgenomics/ferro-hgvs/pull/199))
+- *(project)* protein consequence for CDS indels (PR 2: indel p. nomenclature) ([#203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/203))
+- *(project)* variant-level projection g. -> c./p. (PR 1: foundation + substitutions) ([#202](https://github.com/fulcrumgenomics/ferro-hgvs/pull/202))
+- *(loader)* Phase 4 - FASTA validation + complete migration off shims ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#196](https://github.com/fulcrumgenomics/ferro-hgvs/pull/196))
+- *(loader,cli)* Phase 3 - diagnostics registry + CLI flags + cross-format tests ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#195](https://github.com/fulcrumgenomics/ferro-hgvs/pull/195))
+- *(loader)* Phase 2 - CDS phase/start_codon/stop_codon, UTR-merge, MANE wiring ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/194))
+
+### Fixed
+
+- *(loader)* rewrite GFF/GTF loader pipeline, close #183 ([#191](https://github.com/fulcrumgenomics/ferro-hgvs/pull/191))
+- *(mock)* accept version/genome_build metadata keys in from_json (closes #185) ([#198](https://github.com/fulcrumgenomics/ferro-hgvs/pull/198))
+- *(normalize)* group consecutive sub-flanks of inv-split into delins ([#182](https://github.com/fulcrumgenomics/ferro-hgvs/pull/182)) ([#188](https://github.com/fulcrumgenomics/ferro-hgvs/pull/188))
+- *(normalize)* apply 3' rule to allele-merged del/dup/ins ([#180](https://github.com/fulcrumgenomics/ferro-hgvs/pull/180)) ([#187](https://github.com/fulcrumgenomics/ferro-hgvs/pull/187))
+
+### Other
+
+- *(loader)* Phase 5 - swap parser internals for noodles ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#197](https://github.com/fulcrumgenomics/ferro-hgvs/pull/197))
+- *(spec)* refresh vendored hgvs-nomenclature spec snapshot ([#193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/193))
+
 ### Added
 
 - *(loader)* unified `load_annotations` entry point with `LoaderConfig`/`LoaderReport`; auto-detects GFF3 vs GTF by extension and content (#191, #194, #195)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["ferro-hgvs contributors"]
 description = "HGVS variant normalizer - part of the ferro bioinformatics toolkit"


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `ferro-hgvs` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Strand in /tmp/.tmp1HV7xU/ferro-hgvs/src/reference/transcript.rs:46
  enum Strand in /tmp/.tmp1HV7xU/ferro-hgvs/src/reference/transcript.rs:46

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant FerroError::Io 12 -> 15 in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:354
  variant FerroError::Json 13 -> 16 in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:358
  variant FerroError::Io 12 -> 15 in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:354
  variant FerroError::Json 13 -> 16 in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:358

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ErrorCode:UnsupportedProjection in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:65
  variant PyStrand:Unknown in /tmp/.tmp1HV7xU/ferro-hgvs/src/python.rs:2897
  variant FerroError:TranscriptNotOverlapping in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:339
  variant FerroError:ProteinSequenceUnavailable in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:346
  variant FerroError:UnsupportedProjection in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:350
  variant FerroError:TranscriptNotOverlapping in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:339
  variant FerroError:ProteinSequenceUnavailable in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:346
  variant FerroError:UnsupportedProjection in /tmp/.tmp1HV7xU/ferro-hgvs/src/error.rs:350

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function ferro_hgvs::reference::loader::load_gtf, previously in file /tmp/.tmpL4XEGB/ferro-hgvs/src/reference/loader.rs:475
  function ferro_hgvs::reference::load_gtf, previously in file /tmp/.tmpL4XEGB/ferro-hgvs/src/reference/loader.rs:475
  function ferro_hgvs::reference::loader::load_gff3, previously in file /tmp/.tmpL4XEGB/ferro-hgvs/src/reference/loader.rs:379
  function ferro_hgvs::reference::load_gff3, previously in file /tmp/.tmpL4XEGB/ferro-hgvs/src/reference/loader.rs:379
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16

### Added

- *(project)* compound alleles + project_all + project_normalized (PR 3: closes #200) ([#204](https://github.com/fulcrumgenomics/ferro-hgvs/pull/204))
- *(cli)* add build-transcript subcommand for FASTA + CDS construction (closes #184) ([#199](https://github.com/fulcrumgenomics/ferro-hgvs/pull/199))
- *(project)* protein consequence for CDS indels (PR 2: indel p. nomenclature) ([#203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/203))
- *(project)* variant-level projection g. -> c./p. (PR 1: foundation + substitutions) ([#202](https://github.com/fulcrumgenomics/ferro-hgvs/pull/202))
- *(loader)* Phase 4 - FASTA validation + complete migration off shims ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#196](https://github.com/fulcrumgenomics/ferro-hgvs/pull/196))
- *(loader,cli)* Phase 3 - diagnostics registry + CLI flags + cross-format tests ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#195](https://github.com/fulcrumgenomics/ferro-hgvs/pull/195))
- *(loader)* Phase 2 - CDS phase/start_codon/stop_codon, UTR-merge, MANE wiring ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/194))

### Fixed

- *(loader)* rewrite GFF/GTF loader pipeline, close #183 ([#191](https://github.com/fulcrumgenomics/ferro-hgvs/pull/191))
- *(mock)* accept version/genome_build metadata keys in from_json (closes #185) ([#198](https://github.com/fulcrumgenomics/ferro-hgvs/pull/198))
- *(normalize)* group consecutive sub-flanks of inv-split into delins ([#182](https://github.com/fulcrumgenomics/ferro-hgvs/pull/182)) ([#188](https://github.com/fulcrumgenomics/ferro-hgvs/pull/188))
- *(normalize)* apply 3' rule to allele-merged del/dup/ins ([#180](https://github.com/fulcrumgenomics/ferro-hgvs/pull/180)) ([#187](https://github.com/fulcrumgenomics/ferro-hgvs/pull/187))

### Other

- *(loader)* Phase 5 - swap parser internals for noodles ([#190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/190)) ([#197](https://github.com/fulcrumgenomics/ferro-hgvs/pull/197))
- *(spec)* refresh vendored hgvs-nomenclature spec snapshot ([#193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/193))

### Added

- *(loader)* unified `load_annotations` entry point with `LoaderConfig`/`LoaderReport`; auto-detects GFF3 vs GTF by extension and content (#191, #194, #195)
- *(loader)* exon-derivation ladder closes single-exon GFF3 without `exon` records (#183 fix) (#191)
- *(loader)* phase-aware CDS bounds with `start_codon` / `stop_codon` precedence; GFF3 input now extends `cds_end` to include the stop codon, matching ferro's downstream convention (fixes a latent off-by-one-codon bug in GFF3 protein conversion) (#194)
- *(loader)* UTR-merge ladder step: synthesizes exons from UTR + CDS when no explicit `exon` records (#194)
- *(loader)* `gene_symbol`, `mane_status`, `refseq_match`, `ensembl_match` extracted from attributes (#194)
- *(loader)* optional FASTA-aware validation: CDS length mod 3 and start codon (ATG/CTG/GTG/TTG) checks when `--fasta` is supplied
- *(error_handling)* 13 loader diagnostic codes (E-LOAD-*, W-LOAD-*) registered for `ferro explain` (#195)
- *(cli)* `ferro convert-gff --strict / --silent / --no-validate-fasta / --diagnostics-json` flags (#195)
- *(strand)* `Strand::Unknown` variant for GFF3 `.` and `?` strand values; transcripts with unknown strand are dropped at load with `E-LOAD-103` (#191)

### Changed

- *(strand)* `Strand`, `LoaderConfig`, and `LoaderReport` are marked `#[non_exhaustive]` for forward compatibility (#191)
- *(loader)* `load_gff3` and `load_gtf` have been removed; use `load_annotations` instead
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).