### PR TITLE
feat(parser): spec-compliant wraparound ranges on m./o. circular refs

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -235,6 +235,34 @@ fn starts_with_special_pos(bytes: &[u8]) -> bool {
 /// Optimized: fast path for simple positions and ranges (starting with digit)
 #[inline]
 fn parse_genome_interval(input: &str) -> IResult<&str, GenomeInterval> {
+    parse_genome_interval_inner(input, false)
+}
+
+/// Parse a genomic-axis interval, optionally relaxing the inverted-range
+/// check for circular references (`m.`/`o.`).
+///
+/// HGVS spec authorises reversed `<high>_<low>` ranges on `o.`/`m.`
+/// references for **deletions** (`deletion.md:17`) and **duplications**
+/// (`docs/consultation/SVD-WG006.md` line 15 + line 23 example
+/// `J01749.1:o.4344_197dup`, line 33 names "deletions/duplications" as
+/// the spec-authorised scope). `delins` inherits the exception via the
+/// `del + ins` composition. `ins` and `inv` are spec-silent — the
+/// general "5'→3'" rule applies. `check_circular_reversed_range`,
+/// called post-parse by `parse_mt_variant` / `parse_circular_variant`
+/// (and the bracket / unknown-phase / inherited-accession helpers),
+/// enforces the edit-kind authorisation so the rejection has access to
+/// the parsed edit kind.
+///
+/// When `circular = true` the parse-level inverted-range check is
+/// removed for the simple-range fast path; post-parse validation in the
+/// caller catches the spec-unauthorised edit kinds. The complex
+/// uncertain-range paths still reject reversed bounds since the spec
+/// exception only applies to plain `<high>_<low>` reversed forms.
+fn parse_genome_interval_for_circular(input: &str) -> IResult<&str, GenomeInterval> {
+    parse_genome_interval_inner(input, true)
+}
+
+fn parse_genome_interval_inner(input: &str, circular: bool) -> IResult<&str, GenomeInterval> {
     let bytes = input.as_bytes();
     if bytes.is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -258,7 +286,10 @@ fn parse_genome_interval(input: &str) -> IResult<&str, GenomeInterval> {
                 // - either position is special (pter/qter have no comparable base values)
                 // - the edit is a structural variant type that may use inverted coordinates
                 //   (insertions, duplications, inversions, and complex delins)
-                let allows_inverted = remaining.starts_with("dupins")
+                // - this is a circular (`m.`/`o.`) reference. The caller validates
+                //   the spec-authorised edit kinds post-parse (#129).
+                let allows_inverted = circular
+                    || remaining.starts_with("dupins")
                     || remaining.starts_with("inv")
                     || remaining.starts_with("ins")
                     || remaining.starts_with("dup");
@@ -462,6 +493,87 @@ fn cds_pos_is_inverted(start: &CdsPos, end: &CdsPos) -> bool {
     } else {
         // 5' UTR or CDS: -100 < -1 < 1 < 100
         start.base > end.base
+    }
+}
+
+/// Validate a parsed circular-axis (`m.`/`o.`) interval+edit pair against
+/// the HGVS spec's circular range-orientation rules.
+///
+/// HGVS spec sources:
+/// - `recommendations/DNA/deletion.md:17` — explicit exception for
+///   `o.`/`m.` references allowing reversed `<high>_<low>` ranges on
+///   deletions.
+/// - `docs/consultation/SVD-WG006.md` (accepted into HGVS v19.01,
+///   founding proposal for circular DNA) — line 15 grants the
+///   exception for any "rearrangement" that "includes both the last
+///   and first nucleotides of the reference sequence", with explicit
+///   examples for both `del` (`NC_012920.1:m.16563_13del`) and `dup`
+///   (`J01749.1:o.4344_197dup`). Line 33 explicitly names
+///   "deletions/duplications" as the scope.
+///
+/// So the spec-authorised set is `del`, `dup`, and `delins` (the
+/// latter by composition: `delins` is a `del + ins` rewrite and the
+/// del side carries the exception). `ins` and `inv` are spec-silent
+/// (no examples and not named in the rationale); the general "5' to 3'"
+/// rule applies and ferro rejects those reversed forms — closing the
+/// silent-accept gap pinned by the audit tests.
+///
+/// This helper is called post-parse from `parse_mt_variant` and
+/// `parse_circular_variant` to reject the unauthorised forms. Returns
+/// `Ok(())` when the form is spec-compliant, or `Err(_)` with a
+/// nom-style verify-error so the caller can short-circuit the parse.
+/// (#129)
+fn check_circular_reversed_range<'a>(
+    interval: &GenomeInterval,
+    edit: &crate::hgvs::edit::NaEdit,
+    input: &'a str,
+) -> Result<(), nom::Err<nom::error::Error<&'a str>>> {
+    use crate::hgvs::edit::NaEdit;
+
+    // Only the plain `<start>_<end>` (Single(Certain), Single(Certain))
+    // shape can be reversed; complex range/uncertain boundaries are
+    // already rejected by parse_genome_interval_inner before reaching
+    // here for reversed cases.
+    let (s, e) = match (&interval.start, &interval.end) {
+        (UncertainBoundary::Single(Mu::Certain(s)), UncertainBoundary::Single(Mu::Certain(e))) => {
+            (s, e)
+        }
+        _ => return Ok(()),
+    };
+    // Special positions (pter/qter/cen) carry base=0 sentinels; ordering
+    // is not numeric. Spec doesn't address these on circular refs;
+    // pass through unchanged.
+    if s.is_special() || e.is_special() {
+        return Ok(());
+    }
+    if s.base <= e.base {
+        return Ok(());
+    }
+    // Reversed range. Allow `del`, `dup`, and `delins` (the
+    // spec-authorised set per SVD-WG006); reject everything else.
+    //
+    // The `_` arm explicitly covers:
+    //   - `Substitution` / `SubstitutionNoRef` — single-position
+    //     edits; `<high>_<low>` is structurally undefined.
+    //   - `Insertion`, `Inversion` — spec-silent on circular refs
+    //     (SVD-WG006 names only del/dup; insertion.md / inversion.md
+    //     give no wraparound exception).
+    //   - `DupIns` — non-standard ClinVar shape; no spec
+    //     authorisation, defensive reject.
+    //   - `Repeat` / `MultiRepeat` — spec is silent on wraparound
+    //     repeat tracts.
+    //   - `Identity` — `<high>_<low>=` is semantically degenerate.
+    //   - `Conversion` — defensive default-reject; the canonicaliser
+    //     rewrites `con` → `delins` post-parse but cannot fire here
+    //     because the validator runs immediately after `parse_na_edit`.
+    //   - `Unknown` — `?` edits carry no positional semantics on a
+    //     reversed range; reject defensively.
+    match edit {
+        NaEdit::Deletion { .. } | NaEdit::Delins { .. } | NaEdit::Duplication { .. } => Ok(()),
+        _ => Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        ))),
     }
 }
 
