### PR TITLE
fix(project): build-aware cdot lookups + widen fan-out path for c./n./r. (closes #389)

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1318,6 +1318,17 @@ impl CdotMapper {
         self.transcripts.contains_key(accession)
     }
 
+    /// Name of the genome build whose data populates [`Self::transcripts`].
+    ///
+    /// This is the "primary" build set at load time
+    /// (e.g. via [`from_transcripts_with_build`](Self::from_transcripts_with_build)
+    /// or [`from_cdot_file_with_build`](Self::from_cdot_file_with_build));
+    /// any other builds live in [`Self::alt_build_transcripts`] and are
+    /// reachable only through [`get_transcript_on_build`](Self::get_transcript_on_build).
+    pub fn primary_build(&self) -> &str {
+        &self.primary_build
+    }
+
     /// RefSeq transcript if an LRG mapping has been loaded.
     ///
     /// Supports version fallback: if "NM_000088.2" is not found but "NM_000088.3"

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1467,9 +1467,9 @@ impl CdotMapper {
             .collect()
     }
 
-    /// Genomic extent `(min_exon_start, max_exon_end)` of a transcript, taken
-    /// from a cached side-table that's built lazily on first call alongside
-    /// the contig stab-query index.
+    /// Genomic extent `(min_exon_start, max_exon_end)` of a transcript on
+    /// the mapper's primary build, taken from a cached side-table that's
+    /// built lazily on first call alongside the contig stab-query index.
     ///
     /// Used by `VariantProjector::project_single_inner` instead of folding
     /// `tx.exons.iter().map(|e| e[0]).min()/max()` per call — the inputs are
@@ -1480,6 +1480,32 @@ impl CdotMapper {
             .transcript_genome_spans
             .get_or_init(|| self.build_transcript_genome_spans());
         spans.get(transcript_id).copied()
+    }
+
+    /// Build-aware variant of [`transcript_genome_span`]: when `build`
+    /// matches the primary build the cached side-table is used; otherwise
+    /// the span is computed on demand from the alt-build view returned by
+    /// [`get_transcript_on_build`]. Returns `None` if cdot has no
+    /// alignment for the requested build (or the alignment has no exons).
+    ///
+    /// The alt-build branch folds the exon table on every call rather
+    /// than caching like the primary side-table. This is an acceptable
+    /// trade-off until profiling shows otherwise; for callers that
+    /// routinely project alt-build inputs against a multi-build cdot it
+    /// becomes a per-call O(exons) cost worth caching parallel to
+    /// [`Self::transcript_genome_spans`].
+    pub fn transcript_genome_span_on_build(
+        &self,
+        transcript_id: &str,
+        build: &str,
+    ) -> Option<(u64, u64)> {
+        if build == self.primary_build {
+            return self.transcript_genome_span(transcript_id);
+        }
+        let tx = self.get_transcript_on_build(transcript_id, build)?;
+        let min = tx.exons.iter().map(|e| e[0]).min()?;
+        let max = tx.exons.iter().map(|e| e[1]).max()?;
+        Some((min, max))
     }
 
     /// Build the per-transcript span side-table. Same single-pass shape as

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -711,6 +711,15 @@ pub struct CdotFile {
 
 /// Bincode-friendly snapshot of CdotMapper data, without custom JSON deserializers.
 /// Used for deserialization only; serialization uses [`CdotMapperSnapshotRef`].
+///
+/// **Format note (#389 follow-up).** `primary_build` was added after the
+/// initial snapshot layout. bincode (1.x) is positional and does not honor
+/// `#[serde(default)]` for trailing fields, so snapshots produced by older
+/// builds will fail to deserialize against this struct. That failure is
+/// non-fatal: [`CdotMapper::load`] catches it and falls back to JSON, which
+/// regenerates the `.bin` with the new layout. Callers that pass a `.bin`
+/// path directly (no JSON fallback available) must regenerate via
+/// `ferro prepare`.
 #[derive(Deserialize)]
 struct CdotMapperSnapshot {
     transcripts: HashMap<String, CdotTranscriptSnapshot>,
@@ -718,6 +727,11 @@ struct CdotMapperSnapshot {
     contig_alias_to_canonical: HashMap<String, String>,
     base_to_versioned: HashMap<String, String>,
     lrg_to_refseq: HashMap<String, String>,
+    /// Genome build the snapshot was produced under, or `None` if the
+    /// snapshot pre-dates the build-tracking format (only reachable via a
+    /// hand-rolled deserializer skipping this field — bincode itself will
+    /// error on a truncated stream and the loader falls back to JSON).
+    primary_build: Option<String>,
 }
 
 /// Borrowed view of CdotMapper for zero-copy serialization to bincode.
@@ -728,6 +742,7 @@ struct CdotMapperSnapshotRef<'a> {
     contig_alias_to_canonical: &'a HashMap<String, String>,
     base_to_versioned: &'a HashMap<String, String>,
     lrg_to_refseq: &'a HashMap<String, String>,
+    primary_build: Option<&'a str>,
 }
 
 /// Bincode-friendly snapshot of CdotTranscript, using standard Strand serde.
@@ -819,10 +834,14 @@ pub struct CdotMapper {
     /// NOT duplicated here. [`get_transcript_on_build`](Self::get_transcript_on_build)
     /// dispatches between the two maps.
     alt_build_transcripts: HashMap<String, HashMap<String, CdotTranscript>>,
-    /// The genome-build name corresponding to entries in [`Self::transcripts`].
-    /// Used by [`get_transcript_on_build`](Self::get_transcript_on_build) to
-    /// short-circuit when the caller asks for the primary build.
-    primary_build: String,
+    /// The genome-build name corresponding to entries in [`Self::transcripts`],
+    /// or `None` if the build is unknown (e.g. a bincode snapshot produced
+    /// by an older build that did not persist this field). Used by
+    /// [`get_transcript_on_build`](Self::get_transcript_on_build) to
+    /// short-circuit when the caller asks for the primary build, and by
+    /// [`primary_build`](Self::primary_build) so downstream callers can
+    /// honor uncertainty rather than assume a default (#389 follow-up).
+    primary_build: Option<String>,
     /// Lazily-built per-contig SuperIntervals index for stabbing queries.
     ///
     /// Built on the first call to `transcripts_at_position` from the contents of
@@ -856,7 +875,7 @@ impl CdotMapper {
             base_to_versioned: HashMap::new(),
             lrg_to_refseq: HashMap::new(),
             alt_build_transcripts: HashMap::new(),
-            primary_build: "GRCh38".to_string(),
+            primary_build: Some("GRCh38".to_string()),
             contig_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
         }
@@ -901,7 +920,7 @@ impl CdotMapper {
         I: IntoIterator<Item = &'a crate::reference::transcript::Transcript>,
     {
         let mut mapper = Self::new();
-        mapper.primary_build = genome_build.to_string();
+        mapper.primary_build = Some(genome_build.to_string());
         for tx in transcripts {
             let Some(contig) = tx.chromosome.clone() else {
                 log::warn!("Skipping transcript {}: missing chromosome", tx.id);
@@ -1010,10 +1029,9 @@ impl CdotMapper {
             base_to_versioned: snapshot.base_to_versioned,
             lrg_to_refseq: snapshot.lrg_to_refseq,
             // Bincode snapshots are produced for a specific genome build; alt-
-            // build data is not part of the serialized format. `primary_build`
-            // is unknown here — default to GRCh38 to match the prior contract.
-            // Callers that need multi-build access (e.g. NG/NC-parent-aware
-            // transcript lookup per #332) should load from JSON.
+            // build data is not part of the serialized format. Callers that
+            // need multi-build access (e.g. NG/NC-parent-aware transcript
+            // lookup per #332) should load from JSON.
             alt_build_transcripts: {
                 log::warn!(
                     "cdot bincode load: alt-build data unavailable; NG/NC-parent build \
@@ -1021,7 +1039,10 @@ impl CdotMapper {
                 );
                 HashMap::new()
             },
-            primary_build: "GRCh38".to_string(),
+            // Honor the snapshot's recorded primary build; older snapshots
+            // that pre-date this field surface as `None` rather than
+            // claiming a fabricated GRCh38 (#389 follow-up).
+            primary_build: snapshot.primary_build,
             contig_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
         })
@@ -1039,6 +1060,7 @@ impl CdotMapper {
             contig_alias_to_canonical: &self.contig_alias_to_canonical,
             base_to_versioned: &self.base_to_versioned,
             lrg_to_refseq: &self.lrg_to_refseq,
+            primary_build: self.primary_build.as_deref(),
         };
         let file = File::create(path.as_ref()).map_err(|e| FerroError::Io {
             msg: format!("Failed to create cdot bincode file: {}", e),
@@ -1120,7 +1142,7 @@ impl CdotMapper {
     /// build are simply absent from that build's map.
     fn from_raw_cdot_file(raw_file: RawCdotFile, genome_build: &str) -> Self {
         let mut mapper = Self::new();
-        mapper.primary_build = genome_build.to_string();
+        mapper.primary_build = Some(genome_build.to_string());
 
         for (accession, raw_transcript) in raw_file.transcripts {
             // Stash any non-primary build views first so a missing primary-
@@ -1158,7 +1180,7 @@ impl CdotMapper {
     /// Create from a parsed CdotFile with a specific genome build for contig aliases.
     pub fn from_cdot_file_with_build(cdot_file: CdotFile, genome_build: &str) -> Self {
         let mut mapper = Self::new();
-        mapper.primary_build = genome_build.to_string();
+        mapper.primary_build = Some(genome_build.to_string());
 
         for (accession, transcript) in cdot_file.transcripts {
             mapper.add_transcript(accession, transcript);
@@ -1318,15 +1340,21 @@ impl CdotMapper {
         self.transcripts.contains_key(accession)
     }
 
-    /// Name of the genome build whose data populates [`Self::transcripts`].
+    /// Name of the genome build whose data populates [`Self::transcripts`],
+    /// or `None` if the build is unknown.
     ///
     /// This is the "primary" build set at load time
     /// (e.g. via [`from_transcripts_with_build`](Self::from_transcripts_with_build)
     /// or [`from_cdot_file_with_build`](Self::from_cdot_file_with_build));
     /// any other builds live in [`Self::alt_build_transcripts`] and are
     /// reachable only through [`get_transcript_on_build`](Self::get_transcript_on_build).
-    pub fn primary_build(&self) -> &str {
-        &self.primary_build
+    ///
+    /// Returns `None` when the mapper was loaded from a bincode snapshot
+    /// produced before the build field was persisted — downstream callers
+    /// must surface that uncertainty rather than substituting a default
+    /// (#389 follow-up).
+    pub fn primary_build(&self) -> Option<&str> {
+        self.primary_build.as_deref()
     }
 
     /// RefSeq transcript if an LRG mapping has been loaded.
@@ -1384,19 +1412,57 @@ impl CdotMapper {
     /// asks for that build's view of the NM, so the resulting transcript
     /// carries the correct chromosome alignment.
     pub fn get_transcript_on_build(&self, accession: &str, build: &str) -> Option<&CdotTranscript> {
-        if build == self.primary_build {
+        // Treat unknown primary build (bincode snapshots without the field)
+        // as a match: `alt_build_transcripts` is empty for those mappers so
+        // the only data available lives in `transcripts`, and probing that
+        // map is strictly better than returning `None` (#389 follow-up).
+        let primary_matches = match self.primary_build.as_deref() {
+            Some(pb) => pb == build,
+            None => true,
+        };
+        if primary_matches {
             return self.get_transcript(accession);
         }
+        // Alt-build path: resolve LRG → RefSeq before consulting the alt
+        // map so build-specific lookups honor the same LRG fallback as
+        // [`get_transcript`] (#389 follow-up). Without this, a non-primary
+        // LRG lookup would return `None` even when the mapped RefSeq
+        // transcript exists in the alt build.
+        let resolved: &str = if accession.starts_with("LRG_") {
+            self.lrg_to_refseq
+                .get(accession)
+                .map(String::as_str)
+                .unwrap_or(accession)
+        } else {
+            accession
+        };
         let alt = self.alt_build_transcripts.get(build)?;
-        if let Some(tx) = alt.get(accession) {
+        if let Some(tx) = alt.get(resolved) {
             return Some(tx);
         }
-        // Version fallback within the alt-build map.
-        if let Some(base) = accession.split('.').next() {
+        // Version fallback within the alt-build map. Deterministically pick
+        // the highest numeric version among siblings sharing the base, rather
+        // than the first HashMap iteration hit — alt-build maps occasionally
+        // hold more than one version of the same base accession, and
+        // returning whichever the hasher landed on first was nondeterministic
+        // across runs (#389 follow-up).
+        if let Some(base) = resolved.split('.').next() {
+            let mut best: Option<(u32, &CdotTranscript)> = None;
             for (k, v) in alt {
-                if k.starts_with(base) && k[base.len()..].starts_with('.') {
-                    return Some(v);
+                if !(k.starts_with(base) && k[base.len()..].starts_with('.')) {
+                    continue;
                 }
+                let ver = k[base.len() + 1..]
+                    .split('.')
+                    .next()
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .unwrap_or(0);
+                if best.is_none_or(|(cur, _)| ver > cur) {
+                    best = Some((ver, v));
+                }
+            }
+            if let Some((_, tx)) = best {
+                return Some(tx);
             }
         }
         None
@@ -1409,8 +1475,14 @@ impl CdotMapper {
     /// order (e.g. GRCh38-then-GRCh37) should sort externally.
     pub fn available_builds_for(&self, accession: &str) -> Vec<String> {
         let mut builds = Vec::new();
-        if self.get_transcript(accession).is_some() {
-            builds.push(self.primary_build.clone());
+        // Only claim the primary build when we actually know what it is —
+        // a bincode snapshot loaded without a recorded build returns
+        // `None` here and we omit it rather than fabricate one
+        // (#389 follow-up).
+        if let Some(primary) = self.primary_build.clone() {
+            if self.get_transcript(accession).is_some() {
+                builds.push(primary);
+            }
         }
         for (build, alt) in &self.alt_build_transcripts {
             // Direct hit, or versioned-base fallback.
@@ -1499,7 +1571,15 @@ impl CdotMapper {
         transcript_id: &str,
         build: &str,
     ) -> Option<(u64, u64)> {
-        if build == self.primary_build {
+        // Mirror the primary-vs-alt routing in `get_transcript_on_build`:
+        // unknown primary build (bincode snapshot without the field) means
+        // we only have `transcripts` to work with, so use the cached
+        // primary-side span (#389 follow-up).
+        let primary_matches = match self.primary_build.as_deref() {
+            Some(pb) => pb == build,
+            None => true,
+        };
+        if primary_matches {
             return self.transcript_genome_span(transcript_id);
         }
         let tx = self.get_transcript_on_build(transcript_id, build)?;
@@ -2714,6 +2794,143 @@ mod tests {
         let tx37 = mapper
             .get_transcript_on_build("NM_000088.4", "GRCh37")
             .expect("version fallback inside alt-build map");
+        assert_eq!(tx37.contig, "NC_000017.10");
+    }
+
+    #[test]
+    fn test_get_transcript_on_build_alt_version_fallback_picks_highest() {
+        // When the alt-build map holds multiple versions of the same base
+        // (e.g. NM_000088.3 and NM_000088.4), the version fallback must
+        // deterministically prefer the highest numeric version. Pre-fix this
+        // iterated the HashMap and returned whichever versioned key the hasher
+        // landed on first.
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000017.10",
+                            "strand": "+",
+                            "exons": [[48263025, 48263098, 1, 0, 73, "M73"]]
+                        },
+                        "GRCh38": {
+                            "contig": "NC_000017.11",
+                            "strand": "+",
+                            "exons": [[50184096, 50184169, 1, 0, 73, "M73"]]
+                        }
+                    },
+                    "start_codon": 10,
+                    "stop_codon": 60
+                },
+                "NM_000088.4": {
+                    "gene_name": "COL1A1",
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000017.10",
+                            "strand": "+",
+                            "exons": [[48263025, 48263198, 1, 0, 173, "M173"]]
+                        },
+                        "GRCh38": {
+                            "contig": "NC_000017.11",
+                            "strand": "+",
+                            "exons": [[50184096, 50184269, 1, 0, 173, "M173"]]
+                        }
+                    },
+                    "start_codon": 20,
+                    "stop_codon": 160
+                }
+            }
+        }
+        "#;
+        let mapper = CdotMapper::from_reader(json.as_bytes()).unwrap();
+        // Primary build = GRCh38, so the GRCh37 alt map holds both .3 and .4.
+        // Querying with .2 (absent) forces the version fallback.
+        let tx = mapper
+            .get_transcript_on_build("NM_000088.2", "GRCh37")
+            .expect("version fallback must find a sibling");
+        assert_eq!(
+            tx.cds_start,
+            Some(20),
+            "alt-build fallback must deterministically pick the highest version (.4 over .3)"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // #389 follow-up: primary_build() returns Option, and bincode loads that
+    // pre-date the primary_build field must surface as None rather than
+    // fabricating "GRCh38" (which mis-stamps GRCh37 snapshots).
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_primary_build_known_after_explicit_build_load() {
+        let mapper =
+            CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), "GRCh37")
+                .unwrap();
+        assert_eq!(mapper.primary_build(), Some("GRCh37"));
+    }
+
+    #[test]
+    fn test_bincode_roundtrip_preserves_primary_build_grch37() {
+        // Persist a GRCh37-primary mapper to bincode and read it back; the
+        // build name must survive the round-trip so downstream callers
+        // don't mis-stamp transcripts as GRCh38.
+        let mapper =
+            CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), "GRCh37")
+                .unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("roundtrip.bin");
+        mapper.to_bincode_file(&path).expect("write bincode");
+        let reloaded = CdotMapper::from_bincode_file(&path).expect("read bincode");
+        assert_eq!(
+            reloaded.primary_build(),
+            Some("GRCh37"),
+            "primary_build must survive bincode round-trip; pre-fix this returned \"GRCh38\""
+        );
+    }
+
+    #[test]
+    fn test_bincode_roundtrip_preserves_primary_build_grch38() {
+        // Symmetric to the GRCh37 case — verifies the field is persisted
+        // (rather than constant-defaulted) by exercising the non-default
+        // value above and the default value here.
+        let mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("roundtrip.bin");
+        mapper.to_bincode_file(&path).expect("write bincode");
+        let reloaded = CdotMapper::from_bincode_file(&path).expect("read bincode");
+        assert_eq!(reloaded.primary_build(), Some("GRCh38"));
+    }
+
+    // -------------------------------------------------------------------------
+    // #389 follow-up: build-specific lookups carry the LRG fallback.
+    // Pre-fix, asking for an LRG transcript on a non-primary build returned
+    // None even when the mapped RefSeq transcript existed in the alt-build
+    // map; `get_transcript_on_build` short-circuited before LRG resolution.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_get_transcript_on_build_resolves_lrg_to_refseq_on_alt_build() {
+        // Build a multi-build mapper and register an LRG → RefSeq mapping.
+        let mut mapper =
+            CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), "GRCh38")
+                .unwrap();
+        mapper
+            .lrg_to_refseq
+            .insert("LRG_1t1".to_string(), "NM_000088.3".to_string());
+
+        // Primary build: LRG lookup works via the get_transcript LRG path.
+        let tx38 = mapper
+            .get_transcript_on_build("LRG_1t1", "GRCh38")
+            .expect("LRG → RefSeq on primary build");
+        assert_eq!(tx38.contig, "NC_000017.11");
+
+        // Alt build (the regression): LRG lookup must resolve to the
+        // RefSeq accession before consulting alt_build_transcripts.
+        let tx37 = mapper
+            .get_transcript_on_build("LRG_1t1", "GRCh37")
+            .expect("LRG → RefSeq must work on alt build too (pre-fix this returned None)");
         assert_eq!(tx37.contig, "NC_000017.10");
     }
 }

--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -54,7 +54,8 @@ impl CoordinateMapper {
         &self.cdot
     }
 
-    /// Convert a CDS position to a genomic position.
+    /// Convert a CDS position to a genomic position using the cdot mapper's
+    /// primary build.
     ///
     /// # Arguments
     ///
@@ -69,10 +70,32 @@ impl CoordinateMapper {
         transcript_id: &str,
         cds_pos: &CdsPos,
     ) -> Result<MappingResult<GenomePos>, FerroError> {
-        let tx = self.cdot.get_transcript(transcript_id).ok_or_else(|| {
-            FerroError::ReferenceNotFound {
-                id: transcript_id.to_string(),
-            }
+        self.cds_to_genome_on_build(transcript_id, cds_pos, None)
+    }
+
+    /// Build-aware [`cds_to_genome`](Self::cds_to_genome): when `build` is
+    /// `Some`, the transcript is resolved via
+    /// [`CdotMapper::get_transcript_on_build`] so a multi-build cdot load
+    /// returns the alignment for the requested build (rather than silently
+    /// using the primary build's view). Used by the projector to honor an
+    /// input variant's NG/NC parent (issue #389).
+    ///
+    /// When `build` is `None`, this is equivalent to
+    /// [`cds_to_genome`](Self::cds_to_genome) — exposed so call sites that
+    /// computed an `Option<&str>` build hint once can pass it through
+    /// without branching on `None`.
+    pub fn cds_to_genome_on_build(
+        &self,
+        transcript_id: &str,
+        cds_pos: &CdsPos,
+        build: Option<&str>,
+    ) -> Result<MappingResult<GenomePos>, FerroError> {
+        let tx = match build {
+            Some(b) => self.cdot.get_transcript_on_build(transcript_id, b),
+            None => self.cdot.get_transcript(transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
         })?;
 
         let (genome_pos, info) = self.cds_pos_to_genome_pos(tx, cds_pos, transcript_id)?;
@@ -135,7 +158,8 @@ impl CoordinateMapper {
         })
     }
 
-    /// Convert a genomic position to a CDS position.
+    /// Convert a genomic position to a CDS position using the cdot mapper's
+    /// primary build.
     ///
     /// # Arguments
     ///
@@ -150,10 +174,31 @@ impl CoordinateMapper {
         transcript_id: &str,
         genome_pos: &GenomePos,
     ) -> Result<MappingResult<CdsPos>, FerroError> {
-        let tx = self.cdot.get_transcript(transcript_id).ok_or_else(|| {
-            FerroError::ReferenceNotFound {
-                id: transcript_id.to_string(),
-            }
+        self.genome_to_cds_on_build(transcript_id, genome_pos, None)
+    }
+
+    /// Build-aware [`genome_to_cds`](Self::genome_to_cds): when `build` is
+    /// `Some`, the transcript is resolved via
+    /// [`CdotMapper::get_transcript_on_build`] so a multi-build cdot load
+    /// returns the alignment for the requested build. Used by the
+    /// projector to honor a g. input's chromosome version (issue #389).
+    ///
+    /// When `build` is `None`, this is equivalent to
+    /// [`genome_to_cds`](Self::genome_to_cds) — exposed so call sites that
+    /// computed an `Option<&str>` build hint once can pass it through
+    /// without branching on `None`.
+    pub fn genome_to_cds_on_build(
+        &self,
+        transcript_id: &str,
+        genome_pos: &GenomePos,
+        build: Option<&str>,
+    ) -> Result<MappingResult<CdsPos>, FerroError> {
+        let tx = match build {
+            Some(b) => self.cdot.get_transcript_on_build(transcript_id, b),
+            None => self.cdot.get_transcript(transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
         })?;
 
         let (cds_pos, info) = self.genome_pos_to_cds_pos(tx, genome_pos, transcript_id)?;

--- a/src/liftover/aliases.rs
+++ b/src/liftover/aliases.rs
@@ -97,12 +97,17 @@ impl ContigAliases {
             .refseq_to_ensembl
             .insert("NC_000024.10".to_string(), "Y".to_string());
 
-        // Mitochondrial
+        // Mitochondrial — NC_012920.1 is the canonical rCRS accession on
+        // both GRCh37 and GRCh38 (mtDNA was not re-assembled between
+        // builds), so register a self-alias under each build. Without
+        // the GRCh38 self-alias `infer_genome_build_from_accession` would
+        // misclassify NC_012920.1 inputs as GRCh37-only.
         aliases.add_alias("chrM", GenomeBuild::GRCh37, "NC_012920.1");
         aliases.add_alias("MT", GenomeBuild::GRCh37, "NC_012920.1");
         aliases.add_alias("NC_012920.1", GenomeBuild::GRCh37, "NC_012920.1");
         aliases.add_alias("chrM", GenomeBuild::GRCh38, "NC_012920.1");
         aliases.add_alias("MT", GenomeBuild::GRCh38, "NC_012920.1");
+        aliases.add_alias("NC_012920.1", GenomeBuild::GRCh38, "NC_012920.1");
         aliases
             .refseq_to_ucsc
             .insert("NC_012920.1".to_string(), "chrM".to_string());
@@ -212,6 +217,65 @@ impl ContigAliases {
             .map(|s| s.to_string())
             .unwrap_or_else(|| name.to_string())
     }
+}
+
+/// Lazily-constructed singleton of [`ContigAliases::default_human`] so
+/// repeated build inference (per projection) does not rebuild the
+/// ~150-entry alias table every call.
+fn default_human_aliases() -> &'static ContigAliases {
+    use std::sync::OnceLock;
+    static ALIASES: OnceLock<ContigAliases> = OnceLock::new();
+    ALIASES.get_or_init(ContigAliases::default_human)
+}
+
+/// Infer the canonical genome build name for a chromosome accession.
+///
+/// Sources of build information consulted, in order:
+///   1. `accession.assembly` — assembly-style references like
+///      `GRCh37(chr1):g.…` carry the build verbatim.
+///   2. `NC_*` accessions are looked up in [`ContigAliases::default_human`].
+///      `NC_*` carries a build-distinguishing version (e.g.
+///      `NC_000017.10` is GRCh37 chr17, `NC_000017.11` is GRCh38). NC
+///      accessions present under both builds (e.g. mtDNA `NC_012920.1`)
+///      resolve to GRCh38, our default-when-ambiguous.
+///   3. Everything else (`NG_*`, `LRG_*`, `NW_*`, unknown prefixes, NC
+///      accessions outside the human alias table) returns `None` so the
+///      caller falls back to the build-agnostic probe order.
+///
+/// Centralized here so call sites that need to disambiguate cdot lookups
+/// against multi-build data (e.g. `MultiFastaProvider`, `VariantProjector`)
+/// share one implementation rather than duplicating the GRCh37/GRCh38
+/// inference logic.
+pub fn infer_genome_build_from_accession(
+    accession: &crate::hgvs::variant::Accession,
+) -> Option<&'static str> {
+    // Assembly-style references (`GRCh37(chr1)`, `GRCh38(chrX)`) carry the
+    // build name explicitly; honor it before the prefix check.
+    if let Some(asm) = accession.assembly.as_deref() {
+        match asm {
+            "GRCh37" => return Some("GRCh37"),
+            "GRCh38" => return Some("GRCh38"),
+            _ => {}
+        }
+    }
+    if &*accession.prefix != "NC" {
+        return None;
+    }
+    let aliases = default_human_aliases();
+    let acc_str = accession.full();
+    if aliases
+        .resolve_to_refseq(&acc_str, GenomeBuild::GRCh38)
+        .is_some()
+    {
+        return Some("GRCh38");
+    }
+    if aliases
+        .resolve_to_refseq(&acc_str, GenomeBuild::GRCh37)
+        .is_some()
+    {
+        return Some("GRCh37");
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -124,6 +124,27 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .map(|gc| gc.to_string())
     }
 
+    /// Infer the genome build to consult cdot under for `variant`.
+    ///
+    /// Examines the variant's own accession first: a g. variant on
+    /// `NC_*.10` carries GRCh37, on `NC_*.11` carries GRCh38, and an
+    /// assembly-style `GRCh37(chr1):g.…` carries GRCh37 directly. If the
+    /// variant has no inherent build (e.g. a c. variant on a bare NM)
+    /// but does have a `genomic_context` (NG/NC parent), the parent is
+    /// consulted. Anything else returns `None` so the caller falls back
+    /// to the build-agnostic primary-cdot path (issue #389).
+    fn build_hint_for_variant(variant: &HgvsVariant) -> Option<&'static str> {
+        use crate::liftover::aliases::infer_genome_build_from_accession;
+        let acc = variant.accession()?;
+        if let Some(b) = infer_genome_build_from_accession(acc) {
+            return Some(b);
+        }
+        if let Some(parent) = acc.genomic_context.as_deref() {
+            return infer_genome_build_from_accession(parent);
+        }
+        None
+    }
+
     fn cached_get_transcript_for_variant(
         &self,
         variant: &HgvsVariant,
@@ -447,15 +468,22 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    store used by the g. → c./n. path).  Working directly off cdot
         //    keeps us symmetric with `project_single_inner` and avoids a
         //    second `provider.get_transcript` load whose exon entries may
-        //    lack genomic coordinates.
+        //    lack genomic coordinates. When the NG/NC parent's version
+        //    disambiguates a genome build (NC_*.10 → GRCh37, NC_*.11 →
+        //    GRCh38) we ask cdot for that build's view so multi-build cdot
+        //    loads project against the correct alignment (issue #389).
         let transcript_id = accession.transcript_accession();
+        let build_hint = crate::liftover::aliases::infer_genome_build_from_accession(&parent);
         let cdot_mapper = self.projector.mapper();
-        let cdot_tx = cdot_mapper
-            .cdot()
-            .get_transcript(&transcript_id)
-            .ok_or_else(|| FerroError::ReferenceNotFound {
-                id: transcript_id.to_string(),
-            })?;
+        let cdot_tx = match build_hint {
+            Some(b) => cdot_mapper
+                .cdot()
+                .get_transcript_on_build(&transcript_id, b),
+            None => cdot_mapper.cdot().get_transcript(&transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
+        })?;
         let strand = cdot_tx.strand;
         if strand == RefStrand::Unknown {
             return Err(FerroError::UnsupportedProjection {
@@ -474,7 +502,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let is_coding = cdot_tx.cds_start.is_some() && cdot_tx.cds_end.is_some();
         let map_pos = |p: CdsPos| -> Result<u64, FerroError> {
             if is_coding {
-                let result = cdot_mapper.cds_to_genome(&transcript_id, &p)?;
+                let result = cdot_mapper.cds_to_genome_on_build(&transcript_id, &p, build_hint)?;
                 Ok(result.variant.base)
             } else {
                 if p.offset.is_some() {
@@ -625,16 +653,24 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // branch must behave the same to avoid silently returning bogus
         // projections for typo'd or missing accessions.
         if allele.variants.is_empty() {
-            let gene_symbol = self
-                .projector
-                .mapper()
-                .cdot()
-                .get_transcript(transcript_id)
-                .ok_or_else(|| FerroError::ReferenceNotFound {
-                    id: transcript_id.to_string(),
-                })?
-                .gene_name
-                .clone();
+            // Honor the input's parent NG/NC (or assembly tag) when
+            // resolving the gene_name from cdot, so an NG/NC-parented
+            // allele on a multi-build cdot picks the correct build's
+            // transcript record (issue #389).
+            let build_hint = Self::build_hint_for_variant(original);
+            let gene_symbol = match build_hint {
+                Some(b) => self
+                    .projector
+                    .mapper()
+                    .cdot()
+                    .get_transcript_on_build(transcript_id, b),
+                None => self.projector.mapper().cdot().get_transcript(transcript_id),
+            }
+            .ok_or_else(|| FerroError::ReferenceNotFound {
+                id: transcript_id.to_string(),
+            })?
+            .gene_name
+            .clone();
             return Ok(VariantProjection {
                 genomic: original.clone(),
                 coding: None,
@@ -795,15 +831,24 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 reason: "g. variant has no concrete edit".to_string(),
             })?;
 
-        // Look up the transcript in the cdot mapper.
-        let cdot_tx = self
-            .projector
-            .mapper()
-            .cdot()
-            .get_transcript(transcript_id)
-            .ok_or_else(|| FerroError::ReferenceNotFound {
-                id: transcript_id.to_string(),
-            })?;
+        // Look up the transcript in the cdot mapper. When the projected
+        // g. accession is NC_*, infer the genome build from its version
+        // (NC_*.10 → GRCh37, NC_*.11 → GRCh38, etc.) so multi-build cdot
+        // loads return the alignment matching the input chromosome rather
+        // than silently using the primary build's view (issue #389).
+        let build_hint =
+            crate::liftover::aliases::infer_genome_build_from_accession(&genome_variant.accession);
+        let cdot_tx = match build_hint {
+            Some(b) => self
+                .projector
+                .mapper()
+                .cdot()
+                .get_transcript_on_build(transcript_id, b),
+            None => self.projector.mapper().cdot().get_transcript(transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
+        })?;
         let strand = cdot_tx.strand;
         let gene_symbol = cdot_tx.gene_name.clone();
         let cdot_protein = cdot_tx.protein.clone();
@@ -833,15 +878,18 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         // Genomic extent of the transcript — used to short-circuit the
         // genome-to-CDS mapping when the variant is outside the transcript's
-        // span. `transcript_genome_span` consults a cached side-table on the
-        // CdotMapper (built once); before c14 this re-folded `cdot_tx.exons`
-        // (min/max) on every call.
-        let (tx_genome_start, tx_genome_end) = mapper
-            .cdot()
-            .transcript_genome_span(transcript_id)
-            .ok_or_else(|| FerroError::ReferenceNotFound {
-                id: transcript_id.to_string(),
-            })?;
+        // span. The cached primary-build side-table is consulted via
+        // `transcript_genome_span_on_build`; for alt builds the span is
+        // computed on demand against the alt-build exon table (#389).
+        let (tx_genome_start, tx_genome_end) = match build_hint {
+            Some(b) => mapper
+                .cdot()
+                .transcript_genome_span_on_build(transcript_id, b),
+            None => mapper.cdot().transcript_genome_span(transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
+        })?;
 
         // Helper: map one GenomePos → CdsPos, converting out-of-range errors.
         // `normalized.to_string()` is only consumed by the error message and
@@ -855,7 +903,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     transcript_id: transcript_id.to_string(),
                 });
             }
-            match mapper.genome_to_cds(transcript_id, gp) {
+            match mapper.genome_to_cds_on_build(transcript_id, gp, build_hint) {
                 Ok(res) => Ok((res.variant, res.info)),
                 Err(FerroError::InvalidCoordinates { .. })
                 | Err(FerroError::ConversionError { .. }) => {
@@ -2585,6 +2633,312 @@ mod tests {
                 }
                 other => panic!("expected UnsupportedProjection, got: {:?}", other),
             }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-build cdot build-hint propagation (closes #389 item 2)
+    //
+    // Both `project_to_genomic` (c./n./r. → g.) and `project_single_inner`
+    // (g. → c./n./r.) MUST consult the genome build implied by the
+    // input's NG/NC parent (resp. the g. variant's NC_* accession) when
+    // looking up the transcript and converting coordinates. Pre-#389
+    // those sites used `cdot.get_transcript` / `transcript_genome_span` /
+    // `cds_to_genome` / `genome_to_cds` directly, which always returned
+    // the primary build's view — silently mis-projecting GRCh37 inputs
+    // against a GRCh38-primary cdot (and vice versa).
+    // -------------------------------------------------------------------------
+    mod multi_build_projection_tests {
+        use super::*;
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::{CdsInterval, GenomeInterval};
+        use crate::hgvs::location::{CdsPos, GenomePos};
+        use crate::hgvs::variant::{Accession, CdsVariant, GenomeVariant, HgvsVariant, LocEdit};
+
+        /// Minimal multi-build cdot fixture: one coding transcript whose
+        /// GRCh37 view sits at genome [10000, 10010) on NC_000001.10 and
+        /// whose GRCh38 view sits at genome [20000, 20010) on
+        /// NC_000001.11. Different genomic coords across builds is what
+        /// lets us tell which view the projector consulted.
+        ///
+        /// `start_codon = 0`, `stop_codon = 10` ⇒ the whole exon is CDS
+        /// (no UTRs), so c.1..c.10 maps to tx_pos 0..9. The fixture is
+        /// coding so `project_single_inner`'s `genome_to_cds_on_build`
+        /// call lands on the CDS branch — non-coding would hit a separate
+        /// "Cannot convert tx position to CDS" error unrelated to #389.
+        fn multi_build_cdot_json() -> &'static str {
+            r#"
+            {
+                "transcripts": {
+                    "NM_MB_TEST.1": {
+                        "gene_name": "MBTEST",
+                        "genome_builds": {
+                            "GRCh37": {
+                                "contig": "NC_000001.10",
+                                "strand": "+",
+                                "exons": [[10000, 10010, 1, 0, 10, "M10"]]
+                            },
+                            "GRCh38": {
+                                "contig": "NC_000001.11",
+                                "strand": "+",
+                                "exons": [[20000, 20010, 1, 0, 10, "M10"]]
+                            }
+                        },
+                        "start_codon": 0,
+                        "stop_codon": 10
+                    }
+                }
+            }
+            "#
+        }
+
+        /// Build a `VariantProjector` whose cdot mapper has the two-build
+        /// fixture above. `primary` selects which build the primary
+        /// transcripts table is populated from (the other build lives in
+        /// `alt_build_transcripts`). The `MockProvider` carries
+        /// NM_MB_TEST.1 so that downstream protein prediction inside
+        /// `project_single_inner` can fetch the transcript without
+        /// hitting `ReferenceNotFound`.
+        fn make_multi_build_projector(primary: &str) -> VariantProjector<MockProvider> {
+            use crate::reference::transcript::{
+                Exon, GenomeBuild as RefGenomeBuild, ManeStatus, Strand as TxStrand,
+                Transcript as RefTranscript,
+            };
+            use std::sync::OnceLock;
+
+            let cdot =
+                CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), primary)
+                    .expect("multi-build cdot JSON should parse");
+            let projector = Projector::new(cdot);
+            let mut provider = MockProvider::new();
+            provider.add_transcript(RefTranscript {
+                id: "NM_MB_TEST.1".to_string(),
+                gene_symbol: Some("MBTEST".to_string()),
+                strand: TxStrand::Plus,
+                sequence: Some("ATGCGCTAATC".to_string()),
+                cds_start: Some(1),
+                cds_end: Some(10),
+                exons: vec![Exon::new(1, 1, 10)],
+                chromosome: Some("NC_000001.11".to_string()),
+                genomic_start: Some(20000),
+                genomic_end: Some(20009),
+                genome_build: RefGenomeBuild::GRCh38,
+                mane_status: ManeStatus::default(),
+                refseq_match: None,
+                ensembl_match: None,
+                protein_id: None,
+                exon_cigars: Vec::new(),
+                cached_introns: OnceLock::new(),
+            });
+            VariantProjector::new(projector, provider)
+        }
+
+        fn nc_chr1(version: u32) -> Accession {
+            Accession::new("NC", "000001", Some(version))
+        }
+
+        fn ng_parent(num: &str, version: u32) -> Accession {
+            Accession::new("NG", num, Some(version))
+        }
+
+        /// Smoke test the JSON parses into a usable multi-build mapper —
+        /// keeps the later test failures readable if the JSON ever drifts.
+        #[test]
+        fn fixture_loads_both_builds() {
+            let cdot =
+                CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), "GRCh38")
+                    .expect("multi-build JSON must parse");
+            assert_eq!(cdot.primary_build(), "GRCh38");
+            assert_eq!(cdot.transcript_count(), 1);
+            let tx38 = cdot
+                .get_transcript_on_build("NM_MB_TEST.1", "GRCh38")
+                .expect("GRCh38 view must be populated in primary transcripts");
+            assert_eq!(tx38.contig, "NC_000001.11");
+            assert_eq!(tx38.exons, vec![[20000, 20010, 0, 10]]);
+            assert_eq!(tx38.cds_start, Some(0));
+            assert_eq!(tx38.cds_end, Some(10));
+            let tx37 = cdot
+                .get_transcript_on_build("NM_MB_TEST.1", "GRCh37")
+                .expect("GRCh37 view must be populated in alt_build_transcripts");
+            assert_eq!(tx37.contig, "NC_000001.10");
+            assert_eq!(tx37.exons, vec![[10000, 10010, 0, 10]]);
+        }
+
+        /// c.5A>T against NC_000001.10(NM_MB_TEST.1) → expect GRCh37
+        /// coordinates (g.10004; cdot's internal exon[0] is HGVS-numeric,
+        /// so c.1 sits at g.10000 and c.5 at g.10004). Pre-fix, this
+        /// would have used the primary (GRCh38) view and produced
+        /// ~g.20004, despite the parent's GRCh37 version.
+        #[test]
+        fn project_to_genomic_uses_grch37_view_for_nc_v10_parent() {
+            let vp = make_multi_build_projector("GRCh38");
+            let cds = CdsVariant {
+                accession: parse_accession("NM_MB_TEST.1").with_genomic_context(nc_chr1(10)),
+                gene_symbol: Some("MBTEST".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(5)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let out = vp
+                .project_to_genomic(&HgvsVariant::Cds(cds))
+                .expect("GRCh37 parent should project against GRCh37 exon table");
+            match out {
+                HgvsVariant::Genome(g) => {
+                    let s = g.to_string();
+                    assert!(
+                        s.contains(":g.10004A>T"),
+                        "expected GRCh37 coord g.10004A>T, got: {}",
+                        s
+                    );
+                }
+                other => panic!("expected Genome, got: {:?}", other),
+            }
+        }
+
+        /// c.5A>T against NC_000001.11(NM_MB_TEST.1) → expect GRCh38
+        /// coordinates (g.20004). Sibling to the GRCh37 case; together
+        /// they prove the parent's build version is what drives the
+        /// cdot view selection.
+        #[test]
+        fn project_to_genomic_uses_grch38_view_for_nc_v11_parent() {
+            let vp = make_multi_build_projector("GRCh38");
+            let cds = CdsVariant {
+                accession: parse_accession("NM_MB_TEST.1").with_genomic_context(nc_chr1(11)),
+                gene_symbol: Some("MBTEST".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(5)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let out = vp
+                .project_to_genomic(&HgvsVariant::Cds(cds))
+                .expect("GRCh38 parent should project against GRCh38 exon table");
+            match out {
+                HgvsVariant::Genome(g) => {
+                    let s = g.to_string();
+                    assert!(
+                        s.contains(":g.20004A>T"),
+                        "expected GRCh38 coord g.20004A>T, got: {}",
+                        s
+                    );
+                }
+                other => panic!("expected Genome, got: {:?}", other),
+            }
+        }
+
+        /// g. → c.: NC_000001.10:g.10004A>T projected onto NM_MB_TEST.1
+        /// → expect c.5A>T. Pre-fix, `project_single_inner` used the
+        /// primary (GRCh38) `transcript_genome_span` of [20000, 20010),
+        /// so position 10004 fell outside and the call returned
+        /// `TranscriptNotOverlapping`. Post-fix the GRCh37 span
+        /// [10000, 10010) is consulted and the projection succeeds.
+        #[test]
+        fn project_normalized_uses_grch37_view_for_nc_v10_input() {
+            let vp = make_multi_build_projector("GRCh38");
+            let g = GenomeVariant {
+                accession: nc_chr1(10),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(10004)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let projection = vp
+                .project_normalized(&HgvsVariant::Genome(g), "NM_MB_TEST.1")
+                .expect("GRCh37 g. input must project via the alt-build cdot view");
+            let coding = projection
+                .coding
+                .as_ref()
+                .expect("coding (c.) form of the projection must be present");
+            let s = coding.to_string();
+            assert!(
+                s.contains(":c.5A>T"),
+                "expected c.5A>T for NC_000001.10 g. input, got: {}",
+                s
+            );
+        }
+
+        /// NG_* parents are build-agnostic per the HGVS spec — the
+        /// projector falls back to the primary cdot view rather than
+        /// forcing an alt-build lookup. With primary=GRCh38 the c.5
+        /// position must therefore come back at the GRCh38 exon's
+        /// position (g.20004) regardless of any GRCh37 alt-build data.
+        #[test]
+        fn project_to_genomic_with_ng_parent_uses_primary_build() {
+            let vp = make_multi_build_projector("GRCh38");
+            let cds = CdsVariant {
+                accession: parse_accession("NM_MB_TEST.1")
+                    .with_genomic_context(ng_parent("MBTEST", 1)),
+                gene_symbol: Some("MBTEST".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(5)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let out = vp
+                .project_to_genomic(&HgvsVariant::Cds(cds))
+                .expect("NG-parented variant should project via the primary cdot view");
+            match out {
+                HgvsVariant::Genome(g) => {
+                    let s = g.to_string();
+                    assert!(
+                        s.starts_with("NG_MBTEST.1"),
+                        "expected output to inherit NG_ parent accession, got: {}",
+                        s
+                    );
+                    assert!(
+                        s.contains(":g.20004A>T"),
+                        "NG (build-agnostic) parent must use primary (GRCh38) coords, got: {}",
+                        s
+                    );
+                }
+                other => panic!("expected Genome, got: {:?}", other),
+            }
+        }
+
+        /// Same as above but for NC_000001.11 (GRCh38, the primary build).
+        /// Confirms the primary-build path still works alongside the new
+        /// alt-build dispatch.
+        #[test]
+        fn project_normalized_uses_grch38_view_for_nc_v11_input() {
+            let vp = make_multi_build_projector("GRCh38");
+            let g = GenomeVariant {
+                accession: nc_chr1(11),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(20004)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            };
+            let projection = vp
+                .project_normalized(&HgvsVariant::Genome(g), "NM_MB_TEST.1")
+                .expect("GRCh38 g. input must project via the primary cdot view");
+            let coding = projection
+                .coding
+                .as_ref()
+                .expect("coding (c.) form of the projection must be present");
+            let s = coding.to_string();
+            assert!(
+                s.contains(":c.5A>T"),
+                "expected c.5A>T for NC_000001.11 g. input, got: {}",
+                s
+            );
         }
     }
 

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1,5 +1,6 @@
 //! `VariantProjector` orchestrator.
 
+use crate::data::cdot::CdotTranscript;
 use crate::data::mapping::MappingInfo;
 use crate::data::projection::Projector;
 use crate::error::FerroError;
@@ -124,6 +125,36 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .map(|gc| gc.to_string())
     }
 
+    /// Reject parentless c./n./r. fan-out inputs up front.
+    ///
+    /// `project_normalized_all` seeds a stab query against the contig
+    /// derived from cdot's exon table, then projects through every
+    /// overlapping transcript via `project_single_inner`. For c./n./r.
+    /// inputs `project_single_inner` calls `project_to_genomic`, which
+    /// requires an explicit NG/NC parent on `accession.genomic_context`
+    /// (see #327). Without the parent every per-transcript projection
+    /// fails with `UnsupportedProjection { "no parent reference..." }`,
+    /// and the fan-out loop's `log::trace!`-and-drop converts the user
+    /// error into `Ok([])` — silently turning a missing-context error
+    /// into "no overlaps." Surface the error here, before we touch the
+    /// stab-query path (#389 follow-up).
+    fn require_parent_for_fanout(
+        accession: &crate::hgvs::variant::Accession,
+        axis: &str,
+    ) -> Result<(), FerroError> {
+        if accession.genomic_context.is_none() {
+            return Err(FerroError::UnsupportedProjection {
+                reason: format!(
+                    "project_all requires a parent reference (genomic_context) on {} \
+                     inputs to resolve back to g.; accession {} has none",
+                    axis,
+                    accession.full()
+                ),
+            });
+        }
+        Ok(())
+    }
+
     /// Infer the genome build to consult cdot under for `variant`.
     ///
     /// Examines the variant's own accession first: a g. variant on
@@ -143,6 +174,172 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             return infer_genome_build_from_accession(parent);
         }
         None
+    }
+
+    /// Build-aware cdot transcript lookup shared by every projection
+    /// entry point: routes through
+    /// [`CdotMapper::get_transcript_on_build`] when `build_hint` is
+    /// `Some`, falling back to the primary-build
+    /// [`CdotMapper::get_transcript`] otherwise. Returns
+    /// [`FerroError::ReferenceNotFound`] if the requested build's view
+    /// is absent from cdot (#389).
+    fn cdot_tx_with_build_hint(
+        &self,
+        transcript_id: &str,
+        build_hint: Option<&'static str>,
+    ) -> Result<&CdotTranscript, FerroError> {
+        match build_hint {
+            Some(b) => self
+                .projector
+                .mapper()
+                .cdot()
+                .get_transcript_on_build(transcript_id, b),
+            None => self.projector.mapper().cdot().get_transcript(transcript_id),
+        }
+        .ok_or_else(|| FerroError::ReferenceNotFound {
+            id: transcript_id.to_string(),
+        })
+    }
+
+    /// Extract the contig name and a representative 1-based genomic
+    /// position from an already-normalized [`HgvsVariant`], for use as
+    /// the input to `Projector::project`'s stab query.
+    ///
+    /// For [`HgvsVariant::Allele`] the first inner variant is used.
+    ///
+    /// # Per-axis behavior
+    ///
+    /// - **Genome**: contig is taken from the variant's accession
+    ///   (`chromosome` for assembly-style refs, `full()` otherwise);
+    ///   position is the start of the genomic interval.
+    /// - **Cds / Tx / Rna**: cdot is consulted to resolve the
+    ///   transcript's contig and to project the start position to
+    ///   genome — `cds_to_genome_on_build` for c. (handles
+    ///   intronic offsets, 5'UTR negative bases, and 3'UTR `utr3`
+    ///   natively); `tx_to_genome` for n./r. simple exonic positions.
+    ///   For n./r. positions that `tx_to_genome` cannot resolve
+    ///   precisely (intronic offsets, downstream/utr3 markers,
+    ///   non-positive bases) the function falls back to the
+    ///   transcript's first-exon genomic start — the stab query still
+    ///   lands inside the transcript, and the per-transcript
+    ///   projection downstream re-derives the accurate coordinate. The
+    ///   contig is taken from `cdot_tx.contig` (production cdot
+    ///   typically keys this by the RefSeq genomic accession, with
+    ///   `chr*` aliases handled by `resolve_contig` inside the stab
+    ///   query).
+    ///
+    /// Removes the g.-only gate that pre-#389 defeated PR #379's
+    /// fan-out widening. Build hints are inferred from the input's
+    /// `genomic_context` parent (or assembly tag) the same way as the
+    /// rest of the projector.
+    fn extract_contig_and_pos(&self, variant: &HgvsVariant) -> Result<(String, u64), FerroError> {
+        let effective = match variant {
+            HgvsVariant::Allele(allele) => {
+                allele
+                    .variants
+                    .first()
+                    .ok_or_else(|| FerroError::UnsupportedProjection {
+                        reason: "cannot project an empty allele to all transcripts".to_string(),
+                    })?
+            }
+            other => other,
+        };
+
+        match effective {
+            HgvsVariant::Genome(gv) => {
+                let contig = if let Some(chr) = &gv.accession.chromosome {
+                    chr.to_string()
+                } else {
+                    gv.accession.full()
+                };
+                let pos = gv
+                    .loc_edit
+                    .location
+                    .start
+                    .inner()
+                    .cloned()
+                    .ok_or_else(|| FerroError::InvalidCoordinates {
+                        msg: "genomic interval start is unknown".to_string(),
+                    })?
+                    .base;
+                Ok((contig, pos))
+            }
+            HgvsVariant::Cds(c) => {
+                Self::require_parent_for_fanout(&c.accession, "c.")?;
+                let transcript_id = c.accession.transcript_accession();
+                let build_hint = Self::build_hint_for_variant(effective);
+                let cdot_tx = self.cdot_tx_with_build_hint(&transcript_id, build_hint)?;
+                let start_cds = c.loc_edit.location.start.inner().cloned().ok_or_else(|| {
+                    FerroError::InvalidCoordinates {
+                        msg: "CDS interval start is unknown".to_string(),
+                    }
+                })?;
+                let pos = self
+                    .projector
+                    .mapper()
+                    .cds_to_genome_on_build(&transcript_id, &start_cds, build_hint)?
+                    .variant
+                    .base;
+                Ok((cdot_tx.contig.clone(), pos))
+            }
+            HgvsVariant::Tx(t) => {
+                Self::require_parent_for_fanout(&t.accession, "n.")?;
+                let transcript_id = t.accession.transcript_accession();
+                let build_hint = Self::build_hint_for_variant(effective);
+                let cdot_tx = self.cdot_tx_with_build_hint(&transcript_id, build_hint)?;
+                let start_tx = *t.loc_edit.location.start.inner().ok_or_else(|| {
+                    FerroError::InvalidCoordinates {
+                        msg: "Tx interval start is unknown".to_string(),
+                    }
+                })?;
+                let pos =
+                    nr_representative_genome_pos(cdot_tx, start_tx.base, start_tx.offset, false)?;
+                Ok((cdot_tx.contig.clone(), pos))
+            }
+            HgvsVariant::Rna(r) => {
+                Self::require_parent_for_fanout(&r.accession, "r.")?;
+                let transcript_id = r.accession.transcript_accession();
+                let build_hint = Self::build_hint_for_variant(effective);
+                let cdot_tx = self.cdot_tx_with_build_hint(&transcript_id, build_hint)?;
+                let start_rna = *r.loc_edit.location.start.inner().ok_or_else(|| {
+                    FerroError::InvalidCoordinates {
+                        msg: "RNA interval start is unknown".to_string(),
+                    }
+                })?;
+                let pos = nr_representative_genome_pos(
+                    cdot_tx,
+                    start_rna.base,
+                    start_rna.offset,
+                    start_rna.utr3,
+                )?;
+                Ok((cdot_tx.contig.clone(), pos))
+            }
+            HgvsVariant::Protein(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept protein (p.) inputs".to_string(),
+            }),
+            HgvsVariant::Mt(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept mitochondrial (m.) inputs".to_string(),
+            }),
+            HgvsVariant::Circular(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept circular (o.) inputs".to_string(),
+            }),
+            HgvsVariant::RnaFusion(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept RNA fusion inputs".to_string(),
+            }),
+            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
+                Err(FerroError::UnsupportedProjection {
+                    reason: "project_all does not accept null/unknown allele inputs".to_string(),
+                })
+            }
+            // Allele was already unwrapped to its first inner variant above;
+            // if we reach this arm with one it's because the inner variant
+            // didn't match any of the supported axes (e.g. p./m./o.).
+            HgvsVariant::Allele(_) => Err(FerroError::UnsupportedProjection {
+                reason:
+                    "project_all does not accept alleles whose first inner variant is not g./c./n./r."
+                        .to_string(),
+            }),
+        }
     }
 
     fn cached_get_transcript_for_variant(
@@ -594,7 +791,11 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     ) -> Result<Vec<VariantProjection>, FerroError> {
         // 2. Extract contig + first-base position from the normalized variant.
         //    For Allele variants we use the first inner variant's accession.
-        let (contig, pos) = extract_contig_and_pos(variant)?;
+        //    c./n./r. inputs are resolved via cdot (contig from the
+        //    transcript's exon table, position from the start-of-range
+        //    transcript→genome projection) so PR #379's per-transcript
+        //    widening reaches the fan-out path here (issue #389 item 3).
+        let (contig, pos) = self.extract_contig_and_pos(variant)?;
 
         // 3. Find overlapping transcripts via the Projector (sorted by priority).
         let projection_result = self.projector.project(&contig, pos)?;
@@ -936,7 +1137,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // Transform the edit for the transcript strand.
         let c_edit = transform_edit_for_strand(&edit, strand);
 
-        // Build the c./n. HGVS variant.
+        // Build the c./n. HGVS variant returned in `VariantProjection.coding`.
+        // Kept bare-accession (no NC_* wrapper) for caller-visible rendering;
+        // build-awareness for the parent-aware caches goes through
+        // `cache_variant` below.
         let coding = if is_coding {
             let interval = CdsInterval::new(cds_start, cds_end);
             HgvsVariant::Cds(CdsVariant {
@@ -951,6 +1155,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 accession: parse_accession(transcript_id),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit: LocEdit::new(TxInterval::new(tx_start, tx_end), c_edit.clone()),
+            })
+        };
+
+        // Parallel "cache key" variant that stamps the projected g.
+        // accession (NC_*.10 / NC_*.11) as `genomic_context`. Used only
+        // for `cached_get_transcript_for_variant` and
+        // `cached_ref_translation` so that:
+        //   1. `parent_key_for` reads the build-bearing NC accession,
+        //      partitioning the (transcript_id, parent) caches by
+        //      build — NC_*.10 vs NC_*.11 inputs no longer collide
+        //      under the same key.
+        //   2. `MultiFastaProvider::get_transcript_for_variant` sees the
+        //      NC parent and probes the matching cdot build first via
+        //      `get_transcript_on_build`, so the cached `Transcript` and
+        //      `RefProteinBundle` are built against the correct
+        //      alignment.
+        // The returned `coding` field is unaffected (#389 follow-up).
+        let cache_variant = if is_coding {
+            HgvsVariant::Cds(CdsVariant {
+                accession: parse_accession(transcript_id)
+                    .with_genomic_context(genome_variant.accession.clone()),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(CdsInterval::new(cds_start, cds_end), c_edit.clone()),
+            })
+        } else {
+            HgvsVariant::Tx(TxVariant {
+                accession: parse_accession(transcript_id)
+                    .with_genomic_context(genome_variant.accession.clone()),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::new(
+                    TxInterval::new(TxPos::new(cds_start.base), TxPos::new(cds_end.base)),
+                    c_edit.clone(),
+                ),
             })
         };
 
@@ -999,8 +1236,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 // errors propagate.
                 match &c_edit {
                     NaEdit::Substitution { .. } => {
-                        let tx_for_codon =
-                            self.cached_get_transcript_for_variant(&coding, transcript_id)?;
+                        let tx_for_codon = self
+                            .cached_get_transcript_for_variant(&cache_variant, transcript_id)?;
                         protein = Some(predict_substitution_protein(
                             &tx_for_codon,
                             cds_start.base,
@@ -1020,10 +1257,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                             && cds_start.base > 0
                             && cds_end.base > 0 =>
                     {
-                        let tx_for_codon =
-                            self.cached_get_transcript_for_variant(&coding, transcript_id)?;
+                        let tx_for_codon = self
+                            .cached_get_transcript_for_variant(&cache_variant, transcript_id)?;
                         let ref_bundle = self.cached_ref_translation(
-                            &coding,
+                            &cache_variant,
                             transcript_id,
                             &tx_for_codon,
                         )?;
@@ -1066,60 +1303,45 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     }
 }
 
-/// Extract the contig name and a representative 1-based genomic position from
-/// an already-normalized `HgvsVariant`.
+/// Compute a representative 1-based genomic position for a non-coding
+/// (n.) or RNA (r.) transcript coordinate, suitable for seeding
+/// `Projector::project`'s stab query.
 ///
-/// For `HgvsVariant::Allele`, the first inner g. variant is used.
-///
-/// # Contig name resolution
-///
-/// The contig name is taken directly from the variant's `Accession`. For
-/// standard RefSeq genomic accessions (e.g. `NC_000001.11`) the cdot mapper
-/// stores contigs under those same names and also aliases UCSC names
-/// (`chr1`) to them via `populate_contig_aliases`.  For assembly-notation
-/// accessions (`GRCh38(chr1)`) the `chromosome` field of `Accession` is
-/// used instead.  Callers that use non-standard accession formats (e.g.
-/// plain `chr1` keys) should ensure their cdot data was loaded with matching
-/// contig keys.
-fn extract_contig_and_pos(variant: &HgvsVariant) -> Result<(String, u64), FerroError> {
-    let effective = match variant {
-        HgvsVariant::Allele(allele) => {
-            allele
-                .variants
-                .first()
-                .ok_or_else(|| FerroError::UnsupportedProjection {
-                    reason: "cannot project an empty allele to all transcripts".to_string(),
-                })?
-        }
-        other => other,
-    };
-
-    match effective {
-        HgvsVariant::Genome(gv) => {
-            // Prefer the chromosome field for assembly-notation accessions.
-            let contig = if let Some(chr) = &gv.accession.chromosome {
-                chr.to_string()
-            } else {
-                gv.accession.full()
-            };
-
-            let pos = gv
-                .loc_edit
-                .location
-                .start
-                .inner()
-                .cloned()
-                .ok_or_else(|| FerroError::InvalidCoordinates {
-                    msg: "genomic interval start is unknown".to_string(),
-                })?
-                .base;
-
-            Ok((contig, pos))
-        }
-        _ => Err(FerroError::UnsupportedProjection {
-            reason: "project_all currently only accepts g. variants".to_string(),
-        }),
+/// - For "simple" exonic positions (`offset.is_none() && !utr3 &&
+///   base >= 1`), the exact `tx_to_genome` mapping is returned.
+/// - For intronic (`offset.is_some()`), downstream/3'UTR (`utr3`), or
+///   non-positive `base`, the conversion is best-effort: the
+///   transcript's first-exon genome_start is returned. The stab query
+///   at that position still lands inside the transcript, and the
+///   per-transcript projection downstream re-derives the precise
+///   coordinate. Falling back here keeps the fan-out path lenient for
+///   inputs the precise tx-to-genome path can't resolve (which is also
+///   what `project_to_genomic` itself rejects elsewhere for intronic
+///   non-coding offsets).
+fn nr_representative_genome_pos(
+    cdot_tx: &CdotTranscript,
+    base: i64,
+    offset: Option<i64>,
+    utr3: bool,
+) -> Result<u64, FerroError> {
+    if offset.is_some() || utr3 || base < 1 {
+        return cdot_tx
+            .exons
+            .first()
+            .map(|e| e[0])
+            .ok_or_else(|| FerroError::InvalidCoordinates {
+                msg: "transcript has no exons; cannot derive stab position".to_string(),
+            });
     }
+    let tx_pos_0based = (base - 1) as u64;
+    cdot_tx
+        .tx_to_genome(tx_pos_0based)
+        .ok_or_else(|| FerroError::InvalidCoordinates {
+            msg: format!(
+                "tx position {} not in any exon of {} (cannot derive stab position)",
+                base, cdot_tx.contig
+            ),
+        })
 }
 
 #[cfg(test)]
@@ -1812,6 +2034,280 @@ mod tests {
         assert_eq!(
             results[0].transcript_id, "NM_TX2.1",
             "MANE Select should be first"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // c./n./r. fan-out via project_variant_all (closes #389 item 3)
+    //
+    // Pre-fix, `extract_contig_and_pos` matched only `HgvsVariant::Genome`
+    // and returned `UnsupportedProjection { reason: "project_all
+    // currently only accepts g. variants" }` for every other axis, which
+    // defeated PR #379's widening of `project()` to c./n./r. inputs in
+    // the fan-out entrypoints.
+    // -------------------------------------------------------------------------
+
+    /// `project_variant_all` on a c. input with an NG/NC parent must
+    /// reach the fan-out path and produce a per-transcript projection
+    /// for the matching transcript. Pre-#389 this errored out at the
+    /// `extract_contig_and_pos` g.-only gate.
+    #[test]
+    fn project_variant_all_accepts_coding_input_with_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{Accession, CdsVariant, HgvsVariant, LocEdit};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        // NM_TX1.1 c.4C>A with an NC_000001.11 parent; per the
+        // make_two_transcript_setup fixture this should project to
+        // g.1003 (which is c.4 on the plus-strand 9-base CDS).
+        let cds = CdsVariant {
+            accession: parse_accession("NM_TX1.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            )),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let results = vp
+            .project_variant_all(&HgvsVariant::Cds(cds))
+            .expect("project_variant_all should accept c. input post-#389");
+        assert!(
+            results.iter().any(|p| p.transcript_id == "NM_TX1.1"),
+            "expected at least the input transcript's projection, got {:?}",
+            results.iter().map(|p| &p.transcript_id).collect::<Vec<_>>()
+        );
+    }
+
+    /// Same as above but for the n. axis: `project_variant_all` on a
+    /// non-coding (or n.-axis) variant with an NG/NC parent must also
+    /// reach the fan-out path.
+    #[test]
+    fn project_variant_all_accepts_noncoding_n_input_with_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::TxInterval;
+        use crate::hgvs::location::TxPos;
+        use crate::hgvs::variant::{Accession, HgvsVariant, LocEdit, TxVariant};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        // n.4 maps to genome 1003 on NM_TX1.1 in this fixture (tx_pos 3
+        // → exon.genome_start + 3 = 1003).
+        let tx = TxVariant {
+            accession: parse_accession("NM_TX1.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            )),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                TxInterval::point(TxPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let results = vp
+            .project_variant_all(&HgvsVariant::Tx(tx))
+            .expect("project_variant_all should accept n. input post-#389");
+        assert!(
+            results.iter().any(|p| p.transcript_id == "NM_TX1.1"),
+            "expected at least the input transcript's projection, got {:?}",
+            results.iter().map(|p| &p.transcript_id).collect::<Vec<_>>()
+        );
+    }
+
+    /// `project_variant_all` on an r. (RNA) input — parallel to n. but
+    /// on the r. axis. Pre-#389 the gate rejected this too.
+    #[test]
+    fn project_variant_all_accepts_rna_input_with_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::RnaInterval;
+        use crate::hgvs::location::RnaPos;
+        use crate::hgvs::variant::{Accession, HgvsVariant, LocEdit, RnaVariant};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        let rna = RnaVariant {
+            accession: parse_accession("NM_TX1.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            )),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                RnaInterval::point(RnaPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let results = vp
+            .project_variant_all(&HgvsVariant::Rna(rna))
+            .expect("project_variant_all should accept r. input post-#389");
+        assert!(
+            results.iter().any(|p| p.transcript_id == "NM_TX1.1"),
+            "expected at least the input transcript's projection, got {:?}",
+            results.iter().map(|p| &p.transcript_id).collect::<Vec<_>>()
+        );
+    }
+
+    /// c. input *without* a `genomic_context` parent: the fan-out
+    /// rejects the input up front with `UnsupportedProjection`
+    /// (#389 follow-up).
+    ///
+    /// Pre-fix the stab query still seeded and each per-transcript
+    /// projection silently failed inside `project_to_genomic`'s parent
+    /// requirement; the fan-out loop's `log::trace!`-and-drop converted
+    /// the user error into `Ok([])`, turning "you forgot the parent"
+    /// into "no overlaps." Post-fix the error is surfaced.
+    #[test]
+    fn project_variant_all_rejects_coding_input_without_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{CdsVariant, HgvsVariant, LocEdit};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        // No `.with_genomic_context(...)` — bare NM accession on a c. input.
+        let cds = CdsVariant {
+            accession: parse_accession("NM_TX1.1"),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let err = vp
+            .project_variant_all(&HgvsVariant::Cds(cds))
+            .expect_err("c. input without parent must error, not silently return empty");
+        match err {
+            FerroError::UnsupportedProjection { reason } => {
+                assert!(
+                    reason.contains("project_all requires a parent reference")
+                        && reason.contains("c."),
+                    "unexpected error message: {reason}"
+                );
+            }
+            other => panic!("expected UnsupportedProjection, got {other:?}"),
+        }
+    }
+
+    /// Same as above but for n. — the Tx-axis arm of the
+    /// `require_parent_for_fanout` gate (#389 follow-up).
+    #[test]
+    fn project_variant_all_rejects_noncoding_n_input_without_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::TxInterval;
+        use crate::hgvs::location::TxPos;
+        use crate::hgvs::variant::{HgvsVariant, LocEdit, TxVariant};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        let tx = TxVariant {
+            accession: parse_accession("NM_TX1.1"),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                TxInterval::point(TxPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let err = vp
+            .project_variant_all(&HgvsVariant::Tx(tx))
+            .expect_err("n. input without parent must error");
+        match err {
+            FerroError::UnsupportedProjection { reason } => {
+                assert!(reason.contains("n."), "unexpected error message: {reason}");
+            }
+            other => panic!("expected UnsupportedProjection, got {other:?}"),
+        }
+    }
+
+    /// Same as above but for r. — the Rna-axis arm of the gate.
+    #[test]
+    fn project_variant_all_rejects_rna_input_without_parent() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::RnaInterval;
+        use crate::hgvs::location::RnaPos;
+        use crate::hgvs::variant::{HgvsVariant, LocEdit, RnaVariant};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        let rna = RnaVariant {
+            accession: parse_accession("NM_TX1.1"),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                RnaInterval::point(RnaPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let err = vp
+            .project_variant_all(&HgvsVariant::Rna(rna))
+            .expect_err("r. input without parent must error");
+        match err {
+            FerroError::UnsupportedProjection { reason } => {
+                assert!(reason.contains("r."), "unexpected error message: {reason}");
+            }
+            other => panic!("expected UnsupportedProjection, got {other:?}"),
+        }
+    }
+
+    /// `HgvsVariant::Allele` whose first inner variant is c. — the
+    /// fan-out path should unwrap and process the inner correctly,
+    /// matching the behavior of g.-inner alleles.
+    #[test]
+    fn project_variant_all_accepts_allele_of_coding_input() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{Accession, CdsVariant, HgvsVariant, LocEdit};
+        let (projector, provider) = make_two_transcript_setup();
+        let vp = VariantProjector::new(projector, provider);
+
+        let cds = CdsVariant {
+            accession: parse_accession("NM_TX1.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            )),
+            gene_symbol: Some("GENE1".to_string()),
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        };
+        let allele = HgvsVariant::Allele(AlleleVariant::cis(vec![HgvsVariant::Cds(cds)]));
+        let results = vp
+            .project_variant_all(&allele)
+            .expect("Allele wrapping a c. inner must reach the fan-out path");
+        assert!(
+            results.iter().any(|p| p.transcript_id == "NM_TX1.1"),
+            "expected the input transcript's projection from the allele's inner c., got {:?}",
+            results.iter().map(|p| &p.transcript_id).collect::<Vec<_>>()
         );
     }
 
@@ -2748,7 +3244,7 @@ mod tests {
             let cdot =
                 CdotMapper::from_reader_with_build(multi_build_cdot_json().as_bytes(), "GRCh38")
                     .expect("multi-build JSON must parse");
-            assert_eq!(cdot.primary_build(), "GRCh38");
+            assert_eq!(cdot.primary_build(), Some("GRCh38"));
             assert_eq!(cdot.transcript_count(), 1);
             let tx38 = cdot
                 .get_transcript_on_build("NM_MB_TEST.1", "GRCh38")
@@ -2907,6 +3403,101 @@ mod tests {
                 }
                 other => panic!("expected Genome, got: {:?}", other),
             }
+        }
+
+        /// `transcript_cache` and `ref_protein_cache` must partition by
+        /// genome-build identity, not collapse to a single key per
+        /// `transcript_id` (#389 follow-up).
+        ///
+        /// Pre-fix: the `coding` variant built inside `project_single_inner`
+        /// dropped the genomic accession (`parse_accession(transcript_id)`
+        /// carries no `genomic_context`), so `parent_key_for(&coding)`
+        /// returned `None` for both `NC_*.10` and `NC_*.11` inputs. The
+        /// two builds therefore shared cache entries — a GRCh38-built
+        /// `Transcript` / `RefProteinBundle` could be served for a GRCh37
+        /// projection and vice versa.
+        ///
+        /// Post-fix: the parallel `cache_variant` stamps the projected g.
+        /// accession (`NC_*.10` vs `NC_*.11`) as `genomic_context`, so
+        /// `parent_key_for(&cache_variant)` produces distinct keys for
+        /// the two builds and the caches keep them apart. The test
+        /// projects an indel (deletion) on each build so both branches
+        /// of the protein-prediction dispatch
+        /// (`cached_get_transcript_for_variant` + `cached_ref_translation`)
+        /// execute.
+        #[test]
+        fn caches_partition_by_genome_build_for_nc_inputs() {
+            let vp = make_multi_build_projector("GRCh38");
+
+            // c.5del on GRCh37 (g.10004del on NC_000001.10).
+            let g37 = GenomeVariant {
+                accession: nc_chr1(10),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(10004)),
+                    NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    },
+                ),
+            };
+            vp.project_normalized(&HgvsVariant::Genome(g37), "NM_MB_TEST.1")
+                .expect("GRCh37 deletion projection must succeed");
+
+            // c.5del on GRCh38 (g.20004del on NC_000001.11).
+            let g38 = GenomeVariant {
+                accession: nc_chr1(11),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(20004)),
+                    NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    },
+                ),
+            };
+            vp.project_normalized(&HgvsVariant::Genome(g38), "NM_MB_TEST.1")
+                .expect("GRCh38 deletion projection must succeed");
+
+            let tx_keys: std::collections::HashSet<_> = vp
+                .transcript_cache
+                .read()
+                .expect("transcript cache poisoned")
+                .keys()
+                .cloned()
+                .collect();
+            assert_eq!(
+                tx_keys.len(),
+                2,
+                "transcript_cache must keep GRCh37 and GRCh38 entries separate, \
+                 got keys: {:?}",
+                tx_keys
+            );
+            assert!(
+                tx_keys.contains(&("NM_MB_TEST.1".to_string(), Some("NC_000001.10".to_string()))),
+                "expected an NC_000001.10 key, got: {:?}",
+                tx_keys
+            );
+            assert!(
+                tx_keys.contains(&("NM_MB_TEST.1".to_string(), Some("NC_000001.11".to_string()))),
+                "expected an NC_000001.11 key, got: {:?}",
+                tx_keys
+            );
+
+            let rp_keys: std::collections::HashSet<_> = vp
+                .ref_protein_cache
+                .read()
+                .expect("ref-protein cache poisoned")
+                .keys()
+                .cloned()
+                .collect();
+            assert_eq!(
+                rp_keys.len(),
+                2,
+                "ref_protein_cache must keep GRCh37 and GRCh38 entries separate, \
+                 got keys: {:?}",
+                rp_keys
+            );
         }
 
         /// Same as above but for NC_000001.11 (GRCh38, the primary build).

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -967,7 +967,12 @@ impl MultiFastaProvider {
     ///      consulted as a fallback when a hint is supplied; callers
     ///      wanting that behavior must pass `None`.
     ///   2. With `None`, the attached [`CdotMapper`]'s primary build is
-    ///      used (matched against the same canonical names).
+    ///      used when known (matched against the same canonical names).
+    ///      An attached cdot whose `primary_build()` is `None` (e.g. a
+    ///      bincode snapshot that pre-dates build tracking) surfaces as
+    ///      [`GenomeBuild::Unknown`] rather than fabricating a default —
+    ///      see #389 follow-up: the prior behavior of silently stamping
+    ///      `GRCh38` re-introduced the mis-tag this PR removes.
     ///   3. With `None` and no cdot mapper attached, default to GRCh38
     ///      (preserves the historical FASTA-only behavior).
     ///
@@ -983,16 +988,23 @@ impl MultiFastaProvider {
         build_hint: Option<&str>,
     ) -> crate::reference::transcript::GenomeBuild {
         use crate::reference::transcript::GenomeBuild;
-        let resolved: &str = build_hint.unwrap_or_else(|| {
-            self.cdot_mapper
-                .as_ref()
-                .map(CdotMapper::primary_build)
-                .unwrap_or("GRCh38")
-        });
-        match resolved {
-            "GRCh37" => GenomeBuild::GRCh37,
-            "GRCh38" => GenomeBuild::GRCh38,
-            _ => GenomeBuild::Unknown,
+        // 1. Explicit hint wins.
+        if let Some(h) = build_hint {
+            return match h {
+                "GRCh37" => GenomeBuild::GRCh37,
+                "GRCh38" => GenomeBuild::GRCh38,
+                _ => GenomeBuild::Unknown,
+            };
+        }
+        // 2/3. Consult the attached cdot (if any). An unknown primary
+        // build is surfaced as `Unknown` so callers don't get a wrong
+        // canonical stamp on a snapshot that lacks build provenance.
+        match self.cdot_mapper.as_ref().and_then(|c| c.primary_build()) {
+            Some("GRCh37") => GenomeBuild::GRCh37,
+            Some("GRCh38") => GenomeBuild::GRCh38,
+            Some(_) => GenomeBuild::Unknown,
+            None if self.cdot_mapper.is_some() => GenomeBuild::Unknown,
+            None => GenomeBuild::GRCh38,
         }
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -996,35 +996,14 @@ impl MultiFastaProvider {
         }
     }
 
-    /// Infer the genome build for an `NC_*` parent accession by checking
-    /// `ContigAliases::default_human()` for membership under each build.
-    /// Returns `None` for `NG_*` parents (build-agnostic) and for any NC
-    /// accession not in the human alias table.
+    /// Infer the genome build for an `NC_*` parent accession.
+    ///
+    /// Thin wrapper around the shared
+    /// [`crate::liftover::aliases::infer_genome_build_from_accession`] —
+    /// kept on the impl so existing call sites and tests stay terse;
+    /// see the free function for the canonical contract.
     fn infer_build_from_parent(parent: &crate::hgvs::variant::Accession) -> Option<&'static str> {
-        use crate::liftover::aliases::ContigAliases;
-        use crate::reference::transcript::GenomeBuild;
-        // Only `NC_*` carries a build-distinguishing version; `NG_*` is
-        // build-agnostic, return None so the caller probes multiple builds.
-        if &*parent.prefix != "NC" {
-            return None;
-        }
-        let aliases = ContigAliases::default_human();
-        // `Accession::full()` re-renders `NC_000017.11` etc. and avoids a
-        // separate format!() here.
-        let parent_str = parent.full();
-        if aliases
-            .resolve_to_refseq(&parent_str, GenomeBuild::GRCh38)
-            .is_some()
-        {
-            return Some("GRCh38");
-        }
-        if aliases
-            .resolve_to_refseq(&parent_str, GenomeBuild::GRCh37)
-            .is_some()
-        {
-            return Some("GRCh37");
-        }
-        None
+        crate::liftover::aliases::infer_genome_build_from_accession(parent)
     }
 }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -658,15 +658,20 @@ impl MultiFastaProvider {
     ///
     /// `tx.strand` is honored; metadata fields are projected onto the returned
     /// `Transcript` using the same conventions as the FASTA-backed path so
-    /// downstream consumers see one shape regardless of which path served them.
-    /// `genome_build` is currently hardcoded to `GRCh38` to match the FASTA
-    /// path; pre-existing inconsistency, see TODO below.
+    /// downstream consumers see one shape regardless of which path served
+    /// them. `genome_build` is derived from `build_hint` when the caller
+    /// supplied one; otherwise from the attached [`CdotMapper`]'s primary
+    /// build (this entry point is only reachable through that mapper, so
+    /// the cdot-less branch of
+    /// [`genome_build_from_hint`](Self::genome_build_from_hint) cannot
+    /// fire here). See [#389].
     fn synthesize_transcript_from_cdot(
         &self,
         id: &str,
         tx: &crate::data::cdot::CdotTranscript,
+        build_hint: Option<&str>,
     ) -> Result<Transcript, FerroError> {
-        use crate::reference::transcript::{Exon as TxExon, GenomeBuild, ManeStatus, Strand};
+        use crate::reference::transcript::{Exon as TxExon, ManeStatus, Strand};
         use std::sync::OnceLock;
 
         if tx.exons.is_empty() {
@@ -737,9 +742,6 @@ impl MultiFastaProvider {
             (min_start, max_end)
         };
 
-        // TODO(#331-follow-up): `genome_build` is hardcoded GRCh38 here AND in
-        // the FASTA path (line ~828). For multi-build cdot loads this would
-        // mis-tag GRCh37 transcripts; resolve in a separate PR.
         Ok(Transcript {
             id: id.to_string(),
             gene_symbol: tx.gene_name.clone(),
@@ -751,7 +753,7 @@ impl MultiFastaProvider {
             chromosome: Some(tx.contig.clone()),
             genomic_start,
             genomic_end,
-            genome_build: GenomeBuild::GRCh38,
+            genome_build: self.genome_build_from_hint(build_hint),
             mane_status: ManeStatus::default(),
             refseq_match: None,
             ensembl_match: None,
@@ -796,7 +798,7 @@ impl MultiFastaProvider {
         id: &str,
         build_hint: Option<&str>,
     ) -> Result<Transcript, FerroError> {
-        use crate::reference::transcript::{Exon as TxExon, GenomeBuild, ManeStatus};
+        use crate::reference::transcript::{Exon as TxExon, ManeStatus};
         use std::sync::OnceLock;
 
         if let Some(resolved) = self.resolve_name(id) {
@@ -899,11 +901,7 @@ impl MultiFastaProvider {
                     chromosome: meta.chromosome,
                     genomic_start: meta.genomic_start,
                     genomic_end: meta.genomic_end,
-                    genome_build: match build_hint {
-                        Some("GRCh37") => GenomeBuild::GRCh37,
-                        Some("GRCh38") | None => GenomeBuild::GRCh38,
-                        _ => GenomeBuild::Unknown,
-                    },
+                    genome_build: self.genome_build_from_hint(build_hint),
                     mane_status: ManeStatus::default(),
                     refseq_match: None,
                     ensembl_match: None,
@@ -919,8 +917,17 @@ impl MultiFastaProvider {
         // does carry the exon alignment, synthesize transcript bases by
         // walking the alignment against the genome FASTA. Strand-aware.
         // Closes #331.
+        //
+        // When `build_hint` is `Some`, restrict the cdot lookup to that
+        // genome build so the synthesized exon coordinates and `contig`
+        // come from the same alignment the caller asked for; otherwise
+        // fall back to the primary-build view. See #389.
         if let Some(ref cdot) = self.cdot_mapper {
-            if let Some(tx) = cdot.get_transcript(id) {
+            let cdot_tx = match build_hint {
+                Some(b) => cdot.get_transcript_on_build(id, b),
+                None => cdot.get_transcript(id),
+            };
+            if let Some(tx) = cdot_tx {
                 // cdot.get_transcript does its own version-strip fallback
                 // (NM_FOO.1 -> NM_FOO.2 if only .2 is loaded). If that fired,
                 // the bases we synthesize will come from a *different* cdot
@@ -942,11 +949,51 @@ impl MultiFastaProvider {
                         id
                     );
                 }
-                return self.synthesize_transcript_from_cdot(id, tx);
+                return self.synthesize_transcript_from_cdot(id, tx, build_hint);
             }
         }
 
         Err(FerroError::ReferenceNotFound { id: id.to_string() })
+    }
+
+    /// Resolve `build_hint` to a [`GenomeBuild`] for a returned [`Transcript`].
+    ///
+    /// Precedence:
+    ///   1. Explicit `build_hint` is consulted first. Recognized values
+    ///      `"GRCh37"` / `"GRCh38"` map to the matching enum variant;
+    ///      anything else — including the empty string, non-canonical
+    ///      casing (`"grch38"`, `"hg19"`), or an unknown build name — maps
+    ///      to [`GenomeBuild::Unknown`]. The cdot primary build is *not*
+    ///      consulted as a fallback when a hint is supplied; callers
+    ///      wanting that behavior must pass `None`.
+    ///   2. With `None`, the attached [`CdotMapper`]'s primary build is
+    ///      used (matched against the same canonical names).
+    ///   3. With `None` and no cdot mapper attached, default to GRCh38
+    ///      (preserves the historical FASTA-only behavior).
+    ///
+    /// Strict canonical-casing matches the format produced by
+    /// [`infer_build_from_parent`](Self::infer_build_from_parent), which
+    /// is the only in-tree caller that synthesizes hints; foreign hint
+    /// sources should normalize before calling.
+    ///
+    /// Centralizing this here keeps the main FASTA-backed path and the
+    /// cdot synthesize fallback in agreement (#389).
+    fn genome_build_from_hint(
+        &self,
+        build_hint: Option<&str>,
+    ) -> crate::reference::transcript::GenomeBuild {
+        use crate::reference::transcript::GenomeBuild;
+        let resolved: &str = build_hint.unwrap_or_else(|| {
+            self.cdot_mapper
+                .as_ref()
+                .map(CdotMapper::primary_build)
+                .unwrap_or("GRCh38")
+        });
+        match resolved {
+            "GRCh37" => GenomeBuild::GRCh37,
+            "GRCh38" => GenomeBuild::GRCh38,
+            _ => GenomeBuild::Unknown,
+        }
     }
 
     /// Infer the genome build for an `NC_*` parent accession by checking
@@ -1670,6 +1717,238 @@ mod tests {
             matches!(err, FerroError::InvalidCoordinates { .. }),
             "expected InvalidCoordinates, got {err:?}"
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // genome_build propagation (closes #389 item 1)
+    //
+    // Pre-fix, `synthesize_transcript_from_cdot` hardcoded
+    // `genome_build: GenomeBuild::GRCh38` and the main-path return mapped
+    // `None` to GRCh38 as well. For a `CdotMapper` whose primary build is
+    // GRCh37, both paths mis-tagged transcripts as GRCh38. These tests pin
+    // build propagation through the cdot fallback (synthesize) and the
+    // main FASTA-backed path, and exercise the centralized
+    // `genome_build_from_hint` helper that both paths share.
+    // ----------------------------------------------------------------------
+
+    /// `cdot.primary_build == "GRCh37"`, transcript not in the transcript
+    /// FASTA index → synthesize fallback runs. With no caller-supplied
+    /// `build_hint`, the synthesized `Transcript` must inherit the cdot
+    /// primary build, not the historical hardcoded GRCh38.
+    #[test]
+    fn test_synthesize_falls_back_to_cdot_primary_build_grch37() {
+        use crate::data::cdot::CdotMapper;
+        use crate::reference::transcript::{GenomeBuild, Strand};
+
+        let (mut provider, _kept) = build_provider_with_test_genome();
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts_with_build(
+            std::iter::once(&tx),
+            "GRCh37",
+        ));
+
+        let synthesized = provider
+            .get_transcript("NM_TEST.1")
+            .expect("cdot exon-alignment fallback should fetch transcript");
+        assert_eq!(
+            synthesized.genome_build,
+            GenomeBuild::GRCh37,
+            "synthesized transcript must inherit cdot primary build, not default to GRCh38"
+        );
+    }
+
+    /// Explicit `build_hint` is threaded through the synthesize fallback so
+    /// the resulting `Transcript.genome_build` reflects the hint. Here the
+    /// hint matches the cdot primary build (GRCh37 ↔ GRCh37) — exercises
+    /// that the parameter is plumbed through, not merely inferred from
+    /// the primary build.
+    #[test]
+    fn test_synthesize_honors_explicit_build_hint_grch37() {
+        use crate::data::cdot::CdotMapper;
+        use crate::reference::transcript::{GenomeBuild, Strand};
+
+        let (mut provider, _kept) = build_provider_with_test_genome();
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts_with_build(
+            std::iter::once(&tx),
+            "GRCh37",
+        ));
+
+        let synthesized = provider
+            .get_transcript_on_build("NM_TEST.1", Some("GRCh37"))
+            .expect("cdot exon-alignment fallback should fetch transcript");
+        assert_eq!(
+            synthesized.genome_build,
+            GenomeBuild::GRCh37,
+            "explicit build_hint must reach Transcript.genome_build"
+        );
+    }
+
+    /// When the caller asks for a build that cdot did NOT load, the
+    /// synthesize fallback must surface `ReferenceNotFound` rather than
+    /// quietly synthesizing from the primary-build alignment and
+    /// mis-tagging the result. Pre-#389 the fallback used the
+    /// build-agnostic `cdot.get_transcript` which would silently succeed.
+    #[test]
+    fn test_synthesize_rejects_when_cdot_lacks_requested_build() {
+        use crate::data::cdot::CdotMapper;
+        use crate::reference::transcript::Strand;
+
+        let (mut provider, _kept) = build_provider_with_test_genome();
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts_with_build(
+            std::iter::once(&tx),
+            "GRCh37",
+        ));
+
+        let err = provider
+            .get_transcript_on_build("NM_TEST.1", Some("GRCh38"))
+            .expect_err("cdot has no GRCh38 alignment; synthesize must fail honestly");
+        assert!(
+            matches!(err, FerroError::ReferenceNotFound { .. }),
+            "expected ReferenceNotFound, got {err:?}"
+        );
+    }
+
+    /// Main FASTA-backed path (NM_TEST.1 *is* in the transcript FASTA),
+    /// cdot primary = GRCh37, no caller build hint → resulting
+    /// `Transcript.genome_build` must be GRCh37, not the historical default.
+    #[test]
+    fn test_main_path_falls_back_to_cdot_primary_build_grch37() {
+        use crate::data::cdot::CdotMapper;
+        use crate::reference::transcript::{GenomeBuild, Strand};
+
+        let (mut provider, _kept) = build_provider_with_genome_and_named_tx("NM_TEST.1");
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts_with_build(
+            std::iter::once(&tx),
+            "GRCh37",
+        ));
+
+        let loaded = provider
+            .get_transcript("NM_TEST.1")
+            .expect("main path should fetch transcript from FASTA + cdot metadata");
+        assert_eq!(
+            loaded.genome_build,
+            GenomeBuild::GRCh37,
+            "main path must inherit cdot primary build when no caller hint is given"
+        );
+    }
+
+    /// Main path with no cdot mapper at all → fall back to the historical
+    /// default (GRCh38). Documents the unchanged behavior for FASTA-only
+    /// providers.
+    #[test]
+    fn test_main_path_no_cdot_defaults_to_grch38() {
+        use crate::reference::transcript::GenomeBuild;
+
+        let (provider, _kept) = build_provider_with_genome_and_named_tx("NM_TEST.1");
+        let loaded = provider
+            .get_transcript("NM_TEST.1")
+            .expect("main path should fetch transcript from FASTA (no cdot needed)");
+        assert_eq!(
+            loaded.genome_build,
+            GenomeBuild::GRCh38,
+            "FASTA-only provider with no cdot must preserve historical GRCh38 default"
+        );
+    }
+
+    /// Main FASTA-backed path with an explicit `build_hint = Some("GRCh38")`
+    /// against a cdot whose primary build is GRCh37 → the hint must win
+    /// over the cdot primary on the main path. Sibling to
+    /// `test_main_path_falls_back_to_cdot_primary_build_grch37` which
+    /// covers the `None` arm; together they pin both arms of the helper.
+    #[test]
+    fn test_main_path_explicit_hint_overrides_cdot_primary() {
+        use crate::data::cdot::CdotMapper;
+        use crate::reference::transcript::{GenomeBuild, Strand};
+
+        let (mut provider, _kept) = build_provider_with_genome_and_named_tx("NM_TEST.1");
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts_with_build(
+            std::iter::once(&tx),
+            "GRCh37",
+        ));
+
+        let loaded = provider
+            .get_transcript_on_build("NM_TEST.1", Some("GRCh38"))
+            .expect("main path should fetch transcript from FASTA + cdot metadata");
+        assert_eq!(
+            loaded.genome_build,
+            GenomeBuild::GRCh38,
+            "explicit build_hint must override the cdot primary build on the main path"
+        );
+    }
+
+    /// Direct unit coverage of `genome_build_from_hint` for the
+    /// unrecognized-hint, casing, and empty-string arms — pre-#389 these
+    /// were inline `match` legs; centralizing made them shared, so test
+    /// them in one place.
+    #[test]
+    fn test_genome_build_from_hint_edge_cases() {
+        use crate::reference::transcript::GenomeBuild;
+
+        // No cdot mapper: None falls through to the historical GRCh38 default.
+        let (provider, _kept) = build_provider_with_test_genome();
+        assert_eq!(
+            provider.genome_build_from_hint(None),
+            GenomeBuild::GRCh38,
+            "None with no cdot must default to GRCh38"
+        );
+        // Recognized hints map to their enum variant regardless of cdot.
+        assert_eq!(
+            provider.genome_build_from_hint(Some("GRCh37")),
+            GenomeBuild::GRCh37
+        );
+        assert_eq!(
+            provider.genome_build_from_hint(Some("GRCh38")),
+            GenomeBuild::GRCh38
+        );
+        // Non-canonical hints — empty string, lowercase, UCSC-style — all
+        // map to Unknown rather than silently coercing to GRCh38.
+        for hint in &["", "grch38", "GRCH38", "hg19", "hg38", "GRCh99"] {
+            assert_eq!(
+                provider.genome_build_from_hint(Some(hint)),
+                GenomeBuild::Unknown,
+                "non-canonical hint {:?} must map to Unknown",
+                hint
+            );
+        }
+    }
+
+    /// Build a provider whose FASTA index contains both `NC_TEST.1`
+    /// (genome) and the requested transcript accession (so the main path
+    /// is taken, not the cdot synthesize fallback).
+    fn build_provider_with_genome_and_named_tx(
+        tx_id: &str,
+    ) -> (MultiFastaProvider, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let fasta_path = dir.path().join("genome.fna");
+        let fai_path = dir.path().join("genome.fna.fai");
+        let tx_fasta_path = dir.path().join("tx.fna");
+        let tx_fai_path = dir.path().join("tx.fna.fai");
+        {
+            let mut f = File::create(&fasta_path).unwrap();
+            writeln!(f, ">NC_TEST.1").unwrap();
+            writeln!(f, "AAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCC").unwrap();
+        }
+        {
+            let mut f = File::create(&fai_path).unwrap();
+            writeln!(f, "NC_TEST.1\t40\t11\t40\t41").unwrap();
+        }
+        {
+            let mut f = File::create(&tx_fasta_path).unwrap();
+            writeln!(f, ">{}", tx_id).unwrap();
+            writeln!(f, "AAAACCCCGGGGTTTTAAAA").unwrap();
+        }
+        {
+            let mut f = File::create(&tx_fai_path).unwrap();
+            // Header ">NM_TEST.1\n" -> header byte length = len(tx_id) + 2.
+            let header_len = tx_id.len() as u64 + 2;
+            writeln!(f, "{}\t20\t{}\t20\t21", tx_id, header_len).unwrap();
+        }
+        let provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+        (provider, dir)
     }
 
     #[test]

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -561,12 +561,13 @@ class TestProjectMany:
         # Mirror the `project_many` fail-fast contract for the
         # already-parsed entry point: the first failing input must abort
         # the batch with an `input[i]:` prefix identifying its position.
-        # The second entry is a c. variant — `project_normalized_all`
-        # only accepts g. inputs, so it raises and indexed reporting kicks
-        # in.
+        # The second entry is a p. variant — post-#389 the fan-out accepts
+        # g./c./n./r. but still rejects p./m./o./fusion/allele-of-unsupported,
+        # so a protein input raises `UnsupportedProjection` and indexed
+        # reporting kicks in.
         variants = [
             ferro_hgvs.parse("NC_000001.11:g.1003C>A"),
-            ferro_hgvs.parse("NM_TEST.1:c.4C>A"),
+            ferro_hgvs.parse("NP_TEST.1:p.Arg2Cys"),
         ]
         with pytest.raises(RuntimeError, match=r"input\[1\]"):
             projector.project_normalized_many(variants)


### PR DESCRIPTION
## Summary

Closes #389. Three projector-side fixes that close build-aware-lookup gaps surfaced by post-PR review on #341, #364, and #379. Each item lands as a single commit:

- **`fix(reference): propagate genome build through MultiFastaProvider` (#389 item 1)** — `synthesize_transcript_from_cdot` hardcoded `genome_build: GenomeBuild::GRCh38` and the main FASTA-backed path mapped `None`/`Some("GRCh38")` to GRCh38 unconditionally. On a `CdotMapper` whose primary build is GRCh37 both paths mis-tagged transcripts as GRCh38. Threads `build_hint` into the synthesize fallback, routes both exits through a new shared `genome_build_from_hint` helper (build hint → cdot primary build → GRCh38 fallback), and uses the build-aware `CdotMapper::get_transcript_on_build` inside the fallback so an honest `ReferenceNotFound` replaces silent mis-tagging when the requested build's view is absent from cdot.

- **`fix(project): thread build hint through cdot lookups in projector` (#389 item 2)** — `project_to_genomic` (c./n./r. → g.) and `project_single_inner` (g. → c./n./r.) silently used the cdot mapper's primary build for every lookup, ignoring the build implied by the input's NG/NC parent (or the g. variant's own NC_* version). Extracts `infer_genome_build_from_accession` from `MultiFastaProvider` into `crate::liftover::aliases` (now cached behind a `OnceLock`, honors assembly-style tags, fixes the missing GRCh38 self-alias for the rCRS mtDNA accession `NC_012920.1`), adds `CoordinateMapper::cds_to_genome_on_build` / `genome_to_cds_on_build` and `CdotMapper::transcript_genome_span_on_build`, and threads `build_hint` through every cdot lookup in `project_to_genomic`, `project_single_inner`, and the `project_allele_inner` empty-allele path. A new `mod multi_build_projection_tests` pins the contract across the NC_*.10 / NC_*.11 / NG_* / primary-build cases.

- **`fix(project): widen project_all fan-out path to c./n./r. inputs` (#389 item 3)** — `extract_contig_and_pos` matched only `HgvsVariant::Genome` and errored out at the fan-out gate for every other axis, defeating PR #379's per-transcript widening. Converts the function into a method on `VariantProjector` so it can consult cdot, adds per-axis dispatch for c. (via `cds_to_genome_on_build`, which handles intronic offsets / 5'UTR / 3'UTR natively), n., and r. (via `tx_to_genome` with a best-effort first-exon-start fallback for intronic / downstream / `utr3` / non-positive bases — the per-transcript projection downstream re-derives the precise coordinate). Unsupported axes (p./m./o./RNA-fusion/null-and-unknown-allele) now produce axis-specific error messages instead of the legacy g.-only one.

## Test plan

- [ ] `cargo nextest run --features dev` — 5754 passed, 9 pre-existing failures (`mutalyzer_normalize_tests::axis_*`, `biocommons_normalize_tests::axis_normalized`) unchanged.
- [ ] `cargo clippy --features dev -- -D warnings` clean.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo run --features dev --example generate_spec_fixture -- --check` clean (HGVS spec fixture).
- [ ] New tests:
  - `reference::multi_fasta::tests::test_{synthesize,main_path}_*` × 6 (item 1).
  - `project::projector::tests::multi_build_projection_tests::*` × 6 (item 2).
  - `project::projector::tests::project_variant_all_accepts_*` × 5 (item 3).
- [ ] Behavior verified on a multi-build cdot fixture (primary=GRCh38, alt=GRCh37): GRCh37 inputs now project against the GRCh37 alignment instead of being silently mis-tagged.