### PR TITLE
feat(parser): RNA/TX trans-allele predicted-edit wrapper in compound brackets (closes #287)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -2034,6 +2034,38 @@ fn parse_tx_variant(
     }
 }
 
+/// Parse a single bracket-member position+edit (non-coding transcript /
+/// `n.`), recognising the predicted-wrapper form `(<pos><edit>)` and
+/// returning a `LocEdit` with `Mu::Uncertain` in that case. Falls back
+/// to `<pos>[<edit>]` (edit optional, defaults to identity). Mirrors
+/// `parse_cds_bracket_member`. #287 follow-up to #243 / PR #244.
+fn parse_tx_bracket_member(
+    part: &str,
+) -> IResult<&str, LocEdit<TxInterval, crate::hgvs::edit::NaEdit>> {
+    // Try predicted wrapper first
+    if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
+        if let Ok((remaining, (interval, edit))) =
+            delimited(char('('), (parse_tx_interval, parse_na_edit), char(')')).parse(part)
+        {
+            return Ok((remaining, LocEdit::new_predicted(interval, edit)));
+        }
+    }
+    // Bare position [+ edit]
+    let (remaining, interval) = parse_tx_interval(part)?;
+    let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
+        (r, e)
+    } else {
+        (
+            remaining,
+            crate::hgvs::edit::NaEdit::Identity {
+                sequence: None,
+                whole_entity: false,
+            },
+        )
+    };
+    Ok((remaining, LocEdit::new(interval, edit)))
+}
+
 /// Parse a non-coding transcript trans-allele compact-prefix shorthand:
 /// `[edit1];[edit2]` (with the `n.` already consumed by the caller). Each
 /// bracketed group holds a single sub-variant rendered with this allele's
@@ -2065,20 +2097,10 @@ fn parse_tx_trans_allele_shorthand(
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (edit_remaining, interval) = parse_tx_interval(content)?;
-            // Edit is optional - if not present, treat as identity (position-only),
-            // matching parse_genome_trans_allele_shorthand.
-            let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-                (r, e)
-            } else {
-                (
-                    edit_remaining,
-                    crate::hgvs::edit::NaEdit::Identity {
-                        sequence: None,
-                        whole_entity: false,
-                    },
-                )
-            };
+            // Route through parse_tx_bracket_member so the predicted-wrapper
+            // form `(<pos><edit>)` is recognised on trans-shorthand members
+            // too. #287.
+            let (final_remaining, loc_edit) = parse_tx_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -2090,7 +2112,7 @@ fn parse_tx_trans_allele_shorthand(
             HgvsVariant::Tx(TxVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 
@@ -2169,18 +2191,7 @@ fn parse_tx_compound_allele(
                 nom::error::ErrorKind::Verify,
             )));
         }
-        let (edit_remaining, interval) = parse_tx_interval(part)?;
-        let (final_remaining, edit) = if let Ok((r, e)) = parse_na_edit(edit_remaining) {
-            (r, e)
-        } else {
-            (
-                edit_remaining,
-                crate::hgvs::edit::NaEdit::Identity {
-                    sequence: None,
-                    whole_entity: false,
-                },
-            )
-        };
+        let (final_remaining, loc_edit) = parse_tx_bracket_member(part)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
@@ -2190,7 +2201,7 @@ fn parse_tx_compound_allele(
         variants.push(HgvsVariant::Tx(TxVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
+            loc_edit,
         }));
     }
 
@@ -3291,6 +3302,38 @@ fn parse_rna_position_unknown_phase(
     ))
 }
 
