### PR TITLE
test: update stale Display test expectations to HGVS spec-canonical forms

### DIFF
--- a/tests/issue_275_codon_frame_extensions.rs
+++ b/tests/issue_275_codon_frame_extensions.rs
@@ -262,10 +262,14 @@ fn codon_frame_del_then_sub_one_codon() {
 #[test]
 fn codon_frame_sub_then_del_rna() {
     // RNA analogue of sub+del: r. axis matches c. axis, so the same
-    // codon-frame rule applies. Lowercase bases per r. display.
+    // codon-frame rule applies. Lowercase RNA bases per r. display —
+    // the RNA alphabet is `a/c/g/u` per HGVS spec
+    // (recommendations/RNA/{substitution,delins,repeated}.md, e.g.
+    // `r.142_144delinsugg`), and PR #293 wired the display-side T→u
+    // canonicalization so the merged delins emits `cu`, not `ct`.
     assert_eq!(
         normalize_with(provider_simple(), "NM_TEST.1:r.[1a>c;3del]"),
-        "NM_TEST.1:r.1_3delinsct",
+        "NM_TEST.1:r.1_3delinscu",
     );
 }
 

--- a/tests/issue_283_convert_c_to_r_audit.rs
+++ b/tests/issue_283_convert_c_to_r_audit.rs
@@ -687,40 +687,32 @@ mod compound_brackets {
 mod predicted_edit_wrapper {
     use super::*;
 
-    /// Predicted substitution `c.(123A>G)` currently parses to a
-    /// `CdsVariant`, and Display emits it as `c.123(A>G)` — the
-    /// parens migrate from wrapping the whole edit to wrapping only
-    /// the substitution body. Pin this observed re-shaping.
-    ///
-    /// TODO(issue #300): the c. side reshapes parens around the
-    /// edit body; the r. side **drops them entirely** (see the next
-    /// test). That asymmetry is a parser/Display divergence between
-    /// the two paths and is the only behavioural inconsistency the
-    /// audit surfaced. Tracked under issue #300 — either drop parens
-    /// on both sides (current `r.` behavior), or keep parens around
-    /// the body on both sides (current `c.` behavior).
-    ///
-    /// In-flight predicted-edit support: #242 / #244 / #246.
+    /// Predicted substitution `c.(123A>G)` round-trips through Display
+    /// with the outer parens preserved, matching the HGVS spec form for
+    /// predicted edits (`recommendations/uncertain.md`: examples like
+    /// `c.(76A>G)`, `r.(1388g>a)`, `p.(Cys123Gly)` all wrap position+edit
+    /// in outer parens). PR #309 harmonized the c./r. surfaces; this test
+    /// pins the spec-canonical form for the c. side.
     #[test]
-    fn predicted_cds_sub_display_wraps_edit_body() {
+    fn predicted_cds_sub_display_round_trips_outer_parens() {
         let input = format!("{ACC}:c.(123A>G)");
         let v = parse_hgvs(&input).expect("predicted c.(...) sub must parse");
         assert!(matches!(v, HgvsVariant::Cds(_)));
-        // Observed today: outer parens become body parens.
-        assert_eq!(format!("{}", v), format!("{ACC}:c.123(A>G)"));
+        assert_eq!(format!("{}", v), format!("{ACC}:c.(123A>G)"));
     }
 
-    /// Predicted RNA substitution `r.(123a>g)` parses but Display
-    /// **drops the parens entirely**, asymmetric to the c. side.
-    /// Pin this asymmetry. See TODO on the c. test above for the
-    /// follow-up to harmonize the two surfaces.
+    /// Predicted RNA substitution `r.(123a>g)` round-trips through Display
+    /// with the outer parens preserved, matching the HGVS spec
+    /// (`recommendations/uncertain.md` / `recommendations/RNA/substitution.md`
+    /// — `r.(76a>c)`, `r.(1388g>a)`, `r.(3277_3432del)` all wrap the entire
+    /// edit). PR #309 harmonized the c./r. surfaces so r. no longer drops
+    /// the parens.
     #[test]
-    fn predicted_rna_sub_display_drops_parens() {
+    fn predicted_rna_sub_display_round_trips_outer_parens() {
         let input = format!("{ACC}:r.(123a>g)");
         let v = parse_hgvs(&input).expect("predicted r.(...) sub must parse");
         assert!(matches!(v, HgvsVariant::Rna(_)));
-        // Observed today: parens are dropped on the r. side.
-        assert_eq!(format!("{}", v), format!("{ACC}:r.123a>g"));
+        assert_eq!(format!("{}", v), format!("{ACC}:r.(123a>g)"));
     }
 
     /// Coordinate mapping is unchanged by the predicted wrapper —


### PR DESCRIPTION
## Summary

Main has had three test failures in CI since PRs #293 and #309 landed — they pin pre-spec-canonical Display outputs that no longer match the (now spec-correct) emitted form. This PR catches each test up to the current behavior, all of which is justified by the HGVS spec.

- `tests/issue_275_codon_frame_extensions.rs::codon_frame_sub_then_del_rna` — was asserting `r.1_3delinsct`, code emits `r.1_3delinscu`. HGVS RNA alphabet is `a/c/g/u` (`recommendations/RNA/{substitution,delins,repeated}.md` — e.g. `r.142_144delinsugg`); PR #293 wired the display-side T→u canonicalization.
- `tests/issue_283_convert_c_to_r_audit.rs::predicted_cds_sub_display_wraps_edit_body` — was asserting `c.(123A>G)` → `c.123(A>G)`. Spec form for predicted edits keeps outer parens around the full description (`recommendations/uncertain.md` — `c.(76A>G)`, `p.(Cys123Gly)`); PR #309 harmonized this. Renamed to `predicted_cds_sub_display_round_trips_outer_parens`.
- `tests/issue_283_convert_c_to_r_audit.rs::predicted_rna_sub_display_drops_parens` — was asserting `r.(123a>g)` → `r.123a>g`. Same spec rule on the r. axis (`recommendations/RNA/substitution.md` — `r.(76a>c)`, `r.(1388g>a)`, `r.(3277_3432del)`); PR #309 stopped dropping parens. Renamed to `predicted_rna_sub_display_round_trips_outer_parens`.

Both predicted-edit tests carried TODO comments referencing issue #300 / a follow-up to harmonize the c./r. surfaces — the follow-up landed via PR #309; this PR catches the tests up.

## Test plan

- [x] `cargo nextest run --features dev` → 5403/5407 pass on the new branch (4 failures are mutalyzer-axis baseline trackers that skip in CI without `FERRO_MANIFEST`)
- [x] `cargo clippy --features dev -- -D warnings` clean
- [ ] CI passes (this PR unblocks every in-flight branch whose rebase onto main was inheriting these failures)