### PR TITLE
fix(parser,display): single uncertain position range c.(a_b)<edit> (closes #237)

### DIFF
--- a/src/hgvs/interval.rs
+++ b/src/hgvs/interval.rs
@@ -192,6 +192,14 @@ impl<T: fmt::Display + PartialEq> fmt::Display for Interval<T> {
                     _ => write!(f, "{}_{}", self.start, self.end),
                 }
             }
+            // Single uncertain position with bounded range: (a_b) describes one
+            // position somewhere in [a,b], encoded as the same `Range` on both
+            // sides of the Interval. Emit `(a_b)` once, not `(a_b)_(a_b)`.
+            (UncertainBoundary::Range { .. }, UncertainBoundary::Range { .. })
+                if self.start == self.end =>
+            {
+                write!(f, "{}", self.start)
+            }
             // Complex boundaries or mixed - always show both
             _ => write!(f, "{}_{}", self.start, self.end),
         }

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -288,8 +288,10 @@ fn parse_genome_interval(input: &str) -> IResult<&str, GenomeInterval> {
 
     // Complex cases: starts with ( or ?
     alt((
-        // Simple uncertain interval: (pos_pos) NOT followed by _
-        // This produces (pos)_(pos) in output
+        // Single uncertain position bounded by a range: (pos_pos) NOT followed
+        // by _ — per HGVS v21 uncertain.md this is *one* position somewhere
+        // in [start, end], not a multi-base range. Encoded as the same Range
+        // on both Interval boundaries; Display collapses to `(a_b)` once.
         |input| {
             let (remaining, (start, _, end)) = delimited(
                 char('('),
@@ -304,16 +306,19 @@ fn parse_genome_interval(input: &str) -> IResult<&str, GenomeInterval> {
                     nom::error::ErrorKind::Verify,
                 )));
             }
-            // Reject inverted ranges
-            if start.base > end.base {
+            // Reject inverted ranges (skip ordering when either bound is a special
+            // position like pter/qter/cen — those carry base=0 sentinels so a raw
+            // base comparison wrongly rejects forms like (12345_qter)).
+            if !start.is_special() && !end.is_special() && start.base > end.base {
                 return Err(nom::Err::Error(nom::error::Error::new(
                     input,
                     nom::error::ErrorKind::Verify,
                 )));
             }
+            let boundary = UncertainBoundary::range(Mu::certain(start), Mu::certain(end));
             Ok((
                 remaining,
-                Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end)),
+                Interval::with_complex_boundaries(boundary.clone(), boundary),
             ))
         },
         // Complex interval with range boundaries: (start_boundary)_(end_boundary)
@@ -377,11 +382,15 @@ fn parse_simple_uncertain_cds_interval(input: &str) -> IResult<&str, CdsInterval
         )));
     }
 
-    // Only if NEITHER has an offset, treat as simple uncertain interval
+    // Only if NEITHER has an offset, treat as simple uncertain interval.
+    // Per HGVS v21 uncertain.md, `(a_b)<edit>` is *one* position somewhere in
+    // [a, b], not a multi-base range. Encoded as the same Range on both
+    // Interval boundaries; Display collapses to `(a_b)` once.
     if start.offset.is_none() && end.offset.is_none() {
+        let boundary = UncertainBoundary::range(Mu::certain(start), Mu::certain(end));
         Ok((
             remaining,
-            Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end)),
+            Interval::with_complex_boundaries(boundary.clone(), boundary),
         ))
     } else {
         // Check if followed by another parenthesized range without underscore
@@ -595,7 +604,9 @@ fn parse_tx_boundary(
 
 fn parse_tx_interval(input: &str) -> IResult<&str, TxInterval> {
     alt((
-        // Whole interval uncertain: (100_200) NOT followed by _
+        // Single uncertain position bounded by a range: (a_b) NOT followed by _.
+        // Per HGVS v21 uncertain.md, `(a_b)<edit>` is *one* position somewhere
+        // in [a, b]; same Range on both Interval boundaries.
         |input| {
             let (remaining, (start, _, end)) =
                 delimited(char('('), (parse_tx_pos, tag("_"), parse_tx_pos), char(')'))
@@ -607,9 +618,10 @@ fn parse_tx_interval(input: &str) -> IResult<&str, TxInterval> {
                     nom::error::ErrorKind::Verify,
                 )));
             }
+            let boundary = UncertainBoundary::range(Mu::certain(start), Mu::certain(end));
             Ok((
                 remaining,
-                Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end)),
+                Interval::with_complex_boundaries(boundary.clone(), boundary),
             ))
         },
         // Complex interval with range boundaries: (pos_pos)_(pos_pos)
