### PR TITLE
fix(projector): protein prediction for non-RefSeq transcripts + drop (GENE) selector from p. Display

### DIFF
--- a/docs/transcripts_json_schema.md
+++ b/docs/transcripts_json_schema.md
@@ -59,6 +59,7 @@ Each transcript object has the following fields:
 | `mane_status` | string | MANE designation: `"MANE_Select"`, `"MANE_Plus_Clinical"`, or omitted if not MANE |
 | `refseq_match` | string | For Ensembl transcripts: matched RefSeq accession |
 | `ensembl_match` | string | For RefSeq transcripts: matched Ensembl accession |
+| `protein_id` | string | Protein accession (e.g. `"NP_000079.2"` or `"MYGENE-protein.1"`). Used as the `p.` accession for c. → p. projection. When omitted, the projector infers `NP_*` from `NM_*` and `XP_*` from `XM_*`; if neither applies, it falls back to using the transcript ID itself as the `p.` accession so protein prediction is never silently dropped. |
 
 ## Exon Object
 

--- a/src/convert/coding.rs
+++ b/src/convert/coding.rs
@@ -121,6 +121,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -191,6 +192,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -727,6 +727,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -850,6 +851,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -879,6 +881,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -1000,6 +1003,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -1241,6 +1245,7 @@ mod intronic_debug_tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/convert/noncoding.rs
+++ b/src/convert/noncoding.rs
@@ -314,6 +314,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -802,6 +803,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/convert/protein.rs
+++ b/src/convert/protein.rs
@@ -84,6 +84,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1573,6 +1573,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1608,6 +1609,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1640,6 +1642,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1674,6 +1677,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1710,6 +1714,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1745,6 +1750,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1780,6 +1786,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -852,7 +852,10 @@ impl CdotMapper {
                 // cds_end: 1-based tx inclusive → 0-based exclusive (same value)
                 cds_end: tx.cds_end,
                 gene_id: None,
-                protein: None,
+                // Propagate the ferro reference's explicit protein accession so
+                // c. → p. projection works for non-RefSeq transcript IDs without
+                // needing a cdot JSON. See #310.
+                protein: tx.protein_id.clone(),
                 exon_cigars: Vec::new(),
             };
             mapper.add_transcript(tx.id.clone(), cdot_tx);

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1355,8 +1355,16 @@ impl ProteinVariant {
 
 impl fmt::Display for ProteinVariant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
-        write!(f, ":p.")?;
+        // Per HGVS syntax.yaml lines 119–128 the protein-variant grammar is
+        // `sequence_identifier ":" coordinate_type "." aa_position alternate_base`
+        // — no parenthesized selector position. The `accession(selector):c.`
+        // form (syntax.yaml line 213) is reserved for genomic-to-transcript
+        // projection on c./n., not for p. The struct still stores
+        // `gene_symbol` so callers can read it programmatically and so the
+        // parser (which is permissive about the legacy `NP_*(GENE):p.`
+        // form) can round-trip the value; it is just not emitted here. See
+        // #310.
+        write!(f, "{}:p.", self.accession)?;
         self.fmt_loc_edit(f)
     }
 }

--- a/src/normalize/boundary.rs
+++ b/src/normalize/boundary.rs
@@ -93,6 +93,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4390,6 +4390,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -4457,6 +4458,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -4751,6 +4753,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -4855,6 +4858,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -4920,6 +4924,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -5053,6 +5058,7 @@ mod tests {
             mane_status: Default::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: std::sync::OnceLock::new(),
         });
@@ -5101,6 +5107,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: std::sync::OnceLock::new(),
         });

--- a/src/project/accession.rs
+++ b/src/project/accession.rs
@@ -2,24 +2,58 @@
 
 use crate::hgvs::variant::Accession;
 
-/// Parse an HGVS-style accession string like "NM_000088.3" or "NP_000079.2".
+/// Parse an HGVS-style accession string like "NM_000088.3" or "ENSP00000256509.1".
 ///
 /// Accepts:
 /// - "PREFIX_NUMBER.VERSION" (e.g. `NM_000088.3` → prefix `NM`, number `000088`, version `Some(3)`)
 /// - "PREFIX_NUMBER" (no version)
