### PR TITLE
chore(spec): refresh vendored hgvs-nomenclature spec snapshot

### DIFF
--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -3,32 +3,32 @@
   "spec": {
     "source": "https://github.com/HGVSnomenclature/hgvs-nomenclature",
     "tag": "21.0.0",
-    "commit_sha": "a32f970d1d2eb14248c97a50d32c0974e3bb1daf"
+    "commit_sha": "6f85311989e76ead95d3547828f97ebaa3802e35"
   },
   "generated_utc": "fixture-byte-stable",
   "summary": {
-    "total": 823,
+    "total": 1272,
     "by_status": {
-      "correctly-rejected": 12,
-      "diverges": 142,
-      "false-acceptance": 22,
-      "parse-error": 197,
-      "preserved": 450
+      "correctly-rejected": 42,
+      "diverges": 187,
+      "false-acceptance": 86,
+      "parse-error": 343,
+      "preserved": 614
     },
     "by_coordinate_system": {
-      "c": 298,
-      "g": 175,
-      "m": 4,
-      "n": 2,
-      "p": 192,
-      "r": 152
+      "c": 464,
+      "g": 320,
+      "m": 8,
+      "n": 15,
+      "o": 7,
+      "p": 218,
+      "r": 240
     },
     "by_source_kind": {
-      "background": 51,
-      "consultation": 6,
-      "ported_legacy_probe": 2,
-      "recommendation": 721,
-      "syntax_yaml": 43
+      "background": 138,
+      "consultation": 114,
+      "recommendation": 976,
+      "syntax_yaml": 44
     }
   },
   "rows": [
@@ -41,6 +41,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "NM_004006.1:c.123+45_123+51TSDinsL1.603bp",
+      "current": "parse error: Parse error at position 30: Unexpected trailing characters: 'insL1.603bp'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NM_004006.1:c.76A/G",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"A\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
       ]
     },
     {
@@ -68,9 +90,117 @@
       ]
     },
     {
+      "input": "c.4072-1234_5155-246delXXXXX",
+      "input_prefixed": "NM_004006.2:c.4072-1234_5155-246delXXXXX",
+      "current": "parse error: Parse error at position 35: Unexpected trailing characters: 'XXXXX'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "c.4072-1234_5155-246dupXXXXX",
+      "input_prefixed": "NM_004006.2:c.4072-1234_5155-246dupXXXXX",
+      "current": "parse error: Parse error at position 35: Unexpected trailing characters: 'XXXXX'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "c.5439_5430ins6",
+      "input_prefixed": "NM_004006.2:c.5439_5430ins6",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"5439_5430ins6\", code: Verify })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
+      ]
+    },
+    {
+      "input": "c.76A/G",
+      "input_prefixed": "NM_004006.2:c.76A/G",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"A\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ]
+    },
+    {
+      "input": "c.EX17del",
+      "input_prefixed": "NM_004006.2:c.EX17del",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"EX17del\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "c.IVS2+2T>G",
+      "input_prefixed": "NM_004006.2:c.IVS2+2T>G",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"IVS2+2T>G\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.IVS2-1G>T",
+      "input_prefixed": "NM_004006.2:c.IVS2-1G>T",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"IVS2-1G>T\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.IVS4-2A>G",
+      "input_prefixed": "NM_004006.2:c.IVS4-2A>G",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"IVS4-2A>G\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
+      ]
+    },
+    {
       "input": "c.[2376G>C;3103=];[2376=;3103del]",
       "input_prefixed": "NM_004006.2:c.[2376G>C;3103=];[2376=;3103del]",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \";3103=\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "c.[76A>C];[]",
+      "input_prefixed": "NM_004006.2:c.[76A>C];[]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
       "spec_expected": null,
       "status": "correctly-rejected",
       "coordinate_system": "c",
@@ -92,21 +222,33 @@
       ]
     },
     {
-      "input": "GJB2:c.76AC",
-      "current": "GJB2:c.76AC=",
-      "spec_expected": "GJB2:c.76AC",
+      "input": "LRG_199t1:c.(71_72)G>A",
+      "current": "LRG_199t1:c.(71)_(72)G>A",
+      "spec_expected": "LRG_199t1:c.(71_72)G>A",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:c.(71_72)G>A",
-      "current": "LRG_199t1:c.(71)_(72)G>A",
-      "spec_expected": "LRG_199t1:c.(71_72)G>A",
+      "input": "NM_000044.3:c.(92_331)insN[33]",
+      "current": "NM_000044.3:c.(92)_(331)insN[33]",
+      "spec_expected": "NM_000044.3:c.(92_331)insN[33]",
+      "status": "diverges",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_000333.3:c.(4_246)insN[(150_180)]",
+      "current": "NM_000333.3:c.(4)_(246)insN[150_180]",
+      "spec_expected": "NM_000333.3:c.(4_246)insN[(150_180)]",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -128,26 +270,14 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_000333.3:c.(4_246)inssN[(150_180)]",
-      "current": "NM_000333.3:c.(4)_(246)insSN[150_180]",
-      "spec_expected": "NM_000333.3:c.(4_246)inssN[(150_180)]",
+      "input": "NM_000333.3:c.(4_246)insN[9]",
+      "current": "NM_000333.3:c.(4)_(246)insN[9]",
+      "spec_expected": "NM_000333.3:c.(4_246)insN[9]",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_000492.3:c.1522_1524delTTT",
-      "current": "NM_000492.3:c.1522_1524del",
-      "spec_expected": "NM_000492.3:c.1522_1524delTTT",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -238,93 +368,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_007294.3:c.[2077G>A;2077_2078insTA]",
-      "current": "NM_007294.3:c.2077delinsATA",
-      "spec_expected": "NM_007294.3:c.[2077G>A;2077_2078insTA]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118AA",
-      "current": "OPRM1:c.118AA=",
-      "spec_expected": "OPRM1:c.118AA",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118GA",
-      "current": "OPRM1:c.118GA=",
-      "spec_expected": "OPRM1:c.118GA",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118GG",
-      "current": "OPRM1:c.118GG=",
-      "spec_expected": "OPRM1:c.118GG",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.1210-12_1210-6T[(5_9)]",
-      "input_prefixed": "NM_004006.2:c.1210-12_1210-6T[(5_9)]",
-      "current": "NM_004006.2:c.1210-12_1210-6T[5_9]",
-      "spec_expected": "NM_004006.2:c.1210-12_1210-6T[(5_9)]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.1210-33_1210-6GT[(9_13)]T[(4_8)]",
-      "input_prefixed": "NM_004006.2:c.1210-33_1210-6GT[(9_13)]T[(4_8)]",
-      "current": "NM_004006.2:c.1210-33_1210-6GT[9_13]T[4_8]",
-      "spec_expected": "NM_004006.2:c.1210-33_1210-6GT[(9_13)]T[(4_8)]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.12delC",
-      "input_prefixed": "NM_004006.2:c.12delC",
-      "current": "NM_004006.2:c.12del",
-      "spec_expected": "NM_004006.2:c.12delC",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/frameshift.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "c.35delG",
       "input_prefixed": "NM_004006.2:c.35delG",
       "current": "NM_004006.2:c.35del",
@@ -338,37 +381,35 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.76delA",
-      "input_prefixed": "NM_004006.2:c.76delA",
-      "current": "NM_004006.2:c.76del",
-      "spec_expected": "NM_004006.2:c.76delA",
+      "input": "c.849_850ins858_895",
+      "input_prefixed": "NM_004006.2:c.849_850ins858_895",
+      "current": "NM_004006.2:c.849_850ins[858_895]",
+      "spec_expected": "NM_004006.2:c.849_850ins858_895",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/general.md"
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.76dupA",
-      "input_prefixed": "NM_004006.2:c.76dupA",
-      "current": "NM_004006.2:c.76dup",
-      "spec_expected": "NM_004006.2:c.76dupA",
-      "status": "diverges",
+      "input": "LRG_199:c.357+1G>A",
+      "current": "LRG_199:c.357+1G>A",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/general.md"
+        "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.79GC>TT",
-      "input_prefixed": "NM_004006.2:c.79GC>TT",
-      "current": "NM_004006.2:c.79delinsTT",
-      "spec_expected": "NM_004006.2:c.79GC>TT",
-      "status": "diverges",
+      "input": "NM_000109.3:c.-401C>T",
+      "current": "NM_000109.3:c.-401C>T",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
@@ -377,11 +418,34 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.79_80GC>TT",
-      "input_prefixed": "NM_004006.2:c.79_80GC>TT",
-      "current": "NM_004006.2:c.79_80delinsTT",
-      "spec_expected": "NM_004006.2:c.79_80GC>TT",
-      "status": "diverges",
+      "input": "NM_000492.3:c.1522_1524delTTT",
+      "current": "NM_000492.3:c.1522_1524del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_002111:c.211C>T",
+      "current": "NM_002111:c.211C>T",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_004006.1:c.-128354C>T",
+      "current": "NM_004006.1:c.-128354C>T",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
@@ -390,41 +454,50 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.[2077G>A;2077_2078insTA]",
-      "input_prefixed": "NM_004006.2:c.[2077G>A;2077_2078insTA]",
-      "current": "NM_004006.2:c.2077delinsATA",
-      "spec_expected": "NM_004006.2:c.[2077G>A;2077_2078insTA]",
-      "status": "diverges",
+      "input": "NM_004006.2:c.20dupG",
+      "current": "NM_004006.2:c.20dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.[76A>C]",
-      "input_prefixed": "NM_004006.2:c.[76A>C]",
-      "current": "NM_004006.2:c.76A>C",
-      "spec_expected": "NM_004006.2:c.[76A>C]",
-      "status": "diverges",
+      "input": "NM_004006.2:c.20dupT",
+      "current": "NM_004006.2:c.20dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.[79G>T;80C>T]",
-      "input_prefixed": "NM_004006.2:c.[79G>T;80C>T]",
-      "current": "NM_004006.2:c.79_80delinsTT",
-      "spec_expected": "NM_004006.2:c.[79G>T;80C>T]",
-      "status": "diverges",
+      "input": "NM_004006.2:c.357+1G>A",
+      "current": "NM_004006.2:c.357+1G>A",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_004006.2:c.4072-1234_5155-246dup",
+      "current": "NM_004006.2:c.4072-1234_5155-246dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -437,6 +510,80 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_004006.2:c.6775_6777delGAGinsC",
+      "current": "NM_004006.2:c.6775_6777delGAGinsC",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_004006.2:c.6775_6777delGTGinsC",
+      "current": "NM_004006.2:c.6775_6777delGTGinsC",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_007294.3:c.[2077G>A;2077_2078insTA]",
+      "current": "NM_007294.3:c.2077delinsATA",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_024312.4:c.1738TA[6]",
+      "current": "NM_024312.4:c.1738TA[6]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_024312.4:c.2686A[10]",
+      "current": "NM_024312.4:c.2686A[10]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.-14insG",
+      "input_prefixed": "NM_004006.2:c.-14insG",
+      "current": "NM_004006.2:c.-14insG",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -454,28 +601,266 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.3922del",
-      "input_prefixed": "NM_004006.2:c.3922del",
-      "current": "NM_004006.2:c.3922del",
+      "input": "c.123-65_-50",
+      "input_prefixed": "NM_004006.2:c.123-65_-50",
+      "current": "NM_004006.2:c.123-65_-50",
       "spec_expected": null,
       "status": "false-acceptance",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/checklist.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:c.57_58del.",
-      "current": "parse error: Parse error at position 20: Unexpected trailing characters: '.'",
-      "spec_expected": "LRG_199t1:c.57_58del.",
+      "input": "c.1823A=",
+      "input_prefixed": "NM_004006.2:c.1823A=",
+      "current": "NM_004006.2:c.1823A=",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.20_23dupTAGA",
+      "input_prefixed": "NM_004006.2:c.20_23dupTAGA",
+      "current": "NM_004006.2:c.20_23dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.20_23dupTGGA",
+      "input_prefixed": "NM_004006.2:c.20_23dupTGGA",
+      "current": "NM_004006.2:c.20_23dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.22insG",
+      "input_prefixed": "NM_004006.2:c.22insG",
+      "current": "NM_004006.2:c.22insG",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md",
+        "docs/recommendations/RNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.23ins24",
+      "input_prefixed": "NM_004006.2:c.23ins24",
+      "current": "NM_004006.2:c.23ins24",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4375_4376delCGinsAGTT",
+      "input_prefixed": "NM_004006.2:c.4375_4376delCGinsAGTT",
+      "current": "NM_004006.2:c.4375_4376delCGinsAGTT",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4375_4379delCGATT",
+      "input_prefixed": "NM_004006.2:c.4375_4379delCGATT",
+      "current": "NM_004006.2:c.4375_4379del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4375_4385dupCGATTATTCCA",
+      "input_prefixed": "NM_004006.2:c.4375_4385dupCGATTATTCCA",
+      "current": "NM_004006.2:c.4375_4385dup",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4385_4386insCGATTATTCCA",
+      "input_prefixed": "NM_004006.2:c.4385_4386insCGATTATTCCA",
+      "current": "NM_004006.2:c.4385_4386insCGATTATTCCA",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.456-13insG",
+      "input_prefixed": "NM_004006.2:c.456-13insG",
+      "current": "NM_004006.2:c.456-13insG",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.52insT",
+      "input_prefixed": "NM_004006.2:c.52insT",
+      "current": "NM_004006.2:c.52insT",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.650-?_1331+?del",
+      "input_prefixed": "NM_004006.2:c.650-?_1331+?del",
+      "current": "NM_004006.2:c.650-?_1331+?del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.79GC>TT",
+      "input_prefixed": "NM_004006.2:c.79GC>TT",
+      "current": "NM_004006.2:c.79delinsTT",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.79_80GC>TT",
+      "input_prefixed": "NM_004006.2:c.79_80GC>TT",
+      "current": "NM_004006.2:c.79_80delinsTT",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.[145C>T;147C>G]",
+      "input_prefixed": "NM_004006.2:c.[145C>T;147C>G]",
+      "current": "NM_004006.2:c.[145C>T;147C>G]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.[76A>C]",
+      "input_prefixed": "NM_004006.2:c.[76A>C]",
+      "current": "NM_004006.2:c.76A>C",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.[79G>T;80C>T]",
+      "input_prefixed": "NM_004006.2:c.[79G>T;80C>T]",
+      "current": "NM_004006.2:c.79_80delinsTT",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": ":c.11T>G",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \":c.11T>G\", code: Alpha })",
+      "spec_expected": ":c.11T>G",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
       ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "LRG_199t1:c.[633A>G];[531_648=;961_1149=]",
+      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \";961_1149=\", code: Tag })",
+      "spec_expected": "LRG_199t1:c.[633A>G];[531_648=;961_1149=]",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -486,6 +871,7 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/repeated.md",
         "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -503,26 +889,14 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_002111:c.211C>T.",
-      "current": "parse error: Parse error at position 18: Unexpected trailing characters: '.'",
-      "spec_expected": "NM_002111:c.211C>T.",
+      "input": "NM_004006.1:c.5690",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.1:c.5690",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.1:c.76A/G?",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"A\", code: Tag })",
-      "spec_expected": "NM_004006.1:c.76A/G?",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -558,7 +932,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -611,64 +986,21 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_04006.1:c.123+45_123+51TSDinsL1.603bp",
-      "current": "parse error: Parse error at position 29: Unexpected trailing characters: 'insL1.603bp'",
-      "spec_expected": "NM_04006.1:c.123+45_123+51TSDinsL1.603bp",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/complex.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118A",
-      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"A\", code: Tag })",
-      "spec_expected": "OPRM1:c.118A",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118AA,",
-      "current": "parse error: Parse error at position 13: Unexpected trailing characters: ','",
-      "spec_expected": "OPRM1:c.118AA,",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "OPRM1:c.118G",
-      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"G\", code: Tag })",
-      "spec_expected": "OPRM1:c.118G",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "c.",
       "input_prefixed": "NM_004006.2:c.",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
       "spec_expected": "NM_004006.2:c.",
       "status": "parse-error",
       "coordinate_system": "c",
-      "source_kind": "background",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/background/refseq.md"
+        "docs/background/numbering.md",
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG002.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
+        "docs/recommendations/checklist.md"
       ],
+      "working_group": "SVD-WG002",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -681,6 +1013,19 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/general.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.*",
+      "input_prefixed": "NM_004006.2:c.*",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
+      "spec_expected": "NM_004006.2:c.*",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -698,6 +1043,46 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.0",
+      "input_prefixed": "NM_004006.2:c.0",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"0\", code: Verify })",
+      "spec_expected": "NM_004006.2:c.0",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.1",
+      "input_prefixed": "NM_004006.2:c.1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.1149",
+      "input_prefixed": "NM_004006.2:c.1149",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1149",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.12",
       "input_prefixed": "NM_004006.2:c.12",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -711,23 +1096,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.12*14del",
-      "input_prefixed": "NM_004006.2:c.12*14del",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"*14del\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.12*14del",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/checklist.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.1210-12_1210-6T[7].",
-      "input_prefixed": "NM_004006.2:c.1210-12_1210-6T[7].",
-      "current": "parse error: Parse error at position 32: Unexpected trailing characters: '.'",
-      "spec_expected": "NM_004006.2:c.1210-12_1210-6T[7].",
+      "input": "c.1210-33",
+      "input_prefixed": "NM_004006.2:c.1210-33",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1210-33",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -737,15 +1109,28 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.1210-33_1210-6GT[11]T[6].",
-      "input_prefixed": "NM_004006.2:c.1210-33_1210-6GT[11]T[6].",
-      "current": "parse error: Parse error at position 38: Unexpected trailing characters: '.'",
-      "spec_expected": "NM_004006.2:c.1210-33_1210-6GT[11]T[6].",
+      "input": "c.1210-6",
+      "input_prefixed": "NM_004006.2:c.1210-6",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1210-6",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.1211-703",
+      "input_prefixed": "NM_004006.2:c.1211-703",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1211-703",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -758,22 +1143,41 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG001.md",
         "docs/recommendations/DNA/other.md",
         "docs/recommendations/DNA/substitution.md"
       ],
+      "working_group": "SVD-WG001",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.123-65**_-50**",
-      "input_prefixed": "NM_004006.2:c.123-65**_-50**",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"**_-50**\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.123-65**_-50**",
+      "input": "c.1331",
+      "input_prefixed": "NM_004006.2:c.1331",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1331",
       "status": "parse-error",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "consultation",
       "source_paths": [
-        "docs/recommendations/checklist.md"
+        "docs/consultation/SVD-WG003.md"
       ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.1332",
+      "input_prefixed": "NM_004006.2:c.1332",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1332",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -832,6 +1236,33 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.1970",
+      "input_prefixed": "NM_004006.2:c.1970",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.1970",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.20",
+      "input_prefixed": "NM_004006.2:c.20",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.20",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.2074",
       "input_prefixed": "NM_004006.2:c.2074",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -856,6 +1287,58 @@
       "source_paths": [
         "docs/recommendations/DNA/delins.md",
         "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.23",
+      "input_prefixed": "NM_004006.2:c.23",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.23",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.246",
+      "input_prefixed": "NM_004006.2:c.246",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.246",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.260",
+      "input_prefixed": "NM_004006.2:c.260",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.260",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.264+48",
+      "input_prefixed": "NM_004006.2:c.264+48",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.264+48",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -886,15 +1369,15 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.358",
-      "input_prefixed": "NM_004006.2:c.358",
+      "input": "c.331",
+      "input_prefixed": "NM_004006.2:c.331",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.358",
+      "spec_expected": "NM_004006.2:c.331",
       "status": "parse-error",
       "coordinate_system": "c",
-      "source_kind": "background",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/background/refseq.md"
+        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -907,7 +1390,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -925,6 +1409,32 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.4",
+      "input_prefixed": "NM_004006.2:c.4",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.401",
+      "input_prefixed": "NM_004006.2:c.401",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.401",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.4071",
       "input_prefixed": "NM_004006.2:c.4071",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -933,7 +1443,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -946,7 +1457,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -959,7 +1471,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -972,7 +1485,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -985,20 +1499,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.4072-1234_5155-246delXXXXX",
-      "input_prefixed": "NM_004006.2:c.4072-1234_5155-246delXXXXX",
-      "current": "parse error: Parse error at position 35: Unexpected trailing characters: 'XXXXX'",
-      "spec_expected": "NM_004006.2:c.4072-1234_5155-246delXXXXX",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1011,7 +1513,47 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4145",
+      "input_prefixed": "NM_004006.2:c.4145",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4145",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4160",
+      "input_prefixed": "NM_004006.2:c.4160",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4160",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.419",
+      "input_prefixed": "NM_004006.2:c.419",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.419",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1029,10 +1571,62 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.456-12",
-      "input_prefixed": "NM_004006.2:c.456-12",
+      "input": "c.4375",
+      "input_prefixed": "NM_004006.2:c.4375",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.456-12",
+      "spec_expected": "NM_004006.2:c.4375",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4376",
+      "input_prefixed": "NM_004006.2:c.4376",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4376",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4379",
+      "input_prefixed": "NM_004006.2:c.4379",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4379",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.4385",
+      "input_prefixed": "NM_004006.2:c.4385",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.4385",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.450",
+      "input_prefixed": "NM_004006.2:c.450",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.450",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -1042,49 +1636,25 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.456-13,",
-      "input_prefixed": "NM_004006.2:c.456-13,",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \",\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.456-13,",
+      "input": "c.456",
+      "input_prefixed": "NM_004006.2:c.456",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.456",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
+        "docs/consultation/SVD-WG001.md",
+        "docs/recommendations/DNA/other.md"
       ],
+      "working_group": "SVD-WG001",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.456-13insG,",
-      "input_prefixed": "NM_004006.2:c.456-13insG,",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ','",
-      "spec_expected": "NM_004006.2:c.456-13insG,",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.456-13insG.",
-      "input_prefixed": "NM_004006.2:c.456-13insG.",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '.'",
-      "spec_expected": "NM_004006.2:c.456-13insG.",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.456-14?",
-      "input_prefixed": "NM_004006.2:c.456-14?",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"?\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.456-14?",
+      "input": "c.470",
+      "input_prefixed": "NM_004006.2:c.470",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.470",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -1115,7 +1685,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1128,7 +1699,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1141,7 +1713,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1154,7 +1727,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1167,7 +1741,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1180,8 +1755,37 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.516",
+      "input_prefixed": "NM_004006.2:c.516",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.516",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.517",
+      "input_prefixed": "NM_004006.2:c.517",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.517",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -1211,6 +1815,20 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.531",
+      "input_prefixed": "NM_004006.2:c.531",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.531",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.531-23",
       "input_prefixed": "NM_004006.2:c.531-23",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1232,20 +1850,34 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/repeated.md",
         "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.5439_5430**ins6**",
-      "input_prefixed": "NM_004006.2:c.5439_5430**ins6**",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"5439_5430**ins6**\", code: Verify })",
-      "spec_expected": "NM_004006.2:c.5439_5430**ins6**",
+      "input": "c.5657",
+      "input_prefixed": "NM_004006.2:c.5657",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.5657",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/checklist.md"
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.5660",
+      "input_prefixed": "NM_004006.2:c.5660",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.5660",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1258,7 +1890,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1271,7 +1904,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1306,6 +1940,19 @@
       "input_prefixed": "NM_004006.2:c.6278",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
       "spec_expected": "NM_004006.2:c.6278",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.6291-1",
+      "input_prefixed": "NM_004006.2:c.6291-1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.6291-1",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -1354,6 +2001,75 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.648",
+      "input_prefixed": "NM_004006.2:c.648",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.648",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.649",
+      "input_prefixed": "NM_004006.2:c.649",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.649",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.650",
+      "input_prefixed": "NM_004006.2:c.650",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.650",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.675-542",
+      "input_prefixed": "NM_004006.2:c.675-542",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.675-542",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.6774",
+      "input_prefixed": "NM_004006.2:c.6774",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.6774",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.6775",
       "input_prefixed": "NM_004006.2:c.6775",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1380,15 +2096,28 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.689*690insT",
-      "input_prefixed": "NM_004006.2:c.689*690insT",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"*690insT\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.689*690insT",
+      "input": "c.6955",
+      "input_prefixed": "NM_004006.2:c.6955",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.6955",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.720",
+      "input_prefixed": "NM_004006.2:c.720",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.720",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1432,6 +2161,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.7542+49",
+      "input_prefixed": "NM_004006.2:c.7542+49",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.7542+49",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.7575",
       "input_prefixed": "NM_004006.2:c.7575",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1441,6 +2183,32 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.761",
+      "input_prefixed": "NM_004006.2:c.761",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.761",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.762",
+      "input_prefixed": "NM_004006.2:c.762",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.762",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1479,8 +2247,10 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG001.md",
         "docs/recommendations/DNA/other.md"
       ],
