### PR TITLE
test(audit): boundary-spanning del/delins ranges across UTR/CDS (closes #81 J1)

### DIFF
--- a/tests/issue_253_boundary_spanning.rs
+++ b/tests/issue_253_boundary_spanning.rs
@@ -1,0 +1,141 @@
+//! Audit for #81 § J1 — user-supplied ranges spanning the 5'UTR↔CDS
+//! or CDS↔3'UTR boundary (and the `n.` upstream↔transcript and
+//! transcript↔downstream analogs).
+//!
+//! Policy: accept on input, preserve verbatim on Display, no warning.
+//! The HGVS v21 spec does not explicitly forbid these forms. The
+//! merge-barrier behavior from #103 / #89 is orthogonal — it only
+//! prevents adjacent same-coord-system edits in opposite regions from
+//! being folded into a single delins, never rejects user-supplied
+//! boundary-spanning ranges.
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+// =============================================================================
+// SECTION 1 — c. 5'UTR↔CDS boundary
+// =============================================================================
+
+mod cds_5utr_boundary {
+    use super::*;
+
+    #[test]
+    fn neg_to_pos_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_5del");
+    }
+
+    #[test]
+    fn neg_to_pos_del_with_ref_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_5delAGCCC");
+    }
+
+    #[test]
+    fn neg_to_pos_delins_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_5delinsAGCCC");
+    }
+
+    #[test]
+    fn neg_to_pos_dup_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_5dup");
+    }
+
+    #[test]
+    fn neg_to_pos_inv_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_5inv");
+    }
+
+    /// `c.-1_1insAAA` — insertion across the boundary (no nucleotides
+    /// removed, just an insertion at the UTR↔CDS junction).
+    #[test]
+    fn boundary_insertion_round_trips() {
+        assert_round_trips("NM_000088.3:c.-1_1insAAA");
+    }
+}
+
+// =============================================================================
+// SECTION 2 — c. CDS↔3'UTR boundary
+// =============================================================================
+
+mod cds_3utr_boundary {
+    use super::*;
+
+    #[test]
+    fn pos_to_star_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.4548_*3del");
+    }
+
+    #[test]
+    fn pos_to_star_delins_round_trips() {
+        assert_round_trips("NM_000088.3:c.4548_*3delinsAGC");
+    }
+
+    #[test]
+    fn star_to_star_insertion_round_trips() {
+        assert_round_trips("NM_000088.3:c.*1_*2insAAA");
+    }
+}
+
+// =============================================================================
+// SECTION 3 — c. ranges spanning both boundaries (entire CDS)
+// =============================================================================
+
+mod entire_cds_spanning {
+    use super::*;
+
+    /// `c.-3_*3del` — spans 5'UTR → CDS → 3'UTR. Accepted by the spec
+    /// for completeness (no rule forbids the form).
+    #[test]
+    fn full_span_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.-3_*3del");
+    }
+}
+
+// =============================================================================
+// SECTION 4 — n. upstream↔transcript and transcript↔downstream
+// =============================================================================
+
+mod nx_boundaries {
+    use super::*;
+
+    #[test]
+    fn n_upstream_to_body_del_round_trips() {
+        assert_round_trips("NR_037639.1:n.-3_5del");
+    }
+
+    #[test]
+    fn n_body_to_downstream_del_round_trips() {
+        assert_round_trips("NR_037639.1:n.40_*3del");
+    }
+}
+
+// =============================================================================
+// SECTION 5 — Same-region positive controls
+// =============================================================================
+//
+// Pin that the same-region ranges keep round-tripping; the
+// boundary-spanning audit cases above must not regress them.
+
+mod same_region_positive_controls {
+    use super::*;
+
+    #[test]
+    fn five_utr_only_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.-5_-3del");
+    }
+
+    #[test]
+    fn cds_only_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.3_5del");
+    }
+
+    #[test]
+    fn three_utr_only_del_round_trips() {
+        assert_round_trips("NM_000088.3:c.*1_*5del");
+    }
+}


### PR DESCRIPTION
Closes #253. Closes #81 § J1.

## Summary

Pure-coverage audit pinning ferro's existing policy for user-supplied \`c.\` / \`n.\` ranges that span the 5'UTR↔CDS or CDS↔3'UTR boundary (and the \`n.\` upstream↔transcript / transcript↔downstream analogs).

**Policy:** accept on input, preserve verbatim on Display, no warning.

## Spec position

HGVS Nomenclature v21 does not explicitly forbid these forms. The \"deletions extending beyond the transcribed region\" prohibition in \`recommendations/DNA/deletion.md\` applies to ranges past the transcript ends (\`-244\`, \`*2691\`), not the UTR↔CDS interior boundary. The spec accepts the analogous exon/intron-spanning forms (\`c.183_186+48del\`).

## Boundary cases pinned

- c. 5'UTR↔CDS: \`c.-3_5\` × {del, delAGCCC, delins, dup, inv}; \`c.-1_1insAAA\`
- c. CDS↔3'UTR: \`c.4548_*3\` × {del, delins}; \`c.*1_*2insAAA\`
- c. entire-CDS span: \`c.-3_*3del\`
- n. upstream↔transcript: \`n.-3_5del\`
- n. transcript↔downstream: \`n.40_*3del\`
- Same-region positive controls (5'UTR-only, CDS-only, 3'UTR-only)

15 new tests, all passing. No source changes.

## Merge barrier is orthogonal

The merge-barrier from #103 / #89 (closes #89) only prevents folding adjacent same-coord-system edits in opposite regions into a single delins. It never rejects user-supplied boundary-spanning ranges, and is unchanged.

This is a pure-coverage audit; the parallel-review ritual was skipped per workflow.

## Test plan

- [x] \`cargo nextest run --features dev --test issue_253_boundary_spanning\` — 15 / 15 pass
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — clean