### PR TITLE
feat(parser): whole-entity predicted forms `c.(=)`, `c.(?)`, `r.(=)`, `r.(?)`, `r.(0)` (closes #245)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -923,7 +923,7 @@ fn parse_genome_variant(
     move |input: &str| {
         let (input, _) = tag("g.").parse(input)?;
 
-        // First try whole-genome identity (g.=) - no position
+        // First try whole-genome identity (g.= or g.(=)) - no position
         if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
             let dummy_pos = crate::hgvs::location::GenomePos::new(1);
             let dummy_interval = GenomeInterval::point(dummy_pos);
@@ -932,12 +932,12 @@ fn parse_genome_variant(
                 HgvsVariant::Genome(GenomeVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
 
-        // Try whole-genome unknown (g.?) - no position
+        // Try whole-genome unknown (g.? or g.(?)) - no position
         if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
             let dummy_pos = crate::hgvs::location::GenomePos::new(1);
             let dummy_interval = GenomeInterval::point(dummy_pos);
@@ -946,7 +946,7 @@ fn parse_genome_variant(
                 HgvsVariant::Genome(GenomeVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
@@ -1436,14 +1436,21 @@ fn parse_genome_trans_allele_shorthand(
 }
 
 /// Parse whole-genome identity: g.=
-fn parse_whole_genome_identity(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+fn parse_whole_genome_identity(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    // Predicted: g.(=)
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(=)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_identity()),
+        ));
+    }
     map(tag("="), |_| {
-        crate::hgvs::edit::NaEdit::whole_entity_identity()
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_identity())
     })
     .parse(input)
 }
 
-/// Parse whole-genome unknown: g.?
+/// Parse whole-genome unknown: g.? or g.(?)
 ///
 /// Only matches a terminal `?`: rejects `?` followed by an interval
 /// continuation (`_`), an offset (`+`/`-`), an edit keyword (`dup`,
@@ -1451,7 +1458,16 @@ fn parse_whole_genome_identity(input: &str) -> IResult<&str, crate::hgvs::edit::
 /// `>`) so that those forms fall through to the position-based
 /// parser (`?<edit>` means edit at unknown position, not whole-entity
 /// unknown). #239.
-fn parse_whole_genome_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+///
+/// The `g.(?)` predicted form is returned as `Mu::Uncertain`. #245.
+fn parse_whole_genome_unknown(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    // Predicted: g.(?)
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(?)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+        ));
+    }
     let (remaining, _) = tag("?").parse(input)?;
     if is_edit_continuation_after_unknown(remaining) {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -1459,7 +1475,10 @@ fn parse_whole_genome_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::N
             nom::error::ErrorKind::Tag,
         )));
     }
-    Ok((remaining, crate::hgvs::edit::NaEdit::whole_entity_unknown()))
+    Ok((
+        remaining,
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+    ))
 }
 
 /// Returns true when `remaining` (the input after a `?`) starts with
@@ -1502,19 +1521,34 @@ fn is_edit_continuation_after_unknown(remaining: &str) -> bool {
     false
 }
 
-/// Parse whole-CDS identity: c.=
-fn parse_whole_cds_identity(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+/// Parse whole-CDS identity: c.= or c.(=)
+fn parse_whole_cds_identity(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(=)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_identity()),
+        ));
+    }
     map(tag("="), |_| {
-        crate::hgvs::edit::NaEdit::whole_entity_identity()
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_identity())
     })
     .parse(input)
 }
 
-/// Parse whole-CDS unknown: c.?
-/// Only matches if ? is at end (not followed by `_`, `+`/`-`, edit
+/// Parse whole-CDS unknown: c.? or c.(?)
+///
+/// Only matches if `?` is at end (not followed by `_`, `+`/`-`, edit
 /// keywords, or a substitution pattern — those route to the
 /// position-based parser as edits at unknown position). #239.
-fn parse_whole_cds_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+///
+/// The `c.(?)` predicted form is returned as `Mu::Uncertain`. #245.
+fn parse_whole_cds_unknown(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(?)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+        ));
+    }
     let (remaining, _) = tag("?").parse(input)?;
     if is_edit_continuation_after_unknown(remaining) {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -1522,7 +1556,10 @@ fn parse_whole_cds_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEd
             nom::error::ErrorKind::Tag,
         )));
     }
