### PR TITLE
feat(loader): Phase 2 - CDS phase/start_codon/stop_codon, UTR-merge, MANE wiring (#190)

### DIFF
--- a/src/reference/annotation/builder.rs
+++ b/src/reference/annotation/builder.rs
@@ -80,7 +80,7 @@ pub fn build_transcripts(
 fn build_single(
     graph: &FeatureGraph,
     tx_fid: FeatureId,
-    _format: AnnotationFormat,
+    format: AnnotationFormat,
     genome_build: GenomeBuild,
     source_path: &Path,
     report: &mut LoaderReport,
@@ -114,41 +114,60 @@ fn build_single(
             .iter()
             .map(|fid| graph.feature(*fid).range)
             .collect()
-    } else if !cds_fids.is_empty() {
-        // Step 3: CDS-as-exon (issue #183).
-        //
-        // A single CDS child is the only signal we have for UTR sequence:
-        // the rest of the mRNA span is flanking UTR. Use the transcript's
-        // own range as the single exon so 5'/3' UTRs survive the load.
-        // Multiple CDS fragments instead encode the spliced exon structure
-        // of a coding transcript, so we keep the existing fallback for
-        // that case.
-        if cds_fids.len() == 1 {
-            vec![tx_feat.range]
-        } else {
-            cds_fids
-                .iter()
-                .map(|fid| graph.feature(*fid).range)
-                .collect()
-        }
     } else {
-        // Step 4: drop.
-        report.record(LoaderDiagnostic::warning(
-            "W-LOAD-100",
-            format!(
-                "TranscriptWithoutExons: {} has no exon/UTR/CDS children",
-                tx_id_str
-            ),
-            SourceLocation {
-                path: source_path.to_path_buf(),
-                line: tx_feat.source_line,
-            },
-            Some(tx_id_str.clone()),
-            DiagnosticPayload::NoExonsDerivable {
-                transcript_id: tx_id_str.clone(),
-            },
-        ));
-        return None;
+        // Step 2 candidates: UTR records that, together with CDS, span the transcript.
+        let utr5 = graph.descendants_of_type(tx_fid, &FeatureType::FivePrimeUtr);
+        let utr3 = graph.descendants_of_type(tx_fid, &FeatureType::ThreePrimeUtr);
+        let utr_generic = graph.descendants_of_type(tx_fid, &FeatureType::Utr);
+        let has_utr = !utr5.is_empty() || !utr3.is_empty() || !utr_generic.is_empty();
+
+        if has_utr && !cds_fids.is_empty() {
+            // Step 2: merge UTR + CDS into synthetic exons.
+            let mut all: Vec<(u64, u64)> = utr5
+                .iter()
+                .chain(utr3.iter())
+                .chain(utr_generic.iter())
+                .chain(cds_fids.iter())
+                .map(|f| graph.feature(*f).range)
+                .collect();
+            all.sort_by_key(|(s, _)| *s);
+            merge_adjacent(&all)
+        } else if !cds_fids.is_empty() {
+            // Step 3: CDS-as-exon (issue #183).
+            //
+            // A single CDS child is the only signal we have for UTR sequence:
+            // the rest of the mRNA span is flanking UTR. Use the transcript's
+            // own range as the single exon so 5'/3' UTRs survive the load.
+            // Multiple CDS fragments instead encode the spliced exon structure
+            // of a coding transcript, so we keep the existing fallback for
+            // that case.
+            if cds_fids.len() == 1 {
+                vec![tx_feat.range]
+            } else {
+                cds_fids
+                    .iter()
+                    .map(|fid| graph.feature(*fid).range)
+                    .collect()
+            }
+        } else {
+            // Step 4: drop.
+            report.record(LoaderDiagnostic::warning(
+                "W-LOAD-100",
+                format!(
+                    "TranscriptWithoutExons: {} has no exon/UTR/CDS children",
+                    tx_id_str
+                ),
+                SourceLocation {
+                    path: source_path.to_path_buf(),
+                    line: tx_feat.source_line,
+                },
+                Some(tx_id_str.clone()),
+                DiagnosticPayload::NoExonsDerivable {
+                    transcript_id: tx_id_str.clone(),
+                },
+            ));
+            return None;
+        }
     };
 
     // Order exons in transcript-space (5'→3'). For plus strand that's
@@ -162,14 +181,22 @@ fn build_single(
         sorted_exons.sort_by_key(|(s, _)| *s);
     }
 
-    let cds_ranges: Vec<(u64, u64)> = cds_fids.iter().map(|f| graph.feature(*f).range).collect();
-    let (cds_g_start, cds_g_end) = if !cds_ranges.is_empty() {
-        let s = cds_ranges.iter().map(|(s, _)| *s).min().unwrap();
-        let e = cds_ranges.iter().map(|(_, e)| *e).max().unwrap();
-        (Some(s), Some(e))
-    } else {
-        (None, None)
-    };
+    // `derive_cds_bounds` needs ranges in genomic-ascending order to find the
+    // exon containing a given genomic position; pass a genomic-sorted copy.
+    let mut genomic_sorted_exons = sorted_exons.clone();
+    genomic_sorted_exons.sort_by_key(|(s, _)| *s);
+
+    let (cds_g_start, cds_g_end) = derive_cds_bounds(
+        graph,
+        tx_fid,
+        &cds_fids,
+        &genomic_sorted_exons,
+        tx_feat.strand,
+        &tx_id_str,
+        format,
+        source_path,
+        report,
+    );
 
     let mut tx_pos = 1u64;
     let exons: Vec<Exon> = sorted_exons
@@ -221,9 +248,58 @@ fn build_single(
     let g_start = exons.iter().filter_map(|e| e.genomic_start).min();
     let g_end = exons.iter().filter_map(|e| e.genomic_end).max();
 
+    let attrs = &tx_feat.attrs;
+    // gene_symbol resolution differs by format. In GTF, the only spec-defined
+    // symbol attributes are `gene_name` (preferred) and `gene_id` (last resort:
+    // the ID itself, but better than nothing). In GFF3, `Name` is a generic
+    // display attribute that some sources use for the gene symbol, and `gene=`
+    // is a GFF3 convention used by RefSeq.
+    let gene_symbol = match format {
+        AnnotationFormat::Gtf => {
+            crate::reference::annotation::feature::attr_get(attrs, "gene_name")
+                .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "gene_id"))
+                .map(String::from)
+        }
+        AnnotationFormat::Gff3 => {
+            crate::reference::annotation::feature::attr_get(attrs, "gene_name")
+                .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "gene"))
+                .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "Name"))
+                .map(String::from)
+        }
+    };
+
+    let mane_status = {
+        let tag = crate::reference::annotation::feature::attr_get(attrs, "tag").unwrap_or("");
+        let mane = crate::reference::annotation::feature::attr_get(attrs, "MANE")
+            .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "mane_status"))
+            .unwrap_or("");
+        if tag.contains("MANE_Select")
+            || tag.contains("MANE Select")
+            || mane.to_lowercase().contains("select")
+        {
+            ManeStatus::Select
+        } else if tag.contains("MANE_Plus_Clinical")
+            || tag.contains("MANE Plus Clinical")
+            || mane.to_lowercase().contains("plus")
+            || mane.to_lowercase().contains("clinical")
+        {
+            ManeStatus::PlusClinical
+        } else {
+            ManeStatus::None
+        }
+    };
+
+    let refseq_match = crate::reference::annotation::feature::attr_get(attrs, "RefSeq")
+        .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "refseq_id"))
+        .map(String::from);
+
+    let ensembl_match = crate::reference::annotation::feature::attr_get(attrs, "Ensembl")
+        .or_else(|| crate::reference::annotation::feature::attr_get(attrs, "ensembl_id"))
+        .map(String::from);
+
     Some(Transcript {
         id: tx_id_str,
-        gene_symbol: None, // Phase 2 wires this
+        gene_symbol,
         strand: tx_feat.strand,
         // Coordinate-only load: actual bases are supplied later by a FASTA
         // provider. `sequence_length()` derives from exons, so callers that
@@ -236,12 +312,220 @@ fn build_single(
         genomic_start: g_start,
         genomic_end: g_end,
         genome_build,
-        mane_status: ManeStatus::None,
-        refseq_match: None,
-        ensembl_match: None,
+        mane_status,
+        refseq_match,
+        ensembl_match,
         exon_cigars: Vec::new(),
         cached_introns: OnceLock::new(),
     })
+}
+
+/// Merge sorted, possibly overlapping, possibly adjacent (touching) intervals into
+/// the minimum set of disjoint ranges. Input must be sorted by start.
+fn merge_adjacent(ranges: &[(u64, u64)]) -> Vec<(u64, u64)> {
+    if ranges.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(ranges.len());
+    let mut cur = ranges[0];
+    for &(s, e) in &ranges[1..] {
+        // Adjacent or overlapping: extend.
+        if s <= cur.1 + 1 {
+            cur.1 = cur.1.max(e);
+        } else {
+            out.push(cur);
+            cur = (s, e);
+        }
+    }
+    out.push(cur);
+    out
+}
+
+/// Derive `(cds_g_start_genomic_lo, cds_g_end_genomic_hi)` as a `(lo, hi)` pair in
+/// genomic (not biological 5'→3') coordinate order.
+///
+/// - `cds_start_genomic`: the 5'-most coding base. Uses `start_codon` feature when
+///   present; otherwise applies CDS phase to shift the leading CDS edge. Emits
+///   W-LOAD-110 (phase applied) or W-LOAD-111 (phase unavailable) when phase is used.
+/// - `cds_end_genomic`: the 3'-most coding base **including** the stop codon, matching
+///   ferro's downstream convention. Uses `stop_codon` feature when present. For GTF
+///   the stop is already included in CDS. For GFF3 the CDS 3' edge is extended by 3 bp
+///   (clipped at the exon boundary). Emits W-LOAD-112 (StopCodonAssumed) when
+///   extending.
+///
+/// `sorted_exon_ranges` must be sorted by ascending genomic start; the clipping
+/// step uses it to look up the exon containing the 3'-most CDS base.
+///
+/// Returns `(None, None)` when there are no CDS features.
+#[allow(clippy::too_many_arguments)]
+fn derive_cds_bounds(
+    graph: &FeatureGraph,
+    tx_fid: FeatureId,
+    cds_fids: &[FeatureId],
+    sorted_exon_ranges: &[(u64, u64)],
+    strand: Strand,
+    tx_id: &str,
+    format: AnnotationFormat,
+    source_path: &Path,
+    report: &mut LoaderReport,
+) -> (Option<u64>, Option<u64>) {
+    if cds_fids.is_empty() {
+        return (None, None);
+    }
+
+    let start_codons = graph.descendants_of_type(tx_fid, &FeatureType::StartCodon);
+    let stop_codons = graph.descendants_of_type(tx_fid, &FeatureType::StopCodon);
+
+    let plus = matches!(strand, Strand::Plus);
+
+    // 5'-most CDS edge in genomic coords.
+    let cds_5prime_genomic: u64 = if plus {
+        cds_fids
+            .iter()
+            .map(|f| graph.feature(*f).range.0)
+            .min()
+            .unwrap()
+    } else {
+        cds_fids
+            .iter()
+            .map(|f| graph.feature(*f).range.1)
+            .max()
+            .unwrap()
+    };
+
+    // Find the "leading" CDS feature (the one whose 5'-most edge matches cds_5prime_genomic).
+    let leading_cds = cds_fids
+        .iter()
+        .copied()
+        .find(|f| {
+            let r = graph.feature(*f).range;
+            if plus {
+                r.0 == cds_5prime_genomic
+            } else {
+                r.1 == cds_5prime_genomic
+            }
+        })
+        .unwrap();
+
+    // Step 1: resolve cds_start_genomic.
+    let resolved_start: u64 = if let Some(sc) = start_codons.first() {
+        let r = graph.feature(*sc).range;
+        if plus {
+            r.0
+        } else {
+            r.1
+        }
+    } else {
+        let phase = graph.feature(leading_cds).phase;
+        // Phase per GFF3/GTF spec is exactly one of {0, 1, 2}. The record
+        // parser stores phase as `u8`, so out-of-range values (e.g. a
+        // malformed `3`) survive parsing. Treat them as if phase were
+        // missing rather than blindly shifting the CDS edge by the
+        // attacker-controlled offset.
+        match phase {
+            Some(0) => cds_5prime_genomic,
+            Some(p @ (1 | 2)) => {
+                report.record(LoaderDiagnostic::warning(
+                    "W-LOAD-110",
+                    format!("PhaseAppliedToCdsStart: tx {} phase={}", tx_id, p),
+                    SourceLocation {
+                        path: source_path.to_path_buf(),
+                        line: graph.feature(leading_cds).source_line,
+                    },
+                    Some(tx_id.into()),
+                    DiagnosticPayload::PhaseAppliedToCdsStart {
+                        transcript_id: tx_id.into(),
+                        phase: p,
+                    },
+                ));
+                if plus {
+                    cds_5prime_genomic + p as u64
+                } else {
+                    cds_5prime_genomic.saturating_sub(p as u64)
+                }
+            }
+            Some(_) | None => {
+                report.record(LoaderDiagnostic::warning(
+                    "W-LOAD-111",
+                    format!("PhaseUnavailable: tx {}", tx_id),
+                    SourceLocation {
+                        path: source_path.to_path_buf(),
+                        line: graph.feature(leading_cds).source_line,
+                    },
+                    Some(tx_id.into()),
+                    DiagnosticPayload::PhaseUnavailable {
+                        transcript_id: tx_id.into(),
+                    },
+                ));
+                cds_5prime_genomic
+            }
+        }
+    };
+
+    // Step 2: resolve cds_end_genomic (3'-most coding base, stop INCLUDED).
+    let cds_3prime_genomic: u64 = if plus {
+        cds_fids
+            .iter()
+            .map(|f| graph.feature(*f).range.1)
+            .max()
+            .unwrap()
+    } else {
+        cds_fids
+            .iter()
+            .map(|f| graph.feature(*f).range.0)
+            .min()
+            .unwrap()
+    };
+
+    let resolved_end: u64 = if let Some(stop) = stop_codons.first() {
+        let r = graph.feature(*stop).range;
+        if plus {
+            r.1
+        } else {
+            r.0
+        }
+    } else if matches!(format, AnnotationFormat::Gtf) {
+        // GTF already includes stop codon in CDS.
+        cds_3prime_genomic
+    } else {
+        // GFF3: extend by 3 bp on the 3' side, clipping at exon boundary.
+        report.record(LoaderDiagnostic::warning(
+            "W-LOAD-112",
+            format!("StopCodonAssumed: extending CDS for tx {}", tx_id),
+            SourceLocation {
+                path: source_path.to_path_buf(),
+                line: graph.feature(leading_cds).source_line,
+            },
+            Some(tx_id.into()),
+            DiagnosticPayload::StopCodonAssumed {
+                transcript_id: tx_id.into(),
+            },
+        ));
+        if plus {
+            // Find the exon containing cds_3prime_genomic and clip the extension to its end.
+            let extended = cds_3prime_genomic + 3;
+            sorted_exon_ranges
+                .iter()
+                .find(|(es, ee)| cds_3prime_genomic >= *es && cds_3prime_genomic <= *ee)
+                .map(|(_, ee)| extended.min(*ee))
+                .unwrap_or(cds_3prime_genomic)
+        } else {
+            let extended = cds_3prime_genomic.saturating_sub(3);
+            sorted_exon_ranges
+                .iter()
+                .find(|(es, ee)| cds_3prime_genomic >= *es && cds_3prime_genomic <= *ee)
+                .map(|(es, _)| extended.max(*es))
+                .unwrap_or(cds_3prime_genomic)
+        }
+    };
+
+    // Return as (lo, hi) by GENOMIC coordinate (not biological 5'→3').
+    let (lo, hi) = if plus {
+        (resolved_start, resolved_end)
+    } else {
+        (resolved_end, resolved_start)
+    };
+    (Some(lo), Some(hi))
 }
 
 #[cfg(test)]
