### PR TITLE
fix(spdi): preserve inv and m. coord system on SPDI -> HGVS (closes #81 K1 follow-up)

### DIFF
--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1343,6 +1343,30 @@ pub fn spdi_to_hgvs(spdi: &SpdiVariant) -> Result<HgvsVariant, ConversionError> 
                 sequence: InsertedSequence::Literal(ins_seq),
             },
         )
+    } else if !spdi.deletion.is_empty()
+        && spdi.deletion.len() == spdi.insertion.len()
+        && spdi.deletion.len() >= 2
+        && reverse_complement(&spdi.deletion).eq_ignore_ascii_case(&spdi.insertion)
+    {
+        // Inversion recovery (#270): SPDI delins where the inserted seq
+        // is the reverse complement of the deleted seq is canonically a
+        // tandem inversion. Length-1 cases are SNVs and handled above;
+        // self-RC palindromes of length 2+ (e.g. `AT:AT`, `GC:GC`) only
+        // recover when the seqs differ from a plain identity — which
+        // they don't, so identity catches them first.
+        let inv_seq = string_to_sequence(&spdi.deletion)?;
+        let del_len = spdi.deletion.len();
+        let interval = Interval::new(
+            GenomePos::new(hgvs_pos),
+            GenomePos::new(hgvs_pos + del_len as u64 - 1),
+        );
+        (
+            interval,
+            NaEdit::Inversion {
+                sequence: Some(inv_seq),
+                length: None,
+            },
+        )
     } else {
         // Delins (different lengths or MNV)
         let del_len = spdi.deletion.len();
@@ -1365,11 +1389,34 @@ pub fn spdi_to_hgvs(spdi: &SpdiVariant) -> Result<HgvsVariant, ConversionError> 
         )
     };
 
+    // m. coord system recovery (#270): NC_012920.* is the canonical
+    // human mitochondrial accession; SPDI carries no coord-system tag
+    // so the bare reverse path defaults to g. Emit m. when the
+    // accession matches a known mitochondrial reference.
+    if is_mitochondrial_accession(&accession) {
+        return Ok(HgvsVariant::Mt(MtVariant {
+            accession,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(interval, edit),
+        }));
+    }
+
     Ok(HgvsVariant::Genome(GenomeVariant {
         accession,
         gene_symbol: None,
         loc_edit: LocEdit::new(interval, edit),
     }))
+}
+
+/// Returns true if `accession` is a known mitochondrial reference. Used
+/// by `spdi_to_hgvs` to emit `m.` instead of `g.` for these accessions
+/// (SPDI carries no coord-system tag).
+fn is_mitochondrial_accession(accession: &Accession) -> bool {
+    let prefix: &str = accession.prefix.as_ref();
+    let number: &str = accession.number.as_ref();
+    // NC_012920 = human GRCh38 mitochondrion (rCRS).
+    // NC_001807 = older rCRS draft (deprecated but still seen).
+    matches!((prefix, number), ("NC", "012920") | ("NC", "001807"))
 }
 
 /// Convert an SPDI variant to HGVS, using a reference provider to recover
@@ -1531,20 +1578,22 @@ where
         uncertain_extent: None,
     };
 
-    // Reuse the accession (and gene_symbol, which is None for SPDI inputs)
-    // from the base ins-form variant. SPDI→HGVS only produces Genome
-    // variants, so we expect HgvsVariant::Genome here.
-    let HgvsVariant::Genome(g) = base else {
-        // Defensive: SPDI→HGVS should always produce Genome. If it doesn't,
-        // do not attempt dup recovery.
-        return Ok(None);
-    };
-
-    Ok(Some(HgvsVariant::Genome(GenomeVariant {
-        accession: g.accession.clone(),
-        gene_symbol: g.gene_symbol.clone(),
-        loc_edit: LocEdit::new(interval, edit),
-    })))
+    // Reuse the accession + gene_symbol from the base ins-form variant.
+    // SPDI→HGVS produces either Genome or Mt (mitochondrial), depending
+    // on the accession; preserve whichever shape the base has.
+    match base {
+        HgvsVariant::Genome(g) => Ok(Some(HgvsVariant::Genome(GenomeVariant {
+            accession: g.accession.clone(),
+            gene_symbol: g.gene_symbol.clone(),
+            loc_edit: LocEdit::new(interval, edit),
+        }))),
+        HgvsVariant::Mt(m) => Ok(Some(HgvsVariant::Mt(MtVariant {
+            accession: m.accession.clone(),
+            gene_symbol: m.gene_symbol.clone(),
+            loc_edit: LocEdit::new(interval, edit),
+        }))),
+        _ => Ok(None),
+    }
 }
 
 /// Helper to convert a string to a Sequence.
