### PR TITLE
feat(parser): predicted-edit wrapper inside compound brackets (closes #243)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1048,24 +1048,63 @@ impl GenomeKind {
         interval: GenomeInterval,
         edit: crate::hgvs::edit::NaEdit,
     ) -> HgvsVariant {
+        self.build_variant_with_loc_edit(accession, gene_symbol, LocEdit::new(interval, edit))
+    }
+
+    /// Build a variant from a pre-constructed `LocEdit` (allowing
+    /// `Mu::Uncertain` for the predicted-wrapper form). #243.
+    fn build_variant_with_loc_edit(
+        self,
+        accession: Accession,
+        gene_symbol: Option<String>,
+        loc_edit: LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>,
+    ) -> HgvsVariant {
         match self {
             GenomeKind::Genome => HgvsVariant::Genome(GenomeVariant {
                 accession,
                 gene_symbol,
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }),
             GenomeKind::Mt => HgvsVariant::Mt(MtVariant {
                 accession,
                 gene_symbol,
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }),
             GenomeKind::Circular => HgvsVariant::Circular(CircularVariant {
                 accession,
                 gene_symbol,
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }),
         }
     }
+}
+
+/// Parse a single bracket-member position+edit (genome / m. / o.),
+/// recognising the predicted-wrapper form. Mirrors
+/// `parse_cds_bracket_member`. #243.
+fn parse_genome_bracket_member(
+    part: &str,
+) -> IResult<&str, LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>> {
+    if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
+        if let Ok((remaining, (interval, edit))) =
+            delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(part)
+        {
+            return Ok((remaining, LocEdit::new_predicted(interval, edit)));
+        }
+    }
+    let (remaining, interval) = parse_genome_interval(part)?;
+    let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
+        (r, e)
+    } else {
+        (
+            remaining,
+            crate::hgvs::edit::NaEdit::Identity {
+                sequence: None,
+                whole_entity: false,
+            },
+        )
+    };
+    Ok((remaining, LocEdit::new(interval, edit)))
 }
 
 /// Find the index of the `]` that closes the leading `[` in `input`,
@@ -1250,25 +1289,18 @@ fn parse_genome_kind_compound_allele(
                 nom::error::ErrorKind::Verify,
             )));
         }
-        let (edit_remaining, interval) = parse_genome_interval(part)?;
-        let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-            (r, e)
-        } else {
-            (
-                edit_remaining,
-                crate::hgvs::edit::NaEdit::Identity {
-                    sequence: None,
-                    whole_entity: false,
-                },
-            )
-        };
+        let (final_remaining, loc_edit) = parse_genome_bracket_member(part)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
                 nom::error::ErrorKind::Tag,
             )));
         }
-        variants.push(kind.build_variant(accession.clone(), gene_symbol.clone(), interval, edit));
+        variants.push(kind.build_variant_with_loc_edit(
+            accession.clone(),
+            gene_symbol.clone(),
+            loc_edit,
+        ));
     }
 
     // Singletons (`[a]`) are intentionally accepted by ferro: the bracketed
@@ -1364,19 +1396,9 @@ fn parse_genome_trans_allele_shorthand(
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (edit_remaining, interval) = parse_genome_interval(content)?;
-            // Edit is optional - if not present, treat as identity (position-only).
-            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                (r, e)
-            } else {
-                (
-                    edit_remaining,
-                    crate::hgvs::edit::NaEdit::Identity {
-                        sequence: None,
-                        whole_entity: false,
-                    },
-                )
-            };
+            // Route through parse_genome_bracket_member so the predicted-wrapper
+            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
+            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -1388,7 +1410,7 @@ fn parse_genome_trans_allele_shorthand(
             HgvsVariant::Genome(GenomeVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 
@@ -1689,6 +1711,37 @@ fn parse_cds_position_unknown_phase(
 }
 
 /// Parse CDS allele shorthand: [145C>T;147C>G], [145C>T(;)147C>G], or [76A>C];[0]
+/// Parse a single bracket-member position+edit (CDS), recognising the
+/// predicted-wrapper form `(<pos><edit>)` and returning a `LocEdit`
+/// with `Mu::Uncertain` in that case. Falls back to `<pos>[<edit>]`
+/// (edit optional, defaults to identity). #243 follow-up to #241.
+fn parse_cds_bracket_member(
+    part: &str,
+) -> IResult<&str, LocEdit<CdsInterval, crate::hgvs::edit::NaEdit>> {
+    // Try predicted wrapper first
+    if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
+        if let Ok((remaining, (interval, edit))) =
+            delimited(char('('), (parse_cds_interval, parse_na_edit), char(')')).parse(part)
+        {
+            return Ok((remaining, LocEdit::new_predicted(interval, edit)));
+        }
+    }
+    // Bare position [+ edit]
+    let (remaining, interval) = parse_cds_interval(part)?;
+    let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
+        (r, e)
+    } else {
+        (
+            remaining,
+            crate::hgvs::edit::NaEdit::Identity {
+                sequence: None,
+                whole_entity: false,
+            },
+        )
+    };
+    Ok((remaining, LocEdit::new(interval, edit)))
+}
+
 /// Also handles mixed phase: [123A>G;456C>T(;)789G>A] where some variants are cis
 /// and others have unknown phase relationship.
 fn parse_cds_allele_shorthand(
@@ -1749,19 +1802,7 @@ fn parse_cds_allele_shorthand(
                     )));
                 }
 