-/// - Anything else (e.g. Ensembl-style `ENSP00000256509`): pass through as the prefix with empty number.
+/// - Ensembl-style "PREFIXNUMBER.VERSION" or "PREFIXNUMBER" with no underscore
+///   (e.g. `ENSP00000256509.1` → prefix `ENSP`, number `00000256509`, version `Some(1)`,
+///   `ensembl_style = true` so `Display` does not synthesize an underscore).
+/// - Anything else: pass through as the prefix with empty number.
 pub(crate) fn parse_accession(s: &str) -> Accession {
     if let Some((prefix_num, version)) = s.rsplit_once('.') {
         if let Ok(v) = version.parse::<u32>() {
             if let Some((prefix, number)) = prefix_num.split_once('_') {
                 return Accession::new(prefix, number, Some(v));
             }
+            if let Some((prefix, number)) = split_alpha_digits(prefix_num) {
+                return Accession::with_style(prefix, number, Some(v), true);
+            }
+            // No underscore and no alpha→digit split: treat the entire
+            // prefix_num as a no-underscore prefix so Display emits
+            // `<prefix_num>.<v>` without synthesizing a trailing underscore.
+            return Accession::with_style(prefix_num, "", Some(v), true);
         }
     }
     if let Some((prefix, number)) = s.split_once('_') {
         return Accession::new(prefix, number, None);
     }
-    Accession::new(s, "", None)
+    if let Some((prefix, number)) = split_alpha_digits(s) {
+        return Accession::with_style(prefix, number, None, true);
+    }
+    // Same rationale as above: no underscore and no alpha→digit split, so
+    // use `ensembl_style = true` to avoid a `<s>_` Display rendering.
+    Accession::with_style(s, "", None, true)
+}
+
+/// Split an accession at the first ASCII digit, returning `(alpha_prefix,
+/// digits_and_rest)`. Returns `None` if the input does not start with an
+/// alphabetic character followed by at least one digit.
+///
+/// This is the no-underscore (Ensembl-style) split path; it avoids the
+/// `format!("{}_{}", prefix, number)` rendering that `Accession::full` uses
+/// when `ensembl_style = false`.
+fn split_alpha_digits(s: &str) -> Option<(&str, &str)> {
+    let digit_start = s.find(|c: char| c.is_ascii_digit())?;
+    if digit_start == 0 {
+        return None;
+    }
+    let prefix = &s[..digit_start];
+    if !prefix.chars().all(|c| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    Some((prefix, &s[digit_start..]))
 }
 
 #[cfg(test)]
@@ -42,5 +76,20 @@ mod tests {
     fn parse_without_version() {
         let acc = parse_accession("NM_000088");
         assert_eq!(acc.to_string(), "NM_000088");
+    }
+
+    #[test]
+    fn split_alpha_digits_requires_ascii_alpha_prefix() {
+        // Strictly alphabetic prefix is accepted (Ensembl-style path).
+        assert_eq!(
+            split_alpha_digits("ENSP00000256509"),
+            Some(("ENSP", "00000256509"))
+        );
+        // Non-alphabetic characters before the first digit are rejected so we
+        // do not misclassify arbitrary IDs as Ensembl-style.
+        assert_eq!(split_alpha_digits("A B1"), None);
+        assert_eq!(split_alpha_digits("A-B1"), None);
+        // A digit at position 0 is already rejected.
+        assert_eq!(split_alpha_digits("1ABC"), None);
     }
 }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -581,6 +581,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -626,6 +627,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -691,6 +693,7 @@ mod tests {
                 mane_status: ManeStatus::default(),
                 refseq_match: None,
                 ensembl_match: None,
+                protein_id: None,
                 exon_cigars: Vec::new(),
                 cached_introns: OnceLock::new(),
             });
