### PR TITLE
ci(external-validation): use --features dev to keep slow-tests opt-in (closes #40)

### DIFF
--- a/.github/workflows/external-validation.yml
+++ b/.github/workflows/external-validation.yml
@@ -200,11 +200,14 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+      # `dev` bundles every testable feature; `slow-tests` is
+      # intentionally opt-in because it requires a ~1 GB ClinVar
+      # fixture that is not committed to the repo.
       - name: Run standard tests
-        run: cargo test --all-features
+        run: cargo test --features dev
 
       - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --features dev --all-targets -- -D warnings
 
   fetch-external-databases:
     name: Fetch External Database Data


### PR DESCRIPTION
Closes #40.

## Summary

`.github/workflows/external-validation.yml` ran `cargo test --all-features` and `cargo clippy --all-features` in the `run-standard-tests` job. `--all-features` enables the `slow-tests` feature, which compiles `tests/clinvar_validation.rs` — the file is gated behind `#![cfg(feature = "slow-tests")]` and requires the ~1 GB `tests/fixtures/bulk/hgvs4variation.txt.gz` ClinVar dump that is not committed and not fetched by the workflow. The test panics at runtime when the fixture is missing.

The `dev` feature flag was created for exactly this case: per `Cargo.toml` it bundles every testable feature (`validation`, `mmap`, `benchmark`, `parallel`, `protein-fetch`, `web-service`) while deliberately excluding `slow-tests`. `ci.yml` already uses `--features dev` for both `cargo nextest run` and `cargo clippy`. This change brings external-validation in line.

## Diff

```diff
       - name: Run standard tests
-        run: cargo test --all-features
+        run: cargo test --features dev

       - name: Run clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --features dev -- -D warnings
```

## Verification

- `tests/clinvar_validation.rs:8` is gated `#![cfg(feature = "slow-tests")]`.
- `Cargo.toml:76` defines `dev = ["validation", "mmap", "benchmark", "parallel", "protein-fetch", "web-service"]` — no `slow-tests`.
- `cargo test --features dev --no-run` builds the `clinvar_validation` test binary as an empty shell (`0 tests, 0 benchmarks` reported by the binary's `--list`), so no fixture access is attempted.
- Default features (`default = []`) carry no `slow-tests` either, so the `fetch-external-databases` job's `cargo test --test ...` calls (lines 128/133/138) are unaffected.

The fully-gated `slow-tests` job remains available via explicit `cargo test --release --features slow-tests` when someone provides the fixture.

## Test plan

- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Local `cargo test --features dev --no-run` succeeds; `clinvar_validation` binary reports 0 tests
- [ ] Fork `workflow_dispatch` on this branch reaches `Run standard tests` step and passes (requires merge or a manual fork dispatch)