+      "working_group": "SVD-WG001",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -1536,6 +2306,33 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.849",
+      "input_prefixed": "NM_004006.2:c.849",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.849",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.85",
+      "input_prefixed": "NM_004006.2:c.85",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.85",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.850",
       "input_prefixed": "NM_004006.2:c.850",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1544,7 +2341,75 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.851",
+      "input_prefixed": "NM_004006.2:c.851",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.851",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.858",
+      "input_prefixed": "NM_004006.2:c.858",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.858",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.87+1",
+      "input_prefixed": "NM_004006.2:c.87+1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.87+1",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.87+2",
+      "input_prefixed": "NM_004006.2:c.87+2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.87+2",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.87+3",
+      "input_prefixed": "NM_004006.2:c.87+3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.87+3",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1601,6 +2466,97 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.876",
+      "input_prefixed": "NM_004006.2:c.876",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.876",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.876+1",
+      "input_prefixed": "NM_004006.2:c.876+1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.876+1",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.876+2",
+      "input_prefixed": "NM_004006.2:c.876+2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.876+2",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.876+3",
+      "input_prefixed": "NM_004006.2:c.876+3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.876+3",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.88-1",
+      "input_prefixed": "NM_004006.2:c.88-1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.88-1",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.88-2",
+      "input_prefixed": "NM_004006.2:c.88-2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.88-2",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.88-3",
+      "input_prefixed": "NM_004006.2:c.88-3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.88-3",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.88-676",
       "input_prefixed": "NM_004006.2:c.88-676",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1640,6 +2596,74 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "c.884",
+      "input_prefixed": "NM_004006.2:c.884",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.884",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.886",
+      "input_prefixed": "NM_004006.2:c.886",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.886",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.89",
+      "input_prefixed": "NM_004006.2:c.89",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.89",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.895",
+      "input_prefixed": "NM_004006.2:c.895",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.895",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.900",
+      "input_prefixed": "NM_004006.2:c.900",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.900",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "c.9002",
       "input_prefixed": "NM_004006.2:c.9002",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
@@ -1674,7 +2698,23 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.902",
+      "input_prefixed": "NM_004006.2:c.902",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.902",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1688,6 +2728,19 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.92",
+      "input_prefixed": "NM_004006.2:c.92",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.92",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1718,15 +2771,43 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.EX17del",
-      "input_prefixed": "NM_004006.2:c.EX17del",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"EX17del\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.EX17del",
+      "input": "c.940",
+      "input_prefixed": "NM_004006.2:c.940",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.940",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.961",
+      "input_prefixed": "NM_004006.2:c.961",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.961",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "c.991",
+      "input_prefixed": "NM_004006.2:c.991",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
+      "spec_expected": "NM_004006.2:c.991",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1744,15 +2825,51 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.[76A>C];[]",
-      "input_prefixed": "NM_004006.2:c.[76A>C];[]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
-      "spec_expected": "NM_004006.2:c.[76A>C];[]",
+      "input": "class=\"invalid\">NM_000109.3:c.-401C>T</code>",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_000109.3:c.-401C>T<\", code: Alpha })",
+      "spec_expected": "class=\"invalid\">NM_000109.3:c.-401C>T</code>",
       "status": "parse-error",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "class=\"invalid\">NM_002111:c.211C>T</code>.",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_002111:c.211C>T<\", code: Alpha })",
+      "spec_expected": "class=\"invalid\">NM_002111:c.211C>T</code>.",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "class=\"invalid\">NM_004006.1:c.-128354C>T</code>",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_004006.1:c.-128354C>T<\", code: Alpha })",
+      "spec_expected": "class=\"invalid\">NM_004006.1:c.-128354C>T</code>",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "class=\"invalid\">NM_007294.3:c.[2077G>A;2077_2078insTA]</code>.\"",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_007294.3:c.[2077G>A;2077_2078insTA]<\", code: Alpha })",
+      "spec_expected": "class=\"invalid\">NM_007294.3:c.[2077G>A;2077_2078insTA]</code>.\"",
+      "status": "parse-error",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -1823,6 +2940,18 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.123C>T",
+      "current": "LRG_199t1:c.123C>T",
+      "spec_expected": "LRG_199t1:c.123C>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
       "input": "LRG_199t1:c.123_145=",
       "current": "LRG_199t1:c.123_145=",
       "spec_expected": "LRG_199t1:c.123_145=",
@@ -1867,6 +2996,42 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.235A>T(;)237G>T",
+      "current": "LRG_199t1:c.235A>T(;)237G>T",
+      "spec_expected": "LRG_199t1:c.235A>T(;)237G>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "LRG_199t1:c.235_236delinsTT",
+      "current": "LRG_199t1:c.235_236delinsTT",
+      "spec_expected": "LRG_199t1:c.235_236delinsTT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "LRG_199t1:c.235_237delinsTAT",
+      "current": "LRG_199t1:c.235_237delinsTAT",
+      "spec_expected": "LRG_199t1:c.235_237delinsTAT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "LRG_199t1:c.240_241insAGG",
       "current": "LRG_199t1:c.240_241insAGG",
       "spec_expected": "LRG_199t1:c.240_241insAGG",
@@ -1878,6 +3043,18 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.357+1G>A",
+      "current": "LRG_199t1:c.357+1G>A",
+      "spec_expected": "LRG_199t1:c.357+1G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:c.3921del",
       "current": "LRG_199t1:c.3921del",
       "spec_expected": "LRG_199t1:c.3921del",
@@ -1885,6 +3062,7 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/background/numbering.md",
         "docs/recommendations/DNA/deletion.md"
       ]
     },
@@ -1930,6 +3108,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
+      "input": "LRG_199t1:c.5234G>A",
+      "current": "LRG_199t1:c.5234G>A",
+      "spec_expected": "LRG_199t1:c.5234G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
       ]
     },
     {
@@ -2034,6 +3223,30 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.992_1004delinsAC",
+      "current": "LRG_199t1:c.992_1004delinsAC",
+      "spec_expected": "LRG_199t1:c.992_1004delinsAC",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "LRG_199t1:c.[235A>T;238G>T]",
+      "current": "LRG_199t1:c.[235A>T;238G>T]",
+      "spec_expected": "LRG_199t1:c.[235A>T;238G>T]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "LRG_199t1:c.[2376G>C];[2376=]",
       "current": "LRG_199t1:c.[2376G>C];[2376=]",
       "spec_expected": "LRG_199t1:c.[2376G>C];[2376=]",
@@ -2054,6 +3267,30 @@
       "source_paths": [
         "docs/recommendations/DNA/alleles.md"
       ]
+    },
+    {
+      "input": "LRG_199t1:c.[2962T>G;2970A>T]",
+      "current": "LRG_199t1:c.[2962T>G;2970A>T]",
+      "spec_expected": "LRG_199t1:c.[2962T>G;2970A>T]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "LRG_199t1:c.[633A>G];[633=]",
+      "current": "LRG_199t1:c.[633A>G];[633=]",
+      "spec_expected": "LRG_199t1:c.[633A>G];[633=]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "LRG_199t61:c.(6278_6291-1)_(7542+49_7575)dup",
@@ -2100,17 +3337,6 @@
       ]
     },
     {
-      "input": "LRG_763t1:c.54_110GAC[23]",
-      "current": "LRG_763t1:c.54_110GAC[23]",
-      "spec_expected": "LRG_763t1:c.54_110GAC[23]",
-      "status": "preserved",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
-      ]
-    },
-    {
       "input": "LRG_763t1:c.54_110GCA[23]",
       "current": "LRG_763t1:c.54_110GCA[23]",
       "spec_expected": "LRG_763t1:c.54_110GCA[23]",
@@ -2122,9 +3348,9 @@
       ]
     },
     {
-      "input": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-704insGTAAA]",
-      "current": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-704insGTAAA]",
-      "spec_expected": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-704insGTAAA]",
+      "input": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-702insGTAAA]",
+      "current": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-702insGTAAA]",
+      "spec_expected": "NC_000001.11(NM_206933.2):c.[675-542_1211-703dup;1211-703_1211-702insGTAAA]",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -2144,6 +3370,18 @@
       ]
     },
     {
+      "input": "NC_000023.10(NM_004006.2):c.357+1G>A",
+      "current": "NC_000023.10(NM_004006.2):c.357+1G>A",
+      "spec_expected": "NC_000023.10(NM_004006.2):c.357+1G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md"
+      ]
+    },
+    {
       "input": "NC_000023.10(NM_004006.2):c.94-2A>G",
       "current": "NC_000023.10(NM_004006.2):c.94-2A>G",
       "spec_expected": "NC_000023.10(NM_004006.2):c.94-2A>G",
@@ -2155,36 +3393,14 @@
       ]
     },
     {
-      "input": "NC_000023.11(NM_004006.2):c.(-205839_-62966)_(*21568_*61692)dup",
-      "current": "NC_000023.11(NM_004006.2):c.(-205839_-62966)_(*21568_*61692)dup",
-      "spec_expected": "NC_000023.11(NM_004006.2):c.(-205839_-62966)_(*21568_*61692)dup",
+      "input": "NC_000023.10(NM_004006.3):c.357+1G>A",
+      "current": "NC_000023.10(NM_004006.3):c.357+1G>A",
+      "spec_expected": "NC_000023.10(NM_004006.3):c.357+1G>A",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
-      ]
-    },
-    {
-      "input": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)del",
-      "current": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)del",
-      "spec_expected": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)del",
-      "status": "preserved",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
-      ]
-    },
-    {
-      "input": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)dup",
-      "current": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)dup",
-      "spec_expected": "NC_000023.11(NM_004006.2):c.(10086+1_10087-1)_(*2691_?)dup",
-      "status": "preserved",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
+        "docs/background/refseq.md"
       ]
     },
     {
@@ -2232,14 +3448,25 @@
       ]
     },
     {
-      "input": "NC_000023.11(NM_004006.2):c.(?_-244)_(31+1_32-1)del",
-      "current": "NC_000023.11(NM_004006.2):c.(?_-244)_(31+1_32-1)del",
-      "spec_expected": "NC_000023.11(NM_004006.2):c.(?_-244)_(31+1_32-1)del",
+      "input": "NC_000023.11(NM_004006.2):c.1704+1dup",
+      "current": "NC_000023.11(NM_004006.2):c.1704+1dup",
+      "spec_expected": "NC_000023.11(NM_004006.2):c.1704+1dup",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11(NM_004006.2):c.1813dup",
+      "current": "NC_000023.11(NM_004006.2):c.1813dup",
+      "spec_expected": "NC_000023.11(NM_004006.2):c.1813dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -2251,6 +3478,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11(NM_004006.2):c.260_264+48dup",
+      "current": "NC_000023.11(NM_004006.2):c.260_264+48dup",
+      "spec_expected": "NC_000023.11(NM_004006.2):c.260_264+48dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11(NM_004006.2):c.3921dup",
+      "current": "NC_000023.11(NM_004006.2):c.3921dup",
+      "spec_expected": "NC_000023.11(NM_004006.2):c.3921dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -2298,6 +3547,29 @@
       ]
     },
     {
+      "input": "NC_000023.11(NM_004006.2):c.93+1G>T",
+      "current": "NC_000023.11(NM_004006.2):c.93+1G>T",
+      "spec_expected": "NC_000023.11(NM_004006.2):c.93+1G>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1(NM_004006.2):c.357+1G>A",
+      "current": "NG_012232.1(NM_004006.2):c.357+1G>A",
+      "spec_expected": "NG_012232.1(NM_004006.2):c.357+1G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md"
+      ]
+    },
+    {
       "input": "NG_012232.1(NM_004006.2):c.93+1G>T",
       "current": "NG_012232.1(NM_004006.2):c.93+1G>T",
       "spec_expected": "NG_012232.1(NM_004006.2):c.93+1G>T",
@@ -2305,8 +3577,31 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/background/refseq.md",
         "docs/recommendations/DNA/substitution.md",
         "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NM_000044.3:c.171_239GCA[34]",
+      "current": "NM_000044.3:c.171_239GCA[34]",
+      "spec_expected": "NM_000044.3:c.171_239GCA[34]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_000109.3:c.5210G>A",
+      "current": "NM_000109.3:c.5210G>A",
+      "spec_expected": "NM_000109.3:c.5210G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
       ]
     },
     {
@@ -2321,6 +3616,17 @@
       ]
     },
     {
+      "input": "NM_000492.3:c.1210-12_1210-6T[7]",
+      "current": "NM_000492.3:c.1210-12_1210-6T[7]",
+      "spec_expected": "NM_000492.3:c.1210-12_1210-6T[7]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "NM_000492.3:c.1210-33_1210-6GT[11]T[6]",
       "current": "NM_000492.3:c.1210-33_1210-6GT[11]T[6]",
       "spec_expected": "NM_000492.3:c.1210-33_1210-6GT[11]T[6]",
@@ -2330,6 +3636,41 @@
       "source_paths": [
         "docs/recommendations/DNA/repeated.md"
       ]
+    },
+    {
+      "input": "NM_000552.3:c.3675-45_3692",
+      "current": "NM_000552.3:c.3675-45_3692",
+      "spec_expected": "NM_000552.3:c.3675-45_3692",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
+      "input": "NM_001849.3:c.-1_*1=",
+      "current": "NM_001849.3:c.-1_*1=",
+      "spec_expected": "NM_001849.3:c.-1_*1=",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "NM_001849.3:c.=",
+      "current": "NM_001849.3:c.=",
+      "spec_expected": "NM_001849.3:c.=",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "NM_002024.5:c.-128_-69GGC[10]GGA[1]GGC[9]GGA[1]GGC[10]",
@@ -2365,6 +3706,17 @@
       ]
     },
     {
+      "input": "NM_002024.5:c.-129CGG[79]",
+      "current": "NM_002024.5:c.-129CGG[79]",
+      "spec_expected": "NM_002024.5:c.-129CGG[79]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "NM_003079.4:c.374_395inv",
       "current": "NM_003079.4:c.374_395inv",
       "spec_expected": "NM_003079.4:c.374_395inv",
@@ -2373,6 +3725,29 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md"
+      ]
+    },
+    {
+      "input": "NM_004006.1:c.123=",
+      "current": "NM_004006.1:c.123=",
+      "spec_expected": "NM_004006.1:c.123=",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "NM_004006.1:c.5697del",
+      "current": "NM_004006.1:c.5697del",
+      "spec_expected": "NM_004006.1:c.5697del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
       ]
     },
     {
@@ -2385,6 +3760,18 @@
       "source_paths": [
         "docs/recommendations/DNA/insertion.md"
       ]
+    },
+    {
+      "input": "NM_004006.1:c.[123=;456=;789=]",
+      "current": "NM_004006.1:c.[123=;456=;789=]",
+      "spec_expected": "NM_004006.1:c.[123=;456=;789=]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "NM_004006.2:c.123=",
@@ -2426,8 +3813,9 @@
       "spec_expected": "NM_004006.2:c.20_23dup",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "ported_legacy_probe",
+      "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/duplication.md",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
       ]
     },
@@ -2437,8 +3825,9 @@
       "spec_expected": "NM_004006.2:c.20dup",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "ported_legacy_probe",
+      "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/duplication.md",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
       ]
     },
@@ -2501,6 +3890,17 @@
       ]
     },
     {
+      "input": "NM_004006.2:c.5690dup",
+      "current": "NM_004006.2:c.5690dup",
+      "spec_expected": "NM_004006.2:c.5690dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "NM_004006.2:c.5697del",
       "current": "NM_004006.2:c.5697del",
       "spec_expected": "NM_004006.2:c.5697del",
@@ -2512,25 +3912,14 @@
       ]
     },
     {
-      "input": "NM_004006.2:c.6775_6777delGAGinsC",
-      "current": "NM_004006.2:c.6775_6777delGAGinsC",
-      "spec_expected": "NM_004006.2:c.6775_6777delGAGinsC",
+      "input": "NM_004006.2:c.5697dup",
+      "current": "NM_004006.2:c.5697dup",
+      "spec_expected": "NM_004006.2:c.5697dup",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
-      ]
-    },
-    {
-      "input": "NM_004006.2:c.6775_6777delGTGinsC",
-      "current": "NM_004006.2:c.6775_6777delGTGinsC",
-      "spec_expected": "NM_004006.2:c.6775_6777delGTGinsC",
-      "status": "preserved",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -2690,6 +4079,17 @@
       ]
     },
     {
+      "input": "NM_004006.3:c.5234G>A",
+      "current": "NM_004006.3:c.5234G>A",
+      "spec_expected": "NM_004006.3:c.5234G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
       "input": "NM_004006.3:c.897T>G",
       "current": "NM_004006.3:c.897T>G",
       "spec_expected": "NM_004006.3:c.897T>G",
@@ -2698,6 +4098,61 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/substitution.md"
+      ]
+    },
+    {
+      "input": "NM_004007.2:c.4865G>A",
+      "current": "NM_004007.2:c.4865G>A",
+      "spec_expected": "NM_004007.2:c.4865G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NM_004009.3:c.5222G>A",
+      "current": "NM_004009.3:c.5222G>A",
+      "spec_expected": "NM_004009.3:c.5222G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NM_004010.3:c.4865G>A",
+      "current": "NM_004010.3:c.4865G>A",
+      "spec_expected": "NM_004010.3:c.4865G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NM_004011.3:c.1211G>A",
+      "current": "NM_004011.3:c.1211G>A",
+      "spec_expected": "NM_004011.3:c.1211G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NM_004012.3:c.1202G>A",
+      "current": "NM_004012.3:c.1202G>A",
+      "spec_expected": "NM_004012.3:c.1202G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
       ]
     },
     {
@@ -2723,9 +4178,65 @@
       ]
     },
     {
+      "input": "NM_007294.3:c.2077G>A",
+      "current": "NM_007294.3:c.2077G>A",
+      "spec_expected": "NM_007294.3:c.2077G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md",
+        "docs/recommendations/DNA/substitution.md"
+      ]
+    },
+    {
       "input": "NM_021080.3:c.-136-75952_-136-75878ATTTT[15]",
       "current": "NM_021080.3:c.-136-75952_-136-75878ATTTT[15]",
       "spec_expected": "NM_021080.3:c.-136-75952_-136-75878ATTTT[15]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_023035.2:c.6955_6993CAG[26]",
+      "current": "NM_023035.2:c.6955_6993CAG[26]",
+      "spec_expected": "NM_023035.2:c.6955_6993CAG[26]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:c.-6_-3G[6]",
+      "current": "NM_024312.4:c.-6_-3G[6]",
+      "spec_expected": "NM_024312.4:c.-6_-3G[6]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:c.1741_1742insTATATATA",
+      "current": "NM_024312.4:c.1741_1742insTATATATA",
+      "spec_expected": "NM_024312.4:c.1741_1742insTATATATA",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:c.2692_2693dup",
+      "current": "NM_024312.4:c.2692_2693dup",
+      "spec_expected": "NM_024312.4:c.2692_2693dup",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -2756,15 +4267,69 @@
       ]
     },
     {
-      "input": "OPRM1:c.118A>G",
-      "current": "OPRM1:c.118A>G",
-      "spec_expected": "OPRM1:c.118A>G",
+      "input": "c.(516+1_517-1)_(1970_6774)del",
+      "input_prefixed": "NM_004006.2:c.(516+1_517-1)_(1970_6774)del",
+      "current": "NM_004006.2:c.(516+1_517-1)_(1970_6774)del",
+      "spec_expected": "NM_004006.2:c.(516+1_517-1)_(1970_6774)del",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "consultation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ]
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003"
+    },
+    {
+      "input": "c.(516+1_517-1)_(1970_6774)dup",
+      "input_prefixed": "NM_004006.2:c.(516+1_517-1)_(1970_6774)dup",
+      "current": "NM_004006.2:c.(516+1_517-1)_(1970_6774)dup",
+      "spec_expected": "NM_004006.2:c.(516+1_517-1)_(1970_6774)dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003"
+    },
+    {
+      "input": "c.(649+1_650-1)_(1331+1_1332-1)del",
+      "input_prefixed": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)del",
+      "current": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)del",
+      "spec_expected": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003"
+    },
+    {
+      "input": "c.(649+1_650-1)_(1331+1_1332-1)dup",
+      "input_prefixed": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)dup",
+      "current": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)dup",
+      "spec_expected": "NM_004006.2:c.(649+1_650-1)_(1331+1_1332-1)dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003"
+    },
+    {
+      "input": "c.(649_650)_(1331_1332)del",
+      "input_prefixed": "NM_004006.2:c.(649_650)_(1331_1332)del",
+      "current": "NM_004006.2:c.(649_650)_(1331_1332)del",
+      "spec_expected": "NM_004006.2:c.(649_650)_(1331_1332)del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG003.md"
+      ],
+      "working_group": "SVD-WG003"
     },
     {
       "input": "c.*1",
@@ -2775,8 +4340,10 @@
       "coordinate_system": "c",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/numbering.md"
-      ]
+        "docs/background/numbering.md",
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "c.*1-1",
@@ -2956,19 +4523,70 @@
       "coordinate_system": "c",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/numbering.md"
