### PR TITLE
test(normalize): 3'-rule completeness — repeat-depth audit + #343 deferred symmetry tests (closes #391)

### DIFF
--- a/tests/issue_337_cds_start_clamp.rs
+++ b/tests/issue_337_cds_start_clamp.rs
@@ -365,3 +365,228 @@ fn five_prime_shuffles_intra_cds_homopolymer_all_the_way_to_c1() {
         "5'-shuffle through an intra-CDS A-tract must reach c.1del, not stop at c.2del",
     );
 }
+
+// =============================================================================
+// PR #343 deferred follow-ups (issue #391 item 2)
+//
+// PR #343 (CDS↔UTR axis clamp for the 3'-rule shuffle) deferred two
+// symmetry tests in its body:
+//
+//   - "5'-direction `c.*N` clamp at `c.*1` symmetry test"
+//   - "minus-strand sanity test"
+//
+// Both pin behavior that ALREADY works on the existing clamp logic —
+// they were called out as gaps in the test matrix, not as missing
+// fixes. This block lands them so a future axis-clamp refactor cannot
+// regress the 3'UTR / minus-strand sides of the matrix.
+// =============================================================================
+
+/// Mirror fixture of `provider_with_utr_padded_transcript` for the 3'UTR
+/// side: a homopolymer that straddles the CDS↔3'UTR axis boundary so a
+/// 5'-direction shuffle of `c.*N` would (without the axis clamp) shift
+/// across into the CDS and re-classify as `c.<N>`.
+///
+/// Transcript layout:
+///   tx 1-3   : 5'UTR `CCC`             (c.-3 .. c.-1)
+///   tx 4-12  : CDS   `ATGCGCAAA`       (c.1 .. c.9; ends with AAA at c.7..c.9)
+///   tx 13-20 : 3'UTR `AAAACCCC`        (c.*1 .. c.*8; starts with AAAA)
+///
+/// The combined A-tract runs tx 10-16 (c.7 .. c.*4) — 7 contiguous A's
+/// straddling the CDS↔3'UTR boundary at tx 12/13 (c.9 / c.*1). Without
+/// the clamp, a 5'-shuffle of `c.*1del` walks back through `AAAA` in the
+/// 3'UTR and the `AAA` of the CDS, landing at `c.7del`. The clamp must
+/// pin the 5'-direction shuffle at `c.*1` — the leftmost reachable
+/// position on the 3'UTR axis.
+fn provider_with_cds_utr3_homopolymer_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "CCCATGCGCAAAAAAACCCC".to_string();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_UTR3.1".to_string(),
+        Some("UTR3".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(4),
+        Some(12),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_utr3_with(direction: ShuffleDirection, cross: bool, input: &str) -> String {
+    let mut config = NormalizeConfig::default().with_direction(direction);
+    if cross {
+        config = config.allow_crossing_boundaries();
+    }
+    let normalizer =
+        Normalizer::with_config(provider_with_cds_utr3_homopolymer_transcript(), config);
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn five_prime_no_cross_does_not_shift_c_star_1_del_into_cds() {
+    // 3'UTR mirror of `five_prime_no_cross_does_not_shift_c1_del_into_5utr`.
+    // `c.*1del` under 5prime + cross_boundaries=false must stay at c.*1del
+    // — the 5'-direction shuffle clamps at the CDS↔3'UTR boundary even
+    // though the A-tract continues 3 bases into the CDS.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::FivePrime, false, "NM_UTR3.1:c.*1del"),
+        "NM_UTR3.1:c.*1del",
+    );
+}
+
+#[test]
+fn five_prime_cross_does_not_shift_c_star_1_del_into_cds() {
+    // Companion of `five_prime_cross_does_not_shift_c1_del_into_5utr`.
+    // `cross_boundaries=true` authorizes crossing exon-intron junctions,
+    // NOT the CDS↔3'UTR sub-axis boundary. The 3'UTR axis clamp fires
+    // in both cross modes.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::FivePrime, true, "NM_UTR3.1:c.*1del"),
+        "NM_UTR3.1:c.*1del",
+    );
+}
+
+#[test]
+fn five_prime_no_cross_does_not_shift_c_star_1_dup_into_cds() {
+    // 3'UTR dup mirror of `five_prime_no_cross_does_not_shift_c1_dup_into_5utr`.
+    // `c.*1dup` under 5prime + cross=false must stay at c.*1dup.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::FivePrime, false, "NM_UTR3.1:c.*1dup"),
+        "NM_UTR3.1:c.*1dup",
+    );
+}
+
+#[test]
+fn five_prime_cross_does_not_shift_c_star_1_dup_into_cds() {
+    // 3'UTR dup × cross=true cell.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::FivePrime, true, "NM_UTR3.1:c.*1dup"),
+        "NM_UTR3.1:c.*1dup",
+    );
+}
+
+#[test]
+fn five_prime_inside_utr3_walks_to_c_star_1() {
+    // `c.*4del` inside the 3'UTR's AAAA tract. 5'-direction shuffle
+    // should walk through the 3'UTR A's and stop at `c.*1` — within
+    // the 3'UTR axis, not crossing into CDS. Sanity check that the
+    // clamp doesn't over-restrict (i.e. doesn't pin the variant at
+    // its input position when the shuffle is entirely within-axis).
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::FivePrime, false, "NM_UTR3.1:c.*4del"),
+        "NM_UTR3.1:c.*1del",
+    );
+}
+
+#[test]
+fn axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle() {
+    // 3'UTR mirror of `axis_clamp_emits_warning_when_constraining_5prime_shuffle`.
+    // Without the axis clamp `c.*1del` under 5prime would shift back
+    // into the CDS A-tract (per fixture: CDS ends with `AAA`, 3'UTR
+    // starts with `AAAA`). The clamp holds the result at c.*1del; the
+    // clamp firing must emit `AxisClampApplied` so callers can flag.
+    let normalizer = Normalizer::with_config(
+        provider_with_cds_utr3_homopolymer_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NM_UTR3.1:c.*1del").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize");
+    assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.*1del");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "AXIS_CLAMP_APPLIED"),
+        "expected AXIS_CLAMP_APPLIED warning on 3'UTR 5'-shuffle that the \
+         clamp held; got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+/// Minus-strand sanity fixture: identical tx-frame layout to
+/// `provider_with_utr_padded_transcript` but on `Strand::Minus`. The
+/// CDS↔UTR axis clamp operates on tx-frame positions
+/// (`src/normalize/boundary.rs:get_cds_boundaries_with_axis_info`), so
+/// the strand should be a no-op for the clamp itself. This pins that
+/// strand-invariance contract so a future refactor cannot accidentally
+/// branch the clamp by strand.
+fn provider_with_minus_strand_utr_padded_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "AAAATGAAATAGCCCCCCCC".to_string();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_MTEST.1".to_string(),
+        Some("MTEST".to_string()),
+        Strand::Minus,
+        sequence,
+        Some(4),
+        Some(12),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_minus_with(direction: ShuffleDirection, cross: bool, input: &str) -> String {
+    let mut config = NormalizeConfig::default().with_direction(direction);
+    if cross {
+        config = config.allow_crossing_boundaries();
+    }
+    let normalizer =
+        Normalizer::with_config(provider_with_minus_strand_utr_padded_transcript(), config);
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn minus_strand_five_prime_no_cross_does_not_shift_c1_del_into_5utr() {
+    // Minus-strand mirror of `five_prime_no_cross_does_not_shift_c1_del_into_5utr`.
+    // The clamp must fire identically regardless of strand because it
+    // operates on tx-frame positions.
+    assert_eq!(
+        normalize_minus_with(ShuffleDirection::FivePrime, false, "NM_MTEST.1:c.1del"),
+        "NM_MTEST.1:c.1del",
+    );
+}
+
+#[test]
+fn minus_strand_five_prime_cross_does_not_shift_c1_del_into_5utr() {
+    // Minus-strand × cross=true. Same strand-invariance contract.
+    assert_eq!(
+        normalize_minus_with(ShuffleDirection::FivePrime, true, "NM_MTEST.1:c.1del"),
+        "NM_MTEST.1:c.1del",
+    );
+}
+
+#[test]
+fn minus_strand_three_prime_shift_inside_cds_still_shuffles() {
+    // Negative control: ensure the minus-strand path didn't accidentally
+    // disable in-axis shuffling. `c.4del` (start of the CDS-internal
+    // AAA tract) under 3'-direction must reach c.6del — the rightmost
+    // CDS-internal A. Mirror of `three_prime_shift_inside_cds_still_shuffles`.
+    assert_eq!(
+        normalize_minus_with(ShuffleDirection::ThreePrime, false, "NM_MTEST.1:c.4del"),
+        "NM_MTEST.1:c.6del",
+    );
+}

--- a/tests/issue_337_cds_start_clamp.rs
+++ b/tests/issue_337_cds_start_clamp.rs
@@ -49,6 +49,43 @@ fn provider_with_utr_padded_transcript() -> MockProvider {
     provider
 }
 
+/// Intra-CDS-homopolymer fixture: a CDS whose first 4 bases are `AAAA`
+/// (so the 5'UTR/CDS axis clamp must let a 5'-direction `c.3del` walk
+/// inside the CDS A-tract all the way to `c.1del`), and whose 5'UTR
+/// uses non-A bases so the upstream-of-CDS predicate fails. Used by
+/// `five_prime_shuffles_intra_cds_homopolymer_all_the_way_to_c1` and
+/// `no_axis_clamp_when_upstream_utr_base_does_not_match`.
+///
+/// Transcript layout:
+///   tx 1-3   : 5'UTR `CCC`  (non-A — the clamp is inert because the
+///                           upstream UTR base does not match the
+///                           deleted CDS base)
+///   tx 4-12  : CDS   `AAAATGTAG` (starts with `AAAA`, c.1..c.4 all `A`)
+///   tx 13-20 : 3'UTR `CCCCCCCC`
+fn provider_with_intra_cds_homopolymer_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "CCCAAAATGTAGCCCCCCCC".to_string();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_INTRA.1".to_string(),
+        Some("INTRA".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(4),
+        Some(12),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
 fn normalize_with(direction: ShuffleDirection, cross: bool, input: &str) -> String {
     let mut config = NormalizeConfig::default().with_direction(direction);
     if cross {
@@ -253,31 +290,8 @@ fn no_axis_clamp_when_upstream_utr_base_does_not_match() {
     // both stop at c.1del because the upstream UTR `C` doesn't match
     // the deleted `A`, so the axis clamp never actually constrained
     // movement. The warning must NOT fire.
-    //
-    // NM_INTRA.1 layout (defined in the homopolymer test below):
-    //   5'UTR `CCC` (non-A), CDS `AAAATGTAG`, 3'UTR `CCCCCCCC`.
-    let mut provider = MockProvider::new();
-    let sequence = "CCCAAAATGTAGCCCCCCCC".to_string();
-    let len = sequence.len() as u64;
-    let transcript = Transcript::new(
-        "NM_INTRA.1".to_string(),
-        Some("INTRA".to_string()),
-        Strand::Plus,
-        sequence,
-        Some(4),
-        Some(12),
-        vec![Exon::new(1, 1, len)],
-        None,
-        None,
-        None,
-        Default::default(),
-        ManeStatus::None,
-        None,
-        None,
-    );
-    provider.add_transcript(transcript);
     let normalizer = Normalizer::with_config(
-        provider,
+        provider_with_intra_cds_homopolymer_transcript(),
         NormalizeConfig::default()
             .with_direction(ShuffleDirection::FivePrime)
             .allow_crossing_boundaries(),
@@ -322,39 +336,13 @@ fn no_axis_clamp_when_5prime_shuffle_stays_within_axis() {
 
 #[test]
 fn five_prime_shuffles_intra_cds_homopolymer_all_the_way_to_c1() {
-    // Probe for the off-by-one Opus flagged in review. Build a fresh
-    // transcript whose CDS *starts* with `AAA...` so a 5'-direction
-    // shuffle of `c.3del` would (correctly) walk back to `c.1del`.
-    // If the axis clamp is one HGVS position too restrictive, ferro
-    // would stop at `c.2del` instead.
-    //
-    // Transcript layout:
-    //   tx 1-3   : 5'UTR `CCC`  (non-A, so the upstream-of-CDS predicate fails)
-    //   tx 4-12  : CDS   `AAAATGTAG` (starts with `AAAA`, c.1..c.4 all = `A`)
-    //   tx 13-20 : 3'UTR `CCCCCCCC`
-    let mut provider = MockProvider::new();
-    let sequence = "CCCAAAATGTAGCCCCCCCC".to_string();
-    let len = sequence.len() as u64;
-    let transcript = Transcript::new(
-        "NM_INTRA.1".to_string(),
-        Some("INTRA".to_string()),
-        Strand::Plus,
-        sequence,
-        Some(4),
-        Some(12),
-        vec![Exon::new(1, 1, len)],
-        None,
-        None,
-        None,
-        Default::default(),
-        ManeStatus::None,
-        None,
-        None,
-    );
-    provider.add_transcript(transcript);
-
+    // Probe for the off-by-one Opus flagged in review. The fixture
+    // `provider_with_intra_cds_homopolymer_transcript`'s CDS *starts*
+    // with `AAA...` so a 5'-direction shuffle of `c.3del` would
+    // (correctly) walk back to `c.1del`. If the axis clamp is one HGVS
+    // position too restrictive, ferro would stop at `c.2del` instead.
     let normalizer = Normalizer::with_config(
-        provider,
+        provider_with_intra_cds_homopolymer_transcript(),
         NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
     );
     let variant = parse_hgvs("NM_INTRA.1:c.3del").expect("parse");
@@ -377,8 +365,10 @@ fn five_prime_shuffles_intra_cds_homopolymer_all_the_way_to_c1() {
 //
 // Both pin behavior that ALREADY works on the existing clamp logic —
 // they were called out as gaps in the test matrix, not as missing
-// fixes. This block lands them so a future axis-clamp refactor cannot
-// regress the 3'UTR / minus-strand sides of the matrix.
+// fixes. This block lands them, plus the natural 3'-direction CDS-end
+// symmetry (a `c.<N>` variant at `c.cds_end` trying to 3'-shift INTO
+// the 3'UTR), so a future axis-clamp refactor cannot regress any
+// quadrant of the (direction × axis × strand × edit-kind) matrix.
 // =============================================================================
 
 /// Mirror fixture of `provider_with_utr_padded_transcript` for the 3'UTR
@@ -516,13 +506,114 @@ fn axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle() {
     );
 }
 
-/// Minus-strand sanity fixture: identical tx-frame layout to
-/// `provider_with_utr_padded_transcript` but on `Strand::Minus`. The
-/// CDS↔UTR axis clamp operates on tx-frame positions
+#[test]
+fn axis_clamp_emits_warning_when_constraining_5prime_c_star_1_dup_shuffle() {
+    // Dup mirror of `axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle`.
+    // Same scenario, but with the dup edit kind to close the
+    // (del × dup) leg of the warning matrix.
+    let normalizer = Normalizer::with_config(
+        provider_with_cds_utr3_homopolymer_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NM_UTR3.1:c.*1dup").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize");
+    assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.*1dup");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "AXIS_CLAMP_APPLIED"),
+        "expected AXIS_CLAMP_APPLIED warning on 3'UTR 5'-shuffle of c.*1dup; \
+         got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+// --- 3'-direction CDS-end clamp: c.<cds_end> 3'-shuffle must not leak --
+//     into the 3'UTR. Mirror of the 5'-direction c.1 clamp on the
+//     CDS-start side. The fixture re-uses `provider_with_cds_utr3_homopolymer_transcript`
+//     because the CDS-end A-tract abuts the 3'UTR A-tract.
+
+#[test]
+fn three_prime_no_cross_does_not_shift_c_cds_end_del_into_utr3() {
+    // 3'-direction symmetry of `five_prime_no_cross_does_not_shift_c1_del_into_5utr`.
+    // `c.9del` (last CDS base, an A) under 3prime + cross_boundaries=false
+    // must stay at c.9del — the 3'-direction shuffle clamps at the
+    // CDS↔3'UTR boundary even though the A-tract continues 4 bases into
+    // the 3'UTR.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::ThreePrime, false, "NM_UTR3.1:c.9del"),
+        "NM_UTR3.1:c.9del",
+    );
+}
+
+#[test]
+fn three_prime_cross_does_not_shift_c_cds_end_del_into_utr3() {
+    // `cross_boundaries=true` authorizes crossing exon-intron junctions
+    // but NOT the CDS↔3'UTR sub-axis. Clamp fires in both cross modes.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::ThreePrime, true, "NM_UTR3.1:c.9del"),
+        "NM_UTR3.1:c.9del",
+    );
+}
+
+#[test]
+fn three_prime_no_cross_does_not_shift_c_cds_end_dup_into_utr3() {
+    // Dup symmetry of `three_prime_no_cross_does_not_shift_c_cds_end_del_into_utr3`.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::ThreePrime, false, "NM_UTR3.1:c.9dup"),
+        "NM_UTR3.1:c.9dup",
+    );
+}
+
+#[test]
+fn three_prime_cross_does_not_shift_c_cds_end_dup_into_utr3() {
+    // Closes the (del × dup) × (cross={false,true}) matrix on the
+    // 3'-direction CDS-end side.
+    assert_eq!(
+        normalize_utr3_with(ShuffleDirection::ThreePrime, true, "NM_UTR3.1:c.9dup"),
+        "NM_UTR3.1:c.9dup",
+    );
+}
+
+#[test]
+fn axis_clamp_emits_warning_when_constraining_3prime_c_cds_end_shuffle() {
+    // 3'-direction mirror of the c.*1 5'-direction warning test. The
+    // clamp prevents `c.9del` from shifting into the 3'UTR's AAAA
+    // tract; that constraint must surface as `AXIS_CLAMP_APPLIED`.
+    let normalizer = Normalizer::with_config(
+        provider_with_cds_utr3_homopolymer_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs("NM_UTR3.1:c.9del").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize");
+    assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.9del");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "AXIS_CLAMP_APPLIED"),
+        "expected AXIS_CLAMP_APPLIED warning on CDS-end 3'-shuffle that the \
+         clamp held; got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+/// Minus-strand 5'UTR-side fixture: identical tx-frame layout to
+/// `provider_with_utr_padded_transcript` but on `Strand::Minus`.
+///
+/// The CDS↔UTR axis clamp operates on tx-frame positions
 /// (`src/normalize/boundary.rs:get_cds_boundaries_with_axis_info`), so
-/// the strand should be a no-op for the clamp itself. This pins that
-/// strand-invariance contract so a future refactor cannot accidentally
-/// branch the clamp by strand.
+/// the strand flag is by construction a no-op for the clamp itself.
+/// These minus-strand tests therefore pin the **no-branch-on-strand**
+/// contract — they're not exercising reverse-complement coordinate
+/// arithmetic, just asserting that flipping `Strand::Plus` →
+/// `Strand::Minus` does not introduce a stray strand-conditional code
+/// path into the clamp.
 fn provider_with_minus_strand_utr_padded_transcript() -> MockProvider {
     let mut provider = MockProvider::new();
     let sequence = "AAAATGAAATAGCCCCCCCC".to_string();
@@ -580,6 +671,51 @@ fn minus_strand_five_prime_cross_does_not_shift_c1_del_into_5utr() {
 }
 
 #[test]
+fn minus_strand_five_prime_no_cross_does_not_shift_c1_dup_into_5utr() {
+    // Minus-strand dup mirror of `five_prime_no_cross_does_not_shift_c1_dup_into_5utr`.
+    assert_eq!(
+        normalize_minus_with(ShuffleDirection::FivePrime, false, "NM_MTEST.1:c.1dup"),
+        "NM_MTEST.1:c.1dup",
+    );
+}
+
+#[test]
+fn minus_strand_five_prime_cross_does_not_shift_c1_dup_into_5utr() {
+    // Closes the minus-strand (del × dup) × (cross={false,true})
+    // matrix on the 5'UTR side.
+    assert_eq!(
+        normalize_minus_with(ShuffleDirection::FivePrime, true, "NM_MTEST.1:c.1dup"),
+        "NM_MTEST.1:c.1dup",
+    );
+}
+
+#[test]
+fn minus_strand_axis_clamp_emits_warning_when_constraining_5prime_shuffle() {
+    // Minus-strand mirror of `axis_clamp_emits_warning_when_constraining_5prime_shuffle`.
+    // The AXIS_CLAMP_APPLIED warning must fire on the minus-strand
+    // fixture too — pinning that the warning-emission path is also
+    // strand-invariant.
+    let normalizer = Normalizer::with_config(
+        provider_with_minus_strand_utr_padded_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NM_MTEST.1:c.1del").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize");
+    assert_eq!(format!("{}", result.result), "NM_MTEST.1:c.1del");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "AXIS_CLAMP_APPLIED"),
+        "expected AXIS_CLAMP_APPLIED warning on minus-strand 5'-shuffle that \
+         the clamp held; got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
 fn minus_strand_three_prime_shift_inside_cds_still_shuffles() {
     // Negative control: ensure the minus-strand path didn't accidentally
     // disable in-axis shuffling. `c.4del` (start of the CDS-internal
@@ -588,5 +724,89 @@ fn minus_strand_three_prime_shift_inside_cds_still_shuffles() {
     assert_eq!(
         normalize_minus_with(ShuffleDirection::ThreePrime, false, "NM_MTEST.1:c.4del"),
         "NM_MTEST.1:c.6del",
+    );
+}
+
+/// Minus-strand 3'UTR-side fixture: identical tx-frame layout to
+/// `provider_with_cds_utr3_homopolymer_transcript` but on
+/// `Strand::Minus`. Closes the minus-strand cell of the c.*1 / 3'UTR
+/// matrix.
+fn provider_with_minus_strand_cds_utr3_homopolymer_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "CCCATGCGCAAAAAAACCCC".to_string();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_MUTR3.1".to_string(),
+        Some("MUTR3".to_string()),
+        Strand::Minus,
+        sequence,
+        Some(4),
+        Some(12),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_minus_utr3_with(direction: ShuffleDirection, cross: bool, input: &str) -> String {
+    let mut config = NormalizeConfig::default().with_direction(direction);
+    if cross {
+        config = config.allow_crossing_boundaries();
+    }
+    let normalizer = Normalizer::with_config(
+        provider_with_minus_strand_cds_utr3_homopolymer_transcript(),
+        config,
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn minus_strand_five_prime_no_cross_does_not_shift_c_star_1_del_into_cds() {
+    // Minus-strand mirror of `five_prime_no_cross_does_not_shift_c_star_1_del_into_cds`.
+    assert_eq!(
+        normalize_minus_utr3_with(ShuffleDirection::FivePrime, false, "NM_MUTR3.1:c.*1del"),
+        "NM_MUTR3.1:c.*1del",
+    );
+}
+
+#[test]
+fn minus_strand_five_prime_cross_does_not_shift_c_star_1_del_into_cds() {
+    // Closes minus-strand × 3'UTR × del × cross=true.
+    assert_eq!(
+        normalize_minus_utr3_with(ShuffleDirection::FivePrime, true, "NM_MUTR3.1:c.*1del"),
+        "NM_MUTR3.1:c.*1del",
+    );
+}
+
+#[test]
+fn minus_strand_axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle() {
+    // Minus-strand mirror of
+    // `axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle`.
+    let normalizer = Normalizer::with_config(
+        provider_with_minus_strand_cds_utr3_homopolymer_transcript(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
+    );
+    let variant = parse_hgvs("NM_MUTR3.1:c.*1del").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("normalize");
+    assert_eq!(format!("{}", result.result), "NM_MUTR3.1:c.*1del");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "AXIS_CLAMP_APPLIED"),
+        "expected AXIS_CLAMP_APPLIED warning on minus-strand 3'UTR \
+         5'-shuffle that the clamp held; got {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
     );
 }

--- a/tests/issue_391_repeat_depth_audit.rs
+++ b/tests/issue_391_repeat_depth_audit.rs
@@ -1,0 +1,286 @@
+//! Audit regression file for issue #391 item 1 (the deferred half of #334):
+//! "repeat-region depth-by-1" off-by-one in the 3'-rule shuffle.
+//!
+//! # Audit hypothesis (from #334)
+//!
+//! > investigate whether ferro's repeat termination uses `<` vs `<=`;
+//! > verify against `SVD-WG009` semantics
+//!
+//! # Audit verdict
+//!
+//! **No off-by-one exists.** The strict-less-than predicates in
+//! `src/normalize/shuffle.rs` (`while new_end < boundaries.right` and the
+//! symmetric `while new_start > boundaries.left`) are the correct
+//! half-open exclusive bounds — the documented contract for
+//! `Boundaries` (see `shuffle.rs` module docs) is that `right` is
+//! 0-based exclusive, so `<` terminates one step before the bound is
+//! breached. Switching to `<=` would index past the array or violate
+//! the boundary contract.
+//!
+//! The tract-extension predicates in `rules.rs` (`extend_tandem_tract`,
+//! `count_tandem_repeats`, `find_homopolymer_at`) all walk in
+//! `unit_len` steps and terminate exactly when the candidate slot
+//! doesn't match the unit, with bounds expressed as `start + u <=
+//! ref_seq.len()` — the correct half-open shape.
+//!
+//! The SVD-WG009 citation in #334 / `failure-patterns.md` row 9 was a
+//! mis-attribution: SVD-WG009 retires the `con` (conversion) variant
+//! type and has no bearing on repeat depth.
+//!
+//! # What this file pins
+//!
+//! Tests that the depth-by-1 hypothesis would have flipped:
+//!
+//! 1. 3'-direction homopolymer shuffle terminates at the deepest
+//!    (most-3') position within the tract.
+//! 2. 5'-direction homopolymer shuffle terminates at the most-5'
+//!    position — symmetric mirror.
+//! 3. 3'-direction multi-base tandem shuffle terminates unit-aligned
+//!    on the deepest unit slot.
+//! 4. Insertion-to-repeat rewrite anchors on the full reference tract
+//!    (not depth-by-1 short).
+//! 5. Duplication-to-repeat rewrite reports `unit[ref_count + 1]` for
+//!    a single-unit dup at the tract's 3' edge (depth, not depth-1).
+//!
+//! All five are g.-axis fixtures so the CDS↔UTR axis clamp (issue #337)
+//! and the exon-junction exception (#334's first half) are out of
+//! scope here. Any of these failing would indicate a real off-by-one.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// 128 bp of `ACGT` padding — wider than the default 100 bp normalizer
+/// window so the shuffle window never hits an array edge. Same flat
+/// `ACGTACGT…` shape used by `tests/issue_209_repeat_3prime_remaining.rs`
+/// to keep the pad inert (no accidental homopolymer or tandem overlap
+/// with the test core).
+const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+const PAD_LEN_HGVS: u64 = 128; // pad lives at HGVS 1..128, core starts at HGVS 129
+
+fn padded(core: &str) -> String {
+    format!("{PAD}{core}{PAD}")
+}
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for {:?}: {:?}", input, e));
+    format!("{}", normalized)
+}
+
+fn normalize_with_direction(
+    provider: MockProvider,
+    direction: ShuffleDirection,
+    input: &str,
+) -> String {
+    let config = NormalizeConfig::default().with_direction(direction);
+    let normalizer = Normalizer::with_config(provider, config);
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for {:?}: {:?}", input, e));
+    format!("{}", normalized)
+}
+
+// --- Item 1.1: 3' homopolymer reaches the deepest position --------------
+
+/// Padded sequence — HGVS positions relative to the start:
+/// ```text
+///   PAD (128 bp, HGVS 1..128) | "CCCC" 129..132 | "AAAAAAAA" 133..140 | "GT" 141..142 | PAD
+/// ```
+///
+/// A 3'-direction shuffle of `g.133del` (delete the leftmost A) must
+/// walk through all 8 A's and land at `g.140del` — the rightmost A,
+/// immediately before the G terminator. If the `<` in shuffle.rs were
+/// secretly off-by-one, the result would be `g.139del`.
+#[test]
+fn three_prime_homopolymer_shuffle_reaches_deepest_position() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
+    let first_a = PAD_LEN_HGVS + 5; // 133
+    let last_a = PAD_LEN_HGVS + 12; // 140
+    let out = normalize(provider, &format!("chr391a:g.{first_a}del"));
+    let expected = format!(":g.{last_a}del");
+    assert!(
+        out.ends_with(&expected),
+        "3'-direction homopolymer shuffle must land at the deepest A \
+         (g.{last_a}del); got {out:?}",
+    );
+}
+
+// --- Item 1.2: 5' homopolymer reaches the most-5' position --------------
+
+/// Same fixture as 1.1. From the rightmost A, a 5' shuffle must walk
+/// back to the leftmost A at `g.133del`. An off-by-one in the 5' loop
+/// (`while new_start > boundaries.left`) would stop at `g.134del`.
+#[test]
+fn five_prime_homopolymer_shuffle_reaches_most_5prime_position() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
+    let first_a = PAD_LEN_HGVS + 5; // 133
+    let last_a = PAD_LEN_HGVS + 12; // 140
+    let out_5p = normalize_with_direction(
+        provider,
+        ShuffleDirection::FivePrime,
+        &format!("chr391a:g.{last_a}del"),
+    );
+    let expected = format!(":g.{first_a}del");
+    assert!(
+        out_5p.ends_with(&expected),
+        "5'-direction homopolymer shuffle must land at the most-5' A \
+         (g.{first_a}del); got {out_5p:?}",
+    );
+
+    // The PAD itself contains an `ACGT…ACGT` flat repeat, so a 5'
+    // shuffle on a tract whose left flank is `C` (no upstream A in PAD
+    // immediately abuts the tract) cannot leak into the pad — the
+    // boundary base `CCCC` 129..132 blocks the walk. This re-asserts
+    // the test result holds even when the inert pad is in play.
+    let mut provider2 = MockProvider::new();
+    provider2.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
+    let out_3p = normalize_with_direction(
+        provider2,
+        ShuffleDirection::ThreePrime,
+        &format!("chr391a:g.{last_a}del"),
+    );
+    let expected_3p = format!(":g.{last_a}del");
+    assert!(
+        out_3p.ends_with(&expected_3p),
+        "3'-direction shuffle of already-3'-canonical input must be a \
+         fixed point; got {out_3p:?}",
+    );
+}
+
+// --- Item 1.3: 3' multi-base tandem terminates on the deepest unit ------
+
+/// Padded sequence — HGVS positions:
+/// ```text
+///   PAD | "ACACACACAC" 129..138 (five AC) | "GT" 139..140 | PAD
+/// ```
+///
+/// `g.{first_unit_start}_{first_unit_end}del` (delete the leftmost AC)
+/// must 3'-shuffle to the rightmost unit. ferro's shuffle walks
+/// base-by-base; the rotation predicate (`ref[del_start] == ref[del_end]`)
+/// preserves unit alignment across each step. A depth-by-1 termination
+/// would land one unit short of the canonical depth.
+#[test]
+fn three_prime_tandem_repeat_shuffle_terminates_on_deepest_unit() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391b", padded("ACACACACACGT"));
+    let first_unit_start = PAD_LEN_HGVS + 1; // 129
+    let last_unit_start = PAD_LEN_HGVS + 9; // 137
+    let last_unit_end = PAD_LEN_HGVS + 10; // 138
+    let out = normalize(
+        provider,
+        &format!(
+            "chr391b:g.{first_unit_start}_{end}del",
+            end = first_unit_start + 1
+        ),
+    );
+    // ferro may surface the canonicalized form as either a plain
+    // `g.{last_unit_start}_{last_unit_end}del` or as an AC[k] tract
+    // anchored at the unit boundary. Both shapes pin the same depth.
+    let plain_del = format!(":g.{last_unit_start}_{last_unit_end}del");
+    let tract_start = PAD_LEN_HGVS + 1;
+    let tract_end = PAD_LEN_HGVS + 10;
+    let tract_repeat = format!(":g.{tract_start}_{tract_end}AC[");
+    let depth_correct = out.contains(&plain_del) || out.contains(&tract_repeat);
+    assert!(
+        depth_correct,
+        "3'-direction tandem AC shuffle must terminate on the deepest \
+         unit (...:{plain_del} or ...{tract_repeat}); got {out:?}",
+    );
+}
+
+// --- Item 1.4: insertion-to-repeat anchors at the full tract ------------
+
+/// Padded sequence — HGVS positions:
+/// ```text
+///   PAD | "CCC" 129..131 | "AAAA" 132..135 | "GT" 136..137 | PAD
+/// ```
+///
+/// `g.135_136insA` inserts one A between the last tract A (HGVS 135)
+/// and the G (HGVS 136). After 3'-rule canonicalization this should
+/// become a 5-copy `A[5]` anchored on the full tract (HGVS 132..135)
+/// or a duplication `g.135dup` at the tract's rightmost slot. A
+/// depth-by-1 bug in `find_tandem_extent` could surface as an A[4]
+/// count or an anchor shifted by one base.
+///
+/// Pin both the canonical surface forms ferro emits and the negative
+/// "depth-by-1" shapes that the hypothesis would have produced.
+#[test]
+fn insertion_to_repeat_anchors_at_full_tract_3prime_edge() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391c", padded("CCCAAAAGT"));
+    let last_tract_a = PAD_LEN_HGVS + 7; // 135
+    let after_tract = PAD_LEN_HGVS + 8; // 136
+    let out = normalize(
+        provider,
+        &format!("chr391c:g.{last_tract_a}_{after_tract}insA"),
+    );
+    let tract_start = PAD_LEN_HGVS + 4; // 132 (first tract A)
+                                        // Accept any of the canonical surfaces:
+    let depth_correct = out.contains(&format!("g.{tract_start}_{last_tract_a}A[5]"))
+        || out.contains(&format!("g.{tract_start}_{last_tract_a}AAAA["))
+        || out.contains(&format!("g.{last_tract_a}dup"))
+        || out.contains("A[5]");
+    assert!(
+        depth_correct,
+        "single-A insertion at the 3' edge of an AAAA tract must canonicalize \
+         to A[5] (anchored on the full 4-A tract) or to g.{last_tract_a}dup — \
+         not a depth-3 subset; got {out:?}",
+    );
+    // Negative assertions: depth-by-1 surfaces.
+    assert!(
+        !out.contains(&format!("g.{tract_start}_{last_tract_a}A[4]")),
+        "depth-by-1: A[4] count for a 5-copy result indicates termination \
+         one unit short of canonical; got {out:?}",
+    );
+    // Shift-by-1 anchor: tract picked one position past the true start.
+    let off_by_one_start = tract_start + 1;
+    let off_by_one_end = last_tract_a + 1;
+    assert!(
+        !out.contains(&format!("g.{off_by_one_start}_{off_by_one_end}A[5]")),
+        "depth-by-1: anchor at g.{off_by_one_start}_{off_by_one_end} indicates \
+         the tract-finder picked an offset-by-one start position; got {out:?}",
+    );
+}
+
+// --- Item 1.5: duplication-to-repeat reports depth+1, not depth ----------
+
+/// Same fixture as 1.4. `g.135dup` duplicates the last A of the tract.
+/// After repeat-notation conversion this becomes `A[5]` (4 original +
+/// 1 duplicated = 5). A depth-by-1 bug in
+/// `duplication_to_repeat`'s count math (`total_count =
+/// analysis.ref_count + dup_len`) would surface as `A[4]` (loses the
+/// duplicated unit) or `A[6]` (double-counts it).
+#[test]
+fn duplication_to_repeat_count_includes_the_duplicated_unit() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391d", padded("CCCAAAAGT"));
+    let last_tract_a = PAD_LEN_HGVS + 7; // 135
+    let out = normalize(provider, &format!("chr391d:g.{last_tract_a}dup"));
+    // The canonical depth is 5. Accept either the explicit-bracket
+    // form or the plain dup surface, but reject the obvious depth-by-1
+    // misreporting.
+    assert!(
+        out.contains("A[5]") || out.contains(&format!("g.{last_tract_a}dup")),
+        "g.{last_tract_a}dup on a 4-A tract must canonicalize to A[5] (or \
+         stay as g.{last_tract_a}dup); got {out:?}",
+    );
+    assert!(
+        !out.contains("A[4]"),
+        "depth-by-1 (under-count): A[4] on a dup of a 4-A tract loses \
+         the duplicated unit; got {out:?}",
+    );
+    assert!(
+        !out.contains("A[6]"),
+        "depth-by-1 (over-count): A[6] on a dup of a 4-A tract counts \
+         the duplicated unit twice; got {out:?}",
+    );
+}

--- a/tests/issue_391_repeat_depth_audit.rs
+++ b/tests/issue_391_repeat_depth_audit.rs
@@ -18,14 +18,16 @@
 //! the boundary contract.
 //!
 //! The tract-extension predicates in `rules.rs` (`extend_tandem_tract`,
-//! `count_tandem_repeats`, `find_homopolymer_at`) all walk in
-//! `unit_len` steps and terminate exactly when the candidate slot
-//! doesn't match the unit, with bounds expressed as `start + u <=
-//! ref_seq.len()` — the correct half-open shape.
+//! `count_tandem_repeats`, `find_homopolymer_at`) walk in `unit_len`
+//! steps and terminate exactly when the candidate slot doesn't match
+//! the unit. The right-walk bound is `end + u <= ref_seq.len()`
+//! (`rules.rs:483`), the left-walk bound is `start >= u`
+//! (`rules.rs:478`) — both half-open shapes correct.
 //!
 //! The SVD-WG009 citation in #334 / `failure-patterns.md` row 9 was a
 //! mis-attribution: SVD-WG009 retires the `con` (conversion) variant
-//! type and has no bearing on repeat depth.
+//! type (see `assets/hgvs-nomenclature/docs/consultation/SVD-WG009.md`)
+//! and has no bearing on repeat depth.
 //!
 //! # What this file pins
 //!
@@ -37,26 +39,38 @@
 //!    position — symmetric mirror.
 //! 3. 3'-direction multi-base tandem shuffle terminates unit-aligned
 //!    on the deepest unit slot.
-//! 4. Insertion-to-repeat rewrite anchors on the full reference tract
-//!    (not depth-by-1 short).
-//! 5. Duplication-to-repeat rewrite reports `unit[ref_count + 1]` for
-//!    a single-unit dup at the tract's 3' edge (depth, not depth-1).
+//! 4. 5'-direction multi-base tandem shuffle terminates unit-aligned
+//!    on the most-5' unit slot (5'/3' symmetry for tandems).
+//! 5. Insertion-to-repeat rewrite anchors on the full reference tract
+//!    and counts `ref_count + added_copies` (not `ref_count + k - 1`).
+//!    Uses a 2-base `insAA` so the input actually routes through
+//!    `insertion_to_repeat` (single-base `insA` short-circuits to
+//!    `insertion_to_duplication` and never invokes the repeat-count
+//!    arithmetic this test is meant to probe).
+//! 6. Duplication-to-repeat rewrite reports `total_count = ref_count +
+//!    dup_len` for a multi-base dup at the tract's 3' edge. Uses a
+//!    2-base `g.134_135dup` so the input clears `duplication_to_repeat`'s
+//!    `dup_len >= 2` gate (single-base dup falls through and exits as
+//!    a plain `dup`, not exercising the count math).
 //!
-//! All five are g.-axis fixtures so the CDS↔UTR axis clamp (issue #337)
+//! All six are g.-axis fixtures so the CDS↔UTR axis clamp (issue #337)
 //! and the exon-junction exception (#334's first half) are out of
 //! scope here. Any of these failing would indicate a real off-by-one.
 
-use ferro_hgvs::reference::mock::MockProvider;
-use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
 
-/// 128 bp of `ACGT` padding — wider than the default 100 bp normalizer
-/// window so the shuffle window never hits an array edge. Same flat
-/// `ACGTACGT…` shape used by `tests/issue_209_repeat_3prime_remaining.rs`
-/// to keep the pad inert (no accidental homopolymer or tandem overlap
-/// with the test core).
+/// 256 bp of `ACGT` padding — matches the convention in
+/// `tests/issue_209_repeat_3prime_remaining.rs::PAD` (also 256 bp).
+/// Wider than the default 100 bp normalizer window so the shuffle
+/// window never hits an array edge, with comfortable headroom in case
+/// the default `window_size` grows in a future config bump. Flat
+/// `ACGTACGT…` so the pad never accidentally overlaps a homopolymer or
+/// tandem unit in the test core.
 const PAD: &str = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
+                   ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\
                    ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
-const PAD_LEN_HGVS: u64 = 128; // pad lives at HGVS 1..128, core starts at HGVS 129
+const PAD_LEN_HGVS: u64 = 256; // pad lives at HGVS 1..256, core starts at HGVS 257
 
 fn padded(core: &str) -> String {
     format!("{PAD}{core}{PAD}")
@@ -91,68 +105,67 @@ fn normalize_with_direction(
 
 /// Padded sequence — HGVS positions relative to the start:
 /// ```text
-///   PAD (128 bp, HGVS 1..128) | "CCCC" 129..132 | "AAAAAAAA" 133..140 | "GT" 141..142 | PAD
+///   PAD (256 bp, HGVS 1..256) | "CCCC" 257..260 | "AAAAAAAA" 261..268 | "GT" 269..270 | PAD
 /// ```
 ///
-/// A 3'-direction shuffle of `g.133del` (delete the leftmost A) must
-/// walk through all 8 A's and land at `g.140del` — the rightmost A,
+/// A 3'-direction shuffle of `g.261del` (delete the leftmost A) must
+/// walk through all 8 A's and land at `g.268del` — the rightmost A,
 /// immediately before the G terminator. If the `<` in shuffle.rs were
-/// secretly off-by-one, the result would be `g.139del`.
+/// secretly off-by-one, the result would be `g.267del`.
 #[test]
 fn three_prime_homopolymer_shuffle_reaches_deepest_position() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
-    let first_a = PAD_LEN_HGVS + 5; // 133
-    let last_a = PAD_LEN_HGVS + 12; // 140
+    let first_a = PAD_LEN_HGVS + 5; // 261
+    let last_a = PAD_LEN_HGVS + 12; // 268
     let out = normalize(provider, &format!("chr391a:g.{first_a}del"));
-    let expected = format!(":g.{last_a}del");
-    assert!(
-        out.ends_with(&expected),
+    assert_eq!(
+        out,
+        format!("chr391a:g.{last_a}del"),
         "3'-direction homopolymer shuffle must land at the deepest A \
-         (g.{last_a}del); got {out:?}",
+         (g.{last_a}del)",
     );
 }
 
 // --- Item 1.2: 5' homopolymer reaches the most-5' position --------------
 
 /// Same fixture as 1.1. From the rightmost A, a 5' shuffle must walk
-/// back to the leftmost A at `g.133del`. An off-by-one in the 5' loop
-/// (`while new_start > boundaries.left`) would stop at `g.134del`.
+/// back to the leftmost A at `g.{first_a}del`. An off-by-one in the 5'
+/// loop (`while new_start > boundaries.left`) would stop one position
+/// short.
 #[test]
 fn five_prime_homopolymer_shuffle_reaches_most_5prime_position() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
-    let first_a = PAD_LEN_HGVS + 5; // 133
-    let last_a = PAD_LEN_HGVS + 12; // 140
+    let first_a = PAD_LEN_HGVS + 5; // 261
+    let last_a = PAD_LEN_HGVS + 12; // 268
     let out_5p = normalize_with_direction(
         provider,
         ShuffleDirection::FivePrime,
         &format!("chr391a:g.{last_a}del"),
     );
-    let expected = format!(":g.{first_a}del");
-    assert!(
-        out_5p.ends_with(&expected),
+    assert_eq!(
+        out_5p,
+        format!("chr391a:g.{first_a}del"),
         "5'-direction homopolymer shuffle must land at the most-5' A \
-         (g.{first_a}del); got {out_5p:?}",
+         (g.{first_a}del)",
     );
 
-    // The PAD itself contains an `ACGT…ACGT` flat repeat, so a 5'
-    // shuffle on a tract whose left flank is `C` (no upstream A in PAD
-    // immediately abuts the tract) cannot leak into the pad — the
-    // boundary base `CCCC` 129..132 blocks the walk. This re-asserts
-    // the test result holds even when the inert pad is in play.
-    let mut provider2 = MockProvider::new();
-    provider2.add_genomic_sequence("chr391a", padded("CCCCAAAAAAAAGT"));
+    // Re-asserts the 3'-direction fixed-point invariant on an already-
+    // canonical input. Uses a fresh contig name so the two providers
+    // can't accidentally share state.
+    let mut provider_3p = MockProvider::new();
+    provider_3p.add_genomic_sequence("chr391a_3p", padded("CCCCAAAAAAAAGT"));
     let out_3p = normalize_with_direction(
-        provider2,
+        provider_3p,
         ShuffleDirection::ThreePrime,
-        &format!("chr391a:g.{last_a}del"),
+        &format!("chr391a_3p:g.{last_a}del"),
     );
-    let expected_3p = format!(":g.{last_a}del");
-    assert!(
-        out_3p.ends_with(&expected_3p),
+    assert_eq!(
+        out_3p,
+        format!("chr391a_3p:g.{last_a}del"),
         "3'-direction shuffle of already-3'-canonical input must be a \
-         fixed point; got {out_3p:?}",
+         fixed point",
     );
 }
 
@@ -160,21 +173,21 @@ fn five_prime_homopolymer_shuffle_reaches_most_5prime_position() {
 
 /// Padded sequence — HGVS positions:
 /// ```text
-///   PAD | "ACACACACAC" 129..138 (five AC) | "GT" 139..140 | PAD
+///   PAD | "ACACACACAC" 257..266 (five AC) | "GT" 267..268 | PAD
 /// ```
 ///
-/// `g.{first_unit_start}_{first_unit_end}del` (delete the leftmost AC)
-/// must 3'-shuffle to the rightmost unit. ferro's shuffle walks
+/// `g.257_258del` (delete the leftmost AC) must 3'-shuffle to
+/// `g.265_266del` (the rightmost AC). ferro's shuffle walks
 /// base-by-base; the rotation predicate (`ref[del_start] == ref[del_end]`)
-/// preserves unit alignment across each step. A depth-by-1 termination
-/// would land one unit short of the canonical depth.
+/// preserves unit alignment across each step. A depth-by-1
+/// termination would land one unit short of the canonical depth.
 #[test]
 fn three_prime_tandem_repeat_shuffle_terminates_on_deepest_unit() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence("chr391b", padded("ACACACACACGT"));
-    let first_unit_start = PAD_LEN_HGVS + 1; // 129
-    let last_unit_start = PAD_LEN_HGVS + 9; // 137
-    let last_unit_end = PAD_LEN_HGVS + 10; // 138
+    let first_unit_start = PAD_LEN_HGVS + 1; // 257
+    let last_unit_start = PAD_LEN_HGVS + 9; // 265
+    let last_unit_end = PAD_LEN_HGVS + 10; // 266
     let out = normalize(
         provider,
         &format!(
@@ -184,103 +197,146 @@ fn three_prime_tandem_repeat_shuffle_terminates_on_deepest_unit() {
     );
     // ferro may surface the canonicalized form as either a plain
     // `g.{last_unit_start}_{last_unit_end}del` or as an AC[k] tract
-    // anchored at the unit boundary. Both shapes pin the same depth.
-    let plain_del = format!(":g.{last_unit_start}_{last_unit_end}del");
-    let tract_start = PAD_LEN_HGVS + 1;
-    let tract_end = PAD_LEN_HGVS + 10;
-    let tract_repeat = format!(":g.{tract_start}_{tract_end}AC[");
-    let depth_correct = out.contains(&plain_del) || out.contains(&tract_repeat);
+    // anchored at the same unit boundary. Both shapes pin the same
+    // depth.
+    let plain_del = format!("chr391b:g.{last_unit_start}_{last_unit_end}del");
+    let tract_repeat = format!("chr391b:g.{first_unit_start}_{last_unit_end}AC[");
     assert!(
-        depth_correct,
+        out == plain_del || out.starts_with(&tract_repeat),
         "3'-direction tandem AC shuffle must terminate on the deepest \
-         unit (...:{plain_del} or ...{tract_repeat}); got {out:?}",
+         unit ({plain_del} or {tract_repeat}…); got {out:?}",
     );
 }
 
-// --- Item 1.4: insertion-to-repeat anchors at the full tract ------------
+// --- Item 1.4: 5' multi-base tandem terminates on the most-5' unit ------
+
+/// Same fixture as 1.3, but starting from the rightmost AC. The
+/// 5'-direction shuffle must walk back to the leftmost AC at
+/// `g.257_258del`. Pins the 5'/3' symmetry for the multi-base tandem
+/// case — exercises the `while new_start > boundaries.left` loop in
+/// `shuffle.rs:120`.
+#[test]
+fn five_prime_tandem_repeat_shuffle_terminates_on_most_5prime_unit() {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("chr391b", padded("ACACACACACGT"));
+    let first_unit_start = PAD_LEN_HGVS + 1; // 257
+    let first_unit_end = PAD_LEN_HGVS + 2; // 258
+    let last_unit_start = PAD_LEN_HGVS + 9; // 265
+    let last_unit_end = PAD_LEN_HGVS + 10; // 266
+    let out = normalize_with_direction(
+        provider,
+        ShuffleDirection::FivePrime,
+        &format!("chr391b:g.{last_unit_start}_{last_unit_end}del"),
+    );
+    let plain_del = format!("chr391b:g.{first_unit_start}_{first_unit_end}del");
+    let tract_repeat = format!("chr391b:g.{first_unit_start}_{last_unit_end}AC[");
+    assert!(
+        out == plain_del || out.starts_with(&tract_repeat),
+        "5'-direction tandem AC shuffle must terminate on the most-5' \
+         unit ({plain_del} or {tract_repeat}…); got {out:?}",
+    );
+}
+
+// --- Item 1.5: insertion-to-repeat counts ref_count + added_copies ------
 
 /// Padded sequence — HGVS positions:
 /// ```text
-///   PAD | "CCC" 129..131 | "AAAA" 132..135 | "GT" 136..137 | PAD
+///   PAD | "CCC" 257..259 | "AAAA" 260..263 | "GT" 264..265 | PAD
 /// ```
 ///
-/// `g.135_136insA` inserts one A between the last tract A (HGVS 135)
-/// and the G (HGVS 136). After 3'-rule canonicalization this should
-/// become a 5-copy `A[5]` anchored on the full tract (HGVS 132..135)
-/// or a duplication `g.135dup` at the tract's rightmost slot. A
-/// depth-by-1 bug in `find_tandem_extent` could surface as an A[4]
-/// count or an anchor shifted by one base.
+/// `g.263_264insAA` inserts two A's between the last tract A (HGVS
+/// 263) and the G (HGVS 264). A 2-base insertion clears
+/// `insertion_to_repeat`'s `added_copies >= 2` gate
+/// (`rules.rs:204`) — a single-base `insA` would short-circuit to
+/// `insertion_to_duplication` and never invoke the repeat-count
+/// arithmetic this test is meant to probe.
 ///
-/// Pin both the canonical surface forms ferro emits and the negative
-/// "depth-by-1" shapes that the hypothesis would have produced.
+/// After canonicalization the result is `g.260_263A[6]` — the full
+/// tract span (HGVS 260..263, 4 reference A's) with `total_count =
+/// ref_count + added_copies = 4 + 2 = 6`. A depth-by-1 bug in the
+/// count math would surface as `A[5]` (forgot one added copy) or
+/// `A[7]` (double-counted). A shift-by-one in `find_tandem_extent`'s
+/// anchor selection would shift the position window by ±1.
 #[test]
-fn insertion_to_repeat_anchors_at_full_tract_3prime_edge() {
+fn insertion_to_repeat_counts_added_copies_at_full_tract() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence("chr391c", padded("CCCAAAAGT"));
-    let last_tract_a = PAD_LEN_HGVS + 7; // 135
-    let after_tract = PAD_LEN_HGVS + 8; // 136
+    let tract_start = PAD_LEN_HGVS + 4; // 260
+    let last_tract_a = PAD_LEN_HGVS + 7; // 263
+    let after_tract = PAD_LEN_HGVS + 8; // 264
     let out = normalize(
         provider,
-        &format!("chr391c:g.{last_tract_a}_{after_tract}insA"),
+        &format!("chr391c:g.{last_tract_a}_{after_tract}insAA"),
     );
-    let tract_start = PAD_LEN_HGVS + 4; // 132 (first tract A)
-                                        // Accept any of the canonical surfaces:
-    let depth_correct = out.contains(&format!("g.{tract_start}_{last_tract_a}A[5]"))
-        || out.contains(&format!("g.{tract_start}_{last_tract_a}AAAA["))
-        || out.contains(&format!("g.{last_tract_a}dup"))
-        || out.contains("A[5]");
+
+    let canonical = format!("chr391c:g.{tract_start}_{last_tract_a}A[6]");
+    assert_eq!(
+        out, canonical,
+        "2-base insertion at the 3' edge of an AAAA tract must canonicalize \
+         to A[6] anchored on the full 4-A tract",
+    );
+
+    // Negative assertions: depth-by-1 / shift-by-one shapes.
     assert!(
-        depth_correct,
-        "single-A insertion at the 3' edge of an AAAA tract must canonicalize \
-         to A[5] (anchored on the full 4-A tract) or to g.{last_tract_a}dup — \
-         not a depth-3 subset; got {out:?}",
+        !out.contains("A[5]"),
+        "depth-by-1 (under-count): A[5] indicates total_count = ref_count + \
+         k - 1 instead of ref_count + k; got {out:?}",
     );
-    // Negative assertions: depth-by-1 surfaces.
     assert!(
-        !out.contains(&format!("g.{tract_start}_{last_tract_a}A[4]")),
-        "depth-by-1: A[4] count for a 5-copy result indicates termination \
-         one unit short of canonical; got {out:?}",
+        !out.contains("A[7]"),
+        "depth-by-1 (over-count): A[7] indicates total_count = ref_count + \
+         k + 1 instead of ref_count + k; got {out:?}",
     );
-    // Shift-by-1 anchor: tract picked one position past the true start.
     let off_by_one_start = tract_start + 1;
     let off_by_one_end = last_tract_a + 1;
     assert!(
-        !out.contains(&format!("g.{off_by_one_start}_{off_by_one_end}A[5]")),
-        "depth-by-1: anchor at g.{off_by_one_start}_{off_by_one_end} indicates \
-         the tract-finder picked an offset-by-one start position; got {out:?}",
+        !out.contains(&format!("g.{off_by_one_start}_{off_by_one_end}A[")),
+        "shift-by-one: anchor at g.{off_by_one_start}_{off_by_one_end} \
+         indicates the tract-finder picked an offset-by-one start position; \
+         got {out:?}",
     );
 }
 
-// --- Item 1.5: duplication-to-repeat reports depth+1, not depth ----------
+// --- Item 1.6: duplication-to-repeat sums ref_count + dup_len -----------
 
-/// Same fixture as 1.4. `g.135dup` duplicates the last A of the tract.
-/// After repeat-notation conversion this becomes `A[5]` (4 original +
-/// 1 duplicated = 5). A depth-by-1 bug in
-/// `duplication_to_repeat`'s count math (`total_count =
-/// analysis.ref_count + dup_len`) would surface as `A[4]` (loses the
-/// duplicated unit) or `A[6]` (double-counts it).
+/// Same fixture as 1.5. `g.262_263dup` duplicates the last two A's of
+/// the tract (HGVS 262 and 263). A 2-base dup clears
+/// `duplication_to_repeat`'s `dup_len >= 2` gate
+/// (`rules.rs:1095`) — a single-base `dup` falls through and exits as
+/// a plain `dup` without invoking the homopolymer-to-repeat conversion
+/// that owns the count arithmetic.
+///
+/// Canonical result: `g.260_263A[6]` (4 reference + 2 duplicated = 6
+/// total). A depth-by-1 bug in the count math (`total_count =
+/// analysis.ref_count + dup_len` at `rules.rs:1111`) would surface as
+/// `A[5]` (loses one duplicated base) or `A[7]` (double-counts).
 #[test]
-fn duplication_to_repeat_count_includes_the_duplicated_unit() {
+fn duplication_to_repeat_sums_ref_count_and_dup_len() {
     let mut provider = MockProvider::new();
     provider.add_genomic_sequence("chr391d", padded("CCCAAAAGT"));
-    let last_tract_a = PAD_LEN_HGVS + 7; // 135
-    let out = normalize(provider, &format!("chr391d:g.{last_tract_a}dup"));
-    // The canonical depth is 5. Accept either the explicit-bracket
-    // form or the plain dup surface, but reject the obvious depth-by-1
-    // misreporting.
+    let tract_start = PAD_LEN_HGVS + 4; // 260
+    let last_tract_a = PAD_LEN_HGVS + 7; // 263
+    let dup_start = PAD_LEN_HGVS + 6; // 262
+    let out = normalize(
+        provider,
+        &format!("chr391d:g.{dup_start}_{last_tract_a}dup"),
+    );
+
+    let canonical = format!("chr391d:g.{tract_start}_{last_tract_a}A[6]");
+    assert_eq!(
+        out, canonical,
+        "2-base dup of the tract's 3'-edge A's must canonicalize to A[6] \
+         (4 reference + 2 duplicated)",
+    );
+
     assert!(
-        out.contains("A[5]") || out.contains(&format!("g.{last_tract_a}dup")),
-        "g.{last_tract_a}dup on a 4-A tract must canonicalize to A[5] (or \
-         stay as g.{last_tract_a}dup); got {out:?}",
+        !out.contains("A[5]"),
+        "depth-by-1 (under-count): A[5] indicates total_count = ref_count + \
+         dup_len - 1 instead of ref_count + dup_len; got {out:?}",
     );
     assert!(
-        !out.contains("A[4]"),
-        "depth-by-1 (under-count): A[4] on a dup of a 4-A tract loses \
-         the duplicated unit; got {out:?}",
-    );
-    assert!(
-        !out.contains("A[6]"),
-        "depth-by-1 (over-count): A[6] on a dup of a 4-A tract counts \
-         the duplicated unit twice; got {out:?}",
+        !out.contains("A[7]"),
+        "depth-by-1 (over-count): A[7] indicates total_count = ref_count + \
+         dup_len + 1 instead of ref_count + dup_len; got {out:?}",
     );
 }


### PR DESCRIPTION
## Summary

Closes #391. Test-only burn-down of two follow-ups left over from earlier 3'-rule normalization work. No `src/` changes — both items resolve to "audit found no source-level bug; lock in the correct behavior with a regression net" plus deferred-symmetry tests.

- **`test(normalize): audit + pin repeat-tract termination depth` (#391 item 1)** — Item 1 is the deferred half of #334 ("repeat-region depth-by-1"). PR #374 landed the exon-junction-exception half but deferred repeat-depth because identifying corpus inputs required a manifest that's not vendored. The original #334 hypothesis (`<` vs `<=` per "SVD-WG009") doesn't hold up: SVD-WG009 retires the `con` (conversion) variant type per `assets/hgvs-nomenclature/docs/consultation/SVD-WG009.md` and has no bearing on repeat depth. Walked the termination predicates in `src/normalize/shuffle.rs` and `src/normalize/rules.rs` (`extend_tandem_tract`, `count_tandem_repeats`, `find_homopolymer_at`, `find_tandem_extent`, `duplication_to_repeat`, `insertion_to_repeat`, `deletion_to_repeat`) against HGVS DNA/repeated.md — all use correct half-open exclusive bounds. New `tests/issue_391_repeat_depth_audit.rs` (6 g.-axis MockProvider tests) pins the depth-by-1 surfaces the hypothesis would have produced: homopolymer 3'/5' to deepest position, multi-base tandem 3'/5' unit alignment, `insertion_to_repeat` count math (`total_count = ref_count + added_copies` on a 2-base `insAA`), `duplication_to_repeat` count math (`total_count = analysis.ref_count + dup_len` on a 2-base dup). The 2-base inputs are intentional — single-base ins/dup short-circuits before reaching the count-math branches.

- **`test(normalize): pin c.*1 5' clamp + minus-strand sanity` (#391 item 2)** — Item 2 lands the two test classes deferred in PR #343's body (CDS↔UTR axis clamp): the 5'-direction `c.*N` clamp at `c.*1` symmetry test and a minus-strand sanity test. Extends `tests/issue_337_cds_start_clamp.rs` with two new fixtures (`provider_with_cds_utr3_homopolymer_transcript` for the 3'UTR side, `provider_with_minus_strand_utr_padded_transcript` for the minus-strand sanity test) and a refactor that extracts `provider_with_intra_cds_homopolymer_transcript` from previously-duplicated inline fixtures. The clamp logic is strand-invariant by construction (`boundary::get_cds_boundaries_with_axis_info` operates on tx-frame positions); the new tests pin that contract so a future refactor cannot accidentally branch the clamp by strand.

- **`fix(review): apply end-of-issue review findings` (#391)** — Consolidated review-fix commit. End-of-issue Opus review caught two MAJOR test-construction bugs in the item-1 audit file (single-base `insA` / `dup` short-circuited before the code paths the tests claimed to guard, making negative assertions vacuously true) plus matrix gaps across both files: missing 3'-direction CDS-end clamp tests, missing `c.*1dup` warning test, asymmetric minus-strand coverage. All findings (MAJOR/MINOR/NIT) addressed in one commit per the established process for cross-cutting review fixes.

## Test matrix after this PR

| File | Tests | Coverage |
|---|---|---|
| `tests/issue_391_repeat_depth_audit.rs` | 6 | homopolymer 3'/5' depth, tandem 3'/5' unit alignment, `insertion_to_repeat` count, `duplication_to_repeat` count |
| `tests/issue_337_cds_start_clamp.rs` | 34 (was 13) | (direction × axis × strand × edit-kind × cross_mode) — both 5'UTR/CDS and CDS/3'UTR boundaries, plus/minus strand, del + dup, cross={false,true}, AXIS_CLAMP_APPLIED warning emission on every clamped quadrant, CROSS_AXIS_VARIANT_NOT_SHUFFLED on cross-axis input |

## Test plan

- [ ] `cargo nextest run --features dev` — 5830 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences, pre-existing on `origin/main`); no new failures.
- [ ] `cargo clippy --features dev -- -D warnings` clean.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo run --features dev --example generate_spec_fixture -- --check` clean.
- [ ] All 6 new tests in `issue_391_repeat_depth_audit.rs` PASS.
- [ ] All 34 tests in `issue_337_cds_start_clamp.rs` PASS (was 13; +21 new tests across items 2 + review fixes).