### PR TITLE
fix(mock): accept version/genome_build metadata keys in from_json (closes #185)

### DIFF
--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -42,6 +42,13 @@ impl MockProvider {
             proteins: HashMap<String, String>,
             #[serde(default)]
             genomic_sequences: HashMap<String, String>,
+            /// Container metadata emitted by `ferro convert-gff`; accepted but ignored.
+            #[serde(default, rename = "version")]
+            _version: Option<String>,
+            /// Container metadata emitted by `ferro convert-gff`; per-transcript
+            /// `genome_build` on each `Transcript` is authoritative.
+            #[serde(default, rename = "genome_build")]
+            _genome_build: Option<String>,
         }
 
         let content = std::fs::read_to_string(path)?;
@@ -534,5 +541,54 @@ mod tests {
             ),
             Ok(_) => panic!("expected unknown field to be rejected"),
         }
+    }
+
+    #[test]
+    fn from_json_accepts_convert_gff_output_with_metadata_keys() {
+        // The container shape produced by `ferro convert-gff`.
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+            "version": "1.0",
+            "genome_build": "GRCh38",
+            "transcripts": []
+        }"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider = MockProvider::from_json(file.path())
+            .expect("convert-gff JSON with version/genome_build metadata should load");
+        assert!(provider.is_empty());
+    }
+
+    #[test]
+    fn from_json_loads_convert_gff_output_with_transcript() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+            "version": "1.0",
+            "genome_build": "GRCh38",
+            "transcripts": [
+                {
+                    "id": "NM_000001.1",
+                    "strand": "+",
+                    "sequence": "ATGC",
+                    "exons": [{"number": 1, "start": 1, "end": 4}]
+                }
+            ]
+        }"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider = MockProvider::from_json(file.path())
+            .expect("convert-gff JSON with transcript should load");
+        let tx = provider
+            .get_transcript("NM_000001.1")
+            .expect("tx not found");
+        assert_eq!(tx.sequence, "ATGC");
     }
 }


### PR DESCRIPTION
## Summary

Closes #185.

`MockProvider::from_json()` rejected the top-level `version` and `genome_build` keys that `ferro convert-gff` emits, breaking the round-trip from `convert-gff` to `Normalizer(reference_json=...)` with:

```
RuntimeError: Failed to load reference: JSON error: unknown field 'genome_build',
  expected one of 'transcripts', 'proteins', 'genomic_sequences'
```

## Fix

Add `version` and `genome_build` as optional fields to the private `ObjectForm` struct in `src/reference/mock.rs`. The metadata values are silently ignored — `Transcript` carries its own per-record `genome_build` and `version` is informational. `#[serde(deny_unknown_fields)]` is preserved so typos (e.g. `transripts`) still produce a clear error.

```rust
#[serde(deny_unknown_fields)]
struct ObjectForm {
    #[serde(default)] transcripts: ...,
    #[serde(default)] proteins: ...,
    #[serde(default)] genomic_sequences: ...,
    /// Container metadata emitted by ferro convert-gff; accepted but ignored.
    #[serde(default, rename = "version")] _version: Option<String>,
    /// Container metadata; per-transcript genome_build is authoritative.
    #[serde(default, rename = "genome_build")] _genome_build: Option<String>,
}
```

## Test plan

- [x] \`cargo nextest run --features dev\` — full suite green (+2 new round-trip tests)
- [x] \`cargo clippy --features dev -- -D warnings\` — clean
- [x] Round-trip test: parse a minimal \`convert-gff\`-shaped JSON (version + genome_build + transcripts) and confirm a transcript is retrievable
- [x] Confirmed the test FAILED before the fix with the exact error from the issue