### PR TITLE
fix(normalize): preserve spanning duplications in CDS-start canon clamp (closes #401)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1432,7 +1432,23 @@ impl<P: ReferenceProvider> Normalizer<P> {
         //     shared-affix trim is what pushed the residual past the
         //     boundary; suppressing it leaves the spec-canonical form
         //     (the input itself).
-        if matches!(start_axis, boundary::AxisRegion::Cds) && new_tx_start < cds_start {
+        //
+        // Spanning-dup exception (#401): when the canon output is a
+        // `Duplication` whose `new_tx_end >= cds_start`, the dup-source
+        // spans the c.-1/c.1 boundary (one endpoint in UTR, one in CDS).
+        // That IS the spec-canonical form (HGVS §general; edit-type
+        // priority `dup > ins`) — biocommons emits it on inputs whose
+        // alt equals `ref[c.-1] ++ ref[c.1]`. The clamp would
+        // incorrectly collapse the spanning dup to `c.1delins<…>`, so
+        // we skip the clamp in that case and keep the canon output.
+        // Entirely-UTR dups (`new_tx_end < cds_start`) still clamp
+        // unchanged.
+        let spanning_dup_exception =
+            matches!(new_edit, NaEdit::Duplication { .. }) && new_tx_end >= cds_start;
+        if matches!(start_axis, boundary::AxisRegion::Cds)
+            && new_tx_start < cds_start
+            && !spanning_dup_exception
+        {
             match edit {
                 NaEdit::Insertion {
                     sequence: InsertedSequence::Literal(in_lit),

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1575,6 +1575,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // post-canon edit-type is `Insertion` (= ins didn't promote to
         // dup). Duplication outputs that touch / cross `cds_end` are
         // the spec-canonical form and stay.
+        //
+        // Mirror of the CDS-start clamp's `spanning_dup_exception` gate
+        // above (#401). The two clamps use opposite gate styles —
+        // CDS-end positive-lists `Insertion`, CDS-start negative-lists
+        // `Duplication` whose end reaches CDS — but both have the same
+        // intent: preserve spanning duplications, clamp everything
+        // else.
         if let Some(cds_end_tx) = transcript.cds_end {
             if matches!(start_axis, boundary::AxisRegion::Cds)
                 && new_tx_end > cds_end_tx

--- a/tests/issue_401_cds_start_clamp_spanning_dup.rs
+++ b/tests/issue_401_cds_start_clamp_spanning_dup.rs
@@ -1,0 +1,107 @@
+//! Regression for #401.
+//!
+//! Surfaced by `tests/fixtures/biocommons-normalize/baseline-failures/normalized.txt`:
+//! `NM_000051.3:c.1_2insCA` (5'+cross) should canonicalise to
+//! `NM_000051.3:c.-1_1dup` per biocommons; ferro currently emits
+//! `NM_000051.3:c.1delinsACA` (the PR #385 / #383 clamp output, applied
+//! where the canonical form is actually a *spanning* dup — one endpoint
+//! in 5'UTR (c.-1), one endpoint in CDS (c.1)).
+//!
+//! Root cause: PR #385's CDS-start canon clamp fires unconditionally on
+//! `start_axis == Cds && new_tx_start < cds_start`. When the
+//! canonicalisation produces a `Duplication` whose `tx_end >= cds_start`,
+//! the dup-source spans the c.-1/c.1 boundary and IS the spec-canonical
+//! form (HGVS DNA §general; edit-type priority `dup > ins`). The clamp
+//! must skip these spanning duplications and keep the dup output.
+//!
+//! The PR #385 clamp continues to fire for:
+//!   - Entirely-UTR rewrites (`new_tx_end < cds_start`) — e.g.
+//!     `c.-2_-1dup` on `NM_212556.2` (GGG-ATG context) → `c.1delinsACA`.
+//!   - Spanning Insertion / Delins outputs — e.g. `c.-1_1insCAT` on
+//!     `NM_212556.2:c.2_3insCAT` → `c.1delinsATCA`. (Spanning *insertions*
+//!     are not the canonical form; only spanning *duplications* are
+//!     preserved.)
+//!
+//! Synthetic transcript here reproduces `NM_000051.3`'s c.-1..c.3 = "C |
+//! A T G" context, the only difference vs the existing
+//! `tests/issue_383_canon_cds_start_clamp.rs` (which uses "G | A T G"
+//! UTR-flank) is `c.-1 = C`. That single base difference makes
+//! `ref[c.-1] ++ ref[c.1] = "CA" == alt`, so the canon ins → dup
+//! recogniser emits `c.-1_1dup` — which must survive the clamp.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Synthetic transcript whose c.-1 = C, c.1..c.3 = "ATG" — same shape as
+/// `NM_000051.3` around the failing input.
+///
+///   axis: c.-3 c.-2 c.-1 | c.1 c.2 c.3 c.4 c.5 ...
+///   base:  G    G    C   | A   T   G   C   ...
+///
+/// CDS spans c.1..c.200 (synthetic; CDS-end side is irrelevant here).
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let mut seq = String::from("GGC"); // 5'UTR (c.-3 = G, c.-2 = G, c.-1 = C)
+    seq.push_str("ATGC"); // c.1..c.4 = A, T, G, C
+    while seq.len() < 203 {
+        seq.push('G');
+    }
+    let len = seq.len() as u64;
+    // c.1 is at byte index 3 (0-based) = byte position 4 (1-based);
+    // matches tests/issue_383_canon_cds_start_clamp.rs layout.
+    let transcript = Transcript::new(
+        "NM_TEST401.1".to_string(),
+        Some("TEST401".to_string()),
+        Strand::Plus,
+        seq,
+        Some(4),
+        Some(203),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{normalized}")
+}
+
+#[test]
+fn five_prime_insertion_emits_spanning_dup_when_alt_matches_boundary_bases() {
+    // c.1_2insCA on a transcript whose c.-1 = C, c.1 = A: the inserted
+    // "CA" equals ref[c.-1] ++ ref[c.1], so the canonical form is the
+    // spanning dup `c.-1_1dup` (dup-source = the two boundary bases).
+    // PR #385's clamp must NOT collapse this to `c.1delinsACA`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST401.1:c.1_2insCA"),
+        "NM_TEST401.1:c.-1_1dup",
+    );
+}
+
+#[test]
+fn three_prime_direction_also_emits_spanning_dup() {
+    // 3'-direction sanity. On this transcript the only adjacent tandem
+    // unit matching the inserted "CA" is the spanning c.-1_1 pair; the
+    // 3'-direction tie-break still anchors there because there is no
+    // 3'-side tract to prefer. The PR #385 clamp must not collapse this
+    // either.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST401.1:c.1_2insCA"),
+        "NM_TEST401.1:c.-1_1dup",
+    );
+}


### PR DESCRIPTION
Closes #401.

## Summary

PR #385's CDS-start canonicalisation-rewrite clamp fired unconditionally on `start_axis == Cds && new_tx_start < cds_start`, collapsing every canon output that started in 5'UTR to `c.1delins<absorbed alt>`. That over-applies when the canon output is a `Duplication` whose `new_tx_end >= cds_start` — a *spanning* dup whose dup-source bases straddle the c.-1/c.1 boundary. Per HGVS DNA §general (edit-type priority `dup > ins` + per-axis coordinate treatment) the spanning dup IS the spec-canonical form and biocommons emits it.

Live row:

| Input | direction · cross | biocommons | ferro (pre-fix) |
|---|---|---|---|
| `NM_000051.3:c.1_2insCA` | 5'+cross | `c.-1_1dup` | `c.1delinsACA` |

`NM_000051.3` has `ref[c.-1] = C, ref[c.1] = A`, so `ref[c.-1] ++ ref[c.1] == alt == \"CA\"`, the canon ins → dup recogniser emits `c.-1_1dup`, and biocommons keeps it.

## Note on the issue's original hypothesis

#401's body hypothesised that the clamp must respect `cross_boundaries=true`. Investigation found that hypothesis incorrect: biocommons still clamps under `cross=true` when the canon output is entirely-UTR. The discriminator is the *shape* of the canon output, not the `cross_boundaries` flag. This PR fixes the bug correctly per the actual rule.

## Fix

In `src/normalize/mod.rs::normalize_cds`, the PR #385 clamp now gates on a `spanning_dup_exception`:

\`\`\`rust
let spanning_dup_exception = matches!(new_edit, NaEdit::Duplication { .. })
    && new_tx_end >= cds_start;
if matches!(start_axis, boundary::AxisRegion::Cds)
    && new_tx_start < cds_start
    && !spanning_dup_exception { ... }
\`\`\`

When the exception fires (post-canon `Duplication` whose end reaches CDS), the clamp is skipped and the canon output passes through unchanged. Entirely-UTR dups (`new_tx_end < cds_start`) and all Insertion / Delins outputs continue to clamp exactly as before.

PR #388's symmetric CDS-end clamp already gates on `matches!(new_edit, NaEdit::Insertion { .. })`, so spanning Duplications are never clamped on that side. No symmetric fix required (audit point on #401). The 2nd commit on this PR adds a cross-reference comment so the two opposite-shaped guards don't confuse future readers.

## Spec basis

HGVS DNA recommendations (`assets/hgvs-nomenclature/` v21.0.0):

- **Edit-type priority** — `dup > ins`. When an insertion's adjacent ref matches the inserted alt under any rotation, the canonical form is the duplication.
- **Per-axis coordinate treatment** — a CDS-interior input must not be silently re-axed strictly into 5'UTR. The spanning dup straddles the boundary (one endpoint in UTR, one in CDS) and is treated by biocommons as the canonical form for that geometry, distinct from an entirely-UTR rewrite.

## Test plan

- [x] `tests/issue_401_cds_start_clamp_spanning_dup.rs` — 2 new MockProvider-backed tests on a synthetic transcript whose c.-1 = C, c.1..c.3 = \"ATG\" (mirrors NM_000051.3's failing geometry): FivePrime+cross and ThreePrime+cross both assert `c.-1_1dup` survives the clamp.
- [x] `tests/issue_383_canon_cds_start_clamp.rs` (PR #385's six + extra tests) all continue to pass — the `c.-2_-1dup` entirely-UTR case still clamps to `c.1delinsACA`, and the Delins-suppression cases are unaffected.
- [x] `tests/issue_387_canon_cds_end_clamp.rs` (PR #388) tests still green — the symmetric clamp logic is untouched.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` clean.
- [x] `cargo nextest run --features dev -E 'not test(/^axis_/)'` — 5804 passed, 0 failed, 61 skipped. No non-manifest-mode regressions.
- [x] Manifest-mode biocommons `axis_normalized`: 20 FAIL pre-fix → 19 FAIL post-fix on `origin/main`. Only `NM_000051.3:c.1_2insCA` changed state.
- [x] Independent Opus-model code-review pass: APPROVE on all 8 checkpoints.

## Note on the baseline file

`tests/fixtures/biocommons-normalize/baseline-failures/normalized.txt` is not modified by this PR. The demoted row was missing from the committed baseline already — see PR #405 which opened to resync the file against the live xfail. After both this PR and PR #405 merge the baseline will mirror live xfail.

## Companion

- #325 — biocommons-normalize fixture burn-down (umbrella; one row closer to zero).
- #383 / PR #385 — original CDS-start clamp work; this PR adds the spanning-dup exception.
- #387 / PR #388 — symmetric CDS-end clamp; audited (no fix required, cross-referenced).
- #404 — open question on whether dup-canon should ever apply across the c.-1/c.1 gap. This PR's fix presumes \"yes\" per HGVS §general edit-type priority + the live biocommons behaviour. If #404's verdict reverses that, the gate here will need to be tightened.
- #405 — baseline-failures resync PR.
- PR #408 — fix for #403 (sibling Pattern I residual).