@@ -2631,9 +2680,10 @@ mod tests {
 
         let spdi = SpdiVariant::insertion("NC_012920.1", 101, "ATG");
         let hgvs = spdi_to_hgvs_with_ref(&spdi, &provider).unwrap();
-        // Even for mito, the SPDI→HGVS path produces a g. variant; this
-        // matches the existing convention in this module.
-        assert_eq!(hgvs.to_string(), "NC_012920.1:g.100_102dupATG");
+        // After #270, SPDI→HGVS preserves the m. coord system for known
+        // mitochondrial accessions (NC_012920.*); dup recovery applies
+        // uniformly to genomic and mitochondrial variants.
+        assert_eq!(hgvs.to_string(), "NC_012920.1:m.100_102dupATG");
     }
 
     #[test]

--- a/tests/issue_270_spdi_preservation.rs
+++ b/tests/issue_270_spdi_preservation.rs
@@ -1,0 +1,147 @@
+//! Tests for #270 — preserve `inv` and `m.` coord system through
+//! HGVS ↔ SPDI round-trip.
+//!
+//! SPDI has no `inv` edit type and no coord-system tag, so the
+//! forward leg lost these shapes. The reverse leg now recovers:
+//!
+//! - **inv recovery**: a delins where `ins == reverse_complement(del)`
+//!   is canonically an inversion.
+//! - **m. recovery**: NC_012920 / NC_001807 accessions emit `m.` instead
+//!   of `g.`.
+//!
+//! `dup` recovery is unchanged (still requires reference data via
+//! `spdi_to_hgvs_with_ref`).
+
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::spdi::{hgvs_to_spdi_simple, spdi_to_hgvs, SpdiVariant};
+
+#[track_caller]
+fn assert_round_trips(input: &str) {
+    let hgvs = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let spdi = hgvs_to_spdi_simple(&hgvs).unwrap_or_else(|e| panic!("to_spdi {input:?}: {e}"));
+    let back = spdi_to_hgvs(&spdi).unwrap_or_else(|e| panic!("from_spdi {spdi:?}: {e}"));
+    assert_eq!(
+        format!("{}", back),
+        input,
+        "round-trip mismatch for {input:?}"
+    );
+}
+
+// =============================================================================
+// SECTION 1 — Inversion preservation
+// =============================================================================
+
+mod inversion_preservation {
+    use super::*;
+
+    /// Canonical 4-base inversion round-trips through SPDI.
+    #[test]
+    fn genomic_inv_round_trips() {
+        assert_round_trips("NC_000001.11:g.100_103invTAGC");
+    }
+
+    /// Five-base inversion with non-palindromic seq.
+    #[test]
+    fn genomic_inv_5bp_round_trips() {
+        assert_round_trips("NC_000001.11:g.100_104invATAGC");
+    }
+
+    /// Direct SPDI → HGVS where deleted = reverse_complement(inserted).
+    #[test]
+    fn direct_spdi_with_rc_emits_inversion() {
+        let spdi = SpdiVariant::delins("NC_000001.11", 99, "TAGC", "GCTA");
+        let hgvs = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", hgvs), "NC_000001.11:g.100_103invTAGC");
+    }
+
+    /// Length-1 inversion is just an SNV; identity SPDI doesn't
+    /// canonicalize to inv (we require length >= 2).
+    #[test]
+    fn single_base_not_inversion() {
+        let spdi = SpdiVariant::new("NC_000001.11", 99, "A", "T");
+        let hgvs = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", hgvs), "NC_000001.11:g.100A>T");
+    }
+
+    /// Non-RC delins still emits delins.
+    #[test]
+    fn non_rc_delins_unchanged() {
+        let spdi = SpdiVariant::delins("NC_000001.11", 99, "ATG", "TTCC");
+        let hgvs = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", hgvs), "NC_000001.11:g.100_102delinsTTCC");
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Mitochondrial coord-system preservation
+// =============================================================================
+
+mod mt_preservation {
+    use super::*;
+
+    /// Mitochondrial substitution preserves `m.`.
+    #[test]
+    fn mt_sub_round_trips() {
+        assert_round_trips("NC_012920.1:m.100A>G");
+    }
+
+    /// Mitochondrial deletion preserves `m.`.
+    #[test]
+    fn mt_del_round_trips() {
+        assert_round_trips("NC_012920.1:m.100_102delATG");
+    }
+
+    /// Mitochondrial inversion (combines both #270 features).
+    #[test]
+    fn mt_inv_round_trips() {
+        assert_round_trips("NC_012920.1:m.100_103invTAGC");
+    }
+
+    /// Mitochondrial identity preserves `m.`.
+    #[test]
+    fn mt_identity_round_trips() {
+        assert_round_trips("NC_012920.1:m.100A=");
+    }
+
+    /// Non-mitochondrial accessions still emit `g.`.
+    #[test]
+    fn nuclear_chrom_still_genomic() {
+        assert_round_trips("NC_000001.11:g.12345A>G");
+    }
+
+    /// Older mitochondrial accession (NC_001807) also recognized.
+    #[test]
+    fn older_mt_accession_recognized() {
+        let spdi = SpdiVariant::new("NC_001807.4", 99, "A", "G");
+        let hgvs = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", hgvs), "NC_001807.4:m.100A>G");
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Out-of-scope shapes unchanged
+// =============================================================================
+
+mod unchanged {
+    use super::*;
+
+    /// `dup` still canonicalizes to `ins` on the no-provider path.
+    /// (Provider-required dup recovery is covered by `spdi_to_hgvs_with_ref`.)
+    #[test]
+    fn dup_canonicalizes_to_ins_without_provider() {
+        let hgvs = parse_hgvs("NC_000001.11:g.100_102dupATG").unwrap();
+        let spdi = hgvs_to_spdi_simple(&hgvs).unwrap();
+        let back = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", back), "NC_000001.11:g.102_103insATG");
+    }
+
+    /// `delins` with explicit del seq still drops the deleted seq on
+    /// Display (canonical HGVS form).
+    #[test]
+    fn delins_with_explicit_del_drops_del_seq() {
+        let hgvs = parse_hgvs("NC_000001.11:g.100_102delATGinsTTCC").unwrap();
+        let spdi = hgvs_to_spdi_simple(&hgvs).unwrap();
+        let back = spdi_to_hgvs(&spdi).unwrap();
+        assert_eq!(format!("{}", back), "NC_000001.11:g.100_102delinsTTCC");
+    }
+}


### PR DESCRIPTION
Closes #270. Closes #81 K1 follow-up to #259.

## Background

The reverse leg (\`spdi_to_hgvs\`) lost two HGVS shapes:

- **Inversions**: \`g.100_103invTAGC\` → SPDI \`99:TAGC:GCTA\` → \`g.100_103delinsGCTA\`
- **m. coord system**: \`NC_012920.1:m.100A>G\` → SPDI \`99:A:G\` → \`g.100A>G\`

SPDI itself has no \`inv\` edit type and no coord-system tag, so the forward leg's loss is inherent. But the reverse leg can recover both cases by inspection.

## Changes

1. **inv recovery** in \`spdi_to_hgvs\`: after the existing identity / SNV / pure-del / pure-ins branches, add a branch that emits \`NaEdit::Inversion\` when \`del.len() == ins.len() >= 2\` AND \`ins == reverse_complement(del)\` (case-insensitive).

2. **m. recovery**: after building \`(interval, edit)\`, check the accession against a known set of mitochondrial references (\`NC_012920\` GRCh38 rCRS; \`NC_001807\` older draft). Emit \`HgvsVariant::Mt\` if matched, else \`HgvsVariant::Genome\`.

3. \`recover_dup_from_insertion\` (in \`spdi_to_hgvs_with_ref\`) now also accepts \`HgvsVariant::Mt\` as the base — dup recovery applies uniformly to mitochondrial inputs. Existing test \`spdi_to_hgvs_with_ref_recovers_dup_for_mito_accession\` updated to expect \`m.\` instead of \`g.\`.

4. **Tests**: \`tests/issue_270_spdi_preservation.rs\` — 13 cases across inversion preservation (round-trip + direct-SPDI + length-1 not-inv + non-RC delins), m. preservation (sub, del, inv-combined, identity, nuclear-still-\`g.\`, older NC_001807), and out-of-scope shapes (dup without provider → ins; delins explicit-del drops del seq).

## Out of scope

\`dup\` recovery on the no-provider path is impossible (needs reference comparison) — already covered by \`spdi_to_hgvs_with_ref\`. \`delins\` explicit-del-seq preservation is a policy/API question (the canonical HGVS Display drops the deleted seq).

## Cross-ref

When #259 lands, its \`semantic_round_trip::inv_canonicalizes_to_delins_reverse_complement\` and \`mt_canonicalizes_to_genomic\` tests will need to be flipped to syntactic round-trip — pinned in the #270 audit.

## Test plan

- [x] \`cargo nextest run --features dev\` — 4534 / 4534 pass
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all\` — clean