### PR TITLE
fix(normalize): decompose delins to multi-sub canonical form when sub > delins applies (closes #165)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -518,7 +518,11 @@ fn build_mt_merged(template: &MtVariant, merged: Anchor) -> MtVariant {
 /// Two CDS positions share a codon if they fall in the same 1-indexed
 /// triplet: `c.1..3` is codon 1, `c.4..6` is codon 2, etc. The standard
 /// codon-number formula is `(base - 1) / 3` (integer division).
-fn same_codon(a: i64, b: i64) -> bool {
+///
+/// Exposed at `pub(crate)` so the post-merge `decompose_delins`
+/// pass can re-apply the spec's codon-frame exception (issue #165 /
+/// tracking issue #81 item A10).
+pub(crate) fn same_codon(a: i64, b: i64) -> bool {
     if a < 1 || b < 1 {
         return false;
     }
@@ -631,5 +635,10 @@ mod tests {
         assert!(!same_codon(3, 5)); // codon 1 vs codon 2
         assert!(!same_codon(0, 2)); // 0 invalid
         assert!(!same_codon(-3, -1));
+        // Large positions exercise the `(base - 1) / 3` formula far from
+        // its near-zero edge. c.99997..c.99999 falls in codon 33333;
+        // c.99998..c.100000 straddles codon 33333 and 33334.
+        assert!(same_codon(99997, 99999));
+        assert!(!same_codon(99998, 100000));
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -283,17 +283,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let merged_raw =
             merge::merge_consecutive_edits(allele.variants.clone(), allele.phase, &self.provider);
 
-        // Issue #160: any merged delins (or pre-existing delins that survived
-        // merge unchanged) may decompose into [..., inv, ...] when an inv-
-        // eligible sub-span is present. Run the split per merged variant; the
-        // helper is a no-op for non-Delins variants and for Delins without an
-        // inv sub-span. Only applies in cis phase — trans alleles aren't
+        // Issue #160 + #165: any merged delins (or pre-existing delins
+        // that survived merge unchanged) may decompose into a sequence of
+        // higher-priority forms per `general.md:56` — `[..., inv, ...]`
+        // when an inv-eligible sub-span is present (#160) and/or into
+        // separate substitutions when interior positions match the
+        // reference (#165). Run the split per merged variant; the helper
+        // is a no-op for non-Delins variants and for Delins with nothing
+        // to split out. Only applies in cis phase — trans alleles aren't
         // collapsible in the first place.
         let merged_split: Vec<HgvsVariant> =
             if allele.phase == crate::hgvs::variant::AllelePhase::Cis {
                 merged_raw
                     .into_iter()
-                    .flat_map(|v| self.split_inv_for_variant(v))
+                    .flat_map(|v| self.canonical_split_for_variant(v))
                     .collect()
             } else {
                 merged_raw
@@ -439,10 +442,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ),
         };
 
-        // Issue #160: a normalized Delins may decompose into [..., inv, ...]
-        // when an inv-eligible sub-span is present. Returns the variant
-        // unchanged for non-Delins or no-decomposition cases.
-        let split = self.apply_inv_split(HV::Genome(new_variant));
+        // Issue #160 + #165: a normalized Delins may decompose under the
+        // spec's edit-priority rule (`general.md:56`) — into `[..., inv,
+        // ...]` for rev-comp sub-spans and/or into separate subs across
+        // interior identities. Returns the variant unchanged for
+        // non-Delins or no-decomposition cases.
+        let split = self.apply_canonical_split(HV::Genome(new_variant));
         Ok((wrap_allele_if_split(split), warnings))
     }
 
@@ -560,8 +565,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
             loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
         };
 
-        // Issue #160 inv sub-span split (CDS-proper positions only).
-        let split = self.apply_inv_split(HV::Cds(new_variant));
+        // Issue #160 + #165 post-canonicalization split. The codon-frame
+        // exception applies only to CDS-proper positions, which the
+        // helper filters internally via `simple_cds_pos`.
+        let split = self.apply_canonical_split(HV::Cds(new_variant));
         Ok((wrap_allele_if_split(split), warnings))
     }
 
@@ -659,8 +666,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ),
         };
 
-        // Issue #160 inv sub-span split.
-        let split = self.apply_inv_split(HV::Tx(new_variant));
+        // Issue #160 + #165 post-canonicalization split.
+        let split = self.apply_canonical_split(HV::Tx(new_variant));
         Ok((wrap_allele_if_split(split), warnings))
     }
 
@@ -1019,8 +1026,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
             loc_edit: LocEdit::new(RnaInterval::new(new_start, new_end), new_edit),
         };
 
-        // Issue #160 inv sub-span split (T/U-equivalent comparison).
-        let split = self.apply_inv_split(HV::Rna(new_variant));
+        // Issue #160 + #165 post-canonicalization split (T/U-equivalent
+        // comparison for the rev-comp scan and per-position emissions).
+        let split = self.apply_canonical_split(HV::Rna(new_variant));
         Ok((wrap_allele_if_split(split), warnings))
     }
 
@@ -1096,7 +1104,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         variant: &crate::hgvs::variant::MtVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         // MT variants are similar to genomic. We canonicalize `con` -> `delins`
-        // (SVD-WG009) up front, then route through apply_inv_split so any
+        // (SVD-WG009) up front, then route through apply_canonical_split so any
         // delins whose ref/alt span contains an inv-eligible sub-span
         // decomposes the same way it does for g. (issue #160). Full
         // window-based normalization and the per-edit canonicalization that
@@ -1113,11 +1121,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
                     ),
                 };
-                let split = self.apply_inv_split(HV::Mt(new_variant));
+                let split = self.apply_canonical_split(HV::Mt(new_variant));
                 return Ok((wrap_allele_if_split(split), vec![]));
             }
         }
-        let split = self.apply_inv_split(HV::Mt(variant.clone()));
+        let split = self.apply_canonical_split(HV::Mt(variant.clone()));
         Ok((wrap_allele_if_split(split), vec![]))
     }
 
@@ -2550,15 +2558,27 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
     }
 
-    /// Issue #160 inv sub-span split for a single normalized variant.
+    /// Post-canonicalization split for a single normalized variant.
     /// Coord-system-agnostic: handles `g.`, `m.`, `c.` (CDS-proper positions
     /// only), `n.`, and `r.`. Fetches the per-coord-system reference window
-    /// internally, calls `decompose_delins_inv`, and rebuilds N variants when
+    /// internally, calls `decompose_delins`, and rebuilds N variants when
     /// the decomposition fires. Returns `vec![variant]` if the variant
     /// doesn't decompose (non-Delins, complex location, no provider data,
-    /// no inv sub-span).
+    /// nothing to split out).
     ///
-    /// Position math: `decompose_delins_inv` returns 0-indexed offsets into
+    /// Implements two spec-priority rules from `general.md:56`
+    /// (substitution > deletion > inversion > duplication > insertion):
+    /// - Inversion priority: a delins whose span contains a rev-comp
+    ///   sub-span splits into `[…; inv; …]` (issue #160).
+    /// - Substitution priority: a delins whose post-trim span contains
+    ///   two or more independent single-base mismatches separated by at
+    ///   least one unchanged nucleotide splits into separate substitutions
+    ///   (issue #165 / item A10). The narrow codon-frame exception
+    ///   (`general.md:35-38`) is preserved by `build_split_variants`,
+    ///   which re-groups `[Sub; Identity; Sub]` triplets whose endpoints
+    ///   share a codon when the variant is in CDS.
+    ///
+    /// Position math: `decompose_delins` returns 0-indexed offsets into
     /// the fetched `ref_bytes` slice. `ref_bytes[0]` corresponds to the
     /// variant's HGVS start position, so absolute HGVS pos = `hgvs_start +
     /// offset`.
@@ -2567,9 +2587,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// are `T`. Both slices are normalized to `T` before comparison so the
     /// rev-comp scan works uniformly; the emitted `Substitution` sub-edits
     /// preserve the original alt `Base` (which may be `Base::U`).
