### PR TITLE
feat(normalize): structured info-code surface mirroring W#### warnings

### DIFF
--- a/src/error_handling/info_map.rs
+++ b/src/error_handling/info_map.rs
@@ -1,0 +1,259 @@
+//! Mutalyzer ↔ ferro info-code mapping table.
+//!
+//! Companion to [`crate::error_handling::mutalyzer_map`] for the `infos`
+//! axis. Mutalyzer's normalize output emits structured info codes (`I*`)
+//! alongside the `errors` array; this module translates between those
+//! upstream codes and ferro's [`crate::normalize::NormalizationInfo`]
+//! variants for cross-tool diagnostics and the mutalyzer corpus runner
+//! (`tests/mutalyzer_normalize_tests.rs`).
+//!
+//! Coverage policy mirrors `mutalyzer_map`: every `I*` code emitted by
+//! mutalyzer/mutalyzer at the pinned upstream commit is classified — either
+//! to a concrete `NormalizationInfo` variant tag or explicitly to "no ferro
+//! equivalent" via [`NO_FERRO_INFO_EQUIV`]. The exhaustiveness test
+//! [`tests::forward_all_upstream_info_codes_classified`] guarantees no
+//! upstream code drifts into an unclassified state.
+
+/// Strongly-typed mutalyzer info code.
+///
+/// Closed enum covering every `I*` code emitted by mutalyzer/mutalyzer at
+/// the pinned upstream commit. New codes added upstream will fail to parse
+/// via [`MutalyzerInfoCode::parse`] until added here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MutalyzerInfoCode {
+    ICorrectedCoordinateSystem,
+    ICorrectedLrgReference,
+    ICorrectedPoint,
+    ICorrectedSelectorId,
+    ICorrectedVariantType,
+    ILrgWarning,
+    IMrnaGenomicTip,
+    ISortedVariants,
+    IWholeTranscriptExon,
+}
+
+impl MutalyzerInfoCode {
+    /// Parse a mutalyzer info code string (e.g. `"ICORRECTEDPOINT"`).
+    ///
+    /// Returns `None` for unknown codes.
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "ICORRECTEDCOORDINATESYSTEM" => Self::ICorrectedCoordinateSystem,
+            "ICORRECTEDLRGREFERENCE" => Self::ICorrectedLrgReference,
+            "ICORRECTEDPOINT" => Self::ICorrectedPoint,
+            "ICORRECTEDSELECTORID" => Self::ICorrectedSelectorId,
+            "ICORRECTEDVARIANTTYPE" => Self::ICorrectedVariantType,
+            "ILRGWARNING" => Self::ILrgWarning,
+            "IMRNAGENOMICTIP" => Self::IMrnaGenomicTip,
+            "ISORTEDVARIANTS" => Self::ISortedVariants,
+            "IWHOLETRANSCRIPTEXON" => Self::IWholeTranscriptExon,
+            _ => return None,
+        })
+    }
+
+    /// Get the canonical upper-case mutalyzer string for this code.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ICorrectedCoordinateSystem => "ICORRECTEDCOORDINATESYSTEM",
+            Self::ICorrectedLrgReference => "ICORRECTEDLRGREFERENCE",
+            Self::ICorrectedPoint => "ICORRECTEDPOINT",
+            Self::ICorrectedSelectorId => "ICORRECTEDSELECTORID",
+            Self::ICorrectedVariantType => "ICORRECTEDVARIANTTYPE",
+            Self::ILrgWarning => "ILRGWARNING",
+            Self::IMrnaGenomicTip => "IMRNAGENOMICTIP",
+            Self::ISortedVariants => "ISORTEDVARIANTS",
+            Self::IWholeTranscriptExon => "IWHOLETRANSCRIPTEXON",
+        }
+    }
+}
+
+/// Tag identifying which [`crate::normalize::NormalizationInfo`] variant a
+/// mutalyzer info code maps to.
+///
+/// `code()` returns the stable identifier string returned by
+/// [`crate::normalize::NormalizationInfo::code`] for the corresponding
+/// variant (e.g. `"SHUFFLE_APPLIED"`). The corpus runner uses
+/// this for cross-tool equivalence checks: an expected mutalyzer info maps
+/// to a ferro info code; the runner asserts the same code appears in the
+/// emitted `infos` list.
+///
+/// `is_lossy()` records that the mapping is approximate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FerroInfoTag {
+    code: &'static str,
+    lossy: bool,
+}
+
+impl FerroInfoTag {
+    /// The `NormalizationInfo` code string this tag identifies.
+    pub fn code(self) -> &'static str {
+        self.code
+    }
+
+    /// Returns true if this mapping is approximate (no exact 1:1 with the
+    /// mutalyzer code's semantics).
+    pub fn is_lossy(self) -> bool {
+        self.lossy
+    }
+}
+
+/// Mutalyzer info codes that have no ferro equivalent.
+///
+/// Per-entry rationale follows. ferro does not currently model these
+/// signals as structured info codes; some are mutalyzer-specific
+/// behaviours (LRG handling, auto coordinate-system inference) that ferro
+/// intentionally treats as errors or no-ops instead.
+pub const NO_FERRO_INFO_EQUIV: &[&str] = &[
+    // mutalyzer auto-infers a missing coordinate system prefix
+    // (e.g. `NM_xxx:274del` → `NM_xxx:c.274del`). ferro errors on missing
+    // prefixes rather than silently correcting, so there is no info to
+    // emit.
+    "ICORRECTEDCOORDINATESYSTEM",
+    // LRG-specific reference correction; ferro does not implement the LRG
+    // reference system.
+    "ICORRECTEDLRGREFERENCE",
+    // mutalyzer corrects a missing/wrong selector ID on the input; ferro
+    // requires explicit selectors and errors otherwise.
+    "ICORRECTEDSELECTORID",
+    // mutalyzer corrects the variant type (e.g. del→delins) when the
+    // stated bases force the change. ferro canonicalizes via
+    // `canonicalize_edit` but does not emit a structured info for the
+    // rewrite.
+    "ICORRECTEDVARIANTTYPE",
+    // LRG-specific warning surface; see `ICORRECTEDLRGREFERENCE`.
+    "ILRGWARNING",
+    // mutalyzer recommends adding a genomic tip ("g." accession) when a
+    // c./n. variant is reported alone; ferro has no equivalent
+    // recommendation surface.
+    "IMRNAGENOMICTIP",
+    // mutalyzer reorders cis-allele members by position and emits this
+    // info. ferro's `normalize::merge` layer combines positionally-
+    // adjacent edits but does not sort members; if a future change does
+    // start sorting, this rationale (and the surface) will need
+    // revisiting.
+    "ISORTEDVARIANTS",
+    // mutalyzer flags transcripts where the entire transcript is a single
+    // exon. ferro has no exon-classification info surface.
+    "IWHOLETRANSCRIPTEXON",
+];
+
+/// Forward map: mutalyzer info code → ferro info-variant tag.
+///
+/// Returns `None` for codes in [`NO_FERRO_INFO_EQUIV`].
+pub fn mutalyzer_info_to_ferro(code: &str) -> Option<FerroInfoTag> {
+    let parsed = MutalyzerInfoCode::parse(code)?;
+    forward_info_map(parsed)
+}
+
+fn forward_info_map(code: MutalyzerInfoCode) -> Option<FerroInfoTag> {
+    use MutalyzerInfoCode::*;
+    Some(match code {
+        // Exact-ish 1:1 mapping: mutalyzer's `ICORRECTEDPOINT` fires when
+        // a position is moved by the 3'-rule shuffle. ferro emits the
+        // direction-agnostic `SHUFFLE_APPLIED` code carrying the actual
+        // direction in the variant payload — under the default config
+        // (`ShuffleDirection::ThreePrime`) the two signals coincide.
+        // Mapping is lossy because ferro may also emit `SHUFFLE_APPLIED`
+        // for `FivePrime` configurations that mutalyzer never produces.
+        ICorrectedPoint => lossy("SHUFFLE_APPLIED"),
+
+        // No ferro equivalent — see NO_FERRO_INFO_EQUIV.
+        ICorrectedCoordinateSystem
+        | ICorrectedLrgReference
+        | ICorrectedSelectorId
+        | ICorrectedVariantType
+        | ILrgWarning
+        | IMrnaGenomicTip
+        | ISortedVariants
+        | IWholeTranscriptExon => return None,
+    })
+}
+
+#[allow(dead_code)]
+fn exact(code: &'static str) -> FerroInfoTag {
+    FerroInfoTag { code, lossy: false }
+}
+
+fn lossy(code: &'static str) -> FerroInfoTag {
+    FerroInfoTag { code, lossy: true }
+}
+
+/// Every known mutalyzer info code (canonical upper-case form), for
+/// exhaustiveness tests in downstream callers.
+pub fn all_mutalyzer_info_codes() -> &'static [&'static str] {
+    ALL_INFO_CODES
+}
+
+const ALL_INFO_CODES: &[&str] = &[
+    "ICORRECTEDCOORDINATESYSTEM",
+    "ICORRECTEDLRGREFERENCE",
+    "ICORRECTEDPOINT",
+    "ICORRECTEDSELECTORID",
+    "ICORRECTEDVARIANTTYPE",
+    "ILRGWARNING",
+    "IMRNAGENOMICTIP",
+    "ISORTEDVARIANTS",
+    "IWHOLETRANSCRIPTEXON",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every code listed in `all_mutalyzer_info_codes()` is either mapped
+    /// to a ferro info variant or appears in the `NO_FERRO_INFO_EQUIV`
+    /// allowlist (exclusive). This is the load-bearing exhaustiveness
+    /// guarantee — a future corpus refresh that adds a new `I*` code will
+    /// trip this test until it is classified.
+    #[test]
+    fn forward_all_upstream_info_codes_classified() {
+        for code in all_mutalyzer_info_codes() {
+            let mapped = mutalyzer_info_to_ferro(code).is_some();
+            let allowlisted = NO_FERRO_INFO_EQUIV.contains(code);
+            assert!(
+                mapped ^ allowlisted,
+                "info code {code:?} must be either mapped or in NO_FERRO_INFO_EQUIV (exclusive); mapped={mapped}, allowlisted={allowlisted}"
+            );
+        }
+    }
+
+    /// `MutalyzerInfoCode::parse` round-trips through `as_str()` for every
+    /// variant listed in `all_mutalyzer_info_codes()`.
+    #[test]
+    fn mutalyzer_info_code_parse_roundtrip() {
+        for code in all_mutalyzer_info_codes() {
+            let parsed = MutalyzerInfoCode::parse(code)
+                .unwrap_or_else(|| panic!("known info code {code:?} failed to parse"));
+            assert_eq!(
+                parsed.as_str(),
+                *code,
+                "round-trip failed for {code:?}: parsed.as_str() = {:?}",
+                parsed.as_str()
+            );
+        }
+    }
+
+    /// Unknown info codes return `None` rather than panicking.
+    #[test]
+    fn unknown_info_code_returns_none() {
+        assert!(mutalyzer_info_to_ferro("IBOGUS").is_none());
+        assert!(mutalyzer_info_to_ferro("").is_none());
+        assert!(mutalyzer_info_to_ferro("ECORRECTEDPOINT").is_none()); // wrong prefix
+    }
+
+    /// `ICORRECTEDPOINT` maps to the ferro shuffle-applied info code that
+    /// `NormalizationInfo::ShuffleApplied::code()` returns. Pin the exact
+    /// string so the corpus runner's check is stable. Marked lossy
+    /// because ferro's signal carries an explicit direction
+    /// (3'/5') while mutalyzer's only ever fires for 3'-shift.
+    #[test]
+    fn icorrectedpoint_maps_to_shuffle_applied() {
+        let tag = mutalyzer_info_to_ferro("ICORRECTEDPOINT")
+            .expect("ICORRECTEDPOINT should map to a ferro info variant");
+        assert_eq!(tag.code(), "SHUFFLE_APPLIED");
+        assert!(
+            tag.is_lossy(),
+            "ICORRECTEDPOINT → SHUFFLE_APPLIED is lossy (direction-agnostic)"
+        );
+    }
+}