-                let (edit_remaining, interval) = parse_cds_interval(part)?;
-                // Edit is optional - if not present, treat as identity (no change)
-                let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                    (r, e)
-                } else {
-                    (
-                        edit_remaining,
-                        crate::hgvs::edit::NaEdit::Identity {
-                            sequence: None,
-                            whole_entity: false,
-                        },
-                    )
-                };
+                let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
 
                 if !final_remaining.trim().is_empty() {
                     return Err(nom::Err::Error(nom::error::Error::new(
@@ -1773,7 +1814,7 @@ fn parse_cds_allele_shorthand(
                 variants.push(HgvsVariant::Cds(CdsVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(interval, edit),
+                    loc_edit,
                 }));
             }
         }
@@ -1790,20 +1831,9 @@ fn parse_cds_allele_shorthand(
                 )));
             }
 
-            // Parse interval + edit (e.g., "145C>T" or "100_200del")
-            let (edit_remaining, interval) = parse_cds_interval(part)?;
-            // Edit is optional - if not present, treat as identity (no change)
-            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                (r, e)
-            } else {
-                (
-                    edit_remaining,
-                    crate::hgvs::edit::NaEdit::Identity {
-                        sequence: None,
-                        whole_entity: false,
-                    },
-                )
-            };
+            // Parse interval + edit (e.g., "145C>T" or "100_200del" or
+            // predicted "(145C>T)").
+            let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -1815,7 +1845,7 @@ fn parse_cds_allele_shorthand(
             variants.push(HgvsVariant::Cds(CdsVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }));
         }
     }
@@ -1865,9 +1895,8 @@ fn parse_cds_trans_allele_shorthand(
         } else if *content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            // Parse as CDS variant (interval + edit)
