### PR TITLE
feat(parser): whole-entity predicted forms for m./o./n. variants (closes #288)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1979,6 +1979,50 @@ fn parse_tx_variant(
     move |input: &str| {
         let (input, _) = tag("n.").parse(input)?;
 
+        // First try whole-tx identity (n.= or n.(=)) - no position. #288.
+        // Non-coding transcripts reuse the RNA whole-entity parsers
+        // (`parse_whole_rna_*`, `parse_rna_no_product`) — those are pure
+        // tag-only parsers and don't depend on the coord system.
+        if let Ok((remaining, edit)) = parse_whole_rna_identity(input) {
+            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+            return Ok((
+                remaining,
+                HgvsVariant::Tx(TxVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
+
+        // Try whole-tx unknown (n.? or n.(?)) - no position. #288.
+        if let Ok((remaining, edit)) = parse_whole_rna_unknown(input) {
+            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+            return Ok((
+                remaining,
+                HgvsVariant::Tx(TxVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
+
+        // Try tx-specific no product pattern (n.0 or predicted n.(0)). #288.
+        // `0` is a valid spec form for non-coding transcripts — they can
+        // fail to produce a transcript, exactly like `r.0`.
+        if let Ok((remaining, edit)) = parse_rna_no_product(input) {
+            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+            return Ok((
+                remaining,
+                HgvsVariant::Tx(TxVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
+
         // Compact-prefix trans-allele shorthand: n.[a];[b]. Mirrors
         // parse_genome_variant's dispatch added in PR #146; the expanded
         // form [ACC:n.a];[ACC:n.b] is handled by the top-level allele parser.
@@ -2258,6 +2302,36 @@ fn parse_mt_variant(
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("m.").parse(input)?;
+
+        // First try whole-mtDNA identity (m.= or m.(=)) - no position. #288.
+        // Mitochondrial DNA reuses the genome whole-entity parser because
+        // both share `GenomeInterval`.
+        if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
+            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+            let dummy_interval = GenomeInterval::point(dummy_pos);
+            return Ok((
+                remaining,
+                HgvsVariant::Mt(MtVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
+
+        // Try whole-mtDNA unknown (m.? or m.(?)) - no position. #288.
+        if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
+            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+            let dummy_interval = GenomeInterval::point(dummy_pos);
+            return Ok((
+                remaining,
+                HgvsVariant::Mt(MtVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
 
         // Compact-prefix trans-allele shorthand: m.[a];[b]. Mirrors
         // parse_genome_variant's dispatch added in PR #146.
@@ -3476,6 +3550,36 @@ fn parse_circular_variant(
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("o.").parse(input)?;
+
+        // First try whole-circular identity (o.= or o.(=)) - no position. #288.
+        // Circular DNA reuses the genome whole-entity parser because both
+        // share `GenomeInterval`; SVD-WG006 inherits the DNA grammar.
+        if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
+            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+            let dummy_interval = GenomeInterval::point(dummy_pos);
+            return Ok((
+                remaining,
+                HgvsVariant::Circular(CircularVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
+
+        // Try whole-circular unknown (o.? or o.(?)) - no position. #288.
+        if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
+            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+            let dummy_interval = GenomeInterval::point(dummy_pos);
+            return Ok((
+                remaining,
+                HgvsVariant::Circular(CircularVariant {
+                    accession: accession.clone(),
+                    gene_symbol: gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                }),
+            ));
+        }
 
         // Compact-prefix trans-allele shorthand: o.[a];[b]. Mirrors
         // parse_genome_variant's dispatch added in PR #146; SVD-WG006 says

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1259,6 +1259,17 @@ pub struct TxVariant {
 
 impl TxVariant {
     fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // For whole-entity identity / unknown / no-product (n.=, n.?, n.0
+        // and their predicted wrappers n.(=), n.(?), n.(0)), skip the
+        // position. #288 — mirrors the same short-circuits on g./c./r..
+        if let Some(edit) = self.loc_edit.edit.inner() {
+            if edit.is_whole_entity_identity()
+                || edit.is_whole_entity_unknown()
+                || edit.is_no_product()
+            {
+                return write!(f, "{}", self.loc_edit.edit);
+            }
+        }
         // Predicted form: wrap position+edit in parens. #241.
         if self.loc_edit.edit.is_uncertain() {
             if let Some(edit) = self.loc_edit.edit.inner() {
@@ -1379,6 +1390,15 @@ pub struct MtVariant {
 
 impl MtVariant {
     fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // For whole-entity identity / unknown (m.=, m.? and their
+        // predicted wrappers m.(=), m.(?)), skip the position. #288 —
+        // mirrors the genome short-circuit. There is no m.0 form
+        // (DNA isn't "produced"), so no-product isn't accepted here.
+        if let Some(edit) = self.loc_edit.edit.inner() {
+            if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
+                return write!(f, "{}", self.loc_edit.edit);
+            }
+        }
         // Predicted form: wrap position+edit in parens. #241.
         if self.loc_edit.edit.is_uncertain() {
             if let Some(edit) = self.loc_edit.edit.inner() {
@@ -1410,6 +1430,14 @@ pub struct CircularVariant {
 
 impl CircularVariant {
     fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // For whole-entity identity / unknown (o.=, o.? and their
+        // predicted wrappers o.(=), o.(?)), skip the position. #288 —
+        // mirrors the genome short-circuit. There is no o.0 form.
+        if let Some(edit) = self.loc_edit.edit.inner() {
+            if edit.is_whole_entity_identity() || edit.is_whole_entity_unknown() {
+                return write!(f, "{}", self.loc_edit.edit);
+            }
+        }
         // Predicted form: wrap position+edit in parens. #241.
         if self.loc_edit.edit.is_uncertain() {
             if let Some(edit) = self.loc_edit.edit.inner() {

--- a/tests/issue_288_mito_circular_tx_whole_entity_predicted.rs
+++ b/tests/issue_288_mito_circular_tx_whole_entity_predicted.rs
@@ -1,0 +1,195 @@
+//! Audit for #288 — whole-entity predicted forms across the
+//! mitochondrial (`m.`), circular DNA (`o.`), and non-coding transcript
+//! (`n.`) coordinate systems. Follow-up to #245 / PR #246, which wired
+//! the same shapes for `c.` / `g.` / `r.`.
+//!
+//! Per HGVS v21 `recommendations/uncertain.md`, the predicted-form
+//! wrapper extends to whole-entity edits on every coord system:
+//!
+//! - `m.(=)`, `o.(=)`, `n.(=)` — predicted whole-entity identity.
+//! - `m.(?)`, `o.(?)`, `n.(?)` — predicted whole-entity unknown.
+//! - `n.(0)` — predicted "no product" for the non-coding transcript.
+//!   `m.0` / `o.0` are not spec forms (DNA isn't "produced"), so
+//!   `m.(0)` / `o.(0)` stay rejected, matching the `c.(0)` guard
+//!   pinned in #245.
+//!
+//! The bare forms (`m.=`, `m.?`, `o.=`, `o.?`, `n.=`, `n.?`, `n.0`)
+//! also had no parser dispatch before this issue and are wired in the
+//! same change. The certain/uncertain pair gets pinned together to
+//! make Display round-trips meaningful.
+//!
+//! Accessions:
+//!   - `NC_012920.1` — Homo sapiens mitochondrion (m.)
+//!   - `NC_001416.1` — Enterobacteria phage lambda (o., circular DNA)
+//!   - `NR_046018.2` — Human DDX11L1 non-coding RNA (n.)
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+#[track_caller]
+fn assert_rejected(s: &str) {
+    assert!(
+        parse_hgvs(s).is_err(),
+        "{s:?} unexpectedly parsed — should be rejected"
+    );
+}
+
+const MT: &str = "NC_012920.1";
+const CIRC: &str = "NC_001416.1";
+const TX: &str = "NR_046018.2";
+
+// =============================================================================
+// SECTION 1 — Predicted whole-entity identity `(=)`
+// =============================================================================
+
+mod predicted_identity {
+    use super::*;
+
+    #[test]
+    fn mt_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{MT}:m.(=)"));
+    }
+
+    #[test]
+    fn circular_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{CIRC}:o.(=)"));
+    }
+
+    #[test]
+    fn tx_predicted_identity_round_trips() {
+        assert_round_trips(&format!("{TX}:n.(=)"));
+    }
+}
+
+// =============================================================================
+// SECTION 2 — Predicted whole-entity unknown `(?)`
+// =============================================================================
+
+mod predicted_unknown {
+    use super::*;
+
+    #[test]
+    fn mt_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{MT}:m.(?)"));
+    }
+
+    #[test]
+    fn circular_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{CIRC}:o.(?)"));
+    }
+
+    #[test]
+    fn tx_predicted_unknown_round_trips() {
+        assert_round_trips(&format!("{TX}:n.(?)"));
+    }
+}
+
+// =============================================================================
+// SECTION 3 — Predicted "no product" `(0)` — n. only
+// =============================================================================
+
+mod predicted_no_product {
+    use super::*;
+
+    /// `n.0` (no transcript produced) exists for non-coding transcripts;
+    /// `n.(0)` is its predicted form. Mirrors `r.(0)` from #245.
+    #[test]
+    fn tx_predicted_no_product_round_trips() {
+        assert_round_trips(&format!("{TX}:n.(0)"));
+    }
+
+    /// `m.0` and `o.0` aren't spec forms — DNA isn't "produced" — so
+    /// their predicted wrappers stay rejected. Regression guard
+    /// mirroring `c.(0)` rejection from #245.
+    #[test]
+    fn mt_no_product_rejected() {
+        assert_rejected(&format!("{MT}:m.0"));
+        assert_rejected(&format!("{MT}:m.(0)"));
+    }
+
+    #[test]
+    fn circular_no_product_rejected() {
+        assert_rejected(&format!("{CIRC}:o.0"));
+        assert_rejected(&format!("{CIRC}:o.(0)"));
+    }
+}
+
+// =============================================================================
+// SECTION 4 — Bare (certain) forms — pinned alongside the predicted
+// pair, since the bare forms had no parser dispatch before this issue
+// either.
+// =============================================================================
+
+mod certain_forms {
+    use super::*;
+
+    #[test]
+    fn mt_certain_identity_round_trips() {
+        assert_round_trips(&format!("{MT}:m.="));
+    }
+
+    #[test]
+    fn mt_certain_unknown_round_trips() {
+        assert_round_trips(&format!("{MT}:m.?"));
+    }
+
+    #[test]
+    fn circular_certain_identity_round_trips() {
+        assert_round_trips(&format!("{CIRC}:o.="));
+    }
+
+    #[test]
+    fn circular_certain_unknown_round_trips() {
+        assert_round_trips(&format!("{CIRC}:o.?"));
+    }
+
+    #[test]
+    fn tx_certain_identity_round_trips() {
+        assert_round_trips(&format!("{TX}:n.="));
+    }
+
+    #[test]
+    fn tx_certain_unknown_round_trips() {
+        assert_round_trips(&format!("{TX}:n.?"));
+    }
+
+    #[test]
+    fn tx_certain_no_product_round_trips() {
+        assert_round_trips(&format!("{TX}:n.0"));
+    }
+}
+
+// =============================================================================
+// SECTION 5 — Boundary regression guards: c./g./r. forms from PR #246
+// still work, positional forms on m./o./n. still work.
+// =============================================================================
+
+mod regression_guards {
+    use super::*;
+
+    /// Pinned in #245 — must keep working on top of #288.
+    #[test]
+    fn cds_genome_rna_predicted_forms_still_round_trip() {
+        assert_round_trips("NM_000088.3:c.(=)");
+        assert_round_trips("NM_000088.3:c.(?)");
+        assert_round_trips("NC_000017.11:g.(=)");
+        assert_round_trips("NC_000017.11:g.(?)");
+        assert_round_trips("NM_000088.3:r.(=)");
+        assert_round_trips("NM_000088.3:r.(?)");
+        assert_round_trips("NM_000088.3:r.(0)");
+    }
+
+    /// Sanity: positional m./o./n. forms unaffected.
+    #[test]
+    fn positional_forms_still_round_trip() {
+        assert_round_trips(&format!("{MT}:m.100A>G"));
+        assert_round_trips(&format!("{CIRC}:o.100A>G"));
+        assert_round_trips(&format!("{TX}:n.100A>G"));
+    }
+}


### PR DESCRIPTION
## Summary

**Stacked PR on top of #246.** Not mergeable until #246 lands.

PR #246 (closes #245) added whole-entity predicted parsing for `c.(=)`, `c.(?)`, `r.(=)`, `r.(?)`, `r.(0)`. The mitochondrial, circular, and tx variant parsers do not have whole-entity dispatch and were deferred.

This PR extends the dispatch to `parse_mt_variant`, `parse_circular_variant`, `parse_tx_variant`, mirroring PR #246's pattern. Both bare-form (`m.=`, `o.?`, `n.0`) and predicted-form (`m.(=)`, `o.(?)`, `n.(0)`) are wired — both were missing on `main`.

## Coord-system policy

| Coord | Identity `=` | Unknown `?` | Whole-entity `0` |
|---|---|---|---|
| `m.` (mt DNA) | ✓ bare + `(=)` | ✓ bare + `(?)` | ✗ (DNA isn't "produced", mirrors `g.0`) |
| `o.` (circular DNA) | ✓ bare + `(=)` | ✓ bare + `(?)` | ✗ (same DNA rationale) |
| `n.` (non-coding tx) | ✓ bare + `(=)` | ✓ bare + `(?)` | ✓ bare + `(0)` (mirrors `r.0`) |

## Implementation

- `src/hgvs/parser/variant.rs` — added whole-entity dispatch blocks at the head of `parse_mt_variant`, `parse_circular_variant`, `parse_tx_variant`. Mt/circular reuse `parse_whole_genome_identity` / `parse_whole_genome_unknown` (shared `GenomeInterval`); tx reuses `parse_whole_rna_identity` / `parse_whole_rna_unknown` / `parse_rna_no_product` (the helpers are coord-system-agnostic — pure tag parsers returning `Mu<NaEdit>`).
- `src/hgvs/variant.rs` — added whole-entity short-circuits to `MtVariant::fmt_loc_edit`, `CircularVariant::fmt_loc_edit`, `TxVariant::fmt_loc_edit` so Display emits `m.=` instead of `m.1=` for the dummy-position case.

## Tests

`tests/issue_288_mito_circular_tx_whole_entity_predicted.rs` — 18 tests across 5 sections covering parse, Display, round-trip, predicted vs certain forms, and rejection guards for `m.0` / `o.0` (correctly rejected as DNA non-products).

## Review

Two-reviewer cycle (Opus + Sonnet). Both verdicts: LGTM, no blockers.

## Test plan

- [x] `cargo nextest run --features dev` — 4581 pass / 0 fail / 51 skipped (on top of #246's head).
- [x] `cargo check --features python` — clean.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

Closes #288. Stacked on PR #246 (#245). Once #246 merges to `main`, this PR's base can be retargeted to `main`.