### PR TITLE
feat(project): variant-level projection g. -> c./p. (PR 1: foundation + substitutions)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1425,3 +1425,96 @@ class CoordinateMapper:
     def has_transcript(self, transcript_id: str) -> bool:
         """Check if a transcript exists in the reference."""
         ...
+
+# ============================================================================
+# Variant Projection
+# ============================================================================
+
+class VariantProjection:
+    """The result of projecting a g. variant onto a transcript."""
+
+    @property
+    def g_name(self) -> str:
+        """The normalized g. variant as an HGVS string."""
+        ...
+
+    @property
+    def c_name(self) -> str | None:
+        """The c./n. variant as an HGVS string, or None when projection skipped."""
+        ...
+
+    @property
+    def p_name(self) -> str | None:
+        """The p. variant as an HGVS string, or None for intronic/UTR/non-coding variants."""
+        ...
+
+    @property
+    def transcript_id(self) -> str:
+        """The transcript accession (e.g., "NM_000088.3")."""
+        ...
+
+    @property
+    def gene_symbol(self) -> str | None:
+        """Gene symbol, if available."""
+        ...
+
+    @property
+    def is_frameshift(self) -> bool:
+        """True if the variant causes a frameshift."""
+        ...
+
+    @property
+    def is_intronic(self) -> bool:
+        """True if the variant falls entirely within an intron."""
+        ...
+
+    @property
+    def is_utr(self) -> bool:
+        """True if the variant falls in a UTR."""
+        ...
+
+class VariantProjector:
+    """Projects g. HGVS variants onto transcripts to produce c./p. equivalents."""
+
+    def __init__(
+        self,
+        reference_json: str | None = None,
+        direction: str = "3prime",
+    ) -> None:
+        """Create a variant projector.
+
+        Args:
+            reference_json: Path to a transcripts.json file. If None, uses
+                built-in test data (limited; not for production).
+            direction: Shuffle direction passed to the internal normalizer
+                ("3prime" or "5prime").
+        """
+        ...
+
+    @staticmethod
+    def from_manifest(manifest_path: str, direction: str = "3prime") -> "VariantProjector":
+        """Create a projector from a ferro-prepare manifest.
+
+        Args:
+            manifest_path: Path to manifest.json produced by `ferro prepare`.
+            direction: Shuffle direction ("3prime" or "5prime").
+
+        Returns:
+            A VariantProjector backed by MultiFastaProvider with cdot data.
+        """
+        ...
+
+    def project(self, hgvs_string: str, transcript: str) -> VariantProjection:
+        """Project a g. HGVS string onto a target transcript.
+
+        Args:
+            hgvs_string: A g. HGVS variant string (e.g., "NC_000017.11:g.48275363C>T").
+            transcript: Transcript accession (e.g., "NM_000088.3").
+
+        Returns:
+            VariantProjection with g./c./p. representations and flags.
+
+        Raises:
+            RuntimeError: If parsing or projection fails.
+        """
+        ...

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -12,13 +12,14 @@
 //!
 //! | Field | Basis | Format |
 //! |-------|-------|--------|
-//! | Genomic coordinates (`genome_start`, `genome_end`) | 0-based | Half-open `[start, end)` |
-//! | Transcript coordinates (`tx_start`, `tx_end`) | 1-based | See note below |
+//! | Genomic coordinates (`genome_start`, `genome_end`) | HGVS-value-based | Half-open `[start, end)` where `start` equals the numeric HGVS g. position of the first exonic base |
+//! | Transcript coordinates (`tx_start`, `tx_end`) | 0-based | Half-open `[start, end)` |
 //! | CDS coordinates (`cds_start`, `cds_end`) | 0-based | Half-open `[start, end)` |
 //!
-//! **Note on transcript coordinates**: The cdot format uses 1-based transcript
-//! positions (fixed in commit 944a4e9). This is a common source of bugs when
-//! developers assume all coordinates are 0-based.
+//! **Note on genomic coordinates**: `genome_start` stores the numeric value of the first HGVS
+//! g. position in the exon (e.g., an exon starting at g.1000 has `genome_start = 1000`).
+//! `genome_end` is one past the last HGVS g. position (exclusive). This differs from a
+//! strict 0-based system: an exon at g.1000–g.1008 has `genome_start = 1000, genome_end = 1009`.
 //!
 //! For type-safe coordinate handling, see [`crate::coords`].
 
@@ -36,8 +37,8 @@ use std::path::Path;
 /// cdot transcript alignment data (normalized internal representation).
 ///
 /// # Coordinate Systems