-    Ok((remaining, crate::hgvs::edit::NaEdit::whole_entity_unknown()))
+    Ok((
+        remaining,
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+    ))
 }
 
 /// Parse CDS variant (c.)
@@ -1544,7 +1581,7 @@ fn parse_cds_variant(
             return parse_cds_position_unknown_phase(input, accession.clone(), gene_symbol.clone());
         }
 
-        // First try whole-CDS identity (c.=) - no position
+        // First try whole-CDS identity (c.= or c.(=)) - no position
         if let Ok((remaining, edit)) = parse_whole_cds_identity(input) {
             // Use a dummy interval for whole-entity identity
             let dummy_pos = crate::hgvs::location::CdsPos {
@@ -1558,12 +1595,12 @@ fn parse_cds_variant(
                 HgvsVariant::Cds(CdsVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
 
-        // Try whole-CDS unknown (c.?) - no position
+        // Try whole-CDS unknown (c.? or c.(?)) - no position
         if let Ok((remaining, edit)) = parse_whole_cds_unknown(input) {
             // Use a dummy interval for whole-entity unknown
             let dummy_pos = crate::hgvs::location::CdsPos {
@@ -1577,7 +1614,7 @@ fn parse_cds_variant(
                 HgvsVariant::Cds(CdsVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
@@ -2967,7 +3004,7 @@ fn parse_rna_variant(
             return parse_rna_position_unknown_phase(input, accession.clone(), gene_symbol.clone());
         }
 
-        // First try whole-RNA identity (r.=) - no position
+        // First try whole-RNA identity (r.= or r.(=)) - no position
         if let Ok((remaining, edit)) = parse_whole_rna_identity(input) {
             let dummy_pos = crate::hgvs::location::RnaPos {
                 base: 1,
@@ -2980,12 +3017,12 @@ fn parse_rna_variant(
                 HgvsVariant::Rna(RnaVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
 
-        // Try whole-RNA unknown (r.?) - no position
+        // Try whole-RNA unknown (r.? or r.(?)) - no position
         if let Ok((remaining, edit)) = parse_whole_rna_unknown(input) {
             let dummy_pos = crate::hgvs::location::RnaPos {
                 base: 1,
@@ -2998,7 +3035,7 @@ fn parse_rna_variant(
                 HgvsVariant::Rna(RnaVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
@@ -3021,7 +3058,7 @@ fn parse_rna_variant(
             ));
         }
 
-        // Try RNA-specific no product pattern (r.0)
+        // Try RNA-specific no product pattern (r.0 or predicted r.(0))
         if let Ok((remaining, edit)) = parse_rna_no_product(input) {
             let dummy_pos = crate::hgvs::location::RnaPos {
                 base: 1,
@@ -3034,7 +3071,7 @@ fn parse_rna_variant(
                 HgvsVariant::Rna(RnaVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(dummy_interval, edit),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
                 }),
             ));
         }
@@ -3085,19 +3122,34 @@ fn parse_rna_variant(
     }
 }
 
-/// Parse whole-RNA identity: r.=
-fn parse_whole_rna_identity(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+/// Parse whole-RNA identity: r.= or r.(=)
+fn parse_whole_rna_identity(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(=)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_identity()),
+        ));
+    }
     map(tag("="), |_| {
-        crate::hgvs::edit::NaEdit::whole_entity_identity()
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_identity())
     })
     .parse(input)
 }
 
-/// Parse whole-RNA unknown: r.?
-fn parse_whole_rna_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
-    // Only match terminal ? (not ? followed by `_`, edit keywords, or
-    // a substitution pattern — those route to the position-based
-    // parser as edits at unknown position). #239.
+/// Parse whole-RNA unknown: r.? or r.(?)
+///
+/// Only matches a terminal `?` (not `?` followed by `_`, edit keywords,
+/// or a substitution pattern — those route to the position-based
+/// parser as edits at unknown position). #239.
+///
+/// The `r.(?)` predicted form is returned as `Mu::Uncertain`. #245.
+fn parse_whole_rna_unknown(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(?)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+        ));
+    }
     let (remaining, _) = tag("?").parse(input)?;
     if is_edit_continuation_after_unknown(remaining) {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -3105,7 +3157,10 @@ fn parse_whole_rna_unknown(input: &str) -> IResult<&str, crate::hgvs::edit::NaEd
             nom::error::ErrorKind::Tag,
         )));
     }
-    Ok((remaining, crate::hgvs::edit::NaEdit::whole_entity_unknown()))
+    Ok((
+        remaining,
+        Mu::Certain(crate::hgvs::edit::NaEdit::whole_entity_unknown()),
+    ))
 }
 
 /// Parse RNA splice pattern: `spl` (very-likely-affected) or `spl?` (might-be-affected).
@@ -3140,8 +3195,14 @@ fn parse_whole_rna_predicted_splice(input: &str) -> IResult<&str, crate::hgvs::e
     Ok((input, edit))
 }
 
-/// Parse RNA no product pattern: r.0
-fn parse_rna_no_product(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit> {
+/// Parse RNA no product pattern: r.0 or predicted r.(0)
+fn parse_rna_no_product(input: &str) -> IResult<&str, Mu<crate::hgvs::edit::NaEdit>> {
+    if let Ok((remaining, _)) = tag::<_, _, nom::error::Error<&str>>("(0)").parse(input) {
+        return Ok((
+            remaining,
+            Mu::Uncertain(crate::hgvs::edit::NaEdit::NoProduct),
+        ));
+    }
     // Match "0" but only as a standalone symbol (not followed by digits or other edit characters)
     let (remaining, _) = tag("0").parse(input)?;
     // Make sure it's not followed by more digits (would be a position)
@@ -3151,7 +3212,7 @@ fn parse_rna_no_product(input: &str) -> IResult<&str, crate::hgvs::edit::NaEdit>
             nom::error::ErrorKind::Tag,
         )));
     }
