### PR TITLE
perf(project): rebuild VariantProjector hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,6 +977,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smol_str",
+ "superintervals",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -3350,6 +3351,15 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superintervals"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b0c240b70a6cb7cc14436105c04d71c789c56f6082c1bc913dd6007d94a44"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 url = "2.4"
 regex = "1.10"
 once_cell = "1.20"
+superintervals = "0.3"
 
 [features]
 default = []

--- a/examples/projector-bench.rs
+++ b/examples/projector-bench.rs
@@ -1,0 +1,371 @@
+//! Throughput / latency bench harness for `VariantProjector`.
+//!
+//! Two modes:
+//!   gen-snp   <out.tsv>   — emit g.SNV strings across the CDS of fixed transcripts
+//!   gen-indel <out.tsv>   — emit g.del/ins/dup/delins across the CDS of fixed transcripts
+//!   bench     <in.tsv>    — run project_all over every line and report variants/sec
+//!
+//! Build:  cargo build --release --example projector-bench
+//! Run:    target/release/examples/projector-bench <manifest.json> <subcmd> <path>
+//!
+//! Fixture transcripts (all on chr17 to keep the working set small):
+//!   NM_000088.4  COL1A1
+//!   NM_007294.4  BRCA1
+//!   NM_000546.6  TP53
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use clap::{Parser, Subcommand};
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{FerroError, MultiFastaProvider, ReferenceProvider, VariantProjector};
+
+const TRANSCRIPTS: &[&str] = &["NM_000088.4", "NM_007294.4", "NM_000546.6"];
+
+#[derive(Parser)]
+#[command(about = "VariantProjector throughput bench")]
+struct Cli {
+    /// Path to a ferro-prepare manifest.json.
+    manifest: PathBuf,
+
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Generate a SNP-dense fixture (every CDS base, one alt per ref).
+    GenSnp { out: PathBuf },
+    /// Generate an indel-mixed fixture (every 3rd CDS base, random op).
+    GenIndel { out: PathBuf },
+    /// Run the projector bench over a fixture file.
+    Bench {
+        fixture: PathBuf,
+        /// Stop after this many variants (for quick profiles). 0 = no limit.
+        #[arg(long, default_value_t = 0)]
+        limit: usize,
+        /// Write a deterministic per-variant result line to this path
+        /// (input \t n_projections \t sorted_tx_id:c|p|frameshift|intronic|utr;...).
+        /// Used to byte-diff outputs across perf changes.
+        #[arg(long)]
+        dump: Option<PathBuf>,
+        /// Run the fixture this many times in a row. Used to amortize the
+        /// (large) manifest startup cost when capturing a profile, so the
+        /// per-variant hot path dominates the sample distribution. 1 = single
+        /// pass (default).
+        #[arg(long, default_value_t = 1)]
+        repeat: usize,
+    },
+}
+
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        self.0.get_sequence(id, start, end)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        self.0.get_genomic_sequence(contig, start, end)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        self.0.get_protein_sequence(accession, start, end)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.0.has_protein_data()
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    eprintln!("loading manifest: {}", cli.manifest.display());
+    let t0 = Instant::now();
+    let provider = Arc::new(MultiFastaProvider::from_manifest(&cli.manifest)?);
+    eprintln!("manifest loaded in {:?}", t0.elapsed());
+
+    match cli.cmd {
+        Cmd::GenSnp { out } => gen_snp(&provider, &out),
+        Cmd::GenIndel { out } => gen_indel(&provider, &out),
+        Cmd::Bench {
+            fixture,
+            limit,
+            dump,
+            repeat,
+        } => run_bench(provider, &fixture, limit, dump.as_deref(), repeat),
+    }
+}
+
+fn write_dump_line(
+    w: &mut BufWriter<File>,
+    input: &str,
+    projections: &[ferro_hgvs::VariantProjection],
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Build a deterministic, sorted summary string for each variant.
+    // Sort by transcript_id to be independent of projection ordering changes
+    // that may happen during perf refactors (the projection set must be stable;
+    // its ordering is asserted separately by the existing test suite).
+    let mut entries: Vec<String> = projections
+        .iter()
+        .map(|p| {
+            let c = p.coding.as_ref().map(|v| v.to_string()).unwrap_or_default();
+            let pr = p
+                .protein
+                .as_ref()
+                .map(|v| v.to_string())
+                .unwrap_or_default();
+            format!(
+                "{}|c={}|p={}|fs={}|in={}|utr={}",
+                p.transcript_id, c, pr, p.is_frameshift, p.is_intronic, p.is_utr
+            )
+        })
+        .collect();
+    entries.sort();
+    writeln!(w, "{}\t{}\t{}", input, projections.len(), entries.join(";"))?;
+    Ok(())
+}
+
+fn cds_segments(cdot: &CdotMapper, tx_id: &str) -> Result<Vec<(String, u64, u64)>, String> {
+    let tx = cdot
+        .get_transcript(tx_id)
+        .ok_or_else(|| format!("missing transcript {tx_id} in cdot"))?;
+    let cds_t0 = tx.cds_start.ok_or("transcript has no CDS start")?;
+    let cds_t1 = tx.cds_end.ok_or("transcript has no CDS end")?;
+    let contig = tx.contig.clone();
+    let strand = tx.strand;
+    let mut out = Vec::new();
+    for exon in &tx.exons {
+        let g0 = exon[0];
+        let g1 = exon[1];
+        let t0 = exon[2];
+        let t1 = exon[3];
+        // exon tx-range, clipped to CDS.
+        let clip_t0 = t0.max(cds_t0);
+        let clip_t1 = t1.min(cds_t1);
+        if clip_t1 <= clip_t0 {
+            continue;
+        }
+        // Map clipped tx range back to genome. cdot exons store
+        // `[g_start, g_end)` in genomic order regardless of strand, and
+        // `[t_start, t_end)` in transcript order; for minus-strand
+        // transcripts the first tx base of the exon corresponds to the
+        // last genomic base (`g_end - 1`), so the genomic range mirrors.
+        let (seg_g0, seg_g1) = match strand {
+            Strand::Plus => (g0 + (clip_t0 - t0), g1.min(g0 + (clip_t1 - t0))),
+            Strand::Minus => (g1 - (clip_t1 - t0), g1 - (clip_t0 - t0)),
+            other => return Err(format!("unsupported strand for tx {tx_id}: {other:?}")),
+        };
+        if seg_g1 > seg_g0 {
+            out.push((contig.clone(), seg_g0, seg_g1));
+        }
+    }
+    Ok(out)
+}
+
+fn gen_snp(
+    provider: &Arc<MultiFastaProvider>,
+    out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cdot = provider
+        .cdot_mapper()
+        .ok_or("cdot data not loaded from manifest")?;
+    let mut w = BufWriter::new(File::create(out)?);
+    let alt_map: HashMap<u8, u8> = [(b'A', b'G'), (b'C', b'T'), (b'G', b'A'), (b'T', b'C')]
+        .into_iter()
+        .collect();
+
+    let mut total: u64 = 0;
+    for &tx_id in TRANSCRIPTS {
+        let segs = cds_segments(cdot, tx_id)?;
+        for (contig, g0, g1) in segs {
+            let seq = provider.get_genomic_sequence(&contig, g0, g1)?;
+            for (i, ref_b) in seq.bytes().enumerate() {
+                let upper = ref_b.to_ascii_uppercase();
+                let Some(&alt) = alt_map.get(&upper) else {
+                    continue;
+                };
+                let pos = g0 + i as u64 + 1; // 1-based for HGVS
+                writeln!(w, "{}:g.{}{}>{}", contig, pos, upper as char, alt as char)?;
+                total += 1;
+            }
+        }
+    }
+    eprintln!("snp fixture: {} variants -> {}", total, out.display());
+    Ok(())
+}
+
+fn gen_indel(
+    provider: &Arc<MultiFastaProvider>,
+    out: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cdot = provider
+        .cdot_mapper()
+        .ok_or("cdot data not loaded from manifest")?;
+    let mut w = BufWriter::new(File::create(out)?);
+    // Tiny deterministic LCG (so the fixture is reproducible).
+    let mut rng: u64 = 0xc001_d00d_dead_beef;
+    let mut next_u8 = || -> u8 {
+        rng = rng
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        (rng >> 33) as u8
+    };
+    let mut total: u64 = 0;
+    for &tx_id in TRANSCRIPTS {
+        let segs = cds_segments(cdot, tx_id)?;
+        for (contig, g0, g1) in segs {
+            // Step by 3 to keep the file from being absurdly large.
+            for i in (0..(g1 - g0)).step_by(3) {
+                let pos = g0 + i + 1; // 1-based
+                let r = next_u8() % 4;
+                let line = match r {
+                    0 => format!("{}:g.{}del", contig, pos),
+                    1 => format!("{}:g.{}_{}delinsACG", contig, pos, pos + 2),
+                    2 => format!("{}:g.{}_{}insATG", contig, pos, pos + 1),
+                    _ => format!("{}:g.{}dup", contig, pos),
+                };
+                writeln!(w, "{}", line)?;
+                total += 1;
+            }
+        }
+    }
+    eprintln!("indel fixture: {} variants -> {}", total, out.display());
+    Ok(())
+}
+
+fn run_bench(
+    provider: Arc<MultiFastaProvider>,
+    fixture: &Path,
+    limit: usize,
+    dump_path: Option<&std::path::Path>,
+    repeat: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cdot = provider
+        .cdot_mapper()
+        .ok_or("cdot data not loaded from manifest")?
+        .clone();
+    let projector = Projector::new(cdot);
+    let vp = VariantProjector::new(projector, ArcProvider(provider.clone()));
+
+    let mut lines: Vec<String> = BufReader::new(File::open(fixture)?)
+        .lines()
+        .collect::<Result<_, _>>()?;
+    lines.retain(|s| !s.trim().is_empty());
+    if limit > 0 && lines.len() > limit {
+        lines.truncate(limit);
+    }
+    eprintln!("running over {} variants", lines.len());
+
+    let t_warm = Instant::now();
+    // small warmup: first 200 calls (caches FASTA pages, etc.)
+    let warm_n = lines.len().min(200);
+    for s in lines.iter().take(warm_n) {
+        let _ = vp.project_all(s);
+    }
+    eprintln!("warmup ({} calls) in {:?}", warm_n, t_warm.elapsed());
+
+    let mut latencies_us: Vec<u64> = Vec::with_capacity(lines.len());
+    let mut ok = 0u64;
+    let mut err = 0u64;
+    let mut proj_total = 0u64;
+    let mut dump_w = dump_path
+        .map(|p| -> Result<BufWriter<File>, Box<dyn std::error::Error>> {
+            Ok(BufWriter::new(File::create(p)?))
+        })
+        .transpose()?;
+
+    let t0 = Instant::now();
+    for pass in 0..repeat.max(1) {
+        for s in &lines {
+            let t = Instant::now();
+            match vp.project_all(s) {
+                Ok(v) => {
+                    ok += 1;
+                    proj_total += v.len() as u64;
+                    // Only dump from the first pass — the result is
+                    // deterministic so subsequent passes would just duplicate.
+                    if pass == 0 {
+                        if let Some(w) = dump_w.as_mut() {
+                            write_dump_line(w, s, &v)?;
+                        }
+                    }
+                }
+                Err(e) => {
+                    err += 1;
+                    if pass == 0 {
+                        if let Some(w) = dump_w.as_mut() {
+                            writeln!(w, "{}\tERR\t{}", s, e)?;
+                        }
+                    }
+                }
+            }
+            latencies_us.push(t.elapsed().as_micros() as u64);
+        }
+    }
+    if let Some(mut w) = dump_w {
+        w.flush()?;
+    }
+    let elapsed = t0.elapsed();
+    let n = ok + err;
+    let v_per_s = n as f64 / elapsed.as_secs_f64();
+    eprintln!(
+        "processed {} ({} ok, {} err) in {:?}\n  -> {:.1} variants/sec\n  -> {:.1} projections/sec (sum {} projections)",
+        n, ok, err, elapsed, v_per_s, proj_total as f64 / elapsed.as_secs_f64(), proj_total
+    );
+
+    latencies_us.sort_unstable();
+    let p = |q: f64| -> u64 {
+        if latencies_us.is_empty() {
+            0
+        } else {
+            let i = ((latencies_us.len() as f64) * q) as usize;
+            latencies_us[i.min(latencies_us.len() - 1)]
+        }
+    };
+    eprintln!(
+        "latency µs  P50={} P90={} P99={} P999={} max={}",
+        p(0.5),
+        p(0.9),
+        p(0.99),
+        p(0.999),
+        latencies_us.last().copied().unwrap_or(0)
+    );
+
+    // Print a single-line CSV summary that's easy to grep across runs.
+    println!(
+        "summary,{},{},{},{:.2},{},{},{},{}",
+        fixture.display(),
+        n,
+        elapsed.as_micros(),
+        v_per_s,
+        p(0.5),
+        p(0.9),
+        p(0.99),
+        latencies_us.last().copied().unwrap_or(0)
+    );
+    Ok(())
+}

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1545,6 +1545,43 @@ class VariantProjector:
         """
         ...
 
+    def project_variant(self, variant: HgvsVariant, transcript: str) -> VariantProjection:
+        """Normalize and project an already-parsed g. variant onto a transcript.
+
+        Equivalent to ``project(str(variant), transcript)`` but skips the re-parse.
+        Useful when the caller already holds an HgvsVariant (e.g. from
+        ``ferro_hgvs.parse(...)``) and wants to project without going back through a
+        string.
+
+        Args:
+            variant: An HgvsVariant (g.). Will be normalized before projection.
+            transcript: Transcript accession (e.g., "NM_000088.3").
+
+        Returns:
+            VariantProjection with g./c./p. representations and flags.
+
+        Raises:
+            RuntimeError: If normalization or projection fails.
+        """
+        ...
+
+    def project_variant_all(self, variant: HgvsVariant) -> list[VariantProjection]:
+        """Normalize and project an already-parsed g. variant onto ALL overlapping transcripts.
+
+        Equivalent to ``project_all(str(variant))`` but skips the re-parse.
+
+        Args:
+            variant: An HgvsVariant (g.). Will be normalized before projection.
+
+        Returns:
+            List of VariantProjection objects in clinical priority order.
+            Empty list when no transcripts overlap the variant.
+
+        Raises:
+            RuntimeError: If normalization or projection fails.
+        """
+        ...
+
     def project_normalized(self, variant: HgvsVariant, transcript: str) -> VariantProjection:
         """Project an already-normalized g. variant onto a single transcript, skipping normalization.
 
@@ -1581,5 +1618,45 @@ class VariantProjector:
 
         Raises:
             RuntimeError: If projection fails.
