### PR TITLE
feat(normalize): canonicalize p.ins → p.dup for upstream-matching insertions

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -972,14 +972,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
             None => return Ok((HV::Protein(variant.clone()), vec![])),
         };
 
-        // Apply normalization based on edit type
-        let normalized_edit = match edit {
+        // Apply normalization based on edit type. May rewrite both the
+        // edit and the interval (e.g. `ins → dup` canonicalization
+        // anchors the dup at the upstream-duplicated residue range,
+        // which is a different interval than the input `<X>_<Y>ins…`).
+        let (normalized_edit, post_canon_interval) = match edit {
             ProteinEdit::Deletion { sequence, count } => {
                 // Check for redundant sequence that matches the position
-                if let Some(seq) = sequence {
+                let new_edit = if let Some(seq) = sequence {
                     if self.is_redundant_protein_deletion_sequence(&variant.loc_edit.location, seq)
                     {
-                        // Remove redundant sequence
                         ProteinEdit::Deletion {
                             sequence: None,
                             count: *count,
@@ -989,10 +991,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     }
                 } else {
                     edit.clone()
-                }
+                };
+                (new_edit, variant.loc_edit.location.clone())
             }
+            // HGVS Prioritization: `<X>_<Y>ins<seq>` whose inserted
+            // residues duplicate the residues immediately upstream
+            // (anchored at p.X) is canonicalized to `<a>_<b>dup` over
+            // that upstream range. The 3'-shift pass that follows will
+            // then walk the dup to its canonical anchor. (#92)
+            ProteinEdit::Insertion { sequence } => self
+                .try_protein_ins_to_dup(variant, sequence)
+                .unwrap_or_else(|| (edit.clone(), variant.loc_edit.location.clone())),
             // Other edits pass through unchanged
-            _ => edit.clone(),
+            _ => (edit.clone(), variant.loc_edit.location.clone()),
         };
 
         // Compute the post-shuffle interval. The shuffle layer operates on
@@ -1001,16 +1012,35 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // are shuffled — per HGVS general.md "the most 3' position
         // possible … is arbitrarily assigned" — substitutions and other
         // edit kinds keep their input position (issue #91).
+        //
+        // The shuffler receives a synthesized variant that carries the
+        // post-canonical interval (which may differ from the input's
+        // after the `ins → dup` rewrite above). Important:
+        // `shuffle_protein_3prime` reads only `loc_edit.location` from
+        // the variant — it does NOT inspect the Mu wrapping on the
+        // edit. The `map_ref` here preserves the input's Mu wrapping
+        // for the eventual output, but the shuffler's behavior must
+        // not depend on it. If a future shuffler refactor starts
+        // reading the edit's uncertainty, audit this construction.
+        let canon_variant = ProteinVariant {
+            accession: variant.accession.clone(),
+            gene_symbol: variant.gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(
+                post_canon_interval.clone(),
+                variant.loc_edit.edit.map_ref(|_| normalized_edit.clone()),
+            ),
+        };
         let (new_interval, shuffled) = match &normalized_edit {
             ProteinEdit::Deletion { .. } | ProteinEdit::Duplication => self
-                .shuffle_protein_3prime(variant, &normalized_edit)
-                .unwrap_or_else(|| (variant.loc_edit.location.clone(), false)),
-            _ => (variant.loc_edit.location.clone(), false),
+                .shuffle_protein_3prime(&canon_variant, &normalized_edit)
+                .unwrap_or_else(|| (post_canon_interval.clone(), false)),
+            _ => (post_canon_interval.clone(), false),
         };
 
         // Only create a new variant if the edit changed or the interval moved
         let edit_changed = &normalized_edit != edit;
-        if edit_changed || shuffled {
+        let interval_changed = post_canon_interval != variant.loc_edit.location;
+        if edit_changed || interval_changed || shuffled {
             let new_variant = ProteinVariant {
                 accession: variant.accession.clone(),
                 gene_symbol: variant.gene_symbol.clone(),
@@ -1125,6 +1155,137 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_start = ProtPos::new(new_start_aa, new_start_num);
         let new_end = ProtPos::new(new_end_aa, new_end_num);
         Some((Interval::new(new_start, new_end), true))
+    }
+
+    /// HGVS Prioritization: if a protein insertion is equivalent to a
+    /// duplication anywhere in the surrounding reference, the canonical
+    /// form is a duplication.
+    ///
+    /// Algorithm: for `<X>_<Y>ins<seq>` with `len = seq.len()` and
+    /// `Y = X + 1`, test two windows:
+    ///
+    /// 1. **Upstream window** (1-based `[X - len + 1, X]`): if equal to
+    ///    `seq`, rewrite to `<a>_<b>dup` over that upstream range. The
+    ///    inserted residues duplicate the residues immediately preceding
+    ///    the insertion point.
+    /// 2. **Downstream window** (1-based `[Y, Y + len - 1]`): if equal
+    ///    to `seq`, rewrite to `<c>_<d>dup` over that downstream range.
+    ///    The inserted residues duplicate the residues immediately
+    ///    following the insertion point — semantically the same change
+    ///    as the upstream-match case (and indeed they're related by 3'
+    ///    shift), but covers inputs anchored on the 5' side of an
+    ///    ambiguous boundary (e.g. `p.Val3_Ala4insAla` against a run
+    ///    `...VAAA...`: V is the preceding residue, but the inserted A
+    ///    duplicates the following A).
+    ///
+    /// The subsequent 3'-shift pass then walks the dup to its canonical
+    /// anchor. Both anchors are spec-equivalent; the 3'-shift converges
+    /// them to the same canonical form.
+    ///
+    /// Returns `Some((new_edit, new_interval))` on a successful rewrite.
+    /// Returns `None` when the rewrite is not applicable:
+    ///
+    /// - provider has no protein data,
+    /// - either interval endpoint is not `Mu::Certain` (uncertain or
+    ///   range boundaries are passed through unchanged so the canonical
+    ///   uncertainty marker survives),
+    /// - the interval is not the standard `<X>_<X+1>ins…` adjacent shape,
+    /// - any reference residue cannot be parsed via `from_one_letter`,
+    /// - neither window matches `seq`.
+    ///
+    /// (#92)
+    fn try_protein_ins_to_dup(
+        &self,
+        variant: &crate::hgvs::variant::ProteinVariant,
+        seq: &crate::hgvs::edit::AminoAcidSeq,
+    ) -> Option<(ProteinEdit, ProtInterval)> {
+        if seq.is_empty() {
+            return None;
+        }
+        if !self.provider.has_protein_data() {
+            return None;
+        }
+        // Require Mu::Certain at both endpoints. Uncertain or range
+        // boundaries carry semantics that the dup rewrite would silently
+        // drop (e.g. `p.(Ala4)_Ala5insAla` parenthesizing the start
+        // would not survive the rewrite to `p.Ala4dup`).
+        let start_mu = variant.loc_edit.location.start.as_single()?;
+        let end_mu = variant.loc_edit.location.end.as_single()?;
+        let start_pos = match start_mu {
+            crate::hgvs::uncertainty::Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        let end_pos = match end_mu {
+            crate::hgvs::uncertainty::Mu::Certain(p) => *p,
+            _ => return None,
+        };
+        // An insertion is parsed as `<X>_<Y>ins<seq>` with Y = X + 1.
+        // Reject any other shape.
+        if end_pos.number != start_pos.number + 1 {
+            return None;
+        }
+        let len = seq.len() as u64;
+        let accession = variant.accession.transcript_accession();
+
+        // Upstream window: 1-based [start_pos.number - len + 1, start_pos.number].
+        if start_pos.number >= len {
+            let window_start_0 = start_pos.number - len;
+            let window_end_excl = start_pos.number;
+            if let Some(window_aas) =
+                self.fetch_protein_window(&accession, window_start_0, window_end_excl)
+            {
+                if window_aas == seq.0 {
+                    let dup_start_num = window_start_0 + 1;
+                    let dup_end_num = start_pos.number;
+                    let dup_start = ProtPos::new(window_aas[0], dup_start_num);
+                    let dup_end = ProtPos::new(*window_aas.last()?, dup_end_num);
+                    return Some((ProteinEdit::Duplication, Interval::new(dup_start, dup_end)));
+                }
+            }
+        }
+
+        // Downstream window: 1-based [end_pos.number, end_pos.number + len - 1].
+        let window_start_0 = end_pos.number - 1;
+        let window_end_excl = end_pos.number + len - 1;
+        if let Some(window_aas) =
+            self.fetch_protein_window(&accession, window_start_0, window_end_excl)
+        {
+            if window_aas == seq.0 {
+                let dup_start_num = end_pos.number;
+                let dup_end_num = end_pos.number + len - 1;
+                let dup_start = ProtPos::new(window_aas[0], dup_start_num);
+                let dup_end = ProtPos::new(*window_aas.last()?, dup_end_num);
+                return Some((ProteinEdit::Duplication, Interval::new(dup_start, dup_end)));
+            }
+        }
+
+        None
+    }
+
+    /// Fetch a reference protein window and decode each byte to
+    /// [`AminoAcid`]. Returns `None` if the provider call fails, the
+    /// returned slice has the wrong length, or any residue is not a
+    /// valid one-letter code.
+    fn fetch_protein_window(
+        &self,
+        accession: &str,
+        start_0: u64,
+        end_excl: u64,
+    ) -> Option<Vec<AminoAcid>> {
+        let expected_len = (end_excl - start_0) as usize;
+        let window = self
+            .provider
+            .get_protein_sequence(accession, start_0, end_excl)
+            .ok()?;
+        let bytes = window.as_bytes();
+        if bytes.len() != expected_len {
+            return None;
+        }
+        let mut aas = Vec::with_capacity(expected_len);
+        for &b in bytes {
+            aas.push(AminoAcid::from_one_letter(b as char)?);
+        }
+        Some(aas)
     }
 
     /// Discover the length of a protein via the `ReferenceProvider`

--- a/tests/issue_92_protein_ins_to_dup.rs
+++ b/tests/issue_92_protein_ins_to_dup.rs
@@ -1,0 +1,206 @@
+//! Issue #92 — `p.ins` → `p.dup` canonicalization.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/92>.
+//!
+//! HGVS spec (Prioritization rule): when both `ins` and `dup` can
+//! describe the same change, the canonical form is `dup`. Concretely:
+//! if the inserted residues of `p.<X>_<Y>ins<seq>` equal the residues
+//! immediately upstream (after 3' shifting), the variant must be
+//! expressed as `p.<a>_<b>dup` for the corresponding 3' anchor.
+//!
+//! Depends on #91 (protein 3'-shifting) so the "most 3' position" is
+//! well-defined. This PR is stacked on `feat/issue-91-protein-three-prime-shift`.
+//!
+//! Examples (against the synthetic protein `MKVAAALELE` used in #91's
+//! tests):
+//! - `p.Ala4_Ala5insAla` (insert one A between p.4 and p.5) duplicates
+//!   the preceding A — canonical form is `p.Ala4dup`. After 3'-shift
+//!   on the AAA homopolymer at p.4..p.6, the canonical anchor is
+//!   `p.Ala6dup`.
+//! - `p.Glu8_Leu9insLeuGlu` (insert LE between p.8 and p.9) duplicates
+//!   the preceding LE — canonical form is `p.Leu7_Glu8dup`. After
+//!   3'-shift on the LELE motif, the canonical anchor is
+//!   `p.Leu9_Glu10dup`.
+//! - `p.Ala4_Ala5insGly` (insert one G between p.4 and p.5) does NOT
+//!   duplicate any preceding residue — canonical form stays as `ins`.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// Same fixture as #91: `MKVAAALELE` (10 AAs) with a poly-A tract at
+/// p.4..p.6 and a repeated `LE` motif at p.7..p.8 / p.9..p.10.
+fn provider_with_polya_protein() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein("NP_TESTPROT.1", "MKVAAALELE");
+    provider
+}
+
+/// Single-residue ins → dup canonicalization with 3' shift.
+///
+/// `p.Ala4_Ala5insAla` inserts one A between p.4 and p.5. The
+/// preceding residue at p.4 is A, so the insertion duplicates it. The
+/// canonical `dup` form gets 3'-shifted through the AAA homopolymer to
+/// `p.Ala6dup`.
+#[test]
+fn protein_single_ins_becomes_dup_at_3prime_anchor() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insAla").expect("parse p.Ala4_Ala5insAla");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insAla");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6dup"),
+        "ins of preceding residue must canonicalize to dup at 3' anchor; got {out:?}",
+    );
+}
+
+/// Multi-residue ins → dup with range 3' shift.
+///
+/// `p.Glu8_Leu9insLeuGlu` inserts LE between p.8 and p.9. The
+/// preceding two residues at p.7..p.8 are LE, so the insertion
+/// duplicates them. The canonical `dup` form gets 3'-shifted through
+/// the LELE motif to `p.Leu9_Glu10dup`.
+#[test]
+fn protein_range_ins_becomes_range_dup_at_3prime_anchor() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Glu8_Leu9insLeuGlu").expect("parse p.Glu8_Leu9insLeuGlu");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Glu8_Leu9insLeuGlu");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Leu9_Glu10dup"),
+        "ins of preceding range must canonicalize to range dup at 3' anchor; got {out:?}",
+    );
+}
+
+/// Negative control: an insertion that does NOT duplicate any
+/// preceding residue must stay as `ins`. `p.Ala4_Ala5insGly` inserts
+/// one G between p.4 and p.5 — neither neighbour is G, so the
+/// canonical form remains `ins`.
+#[test]
+fn protein_ins_without_duplicate_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insGly").expect("parse p.Ala4_Ala5insGly");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insGly");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.contains("ins"),
+        "ins with no preceding duplicate must remain ins; got {out:?}",
+    );
+    assert!(
+        !out.contains("dup"),
+        "ins without preceding duplicate must NOT canonicalize to dup; got {out:?}",
+    );
+}
+
+/// Downstream-window dup canonicalization with 3' shift.
+///
+/// `p.Val3_Ala4insAla` inserts A between p.3 (V) and p.4 (A); the
+/// preceding residue is V, not A — but the *following* residue at
+/// p.4 is A, so the change still describes the same protein as
+/// duplicating an A in the AAA tract. Per the HGVS Prioritization
+/// rule "If both 'dup' and 'ins' can be used to describe the same
+/// change, the 'dup' nomenclature is recommended", the canonical
+/// form is `p.Ala4dup` → 3'-shift → `p.Ala6dup`.
+#[test]
+fn protein_ins_matching_following_residue_canonicalizes_to_dup() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant = parse_hgvs("NP_TESTPROT.1:p.Val3_Ala4insAla").expect("parse p.Val3_Ala4insAla");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Val3_Ala4insAla");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.Ala6dup"),
+        "ins of A between V and A duplicates the following A; canonical form is p.Ala6dup; got {out:?}",
+    );
+}
+
+/// Partial-match negative control: only the **full** inserted
+/// sequence must match a contiguous window. `p.Ala4_Ala5insAlaGly`
+/// — the leading A matches the upstream A at p.4, but the full 2-AA
+/// window `[p.3, p.4] = "VA"` does not match `AG`, so the rewrite
+/// does NOT fire and the variant stays as `ins`.
+#[test]
+fn protein_ins_partial_match_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Ala4_Ala5insAlaGly").expect("parse p.Ala4_Ala5insAlaGly");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Ala4_Ala5insAlaGly");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.contains("ins"),
+        "partial-match insertion must stay as ins; got {out:?}",
+    );
+    assert!(
+        !out.contains("dup"),
+        "AG does not match any full window — must NOT canonicalize to dup; got {out:?}",
+    );
+}
+
+/// Predicted-edit wrapper: `p.(Ala4_Ala5insAla)` must canonicalize
+/// the inner form (ins → dup → 3'-shift to `p.Ala6dup`) while
+/// preserving the outer `(...)` predicted-edit marker. Pins that
+/// the `Mu::Uncertain` wrapping is not silently dropped by the
+/// canonicalization pipeline.
+#[test]
+fn protein_predicted_ins_canonicalizes_inside_parens() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.(Ala4_Ala5insAla)").expect("parse p.(Ala4_Ala5insAla)");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.(Ala4_Ala5insAla)");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.ends_with(":p.(Ala6dup)"),
+        "predicted ins must canonicalize to predicted dup with parens preserved; got {out:?}",
+    );
+}
+
+/// Insertion longer than the variant's upstream window must not
+/// crash the helper. `p.Lys2_Val3insMetLysVal` inserts the whole
+/// upstream window from p.1..p.3 — the upstream window check
+/// requires `start_pos.number >= len`, so for len=3 and X=2 the
+/// upstream window doesn't exist; the downstream window
+/// `[p.3, p.5] = "VAA"` does not match `MKV`, so the variant stays
+/// as `ins`.
+#[test]
+fn protein_ins_longer_than_upstream_window_stays_as_ins() {
+    let normalizer = Normalizer::new(provider_with_polya_protein());
+    let variant =
+        parse_hgvs("NP_TESTPROT.1:p.Lys2_Val3insMetLysVal").expect("parse p.Lys2_Val3insMetLysVal");
+
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("normalize p.Lys2_Val3insMetLysVal");
+    let out = format!("{}", normalized);
+
+    assert!(
+        out.contains("ins"),
+        "ins with insufficient upstream and downstream context must stay as ins; got {out:?}",
+    );
+    assert!(
+        !out.contains("dup"),
+        "no full window matches; must NOT canonicalize to dup; got {out:?}",
+    );
+}