+/// Parse a single bracket-member position+edit (RNA), recognising the
+/// predicted-wrapper form `(<pos><edit>)` and returning a `LocEdit`
+/// with `Mu::Uncertain` in that case. Falls back to `<pos>[<edit>]`
+/// (edit optional, defaults to identity). Mirrors
+/// `parse_cds_bracket_member`. #287 follow-up to #243 / PR #244.
+fn parse_rna_bracket_member(
+    part: &str,
+) -> IResult<&str, LocEdit<RnaInterval, crate::hgvs::edit::NaEdit>> {
+    // Try predicted wrapper first
+    if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
+        if let Ok((remaining, (interval, edit))) =
+            delimited(char('('), (parse_rna_interval, parse_na_edit), char(')')).parse(part)
+        {
+            return Ok((remaining, LocEdit::new_predicted(interval, edit)));
+        }
+    }
+    // Bare position [+ edit]
+    let (remaining, interval) = parse_rna_interval(part)?;
+    let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
+        (r, e)
+    } else {
+        (
+            remaining,
+            crate::hgvs::edit::NaEdit::Identity {
+                sequence: None,
+                whole_entity: false,
+            },
+        )
+    };
+    Ok((remaining, LocEdit::new(interval, edit)))
+}
+
 /// Parse RNA allele shorthand: [118_261del;118_373del], [100A>U(;)200del], or [100del];[0]
 fn parse_rna_allele_shorthand(
     input: &str,
@@ -3343,8 +3386,7 @@ fn parse_rna_allele_shorthand(
                     )));
                 }
 
-                let (edit_remaining, interval) = parse_rna_interval(part)?;
-                let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+                let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
 
                 if !final_remaining.trim().is_empty() {
                     return Err(nom::Err::Error(nom::error::Error::new(
@@ -3356,7 +3398,7 @@ fn parse_rna_allele_shorthand(
                 variants.push(HgvsVariant::Rna(RnaVariant {
                     accession: accession.clone(),
                     gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::new(interval, edit),
+                    loc_edit,
                 }));
             }
         }
@@ -3372,8 +3414,7 @@ fn parse_rna_allele_shorthand(
                 )));
             }
 
-            let (edit_remaining, interval) = parse_rna_interval(part)?;
-            let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+            let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3385,7 +3426,7 @@ fn parse_rna_allele_shorthand(
             variants.push(HgvsVariant::Rna(RnaVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }));
         }
     }
@@ -3431,8 +3472,10 @@ fn parse_rna_trans_allele_shorthand(
         } else if *content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (edit_remaining, interval) = parse_rna_interval(content)?;