@@ -256,7 +540,7 @@ mod tests {
         let mut graph = FeatureGraph::new();
         for (i, l) in lines.iter().enumerate() {
             let r = Gff3Record::parse(l, (i + 1) as u64).unwrap().unwrap();
-            graph.ingest(&r);
+            graph.ingest(r);
         }
         graph.resolve();
         let mut report = LoaderReport::default();
@@ -268,6 +552,132 @@ mod tests {
             &mut report,
         );
         (txs, report)
+    }
+
+    #[test]
+    fn cds_start_uses_start_codon_when_present() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1",
+            "chr1\t.\tstart_codon\t150\t152\t.\t+\t0\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        // exon starts at tx pos 1 = genomic 100, so genomic 150 = tx pos 51.
+        assert_eq!(tx.cds_start, Some(51));
+    }
+
+    #[test]
+    fn cds_start_applies_phase_when_no_start_codon() {
+        // Leading CDS at 150 with phase 2 means the first in-frame base is at 152.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t2\tParent=tx1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        assert_eq!(tx.cds_start, Some(53)); // 150 + 2 = 152 → tx pos 53
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-110"), Some(&1));
+    }
+
+    /// Phase is spec-defined as {0, 1, 2} but the record parser stores it as
+    /// `u8`, so a malformed value (here: 5) survives parsing. The CDS-bounds
+    /// resolver must not blindly shift the CDS edge by an out-of-range phase;
+    /// it must treat it as "phase unavailable" (W-LOAD-111) and emit no
+    /// W-LOAD-110.
+    #[test]
+    fn cds_start_rejects_out_of_range_phase_as_unavailable() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t5\tParent=tx1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        // Phase ignored: cds_start_genomic stays at 150 → tx pos 51.
+        assert_eq!(tx.cds_start, Some(51));
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-110"), None);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-111"), Some(&1));
+    }
+
+    #[test]
+    fn gff3_cds_end_extends_to_include_stop_when_within_exon() {
+        // GFF3 input, CDS 150..450 inside exon 100..500, no stop_codon record.
+        // Stop extension by 3 bp → cds_end_genomic = 453, which is inside the exon.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        // genomic 453 → tx pos = 453 - 100 + 1 = 354
+        assert_eq!(tx.cds_end, Some(354));
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-112"), Some(&1));
+    }
+
+    #[test]
+    fn gff3_cds_end_clipped_when_no_room_for_stop_extension() {
+        // Issue-#183 case: CDS = exon = mRNA = 100..1200, no stop_codon, no room.
+        // Extension should clip to the exon end (1200), with W-LOAD-112.
+        let lines = &[
+            "seq1\t.\tgene\t100\t1200\t.\t+\t.\tID=gene01;Name=gene01",
+            "seq1\t.\tmRNA\t100\t1200\t.\t+\t.\tID=gene01.1;Parent=gene01",
+            "seq1\t.\tCDS\t100\t1200\t.\t+\t0\tParent=gene01.1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        // No room: cds_end_genomic clips to 1200 → tx pos 1200 - 100 + 1 = 1101.
+        assert_eq!(tx.cds_end, Some(1101));
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-112"), Some(&1));
+    }
+
+    #[test]
+    fn gff3_cds_end_uses_stop_codon_record_when_present() {
+        // When stop_codon record exists, use it directly — no W-LOAD-112.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1",
+            "chr1\t.\tstop_codon\t451\t453\t.\t+\t0\tParent=tx1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        let tx = &txs[0];
+        assert_eq!(tx.cds_end, Some(354)); // genomic 453 → tx pos 354
+                                           // No W-LOAD-112 because stop_codon was explicit.
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-112"), None);
+    }
+
+    #[test]
+    fn gtf_cds_end_uses_max_cds_verbatim() {
+        // GTF input: stop already included in CDS by convention.
+        let mut graph = crate::reference::annotation::graph::FeatureGraph::new();
+        let lines = &[
+            "chr1\tHAVANA\ttranscript\t100\t500\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";",
+            "chr1\tHAVANA\texon\t100\t500\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";",
+            "chr1\tHAVANA\tCDS\t150\t450\t.\t+\t0\tgene_id \"g1\"; transcript_id \"tx1\";",
+        ];
+        for (i, l) in lines.iter().enumerate() {
+            let r = crate::reference::annotation::record::GtfRecord::parse(l, (i + 1) as u64)
+                .unwrap()
+                .unwrap();
+            graph.ingest(r);
+        }
+        graph.resolve();
+        let mut report = LoaderReport::default();
+        let txs = build_transcripts(
+            &graph,
+            AnnotationFormat::Gtf,
+            crate::reference::transcript::GenomeBuild::GRCh38,
+            "t.gtf".into(),
+            &mut report,
+        );
+        let tx = &txs[0];
+        // GTF: cds_end_genomic = 450 → tx pos 351. No W-LOAD-112.
+        assert_eq!(tx.cds_end, Some(351));
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-112"), None);
     }
 
     #[test]
@@ -324,9 +734,9 @@ mod tests {
         assert_eq!(tx.exons[0].genomic_end, Some(1200));
         // Exon length = 1200 - 100 + 1.
         assert_eq!(tx.exons[0].end, 1101);
-        // CDS in transcript space: genomic 200 → tx 101; genomic 1000 → tx 901.
+        // CDS in transcript space: genomic 200 → tx 101; genomic 1003 (stop-extended) → tx 904.
         assert_eq!(tx.cds_start, Some(101));
-        assert_eq!(tx.cds_end, Some(901));
+        assert_eq!(tx.cds_end, Some(904));
     }
 
     #[test]
@@ -389,8 +799,151 @@ mod tests {
         assert_eq!(tx.exons[1].end, 302);
         // CDS spans genomic 150..=450. On minus strand, the 5'-most CDS base
         // is at genomic 450 (in exon 1, tx position 51); the 3'-most CDS base
-        // is at genomic 150 (in exon 2, tx position 252).
+        // (after GFF3 stop-codon extension shifts 150 → 147) is at genomic 147
+        // (in exon 2, tx position 202 + (200 - 147) = 255).
         assert_eq!(tx.cds_start, Some(51));
-        assert_eq!(tx.cds_end, Some(252));
+        assert_eq!(tx.cds_end, Some(255));
+    }
+
+    #[test]
+    fn ladder_step2_merges_utrs_and_cds_into_one_exon_when_adjacent() {
+        // mRNA with no `exon` records but explicit UTR and CDS children.
+        // The three intervals are adjacent so they merge to a single exon.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\tfive_prime_UTR\t100\t149\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1",
+            "chr1\t.\tthree_prime_UTR\t451\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert_eq!(txs.len(), 1);
+        let tx = &txs[0];
+        assert_eq!(
+            tx.exons.len(),
+            1,
+            "adjacent UTR+CDS+UTR should merge to one exon"
+        );
+        assert_eq!(tx.exons[0].genomic_start, Some(100));
+        assert_eq!(tx.exons[0].genomic_end, Some(500));
+    }
+
+    #[test]
+    fn ladder_step2_keeps_separate_exons_when_intervals_have_gaps() {
+        // mRNA with UTR/CDS/UTR but with a genomic gap → multiple synthetic exons.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t800\t.\t+\t.\tID=tx1",
+            "chr1\t.\tfive_prime_UTR\t100\t149\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tCDS\t150\t300\t.\t+\t0\tParent=tx1",
+            "chr1\t.\tCDS\t500\t650\t.\t+\t0\tParent=tx1",
+            "chr1\t.\tthree_prime_UTR\t651\t800\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert_eq!(txs.len(), 1);
+        let tx = &txs[0];
+        // The 5'UTR + first CDS are adjacent (100..300), then a gap, then second CDS + 3'UTR adjacent (500..800).
+        assert_eq!(tx.exons.len(), 2);
+        assert_eq!(tx.exons[0].genomic_start, Some(100));
+        assert_eq!(tx.exons[0].genomic_end, Some(300));
+        assert_eq!(tx.exons[1].genomic_start, Some(500));
+        assert_eq!(tx.exons[1].genomic_end, Some(800));
+    }
+
+    #[test]
+    fn ladder_step2_with_only_utrs_no_cds_falls_through_to_drop() {
+        // No CDS → step 2 doesn't fire; step 3 needs CDS too; step 4 drops.
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
+            "chr1\t.\tfive_prime_UTR\t100\t250\t.\t+\t.\tParent=tx1",
+            "chr1\t.\tthree_prime_UTR\t251\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, report) = build_db(lines, AnnotationFormat::Gff3);
+        assert!(txs.is_empty());
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-100"), Some(&1));
+    }
+
+    #[test]
+    fn gff3_gene_symbol_extracted_from_gene_attribute() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;gene=GENE1",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert_eq!(txs[0].gene_symbol.as_deref(), Some("GENE1"));
+    }
+
+    #[test]
+    fn gff3_gene_name_attribute_takes_precedence_over_name() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Name=fallback;gene_name=PRIMARY",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert_eq!(txs[0].gene_symbol.as_deref(), Some("PRIMARY"));
+    }
+
+    /// GTF transcripts without `gene_name` must still get a symbol via the
+    /// `gene_id` fallback. The previous chain (`gene_name` → `gene` → `Name`)
+    /// skipped `gene_id`, so common GTF inputs (e.g. GENCODE basic, Ensembl
+    /// stripped down to gene_id/transcript_id) lost the gene symbol entirely.
+    #[test]
+    fn gtf_gene_symbol_falls_back_to_gene_id_when_no_gene_name() {
+        let mut graph = crate::reference::annotation::graph::FeatureGraph::new();
+        let lines = &[
+            "chr1\tHAVANA\ttranscript\t100\t500\t.\t+\t.\tgene_id \"ENSG_NOSYMBOL\"; transcript_id \"tx1\";",
+            "chr1\tHAVANA\texon\t100\t500\t.\t+\t.\tgene_id \"ENSG_NOSYMBOL\"; transcript_id \"tx1\";",
+        ];
+        for (i, l) in lines.iter().enumerate() {
+            let r = crate::reference::annotation::record::GtfRecord::parse(l, (i + 1) as u64)
+                .unwrap()
+                .unwrap();
+            graph.ingest(r);
+        }
+        graph.resolve();
+        let mut report = LoaderReport::default();
+        let txs = build_transcripts(
+            &graph,
+            AnnotationFormat::Gtf,
+            crate::reference::transcript::GenomeBuild::GRCh38,
+            "t.gtf".into(),
+            &mut report,
+        );
+        assert_eq!(txs[0].gene_symbol.as_deref(), Some("ENSG_NOSYMBOL"));
+    }
+
+    #[test]
+    fn mane_select_extracted_from_tag() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;tag=MANE_Select",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert!(matches!(
+            txs[0].mane_status,
+            crate::reference::transcript::ManeStatus::Select
+        ));
+    }
+
+    #[test]
+    fn mane_plus_clinical_extracted_from_tag() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;tag=MANE_Plus_Clinical",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert!(matches!(
+            txs[0].mane_status,
+            crate::reference::transcript::ManeStatus::PlusClinical
+        ));
+    }
+
+    #[test]
+    fn refseq_and_ensembl_cross_refs_extracted() {
+        let lines = &[
+            "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;RefSeq=NM_000088.3;Ensembl=ENST00000000001",
+            "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",
+        ];
+        let (txs, _) = build_db(lines, AnnotationFormat::Gff3);
+        assert_eq!(txs[0].refseq_match.as_deref(), Some("NM_000088.3"));
+        assert_eq!(txs[0].ensembl_match.as_deref(), Some("ENST00000000001"));
     }
 }