@@ -755,8 +767,10 @@ fn parse_prot_boundary(
 
 fn parse_prot_interval(input: &str) -> IResult<&str, ProtInterval> {
     alt((
-        // Simple uncertain interval: (pos_pos) NOT followed by _
-        // This is for patterns like (Lys23_Leu24)del where the whole interval is uncertain
+        // Single uncertain position bounded by a range: (Lys23_Leu24)<edit>.
+        // Per HGVS v21 uncertain.md, the parens wrap *one* residue somewhere
+        // in [start, end]; same Range on both Interval boundaries; Display
+        // collapses to `(Lys23_Leu24)` once.
         |input| {
             let (remaining, (start, _, end)) = delimited(
                 char('('),
@@ -771,9 +785,10 @@ fn parse_prot_interval(input: &str) -> IResult<&str, ProtInterval> {
                     nom::error::ErrorKind::Verify,
                 )));
             }
+            let boundary = UncertainBoundary::range(Mu::certain(start), Mu::certain(end));
             Ok((
                 remaining,
-                Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end)),
+                Interval::with_complex_boundaries(boundary.clone(), boundary),
             ))
         },
         // Complex interval with range boundaries: (?_pos)_pos, pos_(pos_?), etc.
@@ -806,17 +821,83 @@ fn parse_prot_interval(input: &str) -> IResult<&str, ProtInterval> {
     .parse(input)
 }
 
