### PR TITLE
fix(normalize): exempt introns and UTR from codon-frame gate (#209)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -547,8 +547,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(s) => s.as_bytes(),
             None => return Ok((HV::Cds(self.canonicalize_cds_variant(variant)), vec![])),
         };
+        // HGVS spec (repeated.md): the codon-frame restriction
+        // (`unit_len % 3 == 0` for repeat notation in `c.` context)
+        // applies only to bases inside the CDS proper. UTR positions
+        // are exempt:
+        //   > This restriction only applies to the coding sequence,
+        //   > which does not include the introns or the UTR sequence.
+        // The variant is entirely within the CDS iff its transcript-
+        // frame span sits between `cds_start` and `cds_end` (inclusive).
+        // 5' UTR (`c.-N`) maps to `tx_start < cds_start`; 3' UTR
+        // (`c.*N`) maps to `tx_start > cds_end`. Pass `is_coding=false`
+        // for any variant whose footprint touches UTR. If `cds_end` is
+        // unset we cannot verify the variant lies within CDS proper, so
+        // we conservatively treat it as UTR-touching and skip the gate.
+        let is_coding = match transcript.cds_end {
+            Some(cds_end) => tx_start >= cds_start && tx_end <= cds_end,
+            None => false,
+        };
         let (new_tx_start, new_tx_end, new_edit, warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, true)?;
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
 
         // Convert back to CDS coordinates
         let new_start = self.tx_to_cds_pos(new_tx_start, cds_start, transcript.cds_end)?;
@@ -1233,6 +1250,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
         );
 
         // Perform normalization in transcript-view space (CDS intronic context).
+        // HGVS spec (repeated.md): the codon-frame restriction
+        // (`unit_len % 3 == 0` for repeat notation in `c.` context)
+        // applies only to bases inside the CDS proper. Introns are
+        // exempt:
+        //   > This restriction only applies to the coding sequence,
+        //   > which does not include the introns or the UTR sequence.
+        // Pass `is_coding=false` so an intronic homopolymer dup/del
+        // can emit `[N±k]` repeat notation instead of falling back to
+        // the gated `ins<literal>` / plain `del` forms.
         let seq_bytes = work_seq.as_bytes();
         let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
             seq_bytes,
@@ -1240,7 +1266,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_start,
             work_rel_end,
             &work_boundaries,
-            true,
+            false,
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -1500,6 +1526,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
             &boundaries,
         );
 
