### PR TITLE
fix(normalize): extend codon-frame exception to r., 3+ chains, and sub+del (closes #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(parser)* accept `?con<src>` and `?copy<N>` at unknown position, consistent with `?del`/`?dup`/`?ins`/`?inv` (closes #286)
 
+### Fixed
+
+- *(normalize)* extend HGVS codon-frame exception beyond the two-`c.`-SNV case (closes #275, follow-up to #79 / #104): the spec's "two variants separated by one nucleotide, together affecting one amino acid" carve-out now also covers (1) `r.` coding regions, (2) chains of 3+ SNVs where a strict-adjacency merge leaves `prev_a` as a multi-base delins, and (3) `sub`+`del` and `del`+`sub` pairs separated by one unchanged nucleotide.
+
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
 
 ### Added

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -109,20 +109,32 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
             // `c.-3 + 1 == c.-2` is `-3 + 1 == -2`).
             let strict_adjacent = prev_a.end.checked_add(1) == Some(next_start);
 
-            // Codon-frame exception (issue #79): two `c.` exonic SNVs in
-            // the CDS proper, separated by exactly one nucleotide, that
-            // fall within the same codon merge into a delins with the
-            // unchanged middle reference base preserved. Eligibility is
-            // narrow: same accession+region (`Cds`), gap of exactly 1 on
-            // the axis, both endpoints in the same codon, and a
-            // `prev_a` that is still a single-base SUB anchor (so this
-            // doesn't fire on a delins that's already grown via an
-            // earlier merge).
+            // Codon-frame exception (issue #79, extended by issue #275):
+            // two exonic edits on the CDS axis (`c.` or `r.`), separated
+            // by exactly one nucleotide, that fall within the same codon
+            // merge into a delins with the unchanged middle reference base
+            // preserved verbatim. Eligibility:
+            //   * same accession + same kind (checked below).
+            //   * region is `Cds` (for `c.`) or `Rna` (for `r.`) — both
+            //     share a codon-relative axis. `g.` / `n.` / UTR / intron
+            //     are excluded.
+            //   * `prev_a.end + 2 == next_start` (gap of exactly 1 nt).
+            //   * `same_codon(prev_a.end, next_start)` — both endpoints
+            //     fall in the same 1-indexed codon. The right edge of
+            //     `prev_a` is what matters, so a chain that has already
+            //     grown via earlier strict merges can still extend via
+            //     codon-frame (issue #275 item 2).
+            //   * `prev_a.start <= prev_a.end` — `prev_a` is not an
+            //     insertion anchor (those use `start == end + 1`).
+            //   * `next_anchor` is a 1-position substitution OR deletion
+            //     (checked below): `next_anchor.start == next_anchor.end`
+            //     and `next_anchor.alt.len() <= 1`. Issue #275 item 3
+            //     relaxes the original `alt.len() == 1` requirement to
+            //     allow `sub`+`del` (and `del`+`sub` mirror) pairs.
             let codon_frame_eligible = !strict_adjacent
-                && prev_a.region == Region::Cds
+                && (prev_a.region == Region::Cds || prev_a.region == Region::Rna)
                 && prev_a.end.checked_add(2) == Some(next_start)
-                && prev_a.alt.len() == 1
-                && prev_a.start == prev_a.end
+                && prev_a.start <= prev_a.end
                 && same_codon(prev_a.end, next_start);
 
             if !strict_adjacent && !codon_frame_eligible {
@@ -135,8 +147,15 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
                 break 'try_merge false;
             };
             if codon_frame_eligible {
-                // Next must also be a single-base SUB anchor.
-                if next_anchor.alt.len() != 1 || next_anchor.start != next_anchor.end {
+                // Next must be a 1-position substitution OR deletion
+                // (issue #275 item 3 — `del` partners are eligible too).
+                // Insertions and multi-position delins are excluded:
+                // their position semantics ("between p and p+1" for ins,
+                // ranged for delins) don't satisfy "one variant
+                // separated by one nucleotide". A 1-position del has
+                // `start == end` and `alt.len() == 0`; a 1-position sub
+                // has `start == end` and `alt.len() == 1`.
+                if next_anchor.start != next_anchor.end || next_anchor.alt.len() > 1 {
                     break 'try_merge false;
                 }
                 // Look up the unchanged middle reference base. If the
@@ -144,7 +163,7 @@ pub(crate) fn merge_consecutive_edits<P: ReferenceProvider>(
                 // gap position, gracefully decline the codon-frame merge
                 // rather than erroring.
                 let Some(middle_ref) =
-                    lookup_cds_middle_ref(provider, output.last().unwrap(), prev_a.end + 1)
+                    lookup_codon_middle_ref(provider, output.last().unwrap(), prev_a.end + 1)
                 else {
                     break 'try_merge false;
                 };
@@ -529,28 +548,46 @@ pub(crate) fn same_codon(a: i64, b: i64) -> bool {
     (a - 1) / 3 == (b - 1) / 3
 }
 
-/// Look up the reference base at a CDS position on the head variant's
-/// transcript. Returns `None` if the head is not a `CdsVariant`, the
-/// provider has no transcript for the accession, the transcript has no
-/// `cds_start`, or the indexed position falls outside the transcript
-/// sequence. Used by the codon-frame merge to insert the unchanged
-/// middle nucleotide between two SUBs separated by one base; failure
-/// to look it up means the codon-frame merge is silently declined and
-/// the variants pass through unmerged.
-fn lookup_cds_middle_ref<P: ReferenceProvider>(
+/// Look up the reference base at a CDS-axis position on the head variant's
+/// transcript. Used by the codon-frame merge (issue #79, extended for
+/// `r.` and chains in #275) to insert the unchanged middle nucleotide
+/// between two edits separated by one base on the codon axis.
+///
+/// Returns `None` if:
+///   * the head is not a coding-axis variant (`c.` or `r.`);
+///   * the provider has no transcript for the accession;
+///   * the transcript has no `cds_start`;
+///   * `cds_axis < 1` (the codon-frame eligibility check already gates
+///     on `same_codon`, which requires positive values, but we still
+///     guard defensively);
+///   * the resolved transcript index falls outside the sequence.
+///
+/// Both `c.` and `r.` share the CDS-relative axis: in this codebase,
+/// `RnaPos` (see `hgvs/location.rs`) represents positions on the
+/// CDS-relative axis, and `Normalizer::rna_to_tx_pos` (in
+/// `normalize/mod.rs`) maps `r.N` to `cds_start + N - 1` in transcript
+/// coordinates — identical to the `c.N` mapping. This is a property
+/// of the in-repo coordinate model, not a generic HGVS-spec claim:
+/// other implementations sometimes use a transcript-relative `r.`
+/// axis instead. A single lookup therefore handles both `c.` and
+/// `r.`. Failure to look up the byte makes the codon-frame merge
+/// silently decline — the input pair passes through unmerged with
+/// no error.
+fn lookup_codon_middle_ref<P: ReferenceProvider>(
     provider: &P,
     head: &HgvsVariant,
     cds_axis: i64,
 ) -> Option<Base> {
-    let cds_var = match head {
-        HgvsVariant::Cds(v) => v,
+    let accession = match head {
+        HgvsVariant::Cds(v) => &v.accession,
+        HgvsVariant::Rna(v) => &v.accession,
         _ => return None,
     };
     if cds_axis < 1 {
         return None;
     }
     let tx = provider
-        .get_transcript(&cds_var.accession.transcript_accession())
+        .get_transcript(&accession.transcript_accession())
         .ok()?;
     let cds_start = tx.cds_start?;
     let tx_idx_1based = cds_start.checked_add(cds_axis as u64)?.checked_sub(1)?;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2812,13 +2812,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 other => other,
             })
             .collect();
-        // The codon-frame exception (`general.md:35-38`) only applies to
-        // `c.` variants on CDS-proper positions; `fetch_ref_for_canonical_split`
-        // already filters to those via `simple_cds_pos`, so the discriminant
-        // check below is sufficient. The exception fires inside
-        // `build_split_variants` for every embedded `[Sub; Identity; Sub]`
-        // triplet whose endpoints share a codon.
-        let codon_frame_aware = matches!(variant, HgvsVariant::Cds(_));
+        // The codon-frame exception (`general.md:35-38`) applies to any
+        // variant on the CDS-relative axis: `c.` (CDS proper) and `r.`
+        // (RNA CDS-relative; issue #275 item 1).
+        // `fetch_ref_for_canonical_split` already filters to CDS-proper
+        // positions via `simple_cds_pos` / `simple_rna_pos`, so the
+        // discriminant check below is sufficient. The exception fires
+        // inside `build_split_variants` for every embedded
+        // `[Sub; Identity; Sub]` triplet whose endpoints share a codon.
+        // Caveat: the `r.` branch of `fetch_ref_for_canonical_split`
+        // does not translate the RNA axis through `cds_start`, so for
+        // transcripts with `cds_start > 1` the ref window can be
+        // mis-aligned. The codon-frame split path inherits that latent
+        // bug. See #291 — the fix is to apply `rna_to_tx_pos` (or
+        // equivalent) before reading bytes.
+        let codon_frame_aware = matches!(variant, HgvsVariant::Cds(_) | HgvsVariant::Rna(_));
         build_split_variants(&variant, subedits, hgvs_start, codon_frame_aware)
     }
 
@@ -3248,11 +3256,17 @@ fn build_split_variants(
                     if merge::same_codon(cds_p1, cds_p3) {
                         // Codon-frame triplet preserved as a 3-base
                         // delins. `bm` is the unchanged ref byte from
-                        // `decompose_delins`. The codon-frame branch is
-                        // CDS-only (`codon_frame_aware` is `true` only
-                        // for `HgvsVariant::Cds`), so T/U recovery for
-                        // r. inputs is unnecessary here — r. variants
-                        // never reach this branch.
+                        // `decompose_delins`. Both `c.` and `r.` flow
+                        // through this branch (issue #275 item 1 set
+                        // `codon_frame_aware = true` for
+                        // `HgvsVariant::Cds` and `HgvsVariant::Rna`),
+                        // but no T/U recovery is needed here: the
+                        // emitted delins is rendered by the per-variant
+                        // formatter, and the `r.` formatter lowercases
+                        // all of its bases (T → u included) when it
+                        // prints the alt sequence. Forwarding the raw
+                        // ref byte from `decompose_delins` is therefore
+                        // safe for both coordinate systems.
                         flush_substitution_run(&mut output, template, hgvs_start, &mut run);
                         let s = abs(*p1);
                         let e = abs(*p3);

--- a/tests/issue_165_delins_sub_only_decompose.rs
+++ b/tests/issue_165_delins_sub_only_decompose.rs
@@ -121,16 +121,34 @@ fn tx_cis_allele_with_gap_decomposes() {
 }
 
 // =============================================================================
-// RNA (`r.`) — no codon frame, lowercase preserved.
+// RNA (`r.`) — codon-frame aware (issue #275 item 1), lowercase preserved.
 // =============================================================================
 
 #[test]
-fn rna_delins_with_gap_decomposes_lowercase() {
-    // r. spec requires lowercase rendering; the decomposition must
-    // preserve case on both the substituted ref and alt.
+fn rna_delins_with_gap_preserves_codon_frame_triplet_lowercase() {
+    // r. shares the CDS-relative axis with c. and follows the same
+    // codon-frame exception (issue #275 item 1). A `[Sub; Identity; Sub]`
+    // triplet whose endpoints share a codon stays as a single 3-base
+    // delins under the spec's `general.md:35-38` carve-out. Codon 4
+    // covers r.10..r.12, so the input round-trips. RNA display preserves
+    // lowercase on the user-declared alt bases.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:r.10_12delinsaca"),
-        "NM_TEST.1:r.[10c>a;12c>a]",
+        "NM_TEST.1:r.10_12delinsaca",
+    );
+}
+
+#[test]
+fn rna_delins_with_gap_decomposes_when_pair_straddles_codon_boundary() {
+    // r.12 sits in codon 4 and r.14 in codon 5, so the codon-frame
+    // exception does NOT apply. The `[Sub; Identity; Sub]` triplet must
+    // decompose into two separate subs per `general.md:34` (variants
+    // separated by ≥1 unchanged nt are described individually). Ref at
+    // r.12..r.14 is `CCC`; insert `aca` produces `c>a` at 12 and `c>a`
+    // at 14 with an unchanged middle.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.12_14delinsaca"),
+        "NM_TEST.1:r.[12c>a;14c>a]",
     );
 }
 

--- a/tests/issue_275_codon_frame_extensions.rs
+++ b/tests/issue_275_codon_frame_extensions.rs
@@ -1,0 +1,413 @@
+//! Codon-frame exception extensions (issue #275, follow-up to #79 / #104).
+//!
+//! PR #104 implemented the HGVS codon-frame exception for `c.` SNV pairs
+//! separated by one unchanged nucleotide. Three sibling cases were flagged
+//! as out of scope at the time:
+//!
+//! 1. `r.` coding regions — RNA coordinates use the same CDS-relative axis
+//!    as `c.`, and the same "two variants together affecting one amino acid"
+//!    rule applies. The merge pass should accept `Region::Rna` alongside
+//!    `Region::Cds`.
+//! 2. Chains involving 3+ SNVs across a codon — the original pair-detector
+//!    required `prev_a` to still be a single-base SUB anchor. A chain of
+//!    `sub`+`sub` (strict adjacency) followed by a gap-of-1 sub in the same
+//!    codon should still trigger the carve-out, even though `prev_a` has
+//!    already grown into a 2-base delins via the first merge.
+//! 3. `sub`+`del` pairs separated by one unchanged nucleotide — the pair
+//!    rule applied only when both endpoints were single-base subs. A del
+//!    on either side of a gap-of-1 pair within one codon still satisfies
+//!    the spec rationale ("together affecting one amino acid").
+//!
+//! Most tests use the same shared `simple_transcript` fixture as the existing
+//! `merge_consecutive_edits_tests.rs`, with `cds_start = 1` so `c.N` and
+//! `r.N` index the same transcript byte. Reference bases (1-indexed): the
+//! transcript sequence is `ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT...`,
+//! i.e. `c.1=A`, `c.2=T`, `c.3=G`, `c.4=C`, `c.5=A`, `c.6=A`, `c.7=A`,
+//! `c.8=A`, `c.9=A`, `c.10=C`, `c.11=C`, `c.12=C`, `c.13=C`, `c.14=C`,
+//! `c.15=G`, ...
+//!
+//! The minus-strand test uses its own ad-hoc provider so the codon-frame
+//! relaxation can be pinned on a `Strand::Minus` fixture — see
+//! `provider_simple_minus_strand` for the rationale.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Shared plus-strand fixture (`cds_start = 1`) used by almost every test
+/// in this file. Naming follows the `provider_simple()` / `normalize_with()`
+/// pattern from `tests/issue_165_delins_sub_only_decompose.rs`.
+fn provider_simple() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Minus-strand fixture with the same transcript-orientation sequence as
+/// `provider_simple()`. `lookup_codon_middle_ref` reads `tx.sequence`
+/// directly (transcript 5'→3' orientation) and never goes through the
+/// genome, so the codon-frame merge fires regardless of strand. This test
+/// pins that property — a parallel sibling to the plus-strand tests below.
+fn provider_simple_minus_strand() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_MINUS.1".to_string(),
+        Some("MINUS".to_string()),
+        Strand::Minus,
+        sequence,
+        Some(1),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Fixture with `cds_start = 10` so `c.-N` (5'UTR) and `c.*N` (3'UTR)
+/// positions are well-defined. Transcript-byte layout:
+///   tx pos:    1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 ...
+///   c. axis:  -9 -8 -7 -6 -5 -4 -3 -2 -1 1 2 3 4 5 ...
+///   base:      A T G C A A A A A  C  C  C  C  C ...
+/// CDS span = c.1..c.51 (cds_start=10, cds_end=60). 3'UTR begins at `c.*1`.
+fn provider_with_utr() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence: String =
+        "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+    let len = sequence.len() as u64;
+    let exons = vec![Exon::new(1, 1, len)];
+    let transcript = Transcript::new(
+        "NM_UTR.1".to_string(),
+        Some("UTR".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(10),
+        Some(60),
+        exons,
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+// =====================================================================
+// Item 1: codon-frame exception for `r.` coding regions.
+//
+// `r.` positions are CDS-relative (same axis as `c.`), so the same
+// codon-frame exception applies. The merged delins must preserve the
+// RNA-display convention (lowercase nucleotides).
+// =====================================================================
+
+#[test]
+fn codon_frame_rna_two_subs_one_codon() {
+    // r.10 = C, r.11 = C (middle ref), r.12 = C. Codon = 4 (positions
+    // 10-12). User-declared alts `g` and `a` are preserved. The middle
+    // ref base comes from the transcript sequence; r. display rules
+    // emit it lowercase.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.[10c>g;12c>a]"),
+        "NM_TEST.1:r.10_12delinsgca",
+    );
+}
+
+#[test]
+fn no_codon_frame_rna_pair_straddles_codon_boundary() {
+    // r.3 sits in codon 1 (positions 1-3); r.5 sits in codon 2
+    // (positions 4-6). Different codons → no merge.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.[3g>u;5a>c]"),
+        "NM_TEST.1:r.[3g>u;5a>c]",
+    );
+}
+
+#[test]
+fn no_codon_frame_rna_gap_of_two() {
+    // Gap of 2 nt is beyond the spec carve-out, which is exactly one.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.[10c>g;13c>a]"),
+        "NM_TEST.1:r.[10c>g;13c>a]",
+    );
+}
+
+// =====================================================================
+// Item 2: chains of 3+ SNVs across a codon.
+//
+// Original guard required `prev_a.alt.len() == 1`, blocking codon-frame
+// after a strict-adjacency merge has already grown `prev_a` into a 2+
+// base delins. After relaxation, a chain like `[sub at p; sub at p+1;
+// sub at p+3]` (strict 3 then gap-of-1 to same-codon) still merges into
+// a single delins covering the full span, then the post-merge decompose
+// pass splits it back per the codon-frame and `general.md:34` rules.
+// =====================================================================
+
+#[test]
+fn codon_frame_chain_strict_then_gap_in_next_codon() {
+    // Positions 3 (codon 1), 4 (codon 2), 6 (codon 2). 3+4 strict, 4+6
+    // gap-of-1 same-codon. Refs: c.3=G, c.4=C, c.5=A (middle), c.6=A.
+    //
+    // Trace:
+    //   Strict merge 3+4  →  delins[3,4] alt=TG.
+    //   Codon-frame [3,4] + 6 (relaxed)  →  delins[3,6] alt=TGAT
+    //     (middle ref=A injected at position 5).
+    //   Post-decompose: ref=GCAA vs alt=TGAT  →  Sub@3, Sub@4, Id@5, Sub@6.
+    //   build_split_variants (CDS, codon-frame aware) keeps Sub@3 alone
+    //     (no Sub-Id-Sub triplet starting at i=0); at i=1 the
+    //     [Sub@4; Id@5; Sub@6] triplet matches and same_codon(4,6) = codon 2,
+    //     so it emits as a single 3-base delins. The trailing Sub@3 falls
+    //     into the substitution run and flushes as `c.3G>T`.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[3G>T;4C>G;6A>T]"),
+        "NM_TEST.1:c.[3G>T;4_6delinsGAT]",
+    );
+}
+
+#[test]
+fn codon_frame_chain_rna_strict_then_gap_in_next_codon() {
+    // RNA analogue of the c. chain test above. Same positions, lowercase
+    // bases for r. display.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.[3g>u;4c>g;6a>u]"),
+        "NM_TEST.1:r.[3g>u;4_6delinsgau]",
+    );
+}
+
+#[test]
+fn no_codon_frame_chain_strict_then_gap_crosses_codon() {
+    // Positions 4, 5 (codon 2), 7 (codon 3). 4+5 strict, but 5+7 spans
+    // codons 2 and 3 — the codon-frame exception explicitly does NOT
+    // extend across codon boundaries. Result: a strict 2-base delins at
+    // [4,5] plus an unmerged sub at 7.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[4C>G;5A>C;7A>T]"),
+        "NM_TEST.1:c.[4_5delinsGC;7A>T]",
+    );
+}
+
+// =====================================================================
+// Item 3: sub+del pairs separated by one unchanged nucleotide.
+//
+// The exception fired only for sub+sub. With one of the two edits a
+// single-base del, the same spec rationale applies: two edits in one
+// codon together affecting one amino acid become a delins. The merge
+// extends a 1-base del (alt.len() == 0) the same way it extends a
+// 1-base sub.
+// =====================================================================
+
+#[test]
+fn codon_frame_sub_then_del_one_codon() {
+    // c.1 = A, c.2 = T (middle), c.3 = G. Codon 1. SUB at 1 replaces A
+    // with C; DEL at 3 removes the G. Merged span [1,3] with alt
+    // [C(sub), T(middle ref), <empty from del>] = "CT".
+    // Canonicalize: no shared affix between ATG and CT (prefix C vs A,
+    // suffix T vs G), so the form stays as a 3-base→2-base delins.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[1A>C;3del]"),
+        "NM_TEST.1:c.1_3delinsCT",
+    );
+}
+
+#[test]
+fn codon_frame_del_then_sub_one_codon() {
+    // DEL at 1, SUB C>A at 3 (ref G). Merged alt = [<empty>, T(middle
+    // ref), A(sub)] = "TA". Ref ATG vs alt TA: prefix T vs A no, suffix
+    // A vs G no — no trim. Final delins [1,3] alt "TA".
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[1del;3G>A]"),
+        "NM_TEST.1:c.1_3delinsTA",
+    );
+}
+
+#[test]
+fn codon_frame_sub_then_del_rna() {
+    // RNA analogue of sub+del: r. axis matches c. axis, so the same
+    // codon-frame rule applies. Lowercase bases per r. display.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:r.[1a>c;3del]"),
+        "NM_TEST.1:r.1_3delinsct",
+    );
+}
+
+#[test]
+fn no_codon_frame_sub_then_del_pair_straddles_codon_boundary() {
+    // SUB at 12 (codon 4), DEL at 14 (codon 5) → different codons, no
+    // merge. Position 14 is the last C in the CCCCC run at positions
+    // 10-14, next base is G at 15, so the del does not right-shift.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[12C>G;14del]"),
+        "NM_TEST.1:c.[12C>G;14del]",
+    );
+}
+
+#[test]
+fn no_codon_frame_sub_then_del_gap_of_two() {
+    // Gap of 2 nt (positions 3 apart) exceeds the spec carve-out, which
+    // is exactly one unchanged base. SUB at 1 + DEL at 4 (stable: next
+    // base at 5 is A). The pair passes through unchanged.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[1A>C;4del]"),
+        "NM_TEST.1:c.[1A>C;4del]",
+    );
+}
+
+// =====================================================================
+// Extra coverage for cases the relaxation now admits.
+//
+// These tests pin the behavior of inputs that the merge-eligibility
+// check accepts but the original issue scope did not enumerate. For
+// each, the assertion reflects the spec rationale ("two variants in
+// one codon together affecting one amino acid → emit as a delins").
+// =====================================================================
+
+#[test]
+fn codon_frame_del_then_del_one_codon() {
+    // Both endpoints are single-base deletions; codon-frame eligibility
+    // requires `prev_a.start <= prev_a.end` and `next.alt.len() <= 1`,
+    // which a 1-base del (start == end, alt empty) satisfies on both
+    // sides. c.1=A, c.2=T (middle), c.3=G — codon 1. Two dels in one
+    // codon leave only the middle T, an unambiguous "two edits together
+    // affecting one amino acid" case, so the spec rationale supports
+    // merging. Merged alt = [<empty>, T, <empty>] = "T". Ref ATG vs alt
+    // T: prefix A vs T no, suffix G vs T no — final delins [1,3] alt
+    // "T". The post-merge canonicalization (issue #165 path) decomposes
+    // the resulting delins only when interior identities show up between
+    // two SUB edges, so a sub-only split does not fire here.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[1del;3del]"),
+        "NM_TEST.1:c.1_3delinsT",
+    );
+}
+
+#[test]
+fn codon_frame_multibase_delins_head_then_sub_one_codon() {
+    // User-supplied multi-base delins as the chain head. The merge pass
+    // alone would not eat it (anchor_for_variant would yield
+    // `start=3, end=4`, not the 1-base shape codon-frame requires), but
+    // the post-canonicalization split decomposes `c.3_4delinsCG` into
+    // its component subs first — `c.3G>C` and `c.4C>G` — and the merge
+    // pass then chains those with the trailing sub at c.6 (codon 2). The
+    // 4+6 gap-of-1 leg is codon-frame eligible and fires. End state:
+    //   strict merge 3+4 → delins[3,4] alt=CG.
+    //   codon-frame [3,4] + 6 → delins[3,6] alt=CGAT.
+    //   post-decompose: ref GCAA vs alt CGAT → Sub@3, Sub@4, Id@5, Sub@6.
+    //   build_split_variants emits Sub@3 (`c.3G>C`), then the
+    //   [Sub@4; Id@5; Sub@6] triplet in codon 2 as a 3-base delins.
+    // The relaxation's spec rationale applies cleanly here: codons 1
+    // (c.3 alone) and 2 (c.4..6 together) each emit in canonical form.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[3_4delinsCG;6A>T]"),
+        "NM_TEST.1:c.[3G>C;4_6delinsGAT]",
+    );
+}
+
+// =====================================================================
+// Negative coverage: intronic / UTR / wrong-region inputs must NOT
+// trigger the relaxed codon-frame path.
+//
+// The codon-frame eligibility check in `merge_consecutive_edits` requires
+// `Region::Cds` or `Region::Rna`. `simple_cds_pos` / `simple_rna_pos`
+// reject intronic offsets outright (return None), and 5'UTR / 3'UTR
+// positions map to `Region::FivePrimeUtr` / `Region::ThreePrimeUtr` and
+// therefore fail the region match. Both rejections leave the chain
+// un-merged.
+// =====================================================================
+
+#[test]
+fn no_codon_frame_intronic_offset_pair() {
+    // c.1+1A>T sits on an intronic offset (`base=1, offset=+1`), which
+    // `simple_cds_pos` rejects via `pos.is_intronic()`. The pair never
+    // becomes a merge candidate, so it passes through unchanged.
+    assert_eq!(
+        normalize_with(provider_simple(), "NM_TEST.1:c.[1+1A>T;3G>A]"),
+        "NM_TEST.1:c.[1+1A>T;3G>A]",
+    );
+}
+
+#[test]
+fn no_codon_frame_five_prime_utr_pair() {
+    // c.-3 and c.-1 both live in the 5'UTR. `simple_cds_pos` returns
+    // `Region::FivePrimeUtr` rather than `Region::Cds`, and the
+    // codon-frame eligibility check explicitly fails the
+    // `Region::Cds | Region::Rna` filter. UTR positions are not part of
+    // the CDS-relative codon grid, so the relaxation must not fire.
+    assert_eq!(
+        normalize_with(provider_with_utr(), "NM_UTR.1:c.[-3C>G;-1A>T]"),
+        "NM_UTR.1:c.[-3C>G;-1A>T]",
+    );
+}
+
+#[test]
+fn no_codon_frame_three_prime_utr_pair() {
+    // c.*1 and c.*3 are 3'UTR (`utr3=true`), which `simple_cds_pos`
+    // tags as `Region::ThreePrimeUtr`. Same rationale as the 5'UTR
+    // case: outside the CDS codon grid, no relaxation. Refs at the
+    // matching transcript positions follow the test fixture
+    // (`provider_with_utr` uses `cds_start = 10`, `cds_end = 60`, so
+    // c.*1 maps to transcript index 61). Out-of-fixture refs are
+    // unimportant — the assertion only requires that the codon-frame
+    // path does not fire.
+    assert_eq!(
+        normalize_with(provider_with_utr(), "NM_UTR.1:c.[*1A>G;*3C>T]"),
+        "NM_UTR.1:c.[*1A>G;*3C>T]",
+    );
+}
+
+// =====================================================================
+// Minus-strand transcript: the codon-frame relaxation must fire on
+// `Strand::Minus` fixtures too. `lookup_codon_middle_ref` reads
+// `tx.sequence` directly (transcript 5'→3' orientation), which is
+// strand-independent — the merge pass does not consult genomic
+// orientation at all.
+// =====================================================================
+
+#[test]
+fn codon_frame_minus_strand_two_subs_one_codon() {
+    // Mirror of `codon_frame_rna_two_subs_one_codon` but on a minus-
+    // strand fixture. r.10 = C, r.11 = C (middle ref), r.12 = C in
+    // transcript orientation. The codon-frame merge fires identically.
+    assert_eq!(
+        normalize_with(provider_simple_minus_strand(), "NM_MINUS.1:r.[10c>g;12c>a]",),
+        "NM_MINUS.1:r.10_12delinsgca",
+    );
+}


