### PR TITLE
feat(cli): add build-transcript subcommand for FASTA + CDS construction (closes #184)

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -474,6 +474,54 @@ enum Commands {
         #[arg(long, default_value = "ferro-reference")]
         reference: PathBuf,
     },
+
+    /// Build a transcripts.json from a FASTA + CDS coordinates (single-exon).
+    ///
+    /// Useful for synthetic constructs (plasmids, reporter genes, custom amplicons)
+    /// where the user already knows the CDS bounds and does not need a GFF3.
+    BuildTranscript {
+        /// Path to the FASTA file (indexed or plain; index will be built on the fly if absent).
+        #[arg(long)]
+        fasta: PathBuf,
+
+        /// CDS start position (1-based inclusive, in transcript coordinates).
+        ///
+        /// For minus-strand transcripts the sequence is reverse-complemented before
+        /// emission, so the position is relative to the reverse-complemented sequence.
+        #[arg(long)]
+        cds_start: u64,
+
+        /// CDS end position (1-based inclusive, in transcript coordinates).
+        ///
+        /// For minus-strand transcripts the sequence is reverse-complemented before
+        /// emission, so the position is relative to the reverse-complemented sequence.
+        #[arg(long)]
+        cds_end: u64,
+
+        /// Output path for transcripts.json.
+        #[arg(long, short = 'o')]
+        output: PathBuf,
+
+        /// Transcript ID (default: FASTA contig name).
+        #[arg(long)]
+        id: Option<String>,
+
+        /// Strand: + or -.
+        #[arg(long, default_value = "+")]
+        strand: String,
+
+        /// Contig name to use when the FASTA has multiple contigs.
+        #[arg(long)]
+        contig: Option<String>,
+
+        /// Optional gene symbol to embed in the transcript record.
+        #[arg(long)]
+        gene: Option<String>,
+
+        /// Genome build name embedded in the output (default: GRCh38).
+        #[arg(long, default_value = "GRCh38")]
+        genome_build: String,
+    },
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -703,6 +751,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             dry_run,
         ),
         Commands::Check { reference } => run_check(&reference),
+        Commands::BuildTranscript {
+            fasta,
+            cds_start,
+            cds_end,
+            output,
+            id,
+            strand,
+            contig,
+            gene,
+            genome_build,
+        } => run_build_transcript(
+            &fasta,
+            cds_start,
+            cds_end,
+            &output,
+            id.as_deref(),
+            &strand,
+            contig.as_deref(),
+            gene.as_deref(),
+            &genome_build,
+        ),
     }
 }
 
@@ -2704,4 +2773,126 @@ fn run_check(reference: &Path) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         Err("Reference data check failed".into())
     }