-    fn apply_inv_split(&self, variant: HgvsVariant) -> Vec<HgvsVariant> {
+    fn apply_canonical_split(&self, variant: HgvsVariant) -> Vec<HgvsVariant> {
         let Some((hgvs_start, hgvs_end, alt_bytes, ref_bytes)) =
-            self.fetch_ref_for_inv_split(&variant)
+            self.fetch_ref_for_canonical_split(&variant)
         else {
             return vec![variant];
         };
@@ -2581,15 +2601,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
         );
         let ref_norm = normalize_t_u(&ref_bytes);
         let alt_norm = normalize_t_u(&alt_bytes);
-        let Some(subedits) = rules::decompose_delins_inv(&ref_norm, 0, n, &alt_norm) else {
+        let Some(subedits) = rules::decompose_delins(&ref_norm, 0, n, &alt_norm) else {
             return vec![variant];
         };
         // Substitution sub-edits inherit `alt_norm` bytes (T-form) from
-        // decompose_delins_inv, but the user's literal alt may have been U
+        // `decompose_delins`, but the user's literal alt may have been U
         // (r. inputs). Re-derive the substitution `alternative` from the
         // pre-normalized `alt_bytes` so r. variants render `g>u` instead of
         // a silently coerced `g>t`. The position field is a 0-indexed offset
-        // into the same window passed to decompose_delins_inv, so it indexes
+        // into the same window passed to `decompose_delins`, so it indexes
         // alt_bytes directly.
         let subedits = subedits
             .into_iter()
@@ -2610,19 +2630,26 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 other => other,
             })
             .collect();
-        build_split_variants(&variant, subedits, hgvs_start)
+        // The codon-frame exception (`general.md:35-38`) only applies to
+        // `c.` variants on CDS-proper positions; `fetch_ref_for_canonical_split`
+        // already filters to those via `simple_cds_pos`, so the discriminant
+        // check below is sufficient. The exception fires inside
+        // `build_split_variants` for every embedded `[Sub; Identity; Sub]`
+        // triplet whose endpoints share a codon.
+        let codon_frame_aware = matches!(variant, HgvsVariant::Cds(_));
+        build_split_variants(&variant, subedits, hgvs_start, codon_frame_aware)
     }
 
     /// Per-coord-system extraction of `(hgvs_start, hgvs_end, alt_bytes,
-    /// ref_bytes)` for inv-split. Returns `None` when the variant is not a
-    /// single-Delins at simple positions, or when the provider can't supply
-    /// the ref window.
+    /// ref_bytes)` for the post-canonicalization split. Returns `None`
+    /// when the variant is not a single-Delins at simple positions, or
+    /// when the provider can't supply the ref window.
     ///
     /// The `ref_bytes` slice is sized exactly to the variant's HGVS interval
     /// (`hgvs_end - hgvs_start + 1` bytes), with `ref_bytes[0]` aligned to
     /// HGVS pos `hgvs_start`. This invariant lets the caller use a uniform
     /// `hgvs_pos = hgvs_start + offset` formula regardless of coord system.