+fn parse_rna_range_boundary(
+    input: &str,
+) -> IResult<&str, UncertainBoundary<crate::hgvs::location::RnaPos>> {
+    delimited(
+        char('('),
+        alt((
+            // (?_pos)
+            map((tag("?"), tag("_"), parse_rna_pos), |(_, _, end)| {
+                UncertainBoundary::range(Mu::Unknown, Mu::certain(end))
+            }),
+            // (pos_?)
+            map((parse_rna_pos, tag("_"), tag("?")), |(start, _, _)| {
+                UncertainBoundary::range(Mu::certain(start), Mu::Unknown)
+            }),
+            // (pos_pos)
+            map(
+                (parse_rna_pos, tag("_"), parse_rna_pos),
+                |(start, _, end)| UncertainBoundary::range(Mu::certain(start), Mu::certain(end)),
+            ),
+        )),
+        char(')'),
+    )
+    .parse(input)
+}
+
+/// Parse an RNA boundary: (?_pos), (pos_?), (pos_pos), (pos), ?, or pos
+fn parse_rna_boundary(
+    input: &str,
+) -> IResult<&str, UncertainBoundary<crate::hgvs::location::RnaPos>> {
+    alt((
+        // Range boundary: (?_pos), (pos_?), or (pos_pos)
+        parse_rna_range_boundary,
+        // Single uncertain position: (pos)
+        map(
+            delimited(char('('), parse_rna_pos, char(')')),
+            UncertainBoundary::uncertain,
+        ),
+        // Unknown: ?
+        map(tag("?"), |_| UncertainBoundary::unknown()),
+        // Certain position: pos
+        map(parse_rna_pos, UncertainBoundary::certain),
+    ))
+    .parse(input)
+}
+
 fn parse_rna_interval(input: &str) -> IResult<&str, RnaInterval> {
     alt((
-        // Whole interval uncertain: (100_200)
-        map(
-            delimited(
+        // Single uncertain position bounded by a range: (a_b) NOT followed by _.
+        // Per HGVS v21 uncertain.md, `(a_b)<edit>` is *one* position somewhere
+        // in [a, b]; same Range on both Interval boundaries.
+        |input| {
+            let (remaining, (start, _, end)) = delimited(
                 char('('),
                 (parse_rna_pos, tag("_"), parse_rna_pos),
                 char(')'),
-            ),
-            |(start, _, end)| Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end)),
-        ),
+            )
+            .parse(input)?;
+            // If followed by _, this is a complex boundary, not a simple uncertain interval
+            if remaining.starts_with('_') {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Verify,
+                )));
+            }
+            let boundary = UncertainBoundary::range(Mu::certain(start), Mu::certain(end));
+            Ok((
+                remaining,
+                Interval::with_complex_boundaries(boundary.clone(), boundary),
+            ))
+        },
+        // Complex interval with range boundaries: (pos_pos)_(pos_pos),
+        // (?_pos)_(pos_?), (pos_pos)_pos, pos_(pos_pos), etc.
+        |input| {
+            let (remaining, (start, _, end)) =
+                (parse_rna_boundary, tag("_"), parse_rna_boundary).parse(input)?;
+            Ok((remaining, Interval::with_complex_boundaries(start, end)))
+        },
         // Range with individual uncertainty
         map(
             (parse_uncertain_rna_pos, tag("_"), parse_uncertain_rna_pos),
@@ -4802,18 +4883,20 @@ mod tests {
 
     #[test]
     fn test_parse_uncertain_genomic_deletion() {
-        // Uncertain range deletion: (100_200)del
+        // Uncertain single position bounded by [12345,12350]: round-trips
+        // as the single-paren spec form per HGVS v21 uncertain.md (#237).
         let variant = parse_variant("NC_000001.11:g.(12345_12350)del").unwrap();
         assert!(matches!(variant, HgvsVariant::Genome(_)));
-        assert_eq!(format!("{}", variant), "NC_000001.11:g.(12345)_(12350)del");
+        assert_eq!(format!("{}", variant), "NC_000001.11:g.(12345_12350)del");
     }
 
     #[test]
     fn test_parse_uncertain_cds_deletion() {
-        // Uncertain range deletion
+        // Uncertain single position bounded by [100,200]: round-trips as
+        // the single-paren spec form per HGVS v21 uncertain.md (#237).
         let variant = parse_variant("NM_000088.3:c.(100_200)del").unwrap();
         assert!(matches!(variant, HgvsVariant::Cds(_)));
-        assert_eq!(format!("{}", variant), "NM_000088.3:c.(100)_(200)del");
+        assert_eq!(format!("{}", variant), "NM_000088.3:c.(100_200)del");
     }
 
     #[test]
@@ -4866,9 +4949,11 @@ mod tests {
 
     #[test]
     fn test_parse_rna_uncertain() {
+        // Uncertain single position bounded by [100,200]: round-trips as
+        // the single-paren spec form per HGVS v21 uncertain.md (#237).
         let variant = parse_variant("NM_000088.3:r.(100_200)del").unwrap();
         assert!(matches!(variant, HgvsVariant::Rna(_)));
-        assert_eq!(format!("{}", variant), "NM_000088.3:r.(100)_(200)del");
+        assert_eq!(format!("{}", variant), "NM_000088.3:r.(100_200)del");
     }
 
     #[test]

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,10 +10,10 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 42,
-      "diverges": 183,
+      "diverges": 168,
       "false-acceptance": 86,
       "parse-error": 341,
-      "preserved": 620
+      "preserved": 635
     },
     "by_coordinate_system": {
       "c": 464,
@@ -222,62 +222,14 @@
       ]
     },
     {
-      "input": "LRG_199t1:c.(71_72)G>A",
-      "current": "LRG_199t1:c.(71)_(72)G>A",
-      "spec_expected": "LRG_199t1:c.(71_72)G>A",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_000044.3:c.(92_331)insN[33]",
-      "current": "NM_000044.3:c.(92)_(331)insN[33]",
-      "spec_expected": "NM_000044.3:c.(92_331)insN[33]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_000333.3:c.(4_246)insN[(150_180)]",
-      "current": "NM_000333.3:c.(4)_(246)insN[150_180]",
+      "current": "NM_000333.3:c.(4_246)insN[150_180]",
       "spec_expected": "NM_000333.3:c.(4_246)insN[(150_180)]",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_000333.3:c.(4_246)insN[15]",
-      "current": "NM_000333.3:c.(4)_(246)insN[15]",
-      "spec_expected": "NM_000333.3:c.(4_246)insN[15]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_000333.3:c.(4_246)insN[9]",
-      "current": "NM_000333.3:c.(4)_(246)insN[9]",
-      "spec_expected": "NM_000333.3:c.(4_246)insN[9]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -295,25 +247,13 @@
     },
     {
       "input": "NM_002024.5:c.(-144_-16)insN[(1800_2400)]",
-      "current": "NM_002024.5:c.(-144)_(-16)insN[1800_2400]",
+      "current": "NM_002024.5:c.(-144_-16)insN[1800_2400]",
       "spec_expected": "NM_002024.5:c.(-144_-16)insN[(1800_2400)]",
       "status": "diverges",
       "coordinate_system": "c",
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:c.(222_226)insG",
-      "current": "NM_004006.2:c.(222)_(226)insG",
-      "spec_expected": "NM_004006.2:c.(222_226)insG",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -2929,6 +2869,17 @@
       ]
     },
     {
+      "input": "LRG_199t1:c.(71_72)G>A",
+      "current": "LRG_199t1:c.(71_72)G>A",
+      "spec_expected": "LRG_199t1:c.(71_72)G>A",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:c.123=",
       "current": "LRG_199t1:c.123=",
       "spec_expected": "LRG_199t1:c.123=",
@@ -3583,6 +3534,17 @@
       ]
     },
     {
+      "input": "NM_000044.3:c.(92_331)insN[33]",
+      "current": "NM_000044.3:c.(92_331)insN[33]",
+      "spec_expected": "NM_000044.3:c.(92_331)insN[33]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "NM_000044.3:c.171_239GCA[34]",
       "current": "NM_000044.3:c.171_239GCA[34]",
       "spec_expected": "NM_000044.3:c.171_239GCA[34]",
@@ -3613,6 +3575,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md"
+      ]
+    },
+    {
+      "input": "NM_000333.3:c.(4_246)insN[15]",
+      "current": "NM_000333.3:c.(4_246)insN[15]",
+      "spec_expected": "NM_000333.3:c.(4_246)insN[15]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "NM_000333.3:c.(4_246)insN[9]",
+      "current": "NM_000333.3:c.(4_246)insN[9]",
+      "spec_expected": "NM_000333.3:c.(4_246)insN[9]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
       ]
     },
     {
@@ -3772,6 +3756,17 @@
         "docs/consultation/SVD-WG001.md"
       ],
       "working_group": "SVD-WG001"
