### PR TITLE
fix(fasta): require version-boundary equality in MmapFastaProvider transcript lookup (closes #314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - *(parser)* accept `?con<src>` and `?copy<N>` at unknown position, consistent with `?del`/`?dup`/`?ins`/`?inv` (closes #286)
+- *(fasta)* require version-boundary equality in `MmapFastaProvider::get_transcript`'s unversioned-prefix fallback (closes #314)
 
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -836,10 +836,14 @@ impl ReferenceProvider for MmapFastaProvider {
             return Ok(tx.clone());
         }
 
-        // Try without version
+        // Try without version: only match a stored key whose base id (the
+        // segment before the version dot) equals the requested id. A bare
+        // `starts_with` would also match unrelated keys that merely share
+        // a prefix (e.g. `chr1-gene.1` for a `chr1` lookup), causing a
+        // genomic accession to be resolved as a transcript — see #314.
         let base_id = id.split('.').next().unwrap_or(id);
         for (key, tx) in &self.transcripts {
-            if key.starts_with(base_id) {
+            if key.split('.').next().unwrap_or(key) == base_id {
                 return Ok(tx.clone());
             }
         }

--- a/tests/issue_314_mmap_prefix_collision.rs
+++ b/tests/issue_314_mmap_prefix_collision.rs
@@ -1,0 +1,101 @@
+//! Tests for issue #314 — `MmapFastaProvider::get_transcript` carries the
+//! same permissive `starts_with(base_id)` fallback that `MockProvider`
+//! had before #312. A lookup for a chromosome accession (e.g. `chr1`)
+//! resolves to any transcript whose id literally starts with that
+//! string (e.g. `chr1-gene.1`).
+//!
+//! These tests pin the corrected lookup contract:
+//!
+//! - the unversioned-prefix fallback must match a stored key only when
+//!   the segment before the version dot equals the requested id, so an
+//!   `NM_000088` query still resolves to `NM_000088.3` but `chr1` does
+//!   not resolve to `chr1-gene.1`.
+//! - exact id matches keep working.
+//! - the fallback must not match arbitrary prefixes that stop at a
+//!   non-version-boundary character.
+
+#![cfg(feature = "mmap")]
+
+use std::io::Write;
+
+use ferro_hgvs::reference::fasta::MmapFastaProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::ReferenceProvider;
+
+/// Minimal viable FASTA file: one contig, one base. `MmapFastaProvider`
+/// needs a real file to memory-map, but the bug under test lives in the
+/// transcript registry and never touches the index.
+fn tiny_mmap_provider() -> (tempfile::TempDir, MmapFastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr1").expect("write fasta header");
+    writeln!(f, "A").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = MmapFastaProvider::new(&fa_path).expect("mmap fasta");
+    (dir, provider)
+}
+
+fn synthetic_transcript(id: &str) -> Transcript {
+    Transcript::new(
+        id.to_string(),
+        None,
+        Strand::Plus,
+        "ACGTACGT".to_string(),
+        Some(1),
+        Some(8),
+        vec![Exon::new(1, 1, 8)],
+        Some("chr1".to_string()),
+        Some(1),
+        Some(8),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+#[test]
+fn get_transcript_does_not_collide_with_chromosome_prefix() {
+    let (_dir, mut p) = tiny_mmap_provider();
+    p.add_transcript(synthetic_transcript("chr1-gene.1"));
+    if let Ok(tx) = p.get_transcript("chr1") {
+        panic!(
+            "expected ReferenceNotFound for 'chr1'; got transcript {:?}",
+            tx.id
+        );
+    }
+}
+
+#[test]
+fn get_transcript_resolves_unversioned_query_to_versioned_key() {
+    let (_dir, mut p) = tiny_mmap_provider();
+    p.add_transcript(synthetic_transcript("NM_000088.3"));
+    let tx = p
+        .get_transcript("NM_000088")
+        .expect("unversioned id should resolve to NM_000088.3");
+    assert_eq!(tx.id, "NM_000088.3");
+}
+
+#[test]
+fn get_transcript_resolves_exact_id() {
+    let (_dir, mut p) = tiny_mmap_provider();
+    p.add_transcript(synthetic_transcript("NM_000088.3"));
+    let tx = p
+        .get_transcript("NM_000088.3")
+        .expect("exact id should resolve");
+    assert_eq!(tx.id, "NM_000088.3");
+}
+
+#[test]
+fn get_transcript_rejects_non_version_boundary_prefix() {
+    let (_dir, mut p) = tiny_mmap_provider();
+    p.add_transcript(synthetic_transcript("NM_000088.3"));
+    if let Ok(tx) = p.get_transcript("NM_0000") {
+        panic!(
+            "expected ReferenceNotFound for 'NM_0000'; got transcript {:?}",
+            tx.id
+        );
+    }
+}


### PR DESCRIPTION
Closes #314. Follow-up to #311 / #312.

## Summary

\`MmapFastaProvider::get_transcript\` at \`src/reference/fasta.rs:833-848\` carried the same permissive \`key.starts_with(base_id)\` fallback that \`MockProvider\` had before #312, so a lookup for a chromosome accession (e.g. \`chr1\`) silently resolved to any transcript whose id literally began with that string (e.g. \`chr1-gene.1\`). This is the same collision class fixed in #312, just on a different provider.

The fix mirrors #312: the unversioned-prefix fallback now matches a stored key only when the segment before the version dot equals the requested id. \`NM_000088\` still resolves to \`NM_000088.3\`; \`chr1\` no longer resolves to \`chr1-gene.1\`.

## Why no existing test caught it

No fixture pairs a transcript id with a prefix-colliding chromosome name on the \`MmapFastaProvider\` path — the same coverage gap #312 called out for the synthetic matrix. The broader fixture work is tracked in #316. This PR adds a targeted regression test alongside the fix.

## Tests

\`tests/issue_314_mmap_prefix_collision.rs\` — four cases, gated behind the \`mmap\` feature:

- \`get_transcript("chr1")\` does not resolve to \`chr1-gene.1\`
- \`get_transcript("NM_000088")\` still resolves to \`NM_000088.3\` (unversioned ↔ versioned)
- \`get_transcript("NM_000088.3")\` still resolves exactly
- \`get_transcript("NM_0000")\` does not resolve to \`NM_000088.3\` (non-version-boundary prefix)

## Test plan

- [x] \`cargo nextest run --features dev\` — 5048 / 5048 pass, 51 skipped.
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.