-      ]
+        "docs/background/numbering.md",
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
-      "input": "c.-14insG",
-      "input_prefixed": "NM_004006.2:c.-14insG",
-      "current": "NM_004006.2:c.-14insG",
-      "spec_expected": "NM_004006.2:c.-14insG",
+      "input": "c.-128",
+      "input_prefixed": "NM_004006.2:c.-128",
+      "current": "NM_004006.2:c.-128",
+      "spec_expected": "NM_004006.2:c.-128",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/DNA/repeated.md",
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.-129",
+      "input_prefixed": "NM_004006.2:c.-129",
+      "current": "NM_004006.2:c.-129",
+      "spec_expected": "NM_004006.2:c.-129",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.-14",
+      "input_prefixed": "NM_004006.2:c.-14",
+      "current": "NM_004006.2:c.-14",
+      "spec_expected": "NM_004006.2:c.-14",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.-144",
+      "input_prefixed": "NM_004006.2:c.-144",
+      "current": "NM_004006.2:c.-144",
+      "spec_expected": "NM_004006.2:c.-144",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.-16",
+      "input_prefixed": "NM_004006.2:c.-16",
+      "current": "NM_004006.2:c.-16",
+      "spec_expected": "NM_004006.2:c.-16",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -2992,7 +4610,8 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -3000,6 +4619,54 @@
       "input_prefixed": "NM_004006.2:c.-3",
       "current": "NM_004006.2:c.-3",
       "spec_expected": "NM_004006.2:c.-3",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.-69",
+      "input_prefixed": "NM_004006.2:c.-69",
+      "current": "NM_004006.2:c.-69",
+      "spec_expected": "NM_004006.2:c.-69",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.-84-1",
+      "input_prefixed": "NM_004006.2:c.-84-1",
+      "current": "NM_004006.2:c.-84-1",
+      "spec_expected": "NM_004006.2:c.-84-1",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.-84-2",
+      "input_prefixed": "NM_004006.2:c.-84-2",
+      "current": "NM_004006.2:c.-84-2",
+      "spec_expected": "NM_004006.2:c.-84-2",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.-84-3",
+      "input_prefixed": "NM_004006.2:c.-84-3",
+      "current": "NM_004006.2:c.-84-3",
+      "spec_expected": "NM_004006.2:c.-84-3",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "background",
@@ -3044,6 +4711,31 @@
       ]
     },
     {
+      "input": "c.-99",
+      "input_prefixed": "NM_004006.2:c.-99",
+      "current": "NM_004006.2:c.-99",
+      "spec_expected": "NM_004006.2:c.-99",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.1004T>C",
+      "input_prefixed": "NM_004006.2:c.1004T>C",
+      "current": "NM_004006.2:c.1004T>C",
+      "spec_expected": "NM_004006.2:c.1004T>C",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "c.1083A>C",
       "input_prefixed": "NM_004006.2:c.1083A>C",
       "current": "NM_004006.2:c.1083A>C",
@@ -3065,6 +4757,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "c.1210-14TG[13]T[5]",
+      "input_prefixed": "NM_004006.2:c.1210-14TG[13]T[5]",
+      "current": "NM_004006.2:c.1210-14TG[13]T[5]",
+      "spec_expected": "NM_004006.2:c.1210-14TG[13]T[5]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.1210-6T[5]",
+      "input_prefixed": "NM_004006.2:c.1210-6T[5]",
+      "current": "NM_004006.2:c.1210-6T[5]",
+      "spec_expected": "NM_004006.2:c.1210-6T[5]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -3112,8 +4828,36 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG001.md",
         "docs/recommendations/DNA/other.md"
-      ]
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "c.123C>T",
+      "input_prefixed": "NM_004006.2:c.123C>T",
+      "current": "NM_004006.2:c.123C>T",
+      "spec_expected": "NM_004006.2:c.123C>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "c.123dup",
+      "input_prefixed": "NM_004006.2:c.123dup",
+      "current": "NM_004006.2:c.123dup",
+      "spec_expected": "NM_004006.2:c.123dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "c.124-56C>T",
@@ -3137,6 +4881,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/checklist.md"
+      ]
+    },
+    {
+      "input": "c.12_14del",
+      "input_prefixed": "NM_004006.2:c.12_14del",
+      "current": "NM_004006.2:c.12_14del",
+      "spec_expected": "NM_004006.2:c.12_14del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
+      ]
+    },
+    {
+      "input": "c.12del",
+      "input_prefixed": "NM_004006.2:c.12del",
+      "current": "NM_004006.2:c.12del",
+      "spec_expected": "NM_004006.2:c.12del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/frameshift.md"
       ]
     },
     {
@@ -3164,6 +4932,18 @@
       ]
     },
     {
+      "input": "c.1704dup",
+      "input_prefixed": "NM_004006.2:c.1704dup",
+      "current": "NM_004006.2:c.1704dup",
+      "spec_expected": "NM_004006.2:c.1704dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "c.1732_1794del",
       "input_prefixed": "NM_004006.2:c.1732_1794del",
       "current": "NM_004006.2:c.1732_1794del",
@@ -3188,6 +4968,43 @@
       ]
     },
     {
+      "input": "c.1813-1dup",
+      "input_prefixed": "NM_004006.2:c.1813-1dup",
+      "current": "NM_004006.2:c.1813-1dup",
+      "spec_expected": "NM_004006.2:c.1813-1dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "c.1823=",
+      "input_prefixed": "NM_004006.2:c.1823=",
+      "current": "NM_004006.2:c.1823=",
+      "spec_expected": "NM_004006.2:c.1823=",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "c.19_20insT",
+      "input_prefixed": "NM_004006.2:c.19_20insT",
+      "current": "NM_004006.2:c.19_20insT",
+      "spec_expected": "NM_004006.2:c.19_20insT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "c.1_24dup",
       "input_prefixed": "NM_004006.2:c.1_24dup",
       "current": "NM_004006.2:c.1_24dup",
@@ -3200,6 +5017,19 @@
       ]
     },
     {
+      "input": "c.235A>T",
+      "input_prefixed": "NM_004006.2:c.235A>T",
+      "current": "NM_004006.2:c.235A>T",
+      "spec_expected": "NM_004006.2:c.235A>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "c.235_237delinsTAT",
       "input_prefixed": "NM_004006.2:c.235_237delinsTAT",
       "current": "NM_004006.2:c.235_237delinsTAT",
@@ -3208,9 +5038,37 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG010.md",
         "docs/recommendations/DNA/delins.md",
         "docs/recommendations/DNA/substitution.md"
-      ]
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "c.235_238delinsTAGT",
+      "input_prefixed": "NM_004006.2:c.235_238delinsTAGT",
+      "current": "NM_004006.2:c.235_238delinsTAGT",
+      "spec_expected": "NM_004006.2:c.235_238delinsTAGT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "c.236A>T",
+      "input_prefixed": "NM_004006.2:c.236A>T",
+      "current": "NM_004006.2:c.236A>T",
+      "spec_expected": "NM_004006.2:c.236A>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "c.2376=",
@@ -3237,16 +5095,30 @@
       ]
     },
     {
-      "input": "c.23ins24",
-      "input_prefixed": "NM_004006.2:c.23ins24",
-      "current": "NM_004006.2:c.23ins24",
-      "spec_expected": "NM_004006.2:c.23ins24",
+      "input": "c.237G>T",
+      "input_prefixed": "NM_004006.2:c.237G>T",
+      "current": "NM_004006.2:c.237G>T",
+      "spec_expected": "NM_004006.2:c.237G>T",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "consultation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ]
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "c.238G>T",
+      "input_prefixed": "NM_004006.2:c.238G>T",
+      "current": "NM_004006.2:c.238G>T",
+      "spec_expected": "NM_004006.2:c.238G>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "c.296T>G",
@@ -3273,15 +5145,28 @@
       ]
     },
     {
-      "input": "c.358C>T",
-      "input_prefixed": "NM_004006.2:c.358C>T",
-      "current": "NM_004006.2:c.358C>T",
-      "spec_expected": "NM_004006.2:c.358C>T",
+      "input": "c.3921dup",
+      "input_prefixed": "NM_004006.2:c.3921dup",
+      "current": "NM_004006.2:c.3921dup",
+      "spec_expected": "NM_004006.2:c.3921dup",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "background",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/background/refseq.md"
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "c.3922del",
+      "input_prefixed": "NM_004006.2:c.3922del",
+      "current": "NM_004006.2:c.3922del",
+      "spec_expected": "NM_004006.2:c.3922del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/recommendations/DNA/deletion.md"
       ]
     },
     {
@@ -3331,6 +5216,67 @@
       "source_paths": [
         "docs/background/simple.md"
       ]
+    },
+    {
+      "input": "c.4375_4376delinsAGTT",
+      "input_prefixed": "NM_004006.2:c.4375_4376delinsAGTT",
+      "current": "NM_004006.2:c.4375_4376delinsAGTT",
+      "spec_expected": "NM_004006.2:c.4375_4376delinsAGTT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "c.4375_4376insACCT",
+      "input_prefixed": "NM_004006.2:c.4375_4376insACCT",
+      "current": "NM_004006.2:c.4375_4376insACCT",
+      "spec_expected": "NM_004006.2:c.4375_4376insACCT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "c.4375_4379del",
+      "input_prefixed": "NM_004006.2:c.4375_4379del",
+      "current": "NM_004006.2:c.4375_4379del",
+      "spec_expected": "NM_004006.2:c.4375_4379del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "c.4375_4385dup",
+      "input_prefixed": "NM_004006.2:c.4375_4385dup",
+      "current": "NM_004006.2:c.4375_4385dup",
+      "spec_expected": "NM_004006.2:c.4375_4385dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "c.470=",
+      "input_prefixed": "NM_004006.2:c.470=",
+      "current": "NM_004006.2:c.470=",
+      "spec_expected": "NM_004006.2:c.470=",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "c.472_473delinsGT",
@@ -3393,15 +5339,15 @@
       ]
     },
     {
-      "input": "c.52insT",
-      "input_prefixed": "NM_004006.2:c.52insT",
-      "current": "NM_004006.2:c.52insT",
-      "spec_expected": "NM_004006.2:c.52insT",
+      "input": "c.5234G>A",
+      "input_prefixed": "NM_004006.2:c.5234G>A",
+      "current": "NM_004006.2:c.5234G>A",
+      "spec_expected": "NM_004006.2:c.5234G>A",
       "status": "preserved",
       "coordinate_system": "c",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/checklist.md"
+        "docs/background/simple.md"
       ]
     },
     {
@@ -3426,6 +5372,91 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "c.633A>G",
+      "input_prefixed": "NM_004006.2:c.633A>G",
+      "current": "NM_004006.2:c.633A>G",
+      "spec_expected": "NM_004006.2:c.633A>G",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "c.650-1401T>G",
+      "input_prefixed": "NM_004006.2:c.650-1401T>G",
+      "current": "NM_004006.2:c.650-1401T>G",
+      "spec_expected": "NM_004006.2:c.650-1401T>G",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "c.650-1G>C",
+      "input_prefixed": "NM_004006.2:c.650-1G>C",
+      "current": "NM_004006.2:c.650-1G>C",
+      "spec_expected": "NM_004006.2:c.650-1G>C",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "c.650-52_650-51del",
+      "input_prefixed": "NM_004006.2:c.650-52_650-51del",
+      "current": "NM_004006.2:c.650-52_650-51del",
+      "spec_expected": "NM_004006.2:c.650-52_650-51del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "c.689_690insT",
+      "input_prefixed": "NM_004006.2:c.689_690insT",
+      "current": "NM_004006.2:c.689_690insT",
+      "spec_expected": "NM_004006.2:c.689_690insT",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "c.6955_6993dup",
+      "input_prefixed": "NM_004006.2:c.6955_6993dup",
+      "current": "NM_004006.2:c.6955_6993dup",
+      "spec_expected": "NM_004006.2:c.6955_6993dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "c.6_13dup",
+      "input_prefixed": "NM_004006.2:c.6_13dup",
+      "current": "NM_004006.2:c.6_13dup",
+      "spec_expected": "NM_004006.2:c.6_13dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/frameshift.md"
       ]
     },
     {
@@ -3489,6 +5520,54 @@
       ]
     },
     {
+      "input": "c.76del",
+      "input_prefixed": "NM_004006.2:c.76del",
+      "current": "NM_004006.2:c.76del",
+      "spec_expected": "NM_004006.2:c.76del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "c.76dup",
+      "input_prefixed": "NM_004006.2:c.76dup",
+      "current": "NM_004006.2:c.76dup",
+      "spec_expected": "NM_004006.2:c.76dup",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "c.831+2T>A",
+      "input_prefixed": "NM_004006.2:c.831+2T>A",
+      "current": "NM_004006.2:c.831+2T>A",
+      "spec_expected": "NM_004006.2:c.831+2T>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "c.831+71C>A",
+      "input_prefixed": "NM_004006.2:c.831+71C>A",
+      "current": "NM_004006.2:c.831+71C>A",
+      "spec_expected": "NM_004006.2:c.831+71C>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
       "input": "c.85=",
       "input_prefixed": "NM_004006.2:c.85=",
       "current": "NM_004006.2:c.85=",
@@ -3515,6 +5594,54 @@
       ]
     },
     {
+      "input": "c.88+2T>G",
+      "input_prefixed": "NM_004006.2:c.88+2T>G",
+      "current": "NM_004006.2:c.88+2T>G",
+      "spec_expected": "NM_004006.2:c.88+2T>G",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.89-1G>T",
+      "input_prefixed": "NM_004006.2:c.89-1G>T",
+      "current": "NM_004006.2:c.89-1G>T",
+      "spec_expected": "NM_004006.2:c.89-1G>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "c.897T>G",
+      "input_prefixed": "NM_004006.2:c.897T>G",
+      "current": "NM_004006.2:c.897T>G",
+      "spec_expected": "NM_004006.2:c.897T>G",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "c.89_118AGC[13]",
+      "input_prefixed": "NM_004006.2:c.89_118AGC[13]",
+      "current": "NM_004006.2:c.89_118AGC[13]",
+      "spec_expected": "NM_004006.2:c.89_118AGC[13]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "c.93G>T",
       "input_prefixed": "NM_004006.2:c.93G>T",
       "current": "NM_004006.2:c.93G>T",
@@ -3527,15 +5654,28 @@
       ]
     },
     {
-      "input": "c.9_32dup",
-      "input_prefixed": "NM_004006.2:c.9_32dup",
-      "current": "NM_004006.2:c.9_32dup",
-      "spec_expected": "NM_004006.2:c.9_32dup",
+      "input": "c.992_1002del",
+      "input_prefixed": "NM_004006.2:c.992_1002del",
+      "current": "NM_004006.2:c.992_1002del",
+      "spec_expected": "NM_004006.2:c.992_1002del",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "c.9_10insGGGTAG",
+      "input_prefixed": "NM_004006.2:c.9_10insGGGTAG",
+      "current": "NM_004006.2:c.9_10insGGGTAG",
+      "spec_expected": "NM_004006.2:c.9_10insGGGTAG",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/protein/insertion.md"
       ]
     },
     {
@@ -3564,19 +5704,6 @@
       ]
     },
     {
-      "input": "c.[145C>T;147C>G]",
-      "input_prefixed": "NM_004006.2:c.[145C>T;147C>G]",
-      "current": "NM_004006.2:c.[145C>T;147C>G]",
-      "spec_expected": "NM_004006.2:c.[145C>T;147C>G]",
-      "status": "preserved",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/delins.md",
-        "docs/recommendations/DNA/substitution.md"
-      ]
-    },
-    {
       "input": "c.[235A>T;237G>T]",
       "input_prefixed": "NM_004006.2:c.[235A>T;237G>T]",
       "current": "NM_004006.2:c.[235A>T;237G>T]",
@@ -3585,9 +5712,11 @@
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG010.md",
         "docs/recommendations/DNA/delins.md",
         "docs/recommendations/DNA/substitution.md"
-      ]
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "c.[2376_2377insGT];[2376_2377=]",
@@ -3638,6 +5767,76 @@
       ]
     },
     {
+      "input": "NC_000002.12:g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"::NC_000011.10:g.15825273_cen_qter\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000011.10:g.pter_15825272::NC_000002.12:g.8247757_cen_qter",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"::NC_000002.12:g.8247757_cen_qter\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "g.123_234dupinv",
+      "input_prefixed": "NC_000023.11:g.123_234dupinv",
+      "current": "parse error: Parse error at position 25: Unexpected trailing characters: 'inv'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ]
+    },
+    {
+      "input": "g.123_456dupinv",
+      "input_prefixed": "NC_000023.11:g.123_456dupinv",
+      "current": "parse error: Parse error at position 25: Unexpected trailing characters: 'inv'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ]
+    },
+    {
+      "input": "g.123ˆ124G",
+      "input_prefixed": "NC_000023.11:g.123ˆ124G",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"ˆ124G\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
+      "input": "g.123ˆ124insG",
+      "input_prefixed": "NC_000023.11:g.123ˆ124insG",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"ˆ124insG\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
       "input": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
       "current": "NC_000002.11:g.?ins[NC_000022.10:g.35788169_35788352]",
       "spec_expected": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
@@ -3674,9 +5873,33 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "NC_000003.12:g.(63912602_63912844)insN[9]",
+      "current": "NC_000003.12:g.(63912602)_(63912844)insN[9]",
+      "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[9]",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "NC_000003.12:g.63912687AGC[(50_60)]",
       "current": "NC_000003.12:g.63912687AGC[50_60]",
       "spec_expected": "NC_000003.12:g.63912687AGC[(50_60)]",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000003.12:g.63912687AGC[(60_?)]",
+      "current": "NC_000003.12:g.63912687AGC[60_?]",
+      "spec_expected": "NC_000003.12:g.63912687AGC[(60_?)]",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -3705,8 +5928,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG009.md",
         "docs/recommendations/DNA/delins.md"
       ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -3718,6 +5943,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.10:g.32361293",
+      "current": "NC_000023.10:g.32361293=",
+      "spec_expected": "NC_000023.10:g.32361293",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.10:g.32361300",
+      "current": "NC_000023.10:g.32361300=",
+      "spec_expected": "NC_000023.10:g.32361300",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -3734,6 +5983,18 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "NC_000023.11:g.(86200001_103700000)del",
+      "current": "NC_000023.11:g.(86200001)_(103700000)del",
+      "spec_expected": "NC_000023.11:g.(86200001_103700000)del",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "NC_000023.11:g.32343183",
       "current": "NC_000023.11:g.32343183=",
       "spec_expected": "NC_000023.11:g.32343183",
@@ -3741,63 +6002,120 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.33344590_33344592delGAT",
-      "current": "NC_000023.11:g.33344590_33344592del",
-      "spec_expected": "NC_000023.11:g.33344590_33344592delGAT",
+      "input": "chrX:g.[89555676_100352080del]",
+      "current": "chrX:g.89555676_100352080del",
+      "spec_expected": "chrX:g.[89555676_100352080del]",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.(100_150)insN[25]",
+      "input_prefixed": "NC_000023.11:g.(100_150)insN[25]",
+      "current": "NC_000023.11:g.(100)_(150)insN[25]",
+      "spec_expected": "NC_000023.11:g.(100_150)insN[25]",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.33344590_33344592delTTA",
-      "current": "NC_000023.11:g.33344590_33344592del",
-      "spec_expected": "NC_000023.11:g.33344590_33344592delTTA",
+      "input": "g.1",
+      "input_prefixed": "NC_000023.11:g.1",
+      "current": "NC_000023.11:g.1=",
+      "spec_expected": "NC_000023.11:g.1",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.101179660",
+      "input_prefixed": "NC_000023.11:g.101179660",
+      "current": "NC_000023.11:g.101179660=",
+      "spec_expected": "NC_000023.11:g.101179660",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.33344591delG",
-      "current": "NC_000023.11:g.33344591del",
-      "spec_expected": "NC_000023.11:g.33344591delG",
+      "input": "g.106370094",
+      "input_prefixed": "NC_000023.11:g.106370094",
+      "current": "NC_000023.11:g.106370094=",
+      "spec_expected": "NC_000023.11:g.106370094",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.33344591delT",
-      "current": "NC_000023.11:g.33344591del",
-      "spec_expected": "NC_000023.11:g.33344591delT",
+      "input": "g.106370420",
+      "input_prefixed": "NC_000023.11:g.106370420",
+      "current": "NC_000023.11:g.106370420=",
+      "spec_expected": "NC_000023.11:g.106370420",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.122_123ins123_234inv",
-      "input_prefixed": "NC_000023.11:g.122_123ins123_234inv",
-      "current": "NC_000023.11:g.122_123ins[123_234inv]",
-      "spec_expected": "NC_000023.11:g.122_123ins123_234inv",
+      "input": "g.10791926",
+      "input_prefixed": "NC_000023.11:g.10791926",
+      "current": "NC_000023.11:g.10791926=",
+      "spec_expected": "NC_000023.11:g.10791926",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.10791927",
+      "input_prefixed": "NC_000023.11:g.10791927",
+      "current": "NC_000023.11:g.10791927=",
+      "spec_expected": "NC_000023.11:g.10791927",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.111754331",
+      "input_prefixed": "NC_000023.11:g.111754331",
+      "current": "NC_000023.11:g.111754331=",
+      "spec_expected": "NC_000023.11:g.111754331",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -3807,16 +6125,56 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.123",
-      "input_prefixed": "NC_000023.11:g.123",
-      "current": "NC_000023.11:g.123=",
-      "spec_expected": "NC_000023.11:g.123",
+      "input": "g.111966764",
+      "input_prefixed": "NC_000023.11:g.111966764",
+      "current": "NC_000023.11:g.111966764=",
+      "spec_expected": "NC_000023.11:g.111966764",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
+        "docs/recommendations/DNA/inversion.md"
       ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.112036755",
+      "input_prefixed": "NC_000023.11:g.112036755",
+      "current": "NC_000023.11:g.112036755=",
+      "spec_expected": "NC_000023.11:g.112036755",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.112036823",
+      "input_prefixed": "NC_000023.11:g.112036823",
+      "current": "NC_000023.11:g.112036823=",
+      "spec_expected": "NC_000023.11:g.112036823",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.12345678",
+      "input_prefixed": "NC_000023.11:g.12345678",
+      "current": "NC_000023.11:g.12345678=",
+      "spec_expected": "NC_000023.11:g.12345678",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -3829,6 +6187,33 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/general.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.12345901",
+      "input_prefixed": "NC_000023.11:g.12345901",
+      "current": "NC_000023.11:g.12345901=",
+      "spec_expected": "NC_000023.11:g.12345901",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.123_456",
+      "input_prefixed": "NC_000023.11:g.123_456",
+      "current": "NC_000023.11:g.123_456=",
+      "spec_expected": "NC_000023.11:g.123_456",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -3846,17 +6231,44 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.17",
-      "input_prefixed": "NC_000023.11:g.17",
-      "current": "NC_000023.11:g.17=",
-      "spec_expected": "NC_000023.11:g.17",
+      "input": "g.1649",
+      "input_prefixed": "NC_000023.11:g.1649",
+      "current": "NC_000023.11:g.1649=",
+      "spec_expected": "NC_000023.11:g.1649",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/RNA/delins.md"
       ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.17178616",
+      "input_prefixed": "NC_000023.11:g.17178616",
+      "current": "NC_000023.11:g.17178616=",
+      "spec_expected": "NC_000023.11:g.17178616",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.17178886",
+      "input_prefixed": "NC_000023.11:g.17178886",
+      "current": "NC_000023.11:g.17178886=",
+      "spec_expected": "NC_000023.11:g.17178886",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -3886,16 +6298,28 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.18",
-      "input_prefixed": "NC_000023.11:g.18",
-      "current": "NC_000023.11:g.18=",
-      "spec_expected": "NC_000023.11:g.18",
+      "input": "g.19385993",
+      "input_prefixed": "NC_000023.11:g.19385993",
+      "current": "NC_000023.11:g.19385993=",
+      "spec_expected": "NC_000023.11:g.19385993",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.19394916",
+      "input_prefixed": "NC_000023.11:g.19394916",
+      "current": "NC_000023.11:g.19394916=",
+      "spec_expected": "NC_000023.11:g.19394916",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -3926,6 +6350,47 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.2",
+      "input_prefixed": "NC_000023.11:g.2",
+      "current": "NC_000023.11:g.2=",
+      "spec_expected": "NC_000023.11:g.2",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.23456789",
+      "input_prefixed": "NC_000023.11:g.23456789",
+      "current": "NC_000023.11:g.23456789=",
+      "spec_expected": "NC_000023.11:g.23456789",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.23456901",
+      "input_prefixed": "NC_000023.11:g.23456901",
+      "current": "NC_000023.11:g.23456901=",
+      "spec_expected": "NC_000023.11:g.23456901",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.234_235ins123_234inv",
       "input_prefixed": "NC_000023.11:g.234_235ins123_234inv",
       "current": "NC_000023.11:g.234_235ins[123_234inv]",
@@ -3934,7 +6399,74 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/duplication.md",
+        "docs/recommendations/DNA/insertion.md",
         "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.25045592",
+      "input_prefixed": "NC_000023.11:g.25045592",
+      "current": "NC_000023.11:g.25045592=",
+      "spec_expected": "NC_000023.11:g.25045592",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.25059364",
+      "input_prefixed": "NC_000023.11:g.25059364",
+      "current": "NC_000023.11:g.25059364=",
+      "spec_expected": "NC_000023.11:g.25059364",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.3",
+      "input_prefixed": "NC_000023.11:g.3",
+      "current": "NC_000023.11:g.3=",
+      "spec_expected": "NC_000023.11:g.3",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.3076562",
+      "input_prefixed": "NC_000023.11:g.3076562",
+      "current": "NC_000023.11:g.3076562=",
+      "spec_expected": "NC_000023.11:g.3076562",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.3076732",
+      "input_prefixed": "NC_000023.11:g.3076732",
+      "current": "NC_000023.11:g.3076732=",
+      "spec_expected": "NC_000023.11:g.3076732",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -3947,7 +6479,8 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -3969,6 +6502,19 @@
       "input_prefixed": "NC_000023.11:g.31729663",
       "current": "NC_000023.11:g.31729663=",
       "spec_expected": "NC_000023.11:g.31729663",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.31729716",
+      "input_prefixed": "NC_000023.11:g.31729716",
+      "current": "NC_000023.11:g.31729716=",
+      "spec_expected": "NC_000023.11:g.31729716",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4043,6 +6589,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.32057077",
+      "input_prefixed": "NC_000023.11:g.32057077",
+      "current": "NC_000023.11:g.32057077=",
+      "spec_expected": "NC_000023.11:g.32057077",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.32214437_32218461",
       "input_prefixed": "NC_000023.11:g.32214437_32218461",
       "current": "NC_000023.11:g.32214437_32218461=",
@@ -4086,6 +6645,19 @@
       "input_prefixed": "NC_000023.11:g.32216973",
       "current": "NC_000023.11:g.32216973=",
       "spec_expected": "NC_000023.11:g.32216973",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32278336_32289141",
+      "input_prefixed": "NC_000023.11:g.32278336_32289141",
+      "current": "NC_000023.11:g.32278336_32289141=",
+      "spec_expected": "NC_000023.11:g.32278336_32289141",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4142,7 +6714,8 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4155,7 +6728,34 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32361330",
+      "input_prefixed": "NC_000023.11:g.32361330",
+      "current": "NC_000023.11:g.32361330=",
+      "spec_expected": "NC_000023.11:g.32361330",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32361333",
+      "input_prefixed": "NC_000023.11:g.32361333",
+      "current": "NC_000023.11:g.32361333=",
+      "spec_expected": "NC_000023.11:g.32361333",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4186,6 +6786,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.32441180",
+      "input_prefixed": "NC_000023.11:g.32441180",
+      "current": "NC_000023.11:g.32441180=",
+      "spec_expected": "NC_000023.11:g.32441180",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.32456507",
       "input_prefixed": "NC_000023.11:g.32456507",
       "current": "NC_000023.11:g.32456507=",
@@ -4199,6 +6812,84 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.32717298",
+      "input_prefixed": "NC_000023.11:g.32717298",
+      "current": "NC_000023.11:g.32717298=",
+      "spec_expected": "NC_000023.11:g.32717298",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32717299",
+      "input_prefixed": "NC_000023.11:g.32717299",
+      "current": "NC_000023.11:g.32717299=",
+      "spec_expected": "NC_000023.11:g.32717299",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32862923",
+      "input_prefixed": "NC_000023.11:g.32862923",
+      "current": "NC_000023.11:g.32862923=",
+      "spec_expected": "NC_000023.11:g.32862923",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32862924",
+      "input_prefixed": "NC_000023.11:g.32862924",
+      "current": "NC_000023.11:g.32862924=",
+      "spec_expected": "NC_000023.11:g.32862924",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32867861",
+      "input_prefixed": "NC_000023.11:g.32867861",
+      "current": "NC_000023.11:g.32867861=",
+      "spec_expected": "NC_000023.11:g.32867861",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32867862",
+      "input_prefixed": "NC_000023.11:g.32867862",
+      "current": "NC_000023.11:g.32867862=",
+      "spec_expected": "NC_000023.11:g.32867862",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.32867908",
       "input_prefixed": "NC_000023.11:g.32867908",
       "current": "NC_000023.11:g.32867908=",
@@ -4207,8 +6898,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG001.md",
         "docs/recommendations/DNA/other.md"
       ],