--- a/src/error_handling/mod.rs
+++ b/src/error_handling/mod.rs
@@ -49,6 +49,7 @@
 
 pub mod codes;
 pub mod corrections;
+pub mod info_map;
 pub mod mutalyzer_map;
 mod preprocessor;
 pub mod registry;
@@ -59,6 +60,9 @@ pub use corrections::{
     detect_accession_typo, detect_amino_acid_typo, detect_edit_type_typo, detect_missing_version,
     detect_swapped_positions, detect_typos, find_closest_match, levenshtein_distance,
     DetectedCorrection, FuzzyMatch, TypoSuggestion, TypoTokenType,
+};
+pub use info_map::{
+    all_mutalyzer_info_codes, mutalyzer_info_to_ferro, FerroInfoTag, MutalyzerInfoCode,
 };
 pub use mutalyzer_map::{
     all_mutalyzer_codes, ferro_to_mutalyzer, mutalyzer_to_ferro, FerroErrorTag, MutalyzerCode,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -200,27 +200,110 @@ impl NormalizationWarning {
     }
 }
 
-/// Result of normalization with optional warnings
+/// Info-grade signal generated during normalization.
+///
+/// Mirrors [`NormalizationWarning`] but for non-error, non-warning events
+/// callers may want to record (e.g. the shuffle layer moved the variant
+/// to a canonical position). The enum is open-ended: each variant owns the
+/// fields its code needs. Future info codes add new variants without
+/// touching existing emit sites.
+///
+/// This is the structural counterpart to mutalyzer/mutalyzer's `infos`
+/// array (codes prefixed with `I`); see [`crate::error_handling::info_map`]
+/// for the upstream-equivalent string mapping used by the corpus runner.
+///
+/// Marked `#[non_exhaustive]` so adding new info variants is non-breaking
+/// for downstream `match` arms.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum NormalizationInfo {
+    /// The shuffle layer relocated the variant per the HGVS arbitrary-
+    /// position rule. The HGVS spec mandates the 3' (rightmost) form, but
+    /// ferro supports both 3' and 5' shuffling via
+    /// [`config::ShuffleDirection`] (some VCF pipelines prefer 5'); the
+    /// direction is carried explicitly so callers can interpret the
+    /// signal correctly. Code: `SHUFFLE_APPLIED`. Mutalyzer-equivalent:
+    /// `ICORRECTEDPOINT` (mutalyzer only emits 3').
+    ShuffleApplied {
+        /// Human-readable description of the shift.
+        message: String,
+        /// Accession of the reference sequence.
+        accession: String,
+        /// Direction in which the shuffle ran for this normalization.
+        direction: config::ShuffleDirection,
+        /// Position text of the input variant (HGVS, no accession),
+        /// e.g. `"4"` or `"100_103"`.
+        original_position: String,
+        /// Position text of the normalized variant (HGVS, no accession),
+        /// e.g. `"12"` or `"108_111"`.
+        normalized_position: String,
+    },
+}
+
+impl NormalizationInfo {
+    /// The info's user-facing code string.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::ShuffleApplied { .. } => "SHUFFLE_APPLIED",
+        }
+    }
+
+    /// Human-readable message for the info.
+    pub fn message(&self) -> &str {
+        match self {
+            Self::ShuffleApplied { message, .. } => message,
+        }
+    }
+}
+
+/// Result of normalization with optional warnings and info-grade signals.
+///
+/// Marked `#[non_exhaustive]` so future diagnostic axes (e.g. a separate
+/// `notices` list) can be added without breaking downstream construction
+/// via struct literals.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct NormalizeResultWithWarnings {
     /// The normalized variant
     pub result: HgvsVariant,
     /// Warnings generated during normalization
     pub warnings: Vec<NormalizationWarning>,
