### PR TITLE
fix(parser): depth-aware close-bracket lookup in nested HGVS brackets (closes #207)

### DIFF
--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -419,8 +419,14 @@ fn parse_bracketed_inserted_sequence(input: &str) -> IResult<&str, InsertedSeque
     // Check for reference location inside brackets (e.g., [NC_000022.11:g.100_200])
     // Reference accession prefixes: NC_, NG_, NM_, NP_, NR_, NT_, NW_, XM_, XP_, XR_, ENST, ENSP, LRG_
     if is_reference_accession_prefix(input) {
-        // Find the closing bracket
-        if let Some(close_pos) = input.find(']') {
+        // Depth-aware close lookup: the reference payload itself can
+        // legally contain `[N]` repeat counts or nested `delins[…]`
+        // groups, so a plain `input.find(']')` would truncate at the
+        // first inner `]`. The `char('[')` combinator above already
+        // consumed the opening bracket, hence the
+        // `find_close_after_consumed_open` (depth-1) variant.
+        if let Some(close_pos) = crate::hgvs::parser::variant::find_close_after_consumed_open(input)
+        {
             let reference = &input[..close_pos];
             let remaining = &input[close_pos + 1..];
             return Ok((

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -971,18 +971,33 @@ impl GenomeKind {
     }
 }
 
-/// Find the index of the `]` that closes the leading `[` in `input`, scanning
-/// at bracket depth 0. Returns `None` if `input` does not start with `[` or if
-/// the bracket is unbalanced.
+/// Find the index of the `]` that closes the leading `[` in `input`,
+/// scanning at bracket depth 0. Returns `None` if `input` does not start
+/// with `[` or if the bracket is unbalanced.
 ///
 /// Plain `input.find(']')` would truncate at any inner edit bracket
-/// (`delins[ACC:g.x_y]`, `delins[A;T]`, etc.); plain `input.rfind(']')` would
-/// over-consume on trans-form `[a];[b]`. The depth-tracking scan handles both.
-fn find_top_level_close_bracket(input: &str) -> Option<usize> {
+/// (`delins[ACC:g.x_y]`, `delins[A;T]`, `TG[14]`, etc.); plain
+/// `input.rfind(']')` would over-consume on trans-form `[a];[b]`. The
+/// depth-tracking scan handles both.
+pub(crate) fn find_top_level_close_bracket(input: &str) -> Option<usize> {
     if !input.starts_with('[') {
         return None;
     }
-    let mut depth: i32 = 0;
+    // Skip the leading `[` and delegate to the after-open primitive,
+    // shifting the returned index back into the original slice.
+    find_close_after_consumed_open(&input[1..]).map(|i| i + 1)
+}
+
+/// Variant of [`find_top_level_close_bracket`] for callers that have
+/// already consumed the opening `[` (typically via a `nom` combinator).
+/// Treats the slice as the bracket's content and returns the index of
+/// the matching `]` (relative to `input`). See
+/// `parse_bracketed_inserted_sequence` in `parser/edit.rs` for a
+/// caller.
+pub(crate) fn find_close_after_consumed_open(input: &str) -> Option<usize> {
+    // Caller has already passed one level deep; start depth at 1 so
+    // the scan returns when the first un-paired `]` brings it back to 0.
+    let mut depth: i32 = 1;
     for (i, b) in input.bytes().enumerate() {
         match b {
             b'[' => depth += 1,
@@ -1174,7 +1189,7 @@ fn parse_genome_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -1645,7 +1660,7 @@ fn parse_cds_trans_allele_shorthand(
         }
 
         // Find closing bracket
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -1764,7 +1779,7 @@ fn parse_tx_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -2035,7 +2050,7 @@ fn parse_mt_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -2280,7 +2295,7 @@ fn parse_protein_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -3094,7 +3109,7 @@ fn parse_rna_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -3218,7 +3233,7 @@ fn parse_circular_trans_allele_shorthand(
             break;
         }
 
-        let close_bracket = remaining.find(']').ok_or_else(|| {
+        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
             nom::Err::Error(nom::error::Error::new(
                 remaining,
                 nom::error::ErrorKind::Tag,
@@ -3575,11 +3590,12 @@ fn parse_trans_allele(input: &str) -> Result<HgvsVariant, FerroError> {
         }
 
         // Find closing bracket
-        let close_bracket = remaining.find(']').ok_or_else(|| FerroError::Parse {
-            pos: input.len() - remaining.len(),
-            msg: "Missing closing ']' in trans allele".to_string(),
-            diagnostic: None,
-        })?;
+        let close_bracket =
+            find_top_level_close_bracket(remaining).ok_or_else(|| FerroError::Parse {
+                pos: input.len() - remaining.len(),
+                msg: "Missing closing ']' in trans allele".to_string(),
+                diagnostic: None,
+            })?;
 
         // Parse the variant inside the brackets
         let variant_str = &remaining[1..close_bracket].trim();

--- a/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
@@ -4,10 +4,6 @@
       "category": "malformed_input",
       "reason": "Three positions in one open paren."
     },
-    "[trans_compound_with_uncertain_first_and_repeat_second]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans-phase compound `[a];[b]` (recommendations/DNA/alleles.md) where the first allele is an uncertain-range del (recommendations/uncertain.md) and the second has a bracketed repeat. Each form is spec-valid; the combination is not yet parsed."
-    },
     "[trans_compound_with_mosaic]": {
       "category": "spec_not_yet_supported",
       "reason": "Trans-phase compound `[a];[b]` with mosaic `=/` in each allele. Spec form per recommendations/DNA/alleles.md (compound) and deletion.md (mosaic `=/`)."
@@ -27,7 +23,6 @@
   },
   "expected_failures": {
     "NC_000005.9:g.(?_13922436_13923774del": "[malformed_unbalanced_paren_three_positions]",
-    "NC_000017.10:g.[(729319_882558)_(882998_?)del];[704262_704264[1]]": "[trans_compound_with_uncertain_first_and_repeat_second]",
     "NM_000090.3:c.[=/3426_3452del];[=/3440_3466del]": "[trans_compound_with_mosaic]",
     "NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]": "[trans_compound_with_internal_cis]",
     "NM_020469.3:c.[297A>C;496del526=657C>T703G>A796C>A803G>C930G>A]": "[malformed_compound_missing_semicolon]",

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -101,10 +101,6 @@
       "category": "malformed_input",
       "reason": "Commas inside coordinates. Coordinates are bare integers per recommendations/background/numbering.md."
     },
-    "[trans_compound_with_uncertain_first_and_repeat_second]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans-phase compound `[a];[b]` (recommendations/DNA/alleles.md) where the first allele is an uncertain-range del (recommendations/uncertain.md) and the second has a bracketed repeat. Each form is spec-valid; the combination is not yet parsed."
-    },
     "[malformed_dash_inside_paren_range]": {
       "category": "malformed_input",
       "reason": "Dash `-` between coordinates inside paren. Spec uses `_`."
@@ -261,10 +257,6 @@
       "category": "malformed_input",
       "reason": "`-` between coordinates inside paren (`5074+1-5075-1`). Spec uses `_`."
     },
-    "[trans_compound_del_then_repeat]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans `[a];[b]` of del + bracket-repeat. Each form is spec; the combination is not yet parsed."
-    },
     "[chimeric_compound_comma]": {
       "category": "spec_not_yet_supported",
       "reason": "Chimeric compound `[a,b]`."
@@ -273,10 +265,6 @@
       "category": "spec_not_yet_supported",
       "reason": "Trans `[a];[b;c]` \u2014 first allele a single del, second allele a cis pair. Spec recommendations/DNA/alleles.md."
     },
-    "[trans_compound_substitution_then_repeat]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans `[a];[b]` sub + bracket-repeat."
-    },
     "[malformed_trailing_word_annotation]": {
       "category": "malformed_input",
       "reason": "Trailing word `transition` is annotation, not HGVS."
@@ -284,10 +272,6 @@
     "[redundant_c_prefix_inside_compound_trans]": {
       "category": "rejected_by_design",
       "reason": "Trans `[a];[c.b]` \u2014 second allele has redundant `c.` prefix."
-    },
-    "[trans_compound_repeat_then_substitution]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans `[a];[b]` bracket-repeat + sub."
     },
     "[malformed_omim_id_appended]": {
       "category": "malformed_input",
@@ -397,7 +381,6 @@
     "NC_000017.10:g.(?_34,822,466)_(36,410,720_?)del": "[malformed_commas_in_coordinates]",
     "NC_000017.10:g.(?_48243138_48245027del": "[malformed_unbalanced_paren_three_positions]",
     "NC_000017.10:g.(?_59878633_59883038del": "[malformed_unbalanced_paren_three_positions]",
-    "NC_000017.10:g.[(729319_882558)_(882998_?)del];[704262_704264[1]]": "[trans_compound_with_uncertain_first_and_repeat_second]",
     "NC_000017.11:g.(?_14180000-15550000_?)dup": "[malformed_dash_inside_paren_range]",
     "NC_000018.9:g.(?_55710610_56069772del": "[malformed_unbalanced_paren_three_positions]",
     "NC_000019.10:g.(?_45485294_45497047_?)del": "[malformed_four_positions_in_one_paren]",
@@ -501,14 +484,12 @@
     "NM_013236.2:c.1173+54822_1173+54826ATTCT(360_370)": "[deprecated_repeat_paren_no_brackets]",
     "NM_013236.2:c.1173+54822_1173+54826ATTCT(400_760)": "[deprecated_repeat_paren_no_brackets]",
     "NM_013236.2:c.1173+54822_1173+54826ATTCT(800_4500)": "[deprecated_repeat_paren_no_brackets]",
-    "NM_014149.4:c.[588_589del];[857_858AG[1]]": "[trans_compound_del_then_repeat]",
     "NM_014762.3:c.[881A>C,918G>C]": "[chimeric_compound_comma]",
     "NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]": "[trans_compound_with_internal_cis]",
     "NM_016124.4:c.[186G>T;410C>T455A>C667T>G]": "[malformed_compound_missing_semicolon]",
     "NM_016124.4:c.[410C>T;455A>C509T>C667T>G]": "[malformed_compound_missing_semicolon]",
     "NM_016124.6:c.[186G>T;410C>T455A>C602C>G604G>A733G>C]": "[malformed_compound_missing_semicolon]",
     "NM_017613.3:c.[1466A>C;786-33A>G82A>C]": "[malformed_compound_missing_semicolon]",
-    "NM_017917.4:c.[1174-1G>A];[1262CCA[1]]": "[trans_compound_substitution_then_repeat]",
     "NM_020469.3:c.[1061del;467C>T989T>C]": "[malformed_compound_missing_semicolon]",
     "NM_020469.3:c.[15dup;297A>C526C>G657C>T703G>A796C>A803G>C930G>A]": "[malformed_compound_missing_semicolon]",
     "NM_020469.3:c.[1_5dup;297A>C526C>G657C>T703G>A796C>A803G>C930G>A]": "[malformed_compound_missing_semicolon]",
@@ -518,8 +499,6 @@
     "NM_022154.5:c.[97G>A;1004G>C];[c.610G>T]": "[redundant_c_prefix_inside_compound_trans]",
     "NM_022455.4:c.5623-?_c.8091+?del": "[redundant_c_prefix_inside_range]",
     "NM_024339.5:c.[298T>A;700G>C824G>A]": "[malformed_compound_missing_semicolon]",
-    "NM_025114.4:c.[3904C>T];[4655AAG[2]]": "[trans_compound_substitution_then_repeat]",
-    "NM_025114.4:c.[4655AAG[2]];[6012-12T>A]": "[trans_compound_repeat_then_substitution]",
     "NM_145064.2:c.763_766delCTCT;615521.0004": "[malformed_omim_id_appended]",
     "NM_145064.2:c.997-G>T": "[malformed_intronic_offset_no_number]",
     "NM_145698.4:c.626-689_937-234delins936+1075_c.936+1230inv": "[chained_delins_inv_with_redundant_prefix]",

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -12,8 +12,8 @@
       "correctly-rejected": 42,
       "diverges": 187,
       "false-acceptance": 86,
-      "parse-error": 343,
-      "preserved": 614
+      "parse-error": 341,
+      "preserved": 616
     },
     "by_coordinate_system": {
       "c": 464,
@@ -7605,18 +7605,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
-      "current": "parse error: Parse error at position 76: Unexpected trailing characters: ']'",
-      "spec_expected": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv",
       "current": "parse error: Parse error at position 82: Unexpected trailing characters: 'inv'",
       "spec_expected": "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv",
@@ -7649,18 +7637,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/complex.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
-      "current": "parse error: Parse error at position 41: Unexpected trailing characters: ';[101179660_101179695TG[18]]'",
-      "spec_expected": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
-      "status": "parse-error",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -8485,6 +8461,17 @@
       ]
     },
     {
+      "input": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
+      "current": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
+      "spec_expected": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
       "input": "NC_000006.11:g.8897754_8897755ins[N[543];8897743_8897754]",
       "current": "NC_000006.11:g.8897754_8897755ins[N[543];8897743_8897754]",
       "spec_expected": "NC_000006.11:g.8897754_8897755ins[N[543];8897743_8897754]",
@@ -8670,6 +8657,17 @@
       "source_kind": "syntax_yaml",
       "source_paths": [
         "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
+      "current": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
+      "spec_expected": "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {

--- a/tests/issue_207_multi_repeat_compound_roundtrip.rs
+++ b/tests/issue_207_multi_repeat_compound_roundtrip.rs
@@ -1,0 +1,241 @@
+//! Audit (item B3 of tracking issue #81 / closes #207): multi-repeat
+//! compound rendering `[A];[B]` round-trip.
+//!
+//! HGVS DNA `repeated.md` example (spec line cited in the tests):
+//!
+//! ```
+//! NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]
+//! ```
+//!
+//! A trans-phase allele where each allele carries the same repeat locus
+//! at a different copy count. `[X];[Y]` is the spec's canonical form for
+//! "X on one allele, Y on the other"; the two alleles are siblings in
+//! trans phase, not a cis bracket.
+//!
+//! Goal: pin parse + normalize round-trip across every coord system that
+//! admits the repeat shape (`g.`, `c.`, `n.`, `r.`, `m.`), and cover the
+//! single-allele baseline plus the cis-phase form `[X; Y]` as a foil so
+//! a regression flips one without the others.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn round_trip(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for {:?}: {:?}", input, e));
+    format!("{}", normalized)
+}
+
+// =============================================================================
+// Spec textbook example — genomic trans-phase compound repeat.
+// =============================================================================
+
+#[test]
+fn genomic_trans_compound_repeat_spec_example() {
+    // `assets/hgvs-nomenclature/docs/recommendations/DNA/repeated.md`:
+    //   NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]
+    // "a repeated TG di-nucleotide sequence, starting at position
+    //  g.101179660 on human chromosome 14, is present with 14 TG copies on
+    //  one allele and 18 TG copies on the other allele."
+    let s = "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn genomic_single_allele_repeat_baseline() {
+    // The single-allele baseline (no bracket wrapper) must round-trip
+    // unchanged — if this fails the compound case can't possibly work.
+    let s = "NC_000014.8:g.101179660_101179695TG[14]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn genomic_cis_compound_repeat_at_two_loci() {
+    // Cis form: a single allele bracket carrying two repeat edits at
+    // distinct loci. Different from B3's trans case but worth pinning so
+    // a parser regression that broke the trans bracket separator also
+    // shows up against the cis form.
+    let s = "NC_000001.11:g.[100_105TG[3];200_205AC[4]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Per-coord-system trans-phase compound repeat round-trips.
+// =============================================================================
+
+#[test]
+fn cds_trans_compound_repeat() {
+    let s = "NM_000088.3:c.[10_15TG[3]];[10_15TG[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn noncoding_trans_compound_repeat() {
+    let s = "NR_046018.2:n.[10_15TG[3]];[10_15TG[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn rna_trans_compound_repeat_lowercase() {
+    // RNA spec requires lowercase bases; the compound trans form must
+    // preserve case end-to-end.
+    let s = "NM_000088.3:r.[10_15ug[3]];[10_15ug[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn mt_trans_compound_repeat() {
+    let s = "NC_012920.1:m.[100_105TG[3]];[100_105TG[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Range counts and uncertainty inside compound repeats.
+// =============================================================================
+
+#[test]
+fn genomic_trans_compound_repeat_range_count() {
+    // `TG[14_18]` carries an uncertain `(min_max)` count. Each allele in
+    // the trans pair may itself express uncertainty independently.
+    let s = "NC_000014.8:g.[101179660_101179695TG[14_18]];[101179660_101179695TG[20]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn genomic_trans_compound_repeat_unknown_count() {
+    // `TG[?]` is the spec's "present, count unknown" shape; the compound
+    // round-trip must preserve it on either allele.
+    let s = "NC_000014.8:g.[101179660_101179695TG[?]];[101179660_101179695TG[18]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Single-unit repeats inside the compound trans form.
+// =============================================================================
+
+#[test]
+fn genomic_trans_compound_single_base_repeat() {
+    // Single-base repeat (`A[N]`) inside the trans compound. The repeat
+    // alphabet is intentionally narrow — `A` vs `T` vs `C` vs `G` — so
+    // any single-letter parser regression shows up here.
+    let s = "NC_000001.11:g.[100A[6]];[100A[8]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Structural variants — distinct loci / distinct units. These must
+// round-trip without the trans bracket quietly normalising the two
+// halves toward each other.
+// =============================================================================
+
+#[test]
+fn genomic_trans_compound_repeat_distinct_loci() {
+    // Two alleles at different loci, each its own repeat. Spec admits
+    // this as a valid trans description; ferro must round-trip both
+    // halves without merging or reordering.
+    let s = "NC_000001.11:g.[100_105TG[3]];[200_205AC[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn genomic_trans_compound_repeat_distinct_units() {
+    // Two alleles at the same locus but different repeat units (TG vs
+    // GT). Round-trip must preserve the units verbatim.
+    let s = "NC_000001.11:g.[100_105TG[3]];[100_105GT[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Coverage for the remaining parsers touched by the fix.
+// =============================================================================
+
+#[test]
+fn circular_trans_compound_repeat() {
+    // The `o.` (circular genome) trans-allele parser
+    // (`parse_circular_trans_allele_shorthand`) is part of the
+    // 8-site fix; lock in a regression test against the same
+    // `[A];[B]` shape with nested repeat counts.
+    let s = "NC_001422.1:o.[100_105TG[3]];[100_105TG[5]]";
+    assert_eq!(round_trip(s), s);
+}
+
+#[test]
+fn top_level_trans_compound_repeat_fully_qualified() {
+    // The top-level `parse_trans_allele` (driven via
+    // `detect_allele_type` for ClinVar-style fully-qualified shapes
+    // where every member carries its own `ACC:coord.edit` prefix) is
+    // the eighth call site touched by the fix and deserves its own
+    // direct regression test. Each member shares an accession so
+    // Display normalizes to the compact-prefix `ACC:g.[X];[Y]` form;
+    // re-parsing that canonical output must round-trip stably.
+    let fully_qualified =
+        "[NC_000014.8:g.101179660_101179695TG[14]];[NC_000014.8:g.101179660_101179695TG[18]]";
+    let canonical = "NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]";
+    assert_eq!(round_trip(fully_qualified), canonical);
+    assert_eq!(round_trip(canonical), canonical);
+}
+
+#[test]
+fn delins_reference_with_nested_repeat_count_round_trip() {
+    // Companion fix in `parser/edit.rs::parse_bracketed_inserted_sequence`:
+    // a `delins[…]` whose bracketed payload is a reference range that
+    // *itself* contains an `[N]` repeat-count bracket previously had
+    // its close-bracket lookup truncated. The reference payload
+    // (e.g. `NC_000022.11:g.100_200TG[3]`) is now scanned with the
+    // depth-aware variant of the helper used by the trans-allele
+    // parsers above.
+    let s = "NC_000001.11:g.100_105delins[NC_000022.11:g.100_200TG[3]]";
+    assert_eq!(round_trip(s), s);
+}
+
+// =============================================================================
+// Trans-allele branches whose sibling is a null/unknown marker.
+// =============================================================================
+
+#[test]
+fn trans_compound_repeat_alongside_null_allele() {
+    // `[0]` is the spec's "no allele" marker. The trans helper has a
+    // dedicated branch for it (`content == "0"`); confirm it still
+    // works when the *other* allele contains a nested repeat
+    // count's `[N]`. The Display path falls back to the
+    // fully-qualified form `[ACC:variant];[0]` (compact-prefix is
+    // only used when both alleles are real variants sharing an
+    // accession).
+    let input = "NC_000001.11:g.[100_105TG[3]];[0]";
+    let canonical = "[NC_000001.11:g.100_105TG[3]];[0]";
+    assert_eq!(round_trip(input), canonical);
+    assert_eq!(round_trip(canonical), canonical);
+}
+
+#[test]
+fn trans_compound_repeat_alongside_unknown_allele() {
+    // `[?]` is the spec's "unknown allele" marker. Same Display shape
+    // as the null-allele test above.
+    let input = "NC_000001.11:g.[100_105TG[3]];[?]";
+    let canonical = "[NC_000001.11:g.100_105TG[3]];[?]";
+    assert_eq!(round_trip(input), canonical);
+    assert_eq!(round_trip(canonical), canonical);
+}
+
+// =============================================================================
+// Empty-member rejection — `[];[A]` is malformed.
+// =============================================================================
+
+#[test]
+fn empty_first_member_is_rejected() {
+    // The trans helper accepts a content of `"0"` or `"?"` (the null
+    // and unknown markers) and otherwise routes to the coord-system
+    // variant parser; an empty content fails fast inside that parser.
+    // Locks in the rejection so a future "fix" that silently accepts
+    // it shows up as a regression.
+    let normalizer = Normalizer::new(MockProvider::new());
+    let result = parse_hgvs("NC_000001.11:g.[];[100_105TG[3]]");
+    assert!(
+        result.is_err(),
+        "expected parse error for empty first member, got: {:?}",
+        result.map(|v| normalizer.normalize(&v).map(|n| n.to_string()))
+    );
+}


### PR DESCRIPTION
## Summary

Closes #207. Addresses #81 item B3.

Every per-coord-system `parse_*_trans_allele_shorthand` function in `src/hgvs/parser/variant.rs` (eight call sites — `g.`, `c.`, `n.`, `r.`, `m.`, `p.`, `o.`, plus the top-level `parse_trans_allele`) located the closing `]` of each `[A];[B]` member via `remaining.find(']')`. That picks the first `]` in the slice, so the moment a member contains a nested `[N]` repeat-count bracket the parser truncates the member at the inner bracket and fails on the surrounding garbage. The HGVS DNA `repeated.md` textbook example `NC_000014.8:g.[101179660_101179695TG[14]];[101179660_101179695TG[18]]` failed to parse at all as a result.

The same bug shape lived in `parser/edit.rs::parse_bracketed_inserted_sequence`: a `delins[NC_000022.11:g.100_200…]` whose bracketed reference payload itself contained an `[N]` repeat count had its close-bracket lookup truncated.

This change promotes `find_top_level_close_bracket` to `pub(crate)`, refactors it to delegate to a sibling `find_close_after_consumed_open` primitive (for callers where a `nom` combinator has already pulled the `[` off the stream), and routes every affected site through one of the two helpers.

## Fixture updates

- `tests/fixtures/grammar/hgvs_spec_normalization.json` — two rows flip from `parse-error` (with a `todo:` link) to `preserved`: the B3 textbook trans-repeat example, and the `ins[NC_000004.11:…;A[26]]` example from `recommendations/DNA/insertion.md`. Regenerated via the project's `generate_spec_fixture` example.
- `tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json` and `…_unique_failure_expectations.json` — drop the 1+5 previously-failing trans-repeat entries plus their now-unreferenced curated kinds. Edited surgically rather than via `UPDATE_FAILURE_EXPECTATIONS=1` to preserve the rest of the human-curated triage labels (a wholesale regen would have re-bucketed every remaining kind into `needs_triage` error-string IDs).

## Review

Parallel Opus + Sonnet reviews ran against the initial commit. The follow-up addressed every finding:
- Must-fix correctness on the `parser/edit.rs` companion site (same bug shape, same depth-aware fix).
- Missing test coverage for the two of eight patched parsers that the initial test file did not exercise (`o.` circular, top-level `parse_trans_allele`), plus the new `delins[ACC:…[N]]` case from the `edit.rs` fix.
- Missing `[0]` / `[?]` null/unknown-allele-next-to-repeat coverage.
- Missing empty-member negative case.
- Misleading "Negative shapes" section heading.

## Test plan

- [x] `cargo nextest run --features dev` — 4406 passed, 0 failed.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `pytest tests/python/` — 154 passed.
- [x] New `tests/issue_207_multi_repeat_compound_roundtrip.rs` covers all eight patched parsers plus the `delins[ACC:…[N]]` companion fix (18 cases).