### PR TITLE
build(python): migrate PyO3 bindings to abi3 stable ABI

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -18,6 +18,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # abi3 wheels: one wheel per (OS, arch) tagged `cp310-abi3`, runs on
+  # every CPython >= 3.10. The `-i python<X>` flag is omitted so maturin
+  # builds against pyo3's `abi3-py310` limited-API target (set in
+  # `Cargo.toml`). See
+  # https://pyo3.rs/main/building-and-distribution.html#py_limited_apiabi3
+  # and https://www.maturin.rs/bindings#py_limited_apiabi3
   linux:
     name: Linux ${{ matrix.target }} ${{ matrix.manylinux }}
     runs-on: ${{ matrix.runner }}
@@ -45,12 +51,12 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-      - name: Build wheels
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          args: --release --out dist --features python -i python3.10 python3.11 python3.12 python3.13 python3.14
+          args: --release --out dist --features python
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}
@@ -58,18 +64,24 @@ jobs:
           if-no-files-found: error
 
   macos:
-    name: macOS ${{ matrix.target }} py${{ matrix.python-version }}
+    name: macOS ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-15-intel, macos-14]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - runner: macos-15-intel
             target: x86_64
+            # macOS deployment target floor for the wheel. Pinned
+            # explicitly (rather than inherited from setup-python's
+            # build target) so a runner-image refresh that bumps the
+            # default min-target doesn't silently move the abi3 wheel's
+            # macOS floor on us.
+            macosx_deployment_target: "10.13"
           - runner: macos-14
             target: aarch64
+            # Apple Silicon: Python 3.10 on arm64 requires macOS 11+.
+            macosx_deployment_target: "11.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -77,25 +89,23 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build wheel
+          python-version: "3.12"
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        env:
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --features python -i python
+          args: --release --out dist --features python
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-macos-${{ matrix.target }}
           path: dist
           if-no-files-found: error
 
   windows:
-    name: Windows py${{ matrix.python-version }}
+    name: Windows
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -103,16 +113,16 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           architecture: x64
-      - name: Build wheel
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x86_64-pc-windows-msvc
-          args: --release --out dist --features python -i python
+          args: --release --out dist --features python
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: wheels-windows-py${{ matrix.python-version }}
+          name: wheels-windows
           path: dist
           if-no-files-found: error
 
