### PR TITLE
fix(fasta): route known-contig lookups in FastaProvider through the FASTA path (closes #315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(parser)* accept `?con<src>` and `?copy<N>` at unknown position, consistent with `?del`/`?dup`/`?ins`/`?inv` (closes #286)
 - *(fasta)* require version-boundary equality in `MmapFastaProvider::get_transcript`'s unversioned-prefix fallback (closes #314)
+- *(fasta)* route `FastaProvider::get_sequence` for known contigs through the FASTA path so a transcript registered with a chromosome-colliding id no longer wins over the genomic index (closes #315)
 
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -219,6 +219,22 @@ impl FastaProvider {
     pub fn add_transcript(&mut self, transcript: Transcript) {
         self.transcripts.insert(transcript.id.clone(), transcript);
     }
+
+    /// True when `id` is declared as a chromosome/contig name — either
+    /// resolves against the FASTA `.fai` index (directly or via an alias
+    /// chain) or appears as the `chromosome` field on a registered
+    /// transcript. Used by `get_sequence` to disambiguate genomic
+    /// lookups from transcript-id lookups when the two namespaces
+    /// collide (e.g. a transcript whose id is `chrN`; see #315).
+    fn is_known_contig(&self, id: &str) -> bool {
+        let resolved = self.resolve_name(id);
+        if self.index.contains_key(&resolved) {
+            return true;
+        }
+        self.transcripts
+            .values()
+            .any(|tx| tx.chromosome.as_deref() == Some(id))
+    }
 }
 
 impl ReferenceProvider for FastaProvider {
@@ -230,6 +246,17 @@ impl ReferenceProvider for FastaProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        // If the requested id is registered as a contig — either present
+        // in the FASTA index (directly or via an alias) or referenced as
+        // the `chromosome` field on a registered transcript — resolve it
+        // strictly against the FASTA path. Without this dispatch, a
+        // transcript whose id happens to match a contig name would
+        // short-circuit the lookup and silently interpret genomic
+        // coordinates as transcript-relative indices (#315 / #311).
+        if self.is_known_contig(id) {
+            return self.get_fasta_sequence(id, start, end);
+        }
+
         // First try as transcript ID. Only return a hit when the transcript
         // has cached sequence bases; coordinate-only transcripts fall through
         // to the FASTA index lookup below.

--- a/tests/issue_315_fasta_known_contig.rs
+++ b/tests/issue_315_fasta_known_contig.rs
@@ -1,0 +1,119 @@
+//! Tests for issue #315 — `FastaProvider::get_sequence` routes every
+//! lookup through the transcript registry before consulting the FASTA
+//! index. Exact-match only (no `starts_with` fallback), but if any
+//! caller registers a transcript with `id = "chrN"` alongside a FASTA
+//! that also contains `chrN`, the transcript wins and a genomic
+//! coordinate lookup silently reads transcript-relative bases — the
+//! same wrong-coordinate-frame bug #311 hit on `MockProvider`.
+//!
+//! These tests pin the corrected dispatch contract:
+//!
+//! - when the id is a known contig (in the FASTA `.fai` index, or as the
+//!   `chromosome` field on any registered transcript), `get_sequence`
+//!   resolves strictly against the FASTA path.
+//! - transcript-id lookups for ids that are NOT known contigs keep
+//!   returning the transcript's cached sequence (no regression).
+//! - a known contig with no FASTA backing surfaces as `Err`, which
+//!   `normalize_genome` already falls back to canonicalize-only.
+
+use std::io::Write;
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::{FastaProvider, ReferenceProvider};
+
+/// FASTA file with a single contig `chr1` whose sequence is 12 bytes
+/// of `A`. `MmapFastaProvider` and `FastaProvider` both read from a
+/// real file; `tempfile::TempDir` keeps the file alive for the
+/// duration of the test.
+fn provider_with_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr1").expect("write fasta header");
+    writeln!(f, "AAAAAAAAAAAA").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn provider_no_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr2").expect("write fasta header");
+    writeln!(f, "GGGGGGGG").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn synthetic_transcript(id: &str, chromosome: Option<&str>) -> Transcript {
+    Transcript::new(
+        id.to_string(),
+        None,
+        Strand::Plus,
+        "TTTTTTTT".to_string(),
+        Some(1),
+        Some(8),
+        vec![Exon::new(1, 1, 8)],
+        chromosome.map(str::to_string),
+        Some(1),
+        Some(8),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+/// Exact id collision: a transcript with id `chr1` is registered on
+/// the same provider whose FASTA index also has `chr1`. The FASTA
+/// bytes (`AAA`) must win over the transcript's cached bases (`TTT`).
+#[test]
+fn get_sequence_prefers_fasta_index_over_colliding_transcript_id() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("chr1", Some("chr1")));
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA", "expected FASTA bytes, got transcript bases");
+}
+
+/// Soft-collision: a transcript declares `chr1` as its `chromosome`
+/// field, but the FASTA index has no `chr1` entry. A `get_sequence`
+/// call on `chr1` must NOT silently slide into the transcript's bases
+/// for an unrelated transcript id — it must Err so callers can fall
+/// back to canonicalize-only.
+#[test]
+fn get_sequence_for_known_contig_without_fasta_backing_errors() {
+    let (_dir, mut p) = provider_no_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    if let Ok(seq) = p.get_sequence("chr1", 0, 3) {
+        panic!("expected ReferenceNotFound for 'chr1'; got {:?}", seq);
+    }
+}
+
+/// Negative control: a transcript id with no colliding chromosome must
+/// keep returning the transcript's cached sequence.
+#[test]
+fn get_sequence_for_transcript_id_returns_transcript_bases() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    let seq = p
+        .get_sequence("NM_000088.3", 0, 3)
+        .expect("NM_000088.3 lookup should resolve via transcript registry");
+    assert_eq!(seq, "TTT");
+}
+
+/// Negative control: a FASTA-index lookup with no transcript
+/// registered for that name keeps returning FASTA bytes.
+#[test]
+fn get_sequence_for_fasta_only_contig_returns_fasta_bases() {
+    let (_dir, p) = provider_with_chr1_fasta();
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA");
+}


### PR DESCRIPTION
Closes #315. Follow-up to #311 / #312.

## Summary

\`FastaProvider::get_sequence\` routed every lookup through the transcript registry first:

\`\`\`rust
if let Some(transcript) = self.transcripts.get(id) { /* return transcript bases */ }
self.get_fasta_sequence(id, start, end)
\`\`\`

Exact-match only (no \`starts_with\` fallback), so realistic accession names cannot collide. But if any caller registers a transcript with \`id = \"chrN\"\` alongside a FASTA index that also contains \`chrN\`, the transcript wins and \`get_sequence(\"chrN\", ...)\` silently reads transcript-relative bases for a genomic-coordinate query — the same wrong-coordinate-frame bug #311 hit on \`MockProvider\`.

## Fix

Mirror the #312 \`MockProvider::get_sequence\` fix:

- \`get_sequence\` short-circuits to \`get_fasta_sequence\` when the id is a known contig — either resolves against the FASTA \`.fai\` index (directly or via an alias chain) or appears as the \`chromosome\` field on a registered transcript.
- Genuinely missing chromosome data surfaces as \`Err\`, which \`normalize_genome\` already falls back to canonicalize-only.
- Otherwise treat the id as a transcript accession (no change for that path).

A new \`is_known_contig\` helper on \`FastaProvider\` encapsulates the dispatch.

## Tests

\`tests/issue_315_fasta_known_contig.rs\` — four cases:

- exact id collision: a transcript with id \`chr1\` is registered alongside a FASTA \`chr1\` entry → \`get_sequence(\"chr1\", 0, 3)\` returns FASTA bytes (\`AAA\`), not transcript bases (\`TTT\`).
- soft collision: a transcript declares \`chromosome = \"chr1\"\` but the FASTA index has no \`chr1\` entry → \`get_sequence(\"chr1\", 0, 3)\` Errs cleanly (does not silently return unrelated transcript bases for a different id's transcript bases).
- transcript-id lookup for a non-colliding id keeps returning the transcript's cached sequence.
- FASTA-only contig lookup with no colliding transcript is unaffected.

## Test plan

- [x] \`cargo nextest run --features dev\` — full suite pass.
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.