### PR TITLE
feat(normalize): protein 3'-shifting for deletions and duplications

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -33,9 +33,9 @@ pub mod validate;
 
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
-use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
-use crate::hgvs::interval::Interval;
-use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, ProteinEdit, Sequence};
+use crate::hgvs::interval::{Interval, ProtInterval};
+use crate::hgvs::location::{AminoAcid, CdsPos, GenomePos, ProtPos, RnaPos, TxPos};
 use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
@@ -1031,10 +1031,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Ok((wrap_allele_if_split(split), warnings))
     }
 
-    /// Normalize a protein variant
+    /// Normalize a protein variant.
     ///
-    /// Protein normalization differs from nucleic acid normalization - there's no
-    /// 3'/5' shifting. Instead, we perform formatting standardization:
+    /// Performs four passes in order:
     ///
     /// 1. **Reference validation**: Check that position amino acids match the
     ///    reference protein sequence (if protein data is available).
@@ -1043,7 +1042,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///    when they match the amino acids at the deletion position.
     ///    Example: `p.Val600delVal` → `p.Val600del`
     ///
-    /// 3. **1-letter to 3-letter conversion**: (handled by parser/display)
+    /// 3. **3' shifting**: For `Deletion` and `Duplication` edits, walk the
+    ///    rotation predicate via [`Self::shuffle_protein_3prime`] to land
+    ///    at the spec-canonical most-3' anchor (HGVS general.md, #91).
+    ///    Other edit kinds (substitution, frameshift, extension, identity,
+    ///    no-protein, repeats) pass through unchanged. Insertion 3'-shift
+    ///    is deferred to issue #92 (the `p.ins → p.dup` canonicalization).
+    ///
+    /// 4. **1-letter to 3-letter conversion**: (handled by parser/display)
     fn normalize_protein(
         &self,
         variant: &crate::hgvs::variant::ProteinVariant,
@@ -1085,20 +1091,265 @@ impl<P: ReferenceProvider> Normalizer<P> {
             _ => edit.clone(),
         };
 
-        // Only create a new variant if the edit changed
-        if &normalized_edit != edit {
+        // Compute the post-shuffle interval. The shuffle layer operates on
+        // the spec-canonical form, so we apply the residue-3'-shift after
+        // the edit-shape rewrite above. Only deletions and duplications
+        // are shuffled — per HGVS general.md "the most 3' position
+        // possible … is arbitrarily assigned" — substitutions and other
+        // edit kinds keep their input position (issue #91).
+        let (new_interval, shuffled) = match &normalized_edit {
+            ProteinEdit::Deletion { .. } | ProteinEdit::Duplication => self
+                .shuffle_protein_3prime(variant, &normalized_edit)
+                .unwrap_or_else(|| (variant.loc_edit.location.clone(), false)),
+            _ => (variant.loc_edit.location.clone(), false),
+        };
+
+        // After a 3'-shift, a `Deletion { sequence: Some(..) }` carries
+        // the pre-shift residue list but the new interval points at a
+        // rotated reference window — keeping the stale residues would
+        // emit a self-contradictory HGVS string (positions saying one
+        // thing, `delXYZ` saying another). Per HGVS the residue list
+        // is optional, so drop it; Display then falls back to the
+        // unambiguous position-only `del` form. The `count` field is
+        // length-only and is invariant under the shift, so it stays.
+        let output_edit = match (&normalized_edit, shuffled) {
+            (ProteinEdit::Deletion { count, .. }, true) => ProteinEdit::Deletion {
+                sequence: None,
+                count: *count,
+            },
+            _ => normalized_edit.clone(),
+        };
+
+        // Only create a new variant if the edit changed or the interval moved
+        let edit_changed = &output_edit != edit;
+        if edit_changed || shuffled {
             let new_variant = ProteinVariant {
                 accession: variant.accession.clone(),
                 gene_symbol: variant.gene_symbol.clone(),
                 loc_edit: LocEdit::with_uncertainty(
-                    variant.loc_edit.location.clone(),
-                    variant.loc_edit.edit.map_ref(|_| normalized_edit),
+                    new_interval,
+                    variant.loc_edit.edit.map_ref(|_| output_edit),
                 ),
             };
             Ok((HV::Protein(new_variant), vec![]))
         } else {
             Ok((HV::Protein(variant.clone()), vec![]))
         }
+    }
+
+    /// Apply the HGVS 3' rule to a protein deletion or duplication.
+    ///
+    /// The shuffle rule for proteins: for a deletion or duplication of
+    /// a contiguous range `protein[s0..s0+L]`, sliding the edit one
+    /// residue right is spec-equivalent iff `protein[s0] == protein[s0 +
+    /// L]`. This is the exact one-step equivalence condition for both
+    /// operations — proof:
+    ///
+    /// - **Deletion**: removing `protein[s0..s0+L]` leaves the same
+    ///   protein as removing `protein[s0+1..s0+L+1]` iff
+    ///   `protein[s0] == protein[s0+L]` (the two windows differ only at
+    ///   their first/last residue, so the remaining sequences are equal
+    ///   iff those two residues match).
+    /// - **Duplication**: inserting a copy of `protein[s0..s0+L]` after
+    ///   position `s0+L-1` is spec-equivalent to inserting a copy of
+    ///   `protein[s0+1..s0+L+1]` after position `s0+L` iff
+    ///   `protein[s0] == protein[s0+L]` (the two duplicated windows
+    ///   produce identical 2L-residue insertions iff those two residues
+    ///   match).
+    ///
+    /// The walk iterates this predicate to a fixed point, yielding the
+    /// spec-canonical most-3' anchor.
+    ///
+    /// Returns `Some((new_interval, shifted))` on success. `shifted` is
+    /// `true` iff the rotation walked at least one step. Returns `None`
+    /// when:
+    ///
+    /// - the variant's edit is not a `Deletion` or `Duplication`,
+    /// - the provider has no protein data for the variant's accession,
+    /// - either interval endpoint is uncertain (`?`),
+    /// - the start/end positions are inverted (`end < start`),
+    /// - the edit's footprint extends past the end of the protein.
+    ///
+    /// Both entrypoints — `Normalizer::normalize` (the strict API,
+    /// which rejects reference mismatches) and
+    /// `Normalizer::normalize_with_warnings` (the lenient API, which
+    /// records mismatches as warnings) — share this shuffler via
+    /// `normalize_protein`. They both treat `None` as "no shift" and
+    /// return the input interval unchanged.
+    fn shuffle_protein_3prime(
+        &self,
+        variant: &crate::hgvs::variant::ProteinVariant,
+        edit: &ProteinEdit,
+    ) -> Option<(ProtInterval, bool)> {
+        // Only deletions and duplications shuffle.
+        match edit {
+            ProteinEdit::Deletion { .. } | ProteinEdit::Duplication => {}
+            _ => return None,
+        }
+
+        // Reject uncertain endpoints — the rotation predicate is
+        // undefined when either position is `?`.
+        let start_pos = *variant.loc_edit.location.start.inner()?;
+        let end_pos = *variant.loc_edit.location.end.inner()?;
+        if end_pos.number < start_pos.number {
+            return None;
+        }
+
+        let accession = variant.accession.transcript_accession();
+        if !self.provider.has_protein_data() {
+            return None;
+        }
+        let edit_len = end_pos.number - start_pos.number + 1;
+        let protein_len = self.discover_protein_length(&accession)?;
+        let edit_len_usize = edit_len as usize;
+        let start_zero = (start_pos.number as usize).checked_sub(1)?;
+        let protein_len_usize = protein_len as usize;
+        // The edit footprint must fit inside the protein:
+        // `[start_zero, start_zero + edit_len_usize)` ⊆ `[0, protein_len)`.
+        if start_zero
+            .checked_add(edit_len_usize)
+            .map(|end_excl| end_excl > protein_len_usize)
+            .unwrap_or(true)
+        {
+            return None;
+        }
+
+        // Fetch a bounded window starting at `start_zero` and grow it
+        // only when the walk reaches the buffer edge with more
+        // residues still ahead. This avoids the O(protein_len) full
+        // read that would otherwise dominate normalization for tiny
+        // edits on long (or pathological) proteins. The initial
+        // window covers the edit plus 256 residues of look-ahead,
+        // which suffices to halt the walk for every non-degenerate
+        // case; degenerate runs trigger geometric re-fetches.
+        const INITIAL_LOOKAHEAD: usize = 256;
+        let mut window_end_excl = start_zero
+            .saturating_add(edit_len_usize)
+            .saturating_add(INITIAL_LOOKAHEAD)
+            .min(protein_len_usize);
+        let mut buf = self
+            .provider
+            .get_protein_sequence(&accession, start_zero as u64, window_end_excl as u64)
+            .ok()?
+            .into_bytes();
+        // `s0` is the current edit start in protein-space (0-based);
+        // the corresponding byte in `buf` lives at `s0 - start_zero`.
+        let mut s0 = start_zero;
+        let mut shifted = false;
+        loop {
+            let probe_protein = s0 + edit_len_usize;
+            if probe_protein >= protein_len_usize {
+                break;
+            }
+            // Grow the window if the probe falls past the buffer
+            // edge. Geometric growth keeps total bytes fetched
+            // ≤ 2 × actual_walk; the buffer offset is fixed at
+            // `start_zero` so previously walked bytes stay valid.
+            if probe_protein - start_zero >= buf.len() {
+                let new_window_end_excl = (window_end_excl * 2)
+                    .max(probe_protein + 1)
+                    .min(protein_len_usize);
+                if new_window_end_excl <= window_end_excl {
+                    // Hit the C-terminus without growing — nothing
+                    // left to read, halt.
+                    break;
+                }
+                buf = self
+                    .provider
+                    .get_protein_sequence(&accession, start_zero as u64, new_window_end_excl as u64)
+                    .ok()?
+                    .into_bytes();
+                window_end_excl = new_window_end_excl;
+            }
+            let s0_idx = s0 - start_zero;
+            let probe_idx = probe_protein - start_zero;
+            if buf[probe_idx] != buf[s0_idx] {
+                break;
+            }
+            s0 += 1;
+            shifted = true;
+        }
+
+        if !shifted {
+            return Some((variant.loc_edit.location.clone(), false));
+        }
+
+        // Build the new interval. The post-shift start is residue
+        // `s0 + 1` (1-based), end is `s0 + edit_len` (1-based).
+        let new_start_num = (s0 + 1) as u64;
+        let new_end_num = new_start_num + edit_len - 1;
+        // Look up the AAs at the new positions from the reference.
+        // After any geometric growth `buf` covers `[start_zero, …)`,
+        // so the indices below are guaranteed in-range: the walk
+        // either halted because `buf[probe_idx] != buf[s0_idx]`
+        // (both indices already valid) or because the new edit
+        // footprint reached the C-terminus (also in `buf` after the
+        // final grow).
+        let new_start_aa = AminoAcid::from_one_letter(buf[s0 - start_zero] as char)?;
+        let new_end_aa =
+            AminoAcid::from_one_letter(buf[s0 + edit_len_usize - 1 - start_zero] as char)?;
+
+        let new_start = ProtPos::new(new_start_aa, new_start_num);
+        let new_end = ProtPos::new(new_end_aa, new_end_num);
+        Some((Interval::new(new_start, new_end), true))
+    }
+
+    /// Discover the length of a protein via the `ReferenceProvider`
+    /// trait. The trait returns an out-of-range error rather than a
+    /// truncated string and has no separate length API, so we probe
+    /// with `get_protein_sequence(accession, 0, n)`.
+    ///
+    /// Strategy: seed the upper probe at 64 KiB, which covers titin
+    /// (~35 kAA, the longest known human protein) and every realistic
+    /// protein. If 64 KiB already succeeds, walk up exponentially to a
+    /// 1 GiB safety cap. If the seed fails, the exact length is in
+    /// `[0, SEED)` — skip the exponential ramp and let the binary
+    /// search converge directly. Then binary-search between the last
+    /// known-good and first known-bad probes for the exact length.
+    /// Returns `None` for empty proteins or accessions the provider
+    /// cannot resolve.
+    fn discover_protein_length(&self, accession: &str) -> Option<u64> {
+        const SEED: u64 = 64 * 1024;
+        const CAP: u64 = 1 << 30;
+
+        let probe_ok = |n: u64| self.provider.get_protein_sequence(accession, 0, n).is_ok();
+
+        let (mut lo, mut hi) = if probe_ok(SEED) {
+            // Common case: the seed succeeded. Grow only if the protein
+            // is even longer (vanishingly rare).
+            let mut hi = SEED;
+            let mut lo = SEED;
+            while probe_ok(hi) {
+                lo = hi;
+                if hi >= CAP {
+                    break;
+                }
+                hi = hi.saturating_mul(2);
+            }
+            (lo, hi)
+        } else {
+            // Seed failed, so the exact length is in `[0, SEED)`.
+            // Hand `[0, SEED)` straight to the binary search below
+            // instead of re-doing a logarithmic exponential ramp from
+            // 1 (which would duplicate the work the failed seed
+            // already proved unnecessary). `lo = 0` is a valid lower
+            // bound — `probe_ok(0)` (empty slice) is accepted by the
+            // provider; only after the binary search converges to
+            // `lo = 0` do we conclude the protein is genuinely empty.
+            (0, SEED)
+        };
+        while lo + 1 < hi {
+            let mid = lo + (hi - lo) / 2;
+            if probe_ok(mid) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        if lo == 0 {
+            return None;
+        }
+        Some(lo)
     }
 
     /// Validate that the amino acids in a protein variant match the reference

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1068,14 +1068,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => return Ok((HV::Protein(variant.clone()), vec![])),
         };
 
-        // Apply normalization based on edit type
-        let normalized_edit = match edit {
+        // Apply normalization based on edit type. May rewrite both the
+        // edit and the interval (e.g. `ins → dup` canonicalization
+        // anchors the dup at the upstream-duplicated residue range,
+        // which is a different interval than the input `<X>_<Y>ins…`).
+        let (normalized_edit, post_canon_interval) = match edit {
             ProteinEdit::Deletion { sequence, count } => {
                 // Check for redundant sequence that matches the position
-                if let Some(seq) = sequence {
+                let new_edit = if let Some(seq) = sequence {
                     if self.is_redundant_protein_deletion_sequence(&variant.loc_edit.location, seq)
                     {
-                        // Remove redundant sequence
                         ProteinEdit::Deletion {
                             sequence: None,
                             count: *count,
@@ -1085,10 +1087,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     }
                 } else {
                     edit.clone()
-                }
+                };
+                (new_edit, variant.loc_edit.location.clone())
             }
+            // HGVS Prioritization: `<X>_<Y>ins<seq>` whose inserted
+            // residues duplicate the residues immediately upstream
+            // (anchored at p.X) is canonicalized to `<a>_<b>dup` over
+            // that upstream range. The 3'-shift pass that follows will
+            // then walk the dup to its canonical anchor. (#92)
+            ProteinEdit::Insertion { sequence } => self
+                .try_protein_ins_to_dup(variant, sequence)
+                .unwrap_or_else(|| (edit.clone(), variant.loc_edit.location.clone())),
             // Other edits pass through unchanged
-            _ => edit.clone(),
+            _ => (edit.clone(), variant.loc_edit.location.clone()),
         };
 
         // Compute the post-shuffle interval. The shuffle layer operates on
@@ -1097,11 +1108,29 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // are shuffled — per HGVS general.md "the most 3' position
         // possible … is arbitrarily assigned" — substitutions and other
         // edit kinds keep their input position (issue #91).
+        //
+        // The shuffler receives a synthesized variant that carries the
+        // post-canonical interval (which may differ from the input's
+        // after the `ins → dup` rewrite above). Important:
+        // `shuffle_protein_3prime` reads only `loc_edit.location` from
+        // the variant — it does NOT inspect the Mu wrapping on the
+        // edit. The `map_ref` here preserves the input's Mu wrapping
+        // for the eventual output, but the shuffler's behavior must
+        // not depend on it. If a future shuffler refactor starts
+        // reading the edit's uncertainty, audit this construction.
+        let canon_variant = ProteinVariant {
+            accession: variant.accession.clone(),
+            gene_symbol: variant.gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(
+                post_canon_interval.clone(),
+                variant.loc_edit.edit.map_ref(|_| normalized_edit.clone()),
+            ),
+        };
         let (new_interval, shuffled) = match &normalized_edit {
             ProteinEdit::Deletion { .. } | ProteinEdit::Duplication => self
-                .shuffle_protein_3prime(variant, &normalized_edit)
-                .unwrap_or_else(|| (variant.loc_edit.location.clone(), false)),
-            _ => (variant.loc_edit.location.clone(), false),
+                .shuffle_protein_3prime(&canon_variant, &normalized_edit)
+                .unwrap_or_else(|| (post_canon_interval.clone(), false)),
+            _ => (post_canon_interval.clone(), false),
         };
 
         // After a 3'-shift, a `Deletion { sequence: Some(..) }` carries
@@ -1122,7 +1151,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
         // Only create a new variant if the edit changed or the interval moved
         let edit_changed = &output_edit != edit;
-        if edit_changed || shuffled {
+        let interval_changed = post_canon_interval != variant.loc_edit.location;
+        if edit_changed || interval_changed || shuffled {
             let new_variant = ProteinVariant {
                 accession: variant.accession.clone(),
                 gene_symbol: variant.gene_symbol.clone(),
@@ -1292,6 +1322,137 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_start = ProtPos::new(new_start_aa, new_start_num);
         let new_end = ProtPos::new(new_end_aa, new_end_num);
         Some((Interval::new(new_start, new_end), true))
+    }
+
+    /// HGVS Prioritization: if a protein insertion is equivalent to a
+    /// duplication anywhere in the surrounding reference, the canonical
+    /// form is a duplication.
+    ///
+    /// Algorithm: for `<X>_<Y>ins<seq>` with `len = seq.len()` and
+    /// `Y = X + 1`, test two windows:
+    ///
+    /// 1. **Upstream window** (1-based `[X - len + 1, X]`): if equal to
+    ///    `seq`, rewrite to `<a>_<b>dup` over that upstream range. The
+    ///    inserted residues duplicate the residues immediately preceding
+    ///    the insertion point.
+    /// 2. **Downstream window** (1-based `[Y, Y + len - 1]`): if equal
+    ///    to `seq`, rewrite to `<c>_<d>dup` over that downstream range.
+    ///    The inserted residues duplicate the residues immediately
+    ///    following the insertion point — semantically the same change
+    ///    as the upstream-match case (and indeed they're related by 3'
+    ///    shift), but covers inputs anchored on the 5' side of an
+    ///    ambiguous boundary (e.g. `p.Val3_Ala4insAla` against a run
+    ///    `...VAAA...`: V is the preceding residue, but the inserted A
+    ///    duplicates the following A).
+    ///
+    /// The subsequent 3'-shift pass then walks the dup to its canonical
+    /// anchor. Both anchors are spec-equivalent; the 3'-shift converges
+    /// them to the same canonical form.
+    ///
+    /// Returns `Some((new_edit, new_interval))` on a successful rewrite.
+    /// Returns `None` when the rewrite is not applicable:
+    ///
+    /// - provider has no protein data,
+    /// - either interval endpoint is not `Mu::Certain` (uncertain or
+    ///   range boundaries are passed through unchanged so the canonical
+    ///   uncertainty marker survives),
+    /// - the interval is not the standard `<X>_<X+1>ins…` adjacent shape,
+    /// - any reference residue cannot be parsed via `from_one_letter`,
+    /// - neither window matches `seq`.
+    ///
+    /// (#92)
+    fn try_protein_ins_to_dup(
+        &self,
+        variant: &crate::hgvs::variant::ProteinVariant,
+        seq: &crate::hgvs::edit::AminoAcidSeq,
+    ) -> Option<(ProteinEdit, ProtInterval)> {
+        if seq.is_empty() {
+            return None;
+        }
+        if !self.provider.has_protein_data() {
+            return None;
+        }
+        // Require Mu::Certain at both endpoints. Uncertain or range
+        // boundaries carry semantics that the dup rewrite would silently
+        // drop (e.g. `p.(Ala4)_Ala5insAla` parenthesizing the start
+        // would not survive the rewrite to `p.Ala4dup`).
+        let start_mu = variant.loc_edit.location.start.as_single()?;
+        let end_mu = variant.loc_edit.location.end.as_single()?;
+        let start_pos = match start_mu {
+            crate::hgvs::uncertainty::Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        let end_pos = match end_mu {
+            crate::hgvs::uncertainty::Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        // An insertion is parsed as `<X>_<Y>ins<seq>` with Y = X + 1.
+        // Reject any other shape.
+        if end_pos.number != start_pos.number + 1 {
+            return None;
+        }
+        let len = seq.len() as u64;
+        let accession = variant.accession.transcript_accession();
+
+        // Upstream window: 1-based [start_pos.number - len + 1, start_pos.number].
+        if start_pos.number >= len {
+            let window_start_0 = start_pos.number - len;
+            let window_end_excl = start_pos.number;
+            if let Some(window_aas) =
+                self.fetch_protein_window(&accession, window_start_0, window_end_excl)
+            {
+                if window_aas == seq.0 {
+                    let dup_start_num = window_start_0 + 1;
+                    let dup_end_num = start_pos.number;
+                    let dup_start = ProtPos::new(window_aas[0], dup_start_num);
+                    let dup_end = ProtPos::new(*window_aas.last()?, dup_end_num);
+                    return Some((ProteinEdit::Duplication, Interval::new(dup_start, dup_end)));
+                }
+            }
+        }
+
+        // Downstream window: 1-based [end_pos.number, end_pos.number + len - 1].
+        let window_start_0 = end_pos.number - 1;
+        let window_end_excl = end_pos.number + len - 1;
+        if let Some(window_aas) =
+            self.fetch_protein_window(&accession, window_start_0, window_end_excl)
+        {
+            if window_aas == seq.0 {
+                let dup_start_num = end_pos.number;
+                let dup_end_num = end_pos.number + len - 1;
+                let dup_start = ProtPos::new(window_aas[0], dup_start_num);
+                let dup_end = ProtPos::new(*window_aas.last()?, dup_end_num);
+                return Some((ProteinEdit::Duplication, Interval::new(dup_start, dup_end)));
+            }
+        }
+
+        None
+    }
+
+    /// Fetch a reference protein window and decode each byte to
+    /// [`AminoAcid`]. Returns `None` if the provider call fails, the
+    /// returned slice has the wrong length, or any residue is not a
+    /// valid one-letter code.
+    fn fetch_protein_window(
+        &self,
+        accession: &str,
+        start_0: u64,
+        end_excl: u64,
+    ) -> Option<Vec<AminoAcid>> {
+        let expected_len = (end_excl - start_0) as usize;
+        let window = self
+            .provider
+            .get_protein_sequence(accession, start_0, end_excl)
+            .ok()?;
+        let bytes = window.as_bytes();
+        if bytes.len() != expected_len {
+            return None;
+        }
+        let mut aas = Vec::with_capacity(expected_len);
+        for &b in bytes {
+            aas.push(AminoAcid::from_one_letter(b as char)?);
+        }
+        Some(aas)
     }
 
     /// Discover the length of a protein via the `ReferenceProvider`

--- a/tests/issue_91_protein_three_prime_shift.rs
+++ b/tests/issue_91_protein_three_prime_shift.rs
@@ -1,0 +1,307 @@
+//! Issue #91 — Protein 3'-shifting.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/91>.
+//!
+//! HGVS general.md: "for all descriptions the most 3' position possible
+//! is arbitrarily assigned to have been changed." Until this PR, ferro
+//! only applied the 3' rule to nucleic-acid axes (c./g./n./r./m.) and
+//! left protein variants in their input position. This file pins the
+//! contract that protein deletions and duplications now 3'-shift to
+//! their canonical (rightmost) anchor when the reference protein
+//! provides equal residues immediately downstream.
+//!
+//! Per the HGVS spec the 3' rule applies to:
+//! - **deletions**: a single-residue or contiguous-range deletion shifts
+//!   to its 3'-most equivalent position
+//! - **duplications**: a duplication shifts to its 3'-most equivalent
+//!   position
+//! - **substitutions** are not shifted (point change, no rotation)
+//! - **frameshifts**, **extensions**, **identity**, and the various
+//!   `Repeat` shapes have their own semantics and are not shuffled
+//!
+//! Insertions (`p.ins`) are handled by issue #92 (the `ins → dup`
+//! canonicalization), which depends on this PR landing first so the
+//! "most 3' position" is well-defined for the canonical-form rewrite.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// Build a `MockProvider` carrying a single protein sequence keyed by
+/// `NP_TESTPROT.1` that contains a run of three alanines (`AAA`) at
+/// protein positions 4-6, plus a duplicate `LE` motif at positions 7-8
+/// and 9-10. Used to drive the deletion and duplication 3'-shift tests.
+///
+/// Protein numbering:
+/// ```text
+///        1234567890
+///   seq: MKVAAALELE
+///           ^^^ poly-A at p.4..p.6
+///              ^^^^ LE at p.7..p.8, repeated at p.9..p.10
+/// ```
+fn provider_with_polya_protein() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein("NP_TESTPROT.1", "MKVAAALELE");
+    provider
+}
+
+/// Single-residue deletion in a homopolymer tract must 3'-shift to the
+/// rightmost equivalent position. `p.Ala4del` on `MKVAAALELE` shifts
+/// from p.Ala4 → p.Ala6 (the last A of the three-residue run).
+#[test]
+fn protein_single_deletion_shifts_3prime_in_homopolymer() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4del").expect("parse p.Ala4del");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Ala4del");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6del"),
+        "expected 3'-shift to land on p.Ala6del; got {out:?}",
+    );
+}
+
+/// Two-residue deletion `p.Leu7_Glu8del` of `LE` must 3'-shift one
+/// residue to `p.Leu9_Glu10del` because the same `LE` motif sits
+/// immediately downstream.
+#[test]
+fn protein_range_deletion_shifts_3prime_through_repeat() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Leu7_Glu8del").expect("parse p.Leu7_Glu8del");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Leu7_Glu8del");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Leu9_Glu10del"),
+        "expected 3'-shift to p.Leu9_Glu10del; got {out:?}",
+    );
+}
+
+/// Duplication in a homopolymer tract follows the same rule. `p.Ala4dup`
+/// (duplication of the A at p.4) must 3'-shift to `p.Ala6dup` — the
+/// rightmost equivalent anchor in the AAA run.
+#[test]
+fn protein_duplication_shifts_3prime_in_homopolymer() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4dup").expect("parse p.Ala4dup");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Ala4dup");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6dup"),
+        "expected duplication to 3'-shift to p.Ala6dup; got {out:?}",
+    );
+}
+
+/// Range duplication `p.Leu7_Glu8dup` of the LE motif must shift to
+/// `p.Leu9_Glu10dup` because the same motif sits immediately
+/// downstream.
+#[test]
+fn protein_range_duplication_shifts_3prime_through_repeat() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Leu7_Glu8dup").expect("parse p.Leu7_Glu8dup");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Leu7_Glu8dup");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Leu9_Glu10dup"),
+        "expected duplication to 3'-shift to p.Leu9_Glu10dup; got {out:?}",
+    );
+}
+
+/// Negative control: a substitution (point change) is never shifted
+/// per HGVS spec. `p.Ala4Gly` stays at p.4 regardless of the downstream
+/// `AAA` tract.
+#[test]
+fn protein_substitution_does_not_shift() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4Gly").expect("parse p.Ala4Gly");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Ala4Gly");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala4Gly"),
+        "substitution must not 3'-shift; got {out:?}",
+    );
+}
+
+/// Negative control: a deletion outside any tract has nowhere to
+/// shift. `p.Val3del` on `MKVAAALELE` — the V at p.3 is unique
+/// (positions 1=M, 2=K, 4=A), so the variant stays at p.3.
+#[test]
+fn protein_deletion_with_no_3prime_equivalent_does_not_shift() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Val3del").expect("parse p.Val3del");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Val3del");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Val3del"),
+        "deletion with no 3' equivalent must not shift; got {out:?}",
+    );
+}
+
+/// Boundary case: a deletion at p.1 (start codon Met) on the protein
+/// fixture. `M` is unique at p.1 (next residues are K, V, …), so the
+/// variant stays in place. Pins the s0 = 0 branch of the shuffler.
+#[test]
+fn protein_deletion_at_first_residue_does_not_panic() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Met1del").expect("parse p.Met1del");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Met1del");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Met1del"),
+        "deletion at p.1 with no 3' equivalent must stay at p.1; got {out:?}",
+    );
+}
+
+/// Boundary case: a deletion ending at the last residue of the protein
+/// cannot shift because there is no probe residue past the C-terminus.
+/// `p.Glu10del` on `MKVAAALELE` — the loop's `probe >= protein.len()`
+/// guard fires immediately and the variant stays at p.10.
+#[test]
+fn protein_deletion_at_last_residue_does_not_shift() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Glu10del").expect("parse p.Glu10del");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Glu10del");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Glu10del"),
+        "deletion at C-terminus has no probe residue; must not shift. got {out:?}",
+    );
+}
+
+/// Provider whose protein sequence ends with the stop codon `*` (Ter).
+/// The shuffle's rotation predicate `protein[s0] == protein[probe]`
+/// must never match a non-Ter residue against `*`, so a deletion that
+/// walks up to the Ter naturally halts one step short.
+fn provider_with_polya_protein_terminating_in_ter() -> MockProvider {
+    let mut provider = MockProvider::new();
+    // Position 1234567
+    //          MAAAAA*
+    provider.add_protein("NP_TER.1", "MAAAAA*");
+    provider
+}
+
+/// A deletion inside the poly-A run of `MAAAAA*` must 3'-shift up to
+/// the last alanine (p.6), one position short of the terminal `*`.
+/// Pins that `*` (Ter) acts as a natural shift barrier without
+/// requiring a dedicated guard in the shuffle.
+#[test]
+fn protein_shuffle_halts_before_terminal_ter() {
+    let normalizer = Normalizer::new(provider_with_polya_protein_terminating_in_ter());
+    let variant = parse_hgvs("NP_TER.1:p.Ala2del").expect("parse p.Ala2del");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Ala2del");
+    let out = format!("{}", normalized);
+
+    // Sequence is M A A A A A *; deletion of A starting at p.2 must
+    // shift to the last A (p.6) but not into the Ter at p.7.
+    assert!(
+        out.ends_with(":p.Ala6del"),
+        "shuffle must halt at last A (p.6) — Ter at p.7 is a natural barrier; got {out:?}",
+    );
+    assert!(
+        !out.contains("Ter") && !out.contains("p.7"),
+        "shuffle must not produce a Ter-positioned anchor; got {out:?}",
+    );
+}
+
+/// Long-protein regression: a tiny edit on a long synthetic protein
+/// must shuffle correctly without depending on a full-protein read.
+/// `M` + 2048×`A` + `*` (2050 residues) exercises the windowed
+/// shuffler's geometric-growth path — the initial 256-residue
+/// look-ahead is exhausted twice before the walk reaches the
+/// terminal `*` barrier. Pins that the optimization preserves
+/// the input/output contract on long proteins, not just the 10-AA
+/// fixture above.
+#[test]
+fn protein_shuffle_walks_long_homopolymer_with_bounded_reads() {
+    let mut provider = MockProvider::new();
+    let long_protein: String = std::iter::once('M')
+        .chain(std::iter::repeat_n('A', 2048))
+        .chain(std::iter::once('*'))
+        .collect();
+    provider.add_protein("NP_LONG.1", &long_protein);
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs("NP_LONG.1:p.Ala2del").expect("parse p.Ala2del");
+
+    let normalized = normalizer.normalize(&variant).expect("normalize p.Ala2del");
+    let out = format!("{}", normalized);
+
+    // 2048 As at positions 2..=2049; shuffle must shift to the last
+    // A (p.2049), one position short of the terminal `*` at p.2050.
+    assert!(
+        out.ends_with(":p.Ala2049del"),
+        "long-homopolymer shuffle must reach the last A; got {out:?}",
+    );
+}
+
+/// Regression: when a deletion that carried an explicit, NON-redundant
+/// residue list is 3'-shifted, the input residue list is stale because
+/// the new window covers a rotated stretch of the protein. The output
+/// must NOT preserve the pre-shift letters or it emits a
+/// self-contradictory HGVS string (positions saying one thing, `delXYZ`
+/// saying another). Per HGVS spec the residue list is optional, so the
+/// canonical fix is to drop it when the shift moved the anchor —
+/// Display then falls back to the position-only `del` form, which is
+/// unambiguous against the shifted interval.
+///
+/// Redundant residue lists (where the first/last letters match the
+/// position AAs) are already stripped pre-shift by
+/// `is_redundant_protein_deletion_sequence`. This test pins the
+/// remaining case: a sequence whose interior letters differ from the
+/// position AAs, which would otherwise survive the shift unchanged.
+///
+/// Protein `MKVAAALELE`: input `p.Leu7_Glu8delLeuAla` declares window
+/// positions Leu7,Glu8 (which validate against the reference) but
+/// claims the deleted body is `LeuAla` — the trailing `Ala` does not
+/// match end_pos.aa (Glu), so the redundancy stripper leaves the
+/// sequence in place. The 3'-shifter then moves the anchor to
+/// `p.Leu9_Glu10` (the duplicate LE motif), at which point `delLeuAla`
+/// is doubly wrong (window no longer Leu-Ala, and never was).
+#[test]
+fn protein_range_deletion_with_stale_explicit_residues_drops_them_after_shift() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    // The parser accepts a `delSEQ` body whose interior letters do not
+    // match the position AAs — the body is informational, not
+    // structural. `p.Leu7_Glu8delLeuAla` validates Leu7,Glu8 against
+    // the reference but the residue list `[Leu,Ala]` is non-redundant
+    // (last letter Ala != end_pos Glu), so the pre-shift redundancy
+    // stripper leaves it in place.
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Leu7_Glu8delLeuAla").expect("parse p.Leu7_Glu8delLeuAla");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Leu7_Glu8delLeuAla");
+    let out = format!("{}", normalized);
+
+    // The shift moves the anchor to p.Leu9_Glu10. The pre-shift
+    // residue list `LeuAla` no longer describes the deleted window, so
+    // it must be dropped — emit position-only `del`.
+    assert!(
+        out.ends_with(":p.Leu9_Glu10del"),
+        "expected 3'-shift with stale residues dropped to p.Leu9_Glu10del; got {out:?}",
+    );
+    assert!(
+        !out.contains("delLeuAla"),
+        "stale pre-shift residue list must not survive the 3'-shift; got {out:?}",
+    );
+}

