### PR TITLE
test(common): add adversarial-namespace builder for transcript-id ↔ chromosome-name collisions (closes #316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(parser)* accept `?con<src>` and `?copy<N>` at unknown position, consistent with `?del`/`?dup`/`?ins`/`?inv` (closes #286)
 - *(fasta)* require version-boundary equality in `MmapFastaProvider::get_transcript`'s unversioned-prefix fallback (closes #314)
+- *(fasta)* route `FastaProvider::get_sequence` for known contigs through the FASTA path so a transcript registered with a chromosome-colliding id no longer wins over the genomic index (closes #315)
 
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -219,6 +219,22 @@ impl FastaProvider {
     pub fn add_transcript(&mut self, transcript: Transcript) {
         self.transcripts.insert(transcript.id.clone(), transcript);
     }
+
+    /// True when `id` is declared as a chromosome/contig name — either
+    /// resolves against the FASTA `.fai` index (directly or via an alias
+    /// chain) or appears as the `chromosome` field on a registered
+    /// transcript. Used by `get_sequence` to disambiguate genomic
+    /// lookups from transcript-id lookups when the two namespaces
+    /// collide (e.g. a transcript whose id is `chrN`; see #315).
+    fn is_known_contig(&self, id: &str) -> bool {
+        let resolved = self.resolve_name(id);
+        if self.index.contains_key(&resolved) {
+            return true;
+        }
+        self.transcripts
+            .values()
+            .any(|tx| tx.chromosome.as_deref() == Some(id))
+    }
 }
 
 impl ReferenceProvider for FastaProvider {
@@ -230,6 +246,17 @@ impl ReferenceProvider for FastaProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        // If the requested id is registered as a contig — either present
+        // in the FASTA index (directly or via an alias) or referenced as
+        // the `chromosome` field on a registered transcript — resolve it
+        // strictly against the FASTA path. Without this dispatch, a
+        // transcript whose id happens to match a contig name would
+        // short-circuit the lookup and silently interpret genomic
+        // coordinates as transcript-relative indices (#315 / #311).
+        if self.is_known_contig(id) {
+            return self.get_fasta_sequence(id, start, end);
+        }
+
         // First try as transcript ID. Only return a hit when the transcript
         // has cached sequence bases; coordinate-only transcripts fall through
         // to the FASTA index lookup below.

--- a/tests/common/synthetic.rs
+++ b/tests/common/synthetic.rs
@@ -217,6 +217,77 @@ impl SyntheticBuilder {
     }
 }
 
+/// Builder for `MockProvider` fixtures that deliberately put a transcript
+/// id and a chromosome name into the same key space — the failure mode
+/// behind #311 / #312. The fixture mirrors the issue's reproducer:
+///
+/// - one transcript with caller-supplied `id` whose `chromosome` field
+///   is the contig name (no separate `genomic_sequences` entry).
+/// - the transcript sequence is laid out so that the genomic-coordinate
+///   bases at `g.1000..=1002` (= `GAC`) are observably different from
+///   the bases a wrong-frame lookup would return (`AAG`); a wrong-frame
+///   trim therefore collapses an `ACG` delins to a single residual
+///   `1001A>C`. The numerical positions match the issue's reproducer
+///   exactly so downstream cross-PR tests can share assertions.
+///
+/// Sequence layout, all 1102 bp:
+///   - 909 bp poly-A leader
+///   - 93 bp coding segment (`SEGMENT` below)
+///   - 100 bp poly-T trailer
+///
+/// With `genomic_start = 91`, genomic position 1000..=1002 maps to
+/// transcript positions 910..=912 (= `SEGMENT[0..3] = "GAC"`). The
+/// wrong-frame read at transcript indices 999..=1001 returns
+/// `SEGMENT[90..93] = "AAG"`, which is the buggy reference span that
+/// drove #311's collapse to `1001A>C`.
+pub struct AdversarialNamespaceBuilder {
+    transcript_id: String,
+    chromosome: String,
+}
+
+const ADVERSARIAL_SEGMENT: &str =
+    "GACCGGCGGTCTGCAAGTCTCCACCTTCCGAAGCTATCCATAACCGGAACCTATGACCTAAAATCAGTTCTGGGTCAGCTCGGTATCACGAAG";
+
+impl AdversarialNamespaceBuilder {
+    pub fn new(transcript_id: &str, chromosome: &str) -> Self {
+        Self {
+            transcript_id: transcript_id.to_string(),
+            chromosome: chromosome.to_string(),
+        }
+    }
+
+    pub fn build(self) -> MockProvider {
+        let mut s = String::with_capacity(1102);
+        s.extend(std::iter::repeat_n('A', 909));
+        s.push_str(ADVERSARIAL_SEGMENT);
+        s.extend(std::iter::repeat_n('T', 100));
+        debug_assert_eq!(s.len(), 1102);
+        debug_assert_eq!(&s[909..912], "GAC");
+
+        let exons = vec![Exon::with_genomic(1, 1, 1102, 91, 1192)];
+        let transcript = Transcript::new(
+            self.transcript_id,
+            None,
+            Strand::Plus,
+            s,
+            Some(1),
+            Some(1102),
+            exons,
+            Some(self.chromosome),
+            Some(91),
+            Some(1192),
+            GenomeBuild::GRCh38,
+            ManeStatus::None,
+            None,
+            None,
+        );
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(transcript);
+        provider
+    }
+}
+
 /// Substitute 1-based numeric positions into an HGVS template by index.
 ///
 /// Replaces `{0}`, `{1}`, ... in `template` with `args[0]`, `args[1]`, ...

--- a/tests/issue_315_fasta_known_contig.rs
+++ b/tests/issue_315_fasta_known_contig.rs
@@ -1,0 +1,119 @@
+//! Tests for issue #315 — `FastaProvider::get_sequence` routes every
+//! lookup through the transcript registry before consulting the FASTA
+//! index. Exact-match only (no `starts_with` fallback), but if any
+//! caller registers a transcript with `id = "chrN"` alongside a FASTA
+//! that also contains `chrN`, the transcript wins and a genomic
+//! coordinate lookup silently reads transcript-relative bases — the
+//! same wrong-coordinate-frame bug #311 hit on `MockProvider`.
+//!
+//! These tests pin the corrected dispatch contract:
+//!
+//! - when the id is a known contig (in the FASTA `.fai` index, or as the
+//!   `chromosome` field on any registered transcript), `get_sequence`
+//!   resolves strictly against the FASTA path.
+//! - transcript-id lookups for ids that are NOT known contigs keep
+//!   returning the transcript's cached sequence (no regression).
+//! - a known contig with no FASTA backing surfaces as `Err`, which
+//!   `normalize_genome` already falls back to canonicalize-only.
+
+use std::io::Write;
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::reference::{FastaProvider, ReferenceProvider};
+
+/// FASTA file with a single contig `chr1` whose sequence is 12 bytes
+/// of `A`. `MmapFastaProvider` and `FastaProvider` both read from a
+/// real file; `tempfile::TempDir` keeps the file alive for the
+/// duration of the test.
+fn provider_with_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr1").expect("write fasta header");
+    writeln!(f, "AAAAAAAAAAAA").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn provider_no_chr1_fasta() -> (tempfile::TempDir, FastaProvider) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let fa_path = dir.path().join("tiny.fa");
+    let mut f = std::fs::File::create(&fa_path).expect("create fasta");
+    writeln!(f, ">chr2").expect("write fasta header");
+    writeln!(f, "GGGGGGGG").expect("write fasta seq");
+    f.sync_all().expect("sync fasta");
+    drop(f);
+    let provider = FastaProvider::new(&fa_path).expect("load fasta");
+    (dir, provider)
+}
+
+fn synthetic_transcript(id: &str, chromosome: Option<&str>) -> Transcript {
+    Transcript::new(
+        id.to_string(),
+        None,
+        Strand::Plus,
+        "TTTTTTTT".to_string(),
+        Some(1),
+        Some(8),
+        vec![Exon::new(1, 1, 8)],
+        chromosome.map(str::to_string),
+        Some(1),
+        Some(8),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+}
+
+/// Exact id collision: a transcript with id `chr1` is registered on
+/// the same provider whose FASTA index also has `chr1`. The FASTA
+/// bytes (`AAA`) must win over the transcript's cached bases (`TTT`).
+#[test]
+fn get_sequence_prefers_fasta_index_over_colliding_transcript_id() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("chr1", Some("chr1")));
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA", "expected FASTA bytes, got transcript bases");
+}
+
+/// Soft-collision: a transcript declares `chr1` as its `chromosome`
+/// field, but the FASTA index has no `chr1` entry. A `get_sequence`
+/// call on `chr1` must NOT silently slide into the transcript's bases
+/// for an unrelated transcript id — it must Err so callers can fall
+/// back to canonicalize-only.
+#[test]
+fn get_sequence_for_known_contig_without_fasta_backing_errors() {
+    let (_dir, mut p) = provider_no_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    if let Ok(seq) = p.get_sequence("chr1", 0, 3) {
+        panic!("expected ReferenceNotFound for 'chr1'; got {:?}", seq);
+    }
+}
+
+/// Negative control: a transcript id with no colliding chromosome must
+/// keep returning the transcript's cached sequence.
+#[test]
+fn get_sequence_for_transcript_id_returns_transcript_bases() {
+    let (_dir, mut p) = provider_with_chr1_fasta();
+    p.add_transcript(synthetic_transcript("NM_000088.3", Some("chr1")));
+    let seq = p
+        .get_sequence("NM_000088.3", 0, 3)
+        .expect("NM_000088.3 lookup should resolve via transcript registry");
+    assert_eq!(seq, "TTT");
+}
+
+/// Negative control: a FASTA-index lookup with no transcript
+/// registered for that name keeps returning FASTA bytes.
+#[test]
+fn get_sequence_for_fasta_only_contig_returns_fasta_bases() {
+    let (_dir, p) = provider_with_chr1_fasta();
+    let seq = p
+        .get_sequence("chr1", 0, 3)
+        .expect("chr1 lookup should resolve via FASTA");
+    assert_eq!(seq, "AAA");
+}