@@ -780,6 +783,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -998,6 +1002,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -388,22 +388,31 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // Predict protein consequence for CDS variants.
         let mut protein = None;
         if !is_intronic && !is_utr && is_coding {
-            // Prefer the explicit cdot.protein accession; otherwise infer NP_/XP_
-            // from NM_/XM_ by stripping the prefix (not by substring replace, which
-            // would mangle accessions whose suffix happens to contain "NM_"). If
-            // we cannot infer a protein accession, skip protein prediction rather
-            // than fabricate a bogus one.
-            let prot_acc = match cdot_protein {
-                Some(p) => Some(p),
-                None => transcript_id
-                    .strip_prefix("NM_")
-                    .map(|rest| format!("NP_{rest}"))
-                    .or_else(|| {
-                        transcript_id
-                            .strip_prefix("XM_")
-                            .map(|rest| format!("XP_{rest}"))
-                    }),
-            };
+            // Resolve the protein accession in priority order:
+            //   1. `cdot_protein` — explicit value from cdot.protein or from the
+            //      ferro reference JSON's `protein_id` field (which the cdot
+            //      mapper builders plumb into `CdotTranscript.protein`).
+            //   2. RefSeq inference: `NM_*` → `NP_*`, `XM_*` → `XP_*`. Substring
+            //      stripping (not replace) avoids mangling accessions whose
+            //      suffix happens to contain `NM_`.
+            //   3. The transcript ID itself, used as the `p.` accession prefix.
+            //      Keeps protein prediction live for references whose transcript
+            //      IDs do not match a RefSeq convention (e.g. `MY_GENE-gene.1`
+            //      from `ferro convert-gff`). The HGVS protein grammar requires
+            //      a `sequence_identifier`, so accession-less `p.` is not a valid
+            //      alternative. See #310.
+            let prot_acc: Option<String> = cdot_protein
+                .or_else(|| {
+                    transcript_id
+                        .strip_prefix("NM_")
+                        .map(|rest| format!("NP_{rest}"))
+                })
+                .or_else(|| {
+                    transcript_id
+                        .strip_prefix("XM_")
+                        .map(|rest| format!("XP_{rest}"))
+                })
+                .or_else(|| Some(transcript_id.to_string()));
             if let Some(prot_acc) = prot_acc {
                 match &c_edit {
                     NaEdit::Substitution { .. } => {
@@ -967,8 +976,9 @@ mod tests {
     fn make_ensembl_provider_and_projector() -> (Projector, MockProvider) {
         // Same CDS as make_test_provider_and_projector but the transcript ID is
         // an Ensembl accession (no NM_/XM_ prefix) and cdot.protein is absent.
-        // The projector must NOT fabricate a bogus protein accession via
-        // substring substitution; it should skip protein prediction instead.
+        // The projector must not fabricate a bogus accession via substring
+        // substitution; per #310 it falls back to using the transcript id as
+        // the `p.` accession prefix.
         let mut cdot = CdotMapper::new();
         cdot.add_transcript(
             "ENST00000000001.1".to_string(),
@@ -1013,7 +1023,13 @@ mod tests {
     }
 
     #[test]
-    fn project_substitution_no_protein_accession_skips_protein() {
+    fn project_substitution_falls_back_to_transcript_id_as_protein_accession() {
+        // Per #310: when no cdot.protein and no NM_/XM_ prefix is available
+        // to infer NP_/XP_ from, the projector falls back to using the
+        // transcript id directly as the `p.` accession prefix rather than
+        // silently dropping the protein prediction. The HGVS protein
+        // grammar requires a sequence_identifier, so the alternative would
+        // be a non-conformant accession-less `p.` form.
         let (projector, provider) = make_ensembl_provider_and_projector();
         let vp = VariantProjector::new(projector, provider);
         let result = vp
@@ -1021,12 +1037,12 @@ mod tests {
             .expect("projection should succeed");
         let c = result.coding.as_ref().expect("c. expected").to_string();
         assert!(c.contains(":c.4C>A"), "expected c.4C>A, got: {}", c);
-        // Neither NM_/XM_ prefix nor cdot.protein: must skip protein prediction.
-        assert!(
-            result.protein.is_none(),
-            "expected no protein for accession with no NM_/XM_ prefix and no cdot.protein, got: {:?}",
-            result.protein
-        );
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present via transcript-id fallback")
+            .to_string();
+        assert_eq!(p, "ENST00000000001.1:p.(Arg2Ser)");
     }
 
     // -------------------------------------------------------------------------

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -730,7 +730,7 @@ mod tests {
             .as_ref()
             .expect("p. should be present")
             .to_string();
-        assert_eq!(p, "NP_TEST_MINUS.1(TESTGENE):p.(Arg2Cys)");
+        assert_eq!(p, "NP_TEST_MINUS.1:p.(Arg2Cys)");
         assert!(!result.is_frameshift);
         assert!(!result.is_intronic);
         assert!(!result.is_utr);
@@ -851,7 +851,7 @@ mod tests {
             .as_ref()
             .expect("p. should be present")
             .to_string();
-        assert_eq!(p, "NP_TEST.1(TESTGENE):p.(Arg2Ser)");
+        assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
 
         assert!(!result.is_frameshift);
         assert!(!result.is_intronic);

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -231,6 +231,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -605,6 +605,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/project/protein/substitution.rs
+++ b/src/project/protein/substitution.rs
@@ -155,6 +155,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/reference/annotation/builder.rs
+++ b/src/reference/annotation/builder.rs
@@ -315,6 +315,7 @@ fn build_single(
         mane_status,
         refseq_match,
         ensembl_match,
+        protein_id: None,
         exon_cigars: Vec::new(),
         cached_introns: OnceLock::new(),
     })

--- a/src/reference/annotation/validate.rs
+++ b/src/reference/annotation/validate.rs
@@ -213,6 +213,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: vec![],
             cached_introns: OnceLock::new(),
         }
@@ -282,6 +283,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: vec![],
             cached_introns: OnceLock::new(),
         }

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -1048,6 +1048,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1083,6 +1084,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1124,6 +1126,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1164,6 +1167,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/reference/loader.rs
+++ b/src/reference/loader.rs
@@ -323,6 +323,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -352,6 +353,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -371,6 +373,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -401,6 +404,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -439,6 +443,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -458,6 +463,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -496,6 +502,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -515,6 +522,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -583,6 +591,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -625,6 +634,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -644,6 +654,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -682,6 +693,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -702,6 +714,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -734,6 +747,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -753,6 +767,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -801,6 +816,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -833,6 +849,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -852,6 +869,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -883,6 +901,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -909,6 +928,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -934,6 +954,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -126,6 +126,7 @@ impl MockProvider {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -150,6 +151,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -170,6 +172,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
@@ -196,6 +199,7 @@ impl MockProvider {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -610,6 +610,7 @@ impl MultiFastaProvider {
                 exons,
                 genomic_start: None,
                 genomic_end: None,
+                protein_id: None,
                 exon_cigars: Vec::new(),
             }
         } else {
@@ -632,6 +633,7 @@ struct TranscriptMetadata {
     exons: Vec<crate::reference::transcript::Exon>,
     genomic_start: Option<u64>,
     genomic_end: Option<u64>,
+    protein_id: Option<String>,
     exon_cigars: Vec<Option<Vec<crate::data::cdot::CigarOp>>>,
 }
 
@@ -700,6 +702,7 @@ impl ReferenceProvider for MultiFastaProvider {
                                 exons,
                                 genomic_start,
                                 genomic_end,
+                                protein_id: tx.protein.clone(),
                                 exon_cigars: tx.exon_cigars.clone(),
                             }
                         }
@@ -739,7 +742,7 @@ impl ReferenceProvider for MultiFastaProvider {
                     mane_status: ManeStatus::default(),
                     refseq_match: None,
                     ensembl_match: None,
-                    protein_id: None,
+                    protein_id: meta.protein_id,
                     exon_cigars: meta.exon_cigars,
                     cached_introns: OnceLock::new(),
                 });

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -739,6 +739,7 @@ impl ReferenceProvider for MultiFastaProvider {
                     mane_status: ManeStatus::default(),
                     refseq_match: None,
                     ensembl_match: None,
+                    protein_id: None,
                     exon_cigars: meta.exon_cigars,
                     cached_introns: OnceLock::new(),
                 });

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -319,6 +319,13 @@ pub struct Transcript {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ensembl_match: Option<String>,
 
+    /// Protein accession (e.g. "NP_000079.2"), used to drive c. → p.
+    /// projection when the transcript ID does not encode a RefSeq-style
+    /// `NM_*`/`XM_*` prefix. Populated by reference producers such as
+    /// `ferro convert-gff` when the protein accession is known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protein_id: Option<String>,
+
     /// Per-exon CIGAR alignment data (from cdot gap info).
     /// Indexed in the same order as `exons`. Used for CIGAR-aware CDS→tx mapping.
     #[serde(skip)]
@@ -347,6 +354,7 @@ impl Clone for Transcript {
             mane_status: self.mane_status,
             refseq_match: self.refseq_match.clone(),
             ensembl_match: self.ensembl_match.clone(),
+            protein_id: self.protein_id.clone(),
             exon_cigars: self.exon_cigars.clone(),
             // Cache is reset on clone - will be lazily re-initialized
             cached_introns: OnceLock::new(),
@@ -371,6 +379,7 @@ impl PartialEq for Transcript {
             && self.mane_status == other.mane_status
             && self.refseq_match == other.refseq_match
             && self.ensembl_match == other.ensembl_match
+            && self.protein_id == other.protein_id
             && self.exon_cigars == other.exon_cigars
     }
 }
@@ -415,9 +424,21 @@ impl Transcript {
             mane_status,
             refseq_match,
             ensembl_match,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
+    }
+
+    /// Set the explicit protein accession for this transcript.
+    ///
+    /// Used by reference producers (e.g. `ferro convert-gff`) and tests
+    /// to drive c. → p. projection when no RefSeq-style prefix is
+    /// present on the transcript ID.
+    #[must_use]
+    pub fn with_protein_id(mut self, protein_id: impl Into<Option<String>>) -> Self {
+        self.protein_id = protein_id.into();
+        self
     }
 
     /// Length of the transcript in mRNA bases. Uses the cached `sequence`
@@ -975,6 +996,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -1000,6 +1022,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: Some("ENST00000123456.5".to_string()),
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -1032,6 +1055,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1352,6 +1376,7 @@ mod tests {
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: std::sync::OnceLock::new(),
         };

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -486,6 +486,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/vcf/annotator.rs
+++ b/src/vcf/annotator.rs
@@ -308,6 +308,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -331,6 +332,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -577,6 +579,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -596,6 +599,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -647,6 +651,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -681,6 +686,7 @@ mod tests {
             mane_status: ManeStatus::PlusClinical,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/vcf/batch.rs
+++ b/src/vcf/batch.rs
@@ -413,6 +413,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -750,6 +750,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }

--- a/src/vcf/to_hgvs.rs
+++ b/src/vcf/to_hgvs.rs
@@ -631,6 +631,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         }
@@ -1029,6 +1030,7 @@ mod tests {
             mane_status: ManeStatus::None,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };
@@ -1061,6 +1063,7 @@ mod tests {
             mane_status: ManeStatus::Select,
             refseq_match: None,
             ensembl_match: None,
+            protein_id: None,
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         };

--- a/tests/gene_selector_display_preserve.rs
+++ b/tests/gene_selector_display_preserve.rs
@@ -90,10 +90,17 @@ fn display_preserves_gene_selector_refseq_nr_noncoding() {
 }
 
 #[test]
-fn display_preserves_gene_selector_refseq_np_protein() {
-    // Protein with predicted-change parens uses `p.(...)` form; the gene
-    // selector parens sit between the accession and the colon.
-    assert_display_preserves_gene_selector("NP_000079.2(COL1A1):p.(Arg8Gln)", "COL1A1");
+fn display_drops_gene_selector_refseq_np_protein() {
+    // Per HGVS syntax.yaml 119–128 the protein-variant grammar has no
+    // parenthesized selector position; the `accession(selector):c.` form
+    // (syntax.yaml 213) is reserved for genomic-to-transcript projection on
+    // c./n., not p. The parser remains permissive and `gene_symbol` round-trips
+    // on the struct, but Display emits the spec-compliant `NP_*:p.` form.
+    // See #310.
+    use ferro_hgvs::hgvs::parser::parse_hgvs;
+    let v = parse_hgvs("NP_000079.2(COL1A1):p.(Arg8Gln)").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("COL1A1"));
+    assert_eq!(v.to_string(), "NP_000079.2:p.(Arg8Gln)");
 }
 
 #[test]
@@ -110,11 +117,19 @@ fn display_preserves_gene_selector_ensembl() {
 #[test]
 fn display_preserves_gene_selector_lrg() {
     // LRG references come in three flavors: bare (`LRG_<n>`), transcript
-    // (`LRG_<n>t<m>`), and protein (`LRG_<n>p<m>`). All three must accept
-    // and round-trip the gene selector.
+    // (`LRG_<n>t<m>`), and protein (`LRG_<n>p<m>`). The bare and transcript
+    // forms preserve the gene selector verbatim on `c.`/`n.`. The protein
+    // form does NOT round-trip the selector through Display: the HGVS
+    // protein-variant grammar (syntax.yaml 119–128) has no parenthesized
+    // selector position, so Display emits the spec-compliant `LRG_*p*:p.`
+    // form. See #310.
     assert_display_preserves_gene_selector("LRG_199(BRCA1):c.100A>G", "BRCA1");
     assert_display_preserves_gene_selector("LRG_199t1(BRCA1):c.100A>G", "BRCA1");
-    assert_display_preserves_gene_selector("LRG_199p1(BRCA1):p.(Arg8Gln)", "BRCA1");
+
+    use ferro_hgvs::hgvs::parser::parse_hgvs;
+    let v = parse_hgvs("LRG_199p1(BRCA1):p.(Arg8Gln)").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("BRCA1"));
+    assert_eq!(v.to_string(), "LRG_199p1:p.(Arg8Gln)");
 }
 
 #[test]

--- a/tests/gene_selector_roundtrip.rs
+++ b/tests/gene_selector_roundtrip.rs
@@ -154,8 +154,15 @@ fn display_preserves_gene_selector_refseq_nr() {
 }
 
 #[test]
-fn display_preserves_gene_selector_refseq_np() {
-    assert_display_preserves_gene_selector("NP_000079.2(COL1A1):p.(Arg8Gln)");
+fn display_drops_gene_selector_refseq_np() {
+    // Per HGVS syntax.yaml 119–128 the `accession(selector):p.` form is not
+    // part of the protein-variant grammar; the parenthesized selector is only
+    // defined for genomic-to-transcript projection on c./n. (syntax.yaml 213).
+    // Parsing remains permissive — `gene_symbol` round-trips on the struct —
+    // but Display emits the spec-compliant `accession:p.` form. See #310.
+    let v = parse_hgvs("NP_000079.2(COL1A1):p.(Arg8Gln)").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("COL1A1"));
+    assert_eq!(v.to_string(), "NP_000079.2:p.(Arg8Gln)");
 }
 
 #[test]
@@ -243,8 +250,14 @@ fn display_preserves_gene_selector_lrg_transcript_rna() {
 }
 
 #[test]
-fn display_preserves_gene_selector_lrg_protein() {
-    assert_display_preserves_gene_selector("LRG_199p1(BRCA1):p.(Arg8Gln)");
+fn display_drops_gene_selector_lrg_protein() {
+    // Per HGVS syntax.yaml 119–128 the protein-variant grammar has no
+    // parenthesized selector position; Display emits the spec-compliant
+    // `LRG_*p*:p.` form even when the parser accepted a `(GENE)` selector.
+    // See #310.
+    let v = parse_hgvs("LRG_199p1(BRCA1):p.(Arg8Gln)").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("BRCA1"));
+    assert_eq!(v.to_string(), "LRG_199p1:p.(Arg8Gln)");
 }
 
 // =============================================================================
@@ -586,10 +599,13 @@ fn normalize_is_idempotent_with_gene_symbol() {
 
 #[test]
 fn reparse_preserves_gene_symbol() {
+    // Only non-protein accession families round-trip byte-stably — `p.`
+    // Display intentionally drops the gene-symbol selector (#310), so a
+    // protein variant is not identity-preserving across Display in this
+    // sense and is covered separately in `display_drops_gene_selector_refseq_np`.
     let cases: &[(&str, &str)] = &[
         ("NM_000088.3(COL1A1):c.459A>G", "COL1A1"),
         ("NR_046018.2(DDX11L1):n.100A>G", "DDX11L1"),
-        ("NP_000079.2(COL1A1):p.(Arg8Gln)", "COL1A1"),
         ("ENST00000380152.7(BRCA2):c.100A>G", "BRCA2"),
         ("LRG_199t1(BRCA1):c.100A>G", "BRCA1"),
         ("MYREF_SEQ(GENE1):c.100A>G", "GENE1"),

--- a/tests/issue_247_lrg_roundtrip.rs
+++ b/tests/issue_247_lrg_roundtrip.rs
@@ -272,8 +272,18 @@ mod lrg_with_gene_symbol {
     }
 
     #[test]
-    fn protein_with_gene_round_trips() {
-        assert_round_trips("LRG_199p1(BRCA1):p.Arg8Gln");
+    fn protein_with_gene_drops_selector_on_display() {
+        // Per HGVS syntax.yaml 119–128 the protein-variant grammar has no
+        // parenthesized selector position. The parser still accepts the
+        // `LRG_*p*(GENE):p.` form and stores the selector text in
+        // `gene_symbol`, but Display emits the spec-compliant form without
+        // the selector. See #310.
+        let v = parse_hgvs("LRG_199p1(BRCA1):p.Arg8Gln")
+            .unwrap_or_else(|e| panic!("parse failed: {e}"));
+        // Parser remains permissive: gene selector text is retained on the
+        // struct even though Display drops it.
+        assert_eq!(v.gene_symbol(), Some("BRCA1"));
+        assert_eq!(format!("{}", v), "LRG_199p1:p.Arg8Gln");
     }
 }
 

--- a/tests/issue_310_projector_non_refseq.rs
+++ b/tests/issue_310_projector_non_refseq.rs
@@ -1,0 +1,125 @@
+//! Issue #310 — protein prediction for non-RefSeq transcript IDs and
+//! spec-compliant `p.` selector emission.
+//!
+//! Pins:
+//! 1. With `protein_id` set, the projector emits a `p.` prediction using
+//!    that accession even when the transcript ID is not RefSeq-style.
+//! 2. Without `protein_id`, the projector falls back to using the
+//!    transcript ID as the `p.` accession — never silently drops the
+//!    prediction just because of an ID format.
+//! 3. RefSeq `NM_*` transcripts still infer `NP_*` and now omit the
+//!    gene-symbol selector from Display.
+//! 4. The parser still accepts the legacy `NP_*(GENE):p.` form and
+//!    preserves the selector text in `gene_symbol` for callers that
+//!    read it programmatically.
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::{VariantProjection, VariantProjector};
+
+/// Build a mock reference where the transcript ID does NOT match the
+/// RefSeq `NM_*` convention. Mirrors the reproduction in the issue body
+/// but lets the caller supply or omit `protein_id`.
+fn make_provider(transcript_id: &str, protein_id: Option<&str>) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let tx = Transcript::new(
+        transcript_id.to_string(),
+        Some("MYGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    )
+    .with_protein_id(protein_id.map(str::to_string));
+    provider.add_transcript(tx);
+    // Genomic sequence: 1000 N's + "ATGCGCTAA" + 100 N's so g.1003 is the
+    // 4th base of the CDS (= c.4, the first base of codon 2 "CGC" → Arg).
+    let prefix = "N".repeat(1000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+    provider
+}
+
+fn project(provider: MockProvider, variant: &str, transcript_id: &str) -> VariantProjection {
+    let cdot = CdotMapper::from_transcripts(provider.all_transcripts());
+    let projector = Projector::new(cdot);
+    let vp = VariantProjector::new(projector, provider);
+    vp.project(variant, transcript_id)
+        .expect("projection should succeed")
+}
+
+#[test]
+fn non_refseq_id_with_explicit_protein_id_uses_protein_id() {
+    let provider = make_provider("MYGENE-gene.1", Some("MYGENE-protein.1"));
+    let result = project(provider, "chr1:g.1003C>A", "MYGENE-gene.1");
+    let p = result
+        .protein
+        .as_ref()
+        .expect("p. should be set via protein_id")
+        .to_string();
+    assert_eq!(p, "MYGENE-protein.1:p.(Arg2Ser)");
+    assert!(!p.contains("(MYGENE)"), "no (GENE) selector on p.: {p}");
+}
+
+#[test]
+fn non_refseq_id_without_protein_id_falls_back_to_transcript_id() {
+    let provider = make_provider("MYGENE-gene.1", None);
+    let result = project(provider, "chr1:g.1003C>A", "MYGENE-gene.1");
+    let p = result
+        .protein
+        .as_ref()
+        .expect("p. should be set via transcript-id fallback")
+        .to_string();
+    assert_eq!(p, "MYGENE-gene.1:p.(Arg2Ser)");
+}
+
+#[test]
+fn refseq_nm_prefix_still_infers_np_and_omits_gene_selector() {
+    let provider = make_provider("NM_TEST.1", None);
+    let result = project(provider, "chr1:g.1003C>A", "NM_TEST.1");
+    let p = result
+        .protein
+        .as_ref()
+        .expect("p. should be set via NM_ → NP_ inference")
+        .to_string();
+    assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
+    assert!(!p.contains("(MYGENE)"), "no (GENE) selector on p.: {p}");
+}
+
+#[test]
+fn refseq_xm_prefix_still_infers_xp_and_omits_gene_selector() {
+    let provider = make_provider("XM_TEST.1", None);
+    let result = project(provider, "chr1:g.1003C>A", "XM_TEST.1");
+    let p = result
+        .protein
+        .as_ref()
+        .expect("p. should be set via XM_ → XP_ inference")
+        .to_string();
+    assert_eq!(p, "XP_TEST.1:p.(Arg2Ser)");
+    assert!(!p.contains("(MYGENE)"), "no (GENE) selector on p.: {p}");
+}
+
+#[test]
+fn parser_still_accepts_legacy_np_with_selector() {
+    use ferro_hgvs::hgvs::variant::HgvsVariant;
+    use ferro_hgvs::parse_hgvs;
+    let v = parse_hgvs("NP_TEST.1(MYGENE):p.(Arg2Ser)").expect("legacy form should still parse");
+    let p = match v {
+        HgvsVariant::Protein(p) => p,
+        other => panic!("expected ProteinVariant, got {other:?}"),
+    };
+    // The parser preserves the selector text in `gene_symbol` for callers
+    // that read it programmatically, even though Display now drops it.
+    assert_eq!(p.gene_symbol.as_deref(), Some("MYGENE"));
+    assert_eq!(p.to_string(), "NP_TEST.1:p.(Arg2Ser)");
+}

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -78,7 +78,7 @@ fn end_to_end_missense() {
     let c = result.coding.as_ref().unwrap().to_string();
     assert!(c.contains(":c.4C>A"), "got c. = {}", c);
     let p = result.protein.as_ref().unwrap().to_string();
-    assert_eq!(p, "NP_TEST.1(TESTGENE):p.(Arg2Ser)");
+    assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
     assert!(!result.is_frameshift);
     assert!(!result.is_intronic);
     assert!(!result.is_utr);

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -75,7 +75,7 @@ class TestVariantProjector:
         assert result.gene_symbol == "TESTGENE"
         assert result.c_name is not None
         assert ":c.4C>A" in result.c_name
-        assert result.p_name == "NP_TEST.1(TESTGENE):p.(Arg2Ser)"
+        assert result.p_name == "NP_TEST.1:p.(Arg2Ser)"
         assert result.is_frameshift is False
         assert result.is_intronic is False
         assert result.is_utr is False
@@ -186,14 +186,14 @@ class TestIndelProteinNomenclature:
         result = long_projector.project("NC_000002.12:g.2006_2008del", transcript="NM_LONG.1")
         assert result.c_name is not None
         assert "del" in result.c_name
-        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2del)"
+        assert result.p_name == "NP_LONG.1:p.(Arg2del)"
         assert result.is_frameshift is False
 
     def test_del_two_whole_codons(self, long_projector: ferro_hgvs.VariantProjector) -> None:
         # Delete Arg+Lys codons (c.4_9 = g.2006_2014del): p.(Arg2_Lys3del).
         result = long_projector.project("NC_000002.12:g.2006_2011del", transcript="NM_LONG.1")
         assert result.c_name is not None
-        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2_Lys3del)"
+        assert result.p_name == "NP_LONG.1:p.(Arg2_Lys3del)"
         assert result.is_frameshift is False
 
     def test_del_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:
@@ -209,7 +209,7 @@ class TestIndelProteinNomenclature:
         result = long_projector.project("NC_000002.12:g.2006_2008dup", transcript="NM_LONG.1")
         assert result.c_name is not None
         assert "dup" in result.c_name
-        assert result.p_name == "NP_LONG.1(LONGGENE):p.(Arg2dup)"
+        assert result.p_name == "NP_LONG.1:p.(Arg2dup)"
         assert result.is_frameshift is False
 
     def test_dup_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -389,3 +389,63 @@ class TestProjectNormalized:
         result = projector.project_normalized(variant, "NM_TEST.1")
         assert isinstance(result, ferro_hgvs.VariantProjection)
         assert result.c_name is not None
+
+
+class TestIssue310NonRefSeqProtein:
+    """Issue #310 — protein prediction for non-RefSeq transcript IDs and
+    spec-compliant `p.` selector emission. Mirrors the reproduction in the
+    issue body."""
+
+    @staticmethod
+    def _fixture(protein_id: str | None = None) -> dict:
+        tx: dict = {
+            "id": "MYGENE-gene.1",
+            "gene_symbol": "MYGENE",
+            "strand": "+",
+            "sequence": "ATGCGCTAA",
+            "cds_start": 1,
+            "cds_end": 9,
+            "exons": [
+                {
+                    "number": 1,
+                    "start": 1,
+                    "end": 9,
+                    "genomic_start": 1000,
+                    "genomic_end": 1008,
+                }
+            ],
+            "chromosome": "chr1",
+            "genomic_start": 1000,
+            "genomic_end": 1008,
+        }
+        if protein_id is not None:
+            tx["protein_id"] = protein_id
+        return {
+            "transcripts": [tx],
+            "genomic_sequences": {"chr1": "N" * 1000 + "ATGCGCTAA" + "N" * 100},
+        }
+
+    def test_explicit_protein_id_drives_p_name(self, tmp_path):
+        import json
+
+        path = tmp_path / "ref.json"
+        path.write_text(json.dumps(self._fixture(protein_id="MYGENE-protein.1")))
+        projector = ferro_hgvs.VariantProjector(reference_json=str(path))
+        result = projector.project("chr1:g.1003C>A", "MYGENE-gene.1")
+        # c. keeps the (GENE) selector per existing #121 policy; only p.
+        # output is changed by #310 to align with the HGVS protein grammar.
+        assert ":c.4C>A" in (result.c_name or "")
+        assert result.p_name == "MYGENE-protein.1:p.(Arg2Ser)"
+        assert "(MYGENE)" not in (result.p_name or "")
+
+    def test_missing_protein_id_falls_back_to_transcript_id(self, tmp_path):
+        import json
+
+        path = tmp_path / "ref.json"
+        path.write_text(json.dumps(self._fixture(protein_id=None)))
+        projector = ferro_hgvs.VariantProjector(reference_json=str(path))
+        result = projector.project("chr1:g.1003C>A", "MYGENE-gene.1")
+        # The HGVS protein grammar requires a sequence_identifier, so the
+        # projector falls back to the transcript ID rather than silently
+        # dropping the prediction.
+        assert result.p_name == "MYGENE-gene.1:p.(Arg2Ser)"


### PR DESCRIPTION
## Summary

Two related fixes from #310.

**1. Protein prediction for non-RefSeq transcript IDs.** `VariantProjector.project()` previously returned `p_name = None` whenever the transcript ID did not start with `NM_` or `XM_` and no `cdot.protein` value was available — even when the reference had a valid CDS and coding sequence. This surfaced for references produced by `ferro convert-gff`, which emits IDs of the form `{gene}-gene.1`.

This PR adds an optional `protein_id` field to the ferro reference-JSON transcript schema (and the in-memory `Transcript` struct) and replaces the projector's two-branch logic with a four-step priority chain:

1. `cdot.protein` (unchanged for cdot-based references)
2. `transcript.protein_id` (new, plumbed into `CdotTranscript.protein` by `CdotMapper::from_transcripts*`)
3. `NM_*` → `NP_*` / `XM_*` → `XP_*` inference (unchanged)
4. Transcript ID itself used as the `p.` accession prefix (new fallback)

The HGVS protein grammar requires a `sequence_identifier`, so the transcript-ID fallback is what guarantees that protein prediction is never silently dropped for an arbitrary ID format.

**2. Drop `(GENE)` selector from `p.` Display.** `ProteinVariant::Display` previously emitted `NP_*(GENE):p.(...)`. The HGVS protein grammar ([syntax.yaml 119–128](https://hgvs-nomenclature.org/stable/recommendations/summary/)) defines protein variants as `sequence_identifier ":" coordinate_type "." aa_position alternate_base` with no parenthesized selector position; the `accession(selector):c.` form (syntax.yaml 213) is reserved for genomic-to-transcript projection on `c.`/`n.`, not `p.` The reporter also cites HGVS guidance that gene symbols should not be used as specification.

`ProteinVariant::Display` now writes `accession:p....` without the selector. The `gene_symbol` field stays on the struct for the public projection API, and the parser remains permissive on the legacy `NP_*(SELECTOR):p.` form so strings produced by older ferro versions still parse cleanly. Only canonical `p.` output changes; other coordinate systems (`c.`/`n.`/`g.`/`r.`/`m.`) are untouched.

Also fixes a latent bug in `project::accession::parse_accession` where Ensembl-style IDs (and any accession without an underscore) were rendered with a spurious trailing underscore through `Display` — the helper now splits at the alpha→digit boundary and sets `ensembl_style=true`.

## Behavior table

| Reference shape                                | Old `p_name`                       | New `p_name`                       |
| ---------------------------------------------- | ---------------------------------- | ---------------------------------- |
| RefSeq `NM_*` + `cdot.protein`                 | `NP_*(GENE):p.(...)` if gene set   | `NP_*:p.(...)`                     |
| RefSeq `NM_*`, no cdot                         | `NP_*(GENE):p.(...)` if gene set   | `NP_*:p.(...)`                     |
| RefSeq `XM_*`                                  | `XP_*(GENE):p.(...)` if gene set   | `XP_*:p.(...)`                     |
| Non-RefSeq ID + new `protein_id`               | `None`                             | `<protein_id>:p.(...)`             |
| Non-RefSeq ID, no `protein_id`                 | `None`                             | `<transcript_id>:p.(...)`          |
| Non-coding / intronic / UTR                    | `None`                             | `None` (unchanged)                 |

## Test plan
- [x] `cargo nextest run --features dev` — 5048 tests pass.
- [x] `pytest tests/python/` — 159 tests pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean.
- [x] `ruff check python/ tests/python/` clean.
- [x] New `tests/issue_310_projector_non_refseq.rs` covers: protein_id-driven accession; transcript-ID fallback; RefSeq inference still works with the new `:p.` form; parser still accepts the legacy `NP_*(GENE):p.` form and round-trips `gene_symbol` on the struct.
- [x] New `TestIssue310NonRefSeqProtein` in `tests/python/test_variant_projection.py` exercises the same scenarios end-to-end through the Python binding.
- [x] Updated in-tree assertions that pinned the legacy `NP_*(GENE):p.` and `LRG_*p*(GENE):p.` Display output to the new spec-compliant form.

Closes #310.