+}
+
+/// Build a transcripts.json from a FASTA file and CDS coordinates.
+///
+/// Creates a single-exon transcript record directly from a FASTA sequence and
+/// user-supplied CDS start/end positions (in transcript coordinates), without
+/// requiring a GFF3 intermediary. The exon spans the full contig. For plus-strand
+/// transcripts, transcript coordinates equal genomic coordinates; for minus-strand
+/// the sequence is reverse-complemented and the CDS positions are interpreted
+/// against the reverse-complemented (transcript) sequence.
+#[allow(clippy::too_many_arguments)]
+fn run_build_transcript(
+    fasta_path: &PathBuf,
+    cds_start: u64,
+    cds_end: u64,
+    output: &PathBuf,
+    id: Option<&str>,
+    strand: &str,
+    contig: Option<&str>,
+    gene: Option<&str>,
+    genome_build: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let fasta = FastaProvider::new(fasta_path)?;
+
+    // Collect contig names; HashMap iteration order is non-deterministic but we
+    // only need the names to detect single vs. multi-contig.
+    let contig_names: Vec<String> = fasta.sequence_names().cloned().collect();
+
+    let contig_name: String = match (contig, contig_names.as_slice()) {
+        (Some(c), _) => {
+            if !fasta.has_sequence(c) {
+                return Err(format!(
+                    "Contig '{}' not found in FASTA; available: {}",
+                    c,
+                    contig_names.join(", ")
+                )
+                .into());
+            }
+            c.to_string()
+        }
+        (None, [single]) => single.clone(),
+        (None, []) => return Err("FASTA contains no contigs".into()),
+        (None, _) => {
+            return Err(format!(
+                "FASTA has {} contigs; pass --contig to select one (available: {})",
+                contig_names.len(),
+                contig_names.join(", ")
+            )
+            .into())
+        }
+    };
+
+    let contig_length = fasta
+        .sequence_length(&contig_name)
+        .ok_or_else(|| format!("Could not determine length of contig '{}'", contig_name))?;
+
+    // Validate CDS bounds (1-based inclusive)
+    if cds_start < 1 || cds_end < cds_start || cds_end > contig_length {
+        return Err(format!(
+            "Invalid CDS bounds: cds_start={}, cds_end={}, contig length={}",
+            cds_start, cds_end, contig_length
+        )
+        .into());
+    }
+
+    // Parse and validate strand
+    if strand != "+" && strand != "-" {
+        return Err(format!("Invalid strand '{}'; expected + or -", strand).into());
+    }
+
+    // Read the full contig sequence (0-based half-open for get_sequence)
+    use ferro_hgvs::reference::provider::ReferenceProvider;
+    let sequence = fasta.get_sequence(&contig_name, 0, contig_length)?;
+
+    // Reverse-complement for minus-strand transcripts
+    let final_sequence = if strand == "-" {
+        reverse_complement(&sequence)
+    } else {
+        sequence
+    };
+
+    let tx_id = id.unwrap_or(&contig_name).to_string();
+
+    // Build the exon object: single exon spanning the full contig. For a
+    // single-exon synthetic construct, plus-strand transcript coordinates equal
+    // genomic coordinates; for minus-strand the emitted `sequence` is
+    // reverse-complemented and CDS positions are in transcript space.
+    let exon = serde_json::json!({
+        "number": 1,
+        "start": 1_u64,
+        "end": contig_length,
+        "genomic_start": 1_u64,
+        "genomic_end": contig_length,
+    });
+
+    let mut tx_obj = serde_json::json!({
+        "id": tx_id,
+        "strand": strand,
+        "sequence": final_sequence,
+        "cds_start": cds_start,
+        "cds_end": cds_end,
+        "exons": [exon],
+        "chromosome": contig_name,
+        "genomic_start": 1_u64,
+        "genomic_end": contig_length,
+        "genome_build": genome_build,
+    });
+
+    if let Some(g) = gene {
+        tx_obj["gene_symbol"] = serde_json::json!(g);
+    }
+
+    let output_json = serde_json::json!({
+        "version": "1.0",
+        "genome_build": genome_build,
+        "transcripts": [tx_obj],
+    });
+
+    std::fs::write(output, serde_json::to_string_pretty(&output_json)?)?;
+    eprintln!("Wrote 1 transcript ({}) to {}", tx_id, output.display());
+
+    Ok(())
 }