@@ -158,13 +168,18 @@ jobs:
         run: uv run --no-sync twine check --strict dist/*
 
   smoke-test:
+    # Verify the abi3 promise: each OS/arch produces a single
+    # `cp310-abi3` wheel, and that wheel installs and imports under
+    # every supported CPython minor version (3.10..3.14). 3.14 is
+    # included so a future CPython release surfaces ABI breakage in the
+    # release pipeline rather than at customer install-time.
     name: Smoke ${{ matrix.runner }} py${{ matrix.python-version }}
     needs: [linux, macos, windows]
     strategy:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-14, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -179,9 +194,27 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --no-index --only-binary :all: --find-links dist ferro-hgvs
-      - name: Smoke test (import + parse)
+      - name: Smoke test (import + parse + eq_int pyclass)
         shell: bash
-        run: python -c "import ferro_hgvs; v = ferro_hgvs.parse('NM_000088.3:c.459A>G'); print(repr(v))"
+        # Exercise the abi3 surface beyond just `parse`: pyclass `__eq__`
+        # / `__hash__` / `__str__`, an `eq, eq_int` pyclass enum
+        # (Consequence), and a constructor that allocates a pyclass
+        # instance. The first three lines all use pyo3 macro paths that
+        # would surface limited-API breakage if the wheel were ABI-
+        # incompatible with the running CPython.
+        run: |
+          python <<'EOF'
+          import ferro_hgvs
+          v = ferro_hgvs.parse("NM_000088.3:c.459A>G")
+          assert str(v) == "NM_000088.3:c.459A>G", f"str round-trip: {str(v)!r}"
+          assert v == ferro_hgvs.parse("NM_000088.3:c.459A>G"), "__eq__"
+          assert hash(v) == hash(ferro_hgvs.parse("NM_000088.3:c.459A>G")), "__hash__"
+          # eq_int pyclass enum (Consequence). int() cast and equality
+          # use the pyo3 limited-API codegen path that abi3 must support.
+          cons = ferro_hgvs.Consequence.CodingSequenceVariant
+          assert int(cons) == 18, f"eq_int: {int(cons)}"
+          print(f"smoke ok: {v!r} cons={cons}")
+          EOF
 
   upload:
     name: Upload to GitHub Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ noodles-gtf = "0.52"
 smol_str = { version = "0.3", features = ["serde"] }
 flate2 = "1.0"
 ahash = { version = "0.8", optional = true }
-pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["abi3-py310", "extension-module"], optional = true }
 memmap2 = { version = "0.9", optional = true }
 memchr = "2.7"
 ureq = { version = "2.9", optional = true }


### PR DESCRIPTION
## Summary

Migrate the PyO3 bindings to the [abi3 stable ABI](https://docs.python.org/3/c-api/stable.html). The release wheel matrix collapses from ~19 build jobs (one per OS × arch × Python minor version) to **7** (one per OS × arch × libc), and the resulting `cp310-abi3`-tagged wheel runs on every CPython ≥ 3.10 without rebuilding per minor version.

## Changes

- **`Cargo.toml`**: add `abi3-py310` to the `pyo3` feature list alongside the existing `extension-module`. pyo3 0.28 picks up the limited-API target automatically; maturin auto-detects from the Cargo feature and emits a single `cp310-abi3` wheel.
- **`.github/workflows/release-wheels.yml`**:
  - Drop `-i python3.10 python3.11 python3.12 python3.13 python3.14` from each build job's maturin args.
  - Collapse the `python-version` matrix dimension on macOS + Windows (one job per arch, not per arch × Python version).
  - Pin `MACOSX_DEPLOYMENT_TARGET` explicitly per macOS arch (10.13 intel / 11.0 arm64) so a runner-image refresh doesn't silently move the wheel's macOS floor.
  - **Keep** the smoke-test matrix at 5 OS/arch × 5 Python versions (3.10-3.14) so each release confirms the abi3 promise: one wheel, many Pythons. Widened the smoke command from just `parse()` to also exercise `__str__`/`__eq__`/`__hash__` round-trip plus an `eq_int` pyclass enum (`Consequence.CodingSequenceVariant`) — the latter exercises the limited-API codegen path that abi3 must support.

## Source audit

No `src/python.rs` changes needed. The audit found no non-abi3 features in use:

- No buffer protocol (`__getbuffer__`)
- No weakref support
- No custom pickling (`__reduce__`/`__getstate__`/`__setstate__`)
- No raw `pyo3::ffi` calls or direct `PyTypeObject` access
- No `unsafe` code
- All `#[pyclass]` attrs (`name`, `from_py_object`, `eq`, `eq_int`) and dunder methods (`__str__`/`__repr__`/`__eq__`/`__hash__`/`__lt__`/etc.) are abi3-py310-safe per pyo3 0.28 docs

## Local validation

- `cargo check --features python` clean
- `maturin build --features python --release` produces `ferro_hgvs-0.6.0-cp310-abi3-macosx_11_0_arm64.whl` (the `cp310-abi3` tag confirms abi3)
- **171/171 Python tests pass against the cp310-abi3 wheel under Python 3.10, 3.13, and 3.14** — the abi3 promise verified end-to-end on three CPython minor versions
- Full Rust focused suite (5671/5671) passes
- `cargo clippy --features dev --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean

## Notes

- `pyproject.toml`'s `requires-python = ">=3.10"` already aligns with `abi3-py310`. No change needed.
- `__init__.pyi` stubs unchanged because no Rust signatures change.
- Reverting risk is low: PyPI wheel files are immutable; if a future Python version surfaces an abi3-py310 bug, a follow-up release with the per-version matrix restored would shadow the abi3 wheel for that Python version (pip prefers more-specific tags).

## Out of scope

- **musllinux smoke test.** musllinux wheels are still built (`auto` + `musllinux_1_2` matrix entries) but the smoke-test runners are glibc/macOS/Windows only. Pre-existing gap; flagged for a follow-up.
- **CI lint that asserts `abi3-pyXYZ` matches `pyproject.toml`'s `requires-python`.** Would prevent silent floor-drift on a future bump. Tracked as a follow-up infra item.

Closes #59.