### PR TITLE
fix(vcf): classify protein consequences by enum variant, not substring (closes #228)

### DIFF
--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -4,6 +4,8 @@
 //! following conventions similar to VEP and SnpEff.
 
 use crate::error::FerroError;
+use crate::hgvs::edit::ProteinEdit;
+use crate::hgvs::location::AminoAcid;
 use crate::hgvs::variant::HgvsVariant;
 use crate::reference::loader::TranscriptDb;
 
@@ -218,27 +220,34 @@ pub fn determine_consequence(ann: &HgvsAnnotation) -> Consequence {
         HgvsVariant::Tx(_) => Consequence::NonCoding,
         HgvsVariant::Rna(_) => Consequence::NonCoding,
         HgvsVariant::Protein(v) => {
-            let edit_str = format!("{:?}", v.loc_edit.edit);
-
-            if edit_str.contains("Frameshift") {
-                return Consequence::Frameshift;
+            // Classify by the parsed `ProteinEdit` enum variant directly.
+            // The prior implementation matched substrings on the Debug
+            // format of the edit and on the raw HGVS string, which
+            // mis-fired on stop-loss extensions like
+            // `p.Ter315TyrextTer10` whose HGVS text contains `Ter`
+            // (both in the start position and, post-#225, in the
+            // canonical `Ter{count}` extension suffix). Issue #228.
+            //
+            // The edit is wrapped in `Mu<ProteinEdit>` to carry the
+            // predicted-vs-confirmed paren distinction; classification
+            // is the same for both, so we unwrap and dispatch on the
+            // inner edit. `Mu::Unknown` (a `p.?` shape) has no
+            // classifiable structure and falls through to `Unknown`.
+            match v.loc_edit.edit.inner() {
+                Some(ProteinEdit::Frameshift { .. }) => Consequence::Frameshift,
+                Some(ProteinEdit::Extension { .. }) => Consequence::StopLoss,
+                Some(ProteinEdit::Substitution { alternative, .. })
+                    if *alternative == AminoAcid::Ter =>
+                {
+                    Consequence::Nonsense
+                }
+                Some(ProteinEdit::Substitution { .. }) => Consequence::Missense,
+                Some(ProteinEdit::Insertion { .. }) => Consequence::InframeInsertion,
+                Some(ProteinEdit::Deletion { .. }) | Some(ProteinEdit::Delins { .. }) => {
+                    Consequence::InframeDeletion
+                }
+                _ => Consequence::Unknown,
             }
-            if edit_str.contains("Nonsense") || hgvs.contains("Ter") {
-                return Consequence::Nonsense;
-            }
-            if edit_str.contains("Extension") {
-                return Consequence::StopLoss;
-            }
-            if edit_str.contains("Insertion") {
-                return Consequence::InframeInsertion;
-            }
-            if edit_str.contains("Deletion") {
-                return Consequence::InframeDeletion;
-            }
-            if edit_str.contains("Substitution") {
-                return Consequence::Missense;
-            }
-            Consequence::Unknown
         }
         HgvsVariant::Mt(_) => Consequence::Unknown,
         HgvsVariant::Circular(_) => Consequence::Unknown,
@@ -916,8 +925,11 @@ mod tests {
     fn test_determine_consequence_protein_extension() {
         use crate::hgvs::parser::parse_hgvs;
 
-        // Note: Extension variants with "Ter" in the string match the Nonsense check first
-        // because the code checks hgvs.contains("Ter") before checking for Extension
+        // After #228: the classifier dispatches on the parsed
+        // `ProteinEdit` enum variant directly, so an extension at the
+        // stop codon (with `Ter` in both the start position and, post-
+        // #225, the extension count) correctly surfaces as StopLoss
+        // rather than Nonsense.
         let variant = parse_hgvs("NP_000079.2:p.Ter100GlyextTer50").unwrap();
         let ann = HgvsAnnotation {
             variant,
@@ -932,7 +944,6 @@ mod tests {
         };
 
         let consequence = determine_consequence(&ann);
-        // Due to current logic order, this matches Nonsense (Ter in string) before StopLoss
-        assert_eq!(consequence, Consequence::Nonsense);
+        assert_eq!(consequence, Consequence::StopLoss);
     }
 }

--- a/tests/issue_228_vcf_annotate_extension_stop_loss.rs
+++ b/tests/issue_228_vcf_annotate_extension_stop_loss.rs
@@ -1,0 +1,181 @@
+//! Audit for issue #228 — `src/vcf/annotate.rs::determine_consequence`
+//! misclassifies C-terminal protein extensions as `Nonsense` because
+//! the protein-edit dispatcher uses `hgvs.contains("Ter")` as the
+//! Nonsense heuristic, which fires on the `Ter315` start position of a
+//! stop-loss extension (and, post-#225, also on the `extTer10` count).
+//!
+//! Spec: an extension at the stop codon is a `stop_lost`
+//! (`Consequence::StopLoss`), not a `stop_gained` (`Consequence::Nonsense`).
+//! See SO:0001587 (stop_gained) vs SO:0001578 (stop_lost).
+//!
+//! The principled fix is to drive the classification off the
+//! `ProteinEdit` enum variants directly, not off substring matches on
+//! the `Debug`-formatted edit or the HGVS string.
+
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::transcript::ManeStatus;
+use ferro_hgvs::vcf::{determine_consequence, Consequence, HgvsAnnotation};
+
+fn protein_annotation(input: &str) -> HgvsAnnotation {
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{}`: {}", input, e));
+    HgvsAnnotation {
+        variant,
+        gene_symbol: None,
+        transcript_accession: Some("NP_TEST".to_string()),
+        is_coding: true,
+        is_intronic: false,
+        mane_status: ManeStatus::None,
+        intron_number: None,
+        intron_position: None,
+        intronic_consequence: None,
+    }
+}
+
+// =============================================================================
+// SECTION 1 — Extension at the stop codon → StopLoss (the original bug)
+// =============================================================================
+
+mod extension_is_stop_loss {
+    use super::*;
+
+    #[test]
+    fn c_terminal_extension_with_ter_canonical_classifies_as_stop_loss() {
+        let ann = protein_annotation("NP_003997.1:p.Ter315TyrextTer10");
+        assert_eq!(
+            determine_consequence(&ann),
+            Consequence::StopLoss,
+            "C-terminal extension must classify as StopLoss, not Nonsense",
+        );
+    }
+
+    /// Same shape, star canonical form (accepted on input, even though
+    /// Display canonicalizes to `Ter`). The dispatcher must classify by
+    /// the parsed enum, not the raw HGVS text.
+    #[test]
+    fn c_terminal_extension_with_star_input_classifies_as_stop_loss() {
+        let ann = protein_annotation("NP_003997.1:p.Ter315Tyrext*10");
+        assert_eq!(determine_consequence(&ann), Consequence::StopLoss);
+    }
+
+    /// Unknown extension count `Ter?` — classify by enum variant, not
+    /// by whether the HGVS contains `Ter`.
+    #[test]
+    fn c_terminal_extension_unknown_count_classifies_as_stop_loss() {
+        let ann = protein_annotation("NP_003997.1:p.Ter315TyrextTer?");
+        assert_eq!(determine_consequence(&ann), Consequence::StopLoss);
+    }
+
+    /// N-terminal extension (Met loss) — start position is `Met1`, no
+    /// `Ter` substring at all. Still must classify as StopLoss because
+    /// Extension semantics are about gain-of-translated-sequence on
+    /// either terminus.
+    #[test]
+    fn n_terminal_extension_classifies_as_stop_loss() {
+        let ann = protein_annotation("NP_003997.1:p.Met1Valext-12");
+        assert_eq!(determine_consequence(&ann), Consequence::StopLoss);
+    }
+
+    /// Predicted parens around extension — same classification.
+    #[test]
+    fn predicted_c_terminal_extension_classifies_as_stop_loss() {
+        let ann = protein_annotation("NP_003997.1:p.(Ter315TyrextTer10)");
+        assert_eq!(determine_consequence(&ann), Consequence::StopLoss);
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Nonsense classification regression guards
+// =============================================================================
+//
+// The fix must NOT regress nonsense classification — substitutions to
+// `Ter` are the canonical nonsense case and must still surface as
+// `Consequence::Nonsense`.
+
+mod nonsense_classification {
+    use super::*;
+
+    #[test]
+    fn substitution_to_ter_classifies_as_nonsense() {
+        let ann = protein_annotation("NP_003997.1:p.Tyr4Ter");
+        assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
+    }
+
+    /// Star-form input — same classification.
+    #[test]
+    fn substitution_to_star_input_classifies_as_nonsense() {
+        let ann = protein_annotation("NP_003997.1:p.Tyr4*");
+        assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
+    }
+
+    /// One-letter star input — same classification.
+    #[test]
+    fn substitution_one_letter_star_classifies_as_nonsense() {
+        let ann = protein_annotation("NP_003997.1:p.Y4*");
+        assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
+    }
+
+    /// Predicted parens around nonsense — same classification.
+    #[test]
+    fn predicted_substitution_to_ter_classifies_as_nonsense() {
+        let ann = protein_annotation("NP_003997.1:p.(Tyr4Ter)");
+        assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Frameshift classification regression guards
+// =============================================================================
+//
+// Frameshift is checked first today; the rewrite must preserve that.
+// Frameshifts whose Display contains `Ter` (`p.Arg97ProfsTer23`) must
+// not silently collapse to Nonsense.
+
+mod frameshift_classification {
+    use super::*;
+
+    #[test]
+    fn frameshift_with_ter_in_display_classifies_as_frameshift() {
+        let ann = protein_annotation("NP_003997.1:p.Arg97ProfsTer23");
+        assert_eq!(determine_consequence(&ann), Consequence::Frameshift);
+    }
+
+    #[test]
+    fn frameshift_short_form_classifies_as_frameshift() {
+        let ann = protein_annotation("NP_003997.1:p.Arg97fs");
+        assert_eq!(determine_consequence(&ann), Consequence::Frameshift);
+    }
+
+    #[test]
+    fn predicted_frameshift_classifies_as_frameshift() {
+        let ann = protein_annotation("NP_003997.1:p.(Arg97ProfsTer23)");
+        assert_eq!(determine_consequence(&ann), Consequence::Frameshift);
+    }
+}
+
+// =============================================================================
+// SECTION 4 — Other protein edit kinds (regression guards)
+// =============================================================================
+
+mod other_edit_kinds {
+    use super::*;
+
+    /// Missense substitution (non-Ter alternative).
+    #[test]
+    fn non_ter_substitution_classifies_as_missense() {
+        let ann = protein_annotation("NP_003997.1:p.Arg97Trp");
+        assert_eq!(determine_consequence(&ann), Consequence::Missense);
+    }
+
+    #[test]
+    fn deletion_classifies_as_inframe_deletion() {
+        let ann = protein_annotation("NP_003997.1:p.Lys100del");
+        assert_eq!(determine_consequence(&ann), Consequence::InframeDeletion);
+    }
+
+    #[test]
+    fn insertion_classifies_as_inframe_insertion() {
+        let ann = protein_annotation("NP_003997.1:p.Lys100_Arg101insGlySer");
+        assert_eq!(determine_consequence(&ann), Consequence::InframeInsertion);
+    }
+}


### PR DESCRIPTION
Closes #228.

## Background

`src/vcf/annotate.rs::determine_consequence` previously classified protein-level variant consequences by matching substrings on the `Debug` format of the parsed edit and on the raw HGVS string:

```rust
if edit_str.contains("Frameshift") { return Consequence::Frameshift; }
if edit_str.contains("Nonsense") || hgvs.contains("Ter") {
    return Consequence::Nonsense;
}
if edit_str.contains("Extension") { return Consequence::StopLoss; }
// ... etc
```

The `hgvs.contains("Ter")` branch fired for **any** HGVS string containing `Ter` — including stop-loss extensions like `p.Ter315TyrextTer10` whose text contains `Ter` in both the start position (`Ter315`) and (post-#225) the canonical extension count (`extTer10`). Extensions therefore surfaced as `Consequence::Nonsense` (`stop_gained`) instead of the correct `Consequence::StopLoss` (`stop_lost`).

## Fix

Rewrite the protein arm to dispatch on the `ProteinEdit` enum variant directly:

```rust
match v.loc_edit.edit.inner() {
    Some(ProteinEdit::Frameshift { .. }) => Consequence::Frameshift,
    Some(ProteinEdit::Extension { .. }) => Consequence::StopLoss,
    Some(ProteinEdit::Substitution { alternative, .. })
        if *alternative == AminoAcid::Ter => Consequence::Nonsense,
    Some(ProteinEdit::Substitution { .. }) => Consequence::Missense,
    Some(ProteinEdit::Insertion { .. }) => Consequence::InframeInsertion,
    Some(ProteinEdit::Deletion { .. }) | Some(ProteinEdit::Delins { .. })
        => Consequence::InframeDeletion,
    _ => Consequence::Unknown,
}
```

The edit is wrapped in `Mu<ProteinEdit>` to carry the predicted-vs-confirmed paren distinction; classification is identical for both, so the dispatch uses `.inner()` and matches on the inner edit.

## Files

- `src/vcf/annotate.rs` — replaced the substring-based protein arm with enum-variant matching; added `use crate::hgvs::edit::ProteinEdit;` and `use crate::hgvs::location::AminoAcid;`.
- `tests/issue_228_vcf_annotate_extension_stop_loss.rs` — 15 audit cases across 4 sections (extension → StopLoss; nonsense regression; frameshift regression; other edit kinds).
- `src/vcf/annotate.rs::test_determine_consequence_protein_extension` — updated from asserting Nonsense (the documented bug) to asserting StopLoss (the correct behavior).

## Test plan

- [x] `cargo nextest run --features dev` — 4458 / 4458 pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.