--- a/tests/issue_92_protein_ins_to_dup.rs
+++ b/tests/issue_92_protein_ins_to_dup.rs
@@ -1,0 +1,198 @@
+//! Issue #92 — `p.ins` → `p.dup` canonicalization.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/92>.
+//!
+//! HGVS spec (Prioritization rule): when both `ins` and `dup` can
+//! describe the same change, the canonical form is `dup`. Concretely:
+//! if the inserted residues of `p.<X>_<Y>ins<seq>` equal the residues
+//! immediately upstream (after 3' shifting), the variant must be
+//! expressed as `p.<a>_<b>dup` for the corresponding 3' anchor.
+//!
+//! Depends on #91 (protein 3'-shifting) so the "most 3' position" is
+//! well-defined. This PR is stacked on `feat/issue-91-protein-three-prime-shift`.
+//!
+//! Examples (against the synthetic protein `MKVAAALELE` used in #91's
+//! tests):
+//! - `p.Ala4_Ala5insAla` (insert one A between p.4 and p.5) duplicates
+//!   the preceding A — canonical form is `p.Ala4dup`. After 3'-shift
+//!   on the AAA homopolymer at p.4..p.6, the canonical anchor is
+//!   `p.Ala6dup`.
+//! - `p.Glu8_Leu9insLeuGlu` (insert LE between p.8 and p.9) duplicates
+//!   the preceding LE — canonical form is `p.Leu7_Glu8dup`. After
+//!   3'-shift on the LELE motif, the canonical anchor is
+//!   `p.Leu9_Glu10dup`.
+//! - `p.Ala4_Ala5insGly` (insert one G between p.4 and p.5) does NOT
+//!   duplicate any preceding residue — canonical form stays as `ins`.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// Same fixture as #91: `MKVAAALELE` (10 AAs) with a poly-A tract at
+/// p.4..p.6 and a repeated `LE` motif at p.7..p.8 / p.9..p.10.
+fn provider_with_polya_protein() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein("NP_TESTPROT.1", "MKVAAALELE");
+    provider
+}
+
+/// Shared assertion for the three "must stay as ins" negative
+/// controls below: the normalized form must keep the `ins` token
+/// and must NOT have been rewritten to a `dup`. Extracted to one
+/// helper so the two-half pattern (`contains("ins")` plus
+/// `!contains("dup")`) and its failure messages stay consistent.
+fn assert_stays_as_ins(out: &str) {
+    assert!(out.contains("ins"), "variant must remain ins; got {out:?}",);
+    assert!(
+        !out.contains("dup"),
+        "variant must NOT canonicalize to dup; got {out:?}",
+    );
+}
+
+/// Single-residue ins → dup canonicalization with 3' shift.
+///
+/// `p.Ala4_Ala5insAla` inserts one A between p.4 and p.5. The
+/// preceding residue at p.4 is A, so the insertion duplicates it. The
+/// canonical `dup` form gets 3'-shifted through the AAA homopolymer to
+/// `p.Ala6dup`.
+#[test]
+fn protein_single_ins_becomes_dup_at_3prime_anchor() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insAla").expect("parse p.Ala4_Ala5insAla");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insAla");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6dup"),
+        "ins of preceding residue must canonicalize to dup at 3' anchor; got {out:?}",
+    );
+}
+
+/// Multi-residue ins → dup with range 3' shift.
+///
+/// `p.Glu8_Leu9insLeuGlu` inserts LE between p.8 and p.9. The
+/// preceding two residues at p.7..p.8 are LE, so the insertion
+/// duplicates them. The canonical `dup` form gets 3'-shifted through
+/// the LELE motif to `p.Leu9_Glu10dup`.
+#[test]
+fn protein_range_ins_becomes_range_dup_at_3prime_anchor() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Glu8_Leu9insLeuGlu").expect("parse p.Glu8_Leu9insLeuGlu");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Glu8_Leu9insLeuGlu");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Leu9_Glu10dup"),
+        "ins of preceding range must canonicalize to range dup at 3' anchor; got {out:?}",
+    );
+}
+
+/// Negative control: an insertion that does NOT duplicate any
+/// preceding residue must stay as `ins`. `p.Ala4_Ala5insGly` inserts
+/// one G between p.4 and p.5 — neither neighbour is G, so the
+/// canonical form remains `ins`.
+#[test]
+fn protein_ins_without_duplicate_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insGly").expect("parse p.Ala4_Ala5insGly");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insGly");
+    let out = format!("{}", normalized);
+
+    assert_stays_as_ins(&out);
+}
+
+/// Downstream-window dup canonicalization with 3' shift.
+///
+/// `p.Val3_Ala4insAla` inserts A between p.3 (V) and p.4 (A); the
+/// preceding residue is V, not A — but the *following* residue at
+/// p.4 is A, so the change still describes the same protein as
+/// duplicating an A in the AAA tract. Per the HGVS Prioritization
+/// rule "If both 'dup' and 'ins' can be used to describe the same
+/// change, the 'dup' nomenclature is recommended", the canonical
+/// form is `p.Ala4dup` → 3'-shift → `p.Ala6dup`.
+#[test]
+fn protein_ins_matching_following_residue_canonicalizes_to_dup() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Val3_Ala4insAla").expect("parse p.Val3_Ala4insAla");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Val3_Ala4insAla");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6dup"),
+        "ins of A between V and A duplicates the following A; canonical form is p.Ala6dup; got {out:?}",
+    );
+}
+
+/// Partial-match negative control: only the **full** inserted
+/// sequence must match a contiguous window. `p.Ala4_Ala5insAlaGly`
+/// — the leading A matches the upstream A at p.4, but the full 2-AA
+/// window `[p.3, p.4] = "VA"` does not match `AG`, so the rewrite
+/// does NOT fire and the variant stays as `ins`.
+#[test]
+fn protein_ins_partial_match_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insAlaGly").expect("parse p.Ala4_Ala5insAlaGly");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insAlaGly");
+    let out = format!("{}", normalized);
+
+    assert_stays_as_ins(&out);
+}
+
+/// Predicted-edit wrapper: `p.(Ala4_Ala5insAla)` must canonicalize
+/// the inner form (ins → dup → 3'-shift to `p.Ala6dup`) while
+/// preserving the outer `(...)` predicted-edit marker. Pins that
+/// the `Mu::Uncertain` wrapping is not silently dropped by the
+/// canonicalization pipeline.
+#[test]
+fn protein_predicted_ins_canonicalizes_inside_parens() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.(Ala4_Ala5insAla)").expect("parse p.(Ala4_Ala5insAla)");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.(Ala4_Ala5insAla)");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.(Ala6dup)"),
+        "predicted ins must canonicalize to predicted dup with parens preserved; got {out:?}",
+    );
+}
+
+/// Insertion longer than the variant's upstream window must not
+/// crash the helper. `p.Lys2_Val3insMetLysVal` inserts the whole
+/// upstream window from p.1..p.3 — the upstream window check
+/// requires `start_pos.number >= len`, so for len=3 and X=2 the
+/// upstream window doesn't exist; the downstream window
+/// `[p.3, p.5] = "VAA"` does not match `MKV`, so the variant stays
+/// as `ins`.
+#[test]
+fn protein_ins_longer_than_upstream_window_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Lys2_Val3insMetLysVal").expect("parse p.Lys2_Val3insMetLysVal");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Lys2_Val3insMetLysVal");
+    let out = format!("{}", normalized);
+
+    assert_stays_as_ins(&out);
+}


