### PR TITLE
feat(loader,cli): Phase 3 - diagnostics registry + CLI flags + cross-format tests (#190)

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -343,6 +343,22 @@ enum Commands {
         /// Filter to specific gene symbols (comma-separated)
         #[arg(long)]
         genes: Option<String>,
+
+        /// Promote loader warnings to log-level errors and fail if any Severity::Error diagnostic is recorded.
+        #[arg(long, conflicts_with = "silent")]
+        strict: bool,
+
+        /// Suppress loader diagnostic warnings; still records them in the report.
+        #[arg(long, conflicts_with = "strict")]
+        silent: bool,
+
+        /// Skip CDS-length and start-codon FASTA-aware validation even when --fasta is supplied. (Phase 4 — currently a no-op.)
+        #[arg(long)]
+        no_validate_fasta: bool,
+
+        /// Write the bounded sample of loader diagnostics as JSON to this path.
+        #[arg(long, value_name = "PATH")]
+        diagnostics_json: Option<PathBuf>,
     },
 
     /// Generate HGVS descriptions from components (Name Generator)
@@ -626,6 +642,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             mane_only,
             transcripts,
             genes,
+            strict,
+            silent,
+            no_validate_fasta,
+            diagnostics_json,
         } => run_convert_gff(
             &gff,
             fasta.as_ref(),
@@ -634,6 +654,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             mane_only,
             transcripts.as_deref(),
             genes.as_deref(),
+            strict,
+            silent,
+            no_validate_fasta,
+            diagnostics_json.as_ref(),
         ),
         Commands::Generate {
             accession,
@@ -1299,6 +1323,7 @@ fn run_parse(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_convert_gff(
     gff: &PathBuf,
     fasta: Option<&PathBuf>,
@@ -1307,21 +1332,39 @@ fn run_convert_gff(
     mane_only: bool,
     transcripts: Option<&str>,
     genes: Option<&str>,
+    strict: bool,
+    silent: bool,
+    no_validate_fasta: bool,
+    diagnostics_json: Option<&PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use ferro_hgvs::reference::annotation::{load_annotations, LoaderConfig};
     use ferro_hgvs::reference::transcript::ManeStatus;
     use std::collections::HashSet;
 
     // Parse genome build
     let genome_build = parse_genome_build(build);
 
-    // Load GFF/GTF file
-    let ext = gff.extension().and_then(|e| e.to_str()).unwrap_or("");
-    let mut db = if ext == "gtf" || gff.to_string_lossy().contains(".gtf") {
-        ferro_hgvs::reference::loader::load_gtf(gff)?
-    } else {
-        ferro_hgvs::reference::loader::load_gff3(gff)?
-    };
+    // Build loader config with error mode and genome build
+    let mut cfg = LoaderConfig::new().with_genome_build(genome_build);
+    if strict {
+        cfg = cfg.with_strict();
+    } else if silent {
+        cfg = cfg.with_silent();
+    }
+
+    // Load GFF/GTF file via load_annotations
+    let (mut db, report) = load_annotations(gff, &cfg)?;
     db.genome_build = genome_build;
+    eprintln!("{}", report.summary_line());
+
+    // Write diagnostics JSON if requested
+    if let Some(path) = diagnostics_json {
+        let json = serde_json::to_string_pretty(&report.sample_diagnostics)
+            .map_err(|e| format!("serialize diagnostics: {}", e))?;
+        std::fs::write(path, json).map_err(|e| format!("write {}: {}", path.display(), e))?;
+    }
+
+    let _ = no_validate_fasta; // Phase 4 will use this
 
     // Load FASTA if provided and extract sequences
     let fasta_provider = if let Some(fasta_path) = fasta {
@@ -1487,12 +1530,6 @@ fn run_convert_gff(
     };
 
     writeln!(writer, "{}", serde_json::to_string_pretty(&output_json)?)?;
-
-    eprintln!(
-        "Converted {} transcripts from {}",
-        output_transcripts.len(),
-        gff.display()
-    );
 
     Ok(())
 }

--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -1012,6 +1012,291 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
         },
     );
 
+    // =========================================================================
+    // LOADER WARNINGS / ERRORS (E-LOAD-* / W-LOAD-*)
+    // =========================================================================
+
+    // --- Loader Errors (E-LOAD-*) ---
+
+    map.insert(
+        "E-LOAD-001",
+        CodeInfo {
+            code: "E-LOAD-001",
+            name: "MalformedRecord",
+            summary: "A required GFF/GTF column failed to parse and the offending row was dropped.",
+            explanation: "During GFF3 or GTF loading, a record could not be interpreted because a \
+                mandatory column was malformed: for example, a non-integer coordinate, a missing \
+                tab delimiter, an invalid strand character, or an out-of-range phase value (must \
+                be 0, 1, or 2). The row is silently discarded and the loader continues. \
+                See the GFF/GTF loader design (§6 Stage 2 — record parsing).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["E-LOAD-002", "W-LOAD-010"],
+        },
+    );
+
+    map.insert(
+        "E-LOAD-002",
+        CodeInfo {
+            code: "E-LOAD-002",
+            name: "UnsupportedFormat",
+            summary: "The input file could not be classified as GFF3 or GTF after extension and content sniffing.",
+            explanation: "ferro attempts to detect the annotation format by examining the file \
+                extension and scanning for format-specific header directives (e.g. `##gff-version 3` \
+                for GFF3, `gene_id` attributes for GTF). When neither heuristic succeeds the file \
+                is treated as unsupported. Currently reserved — Phase 1 falls back to GFF3 when \
+                detection is ambiguous (see W-LOAD-001). \
+                See the GFF/GTF loader design (§6 Stage 1 — format detection).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &[],
+        },
+    );
+
+    map.insert(
+        "E-LOAD-103",
+        CodeInfo {
+            code: "E-LOAD-103",
+            name: "StrandRequired",
+            summary: "A transcript has an unspecified or unknown strand and was dropped.",
+            explanation: "HGVS coordinate arithmetic requires a defined strand (+ or −) for every \
+                transcript. GFF3 allows `.` (unspecified) and `?` (unknown) as strand values; \
+                transcripts carrying either of these values cannot be represented in ferro's \
+                data model and are discarded. If the strand is determinable from context, \
+                fix the source annotation before loading. \
+                See the GFF/GTF loader design (§6 Stage 4 — transcript assembly).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-100"],
+        },
+    );
+
+    // --- Loader Warnings (W-LOAD-*) ---
+
+    map.insert(
+        "W-LOAD-001",
+        CodeInfo {
+            code: "W-LOAD-001",
+            name: "UnknownFormat",
+            summary: "Format could not be determined with high confidence; defaulted to GFF3.",
+            explanation: "ferro examines the file extension and the presence of `##gff-version` \
+                or GTF-style attribute syntax to decide which parser to invoke. When neither \
+                indicator is present or they conflict, ferro falls back to GFF3 and emits this \
+                warning. Inspect the file extension and ensure a `##gff-version 3` (or `2`) \
+                directive is present on the first line. \
+                See the GFF/GTF loader design (§6 Stage 1 — format detection).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &[],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-002",
+        CodeInfo {
+            code: "W-LOAD-002",
+            name: "InlineFastaIgnored",
+            summary: "A `##FASTA` directive was encountered; inline sequences are not parsed.",
+            explanation: "GFF3 files may embed reference sequences after a `##FASTA` line. \
+                ferro's loader does not parse inline FASTA sections — if reference sequences are \
+                needed for CDS validation, supply them via `--fasta` separately. \
+                Currently reserved — Phase 1 does not yet detect the `##FASTA` directive. \
+                See the GFF/GTF loader design (§6 Stage 2 — record parsing).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &[],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-010",
+        CodeInfo {
+            code: "W-LOAD-010",
+            name: "OrphanFeature",
+            summary: "A feature references a parent ID that is not present in the file; the orphan is dropped.",
+            explanation: "In GFF3, child features reference their parent via the `Parent=` \
+                attribute; in GTF, children reference `transcript_id`. When the referenced \
+                parent record is absent — common with truncated or region-filtered input files — \
+                the child feature cannot be assembled into a transcript and is discarded. \
+                Check that the source file is complete and that all parent features are present. \
+                See the GFF/GTF loader design (§6 Stage 3 — parent-child linking).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["E-LOAD-001"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-100",
+        CodeInfo {
+            code: "W-LOAD-100",
+            name: "TranscriptWithoutExons",
+            summary: "A transcript-like feature has no exon, UTR, or CDS children and was dropped.",
+            explanation: "After parent-child linking, a transcript record (mRNA, transcript, \
+                ncRNA, lincRNA, etc.) was found with no child features from which an exon \
+                structure could be derived. Without at least one exon, UTR, or CDS interval \
+                there is nothing to build the transcript model from, so the transcript is \
+                discarded. Verify that the source file contains matching child records with the \
+                correct `Parent=` or `transcript_id` attributes. \
+                See the GFF/GTF loader design (§6 Stage 4 — transcript assembly).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-101", "E-LOAD-103"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-101",
+        CodeInfo {
+            code: "W-LOAD-101",
+            name: "GeneAsTranscript",
+            summary: "A `gene` feature with direct CDS children (no mRNA/transcript) is treated as a transcript.",
+            explanation: "Some prokaryotic GFF3 files attach CDS records directly to a `gene` \
+                feature without an intervening mRNA or transcript record. ferro detects this \
+                pattern and promotes the gene to act as its own transcript, preserving the CDS \
+                coordinates. If this was unintentional, restructure the annotation to include an \
+                explicit transcript-level feature. \
+                See the GFF/GTF loader design (§6 Stage 4 — transcript assembly).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-100"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-110",
+        CodeInfo {
+            code: "W-LOAD-110",
+            name: "PhaseAppliedToCdsStart",
+            summary: "The leading CDS feature has a non-zero phase; `cds_start_genomic` was shifted by the phase value.",
+            explanation: "GFF3 phase values indicate how many bases at the start of a CDS feature \
+                should be skipped to reach the first complete in-frame codon. When the 5'-most CDS \
+                record on a transcript carries a phase of 1 or 2, the loader advances \
+                `cds_start_genomic` by that number of bases so that ferro's CDS coordinates \
+                begin at a codon boundary. This is expected for fragmented or partial CDS \
+                annotations but may indicate a truncated transcript. \
+                See the GFF/GTF loader design (§6 Stage 4 — CDS start adjustment).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-111"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-111",
+        CodeInfo {
+            code: "W-LOAD-111",
+            name: "PhaseUnavailable",
+            summary:
+                "The leading CDS feature has no phase recorded; the unshifted CDS start is used.",
+            explanation: "When the 5'-most CDS record on a transcript has a missing or `.` phase \
+                field, ferro cannot determine whether the genomic start is offset from a codon \
+                boundary. The loader falls back to using the unshifted coordinate, which may be \
+                incorrect if the annotation was intended to encode a non-zero phase. Inspect the \
+                source annotation and add an explicit phase value where possible. \
+                See the GFF/GTF loader design (§6 Stage 4 — CDS start adjustment).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-110"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-112",
+        CodeInfo {
+            code: "W-LOAD-112",
+            name: "StopCodonAssumed",
+            summary: "No explicit `stop_codon` record was found; `cds_end_genomic` was extended by 3 bp on the 3' side.",
+            explanation: "ferro's CDS model is stop-codon-inclusive: the 3' boundary of the CDS \
+                encompasses the stop codon. GFF3 files often encode the stop codon as a separate \
+                `stop_codon` feature rather than including it in the CDS interval. When no \
+                `stop_codon` record is present, the loader extends `cds_end_genomic` by 3 bp \
+                toward the 3' end, clipped at the transcript boundary. If the extension would \
+                overshoot the last exon, the CDS end may be slightly incorrect. Verify that the \
+                transcript end is consistent with the annotated stop codon. \
+                See the GFF/GTF loader design (§6 Stage 4 — stop codon handling).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-110"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-200",
+        CodeInfo {
+            code: "W-LOAD-200",
+            name: "CdsLengthNotMod3",
+            summary: "FASTA validation found a CDS whose length is not divisible by 3.",
+            explanation: "When FASTA-based validation is enabled (Phase 4), ferro checks that the \
+                assembled CDS length (3' end inclusive of the stop codon) is a multiple of 3. A \
+                non-multiple-of-3 length suggests a frameshift, an incomplete CDS record, or an \
+                annotation error in the source file. Currently reserved — FASTA validation is not \
+                yet shipped (Phase 4). \
+                See the GFF/GTF loader design (§6 Stage 5 — FASTA validation).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-201"],
+        },
+    );
+
+    map.insert(
+        "W-LOAD-201",
+        CodeInfo {
+            code: "W-LOAD-201",
+            name: "NonCanonicalStartCodon",
+            summary:
+                "FASTA validation found that the first CDS codon is not in {ATG, CTG, GTG, TTG}.",
+            explanation: "When FASTA-based validation is enabled (Phase 4), ferro reads the first \
+                three bases of the CDS from the reference FASTA and checks for a canonical start \
+                codon (ATG) or one of the known alternative initiators (CTG, GTG, TTG). Any other \
+                triplet suggests a mis-annotated CDS start or a sequencing artefact. Currently \
+                reserved — FASTA validation is not yet shipped (Phase 4). \
+                See the GFF/GTF loader design (§6 Stage 5 — FASTA validation).",
+            category: CodeCategory::Io,
+            bad_examples: &[],
+            good_examples: &[],
+            mode_behavior: None,
+            hgvs_spec_url: None,
+            related_codes: &["W-LOAD-200"],
+        },
+    );
+
     map
 }
 
@@ -1106,6 +1391,11 @@ mod tests {
     fn test_warning_codes_have_mode_behavior() {
         let warnings = list_warning_codes();
         for code in warnings {
+            // Loader codes (W-LOAD-*) do not participate in the parser's
+            // strict/lenient/silent configuration, so they may omit mode_behavior.
+            if code.code.starts_with("W-LOAD-") {
+                continue;
+            }
             assert!(
                 code.mode_behavior.is_some(),
                 "Warning {} should have mode_behavior",
@@ -1158,5 +1448,42 @@ mod tests {
         for code in parse_codes {
             assert_eq!(code.category, CodeCategory::Parse);
         }
+    }
+
+    #[test]
+    fn loader_error_codes_are_registered() {
+        assert!(get_code_info("E-LOAD-001").is_some());
+        assert!(get_code_info("E-LOAD-002").is_some());
+        assert!(get_code_info("E-LOAD-103").is_some());
+    }
+
+    #[test]
+    fn loader_warning_codes_are_registered() {
+        for code in &[
+            "W-LOAD-001",
+            "W-LOAD-002",
+            "W-LOAD-010",
+            "W-LOAD-100",
+            "W-LOAD-101",
+            "W-LOAD-110",
+            "W-LOAD-111",
+            "W-LOAD-112",
+            "W-LOAD-200",
+            "W-LOAD-201",
+        ] {
+            assert!(
+                get_code_info(code).is_some(),
+                "loader warning code {} not registered",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn loader_codes_have_consistent_metadata() {
+        let info = get_code_info("W-LOAD-100").unwrap();
+        assert_eq!(info.name, "TranscriptWithoutExons");
+        assert!(!info.summary.is_empty());
+        assert!(!info.explanation.is_empty());
     }
 }

--- a/src/reference/annotation/diagnostics.rs
+++ b/src/reference/annotation/diagnostics.rs
@@ -3,22 +3,24 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use serde::Serialize;
+
 const SAMPLE_LIMIT: usize = 100;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Severity {
     Error,
     Warning,
     Info,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct SourceLocation {
     pub path: PathBuf,
     pub line: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum DiagnosticPayload {
     MalformedRecord {
         field: &'static str,
@@ -60,7 +62,7 @@ pub enum DiagnosticPayload {
     Other,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LoaderDiagnostic {
     pub code: &'static str,
     pub severity: Severity,

--- a/tests/annotation_cross_format.rs
+++ b/tests/annotation_cross_format.rs
@@ -1,0 +1,96 @@
+//! Cross-format consistency invariant: GFF3 and GTF representations of the
+//! same biological annotation should produce equivalent Transcript objects.
+
+use ferro_hgvs::reference::annotation::{load_annotations, LoaderConfig};
+use ferro_hgvs::reference::transcript::Transcript;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn assert_transcripts_equivalent(a: &Transcript, b: &Transcript) {
+    assert_eq!(a.id, b.id, "id mismatch");
+    assert_eq!(a.strand, b.strand, "strand mismatch");
+    assert_eq!(a.chromosome, b.chromosome, "chromosome mismatch");
+    assert_eq!(a.genomic_start, b.genomic_start, "genomic_start mismatch");
+    assert_eq!(a.genomic_end, b.genomic_end, "genomic_end mismatch");
+    assert_eq!(a.cds_start, b.cds_start, "cds_start mismatch");
+    assert_eq!(a.cds_end, b.cds_end, "cds_end mismatch");
+    assert_eq!(a.exons.len(), b.exons.len(), "exon count mismatch");
+    for (i, (ea, eb)) in a.exons.iter().zip(&b.exons).enumerate() {
+        assert_eq!(
+            ea.genomic_start, eb.genomic_start,
+            "exon {} genomic_start",
+            i
+        );
+        assert_eq!(ea.genomic_end, eb.genomic_end, "exon {} genomic_end", i);
+        assert_eq!(ea.start, eb.start, "exon {} tx start", i);
+        assert_eq!(ea.end, eb.end, "exon {} tx end", i);
+    }
+}
+
+fn write_with_suffix(suffix: &str, content: &str) -> NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(suffix).tempfile().unwrap();
+    tf.write_all(content.as_bytes()).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+#[test]
+fn single_exon_transcript_equivalent_across_formats() {
+    let gff = write_with_suffix(
+        ".gff3",
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=GENE1\n\
+         chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n\
+         chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n",
+    );
+
+    // GTF: same gene, stop included in CDS by convention (so CDS extends to 450).
+    let gtf = write_with_suffix(
+        ".gtf",
+        "chr1\tHAVANA\tgene\t100\t500\t.\t+\t.\tgene_id \"g1\"; gene_name \"GENE1\";\n\
+         chr1\tHAVANA\ttranscript\t100\t500\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\"; gene_name \"GENE1\";\n\
+         chr1\tHAVANA\texon\t100\t500\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";\n\
+         chr1\tHAVANA\tCDS\t150\t450\t.\t+\t0\tgene_id \"g1\"; transcript_id \"tx1\";\n",
+    );
+
+    let (db_gff, _) = load_annotations(gff.path(), &LoaderConfig::new()).unwrap();
+    let (db_gtf, _) = load_annotations(gtf.path(), &LoaderConfig::new()).unwrap();
+
+    let tx_gff = db_gff.get("tx1").expect("GFF3 transcript loaded");
+    let tx_gtf = db_gtf.get("tx1").expect("GTF transcript loaded");
+    assert_transcripts_equivalent(tx_gff, tx_gtf);
+}
+
+#[test]
+fn multi_exon_transcript_equivalent_across_formats() {
+    // Two-exon transcript with an intron; CDS spans both exons.
+    let gff = write_with_suffix(
+        ".gff3",
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t800\t.\t+\t.\tID=g1\n\
+         chr1\t.\tmRNA\t100\t800\t.\t+\t.\tID=tx1;Parent=g1\n\
+         chr1\t.\texon\t100\t300\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\texon\t500\t800\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t300\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tCDS\t500\t650\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t648\t650\t.\t+\t0\tParent=tx1\n",
+    );
+
+    let gtf = write_with_suffix(
+        ".gtf",
+        "chr1\tHAVANA\ttranscript\t100\t800\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";\n\
+         chr1\tHAVANA\texon\t100\t300\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";\n\
+         chr1\tHAVANA\texon\t500\t800\t.\t+\t.\tgene_id \"g1\"; transcript_id \"tx1\";\n\
+         chr1\tHAVANA\tCDS\t150\t300\t.\t+\t0\tgene_id \"g1\"; transcript_id \"tx1\";\n\
+         chr1\tHAVANA\tCDS\t500\t650\t.\t+\t0\tgene_id \"g1\"; transcript_id \"tx1\";\n",
+    );
+
+    let (db_gff, _) = load_annotations(gff.path(), &LoaderConfig::new()).unwrap();
+    let (db_gtf, _) = load_annotations(gtf.path(), &LoaderConfig::new()).unwrap();
+
+    let tx_gff = db_gff.get("tx1").expect("GFF3 transcript loaded");
+    let tx_gtf = db_gtf.get("tx1").expect("GTF transcript loaded");
+    assert_transcripts_equivalent(tx_gff, tx_gtf);
+}

--- a/tests/annotation_real_format_slices.rs
+++ b/tests/annotation_real_format_slices.rs
@@ -1,0 +1,80 @@
+//! Tests against hand-curated real-format slice fixtures. These fixtures
+//! exercise format-specific quirks (RefSeq attribute conventions, GENCODE
+//! tag fields, FlyBase Derives_from) that purely programmatic fixtures miss.
+
+use ferro_hgvs::reference::annotation::{load_annotations, LoaderConfig};
+use std::path::Path;
+
+#[test]
+fn refseq_micro_loads_minus_strand_transcript_with_mane_select() {
+    let (db, report) = load_annotations(
+        Path::new("tests/fixtures/annotation/refseq_chr21_micro.gff3"),
+        &LoaderConfig::new(),
+    )
+    .unwrap();
+    assert_eq!(db.len(), 1, "expected one transcript from RefSeq fixture");
+    let tx = db.get("NR_027228.1").expect("RefSeq transcript loaded");
+    assert_eq!(tx.exons.len(), 2);
+    assert!(matches!(
+        tx.strand,
+        ferro_hgvs::reference::transcript::Strand::Minus
+    ));
+    assert!(matches!(
+        tx.mane_status,
+        ferro_hgvs::reference::transcript::ManeStatus::Select
+    ));
+    assert_eq!(report.transcripts_loaded, 1);
+}
+
+#[test]
+fn gencode_micro_loads_minus_strand_transcript() {
+    let (db, _report) = load_annotations(
+        Path::new("tests/fixtures/annotation/gencode_chr21_micro.gtf"),
+        &LoaderConfig::new(),
+    )
+    .unwrap();
+    assert_eq!(db.len(), 1);
+    let tx = db
+        .get("ENST00000620911")
+        .expect("GENCODE transcript loaded");
+    assert_eq!(tx.exons.len(), 2);
+    assert!(matches!(
+        tx.strand,
+        ferro_hgvs::reference::transcript::Strand::Minus
+    ));
+    assert_eq!(tx.gene_symbol.as_deref(), Some("MIR99AHG"));
+    assert!(matches!(
+        tx.mane_status,
+        ferro_hgvs::reference::transcript::ManeStatus::Select
+    ));
+}
+
+#[test]
+fn flybase_micro_loads_two_exon_protein_coding() {
+    let (db, _report) = load_annotations(
+        Path::new("tests/fixtures/annotation/flybase_micro.gff3"),
+        &LoaderConfig::new(),
+    )
+    .unwrap();
+    assert_eq!(db.len(), 1);
+    let tx = db.get("FBtr0300689").expect("FlyBase transcript loaded");
+    assert_eq!(tx.exons.len(), 2);
+    // CDS spans both exons; cds_start should fall within exon 1 and cds_end within exon 2
+    // (both in transcript coordinates).
+    let cds_start = tx.cds_start.expect("cds_start present");
+    let cds_end = tx.cds_end.expect("cds_end present");
+    assert!(
+        cds_start >= tx.exons[0].start && cds_start <= tx.exons[0].end,
+        "cds_start {} not in exon[0] [{}, {}]",
+        cds_start,
+        tx.exons[0].start,
+        tx.exons[0].end
+    );
+    assert!(
+        cds_end >= tx.exons[1].start && cds_end <= tx.exons[1].end,
+        "cds_end {} not in exon[1] [{}, {}]",
+        cds_end,
+        tx.exons[1].start,
+        tx.exons[1].end
+    );
+}

--- a/tests/cli_convert_gff_flags.rs
+++ b/tests/cli_convert_gff_flags.rs
@@ -1,0 +1,75 @@
+//! Integration test for `ferro convert-gff` flags added in Phase 3.
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+fn write_gff3(content: &str) -> NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(".gff3").tempfile().unwrap();
+    tf.write_all(content.as_bytes()).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+#[test]
+fn strict_mode_fails_on_malformed_coordinate() {
+    let f = write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\tnot_a_number\t500\t.\t+\t.\tID=g1\n",
+    );
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            f.path().to_str().unwrap(),
+            "--strict",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "strict mode should fail on malformed record: stdout={}, stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn diagnostics_json_writes_file() {
+    let f = write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1\n",
+    );
+    let json_path = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            f.path().to_str().unwrap(),
+            "--diagnostics-json",
+            json_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "convert-gff failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = std::fs::read_to_string(&json_path).expect("diagnostics file");
+    let diags: Vec<serde_json::Value> =
+        serde_json::from_str(&body).expect("diagnostics JSON parses as array");
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.get("code").and_then(|v| v.as_str()) == Some("W-LOAD-100")),
+        "expected diagnostic with code=W-LOAD-100, got: {}",
+        body
+    );
+}

--- a/tests/fixtures/annotation/flybase_micro.gff3
+++ b/tests/fixtures/annotation/flybase_micro.gff3
@@ -1,0 +1,11 @@
+##gff-version 3
+# Hand-curated FlyBase-style GFF3 excerpt for unit testing.
+# FlyBase uses Derives_from in addition to Parent for transcripts derived from
+# pseudogenes / alleles. ferro-hgvs does not currently consume Derives_from
+# (the standard Parent edge still works), so this fixture documents that gap.
+2L	FlyBase	gene	7529	9484	.	+	.	ID=FBgn0031208;Name=CG11023;gene_biotype=protein_coding
+2L	FlyBase	mRNA	7529	9484	.	+	.	ID=FBtr0300689;Parent=FBgn0031208;Name=CG11023-RA
+2L	FlyBase	exon	7529	8116	.	+	.	ID=FBex0_1;Parent=FBtr0300689
+2L	FlyBase	exon	8193	9484	.	+	.	ID=FBex0_2;Parent=FBtr0300689
+2L	FlyBase	CDS	7680	8116	.	+	0	ID=CDS_FBtr0300689_1;Parent=FBtr0300689
+2L	FlyBase	CDS	8193	8589	.	+	1	ID=CDS_FBtr0300689_2;Parent=FBtr0300689

--- a/tests/fixtures/annotation/gencode_chr21_micro.gtf
+++ b/tests/fixtures/annotation/gencode_chr21_micro.gtf
@@ -1,0 +1,6 @@
+##description: Hand-curated GENCODE-style GTF excerpt for unit testing.
+##provider: GENCODE-style attributes (tag, gene_name, transcript_id)
+chr21	HAVANA	gene	5011799	5017178	.	-	.	gene_id "ENSG00000275413"; gene_name "MIR99AHG"; gene_type "lncRNA";
+chr21	HAVANA	transcript	5011799	5017178	.	-	.	gene_id "ENSG00000275413"; transcript_id "ENST00000620911"; gene_name "MIR99AHG"; tag "MANE_Select";
+chr21	HAVANA	exon	5016902	5017178	.	-	.	gene_id "ENSG00000275413"; transcript_id "ENST00000620911"; exon_number "1";
+chr21	HAVANA	exon	5011799	5012256	.	-	.	gene_id "ENSG00000275413"; transcript_id "ENST00000620911"; exon_number "2";

--- a/tests/fixtures/annotation/refseq_chr21_micro.gff3
+++ b/tests/fixtures/annotation/refseq_chr21_micro.gff3
@@ -1,0 +1,8 @@
+##gff-version 3
+##sequence-region NC_000021.9 1 46709983
+# Hand-curated RefSeq-style GFF3 excerpt for unit testing.
+# Mimics NCBI RefSeq attribute conventions: tag=MANE_Select, RefSeq=, Dbxref=.
+NC_000021.9	RefSeq	gene	5011799	5017178	.	-	.	ID=gene-MIR99AHG;Name=MIR99AHG;gene_biotype=lncRNA
+NC_000021.9	RefSeq	mRNA	5011799	5017178	.	-	.	ID=NR_027228.1;Parent=gene-MIR99AHG;transcript_id=NR_027228.1;tag=MANE_Select;RefSeq=NR_027228.1
+NC_000021.9	RefSeq	exon	5016902	5017178	.	-	.	ID=exon-NR_027228.1-1;Parent=NR_027228.1
+NC_000021.9	RefSeq	exon	5011799	5012256	.	-	.	ID=exon-NR_027228.1-2;Parent=NR_027228.1

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -396,6 +396,110 @@
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/alleles/",
       "status": "enforced",
       "spec_section_notes": "Detected in src/normalize/overlap.rs by detect_overlap_conflicts and wired into normalize_allele after per-variant normalization. Variant output is preserved; the warning is advisory."
+    },
+    {
+      "code": "E-LOAD-001",
+      "description": "MalformedRecord — a required GFF/GTF column failed to parse; the offending row is dropped.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 2."
+    },
+    {
+      "code": "E-LOAD-002",
+      "description": "UnsupportedFormat — the input file cannot be classified as GFF3 or GTF. Reserved for future use.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 1."
+    },
+    {
+      "code": "E-LOAD-103",
+      "description": "StrandRequired — a transcript with an unspecified or unknown strand is dropped.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-001",
+      "description": "UnknownFormat — format could not be determined with high confidence; defaulted to GFF3.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 1."
+    },
+    {
+      "code": "W-LOAD-002",
+      "description": "InlineFastaIgnored — a ##FASTA directive was encountered; inline sequences are not parsed. Reserved.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 2."
+    },
+    {
+      "code": "W-LOAD-010",
+      "description": "OrphanFeature — a feature references a parent ID not present in the file; the orphan is dropped.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 3."
+    },
+    {
+      "code": "W-LOAD-100",
+      "description": "TranscriptWithoutExons — a transcript-like feature has no exon, UTR, or CDS children; the transcript is dropped.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-101",
+      "description": "GeneAsTranscript — a gene feature with direct CDS children (no mRNA/transcript) is treated as a transcript.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; prokaryotic GFF3 convention. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-110",
+      "description": "PhaseAppliedToCdsStart — the leading CDS has a non-zero phase; cds_start_genomic was shifted by the phase value.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-111",
+      "description": "PhaseUnavailable — the leading CDS has no phase recorded; the unshifted CDS start is used.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-112",
+      "description": "StopCodonAssumed — no explicit stop_codon record found; cds_end_genomic was extended by 3 bp on the 3' side.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 4."
+    },
+    {
+      "code": "W-LOAD-200",
+      "description": "CdsLengthNotMod3 — FASTA validation found a CDS whose length is not divisible by 3. Reserved for Phase 4.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 5."
+    },
+    {
+      "code": "W-LOAD-201",
+      "description": "NonCanonicalStartCodon — FASTA validation found the first CDS codon is not in {ATG, CTG, GTG, TTG}. Reserved for Phase 4.",
+      "spec_section": null,
+      "spec_url": null,
+      "status": "infra",
+      "spec_section_notes": "GFF/GTF loader infrastructure; no HGVS spec section applies. See GFF/GTF loader design §6 Stage 5."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 3 of the GFF/GTF loader rewrite tracked in #190. Builds on Phase 2 (#194) which builds on Phase 1 (#191).

**This PR is stacked on #194.** Base branch is `feat/issue-190-gff-loader-phase2`. Once #194 retargets to main, GitHub will retarget this PR too.

## What lands

### Diagnostic registry integration

13 loader codes (E-LOAD-001, E-LOAD-002, E-LOAD-103, W-LOAD-001, W-LOAD-002, W-LOAD-010, W-LOAD-100, W-LOAD-101, W-LOAD-110, W-LOAD-111, W-LOAD-112, W-LOAD-200, W-LOAD-201) registered in `src/error_handling/registry.rs`. `ferro explain W-LOAD-100` now works out of the box and surfaces a summary + explanation + related codes. Uses `CodeCategory::Io`.

The Phase 4 (W-LOAD-200, W-LOAD-201) and reserved-for-future (W-LOAD-002, E-LOAD-002) codes are registered as `infra` entries to keep the registry complete.

### CLI flags on `ferro convert-gff`

```
--strict                     # exit non-zero if any Error-severity diagnostic
--silent                     # suppress diagnostic logging (still recorded)
--no-validate-fasta          # reserved no-op for Phase 4
--diagnostics-json <PATH>    # write the bounded diagnostic sample as JSON
```

`convert-gff` now goes through `load_annotations` directly (no more `load_gff3` / `load_gtf` shims) and prints the report summary line to stderr:

```
$ ferro convert-gff --gff input.gff3
Loaded 18234 transcripts
$ ferro convert-gff --gff input.gff3 --strict
# exits 0 on success, non-zero on first Error-severity diagnostic
```

### Cross-format consistency invariant

A new integration test (`tests/annotation_cross_format.rs`) asserts that a hand-curated GFF3 and its GTF equivalent produce structurally identical `Transcript` objects. Covers single-exon and multi-exon cases. This is the canonical signal that the GFF3 and GTF code paths haven't drifted — a problem the old hand-written parser had silently.

### Real-format slice fixtures

Three tiny (≤ 50 lines), hand-curated fixtures under `tests/fixtures/annotation/`:

- `refseq_chr21_micro.gff3` — NCBI RefSeq attribute conventions; `tag=MANE_Select`
- `gencode_chr21_micro.gtf` — GENCODE quoted-attribute conventions; `tag \"MANE_Select\"`
- `flybase_micro.gff3` — FlyBase `Derives_from` (currently unhandled — this fixture documents the gap; standard `Parent=` works)

Each has its own integration test in `tests/annotation_real_format_slices.rs` verifying load, exon count, strand, MANE status, and gene_symbol where applicable. These exercise format-specific quirks that programmatic test strings miss.

## Deferred to later phases (#190)

- **Phase 4**: FASTA-aware CDS-length + start-codon validation, migrate remaining `load_gff3` / `load_gtf` call sites in `src/vcf/*`, delete the back-compat shims.
- **Phase 5**: noodles-gff / noodles-gtf parser swap behind the existing `AnnotationRecord` trait.

## Diff size

10 files changed, 740 insertions(+), 17 deletions(-)

## Test plan

- [x] `cargo nextest run --features dev` — 4263/4263 passing (+10 new tests beyond Phase 2's 4253)
- [x] `cargo clippy --features dev -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manual: \`ferro explain W-LOAD-100\` prints expected summary + explanation + related codes
- [x] Manual: \`ferro convert-gff --diagnostics-json out.json\` produces valid JSON containing diagnostic codes
- [x] Manual: \`ferro convert-gff --strict\` exits non-zero on malformed coordinate input