+      "working_group": "SVD-WG001",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4225,6 +6918,45 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.32894352_33055973",
+      "input_prefixed": "NC_000023.11:g.32894352_33055973",
+      "current": "NC_000023.11:g.32894352_33055973=",
+      "spec_expected": "NC_000023.11:g.32894352_33055973",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.32975163",
+      "input_prefixed": "NC_000023.11:g.32975163",
+      "current": "NC_000023.11:g.32975163=",
+      "spec_expected": "NC_000023.11:g.32975163",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.33038255",
+      "input_prefixed": "NC_000023.11:g.33038255",
+      "current": "NC_000023.11:g.33038255=",
+      "spec_expected": "NC_000023.11:g.33038255",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.33339477",
       "input_prefixed": "NC_000023.11:g.33339477",
       "current": "NC_000023.11:g.33339477=",
@@ -4233,7 +6965,8 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4246,7 +6979,8 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4272,7 +7006,21 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.33394206",
+      "input_prefixed": "NC_000023.11:g.33394206",
+      "current": "NC_000023.11:g.33394206=",
+      "spec_expected": "NC_000023.11:g.33394206",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4285,6 +7033,7 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
         "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -4298,7 +7047,35 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
         "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.39800",
+      "input_prefixed": "NC_000023.11:g.39800",
+      "current": "NC_000023.11:g.39800=",
+      "spec_expected": "NC_000023.11:g.39800",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.409",
+      "input_prefixed": "NC_000023.11:g.409",
+      "current": "NC_000023.11:g.409=",
+      "spec_expected": "NC_000023.11:g.409",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4311,8 +7088,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG009.md",
         "docs/recommendations/DNA/delins.md"
       ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4324,8 +7103,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG009.md",
         "docs/recommendations/DNA/delins.md"
       ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4337,8 +7118,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG009.md",
         "docs/recommendations/DNA/delins.md"
       ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4350,8 +7133,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG009.md",
         "docs/recommendations/DNA/delins.md"
       ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4363,6 +7148,7 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
         "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -4376,22 +7162,51 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/insertion.md",
         "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.5",
-      "input_prefixed": "NC_000023.11:g.5",
-      "current": "NC_000023.11:g.5=",
-      "spec_expected": "NC_000023.11:g.5",
+      "input": "g.4950",
+      "input_prefixed": "NC_000023.11:g.4950",
+      "current": "NC_000023.11:g.4950=",
+      "spec_expected": "NC_000023.11:g.4950",
       "status": "diverges",
       "coordinate_system": "g",
-      "source_kind": "recommendation",
+      "source_kind": "consultation",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/DNA/insertion.md"
+        "docs/consultation/SVD-WG001.md"
       ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.6128479",
+      "input_prefixed": "NC_000023.11:g.6128479",
+      "current": "NC_000023.11:g.6128479=",
+      "spec_expected": "NC_000023.11:g.6128479",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.6128749",
+      "input_prefixed": "NC_000023.11:g.6128749",
+      "current": "NC_000023.11:g.6128749=",
+      "spec_expected": "NC_000023.11:g.6128749",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -4421,6 +7236,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.63912602",
+      "input_prefixed": "NC_000023.11:g.63912602",
+      "current": "NC_000023.11:g.63912602=",
+      "spec_expected": "NC_000023.11:g.63912602",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.6391268",
       "input_prefixed": "NC_000023.11:g.6391268",
       "current": "NC_000023.11:g.6391268=",
@@ -4434,6 +7262,32 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "g.63912687",
+      "input_prefixed": "NC_000023.11:g.63912687",
+      "current": "NC_000023.11:g.63912687=",
+      "spec_expected": "NC_000023.11:g.63912687",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.63912844",
+      "input_prefixed": "NC_000023.11:g.63912844",
+      "current": "NC_000023.11:g.63912844=",
+      "spec_expected": "NC_000023.11:g.63912844",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "g.8247756",
       "input_prefixed": "NC_000023.11:g.8247756",
       "current": "NC_000023.11:g.8247756=",
@@ -4443,6 +7297,45 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.8897743",
+      "input_prefixed": "NC_000023.11:g.8897743",
+      "current": "NC_000023.11:g.8897743=",
+      "spec_expected": "NC_000023.11:g.8897743",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.8897754",
+      "input_prefixed": "NC_000023.11:g.8897754",
+      "current": "NC_000023.11:g.8897754=",
+      "spec_expected": "NC_000023.11:g.8897754",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.8897755",
+      "input_prefixed": "NC_000023.11:g.8897755",
+      "current": "NC_000023.11:g.8897755=",
+      "spec_expected": "NC_000023.11:g.8897755",
+      "status": "diverges",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4473,6 +7366,104 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "NC_000012.12:g.6128479_6128749con[NC_000022.11:g.17178616_17178886]",
+      "current": "NC_000012.12:g.6128479_6128749delins[[NC_000022.11:g.17178616_17178886]]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000022.10:g.42522624_42522669con42536337_42536382",
+      "current": "NC_000022.10:g.42522624_42522669delins42536337_42536382",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.32386323delCinsGA",
+      "current": "NC_000023.11:g.32386323delCinsGA",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.32386323delTinsGA",
+      "current": "NC_000023.11:g.32386323delTinsGA",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592delGAT",
+      "current": "NC_000023.11:g.33344590_33344592del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.33344590_33344592delTTA",
+      "current": "NC_000023.11:g.33344590_33344592del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.33344591delA",
+      "current": "NC_000023.11:g.33344591del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.11:g.33344591delG",
+      "current": "NC_000023.11:g.33344591del",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "NG_012232.1:g.123del6",
       "current": "NG_012232.1:g.123del",
       "spec_expected": null,
@@ -4481,6 +7472,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NG_012232.1:g.12GC>TG",
+      "current": "NG_012232.1:g.12delinsTG",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4498,34 +7501,88 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.6_8dupugc",
-      "input_prefixed": "NC_000023.11:g.6_8dupugc",
-      "current": "NC_000023.11:g.6_8dup",
+      "input": "g.123dup6",
+      "input_prefixed": "NC_000023.11:g.123dup6",
+      "current": "NC_000023.11:g.123dup",
       "spec_expected": null,
       "status": "false-acceptance",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/duplication.md"
+        "docs/recommendations/DNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC*000003.12:g.63912687AGC[(60*?)]",
-      "current": "parse error: Parse error at position 26: Unexpected trailing characters: '[(60*?)]'",
-      "spec_expected": "NC*000003.12:g.63912687AGC[(60*?)]",
-      "status": "parse-error",
+      "input": "g.123insG",
+      "input_prefixed": "NC_000023.11:g.123insG",
+      "current": "NC_000023.11:g.123insG",
+      "spec_expected": null,
+      "status": "false-acceptance",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
+        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
-      "current": "parse error: Parse error at position 13: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found ':g.'",
-      "spec_expected": "NC_000002.12::g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
+      "input": "g.234inv",
+      "input_prefixed": "NC_000023.11:g.234inv",
+      "current": "NC_000023.11:g.234inv",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.456_457ins123_456",
+      "input_prefixed": "NC_000023.11:g.456_457ins123_456",
+      "current": "NC_000023.11:g.456_457ins[123_456]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.4GC>TG",
+      "input_prefixed": "NC_000023.11:g.4GC>TG",
+      "current": "NC_000023.11:g.4delinsTG",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.50377648A=",
+      "input_prefixed": "NC_000023.11:g.50377648A=",
+      "current": "NC_000023.11:g.50377648A=",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[32310435_32310710del;32310711_171827243inv;insG]\", code: Tag })",
+      "spec_expected": "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4542,6 +7599,7 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/DNA/repeated.md",
         "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -4559,9 +7617,69 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000011.10:g.pter_15825272::NC_000002.12:g.8247757_cen_qter",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"::NC_000002.12:g.8247757_cen_qter\", code: Tag })",
-      "spec_expected": "NC_000011.10:g.pter_15825272::NC_000002.12:g.8247757_cen_qter",
+      "input": "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv",
+      "current": "parse error: Parse error at position 82: Unexpected trailing characters: 'inv'",
+      "spec_expected": "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000009.12:g.102425452_qterdelinspter_26393001inv",
+      "current": "parse error: Parse error at position 35: Unexpected trailing characters: 'pter_26393001inv'",
+      "spec_expected": "NC_000009.12:g.102425452_qterdelinspter_26393001inv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000009.12:g.pter_26393001delins102425452_qterinv",
+      "current": "parse error: Parse error at position 31: Unexpected trailing characters: 'ins102425452_qterinv'",
+      "spec_expected": "NC_000009.12:g.pter_26393001delins102425452_qterinv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
+      "current": "parse error: Parse error at position 41: Unexpected trailing characters: ';[101179660_101179695TG[18]]'",
+      "spec_expected": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup\", code: Tag })",
+      "spec_expected": "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"pter_(12200001_14700000)del::(37600001_410000000)_qterdel\", code: Tag })",
+      "spec_expected": "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4583,21 +7701,146 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NG_012232.1:g.12_13delinsTG,",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: ','",
-      "spec_expected": "NG_012232.1:g.12_13delinsTG,",
+      "input": "chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \",825,272::chr2:g.8,247,757_cen_qter\", code: Tag })",
+      "spec_expected": "chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
+        "docs/recommendations/DNA/complex.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "class=\"invalid\">NG_012232.1:g.123del6</code>.<a",
+      "input": "chr11:g.pter_cen_108111981::chr2:g.174500099_qter",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"_108111981::chr2:g.174500099_qter\", code: Tag })",
+      "spec_expected": "chr11:g.pter_cen_108111981::chr2:g.174500099_qter",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr14:g.29,745,314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:g.36,969,142_cen_qter",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \",745,314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:g.36,969,142_cen_qter\", code: Tag })",
+      "spec_expected": "chr14:g.29,745,314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:g.36,969,142_cen_qter",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr14:g.[pter_cen_qter]add",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"[pter_cen_qter]add\", code: Tag })",
+      "spec_expected": "chr14:g.[pter_cen_qter]add",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr14:g.pter_cen_29,745,313::chr3:g.pter_36,969,141inv",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"_29,745,313::chr3:g.pter_36,969,141inv\", code: Tag })",
+      "spec_expected": "chr14:g.pter_cen_29,745,313::chr3:g.pter_36,969,141inv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr22:g.[pter_10000000del::40000000_qterdel]add",
+      "current": "parse error: Parse error at position 6: Failed to parse variant: Error(Error { input: \"[pter_10000000del::40000000_qterdel]add\", code: Tag })",
+      "spec_expected": "chr22:g.[pter_10000000del::40000000_qterdel]add",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr22:g.pter_10000000del::40000000_qterdel",
+      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '::40000000_qterdel'",
+      "spec_expected": "chr22:g.pter_10000000del::40000000_qterdel",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr2:g.[32310435_32310710del;32310711_171827243inv;insG]",
+      "current": "parse error: Parse error at position 5: Failed to parse variant: Error(Error { input: \"[32310435_32310710del;32310711_171827243inv;insG]\", code: Tag })",
+      "spec_expected": "chr2:g.[32310435_32310710del;32310711_171827243inv;insG]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter",
+      "current": "parse error: Parse error at position 5: Failed to parse variant: Error(Error { input: \",247,756::chr11:g.15,825,273_cen_qter\", code: Tag })",
+      "spec_expected": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr2:g.pter_cen_174500098::chr11:g.108111987_qter",
+      "current": "parse error: Parse error at position 5: Failed to parse variant: Error(Error { input: \"_174500098::chr11:g.108111987_qter\", code: Tag })",
+      "spec_expected": "chr2:g.pter_cen_174500098::chr11:g.108111987_qter",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "chr8:g.128746677_128749160dupinv",
+      "current": "parse error: Parse error at position 29: Unexpected trailing characters: 'inv'",
+      "spec_expected": "chr8:g.128746677_128749160dupinv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "class=\"invalid\">NG_012232.1:g.123del6</code>.",
       "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NG_012232.1:g.123del6<\", code: Alpha })",
