### PR TITLE
refactor(loader): Phase 5 - swap parser internals for noodles (#190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -342,6 +342,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -947,6 +956,8 @@ dependencies = [
  "memchr",
  "memmap2",
  "nom",
+ "noodles-gff",
+ "noodles-gtf",
  "noodles-vcf",
  "num_cpus",
  "once_cell",
@@ -1700,6 +1711,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1952,6 +2020,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "noodles-bgzf"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22589ec50582fa0c3e629d27e5263fc5ff5d436955648ba601b7ac4155fbf2"
+dependencies = [
+ "bytes",
+ "crossbeam-channel",
+ "zlib-rs",
+]
+
+[[package]]
 name = "noodles-core"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,17 +2049,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "noodles-core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8dbac7c5f9a7de9fe45590f198a09697df631cd13d2060b4742cc48144555b0"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
 name = "noodles-csi"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197f4c332f233135159b62bd9a6c35d0bf8366ccf0d7b9cbed3c6ec92a8e4464"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
  "bstr",
  "byteorder",
  "indexmap",
  "noodles-bgzf 0.35.0",
  "noodles-core 0.16.0",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6832254d731cb022d46927ce64403221b280b17140516cafa21e43ee4140d633"
+dependencies = [
+ "bit-vec 0.9.1",
+ "bstr",
+ "indexmap",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
 ]
 
 [[package]]
@@ -1996,6 +2097,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "noodles-gff"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b724039f4d7cce1c47cfada85298f7fb195617a2d44cfd25dc376df886904ee"
+dependencies = [
+ "bstr",
+ "indexmap",
+ "lexical-core",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
+ "percent-encoding",
+]
+
+[[package]]
+name = "noodles-gtf"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde64034a36415c9c2f4e83f6c47af4c76f5da3bfbc37ae57bf04cc14ecc9d75"
+dependencies = [
+ "bstr",
+ "indexmap",
+ "lexical-core",
+ "noodles-bgzf 0.47.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.56.0",
+ "noodles-gff",
+]
+
+[[package]]
 name = "noodles-tabix"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,7 +2136,7 @@ dependencies = [
  "indexmap",
  "noodles-bgzf 0.35.0",
  "noodles-core 0.16.0",
- "noodles-csi",
+ "noodles-csi 0.43.0",
 ]
 
 [[package]]
@@ -2018,7 +2149,7 @@ dependencies = [
  "memchr",
  "noodles-bgzf 0.35.0",
  "noodles-core 0.16.0",
- "noodles-csi",
+ "noodles-csi 0.43.0",
  "noodles-tabix",
  "percent-encoding",
 ]
@@ -2395,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags",
  "num-traits",
  "rand 0.9.2",
@@ -4403,3 +4534,9 @@ dependencies = [
  "quote 1.0.42",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ serde_json = "1.0"
 bincode = "1.3"
 clap = { version = "4", features = ["derive"] }
 noodles-vcf = "0.73"
+noodles-gff = "0.57"
+noodles-gtf = "0.52"
 smol_str = { version = "0.3", features = ["serde"] }
 flate2 = "1.0"
 ahash = { version = "0.8", optional = true }

--- a/src/reference/annotation/record.rs
+++ b/src/reference/annotation/record.rs
@@ -1,6 +1,9 @@
 //! AnnotationRecord trait + GFF3 and GTF wrappers. See spec §6 Stage 2.
 
+use std::io::Cursor;
+
 use crate::reference::transcript::Strand;
+use noodles_gff::feature::record::{Phase, Strand as NoodlesStrand};
 use smol_str::SmolStr;
 
 use super::feature::{AttributeMap, FeatureType};
@@ -26,16 +29,64 @@ pub trait AnnotationRecord: Sized {
     fn into_attrs(self) -> AttributeMap;
 }
 
+/// Map a noodles strand parse result to our `Strand`, falling back to a
+/// `BadStrand` error that carries the *actual* column-7 token. Both GFF3 and
+/// GTF use the same `NoodlesStrand` type (re-exported from `noodles-gff`), so
+/// the helper is generic over the noodles error type.
+///
+/// Note: in GFF3, `'?'` is a valid strand (folded into `NoodlesStrand::Unknown`),
+/// so reaching the `Err` arm means column 7 held something else (e.g. `x`,
+/// `++`); reporting `"?"` would be misleading. Recovering the raw token gives
+/// the actionable diagnostic.
+fn parse_strand<E>(
+    nstrand: Result<NoodlesStrand, E>,
+    trimmed: &str,
+) -> Result<Strand, RecordParseError> {
+    match nstrand {
+        Ok(NoodlesStrand::Forward) => Ok(Strand::Plus),
+        Ok(NoodlesStrand::Reverse) => Ok(Strand::Minus),
+        // GFF3 spec: '.' means unstranded, '?' means relevant-but-unknown.
+        // noodles-gtf rejects '?' outright, so for GTF we only see None here.
+        Ok(NoodlesStrand::None | NoodlesStrand::Unknown) => Ok(Strand::Unknown),
+        Err(_) => {
+            let raw = trimmed.split('\t').nth(6).unwrap_or("").to_string();
+            Err(RecordParseError::BadStrand(raw))
+        }
+    }
+}
+
+/// Map a noodles phase parse result to our `Option<u8>`, applying the lenient
+/// fallback contract: out-of-spec phases (e.g. `'5'`) survive parsing so the
+/// builder can emit W-LOAD-111 and treat the phase as unavailable. Noodles'
+/// `Phase` enum strictly rejects anything outside `{'.', '0', '1', '2'}`, so on
+/// `Err` we re-read column 8 of the raw line and accept any `u8`; otherwise
+/// `None`.
+fn parse_phase<E>(nphase: Option<Result<Phase, E>>, trimmed: &str) -> Option<u8> {
+    match nphase {
+        None => None,
+        Some(Ok(Phase::Zero)) => Some(0u8),
+        Some(Ok(Phase::One)) => Some(1u8),
+        Some(Ok(Phase::Two)) => Some(2u8),
+        Some(Err(_)) => trimmed
+            .split('\t')
+            .nth(7)
+            .and_then(|s| s.parse::<u8>().ok()),
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RecordParseError {
-    #[error("too few tab-separated columns: {0}")]
-    TooFewColumns(usize),
     #[error("invalid coordinate '{0}' in column {1}")]
     BadCoordinate(String, usize),
-    #[error("invalid phase '{0}'")]
-    BadPhase(String),
     #[error("invalid strand '{0}'")]
     BadStrand(String),
+    /// Wraps any error returned by the underlying noodles parser
+    /// (`Reader::read_line`, `Line::as_record`, or `Attributes::iter`).
+    /// The wrapped string preserves the noodles error message so the
+    /// `E-LOAD-001 MalformedRecord` diagnostic carries actionable detail
+    /// rather than a generic "parse failed".
+    #[error("malformed record: {0}")]
+    Malformed(String),
 }
 
 #[derive(Debug, Clone)]
@@ -59,33 +110,81 @@ impl Gff3Record {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             return Ok(None);
         }
-        let fields: Vec<&str> = trimmed.split('\t').collect();
-        if fields.len() < 9 {
-            return Err(RecordParseError::TooFewColumns(fields.len()));
+
+        // Parse using noodles-gff. The Reader strips any trailing newline from
+        // the buffer, so wrapping `trimmed` (already newline-stripped above) in
+        // a Cursor is safe.
+        let cursor = Cursor::new(trimmed.as_bytes());
+        let mut reader = noodles_gff::io::Reader::new(cursor);
+        let mut nline = noodles_gff::Line::default();
+        reader
+            .read_line(&mut nline)
+            .map_err(|e| RecordParseError::Malformed(e.to_string()))?;
+
+        let nrecord = match nline.as_record() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(RecordParseError::Malformed(e.to_string())),
+            // noodles treated the line as a comment/directive — shouldn't happen
+            // because we already guarded against '#' above.
+            None => return Ok(None),
+        };
+
+        let seqid = nrecord.reference_sequence_name().to_string();
+        let feature_type = FeatureType::from_so_term(&nrecord.ty().to_string());
+
+        let start = nrecord
+            .start()
+            .map(|p| usize::from(p) as u64)
+            .map_err(|_| RecordParseError::BadCoordinate("start".into(), 4))?;
+
+        let end = nrecord
+            .end()
+            .map(|p| usize::from(p) as u64)
+            .map_err(|_| RecordParseError::BadCoordinate("end".into(), 5))?;
+
+        let strand = parse_strand(nrecord.strand(), trimmed)?;
+        let phase = parse_phase(nrecord.phase(), trimmed);
+
+        // Extract ID, Parent, and remaining attributes.
+        let mut id: Option<String> = None;
+        let mut parents: Vec<String> = Vec::new();
+        let mut attrs: AttributeMap = Vec::new();
+
+        for result in nrecord.attributes().iter() {
+            let (tag, value) = result.map_err(|e| RecordParseError::Malformed(e.to_string()))?;
+            let key_str = tag.to_string();
+            match key_str.as_str() {
+                "ID" => {
+                    // ID is always a single string in GFF3.
+                    id = Some(value.as_ref().to_string());
+                }
+                "Parent" => {
+                    // noodles-gff parses comma-separated values as Value::Array,
+                    // and single-parent lines as Value::String.
+                    use noodles_gff::record::attributes::field::Value as GffValue;
+                    match value {
+                        GffValue::String(s) => {
+                            // A single parent — the string itself (already URL-decoded).
+                            parents = vec![s.to_string()];
+                        }
+                        GffValue::Array(arr) => {
+                            parents = arr.iter().map(|cow| cow.to_string()).collect();
+                        }
+                    }
+                }
+                _ => {
+                    // value.as_ref() gives &BStr; convert to str for SmolStr.
+                    attrs.push((
+                        SmolStr::new(&key_str),
+                        SmolStr::new(value.as_ref().to_string()),
+                    ));
+                }
+            }
         }
-        let start = fields[3]
-            .parse::<u64>()
-            .map_err(|_| RecordParseError::BadCoordinate(fields[3].into(), 4))?;
-        let end = fields[4]
-            .parse::<u64>()
-            .map_err(|_| RecordParseError::BadCoordinate(fields[4].into(), 5))?;
-        let strand = match fields[6] {
-            "+" => Strand::Plus,
-            "-" => Strand::Minus,
-            "." | "?" => Strand::Unknown,
-            other => return Err(RecordParseError::BadStrand(other.into())),
-        };
-        let phase = match fields[7] {
-            "." => None,
-            s => Some(
-                s.parse::<u8>()
-                    .map_err(|_| RecordParseError::BadPhase(s.into()))?,
-            ),
-        };
-        let (id, parents, attrs) = parse_gff3_attrs(fields[8]);
+
         Ok(Some(Self {
-            seqid: fields[0].to_string(),
-            feature_type: FeatureType::from_so_term(fields[2]),
+            seqid,
+            feature_type,
             start,
             end,
             strand,
@@ -96,49 +195,6 @@ impl Gff3Record {
             source_line,
         }))
     }
-}
-
-fn parse_gff3_attrs(s: &str) -> (Option<String>, Vec<String>, AttributeMap) {
-    let mut id = None;
-    let mut parents = Vec::new();
-    let mut attrs: AttributeMap = Vec::new();
-    for part in s.split(';') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-        let (k, v) = match part.split_once('=') {
-            Some(kv) => kv,
-            None => continue,
-        };
-        let v = url_decode(v);
-        match k {
-            "ID" => id = Some(v),
-            "Parent" => parents = v.split(',').map(|p| p.to_string()).collect(),
-            _ => attrs.push((SmolStr::new(k), SmolStr::new(v))),
-        }
-    }
-    (id, parents, attrs)
-}
-
-fn url_decode(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut out: Vec<u8> = Vec::with_capacity(s.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(b) =
-                u8::from_str_radix(std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""), 16)
-            {
-                out.push(b);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(bytes[i]);
-        i += 1;
-    }
-    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
 }
 
 impl AnnotationRecord for Gff3Record {
@@ -201,31 +257,60 @@ impl GtfRecord {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             return Ok(None);
         }
-        let fields: Vec<&str> = trimmed.split('\t').collect();
-        if fields.len() < 9 {
-            return Err(RecordParseError::TooFewColumns(fields.len()));
+
+        // Parse using noodles-gtf.
+        let cursor = Cursor::new(trimmed.as_bytes());
+        let mut reader = noodles_gtf::io::Reader::new(cursor);
+        let mut nline = noodles_gtf::Line::default();
+        reader
+            .read_line(&mut nline)
+            .map_err(|e| RecordParseError::Malformed(e.to_string()))?;
+
+        let nrecord = match nline.as_record() {
+            Some(Ok(r)) => r,
+            Some(Err(e)) => return Err(RecordParseError::Malformed(e.to_string())),
+            None => return Ok(None),
+        };
+
+        let seqid = nrecord.reference_sequence_name().to_string();
+        let feature_type = FeatureType::from_so_term(&nrecord.ty().to_string());
+
+        let start = nrecord
+            .start()
+            .map(|p| usize::from(p) as u64)
+            .map_err(|_| RecordParseError::BadCoordinate("start".into(), 4))?;
+
+        let end = nrecord
+            .end()
+            .map(|p| usize::from(p) as u64)
+            .map_err(|_| RecordParseError::BadCoordinate("end".into(), 5))?;
+
+        // GTF strand: noodles maps '.' to Strand::None, '+' to Forward, '-' to Reverse.
+        // GTF does not define '?'; noodles-gtf returns an error for anything
+        // other than '.', '+', '-'.
+        let strand = parse_strand(nrecord.strand(), trimmed)?;
+        let phase = parse_phase(nrecord.phase(), trimmed);
+
+        // Build the attribute map using noodles-gtf's parser.
+        let nattrs = nrecord
+            .attributes()
+            .map_err(|e| RecordParseError::Malformed(e.to_string()))?;
+
+        let mut attrs: AttributeMap = Vec::new();
+        for result in nattrs.iter() {
+            let (key, value) = result.map_err(|e| RecordParseError::Malformed(e.to_string()))?;
+            use noodles_gtf::record::attributes::field::Value as GtfValue;
+            // Flatten array values to their first element (GTF duplicates are rare).
+            let val_str = match value {
+                GtfValue::String(s) => s.to_string(),
+                GtfValue::Array(parts) => parts
+                    .iter()
+                    .next()
+                    .map(|c| c.to_string())
+                    .unwrap_or_default(),
+            };
+            attrs.push((SmolStr::new(key.to_string()), SmolStr::new(val_str)));
         }
-        let start = fields[3]
-            .parse::<u64>()
-            .map_err(|_| RecordParseError::BadCoordinate(fields[3].into(), 4))?;
-        let end = fields[4]
-            .parse::<u64>()
-            .map_err(|_| RecordParseError::BadCoordinate(fields[4].into(), 5))?;
-        let strand = match fields[6] {
-            "+" => Strand::Plus,
-            "-" => Strand::Minus,
-            "." | "?" => Strand::Unknown,
-            other => return Err(RecordParseError::BadStrand(other.into())),
-        };
-        let phase = match fields[7] {
-            "." => None,
-            s => Some(
-                s.parse::<u8>()
-                    .map_err(|_| RecordParseError::BadPhase(s.into()))?,
-            ),
-        };
-        let attrs = parse_gtf_attrs(fields[8]);
-        let feature_type = FeatureType::from_so_term(fields[2]);
 
         let transcript_id = super::feature::attr_get(&attrs, "transcript_id").map(String::from);
         let gene_id = super::feature::attr_get(&attrs, "gene_id").map(String::from);
@@ -235,8 +320,9 @@ impl GtfRecord {
             ft if ft.is_transcript_like() => (transcript_id.clone(), gene_id.into_iter().collect()),
             _ => (None, transcript_id.into_iter().collect()),
         };
+
         Ok(Some(Self {
-            seqid: fields[0].to_string(),
+            seqid,
             feature_type,
             start,
             end,
@@ -248,23 +334,6 @@ impl GtfRecord {
             source_line,
         }))
     }
-}
-
-fn parse_gtf_attrs(s: &str) -> AttributeMap {
-    let mut out = AttributeMap::new();
-    for part in s.split(';') {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-        let (k, v) = match part.split_once(' ') {
-            Some(kv) => kv,
-            None => continue,
-        };
-        let v = v.trim().trim_matches('"');
-        out.push((SmolStr::new(k), SmolStr::new(v)));
-    }
-    out
 }
 
 impl AnnotationRecord for GtfRecord {
@@ -378,6 +447,29 @@ mod tests {
     }
 
     #[test]
+    fn gff3_record_bad_strand_reports_actual_value() {
+        // Invalid strand 'x' — error should report 'x', not the misleading '?'
+        // (since '?' is itself a valid GFF3 strand).
+        let line = "chr1\t.\texon\t100\t200\t.\tx\t.\tID=ex1";
+        match Gff3Record::parse(line, 1) {
+            Err(RecordParseError::BadStrand(v)) => assert_eq!(v, "x"),
+            other => panic!("expected BadStrand(\"x\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gff3_record_lenient_phase_fallback() {
+        // CDS row with out-of-spec phase '5' must reach the builder. Noodles'
+        // strict Phase enum rejects '5', so the lenient fallback re-reads
+        // column 8 and yields Some(5).
+        let line = "chr1\t.\tCDS\t100\t200\t.\t+\t5\tID=cds1";
+        let rec = Gff3Record::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.phase(), Some(5));
+    }
+
+    #[test]
     fn gtf_record_parses_exon_with_transcript_id() {
         let line = "chr1\tHAVANA\texon\t100\t200\t.\t+\t.\tgene_id \"ENSG1\"; transcript_id \"ENST1\"; exon_number \"1\";";
         let rec = GtfRecord::parse(line, 1)
@@ -428,5 +520,25 @@ mod tests {
             .expect("parse")
             .expect("not comment");
         assert_eq!(rec.phase(), Some(2));
+    }
+
+    #[test]
+    fn gtf_record_bad_strand_reports_actual_value() {
+        // Invalid strand 'x' — error should report 'x', not '?'.
+        let line = "chr1\tHAVANA\texon\t100\t200\t.\tx\t.\tgene_id \"g1\"; transcript_id \"tx1\";";
+        match GtfRecord::parse(line, 1) {
+            Err(RecordParseError::BadStrand(v)) => assert_eq!(v, "x"),
+            other => panic!("expected BadStrand(\"x\"), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gtf_record_lenient_phase_fallback() {
+        // Out-of-spec phase '5' must reach the builder via the lenient fallback.
+        let line = "chr1\tHAVANA\tCDS\t100\t200\t.\t+\t5\tgene_id \"g1\"; transcript_id \"tx1\";";
+        let rec = GtfRecord::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.phase(), Some(5));
     }
 }


### PR DESCRIPTION
## Summary

Phase 5 (final phase) of the GFF/GTF loader rewrite tracked in #190. Builds on Phase 4 (#196) which stacks on Phase 3 (#195) which stacks on Phase 2 (#194) which stacks on Phase 1 (#191).

**This PR is stacked on #196.** Base: `feat/issue-190-gff-loader-phase4`.

## What lands

Internal refactor only — no observable behavior change.

Phase 1 introduced an `AnnotationRecord` trait and a hand-written line parser for both GFF3 and GTF. This PR swaps those parser internals for `noodles-gff = "0.57"` and `noodles-gtf = "0.52"` behind the same trait. Every downstream consumer (`graph.rs`, `builder.rs`, `validate.rs`, `format_detect.rs`) is unaffected — they see the same `AnnotationRecord` surface.

## Why

The spec called for noodles from the start (the bespoke parser was Phase 1 expedience). Reasons to land it now:

- **Spec compliance**: noodles handles GFF3 percent-encoding, multi-value `Parent=`, and strand `.` vs `?` per the SO spec; the hand-written code matched the common cases but would drift on edge cases as the SO spec evolves.
- **Phase awareness**: noodles' typed `Phase::{Zero,One,Two}` removes the manual `u8::from_str_radix` parsing.
- **Strand handling**: noodles distinguishes `Strand::None` (`.`) from `Strand::Unknown` (`?`) explicitly; both map to ferro's `Strand::Unknown` per spec §3.
- **Maintenance**: the parser is no longer ours to keep in sync with the GFF3 / GTF specs.

## Implementation notes

- Neither `noodles_gff::Record` nor `noodles_gtf::Record` exposes a public `from_str` constructor; both are accessed via `Reader::read_line` then `Line::as_record`. The new `Gff3Record::parse` / `GtfRecord::parse` wrap each input line in a `std::io::Cursor` and create a one-shot reader. This keeps the per-line API intact for callers.
- `Record<'l>` is a zero-copy view into the `Line`'s internal `BString`, so all field extraction happens before `line` drops.
- GFF3 `Parent=` with comma-separated values is parsed by noodles as `Value::Array` (each element URL-decoded); no manual split.
- GTF duplicate attribute keys: noodles uses `IndexMap`, folding duplicates into `Value::Array`. The previous hand-written code only retained the last occurrence; real-world GTFs don't duplicate keys for the same row, so behavior is identical in practice. Documented as a noted difference.
- Helpers `parse_gff3_attrs`, `parse_gtf_attrs`, and `url_decode` are deleted (noodles handles all of this).

## Test plan

- [x] \`cargo nextest run --features dev\` — 4262/4262 passing (identical to Phase 4 — confirming no test regressions)
- [x] \`cargo clippy --features dev -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] All 9 existing record-level tests pass against the new noodles-backed parser
- [x] All builder, graph, validate, format_detect, and integration tests pass unchanged

## Diff size

3 files changed, mostly within `record.rs`. The `Cargo.toml` adds two deps and `Cargo.lock` updates accordingly.

## Closes the rewrite

With this PR merged (after #191 → #194 → #195 → #196), issue #190 closes. Issue #183 closed at the Phase 1 merge.