### PR TITLE
fix(normalize): extend W4004 PositionPastEnd to intronic offsets (closes #392)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -62,23 +62,31 @@ fn has_unknown_offset_cds(pos: &CdsPos) -> bool {
 }
 
 /// Intron length (1-based inclusive base count) at the intron addressed by
-/// `tx_boundary` + `offset`, derived from `Transcript::find_intron_at_tx_boundary`
-/// plus the intron's genomic span. Returns `None` when no intron exists at
-/// that boundary OR the intron's genomic coordinates aren't populated —
-/// matching the existing W4004 conservative-skip contract for missing
-/// metadata.
+/// `tx_boundary` + `offset`. Returns `None` when:
+///
+/// - no intron exists at that boundary (e.g. `tx_boundary` is the last
+///   exon's end and `offset` is positive — no 3' intron exists), OR
+/// - the intron's genomic coordinates aren't populated (cdot data missing
+///   per-exon genomic alignment), OR
+/// - the intron's genomic span is inverted (`genomic_end < genomic_start`,
+///   a defensive guard inherited from `Intron::genomic_length`).
+///
+/// All three cases collapse to "conservative skip" per the existing W4004
+/// missing-metadata contract.
 fn intron_length_at_tx_boundary(
     transcript: &crate::reference::transcript::Transcript,
     tx_boundary: u64,
     offset: i64,
 ) -> Option<u64> {
-    let intron = transcript.find_intron_at_tx_boundary(tx_boundary, offset)?;
-    let g_start = intron.genomic_start?;
-    let g_end = intron.genomic_end?;
-    // Saturating arithmetic mirrors `find_intron_at_genomic` in
-    // `src/reference/transcript.rs:695`, which uses the same length
-    // formula on the same genomic span.
-    Some(g_end.saturating_sub(g_start).saturating_add(1))
+    // Delegate to `Intron::genomic_length` so the length formula stays in
+    // one place — the same source-of-truth `find_intron_at_genomic` uses
+    // at `src/reference/transcript.rs:695`. `genomic_length` rejects
+    // inverted spans by construction, removing the silent-zero footgun a
+    // manual `g_end.saturating_sub(g_start)` would produce on a
+    // misconstructed minus-strand fixture.
+    transcript
+        .find_intron_at_tx_boundary(tx_boundary, offset)?
+        .genomic_length()
 }
 
 /// Resolve a `CdsPos` to its transcript-frame position (1-based) ignoring