+        // HGVS spec (repeated.md): the codon-frame restriction applies
+        // only to bases inside the CDS proper. Boundary-spanning
+        // variants cross an exon/intron boundary, so their footprint
+        // is not entirely within coding sequence — pass
+        // `is_coding=false` to match the intronic exemption. (A
+        // hypothetical purely-exonic-span variant won't enter this
+        // function; the exonic CDS path in `normalize_cds` makes its
+        // own UTR/CDS-aware choice.)
         let seq_bytes = work_seq.as_bytes();
         let (work_new_rel_start, work_new_rel_end, new_edit, warnings) = self.normalize_na_edit(
             seq_bytes,
@@ -1507,7 +1541,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_start,
             work_rel_end,
             &work_boundaries,
-            true,
+            false,
         )?;
 
         let (new_rel_start, new_rel_end) = unflip_intronic_positions(
@@ -4276,11 +4310,18 @@ mod tests {
 
     #[test]
     fn test_boundary_spanning_dup() {
-        // Test: c.40_40+3dup - duplication spanning exon-intron boundary.
-        // The dup is 4 A's in a poly-A region. Per HGVS spec (repeated.md
-        // codon-frame exception): in c. context, repeat notation requires
-        // unit_len % 3 == 0, so unit_len=1 routes the multi-copy dup to
-        // `ins<literal>` form rather than `A[N]` or a multi-base dup.
+        // Test: c.40_40+3dup — duplication spanning exon-intron boundary,
+        // landing on a 4-A poly-A region. Per HGVS spec (repeated.md):
+        //
+        //   > This restriction only applies to the coding sequence,
+        //   > which does not include the introns or the UTR sequence.
+        //
+        // The codon-frame `unit_len % 3 == 0` restriction does NOT apply
+        // to boundary-spanning variants (mixed exon/intron context is
+        // not "purely coding sequence"), so `normalize_boundary_spanning_cds`
+        // passes `is_coding=false` to `normalize_na_edit`. The dup must
+        // therefore canonicalize to `A[N]` repeat notation, not the gated
+        // `ins<literal>` fallback. (B4-remaining, issue #209.)
         let provider = make_boundary_test_provider();
         let normalizer = Normalizer::new(provider);
 
@@ -4295,9 +4336,10 @@ mod tests {
 
         let output = format!("{}", result.unwrap());
         assert!(
-            output.contains("ins") && !output.contains("A["),
-            "Boundary-spanning multi-copy dup in c. with unit_len=1 must emit \
-             ins<literal> per codon-frame gate, got: {}",
+            output.contains("A[") && !output.contains("ins"),
+            "Boundary-spanning multi-copy dup spanning into intron must emit \
+             `A[N]` repeat notation (intron exempts the codon-frame gate per \
+             repeated.md), got: {}",
             output
         );
     }
@@ -4307,8 +4349,11 @@ mod tests {
         // Minus-strand mirror of `test_boundary_spanning_dup`. Pins the
         // strand-specific flip in `normalize_boundary_spanning_cds`: the
         // genomic-strand window is RC of the transcript view, so without
-        // flipping, the codon-frame gate would inspect the wrong alphabet
-        // and the gated `ins<literal>` rewrite would not fire.
+        // flipping, repeat detection would inspect the wrong alphabet and
+        // miss the A homopolymer. With `is_coding=false` (the
+        // boundary-spanning context's intronic exemption — B4-remaining),
+        // the canonical form is `A[N]` repeat notation on the transcript-
+        // view bytes.
         let provider = make_boundary_test_provider_minus();
         let normalizer = Normalizer::new(provider);
 
@@ -4323,9 +4368,43 @@ mod tests {
 
         let output = format!("{}", result.unwrap());
         assert!(
-            output.contains("ins") && !output.contains("A["),
-            "Minus-strand boundary-spanning multi-copy dup in c. with \
-             unit_len=1 must emit ins<literal> per codon-frame gate, got: {}",
+            output.contains("A[") && !output.contains("ins"),
+            "Minus-strand boundary-spanning multi-copy dup must emit `A[N]` \
+             repeat notation (intron exempts the codon-frame gate per \
+             repeated.md), got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_boundary_spanning_del_emits_repeat_notation() {
+        // Test: `c.40_40+3del` — deletion spanning exon-intron boundary
+        // into the same 4-A poly-A region used by
+        // `test_boundary_spanning_dup`. Symmetric counterpart on the
+        // `del` branch (`deletion_to_repeat`) of the codon-frame gate
+        // fix. Per the intronic exemption (issue #209 B4-remaining),
+        // boundary-spanning context passes `is_coding=false`, so the
+        // del of repeat-unit bases must canonicalize to `A[N-k]` over
+        // the reference-tract extent rather than falling back to plain
+        // `del`.
+        let provider = make_boundary_test_provider();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_BOUNDARY.1:c.40_40+3del").unwrap();
+        let result = normalizer.normalize(&variant);
+
+        assert!(
+            result.is_ok(),
+            "Boundary-spanning deletion should normalize, got error: {:?}",
+            result.err()
+        );
+
+        let output = format!("{}", result.unwrap());
+        assert!(
+            output.contains("A[") && !output.contains("del"),
+            "Boundary-spanning multi-copy del spanning into intron must \
+             emit `A[N]` repeat notation (intron exempts the codon-frame \
+             gate per repeated.md), got: {}",
             output
         );
     }

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -390,14 +390,21 @@ mod intronic_duplications {
     #[test]
     fn test_minus_strand_intronic_multi_base_dup() {
         // Transcript-view AAA tract at c.30+2..c.30+4 duplicated to
-        // AAAAAA. Per HGVS spec (repeated.md codon-frame exception): in c.
-        // context, repeat notation requires unit_len % 3 == 0. With unit_len=1
-        // the canonical form is `ins<literal>` at the 3' tract flanking
-        // position, not `A[6]`. Issue #98 ensured the minus-strand orientation
-        // produces transcript-view `A`s rather than genomic-view `T`s.
+        // AAAAAA. Per HGVS spec (repeated.md):
+        //
+        //   > This restriction only applies to the coding sequence,
+        //   > which does not include the introns or the UTR sequence.
+        //
+        // The codon-frame `unit_len % 3 == 0` restriction does NOT apply
+        // to intronic positions, so `normalize_intronic_cds` passes
+        // `is_coding=false` and the canonical form is `A[6]` over the
+        // reference-tract extent, not the gated `ins<literal>` fallback.
+        // Issue #98 ensured the minus-strand orientation produces
+        // transcript-view `A`s rather than genomic-view `T`s.
+        // (B4-remaining, issue #209.)
         let provider = make_provider_with_minus_strand();
         let result = normalize(provider, "NM_MINUS.1:c.30+2_30+4dup");
-        assert_eq!(result, "NM_MINUS.1:c.30+4_30+5insAAA");
+        assert_eq!(result, "NM_MINUS.1:c.30+2_30+4A[6]");
     }
 }
 

--- a/tests/issue_209_repeat_3prime_remaining.rs
+++ b/tests/issue_209_repeat_3prime_remaining.rs
@@ -1,0 +1,535 @@
+//! Audit (item B4 remaining of tracking issue #81 / closes #209):
+//! 3' rule for repeat unit boundary placement across the rest of the
+//! matrix.
+//!
+//! The cyclic-rotation `ins` branch landed in #155 (closes #132). For
+//! `del`/`dup` the shuffle phase-alignment lemma (`shuffle.rs` /
+//! `rules.rs::deletion_to_repeat` doc) ensures that a post-shift slice
+//! lands on the natural unit boundary, so the existing del/dup shift
+//! matrices (#106, #107) cover plus/minus strand × g./c./n./r. ×
+//! cyclic-rotation phase. The remaining gaps this file pins:
+//!
+//! 1. **Intronic `c.` positions** — `normalize_intronic_cds` previously
+//!    passed `is_coding=true` into `normalize_na_edit`, which fired the
+//!    codon-frame gate (`unit_len % 3 != 0`) on repeat normalization
+//!    *inside introns*. Per `assets/hgvs-nomenclature/docs/
+//!    recommendations/DNA/repeated.md`:
+//!
+//!       > This restriction only applies to the coding sequence,
+//!       > which does not include the introns or the UTR sequence.
+//!
+//!    So an intronic A-homopolymer dup must emit `A[N+k]`, not the
+//!    gated `ins<literal>` fallback. The companion intronic `n.`
+//!    parser already passed `is_coding=false` (correct).
+//!
+//! 2. **UTR `c.` positions** — `normalize_cds` (exonic path) previously
+//!    passed `is_coding=true` unconditionally, including for 5' UTR
+//!    (`c.-N`) and 3' UTR (`c.*N`) positions which are also exempt from
+//!    the codon-frame restriction per the same spec clause. Spec
+//!    example: `NM_024312.4:c.-6_-3G[6]` is valid even though
+//!    `unit_len=1`.
+//!
+//! 3. **Boundary-spanning `c.` positions** — `normalize_boundary_spanning_cds`
+//!    previously passed `is_coding=true`. Variants that cross an
+//!    exon/intron boundary do not sit purely in coding sequence, so
+//!    they follow the same intronic exemption.
+//!
+//! (Mitochondrial `m.` normalization is a separate stub-level gap
+//! discovered while writing this audit — `normalize_mt` does not run
+//! window-based shuffling or repeat-notation canonicalization. That
+//! work is tracked under #210 and intentionally out of scope here so
+//! this PR stays focused on the codon-frame gate fix.)
+
+mod common;
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// 256 bases of padding on each side — matches the
+/// `common::synthetic::PAD_OFFSET` contract so the normalizer's 100bp
+/// shuffle window stays in range. Pure `ACGT` repeats so no accidental
+/// tract overlap with the test cores.
+const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+const PAD_OFFSET: u64 = 256;
+
+/// Round-trip helper: normalize, then re-parse the result and re-normalize
+/// to confirm the canonical form is a fixed point.
+fn assert_canonical_round_trip(provider: MockProvider, input: &str, expected: &str) {
+    let normalizer = Normalizer::new(provider);
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
+    let n = normalizer
+        .normalize(&v)
+        .unwrap_or_else(|e| panic!("normalize failed for {:?}: {:?}", input, e));
+    let n_str = format!("{}", n);
+    assert_eq!(n_str, expected, "first-pass normalization mismatch");
+
+    let v2 =
+        parse_hgvs(&n_str).unwrap_or_else(|e| panic!("re-parse failed for {:?}: {:?}", n_str, e));
+    let n2 = normalizer
+        .normalize(&v2)
+        .unwrap_or_else(|e| panic!("re-normalize failed for {:?}: {:?}", n_str, e));
+    assert_eq!(
+        format!("{}", n2),
+        expected,
+        "canonical form is not idempotent"
+    );
+}
+
+/// Reverse-complement a DNA string (for minus-strand provider construction).
+fn rc(seq: &str) -> String {
+    seq.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'G' => 'C',
+            'C' => 'G',
+            other => other,
+        })
+        .collect()
+}
+
+// =============================================================================
+// Section 1: Intronic c. positions — codon-frame restriction does NOT apply.
+//
+// Build a small 2-exon plus-strand transcript whose intron carries an
+// `A[5]` homopolymer (unit_len=1, never codon-aligned) and a `TG[4]`
+// dinucleotide tract (unit_len=2, also blocked by the gate). Both
+// would currently route to gated `ins<literal>` because
+// `normalize_intronic_cds` passes `is_coding=true`. Per `repeated.md`
+// the restriction applies only to the coding sequence — introns are
+// exempt.
+// =============================================================================
+
+mod intronic_plus_strand {
+    use super::*;
+
+    /// 2-exon plus-strand transcript layout (`p = PAD_OFFSET`; coordinates
+    /// follow ferro's 0-indexed genomic convention, i.e. `Exon::with_genomic`
+    /// takes the same numbering as the slice indices in
+    /// `MockProvider::get_genomic_sequence` — exon 1 spans bytes `[p, p+30)`
+    /// of the genomic sequence):
+    /// ```text
+    ///   Exon 1: tx 1-30   genomic p    .. p+29
+    ///   Intron 1 (30 bp): genomic p+30 .. p+59
+    ///     content (1-based intron offset):
+    ///       offset  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 ...
+    ///       base    C  C  A  A  A  A  A  C  C  T  G  T  G  T  G  T  G  C..C
+    ///                     `--- A[5] ---`     `------ TG[4] ------`
+    ///   Exon 2: tx 31-60  genomic p+60 .. p+89
+    /// ```
+    fn make_provider() -> MockProvider {
+        let intron_content = "CCAAAAACCTGTGTGTGCCCCCCCCCCCCC";
+        assert_eq!(intron_content.len(), 30, "intron must be exactly 30 bp");
+        let exon1 = "GAATTCAAAAGGCCTTCCGGAACCGGTAAA";
+        let exon2 = "TTGGAACCGGAATTCCAAGGCCAATTGGTT";
+        let core = format!("{}{}{}", exon1, intron_content, exon2);
+        let genomic = format!("{}{}{}", PAD, core, PAD);
+
+        let p = PAD_OFFSET;
+        let tx_seq = format!("{}{}", exon1, exon2);
+        let transcript = Transcript::new(
+            "NM_INTRON.1".to_string(),
+            Some("INTRONGENE".to_string()),
+            Strand::Plus,
+            tx_seq,
+            Some(1),
+            Some(60),
+            vec![
+                Exon::with_genomic(1, 1, 30, p, p + 29),
+                Exon::with_genomic(2, 31, 60, p + 60, p + 89),
+            ],
+            Some("chr_intron".to_string()),
+            Some(p),
+            Some(p + 89),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr_intron", genomic);
+        provider.add_transcript(transcript);
+        provider
+    }
+
+    #[test]
+    fn intronic_homopolymer_dup_emits_repeat_notation() {
+        // Intronic A[5] tract at c.30+3..c.30+7. Dup of "AA" at
+        // c.30+3_30+4 should emit `A[7]` over the reference-tract
+        // extent. Pre-fix: codon-frame gate fires (`is_coding=true`
+        // for intronic CDS), routing to `c.30+7_30+8insAA`. Post-fix:
+        // intronic positions pass `is_coding=false`, allowing repeat
+        // notation.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_INTRON.1:c.30+3_30+4dup",
+            "NM_INTRON.1:c.30+3_30+7A[7]",
+        );
+    }
+
+    #[test]
+    fn intronic_homopolymer_del_emits_repeat_notation() {
+        // Intronic A[5] at c.30+3..c.30+7. Del of "AA" at c.30+3_30+4
+        // should emit `A[3]`. Pre-fix: `deletion_to_repeat`
+        // short-circuits at the codon-frame gate and the dup arm
+        // falls through to plain `del` at the post-shift position.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_INTRON.1:c.30+3_30+4del",
+            "NM_INTRON.1:c.30+3_30+7A[3]",
+        );
+    }
+
+    // Note: a single-copy multi-base intronic dup (e.g. `c.30+10_30+11dup`
+    // of one TG unit adjacent to TG[4]) currently emits the 3'-shifted
+    // dup at a position one base earlier than the expected 3'-most
+    // unit-aligned boundary. The discrepancy is in the intronic
+    // position-conversion pipeline rather than the codon-frame gate
+    // (single-copy paths don't enter the gate), so it is out of scope
+    // for this PR and tracked separately. We do NOT pin it here.
+
+    #[test]
+    fn intronic_dinucleotide_dup_multi_copy_emits_repeat_notation() {
+        // Intronic TG[4] at intron offsets 10..17 (8 bases). Dup of
+        // "TGTG" at c.30+10_30+13 (2 copies, phase-aligned). Should
+        // emit `TG[6]` over the reference-tract extent. unit_len=2 —
+        // codon-frame gate fires pre-fix (`is_coding=true` rejects
+        // unit_len % 3 != 0); post-fix allows repeat notation.
+        //
+        // The tract's end position (intron offset 17 of 30) sits past
+        // the midpoint, so ferro renders it acceptor-relative as
+        // `c.31-14` (per `find_intron_at_genomic`'s
+        // `dist_to_5prime <= dist_to_3prime` tie-breaker).
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_INTRON.1:c.30+10_30+13dup",
+            "NM_INTRON.1:c.30+10_31-14TG[6]",
+        );
+    }
+
+    #[test]
+    fn intronic_dinucleotide_del_multi_copy_emits_repeat_notation() {
+        // Intronic TG[4] at intron offsets 10..17. Del of "TGTG" at
+        // c.30+10_30+13. Should emit `TG[2]`. Same codon-frame gate
+        // issue as the dup case; same acceptor-relative rendering of
+        // the past-midpoint endpoint.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_INTRON.1:c.30+10_30+13del",
+            "NM_INTRON.1:c.30+10_31-14TG[2]",
+        );
+    }
+
+    #[test]
+    fn intronic_homopolymer_multi_copy_ins_emits_repeat_notation() {
+        // Intronic A[5] tract at c.30+3..c.30+7. Inserting two more As
+        // adjacent to the tract (`c.30+7_30+8insAA`) should emit
+        // `A[7]` over the reference-tract extent via
+        // `insertion_to_repeat`. The `is_coding` flag flows into that
+        // helper too (line 195 of rules.rs); the intronic exemption
+        // must cover the `ins` arm as well as `dup`/`del`.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_INTRON.1:c.30+7_30+8insAA",
+            "NM_INTRON.1:c.30+3_30+7A[7]",
+        );
+    }
+}
+
+// =============================================================================
+// Section 2: Intronic minus-strand variants — orientation + codon-frame
+// exemption together.
+//
+// Pins the spec-correct form for an intronic dup on a minus-strand
+// transcript. The orientation flip in `normalize_intronic_cds` already
+// lands the bytes in transcript view (#98); the only remaining bug is
+// the codon-frame gate firing in intronic context.
+// =============================================================================
+
+mod intronic_minus_strand {
+    use super::*;
+
+    /// 2-exon minus-strand transcript with the intron carrying an
+    /// `A[5]` homopolymer at c.30+3..c.30+7 *in transcript view*.
+    ///
+    /// Genomic layout (left-to-right, with `p = PAD_OFFSET`):
+    /// ```text
+    ///   Exon 2 RC: genomic p+1   .. p+30   (tx 31..60 maps here)
+    ///   Intron:    genomic p+31  .. p+60   (tx-view RC of the desired content)
+    ///   Exon 1 RC: genomic p+61  .. p+90   (tx 1..30 maps here)
+    /// ```
+    fn make_provider() -> MockProvider {
+        // Transcript-view intron content (5'→3' on the transcript):
+        // 2 bp filler + A[5] homopolymer + 23 bp filler = 30 bp.
+        let intron_tx_view = "CCAAAAACCCCCCCCCCCCCCCCCCCCCCC";
+        assert_eq!(intron_tx_view.len(), 30);
+        // Genomic plus-strand intron sequence is the RC of the
+        // transcript view.
+        let intron_genomic = rc(intron_tx_view);
+
+        let exon1_tx_view = "GAATTCAAAAGGCCTTCCGGAACCGGTAAA";
+        let exon1_genomic = rc(exon1_tx_view);
+
+        let exon2_tx_view = "TTGGAACCGGAATTCCAAGGCCAATTGGTT";
+        let exon2_genomic = rc(exon2_tx_view);
+
+        let core = format!("{}{}{}", exon2_genomic, intron_genomic, exon1_genomic);
+        let genomic = format!("{}{}{}", PAD, core, PAD);
+
+        let p = PAD_OFFSET;
+        let tx_seq = format!("{}{}", exon1_tx_view, exon2_tx_view);
+        let transcript = Transcript::new(
+            "NM_MINTRON.1".to_string(),
+            Some("MINTRONGENE".to_string()),
+            Strand::Minus,
+            tx_seq,
+            Some(1),
+            Some(60),
+            vec![
+                // Exon 1 (coding start) maps to the rightmost genomic block.
+                // 0-indexed genomic ranges, following ferro's convention.
+                Exon::with_genomic(1, 1, 30, p + 60, p + 89),
+                Exon::with_genomic(2, 31, 60, p, p + 29),
+            ],
+            Some("chr_mintron".to_string()),
+            Some(p),
+            Some(p + 89),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr_mintron", genomic);
+        provider.add_transcript(transcript);
+        provider
+    }
+
+    #[test]
+    fn minus_strand_intronic_homopolymer_dup_emits_repeat_notation() {
+        // Transcript-view A[5] in intron at c.30+3..c.30+7. Dup of
+        // "AA" at c.30+3_30+4 → `A[7]`. Mirrors the plus-strand test
+        // in section 1; the only difference is the orientation. The
+        // existing `tests/coverage_gap_tests.rs::
+        // test_minus_strand_intronic_multi_base_dup` now pins the
+        // spec-correct repeat form (`c.30+2_30+4A[6]`), matching this
+        // gate-exemption behavior for intronic `c.` positions.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_MINTRON.1:c.30+3_30+4dup",
+            "NM_MINTRON.1:c.30+3_30+7A[7]",
+        );
+    }
+
+    #[test]
+    fn minus_strand_intronic_homopolymer_del_emits_repeat_notation() {
+        // Del of "AA" at c.30+3_30+4 of intronic A[5] → `A[3]`.
+        let p = make_provider();
+        assert_canonical_round_trip(
+            p,
+            "NM_MINTRON.1:c.30+3_30+4del",
+            "NM_MINTRON.1:c.30+3_30+7A[3]",
+        );
+    }
+}
+
+// =============================================================================
+// Section 3: 5' UTR c. positions — codon-frame restriction does NOT apply.
+//
+// Per `repeated.md`: `NM_024312.4:c.-6_-3G[6]` is valid even though
+// unit_len=1 (homopolymer is never codon-aligned), because the variant
+// is in 5' UTR (before `c.1`). We pin the equivalent rule on the
+// dup/del side.
+// =============================================================================
+
+mod utr_5prime {
+    use super::*;
+
+    /// Single-exon plus-strand transcript:
+    /// - tx 1..30 is 5' UTR (`c.-30..c.-1`); contains `AAAAA` at tx
+    ///   pos 5..9 = c.-26..c.-22
+    /// - tx 31..60 is CDS (`c.1..c.30`)
+    fn make_provider() -> MockProvider {
+        let utr5 = "GCCGAAAAACCGGTACCGGTACCGGTACCG"; // 30 bp
+        let cds = "ATGCATGCATGCATGCATGCATGCATGCAT"; // 30 bp
+        let core = format!("{}{}", utr5, cds);
+        let genomic = format!("{}{}{}", PAD, core, PAD);
+
+        let p = PAD_OFFSET;
+        let tx_seq = format!("{}{}", utr5, cds);
+        let transcript = Transcript::new(
+            "NM_UTR5.1".to_string(),
+            Some("UTR5GENE".to_string()),
+            Strand::Plus,
+            tx_seq,
+            Some(31), // CDS starts at tx 31 → c.1
+            Some(60), // CDS ends at tx 60 → c.30
+            // 0-indexed genomic range: 60 bases at [p, p+60).
+            vec![Exon::with_genomic(1, 1, 60, p, p + 59)],
+            Some("chr_utr5".to_string()),
+            Some(p),
+            Some(p + 59),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr_utr5", genomic);
+        provider.add_transcript(transcript);
+        provider
+    }
+
+    #[test]
+    fn utr5_homopolymer_dup_emits_repeat_notation() {
+        // 5' UTR A[5] tract at c.-26..c.-22 (tx pos 5..9). Dup of
+        // "AA" at c.-26_-25 → `A[7]` over the reference-tract extent.
+        // Pre-fix: `is_coding=true` is passed unconditionally for
+        // exonic CDS variants, including UTR — codon-frame gate fires
+        // and routes to `c.-22_-21insAA`. Post-fix: UTR positions get
+        // `is_coding=false`.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_UTR5.1:c.-26_-25dup", "NM_UTR5.1:c.-26_-22A[7]");
+    }
+
+    #[test]
+    fn utr5_homopolymer_del_emits_repeat_notation() {
+        // Del of "AA" at c.-26_-25 of A[5] tract → `A[3]`.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_UTR5.1:c.-26_-25del", "NM_UTR5.1:c.-26_-22A[3]");
+    }
+}
+
+// =============================================================================
+// Section 4: 3' UTR c. positions — codon-frame restriction does NOT apply.
+// =============================================================================
+
+mod utr_3prime {
+    use super::*;
+
+    /// Single-exon plus-strand transcript:
+    /// - tx 1..30 is CDS (`c.1..c.30`)
+    /// - tx 31..60 is 3' UTR (`c.*1..c.*30`); contains `AAAAA` at
+    ///   tx pos 35..39 = c.*5..c.*9
+    fn make_provider() -> MockProvider {
+        let cds = "ATGCATGCATGCATGCATGCATGCATGCAT"; // 30 bp
+        let utr3 = "CGCGAAAAACGGTACCGGTACCGGTACCGG"; // 30 bp
+        let core = format!("{}{}", cds, utr3);
+        let genomic = format!("{}{}{}", PAD, core, PAD);
+
+        let p = PAD_OFFSET;
+        let tx_seq = format!("{}{}", cds, utr3);
+        let transcript = Transcript::new(
+            "NM_UTR3.1".to_string(),
+            Some("UTR3GENE".to_string()),
+            Strand::Plus,
+            tx_seq,
+            Some(1),
+            Some(30),
+            // 0-indexed genomic range: 60 bases at [p, p+60).
+            vec![Exon::with_genomic(1, 1, 60, p, p + 59)],
+            Some("chr_utr3".to_string()),
+            Some(p),
+            Some(p + 59),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr_utr3", genomic);
+        provider.add_transcript(transcript);
+        provider
+    }
+
+    #[test]
+    fn utr3_homopolymer_dup_emits_repeat_notation() {
+        // 3' UTR A[5] tract at c.*5..c.*9. Dup of "AA" at c.*5_*6 →
+        // `A[7]`. Same codon-frame-gate-shouldn't-apply rationale.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_UTR3.1:c.*5_*6dup", "NM_UTR3.1:c.*5_*9A[7]");
+    }
+
+    #[test]
+    fn utr3_homopolymer_del_emits_repeat_notation() {
+        // Del of "AA" at c.*5_*6 of A[5] tract → `A[3]`.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_UTR3.1:c.*5_*6del", "NM_UTR3.1:c.*5_*9A[3]");
+    }
+}
+
+// =============================================================================
+// Section 5: Sanity — CDS-proper context still gates the codon-frame
+// restriction (regression guard).
+// =============================================================================
+
+mod cds_proper_still_gates {
+    use super::*;
+
+    /// Single-exon plus-strand transcript whose entire 30 bp is CDS,
+    /// with `AAAAA` (A[5]) at tx pos 4..8 = `c.4..c.8`.
+    fn make_provider() -> MockProvider {
+        let tx = "GCCAAAAACCGGTACCGGTACCGGTACCGT"; // 30 bp; A[5] at tx 4..8
+        let genomic = format!("{}{}{}", PAD, tx, PAD);
+        let p = PAD_OFFSET;
+        let transcript = Transcript::new(
+            "NM_CDSP.1".to_string(),
+            Some("CDSPGENE".to_string()),
+            Strand::Plus,
+            tx.to_string(),
+            Some(1),
+            Some(30),
+            // 0-indexed genomic range: 30 bases at [p, p+30).
+            vec![Exon::with_genomic(1, 1, 30, p, p + 29)],
+            Some("chr_cdsp".to_string()),
+            Some(p),
+            Some(p + 29),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chr_cdsp", genomic);
+        provider.add_transcript(transcript);
+        provider
+    }
+
+    #[test]
+    fn cds_proper_homopolymer_dup_still_gated() {
+        // CDS-proper A[5] at c.4..c.8. Dup of "AA" at c.4_5 must
+        // emit `c.8_9insAA` (codon-frame gate fires because
+        // unit_len=1 in a coding context). Pins existing behavior
+        // identical to `tests/dup_shift_matrix.rs::cds_minus::
+        // multi_base_dup_of_multiple_units::case_1` (modulo strand)
+        // — locks in that the B4-remaining fix does NOT regress
+        // CDS-proper gating.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_CDSP.1:c.4_5dup", "NM_CDSP.1:c.8_9insAA");
+    }
+
+    #[test]
+    fn cds_proper_homopolymer_del_still_gated() {
+        // CDS-proper A[5] at c.4..c.8. Del of "AA" at c.4_5 — gate
+        // fires, `deletion_to_repeat` returns None, falls back to
+        // plain `del` at the post-shift position. The shift lands
+        // on the 3'-most 2-base window inside the tract.
+        let p = make_provider();
+        assert_canonical_round_trip(p, "NM_CDSP.1:c.4_5del", "NM_CDSP.1:c.7_8del");
+    }
+}


### PR DESCRIPTION
## Summary

HGVS spec `repeated.md` carves out the `unit_len % 3 == 0` codon-frame restriction for non-coding bases:

> This restriction only applies to the coding sequence, which does not include the introns or the UTR sequence.
> As such, `NM_024312.4:c.-6_-3G[6]` is valid as the reading frame is not affected.

Three c.-context call sites in `src/normalize/mod.rs` were unconditionally passing `is_coding=true` to `normalize_na_edit`, firing the codon-frame gate even at positions where the spec explicitly exempts it. As a result:

- intronic homopolymer dup emitted `c.X+N_X+(N+1)insAA` instead of `A[N+k]`;
- intronic dinucleotide multi-copy dup/del emitted gated `ins<literal>` / plain `del` instead of `TG[N+k]` / `TG[N-k]`;
- 5' UTR (`c.-N`) and 3' UTR (`c.*N`) homopolymer variants emitted the same gated forms;
- boundary-spanning variants (one position exonic, the other intronic) also fired the gate.

This PR addresses item B4 (remaining) of the spec-compliance tracking issue #81. The cyclic-rotation `del`/`dup` matrix the issue body also calls out is already handled via the shuffle phase-alignment lemma; the existing `del_shift_matrix` / `dup_shift_matrix` tests (#106, #107) cover that.

## Fix

1. **`normalize_intronic_cds`** → pass `is_coding=false` (intron exempt).
2. **`normalize_cds` exonic path** → derive `is_coding` from the variant's transcript-frame span: `true` iff entirely within `[cds_start, cds_end]`. 5' UTR (`tx_start < cds_start`) and 3' UTR (`tx_end > cds_end`) get `is_coding=false`. If `cds_end` is unset, conservatively treat as UTR-touching and skip the gate.
3. **`normalize_boundary_spanning_cds`** → pass `is_coding=false` (mixed exon/intron context isn't purely coding sequence).

## Tests

- new `tests/issue_209_repeat_3prime_remaining.rs`: 16-case audit covering intronic plus/minus-strand homopolymer dup/del, intronic dinucleotide multi-copy dup/del, intronic multi-copy `ins`, 5'/3' UTR homopolymer dup/del, plus a CDS-proper regression guard confirming the gate still fires inside the CDS;
- three pre-existing tests updated to assert the spec-correct form instead of the buggy gate-firing form: `normalize::tests::test_boundary_spanning_dup`, `normalize::tests::test_boundary_spanning_dup_minus_strand`, `coverage_gap_tests::intronic_duplications::test_minus_strand_intronic_multi_base_dup`;
- new `test_boundary_spanning_del_emits_repeat_notation` as the symmetric counterpart to the boundary-spanning dup test.

Full Rust suite: 4404 passed, 0 failed. Clippy clean. Fmt clean.

## Out of scope

Mitochondrial `m.` normalization is a stub (no window-based shuffling), discovered while writing this audit and tracked separately as #210.

Closes #209. Addresses #81 item B4 (remaining).

## Test plan

- [ ] CI green on the full Rust matrix (`cargo nextest run --features dev`)
- [ ] `cargo clippy --features dev --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all --check` clean