### PR TITLE
feat(loader): Phase 4 - FASTA validation + complete migration off shims (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(loader)* unified `load_annotations` entry point with `LoaderConfig`/`LoaderReport`; auto-detects GFF3 vs GTF by extension and content (#191, #194, #195)
+- *(loader)* exon-derivation ladder closes single-exon GFF3 without `exon` records (#183 fix) (#191)
+- *(loader)* phase-aware CDS bounds with `start_codon` / `stop_codon` precedence; GFF3 input now extends `cds_end` to include the stop codon, matching ferro's downstream convention (fixes a latent off-by-one-codon bug in GFF3 protein conversion) (#194)
+- *(loader)* UTR-merge ladder step: synthesizes exons from UTR + CDS when no explicit `exon` records (#194)
+- *(loader)* `gene_symbol`, `mane_status`, `refseq_match`, `ensembl_match` extracted from attributes (#194)
+- *(loader)* optional FASTA-aware validation: CDS length mod 3 and start codon (ATG/CTG/GTG/TTG) checks when `--fasta` is supplied
+- *(error_handling)* 13 loader diagnostic codes (E-LOAD-*, W-LOAD-*) registered for `ferro explain` (#195)
+- *(cli)* `ferro convert-gff --strict / --silent / --no-validate-fasta / --diagnostics-json` flags (#195)
+- *(strand)* `Strand::Unknown` variant for GFF3 `.` and `?` strand values; transcripts with unknown strand are dropped at load with `E-LOAD-103` (#191)
+
+### Changed
+
+- *(strand)* `Strand`, `LoaderConfig`, and `LoaderReport` are marked `#[non_exhaustive]` for forward compatibility (#191)
+- *(loader)* `load_gff3` and `load_gtf` have been removed; use `load_annotations` instead
+
 ## [0.5.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.4.1...v0.5.0) - 2026-05-12
 
 ### Added

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -352,7 +352,7 @@ enum Commands {
         #[arg(long, conflicts_with = "strict")]
         silent: bool,
 
-        /// Skip CDS-length and start-codon FASTA-aware validation even when --fasta is supplied. (Phase 4 — currently a no-op.)
+        /// Skip CDS-length and start-codon FASTA-aware validation even when --fasta is supplied.
         #[arg(long)]
         no_validate_fasta: bool,
 
@@ -743,12 +743,13 @@ fn run_annotate_vcf(
 
     // Load transcript database
     let db = if let Some(gff_path) = gff {
-        let ext = gff_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if ext == "gtf" || ext == "gtf.gz" {
-            ferro_hgvs::reference::loader::load_gtf(gff_path)?
-        } else {
-            ferro_hgvs::reference::loader::load_gff3(gff_path)?
+        let cfg =
+            ferro_hgvs::reference::annotation::LoaderConfig::new().with_genome_build(genome_build);
+        let (db, report) = ferro_hgvs::reference::annotation::load_annotations(gff_path, &cfg)?;
+        if !report.diagnostics_by_code.is_empty() {
+            eprintln!("{}", report.summary_line());
         }
+        db
     } else {
         // Create empty database
         TranscriptDb::with_build(genome_build)
@@ -832,12 +833,13 @@ fn run_vcf_to_hgvs(
 
     // Load transcript database
     let db = if let Some(gff_path) = gff {
-        let ext = gff_path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        if ext == "gtf" || ext == "gtf.gz" {
-            ferro_hgvs::reference::loader::load_gtf(gff_path)?
-        } else {
-            ferro_hgvs::reference::loader::load_gff3(gff_path)?
+        let cfg =
+            ferro_hgvs::reference::annotation::LoaderConfig::new().with_genome_build(genome_build);
+        let (db, report) = ferro_hgvs::reference::annotation::load_annotations(gff_path, &cfg)?;
+        if !report.diagnostics_by_code.is_empty() {
+            eprintln!("{}", report.summary_line());
         }
+        db
     } else {
         TranscriptDb::with_build(genome_build)
     };
@@ -1344,12 +1346,21 @@ fn run_convert_gff(
     // Parse genome build
     let genome_build = parse_genome_build(build);
 
-    // Build loader config with error mode and genome build
+    // Build loader config with error mode, genome build, and optional FASTA validation.
     let mut cfg = LoaderConfig::new().with_genome_build(genome_build);
     if strict {
         cfg = cfg.with_strict();
     } else if silent {
         cfg = cfg.with_silent();
+    }
+    // Pass a FASTA provider to load_annotations for CDS-length / start-codon validation.
+    // A second FastaProvider is constructed below for sequence extraction; FastaProvider::new
+    // is cheap (reads only the index), so the double construction is acceptable.
+    if let Some(fasta_path) = fasta {
+        cfg = cfg.with_fasta(FastaProvider::new(fasta_path)?);
+    }
+    if no_validate_fasta {
+        cfg = cfg.with_no_validate_fasta();
     }
 
     // Load GFF/GTF file via load_annotations
@@ -1363,8 +1374,6 @@ fn run_convert_gff(
             .map_err(|e| format!("serialize diagnostics: {}", e))?;
         std::fs::write(path, json).map_err(|e| format!("write {}: {}", path.display(), e))?;
     }
-
-    let _ = no_validate_fasta; // Phase 4 will use this
 
     // Load FASTA if provided and extract sequences
     let fasta_provider = if let Some(fasta_path) = fasta {

--- a/src/reference/annotation/mod.rs
+++ b/src/reference/annotation/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod feature;
 pub mod format_detect;
 pub(crate) mod graph;
 pub(crate) mod record;
+pub(crate) mod validate;
 
 pub use diagnostics::{
     DiagnosticPayload, LoaderDiagnostic, LoaderReport, Severity, SourceLocation,
@@ -62,6 +63,10 @@ pub struct LoaderConfig {
     pub format: Option<AnnotationFormat>,
     pub error_mode: ErrorMode,
     pub genome_build: Option<GenomeBuild>,
+    /// Optional FASTA provider for CDS-length and start-codon validation.
+    pub(crate) fasta: Option<Box<dyn crate::reference::provider::ReferenceProvider>>,
+    /// When `true` (default) and `fasta` is set, run FASTA-aware validation.
+    pub validate_fasta: bool,
 }
 
 impl Default for LoaderConfig {
@@ -72,12 +77,15 @@ impl Default for LoaderConfig {
 
 impl LoaderConfig {
     /// Create a new `LoaderConfig` with default settings:
-    /// format auto-detected, [`ErrorMode::Lenient`], genome build GRCh38.
+    /// format auto-detected, [`ErrorMode::Lenient`], genome build GRCh38,
+    /// no FASTA provider, FASTA validation enabled.
     pub fn new() -> Self {
         Self {
             format: None,
             error_mode: ErrorMode::Lenient,
             genome_build: None,
+            fasta: None,
+            validate_fasta: true,
         }
     }
 
@@ -108,6 +116,27 @@ impl LoaderConfig {
     /// Set the genome build / assembly version used when constructing transcripts.
     pub fn with_genome_build(mut self, b: GenomeBuild) -> Self {
         self.genome_build = Some(b);
+        self
+    }
+
+    /// Supply a FASTA provider for optional CDS-length and start-codon validation.
+    ///
+    /// When a provider is set and `validate_fasta` is `true` (the default),
+    /// [`load_annotations`] will emit `W-LOAD-200` / `W-LOAD-201` diagnostics
+    /// for transcripts with non-mod-3 CDS lengths or non-canonical start codons.
+    /// Use [`Self::with_no_validate_fasta`] to disable validation while still
+    /// passing a FASTA for other purposes.
+    pub fn with_fasta<F>(mut self, fasta: F) -> Self
+    where
+        F: crate::reference::provider::ReferenceProvider + 'static,
+    {
+        self.fasta = Some(Box::new(fasta));
+        self
+    }
+
+    /// Disable FASTA-aware validation even when a FASTA provider has been supplied.
+    pub fn with_no_validate_fasta(mut self) -> Self {
+        self.validate_fasta = false;
         self
     }
 }
@@ -274,9 +303,20 @@ pub fn load_annotations<P: AsRef<Path>>(
     }
     report.records_dropped += graph.orphan_count;
 
-    let transcripts = build_transcripts(&graph, format, genome_build, source_path, &mut report);
+    let transcripts = build_transcripts(
+        &graph,
+        format,
+        genome_build,
+        source_path.clone(),
+        &mut report,
+    );
 
     let mut db = TranscriptDb::with_build(genome_build);
+    for tx in &transcripts {
+        if let (Some(fasta), true) = (&config.fasta, config.validate_fasta) {
+            validate::validate_transcript(tx, fasta.as_ref(), &source_path, &mut report);
+        }
+    }
     for tx in transcripts {
         db.add(tx);
     }
@@ -520,6 +560,23 @@ mod tests {
         let (db, report) = load_annotations(f.path(), &cfg).unwrap();
         assert_eq!(db.len(), 0);
         assert_eq!(report.transcripts_loaded, 0);
+    }
+
+    #[test]
+    fn gff3_exon_shared_between_two_transcripts_via_comma_separated_parent() {
+        let f = write_gff3(
+            "##gff-version 3\n\
+             chr1\t.\tmRNA\t1000\t2000\t.\t+\t.\tID=tx1;gene=TEST\n\
+             chr1\t.\tmRNA\t1000\t2000\t.\t+\t.\tID=tx2;gene=TEST\n\
+             chr1\t.\texon\t1000\t2000\t.\t+\t.\tParent=tx1,tx2\n",
+        );
+        let cfg = LoaderConfig::new();
+        let (db, _report) = load_annotations(f.path(), &cfg).unwrap();
+        // Both transcripts should have the exon
+        let tx1 = db.get("tx1").unwrap();
+        let tx2 = db.get("tx2").unwrap();
+        assert_eq!(tx1.exons.len(), 1);
+        assert_eq!(tx2.exons.len(), 1);
     }
 
     #[test]

--- a/src/reference/annotation/validate.rs
+++ b/src/reference/annotation/validate.rs
@@ -1,0 +1,379 @@
+//! Optional FASTA-aware validation. See spec §6 Stage 5.
+//!
+//! Checks performed (both are warnings — never reject, never drop):
+//!
+//! - `W-LOAD-200 CdsLengthNotMod3` — the CDS length is not divisible by 3.
+//! - `W-LOAD-201 NonCanonicalStartCodon` — the first codon is not ATG/CTG/GTG/TTG.
+
+use std::path::Path;
+
+use crate::reference::provider::ReferenceProvider;
+use crate::reference::transcript::{Strand, Transcript};
+
+use super::diagnostics::{DiagnosticPayload, LoaderDiagnostic, LoaderReport, SourceLocation};
+
+/// Validate a single transcript against a FASTA reference.
+///
+/// Both diagnostics are warnings; this function never drops a transcript or
+/// returns an error.
+pub(crate) fn validate_transcript(
+    tx: &Transcript,
+    fasta: &dyn ReferenceProvider,
+    source_path: &Path,
+    report: &mut LoaderReport,
+) {
+    let (cds_start, cds_end) = match (tx.cds_start, tx.cds_end) {
+        (Some(s), Some(e)) => (s, e),
+        _ => return, // non-coding transcript — nothing to check
+    };
+
+    // CDS length in transcript coordinates (1-based inclusive).
+    let cds_len = cds_end.saturating_sub(cds_start).saturating_add(1);
+
+    if cds_len % 3 != 0 {
+        report.record(LoaderDiagnostic::warning(
+            "W-LOAD-200",
+            format!("CdsLengthNotMod3: tx {} cds_length={}", tx.id, cds_len),
+            SourceLocation {
+                path: source_path.to_path_buf(),
+                line: 0,
+            },
+            Some(tx.id.clone()),
+            DiagnosticPayload::CdsLengthNotMod3 {
+                transcript_id: tx.id.clone(),
+                length: cds_len,
+            },
+        ));
+    }
+
+    // Locate the chromosome — required for genomic sequence lookup.
+    let chrom = match tx.chromosome.as_deref() {
+        Some(c) => c,
+        None => return,
+    };
+
+    // Build the start codon from spliced CDS bases. A start codon can be split
+    // 1+2 or 2+1 across an exon junction, so walking only the exon that holds
+    // `cds_start` would fetch intronic bases and produce false W-LOAD-201
+    // warnings. `extract_first_codon` collects the first three CDS bases in
+    // transcript order across exon boundaries and strand-corrects.
+    let codon = extract_first_codon(tx, chrom, fasta, cds_start);
+
+    if let Some(c) = codon {
+        let codon_uc = c.to_uppercase();
+        let canonical = matches!(codon_uc.as_str(), "ATG" | "CTG" | "GTG" | "TTG");
+        if !canonical {
+            report.record(LoaderDiagnostic::warning(
+                "W-LOAD-201",
+                format!("NonCanonicalStartCodon: tx {} codon={}", tx.id, codon_uc),
+                SourceLocation {
+                    path: source_path.to_path_buf(),
+                    line: 0,
+                },
+                Some(tx.id.clone()),
+                DiagnosticPayload::NonCanonicalStartCodon {
+                    transcript_id: tx.id.clone(),
+                    codon: codon_uc,
+                },
+            ));
+        }
+    }
+}
+
+/// Assemble the first three CDS bases (the start codon) in transcript order,
+/// strand-corrected. Returns `None` when the transcript has no genomic exon
+/// coordinates, the strand is unknown, the FASTA fetch fails, or fewer than
+/// three CDS bases are available (e.g. a CDS that runs off the end of the
+/// transcript).
+///
+/// Iterates exons in transcript order from the one containing `cds_start`,
+/// taking up to the remaining-bases-needed from each exon. This handles
+/// start codons split 1+2 or 2+1 across an exon junction without ever
+/// fetching intronic bases.
+fn extract_first_codon(
+    tx: &Transcript,
+    chrom: &str,
+    fasta: &dyn ReferenceProvider,
+    cds_start: u64,
+) -> Option<String> {
+    const TARGET: u64 = 3;
+    let mut codon = String::with_capacity(3);
+    let mut tx_pos = cds_start;
+
+    for ex in &tx.exons {
+        if codon.len() as u64 >= TARGET {
+            break;
+        }
+        // Skip exons entirely upstream of the current transcript position.
+        if ex.end < tx_pos {
+            continue;
+        }
+        let (gs, ge) = match (ex.genomic_start, ex.genomic_end) {
+            (Some(gs), Some(ge)) => (gs, ge),
+            _ => return None,
+        };
+        let local_start_tx = tx_pos.max(ex.start);
+        if local_start_tx > ex.end {
+            continue;
+        }
+        let remaining = TARGET - codon.len() as u64;
+        let avail = ex.end - local_start_tx + 1;
+        let take = remaining.min(avail);
+        let local_end_tx = local_start_tx + take - 1;
+
+        // Map the transcript-coordinate slice [local_start_tx, local_end_tx]
+        // to a contiguous genomic range and fetch. `get_sequence` is 0-based
+        // half-open: 1-based genomic g → start = g - 1.
+        let chunk = match tx.strand {
+            Strand::Plus => {
+                let g_lo = gs + (local_start_tx - ex.start);
+                let g_hi = gs + (local_end_tx - ex.start);
+                fasta
+                    .get_sequence(chrom, g_lo.saturating_sub(1), g_hi)
+                    .ok()?
+            }
+            Strand::Minus => {
+                // tx position increases ⇒ genomic decreases on minus strand.
+                // local_start_tx ↦ higher genomic; local_end_tx ↦ lower genomic.
+                let g_hi = ge - (local_start_tx - ex.start);
+                let g_lo = ge - (local_end_tx - ex.start);
+                let raw = fasta
+                    .get_sequence(chrom, g_lo.saturating_sub(1), g_hi)
+                    .ok()?;
+                reverse_complement(&raw)
+            }
+            Strand::Unknown => return None,
+        };
+        codon.push_str(&chunk);
+        tx_pos = local_end_tx + 1;
+    }
+
+    (codon.len() as u64 == TARGET).then_some(codon)
+}
+
+/// Return the reverse complement of a DNA string.
+fn reverse_complement(s: &str) -> String {
+    s.chars()
+        .rev()
+        .map(|c| match c {
+            'A' | 'a' => 'T',
+            'T' | 't' => 'A',
+            'G' | 'g' => 'C',
+            'C' | 'c' => 'G',
+            'N' | 'n' => 'N',
+            other => other,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reference::provider::ReferenceProvider;
+    use crate::reference::transcript::{Exon, GenomeBuild, ManeStatus, Transcript};
+    use std::sync::OnceLock;
+
+    /// Minimal stub that serves a single in-memory sequence for any chromosome name.
+    struct StubFasta {
+        seq: String,
+    }
+
+    impl ReferenceProvider for StubFasta {
+        fn get_transcript(&self, id: &str) -> Result<Transcript, crate::error::FerroError> {
+            Err(crate::error::FerroError::ReferenceNotFound { id: id.to_string() })
+        }
+
+        fn get_sequence(
+            &self,
+            _chrom: &str,
+            start: u64,
+            end: u64,
+        ) -> Result<String, crate::error::FerroError> {
+            Ok(self.seq[(start as usize)..(end as usize)].to_string())
+        }
+    }
+
+    /// Build a minimal plus-strand transcript with transcript-space CDS bounds.
+    ///
+    /// The single exon spans positions 1–100 in both transcript and genomic space
+    /// (i.e., genomic_start = tx.start = 1, genomic_end = tx.end = 100).
+    fn tx_with_cds(cds_start: u64, cds_end: u64) -> Transcript {
+        Transcript {
+            id: "tx1".into(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: None,
+            cds_start: Some(cds_start),
+            cds_end: Some(cds_end),
+            exons: vec![Exon::with_genomic(1, 1, 100, 1, 100)],
+            chromosome: Some("chr1".into()),
+            genomic_start: Some(1),
+            genomic_end: Some(100),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::None,
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: vec![],
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn warns_when_cds_length_not_mod3() {
+        // cds_start=1, cds_end=5 → cds_len = 5, not divisible by 3
+        let tx = tx_with_cds(1, 5);
+        let fa = StubFasta {
+            seq: "ATGCCCAAATAGNNNNNNN".to_string(),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-200"), Some(&1));
+    }
+
+    #[test]
+    fn does_not_warn_when_cds_length_mod3_and_atg_start() {
+        // cds_start=1, cds_end=9 → cds_len = 9 (divisible by 3)
+        // StubFasta seq: "ATGCCCAAATAGNNNNNNN"
+        // Plus strand, gs = genomic_start_of_cds = 1 + (1-1) = 1
+        // fetch(0-based): start = gs-1 = 0, end = gs+2 = 3 → "ATG" ✓
+        let tx = tx_with_cds(1, 9);
+        let fa = StubFasta {
+            seq: "ATGCCCAAATAGNNNNNNN".to_string(),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-200"), None);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), None);
+    }
+
+    /// Build a FASTA seq of length `len` with specific bases planted at the
+    /// given 1-based genomic positions (everything else is 'N').
+    fn seq_with(planted: &[(u64, char)], len: usize) -> String {
+        let mut bytes = vec![b'N'; len];
+        for &(pos1, base) in planted {
+            bytes[(pos1 - 1) as usize] = base as u8;
+        }
+        String::from_utf8(bytes).unwrap()
+    }
+
+    /// Build a two-exon transcript on the requested strand.
+    fn two_exon_tx(
+        strand: Strand,
+        ex1: (u64, u64, u64, u64),
+        ex2: (u64, u64, u64, u64),
+        cds_start: u64,
+        cds_end: u64,
+    ) -> Transcript {
+        Transcript {
+            id: "tx_split".into(),
+            gene_symbol: None,
+            strand,
+            sequence: None,
+            cds_start: Some(cds_start),
+            cds_end: Some(cds_end),
+            exons: vec![
+                Exon::with_genomic(1, ex1.0, ex1.1, ex1.2, ex1.3),
+                Exon::with_genomic(2, ex2.0, ex2.1, ex2.2, ex2.3),
+            ],
+            chromosome: Some("chr1".into()),
+            genomic_start: Some(ex1.2.min(ex2.2)),
+            genomic_end: Some(ex1.3.max(ex2.3)),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::None,
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: vec![],
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn plus_strand_start_codon_split_1_2_across_exon_junction() {
+        // Exon 1: tx [1..1]  → genomic [10..10]   (1 base of codon here)
+        // Exon 2: tx [2..10] → genomic [50..58]   (next 2 bases of codon here)
+        // Without splice-aware extraction, a single-window fetch would read
+        // genomic [10,11,12] = 'A','N','N' and falsely warn.
+        let tx = two_exon_tx(Strand::Plus, (1, 1, 10, 10), (2, 10, 50, 58), 1, 9);
+        let fa = StubFasta {
+            seq: seq_with(&[(10, 'A'), (50, 'T'), (51, 'G')], 100),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        // mod3 ok (cds_len=9), start codon = ATG → no W-LOAD-201
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-200"), None);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), None);
+    }
+
+    #[test]
+    fn plus_strand_start_codon_split_2_1_across_exon_junction() {
+        // Exon 1: tx [1..2]  → genomic [10..11]   (first 2 bases of codon)
+        // Exon 2: tx [3..9]  → genomic [50..56]   (3rd codon base here)
+        let tx = two_exon_tx(Strand::Plus, (1, 2, 10, 11), (3, 9, 50, 56), 1, 9);
+        let fa = StubFasta {
+            seq: seq_with(&[(10, 'A'), (11, 'T'), (50, 'G')], 100),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), None);
+    }
+
+    #[test]
+    fn minus_strand_start_codon_split_1_2_across_exon_junction() {
+        // Exon 1 (transcript order): tx [1..1] → genomic [80..80]
+        // Exon 2 (transcript order): tx [2..10] → genomic [20..28]
+        // Minus strand: tx pos n maps to (ex.ge - (n - ex.start)).
+        //   tx 1 → g 80 → tx base = complement(FASTA[80]) = A iff FASTA[80]='T'
+        //   tx 2 → g 28 → tx base = T iff FASTA[28]='A'
+        //   tx 3 → g 27 → tx base = G iff FASTA[27]='C'
+        let tx = two_exon_tx(Strand::Minus, (1, 1, 80, 80), (2, 10, 20, 28), 1, 9);
+        let fa = StubFasta {
+            seq: seq_with(&[(80, 'T'), (28, 'A'), (27, 'C')], 100),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), None);
+    }
+
+    #[test]
+    fn minus_strand_start_codon_split_2_1_across_exon_junction() {
+        // Exon 1: tx [1..2] → genomic [80..81] (minus: tx 1 → g 81, tx 2 → g 80)
+        // Exon 2: tx [3..9] → genomic [20..26] (tx 3 → g 26)
+        // Codon = (complement of FASTA[81], FASTA[80], FASTA[26])
+        // For ATG: FASTA[81]='T', FASTA[80]='A', FASTA[26]='C'.
+        let tx = two_exon_tx(Strand::Minus, (1, 2, 80, 81), (3, 9, 20, 26), 1, 9);
+        let fa = StubFasta {
+            seq: seq_with(&[(81, 'T'), (80, 'A'), (26, 'C')], 100),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), None);
+    }
+
+    #[test]
+    fn split_start_codon_warns_when_not_canonical() {
+        // Confirms the splice-aware path still emits W-LOAD-201 for true
+        // non-canonical start codons. Same 1+2 layout as the plus-strand
+        // test above but planting GAA instead of ATG.
+        let tx = two_exon_tx(Strand::Plus, (1, 1, 10, 10), (2, 10, 50, 58), 1, 9);
+        let fa = StubFasta {
+            seq: seq_with(&[(10, 'G'), (50, 'A'), (51, 'A')], 100),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), Some(&1));
+    }
+
+    #[test]
+    fn warns_on_non_canonical_start_codon() {
+        // cds_start=1, cds_end=9 → cds_len = 9 (mod 3 == 0, no W-LOAD-200)
+        // StubFasta seq: "AAATTTGGGNNNNNNNNNN"
+        // Plus strand fetch at 0-based [0,3) → "AAA" → non-canonical → W-LOAD-201
+        let tx = tx_with_cds(1, 9);
+        let fa = StubFasta {
+            seq: "AAATTTGGGNNNNNNNNNN".to_string(),
+        };
+        let mut report = LoaderReport::default();
+        validate_transcript(&tx, &fa, Path::new("t"), &mut report);
+        assert_eq!(report.diagnostics_by_code.get("W-LOAD-201"), Some(&1));
+    }
+}

--- a/src/reference/loader.rs
+++ b/src/reference/loader.rs
@@ -267,26 +267,6 @@ impl TranscriptDb {
     }
 }
 
-/// Load transcripts from a GFF3 file
-///
-/// Delegates to [`crate::reference::annotation::load_annotations`] using the GFF3 format.
-pub fn load_gff3<P: AsRef<Path>>(path: P) -> Result<TranscriptDb, FerroError> {
-    let cfg = crate::reference::annotation::LoaderConfig::new()
-        .with_format(crate::reference::annotation::AnnotationFormat::Gff3);
-    let (db, _report) = crate::reference::annotation::load_annotations(path, &cfg)?;
-    Ok(db)
-}
-
-/// Load transcripts from a GTF file
-///
-/// Delegates to [`crate::reference::annotation::load_annotations`] using the GTF format.
-pub fn load_gtf<P: AsRef<Path>>(path: P) -> Result<TranscriptDb, FerroError> {
-    let cfg = crate::reference::annotation::LoaderConfig::new()
-        .with_format(crate::reference::annotation::AnnotationFormat::Gtf);
-    let (db, _report) = crate::reference::annotation::load_annotations(path, &cfg)?;
-    Ok(db)
-}
-
 /// Detect genome build from file header or content
 pub fn detect_genome_build<P: AsRef<Path>>(path: P) -> Result<GenomeBuild, FerroError> {
     let file = File::open(path.as_ref()).map_err(|e| FerroError::Io {
@@ -832,100 +812,6 @@ mod tests {
         assert!(!db.get_by_position("chr1", 1500).is_empty());
     }
 
-    // ===== I/O Tests with Temporary Files =====
-
-    #[test]
-    fn test_load_gff3_primary_transcript() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
-        let mut gff3_file = NamedTempFile::new().unwrap();
-        writeln!(gff3_file, "##gff-version 3").unwrap();
-        writeln!(
-            gff3_file,
-            "chr1\t.\tprimary_transcript\t1000\t2000\t.\t+\t.\tID=tx1;gene=TEST"
-        )
-        .unwrap();
-        writeln!(gff3_file, "chr1\t.\texon\t1000\t2000\t.\t+\t.\tParent=tx1").unwrap();
-        gff3_file.flush().unwrap();
-
-        let db = load_gff3(gff3_file.path()).unwrap();
-        assert_eq!(db.len(), 1);
-    }
-
-    #[test]
-    fn test_load_gff3_transcript_type() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
-        let mut gff3_file = NamedTempFile::new().unwrap();
-        writeln!(gff3_file, "##gff-version 3").unwrap();
-        writeln!(
-            gff3_file,
-            "chr1\t.\ttranscript\t1000\t2000\t.\t+\t.\tID=tx1;gene=TEST"
-        )
-        .unwrap();
-        writeln!(gff3_file, "chr1\t.\texon\t1000\t2000\t.\t+\t.\tParent=tx1").unwrap();
-        gff3_file.flush().unwrap();
-
-        let db = load_gff3(gff3_file.path()).unwrap();
-        assert_eq!(db.len(), 1);
-    }
-
-    #[test]
-    fn test_load_gff3_multiple_parents() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
-        let mut gff3_file = NamedTempFile::new().unwrap();
-        writeln!(gff3_file, "##gff-version 3").unwrap();
-        writeln!(
-            gff3_file,
-            "chr1\t.\tmRNA\t1000\t2000\t.\t+\t.\tID=tx1;gene=TEST"
-        )
-        .unwrap();
-        writeln!(
-            gff3_file,
-            "chr1\t.\tmRNA\t1000\t2000\t.\t+\t.\tID=tx2;gene=TEST"
-        )
-        .unwrap();
-        // Exon belongs to both transcripts
-        writeln!(
-            gff3_file,
-            "chr1\t.\texon\t1000\t2000\t.\t+\t.\tParent=tx1,tx2"
-        )
-        .unwrap();
-        gff3_file.flush().unwrap();
-
-        let db = load_gff3(gff3_file.path()).unwrap();
-
-        // Both transcripts should have the exon
-        let tx1 = db.get("tx1").unwrap();
-        let tx2 = db.get("tx2").unwrap();
-        assert_eq!(tx1.exons.len(), 1);
-        assert_eq!(tx2.exons.len(), 1);
-    }
-
-    #[test]
-    fn test_load_gff3_skip_invalid_lines() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-
-        let mut gff3_file = NamedTempFile::new().unwrap();
-        writeln!(gff3_file, "##gff-version 3").unwrap();
-        writeln!(gff3_file, "short_line").unwrap(); // Invalid - too few fields
-        writeln!(
-            gff3_file,
-            "chr1\t.\tmRNA\t1000\t2000\t.\t+\t.\tID=tx1;gene=TEST"
-        )
-        .unwrap();
-        writeln!(gff3_file, "chr1\t.\texon\t1000\t2000\t.\t+\t.\tParent=tx1").unwrap();
-        gff3_file.flush().unwrap();
-
-        let db = load_gff3(gff3_file.path()).unwrap();
-        assert_eq!(db.len(), 1); // Invalid line should be skipped
-    }
-
     // ===== Additional TranscriptDb Tests =====
 
     #[test]
@@ -1056,23 +942,5 @@ mod tests {
         // Should prefer MANE Select
         let preferred = db.get_preferred_transcript("TEST").unwrap();
         assert_eq!(preferred.id, "NM_000001.1");
-    }
-
-    #[test]
-    fn shim_load_gff3_handles_issue_183() {
-        use std::io::Write;
-        use tempfile::NamedTempFile;
-        let mut tf = NamedTempFile::new().unwrap();
-        writeln!(tf, "##gff-version 3").unwrap();
-        writeln!(tf, "seq1\t.\tgene\t100\t1200\t.\t+\t.\tID=gene01").unwrap();
-        writeln!(
-            tf,
-            "seq1\t.\tmRNA\t100\t1200\t.\t+\t.\tID=gene01.1;Parent=gene01"
-        )
-        .unwrap();
-        writeln!(tf, "seq1\t.\tCDS\t100\t1200\t.\t+\t0\tParent=gene01.1").unwrap();
-        tf.flush().unwrap();
-        let db = load_gff3(tf.path()).unwrap();
-        assert_eq!(db.len(), 1);
     }
 }

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -13,7 +13,7 @@ pub mod transcript;
 
 pub use annotation::{load_annotations, AnnotationFormat, LoaderConfig, LoaderReport};
 pub use fasta::FastaProvider;
-pub use loader::{detect_genome_build, load_gff3, load_gtf, TranscriptDb};
+pub use loader::{detect_genome_build, TranscriptDb};
 pub use mock::MockProvider;
 pub use multi_fasta::MultiFastaProvider;
 pub use protein::ProteinCache;


### PR DESCRIPTION
## Summary

Phase 4 of the GFF/GTF loader rewrite tracked in #190. Builds on Phase 3 (#195) which stacks on Phase 2 (#194) which stacks on Phase 1 (#191).

**This PR is stacked on #195.** Base: `feat/issue-190-gff-loader-phase3`.

## What lands

### FASTA-aware validation

When a `--fasta` is supplied to `ferro convert-gff` (and `--no-validate-fasta` is not given), each built transcript gets two cheap checks:

- **`W-LOAD-200 CdsLengthNotMod3`** — the CDS length is not divisible by 3.
- **`W-LOAD-201 NonCanonicalStartCodon`** — the strand-corrected first codon is not in `{ATG, CTG, GTG, TTG}`.

Warnings only; never rejects, never drops. New module: `src/reference/annotation/validate.rs`.

`LoaderConfig` gains `with_fasta(impl ReferenceProvider)` and `with_no_validate_fasta()` builders.

### Call-site migration

The remaining four `load_gff3` / `load_gtf` callers in `src/bin/ferro.rs` (`run_annotate_vcf` and `run_vcf_to_hgvs`) now go through `load_annotations` directly. Auto-detection handles format choice, so the previous `if ext == \"gtf\" { ... } else { ... }` branches collapse to a single call.

### Shim removal

`load_gff3` and `load_gtf` are deleted from `src/reference/loader.rs` and removed from the `pub use loader::{...}` re-export. `src/reference/loader.rs` now contains only `TranscriptDb`, `ManeStats`, `detect_genome_build`, and their tests.

Four obsolete tests in `loader.rs` were deleted; one (multi-parent exon via comma-separated `Parent=`) was migrated to the annotation module since no existing annotation test covered it.

### CHANGELOG

`CHANGELOG.md` gets an `[Unreleased]` section documenting Phases 1-4: new `load_annotations` API, exon-derivation ladder (#183 fix), phase/start_codon/stop_codon handling, UTR-merge, MANE/gene-symbol/RefSeq/Ensembl wiring, FASTA validation, CLI flags, `ferro explain` for loader codes, `Strand::Unknown` variant + `#[non_exhaustive]` markers, and removal of `load_gff3`/`load_gtf`.

## Diff size

6 files changed, 322 insertions(+), 150 deletions(-)

## Test plan

- [x] \`cargo nextest run --features dev\` — 4262/4262 passing (net -1 vs Phase 3's 4263 due to deleted shim-redundant tests)
- [x] \`cargo clippy --features dev -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] New validate.rs tests cover CDS-length-mod3, ATG start codon, and non-canonical start codon
- [ ] Manual: \`ferro convert-gff --gff input.gff3 --fasta ref.fa\` produces `W-LOAD-200` / `W-LOAD-201` warnings on real-world inputs with annotation errors

## Remaining

Only **Phase 5** (noodles parser swap behind the existing `AnnotationRecord` trait) remains.