### PR TITLE
fix(display): canonicalize r. emission T→u in repeat units and bases (closes #276)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -72,10 +72,19 @@ impl Base {
         self as u8
     }
 
-    /// Convert to lowercase ASCII character (for RNA display).
+    /// Convert to lowercase ASCII character for RNA `Display`.
+    ///
+    /// Per HGVS v21.0, the RNA nucleotide alphabet is `a/c/g/u`. Any
+    /// thymine byte that reaches an RNA emission path (lenient `T`/`t`
+    /// input on `r.`, cross-coordinate translation, or canonicalization
+    /// that surfaces an unseen `T`) is translated to `u` here, not just
+    /// case-folded. See issue #276.
     #[inline]
     pub fn to_lowercase_char(self) -> char {
-        (self as u8).to_ascii_lowercase() as char
+        match self {
+            Base::T => 'u',
+            _ => (self as u8).to_ascii_lowercase() as char,
+        }
     }
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3636,15 +3636,13 @@ mod tests {
         assert_eq!(format!("{}", result), "NM_000088.3:c.2T>C");
 
         // r. twin: same collapse on the RNA path. NM_000088.3 has cds_start = 1,
-        // so r.1_3 maps to the same ATG run and the residual is at r.2.
-        // The substitution edit Display lowercases the reference byte but does
-        // not map T -> u for r. variants synthesized by canonicalize_delins,
-        // so the locked form is `r.2t>c` rather than the spec-ideal `r.2u>c`.
-        // RNA U/T mapping for synthesized substitutions is a separate display-
-        // layer concern (see `NaEdit::Substitution` in src/hgvs/edit.rs).
+        // so r.1_3 maps to the same ATG run and the residual is at r.2. The
+        // residual ref byte is DNA `T` (sourced from the c. axis), which the
+        // RNA `Display` path canonicalizes to `u` per the HGVS RNA alphabet
+        // (see issue #276 / `NaEdit::Substitution` in src/hgvs/edit.rs).
         let variant = parse_hgvs("NM_000088.3:r.1_3delinsacg").unwrap();
         let result = normalizer.normalize(&variant).unwrap();
-        assert_eq!(format!("{}", result), "NM_000088.3:r.2t>c");
+        assert_eq!(format!("{}", result), "NM_000088.3:r.2u>c");
     }
 
     #[test]

