### PR TITLE
feat(variant): add is_frameshift_with_provider for wraparound m./o. (closes #412)

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1728,6 +1728,19 @@ pub fn is_frameshift(variant: &HgvsVariant) -> bool {
     }
 }
 
+/// Like [`is_frameshift`] but uses a provider so wraparound `m.`/`o.`
+/// ranges compute the spec-correct circular indel length via
+/// [`crate::python_helpers::get_indel_length_with_provider`].
+pub fn is_frameshift_with_provider<P: crate::reference::provider::ReferenceProvider + ?Sized>(
+    variant: &HgvsVariant,
+    provider: &P,
+) -> bool {
+    match crate::python_helpers::get_indel_length_with_provider(variant, provider) {
+        Some(len) if len != 0 => len % 3 != 0,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -453,13 +453,11 @@ fn inserted_sequence_len(seq: &InsertedSequence) -> Option<i64> {
 /// so core code (e.g. `crate::project`) does not need to depend on the
 /// Python-bindings helper module.
 ///
-/// Note: no `_with_provider` variant exists. `is_frameshift` calls
-/// [`get_indel_length`] (the no-provider path), which returns `None` for
-/// wraparound `m.`/`o.` ranges — so `is_frameshift` will return `false` on
-/// those variants. Callers needing frameshift detection on wraparound input
-/// should compute it themselves from [`get_indel_length_with_provider`]
-/// (`len.is_some_and(|n| n != 0 && n % 3 != 0)`).
-pub use crate::hgvs::variant::is_frameshift;
+/// Note: `is_frameshift` calls [`get_indel_length`] (the no-provider path),
+/// which returns `None` for wraparound `m.`/`o.` ranges — so `is_frameshift`
+/// returns `false` on those variants. For provider-backed wraparound-aware
+/// detection, use [`is_frameshift_with_provider`] instead.
+pub use crate::hgvs::variant::{is_frameshift, is_frameshift_with_provider};
 
 /// Get the number of sub-variants in an allele, or 1 for simple variants.
 pub fn get_num_variants(variant: &HgvsVariant) -> usize {

--- a/tests/issue_399_mt_circular_followup.rs
+++ b/tests/issue_399_mt_circular_followup.rs
@@ -17,7 +17,7 @@
 //! wraparound.
 
 use ferro_hgvs::parse_hgvs;
-use ferro_hgvs::python_helpers::get_indel_length_with_provider;
+use ferro_hgvs::python_helpers::{get_indel_length_with_provider, is_frameshift_with_provider};
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::reference::transcript::{GenomeBuild, ManeStatus, Strand, Transcript};
 use ferro_hgvs::spdi::convert::{hgvs_to_spdi, hgvs_to_spdi_simple};
@@ -256,4 +256,44 @@ mod validate_response_tests {
             "expected wraps_origin=false on linear m. sub"
         );
     }
+}
+
+// =============================================================================
+// is_frameshift_with_provider: closes #412
+// =============================================================================
+// is_frameshift (no-provider) returns false for wraparound m./o. ranges
+// because get_indel_length returns None. is_frameshift_with_provider closes
+// the gap by routing through get_indel_length_with_provider.
+
+#[test]
+fn wraparound_del_is_frameshift_with_provider_returns_true() {
+    // 2-nt wraparound deletion: 2 % 3 != 0 → frameshift.
+    let v = parse_hgvs("NC_012920.1:m.16569_1del").unwrap();
+    let p = mt_provider();
+    assert!(is_frameshift_with_provider(&v, &p));
+}
+
+#[test]
+fn wraparound_3nt_del_is_frameshift_with_provider_returns_false() {
+    // 3-nt wraparound deletion (start=16569, end=2 → span=(16569-16569+1)+2=3):
+    // in-frame.
+    let v = parse_hgvs("NC_012920.1:m.16569_2del").unwrap();
+    let p = mt_provider();
+    assert!(!is_frameshift_with_provider(&v, &p));
+}
+
+#[test]
+fn wraparound_dup_is_frameshift_with_provider_returns_false_when_in_frame() {
+    // 15-nt wraparound dup: 15 % 3 == 0 → in-frame.
+    let v = parse_hgvs("NC_012920.1:m.16560_5dup").unwrap();
+    let p = mt_provider();
+    assert!(!is_frameshift_with_provider(&v, &p));
+}
+
+#[test]
+fn linear_substitution_is_frameshift_with_provider_returns_false() {
+    // Substitution has indel length 0 → not a frameshift.
+    let v = parse_hgvs("NC_012920.1:m.100A>G").unwrap();
+    let p = mt_provider();
+    assert!(!is_frameshift_with_provider(&v, &p));
 }


### PR DESCRIPTION
## Summary

Closes #412. Adds `is_frameshift_with_provider`, the missing sibling of `is_frameshift` for wraparound `m.`/`o.` ranges.

**Stacked on PR #411** (sibling of #415). Both depend on `get_indel_length_with_provider`, which #411 introduces. GitHub will auto-rebase onto `main` after #411 merges.

## Why

After PR #411, `get_indel_length` returns `None` for wraparound `m.`/`o.` ranges (instead of the previous silently-wrong negative value). The existing `is_frameshift` is a thin 3-line wrapper over `get_indel_length`, so it falls through to `false` on wraparound input — silently wrong for a 2-nt wraparound `del` that is in fact a frameshift. PR #411 documented this gap in the `is_frameshift` re-export's doc comment; this PR closes it.

## What's in scope

- New `pub fn is_frameshift_with_provider<P: ReferenceProvider + ?Sized>(variant: &HgvsVariant, provider: &P) -> bool` in `src/hgvs/variant.rs`, mirroring the existing `is_frameshift` body but routing through `get_indel_length_with_provider`.
- Re-export from `src/python_helpers.rs` alongside the existing `is_frameshift`. Doc comment on the re-export updated to point at the new sibling (replacing the workaround note from PR #411).

## Tests

4 new tests in `tests/issue_399_mt_circular_followup.rs`:

- `wraparound_del_is_frameshift_with_provider_returns_true` — `m.16569_1del` (2-nt span) → `true`
- `wraparound_3nt_del_is_frameshift_with_provider_returns_false` — `m.16569_2del` (3-nt span, in-frame) → `false`
- `wraparound_dup_is_frameshift_with_provider_returns_false_when_in_frame` — `m.16560_5dup` (15-nt span, in-frame) → `false`
- `linear_substitution_is_frameshift_with_provider_returns_false` — `m.100A>G` (no indel) → `false`

18/18 file tests pass; 2354/2354 lib tests pass; `cargo fmt --all --check` clean; `cargo clippy --features dev --all-targets -- -D warnings` clean.

## Refs

- closes #412
- depends on PR #411 (introduces `get_indel_length_with_provider`)
- sibling of PR #415 (W4004 on m. axis — also stacked on #411)
