### PR TITLE
fix(normalize): read dup bases from reference (single-pass idempotency for dup with mismatched stated-ref) (closes #219)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1741,19 +1741,30 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     return Ok((start, end, edit.clone(), warnings.clone()));
                 }
             }
-            NaEdit::Duplication { sequence, .. } => {
-                if let Some(seq) = sequence {
-                    seq.bases().iter().map(|b| b.to_u8()).collect()
+            NaEdit::Duplication { .. } => {
+                // Always read duplicated bytes from the reference,
+                // regardless of any user-stated bases on the input
+                // (`dup<base>` shapes). The canonical HGVS Display
+                // drops the stated bases anyway (see the dup output
+                // arm in `get_canonical_form`); using the stated
+                // bases here when they don't match the reference
+                // (the parser accepts them in lenient mode with a
+                // `RefSeqMismatch` warning) caused the shuffle to
+                // mis-shift and broke single-pass idempotency:
+                // `c.10dupA` against a `CCCCC` homopolymer
+                // canonicalized to `c.10dup` on pass 1 (stated-ref
+                // stripped without shifting) and only shifted to
+                // `c.14dup` on pass 2 (because the now-clean form
+                // reads bytes from reference and the shuffle fires
+                // correctly). Reading from reference up-front
+                // collapses both pass 1 and pass 2 behavior into a
+                // single pass. Issue #219.
+                let s = hgvs_pos_to_index(start);
+                let e = end as usize;
+                if e <= ref_seq.len() {
+                    ref_seq[s..e].to_vec()
                 } else {
-                    // Get duplicated sequence from reference
-                    // start is 1-based, convert to 0-based index for array access
-                    let s = hgvs_pos_to_index(start);
-                    let e = end as usize;
-                    if e <= ref_seq.len() {
-                        ref_seq[s..e].to_vec()
-                    } else {
-                        vec![]
-                    }
+                    vec![]
                 }
             }
             NaEdit::Delins { sequence, .. } => {

--- a/tests/compound_cross_reference.rs
+++ b/tests/compound_cross_reference.rs
@@ -264,10 +264,11 @@ fn test_unknown_phase_cross_reference_round_trip() {
 
 #[test]
 fn test_each_variant_normalizes_against_own_ref() {
-    // c.10dupA at the start of a `CCCCC` run normalizes to c.10dup
-    // (drop redundant base) against the transcript reference. The g.
-    // companion has no resolvable ref data and must round-trip
-    // unchanged. Pins both:
+    // c.10dupA at the start of a `CCCCC` run normalizes to c.14dup
+    // (drop the mismatched stated-ref base AND 3'-shift to the
+    // rightmost copy of the homopolymer, both in a single pass —
+    // see #219). The g. companion has no resolvable ref data and must
+    // round-trip unchanged. Pins both:
     //   * per-variant normalization is independent
     //   * the un-resolvable companion does not block normalization of
     //     its sibling
@@ -276,21 +277,22 @@ fn test_each_variant_normalizes_against_own_ref() {
     let normalized = normalizer.normalize(&parsed).expect("normalize");
     assert_eq!(
         format!("{}", normalized),
-        "[NM_TEST.1:c.10dup;NC_000001.11:g.100A>G]",
+        "[NM_TEST.1:c.14dup;NC_000001.11:g.100A>G]",
     );
 }
 
 #[test]
 fn test_unresolved_companion_does_not_break_resolved_variant_normalize() {
     // Mirror the previous case in trans phase. Each bracket group
-    // normalizes independently; the c.10dupA still collapses to
-    // c.10dup, the g. variant rides through.
+    // normalizes independently; c.10dupA 3'-shifts through the CCCCC
+    // homopolymer to c.14dup (single pass per #219), the g. variant
+    // rides through.
     let normalizer = Normalizer::new(provider_with_simple_transcript());
     let parsed = parse_hgvs("[NM_TEST.1:c.10dupA];[NC_000001.11:g.100A>G]").expect("parse");
     let normalized = normalizer.normalize(&parsed).expect("normalize");
     assert_eq!(
         format!("{}", normalized),
-        "[NM_TEST.1:c.10dup];[NC_000001.11:g.100A>G]",
+        "[NM_TEST.1:c.14dup];[NC_000001.11:g.100A>G]",
     );
 }
 

--- a/tests/issue_218_mixed_accession_alleles.rs
+++ b/tests/issue_218_mixed_accession_alleles.rs
@@ -374,10 +374,11 @@ mod normalize_each_independently {
 
     /// Cis: `NM_TEST.1:c.10dupA` (resolved) paired with
     /// `NM_OTHER.1:c.5A>G` (un-resolved on the same coord system).
-    /// The resolved variant must drop its stated-ref `A` and emit
-    /// `c.10dup`; the un-resolved partner must ride through unchanged.
-    /// Distinct from `compound_cross_reference.rs` (which pairs c.+g.)
-    /// — this is the same-coord, different-accession case.
+    /// The resolved variant drops its mismatched stated-ref `A` AND
+    /// 3'-shifts through the `CCCCC` homopolymer to `c.14dup` (single
+    /// pass per #219); the un-resolved partner rides through
+    /// unchanged. Distinct from `compound_cross_reference.rs` (which
+    /// pairs c.+g.) — this is the same-coord, different-accession case.
     #[test]
     fn cis_partial_provider_resolves_only_known_accession() {
         let normalizer = Normalizer::new(provider_with_test_transcript());
@@ -385,7 +386,7 @@ mod normalize_each_independently {
         let normalized = normalizer.normalize(&parsed).expect("normalize");
         assert_eq!(
             format!("{}", normalized),
-            "[NM_TEST.1:c.10dup;NM_OTHER.1:c.5A>G]",
+            "[NM_TEST.1:c.14dup;NM_OTHER.1:c.5A>G]",
         );
     }
 
@@ -396,16 +397,14 @@ mod normalize_each_independently {
         let normalized = normalizer.normalize(&parsed).expect("normalize");
         assert_eq!(
             format!("{}", normalized),
-            "[NM_TEST.1:c.10dup];[NM_OTHER.1:c.5A>G]",
+            "[NM_TEST.1:c.14dup];[NM_OTHER.1:c.5A>G]",
         );
     }
 
     // Idempotency on a `dupA` input with a same-coord different-accession
-    // partner surfaces a separate pre-existing two-pass-drift bug (pass 1
-    // drops the mismatched stated-ref base without shifting; pass 2
-    // shifts). Tracked in #219 as a dedicated follow-up; deliberately
-    // out of scope for this audit. Not introduced or worsened by the
-    // mixed-accession lattice.
+    // partner was the two-pass drift bug filed as #219 — fixed by the
+    // sibling PR. The cis and trans assertions above now lock the
+    // post-fix single-pass shifted output.
 }
 
 // =============================================================================

--- a/tests/issue_219_dup_stated_ref_idempotent.rs
+++ b/tests/issue_219_dup_stated_ref_idempotent.rs
@@ -1,0 +1,168 @@
+//! Audit for issue #219 — `c.<pos>dup<base>` with a mismatched
+//! stated-ref base is not idempotent across two normalize passes.
+//!
+//! Surfaced during the #218 (C4 mixed-accession) audit. Reproducer:
+//! `c.10dupA` against a transcript where position 10 is `C` (start of
+//! a `CCCCC` homopolymer) normalizes to `c.10dup` on pass 1 (the
+//! stated-ref base is stripped because it doesn't match the
+//! reference, but the position is not 3'-shifted), then shifts to
+//! `c.14dup` on pass 2 (the position-only `c.10dup` form correctly
+//! 3'-shifts through the homopolymer).
+//!
+//! The normalizer invariant `normalize(normalize(v)) == normalize(v)`
+//! requires a single pass to produce the fixed point. After the fix,
+//! pass 1 produces `c.14dup` directly.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Build a `MockProvider` with `NM_TEST.1` containing a 60bp sequence
+/// laid out as: `ATGC | AAAAA | CCCCC | GGGGG | TTTTT | AAAAA | CCCCC
+/// | GGGGG | TTTTT | AAAAA | CCCCC | GGGGG | T`. A dup at any
+/// position inside the `CCCCC` run starting at c.10 should 3'-shift to
+/// the rightmost copy (c.14).
+fn provider_with_test_transcript() -> MockProvider {
+    let mut p = MockProvider::new();
+    let seq = "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = seq.len() as u64;
+    let tx = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        seq,
+        Some(1),
+        Some(len),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    p.add_transcript(tx);
+    p
+}
+
+fn normalize_pass(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let v = parse_hgvs(input).expect("parse");
+    let n = normalizer.normalize(&v).expect("normalize");
+    format!("{}", n)
+}
+
+// =============================================================================
+// SECTION 1 — solo `c.<pos>dup<base>` idempotency (the core bug)
+// =============================================================================
+
+mod solo_dup_stated_ref {
+    use super::*;
+
+    /// Single pass on `c.10dupA` produces the 3'-shifted canonical
+    /// form `c.14dup`, NOT the intermediate `c.10dup`.
+    #[test]
+    fn dup_with_mismatched_stated_ref_shifts_in_one_pass() {
+        let out = normalize_pass(provider_with_test_transcript(), "NM_TEST.1:c.10dupA");
+        assert_eq!(out, "NM_TEST.1:c.14dup");
+    }
+
+    /// Two-pass idempotency: pass 2 over pass 1's output is a fixed
+    /// point. This is the universal invariant the bug was breaking.
+    #[test]
+    fn dup_with_mismatched_stated_ref_is_idempotent() {
+        let normalizer = Normalizer::new(provider_with_test_transcript());
+        let parsed = parse_hgvs("NM_TEST.1:c.10dupA").expect("parse");
+        let p1 = normalizer.normalize(&parsed).expect("normalize pass 1");
+        let p2 = normalizer.normalize(&p1).expect("normalize pass 2");
+        assert_eq!(format!("{}", p1), format!("{}", p2));
+    }
+
+    /// Companion case: `c.10dup` (no stated-ref) already shifts in one
+    /// pass today. Pin as regression guard so a fix doesn't accidentally
+    /// regress the working path.
+    #[test]
+    fn dup_position_only_already_shifts() {
+        let out = normalize_pass(provider_with_test_transcript(), "NM_TEST.1:c.10dup");
+        assert_eq!(out, "NM_TEST.1:c.14dup");
+    }
+
+    /// `c.10dupC` (matching stated-ref): existing behavior — shifts in
+    /// one pass. Pin as regression guard.
+    #[test]
+    fn dup_with_matching_stated_ref_shifts_in_one_pass() {
+        let out = normalize_pass(provider_with_test_transcript(), "NM_TEST.1:c.10dupC");
+        assert_eq!(out, "NM_TEST.1:c.14dup");
+    }
+}
+
+// =============================================================================
+// SECTION 2 — inside cis / trans compounds (the original surfacing context)
+// =============================================================================
+//
+// The bug was originally surfaced inside a mixed-accession compound
+// (`[NM_TEST.1:c.10dupA;NM_OTHER.1:c.5A>G]`). Pin both the cis and
+// trans wrappers across both same-coord-different-accession and
+// cross-coord-system partners.
+
+mod inside_compound {
+    use super::*;
+
+    #[test]
+    fn cis_same_coord_different_accession_idempotent() {
+        let normalizer = Normalizer::new(provider_with_test_transcript());
+        let parsed = parse_hgvs("[NM_TEST.1:c.10dupA;NM_OTHER.1:c.5A>G]").expect("parse");
+        let p1 = normalizer.normalize(&parsed).expect("normalize pass 1");
+        let p2 = normalizer.normalize(&p1).expect("normalize pass 2");
+        assert_eq!(format!("{}", p1), format!("{}", p2));
+        // Also pin the canonical output shape.
+        assert_eq!(format!("{}", p1), "[NM_TEST.1:c.14dup;NM_OTHER.1:c.5A>G]");
+    }
+
+    #[test]
+    fn cis_cross_coord_system_idempotent() {
+        let normalizer = Normalizer::new(provider_with_test_transcript());
+        let parsed = parse_hgvs("[NM_TEST.1:c.10dupA;NC_000001.11:g.100A>G]").expect("parse");
+        let p1 = normalizer.normalize(&parsed).expect("normalize pass 1");
+        let p2 = normalizer.normalize(&p1).expect("normalize pass 2");
+        assert_eq!(format!("{}", p1), format!("{}", p2));
+        assert_eq!(
+            format!("{}", p1),
+            "[NM_TEST.1:c.14dup;NC_000001.11:g.100A>G]"
+        );
+    }
+
+    #[test]
+    fn trans_same_coord_different_accession_idempotent() {
+        let normalizer = Normalizer::new(provider_with_test_transcript());
+        let parsed = parse_hgvs("[NM_TEST.1:c.10dupA];[NM_OTHER.1:c.5A>G]").expect("parse");
+        let p1 = normalizer.normalize(&parsed).expect("normalize pass 1");
+        let p2 = normalizer.normalize(&p1).expect("normalize pass 2");
+        assert_eq!(format!("{}", p1), format!("{}", p2));
+    }
+}
+
+// =============================================================================
+// SECTION 3 — symmetric `del<base>` mismatched-stated-ref pin
+// =============================================================================
+//
+// The same root cause (shuffle uses stated bases when present) could
+// theoretically affect deletions with mismatched stated-ref. The
+// existing `validate_reference` flags the mismatch with a warning,
+// and the shuffle on Deletion in fact does not read alt bases (alt
+// is empty for del). So del should always be idempotent regardless
+// of stated-ref. Pin as a guard.
+
+mod del_stated_ref {
+    use super::*;
+
+    #[test]
+    fn del_with_mismatched_stated_ref_is_idempotent() {
+        let normalizer = Normalizer::new(provider_with_test_transcript());
+        // pos 10 is C; stating A is wrong. del is del regardless.
+        let parsed = parse_hgvs("NM_TEST.1:c.10delA").expect("parse");
+        let p1 = normalizer.normalize(&parsed).expect("normalize pass 1");
+        let p2 = normalizer.normalize(&p1).expect("normalize pass 2");
+        assert_eq!(format!("{}", p1), format!("{}", p2));
+    }
+}


### PR DESCRIPTION
Closes #219.

## Background

`c.10dupA` against a transcript where position 10 is `C` (start of a `CCCCC` homopolymer) was not idempotent across two normalize passes:

| Pass | Input | Output |
|---|---|---|
| 1 | `c.10dupA` | `c.10dup` (mismatched stated-ref stripped, position NOT shifted) |
| 2 | `c.10dup` | `c.14dup` (position-only form correctly 3'-shifts) |
| 3 | `c.14dup` | `c.14dup` (fixed point) |

Surfaced during the #218 (C4 mixed-accession) audit. The drift was visible solo (`c.10dupA`), in cis compounds (both same-coord-different-accession and cross-coord), and in trans compounds.

## Root cause

`normalize_na_edit`'s `NaEdit::Duplication { sequence, .. }` arm used the user-stated `sequence` bytes as the alt sequence for shuffle when present, falling back to reference bytes only when `sequence` was None:

```rust
NaEdit::Duplication { sequence, .. } => {
    if let Some(seq) = sequence {
        seq.bases().iter().map(|b| b.to_u8()).collect()
    } else {
        // read from reference
    }
}
```

When `validate_reference` flagged a stated-ref mismatch in lenient mode, the corrected shape (with `sequence: None`) was only emitted AFTER the shuffle had already run with the bad bases. The shuffle's alt sequence and the actual reference bytes no longer matched, so the shift didn't fire.

## Fix

Always read duplicated bytes from the reference for shuffle, regardless of any user-stated bases on the input. The canonical HGVS Display drops the stated bases (see the dup output arm in `get_canonical_form`), and the stated bases are purely informational — they aren't load-bearing for normalization. Reading from reference up-front collapses pass 1 and pass 2 behavior into a single pass.

## Files

- `src/normalize/mod.rs` — `NaEdit::Duplication` arm in `normalize_na_edit` always reads from reference.
- `tests/issue_219_dup_stated_ref_idempotent.rs` — 8 audit cases (solo + inside-compound + symmetric del regression guard).
- `tests/compound_cross_reference.rs::test_each_variant_normalizes_against_own_ref` + `test_unresolved_companion_does_not_break_resolved_variant_normalize` — updated expected outputs from `c.10dup` (the old pass-1-stuck-at-intermediate result) to `c.14dup` (the now-correct single-pass shifted form).
- `tests/issue_218_mixed_accession_alleles.rs::cis_partial_provider_resolves_only_known_accession` + `trans_partial_provider_resolves_only_known_accession` — updated expected outputs; removed the obsolete "tracked as #219 follow-up" comment.

## Test plan

- [x] `cargo nextest run --features dev` — 4507 / 4507 pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.