-    fn fetch_ref_for_inv_split(
+    fn fetch_ref_for_canonical_split(
         &self,
         variant: &HgvsVariant,
     ) -> Option<(u64, u64, Vec<u8>, Vec<u8>)> {
@@ -2694,23 +2721,27 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Some((hgvs_start, hgvs_end, alt, ref_bytes))
     }
 
-    /// Issue #160 post-merge canonicalization for a single variant. Used by
-    /// the cis-allele merge path; `normalize_allele` applies this per merged
-    /// variant. Conservatively returns `vec![v]` for variants the helper
-    /// can't process.
+    /// Issue #160 + #165 post-merge canonicalization for a single
+    /// variant. Used by the cis-allele merge path; `normalize_allele`
+    /// applies this per merged variant. Conservatively returns
+    /// `vec![v]` for variants the helper can't process.
     ///
-    /// Two spec rules are folded together by re-running normalization on the
-    /// merged variant:
+    /// Three spec rules are folded together by re-running normalization
+    /// on the merged variant:
     /// - Full-span canonicalization (identity / dup / sub / del / ins /
     ///   full-span inv with outer-pair shortening) handled by
     ///   `canonicalize_delins` inside `normalize_na_edit`.
     /// - Sub-span inv decomposition (the issue #160 case) handled by
-    ///   `apply_inv_split` wired into each per-coord-system `normalize_*`.
+    ///   `apply_canonical_split` wired into each per-coord-system
+    ///   `normalize_*`.
+    /// - Sub-only decomposition for delins containing interior identities
+    ///   (issue #165 / item A10), with the spec's codon-frame exception
+    ///   (`general.md:35-38`) preserved inside `build_split_variants`.
     ///
-    /// If the result is an `HgvsVariant::Allele` (sub-span split fired),
-    /// unwrap its inner variants so they flatten into the outer cis-allele
-    /// list rather than nesting.
-    fn split_inv_for_variant(&self, v: HgvsVariant) -> Vec<HgvsVariant> {
+    /// If the result is an `HgvsVariant::Allele` (the split fired and
+    /// produced multiple variants), unwrap its inner variants so they
+    /// flatten into the outer cis-allele list rather than nesting.
+    fn canonical_split_for_variant(&self, v: HgvsVariant) -> Vec<HgvsVariant> {
         if !matches!(
             v,
             HgvsVariant::Genome(_)
@@ -2783,27 +2814,33 @@ fn unflip_intronic_positions(
 }
 
 // =============================================================================
-// Issue #160: inv sub-span split helpers
+// Issue #160 + #165: delins post-canonicalization split helpers
 // =============================================================================
 //
 // After `normalize_na_edit` (or `merge_consecutive_edits` for cis alleles)
-// produces a Delins variant, we may discover the delins span actually contains
-// an `inv`-eligible sub-span. The HGVS spec puts `inv` higher than `delins`
-// in the edit-priority order, so the canonical form is to split the delins
-// into a sequence of [..., inv, ...] sub-edits and wrap them back in a cis
-// allele.
+// produces a Delins variant, the resulting span may be expressible in a
+// higher-priority form under `general.md:56` (sub > del > inv > dup > ins).
+// Two cases fire here:
+// - Inversion sub-span: the delins span contains a rev-comp sub-region —
+//   split into `[…; inv; …]` (issue #160).
+// - Independent substitutions: the delins span contains two or more
+//   single-base mismatches separated by at least one unchanged nucleotide
+//   — split each into its own sub variant (issue #165 / tracking issue
+//   #81 item A10). The codon-frame exception (`general.md:35-38`) is
+//   preserved when applicable (see `build_split_variants`).
 //
 // The split is implemented as a post-pass over an already-built variant. It
 // fetches a reference window via the provider, calls
-// `rules::decompose_delins_inv`, and rebuilds N variants when the
+// `rules::decompose_delins`, and rebuilds N variants when the
 // decomposition fires. For variants that don't decompose (most cases), the
 // helper returns `vec![input]` and is effectively a no-op.
 
 /// Per-coord-system-aware extraction of `(hgvs_start, hgvs_end, alt_bytes)`
 /// from a variant whose edit is a literal `Delins` at simple positions
 /// (no offsets, no uncertainty). Returns `None` for any variant shape that
-/// can't be decomposed by the inv-split rule (non-Delins, intronic, uncertain
-/// boundary, non-literal insert, etc.).
+/// can't be decomposed by the post-canonicalization split rules
+/// (issues #160 / #165): non-Delins, intronic, uncertain boundary,
+/// non-literal insert, etc.
 fn extract_simple_delins(variant: &HgvsVariant) -> Option<(u64, u64, Vec<u8>)> {
     let (start, end, edit) = match variant {
         HgvsVariant::Genome(v) => simple_genome_loc_edit(&v.loc_edit)?,
@@ -2887,7 +2924,7 @@ fn simple_rna_pos(mu: &Mu<RnaPos>) -> Option<u64> {
 /// Build a single HgvsVariant matching `template`'s coord-system kind /
 /// accession / gene_symbol, with a new `[start_1based, end_1based]` location
 /// and the given edit. Used by `build_split_variants` to spread the output
-/// of `decompose_delins_inv` back into a sequence of HgvsVariants.
+/// of `decompose_delins` back into a sequence of HgvsVariants.
 fn build_variant_at(
     template: &HgvsVariant,
     start_1based: u64,
@@ -2953,21 +2990,40 @@ fn build_variant_at(
 /// 1-based HGVS positions are recovered as `offset + hgvs_start`, where
 /// `hgvs_start` is the variant's HGVS start position.
 ///
-/// Consecutive `Substitution` sub-edits whose positions are strictly
-/// adjacent (no gap, no `Inversion` or `IdentityAt` between them) are
-/// grouped into a single `delins` variant per HGVS spec — `substitution.md`:
-/// "changes involving two or more consecutive nucleotides are described as
-/// deletion/insertion (delins)" (issue #182). Singleton sub-runs stay as
-/// `Substitution`; an `Inversion` or `IdentityAt` always breaks a run and
-/// emits separately. `Inversion` therefore acts as a hard barrier — adjacent
-/// sub flanks on either side of an inv are NOT re-merged into the inv span,
-/// preserving the inv-priority decomposition introduced by #166 (which was
-/// adopted to align with the spec's edit-priority list `general.md:45`:
-/// sub > del > inv > dup > ins).
+/// Spec rules implemented (see `general.md`, `substitution.md`):
+///
+/// 1. **Codon-frame exception** (`general.md:35-38`, issue #79 / #165).
+///    When `codon_frame_aware` is true, the scan looks ahead at each
+///    position for a `[Sub@i; Identity@i+1; Sub@i+2]` triplet whose CDS
+///    endpoints (`hgvs_start + i`, `hgvs_start + i + 2`) share a codon.
+///    Such a triplet emits as a single 3-base `delins` with alt
+///    sequence `[Sub@i.alt, Identity@i+1.base, Sub@i+2.alt]`. The flag
+///    is true only for `c.` (CDS) variants — `g.`, `n.`, `r.`, and `m.`
+///    have no codon-frame and skip this branch. The exception is
+///    deliberately narrow (length-3, exact pattern, in-codon endpoints)
+///    so it matches the spec text "two variants separated by one
+///    nucleotide, together affecting one amino acid".
+///
+/// 2. **Adjacent-substitution coalescence** (`substitution.md`,
+///    issue #182). Consecutive `Substitution` sub-edits whose positions
+///    are strictly adjacent (no gap, no `Inversion` or `IdentityAt`
+///    between them) group into a single `delins` variant — "changes
+///    involving two or more consecutive nucleotides are described as
+///    deletion/insertion".
+///
+/// 3. **Inversion as a hard barrier** (issue #166). An `Inversion`
+///    always emits standalone and breaks any in-flight substitution
+///    run, preserving the inv-priority decomposition.
+///
+/// Singleton sub-runs stay as `Substitution`. `IdentityAt` not consumed
+/// by a codon-frame triplet drops (an unchanged base is not an edit) and
+/// always ends any in-flight substitution run — the gap means the
+/// surrounding subs are no longer "consecutive".
 fn build_split_variants(
     template: &HgvsVariant,
     subedits: Vec<DelinsSubedit>,
     hgvs_start: u64,
+    codon_frame_aware: bool,
 ) -> Vec<HgvsVariant> {
     let abs = |idx: usize| -> u64 { idx as u64 + hgvs_start };
 
@@ -2977,26 +3033,84 @@ fn build_split_variants(
     // with `position` the 0-indexed offset into the variant's ref window.
     let mut run: Vec<(usize, Base, Base)> = Vec::new();
 
-    for se in subedits {
-        match se {
+    let n = subedits.len();
+    let mut i = 0;
+    while i < n {
+        // Codon-frame triplet lookahead: try to consume `[Sub; Identity; Sub]`
+        // at offsets `[i, i+1, i+2]` whose endpoints share a codon. Only
+        // fires for CDS variants (`codon_frame_aware`) and is the post-merge
+        // half of issue #79: a pair of in-codon SNVs separated by one
+        // unchanged base must render as a 3-base `delins`, even when the
+        // pair sits inside a longer decomposition.
+        if codon_frame_aware && i + 2 < n {
+            if let (
+                DelinsSubedit::Substitution {
+                    position: p1,
+                    alternative: a1,
+                    ..
+                },
+                DelinsSubedit::IdentityAt {
+                    position: pm,
+                    base: bm,
+                },
+                DelinsSubedit::Substitution {
+                    position: p3,
+                    alternative: a3,
+                    ..
+                },
+            ) = (&subedits[i], &subedits[i + 1], &subedits[i + 2])
+            {
+                if *pm == *p1 + 1 && *p3 == *p1 + 2 {
+                    let cds_p1 = abs(*p1) as i64;
+                    let cds_p3 = abs(*p3) as i64;
+                    if merge::same_codon(cds_p1, cds_p3) {
+                        // Codon-frame triplet preserved as a 3-base
+                        // delins. `bm` is the unchanged ref byte from
+                        // `decompose_delins`. The codon-frame branch is
+                        // CDS-only (`codon_frame_aware` is `true` only
+                        // for `HgvsVariant::Cds`), so T/U recovery for
+                        // r. inputs is unnecessary here — r. variants
+                        // never reach this branch.
+                        flush_substitution_run(&mut output, template, hgvs_start, &mut run);
+                        let s = abs(*p1);
+                        let e = abs(*p3);
+                        let alt_bases = vec![*a1, *bm, *a3];
+                        output.push(build_variant_at(
+                            template,
+                            s,
+                            e,
+                            NaEdit::Delins {
+                                sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
+                                deleted: None,
+                                deleted_length: None,
+                            },
+                        ));
+                        i += 3;
+                        continue;
+                    }
+                }
+            }
+        }
+
+        match &subedits[i] {
             DelinsSubedit::Substitution {
                 position,
                 reference,
                 alternative,
             } => {
-                let breaks_run = matches!(run.last(), Some((prev, _, _)) if *prev + 1 != position);
+                let breaks_run = matches!(run.last(), Some((prev, _, _)) if *prev + 1 != *position);
                 if breaks_run {
                     flush_substitution_run(&mut output, template, hgvs_start, &mut run);
                 }
-                run.push((position, reference, alternative));
+                run.push((*position, *reference, *alternative));
             }
             DelinsSubedit::Inversion { start, end } => {
                 flush_substitution_run(&mut output, template, hgvs_start, &mut run);
                 // Half-open 0-indexed [start, end) of length L=end-start.
                 // HGVS inclusive interval covers L bases starting at
                 // abs(start) and ending at abs(start)+L-1 = abs(end-1).
-                let s = abs(start);
-                let e = abs(end) - 1;
+                let s = abs(*start);
+                let e = abs(*end) - 1;
                 output.push(build_variant_at(
                     template,
                     s,
@@ -3007,16 +3121,18 @@ fn build_split_variants(
                     },
                 ));
             }
-            // Drop IdentityAt: an unchanged base is not an edit, so emitting
-            // a `pos=` sub-variant would clutter the split allele. Both the
-            // codon-frame-merge interior identity (issue #79) and the outer
-            // bases absorbed by `shorten_inversion` map to IdentityAt. An
-            // identity also ends any in-flight substitution run — the gap
-            // means the surrounding subs are no longer "consecutive".
+            // Drop IdentityAt: an unchanged base is not an edit. Outside of
+            // the codon-frame triplet branch above, identities here are
+            // either codon-frame-merge interior bases (issue #79) that did
+            // not pair into a same-codon triplet, or outer bases absorbed
+            // by `shorten_inversion`. An identity also ends any in-flight
+            // substitution run — the gap means the surrounding subs are no
+            // longer "consecutive".
             DelinsSubedit::IdentityAt { .. } => {
                 flush_substitution_run(&mut output, template, hgvs_start, &mut run);
             }
         }
+        i += 1;
     }
     flush_substitution_run(&mut output, template, hgvs_start, &mut run);
     output
@@ -3067,9 +3183,10 @@ fn flush_substitution_run(
 }
 
 /// Normalize DNA `T` and RNA `U` to a single byte (`T`) so byte-wise
-/// comparison works across coord systems. Used by `apply_inv_split` to make
-/// the rev-comp scan T/U-agnostic for `r.` variants whose alt bytes contain
-/// `U` while the transcript ref contains `T`.
+/// comparison works across coord systems. Used by `apply_canonical_split`
+/// to make every decomposition scan (rev-comp inv detection, per-position
+/// sub / identity classification) T/U-agnostic for `r.` variants whose
+/// alt bytes contain `U` while the transcript ref contains `T`.
 fn normalize_t_u(seq: &[u8]) -> Vec<u8> {
     seq.iter()
         .map(|&b| match b {

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -641,11 +641,13 @@ pub enum DelinsCanonical {
     },
 }
 
-/// Per-position sub-edit kind emitted by `decompose_delins_inv` when a delins
-/// span contains an `inv`-eligible sub-span (issue #160).
+/// Per-position sub-edit kind emitted by `decompose_delins` when a delins
+/// span decomposes into the spec-canonical edit-priority form (`inv`
+/// sub-span recognition from issue #160, plus the sub-only branch from
+/// issue #165 / tracking issue #81 item A10).
 ///
 /// All position fields are 0-indexed offsets into `ref_seq` (the same input
-/// passed to `decompose_delins_inv`), matching the convention used by
+/// passed to `decompose_delins`), matching the convention used by
 /// `DelinsCanonical` so callers can convert with the same `index_to_hgvs_pos`
 /// helper.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -659,38 +661,68 @@ pub enum DelinsSubedit {
     /// Inversion over half-open `[start, end)`; by construction `end > start + 1`.
     Inversion { start: usize, end: usize },
     /// 1-base identity at `position` — interior position unchanged from
-    /// reference (e.g. codon-frame merge synthesized middle base, issue #79).
-    /// Renders as `g.<position+1>=`.
-    IdentityAt { position: usize },
+    /// reference (e.g. codon-frame merge synthesized middle base, issue
+    /// #79). The `base` field carries the unchanged reference byte so
+    /// callers can reconstruct the codon-frame triplet's alt sequence
+    /// when preserving the spec's `general.md:35-38` exception during
+    /// decomposition. Always an IUPAC `Base` variant — `decompose_delins`
+    /// abandons the whole decomposition if it sees a non-IUPAC byte at
+    /// an identity position. Renders as `g.<position+1>=` when emitted
+    /// directly.
+    IdentityAt {
+        position: usize,
+        base: crate::hgvs::edit::Base,
+    },
 }
 
-/// Decompose a delins into a sequence of canonical sub-edits when its span
-/// contains at least one inv-eligible sub-span (length >= 2, alt is the
-/// reverse-complement of ref). Returns `Some(edits)` only when the scan emits
-/// at least one `Inversion` element AND the resulting decomposition has more
-/// than one element.
+/// Decompose a delins into a sequence of canonical sub-edits when the
+/// span has at least one inv-eligible sub-span or contains at least one
+/// position whose alt byte equals the ref byte (an interior identity).
+/// Returns `Some(edits)` only when the resulting decomposition has more
+/// than one element AND at least one element is an `Inversion` or an
+/// `IdentityAt`.
+///
+/// Implements:
+/// - Issue #160 (item A2 + A10 inv-branch of tracking issue #81):
+///   reverse-complement sub-spans within a delins are emitted as
+///   `Inversion` per the HGVS edit-priority rule (`general.md:56`:
+///   `inv > delins`).
+/// - Issue #165 (item A10 sub-only branch of #81): an interior position
+///   matching the reference (an `IdentityAt`) is the spec's signal that
+///   the surrounding mismatches are independent variants under
+///   `general.md:34` (variants separated by ≥1 unchanged nt are
+///   described individually) and per the `substitution > delins`
+///   priority. The caller decides whether to emit such triplets as
+///   separate variants or to preserve the spec's codon-frame exception
+///   (`general.md:35-38`) by re-grouping eligible `[Sub; Identity; Sub]`
+///   patterns; this function reports the decomposition either way.
 ///
 /// Returns `None` for:
-/// - Inputs with no inv sub-span (so the caller can leave the delins as-is).
-/// - Inputs where the entire span is a single inversion (already handled by
-///   the existing full-span check in `canonicalize_delins`).
+/// - Inputs whose post-scan emission contains only adjacent
+///   `Substitution` elements (no `Inversion`, no `IdentityAt`). Such a
+///   decomposition would just re-merge into the input delins under the
+///   adjacency rule (`substitution.md`: consecutive nucleotide changes
+///   are described as `delins`, issue #182), so returning `None` lets
+///   the caller short-circuit and avoid pointless churn.
+/// - Inputs where the entire span is a single inversion (already handled
+///   by the full-span check in `canonicalize_delins`).
 /// - Unequal-length delins (`alt.len() != ref.len()`).
 /// - Length-1 inputs (substitution range, never a delins shape).
-/// - Inputs containing a non-IUPAC byte at a substitution position.
+/// - Inputs containing a non-IUPAC byte at any position (substitution
+///   or identity); abandoning the decomposition keeps the original
+///   delins form so a subsequent round-trip lands on the same string.
+/// - Out-of-bounds or empty ranges (`start >= end` or
+///   `end > ref_seq.len()`).
 ///
 /// Algorithm (left-to-right longest-greedy scan over `start..end`):
 /// - At each position `i`, find the largest `j ∈ (i+2 ..= N)` with
 ///   `alt[i..j] == revcomp(ref[i..j])`. If found: emit `Inversion(i, j)`,
 ///   advance `i = j`.
 /// - Else if `alt[i] != ref[i]`: emit `Substitution(i)`, advance `i += 1`.
-/// - Else (`alt[i] == ref[i]`): emit `IdentityAt(i)`, advance `i += 1`.
-///
-/// The "fire only when at least one Inversion is present" trigger preserves
-/// issue #79's codon-frame merge: a codon-frame-merged 3-base delins
-/// `[Sub; Identity; Sub]` cannot contain an inv (the synthesized middle base
-/// satisfies `alt[mid] == ref[mid]`, which is incompatible with revcomp at
-/// the boundary), so it stays as delins.
-pub fn decompose_delins_inv(
+/// - Else (`alt[i] == ref[i]`): emit `IdentityAt(i, ref[i])`, advance
+///   `i += 1`. The byte is recorded so a downstream codon-frame
+///   preservation pass can reconstruct a 3-base delins's alt sequence.
+pub fn decompose_delins(
     ref_seq: &[u8],
     start: usize,
     end: usize,
@@ -711,6 +743,7 @@ pub fn decompose_delins_inv(
 
     let mut emitted: Vec<DelinsSubedit> = Vec::new();
     let mut has_inv = false;
+    let mut has_identity = false;
     let mut i = 0;
     while i < n {
         // Longest j in (i+2 ..= n) with alt[i..j] == revcomp(ref[i..j]) AND
@@ -751,29 +784,39 @@ pub fn decompose_delins_inv(
             });
             i += 1;
         } else {
+            // Record the unchanged ref byte so the caller can rebuild a
+            // codon-frame triplet's alt sequence (issue #165). Abandon
+            // the whole decomposition on non-IUPAC bytes, mirroring the
+            // substitution branch above: an identity position with a
+            // non-IUPAC byte cannot be re-rendered as a 3-base delins
+            // alt without silently coercing the unknown byte to `N`,
+            // which would diverge from the next round-trip's input.
+            let b = Base::from_char(deleted[i] as char)?;
             emitted.push(DelinsSubedit::IdentityAt {
                 position: start + i,
+                base: b,
             });
+            has_identity = true;
             i += 1;
         }
     }
 
-    // Trigger: commit only if at least one Inversion was emitted AND the
-    // decomposition has more than one element. A single-Inversion result is
-    // the same shape that the existing full-span check in
-    // `canonicalize_delins` already produces, so there is no point splitting
-    // for it (returning None lets the caller keep the existing single-form
-    // path).
+    // Trigger: commit only if the decomposition has > 1 element AND it
+    // contains at least one `Inversion` or `IdentityAt`. The former is the
+    // issue #160 path (`inv > delins` priority). The latter is the issue
+    // #165 / item A10 path (`sub > delins` priority, with `IdentityAt`
+    // marking the gap between non-adjacent subs that must split per
+    // `general.md:34`).
     //
-    // TODO(#165): the `has_inv` gate restricts this function to the inv
-    // branch of the spec's edit-priority rule (sub > del > inv > dup > ins).
-    // The same priority rule implies a delins with two or more independent
-    // single-base mismatches (no rev-comp sub-span) should also decompose to
-    // [X>A; B>Y] under sub > delins. Issue #165 tracks loosening this trigger
-    // to fire on any decomposition with > 1 element; the function should
-    // probably be renamed to `decompose_delins` at that point. See also
-    // tracking issue #81 item A10.
-    if has_inv && emitted.len() >= 2 {
+    // A pure-`Substitution` emission of length > 1 has no interior gap and
+    // would be re-merged back into the input delins by the caller's
+    // adjacency rule (`substitution.md` / issue #182), so returning `None`
+    // there lets the caller short-circuit the round-trip.
+    //
+    // A single-`Inversion` result is the same shape that the existing
+    // full-span check in `canonicalize_delins` already produces, so there
+    // is no point splitting for it either.
+    if emitted.len() >= 2 && (has_inv || has_identity) {
         Some(emitted)
     } else {
         None
@@ -2560,7 +2603,7 @@ mod tests {
     }
 
     // =========================================================================
-    // ISSUE #160: decompose_delins_inv tests
+    // ISSUE #160 / #165: decompose_delins tests
     // =========================================================================
 
     fn sub_at(position: usize, r: char, a: char) -> DelinsSubedit {
@@ -2573,15 +2616,18 @@ mod tests {
     fn inv_at(start: usize, end: usize) -> DelinsSubedit {
         DelinsSubedit::Inversion { start, end }
     }
-    fn ident_at(position: usize) -> DelinsSubedit {
-        DelinsSubedit::IdentityAt { position }
+    fn ident_at(position: usize, b: char) -> DelinsSubedit {
+        DelinsSubedit::IdentityAt {
+            position,
+            base: crate::hgvs::edit::Base::from_char(b).unwrap(),
+        }
     }
 
     #[test]
     fn decompose_inv_subspan_at_start() {
         // ref=TCC, alt=GAG: positions 0-1 are inv (revcomp(TC)=GA), position
         // 2 is sub C>G. Mirrors the issue #160 row-2 example.
-        let result = decompose_delins_inv(b"TCC", 0, 3, b"GAG");
+        let result = decompose_delins(b"TCC", 0, 3, b"GAG");
         assert_eq!(result, Some(vec![inv_at(0, 2), sub_at(2, 'C', 'G')]));
     }
 
@@ -2589,7 +2635,7 @@ mod tests {
     fn decompose_inv_subspan_at_end() {
         // ref=AAG, alt=GCT: position 0 is sub A>G, positions 1-2 are inv
         // (revcomp(AG)=CT).
-        let result = decompose_delins_inv(b"AAG", 0, 3, b"GCT");
+        let result = decompose_delins(b"AAG", 0, 3, b"GCT");
         assert_eq!(result, Some(vec![sub_at(0, 'A', 'G'), inv_at(1, 3)]));
     }
 
@@ -2598,14 +2644,14 @@ mod tests {
         // ref=GCT, alt=AGC: revcomp(GCT)=AGC, full span is inv. Single-
         // element result with one Inversion → trigger doesn't fire (already
         // handled by canonicalize_delins's full-span check).
-        let result = decompose_delins_inv(b"GCT", 0, 3, b"AGC");
+        let result = decompose_delins(b"GCT", 0, 3, b"AGC");
         assert_eq!(result, None);
     }
 
     #[test]
     fn decompose_no_inv_returns_none() {
         // ref=AT, alt=GC: no inv possible (revcomp(AT)=AT != GC).
-        let result = decompose_delins_inv(b"AT", 0, 2, b"GC");
+        let result = decompose_delins(b"AT", 0, 2, b"GC");
         assert_eq!(result, None);
     }
 
@@ -2615,7 +2661,7 @@ mod tests {
         //   inv(0,2): revcomp(AG)=CT ✓
         //   sub(2): A>T (no inv possible spanning here)
         //   inv(3,5): revcomp(CC)=GG ✓
-        let result = decompose_delins_inv(b"AGACC", 0, 5, b"CTTGG");
+        let result = decompose_delins(b"AGACC", 0, 5, b"CTTGG");
         assert_eq!(
             result,
             Some(vec![inv_at(0, 2), sub_at(2, 'A', 'T'), inv_at(3, 5)])
@@ -2623,32 +2669,44 @@ mod tests {
     }
 
     #[test]
-    fn decompose_codon_frame_merge_returns_none() {
-        // ref=TAG, alt=AAC: T>A at pos 0, identity at pos 1 (synthesized
-        // middle from issue #79), G>C at pos 2. No inv possible — issue #79
-        // codon-frame merge is preserved.
-        let result = decompose_delins_inv(b"TAG", 0, 3, b"AAC");
-        assert_eq!(result, None);
+    fn decompose_codon_frame_merge_emits_sub_identity_sub() {
+        // ref=TAG, alt=AAC: T>A at pos 0, identity at pos 1 (the
+        // synthesized middle from issue #79), G>C at pos 2. The
+        // decomposition itself yields `[Sub; Identity; Sub]`; preserving
+        // the spec's `general.md:35-38` codon-frame exception when the
+        // surrounding variant lives in a CDS triplet is the caller's
+        // responsibility (`build_split_variants` reads this pattern back
+        // out as a 3-base delins for in-codon `c.` variants). Other
+        // coord systems decompose to two separate subs.
+        let result = decompose_delins(b"TAG", 0, 3, b"AAC");
+        assert_eq!(
+            result,
+            Some(vec![
+                sub_at(0, 'T', 'A'),
+                ident_at(1, 'A'),
+                sub_at(2, 'G', 'C'),
+            ])
+        );
     }
 
     #[test]
     fn decompose_complement_only_returns_none() {
         // complement(AC)=TG matches at each position but isn't reversed.
         // revcomp(AC)=GT != TG.
-        let result = decompose_delins_inv(b"AC", 0, 2, b"TG");
+        let result = decompose_delins(b"AC", 0, 2, b"TG");
         assert_eq!(result, None);
     }
 
     #[test]
     fn decompose_reverse_only_returns_none() {
         // reverse(AC)=CA matches but isn't complemented.
-        let result = decompose_delins_inv(b"AC", 0, 2, b"CA");
+        let result = decompose_delins(b"AC", 0, 2, b"CA");
         assert_eq!(result, None);
     }
 
     #[test]
     fn decompose_unequal_length_returns_none() {
-        let result = decompose_delins_inv(b"AC", 0, 2, b"GTT");
+        let result = decompose_delins(b"AC", 0, 2, b"GTT");
         assert_eq!(result, None);
     }
 
@@ -2660,7 +2718,7 @@ mod tests {
         seq[100] = b'T';
         seq[101] = b'C';
         seq[102] = b'C';
-        let result = decompose_delins_inv(&seq, 100, 103, b"GAG");
+        let result = decompose_delins(&seq, 100, 103, b"GAG");
         assert_eq!(result, Some(vec![inv_at(100, 102), sub_at(102, 'C', 'G')]));
     }
 
@@ -2668,19 +2726,34 @@ mod tests {
     fn decompose_palindromic_full_span_returns_none() {
         // ref=GCTA, alt=TAGC: full-span inv (revcomp(GCTA)=TAGC). Single-
         // element result — trigger doesn't fire.
-        let result = decompose_delins_inv(b"GCTA", 0, 4, b"TAGC");
+        let result = decompose_delins(b"GCTA", 0, 4, b"TAGC");
         assert_eq!(result, None);
     }
 
     #[test]
-    fn decompose_palindromic_inv_subspan_skipped() {
+    fn decompose_palindromic_inv_subspan_skipped_in_isolation() {
         // ATATC -> ATATG: the ATAT prefix is its own revcomp (palindrome) but
-        // shorten_inversion collapses it to identity, so it must NOT be
-        // emitted as an inv. The trailing C>G is a single substitution; with
-        // no inv emitted, the trigger doesn't fire and we return None,
-        // letting the caller keep the (canonicalize_delins-trimmed) form.
-        let result = decompose_delins_inv(b"ATATC", 0, 5, b"ATATG");
-        assert_eq!(result, None);
+        // `shorten_inversion` collapses it to identity, so it must NOT be
+        // emitted as an inv. The scan falls through to per-position
+        // `IdentityAt` for each palindrome base and a single trailing
+        // `Sub` for C>G. Under issue #165's loosened gate the emission
+        // commits because at least one `IdentityAt` is present (item A10
+        // sub-only branch).
+        //
+        // In the full pipeline this input is trimmed away by
+        // `canonicalize_delins` before reaching `decompose_delins`; the
+        // unit-test case here exercises the function in isolation.
+        let result = decompose_delins(b"ATATC", 0, 5, b"ATATG");
+        assert_eq!(
+            result,
+            Some(vec![
+                ident_at(0, 'A'),
+                ident_at(1, 'T'),
+                ident_at(2, 'A'),
+                ident_at(3, 'T'),
+                sub_at(4, 'C', 'G'),
+            ])
+        );
     }
 
     #[test]
@@ -2688,7 +2761,7 @@ mod tests {
         // CTATGC -> CATAGG: revcomp(CTATG)=CATAG matches over [0..5], but
         // outer C/G complement and shorten_inversion peels them off, leaving
         // inv at [1..4] (TAT). The trailing C>G stays as a substitution.
-        let result = decompose_delins_inv(b"CTATGC", 0, 6, b"CATAGG");
+        let result = decompose_delins(b"CTATGC", 0, 6, b"CATAGG");
         assert_eq!(result, Some(vec![inv_at(1, 4), sub_at(5, 'C', 'G')]));
     }
 
@@ -2702,16 +2775,79 @@ mod tests {
         //   No inv (3,5): revcomp(CC)=GG, alt[3..5]=GT ✗
         //   sub(3): C>G; sub(4): C>T.
         // Verify the algorithm threads through: [Inv, Identity, Sub, Sub].
-        let result = decompose_delins_inv(b"AGACC", 0, 5, b"CTAGT");
+        let result = decompose_delins(b"AGACC", 0, 5, b"CTAGT");
         assert_eq!(
             result,
             Some(vec![
                 inv_at(0, 2),
-                ident_at(2),
+                ident_at(2, 'A'),
                 sub_at(3, 'C', 'G'),
                 sub_at(4, 'C', 'T'),
             ])
         );
+    }
+
+    #[test]
+    fn decompose_sub_only_with_two_identity_gap_emits_split() {
+        // ref=ACGT, alt=TCGG: pos 0 sub (A>T), pos 1-2 identity (C, G),
+        // pos 3 sub (T>G). The two-identity gap exercises the issue
+        // #165 sub-only branch with the gate firing on `has_identity`.
+        let result = decompose_delins(b"ACGT", 0, 4, b"TCGG");
+        assert_eq!(
+            result,
+            Some(vec![
+                sub_at(0, 'A', 'T'),
+                ident_at(1, 'C'),
+                ident_at(2, 'G'),
+                sub_at(3, 'T', 'G'),
+            ])
+        );
+    }
+
+    #[test]
+    fn decompose_length_one_returns_none() {
+        // n=1 is below the precondition (`n < 2`). A 1-base "delins" is
+        // a substitution range; never a delins shape.
+        let result = decompose_delins(b"A", 0, 1, b"T");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn decompose_all_identity_emits_identities_in_isolation() {
+        // Pure identity emissions (ref == alt) have no edits to split
+        // out. The `has_identity` gate still fires and the function
+        // returns `Some([Identity; Identity; Identity])`; downstream
+        // `build_split_variants` would emit zero variants. Such inputs
+        // never reach `decompose_delins` in the real pipeline —
+        // `canonicalize_delins` collapses them to `Identity` first —
+        // so the test pins the isolated-call behavior only.
+        let result = decompose_delins(b"AAA", 0, 3, b"AAA");
+        assert_eq!(
+            result,
+            Some(vec![ident_at(0, 'A'), ident_at(1, 'A'), ident_at(2, 'A'),])
+        );
+    }
+
+    #[test]
+    fn decompose_out_of_bounds_returns_none() {
+        // `start >= end` and `end > ref_seq.len()` both fail the bounds
+        // precondition.
+        assert_eq!(decompose_delins(b"AAA", 2, 2, b""), None);
+        assert_eq!(decompose_delins(b"AAA", 0, 5, b"TTTTT"), None);
+    }
+
+    #[test]
+    fn decompose_non_iupac_in_identity_position_returns_none() {
+        // Sub-position non-IUPAC bytes already abandon the
+        // decomposition. After issue #165's review, identity-position
+        // non-IUPAC bytes do the same: the whole decomposition is
+        // discarded so the caller keeps the original delins and the
+        // next round-trip lands on the same string. Without this guard
+        // an identity at a non-IUPAC byte would coerce to `Base::N` in
+        // the emitted codon-frame triplet's alt sequence, diverging
+        // from the input.
+        let result = decompose_delins(b"AXG", 0, 3, b"TXC");
+        assert_eq!(result, None);
     }
 
     #[test]

--- a/tests/issue_165_delins_sub_only_decompose.rs
+++ b/tests/issue_165_delins_sub_only_decompose.rs
@@ -1,0 +1,312 @@
+//! Tests for issue #165 / tracking issue #81 item A10 (sub-only branch).
+//!
+//! A `delins` whose post-trim span contains two or more independent
+//! single-base mismatches separated by at least one unchanged nucleotide
+//! must decompose to the individual `[X>A; B>Y]` form per the HGVS
+//! edit-priority rule (`general.md:56`: substitution > deletion >
+//! inversion > duplication > insertion; `delins` is the residual when no
+//! higher-priority form applies). Adjacent (no-gap) mismatches stay as a
+//! delins per `substitution.md` ("two or more consecutive nucleotides are
+//! described as deletion/insertion") — that run-merge is handled by the
+//! `build_split_variants` adjacency rule introduced in #182.
+//!
+//! Spec exception (`general.md:35-38`): in a coding sequence, two
+//! variants separated by exactly one nucleotide that together affect a
+//! single codon are described as a `delins`. The decomposition preserves
+//! that exact `[Sub; Identity; Sub]` triplet as a 3-base delins even when
+//! it is embedded inside a longer span — the codon-frame merge from #79
+//! survives A10 round-trips.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Test transcript used by every test in this file.
+///
+/// ```text
+///   c. axis: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ...
+///   base:    A T G C A A A A A  C  C  C  C  C  G  G  G  G  G  T ...
+/// ```
+///
+/// CDS = c.1..=c.60. Codons (1-indexed, formula `(base - 1) / 3 + 1`):
+/// codon 4 = c.10..c.12, codon 5 = c.13..c.15. The codon-frame exception
+/// is exercised against this transcript by placing a pair of SNVs inside
+/// codon 4 (c.10, c.12) and across the codon-4 / codon-5 boundary (c.12,
+/// c.14) for the negative case.
+fn provider_simple() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+// =============================================================================
+// Genomic (`g.`) — no codon frame.
+// =============================================================================
+
+#[test]
+fn genomic_delins_with_gap_decomposes() {
+    // Genomic variants have no codon frame, so any `[Sub; Identity; Sub]`
+    // decomposition emits two separate subs per `general.md:34`. Build a
+    // synthetic chromosome where g.100..102 resolves to `CAC`.
+    let mut provider = MockProvider::new();
+    // 0-based slicing reads g.100..102 from bytes[99..102]; the leading
+    // filler keeps the substantive bytes at known indices.
+    let mut seq = String::from_utf8(vec![b'N'; 99]).unwrap();
+    seq.push_str("CAC");
+    seq.push_str(&String::from_utf8(vec![b'N'; 100]).unwrap());
+    provider.add_genomic_sequence("NC_000001.11", seq);
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs("NC_000001.11:g.100_102delinsTAG").expect("parse failed");
+    let result = format!(
+        "{}",
+        normalizer.normalize(&variant).expect("normalize failed")
+    );
+    assert_eq!(result, "NC_000001.11:g.[100C>T;102C>G]");
+}
+
+// =============================================================================
+// Tx (`n.`) — no codon frame, gap-of-1 delins must decompose.
+// =============================================================================
+
+#[test]
+fn tx_delins_with_gap_decomposes_to_individual_subs() {
+    // Literal 3-base `n.` delins whose middle base equals the reference.
+    // The user may have entered this either directly or via cis-allele
+    // merging (`n.[10C>A; 12C>A]` merges to `n.10_12delinsACA`). Either
+    // way, the post-merge canonical form per `general.md:34` (variants
+    // separated by ≥1 unchanged nt are described individually) is two
+    // separate subs.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:n.10_12delinsACA"),
+        "NM_TEST.1:n.[10C>A;12C>A]",
+    );
+}
+
+#[test]
+fn tx_cis_allele_with_gap_decomposes() {
+    // Bracketed-cis form should produce the same canonical decomposition
+    // as the literal delins above. The cis-allele merge does not fire
+    // (gap-of-1 is not strictly-adjacent and `n.` has no codon-frame
+    // exception), so each sub passes through normalize independently.
+    assert_eq!(
+        normalize_with(provider_simple(), "[NM_TEST.1:n.10C>A;NM_TEST.1:n.12C>A]",),
+        "NM_TEST.1:n.[10C>A;12C>A]",
+    );
+}
+
+// =============================================================================
+// RNA (`r.`) — no codon frame, lowercase preserved.
+// =============================================================================
+
+#[test]
+fn rna_delins_with_gap_decomposes_lowercase() {
+    // r. spec requires lowercase rendering; the decomposition must
+    // preserve case on both the substituted ref and alt.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.10_12delinsaca"),
+        "NM_TEST.1:r.[10c>a;12c>a]",
+    );
+}
+
+// =============================================================================
+// Mitochondrial (`m.`) — no codon frame.
+// =============================================================================
+
+#[test]
+fn mt_delins_with_gap_decomposes() {
+    // The mitochondrial coordinate system has no codon-frame exception;
+    // `m.` follows the genomic / `n.` decomposition rule.
+    //
+    // Build a 12-byte synthetic mt sequence so m.10..12 resolves to
+    // ref="CAC". `add_genomic_sequence` stores the contig as-is and
+    // `get_genomic_sequence` reads a 0-based half-open slice — m.10..12
+    // is `bytes[9..12]`.
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_012920.1", "NNNNNNNNNCAC");
+    assert_eq!(
+        normalize_with(provider, "NC_012920.1:m.10_12delinsTAG"),
+        "NC_012920.1:m.[10C>T;12C>G]",
+    );
+}
+
+// =============================================================================
+// Coding (`c.`) — codon-frame exception preserves the [Sub; Identity; Sub] pair.
+// =============================================================================
+
+#[test]
+fn cds_codon_frame_pair_preserved_as_delins() {
+    // c.10 and c.12 are in codon 4 (`(base - 1) / 3` = 3 for both). The
+    // spec exception (`general.md:35-38`) keeps the pair as a 3-base
+    // delins. Equivalent to issue #79's codon-frame merge — A10 must not
+    // regress this.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.10_12delinsTCA"),
+        "NM_TEST.1:c.10_12delinsTCA",
+    );
+}
+
+#[test]
+fn cds_codon_frame_pair_via_cis_allele_preserved() {
+    // The merge stage of `normalize_allele` codon-frame-merges
+    // `c.[10C>T;12C>A]` into `c.10_12delinsTCA`. A10's decomposition
+    // recognises the [Sub; Identity; Sub] triplet as the codon-frame
+    // exception and keeps it as a single delins.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[10C>T;12C>A]"),
+        "NM_TEST.1:c.10_12delinsTCA",
+    );
+}
+
+#[test]
+fn cds_cross_codon_pair_decomposes() {
+    // c.12 is in codon 4, c.14 is in codon 5 — the pair does not "together
+    // affect one amino acid", so the codon-frame exception does not
+    // apply. Per `general.md:34` the canonical form is two separate subs.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.12_14delinsACA"),
+        "NM_TEST.1:c.[12C>A;14C>A]",
+    );
+}
+
+#[test]
+fn cds_embedded_codon_frame_triplet_preserved_within_longer_span() {
+    // c.10..c.13 spans codon 4 (10-12) and the first base of codon 5
+    // (13). After merging `c.[10C>T;12C>A;13C>G]` the cis-allele path
+    // produces `c.10_13delinsTCAG` (codon-frame merge on the first pair
+    // then strict-adjacent chain with the third sub).
+    //
+    // The principled decomposition: the (10, 12) pair satisfies the
+    // codon-frame exception and emits as a 3-base delins; c.13 is in a
+    // different codon and emits as a separate sub. The chained 4-base
+    // delins is non-canonical (spec exception is defined for a *pair*,
+    // not a chain).
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[10C>T;12C>A;13C>G]"),
+        "NM_TEST.1:c.[10_12delinsTCA;13C>G]",
+    );
+}
+
+#[test]
+fn cds_embedded_codon_frame_triplet_from_literal_delins() {
+    // Same shape as the cis-allele case above but entered as a literal
+    // delins. ref c.10..c.13 = CCCC. alt = TCAG matches the [Sub;
+    // Identity; Sub; Sub] decomposition: the (10, 12) pair preserves as
+    // a codon-frame delins and c.13 splits off as a single sub.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.10_13delinsTCAG"),
+        "NM_TEST.1:c.[10_12delinsTCA;13C>G]",
+    );
+}
+
+#[test]
+fn cds_two_codon_frame_triplets_back_to_back() {
+    // ref c.10..c.15 = CCCCCG (codon 4 = c.10..c.12, codon 5 = c.13..c.15).
+    // alt = TCAGCT decomposes to:
+    //   pos 10 C>T   (sub)      — codon 4
+    //   pos 11 C=C   (identity) — codon 4
+    //   pos 12 C>A   (sub)      — codon 4
+    //   pos 13 C>G   (sub)      — codon 5
+    //   pos 14 C=C   (identity) — codon 5
+    //   pos 15 G>T   (sub)      — codon 5
+    //
+    // Both (10, 12) and (13, 15) match the codon-frame exception, so
+    // each triplet emits as its own 3-base delins. The two delins are
+    // strictly adjacent (12 + 1 == 13) but do not re-merge: each is
+    // emitted independently by `build_split_variants`'s triplet
+    // lookahead, and the outer cis-allele wrapper preserves them.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.10_15delinsTCAGCT"),
+        "NM_TEST.1:c.[10_12delinsTCA;13_15delinsGCT]",
+    );
+}
+
+// =============================================================================
+// Adjacent (no-gap) substitutions must stay as a single delins (#182).
+// A10's loosened gate must NOT decompose pure-substitution runs.
+// =============================================================================
+
+#[test]
+fn cds_adjacent_sub_pair_stays_as_delins() {
+    // c.[10C>T;11C>A]: strictly-adjacent merge produces
+    // `c.10_11delinsTA`. The post-merge decomposition would emit
+    // `[Sub@0; Sub@1]` (no Identity, no Inversion); per the
+    // `(has_inv || has_identity)` guard `decompose_delins` returns
+    // `None`, so `build_split_variants` is never called and the delins
+    // stays intact — matching `substitution.md`'s rule that consecutive
+    // nucleotide changes are described as `delins` (#182).
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[10C>T;11C>A]"),
+        "NM_TEST.1:c.10_11delinsTA",
+    );
+}
+
+#[test]
+fn cds_three_adjacent_subs_stay_as_delins() {
+    // Same principle as above for a 3-base adjacent run.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.10_12delinsTAG"),
+        "NM_TEST.1:c.10_12delinsTAG",
+    );
+}
+
+// =============================================================================
+// Round-trip stability — re-normalizing the decomposed form must reproduce it.
+// =============================================================================
+
+#[test]
+fn round_trip_decomposed_form_is_stable() {
+    // n. decomposed pair re-parses as `n.[10C>A;12C>A]` and re-normalizes
+    // to itself. The strict-adjacent merge does not fire (gap-of-1), so
+    // no merge round-trips back to a delins.
+    let once = normalize_with(provider_simple(), "NM_TEST.1:n.10_12delinsACA");
+    let twice = normalize_with(provider_simple(), &once);
+    assert_eq!(once, twice);
+    assert_eq!(once, "NM_TEST.1:n.[10C>A;12C>A]");
+}
+
+#[test]
+fn round_trip_codon_frame_pair_is_stable() {
+    // c. codon-frame pair re-parses and re-normalizes to itself.
+    let once = normalize_with(provider_simple(), "NM_TEST.1:c.10_12delinsTCA");
+    let twice = normalize_with(provider_simple(), &once);
+    assert_eq!(once, twice);
+    assert_eq!(once, "NM_TEST.1:c.10_12delinsTCA");
+}
+
+#[test]
+fn round_trip_embedded_triplet_is_stable() {
+    // c.[10_12delinsTCA;13C>G] re-merges via the cis-allele path
+    // (strict-adjacent merge of the trailing sub onto the delins
+    // produces `c.10_13delinsTCAG`) and then re-decomposes to the same
+    // canonical form.
+    let once = normalize_with(provider_simple(), "NM_TEST.1:c.10_13delinsTCAG");
+    let twice = normalize_with(provider_simple(), &once);
+    assert_eq!(once, twice);
+    assert_eq!(once, "NM_TEST.1:c.[10_12delinsTCA;13C>G]");
+}

--- a/tests/issue_182_postcanon_adjacency.rs
+++ b/tests/issue_182_postcanon_adjacency.rs
@@ -1,7 +1,7 @@
 //! Issue #182: post-canonicalization adjacency of substitution flanks
 //! produced by the inv-split pass (#160 / #166).
 //!
-//! When `decompose_delins_inv` splits a merged delins into `[…; inv; …]`,
+//! When `decompose_delins` splits a merged delins into `[…; inv; …]`,
 //! the non-inv positions are emitted as per-position `Substitution`
 //! sub-edits. Two or more strictly-adjacent (no gap) Substitutions in that
 //! emission stream represent a multi-nucleotide substitution and must

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -685,21 +685,39 @@ fn test_no_codon_frame_genomic() {
 
 #[test]
 fn test_codon_frame_then_strict_chain() {
-    // Issue #79 specifies that the codon-frame merge feeds back into
-    // the strictly-consecutive walk so a third SNV one base 3' of the
-    // pair still merges. Here: c.10 + c.12 codon-frame-merge into a
-    // delins at [10, 12], then c.13 is strictly-adjacent and folds
-    // into it.
-    //   Sequence: ATGCAAAAACCCCC... → c.10=C, c.11=C, c.12=C, c.13=C.
-    //   First merge alt = G + ref(c.11)=C + C = "GCC" at [10, 12].
-    //   Strict-merge with c.13A>T extends end to 13 and appends T →
-    //   "GCCT" at [10, 13].
+    // The merge stage from issue #79 still extends a codon-frame pair
+    // with a strictly-adjacent third SNV — c.10A>G + c.12A>C codon-frame
+    // merge into `c.10_12delinsGCC`, then c.13A>T extends to
+    // `c.10_13delinsGCCT`. After A10 (issue #165) the post-merge
+    // `decompose_delins` pass runs over the 4-base result.
+    //
+    // Sequence: ATGCAAAAACCCCC... → c.10..c.13 = `CCCC` (the user's
+    // declared "A" refs are ignored by the merge and recovered from the
+    // provider during decomposition). Pair-by-pair canonicalization:
+    //   pos 10: ref C, alt G (sub)
+    //   pos 11: ref C, alt C (identity — codon-frame synthesized middle)
+    //   pos 12: ref C, alt C (identity — user-declared `12A>C` is a
+    //                         no-op against the actual reference)
+    //   pos 13: ref C, alt T (sub)
+    //
+    // Per `general.md:34` the canonical form is two separate subs at
+    // c.10 and c.13 — they are >1 unchanged nucleotide apart, so neither
+    // adjacency (`substitution.md`) nor the codon-frame exception
+    // (`general.md:35-38`) applies. The intermediate 4-base delins
+    // produced by #79's chain extension was a ferro-internal stop on the
+    // way to this canonical form; A10 collapses it.
+    //
+    // Spec basis for the chain undoing itself: the codon-frame exception
+    // is defined for a *pair* of variants ("two variants … together
+    // affecting one amino acid"), not for a chain. c.10 and c.13 sit in
+    // codons 4 and 5 respectively, so the chain spans two amino acids
+    // and the exception does not extend to it.
     assert_eq!(
         normalize_with_provider(
             provider_with_simple_transcript(),
             "NM_TEST.1:c.[10A>G;12A>C;13A>T]",
         ),
-        "NM_TEST.1:c.10_13delinsGCCT",
+        "NM_TEST.1:c.[10C>G;13C>T]",
     );
 }
 

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -4395,7 +4395,8 @@ mod cigar_cds_mapping {
 // rule (sub > del > inv > dup > ins). Applies to:
 //   - Cis allele inputs that merge into a delins, then decompose.
 //   - User-typed delins inputs whose post-trim range contains an inv sub-span.
-// Function: rules::decompose_delins_inv() in src/normalize/rules.rs
+// Function: rules::decompose_delins() in src/normalize/rules.rs
+// (item A10 of tracking issue #81; sub-only branch tracked in #165)
 mod issue_160_revcomp_inv_subspans {
     use super::*;
 
@@ -4475,7 +4476,7 @@ mod issue_160_revcomp_inv_subspans {
     fn split_drops_identity_subedit_no_eq_emitted() {
         // ref AGACC at 1300-1304, alt CTAGT decomposes to
         // [Inv(0,2); Identity(2); Sub(3 C>G); Sub(4 C>T)] inside
-        // decompose_delins_inv. The IdentityAt sub-edit must NOT render as a
+        // decompose_delins. The IdentityAt sub-edit must NOT render as a
         // spurious `g.1302=` variant. Per issue #182, the trailing two
         // strictly-adjacent Substitutions group into a single delins
         // (substitution.md: "changes involving two or more consecutive

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -202,6 +202,50 @@ class TestNormalizeMergeConsecutive:
         assert ";" in result
 
 
+class TestNormalizeDelinsSubOnlyDecompose:
+    """Issue #81 item A10 (sub-only branch, tracked in #165): a delins whose
+    span contains two or more independent single-base mismatches separated
+    by at least one unchanged nucleotide decomposes to the individual
+    `[X>A; B>Y]` form per `general.md:56` (sub > delins). The codon-frame
+    exception (`general.md:35-38`) preserves an embedded
+    `[Sub; Identity; Sub]` triplet whose endpoints share a codon.
+
+    Reference: NM_000088.3 has CDS sequence
+    `ATGCCCAAGGTGCTGCCCCAGATGCTGCCAGTGCTGCTGCTGCTGCTGCTGCTGCTGCTG`,
+    so c.10 = G, c.11 = T, c.12 = G, c.13 = C, c.14 = T. Codon 4 spans
+    c.10..c.12 and codon 5 spans c.13..c.15."""
+
+    def test_coding_delins_codon_frame_pair_preserved(self) -> None:
+        # ref c.10..c.12 = GTG, alt = ATC → [Sub(G>A); Identity(T);
+        # Sub(G>C)]. Endpoints 10 and 12 share codon 4, so the spec
+        # codon-frame exception keeps the form as a 3-base delins.
+        result = ferro_hgvs.normalize("NM_000088.3:c.10_12delinsATC")
+        assert result == "NM_000088.3:c.10_12delinsATC"
+
+    def test_coding_cross_codon_pair_decomposes(self) -> None:
+        # ref c.12..c.14 = GCT, alt = ACA → [Sub(G>A); Identity(C);
+        # Sub(T>A)]. Endpoints 12 and 14 sit in codons 4 and 5
+        # respectively, so the codon-frame exception does NOT apply and
+        # the spec's sub > delins priority splits the pair.
+        result = ferro_hgvs.normalize("NM_000088.3:c.12_14delinsACA")
+        assert "12G>A" in result
+        assert "14T>A" in result
+        # No 3-base delins should remain.
+        assert "12_14delins" not in result
+
+    def test_coding_embedded_codon_frame_triplet_within_longer_span(
+        self,
+    ) -> None:
+        # ref c.10..c.13 = GTGC, alt = ATCA → [Sub(G>A); Identity(T);
+        # Sub(G>C); Sub(C>A)]. The (10, 12) pair is in codon 4 and
+        # preserves as a 3-base delins; c.13 sits in codon 5, so the
+        # spec exception "two variants together affecting one amino
+        # acid" does not extend to it and it emits as a separate sub.
+        result = ferro_hgvs.normalize("NM_000088.3:c.10_13delinsATCA")
+        assert "10_12delinsATC" in result
+        assert "13C>A" in result
+
+
 class TestNormalizeEmptyInsertDelinsToDel:
     """Issue #81 item A3: a delins with an empty inserted sequence -> del."""
 


### PR DESCRIPTION
## Summary

Closes #165. Addresses #81 item A10 (sub-only branch).

A `delins` whose post-trim span contains two or more independent single-base mismatches separated by at least one unchanged nucleotide now decomposes to individual `[X>A; B>Y]` form per the HGVS edit-priority rule (`general.md:56`: `sub > del > inv > dup > ins`; `delins` is the residual when no higher-priority form applies). Adjacent (no-gap) mismatches stay as `delins` per `substitution.md`'s consecutive-nucleotides rule (#182). The spec's narrow codon-frame exception (`general.md:35-38`, originally from #79) is preserved inside `build_split_variants`: when a `c.` variant's decomposition contains a `[Sub@i; Identity@i+1; Sub@i+2]` triplet whose CDS endpoints share a codon, the triplet emits as a single 3-base delins even when embedded inside a longer span.

## Behaviour change

`merge_consecutive_edits_tests::test_codon_frame_then_strict_chain` previously expected `c.10_13delinsGCCT` for input `c.[10A>G;12A>C;13A>T]` (the codon-frame merge's strict-adjacency chain extension). The spec exception is defined for a *pair* of variants ("two variants together affecting one amino acid"), not a chain spanning two codons, so A10 collapses the chain back to the spec-canonical `c.[10C>G;13C>T]`. The user-declared `12A>C` against an actual reference C is a no-op that the canonicalization drops, and the surviving subs render with the correct refs from the provider.

## Implementation

- `decompose_delins_inv` renamed to `decompose_delins` in `src/normalize/rules.rs`. Gate loosened to fire on any emission with `>1` element containing at least one `Inversion` or `IdentityAt`. Pure-substitution emissions short-circuit to `None` because the caller would just re-merge them under the adjacency rule. Non-IUPAC bytes at any position abandon the decomposition so the next round-trip lands on the same string.
- `DelinsSubedit::IdentityAt` carries the unchanged ref byte, enabling codon-frame triplet reconstruction.
- `build_split_variants` takes a `codon_frame_aware: bool` flag (true only for `HgvsVariant::Cds`); the new triplet lookahead emits a 3-base delins for in-codon `[Sub; Identity; Sub]` patterns.
- `merge::same_codon` promoted to `pub(crate)` so the post-merge pass can re-apply it.
- Per-`Normalizer` helpers renamed from `_inv_split` to `_canonical_split` to cover both #160 and #165 paths.

## Review

Pre-PR parallel reviews by Opus and Sonnet sub-agents; all findings addressed in the squashed commit (most-fix correctness on the `IdentityAt` `Base::N` fallback, plus naming/doc consistency, missing `g.` integration test, additional unit-test coverage, and large-position `same_codon` assertions).

## Test plan

- [x] `cargo nextest run --features dev` — 4409 passed, 0 failed.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `pytest tests/python/` — 157 passed.
- [x] Round-trip stability tests in `tests/issue_165_delins_sub_only_decompose.rs` (g./n./r./m./c.).