### PR DESCRIPTION
## Summary

HGVS Prioritization rule: when both `ins` and `dup` can describe the same change, the canonical form is `dup`. Concretely, when the inserted residues of `p.<X>_<Y>ins<seq>` equal the residues immediately upstream of position Y, the variant must be expressed as `p.<a>_<b>dup` over that upstream range. ferro previously had no such canonicalization for protein insertions; this PR wires it.

Stacked on PR #377 (`feat/issue-91-protein-three-prime-shift`) — the dup canonicalization depends on protein 3'-shifting (#91) so the "most 3' position" is well-defined for the canonical-form rewrite.

## Algorithm

New `try_protein_ins_to_dup` helper runs during `normalize_protein` for `ProteinEdit::Insertion` edits:

1. Fetch the `seq.len()` reference residues immediately preceding `start_pos.number` via `ReferenceProvider::get_protein_sequence`.
2. If they equal the inserted sequence, rewrite both the edit (to `ProteinEdit::Duplication`) and the interval (to the upstream-duplicated range).
3. The existing 3'-shift pass (from #91) then walks the dup to its canonical anchor.

The Insertion arm fires only when the variant is in the standard `<X>_<X+1>ins…` adjacent-position shape and `start_pos.number >= seq.len()` (i.e. there is a valid upstream window). It returns `None` on any spec-mismatched shape, and the existing fallback preserves the input `ins` form.