+    /// Info-grade signals generated during normalization (e.g. a 3'-rule
+    /// shuffle was applied). Empty when no signals fired. See
+    /// [`NormalizationInfo`] for the variant taxonomy.
+    pub infos: Vec<NormalizationInfo>,
 }
 
 impl NormalizeResultWithWarnings {
-    /// Create a new result without warnings
+    /// Create a new result without warnings or infos
     pub fn new(result: HgvsVariant) -> Self {
         Self {
             result,
             warnings: vec![],
+            infos: vec![],
         }
     }
 
-    /// Create a result with warnings
+    /// Create a result with warnings (and no infos)
     pub fn with_warnings(result: HgvsVariant, warnings: Vec<NormalizationWarning>) -> Self {
-        Self { result, warnings }
+        Self {
+            result,
+            warnings,
+            infos: vec![],
+        }
+    }
+
+    /// Create a result with both warnings and infos
+    pub fn with_diagnostics(
+        result: HgvsVariant,
+        warnings: Vec<NormalizationWarning>,
+        infos: Vec<NormalizationInfo>,
+    ) -> Self {
+        Self {
+            result,
+            warnings,
+            infos,
+        }
     }
 
     /// Add a warning to the result
@@ -228,9 +311,19 @@ impl NormalizeResultWithWarnings {
         self.warnings.push(warning);
     }
 
+    /// Add an info-grade signal to the result
+    pub fn add_info(&mut self, info: NormalizationInfo) {
+        self.infos.push(info);
+    }
+
     /// Check if there are any warnings
     pub fn has_warnings(&self) -> bool {
         !self.warnings.is_empty()
+    }
+
+    /// Check if there are any info-grade signals
+    pub fn has_infos(&self) -> bool {
+        !self.infos.is_empty()
     }
 
     /// Check if there's a reference mismatch warning
@@ -356,7 +449,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
         };
 