@@ -1085,15 +1197,36 @@ impl GenomeKind {
 /// `parse_cds_bracket_member`. #243.
 fn parse_genome_bracket_member(
     part: &str,
+    kind: GenomeKind,
 ) -> IResult<&str, LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>> {
+    let is_circular = matches!(kind, GenomeKind::Mt | GenomeKind::Circular);
+    // For `m.`/`o.` the circular variant allows the spec-authorised
+    // reversed `<high>_<low>` forms; post-parse we still run
+    // `check_circular_reversed_range` to reject edit kinds the spec
+    // doesn't authorise. For `g.` the linear parser is unchanged. (#129)
     if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
-        if let Ok((remaining, (interval, edit))) =
+        let predicted = if is_circular {
+            delimited(
+                char('('),
+                (parse_genome_interval_for_circular, parse_na_edit),
+                char(')'),
+            )
+            .parse(part)
+        } else {
             delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(part)
-        {
+        };
+        if let Ok((remaining, (interval, edit))) = predicted {
+            if is_circular {
+                check_circular_reversed_range(&interval, &edit, part)?;
+            }
             return Ok((remaining, LocEdit::new_predicted(interval, edit)));
         }
     }
-    let (remaining, interval) = parse_genome_interval(part)?;
+    let (remaining, interval) = if is_circular {
+        parse_genome_interval_for_circular(part)?
+    } else {
+        parse_genome_interval(part)?
+    };
     let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
         (r, e)
     } else {
@@ -1105,6 +1238,9 @@ fn parse_genome_bracket_member(
             },
         )
     };
+    if is_circular {
+        check_circular_reversed_range(&interval, &edit, part)?;
+    }
     Ok((remaining, LocEdit::new(interval, edit)))
 }
 
@@ -1322,7 +1458,7 @@ fn parse_genome_kind_compound_allele(
                 nom::error::ErrorKind::Verify,
             )));
         }
-        let (final_remaining, loc_edit) = parse_genome_bracket_member(part)?;
+        let (final_remaining, loc_edit) = parse_genome_bracket_member(part, kind)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
@@ -1372,7 +1508,12 @@ fn parse_genome_position_unknown_phase(
             )));
         }
 
-        let (edit_remaining, interval) = parse_genome_interval(part)?;
+        let is_circular = matches!(kind, GenomeKind::Mt | GenomeKind::Circular);
+        let (edit_remaining, interval) = if is_circular {
+            parse_genome_interval_for_circular(part)?
+        } else {
+            parse_genome_interval(part)?
+        };
         let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
 
         if !final_remaining.trim().is_empty() {
@@ -1380,6 +1521,9 @@ fn parse_genome_position_unknown_phase(
                 final_remaining,
                 nom::error::ErrorKind::Tag,
             )));
+        }
+        if is_circular {
+            check_circular_reversed_range(&interval, &edit, part)?;
         }
 
         variants.push(kind.build_variant(accession.clone(), gene_symbol.clone(), interval, edit));