-/// - Genomic: 0-based half-open `[start, end)`
-/// - Transcript (tx_start/tx_end in exons): 1-based
+/// - Genomic: HGVS-value-based half-open `[start, end)` (see module-level docs)
+/// - Transcript (tx_start/tx_end in exons): 0-based half-open `[start, end)`
 /// - CDS: 0-based half-open `[start, end)` in transcript space
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CdotTranscript {
@@ -53,7 +54,7 @@ pub struct CdotTranscript {
     #[serde(deserialize_with = "deserialize_strand")]
     pub strand: Strand,
 
-    /// Exon alignments: [genome_start(0-based), genome_end(0-based excl), tx_start(1-based), tx_end(1-based)].
+    /// Exon alignments: [genome_start(HGVS-val), genome_end(HGVS-val excl), tx_start(0-based), tx_end(0-based excl)].
     pub exons: Vec<[u64; 4]>,
 
     /// Start of CDS in transcript coordinates (0-based, inclusive).
@@ -315,19 +316,25 @@ where
 /// Parsed exon with named fields for clarity.
 ///
 /// # Coordinate Systems
-/// - Genomic coordinates: 0-based half-open `[genome_start, genome_end)`
-/// - Transcript coordinates: 1-based (NOT 0-based - common source of bugs!)
+/// - Genomic coordinates: HGVS-value-based half-open `[genome_start, genome_end)` where
+///   `genome_start` equals the numeric value of the first HGVS g. position in the exon
+///   and `genome_end` is one past the last (exclusive). For example, an exon spanning
+///   g.1000–g.1008 has `genome_start = 1000`, `genome_end = 1009`.
+/// - Transcript coordinates: 0-based half-open `[tx_start, tx_end)` where `tx_start = 0`
+///   for the first base of the transcript. `contains_tx_pos` uses `pos >= tx_start && pos < tx_end`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Exon {
     /// Exon number (1-based).
     pub number: u32,
-    /// Start position in genomic coordinates (0-based, inclusive).
+    /// Start position in genomic coordinates (HGVS-value-based, inclusive).
+    /// Equals the numeric value of the first HGVS g. position in the exon.
     pub genome_start: u64,
-    /// End position in genomic coordinates (0-based, exclusive).
+    /// End position in genomic coordinates (HGVS-value-based, exclusive).
+    /// Equals genome_start + exon_length.
     pub genome_end: u64,
-    /// Start position in transcript coordinates (1-based, inclusive).
+    /// Start position in transcript coordinates (0-based, inclusive).
     pub tx_start: u64,
-    /// End position in transcript coordinates (1-based, exclusive for range).
+    /// End position in transcript coordinates (0-based, exclusive).
     pub tx_end: u64,
 }
 
@@ -761,47 +768,87 @@ impl CdotMapper {
     }
 
     /// Build a `CdotMapper` from in-memory `Transcript` records (typically loaded into a
-    /// `MockProvider`). Converts the 1-based `Transcript` coordinates to the 0-based half-open
-    /// form expected by `CdotTranscript`.
+    /// `MockProvider`). Converts the 1-based `Transcript` coordinates into the form expected
+    /// by `CdotTranscript`.
     ///
     /// # Coordinate conversions
     ///
-    /// | Transcript field | Basis | CdotTranscript field | Basis |
-    /// |-----------------|-------|----------------------|-------|
-    /// | `Exon.genomic_start` | 1-based inclusive | `exons[][0]` (genome_start) | 0-based |
-    /// | `Exon.genomic_end` | 1-based inclusive | `exons[][1]` (genome_end) | 0-based exclusive |
-    /// | `Exon.start` | 1-based tx | `exons[][2]` (tx_start) | 1-based |
-    /// | `Exon.end` | 1-based tx | `exons[][3]` (tx_end) | 1-based |
-    /// | `cds_start` | 1-based tx | `cds_start` | 0-based |
-    /// | `cds_end` | 1-based tx inclusive | `cds_end` | 0-based exclusive |
+    /// `Transcript.Exon` fields are documented as 1-based inclusive (see
+    /// `src/reference/transcript.rs`). `CdotTranscript` exon arrays use:
+    /// - `exons[][0]` (genome_start): HGVS-value-based — the numeric value of the first
+    ///   HGVS g. position in the exon. Conversion: `genome_start = Exon.genomic_start` (no change).
+    /// - `exons[][1]` (genome_end): exclusive, equals `Exon.genomic_end + 1`.
+    /// - `exons[][2]` (tx_start): 0-based. Conversion: `tx_start = Exon.start - 1`.
+    /// - `exons[][3]` (tx_end): 0-based exclusive. Same numeric value as `Exon.end` (1-based
+    ///   inclusive end equals 0-based exclusive end).
+    /// - `cds_start`: 0-based. Conversion: `cds_start = Transcript.cds_start - 1`.
+    /// - `cds_end`: 0-based exclusive. Same numeric value as `Transcript.cds_end`.
+    ///
+    /// Defaults to GRCh38 for contig alias resolution (so `chr17` ↔ `NC_000017.11`
+    /// works after construction). Use [`from_transcripts_with_build`] to specify a
+    /// different genome build.
     pub fn from_transcripts<'a, I>(transcripts: I) -> Self
+    where
+        I: IntoIterator<Item = &'a crate::reference::transcript::Transcript>,
+    {
+        Self::from_transcripts_with_build(transcripts, "GRCh38")
+    }
+
+    /// Like [`from_transcripts`], but uses `genome_build` (e.g. "GRCh37" or
+    /// "GRCh38") for contig alias resolution.
+    ///
+    /// Transcripts with missing or inconsistent coordinates are skipped with a
+    /// `log::warn!`, rather than silently coerced to bogus intervals. A transcript
+    /// must have a chromosome and, for every exon, all of: `genomic_start`,
+    /// `genomic_end >= genomic_start`, `start >= 1` (1-based), `end >= start`.
+    pub fn from_transcripts_with_build<'a, I>(transcripts: I, genome_build: &str) -> Self
     where
         I: IntoIterator<Item = &'a crate::reference::transcript::Transcript>,
     {
         let mut mapper = Self::new();
         for tx in transcripts {
-            let contig = tx.chromosome.clone().unwrap_or_default();
-            let exons: Vec<[u64; 4]> = tx
-                .exons
-                .iter()
-                .map(|e| {
-                    // genome_start: 1-based inclusive → 0-based
-                    let g_start = e.genomic_start.map(|s| s.saturating_sub(1)).unwrap_or(0);
-                    // genome_end: 1-based inclusive → 0-based exclusive (same value)
-                    let g_end = e.genomic_end.unwrap_or(0);
-                    // tx_start/tx_end: already 1-based — used directly in CdotTranscript
-                    let t_start = e.start;
-                    let t_end = e.end;
-                    [g_start, g_end, t_start, t_end]
-                })
-                .collect();
+            let Some(contig) = tx.chromosome.clone() else {
+                log::warn!("Skipping transcript {}: missing chromosome", tx.id);
+                continue;
+            };
+            let mut exons: Vec<[u64; 4]> = Vec::with_capacity(tx.exons.len());
+            let mut valid = true;
+            for e in &tx.exons {
+                // Require both genomic bounds and a non-empty, well-ordered interval
+                // on both the transcript and genomic axes; 1-based `start == 0` is
+                // invalid input and we refuse to silently turn it into `tx_start = 0`.
+                let (Some(g_start), Some(g_end_inclusive)) = (e.genomic_start, e.genomic_end)
+                else {
+                    valid = false;
+                    break;
+                };
+                let Some(t_start) = e.start.checked_sub(1) else {
+                    valid = false;
+                    break;
+                };
+                if e.end < e.start || g_end_inclusive < g_start {
+                    valid = false;
+                    break;
+                }
+                // genome_end: 1-based inclusive → exclusive (add 1).
+                // tx_end: 1-based inclusive end equals 0-based exclusive end numerically.
+                exons.push([g_start, g_end_inclusive + 1, t_start, e.end]);
+            }
+            if !valid || exons.is_empty() {
+                log::warn!(
+                    "Skipping transcript {}: incomplete or inconsistent exon coordinates",
+                    tx.id
+                );
+                continue;
+            }
             let cdot_tx = CdotTranscript {
                 gene_name: tx.gene_symbol.clone(),
                 contig,
                 strand: tx.strand,
                 exons,
-                // cds_start: 1-based tx → 0-based
-                cds_start: tx.cds_start.map(|c| c.saturating_sub(1)),
+                // cds_start: 1-based tx → 0-based. Use `checked_sub` so a stray `Some(0)`
+                // becomes `None` rather than wrapping to a giant `u64`.
+                cds_start: tx.cds_start.and_then(|c| c.checked_sub(1)),
                 // cds_end: 1-based tx inclusive → 0-based exclusive (same value)
                 cds_end: tx.cds_end,
                 gene_id: None,
@@ -810,6 +857,7 @@ impl CdotMapper {
             };
             mapper.add_transcript(tx.id.clone(), cdot_tx);
         }
+        mapper.populate_contig_aliases(genome_build);
         mapper
     }
 
@@ -1502,6 +1550,248 @@ mod tests {
         assert_eq!(tx.exons.len(), 1);
         assert_eq!(tx.exons[0][0], 48263025); // genome_start
         assert_eq!(tx.exons[0][1], 48263098); // genome_end
+    }
+
+    #[test]
+    fn test_from_transcripts_populates_contig_aliases_grch38() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        let tx = Transcript {
+            id: "NM_000088.3".to_string(),
+            gene_symbol: Some("COL1A1".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(11),
+            cds_end: Some(60),
+            exons: vec![Exon::with_genomic(1, 1, 73, 50184096, 50184168)],
+            chromosome: Some("NC_000017.11".to_string()),
+            genomic_start: Some(50184096),
+            genomic_end: Some(50184168),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+
+        // Canonical RefSeq lookup works.
+        assert_eq!(mapper.transcripts_on_contig("NC_000017.11").len(), 1);
+        // UCSC alias resolution (default GRCh38).
+        assert_eq!(mapper.transcripts_on_contig("chr17").len(), 1);
+        // Ensembl alias resolution.
+        assert_eq!(mapper.transcripts_on_contig("17").len(), 1);
+    }
+
+    #[test]
+    fn test_from_transcripts_with_build_grch37_aliases() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        let tx = Transcript {
+            id: "NM_000088.3".to_string(),
+            gene_symbol: Some("COL1A1".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(11),
+            cds_end: Some(60),
+            exons: vec![Exon::with_genomic(1, 1, 73, 48263025, 48263097)],
+            chromosome: Some("NC_000017.10".to_string()),
+            genomic_start: Some(48263025),
+            genomic_end: Some(48263097),
+            genome_build: GenomeBuild::GRCh37,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts_with_build(std::iter::once(&tx), "GRCh37");
+
+        assert_eq!(mapper.transcripts_on_contig("NC_000017.10").len(), 1);
+        assert_eq!(mapper.transcripts_on_contig("chr17").len(), 1);
+        assert_eq!(mapper.transcripts_on_contig("17").len(), 1);
+    }
+
+    #[test]
+    fn test_from_transcripts_skips_missing_chromosome() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        let tx = Transcript {
+            id: "NM_NOCHR.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+            chromosome: None, // ← missing chromosome
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+        assert_eq!(
+            mapper.transcript_count(),
+            0,
+            "transcript with no chromosome must be skipped, not silently coerced"
+        );
+    }
+
+    #[test]
+    fn test_from_transcripts_skips_exon_missing_genomic_coords() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        // Exon::new(...) leaves genomic_start/genomic_end as None.
+        let tx = Transcript {
+            id: "NM_NOGENOMIC.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::new(1, 1, 9)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+        assert_eq!(
+            mapper.transcript_count(),
+            0,
+            "transcript with exon missing genomic coords must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_from_transcripts_skips_exon_with_zero_start() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        // Exon.start is documented as 1-based; 0 is invalid. We must NOT
+        // silently coerce it to tx_start = 0 (it would collide with a real
+        // first exon and break downstream coordinate math).
+        let tx = Transcript {
+            id: "NM_ZEROSTART.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::with_genomic(1, 0, 9, 1000, 1008)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+        assert_eq!(
+            mapper.transcript_count(),
+            0,
+            "transcript with 1-based start=0 must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_from_transcripts_skips_inverted_exon() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        // end < start on either axis is invalid (empty or inverted interval).
+        let tx = Transcript {
+            id: "NM_INVERTED.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            // Genomic end (1000) < genomic start (1008).
+            exons: vec![Exon::with_genomic(1, 1, 9, 1008, 1000)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+        assert_eq!(
+            mapper.transcript_count(),
+            0,
+            "transcript with inverted exon genomic interval must be skipped"
+        );
+    }
+
+    #[test]
+    fn test_from_transcripts_cds_start_zero_yields_none() {
+        use crate::reference::transcript::{Exon, ManeStatus, Transcript};
+        use crate::reference::Strand as TxStrand;
+        use std::sync::OnceLock;
+
+        // tx.cds_start is documented as 1-based; if upstream feeds Some(0)
+        // we should yield None instead of wrapping to u64::MAX via saturating_sub.
+        let tx = Transcript {
+            id: "NM_CDSZERO.1".to_string(),
+            gene_symbol: Some("X".to_string()),
+            strand: TxStrand::Plus,
+            sequence: None,
+            cds_start: Some(0),
+            cds_end: Some(9),
+            exons: vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: GenomeBuild::GRCh38,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mapper = CdotMapper::from_transcripts(std::iter::once(&tx));
+        let stored = mapper
+            .get_transcript("NM_CDSZERO.1")
+            .expect("transcript should be present (exon coords are valid)");
+        assert_eq!(
+            stored.cds_start, None,
+            "cds_start=Some(0) must become None, not a wrapped u64"
+        );
     }
 
     #[test]

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -760,6 +760,59 @@ impl CdotMapper {
         }
     }
 
+    /// Build a `CdotMapper` from in-memory `Transcript` records (typically loaded into a
+    /// `MockProvider`). Converts the 1-based `Transcript` coordinates to the 0-based half-open
+    /// form expected by `CdotTranscript`.
+    ///
+    /// # Coordinate conversions
+    ///
+    /// | Transcript field | Basis | CdotTranscript field | Basis |
+    /// |-----------------|-------|----------------------|-------|
+    /// | `Exon.genomic_start` | 1-based inclusive | `exons[][0]` (genome_start) | 0-based |
+    /// | `Exon.genomic_end` | 1-based inclusive | `exons[][1]` (genome_end) | 0-based exclusive |
+    /// | `Exon.start` | 1-based tx | `exons[][2]` (tx_start) | 1-based |
+    /// | `Exon.end` | 1-based tx | `exons[][3]` (tx_end) | 1-based |
+    /// | `cds_start` | 1-based tx | `cds_start` | 0-based |
+    /// | `cds_end` | 1-based tx inclusive | `cds_end` | 0-based exclusive |
+    pub fn from_transcripts<'a, I>(transcripts: I) -> Self
+    where
+        I: IntoIterator<Item = &'a crate::reference::transcript::Transcript>,
+    {
+        let mut mapper = Self::new();
+        for tx in transcripts {
+            let contig = tx.chromosome.clone().unwrap_or_default();
+            let exons: Vec<[u64; 4]> = tx
+                .exons
+                .iter()
+                .map(|e| {
+                    // genome_start: 1-based inclusive → 0-based
+                    let g_start = e.genomic_start.map(|s| s.saturating_sub(1)).unwrap_or(0);
+                    // genome_end: 1-based inclusive → 0-based exclusive (same value)
+                    let g_end = e.genomic_end.unwrap_or(0);
+                    // tx_start/tx_end: already 1-based — used directly in CdotTranscript
+                    let t_start = e.start;
+                    let t_end = e.end;
+                    [g_start, g_end, t_start, t_end]
+                })
+                .collect();
+            let cdot_tx = CdotTranscript {
+                gene_name: tx.gene_symbol.clone(),
+                contig,
+                strand: tx.strand,
+                exons,
+                // cds_start: 1-based tx → 0-based
+                cds_start: tx.cds_start.map(|c| c.saturating_sub(1)),
+                // cds_end: 1-based tx inclusive → 0-based exclusive (same value)
+                cds_end: tx.cds_end,
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            };
+            mapper.add_transcript(tx.id.clone(), cdot_tx);
+        }
+        mapper
+    }
+
     /// Load from a cdot JSON file.
     pub fn from_json_file<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
         let file = File::open(path.as_ref()).map_err(|e| FerroError::Io {

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,8 @@ pub enum ErrorCode {
     IntronicVariant = 4001,
     /// Unsupported variant type
     UnsupportedVariant = 4002,
+    /// Unsupported projection between coordinate systems
+    UnsupportedProjection = 4003,
 
     // Conversion errors (E5xxx)
     /// Coordinate conversion failed
@@ -103,6 +105,7 @@ impl ErrorCode {
             ErrorCode::SelfCancellingAllele => "self-cancelling allele (overlapping del+dup)",
             ErrorCode::IntronicVariant => "intronic variant not supported",
             ErrorCode::UnsupportedVariant => "unsupported variant type",
+            ErrorCode::UnsupportedProjection => "unsupported projection between coordinate systems",
             ErrorCode::ConversionFailed => "coordinate conversion failed",
             ErrorCode::NoOverlappingTranscript => "no overlapping transcript",
             ErrorCode::IoError => "file I/O error",
@@ -331,6 +334,21 @@ pub enum FerroError {
     #[error("Coordinate conversion error: {msg}")]
     ConversionError { msg: String },
 
+    /// Variant does not overlap the requested transcript
+    #[error("variant does not overlap transcript {transcript_id}: {variant}")]
+    TranscriptNotOverlapping {
+        variant: String,
+        transcript_id: String,
+    },
+
+    /// Protein sequence is not available for the given accession
+    #[error("protein sequence unavailable for accession {accession}")]
+    ProteinSequenceUnavailable { accession: String },
+
+    /// Projection between the requested coordinate systems is not supported
+    #[error("unsupported projection: {reason}")]
+    UnsupportedProjection { reason: String },
+
     /// IO error (for file operations)
     #[error("IO error: {msg}")]
     Io { msg: String },
@@ -378,6 +396,9 @@ impl FerroError {
             FerroError::IntronicVariant { .. } => Some(ErrorCode::IntronicVariant),
             FerroError::ReferenceMismatch { .. } => Some(ErrorCode::ReferenceMismatch),
             FerroError::ConversionError { .. } => Some(ErrorCode::ConversionFailed),
+            FerroError::TranscriptNotOverlapping { .. } => Some(ErrorCode::NoOverlappingTranscript),
+            FerroError::ProteinSequenceUnavailable { .. } => Some(ErrorCode::SequenceNotFound),
+            FerroError::UnsupportedProjection { .. } => Some(ErrorCode::UnsupportedProjection),
             FerroError::Io { .. } => Some(ErrorCode::IoError),
             FerroError::Json { .. } => Some(ErrorCode::JsonError),
             _ => None,
@@ -741,6 +762,22 @@ mod tests {
             msg: "json error".to_string(),
         };
         assert_eq!(err.code(), Some(ErrorCode::JsonError));
+
+        let err = FerroError::TranscriptNotOverlapping {
+            variant: "chr1:g.5000A>G".to_string(),
+            transcript_id: "NM_TEST.1".to_string(),
+        };
+        assert_eq!(err.code(), Some(ErrorCode::NoOverlappingTranscript));
+
+        let err = FerroError::ProteinSequenceUnavailable {
+            accession: "NP_TEST.1".to_string(),
+        };
+        assert_eq!(err.code(), Some(ErrorCode::SequenceNotFound));
+
+        let err = FerroError::UnsupportedProjection {
+            reason: "g. → r. not supported".to_string(),
+        };
+        assert_eq!(err.code(), Some(ErrorCode::UnsupportedProjection));
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1437,6 +1437,16 @@ impl fmt::Display for RnaFusionVariant {
     }
 }
 
+/// Check if a variant causes a frameshift (net indel length not divisible by 3).
+///
+/// Returns false if the indel length is 0 or cannot be determined.
+pub fn is_frameshift(variant: &HgvsVariant) -> bool {
+    match crate::python_helpers::get_indel_length(variant) {
+        Some(len) if len != 0 => len % 3 != 0,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod normalize;
 #[cfg(feature = "parallel")]
 pub mod parallel;
 pub mod prepare;
+pub mod project;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod python_helpers;
@@ -65,6 +66,7 @@ pub use error::FerroError;
 pub use hgvs::parser::{parse_hgvs, parse_hgvs_fast};
 pub use hgvs::variant::HgvsVariant;
 pub use normalize::{NormalizeConfig, Normalizer, ShuffleDirection};
+pub use project::{VariantProjection, VariantProjector};
 pub use reference::{MockProvider, MultiFastaProvider, ReferenceProvider};
 pub use spdi::{
     hgvs_to_spdi_simple, parse_spdi, spdi_to_hgvs, spdi_to_hgvs_with_ref, ConversionError,

--- a/src/project/accession.rs
+++ b/src/project/accession.rs
@@ -1,0 +1,46 @@
+//! Shared `Accession` parsing for transcript and protein identifiers.
+
+use crate::hgvs::variant::Accession;
+
+/// Parse an HGVS-style accession string like "NM_000088.3" or "NP_000079.2".
+///
+/// Accepts:
+/// - "PREFIX_NUMBER.VERSION" (e.g. `NM_000088.3` → prefix `NM`, number `000088`, version `Some(3)`)
+/// - "PREFIX_NUMBER" (no version)
+/// - Anything else (e.g. Ensembl-style `ENSP00000256509`): pass through as the prefix with empty number.
+pub(crate) fn parse_accession(s: &str) -> Accession {
+    if let Some((prefix_num, version)) = s.rsplit_once('.') {
+        if let Ok(v) = version.parse::<u32>() {
+            if let Some((prefix, number)) = prefix_num.split_once('_') {
+                return Accession::new(prefix, number, Some(v));
+            }
+        }
+    }
+    if let Some((prefix, number)) = s.split_once('_') {
+        return Accession::new(prefix, number, None);
+    }
+    Accession::new(s, "", None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_nm_with_version() {
+        let acc = parse_accession("NM_000088.3");
+        assert_eq!(acc.to_string(), "NM_000088.3");
+    }
+
+    #[test]
+    fn parse_np_with_version() {
+        let acc = parse_accession("NP_000079.2");
+        assert_eq!(acc.to_string(), "NP_000079.2");
+    }
+
+    #[test]
+    fn parse_without_version() {
+        let acc = parse_accession("NM_000088");
+        assert_eq!(acc.to_string(), "NM_000088");
+    }
+}

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -1,6 +1,6 @@
 //! Strand-aware transformation of `NaEdit` from g. to c./n.
 
-use crate::hgvs::edit::{Base, NaEdit, Sequence};
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
 use crate::reference::Strand;
 
 /// Transform a g.-coordinate edit into the equivalent edit on the transcript strand.
@@ -8,10 +8,99 @@ use crate::reference::Strand;
 /// On the plus strand, the edit is returned unchanged. On the minus strand, the
 /// ref/alt bases (and any embedded sequences) are reverse-complemented so the
 /// resulting edit reads correctly on the transcript's sense strand.
+#[allow(dead_code)] // TODO(issue-200): called from projector in Task 7
 pub(crate) fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
-    // Implementation comes next (Task 4).
-    let _ = strand;
-    edit.clone()
+    if strand == Strand::Plus {
+        return edit.clone();
+    }
+    match edit {
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => NaEdit::Substitution {
+            reference: complement_base(*reference),
+            alternative: complement_base(*alternative),
+        },
+        NaEdit::SubstitutionNoRef { alternative } => NaEdit::SubstitutionNoRef {
+            alternative: complement_base(*alternative),
+        },
+        NaEdit::Deletion { sequence, length } => NaEdit::Deletion {
+            sequence: sequence.as_ref().map(revcomp_sequence),
+            length: *length,
+        },
+        NaEdit::Insertion { sequence } => NaEdit::Insertion {
+            sequence: revcomp_inserted(sequence),
+        },
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => NaEdit::Delins {
+            sequence: revcomp_inserted(sequence),
+            deleted: deleted.as_ref().map(revcomp_sequence),
+            deleted_length: *deleted_length,
+        },
+        NaEdit::Duplication {
+            sequence,
+            length,
+            uncertain_extent,
+        } => NaEdit::Duplication {
+            sequence: sequence.as_ref().map(revcomp_sequence),
+            length: *length,
+            uncertain_extent: uncertain_extent.clone(),
+        },
+        NaEdit::DupIns { sequence } => NaEdit::DupIns {
+            sequence: revcomp_inserted(sequence),
+        },
+        NaEdit::Inversion { sequence, length } => NaEdit::Inversion {
+            sequence: sequence.as_ref().map(revcomp_sequence),
+            length: *length,
+        },
+        // Identity, Unknown, Conversion, Repeat, MultiRepeat, Methylation, CopyNumber,
+        // Splice, NoProduct, PositionOnly: no revcomp needed at the edit level.
+        other => other.clone(),
+    }
+}
+
+/// Complement a single IUPAC base (no reversal — reversal is handled by revcomp_sequence).
+fn complement_base(b: Base) -> Base {
+    match b {
+        Base::A => Base::T,
+        Base::T => Base::A,
+        Base::G => Base::C,
+        Base::C => Base::G,
+        Base::U => Base::A,
+        Base::R => Base::Y,
+        Base::Y => Base::R,
+        Base::S => Base::S,
+        Base::W => Base::W,
+        Base::K => Base::M,
+        Base::M => Base::K,
+        Base::B => Base::V,
+        Base::V => Base::B,
+        Base::D => Base::H,
+        Base::H => Base::D,
+        Base::N => Base::N,
+    }
+}
+
+/// Reverse-complement a `Sequence` value.
+fn revcomp_sequence(s: &Sequence) -> Sequence {
+    use crate::sequence::reverse_complement;
+    reverse_complement(&s.to_string())
+        .parse()
+        .expect("reverse_complement produces only valid IUPAC bases")
+}
+
+/// Reverse-complement an `InsertedSequence`, handling only the `Literal` variant.
+///
+/// For non-literal variants (counts, ranges, repeats, named elements, etc.)
+/// there is no embedded sequence to revcomp, so they are cloned unchanged.
+fn revcomp_inserted(ins: &InsertedSequence) -> InsertedSequence {
+    match ins {
+        InsertedSequence::Literal(seq) => InsertedSequence::Literal(revcomp_sequence(seq)),
+        other => other.clone(),
+    }
 }
 
 #[cfg(test)]

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -1,1 +1,142 @@
 //! Strand-aware transformation of `NaEdit` from g. to c./n.
+
+use crate::hgvs::edit::{Base, NaEdit, Sequence};
+use crate::reference::Strand;
+
+/// Transform a g.-coordinate edit into the equivalent edit on the transcript strand.
+///
+/// On the plus strand, the edit is returned unchanged. On the minus strand, the
+/// ref/alt bases (and any embedded sequences) are reverse-complemented so the
+/// resulting edit reads correctly on the transcript's sense strand.
+pub(crate) fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
+    // Implementation comes next (Task 4).
+    let _ = strand;
+    edit.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::edit::{InsertedSequence, NaEdit, Sequence};
+    use crate::reference::Strand;
+
+    fn seq(s: &str) -> Sequence {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn substitution_plus_strand_unchanged() {
+        let edit = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        };
+        assert_eq!(transform_edit_for_strand(&edit, Strand::Plus), edit);
+    }
+
+    #[test]
+    fn substitution_minus_strand_revcomps() {
+        let edit = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        };
+        assert_eq!(
+            transform_edit_for_strand(&edit, Strand::Minus),
+            NaEdit::Substitution {
+                reference: Base::T,
+                alternative: Base::C
+            }
+        );
+    }
+
+    #[test]
+    fn deletion_minus_strand_revcomps_sequence() {
+        let edit = NaEdit::Deletion {
+            sequence: Some(seq("ATG")),
+            length: None,
+        };
+        assert_eq!(
+            transform_edit_for_strand(&edit, Strand::Minus),
+            NaEdit::Deletion {
+                sequence: Some(seq("CAT")),
+                length: None
+            }
+        );
+    }
+
+    #[test]
+    fn insertion_minus_strand_revcomps_sequence() {
+        // InsertedSequence::Literal is the correct variant for literal sequences.
+        let edit = NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(seq("ATG")),
+        };
+        let out = transform_edit_for_strand(&edit, Strand::Minus);
+        assert!(
+            out.to_string().contains("CAT"),
+            "expected revcomp 'CAT' in display, got {}",
+            out
+        );
+    }
+
+    #[test]
+    fn delins_minus_strand_revcomps_both() {
+        // Plus-strand delATGinsCC → minus-strand del(revcomp ATG = CAT) ins(revcomp CC = GG).
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(seq("CC")),
+            deleted: Some(seq("ATG")),
+            deleted_length: None,
+        };
+        let out = transform_edit_for_strand(&edit, Strand::Minus);
+        let s = out.to_string();
+        assert!(
+            s.contains("CAT"),
+            "expected deleted 'CAT' in display, got {}",
+            s
+        );
+        assert!(
+            s.contains("GG"),
+            "expected inserted 'GG' in display, got {}",
+            s
+        );
+    }
+
+    #[test]
+    fn duplication_minus_strand_revcomps_sequence() {
+        let edit = NaEdit::Duplication {
+            sequence: Some(seq("ATG")),
+            length: None,
+            uncertain_extent: None,
+        };
+        let out = transform_edit_for_strand(&edit, Strand::Minus);
+        let s = out.to_string();
+        assert!(
+            s.contains("CAT"),
+            "expected revcomp 'CAT' in dup display, got {}",
+            s
+        );
+    }
+
+    #[test]
+    fn inversion_minus_strand_length_unchanged() {
+        // Length-only inversions don't carry sequence — should be returned as-is.
+        let edit = NaEdit::Inversion {
+            sequence: None,
+            length: Some(5),
+        };
+        assert_eq!(transform_edit_for_strand(&edit, Strand::Minus), edit);
+    }
+
+    #[test]
+    fn inversion_minus_strand_revcomps_sequence() {
+        let edit = NaEdit::Inversion {
+            sequence: Some(seq("ATG")),
+            length: None,
+        };
+        let out = transform_edit_for_strand(&edit, Strand::Minus);
+        let s = out.to_string();
+        assert!(
+            s.contains("CAT"),
+            "expected revcomp 'CAT' in inv display, got {}",
+            s
+        );
+    }
+}

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -1,0 +1,1 @@
+//! Strand-aware transformation of `NaEdit` from g. to c./n.

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -8,7 +8,6 @@ use crate::reference::Strand;
 /// On the plus strand, the edit is returned unchanged. On the minus strand, the
 /// ref/alt bases (and any embedded sequences) are reverse-complemented so the
 /// resulting edit reads correctly on the transcript's sense strand.
-#[allow(dead_code)] // TODO(issue-200): called from projector in Task 7
 pub(crate) fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
     if strand == Strand::Plus {
         return edit.clone();

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,5 +1,6 @@
 //! Variant-level projection: g. variants → c./p. equivalents on a target transcript.
 
+mod accession;
 mod edit;
 mod projector;
 mod protein;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,0 +1,9 @@
+//! Variant-level projection: g. variants → c./p. equivalents on a target transcript.
+
+mod edit;
+mod projector;
+mod protein;
+mod result;
+
+pub use projector::VariantProjector;
+pub use result::VariantProjection;

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -400,6 +400,84 @@ mod tests {
         assert!(!result.is_utr);
     }
 
+    fn make_intronic_test_data() -> (Projector, MockProvider) {
+        // Two-exon coding transcript on chr1, plus strand.
+        //
+        //   Exon 1: genome [1000, 1010), tx [0, 10)  — 10 bp
+        //   Intron: genome [1010, 2000)               — 990 bp
+        //   Exon 2: genome [2000, 2010), tx [10, 20) — 10 bp (last 2 are pad)
+        //
+        // CDS: tx [0, 18) → 18 bp → 6 codons: ATG-CGC-AAA-GGG-TAA-CCC
+        //   (Met-Arg-Lys-Gly-Stop-Pro)
+        //
+        // Test position g.1015 is in the intron, 6 bases after the end of exon 1
+        // (exon 1 ends at genome 1010, exclusive; last exonic base is g.1009;
+        //  distance = 1015-1010+1 = 6).  Maps to c.9+6 or c.10+6 depending on
+        // whether tx_end is inclusive or exclusive in the boundary calculation.
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_INTR.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("INTRGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                exons: vec![[1000, 1010, 0, 10], [2000, 2010, 10, 20]],
+                cds_start: Some(0),
+                cds_end: Some(18),
+                gene_id: None,
+                protein: Some("NP_INTR.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_INTR.1".to_string(),
+            gene_symbol: Some("INTRGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some("ATGCGCAAAGGGTAACCC".to_string()), // 18 bp
+            cds_start: Some(1),
+            cds_end: Some(18),
+            exons: vec![Exon::new(1, 1, 10), Exon::new(2, 11, 20)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(2009),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let exon1 = "ATGCGCAAAG"; // 10 bp (genomic positions 1000..1009)
+        let intron = "N".repeat(990); // genomic positions 1010..1999 (990 bp)
+        let exon2 = "GGTAACCCNN"; // 10 bp pad (genomic positions 2000..2009)
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{prefix}{exon1}{intron}{exon2}{suffix}"));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_intronic_substitution_no_protein() {
+        let (projector, provider) = make_intronic_test_data();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1015 is 6 positions into the intron after exon 1 (which ends at genome
+        // position 1009 inclusive / 1010 exclusive).
+        let result = vp
+            .project("NC_000001.11:g.1015A>G", "NM_INTR.1")
+            .expect("intronic substitution should project to c. with offset");
+        assert!(result.is_intronic, "expected is_intronic=true");
+        assert!(result.protein.is_none(), "no p. for intronic substitutions");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(
+            c.contains('+'),
+            "expected intronic offset notation (e.g. c.9+6 or c.10+6), got: {}",
+            c
+        );
+    }
+
     #[test]
     fn project_substitution_plus_strand_missense() {
         let (projector, provider) = make_test_provider_and_projector();

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -299,6 +299,107 @@ mod tests {
         (projector, provider)
     }
 
+    fn make_minus_strand_provider_and_projector() -> (Projector, MockProvider) {
+        // Same 9bp CDS on chr1, but transcript is on the minus strand.
+        //
+        // Plus-strand chr1:1000..1008 reads "TTAGCGCAT".  The minus-strand
+        // transcript reads the complement strand from g.1008 backwards to
+        // g.1000, giving CDS "ATGCGCTAA" (Met-Arg-Stop).
+        //
+        // cdot coordinate convention (matches make_test_provider_and_projector):
+        //   exons:     [genome_start(0-based), genome_end(0-based excl), tx_start, tx_end]
+        //   cds_start: 0-based tx position of first CDS base
+        //   cds_end:   0-based tx position one-past the last CDS base
+        //
+        // Minus-strand mapping (genome_to_tx for Minus):
+        //   offset = genome_end - 1 - genome_pos
+        //   tx_pos = tx_start + offset
+        //
+        //   g.1008 → offset = 1009-1-1008 = 0 → tx_pos 0 (c.1, 'A')
+        //   g.1007 → offset = 1 → tx_pos 1 (c.2, 'T')
+        //   g.1005 → offset = 3 → tx_pos 3 → tx_to_cds(3, cds_start=0) = 4 → c.4
+        //
+        // Variant: g.1005G>A on the plus strand.
+        //   The plus-strand base at g.1005 is 'G' (stated; actual byte is 'C'
+        //   — but for substitutions the normalizer trusts the stated ref).
+        //   After transform_edit_for_strand(Minus): G>A → revcomp → C>T.
+        //   c.4 of "ATGCGCTAA" is 'C' (first base of codon 2 "CGC" = Arg).
+        //   C>T → "TGC" = Cys.  Protein: p.(Arg2Cys).
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_TEST_MINUS.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Minus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: Some("NP_TEST_MINUS.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_TEST_MINUS.1".to_string(),
+            gene_symbol: Some("TESTGENE".to_string()),
+            strand: TxStrand::Minus,
+            sequence: Some("ATGCGCTAA".to_string()), // CDS as the transcript reads it
+            cds_start: Some(1),                      // 1-based inclusive per Transcript convention
+            cds_end: Some(9),
+            exons: vec![Exon::new(1, 1, 9)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        // Plus-strand sequence on chr1 (not needed for substitution normalization,
+        // provided for completeness).
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{}TTAGCGCAT{}", prefix, suffix));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_substitution_minus_strand_revcomps_ref_alt() {
+        let (projector, provider) = make_minus_strand_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1005G>A: plus-strand G at position 1005.
+        // Minus-strand transcript maps this to c.4 and revcomps G>A → C>T.
+        // Codon 2 "CGC" (Arg) → "TGC" (Cys) = missense.
+        let result = vp
+            .project("chr1:g.1005G>A", "NM_TEST_MINUS.1")
+            .expect("minus-strand projection should succeed");
+        let c = result
+            .coding
+            .as_ref()
+            .expect("c. should be present")
+            .to_string();
+        assert!(
+            c.contains(":c.4C>T"),
+            "expected revcomp c.4C>T for minus strand, got: {}",
+            c
+        );
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present")
+            .to_string();
+        assert_eq!(p, "NP_TEST_MINUS.1(TESTGENE):p.(Arg2Cys)");
+        assert!(!result.is_frameshift);
+        assert!(!result.is_intronic);
+        assert!(!result.is_utr);
+    }
+
     #[test]
     fn project_substitution_plus_strand_missense() {
         let (projector, provider) = make_test_provider_and_projector();

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1,48 +1,335 @@
 //! `VariantProjector` orchestrator.
 
+use crate::data::mapping::MappingInfo;
 use crate::data::projection::Projector;
 use crate::error::FerroError;
-use crate::hgvs::variant::HgvsVariant;
-use crate::normalize::NormalizeConfig;
+use crate::hgvs::edit::NaEdit;
+use crate::hgvs::interval::{CdsInterval, TxInterval};
+use crate::hgvs::location::{CdsPos, GenomePos, TxPos};
+use crate::hgvs::variant::{is_frameshift, CdsVariant, HgvsVariant, LocEdit, TxVariant};
+use crate::normalize::{NormalizeConfig, Normalizer};
+use crate::project::accession::parse_accession;
+use crate::project::edit::transform_edit_for_strand;
+use crate::project::protein::predict_substitution_protein;
 use crate::project::result::VariantProjection;
 use crate::reference::ReferenceProvider;
 
-#[allow(dead_code)] // TODO(issue-200): fields used in Task 7
 pub struct VariantProjector<P: ReferenceProvider + Clone> {
     projector: Projector,
     provider: P,
-    normalize_config: NormalizeConfig,
+    normalizer: Normalizer<P>,
 }
 
 impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     pub fn new(projector: Projector, provider: P) -> Self {
+        let normalizer = Normalizer::with_config(provider.clone(), NormalizeConfig::default());
         Self {
             projector,
             provider,
-            normalize_config: NormalizeConfig::default(),
+            normalizer,
         }
     }
 
     pub fn with_normalize_config(mut self, config: NormalizeConfig) -> Self {
-        self.normalize_config = config;
+        self.normalizer = Normalizer::with_config(self.provider.clone(), config);
         self
-    }
-
-    /// Project an HGVS variant onto a transcript. (Stub — implemented in later task.)
-    pub fn project_variant(
-        &self,
-        _variant: &HgvsVariant,
-        _transcript_id: &str,
-    ) -> Result<VariantProjection, FerroError> {
-        todo!("project_variant not yet implemented")
     }
 
     /// Parse, normalize, and project an HGVS string onto a transcript.
     pub fn project(
         &self,
-        _hgvs_string: &str,
-        _transcript_id: &str,
+        hgvs_string: &str,
+        transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
-        todo!("project not yet implemented")
+        let variant = crate::parse_hgvs(hgvs_string)?;
+        self.project_variant(&variant, transcript_id)
+    }
+
+    /// Normalize and project an already-parsed g. variant onto a transcript.
+    pub fn project_variant(
+        &self,
+        variant: &HgvsVariant,
+        transcript_id: &str,
+    ) -> Result<VariantProjection, FerroError> {
+        // 1. Normalize the genomic variant. The normalizer is built once at
+        // construction time so we don't clone the (potentially heavy) provider
+        // on every call.
+        let normalized = self.normalizer.normalize(variant)?;
+
+        // 2. Require a g. variant for now.
+        let genome_variant = match &normalized {
+            HgvsVariant::Genome(g) => g.clone(),
+            _ => {
+                return Err(FerroError::UnsupportedProjection {
+                    reason: "VariantProjector currently only accepts g. variants".to_string(),
+                });
+            }
+        };
+
+        let edit = genome_variant
+            .loc_edit
+            .edit
+            .inner()
+            .cloned()
+            .ok_or_else(|| FerroError::UnsupportedProjection {
+                reason: "g. variant has no concrete edit".to_string(),
+            })?;
+
+        // 3. Look up the transcript in the cdot mapper.
+        let cdot_tx = self
+            .projector
+            .mapper()
+            .cdot()
+            .get_transcript(transcript_id)
+            .ok_or_else(|| FerroError::ReferenceNotFound {
+                id: transcript_id.to_string(),
+            })?;
+        let strand = cdot_tx.strand;
+        let gene_symbol = cdot_tx.gene_name.clone();
+        let cdot_protein = cdot_tx.protein.clone();
+        let is_coding = cdot_tx.cds_start.is_some();
+
+        // 4. Extract start and end genomic positions from the variant interval.
+        let g_start = genome_variant
+            .loc_edit
+            .location
+            .start
+            .inner()
+            .cloned()
+            .ok_or_else(|| FerroError::InvalidCoordinates {
+                msg: "genomic interval start is unknown".to_string(),
+            })?;
+        let g_end = genome_variant
+            .loc_edit
+            .location
+            .end
+            .inner()
+            .cloned()
+            .ok_or_else(|| FerroError::InvalidCoordinates {
+                msg: "genomic interval end is unknown".to_string(),
+            })?;
+
+        let mapper = self.projector.mapper();
+        let normalized_str = normalized.to_string();
+
+        // We map start and end positions independently rather than calling
+        // CoordinateMapper::genome_interval_to_cds because the latter discards
+        // the end position's MappingInfo (only start_info is propagated for the
+        // is_intronic / in_5utr / in_3utr flags). For a range variant that crosses
+        // an exon-intron boundary, we want is_intronic=true when EITHER end is
+        // intronic, which requires both MappingInfos. The strand swap is otherwise
+        // equivalent to what genome_interval_to_cds does internally.
+        // Helper: map one GenomePos → CdsPos, converting out-of-range errors to
+        // TranscriptNotOverlapping.
+        let map_position = |gp: &GenomePos| -> Result<(CdsPos, MappingInfo), FerroError> {
+            match mapper.genome_to_cds(transcript_id, gp) {
+                Ok(res) => Ok((res.variant, res.info)),
+                Err(FerroError::InvalidCoordinates { .. })
+                | Err(FerroError::ConversionError { .. }) => {
+                    Err(FerroError::TranscriptNotOverlapping {
+                        variant: normalized_str.clone(),
+                        transcript_id: transcript_id.to_string(),
+                    })
+                }
+                Err(other) => Err(other),
+            }
+        };
+
+        let (cds_start_raw, info_start) = map_position(&g_start)?;
+        let (cds_end_raw, info_end) = map_position(&g_end)?;
+
+        // On minus strand the start and end of the c. interval are swapped
+        // relative to the g. interval (transcript reads in the opposite direction).
+        let (cds_start, cds_end) = match strand {
+            crate::reference::Strand::Plus => (cds_start_raw, cds_end_raw),
+            crate::reference::Strand::Minus => (cds_end_raw, cds_start_raw),
+            crate::reference::Strand::Unknown => {
+                return Err(FerroError::UnsupportedProjection {
+                    reason: format!(
+                        "transcript {} has unknown strand; cannot project g. → c./n.",
+                        transcript_id
+                    ),
+                });
+            }
+        };
+
+        // 5. Transform the edit for the transcript strand.
+        let c_edit = transform_edit_for_strand(&edit, strand);
+
+        // 6. Build the c./n. HGVS variant.
+        let coding = if is_coding {
+            let interval = CdsInterval::new(cds_start, cds_end);
+            HgvsVariant::Cds(CdsVariant {
+                accession: parse_accession(transcript_id),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(interval, c_edit.clone()),
+            })
+        } else {
+            // Non-coding transcript: report as n. using transcript positions.
+            // CdsPos.base is signed; for non-coding it acts as the tx position.
+            let tx_start = TxPos::new(cds_start.base);
+            let tx_end = TxPos::new(cds_end.base);
+            HgvsVariant::Tx(TxVariant {
+                accession: parse_accession(transcript_id),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(TxInterval::new(tx_start, tx_end), c_edit.clone()),
+            })
+        };
+
+        // 7. Derive per-position flags from MappingInfo.
+        let is_intronic = info_start.is_intronic || info_end.is_intronic;
+        let is_utr = !is_intronic
+            && (info_start.in_5utr || info_start.in_3utr || info_end.in_5utr || info_end.in_3utr);
+
+        // 8. Predict protein consequence for CDS substitutions.
+        let mut protein = None;
+        if !is_intronic && !is_utr && is_coding && matches!(c_edit, NaEdit::Substitution { .. }) {
+            // Prefer the explicit cdot.protein accession; otherwise infer NP_/XP_
+            // from NM_/XM_ by stripping the prefix (not by substring replace, which
+            // would mangle accessions whose suffix happens to contain "NM_"). If
+            // we cannot infer a protein accession, skip protein prediction rather
+            // than fabricate a bogus one.
+            let prot_acc = match cdot_protein {
+                Some(p) => Some(p),
+                None => transcript_id
+                    .strip_prefix("NM_")
+                    .map(|rest| format!("NP_{rest}"))
+                    .or_else(|| {
+                        transcript_id
+                            .strip_prefix("XM_")
+                            .map(|rest| format!("XP_{rest}"))
+                    }),
+            };
+            if let Some(prot_acc) = prot_acc {
+                let tx_for_codon = self.provider.get_transcript(transcript_id)?;
+                protein = Some(predict_substitution_protein(
+                    &tx_for_codon,
+                    cds_start.base,
+                    &c_edit,
+                    &prot_acc,
+                )?);
+            }
+        }
+
+        let frameshift = is_frameshift(&coding);
+        Ok(VariantProjection {
+            genomic: normalized.clone(),
+            coding: Some(coding),
+            protein,
+            transcript_id: transcript_id.to_string(),
+            gene_symbol,
+            is_frameshift: frameshift,
+            is_intronic,
+            is_utr,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::cdot::{CdotMapper, CdotTranscript};
+    use crate::data::projection::Projector;
+    use crate::reference::mock::MockProvider;
+    use crate::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+    use crate::reference::Strand as ProvStrand;
+    use std::sync::OnceLock;
+
+    fn make_test_provider_and_projector() -> (Projector, MockProvider) {
+        // A single coding transcript on chr1, plus strand.
+        //
+        // Genomic layout (cdot 0-based coords):
+        //   Exon: genome [1000, 1009), tx [0, 9), so 9 bases total.
+        //   cds_start = 0 (0-based, no 5'UTR), cds_end = 9.
+        //
+        // Sequence: "ATGCGCTAA" = Met-Arg-Stop (3 codons).
+        //
+        // Coordinate mapping (cdot genome 0-based → HGVS c. 1-based):
+        //   g.1000 → tx_pos=0 → c.1 (A = first base of Met)
+        //   g.1001 → tx_pos=1 → c.2 (T)
+        //   g.1002 → tx_pos=2 → c.3 (G)
+        //   g.1003 → tx_pos=3 → c.4 (C ← ref base for test substitution)
+        //   g.1004 → tx_pos=4 → c.5 (G)
+        //   ...
+        //
+        // c.4C>A: codon 2 CGC (Arg) → AGC (Ser), missense.
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_TEST.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                // [genome_start(0-based), genome_end(0-based excl), tx_start(1-based), tx_end(1-based)]
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0), // 0-based: CDS starts at tx_pos 0 (no 5'UTR)
+                cds_end: Some(9),   // 0-based exclusive: CDS ends at tx_pos 9
+                gene_id: None,
+                protein: Some("NP_TEST.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        // Transcript: sequence "ATGCGCTAA", cds_start=1 (1-based, first base).
+        provider.add_transcript(Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: Some("TESTGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some("ATGCGCTAA".to_string()),
+            cds_start: Some(1), // 1-based inclusive per Transcript convention
+            cds_end: Some(9),
+            exons: vec![Exon::new(1, 1, 9)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        // Genomic sequence: 999 N's + "ATGCGCTAA" + 100 N's.
+        // At 0-based index 999 = 'A' (g.1000), ..., 0-based index 1002 = 'C' (g.1003).
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{}{}{}", prefix, "ATGCGCTAA", suffix));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_substitution_plus_strand_missense() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+
+        // g.1003 is the 4th base of the exon (0-based index 3 in "ATGCGCTAA" = 'C').
+        // HGVS: g.1003C>A (cdot 0-based genome coord 1003 → tx_pos 3 → c.4).
+        // CDS codon 2: CGC (Arg). Frame 0 substitution C>A → AGC (Ser) = missense.
+        let result = vp
+            .project("chr1:g.1003C>A", "NM_TEST.1")
+            .expect("projection should succeed");
+
+        assert_eq!(result.transcript_id, "NM_TEST.1");
+        assert_eq!(result.gene_symbol.as_deref(), Some("TESTGENE"));
+
+        let c = result
+            .coding
+            .as_ref()
+            .expect("c. should be present")
+            .to_string();
+        assert!(c.contains(":c.4C>A"), "expected ':c.4C>A' in '{}' ", c);
+
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present")
+            .to_string();
+        assert_eq!(p, "NP_TEST.1(TESTGENE):p.(Arg2Ser)");
+
+        assert!(!result.is_frameshift);
+        assert!(!result.is_intronic);
+        assert!(!result.is_utr);
     }
 }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1,0 +1,48 @@
+//! `VariantProjector` orchestrator.
+
+use crate::data::projection::Projector;
+use crate::error::FerroError;
+use crate::hgvs::variant::HgvsVariant;
+use crate::normalize::NormalizeConfig;
+use crate::project::result::VariantProjection;
+use crate::reference::ReferenceProvider;
+
+#[allow(dead_code)] // TODO(issue-200): fields used in Task 7
+pub struct VariantProjector<P: ReferenceProvider + Clone> {
+    projector: Projector,
+    provider: P,
+    normalize_config: NormalizeConfig,
+}
+
+impl<P: ReferenceProvider + Clone> VariantProjector<P> {
+    pub fn new(projector: Projector, provider: P) -> Self {
+        Self {
+            projector,
+            provider,
+            normalize_config: NormalizeConfig::default(),
+        }
+    }
+
+    pub fn with_normalize_config(mut self, config: NormalizeConfig) -> Self {
+        self.normalize_config = config;
+        self
+    }
+
+    /// Project an HGVS variant onto a transcript. (Stub — implemented in later task.)
+    pub fn project_variant(
+        &self,
+        _variant: &HgvsVariant,
+        _transcript_id: &str,
+    ) -> Result<VariantProjection, FerroError> {
+        todo!("project_variant not yet implemented")
+    }
+
+    /// Parse, normalize, and project an HGVS string onto a transcript.
+    pub fn project(
+        &self,
+        _hgvs_string: &str,
+        _transcript_id: &str,
+    ) -> Result<VariantProjection, FerroError> {
+        todo!("project not yet implemented")
+    }
+}

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -554,4 +554,157 @@ mod tests {
         assert!(!result.is_intronic);
         assert!(!result.is_utr);
     }
+
+    #[test]
+    fn project_single_base_deletion_is_frameshift() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1004del deletes a single base — net change -1 → frameshift.
+        let result = vp
+            .project("NC_000001.11:g.1004del", "NM_TEST.1")
+            .expect("deletion should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains(":c."), "expected c. variant, got: {}", c);
+        assert!(c.contains("del"), "expected del notation in c., got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(result.is_frameshift, "1-base del should be frameshift");
+        assert!(!result.is_intronic);
+    }
+
+    #[test]
+    fn project_three_base_deletion_in_frame() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1003_1005del deletes 3 bases — in-frame.
+        let result = vp
+            .project("NC_000001.11:g.1003_1005del", "NM_TEST.1")
+            .expect("3-base del should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains("del"), "expected del notation, got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(!result.is_frameshift, "3-base deletion is in-frame");
+    }
+
+    #[test]
+    fn project_single_base_insertion_is_frameshift() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1003_1004insA inserts one base — frameshift.
+        let result = vp
+            .project("NC_000001.11:g.1003_1004insA", "NM_TEST.1")
+            .expect("insertion should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains("ins"), "expected ins notation, got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(result.is_frameshift, "1-base insertion is frameshift");
+    }
+
+    #[test]
+    fn project_duplication() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1004dup duplicates a single base — frameshift.
+        let result = vp
+            .project("NC_000001.11:g.1004dup", "NM_TEST.1")
+            .expect("dup should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains("dup"), "expected dup notation, got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(result.is_frameshift, "1-base dup is frameshift");
+    }
+
+    #[test]
+    fn project_delins() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1003_1004delinsAT — replace 2 bases with 2 bases → not a frameshift.
+        let result = vp
+            .project("NC_000001.11:g.1003_1004delinsAT", "NM_TEST.1")
+            .expect("delins should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains("delins"), "expected delins notation, got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(
+            !result.is_frameshift,
+            "delins of equal length is not a frameshift"
+        );
+    }
+
+    #[test]
+    fn project_inversion() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1003_1005inv — inversion preserves length → not a frameshift.
+        let result = vp
+            .project("NC_000001.11:g.1003_1005inv", "NM_TEST.1")
+            .expect("inv should project");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains("inv"), "expected inv notation, got: {}", c);
+        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(!result.is_frameshift, "inversion is not a frameshift");
+    }
+
+    fn make_ensembl_provider_and_projector() -> (Projector, MockProvider) {
+        // Same CDS as make_test_provider_and_projector but the transcript ID is
+        // an Ensembl accession (no NM_/XM_ prefix) and cdot.protein is absent.
+        // The projector must NOT fabricate a bogus protein accession via
+        // substring substitution; it should skip protein prediction instead.
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "ENST00000000001.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "ENST00000000001.1".to_string(),
+            gene_symbol: Some("TESTGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some("ATGCGCTAA".to_string()),
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::new(1, 1, 9)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{}{}{}", prefix, "ATGCGCTAA", suffix));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_substitution_no_protein_accession_skips_protein() {
+        let (projector, provider) = make_ensembl_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "ENST00000000001.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. expected").to_string();
+        assert!(c.contains(":c.4C>A"), "expected c.4C>A, got: {}", c);
+        // Neither NM_/XM_ prefix nor cdot.protein: must skip protein prediction.
+        assert!(
+            result.protein.is_none(),
+            "expected no protein for accession with no NM_/XM_ prefix and no cdot.protein, got: {:?}",
+            result.protein
+        );
+    }
 }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -112,6 +112,21 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let mapper = self.projector.mapper();
         let normalized_str = normalized.to_string();
 
+        // Compute the overall genomic extent of the transcript from its exons.
+        // Exon format: [genome_start(0-based), genome_end(0-based excl), tx_start, tx_end].
+        // The transcript's genomic extent is [min(genome_start), max(genome_end)) — 0-based half-open.
+        let (tx_genome_start, tx_genome_end) = {
+            let exons = &cdot_tx.exons;
+            if exons.is_empty() {
+                return Err(FerroError::ReferenceNotFound {
+                    id: transcript_id.to_string(),
+                });
+            }
+            let starts = exons.iter().map(|e| e[0]).min().unwrap();
+            let ends = exons.iter().map(|e| e[1]).max().unwrap();
+            (starts, ends)
+        };
+
         // We map start and end positions independently rather than calling
         // CoordinateMapper::genome_interval_to_cds because the latter discards
         // the end position's MappingInfo (only start_info is propagated for the
@@ -122,6 +137,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // Helper: map one GenomePos → CdsPos, converting out-of-range errors to
         // TranscriptNotOverlapping.
         let map_position = |gp: &GenomePos| -> Result<(CdsPos, MappingInfo), FerroError> {
+            // Check whether the position falls within the transcript's overall genomic
+            // extent before calling genome_to_cds.  genome_to_cds uses intronic
+            // arithmetic to handle positions between exons, so it will happily return
+            // a large offset for a position that is completely outside the transcript.
+            // Exon bounds are 0-based half-open [genome_start, genome_end), so a
+            // position is outside when it is before the first exon's start or at/after
+            // the last exon's end.
+            if gp.base < tx_genome_start || gp.base >= tx_genome_end {
+                return Err(FerroError::TranscriptNotOverlapping {
+                    variant: normalized_str.clone(),
+                    transcript_id: transcript_id.to_string(),
+                });
+            }
             match mapper.genome_to_cds(transcript_id, gp) {
                 Ok(res) => Ok((res.variant, res.info)),
                 Err(FerroError::InvalidCoordinates { .. })
@@ -475,6 +503,21 @@ mod tests {
             c.contains('+'),
             "expected intronic offset notation (e.g. c.9+6 or c.10+6), got: {}",
             c
+        );
+    }
+
+    #[test]
+    fn project_no_overlap_returns_transcript_not_overlapping() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // chr1:5000 is far outside the transcript at 1000..1009.
+        let err = vp
+            .project("NC_000001.11:g.5000A>G", "NM_TEST.1")
+            .expect_err("should fail to project outside the transcript");
+        assert!(
+            matches!(err, FerroError::TranscriptNotOverlapping { .. }),
+            "expected TranscriptNotOverlapping, got: {:?}",
+            err
         );
     }
 

--- a/src/project/protein.rs
+++ b/src/project/protein.rs
@@ -2,15 +2,16 @@
 
 use crate::backtranslate::{Codon, CodonTable};
 use crate::error::FerroError;
-use crate::hgvs::edit::Base;
-use crate::hgvs::location::AminoAcid;
+use crate::hgvs::edit::{Base, NaEdit, ProteinEdit};
+use crate::hgvs::interval::ProtInterval;
+use crate::hgvs::location::{AminoAcid, ProtPos};
+use crate::hgvs::variant::{Accession, HgvsVariant, LocEdit, ProteinVariant};
 use crate::reference::transcript::Transcript;
 
 /// Read the codon (3 bases) covering a given CDS position from a transcript's CDS sequence.
 ///
 /// Returns the codon bases (uppercase) plus the 0/1/2 frame index (which base
 /// within the codon the CDS position corresponds to).
-#[allow(dead_code)] // TODO(issue-200): used in Task 6
 pub(crate) fn read_ref_codon(
     transcript: &Transcript,
     cds_pos: i64,
@@ -63,7 +64,6 @@ pub(crate) fn read_ref_codon(
 }
 
 /// Apply a single-base substitution to a codon at the given 0/1/2 frame index.
-#[allow(dead_code)] // TODO(issue-200): used in Task 6
 pub(crate) fn apply_substitution(codon: &str, frame: u8, alt: Base) -> String {
     let mut bytes = codon.as_bytes().to_vec();
     bytes[frame as usize] = alt.to_u8();
@@ -72,7 +72,6 @@ pub(crate) fn apply_substitution(codon: &str, frame: u8, alt: Base) -> String {
 
 /// Translate a 3-character codon to an `AminoAcid`. Returns `Some(Ter)` for stop codons,
 /// `Some(Xaa)` if the codon is unrecognized; `None` only if the input is not 3 ASCII bases.
-#[allow(dead_code)] // TODO(issue-200): used in Task 6
 pub(crate) fn translate(codon: &str) -> Option<AminoAcid> {
     let parsed = Codon::parse(codon)?;
     let table = CodonTable::standard();
@@ -80,6 +79,75 @@ pub(crate) fn translate(codon: &str) -> Option<AminoAcid> {
         return Some(AminoAcid::Ter);
     }
     Some(*table.amino_acid_for(&parsed).unwrap_or(&AminoAcid::Xaa))
+}
+
+/// Build a predicted `p.(...)` ProteinVariant for a CDS substitution.
+///
+/// Returns `Err(ProteinSequenceUnavailable)` if the transcript's CDS sequence
+/// cannot supply the codon at `cds_pos`. Returns `Err(UnsupportedProjection)`
+/// if `edit` is not a `NaEdit::Substitution`.
+#[allow(dead_code)] // TODO(issue-200): used in Task 7
+pub(crate) fn predict_substitution_protein(
+    transcript: &Transcript,
+    cds_pos: i64,
+    edit: &NaEdit,
+    protein_accession: &str,
+) -> Result<HgvsVariant, FerroError> {
+    let alt = match edit {
+        NaEdit::Substitution { alternative, .. } => *alternative,
+        _ => {
+            return Err(FerroError::UnsupportedProjection {
+                reason: "predict_substitution_protein called with non-substitution edit"
+                    .to_string(),
+            })
+        }
+    };
+    let (ref_codon, frame) = read_ref_codon(transcript, cds_pos)?;
+    let alt_codon = apply_substitution(&ref_codon, frame, alt);
+    let ref_aa = translate(&ref_codon).unwrap_or(AminoAcid::Xaa);
+    let alt_aa = translate(&alt_codon).unwrap_or(AminoAcid::Xaa);
+    let aa_number = ((cds_pos - 1) / 3 + 1) as u64;
+
+    // For the identity case, use predicted: false — the outer Mu::Uncertain wrapper
+    // (from LocEdit::new_predicted) already provides the p.(...) predicted wrapping.
+    // Using predicted: true here would produce double parens: p.(Arg1(=)).
+    let protein_edit = if ref_aa == alt_aa {
+        ProteinEdit::Identity {
+            predicted: false,
+            whole_protein: false,
+        }
+    } else {
+        ProteinEdit::Substitution {
+            reference: ref_aa,
+            alternative: alt_aa,
+        }
+    };
+
+    let accession = parse_protein_accession(protein_accession);
+    let loc = ProtInterval::point(ProtPos::new(ref_aa, aa_number));
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+fn parse_protein_accession(s: &str) -> Accession {
+    // Format: PREFIX_NUMBER.VERSION (e.g. "NP_000288.1") or PREFIX_NUMBER.
+    // For Ensembl-style accessions like "ENSP00000256509" there is no underscore;
+    // pass them through with the whole string as the prefix.
+    if let Some((prefix_num, version)) = s.rsplit_once('.') {
+        if let Ok(v) = version.parse::<u32>() {
+            if let Some((prefix, number)) = prefix_num.split_once('_') {
+                return Accession::new(prefix, number, Some(v));
+            }
+        }
+    }
+    if let Some((prefix, number)) = s.split_once('_') {
+        return Accession::new(prefix, number, None);
+    }
+    Accession::new(s, "", None)
 }
 
 #[cfg(test)]
@@ -168,5 +236,53 @@ mod tests {
         assert_eq!(translate("TAA"), Some(AminoAcid::Ter));
         assert_eq!(translate("CGG"), Some(AminoAcid::Arg));
         assert_eq!(translate("GGG"), Some(AminoAcid::Gly));
+    }
+
+    #[test]
+    fn substitution_missense_arg_to_gly() {
+        // CDS "CGGGGG": codon 1 = CGG = Arg. c.1C>G → codon 1 = GGG = Gly.
+        let tx = tx_with_seq("CGGGGG", 1, 6);
+        let edit = NaEdit::Substitution {
+            reference: Base::C,
+            alternative: Base::G,
+        };
+        let pv = predict_substitution_protein(&tx, 1, &edit, "NP_000288.1").unwrap();
+        let s = match &pv {
+            HgvsVariant::Protein(p) => p.to_string(),
+            _ => panic!("expected Protein variant"),
+        };
+        assert_eq!(s, "NP_000288.1:p.(Arg1Gly)");
+    }
+
+    #[test]
+    fn substitution_synonymous_arg_arg() {
+        // CGG (Arg) → CGC (Arg). Frame 2 of codon 1, alt C.
+        let tx = tx_with_seq("CGGGGG", 1, 6);
+        let edit = NaEdit::Substitution {
+            reference: Base::G,
+            alternative: Base::C,
+        };
+        let pv = predict_substitution_protein(&tx, 3, &edit, "NP_000288.1").unwrap();
+        let s = match &pv {
+            HgvsVariant::Protein(p) => p.to_string(),
+            _ => panic!("expected Protein variant"),
+        };
+        assert_eq!(s, "NP_000288.1:p.(Arg1=)");
+    }
+
+    #[test]
+    fn substitution_nonsense_arg_ter() {
+        // CGA (Arg) → TGA (Ter). Frame 0 of codon 1, alt T.
+        let tx = tx_with_seq("CGAAAA", 1, 6);
+        let edit = NaEdit::Substitution {
+            reference: Base::C,
+            alternative: Base::T,
+        };
+        let pv = predict_substitution_protein(&tx, 1, &edit, "NP_000288.1").unwrap();
+        let s = match &pv {
+            HgvsVariant::Protein(p) => p.to_string(),
+            _ => panic!("expected Protein variant"),
+        };
+        assert_eq!(s, "NP_000288.1:p.(Arg1Ter)");
     }
 }

--- a/src/project/protein.rs
+++ b/src/project/protein.rs
@@ -5,7 +5,8 @@ use crate::error::FerroError;
 use crate::hgvs::edit::{Base, NaEdit, ProteinEdit};
 use crate::hgvs::interval::ProtInterval;
 use crate::hgvs::location::{AminoAcid, ProtPos};
-use crate::hgvs::variant::{Accession, HgvsVariant, LocEdit, ProteinVariant};
+use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
+use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
 
 /// Read the codon (3 bases) covering a given CDS position from a transcript's CDS sequence.
@@ -86,7 +87,6 @@ pub(crate) fn translate(codon: &str) -> Option<AminoAcid> {
 /// Returns `Err(ProteinSequenceUnavailable)` if the transcript's CDS sequence
 /// cannot supply the codon at `cds_pos`. Returns `Err(UnsupportedProjection)`
 /// if `edit` is not a `NaEdit::Substitution`.
-#[allow(dead_code)] // TODO(issue-200): used in Task 7
 pub(crate) fn predict_substitution_protein(
     transcript: &Transcript,
     cds_pos: i64,
@@ -123,7 +123,7 @@ pub(crate) fn predict_substitution_protein(
         }
     };
 
-    let accession = parse_protein_accession(protein_accession);
+    let accession = parse_accession(protein_accession);
     let loc = ProtInterval::point(ProtPos::new(ref_aa, aa_number));
     let variant = ProteinVariant {
         accession,
@@ -131,23 +131,6 @@ pub(crate) fn predict_substitution_protein(
         loc_edit: LocEdit::new_predicted(loc, protein_edit),
     };
     Ok(HgvsVariant::Protein(variant))
-}
-
-fn parse_protein_accession(s: &str) -> Accession {
-    // Format: PREFIX_NUMBER.VERSION (e.g. "NP_000288.1") or PREFIX_NUMBER.
-    // For Ensembl-style accessions like "ENSP00000256509" there is no underscore;
-    // pass them through with the whole string as the prefix.
-    if let Some((prefix_num, version)) = s.rsplit_once('.') {
-        if let Ok(v) = version.parse::<u32>() {
-            if let Some((prefix, number)) = prefix_num.split_once('_') {
-                return Accession::new(prefix, number, Some(v));
-            }
-        }
-    }
-    if let Some((prefix, number)) = s.split_once('_') {
-        return Accession::new(prefix, number, None);
-    }
-    Accession::new(s, "", None)
 }
 
 #[cfg(test)]

--- a/src/project/protein.rs
+++ b/src/project/protein.rs
@@ -1,0 +1,1 @@
+//! Protein consequence prediction for substitutions in the CDS.

--- a/src/project/protein.rs
+++ b/src/project/protein.rs
@@ -1,1 +1,172 @@
 //! Protein consequence prediction for substitutions in the CDS.
+
+use crate::backtranslate::{Codon, CodonTable};
+use crate::error::FerroError;
+use crate::hgvs::edit::Base;
+use crate::hgvs::location::AminoAcid;
+use crate::reference::transcript::Transcript;
+
+/// Read the codon (3 bases) covering a given CDS position from a transcript's CDS sequence.
+///
+/// Returns the codon bases (uppercase) plus the 0/1/2 frame index (which base
+/// within the codon the CDS position corresponds to).
+#[allow(dead_code)] // TODO(issue-200): used in Task 6
+pub(crate) fn read_ref_codon(
+    transcript: &Transcript,
+    cds_pos: i64,
+) -> Result<(String, u8), FerroError> {
+    let cds_start = transcript
+        .cds_start
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS", transcript.id),
+        })?;
+    let cds_end = transcript
+        .cds_end
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS", transcript.id),
+        })?;
+    if cds_pos < 1 {
+        return Err(FerroError::ConversionError {
+            msg: format!("CDS position {} is not in the CDS", cds_pos),
+        });
+    }
+    // Transcript.cds_start/cds_end are 1-based inclusive transcript positions
+    // (see `src/reference/transcript.rs`), so the CDS spans cds_end - cds_start + 1
+    // bases and cds_pos is bounded by that length.
+    let cds_len = cds_end.saturating_sub(cds_start) + 1;
+    if (cds_pos as u64) > cds_len {
+        return Err(FerroError::ConversionError {
+            msg: format!(
+                "CDS position {} is outside the CDS of transcript {} (length {})",
+                cds_pos, transcript.id, cds_len
+            ),
+        });
+    }
+    let codon_index = ((cds_pos - 1) / 3) as u64;
+    let frame = ((cds_pos - 1) % 3) as u8;
+
+    let tx_offset = (cds_start as i64 - 1 + codon_index as i64 * 3) as usize;
+    let seq =
+        transcript
+            .sequence
+            .as_deref()
+            .ok_or_else(|| FerroError::ProteinSequenceUnavailable {
+                accession: transcript.id.clone(),
+            })?;
+    if tx_offset + 3 > seq.len() {
+        return Err(FerroError::ProteinSequenceUnavailable {
+            accession: transcript.id.clone(),
+        });
+    }
+    let codon = seq[tx_offset..tx_offset + 3].to_uppercase();
+    Ok((codon, frame))
+}
+
+/// Apply a single-base substitution to a codon at the given 0/1/2 frame index.
+#[allow(dead_code)] // TODO(issue-200): used in Task 6
+pub(crate) fn apply_substitution(codon: &str, frame: u8, alt: Base) -> String {
+    let mut bytes = codon.as_bytes().to_vec();
+    bytes[frame as usize] = alt.to_u8();
+    String::from_utf8(bytes).expect("alt base is ASCII")
+}
+
+/// Translate a 3-character codon to an `AminoAcid`. Returns `Some(Ter)` for stop codons,
+/// `Some(Xaa)` if the codon is unrecognized; `None` only if the input is not 3 ASCII bases.
+#[allow(dead_code)] // TODO(issue-200): used in Task 6
+pub(crate) fn translate(codon: &str) -> Option<AminoAcid> {
+    let parsed = Codon::parse(codon)?;
+    let table = CodonTable::standard();
+    if table.is_stop(&parsed) {
+        return Some(AminoAcid::Ter);
+    }
+    Some(*table.amino_acid_for(&parsed).unwrap_or(&AminoAcid::Xaa))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reference::transcript::{Exon, ManeStatus, Strand};
+    use std::sync::OnceLock;
+
+    fn tx_with_seq(seq: &str, cds_start: u64, cds_end: u64) -> Transcript {
+        Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: Some(seq.to_string()),
+            cds_start: Some(cds_start),
+            cds_end: Some(cds_end),
+            exons: vec![Exon::new(1, 1, seq.len() as u64)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn read_ref_codon_first_codon_first_base() {
+        // 5' UTR "AA" + CDS "ATGCCCTAG" (Met-Pro-Stop). cds_start=3 (1-based).
+        let tx = tx_with_seq("AAATGCCCTAG", 3, 11);
+        let (codon, frame) = read_ref_codon(&tx, 1).unwrap();
+        assert_eq!(codon, "ATG");
+        assert_eq!(frame, 0);
+    }
+
+    #[test]
+    fn read_ref_codon_second_codon_middle_base() {
+        let tx = tx_with_seq("AAATGCCCTAG", 3, 11);
+        let (codon, frame) = read_ref_codon(&tx, 5).unwrap();
+        assert_eq!(codon, "CCC");
+        assert_eq!(frame, 1);
+    }
+
+    #[test]
+    fn read_ref_codon_rejects_pos_below_one() {
+        let tx = tx_with_seq("AAATGCCCTAG", 3, 11);
+        let err = read_ref_codon(&tx, 0).expect_err("cds_pos < 1 must error");
+        assert!(matches!(err, FerroError::ConversionError { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn read_ref_codon_rejects_pos_past_cds_end() {
+        // CDS spans c.1..c.9 (cds_start=3, cds_end=11; CDS length = 11 - 3 + 1 = 9).
+        let tx = tx_with_seq("AAATGCCCTAG", 3, 11);
+        // c.9 is the last CDS position and still valid.
+        assert!(read_ref_codon(&tx, 9).is_ok());
+        // c.10 is past cds_end → must error rather than read 3'UTR bytes.
+        let err = read_ref_codon(&tx, 10).expect_err("cds_pos past cds_end must error");
+        match &err {
+            FerroError::ConversionError { msg } => {
+                assert!(
+                    msg.contains("outside the CDS"),
+                    "expected message to mention 'outside the CDS', got: {msg}"
+                );
+            }
+            other => panic!("expected ConversionError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_substitution_first_base() {
+        assert_eq!(apply_substitution("ATG", 0, Base::C), "CTG");
+    }
+
+    #[test]
+    fn apply_substitution_middle_base() {
+        assert_eq!(apply_substitution("ATG", 1, Base::A), "AAG");
+    }
+
+    #[test]
+    fn translate_known_codons() {
+        assert_eq!(translate("ATG"), Some(AminoAcid::Met));
+        assert_eq!(translate("TAA"), Some(AminoAcid::Ter));
+        assert_eq!(translate("CGG"), Some(AminoAcid::Arg));
+        assert_eq!(translate("GGG"), Some(AminoAcid::Gly));
+    }
+}

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -1,0 +1,16 @@
+//! `VariantProjection` result type.
+
+use crate::hgvs::variant::HgvsVariant;
+
+/// The result of projecting a g. variant onto a transcript.
+#[derive(Debug, Clone)]
+pub struct VariantProjection {
+    pub genomic: HgvsVariant,
+    pub coding: Option<HgvsVariant>,
+    pub protein: Option<HgvsVariant>,
+    pub transcript_id: String,
+    pub gene_symbol: Option<String>,
+    pub is_frameshift: bool,
+    pub is_intronic: bool,
+    pub is_utr: bool,
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -126,6 +126,19 @@ impl PyProvider {
     fn test_data() -> Self {
         PyProvider::Mock(MockProvider::with_test_data())
     }
+
+    /// Build / extract a CdotMapper for this provider.
+    fn cdot_mapper(&self) -> crate::data::cdot::CdotMapper {
+        match self {
+            PyProvider::Mock(p) => {
+                crate::data::cdot::CdotMapper::from_transcripts(p.all_transcripts())
+            }
+            PyProvider::MultiFasta(p) => p
+                .cdot_mapper()
+                .cloned()
+                .unwrap_or_else(crate::data::cdot::CdotMapper::new),
+        }
+    }
 }
 
 /// Parse an HGVS variant string
@@ -525,6 +538,126 @@ impl PyNormalizer {
             .map_err(|e| PyRuntimeError::new_err(format!("Normalization error: {}", e)))?;
 
         Ok(normalized.to_string())
+    }
+}
+
+// ============================================================================
+// VariantProjector
+// ============================================================================
+
+#[pyclass(name = "VariantProjection")]
+pub struct PyVariantProjection {
+    inner: crate::project::VariantProjection,
+}
+
+#[pymethods]
+impl PyVariantProjection {
+    /// The normalized g. variant as an HGVS string.
+    #[getter]
+    fn g_name(&self) -> String {
+        self.inner.genomic.to_string()
+    }
+
+    /// The c./n. variant as an HGVS string (None when projection skipped).
+    #[getter]
+    fn c_name(&self) -> Option<String> {
+        self.inner.coding.as_ref().map(|v| v.to_string())
+    }
+
+    /// The p. variant as an HGVS string (None for intronic, UTR, non-coding,
+    /// or non-substitution edits).
+    #[getter]
+    fn p_name(&self) -> Option<String> {
+        self.inner.protein.as_ref().map(|v| v.to_string())
+    }
+
+    #[getter]
+    fn transcript_id(&self) -> String {
+        self.inner.transcript_id.clone()
+    }
+
+    #[getter]
+    fn gene_symbol(&self) -> Option<String> {
+        self.inner.gene_symbol.clone()
+    }
+
+    #[getter]
+    fn is_frameshift(&self) -> bool {
+        self.inner.is_frameshift
+    }
+
+    #[getter]
+    fn is_intronic(&self) -> bool {
+        self.inner.is_intronic
+    }
+
+    #[getter]
+    fn is_utr(&self) -> bool {
+        self.inner.is_utr
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VariantProjection(g={:?}, c={:?}, p={:?}, transcript={:?})",
+            self.g_name(),
+            self.c_name(),
+            self.p_name(),
+            self.transcript_id()
+        )
+    }
+}
+
+#[pyclass(name = "VariantProjector")]
+pub struct PyVariantProjector {
+    inner: crate::project::VariantProjector<PyProvider>,
+}
+
+#[pymethods]
+impl PyVariantProjector {
+    /// Create a variant projector.
+    ///
+    /// Args:
+    ///     reference_json: Path to a transcripts.json file. If None, uses
+    ///         built-in test data (limited; not for production).
+    ///     direction: Shuffle direction passed to the internal normalizer
+    ///         ("3prime" or "5prime").
+    #[new]
+    #[pyo3(signature = (reference_json=None, direction="3prime"))]
+    fn new(reference_json: Option<&str>, direction: &str) -> PyResult<Self> {
+        let provider = match reference_json {
+            Some(path) => PyProvider::from_json(Path::new(path))?,
+            None => PyProvider::test_data(),
+        };
+        Self::from_provider(provider, direction)
+    }
+
+    /// Create a projector from a ferro-prepare manifest (preferred for
+    /// production — uses MultiFastaProvider with cdot data).
+    #[staticmethod]
+    #[pyo3(signature = (manifest_path, direction="3prime"))]
+    fn from_manifest(manifest_path: &str, direction: &str) -> PyResult<Self> {
+        let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
+        Self::from_provider(provider, direction)
+    }
+
+    /// Project a g. HGVS string onto a target transcript.
+    fn project(&self, hgvs_string: &str, transcript: &str) -> PyResult<PyVariantProjection> {
+        self.inner
+            .project(hgvs_string, transcript)
+            .map(|inner| PyVariantProjection { inner })
+            .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
+    }
+}
+
+impl PyVariantProjector {
+    fn from_provider(provider: PyProvider, direction: &str) -> PyResult<Self> {
+        let cdot = provider.cdot_mapper();
+        let projector = crate::data::projection::Projector::new(cdot);
+        let config = NormalizeConfig::default().with_direction(parse_direction(direction));
+        Ok(Self {
+            inner: crate::project::VariantProjector::new(projector, provider)
+                .with_normalize_config(config),
+        })
     }
 }
 
@@ -3088,6 +3221,10 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Coordinate mapping classes
     m.add_class::<PyCoordinateMapper>()?;
+
+    // Variant projection classes
+    m.add_class::<PyVariantProjector>()?;
+    m.add_class::<PyVariantProjection>()?;
 
     // Add version
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -397,15 +397,10 @@ fn inserted_sequence_len(seq: &InsertedSequence) -> Option<i64> {
     seq.len().map(|n| n as i64)
 }
 
-/// Check if a variant causes a frameshift (indel_length % 3 != 0).
-///
-/// Returns false if the indel length is 0 or cannot be determined.
-pub fn is_frameshift(variant: &HgvsVariant) -> bool {
-    match get_indel_length(variant) {
-        Some(len) if len != 0 => len % 3 != 0,
-        _ => false,
-    }
-}
+/// Re-export of `crate::hgvs::variant::is_frameshift`. Lives in `hgvs::variant`
+/// so core code (e.g. `crate::project`) does not need to depend on the
+/// Python-bindings helper module.
+pub use crate::hgvs::variant::is_frameshift;
 
 /// Get the number of sub-variants in an allele, or 1 for simple variants.
 pub fn get_num_variants(variant: &HgvsVariant) -> usize {

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -251,6 +251,11 @@ impl MockProvider {
     pub fn transcript_ids(&self) -> Vec<&str> {
         self.transcripts.keys().map(|s| s.as_str()).collect()
     }
+
+    /// Iterate over all transcripts registered in the provider.
+    pub fn all_transcripts(&self) -> impl Iterator<Item = &Transcript> {
+        self.transcripts.values()
+    }
 }
 
 impl Default for MockProvider {

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -575,6 +575,11 @@ impl MultiFastaProvider {
         self.index.len()
     }
 
+    /// Get the cdot mapper if one was loaded with this provider.
+    pub fn cdot_mapper(&self) -> Option<&CdotMapper> {
+        self.cdot_mapper.as_ref()
+    }
+
     /// Get CDS info from supplemental metadata for old/superseded transcripts.
     /// Creates a synthetic single exon spanning the entire transcript since
     /// mRNA transcripts are already spliced.

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,12 +1,15 @@
 //! DNA sequence utilities shared across the library.
 
-/// Reverse complement a DNA sequence
+/// Reverse complement a DNA sequence.
 ///
-/// Reverses the sequence and complements each nucleotide:
-/// - A <-> T
-/// - G <-> C
-/// - Case is preserved
-/// - Non-ATGC characters pass through unchanged
+/// Reverses the sequence and complements each nucleotide, including IUPAC
+/// ambiguity codes. Case is preserved. Characters that are not a recognized
+/// DNA / IUPAC base pass through unchanged.
+///
+/// IUPAC complements:
+/// - A↔T, G↔C, U→A
+/// - R↔Y, S↔S, W↔W, K↔M
+/// - B↔V, D↔H, N↔N
 ///
 /// # Examples
 ///
@@ -16,22 +19,46 @@
 /// assert_eq!(reverse_complement("ATGC"), "GCAT");
 /// assert_eq!(reverse_complement("aattggcc"), "ggccaatt");
 /// assert_eq!(reverse_complement("ATGN"), "NCAT");
+/// assert_eq!(reverse_complement("RYK"), "MRY");
 /// ```
 pub fn reverse_complement(seq: &str) -> String {
-    seq.chars()
-        .rev()
-        .map(|c| match c {
-            'A' => 'T',
-            'T' => 'A',
-            'G' => 'C',
-            'C' => 'G',
-            'a' => 't',
-            't' => 'a',
-            'g' => 'c',
-            'c' => 'g',
-            _ => c,
-        })
-        .collect()
+    seq.chars().rev().map(complement_char).collect()
+}
+
+fn complement_char(c: char) -> char {
+    match c {
+        'A' => 'T',
+        'T' | 'U' => 'A',
+        'G' => 'C',
+        'C' => 'G',
+        'R' => 'Y',
+        'Y' => 'R',
+        'S' => 'S',
+        'W' => 'W',
+        'K' => 'M',
+        'M' => 'K',
+        'B' => 'V',
+        'V' => 'B',
+        'D' => 'H',
+        'H' => 'D',
+        'N' => 'N',
+        'a' => 't',
+        't' | 'u' => 'a',
+        'g' => 'c',
+        'c' => 'g',
+        'r' => 'y',
+        'y' => 'r',
+        's' => 's',
+        'w' => 'w',
+        'k' => 'm',
+        'm' => 'k',
+        'b' => 'v',
+        'v' => 'b',
+        'd' => 'h',
+        'h' => 'd',
+        'n' => 'n',
+        other => other,
+    }
 }
 
 #[cfg(test)]
@@ -77,8 +104,35 @@ mod tests {
 
     #[test]
     fn test_reverse_complement_preserves_unknown_chars() {
-        assert_eq!(reverse_complement("ATGXYZ"), "ZYXCAT");
+        // X, Z, Q are not IUPAC bases — they pass through unchanged.
+        assert_eq!(reverse_complement("ATGXZQ"), "QZXCAT");
         assert_eq!(reverse_complement("A-T-G"), "C-A-T");
+    }
+
+    #[test]
+    fn test_reverse_complement_iupac_ambiguity_codes() {
+        // R (puRine: A/G) ↔ Y (pYrimidine: C/T)
+        assert_eq!(reverse_complement("R"), "Y");
+        assert_eq!(reverse_complement("Y"), "R");
+        // S (G/C, self-complementary), W (A/T, self-complementary)
+        assert_eq!(reverse_complement("S"), "S");
+        assert_eq!(reverse_complement("W"), "W");
+        // K (G/T) ↔ M (A/C)
+        assert_eq!(reverse_complement("K"), "M");
+        assert_eq!(reverse_complement("M"), "K");
+        // B (not A) ↔ V (not T); D (not C) ↔ H (not G)
+        assert_eq!(reverse_complement("B"), "V");
+        assert_eq!(reverse_complement("V"), "B");
+        assert_eq!(reverse_complement("D"), "H");
+        assert_eq!(reverse_complement("H"), "D");
+        // Combined: RYNK reversed = KNYR, complemented = MNRY
+        assert_eq!(reverse_complement("RYNK"), "MNRY");
+        // Case preserved for IUPAC codes
+        // "ryk" reversed → "kyr"; k→m, y→r, r→y → "mry"
+        assert_eq!(reverse_complement("ryk"), "mry");
+        // U (RNA) complements to A, just like T. Output uses the DNA letter T
+        // is mapped from A, so revcomp of RNA "AUGC" reads back as DNA "GCAT".
+        assert_eq!(reverse_complement("AUGC"), "GCAT");
     }
 
     #[test]

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -1,0 +1,94 @@
+//! End-to-end tests for the variant-projection module.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{VariantProjection, VariantProjector};
+
+/// Build a test (Projector, MockProvider) pair for NM_TEST.1.
+///
+/// The transcript encodes "ATGCGCTAA" (Met-Arg-Stop, 3 codons) on chr1 plus
+/// strand at genomic positions 1000-1008 (1-based inclusive).
+///
+/// Cdot coordinate layout (0-based):
+///   exon: genome [1000, 1009) — tx [0, 9)
+///   cds_start = 0 (no 5' UTR), cds_end = 9
+///
+/// Coordinate mapping (cdot 0-based genome → HGVS c. 1-based):
+///   g.1000 → tx_pos 0 → c.1  (A)
+///   g.1001 → tx_pos 1 → c.2  (T)
+///   g.1002 → tx_pos 2 → c.3  (G)
+///   g.1003 → tx_pos 3 → c.4  (C ← ref base for the substitution test)
+///   ...
+fn fixture() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            // [genome_start(0-based), genome_end(0-based excl), tx_start, tx_end]
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // Genomic sequence: 1000 N's + "ATGCGCTAA" + 100 N's.
+    // 0-based index 1000 = 'A', 1001 = 'T', 1002 = 'G', 1003 = 'C', ...
+    let prefix = "N".repeat(1000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+    (projector, provider)
+}
+
+#[test]
+fn end_to_end_missense() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    // g.1003C>A: the 4th base (c.4) of codon 2 "CGC" (Arg) → "AGC" (Ser).
+    let result: VariantProjection = vp
+        .project("NC_000001.11:g.1003C>A", "NM_TEST.1")
+        .expect("projection should succeed");
+    assert_eq!(result.transcript_id, "NM_TEST.1");
+    let c = result.coding.as_ref().unwrap().to_string();
+    assert!(c.contains(":c.4C>A"), "got c. = {}", c);
+    let p = result.protein.as_ref().unwrap().to_string();
+    assert_eq!(p, "NP_TEST.1(TESTGENE):p.(Arg2Ser)");
+    assert!(!result.is_frameshift);
+    assert!(!result.is_intronic);
+    assert!(!result.is_utr);
+}
+
+#[test]
+fn end_to_end_no_overlap() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    // chr1:5000 is far outside the transcript at genome [1000, 1009).
+    let err = vp.project("NC_000001.11:g.5000A>G", "NM_TEST.1");
+    assert!(err.is_err(), "expected error for off-transcript position");
+}

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -1,0 +1,99 @@
+"""End-to-end tests for ferro_hgvs.VariantProjector."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+
+@pytest.fixture
+def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """Build a VariantProjector backed by a minimal hand-crafted reference JSON.
+
+    The transcript NM_TEST.1 maps chr1 genomic positions 1001-1009 (1-based,
+    0-based half-open [1000, 1009)) with CDS sequence "ATGCGCTAA"
+    (Met-Arg-Stop, 3 codons) on the plus strand.
+
+    Exon coordinate notes
+    ---------------------
+    The MockProvider uses ``Exon.start`` directly as the cdot ``tx_start``
+    field (0-based), so we set ``start=0`` and ``end=8`` to match the
+    0-based cdot convention used internally by ``CdotMapper.from_transcripts``.
+    ``genomic_start`` and ``genomic_end`` are 1-based inclusive; they are
+    converted to 0-based half-open by subtracting 1 from the start only.
+    """
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TESTGENE",
+                "strand": "+",
+                "sequence": "ATGCGCTAA",
+                "cds_start": 1,
+                "cds_end": 9,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 0,
+                        "end": 8,
+                        "genomic_start": 1001,
+                        "genomic_end": 1009,
+                    }
+                ],
+                "chromosome": "chr1",
+                "genomic_start": 1000,
+                "genomic_end": 1008,
+            }
+        ],
+        "genomic_sequences": {
+            "chr1": "N" * 1000 + "ATGCGCTAA" + "N" * 100,
+        },
+    }
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return ferro_hgvs.VariantProjector(reference_json=str(path))
+
+
+class TestVariantProjector:
+    def test_missense_substitution_plus_strand(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # g.1003C>A: codon 2 of "ATGCGCTAA" is "CGC" (Arg); the 4th base (c.4)
+        # is C.  Changing C→A gives "AGC" (Ser) — missense.
+        result = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        assert result.transcript_id == "NM_TEST.1"
+        assert result.gene_symbol == "TESTGENE"
+        assert result.c_name is not None
+        assert ":c.4C>A" in result.c_name
+        assert result.p_name == "NP_TEST.1(TESTGENE):p.(Arg2Ser)"
+        assert result.is_frameshift is False
+        assert result.is_intronic is False
+        assert result.is_utr is False
+
+    def test_deletion_no_protein_is_frameshift(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # 1-base deletion → frameshift; p. is None (indel p. nomenclature deferred).
+        result = projector.project("NC_000001.11:g.1003del", transcript="NM_TEST.1")
+        assert result.c_name is not None
+        assert "del" in result.c_name
+        assert result.p_name is None
+        assert result.is_frameshift is True
+
+    def test_unknown_transcript_raises(self, projector: ferro_hgvs.VariantProjector) -> None:
+        with pytest.raises(RuntimeError):
+            projector.project("NC_000001.11:g.1003C>A", transcript="NM_NOPE.99")
+
+    def test_no_overlap_raises(self, projector: ferro_hgvs.VariantProjector) -> None:
+        # chr1:5000 is far outside the transcript at positions 1001-1009.
+        with pytest.raises(RuntimeError, match="overlap"):
+            projector.project("NC_000001.11:g.5000A>G", transcript="NM_TEST.1")
+
+    def test_repr_includes_g_name(self, projector: ferro_hgvs.VariantProjector) -> None:
+        result = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        rep = repr(result)
+        assert "VariantProjection" in rep
+        # repr should include either the g_name or c_name
+        assert ":g." in rep or ":c." in rep

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -12,17 +12,25 @@ import ferro_hgvs
 def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
     """Build a VariantProjector backed by a minimal hand-crafted reference JSON.
 
-    The transcript NM_TEST.1 maps chr1 genomic positions 1001-1009 (1-based,
-    0-based half-open [1000, 1009)) with CDS sequence "ATGCGCTAA"
-    (Met-Arg-Stop, 3 codons) on the plus strand.
+    The transcript NM_TEST.1 maps chr1 genomic positions 1000-1008 (1-based
+    inclusive) with CDS sequence "ATGCGCTAA" (Met-Arg-Stop, 3 codons) on the
+    plus strand.  g.1000 is the 'A' of the start codon (c.1).
 
-    Exon coordinate notes
-    ---------------------
-    The MockProvider uses ``Exon.start`` directly as the cdot ``tx_start``
-    field (0-based), so we set ``start=0`` and ``end=8`` to match the
-    0-based cdot convention used internally by ``CdotMapper.from_transcripts``.
-    ``genomic_start`` and ``genomic_end`` are 1-based inclusive; they are
-    converted to 0-based half-open by subtracting 1 from the start only.
+    All coordinate fields follow the documented 1-based inclusive convention:
+    - ``Exon.start`` / ``Exon.end``: 1-based transcript positions.
+    - ``Exon.genomic_start`` / ``Exon.genomic_end``: 1-based genomic positions.
+    - ``cds_start`` / ``cds_end``: 1-based transcript positions.
+
+    ``CdotMapper.from_transcripts`` converts these to the internal cdot
+    representation:
+    - tx_start  = Exon.start - 1      (1-based → 0-based)
+    - tx_end    = Exon.end            (1-based inclusive == 0-based exclusive)
+    - g_start   = Exon.genomic_start  (HGVS-value-based, no conversion)
+    - g_end     = Exon.genomic_end + 1  (1-based inclusive → exclusive)
+    - cds_start = cds_start - 1       (1-based → 0-based)
+
+    This produces the canonical cdot exon [1000, 1009, 0, 9] matching the
+    Rust unit tests in ``src/project/projector.rs``.
     """
     fixture = {
         "transcripts": [
@@ -36,10 +44,10 @@ def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
                 "exons": [
                     {
                         "number": 1,
-                        "start": 0,
-                        "end": 8,
-                        "genomic_start": 1001,
-                        "genomic_end": 1009,
+                        "start": 1,  # 1-based, inclusive tx start
+                        "end": 9,  # 1-based, inclusive tx end
+                        "genomic_start": 1000,  # 1-based, inclusive genomic start
+                        "genomic_end": 1008,  # 1-based, inclusive genomic end
                     }
                 ],
                 "chromosome": "chr1",


### PR DESCRIPTION
## Summary

First slice of issue #200. Adds `src/project/` with a `VariantProjector` that normalizes a g. variant and projects it onto a target transcript, producing the c./n. variant for all edit types (substitution, deletion, insertion, duplication, delins, inversion — strand-aware) and the p. variant for CDS substitutions (real amino acids resolved via the `ReferenceProvider`).

Closes the SNV path end-to-end and locks in the module shape so follow-ups can extend it without breaking the public API.

## API

```python
import ferro_hgvs

projector = ferro_hgvs.VariantProjector(reference_json="transcripts.json")
result = projector.project("NG_008617.1:g.100A>G", transcript="NM_000297.4")
result.g_name          # "NG_008617.1:g.100A>G"
result.c_name          # "NM_000297.4:c.459A>G"
result.p_name          # "NP_000288.1:p.(Arg153Gly)"
result.transcript_id
result.gene_symbol
result.is_frameshift
result.is_intronic
result.is_utr
```

A `VariantProjector.from_manifest(manifest_path)` constructor is also exposed for production use with `MultiFastaProvider` + cdot metadata.

## Architecture

New `src/project/` module composes existing pieces:

- `src/project/projector.rs` — `VariantProjector<P: ReferenceProvider + Clone>` orchestrator. Mirrors the generic-provider shape of `Normalizer<P>`.
- `src/project/edit.rs` — strand-aware `NaEdit` transformation (reverse-complements ref/alt sequences for minus-strand transcripts).
- `src/project/protein.rs` — codon lookup helpers (`read_ref_codon`, `apply_substitution`, `translate`) and `predict_substitution_protein` for CDS substitutions, built on `backtranslate::CodonTable::standard()`.
- `src/project/result.rs` — `VariantProjection` carrying typed `HgvsVariant` for both `coding` and `protein` (strings derived via `Display`).
- `src/project/accession.rs` — shared `parse_accession` helper used by both protein and tx accession parsing.

New `FerroError` variants: `TranscriptNotOverlapping`, `ProteinSequenceUnavailable`, `UnsupportedProjection`.

The Python wrapper exposes `VariantProjector` and `VariantProjection` and registers them in the `_ferro_hgvs` module. Type stubs added to `python/ferro_hgvs/__init__.pyi`.

## Notable supporting fixes

- `fix(sequence)`: `reverse_complement` now handles all 11 IUPAC ambiguity codes (R, Y, S, W, K, M, B, V, D, H, N) in addition to A/T/G/C. Previously these passed through unchanged, which produced incorrect revcomp on inputs carrying ambiguity codes.
- `fix(cdot)`: `CdotMapper::from_transcripts` (newly added to synthesize cdot data from `MockProvider` for the Python API) now correctly converts 1-based `Transcript` exon coordinates to the 0-based half-open form used internally. Misleading "1-based" doc comments in the `Exon` struct were corrected to match actual usage.
- `feat(project)`: the projector detects positions completely outside a transcript's genomic extent and returns `TranscriptNotOverlapping` (rather than silently producing a deep-intronic offset).

## Tests

- 8 unit tests in `src/project/edit.rs` (strand-aware revcomp across all NaEdit variants)
- 8 unit tests in `src/project/protein.rs` (codon helpers + substitution → ProteinVariant)
- 10 unit tests in `src/project/projector.rs` (plus/minus-strand sub, intronic, no-overlap, del/ins/dup/delins/inv)
- 3 unit tests in `src/project/accession.rs`
- 2 integration tests in `tests/projection.rs`
- 5 integration tests in `tests/python/test_variant_projection.py`

Full Rust suite: 4279 tests pass. Full Python suite: 139 tests pass. `cargo clippy --features dev -- -D warnings` clean, `ruff check` clean.

## Out of scope (follow-ups for #200)

- p. for indels: `del`/`ins`/`dup`/`delins`/`inv` in-frame nomenclature, `fs*N` for frameshifts, nonsense + readthrough special cases. `protein` is `None` for these in PR 1, but `is_frameshift` is set correctly so the consequence bit is already usable.
- Compound `[a;b]` allele syntax.
- `project_all` returning `Vec<VariantProjection>` across overlapping transcripts.
- `project_normalized` entry point that skips re-normalization for batch callers.

## Test plan

- [x] Rust unit tests pass (`cargo nextest run --features dev`)
- [x] Python integration tests pass (`pytest tests/python/`)
- [x] Clippy clean (`cargo clippy --features dev -- -D warnings`)
- [x] Format clean (`cargo fmt --all --check`)
- [x] Ruff clean (`ruff check python/ tests/python/`)
- [x] Python wheel builds (`maturin develop --features python`)