-        Ok(NormalizeResultWithWarnings::with_warnings(result, warnings))
+        let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
+        Ok(NormalizeResultWithWarnings::with_diagnostics(
+            result, warnings, infos,
+        ))
     }
 
     /// Normalize an allele (compound) variant
@@ -3374,6 +3470,114 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Err(_) => vec![v],
         }
     }
+}
+
+/// Position-only Display text for variant kinds that go through the
+/// shuffle pipeline.
+///
+/// Returns the `loc_edit.location` rendering (e.g. `"4"` for `c.4del`,
+/// `"100_103"` for `g.100_103del`) for the six nucleic-acid axes whose
+/// normalizers call `normalize_na_edit`. Returns `None` for:
+///
+/// - `Protein` — protein 3'-shifting not yet implemented (#91).
+/// - `Allele` — handled separately by the per-member compare path in
+///   [`detect_shuffle_infos`].
+/// - `RnaFusion` / `NullAllele` / `UnknownAllele` — no single position to
+///   compare against.
+///
+/// `Circular` (o.) is included even though its current normalizer is a
+/// pass-through clone (positions cannot change); the surface is
+/// forward-safe for when #129 wires real circular shuffling and costs
+/// nothing today (the post-hoc equality check trivially returns no info).
+fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
+    match variant {
+        HV::Genome(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Cds(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Tx(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Rna(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Mt(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Circular(v) => Some(format!("{}", v.loc_edit.location)),
+        HV::Protein(_) | HV::Allele(_) | HV::RnaFusion(_) | HV::NullAllele | HV::UnknownAllele => {
+            None
+        }
+    }
+}
+
+/// Detect shuffle infos by comparing the input variant to the normalized
+/// result.
+///
+/// A shift is recorded when the position-only Display text differs between
+/// input and output. This is structural (not byte-exact on the full
+/// description), so a canonical-form rewrite that leaves the position
+/// unchanged (e.g. an explicit `delA` → `del`, which `canonicalize_edit`
+/// applies only to the edit body, not the location) does not emit a false
+/// positive.
+///
+/// Compound-allele rules (input/output both `HV::Allele` with equal
+/// length): the comparison runs per bracket member in input order.
+/// Bracket-length mismatches (the merge layer combined or split members)
+/// are conservative no-ops — the structural rewrite is not a pure shuffle.
+///
+/// Top-level kind changes (input is `HV::Allele` but output is a bare
+/// variant after cis-collapse, or vice versa via the `wrap_allele_if_split`
+/// canonical-split path) are also conservative no-ops by construction:
+/// `position_text_if_shuffleable` returns `None` for `HV::Allele`, so the
+/// fallback arm yields no info. This narrows the surface to the cases the
+/// signal is unambiguous; #330 explicitly scopes to the simple 3'-shift
+/// channel.
+///
+/// Returns at most one info per shuffle event:
+/// - Single-axis variants: zero or one info.
+/// - Cis/trans alleles: one info per shifted member, in member order.
+fn detect_shuffle_infos(
+    input: &HgvsVariant,
+    output: &HgvsVariant,
+    direction: config::ShuffleDirection,
+) -> Vec<NormalizationInfo> {
+    match (input, output) {
+        (HV::Allele(in_allele), HV::Allele(out_allele)) => {
+            if in_allele.variants.len() != out_allele.variants.len() {
+                return Vec::new();
+            }
+            in_allele
+                .variants
+                .iter()
+                .zip(out_allele.variants.iter())
+                .filter_map(|(i, o)| single_variant_shift_info(i, o, direction))
+                .collect()
+        }
+        _ => single_variant_shift_info(input, output, direction)
+            .into_iter()
+            .collect(),
+    }
+}
+
+/// Single-variant shift detector. Returns `Some(info)` iff the position
+/// text differs between input and output for a shuffle-eligible axis.
+fn single_variant_shift_info(
+    input: &HgvsVariant,
+    output: &HgvsVariant,
+    direction: config::ShuffleDirection,
+) -> Option<NormalizationInfo> {
+    let original_position = position_text_if_shuffleable(input)?;
+    let normalized_position = position_text_if_shuffleable(output)?;
+    if original_position == normalized_position {
+        return None;
+    }
+    let accession = input
+        .accession()
+        .map(|a| format!("{}", a))
+        .unwrap_or_default();
+    let message = format!(
+        "shuffle ({direction}) relocated variant from {original_position} to {normalized_position} on {accession}",
+    );
+    Some(NormalizationInfo::ShuffleApplied {
+        message,
+        accession,
+        direction,
+        original_position,
+        normalized_position,
+    })
 }
 
 /// Flip a fetched intronic genomic-strand window into transcript-view

--- a/tests/issue_330_info_code_surface.rs
+++ b/tests/issue_330_info_code_surface.rs
@@ -1,0 +1,235 @@
+//! Issue #330 — structured info-code surface mirroring the W#### warning
+//! surface.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/330>.
+//!
+//! Production users currently cannot distinguish "ferro silently shifted
+//! your variant per the 3' rule" from "ferro left it alone" without
+//! re-comparing strings. This pins the canonical contract:
+//!
+//! - `Normalizer::normalize_with_warnings` returns a result carrying both
+//!   `warnings: Vec<NormalizationWarning>` and `infos: Vec<NormalizationInfo>`.
+//! - Each [`NormalizationInfo`] exposes `code()` (a stable identifier such as
+//!   `"SHUFFLE_APPLIED"`) and `message()` (a human-readable description).
+//! - When the shuffle layer relocates a variant, `infos` contains a
+//!   [`NormalizationInfo::ShuffleApplied`] variant carrying the direction,
+//!   the original HGVS position text, and the normalized HGVS position
+//!   text.
+//! - When the variant is already canonical (or the edit kind is not
+//!   shuffle-eligible), `infos` is empty.
+//!
+//! Tests use a `MockProvider`-backed `c.` variant on a homopolymer tract,
+//! mirroring the example given in the issue body. Complementary tests pin
+//! the no-info empty case, multi-position spans, the 5'-shift direction,
+//! and that the non-`with_warnings` `normalize()` entry point
+//! intentionally discards infos. The conservative no-op behaviour on
+//! top-level kind changes (`HV::Allele` ↔ bare variant across
+//! cis-collapse / `wrap_allele_if_split`) is documented on
+//! `detect_shuffle_infos` itself rather than pinned here.
+
+use ferro_hgvs::normalize::config::ShuffleDirection;
+use ferro_hgvs::normalize::{NormalizationInfo, NormalizeConfig, Normalizer};
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+
+/// Build a single-exon plus-strand transcript whose CDS contains a run of
+/// `A`s, so that `c.<pos>delA` inside the run is shuffle-eligible.
+fn provider_with_polya() -> MockProvider {
+    let mut provider = MockProvider::new();
+    // Position:  1234567890123456789012345
+    // Sequence:  ATGAAAAAAAAACGTCGTCGTCGTC
+    //               ^^^^^^^^^^ poly-A tract (c.4..c.12)
+    provider.add_transcript(Transcript::new(
+        "NM_POLYA.1".to_string(),
+        Some("POLYA".to_string()),
+        Strand::Plus,
+        Some("ATGAAAAAAAAACGTCGTCGTCGTC".to_string()),
+        Some(1),
+        Some(25),
+        vec![Exon::new(1, 1, 25)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// `c.4del` (a single-base deletion inside the poly-A tract) must 3'-shift
+/// to `c.12del` (the rightmost canonical position). The diagnostics surface
+/// records the shift via a single [`NormalizationInfo::ShuffleApplied`]
+/// with `direction = ThreePrime`.
+#[test]
+fn shuffle_emits_info_on_homopolymer_three_prime() {
+    let normalizer = Normalizer::new(provider_with_polya());
+    let variant = parse_hgvs("NM_POLYA.1:c.4del").expect("parse c.4del");
+
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize c.4del");
+
+    let display = format!("{}", result.result);
+    assert!(
+        display.ends_with(":c.12del"),
+        "expected shuffle to land on c.12del; got {display:?}",
+    );
+
+    assert_eq!(
+        result.infos.len(),
+        1,
+        "expected one info code for the shift; got {:?}",
+        result.infos.iter().map(|i| i.code()).collect::<Vec<_>>(),
+    );
+    let info = &result.infos[0];
+    assert_eq!(info.code(), "SHUFFLE_APPLIED");
+    let NormalizationInfo::ShuffleApplied {
+        direction,
+        original_position,
+        normalized_position,
+        ..
+    } = info
+    else {
+        panic!("expected ShuffleApplied, got {info:?}");
+    };
+    assert_eq!(*direction, ShuffleDirection::ThreePrime);
+    assert_eq!(original_position, "4");
+    assert_eq!(normalized_position, "12");
+}
+
+/// 5'-shift configuration: a deletion at the right edge of the poly-A
+/// tract is shuffled leftward to its 5'-most position. The emitted info
+/// must carry `direction = FivePrime` so callers can interpret the
+/// signal correctly.
+#[test]
+fn shuffle_info_carries_direction_under_five_prime_config() {
+    let config = NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime);
+    let normalizer = Normalizer::with_config(provider_with_polya(), config);
+    let variant = parse_hgvs("NM_POLYA.1:c.12del").expect("parse c.12del");
+
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize c.12del under 5'-shift");
+
+    let display = format!("{}", result.result);
+    assert!(
+        display.ends_with(":c.4del"),
+        "expected 5'-shuffle to land on c.4del; got {display:?}",
+    );
+
+    assert_eq!(result.infos.len(), 1, "one info expected");
+    let NormalizationInfo::ShuffleApplied {
+        direction,
+        original_position,
+        normalized_position,
+        ..
+    } = &result.infos[0]
+    else {
+        panic!("expected ShuffleApplied, got {:?}", result.infos[0]);
+    };
+    assert_eq!(
+        *direction,
+        ShuffleDirection::FivePrime,
+        "info must record the configured direction, not assume 3'",
+    );
+    assert_eq!(original_position, "12");
+    assert_eq!(normalized_position, "4");
+}
+
+/// Multi-position spans (`c.4_5del` inside a poly-A run) shuffle as a
+/// unit. The diagnostics surface records the span move, with
+/// `original_position` and `normalized_position` carrying the multi-base
+/// `start_end` form.
+#[test]
+fn shuffle_info_for_multi_position_span() {
+    let normalizer = Normalizer::new(provider_with_polya());
+    let variant = parse_hgvs("NM_POLYA.1:c.4_5del").expect("parse c.4_5del");
+
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize c.4_5del");
+
+    let display = format!("{}", result.result);
+    assert!(
+        display.ends_with(":c.11_12del"),
+        "expected 3'-shuffle to land on c.11_12del; got {display:?}",
+    );
+
+    assert_eq!(result.infos.len(), 1);
+    let NormalizationInfo::ShuffleApplied {
+        original_position,
+        normalized_position,
+        ..
+    } = &result.infos[0]
+    else {
+        panic!("expected ShuffleApplied, got {:?}", result.infos[0]);
+    };
+    assert_eq!(original_position, "4_5");
+    assert_eq!(normalized_position, "11_12");
+}
+
+/// `c.3G>C` on a unique position cannot shuffle (substitutions don't
+/// shift, and the position is unique anyway). The diagnostics surface
+/// must report an empty `infos` list.
+#[test]
+fn no_info_when_variant_is_already_canonical() {
+    let normalizer = Normalizer::new(provider_with_polya());
+    let variant = parse_hgvs("NM_POLYA.1:c.3G>C").expect("parse c.3G>C");
+
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize c.3G>C");
+
+    assert!(
+        result.infos.is_empty(),
+        "expected empty infos for canonical input; got {:?}",
+        result.infos.iter().map(|i| i.code()).collect::<Vec<_>>(),
+    );
+}
+
+/// `Normalizer::normalize()` (the non-`with_warnings` entry point)
+/// returns only the normalized variant; infos are intentionally
+/// discarded. Callers that need the diagnostic surface must use
+/// `normalize_with_warnings`. Pin this contract so a future refactor
+/// doesn't accidentally surface infos through the bare `normalize()`
+/// return type.
+#[test]
+fn normalize_without_warnings_discards_infos_by_design() {
+    let normalizer = Normalizer::new(provider_with_polya());
+    let variant = parse_hgvs("NM_POLYA.1:c.4del").expect("parse c.4del");
+
+    // Bare normalize returns just HgvsVariant — no infos surface.
+    let normalized = normalizer.normalize(&variant).expect("normalize c.4del");
+    // Sanity: the shuffle still happened.
+    let display = format!("{}", normalized);
+    assert!(
+        display.ends_with(":c.12del"),
+        "shuffle should still apply via bare normalize; got {display:?}",
+    );
+
+    // And the with_warnings entry point is the only path that surfaces
+    // the info.
+    let detailed = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize_with_warnings c.4del");
+    assert_eq!(detailed.infos.len(), 1);
+}
+
+/// `NormalizationInfo::code()` returns a stable identifier suitable for
+/// programmatic dispatch. Pin the spelling so downstream callers can match
+/// on it without depending on `Debug` repr.
+#[test]
+fn info_code_is_stable_identifier() {
+    let info = NormalizationInfo::ShuffleApplied {
+        message: "moved".to_string(),
+        accession: "NM_POLYA.1".to_string(),
+        direction: ShuffleDirection::ThreePrime,
+        original_position: "4".to_string(),
+        normalized_position: "12".to_string(),
+    };
+    assert_eq!(info.code(), "SHUFFLE_APPLIED");
+    assert_eq!(info.message(), "moved");
+}

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -463,6 +463,15 @@ fn map_mutalyzer_code(code: &str) -> Option<&'static str> {
     ferro_hgvs::error_handling::mutalyzer_to_ferro(code).map(|t| t.debug_tag())
 }
 
+/// Map a mutalyzer info code (`I*`) to the `NormalizationInfo::code()`
+/// string emitted by ferro for the equivalent signal. Delegates to
+/// `ferro_hgvs::error_handling::mutalyzer_info_to_ferro`. Unmapped codes
+/// (`None`) name signals ferro intentionally does not emit (see
+/// `info_map::NO_FERRO_INFO_EQUIV`).
+fn map_mutalyzer_info_code(code: &str) -> Option<&'static str> {
+    ferro_hgvs::error_handling::mutalyzer_info_to_ferro(code).map(|t| t.code())
+}
+
 // ----------------------------------------------------------------------------
 // Smoke tests
 // ----------------------------------------------------------------------------
@@ -780,10 +789,10 @@ fn axis_errors() {
 
 #[test]
 fn axis_infos() {
-    if manifest_path().is_none() {
+    let Some(normalizer) = normalizer() else {
         eprintln!("axis_infos: skipping — no manifest");
         return;
-    }
+    };
 
     let mut t = AxisTally::new("infos");
     for case in &fixture().cases {
@@ -794,10 +803,81 @@ fn axis_infos() {
             t.skipped += 1;
             continue;
         };
-        let expected = expected_list.join(",");
-        let actual: Result<String, String> =
-            Err("ferro-hgvs info-code surface not yet wired into this runner".to_string());
-        t.record(case, &expected, actual);
+        let expected_repr = expected_list.join(",");
+
+        let actual = catch_panics(|| -> Result<String, String> {
+            // Translate each expected mutalyzer info code into the
+            // corresponding ferro `NormalizationInfo::code()` string.
+            // Codes ferro intentionally does not model (see
+            // `info_map::NO_FERRO_INFO_EQUIV`) come back as `None`, which
+            // is a real FAIL — ferro cannot match the upstream signal.
+            let mapped: Vec<&str> = expected_list
+                .iter()
+                .map(|c| map_mutalyzer_info_code(c).unwrap_or("<unmapped>"))
+                .collect();
+            if mapped.contains(&"<unmapped>") {
+                return Err(format!(
+                    "no ferro equivalent for one of {expected_list:?} (info-axis)"
+                ));
+            }
+
+            let v = parse_hgvs(&case.input).map_err(|e| format!("parse error: {e:?}"))?;
+            let result = normalizer
+                .normalize_with_warnings(&v)
+                .map_err(|e| format!("normalize error: {e:?}"))?;
+            let emitted: Vec<&str> = result.infos.iter().map(|i| i.code()).collect();
+
+            // Empty expected list ⇒ ferro must also emit nothing. Without
+            // this check the trivial "loop over empty mapped" path passes
+            // every case, even if ferro spuriously emitted infos.
+            if expected_list.is_empty() {
+                if emitted.is_empty() {
+                    return Ok(expected_repr.clone());
+                }
+                return Err(format!(
+                    "mutalyzer expected no infos; ferro emitted {emitted:?}"
+                ));
+            }
+
+            // Compare per-code multiplicities, not just presence. Using
+            // `Vec::contains` would let `[A, A]` pass even when ferro
+            // emits only `[A]` (and vice versa for over-emission). Build
+            // frequency maps over `mapped` and `emitted` so repeated
+            // expected codes require the same number of ferro emissions
+            // and any ferro over-emission is also caught honestly.
+            let mut expected_counts = std::collections::HashMap::<&str, usize>::new();
+            for tag in &mapped {
+                *expected_counts.entry(*tag).or_insert(0) += 1;
+            }
+            let mut emitted_counts = std::collections::HashMap::<&str, usize>::new();
+            for tag in &emitted {
+                *emitted_counts.entry(*tag).or_insert(0) += 1;
+            }
+            for (tag, need) in &expected_counts {
+                let got = emitted_counts.get(tag).copied().unwrap_or(0);
+                if got < *need {
+                    return Err(format!(
+                        "ferro infos {emitted:?} missing expected code {tag:?} x{need} (got {got})"
+                    ));
+                }
+            }
+            // Symmetric over-emission check: any ferro info beyond what
+            // the upstream corpus expected is also a divergence, even
+            // when every expected code is matched. Comparing counts (not
+            // just presence) catches both `[A, A]` vs `[A]` and unknown
+            // extras like `[A, B]` vs `[A]`.
+            for (tag, got) in &emitted_counts {
+                let need = expected_counts.get(tag).copied().unwrap_or(0);
+                if *got > need {
+                    return Err(format!(
+                        "ferro emitted extra info {tag:?} x{got} (expected x{need}) — full emit list {emitted:?}, expected codes {expected_list:?}"
+                    ));
+                }
+            }
+            Ok(expected_repr.clone())
+        });
+
+        t.record(case, &expected_repr, actual);
     }
     t.finish();
 }


### PR DESCRIPTION
## Summary

Adds a structured `infos` axis to the normalizer's diagnostic surface so callers can distinguish "ferro silently shifted your variant per the 3' rule" from "ferro left it alone" without re-comparing strings.

- New `NormalizationInfo` enum with first variant `ThreePrimeShiftApplied { message, accession, original_position, normalized_position }`. Stable identifier via `code()` (e.g. `"THREE_PRIME_SHIFT_APPLIED"`), human-readable text via `message()` — mirrors the existing `NormalizationWarning` API.
- `NormalizeResultWithWarnings` gains an `infos: Vec<NormalizationInfo>` field plus `add_info` / `has_infos` accessors and a `with_diagnostics` constructor. The two existing constructors (`new`, `with_warnings`) keep their signatures and default `infos` to empty.
- Detection happens post-hoc in `normalize_with_warnings`: a free helper compares the input variant's `loc_edit.location` Display text to the output's. If they differ for a shuffle-eligible nucleic-acid axis (g/c/n/r/m/o), a single `ThreePrimeShiftApplied` info fires. Compound alleles emit one info per shifted bracket member, preserving order; bracket-length mismatches (the merge layer combined/split members) are conservative no-ops.
- New `src/error_handling/info_map.rs` mirrors `mutalyzer_map.rs` for the `I*` info-code axis at the pinned upstream commit. `mutalyzer_info_to_ferro("ICORRECTEDPOINT")` → `FerroInfoTag` whose `code()` is `"THREE_PRIME_SHIFT_APPLIED"`. The remaining eight upstream codes are classified into `NO_FERRO_INFO_EQUIV` with per-entry rationale (LRG handling, auto coordinate-system inference, mRNA→g. tip suggestions, etc.); ferro does not currently emit structured signals for those.
- The mutalyzer corpus runner's `axis_infos` test is wired (was stubbed with `Err("ferro-hgvs info-code surface not yet wired into this runner")`). For each case with expected `infos`, the runner maps every expected mutalyzer code through `mutalyzer_info_to_ferro` and asserts the resulting ferro code appears in `result.infos`. Cases that mix ferro-supported and ferro-unsupported expected codes FAIL honestly via `no ferro equivalent for one of [...]` instead of the previous blanket runner stub.

## Tests

- New `tests/issue_330_info_code_surface.rs` (3 tests): `c.4del` on a poly-A tract emits a single `ThreePrimeShiftApplied` info with `original_position = "4"` / `normalized_position = "12"`; `c.3G>C` on a unique position emits empty infos; `code()`/`message()` return the pinned identifier strings.
- New `info_map` unit tests (4 tests): exhaustiveness over `all_mutalyzer_info_codes()`, parse↔as_str round-trip, unknown-code returns `None`, `ICORRECTEDPOINT` maps exact (non-lossy) to `THREE_PRIME_SHIFT_APPLIED`.
- `axis_infos` runs to PASS when the manifest is absent (the no-fixture skip path). With a manifest, cases expecting only `ICORRECTEDPOINT` will PASS; cases expecting ferro-unsupported codes will FAIL with a structured diagnostic.
- Full suite: 5525/5525 pass (excluding pre-existing corpus baselines as usual).

## Coordination

Stacked on PR #362 (`feat/issue-329-error-code-map`). The new info_map module imports nothing from `mutalyzer_map`, but they live in the same `error_handling/` namespace and share the same exhaustiveness pattern.

## Out of scope

- Emitting additional info codes for the seven NO_FERRO_INFO_EQUIV signals — those require ferro behavior changes (auto coord-system correction, LRG support, etc.) that belong in separate PRs.
- Threading a structured "info" channel through inner `normalize_na_edit`. The post-hoc position comparison is sufficient for the 3'-shift signal; if a future info variant needs intra-pipeline state (e.g. distinguishing "applied at the rule layer" from "post-canonicalization"), the plumbing can be added then.

Closes #330.