### PR TITLE
fix(protein): extension Display emits extTerN to match Frameshift Ter canonicalization (closes #224)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -1108,10 +1108,16 @@ impl fmt::Display for ProteinEdit {
                     write!(f, "{}", aa)?;
                 }
                 write!(f, "ext")?;
+                // Three-letter `Ter` is the spec-preferred canonical form
+                // for the translation termination codon
+                // (`background/standards.md`); `*` is an accepted
+                // alternative on input. Display emits `Ter` for both
+                // C-terminal extensions and frameshifts so the
+                // canonical Display form is uniform across edit kinds.
                 match (direction, count) {
                     (ExtDirection::NTerminal, Some(n)) => write!(f, "{}", n)?,
-                    (ExtDirection::CTerminal, Some(n)) => write!(f, "*{}", n)?,
-                    (ExtDirection::CTerminal, None) => write!(f, "*?")?,
+                    (ExtDirection::CTerminal, Some(n)) => write!(f, "Ter{}", n)?,
+                    (ExtDirection::CTerminal, None) => write!(f, "Ter?")?,
                     (ExtDirection::NTerminal, None) => {} // No suffix for unknown N-terminal
                 }
                 Ok(())

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,10 +10,10 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 42,
-      "diverges": 187,
+      "diverges": 183,
       "false-acceptance": 86,
       "parse-error": 341,
-      "preserved": 616
+      "preserved": 620
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10289,21 +10289,9 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.2:p.Ter110GlnextTer17",
-      "current": "NP_003997.2:p.Ter110Glnext*17",
-      "spec_expected": "NP_003997.2:p.Ter110GlnextTer17",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.(*110Glnext*17)",
       "input_prefixed": "NP_003997.1:p.(*110Glnext*17)",
-      "current": "NP_003997.1:p.(Ter110Glnext*17)",
+      "current": "NP_003997.1:p.(Ter110GlnextTer17)",
       "spec_expected": "NP_003997.1:p.(*110Glnext*17)",
       "status": "diverges",
       "coordinate_system": "p",
@@ -10353,19 +10341,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Ter110GlnextTer17)",
-      "input_prefixed": "NP_003997.1:p.(Ter110GlnextTer17)",
-      "current": "NP_003997.1:p.(Ter110Glnext*17)",
-      "spec_expected": "NP_003997.1:p.(Ter110GlnextTer17)",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/extension.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.(Tyr4*)",
       "input_prefixed": "NP_003997.1:p.(Tyr4*)",
       "current": "NP_003997.1:p.(Tyr4Ter)",