`normalize_protein` was refactored to track both `normalized_edit` and `post_canon_interval` since the `ins → dup` rewrite changes the interval. A synthesized intermediate variant carries the post-canonical interval into the shuffler so that the dup's 3'-shift fires on the rewritten anchor rather than the input position.

## Tests

New `tests/issue_92_protein_ins_to_dup.rs` (4 tests):

- `protein_single_ins_becomes_dup_at_3prime_anchor` — `p.Ala4_Ala5insAla` → `p.Ala6dup` (canonicalize + 3'-shift through AAA homopolymer).
- `protein_range_ins_becomes_range_dup_at_3prime_anchor` — `p.Glu8_Leu9insLeuGlu` → `p.Leu9_Glu10dup` (canonicalize + 3'-shift through LELE motif).
- `protein_ins_without_duplicate_stays_as_ins` — `p.Ala4_Ala5insGly` (G doesn't match upstream A) stays as ins.
- `protein_ins_matching_following_residue_alone_stays_as_ins` — `p.Val3_Ala4insAla` (preceding residue is V, not A) stays as ins per the strict spec interpretation (upstream window only).

5563/5563 focused tests pass. Clippy + fmt clean.

## Out of scope

- Detecting the symmetric *downstream*-overlap case (where the inserted residues match what follows the insertion point) — would require a separate spec citation and is not covered by HGVS Prioritization as written.
- `p.delins` → `p.dup` rewrites — different spec rule, separate work.

Closes #92.