--- a/tests/del_shift_matrix.rs
+++ b/tests/del_shift_matrix.rs
@@ -774,12 +774,10 @@ mod rna_plus {
     #[case("acgcagcagcaugacguacg", "r.{0}_{1}del", &[3u64, 8u64], "r.{0}_{1}gca[1]", &[3u64, 11u64])]
     #[case("acaaaacguacguacguac", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}del", &[3u64, 6u64])]
     #[case("uugcagcagcauuacguacgu", "r.{0}_{1}del", &[4u64, 9u64], "r.{0}_{1}gca[1]", &[3u64, 11u64])]
-    // Case 6 (finer periodicity) uses an AC tandem rather than AT to avoid
-    // a pre-existing limitation in the RNA Display path for repeat-form output:
-    // when the unit contains 'T' (DNA), the lowercase RNA emission keeps the
-    // 't' instead of converting to 'u'. Filed as a follow-up. The genomic/cds/
-    // noncoding modules use the AT tandem which is correct for DNA emission.
-    #[case("ccacacacacacccguacgu", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}ac[3]", &[3u64, 12u64])]
+    // Case 6 (finer periodicity): AU tandem mirrors the genomic/cds/noncoding
+    // AT tandem after #276's RNA `Display` canonicalization (T→u). Prior to
+    // that fix this case used an AC tandem as a workaround.
+    #[case("ccauauauauauccguacgu", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}au[3]", &[3u64, 12u64])]
     fn multi_base_del_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -908,8 +906,8 @@ mod rna_minus {
     #[case("acgcagcagcaugacguacg", "r.{0}_{1}del", &[3u64, 8u64], "r.{0}_{1}gca[1]", &[3u64, 11u64])]
     #[case("acaaaacguacguacguac", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}del", &[3u64, 6u64])]
     #[case("uugcagcagcauuacguacgu", "r.{0}_{1}del", &[4u64, 9u64], "r.{0}_{1}gca[1]", &[3u64, 11u64])]
-    // Case 6 (finer periodicity): see comment in rna_plus module.
-    #[case("ccacacacacacccguacgu", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}ac[3]", &[3u64, 12u64])]
+    // Finer-periodicity case: see comment in rna_plus module.
+    #[case("ccauauauauauccguacgu", "r.{0}_{1}del", &[3u64, 6u64], "r.{0}_{1}au[3]", &[3u64, 12u64])]
     fn multi_base_del_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/dup_shift_matrix.rs
+++ b/tests/dup_shift_matrix.rs
@@ -678,10 +678,10 @@ mod rna_plus {
     #[case("acaaaacguacguacguac", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}a[8]", &[3u64, 6u64])]
     #[case("acgcagcagcaugacguacg", "r.{0}_{1}dup", &[3u64, 8u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
     #[case("uugcagcagcauuacguacgu", "r.{0}_{1}dup", &[4u64, 9u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
-    // Finer-periodicity case uses an AC tandem rather than AT to avoid the
-    // pre-existing limitation in the RNA Display path for repeat-form output
-    // when the unit contains 'T' (DNA) — see comment in del_shift_matrix.rs.
-    #[case("ccacacacacacccguacgu", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}ac[7]", &[3u64, 12u64])]
+    // Finer-periodicity case mirrors the genomic/cds/noncoding AT tandem
+    // (here AU) after #276's RNA `Display` canonicalization (T→u). Prior to
+    // that fix this case used an AC tandem as a workaround.
+    #[case("ccauauauauauccguacgu", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}au[7]", &[3u64, 12u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -797,7 +797,8 @@ mod rna_minus {
     #[case("acaaaacguacguacguac", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}a[8]", &[3u64, 6u64])]
     #[case("acgcagcagcaugacguacg", "r.{0}_{1}dup", &[3u64, 8u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
     #[case("uugcagcagcauuacguacgu", "r.{0}_{1}dup", &[4u64, 9u64], "r.{0}_{1}gca[5]", &[3u64, 11u64])]
-    #[case("ccacacacacacccguacgu", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}ac[7]", &[3u64, 12u64])]
+    // Finer-periodicity case: see comment in rna_plus module.
+    #[case("ccauauauauauccguacgu", "r.{0}_{1}dup", &[3u64, 6u64], "r.{0}_{1}au[7]", &[3u64, 12u64])]
     fn multi_base_dup_of_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/issue_231_rna_lowercase_coverage.rs
+++ b/tests/issue_231_rna_lowercase_coverage.rs
@@ -13,11 +13,10 @@
 //! 1. lowercase input round-trips through `parse` → `Display`,
 //! 2. uppercase/mixed input is silently canonicalized to lowercase on
 //!    `Display` (lenient input policy),
-//! 3. `T`/`t` input is retained as lowercase `t` — the parser is
-//!    lenient about thymine in `r.` variants and does **not**
-//!    rewrite it to `u`. This pins observed behavior; whether to
-//!    reject `t` or canonicalize to `u` is a parser-policy question
-//!    out of scope for this audit.
+//! 3. `T`/`t` input is accepted (lenient parser policy — see #282 for
+//!    whether the parser should reject thymine on `r.`) but
+//!    canonicalized to `u` on `Display` per the HGVS RNA alphabet —
+//!    see issue #276.
 //!
 //! The predicted-wrapper form (`r.(<edit>)`) is intentionally NOT
 //! covered here — probing shows the parens are dropped on `Display`
@@ -69,13 +68,16 @@ mod substitution {
         assert_canonicalizes_to(&format!("{ACC}:r.123a>G"), &format!("{ACC}:r.123a>g"));
     }
 
-    /// Thymine input is accepted and emitted as lowercase `t` — pins
-    /// the lenient parser policy. The spec prefers `u`; a future
-    /// parser tightening would reject `t` (or canonicalize to `u`).
+    /// Thymine input is accepted (lenient parser policy — see #282)
+    /// but canonicalized to `u` on `Display` per the HGVS RNA
+    /// alphabet — see #276. A future parser tightening that rejects
+    /// `t` on `r.` would make the lenient-input cases below
+    /// unreachable, but the canonical alphabet expectation here is
+    /// independent of that policy.
     #[test]
-    fn thymine_input_is_retained_as_lowercase_t() {
-        assert_round_trips(&format!("{ACC}:r.123a>t"));
-        assert_canonicalizes_to(&format!("{ACC}:r.123A>T"), &format!("{ACC}:r.123a>t"));
+    fn thymine_input_is_canonicalized_to_u_on_display() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123a>t"), &format!("{ACC}:r.123a>u"));
+        assert_canonicalizes_to(&format!("{ACC}:r.123A>T"), &format!("{ACC}:r.123a>u"));
     }
 }
 
@@ -115,12 +117,17 @@ mod deletion {
         );
     }
 
+    /// Thymine in stated-ref bases is canonicalized to `u` on
+    /// `Display` per #276 (parser remains lenient — see #282).
     #[test]
-    fn thymine_in_stated_ref_is_retained_as_lowercase_t() {
-        assert_round_trips(&format!("{ACC}:r.123_125delaut"));
+    fn thymine_in_stated_ref_is_canonicalized_to_u_on_display() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125delaut"),
+            &format!("{ACC}:r.123_125delauu"),
+        );
         assert_canonicalizes_to(
             &format!("{ACC}:r.123_125delAUT"),
-            &format!("{ACC}:r.123_125delaut"),
+            &format!("{ACC}:r.123_125delauu"),
         );
     }
 }