-      "spec_expected": "class=\"invalid\">NG_012232.1:g.123del6</code>.<a",
+      "spec_expected": "class=\"invalid\">NG_012232.1:g.123del6</code>.",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4607,10 +7850,27 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.(100_150)del(15)",
-      "input_prefixed": "NC_000023.11:g.(100_150)del(15)",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: '(15)'",
-      "spec_expected": "NC_000023.11:g.(100_150)del(15)",
+      "input": "g.",
+      "input_prefixed": "NC_000023.11:g.",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
+      "spec_expected": "NC_000023.11:g.",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG002.md",
+        "docs/recommendations/checklist.md"
+      ],
+      "working_group": "SVD-WG002",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.(100_150)delN[15]",
+      "input_prefixed": "NC_000023.11:g.(100_150)delN[15]",
+      "current": "parse error: Parse error at position 28: Unexpected trailing characters: '[15]'",
+      "spec_expected": "NC_000023.11:g.(100_150)delN[15]",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4620,10 +7880,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.(position-fragment-start_position-fragment-end)del/insN[#]",
-      "input_prefixed": "NC_000023.11:g.(position-fragment-start_position-fragment-end)del/insN[#]",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(position-fragment-start_position-fragment-end)del\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.(position-fragment-start_position-fragment-end)del/insN[#]",
+      "input": "g.(fragment-start_fragment-end)delN[#]",
+      "input_prefixed": "NC_000023.11:g.(fragment-start_fragment-end)delN[#]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(fragment-start_fragment-end)delN[#]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.(fragment-start_fragment-end)delN[#]",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4633,10 +7893,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.(position-fragment-start_position-fragment-end)insN[#]",
-      "input_prefixed": "NC_000023.11:g.(position-fragment-start_position-fragment-end)insN[#]",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(position-fragment-start_position-fragment-end)insN[#]\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.(position-fragment-start_position-fragment-end)insN[#]",
+      "input": "g.(fragment-start_fragment-end)insN[#]",
+      "input_prefixed": "NC_000023.11:g.(fragment-start_fragment-end)insN[#]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(fragment-start_fragment-end)insN[#]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.(fragment-start_fragment-end)insN[#]",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -4646,69 +7906,28 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.123_128dup.",
-      "input_prefixed": "NC_000023.11:g.123_128dup.",
-      "current": "parse error: Parse error at position 25: Unexpected trailing characters: '.'",
-      "spec_expected": "NC_000023.11:g.123_128dup.",
+      "input": "g.(last-normal_first-duplicated)_(last-duplicated_first-normal)dup",
+      "input_prefixed": "NC_000023.11:g.(last-normal_first-duplicated)_(last-duplicated_first-normal)dup",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(last-normal_first-duplicated)_(last-duplicated_first-normal)dup\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.(last-normal_first-duplicated)_(last-duplicated_first-normal)dup",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/duplication.md"
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.123ˆ124G.",
-      "input_prefixed": "NC_000023.11:g.123ˆ124G.",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"ˆ124G.\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.123ˆ124G.",
+      "input": "g.(left-ins-position_right-ins-position)ins(last-normal_first-inserted)_(last-inserted_first-normal)",
+      "input_prefixed": "NC_000023.11:g.(left-ins-position_right-ins-position)ins(last-normal_first-inserted)_(last-inserted_first-normal)",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"(left-ins-position_right-ins-position)ins(last-normal_first-inserted)_(last-inserted_first-normal)\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.(left-ins-position_right-ins-position)ins(last-normal_first-inserted)_(last-inserted_first-normal)",
       "status": "parse-error",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "g.123ˆ124insG",
-      "input_prefixed": "NC_000023.11:g.123ˆ124insG",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"ˆ124insG\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.123ˆ124insG",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "g.16,",
-      "input_prefixed": "NC_000023.11:g.16,",
-      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \",\", code: Tag })",
-      "spec_expected": "NC_000023.11:g.16,",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "g.17_18ins5_16.",
-      "input_prefixed": "NC_000023.11:g.17_18ins5_16.",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: '.'",
-      "spec_expected": "NC_000023.11:g.17_18ins5_16.",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -4749,15 +7968,234 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
-      "current": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
-      "spec_expected": "NC*000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
+      "input": "g.[chr11:pter_15825272::chr2:8247757_cen_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr11:pter_15825272::chr2:8247757_cen_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr11:pter_15825272::chr2:8247757_cen_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr11:pter_15825272::chr2:8247757_cen_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr11:pter_cen_108111981::chr2:174500099_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr11:pter_cen_108111981::chr2:174500099_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr11:pter_cen_108111981::chr2:174500099_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr11:pter_cen_108111981::chr2:174500099_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr14:29745314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:36969142_cen_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr14:29745314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:36969142_cen_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr14:29745314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:36969142_cen_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr14:29745314_qterinv::CATTTGTTCAAATTTAGTTCAAATGA::chr3:36969142_cen_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr14:pter_cen_29745313::chr3:pter_36969141inv]",
+      "input_prefixed": "NC_000023.11:g.[chr14:pter_cen_29745313::chr3:pter_36969141inv]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr14:pter_cen_29745313::chr3:pter_36969141inv]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr14:pter_cen_29745313::chr3:pter_36969141inv]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr2:pter_8247756::chr11:15825273_cen_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr2:pter_8247756::chr11:15825273_cen_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr2:pter_8247756::chr11:15825273_cen_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr2:pter_8247756::chr11:15825273_cen_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr2:pter_cen_174500098::chr11:108111987_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr2:pter_cen_174500098::chr11:108111987_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr2:pter_cen_174500098::chr11:108111987_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr2:pter_cen_174500098::chr11:108111987_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr4:134850793_134850794inschrX:89555676_100352080]",
+      "input_prefixed": "NC_000023.11:g.[chr4:134850793_134850794inschrX:89555676_100352080]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr4:134850793_134850794inschrX:89555676_100352080]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr4:134850793_134850794inschrX:89555676_100352080]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr4:134850793_134850794inschrX:89555676_100352080inv]",
+      "input_prefixed": "NC_000023.11:g.[chr4:134850793_134850794inschrX:89555676_100352080inv]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr4:134850793_134850794inschrX:89555676_100352080inv]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr4:134850793_134850794inschrX:89555676_100352080inv]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr9:102425452_qterinv::chr9:26393002_cen_qter]",
+      "input_prefixed": "NC_000023.11:g.[chr9:102425452_qterinv::chr9:26393002_cen_qter]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr9:102425452_qterinv::chr9:26393002_cen_qter]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr9:102425452_qterinv::chr9:26393002_cen_qter]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.[chr9:pter_cen_102425451::chr9:26393001pterinv]",
+      "input_prefixed": "NC_000023.11:g.[chr9:pter_cen_102425451::chr9:26393001pterinv]",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"[chr9:pter_cen_102425451::chr9:26393001pterinv]\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.[chr9:pter_cen_102425451::chr9:26393001pterinv]",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.chr2:pter_8247756delinschr11:pter_15825266",
+      "input_prefixed": "NC_000023.11:g.chr2:pter_8247756delinschr11:pter_15825266",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"chr2:pter_8247756delinschr11:pter_15825266\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.chr2:pter_8247756delinschr11:pter_15825266",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.chr3:158573187_qterdelinschr8:(128534000_128546000)_qter",
+      "input_prefixed": "NC_000023.11:g.chr3:158573187_qterdelinschr8:(128534000_128546000)_qter",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"chr3:158573187_qterdelinschr8:(128534000_128546000)_qter\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.chr3:158573187_qterdelinschr8:(128534000_128546000)_qter",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.chr4:134850793_134850794inschrX:89555676_100352080inv",
+      "input_prefixed": "NC_000023.11:g.chr4:134850793_134850794inschrX:89555676_100352080inv",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"chr4:134850793_134850794inschrX:89555676_100352080inv\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.chr4:134850793_134850794inschrX:89555676_100352080inv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "g.chr5:pter_29658442delinschr10:67539995_qterinv",
+      "input_prefixed": "NC_000023.11:g.chr5:pter_29658442delinschr10:67539995_qterinv",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"chr5:pter_29658442delinschr10:67539995_qterinv\", code: Tag })",
+      "spec_expected": "NC_000023.11:g.chr5:pter_29658442delinschr10:67539995_qterinv",
+      "status": "parse-error",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "LRG_199:g.954966C>T",
+      "current": "LRG_199:g.954966C>T",
+      "spec_expected": "LRG_199:g.954966C>T",
       "status": "preserved",
       "coordinate_system": "g",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/uncertain.md"
+        "docs/background/simple.md"
       ]
+    },
+    {
+      "input": "LRG_199:g.981731G>A",
+      "current": "LRG_199:g.981731G>A",
+      "spec_expected": "LRG_199:g.981731G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "LRG_476:g.4950_39800=",
+      "current": "LRG_476:g.4950_39800=",
+      "spec_expected": "LRG_476:g.4950_39800=",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "NC_000001.11:g.1234=",
@@ -4923,17 +8361,6 @@
       ]
     },
     {
-      "input": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:35788169_35788352]",
-      "current": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:35788169_35788352]",
-      "spec_expected": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:35788169_35788352]",
-      "status": "preserved",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/general.md"
-      ]
-    },
-    {
       "input": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "current": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "spec_expected": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
@@ -4941,7 +8368,9 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
+        "docs/recommendations/DNA/insertion.md",
+        "docs/recommendations/general.md",
+        "docs/recommendations/uncertain.md"
       ]
     },
     {
@@ -4967,6 +8396,18 @@
       ]
     },
     {
+      "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
+      "current": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
+      "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md",
+        "docs/recommendations/DNA/delins.md"
+      ]
+    },
+    {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
       "current": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
@@ -4975,6 +8416,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
+      "current": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
+      "spec_expected": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000003.12:g.63912687_63912716AGC[13]",
+      "current": "NC_000003.12:g.63912687_63912716AGC[13]",
+      "spec_expected": "NC_000003.12:g.63912687_63912716AGC[13]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -4989,14 +8452,36 @@
       ]
     },
     {
-      "input": "NC_000006.11:g.117198495_117198496del",
-      "current": "NC_000006.11:g.117198495_117198496del",
-      "spec_expected": "NC_000006.11:g.117198495_117198496del",
+      "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
+      "current": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
+      "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
       "status": "preserved",
       "coordinate_system": "g",
-      "source_kind": "background",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/background/refseq.md"
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
+      "current": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
+      "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
+      "current": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
+      "spec_expected": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
       ]
     },
     {
@@ -5008,6 +8493,39 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
+      "input": "NC_000006.12:g.[776788_93191545inv;93191546T>C]",
+      "current": "NC_000006.12:g.[776788_93191545inv;93191546T>C]",
+      "spec_expected": "NC_000006.12:g.[776788_93191545inv;93191546T>C]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000008.11:g.(127300001_131500000)_(131500001_136400000)dup",
+      "current": "NC_000008.11:g.(127300001_131500000)_(131500001_136400000)dup",
+      "spec_expected": "NC_000008.11:g.(127300001_131500000)_(131500001_136400000)dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
+      "current": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
+      "spec_expected": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
       ]
     },
     {
@@ -5044,6 +8562,17 @@
       ]
     },
     {
+      "input": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
+      "current": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
+      "spec_expected": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
       "input": "NC_000011.9:g.12345611G>A",
       "current": "NC_000011.9:g.12345611G>A",
       "spec_expected": "NC_000011.9:g.12345611G>A",
@@ -5077,6 +8606,18 @@
       ]
     },
     {
+      "input": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
+      "current": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
+      "spec_expected": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG009.md"
+      ],
+      "working_group": "SVD-WG009"
+    },
+    {
       "input": "NC_000013.11:g.(19385993_19394916)_(25045592_25059364)del",
       "current": "NC_000013.11:g.(19385993_19394916)_(25045592_25059364)del",
       "spec_expected": "NC_000013.11:g.(19385993_19394916)_(25045592_25059364)del",
@@ -5099,6 +8640,17 @@
       ]
     },
     {
+      "input": "NC_000014.8:g.101179660_101179695TG[14]",
+      "current": "NC_000014.8:g.101179660_101179695TG[14]",
+      "spec_expected": "NC_000014.8:g.101179660_101179695TG[14]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "NC_000014.8:g.123CAG[23]",
       "current": "NC_000014.8:g.123CAG[23]",
       "spec_expected": "NC_000014.8:g.123CAG[23]",
@@ -5118,6 +8670,28 @@
       "source_kind": "syntax_yaml",
       "source_paths": [
         "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
+      "current": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
+      "spec_expected": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000023.10:g.(32057077_32364657)_(32894352_33055973)del",
+      "current": "NC_000023.10:g.(32057077_32364657)_(32894352_33055973)del",
+      "spec_expected": "NC_000023.10:g.(32057077_32364657)_(32894352_33055973)del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ]
     },
     {
@@ -5176,6 +8750,17 @@
       ]
     },
     {
+      "input": "NC_000023.10:g.32361300del",
+      "current": "NC_000023.10:g.32361300del",
+      "spec_expected": "NC_000023.10:g.32361300del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ]
+    },
+    {
       "input": "NC_000023.10:g.32361330_32361333inv",
       "current": "NC_000023.10:g.32361330_32361333inv",
       "spec_expected": "NC_000023.10:g.32361330_32361333inv",
@@ -5187,6 +8772,28 @@
       ]
     },
     {
+      "input": "NC_000023.10:g.32380996C>T",
+      "current": "NC_000023.10:g.32380996C>T",
+      "spec_expected": "NC_000023.10:g.32380996C>T",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NC_000023.10:g.32407761G>A",
+      "current": "NC_000023.10:g.32407761G>A",
+      "spec_expected": "NC_000023.10:g.32407761G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
       "input": "NC_000023.10:g.32459297del",
       "current": "NC_000023.10:g.32459297del",
       "spec_expected": "NC_000023.10:g.32459297del",
@@ -5194,7 +8801,19 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/background/numbering.md",
         "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "NC_000023.10:g.32459297dup",
+      "current": "NC_000023.10:g.32459297dup",
+      "spec_expected": "NC_000023.10:g.32459297dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -5242,6 +8861,18 @@
       ]
     },
     {
+      "input": "NC_000023.10:g.32862927_32862929delinsATA",
+      "current": "NC_000023.10:g.32862927_32862929delinsATA",
+      "spec_expected": "NC_000023.10:g.32862927_32862929delinsATA",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "NC_000023.10:g.32867861_32867862insT",
       "current": "NC_000023.10:g.32867861_32867862insT",
       "spec_expected": "NC_000023.10:g.32867861_32867862insT",
@@ -5263,6 +8894,17 @@
         "docs/recommendations/DNA/substitution.md",
         "docs/syntax.yaml",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
+      ]
+    },
+    {
+      "input": "NC_000023.10:g.33229410dup",
+      "current": "NC_000023.10:g.33229410dup",
+      "spec_expected": "NC_000023.10:g.33229410dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -5409,25 +9051,25 @@
       ]
     },
     {
-      "input": "NC_000023.11:g.32386323delCinsGA",
-      "current": "NC_000023.11:g.32386323delCinsGA",
-      "spec_expected": "NC_000023.11:g.32386323delCinsGA",
+      "input": "NC_000023.11:g.32343183dup",
+      "current": "NC_000023.11:g.32343183dup",
+      "spec_expected": "NC_000023.11:g.32343183dup",
       "status": "preserved",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
-      "input": "NC_000023.11:g.32386323delTinsGA",
-      "current": "NC_000023.11:g.32386323delTinsGA",
-      "spec_expected": "NC_000023.11:g.32386323delTinsGA",
+      "input": "NC_000023.11:g.32362879C>T",
+      "current": "NC_000023.11:g.32362879C>T",
+      "spec_expected": "NC_000023.11:g.32362879C>T",
       "status": "preserved",
       "coordinate_system": "g",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/DNA/delins.md"
+        "docs/background/simple.md"
       ]
     },
     {
@@ -5453,6 +9095,28 @@
       ]
     },
     {
+      "input": "NC_000023.11:g.32441180dup",
+      "current": "NC_000023.11:g.32441180dup",
+      "spec_expected": "NC_000023.11:g.32441180dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.32844735_32844787dup",
+      "current": "NC_000023.11:g.32844735_32844787dup",
+      "spec_expected": "NC_000023.11:g.32844735_32844787dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "NC_000023.11:g.32867908=",
       "current": "NC_000023.11:g.32867908=",
       "spec_expected": "NC_000023.11:g.32867908=",
@@ -5460,8 +9124,10 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/consultation/SVD-WG001.md",
         "docs/recommendations/DNA/other.md"
-      ]
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "NC_000023.11:g.32867908_32867923=",
@@ -5472,6 +9138,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/other.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.33211290_33211293dup",
+      "current": "NC_000023.11:g.33211290_33211293dup",
+      "spec_expected": "NC_000023.11:g.33211290_33211293dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -5552,6 +9229,17 @@
       ]
     },
     {
+      "input": "NC_000023.11:g.pter_qter[2]",
+      "current": "NC_000023.11:g.pter_qter[2]",
+      "spec_expected": "NC_000023.11:g.pter_qter[2]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "NC_000023.9:g.(123456_234567)_(345678_456789)del",
       "current": "NC_000023.9:g.(123456_234567)_(345678_456789)del",
       "spec_expected": "NC_000023.9:g.(123456_234567)_(345678_456789)del",
@@ -5563,15 +9251,95 @@
       ]
     },
     {
-      "input": "NG_012232.1:g.12G>T(;)13C>G",
-      "current": "NG_012232.1:g.12G>T(;)13C>G",
-      "spec_expected": "NG_012232.1:g.12G>T(;)13C>G",
+      "input": "NC_000023.9:g.32290917C>T",
+      "current": "NC_000023.9:g.32290917C>T",
+      "spec_expected": "NC_000023.9:g.32290917C>T",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NC_000023.9:g.32317682G>A",
+      "current": "NC_000023.9:g.32317682G>A",
+      "spec_expected": "NC_000023.9:g.32317682G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1:g.954966C>T",
+      "current": "NG_012232.1:g.954966C>T",
+      "spec_expected": "NG_012232.1:g.954966C>T",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1:g.981731G>A",
+      "current": "NG_012232.1:g.981731G>A",
+      "spec_expected": "NG_012232.1:g.981731G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "chr11:g.12345611G>A",
+      "current": "chr11:g.12345611G>A",
+      "spec_expected": "chr11:g.12345611G>A",
       "status": "preserved",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
+        "docs/recommendations/general.md"
       ]
+    },
+    {
+      "input": "chr6:g.[776788_93191545inv;93191546T>C]",
+      "current": "chr6:g.[776788_93191545inv;93191546T>C]",
+      "spec_expected": "chr6:g.[776788_93191545inv;93191546T>C]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004"
+    },
+    {
+      "input": "chr8:g.128746677_128749160dup",
+      "current": "chr8:g.128746677_128749160dup",
+      "spec_expected": "chr8:g.128746677_128749160dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004"
+    },
+    {
+      "input": "chrX:g.89555676_100352080del",
+      "current": "chrX:g.89555676_100352080del",
+      "spec_expected": "chrX:g.89555676_100352080del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG004.md"
+      ],
+      "working_group": "SVD-WG004"
     },
     {
       "input": "g.(123456_234567)_(345678_456789)del",
@@ -5599,6 +9367,68 @@
       ]
     },
     {
+      "input": "g.12345611G>A",
+      "input_prefixed": "NC_000023.11:g.12345611G>A",
+      "current": "NC_000023.11:g.12345611G>A",
+      "spec_expected": "NC_000023.11:g.12345611G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ]
+    },
+    {
+      "input": "g.12345678_12345901|gom",
+      "input_prefixed": "NC_000023.11:g.12345678_12345901|gom",
+      "current": "NC_000023.11:g.12345678_12345901|gom",
+      "spec_expected": "NC_000023.11:g.12345678_12345901|gom",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005"
+    },
+    {
+      "input": "g.123456G>A",
+      "input_prefixed": "NC_000023.11:g.123456G>A",
+      "current": "NC_000023.11:g.123456G>A",
+      "spec_expected": "NC_000023.11:g.123456G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "g.123456del",
+      "input_prefixed": "NC_000023.11:g.123456del",
+      "current": "NC_000023.11:g.123456del",
+      "spec_expected": "NC_000023.11:g.123456del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "g.12345A>T",
+      "input_prefixed": "NC_000023.11:g.12345A>T",
+      "current": "NC_000023.11:g.12345A>T",
+      "spec_expected": "NC_000023.11:g.12345A>T",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
       "input": "g.12345_12678del",
       "input_prefixed": "NC_000023.11:g.12345_12678del",
       "current": "NC_000023.11:g.12345_12678del",
@@ -5608,6 +9438,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "g.123CAG[23]",
+      "input_prefixed": "NC_000023.11:g.123CAG[23]",
+      "current": "NC_000023.11:g.123CAG[23]",
+      "spec_expected": "NC_000023.11:g.123CAG[23]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -5621,6 +9463,31 @@
       "source_paths": [
         "docs/recommendations/checklist.md"
       ]
+    },
+    {
+      "input": "g.123_191CAG[23]",
+      "input_prefixed": "NC_000023.11:g.123_191CAG[23]",
+      "current": "NC_000023.11:g.123_191CAG[23]",
+      "spec_expected": "NC_000023.11:g.123_191CAG[23]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "g.23456789_23456901|lom",
+      "input_prefixed": "NC_000023.11:g.23456789_23456901|lom",
+      "current": "NC_000023.11:g.23456789_23456901|lom",
+      "spec_expected": "NC_000023.11:g.23456789_23456901|lom",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG005.md"
+      ],
+      "working_group": "SVD-WG005"
     },
     {
       "input": "g.30683643A>G",
@@ -5647,6 +9514,18 @@
       ]
     },
     {
+      "input": "g.32407761G>A",
+      "input_prefixed": "NC_000023.11:g.32407761G>A",
+      "current": "NC_000023.11:g.32407761G>A",
+      "spec_expected": "NC_000023.11:g.32407761G>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
       "input": "g.32456507del",
       "input_prefixed": "NC_000023.11:g.32456507del",
       "current": "NC_000023.11:g.32456507del",
@@ -5655,8 +9534,47 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/background/numbering.md",
         "docs/recommendations/DNA/deletion.md"
       ]
+    },
+    {
+      "input": "g.32456507dup",
+      "input_prefixed": "NC_000023.11:g.32456507dup",
+      "current": "NC_000023.11:g.32456507dup",
+      "spec_expected": "NC_000023.11:g.32456507dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "g.32862927C>A",
+      "input_prefixed": "NC_000023.11:g.32862927C>A",
+      "current": "NC_000023.11:g.32862927C>A",
+      "spec_expected": "NC_000023.11:g.32862927C>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
+      "input": "g.32862929T>A",
+      "input_prefixed": "NC_000023.11:g.32862929T>A",
+      "current": "NC_000023.11:g.32862929T>A",
+      "spec_expected": "NC_000023.11:g.32862929T>A",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "g.33038273T>G",
@@ -5679,7 +9597,8 @@
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/DNA/deletion.md"
+        "docs/recommendations/DNA/deletion.md",
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -5695,6 +9614,31 @@
       ]
     },
     {
+      "input": "g.33344590_33344592dup",
+      "input_prefixed": "NC_000023.11:g.33344590_33344592dup",
+      "current": "NC_000023.11:g.33344590_33344592dup",
+      "spec_expected": "NC_000023.11:g.33344590_33344592dup",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "g.3_4delinsGGT",
+      "input_prefixed": "NC_000023.11:g.3_4delinsGGT",
+      "current": "NC_000023.11:g.3_4delinsGGT",
+      "spec_expected": "NC_000023.11:g.3_4delinsGGT",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "g.4567_4569=",
       "input_prefixed": "NC_000023.11:g.4567_4569=",
       "current": "NC_000023.11:g.4567_4569=",
@@ -5704,6 +9648,31 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/substitution.md"
+      ]
+    },
+    {
+      "input": "g.50377648=",
+      "input_prefixed": "NC_000023.11:g.50377648=",
+      "current": "NC_000023.11:g.50377648=",
+      "spec_expected": "NC_000023.11:g.50377648=",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "g.63912687_63912716AGC[13]",
+      "input_prefixed": "NC_000023.11:g.63912687_63912716AGC[13]",
+      "current": "NC_000023.11:g.63912687_63912716AGC[13]",
+      "spec_expected": "NC_000023.11:g.63912687_63912716AGC[13]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -5731,6 +9700,19 @@
       ]
     },
     {
+      "input": "g.[3C>G;7dup]",
+      "input_prefixed": "NC_000023.11:g.[3C>G;7dup]",
+      "current": "NC_000023.11:g.[3C>G;7dup]",
+      "spec_expected": "NC_000023.11:g.[3C>G;7dup]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "r.415_1655delins[AC096506.5:g.409_1649]",
       "input_prefixed": "NM_004006.3:r.415_1655delins[AC096506.5:g.409_1649]",
       "current": "NM_004006.3:r.415_1655delins[AC096506.5:g.409_1649]",
@@ -5743,10 +9725,10 @@
       ]
     },
     {
-      "input": "NC_012920.1(MT-ND1):m.3460G>A",
-      "current": "NC_012920.1(MT-ND1):m.3460G>A",
-      "spec_expected": "NC_012920.1(MT-ND1):m.3460G>A",
-      "status": "preserved",
+      "input": "MT-ND1{NC_012920.1}:m.[3460G>A]",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"MT-ND1{NC_012920.1}:m.[3460G>A]\", code: Alpha })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
@@ -5754,43 +9736,119 @@
       ]
     },
     {
-      "input": "NC_012920.1(MT-TL1):m.3243A>G",
-      "current": "NC_012920.1(MT-TL1):m.3243A>G",
-      "spec_expected": "NC_012920.1(MT-TL1):m.3243A>G",
-      "status": "preserved",
+      "input": "NC_012920.1:m.16563_13del",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"16563_13del\", code: Verify })",
+      "spec_expected": "NC_012920.1:m.16563_13del",
+      "status": "parse-error",
+      "coordinate_system": "m",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "m.",
+      "input_prefixed": "NC_012920.1:m.",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
+      "spec_expected": "NC_012920.1:m.",
+      "status": "parse-error",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/refseq.md"
-      ]
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG002.md",
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_012920.1:m.3243A>G",
-      "current": "NC_012920.1:m.3243A>G",
-      "spec_expected": "NC_012920.1:m.3243A>G",
-      "status": "preserved",
+      "input": "m.1",
+      "input_prefixed": "NC_012920.1:m.1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_012920.1:m.1",
+      "status": "parse-error",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/refseq.md"
-      ]
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_012920.1:m.3460G>A",
-      "current": "NC_012920.1:m.3460G>A",
-      "spec_expected": "NC_012920.1:m.3460G>A",
-      "status": "preserved",
+      "input": "m.13",
+      "input_prefixed": "NC_012920.1:m.13",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_012920.1:m.13",
+      "status": "parse-error",
+      "coordinate_system": "m",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "m.16563",
+      "input_prefixed": "NC_012920.1:m.16563",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_012920.1:m.16563",
+      "status": "parse-error",
+      "coordinate_system": "m",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "m.2",
+      "input_prefixed": "NC_012920.1:m.2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_012920.1:m.2",
+      "status": "parse-error",
       "coordinate_system": "m",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/refseq.md"