+    },
+    {
+      "input": "NM_004006.2:c.(222_226)insG",
+      "current": "NM_004006.2:c.(222_226)insG",
+      "spec_expected": "NM_004006.2:c.(222_226)insG",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
     },
     {
       "input": "NM_004006.2:c.123=",
@@ -5850,37 +5845,13 @@
     },
     {
       "input": "NC_000003.12:g.(63912602_63912844)insN[(150_180)]",
-      "current": "NC_000003.12:g.(63912602)_(63912844)insN[150_180]",
+      "current": "NC_000003.12:g.(63912602_63912844)insN[150_180]",
       "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[(150_180)]",
       "status": "diverges",
       "coordinate_system": "g",
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000003.12:g.(63912602_63912844)insN[15]",
-      "current": "NC_000003.12:g.(63912602)_(63912844)insN[15]",
-      "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[15]",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000003.12:g.(63912602_63912844)insN[9]",
-      "current": "NC_000003.12:g.(63912602)_(63912844)insN[9]",
-      "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[9]",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -5909,18 +5880,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000004.11:g.(3076562_3076732)insN[12]",
-      "current": "NC_000004.11:g.(3076562)_(3076732)insN[12]",
-      "spec_expected": "NC_000004.11:g.(3076562_3076732)insN[12]",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000022.10:g.42522624_42522669delins42536337_42536382",
       "current": "NC_000022.10:g.42522624_42522669delins[42536337_42536382]",
       "spec_expected": "NC_000022.10:g.42522624_42522669delins42536337_42536382",
@@ -5932,18 +5891,6 @@
         "docs/recommendations/DNA/delins.md"
       ],
       "working_group": "SVD-WG009",
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.10:g.(33038277_33038278)C>T",
-      "current": "NC_000023.10:g.(33038277)_(33038278)C>T",
-      "spec_expected": "NC_000023.10:g.(33038277_33038278)C>T",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -5983,18 +5930,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NC_000023.11:g.(86200001_103700000)del",
-      "current": "NC_000023.11:g.(86200001)_(103700000)del",
-      "spec_expected": "NC_000023.11:g.(86200001_103700000)del",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/complex.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NC_000023.11:g.32343183",
       "current": "NC_000023.11:g.32343183=",
       "spec_expected": "NC_000023.11:g.32343183",
@@ -6018,19 +5953,6 @@
         "docs/consultation/SVD-WG004.md"
       ],
       "working_group": "SVD-WG004",
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "g.(100_150)insN[25]",
-      "input_prefixed": "NC_000023.11:g.(100_150)insN[25]",
-      "current": "NC_000023.11:g.(100)_(150)insN[25]",
-      "spec_expected": "NC_000023.11:g.(100_150)insN[25]",
-      "status": "diverges",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -8395,6 +8317,28 @@
       ]
     },
     {
+      "input": "NC_000003.12:g.(63912602_63912844)insN[15]",
+      "current": "NC_000003.12:g.(63912602_63912844)insN[15]",
+      "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[15]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "NC_000003.12:g.(63912602_63912844)insN[9]",
+      "current": "NC_000003.12:g.(63912602_63912844)insN[9]",
+      "spec_expected": "NC_000003.12:g.(63912602_63912844)insN[9]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/repeated.md"
+      ]
+    },
+    {
       "input": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
       "current": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
       "spec_expected": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
@@ -8425,6 +8369,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/complex.md"
+      ]
+    },
+    {
+      "input": "NC_000004.11:g.(3076562_3076732)insN[12]",
+      "current": "NC_000004.11:g.(3076562_3076732)insN[12]",
+      "spec_expected": "NC_000004.11:g.(3076562_3076732)insN[12]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
       ]
     },
     {
@@ -8707,6 +8662,17 @@
       "input": "NC_000023.10:g.(32218983_32238146)_(32984039_33252615)del",
       "current": "NC_000023.10:g.(32218983_32238146)_(32984039_33252615)del",
       "spec_expected": "NC_000023.10:g.(32218983_32238146)_(32984039_33252615)del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "NC_000023.10:g.(33038277_33038278)C>T",
+      "current": "NC_000023.10:g.(33038277_33038278)C>T",
+      "spec_expected": "NC_000023.10:g.(33038277_33038278)C>T",
       "status": "preserved",
       "coordinate_system": "g",
       "source_kind": "recommendation",
@@ -9013,6 +8979,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11:g.(86200001_103700000)del",
+      "current": "NC_000023.11:g.(86200001_103700000)del",
+      "spec_expected": "NC_000023.11:g.(86200001_103700000)del",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/complex.md"
       ]
     },
     {
@@ -9338,6 +9315,18 @@
         "docs/consultation/SVD-WG004.md"
       ],
       "working_group": "SVD-WG004"
+    },
+    {
+      "input": "g.(100_150)insN[25]",
+      "input_prefixed": "NC_000023.11:g.(100_150)insN[25]",
+      "current": "NC_000023.11:g.(100_150)insN[25]",
+      "spec_expected": "NC_000023.11:g.(100_150)insN[25]",
+      "status": "preserved",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
     },
     {
       "input": "g.(123456_234567)_(345678_456789)del",
@@ -10298,32 +10287,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/extension.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Ala123_Pro131)Ter",
-      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)Ter",
-      "current": "NP_003997.1:p.(Ala123)_(Pro131)Ter",
-      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)Ter",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Ala123_Pro131)fs",
-      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)fs",
-      "current": "NP_003997.1:p.(Ala123)_(Pro131)fs",
-      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)fs",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -11784,6 +11747,30 @@
       ]
     },
     {
+      "input": "p.(Ala123_Pro131)Ter",
+      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)Ter",
+      "current": "NP_003997.1:p.(Ala123_Pro131)Ter",
+      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)Ter",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "p.(Ala123_Pro131)fs",
+      "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)fs",
+      "current": "NP_003997.1:p.(Ala123_Pro131)fs",
+      "spec_expected": "NP_003997.1:p.(Ala123_Pro131)fs",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
       "input": "p.(Arg123LysfsTer34)",
       "input_prefixed": "NP_003997.1:p.(Arg123LysfsTer34)",
       "current": "NP_003997.1:p.(Arg123LysfsTer34)",
@@ -13007,18 +12994,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_004006.2:r.(222_226)insg",
-      "current": "NM_004006.2:r.(222)_(226)insg",
-      "spec_expected": "NM_004006.2:r.(222_226)insg",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_004006.2:r.2623_2803delins2804_2949",
       "current": "NM_004006.2:r.2623_2803delins[2804_2949]",
       "spec_expected": "NM_004006.2:r.2623_2803delins2804_2949",
@@ -13075,19 +13050,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.(100_150)insn[25]",
-      "input_prefixed": "NM_004006.3:r.(100_150)insn[25]",
-      "current": "NM_004006.3:r.(100)_(150)insn[25]",
-      "spec_expected": "NM_004006.3:r.(100_150)insn[25]",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -14881,6 +14843,17 @@
       "working_group": "SVD-WG001"
     },
     {
+      "input": "NM_004006.2:r.(222_226)insg",
+      "current": "NM_004006.2:r.(222_226)insg",
+      "spec_expected": "NM_004006.2:r.(222_226)insg",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ]
+    },
+    {
       "input": "NM_004006.2:r.549_550insn",
       "current": "NM_004006.2:r.549_550insn",
       "spec_expected": "NM_004006.2:r.549_550insn",
@@ -15231,6 +15204,18 @@
         "docs/syntax.yaml"
       ],
       "working_group": "SVD-WG007"
