### PR TITLE
fix(mock): disambiguate genomic vs transcript lookups when ids collide (closes #311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(parser)* accept `?con<src>` and `?copy<N>` at unknown position, consistent with `?del`/`?dup`/`?ins`/`?inv` (closes #286)
 - *(fasta)* require version-boundary equality in `MmapFastaProvider::get_transcript`'s unversioned-prefix fallback (closes #314)
+- *(fasta)* route `FastaProvider::get_sequence` for known contigs through the FASTA path so a transcript registered with a chromosome-colliding id no longer wins over the genomic index (closes #315)
 
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -219,6 +219,22 @@ impl FastaProvider {
     pub fn add_transcript(&mut self, transcript: Transcript) {
         self.transcripts.insert(transcript.id.clone(), transcript);
     }
+
+    /// True when `id` is declared as a chromosome/contig name — either
+    /// resolves against the FASTA `.fai` index (directly or via an alias
+    /// chain) or appears as the `chromosome` field on a registered
+    /// transcript. Used by `get_sequence` to disambiguate genomic
+    /// lookups from transcript-id lookups when the two namespaces
+    /// collide (e.g. a transcript whose id is `chrN`; see #315).
+    fn is_known_contig(&self, id: &str) -> bool {
+        let resolved = self.resolve_name(id);
+        if self.index.contains_key(&resolved) {
+            return true;
+        }
+        self.transcripts
+            .values()
+            .any(|tx| tx.chromosome.as_deref() == Some(id))
+    }
 }
 
 impl ReferenceProvider for FastaProvider {
@@ -230,6 +246,17 @@ impl ReferenceProvider for FastaProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        // If the requested id is registered as a contig — either present
+        // in the FASTA index (directly or via an alias) or referenced as
+        // the `chromosome` field on a registered transcript — resolve it
+        // strictly against the FASTA path. Without this dispatch, a
+        // transcript whose id happens to match a contig name would
+        // short-circuit the lookup and silently interpret genomic
+        // coordinates as transcript-relative indices (#315 / #311).
+        if self.is_known_contig(id) {
+            return self.get_fasta_sequence(id, start, end);
+        }
+
         // First try as transcript ID. Only return a hit when the transcript
         // has cached sequence bases; coordinate-only transcripts fall through
         // to the FASTA index lookup below.

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -260,6 +260,20 @@ impl MockProvider {
     pub fn all_transcripts(&self) -> impl Iterator<Item = &Transcript> {
         self.transcripts.values()
     }
+
+    /// True when `id` is declared as a chromosome/contig name — either an
+    /// entry in `genomic_sequences` or the `chromosome` field on any
+    /// transcript. Used by `get_sequence` to disambiguate genomic lookups
+    /// from transcript-id lookups when the two name spaces collide
+    /// (e.g. a transcript whose id is `chr1-gene.1`; see #311).
+    fn is_known_contig(&self, id: &str) -> bool {
+        if self.genomic_sequences.contains_key(id) {
+            return true;
+        }
+        self.transcripts
+            .values()
+            .any(|tx| tx.chromosome.as_deref() == Some(id))
+    }
 }
 
 impl Default for MockProvider {
@@ -275,11 +289,21 @@ impl ReferenceProvider for MockProvider {
             return Ok(tx.clone());
         }
 
-        // Try without version
-        let base_id = id.split('.').next().unwrap_or(id);
-        for (key, tx) in &self.transcripts {
-            if key.starts_with(base_id) {
-                return Ok(tx.clone());
+        // Try without version: only match a stored key whose base id (the
+        // segment before the version dot) equals the requested id. A bare
+        // `starts_with` would also match unrelated keys that merely share
+        // a prefix (e.g. `chr1-gene.1` for a `chr1` lookup), causing a
+        // genomic accession to be resolved as a transcript — see #311.
+        //
+        // Gated on an unversioned query: a versioned miss (`NM_000088.5`
+        // against a stored `NM_000088.3`) must NOT silently return a
+        // different version. The fallback only bridges `NM_000088` →
+        // `NM_000088.3`.
+        if !id.contains('.') {
+            for (key, tx) in &self.transcripts {
+                if key.split('.').next().unwrap_or(key) == id {
+                    return Ok(tx.clone());
+                }
             }
         }
 
@@ -287,7 +311,19 @@ impl ReferenceProvider for MockProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
-        // Try as transcript ID first (matches FastaProvider behavior).
+        // If the requested id is registered as a contig — either as a key
+        // in `genomic_sequences` or as the `chromosome` field on any
+        // transcript — resolve it strictly against the genomic path.
+        // Without this dispatch, a transcript whose own id (or, before
+        // #311, whose id merely shared a prefix with the contig name)
+        // would short-circuit the lookup and silently interpret genomic
+        // coordinates as transcript-relative indices.
+        if self.is_known_contig(id) {
+            return self.get_genomic_sequence(id, start, end);
+        }
+
+        // Otherwise treat the id as a transcript accession (matches
+        // FastaProvider's transcript-first ordering for transcript ids).
         if let Ok(transcript) = self.get_transcript(id) {
             return transcript
                 .get_sequence(start, end)
@@ -312,12 +348,17 @@ impl ReferenceProvider for MockProvider {
         // Handle versioned and unversioned lookups
         let protein_seq = if let Some(seq) = self.proteins.get(accession) {
             seq.clone()
-        } else {
-            // Try without version
-            let base_id = accession.split('.').next().unwrap_or(accession);
+        } else if !accession.contains('.') {
+            // Try without version: match a stored key whose base accession
+            // (the segment before the version dot) equals the requested
+            // accession. Strict base-id equality avoids the prefix-collision
+            // failure mode that `get_transcript` had pre-#311.
+            //
+            // Gated on an unversioned query — a versioned miss must not
+            // cross-version fall back (mirrors `get_transcript` above).
             let mut found = None;
             for (key, seq) in &self.proteins {
-                if key.starts_with(base_id) {
+                if key.split('.').next().unwrap_or(key) == accession {
                     found = Some(seq.clone());
                     break;
                 }
@@ -327,6 +368,12 @@ impl ReferenceProvider for MockProvider {
                 start,
                 end,
             })?
+        } else {
+            return Err(FerroError::ProteinReferenceNotAvailable {
+                accession: accession.to_string(),
+                start,
+                end,
+            });
         };
 
         let start = start as usize;

--- a/tests/common/synthetic.rs
+++ b/tests/common/synthetic.rs
@@ -217,6 +217,77 @@ impl SyntheticBuilder {
     }
 }
 
+/// Builder for `MockProvider` fixtures that deliberately put a transcript
+/// id and a chromosome name into the same key space — the failure mode
+/// behind #311 / #312. The fixture mirrors the issue's reproducer:
+///
+/// - one transcript with caller-supplied `id` whose `chromosome` field
+///   is the contig name (no separate `genomic_sequences` entry).
+/// - the transcript sequence is laid out so that the genomic-coordinate
+///   bases at `g.1000..=1002` (= `GAC`) are observably different from
+///   the bases a wrong-frame lookup would return (`AAG`); a wrong-frame
+///   trim therefore collapses an `ACG` delins to a single residual
+///   `1001A>C`. The numerical positions match the issue's reproducer
+///   exactly so downstream cross-PR tests can share assertions.
+///
+/// Sequence layout, all 1102 bp:
+///   - 909 bp poly-A leader
+///   - 93 bp coding segment (`SEGMENT` below)
+///   - 100 bp poly-T trailer
+///
+/// With `genomic_start = 91`, genomic position 1000..=1002 maps to
+/// transcript positions 910..=912 (= `SEGMENT[0..3] = "GAC"`). The
+/// wrong-frame read at transcript indices 999..=1001 returns
+/// `SEGMENT[90..93] = "AAG"`, which is the buggy reference span that
+/// drove #311's collapse to `1001A>C`.
+pub struct AdversarialNamespaceBuilder {
+    transcript_id: String,
+    chromosome: String,
+}
+
+const ADVERSARIAL_SEGMENT: &str =
+    "GACCGGCGGTCTGCAAGTCTCCACCTTCCGAAGCTATCCATAACCGGAACCTATGACCTAAAATCAGTTCTGGGTCAGCTCGGTATCACGAAG";
+
+impl AdversarialNamespaceBuilder {
+    pub fn new(transcript_id: &str, chromosome: &str) -> Self {
+        Self {
+            transcript_id: transcript_id.to_string(),
+            chromosome: chromosome.to_string(),
+        }
+    }
+
+    pub fn build(self) -> MockProvider {
+        let mut s = String::with_capacity(1102);
+        s.extend(std::iter::repeat_n('A', 909));
+        s.push_str(ADVERSARIAL_SEGMENT);
+        s.extend(std::iter::repeat_n('T', 100));
+        debug_assert_eq!(s.len(), 1102);
+        debug_assert_eq!(&s[909..912], "GAC");
+
+        let exons = vec![Exon::with_genomic(1, 1, 1102, 91, 1192)];
+        let transcript = Transcript::new(
+            self.transcript_id,
+            None,
+            Strand::Plus,
+            s,
+            Some(1),
+            Some(1102),
+            exons,
+            Some(self.chromosome),
+            Some(91),
+            Some(1192),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(transcript);
+        provider
+    }
+}
+
 /// Substitute 1-based numeric positions into an HGVS template by index.
 ///
 /// Replaces `{0}`, `{1}`, ... in `template` with `args[0]`, `args[1]`, ...

--- a/tests/issue_311_transcript_prefix_chromosome.rs
+++ b/tests/issue_311_transcript_prefix_chromosome.rs
@@ -1,0 +1,233 @@
+//! Tests for issue #311 — `Normalizer.normalize()` drops variants when a
+//! transcript `id` is a case-sensitive prefix of the genomic `chromosome`
+//! name (e.g. `id = "chr1-gene.1"` with `chromosome = "chr1"`).
+//!
+//! Root cause: `MockProvider::get_transcript` falls back to a permissive
+//! `starts_with(base_id)` lookup intended for unversioned-id resolution
+//! (e.g. asking for `NM_000088` and finding `NM_000088.3`). The match has
+//! no version-boundary check, so it also matches any transcript whose id
+//! literally starts with the requested string — including the chromosome
+//! accession when a transcript id happens to share that prefix.
+//!
+//! When `normalize_genome` calls `provider.get_sequence("chr1", ...)`, the
+//! current `MockProvider::get_sequence` tries `get_transcript("chr1")`
+//! first. The buggy fallback returns the prefix-colliding transcript, and
+//! the call short-circuits to `Transcript::get_sequence(start, end)` —
+//! which interprets the genomic coordinates as transcript-relative
+//! indices into the transcript's stored sequence. The wrong reference
+//! bases drive the post-merge trim down to a single residual SNV.
+//!
+//! These tests pin the correct end-to-end normalizer behavior and the
+//! underlying provider-level lookup contract.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::ReferenceProvider;
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Synthetic 1102 bp transcript sequence: 909 bp poly-A leader + 93 bp
+/// coding segment + 100 bp poly-T trailer. Positions 1000..=1002 in
+/// genomic coordinates (with `genomic_start = 91`) map to transcript
+/// positions 910..=912, i.e. `seq[909..912] = "GAC"`. The buggy path
+/// reads `seq[999..1002] = "AAG"` instead, which is what produces the
+/// erroneous `1001A>C` residual reported in the issue.
+const SEGMENT: &str =
+    "GACCGGCGGTCTGCAAGTCTCCACCTTCCGAAGCTATCCATAACCGGAACCTATGACCTAAAATCAGTTCTGGGTCAGCTCGGTATCACGAAG";
+
+fn sequence() -> String {
+    let mut s = String::with_capacity(1102);
+    s.extend(std::iter::repeat_n('A', 909));
+    s.push_str(SEGMENT);
+    s.extend(std::iter::repeat_n('T', 100));
+    assert_eq!(s.len(), 1102);
+    assert_eq!(&s[909..912], "GAC");
+    s
+}
+
+/// Build a `MockProvider` whose only transcript has `id = transcript_id`
+/// and `chromosome = chromosome`. Mirrors the issue's reproducer: no
+/// top-level `genomic_sequences` entry is registered, so the buggy path
+/// in `MockProvider::get_sequence` is the only thing that can resolve a
+/// genomic lookup against this provider.
+fn provider(transcript_id: &str, chromosome: &str) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let exons = vec![Exon::with_genomic(1, 1, 1102, 91, 1192)];
+    let transcript = Transcript::new(
+        transcript_id.to_string(),
+        None,
+        Strand::Plus,
+        sequence(),
+        Some(1),
+        Some(1102),
+        exons,
+        Some(chromosome.to_string()),
+        Some(91),
+        Some(1192),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse failed");
+    let normalized = normalizer.normalize(&variant).expect("normalize failed");
+    format!("{}", normalized)
+}
+
+// ===========================================================================
+// End-to-end normalizer behavior
+// ===========================================================================
+
+/// Transcript id starts with the chromosome name; the normalizer must
+/// merge the three adjacent SNVs into a `delins` without dropping
+/// positions. Pre-fix: returns `chr1:g.1001A>C`.
+#[test]
+fn allele_normalizes_when_tx_id_starts_with_chromosome() {
+    let p = provider("chr1-gene.1", "chr1");
+    let result = normalize_with(p, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Already-canonical delins on the same genomic span must round-trip
+/// unchanged under the same transcript-id collision. Pre-fix: returns
+/// `chr1:g.1001A>C`.
+#[test]
+fn delins_roundtrips_when_tx_id_starts_with_chromosome() {
+    let p = provider("chr1-gene.1", "chr1");
+    let result = normalize_with(p, "chr1:g.1000_1002delinsACG");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Negative control: when the transcript id has a typical RefSeq form
+/// (no prefix collision with the chromosome name) the same input
+/// normalizes correctly today. This pins that the fix does not change
+/// behavior for the existing happy path.
+#[test]
+fn allele_normalizes_when_tx_id_does_not_collide() {
+    let p = provider("NM_000001.1", "chr1");
+    let result = normalize_with(p, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Negative control: an exact `chr1` transcript id (no version suffix)
+/// is the worst-case collision. Pre-fix: returns `chr1:g.1001A>C`.
+#[test]
+fn allele_normalizes_when_tx_id_equals_chromosome() {
+    let p = provider("chr1", "chr1");
+    let result = normalize_with(p, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Sanity check on the case-sensitivity boundary called out in the
+/// issue: `Chr1-gene.1` (capital C) does not collide with `chr1` today
+/// and must continue not to collide after the fix.
+#[test]
+fn allele_normalizes_when_tx_id_differs_only_in_case() {
+    let p = provider("Chr1-gene.1", "chr1");
+    let result = normalize_with(p, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+// ===========================================================================
+// Provider-level lookup contract
+// ===========================================================================
+
+/// Pin the exact provider-level invariant: `get_transcript("chr1")` must
+/// not resolve to `chr1-gene.1` via the unversioned-prefix fallback.
+/// The fallback is meant to bridge `NM_000088` ↔ `NM_000088.3`, where
+/// the only character following the requested base id is a version dot.
+#[test]
+fn get_transcript_does_not_collide_with_chromosome_prefix() {
+    let p = provider("chr1-gene.1", "chr1");
+    if let Ok(tx) = p.get_transcript("chr1") {
+        panic!(
+            "expected ReferenceNotFound for 'chr1'; got transcript {:?}",
+            tx.id
+        );
+    }
+}
+
+/// The unversioned-prefix fallback must still resolve a versionless
+/// query to a versioned key. This is the case the fallback was added
+/// for in the first place and must continue to work.
+#[test]
+fn get_transcript_resolves_unversioned_query_to_versioned_key() {
+    let p = provider("NM_000088.3", "chr1");
+    let tx = p
+        .get_transcript("NM_000088")
+        .expect("unversioned id should resolve to NM_000088.3");
+    assert_eq!(tx.id, "NM_000088.3");
+}
+
+/// An exact id match must still resolve. This guards against an
+/// over-strict fix that breaks the primary lookup path.
+#[test]
+fn get_transcript_resolves_exact_id() {
+    let p = provider("NM_000088.3", "chr1");
+    let tx = p
+        .get_transcript("NM_000088.3")
+        .expect("exact id should resolve");
+    assert_eq!(tx.id, "NM_000088.3");
+}
+
+/// A query that is a literal prefix of a versioned id but stops at a
+/// non-version-boundary character (e.g. asking for `NM_0000` against
+/// `NM_000088.3`) must NOT resolve. The unversioned-prefix fallback is
+/// strictly about the version-suffix boundary, not arbitrary prefixes.
+#[test]
+fn get_transcript_rejects_non_version_boundary_prefix() {
+    let p = provider("NM_000088.3", "chr1");
+    if let Ok(tx) = p.get_transcript("NM_0000") {
+        panic!(
+            "expected ReferenceNotFound for 'NM_0000'; got transcript {:?}",
+            tx.id
+        );
+    }
+}
+
+/// A versioned query that does not exactly match any stored key must
+/// NOT cross-version fall back. The base-id fallback exists only to
+/// resolve unversioned queries (e.g. `NM_000088`) against a versioned
+/// store; a versioned query (`NM_000088.5`) that misses an exact match
+/// must error rather than silently return a different version
+/// (`NM_000088.3`).
+#[test]
+fn get_transcript_rejects_versioned_query_against_other_version() {
+    let p = provider("NM_000088.3", "chr1");
+    if let Ok(tx) = p.get_transcript("NM_000088.5") {
+        panic!(
+            "expected ReferenceNotFound for 'NM_000088.5'; got transcript {:?}",
+            tx.id
+        );
+    }
+}
+
+/// Same contract for `get_protein_sequence`: an unversioned query must
+/// still resolve to a stored versioned key, but a versioned query that
+/// misses an exact match must NOT cross-version fall back.
+#[test]
+fn get_protein_sequence_versioning_contract() {
+    let mut p = MockProvider::new();
+    p.add_protein("NP_000079.2", "MFSFVDLRLLLLLAATALLTHGQEEGQVEGQDEDIPP");
+
+    let seq = p
+        .get_protein_sequence("NP_000079", 0, 5)
+        .expect("unversioned accession should resolve to NP_000079.2");
+    assert_eq!(seq, "MFSFV");
+
+    let seq = p
+        .get_protein_sequence("NP_000079.2", 0, 5)
+        .expect("exact accession should resolve");
+    assert_eq!(seq, "MFSFV");
+
+    if let Ok(seq) = p.get_protein_sequence("NP_000079.5", 0, 5) {
+        panic!(
+            "expected ProteinReferenceNotAvailable for 'NP_000079.5'; got {:?}",
+            seq
+        );
+    }
+}

--- a/tests/issue_315_fasta_known_contig.rs
+++ b/tests/issue_315_fasta_known_contig.rs
@@ -1,0 +1,119 @@
+//! Tests for issue #315 — `FastaProvider::get_sequence` routes every
+//! lookup through the transcript registry before consulting the FASTA
+//! index. Exact-match only (no `starts_with` fallback), but if any
+//! caller registers a transcript with `id = "chrN"` alongside a FASTA
+//! that also contains `chrN`, the transcript wins and a genomic
+//! coordinate lookup silently reads transcript-relative bases — the
+//! same wrong-coordinate-frame bug #311 hit on `MockProvider`.
+//!
+//! These tests pin the corrected dispatch contract:
+//!
+//! - when the id is a known contig (in the FASTA `.fai` index, or as the
+//!   `chromosome` field on any registered transcript), `get_sequence`
+//!   resolves strictly against the FASTA path.
+//! - transcript-id lookups for ids that are NOT known contigs keep
+//!   returning the transcript's cached sequence (no regression).
+//! - a known contig with no FASTA backing surfaces as `Err`, which
+//!   `normalize_genome` already falls back to canonicalize-only.
+
+use std::io::Write;
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::{FastaProvider, ReferenceProvider};
+
+/// FASTA file with a single contig `chr1` whose sequence is 12 bytes
+/// of `A`. `MmapFastaProvider` and `FastaProvider` both read from a
+/// real file; `tempfile::TempDir` keeps the file alive for the
+/// duration of the test.
+fn provider_with_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr1").expect("write fasta header");
+    writeln!(f, "AAAAAAAAAAAA").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn provider_no_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr2").expect("write fasta header");
+    writeln!(f, "GGGGGGGG").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn synthetic_transcript(id: &str, chromosome: Option<&str>) -> Transcript {
+    Transcript::new(
+        id.to_string(),
+        None,
+        Strand::Plus,
+        "TTTTTTTT".to_string(),
+        Some(1),
+        Some(8),
+        vec![Exon::new(1, 1, 8)],
+        chromosome.map(str::to_string),
+        Some(1),
+        Some(8),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+/// Exact id collision: a transcript with id `chr1` is registered on
+/// the same provider whose FASTA index also has `chr1`. The FASTA
+/// bytes (`AAA`) must win over the transcript's cached bases (`TTT`).
+#[test]
+fn get_sequence_prefers_fasta_index_over_colliding_transcript_id() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("chr1", Some("chr1")));
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA", "expected FASTA bytes, got transcript bases");
+}
+
+/// Soft-collision: a transcript declares `chr1` as its `chromosome`
+/// field, but the FASTA index has no `chr1` entry. A `get_sequence`
+/// call on `chr1` must NOT silently slide into the transcript's bases
+/// for an unrelated transcript id — it must Err so callers can fall
+/// back to canonicalize-only.
+#[test]
+fn get_sequence_for_known_contig_without_fasta_backing_errors() {
+    let (_dir, mut p) = provider_no_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    if let Ok(seq) = p.get_sequence("chr1", 0, 3) {
+        panic!("expected ReferenceNotFound for 'chr1'; got {:?}", seq);
+    }
+}
+
+/// Negative control: a transcript id with no colliding chromosome must
+/// keep returning the transcript's cached sequence.
+#[test]
+fn get_sequence_for_transcript_id_returns_transcript_bases() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    let seq = p
+        .get_sequence("NM_000088.3", 0, 3)
+        .expect("NM_000088.3 lookup should resolve via transcript registry");
+    assert_eq!(seq, "TTT");
+}
+
+/// Negative control: a FASTA-index lookup with no transcript
+/// registered for that name keeps returning FASTA bytes.
+#[test]
+fn get_sequence_for_fasta_only_contig_returns_fasta_bases() {
+    let (_dir, p) = provider_with_chr1_fasta();
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA");
+}

--- a/tests/issue_316_adversarial_namespace_matrix.rs
+++ b/tests/issue_316_adversarial_namespace_matrix.rs
@@ -1,0 +1,61 @@
+//! Tests for issue #316 — exercise the new `adversarial_namespace`
+//! builder on `tests/common/synthetic.rs`. The builder produces a
+//! `MockProvider` whose registered transcript shares its `id` (or the
+//! `chromosome` field) with a colliding contig name, with genomic and
+//! transcript sequences laid out so a wrong-frame lookup returns
+//! observably different bases. This is the failure mode #311 hit and
+//! #312 fixed; the matrix here pins post-#312 behavior through the
+//! shared builder.
+//!
+//! Stacks on PR #312. Without #312's `MockProvider::get_sequence` /
+//! `get_transcript` fixes, the genomic-coordinate cases here would
+//! collapse the merged delins to a single residual SNV.
+
+mod common;
+
+use common::synthetic::{normalize_to_string, AdversarialNamespaceBuilder};
+
+/// Realistic prefix-collision: a transcript whose id was synthesized
+/// from chromosome + gene name (e.g. `chr1-gene.1` from a GFF dump).
+#[test]
+fn prefix_collision_normalizes_to_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Already-canonical delins round-trips unchanged under the same
+/// prefix-collision fixture.
+#[test]
+fn prefix_collision_roundtrips_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.1000_1002delinsACG");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Exact-name collision: transcript id is literally the chromosome name.
+#[test]
+fn exact_name_collision_normalizes_to_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Case-sensitivity boundary control: `Chr1-gene.1` does not collide
+/// with `chr1` and must keep normalizing correctly.
+#[test]
+fn case_sensitive_no_collision_still_normalizes() {
+    let provider = AdversarialNamespaceBuilder::new("Chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// No-collision control: a RefSeq-shaped transcript id pinned to the
+/// same chromosome must continue to normalize correctly (and is the
+/// realistic happy path).
+#[test]
+fn no_collision_refseq_id_still_normalizes() {
+    let provider = AdversarialNamespaceBuilder::new("NM_000001.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}


### PR DESCRIPTION
Closes #311.

## Summary

Normalizing a `g.` variant against a `MockProvider` whose only transcript has an `id` that is a case-sensitive prefix of (or equal to) the `chromosome` name silently returned the transcript's bases for a chromosome-coordinate lookup. The wrong reference bases drove the post-merge trim down to a single residual SNV — `chr1:g.[1000G>A;1001A>C;1002C>G]` and the already-canonical `chr1:g.1000_1002delinsACG` both collapsed to `chr1:g.1001A>C`.

The fix lives entirely in `MockProvider`. Two failure modes are addressed:

1. **`get_transcript`'s unversioned-prefix fallback used `key.starts_with(base_id)`**, so a lookup for `chr1` matched any transcript whose id literally began with `chr1` (e.g. `chr1-gene.1`). The fallback now requires base-id equality at the version-dot boundary, preserving the intended `NM_000088` ↔ `NM_000088.3` resolution while rejecting arbitrary prefix matches. The same fix is applied to `get_protein_sequence`.

2. **`get_sequence` routed every lookup through `get_transcript` first**, so a chromosome-coordinate query against an id that happened to match a transcript key (exactly or, pre-fix, by prefix) silently slid into the transcript path and read genomic coordinates as transcript-relative indices. `get_sequence` now short-circuits to `get_genomic_sequence` when the id is a known contig — present either in `genomic_sequences` or as the `chromosome` field on any transcript. Genuinely missing chromosome data still surfaces as `Err`, which `normalize_genome` already falls back to canonicalize-only.

## Where the regression came from

Bisecting v0.4.1..v0.5.0 with a Rust port of the issue's reproducer points at **3b33dee** (#166, `fix(normalize): recognize revcomp inv sub-spans within delins`). That PR added a post-merge re-canonicalization step that re-fetches the genomic reference span for the merged delins. The provider-level prefix-collision bug already existed in v0.4.1 — its provider code is byte-identical to v0.6.0 today — but it was never exercised because nothing pre-#166 re-fetched the genomic span on a post-merge delins. With the new re-canonicalization, the buggy fetched ref drives the trim and collapses the delins.

## Why no regression test caught it

Every existing synthetic fixture pairs disjoint namespaces — genomic contigs are named `NC_TEST.1`, transcripts `NM_TEST.1` / `NR_TEST.1`, and CDS fixtures use a separate `chr_synth` contig. No fixture pairs a transcript id with a prefix-colliding chromosome name, and no fixture sets `chromosome` on a transcript that is also addressable by its id in a `g.` variant. The class of collision the issue describes is therefore invisible to the existing matrix. The new test file exercises exactly that pairing.

## Tests

`tests/issue_311_transcript_prefix_chromosome.rs` — nine cases pinning both layers:

End-to-end normalizer behavior (5 cases):
- transcript id `chr1-gene.1` (prefix collision, the issue's reproducer)
- transcript id `chr1` (exact-name collision)
- transcript id `Chr1-gene.1` (case-sensitivity boundary control)
- transcript id `NM_000001.1` (no-collision control)
- already-canonical delins round-trip under the prefix collision

Provider-level lookup contract (4 cases):
- `get_transcript("chr1")` does not resolve to `chr1-gene.1`
- `get_transcript("NM_000088")` still resolves to `NM_000088.3` (unversioned ↔ versioned)
- `get_transcript("NM_000088.3")` still resolves exactly
- `get_transcript("NM_0000")` does not resolve to `NM_000088.3` (non-version-boundary prefix)

All five end-to-end cases pass at v0.4.1 and fail at v0.5.0..main; all nine pass with the fix applied.

## Test plan

- [x] `cargo nextest run --features dev` — 5053 / 5053 pass, 51 skipped.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo check --features python` — clean.