-      ]
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "n.",
-      "input_prefixed": "NR_002196.1:n.",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
-      "spec_expected": "NR_002196.1:n.",
+      "input": "m.3",
+      "input_prefixed": "NC_012920.1:m.3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_012920.1:m.3",
+      "status": "parse-error",
+      "coordinate_system": "m",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.611T=",
+      "input_prefixed": "NR_002196.1:n.611T=",
+      "current": "NR_002196.1:n.611T=",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": ":n.5C>T",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \":n.5C>T\", code: Alpha })",
+      "spec_expected": ":n.5C>T",
       "status": "parse-error",
       "coordinate_system": "n",
       "source_kind": "background",
@@ -5800,37 +9858,398 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_012920.1(MT-TL1):n.14A>G",
-      "current": "NC_012920.1(MT-TL1):n.14A>G",
-      "spec_expected": "NC_012920.1(MT-TL1):n.14A>G",
+      "input": "n.",
+      "input_prefixed": "NR_002196.1:n.",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
+      "spec_expected": "NR_002196.1:n.",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md",
+        "docs/recommendations/RNA/adjoined_transcript.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.1",
+      "input_prefixed": "NR_002196.1:n.1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.1",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.123",
+      "input_prefixed": "NR_002196.1:n.123",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.123",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.2",
+      "input_prefixed": "NR_002196.1:n.2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.2",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.3",
+      "input_prefixed": "NR_002196.1:n.3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.3",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.695",
+      "input_prefixed": "NR_002196.1:n.695",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.695",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "n.696",
+      "input_prefixed": "NR_002196.1:n.696",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NR_002196.1:n.696",
+      "status": "parse-error",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_000023.10(NR_028379.1):n.696-38544del",
+      "current": "NC_000023.10(NR_028379.1):n.696-38544del",
+      "spec_expected": "NC_000023.10(NR_028379.1):n.696-38544del",
       "status": "preserved",
       "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002"
+    },
+    {
+      "input": "NR_002196.1:n.601G>T",
+      "current": "NR_002196.1:n.601G>T",
+      "spec_expected": "NR_002196.1:n.601G>T",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ]
+    },
+    {
+      "input": "NR_028379.1:n.345A>G",
+      "current": "NR_028379.1:n.345A>G",
+      "spec_expected": "NR_028379.1:n.345A>G",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002"
+    },
+    {
+      "input": "n.345A>G",
+      "input_prefixed": "NR_002196.1:n.345A>G",
+      "current": "NR_002196.1:n.345A>G",
+      "spec_expected": "NR_002196.1:n.345A>G",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002"
+    },
+    {
+      "input": "n.611=",
+      "input_prefixed": "NR_002196.1:n.611=",
+      "current": "NR_002196.1:n.611=",
+      "spec_expected": "NR_002196.1:n.611=",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
+    },
+    {
+      "input": "n.696-38544del",
+      "input_prefixed": "NR_002196.1:n.696-38544del",
+      "current": "NR_002196.1:n.696-38544del",
+      "spec_expected": "NR_002196.1:n.696-38544del",
+      "status": "preserved",
+      "coordinate_system": "n",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002"
+    },
+    {
+      "input": "o.",
+      "input_prefixed": "NC_000023.11:o.",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
+      "spec_expected": "NC_000023.11:o.",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "o.1",
+      "input_prefixed": "NC_000023.11:o.1",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_000023.11:o.1",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "o.197",
+      "input_prefixed": "NC_000023.11:o.197",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_000023.11:o.197",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "o.2",
+      "input_prefixed": "NC_000023.11:o.2",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_000023.11:o.2",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "o.3",
+      "input_prefixed": "NC_000023.11:o.3",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_000023.11:o.3",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "o.4344",
+      "input_prefixed": "NC_000023.11:o.4344",
+      "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NC_000023.11:o.4344",
+      "status": "parse-error",
+      "coordinate_system": "o",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "J01749.1:o.4344_197dup",
+      "current": "J01749.1:o.4344_197dup",
+      "spec_expected": "J01749.1:o.4344_197dup",
+      "status": "preserved",
+      "coordinate_system": "o",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006"
+    },
+    {
+      "input": "MT-ND1{YP_003024026.1}:p.[(Ala52Thr)]",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"MT-ND1{YP_003024026.1}:p.[(Ala52Thr)]\", code: Alpha })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
       ]
     },
     {
-      "input": "NP_003997.1:p.(Ser332_Ser333insX)",
-      "current": "NP_003997.1:p.(Ser332_Ser333insXaa)",
-      "spec_expected": "NP_003997.1:p.(Ser332_Ser333insX)",
-      "status": "diverges",
+      "input": "p.([Phe233Leu;Cys690Trp])",
+      "input_prefixed": "NP_003997.1:p.([Phe233Leu;Cys690Trp])",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Phe233Leu;Cys690Trp])\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.([Ser68Arg;Asn594del])",
+      "input_prefixed": "NP_003997.1:p.([Ser68Arg;Asn594del])",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Ser68Arg;Asn594del])\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.([Ser68Arg];[Ser68Arg])",
+      "input_prefixed": "NP_003997.1:p.([Ser68Arg];[Ser68Arg])",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Ser68Arg];[Ser68Arg])\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.123ˆ124Ala",
+      "input_prefixed": "NP_003997.1:p.123ˆ124Ala",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"123ˆ124Ala\", code: Tag })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+      ]
     },
     {
-      "input": "NP_003997.1:p.Arg1459*",
-      "current": "NP_003997.1:p.Arg1459Ter",
-      "spec_expected": "NP_003997.1:p.Arg1459*",
+      "input": "p.2366Gln/Lys",
+      "input_prefixed": "NP_003997.1:p.2366Gln/Lys",
+      "current": "parse error: Parse error at position 0: Unexpected content after variant: 'ln'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
+      "input": "p.EX17del",
+      "input_prefixed": "NP_003997.1:p.EX17del",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"X17del\", code: Digit })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/deletion.md"
+      ]
+    },
+    {
+      "input": "p.His4Gln5insAla",
+      "input_prefixed": "NP_003997.1:p.His4Gln5insAla",
+      "current": "parse error: Parse error at position 22: Unexpected trailing characters: 'insAla'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ]
+    },
+    {
+      "input": "p.TrpVal24CysArg",
+      "input_prefixed": "NP_003997.1:p.TrpVal24CysArg",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"Val24CysArg\", code: Digit })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/delins.md",
+        "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
+      "input": "p.[Ser73Arg];[]",
+      "input_prefixed": "NP_003997.1:p.[Ser73Arg];[]",
+      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[]'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_002102.4:p.(Gln18)[25]",
+      "current": "NP_002102.4:p.(Gln18)_(Gln18)[25]",
+      "spec_expected": "NP_002102.4:p.(Gln18)[25]",
       "status": "diverges",
       "coordinate_system": "p",
-      "source_kind": "background",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/background/simple.md"
+        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -5897,10 +10316,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Ala123_Pro131)*",
-      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)*",
+      "input": "p.(Ala123_Pro131)Ter",
+      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)Ter",
       "current": "NP_003997.1:p.(Ala123)_(Pro131)Ter",
-      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)*",
+      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)Ter",
       "status": "diverges",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -5923,19 +10342,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Arg1459*)",
-      "input_prefixed": "NP_003997.1:p.(Arg1459*)",
-      "current": "NP_003997.1:p.(Arg1459Ter)",
-      "spec_expected": "NP_003997.1:p.(Arg1459*)",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/simple.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.(Gln18)[(70_80)]",
       "input_prefixed": "NP_003997.1:p.(Gln18)[(70_80)]",
       "current": "NP_003997.1:p.(Gln18)_(Gln18)[70_80]",
@@ -5945,32 +10351,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Gly23Cysfs*26)",
-      "input_prefixed": "NP_003997.1:p.(Gly23Cysfs*26)",
-      "current": "NP_003997.1:p.(Gly23CysfsTer26)",
-      "spec_expected": "NP_003997.1:p.(Gly23Cysfs*26)",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Gly23Glufs*7)",
-      "input_prefixed": "NP_003997.1:p.(Gly23Glufs*7)",
-      "current": "NP_003997.1:p.(Gly23GlufsTer7)",
-      "spec_expected": "NP_003997.1:p.(Gly23Glufs*7)",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -6027,6 +10407,58 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "p.1",
+      "input_prefixed": "NP_003997.1:p.1",
+      "current": "NP_003997.1:p.Xaa1?",
+      "spec_expected": "NP_003997.1:p.1",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.2",
+      "input_prefixed": "NP_003997.1:p.2",
+      "current": "NP_003997.1:p.Xaa2?",
+      "spec_expected": "NP_003997.1:p.2",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.3",
+      "input_prefixed": "NP_003997.1:p.3",
+      "current": "NP_003997.1:p.Xaa3?",
+      "spec_expected": "NP_003997.1:p.3",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Arg1459*",
+      "input_prefixed": "NP_003997.1:p.Arg1459*",
+      "current": "NP_003997.1:p.Arg1459Ter",
+      "spec_expected": "NP_003997.1:p.Arg1459*",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "p.Arg456Glyfs*17",
       "input_prefixed": "NP_003997.1:p.Arg456Glyfs*17",
       "current": "NP_003997.1:p.Arg456GlyfsTer17",
@@ -6066,6 +10498,20 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "p.Gln990",
+      "input_prefixed": "NP_003997.1:p.Gln990",
+      "current": "NP_003997.1:p.Gln990?",
+      "spec_expected": "NP_003997.1:p.Gln990",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "p.Ile327Argfs*?",
       "input_prefixed": "NP_003997.1:p.Ile327Argfs*?",
       "current": "NP_003997.1:p.Ile327Argfs",
@@ -6092,10 +10538,37 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "p.Ser988",
+      "input_prefixed": "NP_003997.1:p.Ser988",
+      "current": "NP_003997.1:p.Ser988?",
+      "spec_expected": "NP_003997.1:p.Ser988",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "p.Ter110GlnextTer17",
       "input_prefixed": "NP_003997.1:p.Ter110GlnextTer17",
       "current": "NP_003997.1:p.Ter110Glnext*17",
       "spec_expected": "NP_003997.1:p.Ter110GlnextTer17",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/extension.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Ter327ArgextTer?",
+      "input_prefixed": "NP_003997.1:p.Ter327ArgextTer?",
+      "current": "NP_003997.1:p.Ter327Argext*?",
+      "spec_expected": "NP_003997.1:p.Ter327ArgextTer?",
       "status": "diverges",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6153,6 +10626,7 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md",
+        "docs/recommendations/protein/frameshift.md",
         "docs/recommendations/protein/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -6185,6 +10659,32 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "p.(Met1Val)",
+      "input_prefixed": "NP_003997.1:p.(Met1Val)",
+      "current": "NP_003997.1:p.(Met1Val)",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.(Val559_Glu562delinsGlu)",
+      "input_prefixed": "NP_003997.1:p.(Val559_Glu562delinsGlu)",
+      "current": "NP_003997.1:p.(Val559_Glu562delinsGlu)",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "p.(Val89_Gln119del)",
       "input_prefixed": "NP_003997.1:p.(Val89_Gln119del)",
       "current": "NP_003997.1:p.(Val89_Gln119del)",
@@ -6194,6 +10694,46 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Ala22insGly",
+      "input_prefixed": "NP_003997.1:p.Ala22insGly",
+      "current": "NP_003997.1:p.Ala22insGly",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Arg45del6",
+      "input_prefixed": "NP_003997.1:p.Arg45del6",
+      "current": "NP_003997.1:p.Arg45del6",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Cys5_Ser6delinsTerGluAsp",
+      "input_prefixed": "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
+      "current": "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/delins.md",
+        "docs/recommendations/protein/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -6224,6 +10764,58 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "p.His4insAla",
+      "input_prefixed": "NP_003997.1:p.His4insAla",
+      "current": "NP_003997.1:p.His4insAla",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Lys23insAsp",
+      "input_prefixed": "NP_003997.1:p.Lys23insAsp",
+      "current": "NP_003997.1:p.Lys23insAsp",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Met1Thr",
+      "input_prefixed": "NP_003997.1:p.Met1Thr",
+      "current": "NP_003997.1:p.Met1Thr",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.Met1Valext-4",
+      "input_prefixed": "NP_003997.1:p.Met1Valext-4",
+      "current": "NP_003997.1:p.Met1Valext-4",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/extension.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "p.Tyr4TerfsTer1",
       "input_prefixed": "NP_003997.1:p.Tyr4TerfsTer1",
       "current": "NP_003997.1:p.Tyr4TerfsTer1",
@@ -6234,6 +10826,32 @@
       "source_paths": [
         "docs/recommendations/protein/frameshift.md",
         "docs/recommendations/protein/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "p.[Arg76Ser;Cys77Trp]",
+      "input_prefixed": "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
+      "current": "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/delins.md",
+        "docs/recommendations/protein/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": ":p.(Val25Gly)",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \":p.(Val25Gly)\", code: Alpha })",
+      "spec_expected": ":p.(Val25Gly)",
+      "status": "parse-error",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -6274,21 +10892,9 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.(Ser73Arg)](;)[(Asn103del)",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '](;)[(Asn103del)'",
-      "spec_expected": "NP_003997.1:p.(Ser73Arg)](;)[(Asn103del)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.(Val582_Asn583insX[5])",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val582_Asn583insX[5])\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.(Val582_Asn583insX[5])",
+      "input": "NP_003997.1:p.(Val582_Asn583insXaa[5])",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val582_Asn583insXaa[5])\", code: Tag })",
+      "spec_expected": "NP_003997.1:p.(Val582_Asn583insXaa[5])",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6430,9 +11036,9 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_01234.5:p.Ala2[10];[11]",
-      "current": "parse error: Parse error at position 21: Unexpected trailing characters: ';[11]'",
-      "spec_expected": "NP_01234.5:p.Ala2[10];[11]",
+      "input": "NP_0123456.1:p.Ala2[10];[11]",
+      "current": "parse error: Parse error at position 23: Unexpected trailing characters: ';[11]'",
+      "spec_expected": "NP_0123456.1:p.Ala2[10];[11]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "syntax_yaml",
@@ -6454,34 +11060,25 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "YP_003024026.1:p.(Ala52Thr).",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: '.'",
-      "spec_expected": "YP_003024026.1:p.(Ala52Thr).",
+      "input": "p.",
+      "input_prefixed": "NP_003997.1:p.",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
+      "spec_expected": "NP_003997.1:p.",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "background",
       "source_paths": [
-        "docs/background/refseq.md"
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG002.md"
       ],
+      "working_group": "SVD-WG002",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "YP_003024031.1:p.Leu156Pro.:",
-      "current": "parse error: Parse error at position 26: Unexpected trailing characters: '.:'",
-      "spec_expected": "YP_003024031.1:p.Leu156Pro.:",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Ala123_Pro131)insX[4]",
-      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)insX[4]",
-      "current": "parse error: Parse error at position 33: Unexpected trailing characters: '[4]'",
-      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)insX[4]",
+      "input": "p.(Ala123_Pro131)insXaa[4]",
+      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
+      "current": "parse error: Parse error at position 35: Unexpected trailing characters: '[4]'",
+      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6491,23 +11088,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Ala52Thr).",
-      "input_prefixed": "NP_003997.1:p.(Ala52Thr).",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '.'",
-      "spec_expected": "NP_003997.1:p.(Ala52Thr).",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Gly23Glufs*7^Gly23Cysfs*26)",
-      "input_prefixed": "NP_003997.1:p.(Gly23Glufs*7^Gly23Cysfs*26)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Gly23Glufs*7^Gly23Cysfs*26)\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.(Gly23Glufs*7^Gly23Cysfs*26)",
+      "input": "p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+      "input_prefixed": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Gly23GlufsTer7^Gly23CysfsTer26)\", code: Tag })",
+      "spec_expected": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6530,71 +11114,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Met3_Ile3418delinsGly),",
-      "input_prefixed": "NP_003997.1:p.(Met3_Ile3418delinsGly),",
-      "current": "parse error: Parse error at position 37: Unexpected trailing characters: ','",
-      "spec_expected": "NP_003997.1:p.(Met3_Ile3418delinsGly),",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.([Phe233Leu;Cys690Trp])",
-      "input_prefixed": "NP_003997.1:p.([Phe233Leu;Cys690Trp])",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Phe233Leu;Cys690Trp])\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.([Phe233Leu;Cys690Trp])",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.([Ser68Arg;Asn594del])",
-      "input_prefixed": "NP_003997.1:p.([Ser68Arg;Asn594del])",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Ser68Arg;Asn594del])\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.([Ser68Arg;Asn594del])",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.([Ser68Arg];[Ser68Arg])",
-      "input_prefixed": "NP_003997.1:p.([Ser68Arg];[Ser68Arg])",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"([Ser68Arg];[Ser68Arg])\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.([Ser68Arg];[Ser68Arg])",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.2366Gln/Lys",
-      "input_prefixed": "NP_003997.1:p.2366Gln/Lys",
-      "current": "parse error: Parse error at position 0: Unexpected content after variant: 'ln'",
-      "spec_expected": "NP_003997.1:p.2366Gln/Lys",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.Ala2[10];[11]",
       "input_prefixed": "NP_003997.1:p.Ala2[10];[11]",
       "current": "parse error: Parse error at position 22: Unexpected trailing characters: ';[11]'",
@@ -6608,10 +11127,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.Arg78_Gly79insX[23]",
-      "input_prefixed": "NP_003997.1:p.Arg78_Gly79insX[23]",
-      "current": "parse error: Parse error at position 29: Unexpected trailing characters: '[23]'",
-      "spec_expected": "NP_003997.1:p.Arg78_Gly79insX[23]",
+      "input": "p.Arg78_Gly79insXaa[23]",
+      "input_prefixed": "NP_003997.1:p.Arg78_Gly79insXaa[23]",
+      "current": "parse error: Parse error at position 31: Unexpected trailing characters: '[23]'",
+      "spec_expected": "NP_003997.1:p.Arg78_Gly79insXaa[23]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6621,23 +11140,23 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.EX17del",
-      "input_prefixed": "NP_003997.1:p.EX17del",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"X17del\", code: Digit })",
-      "spec_expected": "NP_003997.1:p.EX17del",
+      "input": "p.Gln[21]",
+      "input_prefixed": "NP_003997.1:p.Gln[21]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[21]\", code: Digit })",
+      "spec_expected": "NP_003997.1:p.Gln[21]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/protein/deletion.md"
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.Gly719(Ala^Ser)fs*23",
-      "input_prefixed": "NP_003997.1:p.Gly719(Ala^Ser)fs*23",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Ala^Ser)fs*23\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.Gly719(Ala^Ser)fs*23",
+      "input": "p.Gly719(Ala^Ser)fsTer23",
+      "input_prefixed": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Ala^Ser)fsTer23\", code: Tag })",
+      "spec_expected": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6661,10 +11180,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.Lys2_Leu3insX[34]",
-      "input_prefixed": "NP_003997.1:p.Lys2_Leu3insX[34]",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: '[34]'",
-      "spec_expected": "NP_003997.1:p.Lys2_Leu3insX[34]",
+      "input": "p.Lys2_Leu3insXaa[34]",
+      "input_prefixed": "NP_003997.1:p.Lys2_Leu3insXaa[34]",
+      "current": "parse error: Parse error at position 29: Unexpected trailing characters: '[34]'",
+      "spec_expected": "NP_003997.1:p.Lys2_Leu3insXaa[34]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6675,29 +11194,30 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.TrpSer23CysArg",
-      "input_prefixed": "NP_003997.1:p.TrpSer23CysArg",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"Ser23CysArg\", code: Digit })",
-      "spec_expected": "NP_003997.1:p.TrpSer23CysArg",
+      "input": "p.Q[21]",
+      "input_prefixed": "NP_003997.1:p.Q[21]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[21]\", code: Digit })",
+      "spec_expected": "NP_003997.1:p.Q[21]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/protein/delins.md"
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.TrpVal24CysArg",
-      "input_prefixed": "NP_003997.1:p.TrpVal24CysArg",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"Val24CysArg\", code: Digit })",
-      "spec_expected": "NP_003997.1:p.TrpVal24CysArg",
+      "input": "p.[(Lys79*;Lys79Asn)]",
+      "input_prefixed": "NP_003997.1:p.[(Lys79*;Lys79Asn)]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Lys79*;Lys79Asn)]\", code: Tag })",
+      "spec_expected": "NP_003997.1:p.[(Lys79*;Lys79Asn)]",
       "status": "parse-error",
       "coordinate_system": "p",
-      "source_kind": "recommendation",
+      "source_kind": "consultation",
       "source_paths": [
-        "docs/recommendations/protein/substitution.md"
+        "docs/consultation/SVD-WG010.md"
       ],
+      "working_group": "SVD-WG010",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -6714,23 +11234,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.[=]",
-      "input_prefixed": "NP_003997.1:p.[=]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[=]\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.[=]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.[Ser73Arg];[]",
-      "input_prefixed": "NP_003997.1:p.[Ser73Arg];[]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[]'",
-      "spec_expected": "NP_003997.1:p.[Ser73Arg];[]",
+      "input": "p.[Ser68Arg];[=]",
+      "input_prefixed": "NP_003997.1:p.[Ser68Arg];[=]",
+      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[=]'",
+      "spec_expected": "NP_003997.1:p.[Ser68Arg];[=]",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -6749,6 +11256,18 @@
       "source_paths": [
         "docs/recommendations/protein/substitution.md"
       ]