@@ -86,6 +94,14 @@ fn intron_length_at_tx_boundary(
 /// `Normalizer::cds_to_tx_pos`; kept as a free helper so
 /// `check_cds_pos_past_end` can compute the intronic-anchor `tx_boundary`
 /// without holding a `Normalizer` reference.
+///
+/// Note on the `base == 0` arm: `c.0` is rejected by the parser at
+/// `src/hgvs/parser/position.rs` (per #269), and the caller
+/// `check_cds_pos_past_end` short-circuits via `pos.is_unknown()` before
+/// this helper sees `CdsPos { base: 0, utr3: false }`. The arm is dead
+/// code in the W4004 path; kept here for parity with
+/// `Normalizer::cds_to_tx_pos` so this helper remains a drop-in
+/// replacement if a future caller needs it outside the bounds check.
 fn cds_pos_to_tx_boundary(
     pos: &CdsPos,
     transcript: &crate::reference::transcript::Transcript,
@@ -102,8 +118,10 @@ fn cds_pos_to_tx_boundary(
         let signed = cds_start as i64 + pos.base;
         u64::try_from(signed).ok()
     } else if pos.base == 0 {
-        // c.0 isn't a valid HGVS position but historical inputs map it to
-        // the last 5'UTR base (= c.-1), matching `cds_to_tx_pos`.
+        // Defensive parity with `cds_to_tx_pos`; see helper-level doc
+        // note. Unreachable from `check_cds_pos_past_end` because the
+        // caller short-circuits on `pos.is_unknown()` (which keys off
+        // `CDS_BASE_UNKNOWN == 0`).
         Some(cds_start.saturating_sub(1))
     } else {
         // c.<N>: tx_boundary = cds_start + N - 1
@@ -253,39 +271,45 @@ fn check_tx_pos_past_end(
     pos: &TxPos,
     transcript: &crate::reference::transcript::Transcript,
 ) -> Option<NormalizationWarning> {
+    // `has_unknown_offset_tx` matches `OFFSET_UNKNOWN_*` sentinels (not a
+    // base-unknown predicate); there's no `TX_BASE_UNKNOWN` sibling of
+    // `CDS_BASE_UNKNOWN`, so the n.-axis variant skips only on offset.
+    // This is the intentional asymmetry with the c.-axis check above.
     if has_unknown_offset_tx(pos) || pos.is_downstream() {
         return None;
     }
     // Intronic-offset bound check (#392). The tx_boundary is `pos.base`
     // itself (n.-axis positions are direct transcript coordinates).
-    if let Some(offset) = pos.offset {
-        if offset == 0 {
-            // `n.<N>+0` is parser-degenerate (not really intronic); fall
-            // through to the plain `n.<N>` check below.
-        } else {
-            if pos.base < 1 {
-                // 5'-of-transcript intronic offsets are out of domain
-                // (no intron exists upstream of the first exon).
-                return None;
-            }
-            let tx_boundary = pos.base as u64;
-            let intron_length = intron_length_at_tx_boundary(transcript, tx_boundary, offset)?;
-            let abs_offset = offset.unsigned_abs();
-            if abs_offset > intron_length {
-                return Some(NormalizationWarning::PositionPastEnd {
-                    message: format!(
-                        "{}:n.{} lies past the intron-end (intron length {})",
-                        accession, pos, intron_length
-                    ),
-                    accession: accession.to_string(),
-                    coordinate_system: "n".to_string(),
-                    position: pos.to_string(),
-                    bound_kind: "intron-end".to_string(),
-                    bound_value: intron_length,
-                });
-            }
+    // `is_intronic()` is precisely `offset.is_some() && offset !=
+    // Some(0)`, so the parser-degenerate `n.<N>+0` shape falls through
+    // to the plain `n.<N>` check below — symmetric with the c.-axis
+    // dispatch above.
+    if pos.is_intronic() {
+        let offset = pos
+            .offset
+            .expect("is_intronic implies non-zero Some offset");
+        if pos.base < 1 {
+            // 5'-of-transcript intronic offsets are out of domain
+            // (no intron exists upstream of the first exon).
             return None;
         }
+        let tx_boundary = pos.base as u64;
+        let intron_length = intron_length_at_tx_boundary(transcript, tx_boundary, offset)?;
+        let abs_offset = offset.unsigned_abs();
+        if abs_offset > intron_length {
+            return Some(NormalizationWarning::PositionPastEnd {
+                message: format!(
+                    "{}:n.{} lies past the intron-end (intron length {})",
+                    accession, pos, intron_length
+                ),
+                accession: accession.to_string(),
+                coordinate_system: "n".to_string(),
+                position: pos.to_string(),
+                bound_kind: "intron-end".to_string(),
+                bound_value: intron_length,
+            });
+        }
+        return None;
     }
     if pos.base < 1 {
         return None;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -61,33 +61,111 @@ fn has_unknown_offset_cds(pos: &CdsPos) -> bool {
     )
 }
 
+/// Intron length (1-based inclusive base count) at the intron addressed by
+/// `tx_boundary` + `offset`, derived from `Transcript::find_intron_at_tx_boundary`
+/// plus the intron's genomic span. Returns `None` when no intron exists at
+/// that boundary OR the intron's genomic coordinates aren't populated —
+/// matching the existing W4004 conservative-skip contract for missing
+/// metadata.
+fn intron_length_at_tx_boundary(
+    transcript: &crate::reference::transcript::Transcript,
+    tx_boundary: u64,
+    offset: i64,
+) -> Option<u64> {
+    let intron = transcript.find_intron_at_tx_boundary(tx_boundary, offset)?;
+    let g_start = intron.genomic_start?;
+    let g_end = intron.genomic_end?;
+    // Saturating arithmetic mirrors `find_intron_at_genomic` in
+    // `src/reference/transcript.rs:695`, which uses the same length
+    // formula on the same genomic span.
+    Some(g_end.saturating_sub(g_start).saturating_add(1))
+}
+
+/// Resolve a `CdsPos` to its transcript-frame position (1-based) ignoring
+/// the intronic offset. Mirrors the non-intronic branch of
+/// `Normalizer::cds_to_tx_pos`; kept as a free helper so
+/// `check_cds_pos_past_end` can compute the intronic-anchor `tx_boundary`
+/// without holding a `Normalizer` reference.
+fn cds_pos_to_tx_boundary(
+    pos: &CdsPos,
+    transcript: &crate::reference::transcript::Transcript,
+) -> Option<u64> {
+    let cds_start = transcript.cds_start?;
+    if pos.utr3 {
+        // c.*N: tx_boundary = cds_end + N
+        let cds_end = transcript.cds_end?;
+        let base = u64::try_from(pos.base).ok()?;
+        Some(cds_end + base)
+    } else if pos.base < 0 {
+        // c.-N: tx_boundary = cds_start + base  (HGVS skips c.0, see
+        // Normalizer::cds_to_tx_pos and the #97 fix)
+        let signed = cds_start as i64 + pos.base;
+        u64::try_from(signed).ok()
+    } else if pos.base == 0 {
+        // c.0 isn't a valid HGVS position but historical inputs map it to
+        // the last 5'UTR base (= c.-1), matching `cds_to_tx_pos`.
+        Some(cds_start.saturating_sub(1))
+    } else {
+        // c.<N>: tx_boundary = cds_start + N - 1
+        Some(cds_start + (pos.base as u64) - 1)
+    }
+}
+
 /// If `pos` lies past the CDS-end (for plain `c.<N>`), past the
 /// transcript-end (for `c.*<N>`), or past the 5'UTR-start (for `c.-N`),
 /// return a `PositionPastEnd` warning describing the violation;
-/// otherwise `None`. See #336 (CDS-end / `c.*N`) and #348 (`c.-N`).
+/// otherwise `None`. See #336 (CDS-end / `c.*N`), #348 (`c.-N`), and
+/// #392 (intronic offsets).
 ///
-/// **Scope.** This helper handles the c. axis: plain `c.<N>` (cds-end),
-/// `c.*<N>` (transcript-end), and `c.-<N>` (5utr-start). The `n.` axis is
-/// handled by [`check_tx_pos_past_end`] (#347). Intronic offsets
-/// (`c.<N>+<M>` / `c.<N>-<M>`) remain out of scope because their bounds
-/// depend on intron size, which requires genome alignment data this
-/// helper does not consult.
+/// **Scope.** This helper handles the c. axis:
+/// - plain `c.<N>` (cds-end)
+/// - `c.*<N>` (transcript-end)
+/// - `c.-<N>` (5utr-start)
+/// - `c.<N>+<M>` / `c.<N>-<M>` (intron-end, when the intron's genomic
+///   span is known; #392)
+///
+/// The `n.` axis is handled by [`check_tx_pos_past_end`] (#347).
 ///
 /// **Conservative skip.** When the required transcript metadata is missing
-/// (no `cds_start`/`cds_end` for a c. variant), the helper returns `None`
-/// rather than emit a false positive. Bounds are derived from
+/// (no `cds_start`/`cds_end` for a c. variant, or no genomic coords on the
+/// exons enclosing the intron), the helper returns `None` rather than emit
+/// a false positive. Non-intronic bounds derive from
 /// `Transcript::cds_length()` / `utr3_length()` / `utr5_length()`, which
 /// fall back to the exon-sum transcript length when no cached `sequence`
-/// is loaded — so the check still fires on coordinate-only transcripts.
-/// Callers wanting strict gating on missing metadata must check
-/// transcript completeness separately.
+/// is loaded. Intronic bounds derive from the intron's `genomic_end -
+/// genomic_start + 1`, which is only populated when the cdot data carries
+/// per-exon genomic alignment. Callers wanting strict gating on missing
+/// metadata must check transcript completeness separately.
 fn check_cds_pos_past_end(
     accession: &str,
     pos: &CdsPos,
     transcript: &crate::reference::transcript::Transcript,
 ) -> Option<NormalizationWarning> {
-    // Intronic offsets and unknown positions are out of scope.
-    if pos.is_intronic() || pos.is_unknown() {
+    // Unknown positions can't be bounds-checked.
+    if pos.is_unknown() {
+        return None;
+    }
+    // Intronic-offset bound check (#392). Requires both the c.→tx
+    // boundary AND the intron's genomic span; returns None on either
+    // missing piece per the conservative-skip contract.
+    if pos.is_intronic() {
+        let offset = pos.offset?;
+        let tx_boundary = cds_pos_to_tx_boundary(pos, transcript)?;
+        let intron_length = intron_length_at_tx_boundary(transcript, tx_boundary, offset)?;
+        let abs_offset = offset.unsigned_abs();
+        if abs_offset > intron_length {
+            return Some(NormalizationWarning::PositionPastEnd {
+                message: format!(
+                    "{}:c.{} lies past the intron-end (intron length {})",
+                    accession, pos, intron_length
+                ),
+                accession: accession.to_string(),
+                coordinate_system: "c".to_string(),
+                position: pos.to_string(),
+                bound_kind: "intron-end".to_string(),
+                bound_value: intron_length,
+            });
+        }
         return None;
     }
     if pos.utr3 {
@@ -152,25 +230,62 @@ fn check_cds_pos_past_end(
 }
 
 /// If `pos` (an `n.<N>` transcript position) lies past the transcript's
-/// total length, return a `PositionPastEnd` warning describing the
-/// violation; otherwise `None`. Closes #347.
+/// total length OR an intronic-offset position lies past the enclosing
+/// intron, return a `PositionPastEnd` warning describing the violation;
+/// otherwise `None`. Closes #347 (transcript-end) and #392 (intron-end).
 ///
-/// Bounds: plain `n.<N>` must satisfy `1 <= N <= sequence_length`.
-/// Intronic offsets (`n.<N>+<M>`) are out of scope (their bounds depend
-/// on intron size, which requires alignment data this helper does not
-/// consult). Unknown positions (`n.?`) and `N < 1` are skipped.
+/// Bounds:
+/// - plain `n.<N>`: `1 <= N <= sequence_length`
+/// - `n.<N>+<M>` / `n.<N>-<M>`: `|M| <= intron_length` when the intron's
+///   genomic span is known
 ///
-/// Bounds source: `Transcript::sequence_length()`, which falls back to
-/// the sum of exon spans for coordinate-only transcripts — a coordinate
-/// bound check should not silently degrade into a sequence-availability
-/// check, so the gate fires regardless of whether bases are cached.
+/// Unknown positions (`n.?`) and downstream `n.*N` sentinels are skipped.
+/// `N < 1` (a 5'-of-transcript position) is also skipped — outside the
+/// bound check's domain.
+///
+/// Bounds source for non-intronic: `Transcript::sequence_length()`,
+/// which falls back to the sum of exon spans for coordinate-only
+/// transcripts. Bounds source for intronic: intron's `genomic_end -
+/// genomic_start + 1`. Both follow the conservative-skip contract when
+/// metadata is missing.
 fn check_tx_pos_past_end(
     accession: &str,
     pos: &TxPos,
     transcript: &crate::reference::transcript::Transcript,
 ) -> Option<NormalizationWarning> {
-    if has_unknown_offset_tx(pos) || pos.offset.is_some() || pos.is_downstream() {
+    if has_unknown_offset_tx(pos) || pos.is_downstream() {
         return None;
+    }
+    // Intronic-offset bound check (#392). The tx_boundary is `pos.base`
+    // itself (n.-axis positions are direct transcript coordinates).
+    if let Some(offset) = pos.offset {
+        if offset == 0 {
+            // `n.<N>+0` is parser-degenerate (not really intronic); fall
+            // through to the plain `n.<N>` check below.
+        } else {
+            if pos.base < 1 {
+                // 5'-of-transcript intronic offsets are out of domain
+                // (no intron exists upstream of the first exon).
+                return None;
+            }
+            let tx_boundary = pos.base as u64;
+            let intron_length = intron_length_at_tx_boundary(transcript, tx_boundary, offset)?;
+            let abs_offset = offset.unsigned_abs();
+            if abs_offset > intron_length {
+                return Some(NormalizationWarning::PositionPastEnd {
+                    message: format!(
+                        "{}:n.{} lies past the intron-end (intron length {})",
+                        accession, pos, intron_length
+                    ),
+                    accession: accession.to_string(),
+                    coordinate_system: "n".to_string(),
+                    position: pos.to_string(),
+                    bound_kind: "intron-end".to_string(),
+                    bound_value: intron_length,
+                });
+            }
+            return None;
+        }
     }
     if pos.base < 1 {
         return None;

--- a/tests/issue_392_w4004_intronic_offsets.rs
+++ b/tests/issue_392_w4004_intronic_offsets.rs
@@ -42,12 +42,9 @@ use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
 ///   exon 2:                       130-141 (12 bases)
 /// ```
 ///
-/// CDS spans the entire transcript (cds_start=1, cds_end=22) so `c.<N>`
-/// = tx `<N>` to keep position arithmetic transparent. c.7 is the last
-/// CDS base of exon 1 (tx 10); c.8 is the first CDS base of exon 2 (tx
-/// 11). Wait — with cds_start=1, c.1 = tx 1, c.10 = tx 10 (last base of
-/// exon 1), c.11 = tx 11 (first base of exon 2). So the exon-1/exon-2
-/// junction is between c.10 and c.11.
+/// Because cds_start=1 and cds_end=22, `c.<N>` maps 1:1 to tx `<N>`.
+/// The exon-1/exon-2 junction is between c.10 and c.11; intron 1 is
+/// the 20-bp gap between them.
 ///
 /// Intron-1 length = 129 - 110 + 1 = 20 bp. So:
 /// - `c.10+M` valid for `M` in `1..=20`
@@ -123,6 +120,95 @@ fn provider_with_intronic_noncoding_transcript() -> MockProvider {
         Some("chr_int".to_string()),
         Some(100),
         Some(141),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// 3-exon plus-strand transcript with introns inside both the 5'UTR
+/// and the 3'UTR, used to exercise `cds_pos_to_tx_boundary`'s
+/// `pos.base < 0` (5'UTR-intronic) and `pos.utr3` (3'UTR-intronic)
+/// branches that the `provider_with_intronic_transcript` fixture (CDS
+/// = entire transcript) does not reach.
+///
+/// Transcript layout (tx coords on a 33-bp transcript):
+/// ```text
+///   tx pos: 1..6  | 7..18    | 19..33
+///   region: 5'UTR | CDS      | 3'UTR
+///   exons : exon1 | exon2    | exon3
+///   genomic: 100..105 (6 bp) | 130..141 (12 bp) | 170..184 (15 bp)
+///   intron 1 (between exons 1 and 2): genomic 106..129 = 24 bp
+///   intron 2 (between exons 2 and 3): genomic 142..169 = 28 bp
+/// ```
+///
+/// cds_start = 7 (first base of exon 2 = c.1), cds_end = 18 (last
+/// base of exon 2 = c.12). Intron 1 sits entirely in the 5'UTR
+/// (between tx 6 / c.-1 and tx 7 / c.1); intron 2 sits entirely in
+/// the 3'UTR (between tx 18 / c.12 and tx 19 / c.*1). Both UTR
+/// introns therefore live at the *exon-end / next-exon-start*
+/// boundary, addressed via `c.-1+M` (UTR-5 intron 5' side),
+/// `c.1-M` (UTR-5 intron 3' side), `c.12+M` (UTR-3 intron 5' side),
+/// and `c.*1-M` (UTR-3 intron 3' side).
+fn provider_with_utr_intronic_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NM_UTRINT.1".to_string(),
+        Some("UTRINT".to_string()),
+        Strand::Plus,
+        Some("CCCCCCATGAAATAACCCCCCCCCCCCCCCAAA".to_string()),
+        Some(7),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 6, 100, 105),
+            Exon::with_genomic(2, 7, 18, 130, 141),
+            Exon::with_genomic(3, 19, 33, 170, 184),
+        ],
+        Some("chr_int".to_string()),
+        Some(100),
+        Some(184),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// 2-exon **minus-strand** transcript with explicit genomic coords —
+/// mirror of `provider_with_intronic_transcript` to pin
+/// strand-invariance of the intron-length math.
+///
+/// Per `compute_introns` (`src/reference/transcript.rs:649-655`),
+/// minus-strand intron genomic coords are derived from
+/// `downstream.genomic_end + 1 .. upstream.genomic_start - 1`. So with:
+/// ```text
+///   exon 1 (tx 1-10, coding-start side):  genomic 200..209  (10 bp)
+///   exon 2 (tx 11-22, coding-end side):   genomic 130..141  (12 bp)
+///   intron 1: genomic 142..199 = 58 bp
+/// ```
+/// (exon 1 maps to the higher genomic range because the transcript
+/// reads 3'→5' along the genome.)
+fn provider_with_minus_strand_intronic_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NM_MINT.1".to_string(),
+        Some("MINT".to_string()),
+        Strand::Minus,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        Some(1),
+        Some(22),
+        vec![
+            Exon::with_genomic(1, 1, 10, 200, 209),
+            Exon::with_genomic(2, 11, 22, 130, 141),
+        ],
+        Some("chr_mint".to_string()),
+        Some(130),
+        Some(209),
         Default::default(),
         ManeStatus::None,
         None,
@@ -304,5 +390,117 @@ fn intronic_offset_past_last_exon_skips_no_intron_exists() {
     assert!(
         !position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.22+5del"),
         "unexpected POSITION_PAST_END for c.22+5 when no intron exists 3' of the last exon",
+    );
+}
+
+// --- 5'UTR-intronic (c.-N+M / c.-N-M) --------------------------------------
+
+#[test]
+fn c_dot_5utr_intronic_plus_offset_past_intron_end_emits_w4004() {
+    // Intron 1 of `NM_UTRINT.1` is the 24-bp gap between exon 1 (tx 6 =
+    // c.-1, last 5'UTR base) and exon 2 (tx 7 = c.1, first CDS base).
+    // `c.-1+25` (25 > 24) is past-end via the 5'UTR-intron's "+" form.
+    assert!(
+        position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.-1+25del"
+        ),
+        "expected POSITION_PAST_END (W4004) for c.-1+25 on a 24-bp 5'UTR intron",
+    );
+}
+
+#[test]
+fn c_dot_5utr_intronic_plus_offset_within_intron_does_not_emit_w4004() {
+    // `c.-1+5del` is well within the 24-bp 5'UTR intron.
+    assert!(
+        !position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.-1+5del"
+        ),
+        "unexpected POSITION_PAST_END for c.-1+5 (within 24-bp 5'UTR intron)",
+    );
+}
+
+#[test]
+fn c_dot_cds_start_minus_offset_past_intron_5utr_emits_w4004() {
+    // `c.1-25del` — `c.1` is the first CDS base; the intron immediately
+    // 5' of it is the same 24-bp 5'UTR intron. Past-end via the "-" form.
+    assert!(
+        position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.1-25del"
+        ),
+        "expected POSITION_PAST_END (W4004) for c.1-25 on a 24-bp 5'UTR intron",
+    );
+}
+
+// --- 3'UTR-intronic (c.*N+M / c.NNN+M off last CDS base) -------------------
+
+#[test]
+fn c_dot_3utr_intronic_plus_offset_past_intron_end_emits_w4004() {
+    // Intron 2 of `NM_UTRINT.1` is the 28-bp gap between exon 2 (tx 18
+    // = c.12, last CDS base) and exon 3 (tx 19 = c.*1, first 3'UTR
+    // base). `c.12+29` (29 > 28) is past-end on the 3'UTR-intron's "+"
+    // form.
+    assert!(
+        position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.12+29del"
+        ),
+        "expected POSITION_PAST_END (W4004) for c.12+29 on a 28-bp 3'UTR intron",
+    );
+}
+
+#[test]
+fn c_dot_3utr_intronic_minus_offset_past_intron_end_emits_w4004() {
+    // `c.*1-29del` — `c.*1` is the first 3'UTR base; the intron 5' of
+    // it is the same 28-bp 3'UTR intron. Past-end via the "-" form.
+    assert!(
+        position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.*1-29del"
+        ),
+        "expected POSITION_PAST_END (W4004) for c.*1-29 on a 28-bp 3'UTR intron",
+    );
+}
+
+#[test]
+fn c_dot_3utr_intronic_within_intron_does_not_emit_w4004() {
+    // `c.*1-5del` is well within the 28-bp 3'UTR intron.
+    assert!(
+        !position_past_end_fires(
+            provider_with_utr_intronic_transcript(),
+            "NM_UTRINT.1:c.*1-5del"
+        ),
+        "unexpected POSITION_PAST_END for c.*1-5 (within 28-bp 3'UTR intron)",
+    );
+}
+
+// --- Minus-strand symmetry --------------------------------------------------
+
+#[test]
+fn minus_strand_c_dot_plus_offset_past_intron_end_emits_w4004() {
+    // Minus-strand fixture: intron 1 spans genomic 142..199 = 58 bp.
+    // `c.10+59` (59 > 58) is past-end. Pins that the intron-length
+    // computation works through the minus-strand `compute_introns`
+    // branch (`downstream.genomic_end + 1 .. upstream.genomic_start - 1`).
+    assert!(
+        position_past_end_fires(
+            provider_with_minus_strand_intronic_transcript(),
+            "NM_MINT.1:c.10+59del"
+        ),
+        "expected POSITION_PAST_END (W4004) for c.10+59 on a minus-strand 58-bp intron",
+    );
+}
+
+#[test]
+fn minus_strand_c_dot_plus_offset_within_intron_does_not_emit_w4004() {
+    // `c.10+5del` is well within the 58-bp minus-strand intron.
+    assert!(
+        !position_past_end_fires(
+            provider_with_minus_strand_intronic_transcript(),
+            "NM_MINT.1:c.10+5del"
+        ),
+        "unexpected POSITION_PAST_END for minus-strand c.10+5 (within 58-bp intron)",
     );
 }

--- a/tests/issue_392_w4004_intronic_offsets.rs
+++ b/tests/issue_392_w4004_intronic_offsets.rs
@@ -1,0 +1,308 @@
+//! Issue #392 — extend W4004 PositionPastEnd to intronic offsets.
+//!
+//! PR #342 wired W4004 for plain `c.<N>` (cds-end), `c.*<N>`
+//! (transcript-end), and `c.-<N>` (5'utr-start), and PR #347 added the
+//! `n.<N>` (transcript-end) case. All four short-circuit when the
+//! position is intronic (offset present) because the bound depends on
+//! intron size, which requires genomic alignment data. This file pins
+//! the extension: when intron length is computable from the exons'
+//! genomic coords, `|offset| > intron_length` must fire `W4004`.
+//!
+//! Spec basis (`assets/hgvs-nomenclature/docs/background/numbering.md`):
+//! - "nucleotides at the 5' end of an intron are numbered relative to
+//!   the last nucleotide of the directly upstream exon, followed by a
+//!   `+`"; "in the middle of the intron, nucleotide numbering changes
+//!   from `+` to `-`". So `+M` and `-M` are both bounded by the intron
+//!   length (any `|M|` exceeding the intron length is past-end).
+//! - "a coding DNA reference sequence does not contain intron or 5'
+//!   and 3' gene flanking sequences, and can therefore not be used as
+//!   a reference to describe variants in these regions"; "Correct
+//!   descriptions refer to a genomic reference sequence" — so
+//!   intronic bound checks are conditional on the genomic alignment
+//!   being available (`Exon::genomic_start`/`genomic_end` populated).
+//!   When unavailable, ferro conservatively skips per the existing
+//!   W4004 missing-metadata convention.
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer};
+
+/// 2-exon plus-strand transcript with explicit genomic coords on each
+/// exon, so the intron between them has a known 20-bp length.
+///
+/// Transcript layout:
+/// ```text
+///   tx        1         2
+///         1234567890 ⇢⇢ 1234567890 12
+///   seq:  AAAATGCCCC    GGGGTAGAAT AA
+///   genomic
+///   exon 1:    100-109                  (10 bases)
+///   intron 1:           110-129          (20 bases — the test bound)
+///   exon 2:                       130-141 (12 bases)
+/// ```
+///
+/// CDS spans the entire transcript (cds_start=1, cds_end=22) so `c.<N>`
+/// = tx `<N>` to keep position arithmetic transparent. c.7 is the last
+/// CDS base of exon 1 (tx 10); c.8 is the first CDS base of exon 2 (tx
+/// 11). Wait — with cds_start=1, c.1 = tx 1, c.10 = tx 10 (last base of
+/// exon 1), c.11 = tx 11 (first base of exon 2). So the exon-1/exon-2
+/// junction is between c.10 and c.11.
+///
+/// Intron-1 length = 129 - 110 + 1 = 20 bp. So:
+/// - `c.10+M` valid for `M` in `1..=20`
+/// - `c.10+21` past intron-end → W4004 fires
+/// - `c.11-M` valid for `M` in `1..=20`
+/// - `c.11-21` past intron-end → W4004 fires
+fn provider_with_intronic_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NM_INT.1".to_string(),
+        Some("INT".to_string()),
+        Strand::Plus,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        Some(1),
+        Some(22),
+        vec![
+            Exon::with_genomic(1, 1, 10, 100, 109),
+            Exon::with_genomic(2, 11, 22, 130, 141),
+        ],
+        Some("chr_int".to_string()),
+        Some(100),
+        Some(141),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Same shape as `provider_with_intronic_transcript` but with
+/// `Exon::new` (no genomic coords) so the intron-length computation
+/// returns None and the check must conservatively skip.
+fn provider_with_intronic_transcript_no_genomic_coords() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NM_NOGEN.1".to_string(),
+        Some("NOGEN".to_string()),
+        Strand::Plus,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        Some(1),
+        Some(22),
+        vec![Exon::new(1, 1, 10), Exon::new(2, 11, 22)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// 2-exon plus-strand non-coding transcript fixture (no CDS) — same
+/// 20-bp intron-1 shape as `provider_with_intronic_transcript`, used
+/// for the `n.` axis cases.
+fn provider_with_intronic_noncoding_transcript() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NR_INT.1".to_string(),
+        Some("NRINT".to_string()),
+        Strand::Plus,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        None,
+        None,
+        vec![
+            Exon::with_genomic(1, 1, 10, 100, 109),
+            Exon::with_genomic(2, 11, 22, 130, 141),
+        ],
+        Some("chr_int".to_string()),
+        Some(100),
+        Some(141),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Returns `true` iff the lenient-mode normalize call emits a
+/// `POSITION_PAST_END` (W4004) warning for `input`.
+///
+/// When W4004 fires the bounds gate at `normalize_cds` / `normalize_tx`
+/// short-circuits with `Ok(canonical, vec![warning])`, so this helper
+/// reports `true`. When it does not fire the normalize call may
+/// proceed to the downstream intronic-projection pass (which requires
+/// genomic sequence data and surfaces `FerroError::IntronicVariant` on
+/// fixtures that omit it) — that `Err` is treated as "W4004 did not
+/// fire" because if it had, the bounds gate would have intercepted
+/// before the intronic pass ran.
+fn position_past_end_fires(provider: MockProvider, input: &str) -> bool {
+    let config = NormalizeConfig::lenient();
+    let normalizer = Normalizer::with_config(provider, config);
+    let variant =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
+    match normalizer.normalize_with_warnings(&variant) {
+        Ok(result) => result
+            .warnings
+            .iter()
+            .any(|w| w.code() == "POSITION_PAST_END"),
+        // The bounds gate runs BEFORE the downstream intronic pass, so any
+        // downstream `IntronicVariant` (or similar) error implies W4004 did
+        // not fire — if it had, the gate would have returned Ok with the
+        // warning intercepted at the top of normalize_cds / normalize_tx.
+        Err(_) => false,
+    }
+}
+
+// --- c. axis: + offset past intron end --------------------------------------
+
+#[test]
+fn c_dot_plus_offset_past_intron_end_emits_w4004() {
+    // `c.10+21del`: intron-1 is 20 bp, so offset 21 is past-end.
+    assert!(
+        position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.10+21del"),
+        "expected POSITION_PAST_END (W4004) for c.10+21 on a 20-bp intron",
+    );
+}
+
+#[test]
+fn c_dot_plus_offset_within_intron_does_not_emit_w4004() {
+    // `c.10+5del`: well within the 20-bp intron — the bounds gate must
+    // not fire. Downstream normalize may still error on missing genomic
+    // sequence data (intronic projection requires it); that's fine and
+    // distinct from a W4004 false-positive (the helper interprets the
+    // downstream error as "no W4004 fired").
+    assert!(
+        !position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.10+5del"),
+        "unexpected POSITION_PAST_END for c.10+5 (within 20-bp intron)",
+    );
+}
+
+#[test]
+fn c_dot_plus_offset_at_intron_end_boundary_does_not_emit_w4004() {
+    // `c.10+20del`: offset exactly equal to intron length — the last
+    // base of the intron, addressed via the upstream-exon "+" form.
+    // Within bound, must NOT fire.
+    assert!(
+        !position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.10+20del"),
+        "unexpected POSITION_PAST_END for c.10+20 (at intron-end boundary)",
+    );
+}
+
+// --- c. axis: - offset past intron start ------------------------------------
+
+#[test]
+fn c_dot_minus_offset_past_intron_end_emits_w4004() {
+    // `c.11-21del`: 20-bp intron, offset 21 → past-end via the
+    // downstream-exon "-" form.
+    assert!(
+        position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.11-21del"),
+        "expected POSITION_PAST_END (W4004) for c.11-21 on a 20-bp intron",
+    );
+}
+
+#[test]
+fn c_dot_minus_offset_within_intron_does_not_emit_w4004() {
+    // `c.11-5del`: well within the 20-bp intron.
+    assert!(
+        !position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.11-5del"),
+        "unexpected POSITION_PAST_END for c.11-5 (within 20-bp intron)",
+    );
+}
+
+// --- n. axis: intronic offset symmetry --------------------------------------
+
+#[test]
+fn n_dot_plus_offset_past_intron_end_emits_w4004() {
+    // `n.10+21del`: n. axis intronic offset on a non-coding transcript.
+    // Same 20-bp intron as the c. fixture.
+    assert!(
+        position_past_end_fires(
+            provider_with_intronic_noncoding_transcript(),
+            "NR_INT.1:n.10+21del"
+        ),
+        "expected POSITION_PAST_END (W4004) for n.10+21 on a 20-bp intron",
+    );
+}
+
+#[test]
+fn n_dot_minus_offset_past_intron_end_emits_w4004() {
+    assert!(
+        position_past_end_fires(
+            provider_with_intronic_noncoding_transcript(),
+            "NR_INT.1:n.11-21del"
+        ),
+        "expected POSITION_PAST_END (W4004) for n.11-21 on a 20-bp intron",
+    );
+}
+
+#[test]
+fn n_dot_plus_offset_within_intron_does_not_emit_w4004() {
+    assert!(
+        !position_past_end_fires(
+            provider_with_intronic_noncoding_transcript(),
+            "NR_INT.1:n.10+5del"
+        ),
+        "unexpected POSITION_PAST_END for n.10+5 (within 20-bp intron)",
+    );
+}
+
+// --- Conservative skip when genomic coords missing --------------------------
+
+#[test]
+fn intronic_offset_check_skips_when_genomic_coords_missing() {
+    // Same shape as the c.10+21 test but the transcript's exons have no
+    // genomic coords. Intron length is not computable → conservative
+    // skip per the existing W4004 missing-metadata convention.
+    assert!(
+        !position_past_end_fires(
+            provider_with_intronic_transcript_no_genomic_coords(),
+            "NM_NOGEN.1:c.10+21del"
+        ),
+        "expected conservative skip when genomic coords are missing",
+    );
+}
+
+// --- Strict mode promotes the intronic past-end warning to an error --------
+
+#[test]
+fn strict_mode_promotes_intronic_past_end_to_error() {
+    // Strict mode calls `normalize` (not `normalize_with_warnings`), which
+    // promotes a `PositionPastEnd` warning to `FerroError::InvalidCoordinates`.
+    let provider = provider_with_intronic_transcript();
+    let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
+    let variant = parse_hgvs("NM_INT.1:c.10+21del").expect("parse");
+    let err = normalizer
+        .normalize(&variant)
+        .expect_err("strict mode must reject c.10+21del as past-intron-end");
+    match err {
+        FerroError::InvalidCoordinates { msg } => {
+            assert!(
+                msg.contains("W4004") || msg.contains("intron"),
+                "strict-mode error message must reference W4004 or intron; got: {msg}",
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+// --- No-intron edge case: offset off the last exon -------------------------
+
+#[test]
+fn intronic_offset_past_last_exon_skips_no_intron_exists() {
+    // `c.22+5`: c.22 is the last base of the last exon, so there is no
+    // intron 3' of it. `find_intron_at_tx_boundary` returns None →
+    // conservative skip (no false positive). This pins the "no intron
+    // exists" branch of the new logic.
+    assert!(
+        !position_past_end_fires(provider_with_intronic_transcript(), "NM_INT.1:c.22+5del"),
+        "unexpected POSITION_PAST_END for c.22+5 when no intron exists 3' of the last exon",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #392. Extends `W4004 PositionPastEnd` to fire on intronic-offset positions (`c.<N>+<M>`, `c.<N>-<M>`, and the n.-axis analogues). PR #342 wired the check for plain `c.<N>` (cds-end), `c.*<N>` (transcript-end), and `c.-<N>` (5'utr-start); #347 added `n.<N>` (transcript-end). All four short-circuited intronic positions because the bound depends on intron length — only computable from per-exon genomic alignment data. Now that the alignment data is wired through `Transcript::find_intron_at_tx_boundary` + `Intron::genomic_length`, the bound check fires.

- **`fix(normalize): extend W4004 PositionPastEnd to intronic offsets` (#392)** — Two new free helpers in `src/normalize/mod.rs`: `intron_length_at_tx_boundary(transcript, tx_boundary, offset)` (wraps `find_intron_at_tx_boundary` + `Intron::genomic_length`) and `cds_pos_to_tx_boundary(pos, transcript)` (resolves a `CdsPos`'s base to a 1-based tx position, mirroring `Normalizer::cds_to_tx_pos`'s non-intronic branch). The existing `check_cds_pos_past_end` and `check_tx_pos_past_end` helpers each grow an intronic branch that returns `PositionPastEnd { bound_kind: "intron-end", bound_value: intron_length }` when `|offset| > intron_length`. Strict-mode promotion and lenient-mode short-circuit are inherited from the existing wiring (no changes to `Normalizer::normalize`'s strict-mode `find_map`). Spec basis: HGVS `assets/hgvs-nomenclature/docs/background/numbering.md` — intron-internal positions use `+M` (5' half, anchored at upstream exon) and `-M` (3' half, anchored at downstream exon), both bounded by intron length. Conservative-skip semantics inherited from the existing W4004 missing-metadata contract: when intron length can't be computed (no genomic coords, no intron at the boundary, or inverted span), the helper returns `None` and the check is silently skipped.

- **`fix(review): apply end-of-issue review findings` (#392)** — Consolidated review-fix commit. MAJOR: delegate intron-length computation to `Intron::genomic_length` instead of reimplementing the formula with `saturating_sub` (removes the silent-zero footgun on inverted spans). MAJOR: added a 3-exon UTR-intronic fixture exercising `c.-N+M` / `c.1-M` / `c.12+M` / `c.*1-M` (previously unreachable from the CDS-only fixture). MAJOR: added a minus-strand fixture pinning strand-invariance of the intron-length math against `compute_introns`'s minus-strand branch. MINOR/NIT: refactored `check_tx_pos_past_end`'s intronic branch to use `is_intronic()` symmetrically with the c.-axis helper, expanded docstrings on the unreachable `base == 0` branch and the cds/tx unknown-position asymmetry, tightened the test fixture docstring.

## Test matrix

| Axis × Offset | Plus strand | Minus strand | UTR-intronic |
|---|---|---|---|
| `c.<N>+<M>` past-end | ✓ | ✓ | ✓ (`c.12+29`) |
| `c.<N>-<M>` past-end | ✓ | — | ✓ (`c.*1-29`, `c.1-25`) |
| `c.<N>+<M>` in-bound | ✓ (incl. at exact bound) | ✓ | ✓ |
| `c.-<N>+<M>` past-end | — | — | ✓ (`c.-1+25`) |
| `n.<N>+<M>` past-end / in-bound | ✓ / ✓ | — | — |
| `n.<N>-<M>` past-end | ✓ | — | — |
| Conservative skip (no genomic coords) | ✓ | — | — |
| Conservative skip (no intron at boundary) | ✓ (`c.22+5` past last exon) | — | — |
| Strict-mode promotion | ✓ | — | — |

19 tests in `tests/issue_392_w4004_intronic_offsets.rs`, all PASS.

## Test plan

- [ ] `cargo nextest run --features dev` — 5814 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences pre-existing on `origin/main`); no new failures.
- [ ] `cargo clippy --features dev -- -D warnings` clean.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo run --features dev --example generate_spec_fixture -- --check` clean.
- [ ] All 19 new tests in `issue_392_w4004_intronic_offsets.rs` PASS.
- [ ] 28 existing tests in `issue_336_position_past_end.rs` PASS (no regression of the non-intronic W4004 surface).