-    Ok((remaining, crate::hgvs::edit::NaEdit::NoProduct))
+    Ok((remaining, Mu::Certain(crate::hgvs::edit::NaEdit::NoProduct)))
 }
 
 /// Parse predicted RNA variant: r.(100_101insAUG)

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -12,8 +12,8 @@
       "correctly-rejected": 42,
       "diverges": 160,
       "false-acceptance": 86,
-      "parse-error": 341,
-      "preserved": 643
+      "parse-error": 339,
+      "preserved": 645
     },
     "by_coordinate_system": {
       "c": 464,
@@ -13462,32 +13462,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.(=)",
-      "input_prefixed": "NM_004006.3:r.(=)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(=)\", code: Digit })",
-      "spec_expected": "NM_004006.3:r.(=)",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.(?)",
-      "input_prefixed": "NM_004006.3:r.(?)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(?)\", code: Digit })",
-      "spec_expected": "NM_004006.3:r.(?)",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "r.*1924",
       "input_prefixed": "NM_004006.3:r.*1924",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
@@ -15202,6 +15176,30 @@
       "input_prefixed": "NM_004006.3:r.(76a>c)",
       "current": "NM_004006.3:r.(76a>c)",
       "spec_expected": "NM_004006.3:r.(76a>c)",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "r.(=)",
+      "input_prefixed": "NM_004006.3:r.(=)",
+      "current": "NM_004006.3:r.(=)",
+      "spec_expected": "NM_004006.3:r.(=)",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "r.(?)",
+      "input_prefixed": "NM_004006.3:r.(?)",
+      "current": "NM_004006.3:r.(?)",
+      "spec_expected": "NM_004006.3:r.(?)",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",

--- a/tests/issue_245_whole_entity_predicted.rs
+++ b/tests/issue_245_whole_entity_predicted.rs
@@ -1,0 +1,119 @@
+//! Audit for #245 — whole-entity predicted forms across NA coord
+//! systems. Follow-up to #241 / PR #242 and #243 / PR #244.
+//!
+//! Per HGVS v21 `recommendations/uncertain.md`, the predicted-form
+//! wrapper extends to whole-entity edits:
+//!
+//! - `c.(=)`, `g.(=)`, `r.(=)` — predicted whole-entity identity.
+//! - `c.(?)`, `g.(?)`, `r.(?)` — predicted whole-entity unknown.
+//! - `r.(0)` — predicted RNA no-product (RNA-only; no `c.(0)` form).
+//!
+//! Protein `p.(=)` and `p.(?)` already work; `p.(0)` is a separate
+//! protein-level bug (tracked elsewhere).
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+const CDS: &str = "NM_000088.3";
+const GENOME: &str = "NC_000017.11";
+
+// =============================================================================
+// SECTION 1 — Predicted whole-entity identity `(=)`
+// =============================================================================
+
+mod predicted_identity {
+    use super::*;
+
+    #[test]
+    fn cds_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{CDS}:c.(=)"));
+    }
+
+    #[test]
+    fn genome_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{GENOME}:g.(=)"));
+    }
+
+    #[test]
+    fn rna_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{CDS}:r.(=)"));
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Predicted whole-entity unknown `(?)`
+// =============================================================================
+
+mod predicted_unknown {
+    use super::*;
+
+    #[test]
+    fn cds_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{CDS}:c.(?)"));
+    }
+
+    #[test]
+    fn genome_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{GENOME}:g.(?)"));
+    }
+
+    #[test]
+    fn rna_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{CDS}:r.(?)"));
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Predicted RNA no-product `r.(0)`
+// =============================================================================
+
+mod predicted_no_product {
+    use super::*;
+
+    /// `r.0` exists (no transcript produced); `r.(0)` is its predicted form.
+    #[test]
+    fn rna_predicted_no_product_round_trips() {
+        assert_round_trips(&format!("{CDS}:r.(0)"));
+    }
+
+    /// `c.0` is not a spec form — `0` is RNA-specific. The predicted
+    /// `c.(0)` should likewise be rejected. Pinned as regression guard.
+    #[test]
+    fn cds_no_product_rejected() {
+        assert!(parse_hgvs(&format!("{CDS}:c.0")).is_err());
+        assert!(parse_hgvs(&format!("{CDS}:c.(0)")).is_err());
+    }
+}
+
+// =============================================================================
+// SECTION 4 — Certain forms remain working (regression guards)
+// =============================================================================
+
+mod regression_guards {
+    use super::*;
+
+    #[test]
+    fn certain_identity_forms_still_round_trip() {
+        assert_round_trips(&format!("{CDS}:c.="));
+        assert_round_trips(&format!("{GENOME}:g.="));
+        assert_round_trips(&format!("{CDS}:r.="));
+    }
+
+    #[test]
+    fn certain_unknown_forms_still_round_trip() {
+        assert_round_trips(&format!("{CDS}:c.?"));
+        assert_round_trips(&format!("{GENOME}:g.?"));
+        assert_round_trips(&format!("{CDS}:r.?"));
+    }
+
+    #[test]
+    fn certain_rna_no_product_still_round_trips() {
+        assert_round_trips(&format!("{CDS}:r.0"));
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to [#241](https://github.com/fulcrumgenomics/ferro-hgvs/issues/241) / PR #242 and [#243](https://github.com/fulcrumgenomics/ferro-hgvs/issues/243) / PR #244. The variant-level and bracket-level predicted-edit wrappers shipped previously; the whole-entity edits still rejected the wrapper.

After this PR these forms round-trip:

- `c.(=)`, `g.(=)`, `r.(=)` — predicted whole-entity identity.
- `c.(?)`, `g.(?)`, `r.(?)` — predicted whole-entity unknown.
- `r.(0)` — predicted RNA no-product.

`c.(0)` stays rejected because `c.0` is not a spec form (`0` is RNA-specific per #233).

## Stack

Stacked on **#244** (#243). The audit file lives at `tests/issue_245_whole_entity_predicted.rs`. Both PR #244 and this one need to land for the spec fixture to settle cleanly.

## Fix

Each NA whole-entity parser (`parse_whole_<coord>_identity`, `parse_whole_<coord>_unknown`, `parse_rna_no_product`) now returns `Mu<NaEdit>`. The parenthesized form `(=)` / `(?)` / `(0)` is recognised as `Mu::Uncertain`; the bare form remains `Mu::Certain`. Each variant parser's call site builds the `LocEdit` with `with_uncertainty`. Display already handles the `Mu::Uncertain(whole_entity_*)` case correctly thanks to #241.

## Test plan

- [x] New audit `tests/issue_245_whole_entity_predicted.rs` (**11 tests**) — identity / unknown / no-product × cds/genome/rna + regression guards for the certain forms + `c.(0)` rejection.
- [x] Spec fixture: 2 rows (`r.(=)`, `r.(?)`) flipped `parse-error → preserved`.
- [x] `cargo nextest run --features dev` — **4563 / 4563** pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

## Out of scope

- `m.(=)`, `m.(?)`, `o.(=)`, `n.(=)`, etc. — `parse_mt_variant`, `parse_circular_variant`, `parse_tx_variant` don't have whole-entity dispatch today; that's a wider gap.
- `p.(0)` — protein-level whole-entity bug; out of scope.