+    },
+    {
+      "input": "LRG_199p1:p.(Phe41=)",
+      "current": "LRG_199p1:p.(Phe41=)",
+      "spec_expected": "LRG_199p1:p.(Phe41=)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "LRG_199p1:p.0",
@@ -6828,6 +11347,17 @@
       ]
     },
     {
+      "input": "NP_003997.1:p.(Ser332_Ser333insXaa)",
+      "current": "NP_003997.1:p.(Ser332_Ser333insXaa)",
+      "spec_expected": "NP_003997.1:p.(Ser332_Ser333insXaa)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ]
+    },
+    {
       "input": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
       "current": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
       "spec_expected": "NP_003997.1:p.(Ser68Arg)(;)(Asn594del)",
@@ -6850,6 +11380,17 @@
       ]
     },
     {
+      "input": "NP_003997.1:p.(Ser73Arg)(;)(Asn103del)",
+      "current": "NP_003997.1:p.(Ser73Arg)(;)(Asn103del)",
+      "spec_expected": "NP_003997.1:p.(Ser73Arg)(;)(Asn103del)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
+      ]
+    },
+    {
       "input": "NP_003997.1:p.(Trp24Cys)",
       "current": "NP_003997.1:p.(Trp24Cys)",
       "spec_expected": "NP_003997.1:p.(Trp24Cys)",
@@ -6862,6 +11403,17 @@
       ]
     },
     {
+      "input": "NP_003997.1:p.(Val582_Asn583insXaaXaaXaaXaaXaa)",
+      "current": "NP_003997.1:p.(Val582_Asn583insXaaXaaXaaXaaXaa)",
+      "spec_expected": "NP_003997.1:p.(Val582_Asn583insXaaXaaXaaXaaXaa)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ]
+    },
+    {
       "input": "NP_003997.1:p.?",
       "current": "NP_003997.1:p.?",
       "spec_expected": "NP_003997.1:p.?",
@@ -6870,6 +11422,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.Arg1459Ter",
+      "current": "NP_003997.1:p.Arg1459Ter",
+      "spec_expected": "NP_003997.1:p.Arg1459Ter",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
       ]
     },
     {
@@ -6893,6 +11456,18 @@
       "source_paths": [
         "docs/recommendations/protein/substitution.md"
       ]
+    },
+    {
+      "input": "NP_003997.1:p.Ser988_Gln990delinsAlaLeuHis",
+      "current": "NP_003997.1:p.Ser988_Gln990delinsAlaLeuHis",
+      "spec_expected": "NP_003997.1:p.Ser988_Gln990delinsAlaLeuHis",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "NP_003997.1:p.Trp24Cys",
@@ -7183,9 +11758,9 @@
       ]
     },
     {
-      "input": "NP_01234.5:p.Ala2[10]",
-      "current": "NP_01234.5:p.Ala2[10]",
-      "spec_expected": "NP_01234.5:p.Ala2[10]",
+      "input": "NP_0123456.1:p.Ala2[10]",
+      "current": "NP_0123456.1:p.Ala2[10]",
+      "spec_expected": "NP_0123456.1:p.Ala2[10]",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "syntax_yaml",
@@ -7194,9 +11769,9 @@
       ]
     },
     {
-      "input": "NP_01234.5:p.Arg65_Ser67[12]",
-      "current": "NP_01234.5:p.Arg65_Ser67[12]",
-      "spec_expected": "NP_01234.5:p.Arg65_Ser67[12]",
+      "input": "NP_0123456.1:p.Arg65_Ser67[12]",
+      "current": "NP_0123456.1:p.Arg65_Ser67[12]",
+      "spec_expected": "NP_0123456.1:p.Arg65_Ser67[12]",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "syntax_yaml",
@@ -7205,9 +11780,9 @@
       ]
     },
     {
-      "input": "NP_01234.5:p.Arg97ProfsTer23",
-      "current": "NP_01234.5:p.Arg97ProfsTer23",
-      "spec_expected": "NP_01234.5:p.Arg97ProfsTer23",
+      "input": "NP_0123456.1:p.Arg97ProfsTer23",
+      "current": "NP_0123456.1:p.Arg97ProfsTer23",
+      "spec_expected": "NP_0123456.1:p.Arg97ProfsTer23",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "syntax_yaml",
@@ -7216,9 +11791,9 @@
       ]
     },
     {
-      "input": "NP_01234.5:p.Arg97fs",
-      "current": "NP_01234.5:p.Arg97fs",
-      "spec_expected": "NP_01234.5:p.Arg97fs",
+      "input": "NP_0123456.1:p.Arg97fs",
+      "current": "NP_0123456.1:p.Arg97fs",
+      "spec_expected": "NP_0123456.1:p.Arg97fs",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "syntax_yaml",
@@ -7284,6 +11859,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md"
+      ]
+    },
+    {
+      "input": "p.(Arg1459Ter)",
+      "input_prefixed": "NP_003997.1:p.(Arg1459Ter)",
+      "current": "NP_003997.1:p.(Arg1459Ter)",
+      "spec_expected": "NP_003997.1:p.(Arg1459Ter)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/simple.md"
       ]
     },
     {
@@ -7407,6 +11994,54 @@
       ]
     },
     {
+      "input": "p.(Gln2319[26])",
+      "input_prefixed": "NP_003997.1:p.(Gln2319[26])",
+      "current": "NP_003997.1:p.(Gln2319[26])",
+      "spec_expected": "NP_003997.1:p.(Gln2319[26])",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "p.(Gln2319_Gln2331dup)",
+      "input_prefixed": "NP_003997.1:p.(Gln2319_Gln2331dup)",
+      "current": "NP_003997.1:p.(Gln2319_Gln2331dup)",
+      "spec_expected": "NP_003997.1:p.(Gln2319_Gln2331dup)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
+      "input": "p.(Gly23CysfsTer26)",
+      "input_prefixed": "NP_003997.1:p.(Gly23CysfsTer26)",
+      "current": "NP_003997.1:p.(Gly23CysfsTer26)",
+      "spec_expected": "NP_003997.1:p.(Gly23CysfsTer26)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "p.(Gly23GlufsTer7)",
+      "input_prefixed": "NP_003997.1:p.(Gly23GlufsTer7)",
+      "current": "NP_003997.1:p.(Gly23GlufsTer7)",
+      "spec_expected": "NP_003997.1:p.(Gly23GlufsTer7)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
       "input": "p.(Gly26Cys)",
       "input_prefixed": "NP_003997.1:p.(Gly26Cys)",
       "current": "NP_003997.1:p.(Gly26Cys)",
@@ -7431,6 +12066,19 @@
       ]
     },
     {
+      "input": "p.(Lys79Tyr)",
+      "input_prefixed": "NP_003997.1:p.(Lys79Tyr)",
+      "current": "NP_003997.1:p.(Lys79Tyr)",
+      "spec_expected": "NP_003997.1:p.(Lys79Tyr)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
+    },
+    {
       "input": "p.(Lys874=)",
       "input_prefixed": "NP_003997.1:p.(Lys874=)",
       "current": "NP_003997.1:p.(Lys874=)",
@@ -7443,22 +12091,22 @@
       ]
     },
     {
-      "input": "p.(Met1Val)",
-      "input_prefixed": "NP_003997.1:p.(Met1Val)",
-      "current": "NP_003997.1:p.(Met1Val)",
-      "spec_expected": "NP_003997.1:p.(Met1Val)",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/checklist.md"
-      ]
-    },
-    {
       "input": "p.(Met3_His4insGlyTer)",
       "input_prefixed": "NP_003997.1:p.(Met3_His4insGlyTer)",
       "current": "NP_003997.1:p.(Met3_His4insGlyTer)",
       "spec_expected": "NP_003997.1:p.(Met3_His4insGlyTer)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/insertion.md"
+      ]
+    },
+    {
+      "input": "p.(Met3_Ile3418delinsGly)",
+      "input_prefixed": "NP_003997.1:p.(Met3_Ile3418delinsGly)",
+      "current": "NP_003997.1:p.(Met3_Ile3418delinsGly)",
+      "spec_expected": "NP_003997.1:p.(Met3_Ile3418delinsGly)",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -7515,18 +12163,6 @@
       ]
     },
     {
-      "input": "p.(Val559_Glu562delinsGlu)",
-      "input_prefixed": "NP_003997.1:p.(Val559_Glu562delinsGlu)",
-      "current": "NP_003997.1:p.(Val559_Glu562delinsGlu)",
-      "spec_expected": "NP_003997.1:p.(Val559_Glu562delinsGlu)",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/delins.md"
-      ]
-    },
-    {
       "input": "p.(Val89_Gln119dup)",
       "input_prefixed": "NP_003997.1:p.(Val89_Gln119dup)",
       "current": "NP_003997.1:p.(Val89_Gln119dup)",
@@ -7547,7 +12183,8 @@
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/protein/deletion.md"
+        "docs/recommendations/protein/deletion.md",
+        "docs/recommendations/uncertain.md"
       ]
     },
     {
@@ -7559,6 +12196,7 @@
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/protein/alleles.md",
         "docs/recommendations/protein/substitution.md"
       ]
     },
@@ -7647,18 +12285,6 @@
       ]
     },
     {
-      "input": "p.Arg1459Ter",
-      "input_prefixed": "NP_003997.1:p.Arg1459Ter",
-      "current": "NP_003997.1:p.Arg1459Ter",
-      "spec_expected": "NP_003997.1:p.Arg1459Ter",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/simple.md"
-      ]
-    },
-    {
       "input": "p.Arg456GlyfsTer17",
       "input_prefixed": "NP_003997.1:p.Arg456GlyfsTer17",
       "current": "NP_003997.1:p.Arg456GlyfsTer17",
@@ -7671,18 +12297,6 @@
       ]
     },
     {
-      "input": "p.Arg45del6",
-      "input_prefixed": "NP_003997.1:p.Arg45del6",
-      "current": "NP_003997.1:p.Arg45del6",
-      "spec_expected": "NP_003997.1:p.Arg45del6",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/deletion.md"
-      ]
-    },
-    {
       "input": "p.Arg48Trp",
       "input_prefixed": "NP_003997.1:p.Arg48Trp",
       "current": "NP_003997.1:p.Arg48Trp",
@@ -7691,7 +12305,8 @@
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/delins.md"
+        "docs/recommendations/RNA/delins.md",
+        "docs/recommendations/RNA/substitution.md"
       ]
     },
     {
@@ -7804,19 +12419,6 @@
       ]
     },
     {
-      "input": "p.Cys5_Ser6delinsTerGluAsp",
-      "input_prefixed": "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
-      "current": "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
-      "spec_expected": "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/delins.md",
-        "docs/recommendations/protein/substitution.md"
-      ]
-    },
-    {
       "input": "p.Gln18[23]",
       "input_prefixed": "NP_003997.1:p.Gln18[23]",
       "current": "NP_003997.1:p.Gln18[23]",
@@ -7889,18 +12491,6 @@
       ]
     },
     {
-      "input": "p.His4insAla",
-      "input_prefixed": "NP_003997.1:p.His4insAla",
-      "current": "NP_003997.1:p.His4insAla",
-      "spec_expected": "NP_003997.1:p.His4insAla",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/insertion.md"
-      ]
-    },
-    {
       "input": "p.Ile327fs",
       "input_prefixed": "NP_003997.1:p.Ile327fs",
       "current": "NP_003997.1:p.Ile327fs",
@@ -7910,18 +12500,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/frameshift.md"
-      ]
-    },
-    {
-      "input": "p.Lys23insAsp",
-      "input_prefixed": "NP_003997.1:p.Lys23insAsp",
-      "current": "NP_003997.1:p.Lys23insAsp",
-      "spec_expected": "NP_003997.1:p.Lys23insAsp",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/insertion.md"
       ]
     },
     {
@@ -7959,18 +12537,6 @@
       "source_paths": [
         "docs/recommendations/DNA/delins.md",
         "docs/recommendations/DNA/substitution.md"
-      ]
-    },
-    {
-      "input": "p.Met1Valext-4",
-      "input_prefixed": "NP_003997.1:p.Met1Valext-4",
-      "current": "NP_003997.1:p.Met1Valext-4",
-      "spec_expected": "NP_003997.1:p.Met1Valext-4",
-      "status": "preserved",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/extension.md"
       ]
     },
     {
@@ -8049,15 +12615,27 @@
       ]
     },
     {
-      "input": "p.Ter327Argext*?",
-      "input_prefixed": "NP_003997.1:p.Ter327Argext*?",
-      "current": "NP_003997.1:p.Ter327Argext*?",
-      "spec_expected": "NP_003997.1:p.Ter327Argext*?",
+      "input": "p.Trp24Cys",
+      "input_prefixed": "NP_003997.1:p.Trp24Cys",
+      "current": "NP_003997.1:p.Trp24Cys",
+      "spec_expected": "NP_003997.1:p.Trp24Cys",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/protein/extension.md"
+        "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
+      "input": "p.Trp24Ter",
+      "input_prefixed": "NP_003997.1:p.Trp24Ter",
+      "current": "NP_003997.1:p.Trp24Ter",
+      "spec_expected": "NP_003997.1:p.Trp24Ter",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ]
     },
     {
@@ -8124,16 +12702,27 @@
       ]
     },
     {
-      "input": "p.[Arg76Ser;Cys77Trp]",
-      "input_prefixed": "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
-      "current": "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
-      "spec_expected": "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
+      "input": "p.Val7del",
+      "input_prefixed": "NP_003997.1:p.Val7del",
+      "current": "NP_003997.1:p.Val7del",
+      "spec_expected": "NP_003997.1:p.Val7del",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/protein/delins.md",
-        "docs/recommendations/protein/substitution.md"
+        "docs/recommendations/protein/deletion.md"
+      ]
+    },
+    {
+      "input": "p.Val7dup",
+      "input_prefixed": "NP_003997.1:p.Val7dup",
+      "current": "NP_003997.1:p.Val7dup",
+      "spec_expected": "NP_003997.1:p.Val7dup",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/duplication.md"
       ]
     },
     {
@@ -8147,6 +12736,55 @@
       "source_paths": [
         "docs/recommendations/protein/delins.md"
       ]
+    },
+    {
+      "input": "p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]",
+      "input_prefixed": "NP_003997.1:p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]",
+      "current": "NP_003997.1:p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]",
+      "spec_expected": "NP_003997.1:p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.[Ser68_Arg70dup];[Ser68_Arg70=]",
+      "input_prefixed": "NP_003997.1:p.[Ser68_Arg70dup];[Ser68_Arg70=]",
+      "current": "NP_003997.1:p.[Ser68_Arg70dup];[Ser68_Arg70=]",
+      "spec_expected": "NP_003997.1:p.[Ser68_Arg70dup];[Ser68_Arg70=]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.[Ser68del];[Ser68=]",
+      "input_prefixed": "NP_003997.1:p.[Ser68del];[Ser68=]",
+      "current": "NP_003997.1:p.[Ser68del];[Ser68=]",
+      "spec_expected": "NP_003997.1:p.[Ser68del];[Ser68=]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.[Ser988Ala;Gln990His]",
+      "input_prefixed": "NP_003997.1:p.[Ser988Ala;Gln990His]",
+      "current": "NP_003997.1:p.[Ser988Ala;Gln990His]",
+      "spec_expected": "NP_003997.1:p.[Ser988Ala;Gln990His]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG010.md"
+      ],
+      "working_group": "SVD-WG010"
     },
     {
       "input": "r.123_456dupinv",
@@ -8207,6 +12845,18 @@
       ]
     },
     {
+      "input": "r.456_465[4]466_489[9]490_499[3]",
+      "input_prefixed": "NM_004006.3:r.456_465[4]466_489[9]490_499[3]",
+      "current": "parse error: Parse error at position 24: Unexpected trailing characters: '466_489[9]490_499[3]'",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
       "input": "r.76a/g",
       "input_prefixed": "NM_004006.3:r.76a/g",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"a\", code: Verify })",
@@ -8231,6 +12881,18 @@
       ]
     },
     {
+      "input": "r.[76a>c];[]",
+      "input_prefixed": "NM_004006.3:r.[76a>c];[]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:r.(4072_5145del)",
       "current": "LRG_199t1:r.4072_5145del",
       "spec_expected": "LRG_199t1:r.(4072_5145del)",
@@ -8243,50 +12905,38 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:r.(6_8del)",
-      "current": "LRG_199t1:r.6_8del",
-      "spec_expected": "LRG_199t1:r.(6_8del)",
+      "input": "LRG_199t1:r.186_187ins186+1_186+4",
+      "current": "LRG_199t1:r.186_187ins[186+1_186+4]",
+      "spec_expected": "LRG_199t1:r.186_187ins186+1_186+4",
       "status": "diverges",
       "coordinate_system": "r",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/RNA/deletion.md"
+        "docs/background/numbering.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:r.649_650ins650-1400_650-1268",
-      "current": "LRG_199t1:r.649_650ins[650-1400_650-1268]",
-      "spec_expected": "LRG_199t1:r.649_650ins650-1400_650-1268",
+      "input": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
+      "current": "NC_000023.10(NM_004006.2):r.186_187ins[186+1_186+4]",
+      "spec_expected": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
       "status": "diverges",
       "coordinate_system": "r",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
+        "docs/background/numbering.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:r.649_650ins650-50_650-1",
-      "current": "LRG_199t1:r.649_650ins[650-50_650-1]",
-      "spec_expected": "LRG_199t1:r.649_650ins650-50_650-1",
+      "input": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
+      "current": "NC_000023.10(NM_004006.2):r.357_358ins[357+1_357+12]",
+      "spec_expected": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
       "status": "diverges",
       "coordinate_system": "r",
-      "source_kind": "recommendation",
+      "source_kind": "background",
       "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "LRG_199t1:r.831_832ins831+1_831+67",
-      "current": "LRG_199t1:r.831_832ins[831+1_831+67]",
-      "spec_expected": "LRG_199t1:r.831_832ins831+1_831+67",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
+        "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8335,6 +12985,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/splicing.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
+      "current": "NG_012232.1(NM_004006.2):r.186_187ins[186+1_186+4]",
+      "spec_expected": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
+      "current": "NG_012232.1(NM_004006.2):r.357_358ins[357+1_357+12]",
+      "spec_expected": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8424,6 +13098,32 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.(1339a>g)",
+      "input_prefixed": "NM_004006.3:r.(1339a>g)",
+      "current": "NM_004006.3:r.1339a>g",
+      "spec_expected": "NM_004006.3:r.(1339a>g)",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.(1680del)",
+      "input_prefixed": "NM_004006.3:r.(1680del)",
+      "current": "NM_004006.3:r.1680del",
+      "spec_expected": "NM_004006.3:r.(1680del)",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.(306g>u)",
       "input_prefixed": "NM_004006.3:r.(306g>u)",
       "current": "NM_004006.3:r.306g>u",
@@ -8433,6 +13133,19 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.(578c>u)",
+      "input_prefixed": "NM_004006.3:r.(578c>u)",
+      "current": "NM_004006.3:r.578c>u",
+      "spec_expected": "NM_004006.3:r.(578c>u)",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8450,6 +13163,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.-128_-126[(600_800)]",
+      "input_prefixed": "NM_004006.3:r.-128_-126[(600_800)]",
+      "current": "NM_004006.3:r.-128_-126[600_800]",
+      "spec_expected": "NM_004006.3:r.-128_-126[(600_800)]",
+      "status": "diverges",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.234_235ins123_234inv",
       "input_prefixed": "NM_004006.3:r.234_235ins123_234inv",
       "current": "NM_004006.3:r.234_235ins[123_234inv]",
@@ -8459,6 +13185,7 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/duplication.md",
+        "docs/recommendations/RNA/insertion.md",
         "docs/recommendations/RNA/inversion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -8477,19 +13204,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.[76a>c]",
-      "input_prefixed": "NM_004006.3:r.[76a>c]",
-      "current": "NM_004006.3:r.76a>c",
-      "spec_expected": "NM_004006.3:r.[76a>c]",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NG_012232.1(NM_004006.2):r.2949_2950ins[2950-30_2950-12;2950-4_2950-1]",
       "current": "NG_012232.1(NM_004006.2):r.2949_2950ins[2950-30_2950-12;2950-4_2950-1]",
       "spec_expected": null,
@@ -8498,6 +13212,55 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_007294.3:r.[2077g>a;2077_2078insua]",
+      "current": "NM_007294.3:r.2077delinsaua",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_024312.4:r.1738ua[6]",
+      "current": "NM_024312.4:r.1738ua[6]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NM_024312.4:r.2686a[10]",
+      "current": "NM_024312.4:r.2686a[10]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.-125_-123cug[4]",
+      "input_prefixed": "NM_004006.3:r.-125_-123cug[4]",
+      "current": "NM_004006.3:r.-125_-123cug[4]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8554,9 +13317,35 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.234inv",
+      "input_prefixed": "NM_004006.3:r.234inv",
+      "current": "NM_004006.3:r.234inv",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.2949_2950ins[2950-30_2950-12;uuag]",
       "input_prefixed": "NM_004006.3:r.2949_2950ins[2950-30_2950-12;uuag]",
       "current": "NM_004006.3:r.2949_2950ins[2950-30_2950-12;uuag]",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.456_457ins123_456",
+      "input_prefixed": "NM_004006.3:r.456_457ins123_456",
+      "current": "NM_004006.3:r.456_457ins[123_456]",
       "spec_expected": null,
       "status": "false-acceptance",
       "coordinate_system": "r",
@@ -8606,6 +13395,19 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.6_8dupugc",
+      "input_prefixed": "NM_004006.3:r.6_8dupugc",
+      "current": "NM_004006.3:r.6_8dupugc",
+      "spec_expected": null,
+      "status": "false-acceptance",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.76_77aa>ug",
       "input_prefixed": "NM_004006.3:r.76_77aa>ug",
       "current": "NM_004006.3:r.76_77delinsug",
@@ -8632,15 +13434,51 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.[2077g>a;2077_2078insua]",
-      "input_prefixed": "NM_004006.3:r.[2077g>a;2077_2078insua]",
-      "current": "NM_004006.3:r.2077delinsaua",
+      "input": "r.[76a>c]",
+      "input_prefixed": "NM_004006.3:r.[76a>c]",
+      "current": "NM_004006.3:r.76a>c",
       "spec_expected": null,
       "status": "false-acceptance",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/delins.md"
+        "docs/recommendations/RNA/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": ":r.11u>g",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \":r.11u>g\", code: Alpha })",
+      "spec_expected": ":r.11u>g",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "AB053210.2:r.1289-365_1289-73",
+      "current": "parse error: Parse error at position 11: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "AB053210.2:r.1289-365_1289-73",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "LRG_199t1:r.(=/6_8del)",
+      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(=\", code: Digit })",
+      "spec_expected": "LRG_199t1:r.(=/6_8del)",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8688,8 +13526,7 @@
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/alleles.md",
-        "docs/recommendations/RNA/splicing.md"
+        "docs/recommendations/RNA/alleles.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8718,6 +13555,18 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "class=\"invalid\">NM_007294.3:r.[2077g>a;2077_2078insua]</code>.\"",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_007294.3:r.[2077g>a;2077_2078insua]<\", code: Alpha })",
+      "spec_expected": "class=\"invalid\">NM_007294.3:r.[2077g>a;2077_2078insua]</code>.\"",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "class=\"invalid\">r.124_500delins[AB053210.2:r.1289-365_1289-73inv]</code>.",
       "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">r.124_500delins[AB053210.2:r.1289-365_1289-73inv]<\", code: Alpha })",
       "spec_expected": "class=\"invalid\">r.124_500delins[AB053210.2:r.1289-365_1289-73inv]</code>.",
@@ -8730,6 +13579,21 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.",
+      "input_prefixed": "NM_004006.3:r.",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
+      "spec_expected": "NM_004006.3:r.",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md",
+        "docs/consultation/SVD-WG002.md"
+      ],
+      "working_group": "SVD-WG002",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.(100_150)delN[15]",
       "input_prefixed": "NM_004006.3:r.(100_150)delN[15]",
       "current": "parse error: Parse error at position 27: Unexpected trailing characters: '[15]'",
@@ -8739,6 +13603,19 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.(=)",
+      "input_prefixed": "NM_004006.3:r.(=)",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(=)\", code: Digit })",
+      "spec_expected": "NM_004006.3:r.(=)",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8762,9 +13639,10 @@
       "spec_expected": "NM_004006.3:r.*1924",
       "status": "parse-error",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md"
       ],
       "working_group": "SVD-WG007",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -8779,6 +13657,7 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
         "docs/recommendations/RNA/splicing.md"
       ],
       "working_group": "SVD-WG007",
