### PR TITLE
feat(parser): recognize non-human Ensembl accession prefixes

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -6,7 +6,6 @@
 use crate::hgvs::variant::Accession;
 use memchr::memchr;
 use nom::{
-    branch::alt,
     bytes::complete::{tag, take_while, take_while1},
     character::complete::digit1,
     combinator::{map, opt},
@@ -465,17 +464,39 @@ fn parse_ensembl_accession(input: &str) -> IResult<&str, Accession> {
     ))
 }
 
-/// Parse Ensembl prefix (ENST, ENSG, ENSP, ENSE, ENSR)
+/// Parse an Ensembl prefix of the shape `ENS<species_code><feature>`.
+///
+/// `species_code` is 0–5 uppercase letters (`""` for human, `MUS` for mouse,
+/// `RNO` for rat, `BTA` for cow, `DAR` for zebrafish, etc.). `feature` is one
+/// of `G` (gene), `T` (transcript), `P` (peptide), `E` (exon), or `R`
+/// (regulatory). Examples: `ENST`, `ENSP`, `ENSMUST`, `ENSRNOT`.
 #[inline]
 fn parse_ensembl_prefix(input: &str) -> IResult<&str, &str> {
-    alt((
-        tag("ENST"),
-        tag("ENSG"),
-        tag("ENSP"),
-        tag("ENSE"),
-        tag("ENSR"),
-    ))
-    .parse(input)
+    let (after_ens, _) = tag("ENS").parse(input)?;
+    let (after_letters, letters) =
+        take_while1(|c: char| c.is_ascii_uppercase()).parse(after_ens)?;
+    // letters = species_code + feature. Per the Ensembl stable-ID convention
+    // the species code is 0..=5 uppercase letters, so the total length of
+    // `letters` must be at most 6 (5 species + 1 feature). This rejects
+    // arbitrarily long uppercase runs that would otherwise be misparsed as
+    // Ensembl accessions.
+    if letters.len() > 6 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+    // The last letter of the alpha run is the feature suffix; any preceding
+    // letters are the species code.
+    let last = letters.as_bytes()[letters.len() - 1];
+    if !matches!(last, b'G' | b'T' | b'P' | b'E' | b'R') {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+    let prefix_len = 3 + letters.len();
+    Ok((after_letters, &input[..prefix_len]))
 }
 
 /// Parse accession prefix (letters like NC, NM, NP, LRG)
@@ -589,6 +610,51 @@ mod tests {
         assert_eq!(acc.version, None);
         assert!(acc.ensembl_style);
         assert_eq!(acc.full(), "ENST00000012345");
+    }
+
+    #[test]
+    fn test_parse_ensembl_mouse_transcript() {
+        // Mouse Ensembl IDs have species code "MUS" between "ENS" and the
+        // feature suffix.
+        let (remaining, acc) = parse_accession("ENSMUST00000123456.7:c").unwrap();
+        assert_eq!(remaining, ":c");
+        assert_eq!(&*acc.prefix, "ENSMUST");
+        assert_eq!(&*acc.number, "00000123456");
+        assert_eq!(acc.version, Some(7));
+        assert!(acc.ensembl_style);
+        assert_eq!(acc.full(), "ENSMUST00000123456.7");
+    }
+
+    #[test]
+    fn test_parse_ensembl_rat_protein() {
+        let (remaining, acc) = parse_accession("ENSRNOP00000001234.2:p").unwrap();
+        assert_eq!(remaining, ":p");
+        assert_eq!(&*acc.prefix, "ENSRNOP");
+        assert!(acc.ensembl_style);
+        assert_eq!(acc.full(), "ENSRNOP00000001234.2");
+    }
+
+    #[test]
+    fn test_parse_ensembl_zebrafish_gene() {
+        let (remaining, acc) = parse_accession("ENSDARG00000056789:g").unwrap();
+        assert_eq!(remaining, ":g");
+        assert_eq!(&*acc.prefix, "ENSDARG");
+        assert_eq!(acc.version, None);
+        assert!(acc.ensembl_style);
+        assert_eq!(acc.full(), "ENSDARG00000056789");
+    }
+
+    #[test]
+    fn test_parse_ensembl_invalid_feature_suffix_falls_through() {
+        // `A` is not in the feature suffix set {G,T,P,E,R}, so this string is
+        // not recognized as an Ensembl accession by the dedicated path — the
+        // dispatcher falls through to `parse_simple_accession`, which treats
+        // the whole string as an opaque accession.  The structural check is
+        // that the prefix is not "ENSA" (which is what a malformed Ensembl
+        // parse would yield) but the entire name.
+        let (_, acc) = parse_accession("ENSA00000000001:c.100A>G").unwrap();
+        assert_eq!(&*acc.prefix, "ENSA00000000001");
+        assert!(!Accession::is_ensembl_prefix(&acc.prefix));
     }
 
     #[test]

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -188,9 +188,43 @@ impl Accession {
         self.assembly.is_some() && self.chromosome.is_some()
     }
 
-    /// Check if a prefix is an Ensembl-style prefix
+    /// Check if a prefix is an Ensembl-style prefix.
+    ///
+    /// Ensembl stable IDs have the shape `ENS<species_code><feature>` where:
+    /// - `species_code` is 0–5 uppercase letters (`""` for human, `MUS` for
+    ///   mouse, `RNO` for rat, `BTA` for cow, `DAR` for zebrafish, `CAF`
+    ///   for dog, `SSC` for pig, etc.).
+    /// - `feature` is one of `G` (gene), `T` (transcript), `P` (peptide),
+    ///   `E` (exon), or `R` (regulatory).
+    ///
+    /// Examples that match: `ENST`, `ENSP`, `ENSMUST`, `ENSMUSG`,
+    /// `ENSRNOT`, `ENSBTAG`, `ENSDARP`.
+    ///
+    /// Reference: <https://useast.ensembl.org/info/genome/stable_ids/index.html>.
     pub fn is_ensembl_prefix(prefix: &str) -> bool {
-        matches!(prefix, "ENST" | "ENSG" | "ENSP" | "ENSE" | "ENSR")
+        // Must start with "ENS" and have at least one feature letter after it.
+        let Some(body) = prefix.strip_prefix("ENS") else {
+            return false;
+        };
+        if body.is_empty() {
+            return false;
+        }
+        // body = species_code + feature. Per the Ensembl stable-ID convention
+        // the species code is 0..=5 uppercase letters and the feature is 1
+        // letter, so body must be at most 6 chars. This rejects arbitrarily
+        // long uppercase prefixes that would otherwise pass the suffix check.
+        if body.len() > 6 {
+            return false;
+        }
+        // All characters in the body must be uppercase ASCII letters.
+        if !body.chars().all(|c| c.is_ascii_uppercase()) {
+            return false;
+        }
+        // The last letter is the feature suffix.
+        matches!(
+            body.as_bytes()[body.len() - 1],
+            b'G' | b'T' | b'P' | b'E' | b'R'
+        )
     }
 
     /// Check if this accession is an Ensembl accession
@@ -2141,13 +2175,40 @@ mod tests {
 
     #[test]
     fn test_accession_is_ensembl_prefix() {
+        // Human prefixes (empty species code).
         assert!(Accession::is_ensembl_prefix("ENST"));
         assert!(Accession::is_ensembl_prefix("ENSG"));
         assert!(Accession::is_ensembl_prefix("ENSP"));
         assert!(Accession::is_ensembl_prefix("ENSE"));
         assert!(Accession::is_ensembl_prefix("ENSR"));
+
+        // Non-human species prefixes — same five feature suffixes,
+        // species code (`MUS`, `RNO`, `BTA`, `DAR`, `CAF`, `SSC`, …) sits
+        // between `ENS` and the suffix.
+        assert!(Accession::is_ensembl_prefix("ENSMUST"));
+        assert!(Accession::is_ensembl_prefix("ENSMUSG"));
+        assert!(Accession::is_ensembl_prefix("ENSMUSP"));
+        assert!(Accession::is_ensembl_prefix("ENSMUSE"));
+        assert!(Accession::is_ensembl_prefix("ENSMUSR"));
+        assert!(Accession::is_ensembl_prefix("ENSRNOT"));
+        assert!(Accession::is_ensembl_prefix("ENSBTAG"));
+        assert!(Accession::is_ensembl_prefix("ENSDARP"));
+        assert!(Accession::is_ensembl_prefix("ENSCAFT"));
+        assert!(Accession::is_ensembl_prefix("ENSSSCG"));
+
+        // Negative cases.
         assert!(!Accession::is_ensembl_prefix("NM"));
         assert!(!Accession::is_ensembl_prefix("NC"));
+        assert!(!Accession::is_ensembl_prefix("ENS")); // no feature suffix
+        assert!(!Accession::is_ensembl_prefix("ENSA")); // suffix not in {G,T,P,E,R}
+        assert!(!Accession::is_ensembl_prefix("ENSmust")); // lowercase rejected
+        assert!(!Accession::is_ensembl_prefix("ENSMUS1T")); // digit in species code
+        assert!(!Accession::is_ensembl_prefix("")); // empty
+        assert!(!Accession::is_ensembl_prefix("ANYTHING"));
+        // Species-code length is bounded at 5 chars (Ensembl convention).
+        assert!(Accession::is_ensembl_prefix("ENSAAAAAT")); // 5-letter species code + feature: accept
+        assert!(!Accession::is_ensembl_prefix("ENSAAAAAAT")); // 6-letter species code + feature: reject
+        assert!(!Accession::is_ensembl_prefix("ENSAAAAAAAAAT")); // grossly overlong: reject
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Accession::is_ensembl_prefix` (`src/hgvs/variant.rs:192`) and the parser's `parse_ensembl_prefix` (`src/hgvs/parser/accession.rs:470`) previously hardcoded only the **five human** Ensembl prefixes: `ENST`, `ENSG`, `ENSP`, `ENSE`, `ENSR`. Non-human Ensembl stable IDs — mouse (`ENSMUST`/`G`/`P`/`E`/`R`), rat (`ENSRNOT…`), zebrafish (`ENSDART…`), dog (`ENSCAFT…`), cow (`ENSBTAT…`), pig (`ENSSSCT…`), and every other model organism — fell through to `parse_simple_accession`, silently losing:

- `is_ensembl()` / `ensembl_style` tagging.
- Display canonicalization that the human prefixes get (no underscore between prefix and number).
- The 11–15 digit-count validation in `validate_ensembl`.

This surfaced during review of #310, where non-RefSeq transcript IDs are first-class.

## Change

Both predicates now match the Ensembl stable-ID grammar `ENS<species_code><feature>` where:
- `species_code` is 0–5 uppercase letters (`""` for human, `MUS` for mouse, `RNO` for rat, `BTA` for cow, `DAR` for zebrafish, `CAF` for dog, `SSC` for pig, …).
- `feature` is one of `G` (gene), `T` (transcript), `P` (peptide), `E` (exon), `R` (regulatory).

Reference: <https://useast.ensembl.org/info/genome/stable_ids/index.html>.

Drops the now-unused `nom::branch::alt` import.

## Test plan
- [x] New unit cases in `test_accession_is_ensembl_prefix` cover human, mouse, rat, zebrafish, cow, dog, pig prefixes plus negative cases (empty body, invalid suffix, lowercase, digit in species code).
- [x] New parser tests `test_parse_ensembl_mouse_transcript`, `test_parse_ensembl_rat_protein`, `test_parse_ensembl_zebrafish_gene`, `test_parse_ensembl_invalid_feature_suffix_falls_through` pin both the success path and the fall-through.
- [x] `cargo nextest run --features dev` — 5048 tests pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean.