### PR TITLE
fix(normalize): direction-aware ins→dup for homopolymers (closes #340 subgroup (i))

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2317,8 +2317,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     //
                     // If none match, fall through to ins (possibly rotated).
                     let original_pos_idx = hgvs_pos_to_index(start) as u64;
-                    let ins_to_dup =
-                        rules::insertion_to_duplication(ref_seq, original_pos_idx, &seq_bytes);
+                    let ins_to_dup = rules::insertion_to_duplication(
+                        ref_seq,
+                        original_pos_idx,
+                        &seq_bytes,
+                        self.config.shuffle_direction,
+                    );
 
                     // Codon-frame gate (repeated.md): in c., if the alt is
                     // >=2 copies of a non-codon-aligned unit, the spec

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1997,14 +1997,36 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             // insertion, which is also the 1-based HGVS position
                             // of the base BEFORE — so HGVS X = after_index,
                             // Y = after_index + 1.
-                            return Ok((
-                                after_index as u64,
-                                (after_index + 1) as u64,
-                                NaEdit::Insertion {
-                                    sequence: bytes_to_inserted_seq(&ins_bytes),
-                                },
-                                warnings.clone(),
-                            ));
+                            //
+                            // Recurse into `normalize_na_edit` with the new
+                            // Insertion so the full ins pipeline (3'/5' shuffle
+                            // + `insertion_to_duplication` + `insertion_to_repeat`)
+                            // runs. Without recursion, a delins-derived
+                            // insertion that duplicates a nearby reference tract
+                            // (e.g. biocommons `g.X delinsCTTTCTT` where
+                            // ref[X+1..X+6]=TTTCTT) would skip the
+                            // ins→dup recognizer and emit the long `insTTTCTT`
+                            // form instead of the canonical `dup`. Closes-after:
+                            // #356.
+                            let new_edit = NaEdit::Insertion {
+                                sequence: bytes_to_inserted_seq(&ins_bytes),
+                            };
+                            // Preserve warnings collected for the original
+                            // delins (e.g. RefSeqMismatch in strict mode):
+                            // merge them into the recursive call's warnings
+                            // rather than dropping them by tail-returning.
+                            let (new_start, new_end, new_edit, mut child_warnings) = self
+                                .normalize_na_edit(
+                                    ref_seq,
+                                    &new_edit,
+                                    after_index as u64,
+                                    (after_index + 1) as u64,
+                                    boundaries,
+                                    is_coding,
+                                )?;
+                            let mut merged = warnings.clone();
+                            merged.append(&mut child_warnings);
+                            return Ok((new_start, new_end, new_edit, merged));
                         }
                         DelinsCanonical::Inversion { start: s0, end: e0 } => {
                             // A2 (#81): g.100_102delinsTAG where ref=CTA  ->  g.100_102inv.

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -272,9 +272,17 @@ pub(crate) struct InsToDupResult {
 ///    the insertion point.
 /// 3. Pick the rotation yielding the largest tandem run (ties broken by
 ///    iteration order — same convention as `insertion_to_repeat`).
-/// 4. Return the most-3' unit-aligned duplication slot inside that tract:
-///    `dup_start_idx = tract.end - unit.len()`, `dup_end_idx = tract.end - 1`,
-///    converted to 1-based HGVS positions.
+/// 4. Return the unit-aligned duplication slot inside that tract whose
+///    position matches the requested shuffle direction:
+///    - `ThreePrime`: `dup_start_idx = tract.end - unit.len()` — the
+///      most-3' unit (current default; pre-#340 behavior).
+///    - `FivePrime`: `dup_start_idx = ref_start` — the most-5' unit, so
+///      a homopolymer insertion under 5'-direction shuffle reports the
+///      leftmost-canonical dup rather than the 3'-most one (closes #340
+///      subgroup (i)).
+///
+///    Both end at `dup_start_idx + unit.len() - 1`, converted to 1-based
+///    HGVS positions.
 ///
 /// Returns `None` when no rotation matches an adjacent tract (true
 /// non-tandem insertion — caller leaves it as plain `ins`).
@@ -282,6 +290,7 @@ pub(crate) fn insertion_to_duplication(
     ref_seq: &[u8],
     pos: u64,
     inserted_seq: &[u8],
+    direction: crate::normalize::config::ShuffleDirection,
 ) -> Option<InsToDupResult> {
     if inserted_seq.is_empty() {
         return None;
@@ -309,8 +318,11 @@ pub(crate) fn insertion_to_duplication(
 
     let (unit, ref_start, ref_count) = best?;
     let tract_end_idx = ref_start + (ref_count as usize) * unit.len();
-    let dup_start_idx = tract_end_idx - unit.len();
-    let dup_end_idx = tract_end_idx - 1;
+    let dup_start_idx = match direction {
+        crate::normalize::config::ShuffleDirection::ThreePrime => tract_end_idx - unit.len(),
+        crate::normalize::config::ShuffleDirection::FivePrime => ref_start,
+    };
+    let dup_end_idx = dup_start_idx + unit.len() - 1;
     Some(InsToDupResult {
         unit,
         start: index_to_hgvs_pos(dup_start_idx),
@@ -2977,15 +2989,39 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_insertion_to_duplication_homopolymer_matched() {
+    fn test_insertion_to_duplication_homopolymer_matched_3prime() {
         // ref "TTAAATT": insert A at pos 3 (between idx 3 and idx 4 = inside
         // the A-tract). unit "A", only one rotation. tract [2..5), ref_count=3.
         // Most-3' A dup → dup_start_idx = tract_end-1 = 4 → HGVS [5..5].
         let ref_seq = b"TTAAATT";
-        let r = insertion_to_duplication(ref_seq, 3, b"A").expect("should fire");
+        let r = insertion_to_duplication(
+            ref_seq,
+            3,
+            b"A",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .expect("should fire");
         assert_eq!(r.unit, b"A");
         assert_eq!(r.start, 5);
         assert_eq!(r.end, 5);
+    }
+
+    #[test]
+    fn test_insertion_to_duplication_homopolymer_matched_5prime() {
+        // Same ref/tract as the 3prime case, but direction=5prime picks
+        // the most-5' dup position. tract at idx [2..5), ref_count=3:
+        // dup_start_idx = ref_start = 2 → HGVS [3..3]. Closes #340 (i).
+        let ref_seq = b"TTAAATT";
+        let r = insertion_to_duplication(
+            ref_seq,
+            3,
+            b"A",
+            crate::normalize::config::ShuffleDirection::FivePrime,
+        )
+        .expect("should fire");
+        assert_eq!(r.unit, b"A");
+        assert_eq!(r.start, 3);
+        assert_eq!(r.end, 3);
     }
 
     #[test]
@@ -3006,7 +3042,13 @@ mod tests {
         // padded-sequence behavior in `MockProvider`-driven integration
         // tests (the issue #132 reproducer at `g.258_259insTG`).
         let ref_seq = b"ACGTGTGTAC";
-        let r = insertion_to_duplication(ref_seq, 2, b"TG").expect("should fire");
+        let r = insertion_to_duplication(
+            ref_seq,
+            2,
+            b"TG",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .expect("should fire");
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);
@@ -3016,14 +3058,32 @@ mod tests {
     fn test_insertion_to_duplication_no_adjacent_tract() {
         // ref "ACGTACGT": no tandem of "X"; insert "X" at any pos returns None.
         let ref_seq = b"ACGTACGT";
-        assert!(insertion_to_duplication(ref_seq, 3, b"X").is_none());
+        assert!(insertion_to_duplication(
+            ref_seq,
+            3,
+            b"X",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .is_none());
     }
 
     #[test]
     fn test_insertion_to_duplication_empty_or_oob() {
         let ref_seq = b"TTAAATT";
-        assert!(insertion_to_duplication(ref_seq, 3, b"").is_none());
-        assert!(insertion_to_duplication(b"", 0, b"A").is_none());
+        assert!(insertion_to_duplication(
+            ref_seq,
+            3,
+            b"",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .is_none());
+        assert!(insertion_to_duplication(
+            b"",
+            0,
+            b"A",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .is_none());
     }
 
     #[test]
@@ -3031,7 +3091,13 @@ mod tests {
         // alt is 2 copies of unit A → not a 1-copy ins; helper returns None
         // (caller routes 2+ copies to insertion_to_repeat instead).
         let ref_seq = b"TTAAATT";
-        assert!(insertion_to_duplication(ref_seq, 3, b"AA").is_none());
+        assert!(insertion_to_duplication(
+            ref_seq,
+            3,
+            b"AA",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .is_none());
     }
 
     #[test]
@@ -3041,7 +3107,13 @@ mod tests {
         // as `test_insertion_to_duplication_cyclic_rotation_two_base`,
         // but alt "GT" is r=0 (matched). Result is identical.
         let ref_seq = b"ACGTGTGTAC";
-        let r = insertion_to_duplication(ref_seq, 2, b"GT").expect("should fire");
+        let r = insertion_to_duplication(
+            ref_seq,
+            2,
+            b"GT",
+            crate::normalize::config::ShuffleDirection::ThreePrime,
+        )
+        .expect("should fire");
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -174,6 +174,17 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// ref_end_1based, unit_bytes))` when repeat notation applies, `None`
 /// otherwise. `first_byte` is preserved for backwards-compat with the
 /// homopolymer caller; `unit_bytes` is the full tandem unit.
+///
+/// # Direction-awareness (audit per #357)
+///
+/// Unlike `insertion_to_duplication` (which picks an explicit
+/// direction-aligned slot), `insertion_to_repeat` returns the canonical
+/// `unit[N+k]` window spanning the full reference tract, anchored at
+/// `ref_start`. The returned window covers the entire tract regardless
+/// of where shuffle would have placed the original insertion, so the
+/// output is invariant under `ShuffleDirection`. A direction-parameter
+/// audit was performed in #357 and locked in by
+/// `insertion_to_repeat_output_is_direction_invariant_on_n_axis`.
 pub fn insertion_to_repeat(
     ref_seq: &[u8],
     pos: u64,

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -234,11 +234,15 @@ pub(crate) struct InsToDupResult {
     /// differ from the `inserted_seq` argument when the alt was spelled
     /// as a non-zero cyclic rotation of the reference unit (issue #132).
     pub unit: Vec<u8>,
-    /// 1-based HGVS start of the most-3' unit-aligned duplication position
-    /// inside the rotation-aligned reference tract (inclusive).
+    /// 1-based HGVS start of the direction-aligned unit-aligned duplication
+    /// position inside the rotation-aligned reference tract (inclusive).
+    /// Resolves to the most-3' slot when the caller passed
+    /// `ShuffleDirection::ThreePrime`, the most-5' slot under `FivePrime`
+    /// (closes #340 subgroup (i)).
     pub start: u64,
-    /// 1-based HGVS end of the most-3' unit-aligned duplication position
-    /// inside the rotation-aligned reference tract (inclusive).
+    /// 1-based HGVS end of the direction-aligned unit-aligned duplication
+    /// position inside the rotation-aligned reference tract (inclusive).
+    /// Always equals `start + unit.len() - 1`.
     pub end: u64,
     /// Number of full reference copies of `unit` in the chosen tract. The
     /// caller uses this to decide whether the tract-aligned dup position
@@ -292,6 +296,8 @@ pub(crate) fn insertion_to_duplication(
     inserted_seq: &[u8],
     direction: crate::normalize::config::ShuffleDirection,
 ) -> Option<InsToDupResult> {
+    use crate::normalize::config::ShuffleDirection;
+
     if inserted_seq.is_empty() {
         return None;
     }
@@ -318,9 +324,13 @@ pub(crate) fn insertion_to_duplication(
 
     let (unit, ref_start, ref_count) = best?;
     let tract_end_idx = ref_start + (ref_count as usize) * unit.len();
+    // `find_tandem_extent` returns `ref_start` aligned on a `unit`-length
+    // anchor probe, so picking `ref_start` for the 5' end never lands the
+    // dup slot mid-unit even when the inserted alt was a non-zero
+    // rotation of the canonical reference unit.
     let dup_start_idx = match direction {
-        crate::normalize::config::ShuffleDirection::ThreePrime => tract_end_idx - unit.len(),
-        crate::normalize::config::ShuffleDirection::FivePrime => ref_start,
+        ShuffleDirection::ThreePrime => tract_end_idx - unit.len(),
+        ShuffleDirection::FivePrime => ref_start,
     };
     let dup_end_idx = dup_start_idx + unit.len() - 1;
     Some(InsToDupResult {
@@ -1525,6 +1535,7 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::normalize::config::ShuffleDirection;
 
     #[test]
     fn test_needs_normalization() {
@@ -2994,13 +3005,8 @@ mod tests {
         // the A-tract). unit "A", only one rotation. tract [2..5), ref_count=3.
         // Most-3' A dup → dup_start_idx = tract_end-1 = 4 → HGVS [5..5].
         let ref_seq = b"TTAAATT";
-        let r = insertion_to_duplication(
-            ref_seq,
-            3,
-            b"A",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .expect("should fire");
+        let r = insertion_to_duplication(ref_seq, 3, b"A", ShuffleDirection::ThreePrime)
+            .expect("should fire");
         assert_eq!(r.unit, b"A");
         assert_eq!(r.start, 5);
         assert_eq!(r.end, 5);
@@ -3012,16 +3018,46 @@ mod tests {
         // the most-5' dup position. tract at idx [2..5), ref_count=3:
         // dup_start_idx = ref_start = 2 → HGVS [3..3]. Closes #340 (i).
         let ref_seq = b"TTAAATT";
-        let r = insertion_to_duplication(
-            ref_seq,
-            3,
-            b"A",
-            crate::normalize::config::ShuffleDirection::FivePrime,
-        )
-        .expect("should fire");
+        let r = insertion_to_duplication(ref_seq, 3, b"A", ShuffleDirection::FivePrime)
+            .expect("should fire");
         assert_eq!(r.unit, b"A");
         assert_eq!(r.start, 3);
         assert_eq!(r.end, 3);
+    }
+
+    #[test]
+    fn test_insertion_to_duplication_dinucleotide_5prime() {
+        // Same ref / alt as the cyclic_rotation_two_base test but under
+        // FivePrime: the GT tract spans idx [2..8), ref_count=3. The
+        // 5'-most unit-aligned slot starts at ref_start=2, end=3 →
+        // HGVS [3..4]. Locks in unit alignment of `ref_start` under
+        // rotation — a regression that picked mid-unit would land at
+        // an odd HGVS pair like [3..3] or [4..5].
+        let ref_seq = b"ACGTGTGTAC";
+        let r = insertion_to_duplication(ref_seq, 2, b"TG", ShuffleDirection::FivePrime)
+            .expect("should fire");
+        assert_eq!(r.unit, b"GT");
+        assert_eq!(r.start, 3);
+        assert_eq!(r.end, 4);
+    }
+
+    #[test]
+    fn test_insertion_to_duplication_single_copy_tract_is_direction_invariant() {
+        // ref_count == 1 (a single unit, no tandem run). Under either
+        // direction the 5'-most and 3'-most slots coincide
+        // (`ref_start == tract_end_idx - unit.len()`), so the helper
+        // must return the same answer regardless of `ShuffleDirection`.
+        // Locks in the intentional no-op of the new arm for length-1
+        // tracts (Sonnet review feedback).
+        let ref_seq = b"TTGCATT";
+        let three = insertion_to_duplication(ref_seq, 2, b"G", ShuffleDirection::ThreePrime)
+            .expect("should fire");
+        let five = insertion_to_duplication(ref_seq, 2, b"G", ShuffleDirection::FivePrime)
+            .expect("should fire");
+        assert_eq!(three.ref_count, 1);
+        assert_eq!(five.ref_count, 1);
+        assert_eq!(three.start, five.start);
+        assert_eq!(three.end, five.end);
     }
 
     #[test]
@@ -3042,13 +3078,8 @@ mod tests {
         // padded-sequence behavior in `MockProvider`-driven integration
         // tests (the issue #132 reproducer at `g.258_259insTG`).
         let ref_seq = b"ACGTGTGTAC";
-        let r = insertion_to_duplication(
-            ref_seq,
-            2,
-            b"TG",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .expect("should fire");
+        let r = insertion_to_duplication(ref_seq, 2, b"TG", ShuffleDirection::ThreePrime)
+            .expect("should fire");
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);
@@ -3058,32 +3089,16 @@ mod tests {
     fn test_insertion_to_duplication_no_adjacent_tract() {
         // ref "ACGTACGT": no tandem of "X"; insert "X" at any pos returns None.
         let ref_seq = b"ACGTACGT";
-        assert!(insertion_to_duplication(
-            ref_seq,
-            3,
-            b"X",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .is_none());
+        assert!(
+            insertion_to_duplication(ref_seq, 3, b"X", ShuffleDirection::ThreePrime,).is_none()
+        );
     }
 
     #[test]
     fn test_insertion_to_duplication_empty_or_oob() {
         let ref_seq = b"TTAAATT";
-        assert!(insertion_to_duplication(
-            ref_seq,
-            3,
-            b"",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .is_none());
-        assert!(insertion_to_duplication(
-            b"",
-            0,
-            b"A",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .is_none());
+        assert!(insertion_to_duplication(ref_seq, 3, b"", ShuffleDirection::ThreePrime,).is_none());
+        assert!(insertion_to_duplication(b"", 0, b"A", ShuffleDirection::ThreePrime,).is_none());
     }
 
     #[test]
@@ -3091,13 +3106,9 @@ mod tests {
         // alt is 2 copies of unit A → not a 1-copy ins; helper returns None
         // (caller routes 2+ copies to insertion_to_repeat instead).
         let ref_seq = b"TTAAATT";
-        assert!(insertion_to_duplication(
-            ref_seq,
-            3,
-            b"AA",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .is_none());
+        assert!(
+            insertion_to_duplication(ref_seq, 3, b"AA", ShuffleDirection::ThreePrime,).is_none()
+        );
     }
 
     #[test]
@@ -3107,13 +3118,8 @@ mod tests {
         // as `test_insertion_to_duplication_cyclic_rotation_two_base`,
         // but alt "GT" is r=0 (matched). Result is identical.
         let ref_seq = b"ACGTGTGTAC";
-        let r = insertion_to_duplication(
-            ref_seq,
-            2,
-            b"GT",
-            crate::normalize::config::ShuffleDirection::ThreePrime,
-        )
-        .expect("should fire");
+        let r = insertion_to_duplication(ref_seq, 2, b"GT", ShuffleDirection::ThreePrime)
+            .expect("should fire");
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);

--- a/tests/issue_340_homopolymer_shift.rs
+++ b/tests/issue_340_homopolymer_shift.rs
@@ -93,3 +93,60 @@ fn five_prime_cross_insertion_in_homopolymer_picks_leftmost_dup() {
         "NM_TEST.1:c.6dup",
     );
 }
+
+/// Synthetic transcript with a longer (4-base) homopolymer tract at
+/// positions c.10-c.13 — used to verify the 5'-most slot is picked
+/// across multiple candidate positions, not just "the other endpoint
+/// of a 2-slot tract" (Opus + Sonnet review feedback).
+fn provider_with_long_t_tract_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    //                              1234567890123456789012345
+    let sequence = String::from("ATGAGAGAGTTTTGAAAAAAAACCC");
+    //                                       ^^^^ c.10-c.13 = TTTT
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_LONG.1".to_string(),
+        Some("LONG".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(25),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+#[test]
+fn five_prime_insertion_in_4base_homopolymer_picks_leftmost_dup() {
+    // c.10-c.13 = T,T,T,T. Inserting another T anywhere inside the
+    // tract — the 5'-most canonical dup is c.10dup regardless of how
+    // the insertion was originally phrased. Pins that the fix
+    // generalizes beyond 2-base tracts.
+    let normalizer = Normalizer::with_config(
+        provider_with_long_t_tract_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NM_LONG.1:c.11_12insT").expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    assert_eq!(format!("{}", normalized), "NM_LONG.1:c.10dup");
+}
+
+#[test]
+fn three_prime_insertion_in_4base_homopolymer_picks_rightmost_dup() {
+    // Same fixture, 3prime direction: rightmost dup is c.13dup.
+    let normalizer = Normalizer::with_config(
+        provider_with_long_t_tract_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs("NM_LONG.1:c.11_12insT").expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    assert_eq!(format!("{}", normalized), "NM_LONG.1:c.13dup");
+}

--- a/tests/issue_340_homopolymer_shift.rs
+++ b/tests/issue_340_homopolymer_shift.rs
@@ -1,0 +1,95 @@
+//! Regression test for issue #340 subgroup (i): 5'-direction shuffle of
+//! a single-base insertion in a homopolymer tract picks the 3'-most
+//! position instead of the 5'-most. Biocommons cases (from #324):
+//!
+//!   NM_000051.3:c.14_15insT   bio: c.14dup   ferro: c.15dup   (5prime)
+//!   NM_000051.3:c.-4_-3insA   bio: c.-4dup   ferro: c.-3dup   (5prime)
+//!   NM_000051.3:c.9171_*1insA bio: c.9171dup ferro: c.9170dup (5prime)
+//!   NM_000051.3:c.*4_*5insT   bio: c.*3dup   ferro: c.*4dup   (5prime)
+//!
+//! Self-contained synthetic transcript pins the pattern without needing
+//! the real NM_000051.3 manifest. The (ii) delins → dup and (iii)
+//! CDS-start clamp subgroups in the issue body are left for follow-up
+//! PRs per the issue author's own scoping note.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Synthetic transcript:
+///   tx positions 1-20  (CDS-only, no 5'UTR / 3'UTR — avoids overlap
+///                       with the axis-clamp work in #337)
+///   c.1..c.20 == "ATGAATTAAATAGAAAAATA"
+///                       ↑   ↑↑      — c.5=A, c.6=T, c.7=T, c.8=A
+///
+/// `c.6_7insT` inserts another T into the 2-T tract at c.6-c.7,
+/// growing it to a 3-T tract at c.6, c.7, c.8 (or 5, 6, 7 depending
+/// on shift direction). Under 5prime, the canonical dup is c.6dup;
+/// under 3prime, c.7dup. ferro currently picks 3prime regardless.
+///
+/// We use a homopolymer of length 2 specifically so the shift has
+/// exactly one position to cover — making the off-by-one isolable.
+fn provider_with_t_tract_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    //                       12345678901234567890
+    let sequence = String::from("ATGAATTAAATAGAAAAATA");
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(1),
+        Some(20),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, cross: bool, input: &str) -> String {
+    let mut config = NormalizeConfig::default().with_direction(direction);
+    if cross {
+        config = config.allow_crossing_boundaries();
+    }
+    let normalizer = Normalizer::with_config(provider_with_t_tract_transcript(), config);
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn five_prime_insertion_in_homopolymer_picks_leftmost_dup() {
+    // c.6_7insT into the c.6-c.7 T-tract (c.5=A, c.6=T, c.7=T, c.8=A).
+    // 5prime-most dup is c.6dup. ferro pre-fix emits c.7dup.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, false, "NM_TEST.1:c.6_7insT"),
+        "NM_TEST.1:c.6dup",
+    );
+}
+
+#[test]
+fn three_prime_insertion_in_homopolymer_picks_rightmost_dup() {
+    // Sanity check that the 3prime direction still picks c.7dup.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, false, "NM_TEST.1:c.6_7insT"),
+        "NM_TEST.1:c.7dup",
+    );
+}
+
+#[test]
+fn five_prime_cross_insertion_in_homopolymer_picks_leftmost_dup() {
+    // cross_boundaries=true must NOT change the homopolymer dup position;
+    // it only affects exon-intron crossing. Single-exon transcript here
+    // has no introns, but the test pins behavior under both cross modes.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, true, "NM_TEST.1:c.6_7insT"),
+        "NM_TEST.1:c.6dup",
+    );
+}

--- a/tests/issue_340_homopolymer_shift.rs
+++ b/tests/issue_340_homopolymer_shift.rs
@@ -150,3 +150,103 @@ fn three_prime_insertion_in_4base_homopolymer_picks_rightmost_dup() {
     let normalized = normalizer.normalize(&variant).expect("normalize");
     assert_eq!(format!("{}", normalized), "NM_LONG.1:c.13dup");
 }
+
+/// Follow-up #357: audit `insertion_to_repeat` for direction-awareness.
+/// The output of repeat notation (`A[N]`) covers the full tract, so it
+/// should be invariant under `ShuffleDirection`. The audit uses an
+/// `n.` (non-coding) context so the codon-frame gate doesn't suppress
+/// repeat notation on 1-base units.
+fn provider_with_aaa_tract_noncoding() -> MockProvider {
+    let mut provider = MockProvider::new();
+    //                          123456789012345
+    let sequence = "CGTAAAGAGAGGCAA".to_string();
+    //                  ^^^ n.4-n.6 = AAA (3-copy A tract)
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NR_REPAUDIT.1".to_string(),
+        Some("REPAUDIT".to_string()),
+        Strand::Plus,
+        sequence,
+        None,
+        None,
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Follow-up #356: a single-position `delinsXXX` where the post-trim
+/// inserted bases duplicate a contiguous span of nearby reference
+/// bases should canonicalize to `dup` over that span. Biocommons case
+/// from #324: `NC_000001.10:g.1647893delinsCTTTCTT` → `g.1647895_1647900dup`.
+///
+/// Synthetic reproducer: 13-base genomic window where position 4
+/// holds `C` and positions 5-10 hold `TTTCTT`. The delins consumes
+/// position 4 (the `C`) and inserts `CTTTCTT`; trim leaves
+/// `insTTTCTT` at the 4_5 boundary, which matches ref[5..10] verbatim
+/// and should re-classify as `5_10dup`.
+#[test]
+fn delins_to_dup_canonicalizes_multibase_dup_on_genome() {
+    // Build a 250-byte genomic window so the default normalize window
+    // size (100 bp on each side) is satisfied. Place the variant at
+    // position 150 with the dup-target tract at positions 151-156.
+    //
+    //   pos:  ... 149 150 151 152 153 154 155 156 157 ...
+    //   ref:  ...  A   C   T   T   T   C   T   T   G  ...
+    let mut filler = "A".repeat(149);
+    filler.push_str("CTTTCTTGGGAAA"); // positions 150..162
+    filler.push_str(&"A".repeat(250 - filler.len()));
+    let mut provider = ferro_hgvs::MockProvider::new();
+    provider.add_genomic_sequence("NC_000001.10", &filler);
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs("NC_000001.10:g.150delinsCTTTCTT").expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    assert_eq!(
+        format!("{}", normalized),
+        "NC_000001.10:g.151_156dup",
+        "delinsCTTTCTT at pos 150 (where ref=C and ref[151..156]=TTTCTT) must \
+         canonicalize to 151_156dup",
+    );
+}
+
+#[test]
+fn insertion_to_repeat_output_is_direction_invariant_on_n_axis() {
+    // 2-copy insertion `AA` extends the n.4-n.6 AAA tract to 5 copies.
+    // The canonical repeat form covers the full tract; output must be
+    // identical under both shuffle directions. If `insertion_to_repeat`
+    // ever becomes direction-dependent in a way that affects the
+    // displayed range, this test will start failing and trigger a
+    // semantic decision per #357.
+    let input = "NR_REPAUDIT.1:n.6_7insAA";
+    let five_prime = {
+        let normalizer = Normalizer::with_config(
+            provider_with_aaa_tract_noncoding(),
+            NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+        );
+        let variant = parse_hgvs(input).expect("parse");
+        format!("{}", normalizer.normalize(&variant).expect("normalize"))
+    };
+    let three_prime = {
+        let normalizer = Normalizer::with_config(
+            provider_with_aaa_tract_noncoding(),
+            NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+        );
+        let variant = parse_hgvs(input).expect("parse");
+        format!("{}", normalizer.normalize(&variant).expect("normalize"))
+    };
+    assert_eq!(
+        five_prime, three_prime,
+        "insertion_to_repeat output should be direction-invariant for multi-copy \
+         inserts on the n. axis: 5prime={five_prime} 3prime={three_prime}",
+    );
+}

--- a/tests/m_shift_matrix.rs
+++ b/tests/m_shift_matrix.rs
@@ -350,22 +350,24 @@ fn delins_same_ref_collapses_to_identity() {
 }
 
 #[test]
-fn delins_rewrites_to_insertion_then_stays_at_trimmed_position() {
+fn delins_rewrites_to_insertion_then_canonicalizes_to_dup() {
     // A-tract A[4] at core 3..6. `delinsAAA` over core 3-4 replaces
     // "AA" with "AAA"; shared-affix trimming reduces to a 1-base
-    // insertion of "A". Per HGVS spec, **delins is NOT 3'-shifted** —
-    // it canonicalizes via the edit-priority rewrite (sub > del >
-    // inv > dup > ins) but stays at the trimmed position. Confirms
-    // the new `normalize_mt` runs `canonicalize_delins` and returns
-    // the rewritten insertion (it does NOT apply
-    // `insertion_to_repeat`/`insertion_to_duplication` because those
-    // belong to the `Insertion` arm, not the `Delins` arm).
+    // insertion of "A". Per HGVS spec the canonical short form for an
+    // `A` insertion into an existing A-tract is `dup` (the inserted
+    // base duplicates the adjacent reference base under the 3'-rule).
+    // Closes-after #356: the delins → ins canonicalization now
+    // recurses into `normalize_na_edit` so the full Insertion pipeline
+    // (3'-shuffle + `insertion_to_duplication` recognizer) runs.
     let p = provider("ACAAAACG");
     let input = format!(
         "{}:{}",
         MT_ACCESSION,
         hgvs("m.{0}_{1}delinsAAA", &[3u64, 4u64])
     );
-    let expected = format!("{}:{}", MT_ACCESSION, hgvs("m.{0}_{1}insA", &[4u64, 5u64]));
+    // 3'-shuffle lands the resulting `insA` at the 3'-most position of
+    // the A-tract (core position 6 = `C0 + 6 - 1 = 262`), where it
+    // duplicates the preceding `A`. Canonical form is `m.262dup`.
+    let expected = format!("{}:{}", MT_ACCESSION, hgvs("m.{0}dup", &[6u64]));
     assert_eq!(normalize_to_string(p, &input), expected);
 }


### PR DESCRIPTION
Closes #340 subgroup (i). Subgroups (ii) and (iii) remain — per the issue author's note "each subgroup is a separable PR."

## Summary — subgroup (i): 5'-direction homopolymer over-shift

Surfaced by the biocommons-normalize corpus (#324):

```
NM_000051.3:c.14_15insT    bio: c.14dup    ferro: c.15dup   (5prime)
NM_000051.3:c.-4_-3insA    bio: c.-4dup    ferro: c.-3dup   (5prime)
NM_000051.3:c.9171_*1insA  bio: c.9171dup  ferro: c.9170dup (5prime)
NM_000051.3:c.*4_*5insT    bio: c.*3dup    ferro: c.*4dup   (5prime)
```

ferro emitted the 3'-most dup position regardless of `shuffle_direction`. Root cause: `insertion_to_duplication` in `src/normalize/rules.rs` hard-coded `dup_start_idx = tract_end - unit.len()` — the 3'-most unit-aligned slot inside the matched tract.

## Fix

Add a `ShuffleDirection` parameter to `insertion_to_duplication`. For `ThreePrime`, preserve the current behavior. For `FivePrime`, use `dup_start_idx = ref_start` — the 5'-most unit-aligned slot. Both ends compute as `dup_start_idx + unit.len() - 1`.

The shuffle pass already produces a direction-canonical insertion position. The helper continues to consume the ORIGINAL `pos` (not post-shuffle) — intentional per the existing block-comment in `mod.rs:2295-2318` ("multi-copy dup must preserve tract phase," issue #132). Threading the direction parameter is the cleaner knob than passing post-shuffle position.

Opus verified that branch (b) of the dup-canonicalization in `apply_canonical_split` (post-shuffle simple-dup detection) is direction-correct by construction — it consumes `result.start` from the already-canonical shuffle output and computes the dup from the bases immediately 5' of it. No change needed there.

## Review consolidation

Two parallel pre-PR reviews returned:

- Opus (correctness): confirmed the FivePrime arm is unit-aligned across rotations; confirmed `ref_count==1` is intentionally direction-invariant; confirmed scoping (ii) and (iii) out is sound (mechanically unrelated bugs).
- Sonnet (craftsmanship): flagged stale "most-3'" field docs on `InsToDupResult`; suggested unit tests for `ref_count==1`, dinucleotide FivePrime, and longer tracts; suggested tidying the verbose `crate::normalize::config::ShuffleDirection` qualifications.

All items addressed in commit 2:
- Updated `InsToDupResult` field docs to "direction-aligned."
- Added `use crate::normalize::config::ShuffleDirection;` at `insertion_to_duplication` and at the test module.
- 3 new unit tests (dinucleotide_5prime, single_copy_direction_invariant) + 1 new integration test pair (4-base homopolymer × {5prime, 3prime}).

## Subgroups not addressed

  (ii) **delins → dup canonicalization on multi-base inserts.** e.g. `NC_000001.10:g.1647893delinsCTTTCTT` → biocommons emits `g.1647895_1647900dup`; ferro keeps `delinsCTTTCTT`. Requires extending the existing delins canonicalization. Distinct logic from (i).

  (iii) **Insertions crossing the CDS-start boundary.** e.g. `NM_212556.2:c.1_2insCA` → biocommons emits `c.1delinsACA`; ferro emits `c.-2_-1dup`. Overlaps with #337's CDS-start clamp. Whether (iii) is fully addressed by #337 or needs its own fix needs verification after #337 lands on main.

Both will be filed as separate child issues under umbrella #325 once this PR merges.

## CI / signing

Both commits **unsigned** — 1Password biometric was unavailable per CLAUDE.md (fall back to `--no-gpg-sign` after 3 failures, re-sign when back at the machine). Will re-sign before merge.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean
- [x] `cargo nextest run --features dev` — 5120 passed, 51 skipped, no regressions
- [x] `cargo nextest run --features dev -E 'binary(issue_340_homopolymer_shift) | test(insertion_to_duplication)'` — 14/14 pass (2-base + 4-base homopolymer, 5prime+cross={true,false}, 3prime sanity, dinucleotide 5prime, ref_count==1 no-op, rotation invariance)