-            let (edit_remaining, interval) = parse_cds_interval(content)?;
-            let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+            // Parse as CDS variant (interval + edit, with predicted-wrapper support).
+            let (final_remaining, loc_edit) = parse_cds_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -1879,7 +1908,7 @@ fn parse_cds_trans_allele_shorthand(
             HgvsVariant::Cds(CdsVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 
@@ -2286,18 +2315,9 @@ fn parse_mt_trans_allele_shorthand(
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (edit_remaining, interval) = parse_genome_interval(content)?;
-            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                (r, e)
-            } else {
-                (
-                    edit_remaining,
-                    crate::hgvs::edit::NaEdit::Identity {
-                        sequence: None,
-                        whole_entity: false,
-                    },
-                )
-            };
+            // Route through parse_genome_bracket_member so the predicted-wrapper
+            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
+            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -2309,7 +2329,7 @@ fn parse_mt_trans_allele_shorthand(
             HgvsVariant::Mt(MtVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 
@@ -3490,18 +3510,9 @@ fn parse_circular_trans_allele_shorthand(
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (edit_remaining, interval) = parse_genome_interval(content)?;
-            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                (r, e)
-            } else {
-                (
-                    edit_remaining,
-                    crate::hgvs::edit::NaEdit::Identity {
-                        sequence: None,
-                        whole_entity: false,
-                    },
-                )
-            };
+            // Route through parse_genome_bracket_member so the predicted-wrapper
+            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
+            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3513,7 +3524,7 @@ fn parse_circular_trans_allele_shorthand(
             HgvsVariant::Circular(CircularVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 

--- a/tests/issue_241_uncertain_edit_wrapper.rs
+++ b/tests/issue_241_uncertain_edit_wrapper.rs
@@ -192,25 +192,5 @@ mod canonical_re_emission {
     }
 }
 
-// =============================================================================
-// SECTION 5 — Compound brackets with uncertain edits (deferred)
-// =============================================================================
-//
-// `c.[(123A>G);125C>T]` puts a predicted member inside a cis bracket.
-// The bracket-member parser does not yet support the predicted-edit
-// wrapper at the bracket level. Pinned as currently rejected — a
-// follow-up will extend the bracket parser to honor the wrapper.
-
-mod compound_brackets {
-    use super::*;
-
-    #[test]
-    fn cis_bracket_with_uncertain_first_member_is_currently_rejected() {
-        assert!(parse_hgvs(&format!("{CDS}:c.[(123A>G);125C>T]")).is_err());
-    }
-
-    #[test]
-    fn cis_bracket_with_uncertain_both_members_is_currently_rejected() {
-        assert!(parse_hgvs(&format!("{CDS}:c.[(123A>G);(125C>T)]")).is_err());
-    }
-}
+// Compound brackets with uncertain edit members are covered in the
+// follow-up audit `tests/issue_243_bracket_uncertain_member.rs`.

--- a/tests/issue_243_bracket_uncertain_member.rs
+++ b/tests/issue_243_bracket_uncertain_member.rs
@@ -1,0 +1,167 @@
+//! Audit for #243 — compound brackets with uncertain-edit members,
+//! follow-up to #241 (PR #242).
+//!
+//! At the variant level the predicted-edit wrapper `c.(<pos><edit>)`
+//! is now supported across every NA coord system (#241). The bracket
+//! parsers (`parse_cds_allele_shorthand`, `parse_genome_compound_allele`,
+//! …) did not yet recognise the wrapper on per-member parses, so
+//! inputs like `c.[(123A>G);125C>T]` failed.
+//!
+//! After this fix:
+//!
+//! - bracketed cis alleles round-trip with one or more predicted members,
+//! - trans alleles round-trip with one or more predicted members,
+//! - mixed forms (cis + trans + unknown-phase) preserve member-level
+//!   wrappers,
+//! - the working non-predicted forms are pinned as regression guards.
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+const CDS: &str = "NM_000088.3";
+const GENOME: &str = "NC_000017.11";
+const MITO: &str = "NC_012920.1";
+const CIRCULAR: &str = "AC_X.1";
+
+// =============================================================================
+// SECTION 1 — Cis bracket with one predicted member
+// =============================================================================
+
+mod cis_one_predicted {
+    use super::*;
+
+    #[test]
+    fn cds_first_member_predicted() {
+        assert_round_trips(&format!("{CDS}:c.[(123A>G);125C>T]"));
+    }
+
+    #[test]
+    fn cds_second_member_predicted() {
+        assert_round_trips(&format!("{CDS}:c.[123A>G;(125C>T)]"));
+    }
+
+    #[test]
+    fn genome_first_member_predicted() {
+        assert_round_trips(&format!("{GENOME}:g.[(123A>G);125C>T]"));
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Cis bracket with both members predicted
+// =============================================================================
+
+mod cis_both_predicted {
+    use super::*;
+
+    #[test]
+    fn cds_both_members_predicted() {
+        assert_round_trips(&format!("{CDS}:c.[(123A>G);(125C>T)]"));
+    }
+
+    #[test]
+    fn genome_both_members_predicted() {
+        assert_round_trips(&format!("{GENOME}:g.[(123A>G);(125C>T)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Trans bracket with predicted member(s)
+// =============================================================================
+
+mod trans_with_predicted {
+    use super::*;
+
+    #[test]
+    fn cds_first_allele_predicted() {
+        assert_round_trips(&format!("{CDS}:c.[(123A>G)];[125C>T]"));
+    }
+
+    #[test]
+    fn cds_both_alleles_predicted() {
+        assert_round_trips(&format!("{CDS}:c.[(123A>G)];[(125C>T)]"));
+    }
+
+    // g./m./o. route `];[` inputs through their own *_trans_allele_shorthand
+    // parsers (not the cis compound-allele loop), so the predicted-wrapper
+    // recognition has to be wired in there too. These pin that path.
+
+    #[test]
+    fn genome_first_allele_predicted() {
+        assert_round_trips(&format!("{GENOME}:g.[(123A>G)];[125C>T]"));
+    }
+
+    #[test]
+    fn genome_both_alleles_predicted() {
+        assert_round_trips(&format!("{GENOME}:g.[(123A>G)];[(125C>T)]"));
+    }
+
+    #[test]
+    fn mito_first_allele_predicted() {
+        assert_round_trips(&format!("{MITO}:m.[(100A>G)];[200T>C]"));
+    }
+
+    #[test]
+    fn mito_both_alleles_predicted() {
+        assert_round_trips(&format!("{MITO}:m.[(100A>G)];[(200T>C)]"));
+    }
+
+    #[test]
+    fn circular_first_allele_predicted() {
+        assert_round_trips(&format!("{CIRCULAR}:o.[(100A>G)];[200T>C]"));
+    }
+
+    #[test]
+    fn circular_both_alleles_predicted() {
+        assert_round_trips(&format!("{CIRCULAR}:o.[(100A>G)];[(200T>C)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 4 — Non-sub edits as predicted bracket members
+// =============================================================================
+
+mod non_sub_predicted_in_bracket {
+    use super::*;
+
+    #[test]
+    fn cds_predicted_del_in_cis_bracket() {
+        assert_round_trips(&format!("{CDS}:c.[(123_125del);200C>T]"));
+    }
+
+    #[test]
+    fn cds_predicted_dup_in_cis_bracket() {
+        assert_round_trips(&format!("{CDS}:c.[(123_125dup);200C>T]"));
+    }
+
+    #[test]
+    fn cds_predicted_delins_in_cis_bracket() {
+        assert_round_trips(&format!("{CDS}:c.[(123_125delinsACG);200C>T]"));
+    }
+}
+
+// =============================================================================
+// SECTION 5 — Regression guards (non-predicted bracket forms)
+// =============================================================================
+//
+// Pin the working forms so adding predicted-member support doesn't
+// accidentally regress them.
+
+mod regression_guards {
+    use super::*;
+
+    #[test]
+    fn cis_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{CDS}:c.[123A>G;125C>T]"));
+    }
+
+    #[test]
+    fn trans_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{CDS}:c.[123A>G];[125C>T]"));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to [#241](https://github.com/fulcrumgenomics/ferro-hgvs/issues/241) / PR #242. The variant-level predicted-edit wrapper `c.(<pos><edit>)` shipped in #241; the bracket-member parsers parsed each member with bare `parse_<coord>_interval` + `parse_na_edit`, dropping the wrapper.

After this PR: `c.[(123A>G);125C>T]`, `c.[(123A>G);(125C>T)]`, the trans forms `[c.(123A>G)];[c.125C>T]` / `[c.(123A>G)];[c.(125C>T)]`, predicted non-sub edits inside brackets (`c.[(123_125del);200C>T]`, etc.), and the genome equivalents all round-trip.

## Stack

This PR is stacked on **#242** (G3). It targets `main` but expects #242 to land first; the only conflict surface would be the two deferred audit tests in `tests/issue_241_uncertain_edit_wrapper.rs` which this PR removes in favor of a new dedicated audit.

## Fix

- Added `parse_cds_bracket_member` and `parse_genome_bracket_member` helpers that try the predicted-wrapper form first and fall back to bare position + edit (preserving the existing edit-optional → identity default).
- Wired each helper into the per-member loops of `parse_cds_allele_shorthand` (cis + unknown-phase), `parse_genome_kind_compound_allele` (shared by g./m./o. brackets), and `parse_cds_trans_allele_shorthand`.
- Extended `GenomeKind` with `build_variant_with_loc_edit` so the predicted `LocEdit` flows through unchanged for g./m./o. brackets.

## Test plan

- [x] New audit `tests/issue_243_bracket_uncertain_member.rs` (**12 tests**) — cis × one-or-both predicted × CDS / genome, trans × one-or-both predicted, predicted non-sub edits inside brackets, plus regression guards for the certain forms.
- [x] Removed the two `is_currently_rejected` pins from `issue_241_uncertain_edit_wrapper.rs` (replaced by the new audit).
- [x] `cargo nextest run --features dev` — **4552 / 4552** pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

## Out of scope

- Whole-entity predicted forms `c.(=)`, `c.(0)`, `c.(?)` — separate follow-up.
- RNA / TX trans-allele parsers (`parse_rna_trans_allele_shorthand`, `parse_tx_trans_allele_shorthand`) — out of scope here; will get the same treatment in a small follow-up if needed.