--- a/tests/cli_build_transcript.rs
+++ b/tests/cli_build_transcript.rs
@@ -1,0 +1,146 @@
+//! Integration tests for the `ferro build-transcript` subcommand (#184).
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+/// Write a single-contig FASTA to a temporary file.
+///
+/// Returns the `NamedTempFile` (to keep it alive) and its path.
+fn write_fasta(name: &str, seq: &str) -> (NamedTempFile, std::path::PathBuf) {
+    let mut tf = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
+    writeln!(tf, ">{}", name).unwrap();
+    writeln!(tf, "{}", seq).unwrap();
+    tf.flush().unwrap();
+    let path = tf.path().to_path_buf();
+    (tf, path)
+}
+
+#[test]
+fn build_transcript_emits_valid_json_for_single_exon() {
+    // 60 bp synthetic construct, CDS 1..60.
+    let (_keep, fasta_path) = write_fasta(
+        "construct1",
+        "ATGAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCTAA",
+    );
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out); // close handle so build-transcript can overwrite
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "60",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "build-transcript failed: stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+    assert_eq!(json["version"], "1.0");
+    assert_eq!(json["genome_build"], "GRCh38");
+    let tx = &json["transcripts"][0];
+    assert_eq!(tx["id"], "construct1");
+    assert_eq!(tx["chromosome"], "construct1");
+    assert_eq!(tx["strand"], "+");
+    assert_eq!(tx["cds_start"], 1);
+    assert_eq!(tx["cds_end"], 60);
+    assert_eq!(
+        tx["sequence"],
+        "ATGAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCTAA"
+    );
+    assert_eq!(tx["genomic_start"], 1);
+    assert_eq!(tx["genomic_end"], 60);
+    assert_eq!(tx["exons"][0]["genomic_start"], 1);
+    assert_eq!(tx["exons"][0]["genomic_end"], 60);
+    assert_eq!(tx["exons"][0]["start"], 1);
+    assert_eq!(tx["exons"][0]["end"], 60);
+    assert_eq!(tx["exons"][0]["number"], 1);
+}
+
+#[test]
+fn build_transcript_rejects_cds_beyond_contig() {
+    let (_keep, fasta_path) = write_fasta("small", "ATGAAA");
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "100",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !status.status.success(),
+        "expected failure for CDS beyond contig"
+    );
+}
+
+#[test]
+fn build_transcript_supports_minus_strand_and_custom_id() {
+    let (_keep, fasta_path) = write_fasta("construct2", "ATGAAACCCGGGTTTAAACCCGGGTTTTAA");
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "30",
+            "--strand",
+            "-",
+            "--id",
+            "tx_custom",
+            "--gene",
+            "MYGENE",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "build-transcript failed: stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+    let tx = &json["transcripts"][0];
+    assert_eq!(tx["id"], "tx_custom");
+    assert_eq!(tx["gene_symbol"], "MYGENE");
+    assert_eq!(tx["strand"], "-");
+    // Sequence should be reverse-complemented
+    // Original: ATGAAACCCGGGTTTAAACCCGGGTTTTAA (30 bp)
+    // RC: TTAAAACCCGGGTTTAAACCCGGGTTTCAT
+    assert_eq!(tx["sequence"], "TTAAAACCCGGGTTTAAACCCGGGTTTCAT");
+}


### PR DESCRIPTION
## Summary

Closes #184.

Adds a new \`ferro build-transcript\` subcommand that builds a \`transcripts.json\` directly from a FASTA + CDS coordinates, bypassing the FASTA→BED→GFF3→\`convert-gff\` pipeline for single-exon synthetic constructs (plasmids, reporter genes, custom amplicons) where the user already knows the CDS bounds.

## Usage

```bash
ferro build-transcript \\
    --fasta ref.fasta \\
    --cds-start 100 \\
    --cds-end 1200 \\
    --output transcripts.json
```

Optional flags:
- \`--id <name>\` — override transcript ID (default: FASTA contig name)
- \`--strand +|-\` — default \`+\`; on minus strand the stored sequence is the reverse complement of the FASTA
- \`--contig <name>\` — required if the FASTA has multiple contigs
- \`--gene <name>\` — optional gene symbol
- \`--genome-build <name>\` — default \`GRCh38\`

## Output schema

Matches \`ferro convert-gff\` exactly:

\`\`\`json
{
  \"version\": \"1.0\",
  \"genome_build\": \"GRCh38\",
  \"transcripts\": [
    {
      \"id\": \"construct1\",
      \"chromosome\": \"construct1\",
      \"strand\": \"+\",
      \"sequence\": \"ATG...\",
      \"cds_start\": 100,
      \"cds_end\": 1200,
      \"exons\": [{\"number\": 1, \"start\": 1, \"end\": L, \"genomic_start\": 1, \"genomic_end\": L}],
      \"genomic_start\": 1,
      \"genomic_end\": L,
      \"genome_build\": \"GRCh38\"
    }
  ]
}
\`\`\`

## Validation

- CDS bounds must be 1-based inclusive and contained within the contig.
- Multi-contig FASTAs require \`--contig\` to be explicit (no silent guess).
- Bad strand strings (\`*\`, \`u\`, etc.) are rejected before any work happens.

## Test plan

- [x] \`cargo nextest run --features dev\` — full suite green (+3 new integration tests)
- [x] \`cargo clippy --features dev -- -D warnings\` — clean
- [x] Tests cover: single-exon plus-strand emission, CDS-beyond-contig rejection, minus-strand + custom ID + gene symbol
- [x] Manual: \`ferro build-transcript --help\` shows the new subcommand

## Notes

- Reuses \`FastaProvider\` (auto-builds \`.fai\` if missing) and the existing \`reverse_complement\` helper in \`ferro_hgvs::sequence\`.
- Output JSON shape matches \`convert-gff\`'s exactly so the result is loadable by \`MockProvider::from_json()\` (which after #185 accepts the container metadata keys).