@@ -8791,49 +13670,63 @@
       "spec_expected": "NM_004006.3:r.-115",
       "status": "parse-error",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md"
       ],
       "working_group": "SVD-WG007",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.-13",
-      "input_prefixed": "NM_004006.3:r.-13",
+      "input": "r.-123",
+      "input_prefixed": "NM_004006.3:r.-123",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.-13",
+      "spec_expected": "NM_004006.3:r.-123",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.-14,",
-      "input_prefixed": "NM_004006.3:r.-14,",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \",\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.-14,",
+      "input": "r.-124",
+      "input_prefixed": "NM_004006.3:r.-124",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.-124",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.-15?",
-      "input_prefixed": "NM_004006.3:r.-15?",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"?\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.-15?",
+      "input": "r.-124_-123[14];[18]",
+      "input_prefixed": "NM_004006.3:r.-124_-123[14];[18]",
+      "current": "parse error: Parse error at position 27: Unexpected trailing characters: ';[18]'",
+      "spec_expected": "NM_004006.3:r.-124_-123[14];[18]",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/repeated.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.-124ug[14];[18]",
+      "input_prefixed": "NM_004006.3:r.-124ug[14];[18]",
+      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[18]'",
+      "spec_expected": "NM_004006.3:r.-124ug[14];[18]",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8847,9 +13740,129 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
         "docs/recommendations/RNA/splicing.md"
       ],
       "working_group": "SVD-WG007",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.0?",
+      "input_prefixed": "NM_004006.3:r.0?",
+      "current": "parse error: Parse error at position 15: Unexpected trailing characters: '?'",
+      "spec_expected": "NM_004006.3:r.0?",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1",
+      "input_prefixed": "NM_004006.3:r.1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.10",
+      "input_prefixed": "NM_004006.3:r.10",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.10",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1034",
+      "input_prefixed": "NM_004006.3:r.1034",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1034",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1035",
+      "input_prefixed": "NM_004006.3:r.1035",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1035",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1036",
+      "input_prefixed": "NM_004006.3:r.1036",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1036",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1149",
+      "input_prefixed": "NM_004006.3:r.1149",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1149",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1150",
+      "input_prefixed": "NM_004006.3:r.1150",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1150",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.123",
+      "input_prefixed": "NM_004006.3:r.123",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.123",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/background/numbering.md",
+        "docs/background/refseq.md",
+        "docs/recommendations/RNA/substitution.md"
+      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -8861,6 +13874,45 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.123_456",
+      "input_prefixed": "NM_004006.3:r.123_456",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.123_456",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1388",
+      "input_prefixed": "NM_004006.3:r.1388",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1388",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/substitution.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1401",
+      "input_prefixed": "NM_004006.3:r.1401",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1401",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8877,58 +13929,173 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.142",
+      "input_prefixed": "NM_004006.3:r.142",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.142",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.144",
+      "input_prefixed": "NM_004006.3:r.144",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.144",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1446",
+      "input_prefixed": "NM_004006.3:r.1446",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1446",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1513",
+      "input_prefixed": "NM_004006.3:r.1513",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1513",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.1558",
+      "input_prefixed": "NM_004006.3:r.1558",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1558",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.1580",
       "input_prefixed": "NM_004006.3:r.1580",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
       "spec_expected": "NM_004006.3:r.1580",
       "status": "parse-error",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md"
       ],
       "working_group": "SVD-WG007",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.16,",
-      "input_prefixed": "NM_004006.3:r.16,",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \",\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.16,",
+      "input": "r.1655",
+      "input_prefixed": "NM_004006.3:r.1655",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.1655",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/duplication.md",
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.17",
-      "input_prefixed": "NM_004006.3:r.17",
+      "input": "r.177",
+      "input_prefixed": "NM_004006.3:r.177",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.17",
+      "spec_expected": "NM_004006.3:r.177",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/duplication.md",
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/inversion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.18",
-      "input_prefixed": "NM_004006.3:r.18",
+      "input": "r.180",
+      "input_prefixed": "NM_004006.3:r.180",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.18",
+      "spec_expected": "NM_004006.3:r.180",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/duplication.md",
-        "docs/recommendations/RNA/insertion.md"
+        "docs/recommendations/RNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2",
+      "input_prefixed": "NM_004006.3:r.2",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.203",
+      "input_prefixed": "NM_004006.3:r.203",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.203",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2074",
+      "input_prefixed": "NM_004006.3:r.2074",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2074",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2080",
+      "input_prefixed": "NM_004006.3:r.2080",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2080",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8939,23 +14106,260 @@
       "spec_expected": "NM_004006.3:r.212",
       "status": "parse-error",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
+        "docs/recommendations/RNA/splicing.md"
       ],
       "working_group": "SVD-WG007",
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.5",
-      "input_prefixed": "NM_004006.3:r.5",
+      "input": "r.2623",
+      "input_prefixed": "NM_004006.3:r.2623",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.5",
+      "spec_expected": "NM_004006.3:r.2623",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/duplication.md",
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2803",
+      "input_prefixed": "NM_004006.3:r.2803",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2803",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2804",
+      "input_prefixed": "NM_004006.3:r.2804",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2804",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2949",
+      "input_prefixed": "NM_004006.3:r.2949",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2949",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md",
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2950",
+      "input_prefixed": "NM_004006.3:r.2950",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2950",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2950-1",
+      "input_prefixed": "NM_004006.3:r.2950-1",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2950-1",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2950-12",
+      "input_prefixed": "NM_004006.3:r.2950-12",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2950-12",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2950-30",
+      "input_prefixed": "NM_004006.3:r.2950-30",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2950-30",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.2950-4",
+      "input_prefixed": "NM_004006.3:r.2950-4",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.2950-4",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.3",
+      "input_prefixed": "NM_004006.3:r.3",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.3",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.4072",
+      "input_prefixed": "NM_004006.3:r.4072",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.4072",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.414",
+      "input_prefixed": "NM_004006.3:r.414",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.414",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.426",
+      "input_prefixed": "NM_004006.3:r.426",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.426",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.427",
+      "input_prefixed": "NM_004006.3:r.427",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.427",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.470",
+      "input_prefixed": "NM_004006.3:r.470",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.470",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.506",
+      "input_prefixed": "NM_004006.3:r.506",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.506",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/inversion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.5145",
+      "input_prefixed": "NM_004006.3:r.5145",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.5145",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.549",
+      "input_prefixed": "NM_004006.3:r.549",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.549",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.550",
+      "input_prefixed": "NM_004006.3:r.550",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.550",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
         "docs/recommendations/RNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
@@ -8970,9 +14374,24 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
         "docs/recommendations/RNA/splicing.md"
       ],
       "working_group": "SVD-WG007",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.6",
+      "input_prefixed": "NM_004006.3:r.6",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.6",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md",
+        "docs/recommendations/RNA/duplication.md"
+      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -8985,6 +14404,19 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/splicing.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.7",
+      "input_prefixed": "NM_004006.3:r.7",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.7",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -9002,6 +14434,32 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.756",
+      "input_prefixed": "NM_004006.3:r.756",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.756",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.757",
+      "input_prefixed": "NM_004006.3:r.757",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.757",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.76",
       "input_prefixed": "NM_004006.3:r.76",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
@@ -9011,20 +14469,34 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/alleles.md",
-        "docs/recommendations/RNA/splicing.md"
+        "docs/recommendations/RNA/splicing.md",
+        "docs/recommendations/RNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.76[a>c];[=],",
-      "input_prefixed": "NM_004006.3:r.76[a>c];[=],",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[a>c];[=],\", code: TakeWhile1 })",
-      "spec_expected": "NM_004006.3:r.76[a>c];[=],",
+      "input": "r.761",
+      "input_prefixed": "NM_004006.3:r.761",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.761",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/alleles.md"
+        "docs/recommendations/RNA/insertion.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.762",
+      "input_prefixed": "NM_004006.3:r.762",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.762",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -9035,11 +14507,26 @@
       "spec_expected": "NM_004006.3:r.775",
       "status": "parse-error",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
+        "docs/recommendations/RNA/delins.md"
       ],
       "working_group": "SVD-WG007",
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.777",
+      "input_prefixed": "NM_004006.3:r.777",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.777",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -9056,6 +14543,20 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "r.8",
+      "input_prefixed": "NM_004006.3:r.8",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.8",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md",
+        "docs/recommendations/RNA/duplication.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "r.831",
       "input_prefixed": "NM_004006.3:r.831",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
@@ -9065,6 +14566,32 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/splicing.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.902",
+      "input_prefixed": "NM_004006.3:r.902",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.902",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "r.909",
+      "input_prefixed": "NM_004006.3:r.909",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
+      "spec_expected": "NM_004006.3:r.909",
+      "status": "parse-error",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -9109,10 +14636,10 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.[76a>c];[]",
-      "input_prefixed": "NM_004006.3:r.[76a>c];[]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
-      "spec_expected": "NM_004006.3:r.[76a>c];[]",
+      "input": "r.[76a>u];[=]",
+      "input_prefixed": "NM_004006.3:r.[76a>u];[=]",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"=\", code: Digit })",
+      "spec_expected": "NM_004006.3:r.[76a>u];[=]",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
@@ -9168,17 +14695,6 @@
       ]
     },
     {
-      "input": "LRG_199t1:r.649_650ins[650-52_650-2;c]",
-      "current": "LRG_199t1:r.649_650ins[650-52_650-2;c]",
-      "spec_expected": "LRG_199t1:r.649_650ins[650-52_650-2;c]",
-      "status": "preserved",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
-      ]
-    },
-    {
       "input": "LRG_199t1:r.756_757insuacu",
       "current": "LRG_199t1:r.756_757insuacu",
       "spec_expected": "LRG_199t1:r.756_757insuacu",
@@ -9187,17 +14703,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/insertion.md"
-      ]
-    },
-    {
-      "input": "LRG_199t1:r.831_832ins[ga;831+3_831+60]",
-      "current": "LRG_199t1:r.831_832ins[ga;831+3_831+60]",
-      "spec_expected": "LRG_199t1:r.831_832ins[ga;831+3_831+60]",
-      "status": "preserved",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
       ]
     },
     {
@@ -9330,8 +14835,9 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/consultation/SVD-WG007.md",
-        "docs/recommendations/RNA/delins.md",
-        "docs/recommendations/RNA/splicing.md"
+        "docs/recommendations/RNA/adjoined_transcript.md",
+        "docs/recommendations/RNA/splicing.md",
+        "docs/syntax.yaml"
       ],
       "working_group": "SVD-WG007"
     },
@@ -9343,7 +14849,7 @@
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/delins.md"
+        "docs/recommendations/RNA/adjoined_transcript.md"
       ]
     },
     {
@@ -9367,6 +14873,18 @@
       "source_paths": [
         "docs/recommendations/RNA/substitution.md"
       ]
+    },
+    {
+      "input": "NM_004006.1:r.470=",
+      "current": "NM_004006.1:r.470=",
+      "spec_expected": "NM_004006.1:r.470=",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG001.md"
+      ],
+      "working_group": "SVD-WG001"
     },
     {
       "input": "NM_004006.2:r.549_550insn",
@@ -9639,6 +15157,50 @@
       ]
     },
     {
+      "input": "NM_007294.3:r.2077g>a",
+      "current": "NM_007294.3:r.2077g>a",
+      "spec_expected": "NM_007294.3:r.2077g>a",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:r.-6_-3g[6]",
+      "current": "NM_024312.4:r.-6_-3g[6]",
+      "spec_expected": "NM_024312.4:r.-6_-3g[6]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:r.1741_1742insuauauaua",
+      "current": "NM_024312.4:r.1741_1742insuauauaua",
+      "spec_expected": "NM_024312.4:r.1741_1742insuauauaua",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "NM_024312.4:r.2692_2693dup",
+      "current": "NM_024312.4:r.2692_2693dup",
+      "spec_expected": "NM_024312.4:r.2692_2693dup",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
       "input": "NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924",
       "current": "NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924",
       "spec_expected": "NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924",
@@ -9647,9 +15209,20 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/consultation/SVD-WG007.md",
-        "docs/recommendations/RNA/delins.md"
+        "docs/recommendations/RNA/adjoined_transcript.md"
       ],
       "working_group": "SVD-WG007"
+    },
+    {
+      "input": "NM_152263.2:r.-115_775::aggcucccuugg::NM_002609.3:r.1580_*1924",
+      "current": "NM_152263.2:r.-115_775::aggcucccuugg::NM_002609.3:r.1580_*1924",
+      "spec_expected": "NM_152263.2:r.-115_775::aggcucccuugg::NM_002609.3:r.1580_*1924",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
+      ]
     },
     {
       "input": "NM_152263.2:r.?_775::NM_002609.3:r.1580_?",
@@ -9657,11 +15230,109 @@
       "spec_expected": "NM_152263.2:r.?_775::NM_002609.3:r.1580_?",
       "status": "preserved",
       "coordinate_system": "r",
-      "source_kind": "consultation",
+      "source_kind": "recommendation",
       "source_paths": [
-        "docs/consultation/SVD-WG007.md"
+        "docs/consultation/SVD-WG007.md",
+        "docs/recommendations/RNA/adjoined_transcript.md",
+        "docs/syntax.yaml"
       ],
       "working_group": "SVD-WG007"
+    },
+    {
+      "input": "r.-123ug[14]",
+      "input_prefixed": "NM_004006.3:r.-123ug[14]",
+      "current": "NM_004006.3:r.-123ug[14]",
+      "spec_expected": "NM_004006.3:r.-123ug[14]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-123ug[17]",
+      "input_prefixed": "NM_004006.3:r.-123ug[17]",
+      "current": "NM_004006.3:r.-123ug[17]",
+      "spec_expected": "NM_004006.3:r.-123ug[17]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-124_-123[14]",
+      "input_prefixed": "NM_004006.3:r.-124_-123[14]",
+      "current": "NM_004006.3:r.-124_-123[14]",
+      "spec_expected": "NM_004006.3:r.-124_-123[14]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-124ug[14]",
+      "input_prefixed": "NM_004006.3:r.-124ug[14]",
+      "current": "NM_004006.3:r.-124ug[14]",
+      "spec_expected": "NM_004006.3:r.-124ug[14]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-128_-126[79]",
+      "input_prefixed": "NM_004006.3:r.-128_-126[79]",
+      "current": "NM_004006.3:r.-128_-126[79]",
+      "spec_expected": "NM_004006.3:r.-128_-126[79]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-128ggc[79]",
+      "input_prefixed": "NM_004006.3:r.-128ggc[79]",
+      "current": "NM_004006.3:r.-128ggc[79]",
+      "spec_expected": "NM_004006.3:r.-128ggc[79]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-97_-96del",
+      "input_prefixed": "NM_004006.3:r.-97_-96del",
+      "current": "NM_004006.3:r.-97_-96del",
+      "spec_expected": "NM_004006.3:r.-97_-96del",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-99_-96dup",
+      "input_prefixed": "NM_004006.3:r.-99_-96dup",
+      "current": "NM_004006.3:r.-99_-96dup",
+      "spec_expected": "NM_004006.3:r.-99_-96dup",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
     },
     {
       "input": "r.103del",
@@ -9688,6 +15359,78 @@
       ]
     },
     {
+      "input": "r.123_125[23]",
+      "input_prefixed": "NM_004006.3:r.123_125[23]",
+      "current": "NM_004006.3:r.123_125[23]",
+      "spec_expected": "NM_004006.3:r.123_125[23]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.123_191cag[23]",
+      "input_prefixed": "NM_004006.3:r.123_191cag[23]",
+      "current": "NM_004006.3:r.123_191cag[23]",
+      "spec_expected": "NM_004006.3:r.123_191cag[23]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.123a>u",
+      "input_prefixed": "NM_004006.3:r.123a>u",
+      "current": "NM_004006.3:r.123a>u",
+      "spec_expected": "NM_004006.3:r.123a>u",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "r.123c>u",
+      "input_prefixed": "NM_004006.3:r.123c>u",
+      "current": "NM_004006.3:r.123c>u",
+      "spec_expected": "NM_004006.3:r.123c>u",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
+      ]
+    },
+    {
+      "input": "r.123cag[23]",
+      "input_prefixed": "NM_004006.3:r.123cag[23]",
+      "current": "NM_004006.3:r.123cag[23]",
+      "spec_expected": "NM_004006.3:r.123cag[23]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.123cug[23]",
+      "input_prefixed": "NM_004006.3:r.123cug[23]",
+      "current": "NM_004006.3:r.123cug[23]",
+      "spec_expected": "NM_004006.3:r.123cug[23]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
       "input": "r.142_144delinsugg",
       "input_prefixed": "NM_004006.3:r.142_144delinsugg",
       "current": "NM_004006.3:r.142_144delinsugg",
@@ -9696,7 +15439,8 @@
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
-        "docs/recommendations/RNA/delins.md"
+        "docs/recommendations/RNA/delins.md",
+        "docs/recommendations/RNA/substitution.md"
       ]
     },
     {
@@ -9709,6 +15453,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/deletion.md"
+      ]
+    },
+    {
+      "input": "r.1704dup",
+      "input_prefixed": "NM_004006.3:r.1704dup",
+      "current": "NM_004006.3:r.1704dup",
+      "spec_expected": "NM_004006.3:r.1704dup",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
       ]
     },
     {
@@ -9736,34 +15492,22 @@
       ]
     },
     {
+      "input": "r.1813dup",
+      "input_prefixed": "NM_004006.3:r.1813dup",
+      "current": "NM_004006.3:r.1813dup",
+      "spec_expected": "NM_004006.3:r.1813dup",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
       "input": "r.203_506inv",
       "input_prefixed": "NM_004006.3:r.203_506inv",
       "current": "NM_004006.3:r.203_506inv",
       "spec_expected": "NM_004006.3:r.203_506inv",
-      "status": "preserved",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/inversion.md"
-      ]
-    },
-    {
-      "input": "r.2077g>a",
-      "input_prefixed": "NM_004006.3:r.2077g>a",
-      "current": "NM_004006.3:r.2077g>a",
-      "spec_expected": "NM_004006.3:r.2077g>a",
-      "status": "preserved",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/delins.md"
-      ]
-    },
-    {
-      "input": "r.234inv",
-      "input_prefixed": "NM_004006.3:r.234inv",
-      "current": "NM_004006.3:r.234inv",
-      "spec_expected": "NM_004006.3:r.234inv",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",
@@ -9781,6 +15525,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/substitution.md"
+      ]
+    },
+    {
+      "input": "r.53_55[31]",
+      "input_prefixed": "NM_004006.3:r.53_55[31]",
+      "current": "NM_004006.3:r.53_55[31]",
+      "spec_expected": "NM_004006.3:r.53_55[31]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.53agc[19]",
+      "input_prefixed": "NM_004006.3:r.53agc[19]",
+      "current": "NM_004006.3:r.53agc[19]",
+      "spec_expected": "NM_004006.3:r.53agc[19]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
       ]
     },
     {
@@ -9817,18 +15585,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/alleles.md"
-      ]
-    },
-    {
-      "input": "r.76a>g",
-      "input_prefixed": "NM_004006.3:r.76a>g",
-      "current": "NM_004006.3:r.76a>g",
-      "spec_expected": "NM_004006.3:r.76a>g",
-      "status": "preserved",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/substitution.md"
       ]
     },
     {
@@ -9956,6 +15712,18 @@
       ]
     },
     {
+      "input": "r.=",
+      "input_prefixed": "NM_004006.3:r.=",
+      "current": "NM_004006.3:r.=",
+      "spec_expected": "NM_004006.3:r.=",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
+      ]
+    },
+    {
       "input": "r.?",
       "input_prefixed": "NM_004006.3:r.?",
       "current": "NM_004006.3:r.?",
@@ -9964,6 +15732,7 @@
       "coordinate_system": "r",
       "source_kind": "recommendation",
       "source_paths": [
+        "docs/recommendations/RNA/alleles.md",
         "docs/recommendations/uncertain.md"
       ]
     },


### PR DESCRIPTION
## Summary

Bumps `assets/hgvs-nomenclature` from `a32f970` (Jan 13 2024) to upstream `main` HEAD `6f85311`. Headline change for ferro: `docs/consultation/SVD-WG010.md` now reads `Status: rejected` (upstream commit `7b23bf4`, Feb 10 2025) — the vendored copy still showed `Status: decision pending`. The rejection informed the won't-do close of #186; #179's structural justification is independent and unaffected.

This is a wholesale snapshot refresh covering ~220 upstream commits / ~96 files. Largest-impact areas beyond SVD-WG010 are likely the DNA recommendations (delins, insertion, inversion, substitution) and the general priority rules.

Closes #192.

## Why not surgical

Submodules pin to upstream commits; no cherry-pick path without forking the spec repo. The narrowest commit containing the rejection (`7b23bf4`) still drags ~110 commits / ~50 files of unrelated spec changes — better to take a clean snapshot than a partial one.

## Test plan

- [x] `cargo nextest run --features dev` — 4245 passed, 51 skipped, 0 failed
- [x] `pixi run pytest tests/python/ -v` — 134 passed
- [x] `assets/hgvs-nomenclature/docs/consultation/SVD-WG010.md` shows `Status: rejected` post-bump
- [ ] Reviewer spot-check of spec-quoting code/tests in `src/normalize/{merge,rules,shuffle}.rs`, `src/hgvs/edit.rs`, and tests that quote spec text verbatim