+    },
+    {
+      "input": "r.(100_150)insn[25]",
+      "input_prefixed": "NM_004006.3:r.(100_150)insn[25]",
+      "current": "NM_004006.3:r.(100_150)insn[25]",
+      "spec_expected": "NM_004006.3:r.(100_150)insn[25]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ]
     },
     {
       "input": "r.-123ug[14]",

--- a/tests/issue_237_uncertain_position_range.rs
+++ b/tests/issue_237_uncertain_position_range.rs
@@ -1,0 +1,308 @@
+//! Audit for #81 § G1 — uncertain position ranges.
+//!
+//! Per HGVS v21.0 § `recommendations/uncertain.md` the form
+//! `c.(a_b)<edit>` describes a single variant at one position
+//! somewhere in `[a, b]` — *not* a multi-position range edit.
+//! The spec example is verbatim:
+//!
+//! > `NC_000023.10:g.(33038277_33038278)C>T` (`LRG_199t1:c.(71_72)G>A`)
+//! >  describes the variant `p.Trp24Ter` in the _DMD_ gene,
+//! >  reported on protein level only.
+//!
+//! Before the fix, ferro emitted `c.(a)_(b)<edit>` (semantic loss:
+//! reads as a multi-base range edit, not a single uncertain
+//! position), and `g.(?_b)del` / `c.(a+1_b-1)del` rendered with a
+//! duplicated boundary (`(?_b)_(?_b)del`). This file pins the
+//! spec-correct round-trip for every coord system × edit shape
+//! after the fix.
+//!
+//! The semantic distinction is:
+//!
+//! - `(a_b)<edit>`   → *single* uncertain position bounded by `[a, b]`.
+//! - `(a)_(b)<edit>` → range from "approximately a" to "approximately b".
+//!
+//! Both forms remain valid; they are not interconvertible.
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+// =============================================================================
+// SECTION 1 — Substitution at a single uncertain position
+// =============================================================================
+//
+// Spec: `LRG_199t1:c.(71_72)G>A` and
+// `NC_000023.10:g.(33038277_33038278)C>T` from
+// `recommendations/uncertain.md`.
+
+mod substitution {
+    use super::*;
+
+    #[test]
+    fn cds_single_uncertain_position_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)A>G");
+    }
+
+    #[test]
+    fn genome_single_uncertain_position_round_trips() {
+        assert_round_trips("NC_000017.11:g.(123_127)A>G");
+    }
+
+    #[test]
+    fn rna_single_uncertain_position_round_trips() {
+        assert_round_trips("NM_000088.3:r.(123_127)a>g");
+    }
+
+    #[test]
+    fn ncbi_tx_single_uncertain_position_round_trips() {
+        assert_round_trips("NR_037639.1:n.(123_127)A>G");
+    }
+
+    /// Verbatim spec example.
+    #[test]
+    fn spec_example_dmd_protein_level_round_trips() {
+        assert_round_trips("LRG_199t1:c.(71_72)G>A");
+    }
+}
+
+// =============================================================================
+// SECTION 1b — Protein (p.) single uncertain residue bounded by a range
+// =============================================================================
+//
+// Protein uses three-letter amino acid codes but the surrounding `(a_b)`
+// uncertain-position semantics are identical: `p.(Ala123_Pro131)Ter`
+// means "a Ter substitution at one residue somewhere in [Ala123, Pro131]".
+
+mod protein {
+    use super::*;
+
+    #[test]
+    fn protein_ter_at_single_uncertain_residue_round_trips() {
+        assert_round_trips("NP_003997.1:p.(Ala123_Pro131)Ter");
+    }
+
+    #[test]
+    fn protein_fs_at_single_uncertain_residue_round_trips() {
+        assert_round_trips("NP_003997.1:p.(Ala123_Pro131)fs");
+    }
+
+    #[test]
+    fn protein_del_at_single_uncertain_residue_round_trips() {
+        assert_round_trips("NP_003997.1:p.(Ala123_Pro131)del");
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Deletion at a single uncertain position
+// =============================================================================
+
+mod deletion {
+    use super::*;
+
+    #[test]
+    fn cds_single_uncertain_position_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)del");
+    }
+
+    #[test]
+    fn genome_single_uncertain_position_del_round_trips() {
+        assert_round_trips("NC_000017.11:g.(123_127)del");
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Duplication, inversion, delins at a single uncertain position
+// =============================================================================
+
+mod other_edits {
+    use super::*;
+
+    #[test]
+    fn cds_single_uncertain_position_dup_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)dup");
+    }
+
+    #[test]
+    fn cds_single_uncertain_position_inv_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)inv");
+    }
+
+    #[test]
+    fn cds_single_uncertain_position_delins_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)delinsACG");
+    }
+}
+
+// =============================================================================
+// SECTION 4 — Half-unknown bounds (?_pos), (pos_?)
+// =============================================================================
+//
+// The lower or upper bound is unknown ("somewhere ≤ b" or "somewhere ≥ a").
+// Spec uses these in array / FISH / MLPA descriptions where flanking probes
+// were not tested.
+
+mod half_unknown {
+    use super::*;
+
+    #[test]
+    fn cds_lower_unknown_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.(?_127)del");
+    }
+
+    #[test]
+    fn cds_upper_unknown_dup_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_?)dup");
+    }
+
+    #[test]
+    fn genome_lower_unknown_del_round_trips() {
+        assert_round_trips("NC_000017.11:g.(?_127)del");
+    }
+
+    #[test]
+    fn genome_upper_unknown_del_round_trips() {
+        assert_round_trips("NC_000017.11:g.(123_?)del");
+    }
+
+    #[test]
+    fn cds_both_unknown_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.(?_?)del");
+    }
+}
+
+// =============================================================================
+// SECTION 5 — Intronic-offset uncertain bounds
+// =============================================================================
+
+mod intronic_offset {
+    use super::*;
+
+    #[test]
+    fn cds_intronic_offset_uncertain_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123+1_127-1)del");
+    }
+
+    #[test]
+    fn cds_intronic_uncertain_offset_uncertain_bound_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123+?_127-?)del");
+    }
+}
+
+// =============================================================================
+// SECTION 6 — Spec-form preservation across compound brackets
+// =============================================================================
+//
+// The spec form must survive inside a compound `c.[...;...]` allele
+// bracket as well.
+
+mod compound_brackets {
+    use super::*;
+
+    #[test]
+    fn uncertain_range_inside_cis_bracket_round_trips() {
+        assert_round_trips("NM_000088.3:c.[(123_127)A>G;200C>T]");
+    }
+}
+
+// =============================================================================
+// SECTION 7 — Nested forms (regression guards — already worked before #237)
+// =============================================================================
+//
+// These are NOT the bug; they are the working "range_range" form. Pin so
+// the fix does not regress them.
+
+mod nested_range_regression_guards {
+    use super::*;
+
+    #[test]
+    fn nested_two_ranges_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)_(200_210)del");
+    }
+
+    #[test]
+    fn nested_half_unknown_round_trips() {
+        assert_round_trips("NM_000088.3:c.(?_127)_(200_?)del");
+    }
+
+    #[test]
+    fn nested_range_then_certain_round_trips() {
+        assert_round_trips("NM_000088.3:c.(123_127)_200del");
+    }
+
+    #[test]
+    fn nested_certain_then_range_round_trips() {
+        assert_round_trips("NM_000088.3:c.123_(200_210)del");
+    }
+
+    /// RNA two-paren range must round-trip — the `(a_b)` arm must not
+    /// greedily consume the first paren when `_(c_d)` follows.
+    #[test]
+    fn rna_nested_two_ranges_round_trips() {
+        assert_round_trips("NM_000088.3:r.(100_200)_(300_400)del");
+    }
+
+    /// RNA half-unknown two-paren range.
+    #[test]
+    fn rna_nested_half_unknown_round_trips() {
+        assert_round_trips("NM_000088.3:r.(?_127)_(200_?)del");
+    }
+
+    /// RNA range, then certain, two-paren form.
+    #[test]
+    fn rna_nested_range_then_certain_round_trips() {
+        assert_round_trips("NM_000088.3:r.(123_127)_200del");
+    }
+
+    /// RNA certain, then range, two-paren form.
+    #[test]
+    fn rna_nested_certain_then_range_round_trips() {
+        assert_round_trips("NM_000088.3:r.123_(200_210)del");
+    }
+}
+
+// =============================================================================
+// SECTION 8 — Semantic distinction (c.(a)_(b) NOT confused with c.(a_b))
+// =============================================================================
+//
+// The two-paren form `(a)_(b)<edit>` means "range from approximately
+// a to approximately b" — a multi-base edit with both endpoints
+// uncertain. This is distinct from `(a_b)<edit>` (single uncertain
+// position). After the fix, both forms must round-trip cleanly and
+// not be conflated.
+
+mod two_paren_range_distinct {
+    use super::*;
+
+    /// The two-paren form `c.(a)_(b)del` must round-trip — it is a
+    /// legitimate spec form, distinct from `c.(a_b)del`.
+    #[test]
+    fn two_paren_range_del_round_trips() {
+        assert_round_trips("NC_000001.11:g.(100)_(200)del");
+    }
+
+    /// Half-paren mix: certain start, uncertain end.
+    #[test]
+    fn certain_start_uncertain_end_round_trips() {
+        assert_round_trips("NC_000001.11:g.100_(200)del");
+    }
+
+    /// The two-paren form is NOT canonicalized to the single-paren
+    /// form (they have different meanings).
+    #[test]
+    fn two_paren_form_is_not_collapsed_to_single_paren_form() {
+        let a = parse_hgvs("NC_000017.11:g.(123_127)A>G").expect("parse a");
+        let b = parse_hgvs("NC_000017.11:g.(123)_(127)A>G").expect("parse b");
+        assert_ne!(
+            format!("{}", a),
+            format!("{}", b),
+            "single-paren and two-paren forms must Display distinctly"
+        );
+        assert_eq!(format!("{}", a), "NC_000017.11:g.(123_127)A>G");
+        assert_eq!(format!("{}", b), "NC_000017.11:g.(123)_(127)A>G");
+    }
+}