+        """
+        ...
+
+    def project_many(self, hgvs_strings: list[str]) -> list[list[VariantProjection]]:
+        """Batched parse + normalize + project_all over a list of g. HGVS strings.
+
+        Equivalent to ``[self.project_all(s) for s in hgvs_strings]``, but takes a
+        single Python→Rust call, releases the GIL for the entire batch, and reuses
+        the projector's internal transcript / ref-protein caches across all inputs.
+        Use this for fan-out workloads (thousands+ of variants).
+
+        Args:
+            hgvs_strings: List of g. HGVS variant strings.
+
+        Returns:
+            List of result lists — one inner list per input, in the same order.
+            Each inner list holds the per-transcript projections for that variant
+            in clinical priority order.
+
+        Raises:
+            RuntimeError: On the first parse / normalization error. Subsequent
+                inputs are not processed.
+        """
+        ...
+
+    def project_normalized_many(self, variants: list[HgvsVariant]) -> list[list[VariantProjection]]:
+        """Batched ``project_normalized_all`` over a list of already-normalized
+        g. variants.
+
+        Same batching semantics as ``project_many`` but skips renormalization on
+        each input.
+
+        Args:
+            variants: List of HgvsVariant objects (must already be normalized).
+
+        Returns:
+            List of result lists, one per input.
+
+        Raises:
+            RuntimeError: On the first projection error.
         """
         ...

--- a/src/backtranslate/codon.rs
+++ b/src/backtranslate/codon.rs
@@ -45,6 +45,27 @@ impl std::fmt::Display for Base {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Codon([Base; 3]);
 
+impl Base {
+    /// 2-bit packed encoding used by `Codon::index`: A=0, C=1, G=2, T/U=3.
+    fn to_index(self) -> u8 {
+        match self {
+            Base::A => 0,
+            Base::C => 1,
+            Base::G => 2,
+            Base::T => 3,
+        }
+    }
+
+    fn from_index(i: u8) -> Self {
+        match i & 0b11 {
+            0 => Base::A,
+            1 => Base::C,
+            2 => Base::G,
+            _ => Base::T,
+        }
+    }
+}
+
 impl Codon {
     /// Create a new codon from three bases.
     pub fn new(b1: Base, b2: Base, b3: Base) -> Self {
@@ -52,22 +73,47 @@ impl Codon {
     }
 
     /// Parse a codon from a string.
+    ///
+    /// HGVS codons are always 3 ASCII bases; this fast path avoids the
+    /// `Vec<char>` allocation that the previous implementation paid on every
+    /// call (1000+ codons per CDS per overlapping transcript inside
+    /// `translate_full_cds`).
     pub fn parse(s: &str) -> Option<Self> {
-        let chars: Vec<char> = s.chars().collect();
-        if chars.len() != 3 {
+        Self::parse_bytes(s.as_bytes())
+    }
+
+    /// Byte-level variant of [`Codon::parse`] for callers that have already
+    /// produced a `&[u8]` (e.g. from `chunks_exact(3)` over a CDS sequence).
+    /// Skips the `&str` → `&[u8]` indirection so the per-codon loop doesn't
+    /// need a UTF-8 validation step that's redundant for ASCII base inputs.
+    pub fn parse_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != 3 {
             return None;
         }
-
-        let b1 = Base::from_char(chars[0])?;
-        let b2 = Base::from_char(chars[1])?;
-        let b3 = Base::from_char(chars[2])?;
-
+        let b1 = Base::from_char(bytes[0] as char)?;
+        let b2 = Base::from_char(bytes[1] as char)?;
+        let b3 = Base::from_char(bytes[2] as char)?;
         Some(Self([b1, b2, b3]))
     }
 
     /// Get the three bases.
     pub fn bases(&self) -> &[Base; 3] {
         &self.0
+    }
+
+    /// 6-bit packed encoding suitable as an index into a 64-element lookup
+    /// table: `b0 << 4 | b1 << 2 | b2` with each base in 2 bits.
+    pub fn index(&self) -> u8 {
+        (self.0[0].to_index() << 4) | (self.0[1].to_index() << 2) | self.0[2].to_index()
+    }
+
+    /// Inverse of [`Codon::index`].
+    pub fn from_index(i: u8) -> Self {
+        Self([
+            Base::from_index(i >> 4),
+            Base::from_index(i >> 2),
+            Base::from_index(i),
+        ])
     }
 }
 
@@ -80,22 +126,27 @@ impl std::fmt::Display for Codon {
 /// Standard genetic code table.
 #[derive(Debug, Clone)]
 pub struct CodonTable {
-    /// Codon to amino acid mapping.
-    codon_to_aa: HashMap<Codon, AminoAcid>,
-    /// Amino acid to codons mapping.
+    /// Amino acid -> codons mapping (used by back-translation).
     aa_to_codons: HashMap<AminoAcid, Vec<Codon>>,
     /// Stop codons.
     stop_codons: Vec<Codon>,
     /// Start codon(s).
     start_codons: Vec<Codon>,
+    /// 64-entry array indexed by `Codon::index()`. `None` for stop codons.
+    /// The hot read path (`amino_acid_for`) hits this directly so codon
+    /// translation is a single array load with no hashing.
+    aa_lookup: [Option<AminoAcid>; 64],
+    /// 64-entry stop mask indexed by `Codon::index()`.
+    stop_lookup: [bool; 64],
 }
 
 impl CodonTable {
     /// Create the standard genetic code.
     pub fn standard() -> Self {
-        let mut codon_to_aa = HashMap::new();
         let mut aa_to_codons: HashMap<AminoAcid, Vec<Codon>> = HashMap::new();
         let mut stop_codons = Vec::new();
+        let mut aa_lookup: [Option<AminoAcid>; 64] = [None; 64];
+        let mut stop_lookup: [bool; 64] = [false; 64];
 
         // Define the standard genetic code
         let code: &[(&str, Option<AminoAcid>)] = &[
@@ -188,13 +239,14 @@ impl CodonTable {
 
         for (codon_str, aa_opt) in code {
             let codon = Codon::parse(codon_str).unwrap();
-
+            let idx = codon.index() as usize;
             match aa_opt {
                 Some(aa) => {
-                    codon_to_aa.insert(codon.clone(), *aa);
+                    aa_lookup[idx] = Some(*aa);
                     aa_to_codons.entry(*aa).or_default().push(codon);
                 }
                 None => {
+                    stop_lookup[idx] = true;
                     stop_codons.push(codon);
                 }
             }
@@ -203,10 +255,11 @@ impl CodonTable {
         let start_codons = vec![Codon::parse("ATG").unwrap()];
 
         Self {
-            codon_to_aa,
             aa_to_codons,
             stop_codons,
             start_codons,
+            aa_lookup,
+            stop_lookup,
         }
     }
 
@@ -219,13 +272,16 @@ impl CodonTable {
     }
 
     /// Get the amino acid encoded by a codon.
-    pub fn amino_acid_for(&self, codon: &Codon) -> Option<&AminoAcid> {
-        self.codon_to_aa.get(codon)
+    ///
+    /// Backed by a 64-element array indexed by [`Codon::index`]; constant time
+    /// with no hashing. Returns `None` for stop codons.
+    pub fn amino_acid_for(&self, codon: &Codon) -> Option<AminoAcid> {
+        self.aa_lookup[codon.index() as usize]
     }
 
-    /// Check if a codon is a stop codon.
+    /// Check if a codon is a stop codon. Constant-time array lookup.
     pub fn is_stop(&self, codon: &Codon) -> bool {
-        self.stop_codons.contains(codon)
+        self.stop_lookup[codon.index() as usize]
     }
 
     /// Check if a codon is a start codon.
@@ -277,15 +333,15 @@ mod tests {
         // Check some codons
         assert_eq!(
             table.amino_acid_for(&Codon::parse("ATG").unwrap()),
-            Some(&AminoAcid::Met)
+            Some(AminoAcid::Met)
         );
         assert_eq!(
             table.amino_acid_for(&Codon::parse("TTT").unwrap()),
-            Some(&AminoAcid::Phe)
+            Some(AminoAcid::Phe)
         );
         assert_eq!(
             table.amino_acid_for(&Codon::parse("GAG").unwrap()),
-            Some(&AminoAcid::Glu)
+            Some(AminoAcid::Glu)
         );
     }
 
@@ -297,6 +353,129 @@ mod tests {
         assert!(table.is_stop(&Codon::parse("TAG").unwrap()));
         assert!(table.is_stop(&Codon::parse("TGA").unwrap()));
         assert!(!table.is_stop(&Codon::parse("ATG").unwrap()));
+    }
+
+    /// Direct-API safety net for the perf rewrite below: every ACGT triple must
+    /// resolve to its canonical amino acid via `amino_acid_for`, and only the
+    /// three canonical stop codons may report `is_stop = true`.
+    #[test]
+    fn test_amino_acid_for_all_64_codons() {
+        let table = CodonTable::standard();
+        let canonical: &[(&str, Option<AminoAcid>)] = &[
+            ("TTT", Some(AminoAcid::Phe)),
+            ("TTC", Some(AminoAcid::Phe)),
+            ("TTA", Some(AminoAcid::Leu)),
+            ("TTG", Some(AminoAcid::Leu)),
+            ("CTT", Some(AminoAcid::Leu)),
+            ("CTC", Some(AminoAcid::Leu)),
+            ("CTA", Some(AminoAcid::Leu)),
+            ("CTG", Some(AminoAcid::Leu)),
+            ("ATT", Some(AminoAcid::Ile)),
+            ("ATC", Some(AminoAcid::Ile)),
+            ("ATA", Some(AminoAcid::Ile)),
+            ("ATG", Some(AminoAcid::Met)),
+            ("GTT", Some(AminoAcid::Val)),
+            ("GTC", Some(AminoAcid::Val)),
+            ("GTA", Some(AminoAcid::Val)),
+            ("GTG", Some(AminoAcid::Val)),
+            ("TCT", Some(AminoAcid::Ser)),
+            ("TCC", Some(AminoAcid::Ser)),
+            ("TCA", Some(AminoAcid::Ser)),
+            ("TCG", Some(AminoAcid::Ser)),
+            ("AGT", Some(AminoAcid::Ser)),
+            ("AGC", Some(AminoAcid::Ser)),
+            ("CCT", Some(AminoAcid::Pro)),
+            ("CCC", Some(AminoAcid::Pro)),
+            ("CCA", Some(AminoAcid::Pro)),
+            ("CCG", Some(AminoAcid::Pro)),
+            ("ACT", Some(AminoAcid::Thr)),
+            ("ACC", Some(AminoAcid::Thr)),
+            ("ACA", Some(AminoAcid::Thr)),
+            ("ACG", Some(AminoAcid::Thr)),
+            ("GCT", Some(AminoAcid::Ala)),
+            ("GCC", Some(AminoAcid::Ala)),
+            ("GCA", Some(AminoAcid::Ala)),
+            ("GCG", Some(AminoAcid::Ala)),
+            ("TAT", Some(AminoAcid::Tyr)),
+            ("TAC", Some(AminoAcid::Tyr)),
+            ("TAA", None),
+            ("TAG", None),
+            ("TGA", None),
+            ("CAT", Some(AminoAcid::His)),
+            ("CAC", Some(AminoAcid::His)),
+            ("CAA", Some(AminoAcid::Gln)),
+            ("CAG", Some(AminoAcid::Gln)),
+            ("AAT", Some(AminoAcid::Asn)),
+            ("AAC", Some(AminoAcid::Asn)),
+            ("AAA", Some(AminoAcid::Lys)),
+            ("AAG", Some(AminoAcid::Lys)),
+            ("GAT", Some(AminoAcid::Asp)),
+            ("GAC", Some(AminoAcid::Asp)),
+            ("GAA", Some(AminoAcid::Glu)),
+            ("GAG", Some(AminoAcid::Glu)),
+            ("TGT", Some(AminoAcid::Cys)),
+            ("TGC", Some(AminoAcid::Cys)),
+            ("TGG", Some(AminoAcid::Trp)),
+            ("CGT", Some(AminoAcid::Arg)),
+            ("CGC", Some(AminoAcid::Arg)),
+            ("CGA", Some(AminoAcid::Arg)),
+            ("CGG", Some(AminoAcid::Arg)),
+            ("AGA", Some(AminoAcid::Arg)),
+            ("AGG", Some(AminoAcid::Arg)),
+            ("GGT", Some(AminoAcid::Gly)),
+            ("GGC", Some(AminoAcid::Gly)),
+            ("GGA", Some(AminoAcid::Gly)),
+            ("GGG", Some(AminoAcid::Gly)),
+        ];
+        assert_eq!(canonical.len(), 64);
+        for (codon_str, expected) in canonical {
+            let codon = Codon::parse(codon_str).unwrap();
+            assert_eq!(
+                table.amino_acid_for(&codon),
+                *expected,
+                "amino_acid_for({codon_str})"
+            );
+            assert_eq!(
+                table.is_stop(&codon),
+                expected.is_none(),
+                "is_stop({codon_str})"
+            );
+        }
+    }
+
+    /// Cross-check that the array view (`amino_acid_for` / `is_stop`) and the
+    /// `aa_to_codons` / `stop_codons` views agree for every 6-bit codon index.
+    /// Catches accidental drift if the two are ever populated from different
+    /// sources.
+    #[test]
+    fn test_packed_table_matches_inverse_views() {
+        let table = CodonTable::standard();
+        for i in 0..64u8 {
+            let codon = Codon::from_index(i);
+            let via_array = table.amino_acid_for(&codon);
+            // Inverse via aa_to_codons: find the (aa, codons) entry that lists
+            // this codon; absence ⇒ not a sense codon.
+            let via_inverse = table.aa_to_codons.iter().find_map(|(aa, codons)| {
+                if codons.contains(&codon) {
+                    Some(*aa)
+                } else {
+                    None
+                }
+            });
+            assert_eq!(via_array, via_inverse, "aa mismatch for {codon}");
+            assert_eq!(
+                table.is_stop(&codon),
+                table.stop_codons.contains(&codon),
+                "is_stop mismatch for {codon}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codon_index_roundtrip() {
+        for i in 0..64u8 {
+            assert_eq!(Codon::from_index(i).index(), i, "index roundtrip {i}");
+        }
     }
 
     #[test]

--- a/src/benchmark/translate.rs
+++ b/src/benchmark/translate.rs
@@ -32,8 +32,6 @@ pub fn translate_cds_to_protein(cds_sequence: &str) -> Option<String> {
                 break; // Stop at stop codon
             }
             if let Some(aa) = table.amino_acid_for(&codon) {
-                use crate::hgvs::location::AminoAcid;
-                let _: &AminoAcid = aa; // type assertion
                 protein.push(aa.to_one_letter());
             } else {
                 return None; // Unknown codon

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -28,11 +28,13 @@ use crate::liftover::aliases::ContigAliases;
 use crate::reference::transcript::GenomeBuild;
 use crate::reference::Strand;
 use bincode::Options;
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
+use superintervals::IntervalMap;
 
 /// cdot transcript alignment data (normalized internal representation).
 ///
@@ -405,10 +407,26 @@ impl CdotTranscript {
     }
 
     /// Find exon containing a genomic position.
+    ///
+    /// Exons in `self.exons` are sorted by `tx_start` (see
+    /// `RawCdotTranscript::from_genome_build`). On a plus-strand transcript
+    /// that means `genome_start` is monotonically increasing; on a
+    /// minus-strand transcript it's monotonically *decreasing* (the
+    /// 5'→3' transcript order runs against genomic coordinates). Use that
+    /// to early-terminate the scan once we've passed `genome_pos` — for
+    /// intronic / off-transcript positions, the previous unconditional
+    /// linear walk consulted every exon even though the answer was already
+    /// determined a few iterations in.
     pub fn exon_for_genome_pos(&self, genome_pos: u64) -> Option<Exon> {
         for (i, arr) in self.exons.iter().enumerate() {
             if genome_pos >= arr[0] && genome_pos < arr[1] {
                 return Some(Exon::from_array((i + 1) as u32, *arr));
+            }
+            // Early-terminate based on the sort invariant.
+            match self.strand {
+                Strand::Plus if genome_pos < arr[0] => return None,
+                Strand::Minus if genome_pos >= arr[1] => return None,
+                _ => {}
             }
         }
         None
@@ -441,6 +459,40 @@ impl CdotTranscript {
             }
             Strand::Unknown => None,
         }
+    }
+
+    /// Locate `genome_pos` against this transcript's exons in a single scan,
+    /// returning the containing exon and the corresponding transcript-space
+    /// position.
+    ///
+    /// Existing callers chained `genome_to_tx` (which internally scans the
+    /// exon list) with a second `exon_for_genome_pos` call (another scan).
+    /// This helper does both in one pass — relevant in
+    /// [`CoordinateMapper::genome_pos_to_cds_pos`] which is invoked twice per
+    /// projection and is the dominant per-variant cost on the SNP fixture
+    /// after c11.
+    pub fn locate_genome_pos(&self, genome_pos: u64) -> Option<(u64, Exon)> {
+        for (i, arr) in self.exons.iter().enumerate() {
+            if genome_pos >= arr[0] && genome_pos < arr[1] {
+                let exon = Exon::from_array((i + 1) as u32, *arr);
+                let tx_pos = match self.strand {
+                    Strand::Plus => exon.tx_start + (genome_pos - exon.genome_start),
+                    Strand::Minus => exon.tx_start + (exon.genome_end - 1 - genome_pos),
+                    Strand::Unknown => return None,
+                };
+                return Some((tx_pos, exon));
+            }
+            // Same early-termination as in `exon_for_genome_pos`. Exons are
+            // sorted by `tx_start`, which is monotone in `genome_start` on
+            // plus-strand (increasing) and in `genome_end` on minus-strand
+            // (decreasing).
+            match self.strand {
+                Strand::Plus if genome_pos < arr[0] => return None,
+                Strand::Minus if genome_pos >= arr[1] => return None,
+                _ => {}
+            }
+        }
+        None
     }
 
     /// Convert CDS position (1-based) to transcript position (0-based).
@@ -771,6 +823,27 @@ pub struct CdotMapper {
     /// Used by [`get_transcript_on_build`](Self::get_transcript_on_build) to
     /// short-circuit when the caller asks for the primary build.
     primary_build: String,
+    /// Lazily-built per-contig SuperIntervals index for stabbing queries.
+    ///
+    /// Built on the first call to `transcripts_at_position` from the contents of
+    /// `contig_index` + `transcripts`. Replaces a linear scan that re-folded
+    /// every transcript's exon table on every query. The `u32` payload is the
+    /// index into `contig_index[contig]` so the original accession can be
+    /// recovered for the caller.
+    ///
+    /// Built eagerly here because every "real" caller (`from_json_file`,
+    /// `load`, `from_transcripts`) populates `contig_index` once and then only
+    /// queries; `add_transcript` followed by a query in tests still works
+    /// because the cell is initialised on first access. If a caller adds
+    /// transcripts AFTER a query has populated the cell the new transcripts
+    /// will be missing from the index — `add_transcript` clears the cell to
+    /// guard against that.
+    contig_query_index: OnceCell<HashMap<String, IntervalMap<u32>>>,
+    /// Lazily-built per-transcript `(min_genome_start, max_genome_end)`
+    /// cache so `VariantProjector::project_single_inner` doesn't re-fold the
+    /// exon table on every projection. Sharing the same `OnceCell` build
+    /// trigger as `contig_query_index` keeps the two views in sync.
+    transcript_genome_spans: OnceCell<HashMap<String, (u64, u64)>>,
 }
 
 impl CdotMapper {
@@ -784,6 +857,8 @@ impl CdotMapper {
             lrg_to_refseq: HashMap::new(),
             alt_build_transcripts: HashMap::new(),
             primary_build: "GRCh38".to_string(),
+            contig_query_index: OnceCell::new(),
+            transcript_genome_spans: OnceCell::new(),
         }
     }
 
@@ -947,6 +1022,8 @@ impl CdotMapper {
                 HashMap::new()
             },
             primary_build: "GRCh38".to_string(),
+            contig_query_index: OnceCell::new(),
+            transcript_genome_spans: OnceCell::new(),
         })
     }
 
@@ -1107,6 +1184,11 @@ impl CdotMapper {
         }
 
         self.transcripts.insert(accession, transcript);
+
+        // Any previously-built query index is stale now. The next query will
+        // rebuild it from the updated `contig_index` + `transcripts`.
+        self.contig_query_index = OnceCell::new();
+        self.transcript_genome_spans = OnceCell::new();
     }
 
     /// Build contig alias mappings from `ContigAliases` so that UCSC-style names
@@ -1342,26 +1424,101 @@ impl CdotMapper {
     }
 
     /// Find transcripts overlapping a genomic position. Resolves contig aliases.
+    ///
+    /// Backed by a per-contig SuperIntervals stab-query index that is built
+    /// lazily on first call and cached for the lifetime of the `CdotMapper`
+    /// (invalidated by `add_transcript`). Replaces the previous linear scan
+    /// that re-folded every transcript's exon table on every query.
     pub fn transcripts_at_position(&self, contig: &str, pos: u64) -> Vec<(&str, &CdotTranscript)> {
-        self.contig_index
-            .get(self.resolve_contig(contig))
-            .map(|ids| {
-                ids.iter()
-                    .filter_map(|id| {
-                        let tx = self.transcripts.get(id)?;
-                        // Check if position is within transcript genomic range
-                        let (min, max) = tx.exons.iter().fold((u64::MAX, 0), |(min, max), e| {
-                            (min.min(e[0]), max.max(e[1]))
-                        });
-                        if pos >= min && pos < max {
-                            Some((id.as_str(), tx))
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+        let canonical = self.resolve_contig(contig);
+        let by_contig = self
+            .contig_query_index
+            .get_or_init(|| self.build_query_index());
+        let Some(im) = by_contig.get(canonical) else {
+            return Vec::new();
+        };
+        let Some(accessions) = self.contig_index.get(canonical) else {
+            return Vec::new();
+        };
+        // i32 fits every chromosome in any current build (max ~250M < 2.1B).
+        // Positions outside i32 cannot overlap a real transcript span anyway.
+        let Ok(p) = i32::try_from(pos) else {
+            return Vec::new();
+        };
+        let mut hits: Vec<u32> = Vec::with_capacity(16);
+        im.search_stabbed(p, &mut hits);
+        hits.into_iter()
+            .filter_map(|idx| {
+                let acc = accessions.get(idx as usize)?;
+                let tx = self.transcripts.get(acc)?;
+                Some((acc.as_str(), tx))
             })
-            .unwrap_or_default()
+            .collect()
+    }
+
+    /// Genomic extent `(min_exon_start, max_exon_end)` of a transcript, taken
+    /// from a cached side-table that's built lazily on first call alongside
+    /// the contig stab-query index.
+    ///
+    /// Used by `VariantProjector::project_single_inner` instead of folding
+    /// `tx.exons.iter().map(|e| e[0]).min()/max()` per call — the inputs are
+    /// stable for the life of the `CdotMapper`, so re-computing every time
+    /// (~4.4M folds across the SNP fixture) is pure waste.
+    pub fn transcript_genome_span(&self, transcript_id: &str) -> Option<(u64, u64)> {
+        let spans = self
+            .transcript_genome_spans
+            .get_or_init(|| self.build_transcript_genome_spans());
+        spans.get(transcript_id).copied()
+    }
+
+    /// Build the per-transcript span side-table. Same single-pass shape as
+    /// `build_query_index` so the two views can't disagree about what
+    /// "transcript span" means.
+    fn build_transcript_genome_spans(&self) -> HashMap<String, (u64, u64)> {
+        let mut out = HashMap::with_capacity(self.transcripts.len());
+        for (acc, tx) in &self.transcripts {
+            if tx.exons.is_empty() {
+                continue;
+            }
+            let min = tx.exons.iter().map(|e| e[0]).min().unwrap();
+            let max = tx.exons.iter().map(|e| e[1]).max().unwrap();
+            out.insert(acc.clone(), (min, max));
+        }
+        out
+    }
+
+    /// Construct the per-contig stab-query index. Called at most once per
+    /// `CdotMapper` lifetime (until `add_transcript` invalidates the cache).
+    ///
+    /// SuperIntervals' intervals are end-inclusive (`[start, end]`). To
+    /// preserve the old half-open `pos >= min && pos < max` semantics we
+    /// insert `[min, max - 1]` and probe with `search_stabbed(pos)`.
+    fn build_query_index(&self) -> HashMap<String, IntervalMap<u32>> {
+        let mut by_contig: HashMap<String, IntervalMap<u32>> =
+            HashMap::with_capacity(self.contig_index.len());
+        for (contig, accessions) in &self.contig_index {
+            let mut im: IntervalMap<u32> = IntervalMap::new();
+            for (idx, acc) in accessions.iter().enumerate() {
+                let Some(tx) = self.transcripts.get(acc) else {
+                    continue;
+                };
+                if tx.exons.is_empty() {
+                    continue;
+                }
+                let min = tx.exons.iter().map(|e| e[0]).min().unwrap();
+                let max = tx.exons.iter().map(|e| e[1]).max().unwrap();
+                if max <= min {
+                    continue;
+                }
+                let (Ok(s), Ok(e)) = (i32::try_from(min), i32::try_from(max - 1)) else {
+                    continue;
+                };
+                im.add(s, e, idx as u32);
+            }
+            im.build();
+            by_contig.insert(contig.clone(), im);
+        }
+        by_contig
     }
 
     /// Get the number of transcripts loaded.
@@ -1528,6 +1685,63 @@ mod tests {
 
         // Second exon
         assert_eq!(tx.genome_to_tx(2199), Some(150));
+    }
+
+    /// c15 early-termination relies on the cdot sort invariant — exons are
+    /// in `tx_start`-ascending order, which means `genome_start` is
+    /// monotonically increasing on plus-strand and decreasing on
+    /// minus-strand. These tests pin both the off-transcript None return and
+    /// the in-transcript Some return so a future change to either the sort
+    /// invariant or the early-break condition is caught.
+    #[test]
+    fn test_exon_for_genome_pos_plus_strand_early_term() {
+        let tx = sample_transcript(); // exons at [1000,1100), [2000,2200), [3000,3150)
+                                      // Below all exons → None.
+        assert!(tx.exon_for_genome_pos(500).is_none());
+        // Between exon 0 and 1 (intronic) → None.
+        assert!(tx.exon_for_genome_pos(1500).is_none());
+        // Above all exons → None.
+        assert!(tx.exon_for_genome_pos(5000).is_none());
+        // Inside each exon → Some(...).
+        assert!(tx.exon_for_genome_pos(1050).is_some());
+        assert!(tx.exon_for_genome_pos(2100).is_some());
+        assert!(tx.exon_for_genome_pos(3100).is_some());
+    }
+
+    #[test]
+    fn test_exon_for_genome_pos_minus_strand_early_term() {
+        let tx = minus_strand_transcript();
+        // The minus-strand fixture has exons (in tx-order, i.e. high→low
+        // genome): [3000,3150), [2000,2200), [1000,1100).
+        assert!(tx.exon_for_genome_pos(5000).is_none()); // above all
+        assert!(tx.exon_for_genome_pos(2500).is_none()); // intronic between 3000 and 2200
+        assert!(tx.exon_for_genome_pos(500).is_none()); // below all
+        assert!(tx.exon_for_genome_pos(3050).is_some()); // first exon (highest)
+        assert!(tx.exon_for_genome_pos(2100).is_some()); // middle exon
+        assert!(tx.exon_for_genome_pos(1050).is_some()); // last exon (lowest)
+    }
+
+    #[test]
+    fn test_locate_genome_pos_matches_exon_lookup() {
+        // `locate_genome_pos` must agree with `exon_for_genome_pos` +
+        // `genome_to_tx` on which exon (and what tx position) a query maps
+        // to. Sweep a representative range of positions and require either
+        // both succeed with the same exon number or both return None.
+        for tx in [sample_transcript(), minus_strand_transcript()] {
+            for pos in (500..5500).step_by(37) {
+                let combined = tx.locate_genome_pos(pos);
+                let separate = match (tx.genome_to_tx(pos), tx.exon_for_genome_pos(pos)) {
+                    (Some(tp), Some(ex)) => Some((tp, ex)),
+                    _ => None,
+                };
+                assert_eq!(
+                    combined.map(|(tp, ex)| (tp, ex.number)),
+                    separate.map(|(tp, ex)| (tp, ex.number)),
+                    "disagreement at pos {pos} for {:?}-strand",
+                    tx.strand
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -346,17 +346,19 @@ impl CoordinateMapper {
         genome_pos: &GenomePos,
         transcript_id: &str,
     ) -> Result<(CdsPos, MappingInfo), FerroError> {
-        let mut info = MappingInfo {
-            transcript_id: Some(transcript_id.to_string()),
-            ..Default::default()
-        };
+        // `transcript_id` is part of the parameter list for API stability but
+        // no in-tree consumer reads `MappingInfo::transcript_id` — leaving it
+        // None avoids a `String::from` allocation per call (~400 calls per
+        // SNP project_all on chr17 fan-out).
+        let _ = transcript_id;
+        let mut info = MappingInfo::default();
 
-        // Check if position is in an exon
-        if let Some(tx_pos) = tx.genome_to_tx(genome_pos.base) {
-            // Position is exonic
-            if let Some(exon) = tx.exon_for_genome_pos(genome_pos.base) {
-                info.exon_numbers.push(exon.number);
-            }
+        // Check if position is in an exon. `locate_genome_pos` returns both
+        // the exon and the converted tx position in a single scan; before
+        // c12 we called `genome_to_tx` (one scan) and `exon_for_genome_pos`
+        // (a second scan) separately.
+        if let Some((tx_pos, exon)) = tx.locate_genome_pos(genome_pos.base) {
+            info.exon_numbers.push(exon.number);
 
             // Convert to CDS position
             let cds_pos = tx
@@ -709,5 +711,111 @@ mod tests {
         // Position outside all transcripts
         let results = mapper.find_overlapping_transcripts("NC_000001.11", 5000);
         assert!(results.is_empty());
+    }
+
+    /// Boundary semantics of the SuperIntervals index must match the previous
+    /// linear-scan implementation: `pos >= min && pos < max` (half-open). Both
+    /// fixtures span [1000, 3150) on chr1, so:
+    ///   pos = 1000  → in (inclusive lower bound)
+    ///   pos = 3149  → in (last position covered by 3150 exclusive)
+    ///   pos = 3150  → out (exclusive upper bound)
+    ///   pos = 999   → out
+    #[test]
+    fn test_find_overlapping_transcripts_boundary_semantics() {
+        let mapper = create_test_mapper();
+        assert_eq!(
+            mapper
+                .find_overlapping_transcripts("NC_000001.11", 1000)
+                .len(),
+            2,
+            "inclusive lower bound"
+        );
+        assert_eq!(
+            mapper
+                .find_overlapping_transcripts("NC_000001.11", 3149)
+                .len(),
+            2,
+            "inclusive upper bound (3150 - 1)"
+        );
+        assert!(
+            mapper
+                .find_overlapping_transcripts("NC_000001.11", 3150)
+                .is_empty(),
+            "exclusive upper bound"
+        );
+        assert!(
+            mapper
+                .find_overlapping_transcripts("NC_000001.11", 999)
+                .is_empty(),
+            "below lower bound"
+        );
+    }
+
+    /// The query uses each transcript's `[min_exon_start, max_exon_end)` span,
+    /// so intronic positions inside that span (between two exons of the same
+    /// transcript) still return the transcript. The downstream
+    /// `genome_to_cds` is what tells the caller it landed in an intron.
+    #[test]
+    fn test_find_overlapping_transcripts_returns_intronic_spans() {
+        let mapper = create_test_mapper();
+        // Position 1500 is in the intron between exon 1 [1000,1100) and exon 2
+        // [2000,2200). It's inside the transcript span [1000, 3150).
+        let results = mapper.find_overlapping_transcripts("NC_000001.11", 1500);
+        assert_eq!(results.len(), 2, "intronic position must return both txs");
+    }
+
+    /// After `add_transcript` is called following a prior query, the new
+    /// transcript must show up in subsequent queries — i.e. the OnceCell
+    /// invalidation works.
+    #[test]
+    fn test_find_overlapping_transcripts_invalidates_after_add() {
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_FIRST.1".to_string(),
+            CdotTranscript {
+                gene_name: None,
+                contig: "NC_000001.11".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1100, 0, 100]],
+                cds_start: Some(0),
+                cds_end: Some(100),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let mapper = CoordinateMapper::new(cdot);
+        assert_eq!(
+            mapper
+                .find_overlapping_transcripts("NC_000001.11", 1050)
+                .len(),
+            1,
+        );
+
+        // Add a second transcript via a fresh mapper (mimicking the typical
+        // build-once flow but exercising the invalidation explicitly).
+        let mut cdot2 = mapper.cdot().clone();
+        cdot2.add_transcript(
+            "NM_SECOND.1".to_string(),
+            CdotTranscript {
+                gene_name: None,
+                contig: "NC_000001.11".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1100, 0, 100]],
+                cds_start: Some(0),
+                cds_end: Some(100),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let mapper2 = CoordinateMapper::new(cdot2);
+        assert_eq!(
+            mapper2
+                .find_overlapping_transcripts("NC_000001.11", 1050)
+                .len(),
+            2,
+            "second transcript must be visible after add",
+        );
     }
 }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -12,14 +12,54 @@ use crate::hgvs::variant::{
 use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
-use crate::project::protein::{predict_indel_protein, predict_substitution_protein};
+use crate::project::protein::{
+    predict_indel_protein, predict_substitution_protein, RefProteinBundle,
+};
 use crate::project::result::VariantProjection;
+use crate::reference::transcript::Transcript;
 use crate::reference::ReferenceProvider;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// Cache key for [`VariantProjector`]'s transcript cache:
+/// `(transcript_id, parent_accession)`. The parent component is `None` for
+/// non-variant-aware lookups and for inputs without a `genomic_context`; it
+/// is `Some` only when the variant-aware path observes an NG/NC parent that
+/// could steer the lookup to a non-primary cdot build (issue #332).
+type TranscriptCacheKey = (String, Option<String>);
 
 pub struct VariantProjector<P: ReferenceProvider + Clone> {
     projector: Projector,
     provider: P,
     normalizer: Normalizer<P>,
+    /// Cache of fetched transcripts keyed by `(transcript_id, parent_accession)`.
+    ///
+    /// `project_single_inner` looks up each overlapping transcript via the
+    /// provider once per variant; for `project_all` workloads (hundreds of
+    /// overlapping transcripts per variant on dense chromosomes) the same
+    /// transcript ID is fetched repeatedly. Caching collapses N→1 fetches
+    /// per unique key over the projector's lifetime.
+    ///
+    /// The parent-accession component is non-`None` only on the variant-aware
+    /// lookup path (`cached_get_transcript_for_variant`), where the variant's
+    /// `genomic_context` (NG/NC parent) can steer
+    /// `ReferenceProvider::get_transcript_for_variant` to a different cdot
+    /// build for the same `transcript_id` (issue #332). Inputs without a
+    /// `genomic_context` and the legacy `cached_get_transcript` entry point
+    /// both cache under `(transcript_id, None)`, so they share entries.
+    transcript_cache: RwLock<HashMap<TranscriptCacheKey, Arc<Transcript>>>,
+    /// Cache of the translated reference protein (ref CDS + ref protein +
+    /// ref-with-stop) keyed by the same `(transcript_id, parent_accession)`
+    /// identity used by `transcript_cache`. Each entry is stable for the life
+    /// of the projector and is consumed by `predict_indel_protein` to avoid
+    /// retranslating the full CDS on every indel.
+    ///
+    /// The parent-aware key matters because one `transcript_id` can resolve to
+    /// different transcript records (and therefore different reference CDS
+    /// bases) under different NG/NC parents (issue #332). Keying by
+    /// `transcript_id` alone would let the first resolved build poison indel
+    /// protein predictions for projections on the other build.
+    ref_protein_cache: RwLock<HashMap<TranscriptCacheKey, Arc<RefProteinBundle>>>,
 }
 
 impl<P: ReferenceProvider + Clone> VariantProjector<P> {
@@ -29,7 +69,126 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             projector,
             provider,
             normalizer,
+            transcript_cache: RwLock::new(HashMap::new()),
+            ref_protein_cache: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Non-variant-aware transcript fetch with caching. Kept for inline tests
+    /// that need to populate a `Transcript` for `cached_ref_translation`
+    /// without constructing an `HgvsVariant`. Hot-path callers go through
+    /// [`Self::cached_get_transcript_for_variant`] so an NG/NC-parented input
+    /// resolves to the correct cdot build (issue #332).
+    #[cfg(test)]
+    fn cached_get_transcript(&self, transcript_id: &str) -> Result<Arc<Transcript>, FerroError> {
+        let key = (transcript_id.to_string(), None);
+        if let Some(tx) = self
+            .transcript_cache
+            .read()
+            .expect("transcript cache poisoned")
+            .get(&key)
+        {
+            return Ok(Arc::clone(tx));
+        }
+        let tx = self.provider.get_transcript(transcript_id)?;
+        let mut guard = self
+            .transcript_cache
+            .write()
+            .expect("transcript cache poisoned");
+        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        Ok(Arc::clone(entry))
+    }
+
+    /// Variant-aware transcript lookup with caching.
+    ///
+    /// Routes through [`ReferenceProvider::get_transcript_for_variant`] so an
+    /// NG/NC-parented input picks the build-correct cdot transcript (issue
+    /// #332). The cache key is `(transcript_id, parent_accession)` because
+    /// the same `transcript_id` can resolve to different transcripts under
+    /// different parents.
+    ///
+    /// On `ReferenceNotFound` from the variant-aware call, falls back to the
+    /// bare provider lookup (matches the prior `tx_for_codon_with_fallback`
+    /// contract). Other provider errors propagate.
+    /// Build the parent-aware cache key component for a variant.
+    ///
+    /// Returns `Some(parent.to_string())` when the variant's accession carries
+    /// a `genomic_context` (NG/NC parent), `None` otherwise. Shared by
+    /// [`Self::cached_get_transcript_for_variant`] and
+    /// [`Self::cached_ref_translation`] so both caches use byte-identical keys
+    /// for the same variant.
+    fn parent_key_for(variant: &HgvsVariant) -> Option<String> {
+        variant
+            .accession()
+            .and_then(|a| a.genomic_context.as_deref())
+            .map(|gc| gc.to_string())
+    }
+
+    fn cached_get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+        transcript_id: &str,
+    ) -> Result<Arc<Transcript>, FerroError> {
+        let parent_key = Self::parent_key_for(variant);
+        let key = (transcript_id.to_string(), parent_key);
+        if let Some(tx) = self
+            .transcript_cache
+            .read()
+            .expect("transcript cache poisoned")
+            .get(&key)
+        {
+            return Ok(Arc::clone(tx));
+        }
+        let tx = match self.provider.get_transcript_for_variant(variant) {
+            Ok(tx) => tx,
+            Err(FerroError::ReferenceNotFound { .. }) => {
+                self.provider.get_transcript(transcript_id)?
+            }
+            Err(e) => return Err(e),
+        };
+        let mut guard = self
+            .transcript_cache
+            .write()
+            .expect("transcript cache poisoned");
+        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        Ok(Arc::clone(entry))
+    }
+
+    /// Build (or retrieve) the cached `RefProteinBundle` for a transcript.
+    ///
+    /// The reference CDS and its translation are stable for a given
+    /// `(transcript_id, parent_accession)` pair — `predict_indel_protein`
+    /// would otherwise recompute them on every variant. Caching collapses
+    /// that to one translation per (id, parent) over the projector's
+    /// lifetime.
+    ///
+    /// The cache is keyed by the same parent-aware identity as
+    /// [`Self::cached_get_transcript_for_variant`] so that an NG/NC-parented
+    /// input does not reuse the bundle built for a different cdot build of
+    /// the same `transcript_id` (issue #332).
+    pub(crate) fn cached_ref_translation(
+        &self,
+        variant: &HgvsVariant,
+        transcript_id: &str,
+        transcript: &Transcript,
+    ) -> Result<Arc<RefProteinBundle>, FerroError> {
+        let parent_key = Self::parent_key_for(variant);
+        let key = (transcript_id.to_string(), parent_key);
+        if let Some(b) = self
+            .ref_protein_cache
+            .read()
+            .expect("ref-protein cache poisoned")
+            .get(&key)
+        {
+            return Ok(Arc::clone(b));
+        }
+        let bundle = RefProteinBundle::from_transcript(transcript)?;
+        let mut guard = self
+            .ref_protein_cache
+            .write()
+            .expect("ref-protein cache poisoned");
+        let entry = guard.entry(key).or_insert_with(|| Arc::new(bundle));
+        Ok(Arc::clone(entry))
     }
 
     pub fn with_normalize_config(mut self, config: NormalizeConfig) -> Self {
@@ -671,27 +830,28 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             })?;
 
         let mapper = self.projector.mapper();
-        let normalized_str = normalized.to_string();
 
-        // Compute the overall genomic extent of the transcript from its exons.
-        // Exon format: [genome_start(0-based), genome_end(0-based excl), tx_start, tx_end].
-        let (tx_genome_start, tx_genome_end) = {
-            let exons = &cdot_tx.exons;
-            if exons.is_empty() {
-                return Err(FerroError::ReferenceNotFound {
-                    id: transcript_id.to_string(),
-                });
-            }
-            let starts = exons.iter().map(|e| e[0]).min().unwrap();
-            let ends = exons.iter().map(|e| e[1]).max().unwrap();
-            (starts, ends)
-        };
+        // Genomic extent of the transcript — used to short-circuit the
+        // genome-to-CDS mapping when the variant is outside the transcript's
+        // span. `transcript_genome_span` consults a cached side-table on the
+        // CdotMapper (built once); before c14 this re-folded `cdot_tx.exons`
+        // (min/max) on every call.
+        let (tx_genome_start, tx_genome_end) = mapper
+            .cdot()
+            .transcript_genome_span(transcript_id)
+            .ok_or_else(|| FerroError::ReferenceNotFound {
+                id: transcript_id.to_string(),
+            })?;
 
         // Helper: map one GenomePos → CdsPos, converting out-of-range errors.
+        // `normalized.to_string()` is only consumed by the error message and
+        // the happy path doesn't touch it; building it eagerly was ~2% of
+        // SNP CPU per `fmt::write` self-time, so defer it to the moment we
+        // actually construct a `TranscriptNotOverlapping` error.
         let map_position = |gp: &GenomePos| -> Result<(CdsPos, MappingInfo), FerroError> {
             if gp.base < tx_genome_start || gp.base >= tx_genome_end {
                 return Err(FerroError::TranscriptNotOverlapping {
-                    variant: normalized_str.clone(),
+                    variant: normalized.to_string(),
                     transcript_id: transcript_id.to_string(),
                 });
             }
@@ -700,7 +860,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 Err(FerroError::InvalidCoordinates { .. })
                 | Err(FerroError::ConversionError { .. }) => {
                     Err(FerroError::TranscriptNotOverlapping {
-                        variant: normalized_str.clone(),
+                        variant: normalized.to_string(),
                         transcript_id: transcript_id.to_string(),
                     })
                 }
@@ -783,28 +943,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 // Issue #332: route per-codon transcript lookups through the
                 // variant-aware path so an NG/NC-parented input (carried on
                 // the input `coding` variant we're projecting) picks the
-                // build-correct chromosome. Falls back to the bare lookup
-                // for inputs without a `genomic_context`.
-                let get_tx = || -> Result<crate::reference::transcript::Transcript, FerroError> {
-                    self.provider.get_transcript_for_variant(&coding)
-                };
-                // Only fall back to the bare lookup when the variant-aware
-                // lookup explicitly couldn't find a build-resolved transcript
-                // (issue #332). Other provider errors (I/O, parse, etc.)
-                // must propagate so they aren't silently masked.
-                let tx_for_codon_with_fallback =
-                    || -> Result<crate::reference::transcript::Transcript, FerroError> {
-                        match get_tx() {
-                            Ok(tx) => Ok(tx),
-                            Err(FerroError::ReferenceNotFound { .. }) => {
-                                self.provider.get_transcript(transcript_id)
-                            }
-                            Err(e) => Err(e),
-                        }
-                    };
+                // build-correct chromosome. `cached_get_transcript_for_variant`
+                // caches by `(transcript_id, parent_accession)` so repeat
+                // lookups on the same parent are free, and falls back to the
+                // bare provider lookup on `ReferenceNotFound` (the previous
+                // `tx_for_codon_with_fallback` contract). Other provider
+                // errors propagate.
                 match &c_edit {
                     NaEdit::Substitution { .. } => {
-                        let tx_for_codon = tx_for_codon_with_fallback()?;
+                        let tx_for_codon =
+                            self.cached_get_transcript_for_variant(&coding, transcript_id)?;
                         protein = Some(predict_substitution_protein(
                             &tx_for_codon,
                             cds_start.base,
@@ -824,9 +972,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                             && cds_start.base > 0
                             && cds_end.base > 0 =>
                     {
-                        let tx_for_codon = tx_for_codon_with_fallback()?;
+                        let tx_for_codon =
+                            self.cached_get_transcript_for_variant(&coding, transcript_id)?;
+                        let ref_bundle = self.cached_ref_translation(
+                            &coding,
+                            transcript_id,
+                            &tx_for_codon,
+                        )?;
                         match predict_indel_protein(
                             &tx_for_codon,
+                            &ref_bundle,
                             cds_start.base,
                             cds_end.base,
                             &c_edit,
@@ -924,7 +1079,7 @@ mod tests {
     use super::*;
     use crate::data::cdot::{CdotMapper, CdotTranscript};
     use crate::data::projection::Projector;
-    use crate::hgvs::variant::{AllelePhase, AlleleVariant};
+    use crate::hgvs::variant::{Accession, AllelePhase, AlleleVariant};
     use crate::reference::mock::MockProvider;
     use crate::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
     use crate::reference::Strand as ProvStrand;
@@ -1104,6 +1259,112 @@ mod tests {
         let suffix = "N".repeat(100);
         provider.add_genomic_sequence("chr1", format!("{}{}{}", prefix, "ATGCGCTAA", suffix));
         (projector, provider)
+    }
+
+    // -------------------------------------------------------------------------
+    // Cache identity tests
+    // -------------------------------------------------------------------------
+
+    /// Build a minimal coding HgvsVariant pointing at `transcript_id` for use
+    /// in `cached_ref_translation` tests. The variant's `accession` carries
+    /// `genomic_context = ctx`, so `parent_key_for` returns the same string
+    /// the production code would derive at projection time.
+    #[cfg(test)]
+    fn make_coding_variant(transcript_id: &str, ctx: Option<Accession>) -> HgvsVariant {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::variant::{CdsVariant, LocEdit};
+
+        let mut accession = parse_accession(transcript_id);
+        if let Some(parent) = ctx {
+            accession = accession.with_genomic_context(parent);
+        }
+        HgvsVariant::Cds(CdsVariant {
+            accession,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        })
+    }
+
+    /// Two consecutive `cached_ref_translation` calls for the same
+    /// `(transcript_id, parent_accession)` pair must return the same
+    /// `Arc<RefProteinBundle>` (pointer-equal). Catches any future
+    /// regression that accidentally rebuilds the bundle per call.
+    #[test]
+    fn cached_ref_translation_returns_same_arc() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        let tx = vp
+            .cached_get_transcript("NM_TEST.1")
+            .expect("transcript fetch");
+        let variant = make_coding_variant("NM_TEST.1", None);
+        let a = vp
+            .cached_ref_translation(&variant, "NM_TEST.1", &tx)
+            .expect("first translation");
+        let b = vp
+            .cached_ref_translation(&variant, "NM_TEST.1", &tx)
+            .expect("second translation");
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "ref-protein cache must return the same Arc for repeated lookups"
+        );
+        // ATGCGCTAA = Met-Arg-Ter; translate_full_cds stops before the Ter.
+        assert_eq!(a.ref_protein.len(), 2);
+        assert_eq!(a.ref_protein_with_stop.len(), 3);
+    }
+
+    /// Two `cached_ref_translation` lookups for the same `transcript_id`
+    /// but different parent `genomic_context` accessions must produce
+    /// distinct cache entries (different `Arc`s). Without parent-aware
+    /// keying the second call would reuse the bundle built for the first
+    /// parent, which can poison indel protein predictions once the
+    /// underlying transcript resolves to a different cdot build under
+    /// each parent (issue #332).
+    #[test]
+    fn cached_ref_translation_is_parent_aware() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        let tx = vp
+            .cached_get_transcript("NM_TEST.1")
+            .expect("transcript fetch");
+
+        let v_none = make_coding_variant("NM_TEST.1", None);
+        let v_ng1 = make_coding_variant("NM_TEST.1", Some(Accession::new("NG", "TEST", Some(1))));
+        let v_ng2 = make_coding_variant("NM_TEST.1", Some(Accession::new("NG", "TEST", Some(2))));
+
+        let b_none = vp
+            .cached_ref_translation(&v_none, "NM_TEST.1", &tx)
+            .expect("no-parent bundle");
+        let b_ng1 = vp
+            .cached_ref_translation(&v_ng1, "NM_TEST.1", &tx)
+            .expect("NG_TEST.1 bundle");
+        let b_ng2 = vp
+            .cached_ref_translation(&v_ng2, "NM_TEST.1", &tx)
+            .expect("NG_TEST.2 bundle");
+
+        // Each parent identity must occupy its own cache slot.
+        assert!(
+            !Arc::ptr_eq(&b_none, &b_ng1),
+            "no-parent and NG-parented entries must not collide"
+        );
+        assert!(
+            !Arc::ptr_eq(&b_ng1, &b_ng2),
+            "two distinct NG parents must produce distinct cache entries"
+        );
+
+        // Re-querying with the same parent must still hit the cache.
+        let b_ng1_again = vp
+            .cached_ref_translation(&v_ng1, "NM_TEST.1", &tx)
+            .expect("NG_TEST.1 bundle (repeat)");
+        assert!(
+            Arc::ptr_eq(&b_ng1, &b_ng1_again),
+            "repeated lookup with the same parent must hit the cache"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -9,7 +9,7 @@ use crate::hgvs::location::AminoAcid;
 use crate::reference::transcript::Transcript;
 use crate::sequence::reverse_complement;
 
-use super::substitution::translate;
+use super::substitution::translate_bytes;
 
 // ── CDS sequence readers ──────────────────────────────────────────────────────
 
@@ -52,69 +52,102 @@ pub(crate) fn read_full_cds(transcript: &Transcript) -> Result<String, FerroErro
 /// caller sets `cds_start == cds_end`.
 ///
 /// The returned string is the full CDS after the edit, in uppercase.
+#[cfg(test)]
 pub(crate) fn build_mutated_cds(
     transcript: &Transcript,
     cds_pos_start: i64, // 1-based CDS position of edit start
     cds_pos_end: i64,   // 1-based CDS position of edit end (inclusive)
     edit: &NaEdit,
 ) -> Result<String, FerroError> {
-    let tx_cds_start = transcript
-        .cds_start
-        .ok_or_else(|| FerroError::ConversionError {
-            msg: format!("transcript {} has no CDS", transcript.id),
-        })? as usize;
+    let ref_cds = read_full_cds(transcript)?;
+    build_mutated_cds_with_ref(&ref_cds, transcript, cds_pos_start, cds_pos_end, edit)
+}
 
-    let full_cds = read_full_cds(transcript)?;
-
+/// Fast path of [`build_mutated_cds`] for callers that already hold the
+/// reference CDS (e.g. via `RefProteinBundle::ref_cds`). Skips the per-call
+/// `read_full_cds` + `to_uppercase` that would otherwise re-uppercase a
+/// 1-10 kbp string on every indel projection.
+///
+/// The `ref_cds` argument MUST be uppercase ACGT (the form that
+/// `read_full_cds` returns). Inserted / reverse-complemented slices are
+/// uppercased individually before splicing so the result is still uniformly
+/// uppercase without a final whole-string pass.
+pub(crate) fn build_mutated_cds_with_ref(
+    ref_cds: &str,
+    transcript: &Transcript,
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+    edit: &NaEdit,
+) -> Result<String, FerroError> {
     // Convert 1-based CDS positions to 0-based CDS-string indices.
     let idx_start = (cds_pos_start - 1) as usize;
     let idx_end = cds_pos_end as usize; // exclusive upper bound
 
-    if idx_end > full_cds.len() {
+    if idx_end > ref_cds.len() {
         return Err(FerroError::ProteinSequenceUnavailable {
             accession: transcript.id.clone(),
         });
     }
 
-    let before = &full_cds[..idx_start];
-    let affected = &full_cds[idx_start..idx_end];
-    let after = &full_cds[idx_end..];
+    let before = &ref_cds[..idx_start];
+    let affected = &ref_cds[idx_start..idx_end];
+    let after = &ref_cds[idx_end..];
 
     let mutated = match edit {
         NaEdit::Deletion { .. } => {
             // Remove the affected bases.
-            format!("{}{}", before, after)
+            let mut out = String::with_capacity(before.len() + after.len());
+            out.push_str(before);
+            out.push_str(after);
+            out
         }
         NaEdit::Insertion { sequence } => {
-            // HGVS insertion c.N_N+1insX: the inserted bases go between cds_pos_start
-            // and cds_pos_start+1, i.e. at idx_start (after `before`).
-            // The `affected` region here should be 0 bases wide (cds_pos_start == cds_pos_end
-            // for most insertions, or the caller can pass both as the same boundary base).
-            // We treat `before` as everything up through and including cds_pos_start.
+            // HGVS insertion c.N_N+1insX: the inserted bases go between
+            // cds_pos_start and cds_pos_start+1, i.e. at idx_start (after
+            // `before`). Caller passes idx_end == idx_start so `affected` is
+            // empty; preserved in the concat to make this explicit.
             let inserted = extract_literal_sequence(sequence, transcript)?;
-            // For HGVS insertions, idx_end == idx_start (the interval covers the gap),
-            // so before == full_cds[..idx_start] and after == full_cds[idx_start..].
-            // We want to insert between position idx_start-1 and idx_start.
-            // The caller passes cds_pos_start as the last unaffected base's c. position,
-            // so idx_end == idx_start and we insert at that junction.
-            format!("{}{}{}{}", before, affected, inserted, after)
+            let mut out =
+                String::with_capacity(before.len() + affected.len() + inserted.len() + after.len());
+            out.push_str(before);
+            out.push_str(affected);
+            push_ascii_uppercase(&mut out, &inserted);
+            out.push_str(after);
+            out
         }
         NaEdit::Duplication { .. } => {
-            // Duplicate: append a copy of `affected` right after its end.
-            format!("{}{}{}{}", before, affected, affected, after)
+            let mut out = String::with_capacity(before.len() + 2 * affected.len() + after.len());
+            out.push_str(before);
+            out.push_str(affected);
+            out.push_str(affected);
+            out.push_str(after);
+            out
         }
         NaEdit::Delins { sequence, .. } => {
             let inserted = extract_literal_sequence(sequence, transcript)?;
-            format!("{}{}{}", before, inserted, after)
+            let mut out = String::with_capacity(before.len() + inserted.len() + after.len());
+            out.push_str(before);
+            push_ascii_uppercase(&mut out, &inserted);
+            out.push_str(after);
+            out
         }
         NaEdit::Inversion { .. } => {
+            // `affected` is already uppercase; reverse_complement preserves
+            // case, so no additional uppercase pass is needed.
             let rc = reverse_complement(affected);
-            format!("{}{}{}", before, rc, after)
+            let mut out = String::with_capacity(before.len() + rc.len() + after.len());
+            out.push_str(before);
+            out.push_str(&rc);
+            out.push_str(after);
+            out
         }
         NaEdit::Substitution { alternative, .. } => {
-            // Single-base substitution.
-            let alt_char = alternative.to_u8() as char;
-            format!("{}{}{}", before, alt_char, after)
+            // Single-base substitution. `alternative.to_u8()` is ASCII upper.
+            let mut out = String::with_capacity(before.len() + 1 + after.len());
+            out.push_str(before);
+            out.push(alternative.to_u8() as char);
+            out.push_str(after);
+            out
         }
         _ => {
             return Err(FerroError::UnsupportedProjection {
@@ -123,8 +156,16 @@ pub(crate) fn build_mutated_cds(
         }
     };
 
-    let _ = tx_cds_start; // currently unused but kept for clarity
-    Ok(mutated.to_uppercase())
+    Ok(mutated)
+}
+
+/// Push `src` onto `dst`, uppercasing ASCII letters as we go. Avoids the
+/// allocation of `src.to_uppercase()` for the common case where the caller
+/// only has a small inserted slice (typically 1-100 bp).
+fn push_ascii_uppercase(dst: &mut String, src: &str) {
+    for &b in src.as_bytes() {
+        dst.push(b.to_ascii_uppercase() as char);
+    }
 }
 
 /// Extract a literal nucleotide sequence from an `InsertedSequence`.
@@ -155,9 +196,177 @@ fn extract_literal_sequence(
 pub(crate) fn translate_full_cds(cds: &str) -> Vec<AminoAcid> {
     cds.as_bytes()
         .chunks_exact(3)
-        .filter_map(|c| std::str::from_utf8(c).ok().and_then(translate))
+        .filter_map(translate_bytes)
         .take_while(|aa| *aa != AminoAcid::Ter)
         .collect()
+}
+
+/// Pre-translated reference CDS for a transcript.
+///
+/// Cached on [`VariantProjector`] so that fan-out across many indel variants
+/// on the same transcript translates the reference CDS exactly once instead
+/// of once per variant. The fields are exactly the values that
+/// `predict_indel_protein` needs from the reference side of the comparison.
+#[derive(Debug)]
+pub(crate) struct RefProteinBundle {
+    /// Uppercase CDS bytes. Cached so `predict_indel_protein` doesn't
+    /// re-read + re-uppercase the same string for every variant on the same
+    /// transcript; the alt-side CDS is built by slicing this with
+    /// `build_mutated_cds_with_ref`.
+    pub ref_cds: String,
+    pub ref_protein: Vec<AminoAcid>,
+    pub ref_protein_with_stop: Vec<AminoAcid>,
+}
+
+impl RefProteinBundle {
+    /// Build a bundle by reading and translating the CDS of `transcript`.
+    pub(crate) fn from_transcript(transcript: &Transcript) -> Result<Self, FerroError> {
+        let ref_cds = read_full_cds(transcript)?;
+        let ref_protein = translate_full_cds(&ref_cds);
+        let ref_protein_with_stop = translate_full_cds_with_stop(&ref_cds);
+        Ok(Self {
+            ref_cds,
+            ref_protein,
+            ref_protein_with_stop,
+        })
+    }
+}
+
+/// Translate a *mutated* CDS to a protein, reusing the already-translated
+/// reference prefix wherever the alt and ref CDS bytes are identical.
+///
+/// The first `unchanged_prefix_codons` codons of `mut_cds` (positions
+/// `0..unchanged_prefix_codons * 3`) are byte-identical to `ref_cds` by
+/// construction — they're the unedited prefix that `build_mutated_cds_with_ref`
+/// preserved verbatim. We can lift their amino-acid translations straight out
+/// of `ref_protein` and only translate the remaining tail of `mut_cds`.
+///
+/// Correctness notes:
+/// * `ref_protein` may be shorter than `unchanged_prefix_codons` if the
+///   reference's first stop falls inside the unchanged prefix. In that case
+///   the alt protein also stops there (same bytes, same `take_while`), so we
+///   return the ref protein verbatim.
+/// * Stop-codon readthrough (an edit that removes the ref's terminator) still
+///   works because we only short-circuit when the prefix already contained
+///   the stop. When the edit is at or past the ref stop's codon we fall into
+///   the normal translation path.
+/// * Output matches `translate_full_cds(mut_cds)` exactly — verified by
+///   `translate_mutated_cds_matches_full_translation` over substitution /
+///   deletion / insertion / duplication / delins / inversion cases.
+pub(crate) fn translate_mutated_cds(
+    ref_protein: &[AminoAcid],
+    mut_cds: &str,
+    unchanged_prefix_codons: usize,
+) -> Vec<AminoAcid> {
+    let kept = unchanged_prefix_codons.min(ref_protein.len());
+    let mut out: Vec<AminoAcid> = ref_protein[..kept].to_vec();
+    if kept < unchanged_prefix_codons {
+        // The reference already terminated inside the unchanged prefix, so
+        // the alt protein terminates at the same point (same bytes).
+        return out;
+    }
+    let start_byte = unchanged_prefix_codons * 3;
+    if start_byte >= mut_cds.len() {
+        return out;
+    }
+    out.extend(
+        mut_cds.as_bytes()[start_byte..]
+            .chunks_exact(3)
+            .filter_map(translate_bytes)
+            .take_while(|aa| *aa != AminoAcid::Ter),
+    );
+    out
+}
+
+/// In-frame variant of [`translate_mutated_cds`] that also lifts the
+/// post-edit *suffix* from `ref_protein` whenever the mutated and reference
+/// CDS bytes have re-converged.
+///
+/// For an in-frame indel (`net % 3 == 0`), the bytes of `mut_cds` after the
+/// modification region are byte-identical to a (codon-aligned) slice of
+/// `ref_cds`, so we can skip translating them and copy the corresponding
+/// `ref_protein` AAs directly. Only the small edit window — bytes from the
+/// first edited codon's start up to the first codon boundary at-or-past the
+/// last edited byte — is translated normally.
+///
+/// Parameters:
+/// * `cds_pos_start` / `cds_pos_end` — the 1-based CDS positions of the edit
+///   (same values predict_indel_protein passes in).
+/// * `net` — net base-length change (`mut_cds.len() - ref_cds.len()`). Must
+///   be a multiple of 3 (the in-frame contract).
+///
+/// Correctness invariants:
+/// * Output matches `translate_full_cds(mut_cds)` byte-for-byte; verified by
+///   `translate_mutated_cds_inframe_matches_full_translation` over deletion,
+///   insertion, duplication, delins, inversion, and readthrough cases.
+/// * If a stop appears inside the edit window, translation terminates there
+///   and the suffix is not lifted (same as `take_while(!= Ter)`).
+/// * If the alt sequence extends past the ref's stop (readthrough), the
+///   tail of `mut_cds` after the suffix-join point is translated normally.
+pub(crate) fn translate_mutated_cds_inframe(
+    ref_protein: &[AminoAcid],
+    mut_cds: &str,
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+    net: i64,
+) -> Vec<AminoAcid> {
+    debug_assert_eq!(net % 3, 0, "in-frame fast path requires net % 3 == 0");
+
+    let unchanged_prefix_codons = ((cds_pos_start - 1).max(0) / 3) as usize;
+    let kept = unchanged_prefix_codons.min(ref_protein.len());
+    let mut out: Vec<AminoAcid> = ref_protein[..kept].to_vec();
+    if kept < unchanged_prefix_codons {
+        // Reference already stopped inside the unchanged prefix; alt does too.
+        return out;
+    }
+
+    // Locate the first mut-CDS byte at-or-past the modification (this is the
+    // first byte whose value comes from the unchanged ref suffix, shifted by
+    // `net` in ref-space). For all edit categories this is
+    // `idx_start + mut_edit_length` where mut_edit_length = ref_edit_length + net.
+    let idx_start = (cds_pos_start - 1).max(0) as usize;
+    let idx_end = cds_pos_end as usize;
+    let ref_edit_length = idx_end.saturating_sub(idx_start) as i64;
+    let mut_edit_length = (ref_edit_length + net).max(0) as usize;
+    let bx = idx_start + mut_edit_length;
+    let bx_first_full_codon = bx.div_ceil(3) * 3;
+
+    // Translate the edit window: codons starting at `start_byte` up to the
+    // first codon boundary on/after the modification's end.
+    let start_byte = unchanged_prefix_codons * 3;
+    let edit_window_end = bx_first_full_codon.min(mut_cds.len());
+    if start_byte < edit_window_end {
+        for chunk in mut_cds.as_bytes()[start_byte..edit_window_end].chunks_exact(3) {
+            if let Some(aa) = translate_bytes(chunk) {
+                if aa == AminoAcid::Ter {
+                    return out;
+                }
+                out.push(aa);
+            }
+        }
+    }
+
+    // The remaining mut suffix (bytes from `bx_first_full_codon` onward) is
+    // byte-identical to ref bytes from `bx_first_full_codon - net` onward.
+    // Lift the corresponding amino acids from `ref_protein`.
+    let ref_byte_for_join = (bx_first_full_codon as i64 - net).max(0) as usize;
+    let ref_codon_idx = ref_byte_for_join / 3;
+    if ref_codon_idx <= ref_protein.len() {
+        out.extend_from_slice(&ref_protein[ref_codon_idx..]);
+        return out;
+    }
+
+    // Readthrough: alt has codons past ref's first stop. Translate the rest
+    // of mut_cds normally (the join point is past ref_protein's end).
+    if bx_first_full_codon < mut_cds.len() {
+        out.extend(
+            mut_cds.as_bytes()[bx_first_full_codon..]
+                .chunks_exact(3)
+                .filter_map(translate_bytes)
+                .take_while(|aa| *aa != AminoAcid::Ter),
+        );
+    }
+    out
 }
 
 /// Translate a CDS sequence to a protein, including the termination codon.
@@ -166,12 +375,10 @@ pub(crate) fn translate_full_cds(cds: &str) -> Vec<AminoAcid> {
 pub(crate) fn translate_full_cds_with_stop(cds: &str) -> Vec<AminoAcid> {
     let mut result = Vec::new();
     for chunk in cds.as_bytes().chunks_exact(3) {
-        if let Ok(s) = std::str::from_utf8(chunk) {
-            if let Some(aa) = translate(s) {
-                result.push(aa);
-                if aa == AminoAcid::Ter {
-                    break;
-                }
+        if let Some(aa) = translate_bytes(chunk) {
+            result.push(aa);
+            if aa == AminoAcid::Ter {
+                break;
             }
         }
     }
@@ -361,6 +568,166 @@ mod tests {
         // 7 bases → 2 complete codons + 1 incomplete (dropped).
         let aas = translate_full_cds("ATGCGCTA");
         assert_eq!(aas, vec![AminoAcid::Met, AminoAcid::Arg]);
+    }
+
+    /// Locks the per-codon behaviour of `translate_full_cds` end-to-end across
+    /// every ACGT codon. Concatenating all 64 codons gives a 192-base CDS;
+    /// adding three trailing Ns checks that an invalid codon at the end is
+    /// silently skipped (filter_map convention) rather than aborting.
+    #[test]
+    fn translate_full_cds_all_64_codons() {
+        // Build a 192-base CDS that contains every codon exactly once, in a
+        // fixed canonical order. None of the codons before the first stop
+        // matter — the take_while-before-Ter contract means we'd cut off at
+        // the first stop. So instead we use a stop-free synthetic CDS by
+        // omitting TAA/TAG/TGA from the body and asserting via the
+        // `_with_stop` variant for the stop-codon path.
+        let codons = [
+            "TTT", "TTC", "TTA", "TTG", "CTT", "CTC", "CTA", "CTG", "ATT", "ATC", "ATA", "ATG",
+            "GTT", "GTC", "GTA", "GTG", "TCT", "TCC", "TCA", "TCG", "AGT", "AGC", "CCT", "CCC",
+            "CCA", "CCG", "ACT", "ACC", "ACA", "ACG", "GCT", "GCC", "GCA", "GCG", "TAT", "TAC",
+            "CAT", "CAC", "CAA", "CAG", "AAT", "AAC", "AAA", "AAG", "GAT", "GAC", "GAA", "GAG",
+            "TGT", "TGC", "TGG", "CGT", "CGC", "CGA", "CGG", "AGA", "AGG", "GGT", "GGC", "GGA",
+            "GGG",
+        ];
+        // 61 sense codons (no stops). Concat + 2 trailing bases (incomplete).
+        let cds: String = codons.iter().copied().collect::<String>() + "NN";
+        let aas = translate_full_cds(&cds);
+        assert_eq!(
+            aas.len(),
+            61,
+            "61 sense codons translated, incomplete tail dropped"
+        );
+        // First codon TTT → Phe, last codon GGG → Gly.
+        assert_eq!(aas[0], AminoAcid::Phe);
+        assert_eq!(aas[60], AminoAcid::Gly);
+
+        // _with_stop variant: prepend a stop right after the first codon and
+        // confirm translation halts immediately after Ter.
+        let cds_with_stop = String::from("ATGTAA") + &cds;
+        let aas = translate_full_cds_with_stop(&cds_with_stop);
+        assert_eq!(aas, vec![AminoAcid::Met, AminoAcid::Ter]);
+    }
+
+    /// `translate_mutated_cds` must produce byte-identical results to
+    /// `translate_full_cds(mut_cds)` for every prefix offset between 0 and
+    /// the codon count, across every indel category exercised below. This is
+    /// the safety net for the localised-translation perf change: any
+    /// off-by-one in the prefix-keep arithmetic falls out here.
+    #[test]
+    fn translate_mutated_cds_matches_full_translation() {
+        // Reference CDS: 6 sense codons + stop = 21 bases.
+        // Met-Arg-Pro-Thr-Ala-Cys-Ter
+        let ref_cds = "ATGCGGCCCACCGCGTGCTAA";
+        let ref_protein = translate_full_cds(ref_cds);
+        assert_eq!(ref_protein.len(), 6, "Met..Cys (stops before Ter)");
+
+        // Every (mut_cds, unchanged_prefix_codons) pair below was constructed
+        // so that the first `unchanged_prefix_codons * 3` bytes of mut_cds
+        // are identical to `ref_cds[..unchanged_prefix_codons * 3]` — i.e.
+        // it preserves the precondition of `translate_mutated_cds`.
+        let cases: &[(&str, &str, usize)] = &[
+            // edit at codon 0 — no prefix kept; substitution of first base.
+            ("subst codon 0", "GTGCGGCCCACCGCGTGCTAA", 0),
+            // edit at codon 1 — 1 codon kept; mid-codon deletion.
+            ("del codon 1", "ATGCGGCCACCGCGTGCTAA", 1),
+            // edit at codon 2 — 2 codons kept; codon-aligned 3-base deletion.
+            ("del codon 2 whole", "ATGCGGACCGCGTGCTAA", 2),
+            // edit at codon 3 — 3 codons kept; in-frame insertion of 3 bases.
+            ("ins after codon 3", "ATGCGGCCCACCGGGGCGTGCTAA", 3),
+            // edit at codon 4 — 4 codons kept; frameshift insertion (+1 base).
+            ("fs ins codon 4", "ATGCGGCCCACCGCGCTGCTAA", 4),
+            // edit at codon 5 — 5 codons kept; substitution that introduces a
+            // new stop one codon earlier than the ref's stop.
+            ("nonsense codon 5", "ATGCGGCCCACCGCGTAATGCTAA", 5),
+            // edit at codon 6 (past first stop) — 6 codons kept; alt also
+            // stopped at codon 6 in the ref translation, so kept >= ref_len.
+            ("readthrough", "ATGCGGCCCACCGCGTGCCCATAA", 6),
+        ];
+
+        for (name, mut_cds, prefix) in cases {
+            let from_full = translate_full_cds(mut_cds);
+            let from_partial = translate_mutated_cds(&ref_protein, mut_cds, *prefix);
+            assert_eq!(
+                from_full, from_partial,
+                "case '{}': translate_mutated_cds (prefix={}) must match \
+                 translate_full_cds(mut_cds); full={:?}, partial={:?}",
+                name, prefix, from_full, from_partial
+            );
+        }
+    }
+
+    /// Byte-for-byte equivalence between `translate_mutated_cds_inframe`
+    /// (the prefix + suffix lift) and `translate_full_cds` (the unchanged
+    /// reference implementation) across every in-frame indel category. Any
+    /// off-by-one in the suffix-join arithmetic falls out here.
+    #[test]
+    fn translate_mutated_cds_inframe_matches_full_translation() {
+        // Reference CDS: 6 sense codons + stop = 21 bases.
+        // Met-Arg-Pro-Thr-Ala-Cys-Ter
+        let ref_cds = "ATGCGGCCCACCGCGTGCTAA";
+        let ref_protein = translate_full_cds(ref_cds);
+        assert_eq!(ref_protein.len(), 6);
+
+        // (name, mut_cds, cds_pos_start, cds_pos_end, net)
+        // Each mut_cds was constructed by applying the named edit to ref_cds
+        // so that its prefix/suffix invariants match `build_mutated_cds_with_ref`.
+        let cases: &[(&str, &str, i64, i64, i64)] = &[
+            // Codon-aligned in-frame deletion of CCC at c.7-9.
+            ("del whole codon 3", "ATGCGGACCGCGTGCTAA", 7, 9, -3),
+            // 6-base codon-aligned deletion at c.7-12.
+            ("del two whole codons", "ATGCGGGCGTGCTAA", 7, 12, -6),
+            // Mid-codon in-frame deletion (6 bases straddling codon boundaries
+            // c.5-10 — deletes GGCCCA, leaves ATGC + CCGCGTGCTAA = ATGCCCGCGTGCTAA).
+            ("mid-codon 6-base del", "ATGCCCGCGTGCTAA", 5, 10, -6),
+            // Codon-aligned in-frame insertion of GGG after c.3 (between Met
+            // and Arg codons).
+            (
+                "codon-aligned ins after c.3",
+                "ATGGGGCGGCCCACCGCGTGCTAA",
+                3,
+                3,
+                3,
+            ),
+            // Codon-aligned in-frame insertion that also introduces a stop.
+            ("ins introducing stop", "ATGTAACGGCCCACCGCGTGCTAA", 3, 3, 3),
+            // In-frame delins: replace TGC (Cys) with TAATGC (Ter + Cys) at
+            // c.16-18. Length: +3. Introduces a premature stop.
+            (
+                "delins introducing stop",
+                "ATGCGGCCCACCGCGTAATGCTAA",
+                16,
+                18,
+                3,
+            ),
+            // Inversion of codon 2 (CCC → GGG via revcomp).
+            ("inversion of codon 2", "ATGCGGGGGACCGCGTGCTAA", 7, 9, 0),
+            // Same-length delins (net = 0) replacing one codon with another.
+            ("same-length delins", "ATGCGGAAAACCGCGTGCTAA", 7, 9, 0),
+            // Readthrough: delete the entire stop codon, alt extends.
+            // mut = ref minus TAA + 3 new bases after CDS, but for simplicity
+            // we model a same-length stop-substituting delins (TAA → CCG +
+            // 3 new bases that include a downstream stop).
+            (
+                "readthrough w/ downstream stop",
+                "ATGCGGCCCACCGCGTGCCCGCCATAA",
+                19,
+                21,
+                6,
+            ),
+        ];
+
+        for (name, mut_cds, start, end, net) in cases {
+            let from_full = translate_full_cds(mut_cds);
+            let from_inframe =
+                translate_mutated_cds_inframe(&ref_protein, mut_cds, *start, *end, *net);
+            assert_eq!(
+                from_full, from_inframe,
+                "case '{}' (start={}, end={}, net={}): inframe path must \
+                 match full translate; full={:?}, inframe={:?}",
+                name, start, end, net, from_full, from_inframe
+            );
+        }
     }
 
     // ── first_diff_position ───────────────────────────────────────────────────

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -10,8 +10,9 @@ use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
 
 use super::helpers::{
-    build_mutated_cds, first_diff_position, net_length_change, read_full_cds, translate_full_cds,
-    translate_full_cds_with_stop,
+    build_mutated_cds_with_ref, first_diff_position, net_length_change,
+    translate_full_cds_with_stop, translate_mutated_cds, translate_mutated_cds_inframe,
+    RefProteinBundle,
 };
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -26,47 +27,29 @@ use super::helpers::{
 /// on failure.
 pub(crate) fn predict_indel_protein(
     transcript: &Transcript,
+    ref_bundle: &RefProteinBundle,
     cds_pos_start: i64,
     cds_pos_end: i64,
     edit: &NaEdit,
     protein_accession: &str,
 ) -> Result<HgvsVariant, FerroError> {
-    // 1. Build ref and mutated CDS sequences.
-    let ref_cds = read_full_cds(transcript)?;
-    let mut_cds = build_mutated_cds(transcript, cds_pos_start, cds_pos_end, edit)?;
+    // 1. The reference CDS + translation are pre-computed by the caller (and
+    //    cached on `VariantProjector` so fan-out across many indels on the
+    //    same transcript doesn't re-translate (or re-read+re-uppercase) the
+    //    full CDS each time). The mutated CDS is built by splicing the cached
+    //    `ref_cds` directly — no `read_full_cds` per call.
+    let RefProteinBundle {
+        ref_cds,
+        ref_protein,
+        ref_protein_with_stop,
+    } = ref_bundle;
+    let mut_cds =
+        build_mutated_cds_with_ref(ref_cds, transcript, cds_pos_start, cds_pos_end, edit)?;
 
-    // 2. Translate both.
-    let ref_protein = translate_full_cds(&ref_cds);
-    let alt_protein = translate_full_cds(&mut_cds);
-
-    // 3. Check for stop-codon readthrough: the ref had a stop that is now an AA.
-    //    Detected when the mutated protein is longer than the ref protein and
-    //    alt_protein[ref_protein.len()] is not Ter.
-    if alt_protein.len() > ref_protein.len() {
-        // Check whether the ref protein ended at the stop codon position.
-        // ref_cds should have a Ter at codon (ref_protein.len()+1).
-        let ref_protein_with_stop = translate_full_cds_with_stop(&ref_cds);
-        if ref_protein_with_stop.last() == Some(&AminoAcid::Ter)
-            && alt_protein.len() > ref_protein.len()
-        {
-            // Possibly readthrough if the MUTATION affected the stop codon.
-            // The affected CDS region includes the stop codon area.
-            let stop_cds_start = (ref_protein.len() * 3 + 1) as i64; // 1-based CDS pos of stop codon
-            if cds_pos_start >= stop_cds_start
-                || (cds_pos_end >= stop_cds_start && cds_pos_start <= stop_cds_start + 2)
-            {
-                return build_extension_variant(
-                    &ref_protein,
-                    &alt_protein,
-                    &mut_cds,
-                    protein_accession,
-                    transcript,
-                );
-            }
-        }
-    }
-
-    // 4. Net length change and frameshift detection.
+    // 2. Compute net length change up-front so we can pick the right alt
+    //    translation strategy. (We also use `net` again below for the
+    //    frameshift / in-frame branch — moving it here just lifts the
+    //    existing call site, no semantic change.)
     let del_len = (cds_pos_end - cds_pos_start + 1) as usize;
     let net =
         net_length_change(edit, del_len).ok_or_else(|| FerroError::UnsupportedProjection {
@@ -74,9 +57,46 @@ pub(crate) fn predict_indel_protein(
         })?;
     let is_frameshift = net % 3 != 0;
 
+    // 3. Translate the mutated CDS. We can always skip codons whose three
+    //    bytes are byte-identical to the reference (the unchanged prefix
+    //    before the edit). For in-frame edits we can also skip the unchanged
+    //    suffix after the edit: those bytes are a codon-aligned shift of
+    //    `ref_cds`, so their AAs are already in `ref_protein`. For
+    //    frameshift edits the suffix can't be lifted (frame shift breaks the
+    //    codon alignment between mut and ref) — only the prefix lift applies.
+    let alt_protein = if is_frameshift {
+        let unchanged_prefix_codons = ((cds_pos_start - 1).max(0) / 3) as usize;
+        translate_mutated_cds(ref_protein, &mut_cds, unchanged_prefix_codons)
+    } else {
+        translate_mutated_cds_inframe(ref_protein, &mut_cds, cds_pos_start, cds_pos_end, net)
+    };
+
+    // 3. Check for stop-codon readthrough: the ref had a stop that is now an AA.
+    //    Detected when the mutated protein is longer than the ref protein and
+    //    alt_protein[ref_protein.len()] is not Ter.
+    if alt_protein.len() > ref_protein.len()
+        && ref_protein_with_stop.last() == Some(&AminoAcid::Ter)
+    {
+        // Possibly readthrough if the MUTATION affected the stop codon.
+        // The affected CDS region includes the stop codon area.
+        let stop_cds_start = (ref_protein.len() * 3 + 1) as i64; // 1-based CDS pos of stop codon
+        if cds_pos_start >= stop_cds_start
+            || (cds_pos_end >= stop_cds_start && cds_pos_start <= stop_cds_start + 2)
+        {
+            return build_extension_variant(
+                ref_protein,
+                &alt_protein,
+                &mut_cds,
+                protein_accession,
+                transcript,
+            );
+        }
+    }
+
+    // 4. Build the protein variant (net + is_frameshift were computed above).
     if is_frameshift {
         build_frameshift_variant(
-            &ref_protein,
+            ref_protein,
             &alt_protein,
             &mut_cds,
             protein_accession,
@@ -89,7 +109,7 @@ pub(crate) fn predict_indel_protein(
             cds_pos_end,
             edit,
             net,
-            &ref_protein,
+            ref_protein,
             &alt_protein,
             protein_accession,
         )
@@ -618,6 +638,26 @@ mod tests {
         }
     }
 
+    /// Test convenience wrapper: build the `RefProteinBundle` on demand so
+    /// existing tests can keep their original `predict_indel_protein` calls.
+    fn predict_indel(
+        t: &Transcript,
+        cds_pos_start: i64,
+        cds_pos_end: i64,
+        edit: &NaEdit,
+        protein_accession: &str,
+    ) -> Result<HgvsVariant, FerroError> {
+        let bundle = RefProteinBundle::from_transcript(t)?;
+        predict_indel_protein(
+            t,
+            &bundle,
+            cds_pos_start,
+            cds_pos_end,
+            edit,
+            protein_accession,
+        )
+    }
+
     // ─── Frameshift tests ─────────────────────────────────────────────────────
 
     #[test]
@@ -637,7 +677,7 @@ mod tests {
             sequence: None,
             length: None,
         };
-        let result = predict_indel_protein(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         // Arg2[Ala]fsTer? — with no downstream stop in the remaining sequence.
         // alt_protein = [Met, Ala], first_diff=1, new_aa=Ala
@@ -659,7 +699,7 @@ mod tests {
             sequence: None,
             length: None,
         };
-        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert_eq!(s, "NP_TEST.1:p.(Arg2del)");
     }
@@ -676,7 +716,7 @@ mod tests {
             sequence: None,
             length: None,
         };
-        let result = predict_indel_protein(&t, 4, 9, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 9, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert_eq!(s, "NP_TEST.1:p.(Arg2_Lys3del)");
     }
@@ -690,7 +730,7 @@ mod tests {
             sequence: None,
             length: None,
         };
-        let result = predict_indel_protein(&t, 4, 5, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 5, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert!(s.contains("fs"), "expected frameshift in '{}'", s);
     }
@@ -707,7 +747,7 @@ mod tests {
         let edit = NaEdit::Insertion {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
         };
-        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert_eq!(s, "NP_TEST.1:p.(Met1_Arg2insGly)");
     }
@@ -721,7 +761,7 @@ mod tests {
         let edit = NaEdit::Insertion {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
         };
-        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert!(s.contains("fs"), "expected frameshift in '{}'", s);
     }
@@ -738,7 +778,7 @@ mod tests {
             length: None,
             uncertain_extent: None,
         };
-        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert_eq!(s, "NP_TEST.1:p.(Arg2dup)");
     }
@@ -752,7 +792,7 @@ mod tests {
             length: None,
             uncertain_extent: None,
         };
-        let result = predict_indel_protein(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert!(s.contains("fs"), "expected frameshift in '{}'", s);
     }
@@ -773,7 +813,7 @@ mod tests {
             deleted: None,
             deleted_length: None,
         };
-        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         // Should be a delins at Arg2 → Ser: p.(Arg2delinsSer)
         assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
@@ -791,7 +831,7 @@ mod tests {
             sequence: None,
             length: None,
         };
-        let result = predict_indel_protein(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
         assert!(s.contains("delins"), "expected delins in '{}'", s);
@@ -831,7 +871,7 @@ mod tests {
         let edit = NaEdit::Insertion {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
         };
-        let result = predict_indel_protein(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         // delins fallback re-attaches the implicit Ter (truncated by translate_full_cds)
         // before computing the AA diff, so the new stop appears in the inserted sequence.
@@ -856,10 +896,140 @@ mod tests {
             deleted: None,
             deleted_length: None,
         };
-        let result = predict_indel_protein(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
+        let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
         assert!(s.contains("Ter3"), "expected Ter3 in '{}'", s);
         assert!(s.contains("Trp"), "expected Trp in '{}'", s);
         assert!(s.contains("ext"), "expected ext in '{}'", s);
+    }
+
+    // ─── Structural diversity tests (c17) ─────────────────────────────────────
+    //
+    // These cases pin behaviour at the structural edges of the CDS that the
+    // existing tests don't reach: edits that remove the start codon, edits
+    // that delete the entire stop, indels larger than 6 bases, mid-codon
+    // insertions that introduce a new stop, and frame-restoring compound
+    // edits.
+
+    /// Initiator Met loss: deleting c.1_3 removes the entire start codon
+    /// (ATG). HGVS recommendation: report as `p.(Met1?)` because we can't
+    /// predict where translation actually starts on the altered transcript.
+    ///
+    /// We accept either the strict `Met1?` form or any variant that flags
+    /// the first amino acid — what we require is that the prediction not
+    /// silently lose the start-codon edge case.
+    #[test]
+    fn del_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA" → after del c.1_3, mut_cds = "CGCTAA".
+        // CDS-length change: -3 (in-frame at the AA level, but the new
+        // sequence starts with CGC = Arg — no Met at position 1).
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // The codon-aligned in-frame deletion of codon 1 emits a Met1del
+        // (or some Met1-flagged form). Just assert the start codon was
+        // touched and the prediction succeeded.
+        assert!(
+            s.contains("Met1") || s.contains("M1"),
+            "expected Met1 reference in start-codon-loss prediction, got '{}'",
+            s
+        );
+    }
+
+    /// Large multi-codon in-frame deletion (4 codons, 12 bases) — covers
+    /// the codon-aligned `inframe_deletion` builder with N > 2.
+    #[test]
+    fn del_twelve_bases_four_codons_aligned() {
+        // CDS for Met-Arg-Lys-Gly-Phe-Pro-Stop (21 bases).
+        // Delete c.4_15 = "CGCAAAGGGTTT" (codons 2-5).
+        // Mutated CDS: "ATG" + "CCATAA" — wait, c.16_21 = "CCATAA"? Let's
+        // recompute. Original = "ATG CGC AAA GGG TTT CCA TAA" = 21 bases,
+        // 7 codons (Met Arg Lys Gly Phe Pro Stop). Delete c.4_15 removes
+        // 12 bases → leaves "ATG" + "CCATAA" = "ATGCCATAA" = Met-Pro-Stop.
+        let t = tx("ATGCGCAAAGGGTTTCCATAA", 1, 21);
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel(&t, 4, 15, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(s.contains("del"), "expected del in '{}'", s);
+        // Range deletion notation: Arg2_Phe5del or similar.
+        assert!(s.contains("Arg2"), "expected Arg2 in '{}'", s);
+        assert!(
+            s.contains("Phe5") || s.contains("Phe") && s.contains("_"),
+            "expected Phe5 (range end) in '{}'",
+            s
+        );
+    }
+
+    /// Mid-codon insertion that introduces a stop codon — covers the
+    /// `inframe_delins → premature stop` fallback path with a positionally
+    /// non-trivial insertion.
+    #[test]
+    fn ins_mid_codon_introduces_stop() {
+        // CDS "ATGCGCTGCAAATAA" = Met-Arg-Cys-Lys-Stop (15 bases, 5 codons).
+        // Insert "TAA" at c.4_5 (mid-codon, between first and second base of
+        // codon 2 / Arg = "CGC"). Mutated CDS:
+        //   "ATG" + "C" + "TAA" + "GCTGCAAATAA" = "ATGCTAAGCTGCAAATAA"
+        //   = ATG CTA AGC TGC AAA TAA = Met-Leu-Ser-Cys-Lys-Stop.
+        // No premature stop in the codons before the original stop.
+        // (Choosing this fixture so the inserted "TAA" doesn't sit in
+        // codon position; it gets distributed across codons.)
+        let t = tx("ATGCGCTGCAAATAA", 1, 15);
+        let seq: crate::hgvs::edit::Sequence = "TAA".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // Mid-codon ins of multiple of 3 bases is still in-frame; the
+        // protein changes via a delins-at-the-AA-level rewrite.
+        assert!(
+            s.contains("delins") || s.contains("ins"),
+            "expected delins/ins, got '{}'",
+            s
+        );
+    }
+
+    /// Frame-restoring compound: an insertion of net 0 mod 3 that crosses
+    /// a codon boundary. Specifically a 6-base insertion mid-codon — still
+    /// in-frame at the protein level, but every codon downstream of the
+    /// insertion shifts by 6 bases.
+    #[test]
+    fn ins_six_bases_mid_codon_inframe() {
+        // CDS "ATGCGCTGCAAATAA" (Met-Arg-Cys-Lys-Stop).
+        // Insert "TTTCCC" at c.4_5 (mid-codon, between first and second
+        // base of codon 2). Mutated CDS:
+        //   "ATG" + "C" + "TTTCCC" + "GCTGCAAATAA"
+        //   = "ATGCTTTCCCGCTGCAAATAA"
+        //   = ATG CTT TCC CGC TGC AAA TAA
+        //   = Met-Leu-Ser-Arg-Cys-Lys-Stop.
+        // alt = [Met, Leu, Ser, Arg, Cys, Lys], ref = [Met, Arg, Cys, Lys].
+        // At the AA level this is a 2-AA insertion + 1-AA substitution =
+        // an inframe delins.
+        let t = tx("ATGCGCTGCAAATAA", 1, 15);
+        let seq: crate::hgvs::edit::Sequence = "TTTCCC".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        // Mid-codon in-frame edit emits delins at AA level; just assert
+        // it's not a frameshift and not silently identity.
+        assert!(
+            !s.contains('='),
+            "expected non-identity prediction, got '{}'",
+            s
+        );
+        assert!(
+            !s.contains("fs"),
+            "in-frame insertion should not be frameshift, got '{}'",
+            s
+        );
     }
 }

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -15,5 +15,6 @@ mod indel;
 mod substitution;
 
 // Re-export the public API used by `projector.rs`.
+pub(crate) use helpers::RefProteinBundle;
 pub(crate) use indel::predict_indel_protein;
 pub(crate) use substitution::predict_substitution_protein;

--- a/src/project/protein/substitution.rs
+++ b/src/project/protein/substitution.rs
@@ -8,6 +8,12 @@ use crate::hgvs::location::{AminoAcid, ProtPos};
 use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
 use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
+use once_cell::sync::Lazy;
+
+/// Standard genetic-code table, built once and reused. Constructing a fresh
+/// `CodonTable` per call dominates protein-prediction CPU because
+/// `translate_full_cds` invokes `translate` once per codon of every CDS.
+static STANDARD_CODON_TABLE: Lazy<CodonTable> = Lazy::new(CodonTable::standard);
 
 /// Read the codon (3 bases) covering a given CDS position from a transcript's CDS sequence.
 ///
@@ -74,12 +80,21 @@ pub(crate) fn apply_substitution(codon: &str, frame: u8, alt: Base) -> String {
 /// Translate a 3-character codon to an `AminoAcid`. Returns `Some(Ter)` for stop codons,
 /// `Some(Xaa)` if the codon is unrecognized; `None` only if the input is not 3 ASCII bases.
 pub(crate) fn translate(codon: &str) -> Option<AminoAcid> {
-    let parsed = Codon::parse(codon)?;
-    let table = CodonTable::standard();
+    translate_bytes(codon.as_bytes())
+}
+
+/// Byte-slice variant of [`translate`] for hot callers that have already
+/// produced a `&[u8]` (e.g. `chunks_exact(3)` over a CDS sequence). Skips the
+/// `from_utf8` step that the `&str`-taking entry point would imply for
+/// `chunks_exact` output. samply showed that detour at ~18% of indel CPU
+/// after the prior round of perf wins.
+pub(crate) fn translate_bytes(bytes: &[u8]) -> Option<AminoAcid> {
+    let parsed = Codon::parse_bytes(bytes)?;
+    let table = &*STANDARD_CODON_TABLE;
     if table.is_stop(&parsed) {
         return Some(AminoAcid::Ter);
     }
-    Some(*table.amino_acid_for(&parsed).unwrap_or(&AminoAcid::Xaa))
+    Some(table.amino_acid_for(&parsed).unwrap_or(AminoAcid::Xaa))
 }
 
 /// Build a predicted `p.(...)` ProteinVariant for a CDS substitution.
@@ -220,6 +235,107 @@ mod tests {
         assert_eq!(translate("TAA"), Some(AminoAcid::Ter));
         assert_eq!(translate("CGG"), Some(AminoAcid::Arg));
         assert_eq!(translate("GGG"), Some(AminoAcid::Gly));
+    }
+
+    /// Exhaustive: every 3-base ACGT codon must round-trip to the canonical
+    /// amino acid. Used as the safety net for perf changes in this file —
+    /// callers depend on these mappings being byte-stable across releases.
+    #[test]
+    fn translate_all_64_codons() {
+        let table: &[(&str, AminoAcid)] = &[
+            ("TTT", AminoAcid::Phe),
+            ("TTC", AminoAcid::Phe),
+            ("TTA", AminoAcid::Leu),
+            ("TTG", AminoAcid::Leu),
+            ("CTT", AminoAcid::Leu),
+            ("CTC", AminoAcid::Leu),
+            ("CTA", AminoAcid::Leu),
+            ("CTG", AminoAcid::Leu),
+            ("ATT", AminoAcid::Ile),
+            ("ATC", AminoAcid::Ile),
+            ("ATA", AminoAcid::Ile),
+            ("ATG", AminoAcid::Met),
+            ("GTT", AminoAcid::Val),
+            ("GTC", AminoAcid::Val),
+            ("GTA", AminoAcid::Val),
+            ("GTG", AminoAcid::Val),
+            ("TCT", AminoAcid::Ser),
+            ("TCC", AminoAcid::Ser),
+            ("TCA", AminoAcid::Ser),
+            ("TCG", AminoAcid::Ser),
+            ("AGT", AminoAcid::Ser),
+            ("AGC", AminoAcid::Ser),
+            ("CCT", AminoAcid::Pro),
+            ("CCC", AminoAcid::Pro),
+            ("CCA", AminoAcid::Pro),
+            ("CCG", AminoAcid::Pro),
+            ("ACT", AminoAcid::Thr),
+            ("ACC", AminoAcid::Thr),
+            ("ACA", AminoAcid::Thr),
+            ("ACG", AminoAcid::Thr),
+            ("GCT", AminoAcid::Ala),
+            ("GCC", AminoAcid::Ala),
+            ("GCA", AminoAcid::Ala),
+            ("GCG", AminoAcid::Ala),
+            ("TAT", AminoAcid::Tyr),
+            ("TAC", AminoAcid::Tyr),
+            ("TAA", AminoAcid::Ter),
+            ("TAG", AminoAcid::Ter),
+            ("TGA", AminoAcid::Ter),
+            ("CAT", AminoAcid::His),
+            ("CAC", AminoAcid::His),
+            ("CAA", AminoAcid::Gln),
+            ("CAG", AminoAcid::Gln),
+            ("AAT", AminoAcid::Asn),
+            ("AAC", AminoAcid::Asn),
+            ("AAA", AminoAcid::Lys),
+            ("AAG", AminoAcid::Lys),
+            ("GAT", AminoAcid::Asp),
+            ("GAC", AminoAcid::Asp),
+            ("GAA", AminoAcid::Glu),
+            ("GAG", AminoAcid::Glu),
+            ("TGT", AminoAcid::Cys),
+            ("TGC", AminoAcid::Cys),
+            ("TGG", AminoAcid::Trp),
+            ("CGT", AminoAcid::Arg),
+            ("CGC", AminoAcid::Arg),
+            ("CGA", AminoAcid::Arg),
+            ("CGG", AminoAcid::Arg),
+            ("AGA", AminoAcid::Arg),
+            ("AGG", AminoAcid::Arg),
+            ("GGT", AminoAcid::Gly),
+            ("GGC", AminoAcid::Gly),
+            ("GGA", AminoAcid::Gly),
+            ("GGG", AminoAcid::Gly),
+        ];
+        assert_eq!(table.len(), 64, "must enumerate all 64 codons");
+        for (codon, aa) in table {
+            assert_eq!(translate(codon), Some(*aa), "codon {codon}");
+            // Lowercase and U-substitution must yield the same result.
+            assert_eq!(
+                translate(&codon.to_ascii_lowercase()),
+                Some(*aa),
+                "lowercase codon {codon}"
+            );
+            let u_codon: String = codon
+                .chars()
+                .map(|c| if c == 'T' { 'U' } else { c })
+                .collect();
+            assert_eq!(translate(&u_codon), Some(*aa), "RNA codon {u_codon}");
+        }
+    }
+
+    #[test]
+    fn translate_rejects_bad_input() {
+        assert_eq!(translate(""), None, "empty");
+        assert_eq!(translate("AT"), None, "two bases");
+        assert_eq!(translate("ATGC"), None, "four bases");
+        assert_eq!(
+            translate("ATN"),
+            None,
+            "ambiguous N must not silently translate"
+        );
+        assert_eq!(translate("AT*"), None, "non-base char");
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -641,9 +641,16 @@ impl PyVariantProjector {
     }
 
     /// Project a g. HGVS string onto a target transcript.
-    fn project(&self, hgvs_string: &str, transcript: &str) -> PyResult<PyVariantProjection> {
-        self.inner
-            .project(hgvs_string, transcript)
+    fn project(
+        &self,
+        py: Python<'_>,
+        hgvs_string: &str,
+        transcript: &str,
+    ) -> PyResult<PyVariantProjection> {
+        let hgvs_string = hgvs_string.to_string();
+        let transcript = transcript.to_string();
+        let result = py.detach(|| self.inner.project(&hgvs_string, &transcript));
+        result
             .map(|inner| PyVariantProjection { inner })
             .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
     }
@@ -663,9 +670,71 @@ impl PyVariantProjector {
     ///
     /// Raises:
     ///     RuntimeError: If parsing or normalization fails.
-    fn project_all(&self, hgvs_string: &str) -> PyResult<Vec<PyVariantProjection>> {
-        self.inner
-            .project_all(hgvs_string)
+    fn project_all(&self, py: Python<'_>, hgvs_string: &str) -> PyResult<Vec<PyVariantProjection>> {
+        let hgvs_string = hgvs_string.to_string();
+        let result = py.detach(|| self.inner.project_all(&hgvs_string));
+        result
+            .map(|projections| {
+                projections
+                    .into_iter()
+                    .map(|inner| PyVariantProjection { inner })
+                    .collect()
+            })
+            .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
+    }
+
+    /// Normalize and project an already-parsed g. variant onto a transcript.
+    ///
+    /// Equivalent to `project(str(variant), transcript)` but skips the
+    /// re-parse — useful when a Python caller has already produced an
+    /// `HgvsVariant` via `ferro_hgvs.parse(...)` or as the result of an
+    /// earlier projection / conversion step.
+    ///
+    /// Args:
+    ///     variant: An HgvsVariant (g.). Will be normalized before projection.
+    ///     transcript: Transcript accession (e.g., "NM_000088.3").
+    ///
+    /// Returns:
+    ///     VariantProjection with g./c./p. representations and flags.
+    ///
+    /// Raises:
+    ///     RuntimeError: If normalization or projection fails.
+    fn project_variant(
+        &self,
+        py: Python<'_>,
+        variant: &PyHgvsVariant,
+        transcript: &str,
+    ) -> PyResult<PyVariantProjection> {
+        let inner_variant = variant.inner.clone();
+        let transcript = transcript.to_string();
+        let result = py.detach(|| self.inner.project_variant(&inner_variant, &transcript));
+        result
+            .map(|inner| PyVariantProjection { inner })
+            .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
+    }
+
+    /// Normalize and project an already-parsed g. variant onto ALL
+    /// overlapping transcripts.
+    ///
+    /// Equivalent to `project_all(str(variant))` but skips the re-parse.
+    ///
+    /// Args:
+    ///     variant: An HgvsVariant (g.). Will be normalized before projection.
+    ///
+    /// Returns:
+    ///     List of VariantProjection objects in clinical priority order.
+    ///     Empty list when no transcripts overlap the variant.
+    ///
+    /// Raises:
+    ///     RuntimeError: If normalization or projection fails.
+    fn project_variant_all(
+        &self,
+        py: Python<'_>,
+        variant: &PyHgvsVariant,
+    ) -> PyResult<Vec<PyVariantProjection>> {
+        let inner_variant = variant.inner.clone();
+        let result = py.detach(|| self.inner.project_variant_all(&inner_variant));
+        result
             .map(|projections| {
                 projections
                     .into_iter()
@@ -695,11 +764,14 @@ impl PyVariantProjector {
     ///     RuntimeError: If projection fails.
     fn project_normalized(
         &self,
+        py: Python<'_>,
         variant: &PyHgvsVariant,
         transcript: &str,
     ) -> PyResult<PyVariantProjection> {
-        self.inner
-            .project_normalized(&variant.inner, transcript)
+        let inner_variant = variant.inner.clone();
+        let transcript = transcript.to_string();
+        let result = py.detach(|| self.inner.project_normalized(&inner_variant, &transcript));
+        result
             .map(|inner| PyVariantProjection { inner })
             .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
     }
@@ -721,10 +793,12 @@ impl PyVariantProjector {
     ///     RuntimeError: If projection fails.
     fn project_normalized_all(
         &self,
+        py: Python<'_>,
         variant: &PyHgvsVariant,
     ) -> PyResult<Vec<PyVariantProjection>> {
-        self.inner
-            .project_normalized_all(&variant.inner)
+        let inner_variant = variant.inner.clone();
+        let result = py.detach(|| self.inner.project_normalized_all(&inner_variant));
+        result
             .map(|projections| {
                 projections
                     .into_iter()
@@ -766,6 +840,101 @@ impl PyVariantProjector {
             .project_to_genomic(&variant.inner)
             .map(|inner| PyHgvsVariant { inner })
             .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
+    }
+
+    /// Batched parse + normalize + project_all over a list of g. HGVS strings.
+    ///
+    /// Equivalent to `[self.project_all(s) for s in hgvs_strings]`, but takes a
+    /// single Python→Rust call, releases the GIL for the entire batch, and
+    /// reuses the projector's internal transcript / ref-protein caches across
+    /// all inputs. Fast path for SatMut-style fan-out workloads.
+    ///
+    /// Args:
+    ///     hgvs_strings: List of g. HGVS variant strings.
+    ///
+    /// Returns:
+    ///     List of result lists — one inner list per input, in the same order.
+    ///     Each inner list contains the projections for that variant in
+    ///     clinical priority order.
+    ///
+    /// Raises:
+    ///     RuntimeError: On the first parse / normalization error. Subsequent
+    ///         inputs are not processed.
+    fn project_many(
+        &self,
+        py: Python<'_>,
+        hgvs_strings: Vec<String>,
+    ) -> PyResult<Vec<Vec<PyVariantProjection>>> {
+        // Capture the input index alongside the error so callers can isolate
+        // which entry in the batch failed; the underlying error is preserved
+        // unchanged after the `input[i]:` prefix.
+        let result: Result<Vec<Vec<_>>, (usize, crate::error::FerroError)> = py.detach(|| {
+            hgvs_strings
+                .iter()
+                .enumerate()
+                .map(|(i, s)| self.inner.project_all(s).map_err(|e| (i, e)))
+                .collect()
+        });
+        result
+            .map(|outer| {
+                outer
+                    .into_iter()
+                    .map(|projections| {
+                        projections
+                            .into_iter()
+                            .map(|inner| PyVariantProjection { inner })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .map_err(|(i, e)| {
+                PyRuntimeError::new_err(format!("Projection error at input[{}]: {}", i, e))
+            })
+    }
+
+    /// Batched `project_normalized_all` over a list of already-normalized g.
+    /// variants. Same batching semantics as `project_many` but skips
+    /// renormalization on each input.
+    ///
+    /// Args:
+    ///     variants: List of HgvsVariant objects (must already be normalized).
+    ///
+    /// Returns:
+    ///     List of result lists, one per input.
+    ///
+    /// Raises:
+    ///     RuntimeError: On the first projection error.
+    fn project_normalized_many(
+        &self,
+        py: Python<'_>,
+        variants: Vec<PyHgvsVariant>,
+    ) -> PyResult<Vec<Vec<PyVariantProjection>>> {
+        let inner_variants: Vec<HgvsVariant> = variants.into_iter().map(|v| v.inner).collect();
+        // Capture the input index alongside the error so callers can isolate
+        // which entry in the batch failed; the underlying error is preserved
+        // unchanged after the `input[i]:` prefix.
+        let result: Result<Vec<Vec<_>>, (usize, crate::error::FerroError)> = py.detach(|| {
+            inner_variants
+                .iter()
+                .enumerate()
+                .map(|(i, v)| self.inner.project_normalized_all(v).map_err(|e| (i, e)))
+                .collect()
+        });
+        result
+            .map(|outer| {
+                outer
+                    .into_iter()
+                    .map(|projections| {
+                        projections
+                            .into_iter()
+                            .map(|inner| PyVariantProjection { inner })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .map_err(|(i, e)| {
+                PyRuntimeError::new_err(format!("Projection error at input[{}]: {}", i, e))
+            })
     }
 }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -547,15 +547,30 @@ impl MultiFastaProvider {
             msg: format!("Failed to read from FASTA file: {}", e),
         })?;
 
-        // Filter out newlines and take exact length
-        let sequence: String = buffer
-            .iter()
-            .filter(|&&b| b != b'\n' && b != b'\r')
-            .take(seq_len as usize)
-            .map(|&b| b as char)
-            .collect();
-
-        Ok(sequence.to_uppercase())
+        // Strip newlines and ASCII-uppercase in a single byte pass.
+        //
+        // The previous implementation built a `String` char-by-char with
+        // `filter().map(|&b| b as char).collect()` and then called
+        // `to_uppercase()`, which walked the string a second time and
+        // re-allocated. Both passes show up in samply (~3% of total CPU on
+        // the SNP fixture before this change; more on cold workloads).
+        let target_len = seq_len as usize;
+        let mut sequence_bytes: Vec<u8> = Vec::with_capacity(target_len);
+        for &b in &buffer {
+            if b != b'\n' && b != b'\r' {
+                sequence_bytes.push(b.to_ascii_uppercase());
+                if sequence_bytes.len() == target_len {
+                    break;
+                }
+            }
+        }
+        // FASTA bases are ASCII; `to_ascii_uppercase()` is a no-op on
+        // already-uppercase bytes. The `from_utf8` validity check is O(n)
+        // but extremely fast for short-ASCII inputs and doesn't reallocate.
+        let sequence = String::from_utf8(sequence_bytes).map_err(|e| FerroError::Io {
+            msg: format!("FASTA contains non-UTF8 bytes for {}: {}", entry.name, e),
+        })?;
+        Ok(sequence)
     }
 
     /// Check if a sequence exists

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -4,8 +4,10 @@ use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
 use ferro_hgvs::data::projection::Projector;
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
-use ferro_hgvs::reference::Strand;
-use ferro_hgvs::{VariantProjection, VariantProjector};
+use ferro_hgvs::reference::{ReferenceProvider, Strand};
+use ferro_hgvs::{FerroError, VariantProjection, VariantProjector};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Build a test (Projector, MockProvider) pair for NM_TEST.1.
 ///
@@ -200,4 +202,89 @@ fn project_intronic_c_dot_succeeds() {
     );
     // Intronic substitutions skip protein prediction.
     assert!(result.protein.is_none(), "no p. for intronic substitutions");
+}
+
+// ─── transcript-cache regression test ────────────────────────────────────────
+//
+// A counting wrapper around any `ReferenceProvider` that tallies how many times
+// each downstream method is invoked. Used below to assert that the projector's
+// transcript cache collapses N identical lookups into one.
+
+#[derive(Clone)]
+struct CountingProvider<P: ReferenceProvider + Clone> {
+    inner: P,
+    transcript_calls: Arc<AtomicUsize>,
+}
+
+impl<P: ReferenceProvider + Clone> CountingProvider<P> {
+    fn new(inner: P) -> Self {
+        Self {
+            inner,
+            transcript_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl<P: ReferenceProvider + Clone> ReferenceProvider for CountingProvider<P> {
+    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+        self.transcript_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.get_transcript(id)
+    }
+    fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        self.inner.get_sequence(id, start, end)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        self.inner.get_genomic_sequence(contig, start, end)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.inner.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        self.inner.get_protein_sequence(accession, start, end)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.inner.has_protein_data()
+    }
+}
+
+/// Project many substitutions on a single transcript and assert that the
+/// projector only fetches that transcript once.
+///
+/// Without the cache, every substitution variant pulls the transcript from the
+/// provider during protein prediction. With the cache, a `VariantProjector`
+/// fetches each unique `transcript_id` at most once for the lifetime of the
+/// projector.
+#[test]
+fn transcript_cache_collapses_repeat_lookups() {
+    let (projector, provider) = fixture();
+    let counting = CountingProvider::new(provider);
+    let counter = counting.transcript_calls.clone();
+    let vp = VariantProjector::new(projector, counting);
+
+    // Three substitutions at three CDS positions on the same transcript. Each
+    // hits the protein-prediction path, which is the user of `get_transcript`.
+    for s in [
+        "NC_000001.11:g.1003C>A",
+        "NC_000001.11:g.1004G>A",
+        "NC_000001.11:g.1005C>A",
+    ] {
+        vp.project(s, "NM_TEST.1")
+            .expect("projection should succeed");
+    }
+
+    let calls = counter.load(Ordering::SeqCst);
+    assert_eq!(
+        calls, 1,
+        "expected exactly one get_transcript call across 3 variants (got {calls})"
+    );
 }

--- a/tests/projection_coverage.rs
+++ b/tests/projection_coverage.rs
@@ -1,0 +1,401 @@
+//! End-to-end projector coverage matrix.
+//!
+//! Closes the gap identified after c14:
+//!
+//! 1. Pre-c16 the projector had exactly ONE minus-strand end-to-end test
+//!    (a single-base substitution on a single-exon transcript). The
+//!    component-level tests (`src/project/edit.rs`, `src/data/cdot.rs`)
+//!    exercise pieces of the pipeline but don't compose them through
+//!    `VariantProjector::project`. The cases here run the full pipeline
+//!    for both strands and every NaEdit category.
+//!
+//! 2. Pre-c17 the indel-protein tests covered each edit *type* but not
+//!    each edit *position* (start of CDS, end of CDS, exon junction,
+//!    UTR-adjacent, etc.). The cases here pin those structural edges.
+//!
+//! Fixture conventions: minimal hand-built `CdotTranscript` +
+//! `MockProvider` pairs so the test reads the same way the existing
+//! `tests/projection.rs` fixtures do. No external manifest required.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::sequence::reverse_complement;
+use ferro_hgvs::VariantProjector;
+
+// ─── shared fixture builders ─────────────────────────────────────────────────
+
+/// Plus-strand single-exon transcript on chr1:
+///   genome 1000..1009 (1-based 1000-1008 inclusive)
+///   CDS: full 9 bases — Met-Arg-Stop (ATG CGC TAA)
+fn plus_single_exon() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_PLUS1.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("PLUSGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_PLUS1.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_PLUS1.1".to_string(),
+        Some("PLUSGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(1000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+    (projector, provider)
+}
+
+/// Minus-strand single-exon transcript on chr1:
+///   genome 1000..1009 same coordinates, but the transcript's 5'→3'
+///   direction is the reverse-complement.
+///   Transcript reads "ATGCGCTAA" (same Met-Arg-Stop) — that means the
+///   genomic + strand at this range carries the reverse-complement of
+///   the transcript: "TTAGCGCAT".
+fn minus_single_exon() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_MINUS1.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("MINUSGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Minus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_MINUS1.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_MINUS1.1".to_string(),
+        Some("MINUSGENE".to_string()),
+        TxStrand::Minus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // Genomic + strand carries revcomp("ATGCGCTAA") = "TTAGCGCAT" at
+    // 1-based positions 1000-1008.
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    let genomic = format!("{}{}{}", prefix, reverse_complement("ATGCGCTAA"), suffix);
+    provider.add_genomic_sequence("chr1", genomic);
+    (projector, provider)
+}
+
+/// Plus-strand two-exon transcript on chr2:
+///   Exon 1: genome 2000..2006, tx 0..6   ("ATGCGC")  — Met + first codon Arg
+///   Intron : genome 2006..2100
+///   Exon 2: genome 2100..2103, tx 6..9   ("TAA")     — Stop
+///   CDS spans the whole transcript.
+fn plus_two_exon() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_PLUS2.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("PLUS2GENE".to_string()),
+            contig: "chr2".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[2000, 2006, 0, 6], [2100, 2103, 6, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_PLUS2.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_PLUS2.1".to_string(),
+        Some("PLUS2GENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![
+            Exon::with_genomic(1, 1, 6, 2000, 2005),
+            Exon::with_genomic(2, 7, 9, 2100, 2102),
+        ],
+        Some("chr2".to_string()),
+        Some(2000),
+        Some(2102),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // Build genome: exon1 + intron + exon2.
+    let mut genomic = "N".repeat(2000);
+    genomic.push_str("ATGCGC"); // exon 1
+    genomic.push_str(&"N".repeat(94)); // intron 2006..2100
+    genomic.push_str("TAA"); // exon 2
+    genomic.push_str(&"N".repeat(100));
+    provider.add_genomic_sequence("chr2", genomic);
+    (projector, provider)
+}
+
+// ─── minus-strand × full edit matrix ─────────────────────────────────────────
+
+/// Minus-strand substitution: c.4C>A.
+///
+/// Transcript reads "ATG CGC TAA". c.4 is the first base of codon 2 (Arg
+/// codon CGC), so c.4C>A changes CGC → AGC = Ser. On the genome (+ strand)
+/// this is at the position carrying the revcomp of c.4 = revcomp(C) = G,
+/// changing to revcomp(A) = T.
+///
+///   genome 1004 carries reverse-complement of c.4 (1004 = 1008-4):
+///   1008 ← c.1 / 1007 ← c.2 / 1006 ← c.3 / 1005 ← c.4 / …
+///   Wait — for a 9-base exon on `-` strand the mapping is
+///     c.i = (genome_end - 1) - g_pos_0based = 1008 - g_pos
+///   so c.4 ↔ g.1005 (genome 1-based).
+#[test]
+fn minus_strand_substitution() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1005G>T", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.4C>A"), "got c. = {c}");
+    let p = res.protein.unwrap().to_string();
+    assert!(p.contains("Arg2Ser"), "got p. = {p}");
+    assert!(!res.is_frameshift && !res.is_intronic && !res.is_utr);
+}
+
+/// Minus-strand single-base deletion at c.4 — frameshift.
+#[test]
+fn minus_strand_deletion_frameshift() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1005del", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains("del"), "got c. = {c}");
+    assert!(res.is_frameshift);
+}
+
+/// Minus-strand codon-aligned deletion (whole codon CGC at c.4_6).
+#[test]
+fn minus_strand_codon_aligned_deletion() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // Delete c.4_6 = CGC. On the genome (+ strand) that's bases carrying
+    // revcomp(CGC) = GCG, which are at g.1003_1005.
+    let res = vp.project("chr1:g.1003_1005del", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.4_6del"), "got c. = {c}");
+    let p = res.protein.unwrap().to_string();
+    assert!(p.contains("Arg2del"), "got p. = {p}");
+    assert!(!res.is_frameshift);
+}
+
+/// Minus-strand insertion of three bases between c.3 and c.4 (codon-aligned).
+/// Inserted "GGG" on the transcript = "CCC" on the genome.
+///
+/// The HGVS canonical form may render this as a `repeat` (`c.<pos><base>[<n>]`)
+/// rather than `ins` when the inserted bases adjoin a homopolymer run — both
+/// representations are valid. We assert structural properties (success +
+/// in-frame + non-empty c.) rather than the exact lexical form.
+#[test]
+fn minus_strand_codon_aligned_insertion() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1005_1006insCCC", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.starts_with("NM_MINUS1.1"), "got c. = {c}");
+    assert!(c.contains(":c."), "got c. = {c}");
+    assert!(!res.is_frameshift);
+}
+
+/// Minus-strand single-base insertion — frameshift.
+#[test]
+fn minus_strand_insertion_frameshift() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1005_1006insT", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains("ins"), "got c. = {c}");
+    assert!(res.is_frameshift);
+}
+
+/// Minus-strand duplication of c.4_6 (whole Arg codon).
+#[test]
+fn minus_strand_codon_aligned_duplication() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1003_1005dup", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains("dup"), "got c. = {c}");
+    let p = res.protein.unwrap().to_string();
+    // Duplicating Arg → inserts an extra Arg after position 2.
+    assert!(p.contains("Arg") && p.contains("dup"), "got p. = {p}");
+}
+
+/// Minus-strand delins replacing the Arg codon with two codons.
+#[test]
+fn minus_strand_delins() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // c.4_6delinsAAATTT (replace CGC with AAATTT = Lys+Phe, in-frame +3 bases).
+    // On the genome (+ strand) the replacement bases are revcomp(AAATTT) =
+    // "AAATTT" → "AAATTT" reversed = "TTTAAA"? Actually
+    // revcomp("AAATTT") = "AAATTT" (palindrome-like). Compute:
+    //   AAATTT → complement TTTAAA → reverse AAATTT. Yes palindromic.
+    let res = vp
+        .project("chr1:g.1003_1005delinsAAATTT", "NM_MINUS1.1")
+        .unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains("delins"), "got c. = {c}");
+    assert!(!res.is_frameshift);
+}
+
+/// Minus-strand inversion of the Arg codon CGC → GCG (in-frame, same length).
+#[test]
+fn minus_strand_inversion() {
+    let (projector, provider) = minus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1003_1005inv", "NM_MINUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains("inv"), "got c. = {c}");
+    assert!(!res.is_frameshift);
+}
+
+// ─── multi-exon spans (plus strand) ──────────────────────────────────────────
+
+/// Substitution at the last base of exon 1 on a two-exon plus-strand
+/// transcript. This exercises the per-exon mapping logic at an exon
+/// boundary.
+#[test]
+fn plus_two_exon_substitution_in_exon1() {
+    let (projector, provider) = plus_two_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // g.2005 is the last base of exon 1 → c.6 (the 'C' of codon 2 CGC).
+    let res = vp.project("chr2:g.2005C>A", "NM_PLUS2.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.6C>A"), "got c. = {c}");
+}
+
+/// Substitution at the first base of exon 2.
+#[test]
+fn plus_two_exon_substitution_in_exon2() {
+    let (projector, provider) = plus_two_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // g.2100 is the first base of exon 2 → c.7 (the 'T' of the stop codon).
+    let res = vp.project("chr2:g.2100T>A", "NM_PLUS2.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.7T>A"), "got c. = {c}");
+}
+
+/// Intronic substitution should project to c.N+offset notation and flag
+/// intronic.
+#[test]
+fn plus_two_exon_intronic_substitution() {
+    let (projector, provider) = plus_two_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // g.2050 is well inside the intron between exon 1 (ends at 2005) and
+    // exon 2 (starts at 2100).
+    let res = vp.project("chr2:g.2050N>A", "NM_PLUS2.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    // Intronic offset notation: c.6+44 (44 bp past the last base of exon 1).
+    assert!(
+        c.contains('+') || c.contains('-'),
+        "expected intronic notation, got {c}"
+    );
+    assert!(res.is_intronic);
+}
+
+// ─── indel structural edges (plus-strand, simple exon) ───────────────────────
+
+/// Edit at the very first base of CDS (c.1): substitution of the start
+/// codon's first base.
+#[test]
+fn substitution_at_c1_first_cds_base() {
+    let (projector, provider) = plus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    let res = vp.project("chr1:g.1000A>G", "NM_PLUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.1A>G"), "got c. = {c}");
+    // c.1A>G changes ATG (Met) → GTG (Val). HGVS p. recommendation: report
+    // as p.(Met1?) since we can't tell if translation still starts there.
+    // We accept either the strict ? or the explicit Met1Val depending on
+    // implementation; just assert SOMETHING with Met1 was emitted.
+    let p = res.protein.unwrap().to_string();
+    assert!(p.contains("Met1") || p.contains("M1"), "got p. = {p}");
+}
+
+/// Edit at the last base before the stop codon — codon 2 last base
+/// substitution.
+#[test]
+fn substitution_at_last_cds_base_before_stop() {
+    let (projector, provider) = plus_single_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // c.6 is the last base of Arg codon (CGC). Change C→A → CGA (still Arg).
+    let res = vp.project("chr1:g.1005C>A", "NM_PLUS1.1").unwrap();
+    let c = res.coding.unwrap().to_string();
+    assert!(c.contains(":c.6C>A"), "got c. = {c}");
+    let p = res.protein.unwrap().to_string();
+    // Synonymous substitution: HGVS uses p.(Arg2=) or similar identity form.
+    assert!(
+        p.contains('='),
+        "expected synonymous identity, got p. = {p}"
+    );
+}
+
+/// Indel that spans an exon-intron junction — the c./n. position lands at
+/// the splice site. We just assert the projection succeeds and the result
+/// reflects the junction (intronic-flagged or splice-distance reported).
+#[test]
+fn indel_spanning_exon_intron_junction() {
+    let (projector, provider) = plus_two_exon();
+    let vp = VariantProjector::new(projector, provider);
+    // Delete g.2005_2006 — last base of exon 1 + first base of intron.
+    let res = vp.project("chr2:g.2005_2006del", "NM_PLUS2.1");
+    // Some projectors will treat this as intronic with `del` notation;
+    // others as a splice-affecting deletion. Accept either path as long
+    // as it didn't error.
+    assert!(
+        res.is_ok(),
+        "exon/intron-junction del must project, got {:?}",
+        res.err()
+    );
+    let r = res.unwrap();
+    let c = r.coding.unwrap().to_string();
+    assert!(c.contains("del"), "got c. = {c}");
+}

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -486,3 +486,132 @@ class TestIssue310NonRefSeqProtein:
         # projector falls back to the transcript ID rather than silently
         # dropping the prediction.
         assert result.p_name == "MYGENE-gene.1:p.(Arg2Ser)"
+
+
+class TestProjectMany:
+    """Batched project_many / project_normalized_many entry points."""
+
+    def test_project_many_matches_individual_calls(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        """`project_many(strings)` must return the same per-input projections as
+        a list comprehension of `project_all(s)`. Result is `list[list[VariantProjection]]`."""
+        inputs = [
+            "NC_000001.11:g.1003C>A",
+            "NC_000001.11:g.1004G>A",
+            "NC_000001.11:g.1005C>A",
+        ]
+        batched = projector.project_many(inputs)
+        per_call = [projector.project_all(s) for s in inputs]
+        assert len(batched) == len(per_call) == 3
+        for b, p in zip(batched, per_call, strict=True):
+            assert len(b) == len(p)
+            for bp, pp in zip(b, p, strict=True):
+                assert bp.transcript_id == pp.transcript_id
+                assert bp.c_name == pp.c_name
+                assert bp.p_name == pp.p_name
+                assert bp.is_frameshift == pp.is_frameshift
+                assert bp.is_intronic == pp.is_intronic
+                assert bp.is_utr == pp.is_utr
+
+    def test_project_many_empty_list_returns_empty(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        assert projector.project_many([]) == []
+
+    def test_project_many_propagates_first_error(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # All-invalid input case.
+        with pytest.raises(RuntimeError):
+            projector.project_many(["not a valid hgvs string"])
+
+        # Mixed valid/invalid/valid: the invalid second entry must abort the
+        # batch immediately rather than swallow the error or carry on. The
+        # error message includes the failing input's index for diagnostics.
+        with pytest.raises(RuntimeError, match=r"input\[1\]"):
+            projector.project_many(
+                [
+                    "NC_000001.11:g.1003C>A",
+                    "not a valid hgvs string",
+                    "NC_000001.11:g.1005C>A",
+                ]
+            )
+
+    def test_project_normalized_many_matches_individual_calls(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        variants = [
+            ferro_hgvs.parse("NC_000001.11:g.1003C>A"),
+            ferro_hgvs.parse("NC_000001.11:g.1004G>A"),
+        ]
+        batched = projector.project_normalized_many(variants)
+        per_call = [projector.project_normalized_all(v) for v in variants]
+        assert len(batched) == len(per_call) == 2
+        for b, p in zip(batched, per_call, strict=True):
+            assert len(b) == len(p)
+            for bp, pp in zip(b, p, strict=True):
+                assert bp.transcript_id == pp.transcript_id
+                assert bp.c_name == pp.c_name
+                assert bp.p_name == pp.p_name
+
+    def test_project_normalized_many_propagates_first_error(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # Mirror the `project_many` fail-fast contract for the
+        # already-parsed entry point: the first failing input must abort
+        # the batch with an `input[i]:` prefix identifying its position.
+        # The second entry is a c. variant — `project_normalized_all`
+        # only accepts g. inputs, so it raises and indexed reporting kicks
+        # in.
+        variants = [
+            ferro_hgvs.parse("NC_000001.11:g.1003C>A"),
+            ferro_hgvs.parse("NM_TEST.1:c.4C>A"),
+        ]
+        with pytest.raises(RuntimeError, match=r"input\[1\]"):
+            projector.project_normalized_many(variants)
+
+
+class TestProjectVariant:
+    """Parse-once-then-project entry points: project_variant / project_variant_all.
+
+    These exist so callers that already hold an HgvsVariant (e.g. from
+    `ferro_hgvs.parse(...)`) can project without going back through a string.
+    They normalize internally — unlike `project_normalized*` which trust the
+    caller has already canonicalized."""
+
+    def test_project_variant_matches_project_string(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        hgvs_string = "NC_000001.11:g.1003C>A"
+        via_string = projector.project(hgvs_string, "NM_TEST.1")
+        variant = ferro_hgvs.parse(hgvs_string)
+        via_variant = projector.project_variant(variant, "NM_TEST.1")
+        assert via_string.c_name == via_variant.c_name
+        assert via_string.p_name == via_variant.p_name
+        assert via_string.transcript_id == via_variant.transcript_id
+
+    def test_project_variant_all_matches_project_all(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        hgvs_string = "NC_000001.11:g.1003C>A"
+        via_string = projector.project_all(hgvs_string)
+        variant = ferro_hgvs.parse(hgvs_string)
+        via_variant = projector.project_variant_all(variant)
+        assert len(via_variant) == len(via_string)
+        for a, b in zip(via_variant, via_string, strict=True):
+            assert a.transcript_id == b.transcript_id
+            assert a.c_name == b.c_name
+            assert a.p_name == b.p_name
+
+    def test_project_variant_and_project_normalized_agree_on_canonical_input(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # `project_variant` normalizes before projecting, `project_normalized`
+        # does not. For an already-canonical input they agree; this test pins
+        # that contract rather than chasing a fixture where shuffling would
+        # actually move the position.
+        variant = ferro_hgvs.parse("NC_000001.11:g.1003C>A")
+        canonical = projector.project_variant(variant, "NM_TEST.1")
+        skip_norm = projector.project_normalized(variant, "NM_TEST.1")
+        assert canonical.c_name == skip_norm.c_name


### PR DESCRIPTION
## Summary

- `VariantProjector` hot paths rewritten: codon-translation pipeline (memoised table, packed-array lookup, localised mutated-CDS translation) + projector-level caches (transcripts, reference protein, transcript spans) + interval index for `transcripts_at_position` (`superintervals` stab queries).
- Python surface: GIL released on every projection call; new batched entry points (`project_many`, `project_normalized_many`) and new parse-once entry points (`project_variant`, `project_variant_all`).
- Test coverage matrix expanded: minus-strand × full edit category (8 new end-to-end cases), multi-exon spans, indel structural edges.

## Throughput

Single-pass full fixtures, single thread, page cache warm; bench harness + fixtures in `examples/projector-bench.rs`:

| Fixture | Baseline | After | Speedup |
|---|---:|---:|---:|
| `snp_dense.tsv` (11,089 SNVs) | 98 v/s, 113 s wall | **2,865 v/s, 3.9 s wall** | **29.2×** |
| `indel_mixed.tsv` (3,726 indels) | killed at 15 min wall | **1,862 v/s, 2.0 s wall** | **≥450×** (lower bound) |

Indel P50 latency: 140 ms → ~460 µs. Run-to-run variance: ~5 % steady-state on a `--repeat 5` long bench.

The same kernel powers the Python `project_many` / `project_normalized_many` batched entry points so callers driving many-variants-many-transcripts pipelines from Python see the same speedup once they switch to the batched API.

## Commits

1. **`test(project): bench harness + projector coverage matrix`** — adds `examples/projector-bench.rs` (fixture generator, bench mode, `--dump` byte-diff harness, `--repeat N` for profile capture) and `tests/projection_coverage.rs` (14 end-to-end tests closing minus-strand + multi-exon + edit-position coverage gaps). Pure scaffolding for the perf work that follows.

2. **`perf(project): rebuild translation pipeline for fan-out throughput`** — codon-table memoisation, packed-array codon lookup, byte-level translate, prefix-only translation for frameshift indels (skip codons before the edit), prefix+suffix translation for in-frame indels (skip codons after re-sync too). Each step ships with a TDD safety net comparing the new helper byte-for-byte against `translate_full_cds(mut_cds)`. Touches `backtranslate/codon.rs`, `project/protein/{helpers,indel,substitution}.rs`.

3. **`perf(data): indexing + caching + I/O for fan-out throughput`** — replaces the per-call linear scan in `CdotMapper::transcripts_at_position` with a `superintervals::IntervalMap<u32>` per contig (built lazily, invalidated on `add_transcript`); per-projector caches of `get_transcript` and `RefProteinBundle`; per-mapper cache of transcript genome spans; combined exon walk with strand-aware early-termination; single-pass byte-level FASTA read; lazy `to_string` on the error path. New direct dep: `superintervals = "0.3"` (MIT, single transitive dep `serde`). Choice of crate informed by the polars-bio Sept-2025 benchmark — SuperIntervals beat rust-lapper (which "collapses" ~25× slower on some inputs), COITrees, AVL, and IITree there.

4. **`feat(python): GIL release, batched API, parse-once entry points`** — wraps the four existing projector methods in `py.detach` so multi-threaded Python callers can make progress in parallel; adds `project_many(list[str])` / `project_normalized_many(list[HgvsVariant])` (batched, fail-fast) and `project_variant(HgvsVariant, str)` / `project_variant_all(HgvsVariant)` (skip the re-parse for callers that already hold a parsed variant). Type stubs updated.

## Validation

Every perf commit was validated against a `--dump` byte-stable JSONL baseline captured at commit 1 (test-only, projector code identical to `main`). The dump records `(input, n_projections, sorted [transcript_id, c., p., flags] tuple)` per variant; both fixtures' outputs are byte-identical at every commit boundary on the rebased branch. The `--dump` flag is on the bench example so reviewers can reproduce.

## Test plan

- [ ] `cargo test --lib` — 2,226 unit tests pass.
- [ ] `cargo test --test projection --test projection_coverage` — 17 integration tests pass (3 pre-existing + 14 new).
- [ ] `cargo test --test issue_259_hgvs_spdi_coverage` — 26 tests pass (was failing on stale branch base; fixed by rebase onto current `origin/main`).
- [ ] `cargo clippy --lib --tests -- -D warnings` — clean.
- [ ] `cargo fmt --check` — clean.
- [ ] `maturin develop --features python && pytest tests/python/test_variant_projection.py` — 29 tests pass (22 pre-existing + 7 new).
- [ ] (manual reproducer) `cargo build --release --example projector-bench`, then run with `gen-snp` / `gen-indel` to derive deterministic fixtures from cdot for COL1A1 / BRCA1 / TP53 on chr17, then `bench <fixture> --dump <jsonl>` and confirm the dump is byte-identical to a baseline captured at commit 1 (test-only, no projector code change).

## Notes

- Fixture data is synthetic, derived in-process from publicly available RefSeq transcripts (COL1A1 / BRCA1 / TP53 on chr17). No external manifest needs to be checked in; the bench reads from a `ferro-prepare` manifest passed on the command line.
- `superintervals` is the only new direct dependency. Rationale and benchmark comparison vs `rust-lapper` / `coitrees` / `gia` / `grit-genomics` documented in the commit message of commit 3.