### PR TITLE
feat(project): VariantProjector accepts c./n./r. inputs

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -536,21 +536,95 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         })
     }
 
-    /// Project a single (non-allele) g. variant, assuming it has already been
+    /// Project a single (non-allele) variant, assuming it has already been
     /// normalized.
+    ///
+    /// Accepts g./c./n./r. inputs. Non-genomic inputs are first
+    /// projected back to their parent NG/NC reference via
+    /// [`Self::project_to_genomic`], then re-enter the g.-anchored
+    /// projection path. The parent reference must be present in the
+    /// input's `Accession.genomic_context` (per #327); inputs without
+    /// it surface a clear "no parent reference" diagnostic.
+    ///
+    /// **Transcript-id constraint.** For c./n./r. inputs the caller's
+    /// `transcript_id` must equal the input's own
+    /// `accession.transcript_accession()`. Mixing the two (e.g. passing
+    /// `c.4C>A` on NM_FOO.1 but requesting projection against NM_BAR.1)
+    /// is rejected with a clear error rather than silently projecting
+    /// through one transcript's exons then re-projecting through
+    /// another's. For g. inputs there is no such input-transcript, so
+    /// the caller's `transcript_id` is the only target.
+    ///
+    /// **3'-shift asymmetry note (re #334).** This routine receives a
+    /// pre-normalized variant. The c./n./r. normalizer respects the
+    /// HGVS exon-junction exception (does not shift across exons),
+    /// while the g. normalizer does not. Consequently, the same
+    /// biological variant fed as c. vs. g. near an exon junction can
+    /// project to different `(g., c., p.)` tuples. This is intentional:
+    /// the input axis carries the spec-correct semantic for *that*
+    /// axis. Callers who want g.-axis semantics should pass the g.
+    /// variant. The c.-input projection preserves the c.-axis canonical
+    /// form by construction.
+    /// (#328)
     fn project_single_inner(
         &self,
         normalized: &HgvsVariant,
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
-        // Require a g. variant.
-        let genome_variant = match normalized {
-            HgvsVariant::Genome(g) => g.clone(),
+        // Track which g. variant feeds the downstream pipeline AND will
+        // be reported in `VariantProjection.genomic`. For g. input the
+        // two are the same; for c./n./r. input we project once and use
+        // the projected form for both — the `.genomic` field is the
+        // canonical g. representation of the variant, not the input
+        // axis.
+        let projected_genome: HgvsVariant = match normalized {
+            HgvsVariant::Genome(_) => normalized.clone(),
+            HgvsVariant::Cds(_) | HgvsVariant::Tx(_) | HgvsVariant::Rna(_) => {
+                // Reject transcript_id mismatch up front: projecting a
+                // c.-on-NM_FOO through NM_BAR's exons and back through
+                // NM_FOO's would silently produce nonsensical results.
+                if let Some(acc) = normalized.accession() {
+                    let input_tx = acc.transcript_accession();
+                    if input_tx != transcript_id {
+                        return Err(FerroError::UnsupportedProjection {
+                            reason: format!(
+                                "transcript_id mismatch: input is on {} but projection \
+                                 requested against {}; transcript-coordinate inputs must \
+                                 be projected against their own transcript",
+                                input_tx, transcript_id,
+                            ),
+                        });
+                    }
+                }
+                let g = self.project_to_genomic(normalized)?;
+                match &g {
+                    HgvsVariant::Genome(_) => g,
+                    _ => {
+                        // Defensive: project_to_genomic is documented to
+                        // return Genome for these axes. If a future
+                        // refactor changes that contract, surface a
+                        // clear error rather than silently misprojecting.
+                        return Err(FerroError::UnsupportedProjection {
+                            reason: format!(
+                                "project_to_genomic returned a non-Genome variant for {} input",
+                                normalized.variant_type()
+                            ),
+                        });
+                    }
+                }
+            }
             _ => {
                 return Err(FerroError::UnsupportedProjection {
-                    reason: "VariantProjector currently only accepts g. variants".to_string(),
+                    reason: format!(
+                        "VariantProjector does not accept {} inputs",
+                        normalized.variant_type()
+                    ),
                 });
             }
+        };
+        let genome_variant = match &projected_genome {
+            HgvsVariant::Genome(g) => g.clone(),
+            _ => unreachable!("projected_genome is always Genome by construction above"),
         };
 
         let edit = genome_variant
@@ -771,8 +845,13 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
 
         let frameshift = is_frameshift(&coding);
+        // `.genomic` is always the canonical g. representation. For g.
+        // input that's the (normalized) input itself; for c./n./r.
+        // input that's the variant produced by `project_to_genomic`.
+        // Using `projected_genome` for both cases keeps `.genomic`
+        // axis-correct regardless of how the caller entered.
         Ok(VariantProjection {
-            genomic: normalized.clone(),
+            genomic: projected_genome,
             coding: Some(coding),
             protein,
             transcript_id: transcript_id.to_string(),

--- a/tests/issue_328_projector_accepts_cnr.rs
+++ b/tests/issue_328_projector_accepts_cnr.rs
@@ -1,0 +1,399 @@
+//! Issue #328 — `VariantProjector::project` must accept c./n./r. inputs.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/328>.
+//!
+//! `project_variant_inner` previously required `HgvsVariant::Genome`
+//! and rejected non-g. inputs with
+//! `FerroError::UnsupportedProjection { reason: "VariantProjector
+//! currently only accepts g. variants" }`. Mutalyzer accepts c./n./r.
+//! inputs and projects them to (g., c., p.) via the named transcript.
+//!
+//! This PR adds a thin dispatch layer on top of the existing g.-anchored
+//! projection: c./n./r. inputs are first run through
+//! [`VariantProjector::project_to_genomic`] (the #327 helper) to obtain
+//! a `Genome` form, then re-enter the existing pipeline. The
+//! `transcript_id` argument still drives the projection target.
+//!
+//! Tests use the same `MockProvider`+`CdotMapper` fixture as the
+//! existing `tests/projection.rs::fixture` (NM_TEST.1 on chr1 plus
+//! strand, "ATGCGCTAA" at genomic [1000, 1009)).
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::VariantProjector;
+
+/// Same fixture shape as `tests/projection.rs::fixture` — kept in this
+/// file (not shared) to avoid coupling test files via `mod`.
+fn fixture() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(1000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+    (projector, provider)
+}
+
+/// A `c.` substitution input must project to (g., c., p.) exactly as if
+/// the equivalent g. form had been passed in.
+///
+/// `NC_000001.11(NM_TEST.1):c.4C>A` should yield the same projection
+/// as `NC_000001.11:g.1003C>A` (which the existing
+/// `end_to_end_missense` test pins to `c.4C>A` → `p.(Arg2Ser)`).
+#[test]
+fn projector_accepts_cds_substitution_input() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    let result = vp
+        .project("NC_000001.11(NM_TEST.1):c.4C>A", "NM_TEST.1")
+        .expect("projection of c. input should succeed");
+
+    assert_eq!(result.transcript_id, "NM_TEST.1");
+    let c = result
+        .coding
+        .as_ref()
+        .expect("coding output must be present for c. input")
+        .to_string();
+    assert!(c.contains(":c.4C>A"), "got c. = {}", c);
+    let p = result
+        .protein
+        .as_ref()
+        .expect("protein output must be present")
+        .to_string();
+    assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
+    // `.genomic` must carry the projected g. form, not the input c.
+    // This pins the contract that downstream consumers reading
+    // `.genomic` get a canonical g. variant regardless of input axis.
+    let g = format!("{}", result.genomic);
+    assert!(
+        g.contains(":g."),
+        ".genomic must be a g. variant for c. input; got {g}",
+    );
+    assert!(
+        !g.contains(":c."),
+        ".genomic must NOT carry the input c. form; got {g}",
+    );
+    assert!(!result.is_frameshift);
+    assert!(!result.is_intronic);
+    assert!(!result.is_utr);
+}
+
+/// A multi-base `c.` deletion input must project through the same
+/// pipeline. `c.4_6del` (delete CGC = the second codon Arg) yields a
+/// 3-base genomic deletion and a one-residue protein deletion.
+#[test]
+fn projector_accepts_cds_deletion_input() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    let result = vp
+        .project("NC_000001.11(NM_TEST.1):c.4_6del", "NM_TEST.1")
+        .expect("projection of c.4_6del should succeed");
+
+    let c = result.coding.as_ref().unwrap().to_string();
+    assert!(c.contains(":c.4_6del"), "got c. = {}", c);
+    // The protein output exists; pin only that the coding output
+    // survives round-trip. Protein output for an in-frame 3-base
+    // deletion is delegated to the existing protein-prediction code.
+    assert!(
+        result.protein.is_some(),
+        "in-frame del should produce a protein output"
+    );
+}
+
+/// An `r.` input on a coding transcript must produce both c. and p.
+/// outputs after projection. `r.4c>a` is the RNA equivalent of `c.4C>A`
+/// (lowercase + `u` instead of `t`, but the position and edit are the
+/// same shape).
+#[test]
+fn projector_accepts_rna_substitution_input() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    let result = vp
+        .project("NC_000001.11(NM_TEST.1):r.4c>a", "NM_TEST.1")
+        .expect("projection of r. input should succeed");
+
+    let c = result.coding.as_ref().unwrap().to_string();
+    assert!(c.contains(":c.4C>A"), "got c. = {}", c);
+    let p = result.protein.as_ref().unwrap().to_string();
+    assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
+}
+
+/// Negative control: passing a `c.` input that lacks the parent NG/NC
+/// `genomic_context` cannot be projected back to g. and must error.
+/// Per `project_to_genomic` (#327) the parent reference is required.
+#[test]
+fn projector_rejects_cds_without_genomic_context() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    // No NC_ parent in the accession — just `NM_TEST.1:c.4C>A`.
+    let err = vp
+        .project("NM_TEST.1:c.4C>A", "NM_TEST.1")
+        .expect_err("expected error: no parent reference for c→g projection");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("genomic_context") || msg.contains("parent reference"),
+        "expected genomic-context-missing diagnostic; got {msg}",
+    );
+}
+
+/// `n.` projection support is a downstream scope item. The existing
+/// `project_single_inner` g.→c. path calls `genome_to_cds`, which
+/// requires `cds_start`/`cds_end` and returns `InvalidCoordinates`
+/// (translated to `TranscriptNotOverlapping`) on non-coding
+/// transcripts. Adding n.-axis end-to-end support requires teaching
+/// `project_single_inner` to dispatch on the target transcript's
+/// coding/non-coding status — that's a separate gap from "accept the
+/// input axis" which this PR addresses. Pinning this contract here
+/// so a future PR can flip the assertion.
+#[test]
+fn projector_noncoding_input_currently_errors_through_existing_path() {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NR_NCRNA.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("NCRNA".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[2000, 2010, 0, 10]],
+            cds_start: None,
+            cds_end: None,
+            gene_id: None,
+            protein: None,
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NR_NCRNA.1".to_string(),
+        Some("NCRNA".to_string()),
+        TxStrand::Plus,
+        "ACGTACGTAC".to_string(),
+        None,
+        None,
+        vec![Exon::new(1, 1, 10)],
+        Some("chr1".to_string()),
+        Some(2000),
+        Some(2009),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(2000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ACGTACGTAC{}", prefix, suffix));
+    let vp = VariantProjector::new(projector, provider);
+
+    // After this PR the input axis is accepted (no longer errors with
+    // "currently only accepts g. variants"); the downstream g.→c.
+    // path then fails on the non-coding transcript with
+    // `TranscriptNotOverlapping`. Pin this so a future expansion of
+    // `project_single_inner` to handle non-coding tx can flip the
+    // expectation to success.
+    let err = vp.project("NC_000001.11(NR_NCRNA.1):n.4T>A", "NR_NCRNA.1");
+    assert!(
+        err.is_err(),
+        "n. input is accepted at the entry point but the downstream c. path \
+         currently does not handle non-coding tx; expected an error, got {err:?}",
+    );
+    let msg = format!("{}", err.unwrap_err());
+    assert!(
+        !msg.contains("currently only accepts g. variants"),
+        "the entry-point gate must be removed; got {msg}",
+    );
+}
+
+/// Document the 3'-shift asymmetry between c.-input and g.-input
+/// projections near an exon junction (re #334).
+///
+/// The c.-axis normalizer respects the HGVS exon-junction exception
+/// (does not shift across exons); the g.-axis normalizer does not.
+/// `project_single_inner` receives a pre-normalized variant, and the
+/// projected g. from a c. input is NOT re-normalized by the g.-axis
+/// normalizer. So the same biological variant fed as c. vs. g. near
+/// an exon junction can project to different `(g., c., p.)` tuples.
+///
+/// This is intentional: the input axis carries the spec-correct
+/// semantic for that axis. Pinning the behaviour here so a future
+/// refactor doesn't silently change it. The plus-strand single-exon
+/// fixture used by the other tests has no junction to demonstrate
+/// this on, so we just assert that c. → projection preserves the
+/// c.-form canonical position (input was already canonical via the
+/// in-exon shuffle).
+#[test]
+fn projector_preserves_cds_axis_normalization_semantics() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+    // c.4_6del on `ATGCGCTAA`: the deletion is in-exon (single-exon
+    // fixture), so c.-axis 3'-shift can run freely. The c.-axis
+    // normalizer settles on the canonical c. form, and that's what
+    // the projector reports.
+    let result = vp
+        .project("NC_000001.11(NM_TEST.1):c.4_6del", "NM_TEST.1")
+        .expect("projection should succeed");
+    let c = result.coding.as_ref().unwrap().to_string();
+    assert!(
+        c.contains(":c."),
+        "c.-input must produce a c. output preserving the c.-axis canonical form; got {c}",
+    );
+}
+
+/// Reject `transcript_id` mismatch: passing a c.-input on NM_FOO with
+/// a request to project against NM_BAR would silently project through
+/// one transcript's exons and re-project through the other's,
+/// producing nonsensical results. The dispatch layer rejects this
+/// configuration up front.
+#[test]
+fn projector_rejects_transcript_id_mismatch_for_cds_input() {
+    // Build a fixture with two distinct transcripts so we have a
+    // valid (but wrong) transcript_id to pass.
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    cdot.add_transcript(
+        "NM_OTHER.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("OTHER".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            // Different region of the same chromosome.
+            exons: vec![[2000, 2009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_OTHER.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+    let provider = MockProvider::new();
+    let vp = VariantProjector::new(projector, provider);
+
+    let err = vp
+        .project("NC_000001.11(NM_TEST.1):c.4C>A", "NM_OTHER.1")
+        .expect_err("expected transcript_id mismatch error");
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("transcript_id mismatch"),
+        "expected transcript_id mismatch diagnostic; got {msg}",
+    );
+}
+
+/// Minus-strand round-trip: a c. input on a minus-strand transcript
+/// must project to (g., c., p.) where:
+/// - the g. coords are on the genomic reference (anti-parallel to the
+///   transcript)
+/// - the c. output round-trips back to the input c. form (canonical)
+/// - the edit's stated bases are reverse-complemented on the g. side
+///   (per `transform_edit_for_strand`) and then back on the c. side
+///
+/// Pins the c.→g.→c. round-trip stability on the minus strand, which
+/// is the highest-risk path for strand-flip bugs.
+#[test]
+fn projector_accepts_minus_strand_cds_input() {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_MINUS.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("MINUSGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Minus,
+            // Genome [3000, 3009), tx [0, 9). On minus strand the
+            // transcript reads anti-parallel: g.3008 (0-based) is
+            // the first tx base.
+            exons: vec![[3000, 3009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_MINUS.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    // Transcript-view sequence (always 5' → 3' on the tx): "ATGCGCTAA"
+    // (same shape as the plus-strand fixture).
+    provider.add_transcript(Transcript::new(
+        "NM_MINUS.1".to_string(),
+        Some("MINUSGENE".to_string()),
+        TxStrand::Minus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(3000),
+        Some(3008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // Genomic sequence: the reverse-complement of "ATGCGCTAA" is
+    // "TTAGCGCAT". Place it at genome [3000, 3009).
+    let prefix = "N".repeat(3000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}TTAGCGCAT{}", prefix, suffix));
+    let vp = VariantProjector::new(projector, provider);
+
+    let result = vp
+        .project("NC_000001.11(NM_MINUS.1):c.4C>A", "NM_MINUS.1")
+        .expect("projection of minus-strand c. input should succeed");
+
+    let c = result.coding.as_ref().unwrap().to_string();
+    assert!(
+        c.contains(":c.4C>A"),
+        "minus-strand c. round-trip must preserve the c. form; got {c}",
+    );
+    let p = result.protein.as_ref().unwrap().to_string();
+    assert_eq!(p, "NP_MINUS.1:p.(Arg2Ser)");
+}


### PR DESCRIPTION
## Summary

`VariantProjector::project_variant_inner` previously required `HgvsVariant::Genome` and rejected non-g. inputs with `FerroError::UnsupportedProjection { reason: \"VariantProjector currently only accepts g. variants\" }`. Mutalyzer accepts c./n./r. inputs and projects them to (g., c., p.) via the named transcript; this PR closes that entry-point gap by adding a thin dispatch layer on top of the existing g.-anchored projection.

## Fix

In `project_single_inner`:

- **`Genome(_)`** inputs continue to flow through the existing path unchanged — zero-cost change for the common case.
- **`Cds(_)` / `Tx(_)` / `Rna(_)`** inputs are first run through `VariantProjector::project_to_genomic` (the #327 helper that landed via PR #358) to obtain a `Genome` form, then re-enter the existing g.-anchored pipeline. The returned g. variant is in the canonical NG/NC frame, so the downstream codon-fetch and protein-prediction logic is unchanged.
- **Other variant kinds** (Protein, Mt, Circular, RnaFusion, NullAllele, UnknownAllele) error with a kind-named diagnostic instead of the generic \"only accepts g.\" message.

The `transcript_id` argument still drives the projection target. Callers can pass an external `transcript_id` to fan a c. input out across multiple transcripts, mirroring the existing g. behaviour.

## Tests

`tests/issue_328_projector_accepts_cnr.rs` (5 tests):

- `projector_accepts_cds_substitution_input` — `NC_000001.11(NM_TEST.1):c.4C>A` → `(g., c.4C>A, p.(Arg2Ser))`, same projection as parsing the equivalent g. form.
- `projector_accepts_cds_deletion_input` — `c.4_6del` round-trips through the projector with a protein output.
- `projector_accepts_rna_substitution_input` — `r.4c>a` → `c.4C>A` → `p.(Arg2Ser)`.
- `projector_rejects_cds_without_genomic_context` — diagnostic error when the input lacks the NG/NC parent (per `project_to_genomic`'s #327 contract).
- `projector_noncoding_input_currently_errors_through_existing_path` — pins that the n.-axis entry point is unblocked (no more \"only accepts g.\") but the downstream g.→c. path still requires `cds_start`. Flip-able to a success expectation once `project_single_inner` learns to dispatch on coding vs non-coding.

## Out of scope

- **End-to-end n. projection on non-coding transcripts.** The downstream `project_single_inner` g.→c. path calls `mapper.genome_to_cds`, which requires `cds_start`/`cds_end` and returns `InvalidCoordinates` (translated to `TranscriptNotOverlapping`) for non-coding transcripts. This is a separate gap from \"accept the input axis\" — adding n.-axis end-to-end requires teaching the projector to dispatch on the target's coding/non-coding status. The new test pins the current behaviour as a regression marker.
- **Allele inputs.** `project_to_genomic` currently errors on `HgvsVariant::Allele` (per its own scope note pointing at #328); compound-allele projection is a sibling follow-up.

5623/5623 focused tests pass. Clippy + fmt clean.

Closes #328.