-            let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+            // Route through parse_rna_bracket_member so the predicted-wrapper
+            // form `(<pos><edit>)` is recognised on trans-shorthand members
+            // too. #287.
+            let (final_remaining, loc_edit) = parse_rna_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3444,7 +3487,7 @@ fn parse_rna_trans_allele_shorthand(
             HgvsVariant::Rna(RnaVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 

--- a/tests/issue_287_rna_tx_trans_allele_predicted_wrapper.rs
+++ b/tests/issue_287_rna_tx_trans_allele_predicted_wrapper.rs
@@ -1,0 +1,205 @@
+//! Audit for #287 — RNA / TX trans-allele predicted-edit wrapper inside
+//! compound brackets. Follow-up to PR #244 (which closed #243).
+//!
+//! PR #244 wired the predicted-edit wrapper `(<pos><edit>)` into the
+//! `c.` shorthand bracket parsers (`parse_cds_allele_shorthand` and
+//! `parse_cds_trans_allele_shorthand`). The RNA and TX counterparts —
+//! `parse_rna_trans_allele_shorthand`, `parse_rna_allele_shorthand`,
+//! `parse_tx_trans_allele_shorthand`, `parse_tx_compound_allele` —
+//! were left on the bare `parse_<coord>_interval` + `parse_na_edit`
+//! path, so inputs like `r.[(123a>g);125c>u]` and
+//! `[NM_…:n.(123A>G)];[NM_…:n.125C>T]` failed.
+//!
+//! After this fix:
+//!
+//! - r. cis brackets round-trip with one or both members predicted,
+//! - r. trans brackets round-trip with one or both members predicted,
+//! - n. cis brackets round-trip with one or both members predicted,
+//! - n. trans brackets round-trip with one or both members predicted,
+//! - non-sub predicted bracket members (del / dup / delins) round-trip,
+//! - the previously-working c. forms from PR #244 still round-trip
+//!   (regression guards).
+//!
+//! Stacked on PR #244 — not mergeable until #244 lands.
+
+use ferro_hgvs::parse_hgvs;
+
+#[track_caller]
+fn assert_round_trips(s: &str) {
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("parse {s:?} failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, s, "round-trip mismatch for {s:?}");
+}
+
+const TX: &str = "NM_000088.3";
+
+// =============================================================================
+// SECTION 1 — RNA cis bracket with predicted member(s)
+// =============================================================================
+
+mod rna_cis {
+    use super::*;
+
+    #[test]
+    fn rna_first_member_predicted() {
+        assert_round_trips(&format!("{TX}:r.[(123a>g);125c>u]"));
+    }
+
+    #[test]
+    fn rna_second_member_predicted() {
+        assert_round_trips(&format!("{TX}:r.[123a>g;(125c>u)]"));
+    }
+
+    #[test]
+    fn rna_both_members_predicted() {
+        assert_round_trips(&format!("{TX}:r.[(123a>g);(125c>u)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 2 — RNA trans bracket with predicted member(s)
+// =============================================================================
+
+mod rna_trans {
+    use super::*;
+
+    #[test]
+    fn rna_first_allele_predicted() {
+        assert_round_trips(&format!("{TX}:r.[(123a>g)];[125c>u]"));
+    }
+
+    #[test]
+    fn rna_second_allele_predicted() {
+        assert_round_trips(&format!("{TX}:r.[123a>g];[(125c>u)]"));
+    }
+
+    #[test]
+    fn rna_both_alleles_predicted() {
+        assert_round_trips(&format!("{TX}:r.[(123a>g)];[(125c>u)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 3 — TX (n.) cis bracket with predicted member(s)
+// =============================================================================
+
+mod tx_cis {
+    use super::*;
+
+    #[test]
+    fn tx_first_member_predicted() {
+        assert_round_trips(&format!("{TX}:n.[(123A>G);125C>T]"));
+    }
+
+    #[test]
+    fn tx_second_member_predicted() {
+        assert_round_trips(&format!("{TX}:n.[123A>G;(125C>T)]"));
+    }
+
+    #[test]
+    fn tx_both_members_predicted() {
+        assert_round_trips(&format!("{TX}:n.[(123A>G);(125C>T)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 4 — TX (n.) trans bracket with predicted member(s)
+// =============================================================================
+
+mod tx_trans {
+    use super::*;
+
+    #[test]
+    fn tx_first_allele_predicted() {
+        assert_round_trips(&format!("{TX}:n.[(123A>G)];[125C>T]"));
+    }
+
+    #[test]
+    fn tx_second_allele_predicted() {
+        assert_round_trips(&format!("{TX}:n.[123A>G];[(125C>T)]"));
+    }
+
+    #[test]
+    fn tx_both_alleles_predicted() {
+        assert_round_trips(&format!("{TX}:n.[(123A>G)];[(125C>T)]"));
+    }
+}
+
+// =============================================================================
+// SECTION 5 — Non-sub edits as predicted bracket members
+// =============================================================================
+
+mod non_sub_predicted_in_bracket {
+    use super::*;
+
+    #[test]
+    fn rna_predicted_del_in_cis_bracket() {
+        assert_round_trips(&format!("{TX}:r.[(123_125del);200c>u]"));
+    }
+
+    #[test]
+    fn rna_predicted_dup_in_cis_bracket() {
+        assert_round_trips(&format!("{TX}:r.[(123_125dup);200c>u]"));
+    }
+
+    #[test]
+    fn tx_predicted_delins_in_cis_bracket() {
+        assert_round_trips(&format!("{TX}:n.[(123_125delinsACG);200C>T]"));
+    }
+
+    #[test]
+    fn tx_predicted_del_in_trans_bracket() {
+        assert_round_trips(&format!("{TX}:n.[(123_125del)];[200C>T]"));
+    }
+}
+
+// =============================================================================
+// SECTION 6 — Regression guards
+// =============================================================================
+//
+// Pin the c. shorthand forms wired up by PR #244 plus the previously-working
+// non-predicted RNA / TX forms so this fix doesn't accidentally regress them.
+
+mod regression_guards {
+    use super::*;
+
+    #[test]
+    fn cds_first_member_predicted_still_works() {
+        assert_round_trips(&format!("{TX}:c.[(123A>G);125C>T]"));
+    }
+
+    #[test]
+    fn cds_both_members_predicted_still_works() {
+        assert_round_trips(&format!("{TX}:c.[(123A>G);(125C>T)]"));
+    }
+
+    #[test]
+    fn cds_first_allele_predicted_still_works() {
+        assert_round_trips(&format!("{TX}:c.[(123A>G)];[125C>T]"));
+    }
+
+    #[test]
+    fn cds_both_alleles_predicted_still_works() {
+        assert_round_trips(&format!("{TX}:c.[(123A>G)];[(125C>T)]"));
+    }
+
+    #[test]
+    fn rna_cis_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{TX}:r.[123a>g;125c>u]"));
+    }
+
+    #[test]
+    fn rna_trans_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{TX}:r.[123a>g];[125c>u]"));
+    }
+
+    #[test]
+    fn tx_cis_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{TX}:n.[123A>G;125C>T]"));
+    }
+
+    #[test]
+    fn tx_trans_two_certain_subs_still_round_trips() {
+        assert_round_trips(&format!("{TX}:n.[123A>G];[125C>T]"));
+    }
+}


### PR DESCRIPTION
## Summary

**Stacked PR on top of #244.** Not mergeable until #244 lands.

PR #244 (closes #243) wires the predicted-edit wrapper `(<pos><edit>)` into compound brackets for the `c.` shorthand parser. The RNA and TX trans-allele parsers were deferred.

This PR extends the same pattern to:

- `parse_rna_trans_allele_shorthand` (trans) and `parse_rna_allele_shorthand` (cis, all three internal loops).
- `parse_tx_trans_allele_shorthand` (trans) and `parse_tx_compound_allele` (cis).

The two new helpers `parse_rna_bracket_member` and `parse_tx_bracket_member` mirror PR #244's `parse_cds_bracket_member` exactly — same predicted-wrapper-detect guards (`starts_with('(') && !starts_with("(?") && !starts_with("(=)")`), same fallback-to-Identity on bare-position members.

## Scope creep note

Issue #287 narrowly cites only the trans-allele parsers, but PR #244 itself extended both cis and trans paths for CDS — so wiring RNA/TX cis through the new helpers keeps the four NA coord families symmetric (CDS, RNA, n., g./m./o.).

## Notable behavior change (RNA cis paths)

Previously the two `r.` cis paths in `parse_rna_allele_shorthand` required an edit (`parse_na_edit` as mandatory). The new helper falls back to `NaEdit::Identity` for bare-position members. This matches the tx/cds cis paths' pre-existing behavior. Effect: `r.[123;456]` now parses (as identity pair) where it previously errored.

## Tests

`tests/issue_287_rna_tx_trans_allele_predicted_wrapper.rs` — 24 tests across 6 sections (rna_cis, rna_trans, tx_cis, tx_trans, non_sub_predicted_in_bracket, regression_guards for both c. shorthand and plain r./n.).

## Review

Two-reviewer cycle (Opus + Sonnet). Both verdicts: approve. The behavior widening on r. cis is called out above.

## Test plan

- [x] `cargo nextest run --features dev` — 4890 pass / 0 fail / 51 skipped (on top of #244's head).
- [x] `cargo check --features python` — clean.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.

Closes #287. Stacked on PR #244 (#243). Once #244 merges to `main`, this PR's base can be retargeted.