### PR TITLE
ci(publish): drop submodule checkout from release-plz job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-          submodules: true
+          # No submodules: release-plz only reads Cargo.toml/changelog/git
+          # history. `/assets/` is excluded from the package (Cargo.toml
+          # `exclude`), and checking it out couples this job to upstream
+          # submodule cleanliness — cargo's vcs check rejected the working
+          # tree after the hgvs-nomenclature bump shipped tracked files
+          # matching its own `docs/versions/.gitignore` (`*.md`).
           # release-plz pushes tags/commits via the persisted token; do not disable.
           token: ${{ secrets.RELEASE_PLZ_TOKEN }} # zizmor: ignore[artipacked]
       - name: Install Rust toolchain


### PR DESCRIPTION
## Summary

The `Manage Release PRs and Publish Crates` workflow (`publish.yml`) has been failing on every push to `main` since commit `d255f24` (PR #193, the `hgvs-nomenclature` snapshot refresh). Example failing run: https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/25947409825/job/76278234469.

### Root cause

The bump moved `assets/hgvs-nomenclature` from `a32f970` (Jan 2024) to `6f85311` (upstream `main` HEAD). The new pin contains a self-contradictory state inside the submodule: `docs/versions/.gitignore` says `*.md`, while the same directory tracks four `.md` files (`21.0.md`, `21.1.md`, `index.md`, `older-versions.md`). `git ls-files -ci --exclude-standard` lists all four on the new pin and zero on the old one.

`release-plz release-pr` invokes cargo, which runs a vcs status check that walks the whole working tree — including submodule paths — and refuses to proceed when it finds any tracked-and-ignored files. That produced the error reported in the log:

```
failed to determine next versions
the working directory of this project has uncommitted changes. ...
Otherwise, please commit or stash these changes:
["assets/hgvs-nomenclature"]
```

### Fix

Drop `submodules: true` from the publish job's checkout step. `release-plz` only needs `Cargo.toml`, the changelog, and git history to compute next versions and publish to crates.io. The `/assets/` directory is excluded from the package (`Cargo.toml` `exclude`), there is no `build.rs`, and every `src/` reference to the submodule path is a doc-comment citation rather than a file read — so the publish job has no reason to materialize the submodule. With it absent at checkout time, cargo's vcs check no longer traverses that path and stops being held hostage to upstream submodule hygiene.

### Alternatives considered

- **`allow_dirty = true` in `release-plz.toml`** — would also unblock CI, but silences cargo's vcs check globally for this job, masking future legitimate dirty states.
- **Repin / patch upstream** — leaves us coupled to upstream cleanliness; the next time `HGVSnomenclature/hgvs-nomenclature` introduces a tracked-and-ignored file the same break recurs.

## Test plan

- [ ] After merge, the next push to `main` triggers `publish.yml` and the `Run release-plz` step succeeds (no `failed to determine next versions` error).
- [ ] `release-plz release-pr` either opens a release PR with the unreleased commits since `v0.5.0` or reports `prs_created=false` cleanly.
- [ ] No other workflow regresses (only `publish.yml` is touched; `ci.yml`, `coverage.yml`, `external-validation.yml`, `fuzz.yml`, `release-wheels.yml`, `deploy-local.yml` continue to check out submodules where they need them).