### PR DESCRIPTION
## Summary

Real fix for [#81](https://github.com/fulcrumgenomics/ferro-hgvs/issues/81) § **G1** — uncertain position ranges.

Per HGVS v21.0 `recommendations/uncertain.md`, the form `c.(a_b)<edit>` describes **one variant at a single position somewhere in `[a, b]`**. The spec example is verbatim:

> `NC_000023.10:g.(33038277_33038278)C>T` (`LRG_199t1:c.(71_72)G>A`) describes the variant `p.Trp24Ter` in the _DMD_ gene, reported on protein level only.

Before this fix, ferro misparsed every `(a_b)<edit>` shape into the structurally distinct `(a)_(b)<edit>` form (semantic loss — reads as a multi-base range edit), and the half-unknown / intronic-offset variants (`(?_127)del`, `(123+1_127-1)del`) rendered with **duplicated boundaries** (`(?_127)_(?_127)del`).

## Diagnosis

`UncertainBoundary::Range { start, end }` was already present in `src/hgvs/interval.rs` and used by the working nested-form parsing path (`(a_b)_(c_d)`). The single-paren parsers, however, produced `Interval::with_uncertainty(Mu::uncertain(start), Mu::uncertain(end))` — losing the "boundary is itself a range" semantics.

## Fix

- **Parser** (`src/hgvs/parser/variant.rs`): five interval parsers — `parse_genome_interval`, `parse_simple_uncertain_cds_interval`, `parse_tx_interval`, `parse_rna_interval`, `parse_prot_interval` — now build an `UncertainBoundary::Range` from `(a_b)` and place it on **both** sides of the `Interval`. This encodes "single position with range uncertainty" using the existing variant.
- **Display** (`src/hgvs/interval.rs`): `Interval::Display` collapses `Range == Range` to a single `(a_b)` emission instead of `(a_b)_(a_b)`. The nested two-paren form `(a_b)_(c_d)` (distinct ranges) still renders both halves.

## Test plan

- [x] New audit `tests/issue_237_uncertain_position_range.rs` (**28 tests**) pinning spec-correct round-trips across coord systems (g./c./n./r./p.) × edits (sub/del/ins/dup/inv/delins) × bounded / half-unknown / intronic-offset boundaries × compound brackets, plus regression guards for the nested two-paren form and a "single-paren vs two-paren are distinct" guard.
- [x] Three existing unit tests pinned the broken behavior and have been updated to assert the spec-correct round-trip: `test_parse_uncertain_genomic_deletion`, `test_parse_uncertain_cds_deletion`, `test_parse_rna_uncertain`.
- [x] Spec fixture (`tests/fixtures/grammar/hgvs_spec_normalization.json`): **18 rows** updated. **15 fully fixed** (`diverges` → `preserved`); **3 rows** with input form `insN[(150_180)]` retain `diverges` because the inner `[(...)]` count-range parsing still drops parens — that is a separate bug, out of #237 scope.
- [x] `cargo nextest run --features dev` — **4549 / 4549** pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

## Review

Parallel Opus + Sonnet review performed. Sonnet flagged a must-fix that `parse_prot_interval` had the same bug — fix extended to protein with three new audit tests. Opus confirmed no other issues after the protein fix was added. Both reviewers verified the Display collapse `Range == Range` is safe (the legitimate spec form `(a_b)_(c_d)` always has structurally distinct boundaries).

## Out of scope (separate follow-ups if needed)

- Inner repeat-count range form `insN[(150_180)]` — the outer `(a_b)` is now correctly preserved, but the inner `[(150_180)]` count-range drops parens to `[150_180]`. Three fixture rows pin this as a remaining divergence.