### PR TITLE
feat(project): protein consequence for CDS indels (PR 2: indel p. nomenclature)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -10,7 +10,7 @@ use crate::hgvs::variant::{is_frameshift, CdsVariant, HgvsVariant, LocEdit, TxVa
 use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
-use crate::project::protein::predict_substitution_protein;
+use crate::project::protein::{predict_indel_protein, predict_substitution_protein};
 use crate::project::result::VariantProjection;
 use crate::reference::ReferenceProvider;
 
@@ -209,9 +209,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let is_utr = !is_intronic
             && (info_start.in_5utr || info_start.in_3utr || info_end.in_5utr || info_end.in_3utr);
 
-        // 8. Predict protein consequence for CDS substitutions.
+        // 8. Predict protein consequence for CDS variants.
         let mut protein = None;
-        if !is_intronic && !is_utr && is_coding && matches!(c_edit, NaEdit::Substitution { .. }) {
+        if !is_intronic && !is_utr && is_coding {
             // Prefer the explicit cdot.protein accession; otherwise infer NP_/XP_
             // from NM_/XM_ by stripping the prefix (not by substring replace, which
             // would mangle accessions whose suffix happens to contain "NM_"). If
@@ -229,13 +229,45 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     }),
             };
             if let Some(prot_acc) = prot_acc {
-                let tx_for_codon = self.provider.get_transcript(transcript_id)?;
-                protein = Some(predict_substitution_protein(
-                    &tx_for_codon,
-                    cds_start.base,
-                    &c_edit,
-                    &prot_acc,
-                )?);
+                match &c_edit {
+                    NaEdit::Substitution { .. } => {
+                        let tx_for_codon = self.provider.get_transcript(transcript_id)?;
+                        protein = Some(predict_substitution_protein(
+                            &tx_for_codon,
+                            cds_start.base,
+                            &c_edit,
+                            &prot_acc,
+                        )?);
+                    }
+                    NaEdit::Deletion { .. }
+                    | NaEdit::Insertion { .. }
+                    | NaEdit::Duplication { .. }
+                    | NaEdit::Delins { .. }
+                    | NaEdit::Inversion { .. }
+                        // Only predict when both CDS positions are concrete exonic positions
+                        // (no intronic offsets — already guarded above).
+                        if cds_start.offset.is_none()
+                            && cds_end.offset.is_none()
+                            && cds_start.base > 0
+                            && cds_end.base > 0 =>
+                    {
+                        let tx_for_codon = self.provider.get_transcript(transcript_id)?;
+                        match predict_indel_protein(
+                            &tx_for_codon,
+                            cds_start.base,
+                            cds_end.base,
+                            &c_edit,
+                            &prot_acc,
+                        ) {
+                            Ok(pv) => protein = Some(pv),
+                            // Non-fatal: unsupported edits or missing sequence → leave protein=None.
+                            Err(FerroError::UnsupportedProjection { .. })
+                            | Err(FerroError::ProteinSequenceUnavailable { .. }) => {}
+                            Err(other) => return Err(other),
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
 
@@ -559,14 +591,22 @@ mod tests {
     fn project_single_base_deletion_is_frameshift() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1004del deletes a single base — net change -1 → frameshift.
+        // g.1004del deletes a single base (c.5, the 'G' in the Arg codon CGC) — net=-1 → frameshift.
+        // Mutated CDS: "ATGCCTAA" → Met-Pro-Stop → alt=[Met,Pro].
+        // first_diff=1 (Arg≠Pro) → p.(Arg2Profs).
         let result = vp
             .project("NC_000001.11:g.1004del", "NM_TEST.1")
             .expect("deletion should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains(":c."), "expected c. variant, got: {}", c);
         assert!(c.contains("del"), "expected del notation in c., got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. expected for CDS del")
+            .to_string();
+        assert!(p.contains("Arg2"), "expected Arg2 in p.: {}", p);
+        assert!(p.contains("fs"), "expected fs in p.: {}", p);
         assert!(result.is_frameshift, "1-base del should be frameshift");
         assert!(!result.is_intronic);
     }
@@ -575,13 +615,19 @@ mod tests {
     fn project_three_base_deletion_in_frame() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1003_1005del deletes 3 bases — in-frame.
+        // g.1003_1005del deletes 3 bases (c.4_6 = entire Arg codon CGC) — in-frame.
+        // Mutated CDS: "ATGTAA" → [Met] → p.(Arg2del).
         let result = vp
             .project("NC_000001.11:g.1003_1005del", "NM_TEST.1")
             .expect("3-base del should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains("del"), "expected del notation, got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. expected for in-frame del")
+            .to_string();
+        assert!(p.contains("Arg2del"), "expected Arg2del in p.: {}", p);
         assert!(!result.is_frameshift, "3-base deletion is in-frame");
     }
 
@@ -589,13 +635,14 @@ mod tests {
     fn project_single_base_insertion_is_frameshift() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1003_1004insA inserts one base — frameshift.
+        // g.1003_1004insA inserts one base — frameshift (net=+1).
         let result = vp
             .project("NC_000001.11:g.1003_1004insA", "NM_TEST.1")
             .expect("insertion should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains("ins"), "expected ins notation, got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        // p. should be produced (frameshift) — exact form depends on insertion position.
+        assert!(result.protein.is_some(), "p. expected for CDS insertion");
         assert!(result.is_frameshift, "1-base insertion is frameshift");
     }
 
@@ -603,13 +650,13 @@ mod tests {
     fn project_duplication() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1004dup duplicates a single base — frameshift.
+        // g.1004dup duplicates a single base (c.5 'G') — net=+1 → frameshift.
         let result = vp
             .project("NC_000001.11:g.1004dup", "NM_TEST.1")
             .expect("dup should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains("dup"), "expected dup notation, got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        assert!(result.protein.is_some(), "p. expected for CDS dup");
         assert!(result.is_frameshift, "1-base dup is frameshift");
     }
 
@@ -617,13 +664,21 @@ mod tests {
     fn project_delins() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1003_1004delinsAT — replace 2 bases with 2 bases → not a frameshift.
+        // g.1003_1004delinsAT — replace 2 bases (c.4_5, first 2 bases of Arg codon CGC)
+        // with AT → new codon "ATC" = Ile. Mutated CDS: "ATGATCTAA" → [Met, Ile].
+        // In-frame (net=0), straddles codon → build_inframe_delins.
+        // first_diff=1 (Arg≠Ile) → p.(Arg2delinsIle).
         let result = vp
             .project("NC_000001.11:g.1003_1004delinsAT", "NM_TEST.1")
             .expect("delins should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains("delins"), "expected delins notation, got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. expected for delins")
+            .to_string();
+        assert!(p.contains("delins"), "expected delins in p.: {}", p);
         assert!(
             !result.is_frameshift,
             "delins of equal length is not a frameshift"
@@ -634,13 +689,21 @@ mod tests {
     fn project_inversion() {
         let (projector, provider) = make_test_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
-        // g.1003_1005inv — inversion preserves length → not a frameshift.
+        // g.1003_1005inv — inversion of c.4_6 (CGC → GCG = Ala). Preserves length.
+        // Mutated CDS: "ATGGCGTAA" → [Met, Ala] → p.(Arg2delinsAla).
         let result = vp
             .project("NC_000001.11:g.1003_1005inv", "NM_TEST.1")
             .expect("inv should project");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains("inv"), "expected inv notation, got: {}", c);
-        assert!(result.protein.is_none(), "p. for indels deferred to PR 2");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. expected for inv")
+            .to_string();
+        assert!(p.contains("Arg2"), "expected Arg2 in p.: {}", p);
+        assert!(p.contains("delins"), "expected delins in p.: {}", p);
+        assert!(p.contains("Ala"), "expected Ala in p.: {}", p);
         assert!(!result.is_frameshift, "inversion is not a frameshift");
     }
 

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -28,7 +28,13 @@ pub(crate) fn read_full_cds(transcript: &Transcript) -> Result<String, FerroErro
         .ok_or_else(|| FerroError::ConversionError {
             msg: format!("transcript {} has no CDS end", transcript.id),
         })? as usize;
-    let seq = &transcript.sequence;
+    let seq =
+        transcript
+            .sequence
+            .as_deref()
+            .ok_or_else(|| FerroError::ProteinSequenceUnavailable {
+                accession: transcript.id.clone(),
+            })?;
     if cds_start < 1 || cds_end > seq.len() || cds_start > cds_end + 1 {
         return Err(FerroError::ProteinSequenceUnavailable {
             accession: transcript.id.clone(),
@@ -214,7 +220,7 @@ mod tests {
             id: "NM_TEST.1".to_string(),
             gene_symbol: None,
             strand: Strand::Plus,
-            sequence: seq.to_string(),
+            sequence: Some(seq.to_string()),
             cds_start: Some(cds_start),
             cds_end: Some(cds_end),
             exons: vec![Exon::new(1, 1, seq.len() as u64)],

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -1,0 +1,420 @@
+//! Pure helper functions for protein consequence prediction.
+//!
+//! All functions in this module are side-effect-free and easily unit-tested
+//! independently of the rest of the projector machinery.
+
+use crate::error::FerroError;
+use crate::hgvs::edit::{InsertedSequence, NaEdit};
+use crate::hgvs::location::AminoAcid;
+use crate::reference::transcript::Transcript;
+use crate::sequence::reverse_complement;
+
+use super::substitution::translate;
+
+// ── CDS sequence readers ──────────────────────────────────────────────────────
+
+/// Read the full CDS as an uppercase `String` from a transcript.
+///
+/// `cds_start` and `cds_end` are the 1-based inclusive positions of the CDS in
+/// transcript space (i.e. `Transcript.cds_start` / `Transcript.cds_end`).
+pub(crate) fn read_full_cds(transcript: &Transcript) -> Result<String, FerroError> {
+    let cds_start = transcript
+        .cds_start
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS start", transcript.id),
+        })? as usize;
+    let cds_end = transcript
+        .cds_end
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS end", transcript.id),
+        })? as usize;
+    let seq = &transcript.sequence;
+    if cds_start < 1 || cds_end > seq.len() || cds_start > cds_end + 1 {
+        return Err(FerroError::ProteinSequenceUnavailable {
+            accession: transcript.id.clone(),
+        });
+    }
+    // Transcript.cds_start is 1-based → 0-based index = cds_start - 1.
+    // Transcript.cds_end is 1-based inclusive → exclusive index = cds_end.
+    Ok(seq[cds_start - 1..cds_end].to_uppercase())
+}
+
+/// Build the mutated CDS sequence by applying `edit` at a given CDS coordinate.
+///
+/// `cds_start` and `cds_end` are **1-based CDS positions** (as recorded in a c. variant),
+/// not transcript-space positions.  For a point edit (substitution, point deletion) the
+/// caller sets `cds_start == cds_end`.
+///
+/// The returned string is the full CDS after the edit, in uppercase.
+pub(crate) fn build_mutated_cds(
+    transcript: &Transcript,
+    cds_pos_start: i64, // 1-based CDS position of edit start
+    cds_pos_end: i64,   // 1-based CDS position of edit end (inclusive)
+    edit: &NaEdit,
+) -> Result<String, FerroError> {
+    let tx_cds_start = transcript
+        .cds_start
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS", transcript.id),
+        })? as usize;
+
+    let full_cds = read_full_cds(transcript)?;
+
+    // Convert 1-based CDS positions to 0-based CDS-string indices.
+    let idx_start = (cds_pos_start - 1) as usize;
+    let idx_end = cds_pos_end as usize; // exclusive upper bound
+
+    if idx_end > full_cds.len() {
+        return Err(FerroError::ProteinSequenceUnavailable {
+            accession: transcript.id.clone(),
+        });
+    }
+
+    let before = &full_cds[..idx_start];
+    let affected = &full_cds[idx_start..idx_end];
+    let after = &full_cds[idx_end..];
+
+    let mutated = match edit {
+        NaEdit::Deletion { .. } => {
+            // Remove the affected bases.
+            format!("{}{}", before, after)
+        }
+        NaEdit::Insertion { sequence } => {
+            // HGVS insertion c.N_N+1insX: the inserted bases go between cds_pos_start
+            // and cds_pos_start+1, i.e. at idx_start (after `before`).
+            // The `affected` region here should be 0 bases wide (cds_pos_start == cds_pos_end
+            // for most insertions, or the caller can pass both as the same boundary base).
+            // We treat `before` as everything up through and including cds_pos_start.
+            let inserted = extract_literal_sequence(sequence, transcript)?;
+            // For HGVS insertions, idx_end == idx_start (the interval covers the gap),
+            // so before == full_cds[..idx_start] and after == full_cds[idx_start..].
+            // We want to insert between position idx_start-1 and idx_start.
+            // The caller passes cds_pos_start as the last unaffected base's c. position,
+            // so idx_end == idx_start and we insert at that junction.
+            format!("{}{}{}{}", before, affected, inserted, after)
+        }
+        NaEdit::Duplication { .. } => {
+            // Duplicate: append a copy of `affected` right after its end.
+            format!("{}{}{}{}", before, affected, affected, after)
+        }
+        NaEdit::Delins { sequence, .. } => {
+            let inserted = extract_literal_sequence(sequence, transcript)?;
+            format!("{}{}{}", before, inserted, after)
+        }
+        NaEdit::Inversion { .. } => {
+            let rc = reverse_complement(affected);
+            format!("{}{}{}", before, rc, after)
+        }
+        NaEdit::Substitution { alternative, .. } => {
+            // Single-base substitution.
+            let alt_char = alternative.to_u8() as char;
+            format!("{}{}{}", before, alt_char, after)
+        }
+        _ => {
+            return Err(FerroError::UnsupportedProjection {
+                reason: format!("build_mutated_cds does not support edit type: {:?}", edit),
+            })
+        }
+    };
+
+    let _ = tx_cds_start; // currently unused but kept for clarity
+    Ok(mutated.to_uppercase())
+}
+
+/// Extract a literal nucleotide sequence from an `InsertedSequence`.
+///
+/// Returns an error if the sequence is not a literal (we don't have sequence
+/// data to resolve count / range / named etc. without a reference lookup).
+fn extract_literal_sequence(
+    seq: &InsertedSequence,
+    transcript: &Transcript,
+) -> Result<String, FerroError> {
+    match seq {
+        InsertedSequence::Literal(s) => Ok(s.to_string()),
+        _ => Err(FerroError::UnsupportedProjection {
+            reason: format!(
+                "protein prediction requires a literal inserted sequence; \
+                 got non-literal for transcript {}",
+                transcript.id
+            ),
+        }),
+    }
+}
+
+// ── Translation helpers ───────────────────────────────────────────────────────
+
+/// Translate a CDS sequence to a protein, stopping before the first stop codon.
+///
+/// Incomplete codons at the end are silently dropped.
+pub(crate) fn translate_full_cds(cds: &str) -> Vec<AminoAcid> {
+    cds.as_bytes()
+        .chunks_exact(3)
+        .filter_map(|c| std::str::from_utf8(c).ok().and_then(translate))
+        .take_while(|aa| *aa != AminoAcid::Ter)
+        .collect()
+}
+
+/// Translate a CDS sequence to a protein, including the termination codon.
+///
+/// Stops translation immediately after the first `Ter` is encountered.
+pub(crate) fn translate_full_cds_with_stop(cds: &str) -> Vec<AminoAcid> {
+    let mut result = Vec::new();
+    for chunk in cds.as_bytes().chunks_exact(3) {
+        if let Ok(s) = std::str::from_utf8(chunk) {
+            if let Some(aa) = translate(s) {
+                result.push(aa);
+                if aa == AminoAcid::Ter {
+                    break;
+                }
+            }
+        }
+    }
+    result
+}
+
+// ── Diff helpers ─────────────────────────────────────────────────────────────
+
+/// Return the 0-based index of the first amino acid that differs between `ref_prot`
+/// and `alt_prot`.  If they are identical up to the shorter length, returns that length.
+pub(crate) fn first_diff_position(ref_prot: &[AminoAcid], alt_prot: &[AminoAcid]) -> usize {
+    ref_prot
+        .iter()
+        .zip(alt_prot.iter())
+        .position(|(r, a)| r != a)
+        .unwrap_or(ref_prot.len().min(alt_prot.len()))
+}
+
+/// Compute the net number of nucleotides added (positive) or removed (negative) by `edit`.
+///
+/// Returns `None` when the net change cannot be determined (e.g. non-literal inserted
+/// sequences or uncertain-length edits).
+pub(crate) fn net_length_change(edit: &NaEdit, del_len: usize) -> Option<i64> {
+    match edit {
+        NaEdit::Deletion { .. } => Some(-(del_len as i64)),
+        NaEdit::Insertion { sequence } => sequence.len().map(|n| n as i64),
+        NaEdit::Duplication { .. } => Some(del_len as i64),
+        NaEdit::Delins { sequence, .. } => sequence.len().map(|n| n as i64 - del_len as i64),
+        NaEdit::Inversion { .. } => Some(0),
+        NaEdit::Substitution { .. } => Some(0),
+        _ => None,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::edit::{InsertedSequence, Sequence};
+    use crate::reference::transcript::{Exon, ManeStatus, Strand};
+    use std::sync::OnceLock;
+
+    fn tx(seq: &str, cds_start: u64, cds_end: u64) -> Transcript {
+        Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: seq.to_string(),
+            cds_start: Some(cds_start),
+            cds_end: Some(cds_end),
+            exons: vec![Exon::new(1, 1, seq.len() as u64)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    // ── read_full_cds ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn read_full_cds_no_utr() {
+        // cds_start=1, cds_end=9 (whole transcript = CDS "ATGCGCTAA")
+        let t = tx("ATGCGCTAA", 1, 9);
+        assert_eq!(read_full_cds(&t).unwrap(), "ATGCGCTAA");
+    }
+
+    #[test]
+    fn read_full_cds_with_5utr() {
+        // 2-base 5' UTR "AA" + CDS "ATGCCCTAG" (9 bp).
+        let t = tx("AAATGCCCTAG", 3, 11);
+        assert_eq!(read_full_cds(&t).unwrap(), "ATGCCCTAG");
+    }
+
+    // ── build_mutated_cds ─────────────────────────────────────────────────────
+
+    #[test]
+    fn mutated_cds_deletion_single_base() {
+        // CDS "ATGCGCTAA"; delete c.4 (C, first base of Arg codon).
+        // Mutated CDS = "ATG" + "GCTAA" = "ATGGCTAA"
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = build_mutated_cds(&t, 4, 4, &edit).unwrap();
+        assert_eq!(result, "ATGGCTAA");
+    }
+
+    #[test]
+    fn mutated_cds_deletion_three_bases() {
+        // CDS "ATGCGCTAA"; delete c.4_6 (CGC = Arg codon).
+        // Mutated CDS = "ATG" + "TAA" = "ATGTAA"
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = build_mutated_cds(&t, 4, 6, &edit).unwrap();
+        assert_eq!(result, "ATGTAA");
+    }
+
+    #[test]
+    fn mutated_cds_insertion() {
+        // CDS "ATGCGCTAA"; insert "GGG" at c.3_4 (between positions 3 and 4).
+        // build_mutated_cds receives cds_pos_start=3, cds_pos_end=3 (length=0 gap),
+        // or start=3, end=3 giving affected=""...
+        // Actually for HGVS insertion c.3_4ins the caller should pass start=3, end=3
+        // so affected = "" and we insert between.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(seq),
+        };
+        // Insert at position end-of-codon1 / start-of-codon2: cds 3 to 3
+        // before = "ATG", affected = "", insert = "GGG", after = "CGCTAA"
+        let result = build_mutated_cds(&t, 3, 3, &edit).unwrap();
+        assert_eq!(result, "ATGGGGCGCTAA");
+    }
+
+    #[test]
+    fn mutated_cds_duplication() {
+        // CDS "ATGCGCTAA"; dup c.4_6 (CGC).
+        // Mutated CDS = "ATG" + "CGC" + "CGC" + "TAA" = "ATGCGCCGCTAA"
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Duplication {
+            sequence: None,
+            length: None,
+            uncertain_extent: None,
+        };
+        let result = build_mutated_cds(&t, 4, 6, &edit).unwrap();
+        assert_eq!(result, "ATGCGCCGCTAA");
+    }
+
+    #[test]
+    fn mutated_cds_delins() {
+        // CDS "ATGCGCTAA"; replace c.4_6 (CGC) with "TCC".
+        // Mutated CDS = "ATG" + "TCC" + "TAA" = "ATGTCCTAA"
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: Sequence = "TCC".parse().unwrap();
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
+        };
+        let result = build_mutated_cds(&t, 4, 6, &edit).unwrap();
+        assert_eq!(result, "ATGTCCTAA");
+    }
+
+    #[test]
+    fn mutated_cds_inversion() {
+        // CDS "ATGCGCTAA"; invert c.4_6 (CGC → revcomp = GCG).
+        // Mutated CDS = "ATG" + "GCG" + "TAA" = "ATGGCGTAA"
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Inversion {
+            sequence: None,
+            length: None,
+        };
+        let result = build_mutated_cds(&t, 4, 6, &edit).unwrap();
+        assert_eq!(result, "ATGGCGTAA");
+    }
+
+    // ── translate helpers ─────────────────────────────────────────────────────
+
+    #[test]
+    fn translate_full_cds_met_arg() {
+        // "ATGCGCTAA" → [Met, Arg] (stops before Ter)
+        let aas = translate_full_cds("ATGCGCTAA");
+        assert_eq!(aas, vec![AminoAcid::Met, AminoAcid::Arg]);
+    }
+
+    #[test]
+    fn translate_full_cds_with_stop_includes_ter() {
+        let aas = translate_full_cds_with_stop("ATGCGCTAA");
+        assert_eq!(aas, vec![AminoAcid::Met, AminoAcid::Arg, AminoAcid::Ter]);
+    }
+
+    #[test]
+    fn translate_full_cds_incomplete_codon_dropped() {
+        // 7 bases → 2 complete codons + 1 incomplete (dropped).
+        let aas = translate_full_cds("ATGCGCTA");
+        assert_eq!(aas, vec![AminoAcid::Met, AminoAcid::Arg]);
+    }
+
+    // ── first_diff_position ───────────────────────────────────────────────────
+
+    #[test]
+    fn first_diff_identical() {
+        let r = vec![AminoAcid::Met, AminoAcid::Arg];
+        let a = vec![AminoAcid::Met, AminoAcid::Arg];
+        assert_eq!(first_diff_position(&r, &a), 2);
+    }
+
+    #[test]
+    fn first_diff_at_start() {
+        let r = vec![AminoAcid::Met, AminoAcid::Arg];
+        let a = vec![AminoAcid::Val, AminoAcid::Arg];
+        assert_eq!(first_diff_position(&r, &a), 0);
+    }
+
+    #[test]
+    fn first_diff_second_position() {
+        let r = vec![AminoAcid::Met, AminoAcid::Arg];
+        let a = vec![AminoAcid::Met, AminoAcid::Ser];
+        assert_eq!(first_diff_position(&r, &a), 1);
+    }
+
+    // ── net_length_change ─────────────────────────────────────────────────────
+
+    #[test]
+    fn net_change_deletion() {
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        assert_eq!(net_length_change(&edit, 3), Some(-3));
+    }
+
+    #[test]
+    fn net_change_insertion() {
+        let seq: Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(seq),
+        };
+        assert_eq!(net_length_change(&edit, 0), Some(3));
+    }
+
+    #[test]
+    fn net_change_duplication() {
+        let edit = NaEdit::Duplication {
+            sequence: None,
+            length: None,
+            uncertain_extent: None,
+        };
+        assert_eq!(net_length_change(&edit, 3), Some(3));
+    }
+
+    #[test]
+    fn net_change_inversion() {
+        let edit = NaEdit::Inversion {
+            sequence: None,
+            length: None,
+        };
+        assert_eq!(net_length_change(&edit, 6), Some(0));
+    }
+}

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -234,11 +234,16 @@ fn build_inframe_deletion(
     // In a pure codon-aligned deletion, alt_protein is shorter. The deleted
     // range in ref_protein is [first_diff .. first_diff + (ref_len - alt_len)].
     let n_deleted = ref_protein.len().saturating_sub(alt_protein.len());
-    let last_deleted = first_diff + n_deleted - 1;
 
     if n_deleted == 0 {
+        // Guard before subtracting: alt_protein.len() >= ref_protein.len() means the
+        // "deletion" didn't shorten the protein (e.g. a stop-disrupting deletion whose
+        // extension detection missed an edge case). Avoid the underflow in the
+        // last_deleted computation by short-circuiting to an identity variant.
         return build_identity_variant(ref_protein, protein_accession, transcript);
     }
+
+    let last_deleted = first_diff + n_deleted - 1;
 
     let start_aa = ref_protein
         .get(first_diff)
@@ -282,6 +287,23 @@ fn build_inframe_insertion(
     protein_accession: &str,
     transcript: &Transcript,
 ) -> Result<HgvsVariant, FerroError> {
+    // If the inserted nucleotides translate to a stop, `alt_protein` is truncated
+    // at the new Ter and ends up no longer than `ref_protein`. That's not a pure
+    // insertion any more — re-attach the implicit Ter (the stop that truncated
+    // translation) and fall back to the generic delins pathway, which can
+    // represent the asymmetric ref/alt sizes correctly.
+    if alt_protein.len() <= ref_protein.len() {
+        let mut alt_with_stop = alt_protein.to_vec();
+        alt_with_stop.push(AminoAcid::Ter);
+        return build_inframe_delins(
+            ref_protein,
+            &alt_with_stop,
+            cds_pos_start,
+            protein_accession,
+            transcript,
+        );
+    }
+
     // The insertion happens between codon N and N+1.
     // cds_pos_start is the last base (frame 2) of codon N.
     // codon_N = (cds_pos_start - 1) / 3  (0-based), so 1-based = (cds_pos_start + 2) / 3
@@ -299,9 +321,9 @@ fn build_inframe_insertion(
 
     // The inserted amino acids are the additional ones in alt_protein between
     // aa_before_idx and aa_before_idx+1.
-    let n_inserted = alt_protein.len().saturating_sub(ref_protein.len());
-    let inserted_aas: Vec<AminoAcid> =
-        alt_protein[aa_before_idx + 1..aa_before_idx + 1 + n_inserted].to_vec();
+    let n_inserted = alt_protein.len() - ref_protein.len();
+    let insert_end = (aa_before_idx + 1 + n_inserted).min(alt_protein.len());
+    let inserted_aas: Vec<AminoAcid> = alt_protein[aa_before_idx + 1..insert_end].to_vec();
 
     let protein_edit = ProteinEdit::Insertion {
         sequence: AminoAcidSeq::new(inserted_aas),
@@ -572,7 +594,7 @@ mod tests {
             id: "NM_TEST.1".to_string(),
             gene_symbol: None,
             strand: Strand::Plus,
-            sequence: seq.to_string(),
+            sequence: Some(seq.to_string()),
             cds_start: Some(cds_start),
             cds_end: Some(cds_end),
             exons: vec![Exon::new(1, 1, seq.len() as u64)],
@@ -773,6 +795,46 @@ mod tests {
         assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
         assert!(s.contains("delins"), "expected delins in '{}'", s);
         assert!(s.contains("Ala"), "expected Ala in '{}'", s);
+    }
+
+    // ─── Regression tests for CodeRabbit-flagged edge cases ───────────────────
+
+    #[test]
+    fn inframe_deletion_with_zero_diff_returns_identity_not_panic() {
+        // Regression for the underflow in build_inframe_deletion: if it is ever
+        // called with alt_protein.len() >= ref_protein.len(), `n_deleted` is 0
+        // and `first_diff + n_deleted - 1` would underflow usize. The guard
+        // must run before the subtraction. Calling directly bypasses upstream
+        // detection so we are testing the function's own safety.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let ref_protein = [AminoAcid::Met, AminoAcid::Arg];
+        let alt_protein = [AminoAcid::Met, AminoAcid::Arg];
+        let result =
+            build_inframe_deletion(&ref_protein, &alt_protein, "NP_TEST.1", &t).expect("no panic");
+        let s = prot_str(&result);
+        // Identity variant -- whole-protein "=" representation.
+        assert!(s.contains("(="), "expected identity '(=' in '{}'", s);
+    }
+
+    #[test]
+    fn ins_three_bases_premature_stop_falls_back_to_delins() {
+        // Regression for malformed `p.(...ins)` with empty sequence: insert
+        // "TAA" between c.3 (last base of Met codon) and c.4 (first base of
+        // Arg codon). The inserted codon is a stop, so translate_full_cds
+        // truncates alt_protein to [Met]. ref_protein = [Met, Arg, Lys]
+        // (CDS "ATGCGCAAATAA"). alt is shorter than ref -> falls back to
+        // build_inframe_delins which can represent the asymmetric change
+        // without emitting an empty `ins` sequence.
+        let t = tx("ATGCGCAAATAA", 1, 12);
+        let seq: crate::hgvs::edit::Sequence = "TAA".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // delins fallback re-attaches the implicit Ter (truncated by translate_full_cds)
+        // before computing the AA diff, so the new stop appears in the inserted sequence.
+        assert_eq!(s, "NP_TEST.1:p.(Arg2_Lys3delinsTer)");
     }
 
     #[test]

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -1,0 +1,802 @@
+//! Protein consequence prediction for indels (deletion, insertion, duplication,
+//! deletion-insertion, inversion) in the CDS.
+
+use crate::error::FerroError;
+use crate::hgvs::edit::{AminoAcidSeq, ExtDirection, NaEdit, ProteinEdit};
+use crate::hgvs::interval::ProtInterval;
+use crate::hgvs::location::{AminoAcid, ProtPos};
+use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
+use crate::project::accession::parse_accession;
+use crate::reference::transcript::Transcript;
+
+use super::helpers::{
+    build_mutated_cds, first_diff_position, net_length_change, read_full_cds, translate_full_cds,
+    translate_full_cds_with_stop,
+};
+
+// ── Main entry point ──────────────────────────────────────────────────────────
+
+/// Predict the protein consequence of an indel (non-substitution) CDS edit.
+///
+/// `cds_pos_start` and `cds_pos_end` are the 1-based CDS positions of the
+/// variant's start and end respectively (as they appear in the c. variant).
+///
+/// Returns a `p.(...)` `HgvsVariant::Protein` on success, or a
+/// `FerroError::UnsupportedProjection` / `FerroError::ProteinSequenceUnavailable`
+/// on failure.
+pub(crate) fn predict_indel_protein(
+    transcript: &Transcript,
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+    edit: &NaEdit,
+    protein_accession: &str,
+) -> Result<HgvsVariant, FerroError> {
+    // 1. Build ref and mutated CDS sequences.
+    let ref_cds = read_full_cds(transcript)?;
+    let mut_cds = build_mutated_cds(transcript, cds_pos_start, cds_pos_end, edit)?;
+
+    // 2. Translate both.
+    let ref_protein = translate_full_cds(&ref_cds);
+    let alt_protein = translate_full_cds(&mut_cds);
+
+    // 3. Check for stop-codon readthrough: the ref had a stop that is now an AA.
+    //    Detected when the mutated protein is longer than the ref protein and
+    //    alt_protein[ref_protein.len()] is not Ter.
+    if alt_protein.len() > ref_protein.len() {
+        // Check whether the ref protein ended at the stop codon position.
+        // ref_cds should have a Ter at codon (ref_protein.len()+1).
+        let ref_protein_with_stop = translate_full_cds_with_stop(&ref_cds);
+        if ref_protein_with_stop.last() == Some(&AminoAcid::Ter)
+            && alt_protein.len() > ref_protein.len()
+        {
+            // Possibly readthrough if the MUTATION affected the stop codon.
+            // The affected CDS region includes the stop codon area.
+            let stop_cds_start = (ref_protein.len() * 3 + 1) as i64; // 1-based CDS pos of stop codon
+            if cds_pos_start >= stop_cds_start
+                || (cds_pos_end >= stop_cds_start && cds_pos_start <= stop_cds_start + 2)
+            {
+                return build_extension_variant(
+                    &ref_protein,
+                    &alt_protein,
+                    &mut_cds,
+                    protein_accession,
+                    transcript,
+                );
+            }
+        }
+    }
+
+    // 4. Net length change and frameshift detection.
+    let del_len = (cds_pos_end - cds_pos_start + 1) as usize;
+    let net =
+        net_length_change(edit, del_len).ok_or_else(|| FerroError::UnsupportedProjection {
+            reason: "cannot determine net length change for protein prediction".to_string(),
+        })?;
+    let is_frameshift = net % 3 != 0;
+
+    if is_frameshift {
+        build_frameshift_variant(
+            &ref_protein,
+            &alt_protein,
+            &mut_cds,
+            protein_accession,
+            transcript,
+        )
+    } else {
+        build_inframe_variant(
+            transcript,
+            cds_pos_start,
+            cds_pos_end,
+            edit,
+            net,
+            &ref_protein,
+            &alt_protein,
+            protein_accession,
+        )
+    }
+}
+
+// ── In-frame prediction ───────────────────────────────────────────────────────
+
+/// Build the protein variant for an in-frame (net % 3 == 0) indel.
+#[allow(clippy::too_many_arguments)]
+fn build_inframe_variant(
+    transcript: &Transcript,
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+    edit: &NaEdit,
+    net: i64, // net nucleotide change (negative = deletion, positive = insertion)
+    ref_protein: &[AminoAcid],
+    alt_protein: &[AminoAcid],
+    protein_accession: &str,
+) -> Result<HgvsVariant, FerroError> {
+    // Check identity first: if the proteins are identical, emit p.(=).
+    if ref_protein == alt_protein {
+        return build_identity_variant(ref_protein, protein_accession, transcript);
+    }
+
+    // Is the edit codon-aligned (i.e. starts at the first base of a codon)?
+    let frame_at_start = (cds_pos_start - 1) % 3; // 0, 1, or 2
+
+    match edit {
+        NaEdit::Deletion { .. } => {
+            // Net < 0 always for deletion.
+            if frame_at_start == 0 && net % 3 == 0 {
+                // Codon-aligned deletion: whole codons removed.
+                build_inframe_deletion(ref_protein, alt_protein, protein_accession, transcript)
+            } else {
+                // Straddles a codon boundary: effectively a delins at the AA level.
+                build_inframe_delins(
+                    ref_protein,
+                    alt_protein,
+                    cds_pos_start,
+                    protein_accession,
+                    transcript,
+                )
+            }
+        }
+        NaEdit::Insertion { .. } => {
+            if frame_at_start == 2 && net % 3 == 0 {
+                // Codon-aligned insertion: inserted between two adjacent codons.
+                // cds_pos_end == cds_pos_start (gap position), and the position
+                // is the last base of a codon (frame 2, i.e. cds_pos % 3 == 0).
+                build_inframe_insertion(
+                    ref_protein,
+                    alt_protein,
+                    cds_pos_start,
+                    protein_accession,
+                    transcript,
+                )
+            } else {
+                // Mid-codon insertion: treated as a delins at the AA level.
+                build_inframe_delins(
+                    ref_protein,
+                    alt_protein,
+                    cds_pos_start,
+                    protein_accession,
+                    transcript,
+                )
+            }
+        }
+        NaEdit::Duplication { .. } => {
+            if frame_at_start == 0 && net % 3 == 0 {
+                // Codon-aligned duplication.
+                build_inframe_duplication(
+                    ref_protein,
+                    alt_protein,
+                    cds_pos_start,
+                    cds_pos_end,
+                    protein_accession,
+                    transcript,
+                )
+            } else {
+                // Mid-codon duplication: treated as a delins.
+                build_inframe_delins(
+                    ref_protein,
+                    alt_protein,
+                    cds_pos_start,
+                    protein_accession,
+                    transcript,
+                )
+            }
+        }
+        NaEdit::Delins { .. } | NaEdit::Inversion { .. } => {
+            // Always use the generic delins pathway for delins and inversion.
+            build_inframe_delins(
+                ref_protein,
+                alt_protein,
+                cds_pos_start,
+                protein_accession,
+                transcript,
+            )
+        }
+        _ => Err(FerroError::UnsupportedProjection {
+            reason: format!(
+                "build_inframe_variant does not support edit type for protein prediction: {:?}",
+                edit
+            ),
+        }),
+    }
+}
+
+/// Identity: proteins are identical after the edit (e.g. synonymous codon change).
+fn build_identity_variant(
+    ref_protein: &[AminoAcid],
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    // Use the whole-protein identity representation.
+    let accession = parse_accession(protein_accession);
+    // Point at Met1 for simplicity.
+    let ref_aa = ref_protein.first().copied().unwrap_or(AminoAcid::Met);
+    let loc = ProtInterval::point(ProtPos::new(ref_aa, 1));
+    let edit = crate::hgvs::edit::ProteinEdit::Identity {
+        predicted: false,
+        whole_protein: true,
+    };
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+/// Codon-aligned in-frame deletion: `p.(Xxx{N}del)` or `p.(Xxx{N}_Yyy{M}del)`.
+fn build_inframe_deletion(
+    ref_protein: &[AminoAcid],
+    alt_protein: &[AminoAcid],
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    // Find first and last positions that differ.
+    let first_diff = first_diff_position(ref_protein, alt_protein);
+    // In a pure codon-aligned deletion, alt_protein is shorter. The deleted
+    // range in ref_protein is [first_diff .. first_diff + (ref_len - alt_len)].
+    let n_deleted = ref_protein.len().saturating_sub(alt_protein.len());
+    let last_deleted = first_diff + n_deleted - 1;
+
+    if n_deleted == 0 {
+        return build_identity_variant(ref_protein, protein_accession, transcript);
+    }
+
+    let start_aa = ref_protein
+        .get(first_diff)
+        .copied()
+        .unwrap_or(AminoAcid::Xaa);
+    let start_pos = (first_diff + 1) as u64;
+
+    let protein_edit = ProteinEdit::Deletion {
+        sequence: None,
+        count: None,
+    };
+
+    let loc = if n_deleted == 1 {
+        ProtInterval::point(ProtPos::new(start_aa, start_pos))
+    } else {
+        let end_aa = ref_protein
+            .get(last_deleted)
+            .copied()
+            .unwrap_or(AminoAcid::Xaa);
+        let end_pos = (last_deleted + 1) as u64;
+        ProtInterval::new(
+            ProtPos::new(start_aa, start_pos),
+            ProtPos::new(end_aa, end_pos),
+        )
+    };
+
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+/// Codon-aligned in-frame insertion: `p.(Xxx{N}_Yyy{N+1}ins{AAseq})`.
+fn build_inframe_insertion(
+    ref_protein: &[AminoAcid],
+    alt_protein: &[AminoAcid],
+    cds_pos_start: i64, // last base of the codon before insertion
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    // The insertion happens between codon N and N+1.
+    // cds_pos_start is the last base (frame 2) of codon N.
+    // codon_N = (cds_pos_start - 1) / 3  (0-based), so 1-based = (cds_pos_start + 2) / 3
+    let aa_before_idx = ((cds_pos_start - 1) / 3) as usize; // 0-based index in ref_protein
+    let aa_before = ref_protein
+        .get(aa_before_idx)
+        .copied()
+        .unwrap_or(AminoAcid::Xaa);
+    let aa_before_pos = (aa_before_idx + 1) as u64;
+    let aa_after = ref_protein
+        .get(aa_before_idx + 1)
+        .copied()
+        .unwrap_or(AminoAcid::Ter);
+    let aa_after_pos = aa_before_pos + 1;
+
+    // The inserted amino acids are the additional ones in alt_protein between
+    // aa_before_idx and aa_before_idx+1.
+    let n_inserted = alt_protein.len().saturating_sub(ref_protein.len());
+    let inserted_aas: Vec<AminoAcid> =
+        alt_protein[aa_before_idx + 1..aa_before_idx + 1 + n_inserted].to_vec();
+
+    let protein_edit = ProteinEdit::Insertion {
+        sequence: AminoAcidSeq::new(inserted_aas),
+    };
+
+    let loc = ProtInterval::new(
+        ProtPos::new(aa_before, aa_before_pos),
+        ProtPos::new(aa_after, aa_after_pos),
+    );
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+/// Codon-aligned duplication: `p.(Xxx{N}dup)` or `p.(Xxx{N}_Yyy{M}dup)`.
+fn build_inframe_duplication(
+    ref_protein: &[AminoAcid],
+    _alt_protein: &[AminoAcid],
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    // The duplicated region in CDS coordinates is [cds_pos_start, cds_pos_end].
+    // Convert to 0-based amino acid indices.
+    let aa_start_idx = ((cds_pos_start - 1) / 3) as usize;
+    let aa_end_idx = ((cds_pos_end - 1) / 3) as usize;
+
+    let start_aa = ref_protein
+        .get(aa_start_idx)
+        .copied()
+        .unwrap_or(AminoAcid::Xaa);
+    let start_pos = (aa_start_idx + 1) as u64;
+
+    let loc = if aa_start_idx == aa_end_idx {
+        ProtInterval::point(ProtPos::new(start_aa, start_pos))
+    } else {
+        let end_aa = ref_protein
+            .get(aa_end_idx)
+            .copied()
+            .unwrap_or(AminoAcid::Xaa);
+        let end_pos = (aa_end_idx + 1) as u64;
+        ProtInterval::new(
+            ProtPos::new(start_aa, start_pos),
+            ProtPos::new(end_aa, end_pos),
+        )
+    };
+
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, ProteinEdit::Duplication),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+/// Generic in-frame delins: `p.(Xxx{N}_Yyy{M}delins{ZzzZzz...})`.
+///
+/// Used when the edit straddles a codon boundary or is a delins/inversion.
+fn build_inframe_delins(
+    ref_protein: &[AminoAcid],
+    alt_protein: &[AminoAcid],
+    cds_pos_start: i64,
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    // Find the first and last positions that differ.
+    let first_diff = first_diff_position(ref_protein, alt_protein);
+    let last_diff_ref = find_last_diff(ref_protein, alt_protein);
+    let last_diff_alt = find_last_diff_alt(ref_protein, alt_protein);
+
+    // The affected region in the ref protein spans [first_diff, last_diff_ref].
+    // The replacement sequence from the alt protein spans [first_diff, last_diff_alt].
+    let ref_len = ref_protein.len();
+    let alt_len = alt_protein.len();
+
+    let _ = cds_pos_start; // used implicitly through first_diff
+
+    // If the alt protein is empty or only differs at the last AA:
+    if first_diff >= ref_len && first_diff >= alt_len {
+        // No difference at the amino acid level.
+        return build_identity_variant(ref_protein, protein_accession, transcript);
+    }
+
+    let start_aa = ref_protein
+        .get(first_diff)
+        .copied()
+        .unwrap_or(AminoAcid::Xaa);
+    let start_pos = (first_diff + 1) as u64;
+
+    let end_ref = last_diff_ref.min(ref_len.saturating_sub(1));
+    let end_aa = ref_protein.get(end_ref).copied().unwrap_or(AminoAcid::Xaa);
+    let end_pos = (end_ref + 1) as u64;
+
+    let end_alt = last_diff_alt.min(alt_len.saturating_sub(1));
+    let inserted: Vec<AminoAcid> = if first_diff <= end_alt {
+        alt_protein[first_diff..=end_alt].to_vec()
+    } else {
+        vec![]
+    };
+
+    let protein_edit = ProteinEdit::Delins {
+        sequence: AminoAcidSeq::new(inserted),
+    };
+
+    let loc = if start_pos == end_pos {
+        ProtInterval::point(ProtPos::new(start_aa, start_pos))
+    } else {
+        ProtInterval::new(
+            ProtPos::new(start_aa, start_pos),
+            ProtPos::new(end_aa, end_pos),
+        )
+    };
+
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+/// Find the 0-based index of the last AA in `ref_protein` that is in the "differing" region.
+///
+/// This is needed for range-based protein delins to identify the endpoint in the ref.
+fn find_last_diff(ref_prot: &[AminoAcid], alt_prot: &[AminoAcid]) -> usize {
+    let ref_len = ref_prot.len();
+    let alt_len = alt_prot.len();
+    // Scan from the shorter tail inward.
+    let max_tail = ref_len.min(alt_len);
+    for tail in 0..max_tail {
+        let ri = ref_len - 1 - tail;
+        let ai = alt_len - 1 - tail;
+        if ref_prot[ri] != alt_prot[ai] {
+            return ri;
+        }
+    }
+    // All trailing positions match: the differing region ends at ref_len - alt_len - 1
+    // (if ref is longer) or 0 (if alt is longer or equal).
+    ref_len.saturating_sub(alt_len)
+}
+
+/// Find the 0-based index of the last AA in `alt_protein` that is in the "differing" region.
+fn find_last_diff_alt(ref_prot: &[AminoAcid], alt_prot: &[AminoAcid]) -> usize {
+    let ref_len = ref_prot.len();
+    let alt_len = alt_prot.len();
+    let max_tail = ref_len.min(alt_len);
+    for tail in 0..max_tail {
+        let ri = ref_len - 1 - tail;
+        let ai = alt_len - 1 - tail;
+        if ref_prot[ri] != alt_prot[ai] {
+            return ai;
+        }
+    }
+    alt_len.saturating_sub(ref_len)
+}
+
+// ── Frameshift prediction ─────────────────────────────────────────────────────
+
+/// Build a `p.(Xxx{N}[Yyy]fsTer{K})` frameshift variant.
+fn build_frameshift_variant(
+    ref_protein: &[AminoAcid],
+    alt_protein: &[AminoAcid],
+    mut_cds: &str,
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    let first_diff = first_diff_position(ref_protein, alt_protein);
+    let aa_pos = (first_diff + 1) as u64; // 1-based
+    let ref_aa = ref_protein
+        .get(first_diff)
+        .copied()
+        .unwrap_or(AminoAcid::Xaa);
+    let new_aa = alt_protein.get(first_diff).copied();
+
+    // Scan downstream from first_diff in the mutated CDS to find a stop codon.
+    let codon_byte_offset = first_diff * 3;
+    let ter_pos: Option<u64> = if codon_byte_offset < mut_cds.len() {
+        let downstream = &mut_cds[codon_byte_offset..];
+        let downstream_aas = translate_full_cds_with_stop(downstream);
+        // ter_pos = 1-based position of the Ter in the downstream scan.
+        // HGVS fsTer{K}: K is the number of amino acids (including the new shifted AA) until Ter.
+        downstream_aas
+            .iter()
+            .position(|aa| *aa == AminoAcid::Ter)
+            .map(|p| (p + 1) as u64)
+    } else {
+        None
+    };
+
+    let protein_edit = ProteinEdit::Frameshift { new_aa, ter_pos };
+    let loc = ProtInterval::point(ProtPos::new(ref_aa, aa_pos));
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+// ── Extension (stop-codon readthrough) prediction ─────────────────────────────
+
+/// Build a `p.(Ter{N}{Yyy}ext*{K})` extension variant for stop-codon readthrough.
+fn build_extension_variant(
+    ref_protein: &[AminoAcid],
+    _alt_protein: &[AminoAcid],
+    mut_cds: &str,
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> Result<HgvsVariant, FerroError> {
+    let stop_pos = (ref_protein.len() + 1) as u64; // 1-based position of the original stop codon
+
+    // The new amino acid at the stop codon position.
+    // Translate starting from the stop-codon position in the mutated CDS.
+    let stop_offset = ref_protein.len() * 3;
+    let new_aa: Option<AminoAcid> = if stop_offset + 3 <= mut_cds.len() {
+        let stop_codon_seq = &mut_cds[stop_offset..stop_offset + 3];
+        super::substitution::translate(stop_codon_seq).filter(|aa| *aa != AminoAcid::Ter)
+    } else {
+        None
+    };
+
+    // Count extension amino acids until a new stop is found.
+    let ext_count: Option<i64> = if stop_offset < mut_cds.len() {
+        let downstream = &mut_cds[stop_offset..];
+        let downstream_aas = translate_full_cds_with_stop(downstream);
+        downstream_aas
+            .iter()
+            .position(|aa| *aa == AminoAcid::Ter)
+            .map(|p| (p + 1) as i64) // +1: distance from new AA to new stop (inclusive)
+    } else {
+        None
+    };
+
+    let protein_edit = ProteinEdit::Extension {
+        new_aa,
+        direction: ExtDirection::CTerminal,
+        count: ext_count,
+    };
+
+    let loc = ProtInterval::point(ProtPos::new(AminoAcid::Ter, stop_pos));
+    let accession = parse_accession(protein_accession);
+    let variant = ProteinVariant {
+        accession,
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, protein_edit),
+    };
+    Ok(HgvsVariant::Protein(variant))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reference::transcript::{Exon, ManeStatus, Strand};
+    use std::sync::OnceLock;
+
+    fn tx(seq: &str, cds_start: u64, cds_end: u64) -> Transcript {
+        Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: seq.to_string(),
+            cds_start: Some(cds_start),
+            cds_end: Some(cds_end),
+            exons: vec![Exon::new(1, 1, seq.len() as u64)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    fn prot_str(v: &HgvsVariant) -> String {
+        match v {
+            HgvsVariant::Protein(p) => p.to_string(),
+            _ => panic!("expected Protein variant"),
+        }
+    }
+
+    // ─── Frameshift tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn del_single_base_frameshift_with_ter() {
+        // CDS "ATGCGCTAA": Met-Arg-Stop.
+        // Delete c.4 (first base of Arg codon CGC).
+        // Mutated CDS: "ATGGCTAA" → Met-Ala-Stop (stop at position 2 → fsTer2? No—)
+        // Actually: ATGGCTAA → ATG GCT AA(incomplete) → [Met, Ala] then no stop. Wait.
+        // "ATGGCTAA" = ATG GCT AA (8 bases, 2 complete codons + 2 partial)
+        // → Met, Ala — no stop. fsTer? = no ter found.
+        // But the downstream scan from position 1 (0-indexed): mut_cds = "ATGGCTAA"
+        // first_diff: ref=[Met,Arg], alt=[Met,Ala] → first_diff=1 (Arg≠Ala)
+        // scan from codon 1 onward in mut_cds: "GCTAA" → GCT (Ala), AA (incomplete)
+        // No Ter found → fsTer? should be None.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // Arg2[Ala]fsTer? — with no downstream stop in the remaining sequence.
+        // alt_protein = [Met, Ala], first_diff=1, new_aa=Ala
+        // downstream from byte 3 = "GCTAA" → Ala, then incomplete AA
+        // no Ter → ter_pos = None
+        assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
+        assert!(s.contains("fs"), "expected fs in '{}'", s);
+        assert!(s.contains("Ala"), "expected Ala new_aa in '{}'", s);
+    }
+
+    #[test]
+    fn del_three_bases_codon_aligned_single_aa() {
+        // CDS "ATGCGCTAA": del c.4_6 (entire Arg codon CGC).
+        // Mutated CDS: "ATGTAA" = ATG TAA → Met-Stop
+        // ref=[Met, Arg], alt=[Met]
+        // first_diff=1, n_deleted=1 → p.(Arg2del)
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert_eq!(s, "NP_TEST.1:p.(Arg2del)");
+    }
+
+    #[test]
+    fn del_six_bases_codon_aligned_range() {
+        // CDS "ATGCGCAAATAA": Met-Arg-Lys-Stop (12 bp).
+        // del c.4_9 (CGC AAA = Arg + Lys).
+        // Mutated CDS: "ATGTAA" → [Met]
+        // ref=[Met, Arg, Lys], alt=[Met]
+        // first_diff=1, n_deleted=2 → p.(Arg2_Lys3del)
+        let t = tx("ATGCGCAAATAA", 1, 12);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 9, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert_eq!(s, "NP_TEST.1:p.(Arg2_Lys3del)");
+    }
+
+    #[test]
+    fn del_two_bases_non_aligned_frameshift() {
+        // CDS "ATGCGCAAATAA": del c.4_5 (CG, non-multiple-of-3).
+        // Net = -2 → frameshift.
+        let t = tx("ATGCGCAAATAA", 1, 12);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 5, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("fs"), "expected frameshift in '{}'", s);
+    }
+
+    #[test]
+    fn ins_three_bases_codon_aligned() {
+        // CDS "ATGCGCTAA": insert "GGG" at c.3_4 (between codon 1 end and codon 2 start).
+        // cds_pos_start=3 (last base of Met codon, frame=2), cds_pos_end=3.
+        // Mutated CDS: "ATGGGGCGCTAA" → ATG GGG CGC TAA → [Met, Gly, Arg]
+        // ref=[Met, Arg], alt=[Met, Gly, Arg]
+        // Insertion between aa1 (Met) and aa2 (Arg): p.(Met1_Arg2insGly)
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert_eq!(s, "NP_TEST.1:p.(Met1_Arg2insGly)");
+    }
+
+    #[test]
+    fn ins_one_base_frameshift() {
+        // CDS "ATGCGCTAA": insert "A" at c.3_4.
+        // Net = +1 → frameshift.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "A".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("fs"), "expected frameshift in '{}'", s);
+    }
+
+    #[test]
+    fn dup_three_bases_codon_aligned() {
+        // CDS "ATGCGCTAA": dup c.4_6 (CGC).
+        // Mutated CDS: "ATGCGCCGCTAA" → ATG CGC CGC TAA → [Met, Arg, Arg]
+        // ref=[Met, Arg], alt=[Met, Arg, Arg]
+        // dup of Arg codon (cds 4..6 → aa_start_idx=1, aa_end_idx=1) → p.(Arg2dup)
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Duplication {
+            sequence: None,
+            length: None,
+            uncertain_extent: None,
+        };
+        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert_eq!(s, "NP_TEST.1:p.(Arg2dup)");
+    }
+
+    #[test]
+    fn dup_one_base_frameshift() {
+        // CDS "ATGCGCTAA": dup c.4 (single C, net=+1 → frameshift).
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Duplication {
+            sequence: None,
+            length: None,
+            uncertain_extent: None,
+        };
+        let result = predict_indel_protein(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("fs"), "expected frameshift in '{}'", s);
+    }
+
+    #[test]
+    fn delins_same_length_codon_aligned() {
+        // CDS "ATGCGCTAA": delins c.4_6 (CGC → TCC).
+        // Mutated CDS: "ATGTCCTAA" → ATG TCC TAA → [Met, Ser]
+        // ref=[Met, Arg], alt=[Met, Ser]
+        // first_diff=1, last_diff_ref=1, last_diff_alt=1 → p.(Arg2delinsser)? No:
+        // It's a delins: p.(Arg2delinsSer) → but HGVS for single AA change is really
+        // p.(Arg2Ser) substitution. However since it's a delins NaEdit we go through
+        // build_inframe_delins. Let's check what we actually get.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "TCC".parse().unwrap();
+        let edit = NaEdit::Delins {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // Should be a delins at Arg2 → Ser: p.(Arg2delinsSer)
+        assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
+        assert!(s.contains("delins"), "expected delins in '{}'", s);
+        assert!(s.contains("Ser"), "expected Ser in '{}'", s);
+    }
+
+    #[test]
+    fn inversion_codon_cgc_to_gcg() {
+        // CDS "ATGCGCTAA": inv c.4_6 (CGC → GCG).
+        // GCG = Ala. Mutated CDS: "ATGGCGTAA" → [Met, Ala]
+        // first_diff=1 → delins Arg2 → Ala: p.(Arg2delinsAla)
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Inversion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
+        assert!(s.contains("delins"), "expected delins in '{}'", s);
+        assert!(s.contains("Ala"), "expected Ala in '{}'", s);
+    }
+
+    #[test]
+    fn stop_readthrough_extension() {
+        // CDS "ATGCGCTAA": the stop codon is "TAA" at c.7_9.
+        // Replace TAA with TGG (Trp): delins c.7_9 TGG.
+        // Mutated CDS: "ATGCGCTGG" → [Met, Arg, Trp] and then whatever follows.
+        // The mutated CDS has no stop — translate_full_cds returns [Met, Arg, Trp]
+        // and translate_full_cds_with_stop also returns [Met, Arg, Trp] (no Ter).
+        // alt_protein.len()=3 > ref_protein.len()=2 → extension check.
+        // Stop was at position 3 (1-based), new AA at that position = Trp.
+        // ext_count: downstream from stop_offset=6: "TGG" = Trp — no Ter found → None.
+        // Result: p.(Ter3Trpext*?)
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "TGG".parse().unwrap();
+        let edit = NaEdit::Delins {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
+        };
+        let result = predict_indel_protein(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("Ter3"), "expected Ter3 in '{}'", s);
+        assert!(s.contains("Trp"), "expected Trp in '{}'", s);
+        assert!(s.contains("ext"), "expected ext in '{}'", s);
+    }
+}

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -1,0 +1,19 @@
+//! Protein consequence prediction for CDS variants.
+//!
+//! This module predicts the amino acid level consequence of a variant using the
+//! HGVS protein nomenclature recommendations:
+//! <https://hgvs-nomenclature.org/stable/recommendations/protein/>
+//!
+//! # Submodules
+//!
+//! * [`substitution`] — substitution (missense / synonymous / nonsense) prediction.
+//! * [`indel`]         — deletion / insertion / duplication / delins / inversion prediction.
+//! * [`helpers`]       — shared pure helpers (CDS building, translation, diff-finding).
+
+mod helpers;
+mod indel;
+mod substitution;
+
+// Re-export the public API used by `projector.rs`.
+pub(crate) use indel::predict_indel_protein;
+pub(crate) use substitution::predict_substitution_protein;

--- a/src/project/protein/substitution.rs
+++ b/src/project/protein/substitution.rs
@@ -1,4 +1,4 @@
-//! Protein consequence prediction for substitutions in the CDS.
+//! Protein consequence prediction for CDS substitutions.
 
 use crate::backtranslate::{Codon, CodonTable};
 use crate::error::FerroError;

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -80,14 +80,14 @@ class TestVariantProjector:
         assert result.is_intronic is False
         assert result.is_utr is False
 
-    def test_deletion_no_protein_is_frameshift(
-        self, projector: ferro_hgvs.VariantProjector
-    ) -> None:
-        # 1-base deletion → frameshift; p. is None (indel p. nomenclature deferred).
+    def test_deletion_frameshift_protein(self, projector: ferro_hgvs.VariantProjector) -> None:
+        # g.1003del deletes c.4 (C, first base of Arg codon CGC) — net=-1 → frameshift.
+        # Mutated CDS: "ATGGCTAA" → Met-Ala-Stop → p.(Arg2Alafsx).
         result = projector.project("NC_000001.11:g.1003del", transcript="NM_TEST.1")
         assert result.c_name is not None
         assert "del" in result.c_name
-        assert result.p_name is None
+        assert result.p_name is not None
+        assert "fs" in result.p_name
         assert result.is_frameshift is True
 
     def test_unknown_transcript_raises(self, projector: ferro_hgvs.VariantProjector) -> None:
@@ -105,3 +105,155 @@ class TestVariantProjector:
         assert "VariantProjection" in rep
         # repr should include either the g_name or c_name
         assert ":g." in rep or ":c." in rep
+
+
+@pytest.fixture
+def long_projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """Build a VariantProjector backed by a longer transcript for indel p. tests.
+
+    Transcript NM_LONG.1 on chr2, plus strand, genomic positions 2000-2023 (1-based).
+    CDS sequence: "ATGCGCAAAGGGTTTTAA" (18 bp = 6 codons: Met-Arg-Lys-Gly-Phe-Stop).
+    g.2000 = c.1 (A of start codon).
+    g.2005 = c.6 (A of Lys codon AAA).
+    g.2008 = c.9 (last base of Gly codon GGG).
+
+    The full transcript is 24 bp: 3 bp 5'UTR "AAA" + 18 bp CDS + 3 bp 3'UTR "CCC".
+    So tx positions 1-3 are UTR, 4-21 are CDS (cds_start=4, cds_end=21),
+    and 22-24 are 3'UTR. Genomic: g.2000 = c.1 (tx pos 4 = first CDS base).
+    """
+    # CDS "ATGCGCAAAGGGTTTTAA":
+    #   ATG = Met  (c.1-3,  g.2000-2002)
+    #   CGC = Arg  (c.4-6,  g.2003-2005)
+    #   AAA = Lys  (c.7-9,  g.2006-2008)
+    #   GGG = Gly  (c.10-12, g.2009-2011)
+    #   TTT = Phe  (c.13-15, g.2012-2014)
+    #   TAA = Stop (c.16-18, g.2015-2017)
+    #
+    # Full tx seq (24 bp): "AAA" + "ATGCGCAAAGGGTTTTAA" + "CCC"
+    # cds_start=4 (1-based), cds_end=21 (1-based).
+    cds_seq = "ATGCGCAAAGGGTTTTAA"  # 18 bp
+    full_seq = "AAA" + cds_seq + "CCC"  # 24 bp
+    # Genomic layout: 3 bp UTR at g.2000-2002, CDS at g.2003-2020, UTR at g.2021-2023.
+    # Actually: tx pos 1-3 = UTR (genomic 2000-2002), tx pos 4-21 = CDS (genomic 2003-2020).
+    # Genomic start of transcript = 2000, end = 2023 (1-based inclusive).
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_LONG.1",
+                "gene_symbol": "LONGGENE",
+                "strand": "+",
+                "sequence": full_seq,
+                "cds_start": 4,  # 1-based tx pos of first CDS base
+                "cds_end": 21,  # 1-based tx pos of last CDS base (stop codon included)
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,  # tx pos start (1-based)
+                        "end": 24,  # tx pos end (1-based)
+                        "genomic_start": 2000,  # g.2000 = 'A' of 5'UTR
+                        "genomic_end": 2023,  # g.2023 = last 'C' of 3'UTR
+                    }
+                ],
+                "chromosome": "chr2",
+                "genomic_start": 2000,
+                "genomic_end": 2023,
+            }
+        ],
+        "genomic_sequences": {
+            "chr2": "N" * 2000 + full_seq + "N" * 100,
+        },
+    }
+    path = tmp_path / "long_transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return ferro_hgvs.VariantProjector(reference_json=str(path))
+
+
+class TestIndelProteinNomenclature:
+    """End-to-end p. nomenclature tests for indel projections on NM_LONG.1.
+
+    CDS "ATGCGCAAAGGGTTTTAA": Met1-Arg2-Lys3-Gly4-Phe5-Stop.
+    Genomic positions (1-based):
+      g.2003 = c.1 = Met codon start
+      g.2006 = c.4 = Arg codon start (CGC)
+      g.2009 = c.7 = Lys codon start (AAA)
+      g.2012 = c.10 = Gly codon start (GGG)
+      g.2015 = c.13 = Phe codon start (TTT)
+      g.2018 = c.16 = Stop codon start (TAA)
+    """
+
+    def test_del_whole_codon_single_aa(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Delete Arg codon (c.4_6 = g.2006_2008del): p.(Arg2del).
+        result = long_projector.project("NC_000002.12:g.2006_2008del", transcript="NM_LONG.1")
+        assert result.c_name is not None
+        assert "del" in result.c_name
+        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2del)"
+        assert result.is_frameshift is False
+
+    def test_del_two_whole_codons(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Delete Arg+Lys codons (c.4_9 = g.2006_2014del): p.(Arg2_Lys3del).
+        result = long_projector.project("NC_000002.12:g.2006_2011del", transcript="NM_LONG.1")
+        assert result.c_name is not None
+        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2_Lys3del)"
+        assert result.is_frameshift is False
+
+    def test_del_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Delete one base from Arg codon (g.2006del = c.4del): frameshift.
+        result = long_projector.project("NC_000002.12:g.2006del", transcript="NM_LONG.1")
+        assert result.p_name is not None
+        assert "fs" in result.p_name
+        assert "Arg2" in result.p_name
+        assert result.is_frameshift is True
+
+    def test_dup_whole_codon(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Duplicate Arg codon (g.2006_2008dup): p.(Arg2dup).
+        result = long_projector.project("NC_000002.12:g.2006_2008dup", transcript="NM_LONG.1")
+        assert result.c_name is not None
+        assert "dup" in result.c_name
+        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2dup)"
+        assert result.is_frameshift is False
+
+    def test_dup_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Duplicate one base (g.2006dup = c.4dup): frameshift.
+        result = long_projector.project("NC_000002.12:g.2006dup", transcript="NM_LONG.1")
+        assert result.p_name is not None
+        assert "fs" in result.p_name
+        assert result.is_frameshift is True
+
+    def test_ins_three_bases_codon_boundary(
+        self, long_projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # Insert GGG at codon boundary c.3_4 (g.2005_2006insGGG):
+        # insertion between Met (c.1-3) and Arg (c.4-6) → p.(Met1_Arg2insGly).
+        result = long_projector.project("NC_000002.12:g.2005_2006insGGG", transcript="NM_LONG.1")
+        assert result.c_name is not None
+        assert "ins" in result.c_name
+        assert result.p_name is not None
+        assert "ins" in result.p_name
+        assert result.is_frameshift is False
+
+    def test_ins_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Insert one base (g.2005_2006insA): net=+1 → frameshift.
+        result = long_projector.project("NC_000002.12:g.2005_2006insA", transcript="NM_LONG.1")
+        assert result.p_name is not None
+        assert "fs" in result.p_name
+        assert result.is_frameshift is True
+
+    def test_inversion_whole_codon(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Invert Arg codon (g.2006_2008inv = c.4_6inv = CGC → GCG = Ala):
+        # p.(Arg2delinsAla).
+        result = long_projector.project("NC_000002.12:g.2006_2008inv", transcript="NM_LONG.1")
+        assert result.c_name is not None
+        assert "inv" in result.c_name
+        assert result.p_name is not None
+        assert "Arg2" in result.p_name
+        assert "delins" in result.p_name
+        assert "Ala" in result.p_name
+        assert result.is_frameshift is False
+
+    def test_stop_codon_readthrough(self, long_projector: ferro_hgvs.VariantProjector) -> None:
+        # Replace stop codon TAA (g.2018_2020) with TGG (Trp):
+        # p.(Ter6Trpext*?).
+        result = long_projector.project("NC_000002.12:g.2018_2020delinsTGG", transcript="NM_LONG.1")
+        assert result.p_name is not None
+        assert "Ter6" in result.p_name
+        assert "ext" in result.p_name


### PR DESCRIPTION
## Summary

PR 2 of 3 for issue #200. Stacks on #202.

Adds protein consequence prediction for all non-substitution edit types: in-frame del/ins/dup/delins, frameshift `fs*N` (with downstream stop scan), stop-codon readthrough (`extN`), and inversion-as-delins. The projector now produces a meaningful `p.` for every edit type rather than `None`.

## What ships

| NaEdit | In-frame | Frameshift | Notes |
|---|---|---|---|
| Deletion | `p.(Xxx{N}del)` or `p.(Xxx{N}_Yyy{M}del)` | `p.(Xxx{N}fsTer{K})` | Codon-aligned vs straddle handled |
| Insertion | `p.(Xxx{N}_Yyy{N+1}ins...)` or delins | `p.(Xxx{N}fsTer{K})` | Mid-codon → delins fallback |
| Duplication | `p.(Xxx{N}dup)` or `p.(Xxx{N}_Yyy{M}dup)` | `p.(Xxx{N}fsTer{K})` | — |
| Delins | `p.(Xxx{N}delins...)` | `p.(Xxx{N}fsTer{K})` | — |
| Inversion | `p.(Xxx{N}delins...)` | n/a (length preserved) | Always delins at protein level |
| Stop readthrough (any edit) | `p.(Ter{N}{Yyy}ext*{K})` | — | `ProteinEdit::Extension` |

## Architecture

`src/project/protein.rs` was 250 lines after PR 1; this PR refactors it into a `src/project/protein/` submodule before adding logic:

- `protein/substitution.rs` — existing PR 1 logic, unchanged
- `protein/helpers.rs` — pure helpers: `read_full_cds`, `build_mutated_cds`, `translate_full_cds`/`_with_stop`, `first_diff_position`, `net_length_change`
- `protein/indel.rs` — `predict_indel_protein` entry point + per-shape builders (`build_frameshift_variant`, `build_inframe_deletion`, `build_inframe_insertion`, `build_inframe_duplication`, `build_inframe_delins`, `build_extension_variant`)

The projector now dispatches to `predict_indel_protein` for all five indel `NaEdit` types when the c. positions are concrete and exonic. Non-fatal errors (`UnsupportedProjection`, `ProteinSequenceUnavailable`) leave `protein: None` for graceful degradation rather than propagating.

## HGVS spec judgment calls

- `fsTer{K}`: K counts from the first shifted amino acid to the stop, inclusive. When no downstream stop is found in the mutated CDS, `ter_pos` is `None` → `p.(Xxx{N}[Yyy]fs)` without the Ter position.
- Mid-codon insertion/deletion (length % 3 == 0 but not codon-boundary-aligned): falls through to the generic delins path rather than getting a specific `ins`/`del` label. Matches HGVS recommendations for straddle cases.
- Inversion always emits delins at the protein level (length preserved but sequence always changes — a true delins).

## Tests

- 4308 Rust tests pass (29 new since PR 1).
- 148 Python tests pass (9 new since PR 1).
- `cargo clippy --features dev -- -D warnings` clean.
- `ruff check` clean.

## What's still out of scope (PR 3)

- Compound `[a;b]` allele variants.
- `project_all` returning `Vec<VariantProjection>` across overlapping transcripts sorted by MANE/canonical priority.
- `project_normalized` entry point for batch callers that pre-normalize.

## Test plan

- [x] `cargo nextest run --features dev`
- [x] `pytest tests/python/`
- [x] `cargo clippy --features dev -- -D warnings`
- [x] `ruff check python/ tests/python/`
- [x] `maturin develop --features python` builds