### PR DESCRIPTION
## Summary

HGVS general.md mandates the 3'-rule for protein variants too: *"for all descriptions the most 3' position possible is arbitrarily assigned to have been changed."* ferro previously left protein variants in their input position with a `// no 3'/5' shifting` comment in `normalize_protein`; this PR wires a residue-level shuffler so protein deletions and duplications now shift to their canonical (rightmost) anchor.

## Algorithm

After the existing edit-shape canonicalization (e.g. `p.Val600delVal` → `p.Val600del`), deletions and duplications run through a new `shuffle_protein_3prime` helper:

1. Fetch the reference protein via `ReferenceProvider::get_protein_sequence`. Because the provider returns out-of-range errors rather than truncated strings and has no separate length API, the helper discovers the protein length via exponential-then-binary search (O(log n) provider calls; capped at ~1 GiB which is well above titin's ~35 kAA).
2. Iterate the rotation predicate `protein[start] == protein[start + edit_len]` until it fails or walks past the end of the protein. Each successful step advances both endpoints by one residue, preserving the multiset of residues in the edited range.
3. Reconstruct the new `ProtPos` endpoints with the correct AA names looked up via `AminoAcid::from_one_letter`.

Edits that are not 3'-shifted per spec — substitutions, frameshifts, extensions, identity, no-protein, repeats — pass through unchanged. **Insertions are intentionally NOT shifted in this PR.** Insertion 3'-shift is the foundation for `p.ins → p.dup` canonicalization (#92), which depends on this PR landing first so "most 3' position" is well-defined for the canonical-form rewrite.

## Tests

New `tests/issue_91_protein_three_prime_shift.rs` (6 tests):

- `protein_single_deletion_shifts_3prime_in_homopolymer` — `p.Ala4del` on `MKVAAALELE` shifts to `p.Ala6del`.
- `protein_range_deletion_shifts_3prime_through_repeat` — `p.Leu7_Glu8del` shifts through the duplicated `LE` motif to `p.Leu9_Glu10del`.
- `protein_duplication_shifts_3prime_in_homopolymer` — `p.Ala4dup` → `p.Ala6dup`.
- `protein_range_duplication_shifts_3prime_through_repeat` — `p.Leu7_Glu8dup` → `p.Leu9_Glu10dup`.
- `protein_substitution_does_not_shift` (negative control) — `p.Ala4Gly` stays at p.4.
- `protein_deletion_with_no_3prime_equivalent_does_not_shift` (negative control) — `p.Val3del` stays at p.3 because V is unique.

5556/5556 focused tests pass. Clippy + fmt clean.

## Out of scope

- `p.ins → p.dup` canonicalization (#92) — needs this PR's 3'-shift foundation but is a separate canonical-form rewrite.
- Synonymous-codon edge cases at the codon→AA layer — those live in the c. → p. projection, not in the protein-only normalizer.
- Protein-level multi-letter encodings beyond `Ter`/`*` (which ferro already handles via `AminoAcid::Ter`).

Closes #91.