--- a/src/reference/annotation/feature.rs
+++ b/src/reference/annotation/feature.rs
@@ -87,8 +87,7 @@ pub struct Feature {
     /// CDS phase (0/1/2); populated by the parser but consumed in Phase 2+.
     #[allow(dead_code)]
     pub phase: Option<u8>,
-    /// Raw key-value attributes; populated in Phase 2.5 when ingest takes ownership.
-    #[allow(dead_code)]
+    /// Raw key-value attributes; populated from the parsed record.
     pub attrs: AttributeMap,
     pub source_line: u64,
 }

--- a/src/reference/annotation/graph.rs
+++ b/src/reference/annotation/graph.rs
@@ -25,22 +25,29 @@ impl FeatureGraph {
         Self::default()
     }
 
-    pub fn ingest<R: AnnotationRecord>(&mut self, rec: &R) {
+    pub fn ingest<R: AnnotationRecord>(&mut self, rec: R) {
         let fid = FeatureId(
             u32::try_from(self.features.len()).expect("annotation file exceeds u32::MAX features"),
         );
         let id = rec.id().map(SmolStr::new);
         let parent_ids: Vec<SmolStr> = rec.parents().iter().map(SmolStr::new).collect();
+        let feature_type = rec.feature_type().clone();
+        let seqid = SmolStr::new(rec.seqid());
+        let range = (rec.start(), rec.end());
+        let strand = rec.strand();
+        let phase = rec.phase();
+        let source_line = rec.source_line();
+        let attrs = rec.into_attrs();
         let feature = Feature {
             id: id.clone(),
             parent_ids,
-            feature_type: rec.feature_type().clone(),
-            seqid: SmolStr::new(rec.seqid()),
-            range: (rec.start(), rec.end()),
-            strand: rec.strand(),
-            phase: rec.phase(),
-            attrs: Vec::new(), // attrs populated in Task 2.5 when ingest takes ownership
-            source_line: rec.source_line(),
+            feature_type,
+            seqid,
+            range,
+            strand,
+            phase,
+            attrs,
+            source_line,
         };
         self.features.push(feature);
         if let Some(id) = id {
@@ -134,7 +141,7 @@ mod tests {
 
     fn add_line(graph: &mut FeatureGraph, line: &str, n: u64) {
         let rec = Gff3Record::parse(line, n).unwrap().unwrap();
-        graph.ingest(&rec);
+        graph.ingest(rec);
     }
 
     #[test]

--- a/src/reference/annotation/mod.rs
+++ b/src/reference/annotation/mod.rs
@@ -126,7 +126,7 @@ fn parse_and_ingest<R: AnnotationRecord>(
     report: &mut LoaderReport,
 ) {
     match R::parse(line, line_no) {
-        Ok(Some(rec)) => graph.ingest(&rec),
+        Ok(Some(rec)) => graph.ingest(rec),
         Ok(None) => {}
         Err(e) => report.record(LoaderDiagnostic::error(
             "E-LOAD-001",
@@ -520,5 +520,17 @@ mod tests {
         let (db, report) = load_annotations(f.path(), &cfg).unwrap();
         assert_eq!(db.len(), 0);
         assert_eq!(report.transcripts_loaded, 0);
+    }
+
+    #[test]
+    fn gtf_gene_name_extracted_via_load_annotations() {
+        let f = write_gtf(
+            "chr1\tHAVANA\ttranscript\t100\t500\t.\t+\t.\tgene_id \"g1\"; gene_name \"GENE1\"; transcript_id \"tx1\";\n\
+             chr1\tHAVANA\texon\t100\t500\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";\n",
+        );
+        let cfg = LoaderConfig::new();
+        let (db, _report) = load_annotations(f.path(), &cfg).unwrap();
+        let tx = db.get("tx1").unwrap();
+        assert_eq!(tx.gene_symbol.as_deref(), Some("GENE1"));
     }
 }

--- a/src/reference/annotation/record.rs
+++ b/src/reference/annotation/record.rs
@@ -18,12 +18,11 @@ pub trait AnnotationRecord: Sized {
     fn phase(&self) -> Option<u8>;
     fn id(&self) -> Option<&str>;
     fn parents(&self) -> &[String];
-    /// Look up a single attribute by key; used in Phase 2.5+.
+    /// Look up a single attribute by key.
     #[allow(dead_code)]
     fn attribute(&self, key: &str) -> Option<&str>;
     fn source_line(&self) -> u64;
-    /// Consume the record and return its attribute map; used in Phase 2.5+.
-    #[allow(dead_code)]
+    /// Consume the record and return its attribute map.
     fn into_attrs(self) -> AttributeMap;
 }
 
@@ -49,8 +48,6 @@ pub struct Gff3Record {
     phase: Option<u8>,
     id: Option<String>,
     parents: Vec<String>,
-    /// Raw attributes; consumed by `into_attrs` in Phase 2.5+.
-    #[allow(dead_code)]
     attrs: AttributeMap,
     source_line: u64,
 }
@@ -193,8 +190,6 @@ pub struct GtfRecord {
     phase: Option<u8>,
     id: Option<String>,
     parents: Vec<String>,
-    /// Raw attributes; consumed by `into_attrs` in Phase 2.5+.
-    #[allow(dead_code)]
     attrs: AttributeMap,
     source_line: u64,
 }


### PR DESCRIPTION
## Summary

Phase 2 of the GFF/GTF loader rewrite tracked in #190. Builds on the Phase 1 pipeline introduced in #191 (which closes #183).

**This PR is stacked on #191.** Base branch is `fix/issue-183-convert-gff-single-exon`. Once #191 merges to main, GitHub will retarget this PR to `main` automatically.

## What lands

### CDS bounds resolution (spec §6 Stage 4, §10)

- `cds_start_genomic` now prefers an explicit `start_codon` child when present.
- Non-zero CDS phase on the leading CDS shifts the 5' edge with a `W-LOAD-110 PhaseAppliedToCdsStart` warning.
- Leading CDS with phase missing → emits `W-LOAD-111 PhaseUnavailable` and falls back to the raw edge.
- **Stop-codon convention normalized to stop-INCLUDED.** GFF3 input without an explicit `stop_codon` child now extends `cds_end_genomic` by 3 bp on the 3' side, clipped at the exon boundary, emitting `W-LOAD-112 StopCodonAssumed`. GTF input keeps `max(CDS.end)` verbatim.
- **This fixes a latent GFF3 protein-conversion bug.** Before this PR, GFF3-loaded transcripts produced `cds_end` 3 bp short of the convention assumed by `src/convert/protein.rs:25` and `src/convert/mapper.rs:389-416`, yielding `p.` positions off by one codon. GTF-loaded behavior is unchanged.

### Exon-derivation ladder step 2 (spec §6 Stage 4)

- Transcripts with no explicit `exon` records but with `five_prime_UTR` / `three_prime_UTR` / `UTR` + `CDS` children now collapse those intervals into synthetic exons via a merge of adjacent / overlapping ranges. Gaps yield separate exons. UTR-only transcripts (no CDS) still drop with `W-LOAD-100`.

### Transcript metadata wiring (spec §3, §6 Stage 4)

- `gene_symbol`: resolved from `gene_name=`, `gene=`, or `Name=` (GFF3) and `gene_name`/`gene_id` (GTF), in that precedence order.
- `mane_status`: resolved from `tag=MANE_Select` / `tag=MANE_Plus_Clinical` plus the `MANE=`/`mane_status=` aliases.
- `refseq_match` / `ensembl_match`: resolved from `RefSeq=` / `Ensembl=` (with `refseq_id` / `ensembl_id` aliases).
- All four were `None` placeholders in Phase 1.
- Required threading attribute data through `FeatureGraph::ingest`, which now takes the record by value to enable the `into_attrs()` move. All call sites updated.

## Deferred to later phases (#190)

- CLI flags (`--strict`, `--silent`, `--no-validate-fasta`, `--diagnostics-json`) — **Phase 3**
- `ferro explain W-LOAD-*` registry integration — **Phase 3**
- Cross-format consistency test + real-format slice fixtures — **Phase 3**
- FASTA-aware validation, call-site migration off shims, shim removal — **Phase 4**
- `noodles-gff` / `noodles-gtf` parser swap — **Phase 5**

## Diff size

5 files changed, 546 insertions(+), 57 deletions(-)

## Test plan

- [x] `cargo nextest run --features dev` — 4253/4253 passing (+15 new annotation-module tests beyond Phase 1's 4238)
- [x] `cargo clippy --features dev -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New tests cover: start_codon precedence on plus strand, phase 2 leading-CDS shift, GFF3 stop-extension within exon, GFF3 stop-extension clipping at exon boundary (the issue-#183 case), explicit stop_codon, GTF verbatim max(CDS), adjacent UTR+CDS+UTR merging, multi-exon UTR+CDS with gaps, UTR-only drop, gene_name precedence over Name, MANE Select / Plus Clinical tagging, RefSeq+Ensembl cross-refs, GTF gene_name through `load_annotations`
- [ ] Manual: spot-check the issue-#183 fixture (gene → mRNA → CDS only) — `cds_end` is now extended to the exon boundary