--- a/tests/issue_316_adversarial_namespace_matrix.rs
+++ b/tests/issue_316_adversarial_namespace_matrix.rs
@@ -1,0 +1,61 @@
+//! Tests for issue #316 — exercise the new `adversarial_namespace`
+//! builder on `tests/common/synthetic.rs`. The builder produces a
+//! `MockProvider` whose registered transcript shares its `id` (or the
+//! `chromosome` field) with a colliding contig name, with genomic and
+//! transcript sequences laid out so a wrong-frame lookup returns
+//! observably different bases. This is the failure mode #311 hit and
+//! #312 fixed; the matrix here pins post-#312 behavior through the
+//! shared builder.
+//!
+//! Stacks on PR #312. Without #312's `MockProvider::get_sequence` /
+//! `get_transcript` fixes, the genomic-coordinate cases here would
+//! collapse the merged delins to a single residual SNV.
+
+mod common;
+
+use common::synthetic::{normalize_to_string, AdversarialNamespaceBuilder};
+
+/// Realistic prefix-collision: a transcript whose id was synthesized
+/// from chromosome + gene name (e.g. `chr1-gene.1` from a GFF dump).
+#[test]
+fn prefix_collision_normalizes_to_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Already-canonical delins round-trips unchanged under the same
+/// prefix-collision fixture.
+#[test]
+fn prefix_collision_roundtrips_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.1000_1002delinsACG");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Exact-name collision: transcript id is literally the chromosome name.
+#[test]
+fn exact_name_collision_normalizes_to_canonical_delins() {
+    let provider = AdversarialNamespaceBuilder::new("chr1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// Case-sensitivity boundary control: `Chr1-gene.1` does not collide
+/// with `chr1` and must keep normalizing correctly.
+#[test]
+fn case_sensitive_no_collision_still_normalizes() {
+    let provider = AdversarialNamespaceBuilder::new("Chr1-gene.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}
+
+/// No-collision control: a RefSeq-shaped transcript id pinned to the
+/// same chromosome must continue to normalize correctly (and is the
+/// realistic happy path).
+#[test]
+fn no_collision_refseq_id_still_normalizes() {
+    let provider = AdversarialNamespaceBuilder::new("NM_000001.1", "chr1").build();
+    let result = normalize_to_string(provider, "chr1:g.[1000G>A;1001A>C;1002C>G]");
+    assert_eq!(result, "chr1:g.1000_1002delinsACG");
+}


### PR DESCRIPTION
Closes #316. Follow-up to #311 / #312.

**Stacks on #312.** Base: \`fix/issue-311-transcript-prefix-chromosome\`. Diff against \`main\` will narrow once #312 lands.

## Summary

The shared synthetic-fixture matrix in \`tests/common/synthetic.rs\` used disjoint namespaces by construction — genomic contigs were \`NC_TEST.1\`, transcripts \`NM_TEST.1\` / \`NR_TEST.1\`, CDS fixtures pinned onto a separate \`chr_synth\` contig — and was therefore blind to the entire class of bugs that arise when a transcript id collides with a chromosome name on the same provider. That blindness is why #311 escaped pre-release.

\`AdversarialNamespaceBuilder::new(transcript_id, chromosome).build()\` materializes a \`MockProvider\` whose registered transcript shares its \`id\` (or, via its \`chromosome\` field, the contig name) with a colliding contig name. Sequence layout matches the issue's reproducer exactly:

- 909 bp poly-A leader + 93 bp coding segment + 100 bp poly-T trailer.
- \`genomic_start = 91\`, so genomic 1000..=1002 maps to transcript 910..=912 = \`GAC\`.
- A wrong-frame read at transcript indices 999..=1001 returns \`AAG\` — the buggy reference span that drove the collapse to \`1001A>C\` pre-#312.

## Tests

\`tests/issue_316_adversarial_namespace_matrix.rs\` exercises the builder across five collision shapes and pins the post-#312 expected output:

- prefix collision (\`chr1-gene.1\` ↔ \`chr1\`, the issue's reproducer)
- exact-name collision (\`chr1\` ↔ \`chr1\`)
- case-sensitivity boundary control (\`Chr1-gene.1\` ↔ \`chr1\`)
- no-collision RefSeq control (\`NM_000001.1\` ↔ \`chr1\`)
- already-canonical delins round-trip under the prefix collision

## Coordination notes

- **#312 (closes #311)**: this PR's base. The genomic-coordinate cases here would collapse the merged delins to a single residual SNV without #312's \`MockProvider::get_sequence\` / \`get_transcript\` fixes.
- **#317 (closes #314, \`MmapFastaProvider\`)** and **#318 (closes #315, \`FastaProvider\`)**: orthogonal. Each adds a targeted regression test using an inline fixture; a future cleanup pass can adopt this builder once all three siblings land.

## Test plan

- [x] \`cargo nextest run --features dev\` — 5060 / 5060 pass, 51 skipped.
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all -- --check\` — clean.