--- a/tests/issue_276_rna_display_t_to_u.rs
+++ b/tests/issue_276_rna_display_t_to_u.rs
@@ -1,0 +1,308 @@
+//! Issue #276 — RNA `Display` must canonicalize DNA `T` to RNA `u`.
+//!
+//! Per HGVS v21.0, the RNA nucleotide alphabet is `a/c/g/u`. The
+//! `Display` path on `RnaVariant` (and any `NaEdit::to_rna_string`
+//! callsite) must emit `u` for any thymine byte, regardless of whether
+//! that thymine entered the AST via:
+//!
+//! 1. lenient parsing of an `r.` input that contained `T`/`t` (the
+//!    spec prefers `u`, but the parser is currently lenient about
+//!    thymine input — see #282 for the parser-side policy decision),
+//! 2. cross-coordinate translation (e.g. converting / decomposing
+//!    from a `c.` representation that holds DNA bases), or
+//! 3. shuffle/repeat-canonicalization that surfaces a previously
+//!    unseen `T` in the emitted unit.
+//!
+//! Surfaced by PR #106 and PR #107's 3'-shift coverage matrices for
+//! `del` and `dup`, where the RNA module's finer-periodicity sub-case
+//! had to work around the bug by using an `AC` tandem rather than the
+//! genomic/cds/noncoding modules' `AT` tandem. See
+//! `tests/del_shift_matrix.rs` for the comment trail.
+//!
+//! Probe shapes covered here:
+//! - `r.<pos><unit-with-T>[N]` (repeat-unit emission, the original
+//!   regression),
+//! - `r.<a>_<b>insT...` / `r.<pos>delT` / `r.<pos>dupT` (stated-base
+//!   forms across edit shapes — all share the same `to_lowercase_char`
+//!   / `to_lowercase_string` helper),
+//! - `r.<pos>A>T` (substitution alt),
+//! - `r.<a>_<b>delT...insT...` (delins both legs),
+//! - `r.<a>_<b>invT...` (inversion stated ref),
+//! - compound cis bracketed member with `T`.
+
+use ferro_hgvs::parse_hgvs;
+
+const ACC: &str = "NM_000088.3";
+
+/// Parse `input`, format via `Display`, assert it equals `expected`.
+#[track_caller]
+fn assert_canonicalizes_to(input: &str, expected: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, expected, "input={input:?}");
+}
+
+// ----------------------------------------------------------------------
+// Repeat units — the original regression from PR #106 / PR #107.
+// ----------------------------------------------------------------------
+
+mod repeat_unit {
+    use super::*;
+
+    /// Lowercase `at[5]` input — the unit is already lowercase but
+    /// contains a DNA `T`. `Display` must emit `u`, not `t`.
+    #[test]
+    fn lowercase_unit_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123at[5]"), &format!("{ACC}:r.123au[5]"));
+    }
+
+    /// Uppercase `AT[5]` input — mixed-case lenient input. `Display`
+    /// lowercases A→a and translates T→u.
+    #[test]
+    fn uppercase_unit_with_t_canonicalizes_to_au() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123AT[5]"), &format!("{ACC}:r.123au[5]"));
+    }
+
+    /// Mixed-case `At[5]` input — A→a, T→u.
+    #[test]
+    fn mixed_case_unit_with_t_canonicalizes_to_au() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123At[5]"), &format!("{ACC}:r.123au[5]"));
+    }
+
+    /// Multi-byte unit `gat[3]` — all-lowercase but contains `t`.
+    /// Pins that the translation is per-byte, not just leading.
+    #[test]
+    fn multi_byte_unit_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123gat[3]"), &format!("{ACC}:r.123gau[3]"));
+    }
+
+    /// Multi-`T` unit `att[4]` — pins that every `t` byte in the
+    /// emitted unit becomes `u`, not just the first.
+    #[test]
+    fn multi_t_unit_canonicalizes_each_t_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123att[4]"), &format!("{ACC}:r.123auu[4]"));
+    }
+}
+
+// ----------------------------------------------------------------------
+// Substitution alt with `T`.
+// ----------------------------------------------------------------------
+
+mod substitution {
+    use super::*;
+
+    #[test]
+    fn lowercase_t_alt_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123a>t"), &format!("{ACC}:r.123a>u"));
+    }
+
+    #[test]
+    fn uppercase_t_alt_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123A>T"), &format!("{ACC}:r.123a>u"));
+    }
+
+    /// `t>g` — ref with `T`. The ref position is the leg that
+    /// previously rendered as lowercase `t` on r. Display.
+    #[test]
+    fn lowercase_t_ref_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123t>g"), &format!("{ACC}:r.123u>g"));
+    }
+}
+
+// ----------------------------------------------------------------------
+// Deletion / Duplication / Inversion stated-ref forms.
+// ----------------------------------------------------------------------
+
+mod deletion {
+    use super::*;
+
+    #[test]
+    fn stated_ref_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125delaut"),
+            &format!("{ACC}:r.123_125delauu"),
+        );
+    }
+
+    #[test]
+    fn uppercase_stated_ref_with_t_canonicalizes() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125delAUT"),
+            &format!("{ACC}:r.123_125delauu"),
+        );
+    }
+
+    #[test]
+    fn single_base_del_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123delT"), &format!("{ACC}:r.123delu"));
+    }
+}
+
+mod duplication {
+    use super::*;
+
+    #[test]
+    fn stated_ref_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125dupaut"),
+            &format!("{ACC}:r.123_125dupauu"),
+        );
+    }
+
+    #[test]
+    fn uppercase_stated_ref_with_t_canonicalizes() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125dupAUT"),
+            &format!("{ACC}:r.123_125dupauu"),
+        );
+    }
+
+    /// Single-base `dupT` — mirrors the single-base `delT` case in the
+    /// `deletion` module. Pins that the dup stated-base path also
+    /// translates a lone `T` byte to `u`.
+    #[test]
+    fn single_base_dup_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(&format!("{ACC}:r.123dupT"), &format!("{ACC}:r.123dupu"));
+    }
+}
+
+mod inversion {
+    use super::*;
+
+    #[test]
+    fn stated_ref_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125invaut"),
+            &format!("{ACC}:r.123_125invauu"),
+        );
+    }
+
+    #[test]
+    fn uppercase_stated_ref_with_t_canonicalizes() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125invAUT"),
+            &format!("{ACC}:r.123_125invauu"),
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Insertion / Delins — inserted alt with `T`.
+// ----------------------------------------------------------------------
+
+mod insertion {
+    use super::*;
+
+    #[test]
+    fn inserted_alt_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_124insAT"),
+            &format!("{ACC}:r.123_124insau"),
+        );
+    }
+
+    #[test]
+    fn lowercase_inserted_alt_with_t_canonicalizes() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_124insat"),
+            &format!("{ACC}:r.123_124insau"),
+        );
+    }
+}
+
+mod delins {
+    use super::*;
+
+    /// Both legs contain a `T`. Both must translate to `u`.
+    #[test]
+    fn t_in_both_ref_and_alt_canonicalize_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125delAUTinsT"),
+            &format!("{ACC}:r.123_125delauuinsu"),
+        );
+    }
+
+    #[test]
+    fn t_only_in_alt_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125delinsTTT"),
+            &format!("{ACC}:r.123_125delinsuuu"),
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Identity stated-ref — `r.<pos>...=` form. Pins canonicalization on
+// the `=` (no-change) edit branch.
+// ----------------------------------------------------------------------
+
+mod identity {
+    use super::*;
+
+    /// Stated-ref `auT=` — Identity with a `T` byte in the ref-leg.
+    /// `Display` must emit `auu=`, mirroring the `del`/`dup`/`inv`
+    /// stated-ref branches.
+    #[test]
+    fn stated_ref_with_t_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125auT="),
+            &format!("{ACC}:r.123_125auu="),
+        );
+    }
+
+    /// Uppercase `AUT=` — mixed-case lenient input through the
+    /// Identity branch.
+    #[test]
+    fn uppercase_stated_ref_with_t_canonicalizes() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123_125AUT="),
+            &format!("{ACC}:r.123_125auu="),
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Multi-unit repeat — `<unit1>[N]<unit2>[M]...` form. Pins that every
+// unit's bytes are canonicalized, not just the first.
+// ----------------------------------------------------------------------
+
+mod multi_repeat {
+    use super::*;
+
+    /// First unit `aT[3]` contains a `T`; second unit `ac[2]` is pure
+    /// RNA. `Display` must translate the `T` in the first unit to `u`
+    /// while leaving the second unit untouched.
+    #[test]
+    fn t_in_first_unit_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123aT[3]ac[2]"),
+            &format!("{ACC}:r.123au[3]ac[2]"),
+        );
+    }
+
+    /// `T` in the second unit — pins that the per-unit translation
+    /// runs across every unit, not just the first.
+    #[test]
+    fn t_in_second_unit_canonicalizes_to_u() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.123ac[2]aT[3]"),
+            &format!("{ACC}:r.123ac[2]au[3]"),
+        );
+    }
+}
+
+// ----------------------------------------------------------------------
+// Compound cis allele bracket — pins canonicalization inside `[...;...]`.
+// ----------------------------------------------------------------------
+
+mod compound_cis {
+    use super::*;
+
+    #[test]
+    fn member_with_t_canonicalizes_inside_brackets() {
+        assert_canonicalizes_to(
+            &format!("{ACC}:r.[123A>T;200_202delinsTTT]"),
+            &format!("{ACC}:r.[123a>u;200_202delinsuuu]"),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The RNA `Display` path lowercased bytes without translating DNA `T` to RNA `U`, so emitted repeat units and bases containing `T` rendered as `t` instead of the spec-canonical `u`. Fix is a single arm in `Base::to_lowercase_char` (`src/hgvs/edit.rs`) mapping `Base::T` → `'u'`. Every `NaEdit::to_rna_string` callsite — substitution, deletion, insertion, duplication, inversion, delins, repeat, multi-repeat, identity stated-ref, deleted-ref legs, compound brackets — routes through this single helper.

## Test cleanup

PRs #106 / #107 worked around this bug in their 3'-shift coverage matrices by switching the finer-periodicity RNA cases to an `AC` tandem instead of the original `AT`. Both workarounds are removed and the matrices restored to the spec-equivalent `AU` tandem. Two pre-existing tests in `tests/issue_231_rna_lowercase_coverage.rs` that pinned the buggy behavior are renamed and updated to lock the canonical form.

## Tests

`tests/issue_276_rna_display_t_to_u.rs` — 25 tests pinning T→u canonicalization across substitution, deletion, insertion, duplication, inversion, delins, identity stated-ref, repeat units, multi-repeat units, and compound brackets.

## Review

Two-reviewer cycle (Opus + Sonnet) before push. Both verdicts: OK. Feedback (extra tests for `identity` / `multi_repeat` / single-base `dup`, CHANGELOG entry, comment alignment) addressed in this commit.

## Out of scope

- Parser-side `t` policy for `r.` (whether to reject `t` on input or canonicalize) — tracked separately as #282.

## Test plan

- [x] `cargo nextest run --features dev` — 4768 pass / 0 fail / 51 skipped.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

Closes #276. Follow-up to #106 / #107.