@@ -10381,7 +10356,7 @@
     {
       "input": "p.*110Glnext*17",
       "input_prefixed": "NP_003997.1:p.*110Glnext*17",
-      "current": "NP_003997.1:p.Ter110Glnext*17",
+      "current": "NP_003997.1:p.Ter110GlnextTer17",
       "spec_expected": "NP_003997.1:p.*110Glnext*17",
       "status": "diverges",
       "coordinate_system": "p",
@@ -10394,7 +10369,7 @@
     {
       "input": "p.*327Argext*?",
       "input_prefixed": "NP_003997.1:p.*327Argext*?",
-      "current": "NP_003997.1:p.Ter327Argext*?",
+      "current": "NP_003997.1:p.Ter327ArgextTer?",
       "spec_expected": "NP_003997.1:p.*327Argext*?",
       "status": "diverges",
       "coordinate_system": "p",
@@ -10525,7 +10500,7 @@
     {
       "input": "p.Met1ext",
       "input_prefixed": "NP_003997.1:p.Met1ext",
-      "current": "NP_003997.1:p.Met1ext*?",
+      "current": "NP_003997.1:p.Met1extTer?",
       "spec_expected": "NP_003997.1:p.Met1ext",
       "status": "diverges",
       "coordinate_system": "p",
@@ -10547,32 +10522,6 @@
         "docs/consultation/SVD-WG010.md"
       ],
       "working_group": "SVD-WG010",
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.Ter110GlnextTer17",
-      "input_prefixed": "NP_003997.1:p.Ter110GlnextTer17",
-      "current": "NP_003997.1:p.Ter110Glnext*17",
-      "spec_expected": "NP_003997.1:p.Ter110GlnextTer17",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/extension.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.Ter327ArgextTer?",
-      "input_prefixed": "NP_003997.1:p.Ter327ArgextTer?",
-      "current": "NP_003997.1:p.Ter327Argext*?",
-      "spec_expected": "NP_003997.1:p.Ter327ArgextTer?",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/extension.md"
-      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -11673,6 +11622,17 @@
       ]
     },
     {
+      "input": "NP_003997.2:p.Ter110GlnextTer17",
+      "current": "NP_003997.2:p.Ter110GlnextTer17",
+      "spec_expected": "NP_003997.2:p.Ter110GlnextTer17",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
+      ]
+    },
+    {
       "input": "NP_003997.2:p.Trp4del",
       "current": "NP_003997.2:p.Trp4del",
       "spec_expected": "NP_003997.2:p.Trp4del",
@@ -12161,6 +12121,18 @@
       ]
     },
     {
+      "input": "p.(Ter110GlnextTer17)",
+      "input_prefixed": "NP_003997.1:p.(Ter110GlnextTer17)",
+      "current": "NP_003997.1:p.(Ter110GlnextTer17)",
+      "spec_expected": "NP_003997.1:p.(Ter110GlnextTer17)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/extension.md"
+      ]
+    },
+    {
       "input": "p.(Val89_Gln119dup)",
       "input_prefixed": "NP_003997.1:p.(Val89_Gln119dup)",
       "current": "NP_003997.1:p.(Val89_Gln119dup)",
@@ -12610,6 +12582,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "p.Ter110GlnextTer17",
+      "input_prefixed": "NP_003997.1:p.Ter110GlnextTer17",
+      "current": "NP_003997.1:p.Ter110GlnextTer17",
+      "spec_expected": "NP_003997.1:p.Ter110GlnextTer17",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/extension.md"
+      ]
+    },
+    {
+      "input": "p.Ter327ArgextTer?",
+      "input_prefixed": "NP_003997.1:p.Ter327ArgextTer?",
+      "current": "NP_003997.1:p.Ter327ArgextTer?",
+      "spec_expected": "NP_003997.1:p.Ter327ArgextTer?",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/extension.md"
       ]
     },
     {

--- a/tests/issue_224_protein_extension_ter.rs
+++ b/tests/issue_224_protein_extension_ter.rs
@@ -1,0 +1,150 @@
+//! Audit for issue #224 — protein extension Display emits `extTerN`
+//! (not `ext*N`) for C-terminal extensions, mirroring the `Ter`
+//! canonicalization that Frameshift already uses.
+//!
+//! Spec: `assets/hgvs-nomenclature/docs/background/standards.md` —
+//! three-letter codes (including `Ter`) are preferred; `*` is an
+//! accepted alternative. ferro's canonical Display form is the
+//! three-letter form for substitutions and frameshifts; this audit
+//! pins the same canonicalization for extensions.
+//!
+//! Closes the D2 portion of #81 § D (also reaches into D3 since the
+//! `Ter` canonicalization is a shared concern).
+
+use ferro_hgvs::parse_hgvs;
+
+fn assert_canonicalizes_to(input: &str, expected: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{}`: {}", input, e));
+    let out = format!("{}", v);
+    assert_eq!(
+        out, expected,
+        "canonicalization mismatch:\n  input:    `{}`\n  expected: `{}`\n  got:      `{}`",
+        input, expected, out
+    );
+}
+
+fn assert_round_trips(input: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{}`: {}", input, e));
+    let out = format!("{}", v);
+    assert_eq!(out, input, "round-trip mismatch: `{}` -> `{}`", input, out);
+}
+
+// =============================================================================
+// SECTION 1 — C-terminal extension Ter canonicalization
+// =============================================================================
+
+mod c_terminal_extension {
+    use super::*;
+
+    /// Three-letter `Ter` input round-trips (canonical form).
+    #[test]
+    fn ter_ter_round_trips() {
+        assert_round_trips("NP_003997.1:p.Ter315TyrextTer10");
+    }
+
+    /// Three-letter `Ter` start position + `*` extension count must
+    /// canonicalize to `Ter` extension count.
+    #[test]
+    fn ter_star_canonicalizes_to_ter_ter() {
+        assert_canonicalizes_to(
+            "NP_003997.1:p.Ter315Tyrext*10",
+            "NP_003997.1:p.Ter315TyrextTer10",
+        );
+    }
+
+    /// `*` start position + `*` extension count: both canonicalize.
+    #[test]
+    fn star_star_canonicalizes_to_ter_ter() {
+        assert_canonicalizes_to(
+            "NP_003997.1:p.*315Tyrext*10",
+            "NP_003997.1:p.Ter315TyrextTer10",
+        );
+    }
+
+    /// Unknown extension count `*?` → `Ter?` after canonicalization.
+    #[test]
+    fn unknown_count_canonicalizes_star_to_ter() {
+        assert_canonicalizes_to(
+            "NP_003997.1:p.Ter315Tyrext*?",
+            "NP_003997.1:p.Ter315TyrextTer?",
+        );
+    }
+
+    /// `Ter?` already canonical.
+    #[test]
+    fn unknown_count_ter_form_round_trips() {
+        assert_round_trips("NP_003997.1:p.Ter315TyrextTer?");
+    }
+}
+
+// =============================================================================
+// SECTION 2 — N-terminal extension is unaffected
+// =============================================================================
+//
+// N-terminal extensions use a negative count (`ext-N`), not `*`/`Ter`,
+// so the canonicalization change must NOT touch them. Pin to guard
+// against an over-eager fix.
+
+mod n_terminal_extension {
+    use super::*;
+
+    #[test]
+    fn met_loss_short_round_trips() {
+        assert_round_trips("NP_003997.1:p.Met1ext-5");
+    }
+
+    #[test]
+    fn met_loss_with_new_aa_round_trips() {
+        assert_round_trips("NP_003997.1:p.Met1Valext-12");
+    }
+}
+
+// =============================================================================
+// SECTION 3 — predicted-vs-confirmed parens preserved over extension
+// =============================================================================
+
+mod predicted_parens {
+    use super::*;
+
+    #[test]
+    fn predicted_c_terminal_extension_canonicalizes() {
+        assert_canonicalizes_to(
+            "NP_003997.1:p.(Ter315Tyrext*10)",
+            "NP_003997.1:p.(Ter315TyrextTer10)",
+        );
+    }
+
+    #[test]
+    fn predicted_c_terminal_extension_ter_round_trips() {
+        assert_round_trips("NP_003997.1:p.(Ter315TyrextTer10)");
+    }
+}
+
+// =============================================================================
+// SECTION 4 — consistency with Frameshift Ter canonicalization
+// =============================================================================
+//
+// Spec-relevant invariant: Display for protein edits emits `Ter` (never
+// `*`) as the canonical stop-codon notation, regardless of input form
+// and regardless of which edit kind contains it. Pin a representative
+// frameshift case alongside an extension case to make the
+// cross-edit-kind invariant explicit.
+
+mod cross_edit_kind {
+    use super::*;
+
+    #[test]
+    fn frameshift_star_canonicalizes_to_ter() {
+        // Pre-existing behavior; pinned here so the invariant lives
+        // in one place.
+        assert_canonicalizes_to(
+            "NP_003997.1:p.Arg97Profs*23",
+            "NP_003997.1:p.Arg97ProfsTer23",
+        );
+    }
+
+    #[test]
+    fn substitution_star_canonicalizes_to_ter() {
+        assert_canonicalizes_to("NP_003997.1:p.Tyr4*", "NP_003997.1:p.Tyr4Ter");
+    }
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -1447,10 +1447,12 @@ mod clinvar_normalization {
     #[case("NP_066970.3:p.Val90SerfsTer6", "NP_066970.3:p.Val90SerfsTer6")]
     #[case("NP_004412.2:p.Ser539AlafsTer110", "NP_004412.2:p.Ser539AlafsTer110")]
     #[case("NP_060609.2:p.Gly406ArgfsTer90", "NP_060609.2:p.Gly406ArgfsTer90")]
-    // Extension variants (stop-loss)
-    #[case("NP_001166937.1:p.Ter514Leuext*?", "NP_001166937.1:p.Ter514Leuext*?")]
-    #[case("NP_056480.1:p.Ter547Leuext*?", "NP_056480.1:p.Ter547Leuext*?")]
-    #[case("NP_000654.2:p.Ter501Lysext*?", "NP_000654.2:p.Ter501Lysext*?")]
+    // Extension variants (stop-loss) — canonical Display emits `Ter`
+    // (matching Frameshift), not `*` (accepted alternative input form).
+    // See #224.
+    #[case("NP_001166937.1:p.Ter514Leuext*?", "NP_001166937.1:p.Ter514LeuextTer?")]
+    #[case("NP_056480.1:p.Ter547Leuext*?", "NP_056480.1:p.Ter547LeuextTer?")]
+    #[case("NP_000654.2:p.Ter501Lysext*?", "NP_000654.2:p.Ter501LysextTer?")]
     fn test_protein_frameshift_extension(#[case] input: &str, #[case] expected: &str) {
         let provider = MockProvider::new();
         let normalizer = Normalizer::new(provider);

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -507,18 +507,22 @@ fn test_expected_parse_errors(#[case] input: &str, #[case] _description: &str) {
 #[case("NP_066970.3:p.Val90SerfsTer6", "NP_066970.3:p.Val90SerfsTer6")]
 #[case("NP_004412.2:p.Ser539AlafsTer110", "NP_004412.2:p.Ser539AlafsTer110")]
 #[case("NP_060609.2:p.Gly406ArgfsTer90", "NP_060609.2:p.Gly406ArgfsTer90")]
-// Protein extensions
-#[case("NP_001166937.1:p.Ter514LeuextTer?", "NP_001166937.1:p.Ter514Leuext*?")]
-#[case("NP_056480.1:p.Ter547LeuextTer?", "NP_056480.1:p.Ter547Leuext*?")]
-#[case("NP_000654.2:p.Ter501LysextTer?", "NP_000654.2:p.Ter501Lysext*?")]
+// Protein extensions — canonical Display emits `Ter` (matching Frameshift),
+// not `*` (the accepted-alternative input form). See #224.
+#[case(
+    "NP_001166937.1:p.Ter514LeuextTer?",
+    "NP_001166937.1:p.Ter514LeuextTer?"
+)]
+#[case("NP_056480.1:p.Ter547LeuextTer?", "NP_056480.1:p.Ter547LeuextTer?")]
+#[case("NP_000654.2:p.Ter501LysextTer?", "NP_000654.2:p.Ter501LysextTer?")]
 // Protein deletion with wrong AA
 #[case("NP_000026.2:p.L288delC", "NP_000026.2:p.Leu288delCys")]
 // Protein duplication
 #[case("AAK07616.1:p.Asp200dup", "AAK07616.1:p.Asp200dup")]
 // Protein repeat with uncertain count
 #[case("NP_002102.4:p.Gln18[(40_?)]", "NP_002102.4:p.Gln18[40_?]")]
-// Protein extension notation
-#[case("LRG_763p1:p.Gln40(41_?)", "LRG_763p1:p.Gln40ext*41")]
+// Protein extension notation — canonical Display emits `Ter`, see #224
+#[case("LRG_763p1:p.Gln40(41_?)", "LRG_763p1:p.Gln40extTer41")]
 // Allele with separate brackets
 #[case(
     "NM_000350.2:c.[2588G>C];[5882G>A]",


### PR DESCRIPTION
Closes #224 ([#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) item D2; also covers D3's cross-edit-kind Ter consistency).

## Summary

Per HGVS v21.0 ([`background/standards.md`](../blob/main/assets/hgvs-nomenclature/docs/background/standards.md)), three-letter amino-acid codes — including `Ter` for the translation termination codon — are the preferred form; `*` is an accepted alternative on input. ferro already canonicalizes substitutions and frameshifts to `Ter` (`p.Tyr4*` → `p.Tyr4Ter`, `p.Arg97Profs*23` → `p.Arg97ProfsTer23`). C-terminal extensions were the inconsistent outlier:

| Input | Before | After |
|---|---|---|
| `p.Ter315TyrextTer10` | `p.Ter315Tyrext*10` | `p.Ter315TyrextTer10` ✓ |
| `p.*315Tyrext*10` | `p.Ter315Tyrext*10` | `p.Ter315TyrextTer10` ✓ |
| `p.Ter315Tyrext*?` | `p.Ter315Tyrext*?` | `p.Ter315TyrextTer?` ✓ |

## Files

- `src/hgvs/edit.rs` — `ProteinEdit::Extension::fmt` C-terminal arm emits `Ter{n}` / `Ter?` instead of `*{n}` / `*?`. N-terminal extensions (which use `-N` syntax) unchanged.
- `tests/issue_224_protein_extension_ter.rs` — 11 audit cases: C-terminal Ter+Ter / Ter+star / star+star / unknown-count / Ter? canonical; N-terminal unaffected; predicted-parens; cross-edit-kind invariant for Frameshift and Substitution.
- `tests/parser_tests.rs` — 4 fixture-test rows updated.
- `tests/normalize_tests.rs` — 3 ClinVar normalization rows updated.
- `tests/fixtures/grammar/hgvs_spec_normalization.json` — 8 rows surgically updated in the `current` field.

## Test plan

- [x] `cargo nextest run --features dev` — 4454 / 4454 pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.
- [x] Parallel Opus + Sonnet review — both returned **0 must-fix issues**. Opus separately flagged a pre-existing unrelated bug in `src/vcf/annotate.rs:226-230` (extension misclassified as Nonsense because position `*N` Displays as `TerN`); orthogonal to this PR, can be filed as a follow-up.