### PR DESCRIPTION
## Summary

Extends the HGVS codon-frame exception (from #79 / PR #104) beyond the original two-`c.`-SNV case to the three sibling shapes the spec rationale also covers.

- **`r.` coding regions** — was `c.`-only. RNA shares the CDS-relative coordinate axis in this codebase (`RnaPos` doc, `rna_to_tx_pos`), so the rewrite path now branches on `Region::Cds | Region::Rna`.
- **Three-or-more-SNV chains across a codon** — the pair-detector now admits chain extension via the `prev_a.start <= prev_a.end` relaxation.
- **`sub`+`del` (and `del`+`sub`) pairs separated by one unchanged nucleotide** — the next-anchor gate now accepts `next_anchor.alt.len() <= 1`.

`build_split_variants`' `codon_frame_aware` flag fires for both `Cds` and `Rna` so the post-decompose triplet preservation path also covers `r.`. `lookup_cds_middle_ref` is renamed `lookup_codon_middle_ref` and reads CDS-axis bytes for both head variants.

## Tests

`tests/issue_275_codon_frame_extensions.rs` — 16 tests pinning the three sub-items plus negative guards (codon-straddling chains, intronic offsets, 5′UTR / 3′UTR positions, minus-strand fixture). `tests/issue_165_delins_sub_only_decompose.rs` is updated to reflect that RNA now goes through codon-frame.

## Notable

While implementing this, a latent defect surfaced in `fetch_ref_for_canonical_split`'s `r.` branch (does not translate through `cds_start`). Pre-existing — does not affect this PR's correctness for `cds_start = 1` fixtures — and tracked separately as #291.

## Out of scope

- Hardening `fetch_ref_for_canonical_split` for `cds_start != 1` — tracked as #291.

## Review

Two-reviewer cycle (Opus + Sonnet) before push; feedback addressed in this commit.

## Test plan

- [x] `cargo nextest run --features dev` — 4750 pass / 0 fail / 51 skipped.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

Closes #275. Follow-up to #104 / #79.