@@ -1431,7 +1575,8 @@ fn parse_genome_trans_allele_shorthand(
         } else {
             // Route through parse_genome_bracket_member so the predicted-wrapper
             // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
+            let (final_remaining, loc_edit) =
+                parse_genome_bracket_member(content, GenomeKind::Genome)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -2411,9 +2556,15 @@ fn parse_mt_variant(
 
         // Predicted variant: m.(positionEdit). #241.
         if input.starts_with('(') && !input.starts_with("(?") && !input.starts_with("(=)") {
-            if let Ok((remaining, (interval, edit))) =
-                delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(input)
+            if let Ok((remaining, (interval, edit))) = delimited(
+                char('('),
+                (parse_genome_interval_for_circular, parse_na_edit),
+                char(')'),
+            )
+            .parse(input)
             {
+                // Reject spec-unauthorised reversed ranges (#129).
+                check_circular_reversed_range(&interval, &edit, input)?;
                 return Ok((
                     remaining,
                     HgvsVariant::Mt(MtVariant {
@@ -2425,8 +2576,11 @@ fn parse_mt_variant(
             }
         }
 
-        let (input, interval) = parse_genome_interval(input)?;
+        let original_input = input;
+        let (input, interval) = parse_genome_interval_for_circular(input)?;
         let (input, edit) = parse_na_edit(input)?;
+        // Reject spec-unauthorised reversed ranges (#129).
+        check_circular_reversed_range(&interval, &edit, original_input)?;
 
         Ok((
             input,
@@ -2472,7 +2626,9 @@ fn parse_mt_trans_allele_shorthand(
         } else {
             // Route through parse_genome_bracket_member so the predicted-wrapper
             // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
+            // Pass `GenomeKind::Mt` so the helper uses the circular interval
+            // parser + spec-authorised reversed-range validator (#129).
+            let (final_remaining, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Mt)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3750,9 +3906,15 @@ fn parse_circular_variant(
 
         // Predicted variant: o.(positionEdit). #241.
         if input.starts_with('(') && !input.starts_with("(?") && !input.starts_with("(=)") {
-            if let Ok((remaining, (interval, edit))) =
-                delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(input)
+            if let Ok((remaining, (interval, edit))) = delimited(
+                char('('),
+                (parse_genome_interval_for_circular, parse_na_edit),
+                char(')'),
+            )
+            .parse(input)
             {
+                // Reject spec-unauthorised reversed ranges (#129).
+                check_circular_reversed_range(&interval, &edit, input)?;
                 return Ok((
                     remaining,
                     HgvsVariant::Circular(CircularVariant {
@@ -3764,8 +3926,11 @@ fn parse_circular_variant(
             }
         }
 
-        let (input, interval) = parse_genome_interval(input)?;
+        let original_input = input;
+        let (input, interval) = parse_genome_interval_for_circular(input)?;
         let (input, edit) = parse_na_edit(input)?;
+        // Reject spec-unauthorised reversed ranges (#129).
+        check_circular_reversed_range(&interval, &edit, original_input)?;
 
         Ok((
             input,
@@ -3811,7 +3976,10 @@ fn parse_circular_trans_allele_shorthand(
         } else {
             // Route through parse_genome_bracket_member so the predicted-wrapper
             // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            let (final_remaining, loc_edit) = parse_genome_bracket_member(content)?;
+            // Pass `GenomeKind::Circular` so the helper uses the circular
+            // interval parser + spec-authorised reversed-range validator (#129).
+            let (final_remaining, loc_edit) =
+                parse_genome_bracket_member(content, GenomeKind::Circular)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -4634,11 +4802,16 @@ fn parse_variant_with_inherited_accession(
             loc_edit: LocEdit::new(interval, edit),
         }))
     } else if let Some(rest) = input.strip_prefix("m.") {
-        let (remaining, interval) = parse_genome_interval(rest).map_err(|e| FerroError::Parse {
-            pos: 2,
-            msg: format!("Failed to parse mitochondrial interval: {:?}", e),
-            diagnostic: None,
-        })?;
+        // Use the circular-aware interval parser + post-parse spec
+        // authorisation check so inherited-accession `…/m.<high>_<low>del`
+        // slash-form inputs accept the SVD-WG006 wraparound exception
+        // (#129).
+        let (remaining, interval) =
+            parse_genome_interval_for_circular(rest).map_err(|e| FerroError::Parse {
+                pos: 2,
+                msg: format!("Failed to parse mitochondrial interval: {:?}", e),
+                diagnostic: None,
+            })?;
         let (remaining, edit) = parse_na_edit(remaining).map_err(|e| FerroError::Parse {
             pos: input.len() - remaining.len(),
             msg: format!("Failed to parse edit: {:?}", e),
@@ -4651,17 +4824,23 @@ fn parse_variant_with_inherited_accession(
                 diagnostic: None,
             });
         }
+        check_circular_reversed_range(&interval, &edit, rest).map_err(|e| FerroError::Parse {
+            pos: 2,
+            msg: format!("spec-unauthorised reversed range on m. axis: {:?}", e),
+            diagnostic: None,
+        })?;
         Ok(HgvsVariant::Mt(MtVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.cloned(),
             loc_edit: LocEdit::new(interval, edit),
         }))
     } else if let Some(rest) = input.strip_prefix("o.") {
-        let (remaining, interval) = parse_genome_interval(rest).map_err(|e| FerroError::Parse {
-            pos: 2,
-            msg: format!("Failed to parse circular interval: {:?}", e),
-            diagnostic: None,
-        })?;
+        let (remaining, interval) =
+            parse_genome_interval_for_circular(rest).map_err(|e| FerroError::Parse {
+                pos: 2,
+                msg: format!("Failed to parse circular interval: {:?}", e),
+                diagnostic: None,
+            })?;
         let (remaining, edit) = parse_na_edit(remaining).map_err(|e| FerroError::Parse {
             pos: input.len() - remaining.len(),
             msg: format!("Failed to parse edit: {:?}", e),
@@ -4674,6 +4853,11 @@ fn parse_variant_with_inherited_accession(
                 diagnostic: None,
             });
         }
+        check_circular_reversed_range(&interval, &edit, rest).map_err(|e| FerroError::Parse {
+            pos: 2,
+            msg: format!("spec-unauthorised reversed range on o. axis: {:?}", e),
+            diagnostic: None,
+        })?;
         Ok(HgvsVariant::Circular(CircularVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.cloned(),

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2257,14 +2257,36 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         // Fallback for variants we cannot remap through the window-based
-        // pipeline (unknown position, decorated position, or no provider
-        // data). Runs minimal-notation cleanup, then still applies
-        // `apply_canonical_split` so issue #160 inv-split and issue #165
-        // sub-only decomposition remain in force — those run on a narrow
-        // fetch (`fetch_ref_for_canonical_split`) that can succeed even
-        // when the wider shuffle window does not.
+        // pipeline (unknown position, decorated position, no provider
+        // data, or a reversed `<high>_<low>` wraparound range). Runs
+        // minimal-notation cleanup, then applies `apply_canonical_split`
+        // so issue #160 inv-split and issue #165 sub-only decomposition
+        // remain in force — those run on a narrow fetch
+        // (`fetch_ref_for_canonical_split`) that can succeed even when
+        // the wider shuffle window does not.
+        //
+        // Reversed ranges (`start > end`, per SVD-WG006 wraparound on
+        // `m.`/`o.`) skip `apply_canonical_split`: the helper computes
+        // `expected_span = hgvs_end - hgvs_start + 1` as `u64`, which
+        // underflows on reversed inputs. Today's shipped providers
+        // reject `start > end` at their `get_sequence` boundary, so the
+        // helper currently short-circuits via the `.ok()?` path before
+        // touching that arithmetic. Guarding here removes the latent
+        // dependency on every present and future provider doing that
+        // boundary check correctly — circular-aware split math is its
+        // own design and belongs to #129 Path 2 follow-up.
         let mt_fallback = |v: &crate::hgvs::variant::MtVariant| {
             let canonical = self.canonicalize_mt_variant(v);
+            let is_reversed = canonical
+                .loc_edit
+                .location
+                .start
+                .inner()
+                .zip(canonical.loc_edit.location.end.inner())
+                .is_some_and(|(s, e)| s.base > e.base);
+            if is_reversed {
+                return (HV::Mt(canonical), vec![]);
+            }
             let (split, warnings) = self.apply_canonical_split(HV::Mt(canonical));
             (wrap_allele_if_split(split), warnings)
         };
@@ -2295,10 +2317,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let start = start_pos.base;
         let end = end_pos.base;
 
+        // Wraparound `<high>_<low>` ranges (per SVD-WG006: `del`/`dup`/
+        // `delins` on `m.`/`o.`) have `start > end`. Circular-aware
+        // 3'-shift across the origin is out of scope for #129 (matches
+        // mutalyzer + biocommons + strict spec reading); route these
+        // straight to the canonicalize-only fallback. Doing the gate
+        // here — rather than relying on the provider rejecting `start >
+        // end` and the post-arithmetic `rel_end = end - window_start`
+        // underflow as a fail-safe — keeps the path correct under any
+        // window-size configuration. Issue #129 follow-up: implement
+        // circular-aware shuffle modulo contig length.
+        if start > end {
+            return Ok(mt_fallback(variant));
+        }
+
         // Window-based fetch around the variant. Non-origin-crossing
-        // variants take this path exactly like genomic; wraparound
-        // `dup`/`ins`/`inv` (where `start > end`) drop through to the
-        // canonicalize-only fallback below via `get_sequence` failure.
+        // path: identical to genomic.
         let window_start = start.saturating_sub(self.config.window_size);
         let seq_result = self.provider.get_sequence(
             &accession,

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 146,
       "false-acceptance": 83,
       "needs-reference": 31,
-      "parse-error": 339,
-      "preserved": 631
+      "parse-error": 338,
+      "preserved": 632
     },
     "by_coordinate_system": {
       "c": 464,
@@ -9747,19 +9747,6 @@
       ]
     },
     {
-      "input": "NC_012920.1:m.16563_13del",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"16563_13del\", code: Verify })",
-      "spec_expected": "NC_012920.1:m.16563_13del",
-      "status": "parse-error",
-      "coordinate_system": "m",
-      "source_kind": "consultation",
-      "source_paths": [
-        "docs/consultation/SVD-WG006.md"
-      ],
-      "working_group": "SVD-WG006",
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "m.",
       "input_prefixed": "NC_012920.1:m.",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Eof })",
@@ -9841,6 +9828,18 @@
         "docs/background/numbering.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
+      "input": "NC_012920.1:m.16563_13del",
+      "current": "NC_012920.1:m.16563_13del",
+      "spec_expected": "NC_012920.1:m.16563_13del",
+      "status": "preserved",
+      "coordinate_system": "m",
+      "source_kind": "consultation",
+      "source_paths": [
+        "docs/consultation/SVD-WG006.md"
+      ],
+      "working_group": "SVD-WG006"
     },
     {
       "input": "n.611T=",

--- a/tests/issue_129_mt_circular_wraparound.rs
+++ b/tests/issue_129_mt_circular_wraparound.rs
@@ -1,0 +1,288 @@
+//! Issue #129 — Mitochondrial circular reference handling (Path 1:
+//! strict spec compliance).
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/129>.
+//!
+//! HGVS spec analysis:
+//! - `deletion.md:17` — for `o.`/`m.` circular references, positions
+//!   MAY be listed 3'→5' "when the deletion includes both the last and
+//!   first nucleotides of the reference sequence."
+//! - `docs/consultation/SVD-WG006.md` (accepted into HGVS v19.01,
+//!   founding proposal for circular DNA) — line 15 grants the
+//!   exception for any "rearrangement" that includes both ends, with
+//!   explicit examples for both `del`
+//!   (`NC_012920.1:m.16563_13del`) and `dup`
+//!   (`J01749.1:o.4344_197dup`). Line 33 names
+//!   "deletions/duplications" as the spec-authorised scope.
+//! - `delins` inherits the exception via the `del + ins` composition.
+//! - `insertion.md` and `inversion.md` are spec-silent on wraparound
+//!   forms; no examples and no rationale. The general "5'→3'" rule
+//!   applies.
+//!
+//! Comparison: both mutalyzer and biocommons hgvs reject ALL reversed
+//! ranges including the spec-authorized `del`/`dup` exception (see
+//! `mutalyzer/description.py:889`, `hgvs/location.py:437`). ferro
+//! goes more spec-compliant by accepting the explicitly-authorized
+//! `del`/`dup`/`delins` wraparound forms while rejecting the
+//! unauthorized `ins`/`inv` reversed forms — closing a silent-accept
+//! gap pinned by `tests/mito_circular_audit.rs`.
+//!
+//! What this PR delivers:
+//! - Parser accepts `m.<high>_<low>del`, `m.<high>_<low>delins`, and
+//!   `m.<high>_<low>dup` (and the same on `o.`).
+//! - Parser **rejects** `m.<high>_<low>ins`/`inv` (were silently
+//!   accepted; mis-computed indel length).
+//! - 3'-rule wraparound shift remains **disabled** — matches
+//!   mutalyzer + biocommons + the strict spec reading. A homopolymer
+//!   straddling the origin won't shift across it.
+
+use ferro_hgvs::{parse_hgvs, FerroError, MockProvider, Normalizer};
+
+const MT: &str = "NC_012920.1";
+
+// ============================================================================
+// Wraparound `del` and `delins` — spec-authorized, must parse.
+// ============================================================================
+
+/// Helper: parse + round-trip-display. Tight `assert_eq!` catches any
+/// stray leading/trailing characters in the Display path that a
+/// `contains` check would miss.
+fn assert_roundtrip(input: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input:?}) failed: {e}"));
+    let out = format!("{}", v);
+    assert_eq!(out, input, "round-trip mismatch for {input:?}: got {out:?}");
+}
+
+#[test]
+fn mt_wraparound_del_origin_pair_parses() {
+    // `m.16569_1del` — the 2-nt deletion of "both the last and first
+    // nucleotides of the reference sequence". Spec-authorized.
+    assert_roundtrip(&format!("{MT}:m.16569_1del"));
+}
+
+#[test]
+fn mt_wraparound_del_longer_parses() {
+    // A longer wraparound del. Per the spec exception "includes both
+    // the last and first nucleotides" means the deletion spans the
+    // origin; any `<high>_<low>` form on a circular ref qualifies.
+    assert_roundtrip(&format!("{MT}:m.16500_100del"));
+}
+
+#[test]
+fn mt_wraparound_delins_parses() {
+    // `delins` inherits the deletion-side exception via its `del + ins`
+    // composition.
+    assert_roundtrip(&format!("{MT}:m.16569_1delinsAA"));
+}
+
+// ============================================================================
+// Wraparound `dup` — spec-authorized per SVD-WG006 (line 15 + line 23
+// example `J01749.1:o.4344_197dup`). Must parse.
+// ============================================================================
+
+#[test]
+fn mt_wraparound_dup_parses() {
+    assert_roundtrip(&format!("{MT}:m.16569_1dup"));
+}
+
+#[test]
+fn circular_wraparound_dup_parses_pbr322() {
+    // Verbatim from SVD-WG006:23.
+    assert_roundtrip("J01749.1:o.4344_197dup");
+}
+
+// ============================================================================
+// Wraparound `ins` / `inv` — spec-silent on circular references (no
+// examples or rationale in SVD-WG006). ferro previously silently
+// accepted these with mis-computed length; this PR rejects them per
+// the strict reading of the spec's "5'→3'" general rule.
+// ============================================================================
+
+#[test]
+fn mt_wraparound_ins_is_rejected() {
+    // No spec exception for `ins` on circular refs. (Note: ins is the
+    // standard `<X>_<X+1>ins<seq>` adjacent-position form; `<high>_<low>`
+    // is a separate spec-unauthorized shape.)
+    //
+    // Pin the rejection class to `FerroError::Parse` — not just `is_err()` —
+    // so the test stays meaningful if a downstream stage starts emitting a
+    // different error variant. `check_circular_reversed_range` lifts the
+    // rejection via nom's `ErrorKind::Verify`, which `parse_variant` wraps
+    // as `FerroError::Parse`.
+    let err = parse_hgvs(&format!("{MT}:m.16569_1insA"))
+        .expect_err("wraparound `ins` has no spec exception; must be rejected");
+    assert!(
+        matches!(err, FerroError::Parse { .. }),
+        "wraparound `ins` must reject at parse stage; got {err:?}",
+    );
+}
+
+#[test]
+fn mt_wraparound_inv_is_rejected() {
+    // No spec exception for `inv` on circular refs.
+    let err = parse_hgvs(&format!("{MT}:m.16569_1inv"))
+        .expect_err("wraparound `inv` has no spec exception; must be rejected");
+    assert!(
+        matches!(err, FerroError::Parse { .. }),
+        "wraparound `inv` must reject at parse stage; got {err:?}",
+    );
+}
+
+// ============================================================================
+// `o.` circular references — same rules per `deletion.md:17` (which
+// names both "o" and "m" prefixes).
+// ============================================================================
+
+#[test]
+fn circular_wraparound_del_parses() {
+    assert_roundtrip("NC_000000.0:o.500_100del");
+}
+
+#[test]
+fn circular_wraparound_inv_is_rejected() {
+    // `inv` is spec-silent on circular refs; reject.
+    let err = parse_hgvs("NC_000000.0:o.500_100inv")
+        .expect_err("o. wraparound `inv` has no spec exception; must be rejected");
+    assert!(
+        matches!(err, FerroError::Parse { .. }),
+        "o. wraparound `inv` must reject at parse stage; got {err:?}",
+    );
+}
+
+// ============================================================================
+// Non-wraparound `m.` variants (start < end) must continue to parse
+// for all edit kinds — this is the common case and shouldn't change.
+// ============================================================================
+
+#[test]
+fn mt_non_wraparound_dup_still_parses() {
+    assert_roundtrip(&format!("{MT}:m.100_103dup"));
+}
+
+#[test]
+fn mt_non_wraparound_inv_still_parses() {
+    assert_roundtrip(&format!("{MT}:m.100_103inv"));
+}
+
+// ============================================================================
+// `g.` axis must NOT get the circular exception — genomic references
+// are linear and the spec authorizes the wraparound form only for
+// `o.`/`m.` prefixes. This test pins that the `g.` rejection stays in
+// place.
+// ============================================================================
+
+// ============================================================================
+// Bracketed compound alleles — wraparound must propagate through the
+// shared bracket-member parser too (CodeRabbit follow-up).
+// ============================================================================
+
+#[test]
+fn mt_compound_cis_allele_with_wraparound_del_parses() {
+    // SVD-WG006 wraparound del as a member of a cis-allele.
+    assert_roundtrip(&format!("{MT}:m.[16569_1del;100A>G]"));
+}
+
+#[test]
+fn circular_compound_cis_allele_with_wraparound_dup_parses() {
+    assert_roundtrip("J01749.1:o.[4344_197dup;500A>G]");
+}
+
+#[test]
+fn mt_compound_cis_allele_with_wraparound_ins_is_rejected() {
+    // `ins` is spec-silent on circular refs; reject inside brackets
+    // just like outside.
+    let err = parse_hgvs(&format!("{MT}:m.[16569_1insA;100A>G]"))
+        .expect_err("compound-bracket wraparound ins must reject");
+    assert!(
+        matches!(err, FerroError::Parse { .. }),
+        "compound-bracket wraparound ins must reject at parse stage; got {err:?}",
+    );
+}
+
+#[test]
+fn mt_trans_allele_with_wraparound_del_parses() {
+    // `m.[edit1];[edit2]` shorthand — both members must accept the
+    // circular exception per the same code path.
+    assert_roundtrip(&format!("{MT}:m.[16569_1del];[100A>G]"));
+}
+
+#[test]
+fn genome_wraparound_del_is_still_rejected() {
+    // Linear g. has no circular exception. Rejected by the standard
+    // (non-circular) `parse_genome_interval` inverted-range check rather
+    // than `check_circular_reversed_range`; both surface as
+    // `FerroError::Parse`.
+    let err = parse_hgvs("NC_000001.11:g.16569_1del")
+        .expect_err("linear g. has no circular exception; reversed range must stay rejected");
+    assert!(
+        matches!(err, FerroError::Parse { .. }),
+        "linear g. reversed range must reject at parse stage; got {err:?}",
+    );
+}
+
+// ============================================================================
+// Normalization safety on reversed `m.`/`o.` ranges (CodeRabbit follow-up).
+//
+// `normalize_mt`'s reversed-range branch routes to `mt_fallback`, which
+// historically still invoked `apply_canonical_split`. The canonical-split
+// path computes `expected_span = hgvs_end - hgvs_start + 1` as `u64`, so a
+// reversed range (`end < start`) would underflow into a giant span and
+// trigger a `CanonicalSplitSkipped` warning (or worse, depending on the
+// reference provider's tolerance for `start > end`). Today's shipped
+// providers reject `start > end` at the `get_sequence` boundary, masking
+// the issue, but the latent dependency on every provider doing that guard
+// correctly is fragile. The fix in `normalize/mod.rs::normalize_mt`
+// short-circuits the reversed-range fallback before `apply_canonical_split`
+// runs. This test pins that contract.
+// ============================================================================
+
+#[test]
+fn mt_wraparound_delins_normalize_does_not_emit_canonical_split_skipped() {
+    let variant =
+        parse_hgvs(&format!("{MT}:m.16569_1delinsT")).expect("wraparound delins must parse");
+    let normalizer = Normalizer::new(MockProvider::new());
+    let normalized = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize must succeed on no-reference fallback");
+    assert_eq!(
+        format!("{}", normalized.result),
+        format!("{MT}:m.16569_1delinsT"),
+        "wraparound delins must round-trip unchanged through the no-reference fallback",
+    );
+    assert!(
+        !normalized
+            .warnings
+            .iter()
+            .any(|w| w.code() == "CANONICAL_SPLIT_SKIPPED"),
+        "wraparound mt delins must skip `apply_canonical_split` entirely; \
+         got warnings {:?}",
+        normalized
+            .warnings
+            .iter()
+            .map(|w| w.code())
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn mt_wraparound_del_normalize_does_not_emit_canonical_split_skipped() {
+    let variant =
+        parse_hgvs(&format!("{MT}:m.16563_13del")).expect("wraparound del must parse (SVD-WG006)");
+    let normalizer = Normalizer::new(MockProvider::new());
+    let normalized = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize must succeed on no-reference fallback");
+    assert!(
+        !normalized
+            .warnings
+            .iter()
+            .any(|w| w.code() == "CANONICAL_SPLIT_SKIPPED"),
+        "wraparound mt del must skip `apply_canonical_split` entirely; \
+         got warnings {:?}",
+        normalized
+            .warnings
+            .iter()
+            .map(|w| w.code())
+            .collect::<Vec<_>>(),
+    );
+}

--- a/tests/mito_circular_audit.rs
+++ b/tests/mito_circular_audit.rs
@@ -38,17 +38,18 @@
 //! introduces will need a corresponding extension of the spec-corpus
 //! fixtures — that is also out of scope here.
 //!
-//! ### What ferro does today (May 2026, pre-F1)
+//! ### What ferro does today (May 2026, post-#129 Path 1)
 //!
-//! There is no special handling for circular references anywhere in
-//! the crate:
+//! Partial handling of circular references:
 //!
-//! - `src/hgvs/parser/variant.rs::parse_genome_interval` rejects any
-//!   range whose `start.base > end.base` for non-structural edits — so
-//!   wraparound `del` / `delins` / `sub` ranges fail to parse at all.
-//!   (`ins`, `dup`, `inv`, and complex `delins` are exempt from the
-//!   inverted-range check, but for unrelated reasons. Sections 2, 3, 5
-//!   below pin both halves of the asymmetry.)
+//! - `src/hgvs/parser/variant.rs::parse_genome_interval_for_circular`
+//!   plus the `check_circular_reversed_range` post-parse validator
+//!   accept wraparound `del`, `delins`, and `dup` ranges on `m.`/`o.`
+//!   per SVD-WG006 (and `deletion.md:17`). `ins` and `inv` wraparound
+//!   forms are rejected by `check_circular_reversed_range` — the spec
+//!   is silent on them, and ferro prefers a clear parse error to the
+//!   prior silent-accept with mis-computed indel length. (#129 Path 1;
+//!   see the file-level assertions for each edit kind.)
 //! - `src/normalize/mod.rs::normalize_mt` now mirrors `normalize_genome`
 //!   for non-origin-crossing variants (issue #210): window-based 3'
 //!   shuffle and repeat-notation canonicalization, with
@@ -135,18 +136,18 @@ fn audit_mt_non_wrapping_sub_normalizes_to_self() {
 // circular-aware interval and normalize accordingly.
 // -----------------------------------------------------------------------------
 
-/// `m.16569_1del` is rejected by the parser today (inverted range).
-/// F1 must replace this with a successful parse + circular-aware
-/// normalize result.
+/// `m.16569_1del` is the SVD-WG006 example — spec-authorised wraparound
+/// del. Per HGVS v19.01 + `deletion.md:17`, must parse and round-trip.
+/// (#129 flipped this from the prior parser-rejection assertion.)
 #[test]
-fn audit_mt_wrapping_del_at_origin_currently_rejected() {
+fn audit_mt_wrapping_del_at_origin_parses() {
     let input = "NC_012920.1:m.16569_1del";
-    let result = parse_hgvs(input);
-    assert!(
-        result.is_err(),
-        "PINNED: ferro currently rejects wraparound m. ranges; F1 must change this. \
-         Got Ok({:?}) — update this test as part of the F1 implementation.",
-        result.ok()
+    let variant =
+        parse_hgvs(input).expect("spec-authorised wraparound del must parse (#129, SVD-WG006)");
+    assert_eq!(
+        format!("{}", variant),
+        input,
+        "wraparound del must round-trip 3'→5' on m.",
     );
 }
 
@@ -159,17 +160,14 @@ fn audit_mt_wrapping_del_at_origin_currently_rejected() {
 // general N-nt wraparound case.
 // -----------------------------------------------------------------------------
 
-/// Longer wraparound deletion is also rejected by the parser today.
+/// Longer wraparound deletion also parses per the same SVD-WG006
+/// exception. (#129 flipped this from the prior rejection assertion.)
 #[test]
-fn audit_mt_wrapping_del_longer_currently_rejected() {
+fn audit_mt_wrapping_del_longer_parses() {
     let input = "NC_012920.1:m.16569_5del";
-    let result = parse_hgvs(input);
-    assert!(
-        result.is_err(),
-        "PINNED: wraparound m. deletion across origin is rejected today. \
-         Got Ok({:?}) — update this test as part of the F1 implementation.",
-        result.ok()
-    );
+    let variant =
+        parse_hgvs(input).expect("longer wraparound del must parse on m. (#129, SVD-WG006)");
+    assert_eq!(format!("{}", variant), input);
 }
 
 // -----------------------------------------------------------------------------
@@ -238,40 +236,27 @@ fn audit_mt_full_span_dup_normalizes_to_self_today() {
 // accepted without circular-aware normalize support.
 // -----------------------------------------------------------------------------
 
-/// Wrapping `delins` at the origin is rejected today (same parser path
-/// as `del`).
+/// Wrapping `delins` at the origin parses per the same SVD-WG006
+/// exception (delins inherits via del+ins composition). (#129 flipped
+/// this from the prior rejection assertion.)
 #[test]
-fn audit_mt_wrapping_delins_currently_rejected() {
+fn audit_mt_wrapping_delins_parses() {
     let input = "NC_012920.1:m.16569_1delinsT";
-    let result = parse_hgvs(input);
-    assert!(
-        result.is_err(),
-        "PINNED: wraparound m. delins is rejected today on the same \
-         inverted-range check as del. F1 must change this. \
-         Got Ok({:?}).",
-        result.ok()
-    );
+    let variant = parse_hgvs(input).expect("wraparound delins must parse on m. (#129, SVD-WG006)");
+    assert_eq!(format!("{}", variant), input);
 }
 
-/// Wrapping `dup` at the origin **parses** today and (with no provider
-/// data) falls back to minimal-notation cleanup, which preserves the
-/// input verbatim. Pinned to expose the parser asymmetry: wraparound
-/// `del` is rejected, but wraparound `dup` is silently accepted.
+/// Wrapping `dup` at the origin parses per SVD-WG006:23 (explicit
+/// example `J01749.1:o.4344_197dup`) and SVD-WG006:33 ("simplifies
+/// the description of deletions/duplications"). (#129 made this
+/// official-rather-than-silently-accepted; the round-trip and
+/// no-reference-fallback behaviour are unchanged.)
 #[test]
-fn audit_mt_wrapping_dup_silently_accepted_today() {
+fn audit_mt_wrapping_dup_parses() {
     let input = "NC_012920.1:m.16560_5dup";
-    let variant = parse_hgvs(input).unwrap_or_else(|e| {
-        panic!(
-            "PINNED: wraparound m. dup parses today (parser exempts dup from \
-             the inverted-range check). Got Err({e}); update if F1 tightens this."
-        )
-    });
-    assert_eq!(
-        format!("{}", variant),
-        input,
-        "PINNED: wraparound m. dup round-trips verbatim today. F1 must \
-         define a circular-aware canonical form."
-    );
+    let variant =
+        parse_hgvs(input).expect("spec-authorised wraparound dup must parse (#129, SVD-WG006)");
+    assert_eq!(format!("{}", variant), input);
     let normalizer = Normalizer::new(MockProvider::new());
     let normalized = normalizer
         .normalize(&variant)
@@ -280,35 +265,37 @@ fn audit_mt_wrapping_dup_silently_accepted_today() {
         format!("{}", normalized),
         input,
         "PINNED: with no provider data, wraparound dup falls back to \
-         minimal-notation cleanup and is preserved unchanged. F1 must \
-         define a circular-aware canonical form."
+         minimal-notation cleanup and is preserved unchanged. \
+         Wraparound 3'-shift is still a no-op (matches mutalyzer + \
+         biocommons + strict spec reading).",
     );
 }
 
-/// Wrapping `inv` at the origin parses today (same parser exemption).
+/// Wrapping `inv` is rejected per #129 (spec-silent on inv wraparound;
+/// SVD-WG006 names only del/dup in its rationale and examples).
+/// Was previously silently accepted with mis-computed length.
 #[test]
-fn audit_mt_wrapping_inv_silently_accepted_today() {
+fn audit_mt_wrapping_inv_rejected() {
     let input = "NC_012920.1:m.16500_500inv";
-    let variant = parse_hgvs(input).unwrap_or_else(|e| {
-        panic!(
-            "PINNED: wraparound m. inv parses today (parser exempts inv from \
-             the inverted-range check). Got Err({e})."
-        )
-    });
-    assert_eq!(format!("{}", variant), input);
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "wraparound inv has no spec exception (SVD-WG006 names only \
+         del/dup); must be rejected. Got {result:?}",
+    );
 }
 
-/// Wrapping `ins` at the origin parses today (same parser exemption).
+/// Wrapping `ins` is rejected per #129 (spec-silent on ins
+/// wraparound). Was previously silently accepted.
 #[test]
-fn audit_mt_wrapping_ins_silently_accepted_today() {
+fn audit_mt_wrapping_ins_rejected() {
     let input = "NC_012920.1:m.16569_1insT";
-    let variant = parse_hgvs(input).unwrap_or_else(|e| {
-        panic!(
-            "PINNED: wraparound m. ins parses today (parser exempts ins from \
-             the inverted-range check). Got Err({e})."
-        )
-    });
-    assert_eq!(format!("{}", variant), input);
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "wraparound ins has no spec exception (SVD-WG006 names only \
+         del/dup); must be rejected. Got {result:?}",
+    );
 }
 
 // -----------------------------------------------------------------------------
@@ -325,24 +312,66 @@ fn audit_mt_wrapping_ins_silently_accepted_today() {
 
 /// `get_indel_length` on a wrapping m. dup returns a value that is
 /// **wrong** under circular semantics (today: a large negative number,
-/// because compute_span = end - start + 1 with end < start). Pin the
-/// exact value so F1 surfaces.
+/// because compute_span = end - start + 1 with end < start). #129
+/// accepts the parse but does NOT yet wire contig-length math, so the
+/// indel-length miscompute is still pinned as a known follow-up. Pin
+/// the exact value so a future contig-length-aware fix surfaces.
 #[test]
-fn audit_mt_wrapping_dup_indel_length_silent_miscompute_today() {
+fn audit_mt_wrapping_dup_indel_length_still_miscomputes_today() {
     let input = "NC_012920.1:m.16560_5dup";
-    let variant = parse_hgvs(input).expect("parse should succeed (Scenario 5)");
+    let variant = parse_hgvs(input).expect("parse should succeed per #129 / SVD-WG006");
     let observed = get_indel_length(&variant);
     // Today: end (5) - start (16560) + 1 = -16554; sign flipped by the
     // Duplication branch is not applied — that branch returns
     // `Some(compute_span(variant)?)` directly, so we get -16554.
     // The right answer for a wraparound dup of length (16569 - 16560 +
-    // 1) + 5 = 15 is +15. We are nowhere near that.
+    // 1) + 5 = 15 is +15. Tracked as a follow-up to #129; needs
+    // contig-length plumbing.
     assert_eq!(
         observed,
         Some(-16554),
-        "PINNED: `compute_span` lacks an `Mt` guard, so a wraparound m. \
-         dup yields a silently-wrong indel length. F1 must extend the \
-         guard or compute the real circular span using contig length."
+        "PINNED: `compute_span` lacks circular-aware math, so a wraparound \
+         m. dup yields a silently-wrong indel length. Follow-up to #129 \
+         must compute the real circular span using contig length."
+    );
+}
+
+/// Wraparound `del` newly parses post-#129 and hits the same
+/// `compute_span` miscompute as `dup`. Pin the value so the
+/// contig-length-aware fix surfaces this case too.
+#[test]
+fn audit_mt_wrapping_del_indel_length_still_miscomputes_today() {
+    let input = "NC_012920.1:m.16569_1del";
+    let variant = parse_hgvs(input).expect("parse should succeed per #129 / SVD-WG006");
+    let observed = get_indel_length(&variant);
+    // Today: ref-span = end (1) - start (16569) + 1 = -16567; the
+    // del branch reports the magnitude of the deleted region, so the
+    // observed value is 16567 (the wrong way to compute span on a
+    // circle). Spec-correct answer is 2 (positions 16569 and 1).
+    assert_eq!(
+        observed,
+        Some(16567),
+        "PINNED: wraparound m. del shares the dup miscompute; follow-up \
+         to #129 must teach compute_span the contig-length-aware math."
+    );
+}
+
+/// Wraparound `delins` shares the same miscompute. Pin alongside del/dup.
+#[test]
+fn audit_mt_wrapping_delins_indel_length_still_miscomputes_today() {
+    let input = "NC_012920.1:m.16569_1delinsT";
+    let variant = parse_hgvs(input).expect("parse should succeed per #129 / SVD-WG006");
+    let observed = get_indel_length(&variant);
+    // Today: ref-span = -16567 with the delins branch adjusting by the
+    // inserted-length offset, yielding 16568 (= 16567 + 1, both signs
+    // unfortunate). Spec-correct answer for delinsT (replacing the
+    // 2-nt wraparound window with 1 nt) is -1; pinned exact so a
+    // future contig-length-aware fix surfaces this case too.
+    assert_eq!(
+        observed,
+        Some(16568),
+        "PINNED: wraparound m. delins miscomputes; follow-up to #129 \
+         must teach compute_span contig-length-aware math.",
     );
 }
 


### PR DESCRIPTION
## Summary

HGVS spec ([SVD-WG006](../blob/main/assets/hgvs-nomenclature/docs/consultation/SVD-WG006.md), accepted into HGVS v19.01) authorises reversed `<high>_<low>` ranges on circular references (`o.`/`m.`) "when the rearrangement includes both the last and first nucleotides of the reference sequence", with explicit examples for **both** `del` (`NC_012920.1:m.16563_13del`) and `dup` (`J01749.1:o.4344_197dup`). The `deletion.md:17` rule + `delins`'s `del + ins` composition extend the exception to `delins`. `ins` and `inv` wraparound forms are spec-silent.

ferro previously rejected the parser-side spec-authorised forms (`del`, `delins`) while silently accepting the spec-unauthorised forms (`dup`, `ins`, `inv`) — the latter with silently mis-computed indel length. Both halves of that asymmetry were pinned in `tests/mito_circular_audit.rs` as a tracking surface for this issue.

## What this PR delivers

- Parser **accepts** wraparound `del`, `delins`, and `dup` on `m.` and `o.`. Round-trip-stable.
- Parser **rejects** wraparound `ins` and `inv` with a clear `Verify` error — the spec gives no authorisation for those reversed forms.
- `normalize_mt` gates wraparound inputs (`start > end`) to the canonicalize-only fallback at the top of the function, removing the dependency on the provider error-path or window-arithmetic fail-safe that Opus flagged.
- 3'-rule wraparound shift remains **disabled**: matches mutalyzer (`mutalyzer/description.py:889` rejects all reversed ranges) and biocommons hgvs (`hgvs/location.py:437` "base start position must be <= end position"). The spec's `general.md:41` "most 3' position possible **of the reference sequence**" wording does not define circular semantics; ferro doesn't invent them.

## Comparison with other tools

| Tool | wraparound `del` | wraparound `dup` | wraparound `ins`/`inv` | wrap 3'-shift |
|---|---|---|---|---|
| **HGVS spec** | Authorised | Authorised (SVD-WG006) | Spec-silent | Undefined |
| **mutalyzer** | Rejected (`ERANGEREVERSED`) | Rejected | Rejected | No |
| **biocommons hgvs** | Rejected ("base start position must be <= end position") | Rejected | Rejected | No |
| **ferro (after this PR)** | **Accepted** ✅ | **Accepted** ✅ | Rejected | No (matches others) |

ferro is the only tool of the three that implements the spec-authorised wraparound exception. mutalyzer and biocommons are both under-compliant on this surface.

## Implementation

`parse_genome_interval` gains a sibling `parse_genome_interval_for_circular` (loosens the fast-path inverted check) plus a `check_circular_reversed_range` post-parse validator that rejects the spec-unauthorised edit kinds. Both `parse_mt_variant` and `parse_circular_variant` route through these, on the bare and `(...)` predicted-form branches. The genomic (`g.`) path is unchanged — linear references still reject reversed ranges per the general 5'→3' rule.

`normalize_mt` adds a top-of-function `if start > end { return mt_fallback(variant); }` gate so wraparound inputs route directly to the canonicalize-only fallback. Doing this here, rather than relying on the provider rejecting `start > end` and the post-arithmetic `rel_end = end - window_start` underflow, keeps the path correct under any window-size configuration.

## Tests

- New `tests/issue_129_mt_circular_wraparound.rs` (12 tests): pins the new accept/reject contract for `m.` and `o.`, including the SVD-WG006 examples verbatim (`m.16569_1del`, `J01749.1:o.4344_197dup`), non-wraparound regression coverage for `dup`/`inv` (must still parse for `start < end`), and the `g.`-axis-must-still-reject negative control. Uses `assert_eq!` round-trip checks for tighter regression coverage.
- `tests/mito_circular_audit.rs` (existing 26 tests + 2 new pins): three audit assertions flipped from "currently rejected"/"silently accepted" to the spec-compliant behaviour. Added sibling pins for wraparound `del` and `delins` indel-length miscomputes (joining the existing wraparound `dup` pin) so the contig-length-aware fix surfaces all three cases together.
- `tests/fixtures/grammar/hgvs_spec_normalization.json`: corpus entry for `NC_012920.1:m.16563_13del` flipped from `parse-error` to `preserved` per the spec-authorised parse.

5640/5640 focused tests pass. Clippy + fmt clean.

## Delivered after initial body (amend `46ecce7`)

- **Bracketed compound alleles with wraparound** now parse on both cis and trans forms. `parse_genome_bracket_member` gains a `kind` parameter and routes through `parse_genome_interval_for_circular` + `check_circular_reversed_range`. Tests added to `tests/issue_129_mt_circular_wraparound.rs`: `assert_roundtrip("{MT}:m.[16569_1del;100A>G]")`, reject test for `m.[16569_1insA;100A>G]`, and trans-form round-trip `m.[16569_1del];[100A>G]`.

## Out of scope (follow-ups)

- **Contig-length-aware indel-length / span math for wraparound del/dup/delins.** Pinned by `audit_mt_wrapping_{del,dup,delins}_indel_length_still_miscomputes_today`. Needs contig-length plumbing from the provider.
- **3'-rule shuffle across the origin.** Intentionally deferred to match mutalyzer/biocommons + strict spec reading. `general.md:41` does not define circular shift semantics.
- **Contig-length validation.** Positions past the contig end (e.g. `m.16570A>G`) still parse; separate concern from wraparound. Pinned by `audit_mt_position_past_end_silently_accepted_today`. Filed as #393.

Refs #129.
