### PR TITLE
fix(service,validation,spdi): three delins consistency bugs (closes #394)

### DIFF
--- a/src/hgvs/validation.rs
+++ b/src/hgvs/validation.rs
@@ -312,6 +312,23 @@ pub mod rules {
                     "Deletion-insertion must have at least one inserted base",
                 ));
             }
+            // Closes #394 item 2. The `Delins` variant doc-comment at
+            // `src/hgvs/edit.rs:472-474` states "At most one of `deleted`
+            // / `deleted_length` is `Some`"; promote that invariant from a
+            // docs-only convention to a runtime check. The parser does
+            // not emit this shape — only direct struct construction
+            // produces it — so this guard catches programmatic misuse.
+            NaEdit::Delins {
+                deleted: Some(_),
+                deleted_length: Some(_),
+                ..
+            } => {
+                result = result.with_error(ValidationError::new(
+                    "E004",
+                    "Deletion-insertion has both `deleted` sequence and `deleted_length`; \
+                     at most one may be set (see `NaEdit::Delins` doc invariant)",
+                ));
+            }
             _ => {}
         }
 

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -88,10 +88,14 @@ fn predict_from_variant(
             let accession = v.accession.to_string();
             let cds_pos = extract_cds_position(&v.loc_edit);
 
+            // Span length derived from the position interval; required for
+            // accurate delins frameshift classification (closes #394 item 1).
+            let span_len = span_len_from_cds_interval(&v.loc_edit.location);
+
             // Get the edit info
             let (edit_type, is_frameshift, ref_len, alt_len) =
                 if let Some(edit) = v.loc_edit.edit.inner() {
-                    analyze_na_edit(edit)
+                    analyze_na_edit(edit, span_len)
                 } else {
                     ("unknown", false, 0, 0)
                 };
@@ -122,7 +126,8 @@ fn predict_from_variant(
         }
         HgvsVariant::Genome(v) => {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (edit_type, _, _, _) = analyze_na_edit(edit);
+                let span_len = span_len_from_genome_interval(&v.loc_edit.location);
+                let (edit_type, _, _, _) = analyze_na_edit(edit, span_len);
                 let effect = predict_genomic_effect(edit_type);
                 (Some(effect), None, None)
             } else {
@@ -148,7 +153,8 @@ fn predict_from_variant(
         }
         HgvsVariant::Tx(v) => {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (edit_type, _, _, _) = analyze_na_edit(edit);
+                let span_len = span_len_from_tx_interval(&v.loc_edit.location);
+                let (edit_type, _, _, _) = analyze_na_edit(edit, span_len);
                 let effect = SequenceEffect {
                     so_term: "SO:0001619".to_string(),
                     name: "non_coding_transcript_variant".to_string(),
@@ -183,8 +189,24 @@ fn extract_cds_position(
     }
 }
 
-/// Analyze nucleic acid edit to determine type and properties
-fn analyze_na_edit(edit: &crate::hgvs::edit::NaEdit) -> (&'static str, bool, usize, usize) {
+/// Analyze nucleic acid edit to determine type and properties.
+///
+/// Returns `(edit_type, is_frameshift, ref_len, alt_len)`. The
+/// `span_len` parameter is the length of the position interval (`end -
+/// start + 1`) when computable from base coordinates; pass `None` when
+/// the interval has intronic offsets, decorated positions (pter/qter/
+/// cen), or unknown endpoints. Used by the `Delins` arm to derive
+/// `ref_len` and `is_frameshift = (alt_len - ref_len) % 3 != 0` per the
+/// HGVS frameshift spec (`recommendations/protein/frameshift.md`).
+///
+/// When `span_len` is `None` for a delins, `is_frameshift` is
+/// conservatively reported as `false` — better than the previous
+/// always-`true` default which over-predicted frameshift on every
+/// non-trivial delins.
+pub fn analyze_na_edit(
+    edit: &crate::hgvs::edit::NaEdit,
+    span_len: Option<usize>,
+) -> (&'static str, bool, usize, usize) {
     use crate::hgvs::edit::NaEdit;
 
     match edit {
@@ -214,9 +236,20 @@ fn analyze_na_edit(edit: &crate::hgvs::edit::NaEdit) -> (&'static str, bool, usi
             ("insertion", len % 3 != 0, 0, len)
         }
         NaEdit::Delins { sequence, .. } => {
+            // Closes #394 item 1. Previously hardcoded `is_frameshift =
+            // true` with "Can't determine ref length easily"; the
+            // information IS available via `span_len`. Conservative
+            // fallback (false) when the interval can't yield a span_len
+            // (intronic / decorated / unknown endpoints).
             let alt_len = sequence.to_string().len();
-            // Delins is frameshift if net change not divisible by 3
-            ("delins", true, 0, alt_len) // Can't determine ref length easily
+            let (ref_len, is_frameshift) = match span_len {
+                Some(rl) => {
+                    let net_delta = alt_len as isize - rl as isize;
+                    (rl, net_delta.rem_euclid(3) != 0)
+                }
+                None => (0, false),
+            };
+            ("delins", is_frameshift, ref_len, alt_len)
         }
         NaEdit::Duplication {
             sequence, length, ..
@@ -234,6 +267,87 @@ fn analyze_na_edit(edit: &crate::hgvs::edit::NaEdit) -> (&'static str, bool, usi
         NaEdit::Unknown { .. } => ("unknown", false, 0, 0),
         _ => ("other", false, 0, 0),
     }
+}
+
+/// Compute the position-interval span length for a c. (CDS) interval.
+///
+/// Returns `Some(end.base - start.base + 1)` only when both endpoints are
+/// present, integer-only (no offset), non-special (no pter/qter/cen),
+/// and on the same coordinate sub-axis (both 5'UTR, both CDS, or both
+/// 3'UTR — mixed `c.-N_M` style ranges have no well-defined integer
+/// span in tx-frame from the c. values alone).
+///
+/// Returns `None` for any case where the span can't be computed from
+/// base coordinates alone — the conservative-skip contract used by the
+/// effect classifier for delins frameshift inference.
+pub fn span_len_from_cds_interval(interval: &crate::hgvs::interval::CdsInterval) -> Option<usize> {
+    let start = interval.start.inner()?;
+    let end = interval.end.inner()?;
+    // Intronic-offset positions have no base-only span.
+    if start.offset.is_some() || end.offset.is_some() {
+        return None;
+    }
+    // Mixed axis sides (5'UTR ↔ CDS, CDS ↔ 3'UTR, etc.) — base values
+    // are in different numbering frames, so `end - start + 1` does not
+    // count tx-frame nucleotides.
+    if start.utr3 != end.utr3 {
+        return None;
+    }
+    // 5'UTR vs CDS distinction (signed base): same `utr3` flag but
+    // negative-vs-positive bases also cross the CDS-start boundary.
+    if (start.base < 0) != (end.base < 0) {
+        return None;
+    }
+    if end.base < start.base {
+        return None;
+    }
+    Some(((end.base - start.base) + 1) as usize)
+}
+
+/// Compute the position-interval span length for a g. (genome) interval.
+///
+/// Returns `Some(end.base - start.base + 1)` only when both endpoints are
+/// present, integer-only, and non-special. See
+/// [`span_len_from_cds_interval`] for the conservative-skip contract.
+pub fn span_len_from_genome_interval(
+    interval: &crate::hgvs::interval::GenomeInterval,
+) -> Option<usize> {
+    let start = interval.start.inner()?;
+    let end = interval.end.inner()?;
+    if start.offset.is_some() || end.offset.is_some() {
+        return None;
+    }
+    if start.is_special() || end.is_special() {
+        return None;
+    }
+    if end.base < start.base {
+        return None;
+    }
+    Some(((end.base - start.base) + 1) as usize)
+}
+
+/// Compute the position-interval span length for an n. (tx) interval.
+///
+/// Returns `Some(end.base - start.base + 1)` only when both endpoints are
+/// present, integer-only (no offset), and non-downstream (no `n.*N`).
+/// See [`span_len_from_cds_interval`] for the conservative-skip
+/// contract.
+pub fn span_len_from_tx_interval(interval: &crate::hgvs::interval::TxInterval) -> Option<usize> {
+    let start = interval.start.inner()?;
+    let end = interval.end.inner()?;
+    if start.offset.is_some() || end.offset.is_some() {
+        return None;
+    }
+    if start.downstream != end.downstream {
+        return None;
+    }
+    if (start.base < 0) != (end.base < 0) {
+        return None;
+    }
+    if end.base < start.base {
+        return None;
+    }
+    Some(((end.base - start.base) + 1) as usize)
 }
 
 /// Predict effect for CDS variant
@@ -573,7 +687,7 @@ mod tests {
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350C>T").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (edit_type, is_frameshift, _, _) = analyze_na_edit(edit);
+                let (edit_type, is_frameshift, _, _) = analyze_na_edit(edit, None);
                 assert_eq!(edit_type, "substitution");
                 assert!(!is_frameshift);
             }
@@ -585,7 +699,7 @@ mod tests {
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350del").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (edit_type, is_frameshift, _, _) = analyze_na_edit(edit);
+                let (edit_type, is_frameshift, _, _) = analyze_na_edit(edit, None);
                 assert_eq!(edit_type, "deletion");
                 assert!(is_frameshift); // Single base deletion causes frameshift
             }
@@ -597,7 +711,7 @@ mod tests {
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_352del").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let (edit_type, _is_frameshift, _, _) = analyze_na_edit(edit);
+                let (edit_type, _is_frameshift, _, _) = analyze_na_edit(edit, None);
                 assert_eq!(edit_type, "deletion");
                 // Note: For span deletions, we'd need to calculate the actual length
                 // This test shows the structure works

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -106,10 +106,26 @@ fn predict_from_variant(
             // Predict SO effect
             let effect = predict_cds_effect(edit_type, is_intronic, is_frameshift, &cds_pos);
 
-            // Try to get protein consequence if we have cdot data
+            // Try to get protein consequence if we have cdot data.
+            // Pass `is_frameshift` through from `analyze_na_edit` rather
+            // than letting `predict_protein_consequence` recompute it
+            // from `(alt_len - ref_len)`. The classifier is the
+            // authoritative source — it returns `false` for shapes
+            // where the net delta can't be determined (intronic /
+            // mixed-axis / non-literal insert with unknown length),
+            // and `ref_len`/`alt_len` are reported as `0` in those
+            // cases. A naive recompute here would mis-flag those as
+            // frameshift whenever `alt_len % 3 != 0` (e.g. an
+            // unknown-span delins with a single-nt literal insert).
             let protein_consequence = if !is_intronic && !cds_pos.utr3 && cds_pos.base > 0 {
                 predict_protein_consequence(
-                    state, &accession, &cds_pos, edit_type, ref_len, alt_len,
+                    state,
+                    &accession,
+                    &cds_pos,
+                    edit_type,
+                    is_frameshift,
+                    ref_len,
+                    alt_len,
                 )
             } else {
                 None
@@ -126,8 +142,11 @@ fn predict_from_variant(
         }
         HgvsVariant::Genome(v) => {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let span_len = span_len_from_genome_interval(&v.loc_edit.location);
-                let (edit_type, _, _, _) = analyze_na_edit(edit, span_len);
+                // span_len matters only when downstream consumers
+                // (protein-consequence / NMD) use the frameshift signal;
+                // the genome path keeps only `edit_type`, so passing
+                // `None` skips the unused interval-length computation.
+                let (edit_type, _, _, _) = analyze_na_edit(edit, None);
                 let effect = predict_genomic_effect(edit_type);
                 (Some(effect), None, None)
             } else {
@@ -153,8 +172,9 @@ fn predict_from_variant(
         }
         HgvsVariant::Tx(v) => {
             if let Some(edit) = v.loc_edit.edit.inner() {
-                let span_len = span_len_from_tx_interval(&v.loc_edit.location);
-                let (edit_type, _, _, _) = analyze_na_edit(edit, span_len);
+                // Same rationale as the Genome arm above — the Tx path
+                // keeps only `edit_type` for the effect description.
+                let (edit_type, _, _, _) = analyze_na_edit(edit, None);
                 let effect = SequenceEffect {
                     so_term: "SO:0001619".to_string(),
                     name: "non_coding_transcript_variant".to_string(),
@@ -232,22 +252,43 @@ pub fn analyze_na_edit(
             ("deletion", len % 3 != 0, len, 0)
         }
         NaEdit::Insertion { sequence } => {
-            let len = sequence.to_string().len();
-            ("insertion", len % 3 != 0, 0, len)
+            // `InsertedSequence::len()` is the spec-aligned primitive:
+            // `Some(n)` only when the inserted nt count is known
+            // (`Literal`, `Count`, `PositionRange`, `Repeat` with
+            // `Exact` count, ...). For non-literal shapes whose nt
+            // count is unknown (`Range`, `Reference`, `Named`,
+            // `Uncertain`, ...), it returns `None`. The previous
+            // `to_string().len()` was the *rendered notation* length,
+            // which is unrelated to nt count for those variants
+            // (e.g. `ins[NC_...]` rendered to ~25 chars). Conservative
+            // fallback `is_frameshift = false` when length is unknown.
+            match sequence.len() {
+                Some(len) => ("insertion", len % 3 != 0, 0, len),
+                None => ("insertion", false, 0, 0),
+            }
         }
         NaEdit::Delins { sequence, .. } => {
             // Closes #394 item 1. Previously hardcoded `is_frameshift =
             // true` with "Can't determine ref length easily"; the
-            // information IS available via `span_len`. Conservative
-            // fallback (false) when the interval can't yield a span_len
-            // (intronic / decorated / unknown endpoints).
-            let alt_len = sequence.to_string().len();
-            let (ref_len, is_frameshift) = match span_len {
-                Some(rl) => {
-                    let net_delta = alt_len as isize - rl as isize;
-                    (rl, net_delta.rem_euclid(3) != 0)
+            // information IS available via `span_len` (ref) and
+            // `InsertedSequence::len()` (alt). Conservative fallback
+            // (`is_frameshift = false`) when either ref_len or alt_len
+            // is unknown — better than the previous always-true default
+            // which over-predicted frameshift on every non-trivial
+            // delins, and better than the intermediate fix that used
+            // `to_string().len()` (rendered notation length, not nt
+            // count) for non-literal inserted sequences.
+            let alt_len_opt = sequence.len();
+            let (ref_len, alt_len, is_frameshift) = match (span_len, alt_len_opt) {
+                (Some(rl), Some(al)) => {
+                    let net_delta = al as isize - rl as isize;
+                    (rl, al, net_delta.rem_euclid(3) != 0)
                 }
-                None => (0, false),
+                // Either endpoint of the (ref, alt) net-delta is
+                // unknown — frameshift undecidable; conservative false.
+                (Some(rl), None) => (rl, 0, false),
+                (None, Some(al)) => (0, al, false),
+                (None, None) => (0, 0, false),
             };
             ("delins", is_frameshift, ref_len, alt_len)
         }
@@ -272,10 +313,15 @@ pub fn analyze_na_edit(
 /// Compute the position-interval span length for a c. (CDS) interval.
 ///
 /// Returns `Some(end.base - start.base + 1)` only when both endpoints are
-/// present, integer-only (no offset), non-special (no pter/qter/cen),
+/// present, integer-only (no offset), non-unknown (`c.?` placeholder),
 /// and on the same coordinate sub-axis (both 5'UTR, both CDS, or both
-/// 3'UTR — mixed `c.-N_M` style ranges have no well-defined integer
-/// span in tx-frame from the c. values alone).
+/// 3'UTR).
+///
+/// Mixed `c.-N_M` style ranges (5'UTR-to-CDS or CDS-to-3'UTR) have no
+/// well-defined integer span in tx-frame from the c. values alone
+/// because HGVS skips `c.0`: `c.-1_1` covers 2 bases, not the naive
+/// `1 - (-1) + 1 = 3`. The same-sign + same-utr3 guards collapse those
+/// shapes to `None` per the conservative-skip contract.
 ///
 /// Returns `None` for any case where the span can't be computed from
 /// base coordinates alone — the conservative-skip contract used by the
@@ -283,6 +329,13 @@ pub fn analyze_na_edit(
 pub fn span_len_from_cds_interval(interval: &crate::hgvs::interval::CdsInterval) -> Option<usize> {
     let start = interval.start.inner()?;
     let end = interval.end.inner()?;
+    // Unknown placeholder (`c.?`): `CdsPos::is_unknown()` keys off
+    // `CDS_BASE_UNKNOWN == 0 && !utr3`. The parser rejects `c.0` (#269)
+    // but programmatic construction can produce this shape, so guard
+    // explicitly to avoid emitting `Some(1)` for a placeholder.
+    if start.is_unknown() || end.is_unknown() {
+        return None;
+    }
     // Intronic-offset positions have no base-only span.
     if start.offset.is_some() || end.offset.is_some() {
         return None;
@@ -294,7 +347,8 @@ pub fn span_len_from_cds_interval(interval: &crate::hgvs::interval::CdsInterval)
         return None;
     }
     // 5'UTR vs CDS distinction (signed base): same `utr3` flag but
-    // negative-vs-positive bases also cross the CDS-start boundary.
+    // negative-vs-positive bases also cross the CDS-start boundary,
+    // and HGVS skips `c.0` (`c.-1_1` spans 2 bases, not 3).
     if (start.base < 0) != (end.base < 0) {
         return None;
     }
@@ -338,7 +392,18 @@ pub fn span_len_from_tx_interval(interval: &crate::hgvs::interval::TxInterval) -
     if start.offset.is_some() || end.offset.is_some() {
         return None;
     }
-    if start.downstream != end.downstream {
+    // Per the helper's contract, any downstream (`n.*N`) endpoint is a
+    // conservative skip — both pure-downstream spans (`n.*5_*10`) and
+    // mixed downstream/non-downstream spans cross axes that the
+    // `end.base - start.base + 1` arithmetic does not count correctly.
+    if start.downstream || end.downstream {
+        return None;
+    }
+    // The parser rejects `n.0` (`src/hgvs/parser/position.rs:268-275`)
+    // but programmatic construction can produce that shape; guard
+    // explicitly for symmetry with `span_len_from_cds_interval`'s
+    // `is_unknown()` guard.
+    if start.base == 0 || end.base == 0 {
         return None;
     }
     if (start.base < 0) != (end.base < 0) {
@@ -529,14 +594,22 @@ fn predict_genomic_effect(edit_type: &str) -> SequenceEffect {
     }
 }
 
-/// Predict protein consequence using transcript data
+/// Predict protein consequence using transcript data.
+///
+/// `is_frameshift` must be the value returned by [`analyze_na_edit`] —
+/// the classifier already accounts for unknown ref/alt lengths and
+/// reports `false` for those cases. Recomputing from `alt_len - ref_len`
+/// here would silently overturn that decision whenever
+/// `alt_len.rem_euclid(3) != 0` (e.g. unknown-span delins where
+/// `ref_len = 0` is a placeholder, not a true zero-length ref).
 fn predict_protein_consequence(
     state: &AppState,
     accession: &str,
     cds_pos: &CdsPos,
     edit_type: &str,
+    is_frameshift: bool,
     ref_len: usize,
-    alt_len: usize,
+    _alt_len: usize,
 ) -> Option<ProteinConsequence> {
     // Need cdot data for protein prediction
     let cdot = state.cdot.as_ref()?;
@@ -554,9 +627,13 @@ fn predict_protein_consequence(
     // Calculate codon phase (position within codon: 0, 1, or 2)
     let codon_phase = ((cds_pos.base - 1) % 3) as u8;
 
-    // Determine if frameshift
-    let net_change = alt_len as i64 - ref_len as i64;
-    let is_frameshift = net_change % 3 != 0 && edit_type != "substitution";
+    // `is_frameshift` is authoritative from the classifier; the
+    // `edit_type != "substitution"` guard is belt-and-braces (the
+    // classifier already returns `false` for the substitution arms).
+    // `_alt_len` is unused for the frameshift decision after this fix
+    // — the classifier handles unknown-length insert shapes correctly;
+    // kept in the signature for symmetry with `ref_len`.
+    let is_frameshift = is_frameshift && edit_type != "substitution";
 
     // Get protein accession - prefer transcript's protein field if available
     let prot_acc = cdot_tx

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -997,9 +997,16 @@ where
             deleted,
             deleted_length: _,
         } => {
+            // Closes #394 item 3. Non-literal delins inserted sequences
+            // (Reference / PositionRange / Empty) are a shape SPDI
+            // cannot encode, not a missing-reference problem. Matches
+            // the sibling arms for Repeat / Inversion / Conversion which
+            // already use `UnsupportedEditType` for the same category.
             let ins_str = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
-                ConversionError::MissingReferenceData {
-                    description: "delins inserted sequence is not a literal sequence".to_string(),
+                ConversionError::UnsupportedEditType {
+                    description: "delins inserted sequence is not a literal sequence; \
+                         range / cross-reference / empty inserts cannot be encoded as SPDI"
+                        .to_string(),
                 }
             })?;
             let del_str = match deleted {

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -998,14 +998,15 @@ where
             deleted_length: _,
         } => {
             // Closes #394 item 3. Non-literal delins inserted sequences
-            // (Reference / PositionRange / Empty) are a shape SPDI
-            // cannot encode, not a missing-reference problem. Matches
-            // the sibling arms for Repeat / Inversion / Conversion which
-            // already use `UnsupportedEditType` for the same category.
+            // (any `InsertedSequence` variant other than `Literal`) are
+            // a shape SPDI cannot encode, not a missing-reference
+            // problem. Matches the sibling arms for Repeat / Inversion /
+            // Conversion which already use `UnsupportedEditType` for the
+            // same category.
             let ins_str = inserted_sequence_to_string(ins_seq).ok_or_else(|| {
                 ConversionError::UnsupportedEditType {
                     description: "delins inserted sequence is not a literal sequence; \
-                         range / cross-reference / empty inserts cannot be encoded as SPDI"
+                                  non-literal inserts cannot be encoded as SPDI"
                         .to_string(),
                 }
             })?;

--- a/tests/issue_394_delins_frameshift_classifier.rs
+++ b/tests/issue_394_delins_frameshift_classifier.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "web-service")]
 //! Issue #394 item 1 — effect classifier classifies delins frameshift
 //! correctly.
 //!
@@ -25,8 +26,10 @@
 //! exercise it directly without invoking the async `predict_effect`
 //! HTTP handler.
 
+use ferro_hgvs::hgvs::edit::{InsertedSequence, NaEdit};
 use ferro_hgvs::service::handlers::effect::{
     analyze_na_edit, span_len_from_cds_interval, span_len_from_genome_interval,
+    span_len_from_tx_interval,
 };
 use ferro_hgvs::{parse_hgvs, HgvsVariant};
 
@@ -124,5 +127,331 @@ fn delins_single_position_alt1_is_substitution_shape_but_classifier_says_delins(
     assert!(
         !is_fs,
         "1->1 delins is in-frame regardless of canonical form"
+    );
+}
+
+// --- UTR-only and Tx-axis coverage (review fixes) --------------------------
+
+#[test]
+fn delins_5utr_only_in_frame_minus3_to_minus1() {
+    // `c.-3_-1delinsAAAAAA`: ref_len = 3 (5'UTR positions -3, -2, -1
+    // contiguous), alt_len = 6 → net_delta = +3 → in-frame. Pins the
+    // 5'UTR-only branch of `span_len_from_cds_interval` (both negative
+    // bases, same utr3=false).
+    let v = parse_hgvs("NM_000001.1:c.-3_-1delinsAAAAAA").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let span = span_len_from_cds_interval(&cv.loc_edit.location).expect("5'UTR span computable");
+    assert_eq!(
+        span, 3,
+        "5'UTR span_len = end - start + 1 = -1 - -3 + 1 = 3"
+    );
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, ref_len, _) = analyze_na_edit(edit, Some(span));
+    assert_eq!(ref_len, 3);
+    assert!(!is_fs, "5'UTR 3->6 delins (+3) is in-frame");
+}
+
+#[test]
+fn delins_3utr_only_frameshift_star1_star2_to_1() {
+    // `c.*1_*2delinsA`: ref_len = 2 (3'UTR positions *1, *2), alt_len = 1
+    // → net_delta = -1 → frameshift. Pins the 3'UTR-only branch
+    // (both utr3=true).
+    let v = parse_hgvs("NM_000001.1:c.*1_*2delinsA").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let span = span_len_from_cds_interval(&cv.loc_edit.location).expect("3'UTR span computable");
+    assert_eq!(span, 2, "3'UTR span_len = end - start + 1 = 2 - 1 + 1 = 2");
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, ref_len, _) = analyze_na_edit(edit, Some(span));
+    assert_eq!(ref_len, 2);
+    assert!(is_fs, "3'UTR 2->1 delins (-1) is a frameshift");
+}
+
+#[test]
+fn delins_mixed_5utr_to_cds_returns_none_span() {
+    // `c.-1_1delinsAAA`: 5'UTR-to-CDS straddle. HGVS skips `c.0`, so
+    // the tx-frame span is 2 — but the helper cannot derive that from
+    // the c.-1 vs c.1 sign asymmetry alone. Conservative-skip per
+    // documented contract; pin to `None`.
+    let v = parse_hgvs("NM_000001.1:c.-1_1delinsAAA").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let span = span_len_from_cds_interval(&cv.loc_edit.location);
+    assert!(
+        span.is_none(),
+        "mixed 5'UTR-to-CDS span_len must be None (HGVS skips c.0)",
+    );
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, span);
+    assert!(
+        !is_fs,
+        "mixed-axis delins with unknown span_len must conservatively report \
+         is_frameshift = false",
+    );
+}
+
+#[test]
+fn delins_tx_axis_in_frame_10_to_12() {
+    // `n.10_12delinsAAA`: ref_len = 3, alt_len = 3 → in-frame. Pins
+    // `span_len_from_tx_interval`'s happy-path branch which had no
+    // direct test coverage in the initial commit (called out as a
+    // MAJOR coverage gap in review).
+    let v = parse_hgvs("NR_000001.1:n.10_12delinsAAA").unwrap();
+    let HgvsVariant::Tx(tv) = v else {
+        panic!("expected Tx")
+    };
+    let span = span_len_from_tx_interval(&tv.loc_edit.location).expect("tx span computable");
+    assert_eq!(span, 3);
+    let edit = tv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert!(!is_fs, "n. 3->3 delins is in-frame");
+}
+
+#[test]
+fn delins_tx_axis_frameshift_10_to_12_alt5() {
+    // `n.10_12delinsAAAAA`: ref_len = 3, alt_len = 5 → net_delta = +2
+    // → frameshift on the n. axis. The frameshift concept is a
+    // CDS-only spec construct, but the classifier's `is_frameshift`
+    // signal still flips here because the math is shared.
+    let v = parse_hgvs("NR_000001.1:n.10_12delinsAAAAA").unwrap();
+    let HgvsVariant::Tx(tv) = v else {
+        panic!("expected Tx")
+    };
+    let span = span_len_from_tx_interval(&tv.loc_edit.location).expect("tx span computable");
+    let edit = tv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert!(is_fs, "n. 3->5 delins (+2) flips the frameshift signal");
+}
+
+#[test]
+fn span_len_from_tx_interval_rejects_pure_downstream() {
+    // The helper's contract states: "Returns `Some(...)` only when both
+    // endpoints are present, integer-only (no offset), and non-downstream
+    // (no `n.*N`)." Programmatic construction of a pure-downstream span
+    // such as `n.*5_*10` must return `None`, not a base-difference span
+    // (the `*` axis is a separate numbering frame from the n. body and
+    // `end.base - start.base + 1` is not a meaningful nt count).
+    //
+    // Pinned at the helper level because the parser does not currently
+    // construct `TxInterval` with both endpoints downstream from this
+    // path, but downstream callers (e.g. coordinate-system conversions)
+    // could.
+    use ferro_hgvs::hgvs::interval::TxInterval;
+    use ferro_hgvs::hgvs::location::TxPos;
+    let interval = TxInterval::new(TxPos::downstream(5), TxPos::downstream(10));
+    assert!(
+        span_len_from_tx_interval(&interval).is_none(),
+        "pure downstream `n.*5_*10` violates the non-downstream contract → None",
+    );
+}
+
+#[test]
+fn span_len_from_tx_interval_rejects_mixed_downstream() {
+    // Symmetric guard: one downstream endpoint and one body endpoint
+    // straddles the transcript-end boundary. `end.base - start.base + 1`
+    // would silently span across that boundary, which is meaningless.
+    use ferro_hgvs::hgvs::interval::TxInterval;
+    use ferro_hgvs::hgvs::location::TxPos;
+    let interval = TxInterval::new(TxPos::new(95), TxPos::downstream(5));
+    assert!(
+        span_len_from_tx_interval(&interval).is_none(),
+        "mixed body↔downstream `n.95_*5` straddles tx-end → None",
+    );
+}
+
+// --- Non-literal delins inserted sequences (CodeRabbit thread 1) ----------
+//
+// Previously the Delins arm used `sequence.to_string().len()` to derive
+// `alt_len`. For non-literal `InsertedSequence` variants
+// (`Reference("...")`, `PositionRange`, `Count`, `Repeat`, etc.), the
+// rendered notation length is NOT the nucleotide count. Counting it
+// silently lies to the frameshift classifier — e.g. `delins[NC_...:g.500_510]`
+// renders to ~25 chars, not 11 nt.
+//
+// Spec basis: `assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md`
+// allows `delinsN[12]`, `delins<cross_ref>`, and `delins<pos_range>`.
+// `InsertedSequence::len()` already encodes the spec-correct nt-count
+// semantics (Some(n) only when computable). Use it.
+
+#[test]
+fn delins_reference_insert_alt_len_unknown_falls_back_to_false() {
+    // `g.100_105delins[NC_000002.12:g.500_510]` — Reference cross-ref
+    // insert. `InsertedSequence::len()` returns None (requires lookup).
+    // Span_len is known (= 6), but alt_len is unknown → conservative
+    // `is_frameshift = false`. The previous `to_string().len()` would
+    // count ~25 characters and report `(25 - 6).rem_euclid(3) = 1 != 0`
+    // → frameshift, which is wrong.
+    let v = parse_hgvs("NC_000001.11:g.100_105delins[NC_000002.12:g.500_510]").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    assert_eq!(span, 6, "g.100_105 span_len = 6");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (kind, is_fs, ref_len, alt_len) = analyze_na_edit(edit, Some(span));
+    assert_eq!(kind, "delins");
+    assert_eq!(ref_len, 6, "ref_len comes from span_len");
+    assert_eq!(
+        alt_len, 0,
+        "non-literal alt must be reported as unknown (0), NOT counted from rendered notation",
+    );
+    assert!(
+        !is_fs,
+        "Reference-insert delins has unknown alt nt count → conservative is_frameshift = false",
+    );
+}
+
+#[test]
+fn delins_position_range_insert_alt_len_unknown_falls_back_to_false() {
+    // `g.100_105delins200_210` — the parser wraps a bare position
+    // range into `InsertedSequence::Complex(vec![PositionRange{...}])`
+    // (see `parse_inserted_sequence` in `src/hgvs/parser/edit.rs`).
+    // `InsertedSequence::len()` returns None for Complex (would need
+    // to sum parts), so alt_len is reported as unknown and
+    // `is_frameshift` falls back to false. The previous
+    // `to_string().len()` would count "200_210" = 7 characters
+    // (rendered notation length) — that math is wrong by construction
+    // for non-literal inserts, regardless of whether Complex could in
+    // principle yield a known length. Pin the conservative-skip
+    // contract.
+    let v = parse_hgvs("NC_000001.11:g.100_105delins200_210").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, ref_len, alt_len) = analyze_na_edit(edit, Some(span));
+    assert_eq!(ref_len, 6, "ref_len comes from span_len");
+    assert_eq!(
+        alt_len, 0,
+        "Complex/PositionRange alt is unknown length, NOT len(\"200_210\") = 7",
+    );
+    assert!(
+        !is_fs,
+        "PositionRange-insert delins has unknown alt nt count → conservative is_frameshift = false",
+    );
+}
+
+#[test]
+fn delins_count_insert_uses_count_value_not_digit_string_length() {
+    // `g.100_102delins12` — Count(12) insert. nt count = 12.
+    // `InsertedSequence::len()` returns Some(12). Net delta = +9 →
+    // in-frame. The previous `to_string().len()` would count "12" = 2
+    // characters → net delta = -1 → frameshift (wrong).
+    let v = parse_hgvs("NC_000001.11:g.100_102delins12").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, alt_len) = analyze_na_edit(edit, Some(span));
+    assert_eq!(
+        alt_len, 12,
+        "Count alt_len = count value, NOT the digit-string render length",
+    );
+    assert!(!is_fs, "3 -> 12 delins (+9) is in-frame");
+}
+
+#[test]
+fn delins_repeat_insert_uses_total_repeat_length() {
+    // `g.100_102delinsN[12]` — Repeat { count: Exact(12) } insert.
+    // nt count = 12. `InsertedSequence::len()` returns Some(12). Net
+    // delta = +9 → in-frame. The previous `to_string().len()` would
+    // count "N[12]" = 5 characters → net delta = +2 → frameshift
+    // (wrong).
+    let v = parse_hgvs("NC_000001.11:g.100_102delinsN[12]").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, alt_len) = analyze_na_edit(edit, Some(span));
+    assert_eq!(alt_len, 12, "Repeat alt_len uses count, not display chars");
+    assert!(!is_fs, "3 -> 12 delins (+9) is in-frame");
+}
+
+#[test]
+fn delins_uncertain_range_insert_alt_len_unknown_falls_back_to_false() {
+    // Direct struct construction: `Delins { sequence: Range(10, 20),
+    // ... }`. `InsertedSequence::len()` returns None for Range
+    // (unknown exact length). With span_len = Some(3), the result must
+    // still be `is_frameshift = false` — we can't compute net_delta
+    // without alt_len.
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Range(10, 20),
+        deleted: None,
+        deleted_length: None,
+    };
+    let (kind, is_fs, ref_len, alt_len) = analyze_na_edit(&edit, Some(3));
+    assert_eq!(kind, "delins");
+    assert_eq!(ref_len, 3, "ref_len comes from span_len");
+    assert_eq!(alt_len, 0, "Range alt nt count is unknown");
+    assert!(
+        !is_fs,
+        "Range-insert delins with span_len known but alt_len unknown → conservative false",
+    );
+}
+
+#[test]
+fn delins_empty_insert_with_known_span_is_pure_deletion() {
+    // `Delins { sequence: Empty, ... }` is shape-equivalent to a
+    // deletion. `InsertedSequence::len()` returns Some(0). With
+    // span_len = 3, net_delta = -3 → in-frame (deletion of full codon).
+    // Pins that `Empty` does flow into the frameshift math (alt_len = 0
+    // is *known*, not unknown).
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Empty,
+        deleted: None,
+        deleted_length: None,
+    };
+    let (_, is_fs, ref_len, alt_len) = analyze_na_edit(&edit, Some(3));
+    assert_eq!(ref_len, 3);
+    assert_eq!(alt_len, 0);
+    assert!(!is_fs, "3 -> 0 delins (-3) is in-frame");
+
+    // And span_len = 4 with Empty alt → net_delta = -4 → frameshift.
+    let (_, is_fs, _, _) = analyze_na_edit(&edit, Some(4));
+    assert!(is_fs, "4 -> 0 delins (-4) is a frameshift");
+}
+
+// --- Insertion arm sibling-audit: same to_string() bug shape ---------------
+//
+// `NaEdit::Insertion { sequence: InsertedSequence }` had the same
+// rendered-notation-length bug as Delins. Fix it the same way.
+
+#[test]
+fn insertion_count_uses_count_value_not_digit_string_length() {
+    // `g.100_101ins12` — Count(12) insert. The insertion arm's
+    // frameshift heuristic is `len % 3 != 0`. nt count = 12 → in-frame.
+    // The previous `to_string().len()` would count "12" = 2 characters
+    // → frameshift (wrong).
+    let v = parse_hgvs("NC_000001.11:g.100_101ins12").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (kind, is_fs, _, alt_len) = analyze_na_edit(edit, None);
+    assert_eq!(kind, "insertion");
+    assert_eq!(alt_len, 12, "Count alt_len = count value");
+    assert!(!is_fs, "ins of 12 nt is in-frame");
+}
+
+#[test]
+fn insertion_unknown_length_falls_back_to_false() {
+    // `Insertion { sequence: Range(10, 20) }` — length unknown.
+    // Conservative `is_frameshift = false`. The previous code would
+    // return `("?_?")".len() % 3 != 0` which is meaningless.
+    let edit = NaEdit::Insertion {
+        sequence: InsertedSequence::Range(10, 20),
+    };
+    let (_, is_fs, _, alt_len) = analyze_na_edit(&edit, None);
+    assert_eq!(alt_len, 0, "Range alt nt count is unknown");
+    assert!(
+        !is_fs,
+        "ins with unknown alt nt count → conservative is_frameshift = false",
     );
 }

--- a/tests/issue_394_delins_frameshift_classifier.rs
+++ b/tests/issue_394_delins_frameshift_classifier.rs
@@ -1,0 +1,128 @@
+//! Issue #394 item 1 — effect classifier classifies delins frameshift
+//! correctly.
+//!
+//! `src/service/handlers/effect.rs:216-219` previously hardcoded
+//! `is_frameshift = true` for every `NaEdit::Delins`, with the comment
+//! "Can't determine ref length easily". The information IS available
+//! via the position interval (`end - start + 1`). This file pins the
+//! spec-correct behavior.
+//!
+//! # Spec basis
+//!
+//! `assets/hgvs-nomenclature/docs/recommendations/protein/frameshift.md`:
+//! frameshift is a CDS-level concept tied to `net_delta % 3 != 0`,
+//! where `net_delta = alt_len - ref_len`.
+//!
+//! # Span-length computability
+//!
+//! The new `span_len_from_*_interval` helpers compute span length only
+//! when both endpoints are integer-only (no offset / no special marker
+//! / non-mixed axis sides). Anything else returns `None` and the
+//! delins frameshift signal falls back to `false` — conservative, safer
+//! than the previous always-true default.
+//!
+//! The `analyze_na_edit` helper is `pub` so this integration test can
+//! exercise it directly without invoking the async `predict_effect`
+//! HTTP handler.
+
+use ferro_hgvs::service::handlers::effect::{
+    analyze_na_edit, span_len_from_cds_interval, span_len_from_genome_interval,
+};
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn delins_in_frame_genomic_same_length() {
+    // g.10_12delinsATG: ref_len = 3, alt_len = 3 → in-frame.
+    let v = parse_hgvs("NC_000001.11:g.10_12delinsATG").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (kind, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert_eq!(kind, "delins");
+    assert!(!is_fs, "3->3 delins is in-frame");
+}
+
+#[test]
+fn delins_frameshift_genomic_3_to_1() {
+    // g.10_12delinsA: ref_len = 3, alt_len = 1 → net_delta = -2 → frameshift.
+    let v = parse_hgvs("NC_000001.11:g.10_12delinsA").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (kind, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert_eq!(kind, "delins");
+    assert!(is_fs, "3->1 delins (-2) is a frameshift");
+}
+
+#[test]
+fn delins_in_frame_genomic_3_to_6() {
+    // g.10_12delinsATGCAT: ref_len = 3, alt_len = 6 → net_delta = +3 → in-frame.
+    let v = parse_hgvs("NC_000001.11:g.10_12delinsATGCAT").unwrap();
+    let HgvsVariant::Genome(gv) = v else {
+        panic!("expected Genome")
+    };
+    let span = span_len_from_genome_interval(&gv.loc_edit.location).expect("span computable");
+    let edit = gv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert!(!is_fs, "3->6 delins (+3) is in-frame");
+}
+
+#[test]
+fn delins_frameshift_cds_2_to_3() {
+    // c.10_11delinsATG: ref_len = 2, alt_len = 3 → net_delta = +1 → frameshift.
+    let v = parse_hgvs("NM_000001.1:c.10_11delinsATG").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let span = span_len_from_cds_interval(&cv.loc_edit.location).expect("span computable");
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, Some(span));
+    assert!(is_fs, "2->3 delins (+1) is a frameshift");
+}
+
+#[test]
+fn delins_intronic_span_unknown_frameshift_false() {
+    // c.10+5_10+7delinsA: both endpoints intronic. Span can't be
+    // computed from base alone (needs intron length); span_len = None →
+    // conservative `is_frameshift = false`. Pins the new behavior
+    // against the prior always-true default.
+    let v = parse_hgvs("NM_000001.1:c.10+5_10+7delinsA").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let span = span_len_from_cds_interval(&cv.loc_edit.location);
+    assert!(
+        span.is_none(),
+        "intronic-endpoint interval must produce None span_len",
+    );
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let (_, is_fs, _, _) = analyze_na_edit(edit, span);
+    assert!(
+        !is_fs,
+        "intronic delins with unknown span_len must conservatively report \
+         is_frameshift = false (NOT the prior hardcoded true)",
+    );
+}
+
+#[test]
+fn delins_single_position_alt1_is_substitution_shape_but_classifier_says_delins() {
+    // c.10delinsA: ref_len = 1, alt_len = 1. This is the substitution
+    // canonical form per spec, but the parser may preserve it as
+    // delins. Whichever form survives, the frameshift signal must be
+    // `false`.
+    let v = parse_hgvs("NM_000001.1:c.10delinsA").unwrap();
+    let HgvsVariant::Cds(cv) = v else {
+        panic!("expected Cds")
+    };
+    let edit = cv.loc_edit.edit.inner().unwrap();
+    let span = span_len_from_cds_interval(&cv.loc_edit.location);
+    let (_, is_fs, _, _) = analyze_na_edit(edit, span);
+    assert!(
+        !is_fs,
+        "1->1 delins is in-frame regardless of canonical form"
+    );
+}

--- a/tests/issue_394_delins_mutex_validation.rs
+++ b/tests/issue_394_delins_mutex_validation.rs
@@ -1,0 +1,88 @@
+//! Issue #394 item 2 — validation rejects `Delins { deleted: Some(_),
+//! deleted_length: Some(_) }`.
+//!
+//! `src/hgvs/edit.rs:472-474` docstring states: "At most one of
+//! `deleted` / `deleted_length` is `Some`". Previously this was a
+//! documentation-only invariant; the parser doesn't emit the
+//! dual-Some shape, but direct struct construction could. The
+//! `Display` impl silently prefers `deleted` and drops
+//! `deleted_length`, masking the inconsistency.
+//!
+//! This file promotes the invariant to runtime validation via a new
+//! `E004` error in `validate_na_edit`.
+
+use std::str::FromStr;
+
+use ferro_hgvs::hgvs::edit::{InsertedSequence, NaEdit, Sequence};
+use ferro_hgvs::hgvs::validation::rules::validate_na_edit;
+
+#[test]
+fn validation_rejects_delins_with_both_deleted_and_deleted_length() {
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
+        deleted: Some(Sequence::from_str("ATGC").unwrap()),
+        deleted_length: Some(4),
+    };
+    let result = validate_na_edit(&edit);
+    assert!(
+        !result.valid,
+        "validation must reject Delins with both `deleted` and `deleted_length` set; \
+         got valid result: {:?}",
+        result,
+    );
+    let has_mutex_error = result
+        .errors
+        .iter()
+        .any(|e| e.message.to_lowercase().contains("deleted"));
+    assert!(
+        has_mutex_error,
+        "validation error must mention `deleted` / `deleted_length` mutual exclusion; \
+         got errors: {:?}",
+        result.errors,
+    );
+}
+
+#[test]
+fn validation_accepts_delins_with_deleted_only() {
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
+        deleted: Some(Sequence::from_str("ATGC").unwrap()),
+        deleted_length: None,
+    };
+    let result = validate_na_edit(&edit);
+    assert!(
+        result.valid,
+        "validation must accept Delins with only `deleted` set; got errors: {:?}",
+        result.errors,
+    );
+}
+
+#[test]
+fn validation_accepts_delins_with_deleted_length_only() {
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
+        deleted: None,
+        deleted_length: Some(4),
+    };
+    let result = validate_na_edit(&edit);
+    assert!(
+        result.valid,
+        "validation must accept Delins with only `deleted_length` set; got errors: {:?}",
+        result.errors,
+    );
+}
+
+#[test]
+fn validation_accepts_canonical_short_form_delins() {
+    let edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
+        deleted: None,
+        deleted_length: None,
+    };
+    let result = validate_na_edit(&edit);
+    assert!(
+        result.valid,
+        "validation must accept canonical short-form Delins; got errors: {:?}",
+        result.errors,
+    );
+}

--- a/tests/issue_394_delins_protein_consequence_passthrough.rs
+++ b/tests/issue_394_delins_protein_consequence_passthrough.rs
@@ -1,0 +1,154 @@
+#![cfg(feature = "dev")]
+//! Issue #394 follow-up — `predict_protein_consequence` must honor the
+//! `is_frameshift` decision from `analyze_na_edit`, NOT recompute it
+//! from `(alt_len - ref_len)`.
+//!
+//! Bug (CodeRabbit, post-merge follow-up review of #419): the previous
+//! body of `predict_protein_consequence` overwrote the classifier's
+//! decision with `(alt_len as i64 - ref_len as i64).rem_euclid(3) != 0`.
+//! That undoes the conservative fallback for shapes where the
+//! classifier returned `(_, false, 0, alt_len)` because span_len was
+//! unknown. Concretely: an intronic-endpoint or unknown-span delins
+//! with a single-nt literal insert (alt_len = 1, ref_len = 0
+//! placeholder) used to be re-flagged as a frameshift at the protein
+//! consequence step.
+//!
+//! This file pins the through-pass via a CDS variant that exercises
+//! the classifier's `None`-span branch and asserts the resulting
+//! `protein_consequence.is_frameshift` is `false`.
+
+use axum::{extract::State, response::Json};
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::service::config::ServiceConfig;
+use ferro_hgvs::service::handlers::effect::predict_effect;
+use ferro_hgvs::service::server::{AppState, HealthCache};
+use ferro_hgvs::service::tools::ToolManager;
+use ferro_hgvs::service::types::EffectRequest;
+use std::sync::Arc;
+
+/// Build a minimal `AppState` with a cdot mapper containing `NM_999999.1`
+/// so `predict_protein_consequence` does not short-circuit on
+/// `state.cdot.as_ref()?`.
+fn state_with_test_transcript() -> AppState {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_999999.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+
+    AppState {
+        tool_manager: Arc::new(ToolManager::empty()),
+        config: Arc::new(ServiceConfig::default()),
+        cdot: Some(Arc::new(cdot)),
+        liftover: None,
+        health_cache: HealthCache::default(),
+    }
+}
+
+#[tokio::test]
+async fn predict_effect_honors_classifier_is_frameshift_for_unknown_span_delins() {
+    // `c.4_5+2delinsT` — endpoint `c.5+2` is intronic, so the cds
+    // interval helper returns `None` for span_len. `analyze_na_edit`
+    // therefore reports `(is_frameshift = false, ref_len = 0,
+    // alt_len = 1)`. The previous body of `predict_protein_consequence`
+    // would recompute `(1 - 0).rem_euclid(3) != 0` → `true` and emit a
+    // `p.(?2fs)` despite the classifier's "unknown, report false"
+    // decision. After the fix the protein consequence must NOT be a
+    // frameshift.
+    let state = state_with_test_transcript();
+    let request = EffectRequest {
+        hgvs: "NM_999999.1:c.4_5+2delinsT".to_string(),
+        include_nmd: false,
+    };
+
+    let response = predict_effect(State(state), Json(request))
+        .await
+        .expect("predict_effect must succeed for valid input")
+        .0;
+
+    assert!(
+        response.error.is_none(),
+        "predict_effect must parse cleanly; got error: {:?}",
+        response.error,
+    );
+    let protein = response
+        .protein_consequence
+        .expect("CDS delins must produce a protein_consequence");
+    assert!(
+        !protein.is_frameshift,
+        "protein_consequence.is_frameshift must mirror the classifier's `false` decision \
+         when span_len is None; was {:?}, hgvs_p = {}",
+        protein.is_frameshift, protein.hgvs_p,
+    );
+    assert!(
+        !protein.hgvs_p.contains("fs"),
+        "hgvs_p must not render the frameshift suffix when classifier said false; got {}",
+        protein.hgvs_p,
+    );
+}
+
+#[tokio::test]
+async fn predict_effect_in_frame_delins_with_known_span_remains_in_frame() {
+    // Sanity baseline: `c.4_6delinsAAA` — same length on both sides
+    // (ref_len = 3, alt_len = 3), classifier reports
+    // `is_frameshift = false`. The previous (broken) recompute would
+    // also have arrived at `false` here, so this test pins the
+    // post-fix behavior on a known-good shape so the passthrough
+    // doesn't silently regress on it.
+    let state = state_with_test_transcript();
+    let request = EffectRequest {
+        hgvs: "NM_999999.1:c.4_6delinsAAA".to_string(),
+        include_nmd: false,
+    };
+
+    let response = predict_effect(State(state), Json(request))
+        .await
+        .expect("predict_effect must succeed")
+        .0;
+
+    let protein = response
+        .protein_consequence
+        .expect("CDS delins must produce a protein_consequence");
+    assert!(
+        !protein.is_frameshift,
+        "3->3 delins is in-frame; got is_frameshift = {}",
+        protein.is_frameshift,
+    );
+}
+
+#[tokio::test]
+async fn predict_effect_frameshift_delins_with_known_span_is_frameshift() {
+    // Sanity baseline: `c.4_6delinsAAAA` — ref_len = 3, alt_len = 4,
+    // net_delta = +1, classifier reports `is_frameshift = true`. The
+    // passthrough must surface that to the protein consequence layer.
+    let state = state_with_test_transcript();
+    let request = EffectRequest {
+        hgvs: "NM_999999.1:c.4_6delinsAAAA".to_string(),
+        include_nmd: false,
+    };
+
+    let response = predict_effect(State(state), Json(request))
+        .await
+        .expect("predict_effect must succeed")
+        .0;
+
+    let protein = response
+        .protein_consequence
+        .expect("CDS delins must produce a protein_consequence");
+    assert!(
+        protein.is_frameshift,
+        "3->4 delins (+1) is a frameshift; got is_frameshift = {}, hgvs_p = {}",
+        protein.is_frameshift, protein.hgvs_p,
+    );
+}

--- a/tests/issue_394_spdi_delins_unsupported.rs
+++ b/tests/issue_394_spdi_delins_unsupported.rs
@@ -1,0 +1,44 @@
+//! Issue #394 item 3 — SPDI returns `UnsupportedEditType` (not
+//! `MissingReferenceData`) for non-literal delins inserted sequences.
+//!
+//! `src/spdi/convert.rs:1000-1004` previously returned
+//! `ConversionError::MissingReferenceData` for non-literal delins
+//! inserted sequences (`InsertedSequence::Reference`,
+//! `PositionRange`, `Empty`). Semantically that's "reference data
+//! missing"; the actual category is "this edit shape cannot be encoded
+//! as a single SPDI variant". Sibling arms for `Repeat` /
+//! `Inversion` / `Conversion` already use `UnsupportedEditType` for
+//! the same shape-not-encodable category — this file pins the
+//! consistency.
+
+use ferro_hgvs::spdi::{hgvs_to_spdi, ConversionError};
+use ferro_hgvs::{parse_hgvs, MockProvider};
+
+#[test]
+fn spdi_non_literal_delins_inserted_sequence_returns_unsupported_edit_type() {
+    // `g.100_105delins[NC_000002.12:g.500_510]` — a delins whose
+    // inserted sequence is a cross-reference range. SPDI carries no
+    // multi-reference encoding; the conversion must fail with
+    // `UnsupportedEditType`, NOT `MissingReferenceData`.
+    let v = parse_hgvs("NC_000001.11:g.100_105delins[NC_000002.12:g.500_510]").unwrap();
+    let provider = MockProvider::new();
+    let result = hgvs_to_spdi(&v, &provider);
+    let err = result.expect_err("non-literal delins must error");
+    match err {
+        ConversionError::UnsupportedEditType { description } => {
+            assert!(
+                description.to_lowercase().contains("delins")
+                    || description.to_lowercase().contains("literal"),
+                "error description must reference delins or literal sequence; got: {description}",
+            );
+        }
+        ConversionError::MissingReferenceData { description } => {
+            panic!(
+                "regressed: non-literal delins must surface UnsupportedEditType, not \
+                 MissingReferenceData (which means 'reference fetch failed'). \
+                 Description: {description}",
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Closes #394. Three latent delins-consistency bugs across the service tier and SPDI conversion, surfaced by CodeRabbit on PR #154 but never folded into a fix. Each lands as a single commit.

- **`fix(service): derive delins ref_len from interval for frameshift classifier` (#394 item 1)** — `src/service/handlers/effect.rs:216-219` previously hardcoded `is_frameshift = true` for every `NaEdit::Delins` with the comment "Can't determine ref length easily". The information IS available via the position interval. Extends `analyze_na_edit` to take an `Option<usize>` span_len; adds three new `pub` helpers `span_len_from_{cds,genome,tx}_interval` that compute span only when both endpoints are integer-only, non-special, non-unknown, and on the same coordinate sub-axis (returns `None` for intronic / decorated / mixed-axis / unknown shapes per the conservative-skip contract). The `Delins` arm now derives `ref_len = span_len.unwrap_or(0)` and computes `is_frameshift = (alt_len - ref_len).rem_euclid(3) != 0`. When span_len is `None`, reports `is_frameshift = false` (safer than the prior always-true default which over-predicted frameshift on every delins). Same spec citation as the protein-consequence path: `assets/hgvs-nomenclature/docs/recommendations/protein/frameshift.md`.

- **`fix(validation): reject delins with both deleted and deleted_length` (#394 item 2)** — `src/hgvs/edit.rs:472-474` docstring states "At most one of `deleted` / `deleted_length` is `Some`"; previously documentation-only. The parser doesn't emit the dual-Some shape (the notations `del<SEQ>` and `del<N>` are mutually exclusive at the grammar level) but direct struct construction could violate the invariant, and the `Display` impl silently prefers `deleted` and drops `deleted_length`. Adds a new `E004` validation error rejecting the dual-Some shape with a message naming both fields and the invariant location.

- **`fix(spdi): return UnsupportedEditType for non-literal delins inserted sequence` (#394 item 3)** — `src/spdi/convert.rs:1000-1004` previously returned `ConversionError::MissingReferenceData` for non-literal delins inserted sequences (`Reference`, `PositionRange`, `Empty`, etc.). Semantic category is "shape not encodable in SPDI", not "reference data missing". Sibling arms (Repeat at 1075, Inversion at 1099, Conversion at 1120) already use `UnsupportedEditType` for the same category. Aligns the delins arm with that convention. Single regression test pins a cross-reference delins `g.100_105delins[NC_000002.12:g.500_510]` returning `UnsupportedEditType`, not `MissingReferenceData`.

- **`fix(review): apply end-of-issue review findings` (#394)** — Consolidated review-fix commit. BLOCKING: added `#![cfg(feature = "web-service")]` to the service-dependent integration test (without it, `cargo test` with no features would fail to compile). MAJOR: added `is_unknown()` / `base == 0` guards in the span_len helpers to defend against programmatic placeholder construction; dropped dead span_len computation at the Genome/Tx callsites that only consume `edit_type`; added 5 coverage tests for previously-untested 5'UTR-only, 3'UTR-only, mixed-axis, and Tx-axis branches. MINOR: standardized `rem_euclid` in `predict_protein_consequence`; broadened SPDI error message to "non-literal inserts" (the function returns `None` for ~10 variants, not just three).

## Test counts

| File | Tests | Coverage |
|---|---|---|
| `tests/issue_394_delins_frameshift_classifier.rs` | 11 | CDS in-frame/frameshift, genome in-frame/frameshift/expansion, intronic conservative-skip, 5'UTR-only, 3'UTR-only, mixed 5'UTR-CDS conservative-skip, Tx-axis in-frame/frameshift |
| `tests/issue_394_delins_mutex_validation.rs` | 4 | dual-Some rejection, deleted-only accept, deleted_length-only accept, canonical short-form accept |
| `tests/issue_394_spdi_delins_unsupported.rs` | 1 | cross-reference delins returns UnsupportedEditType, not MissingReferenceData |

16 new tests total; all pass.

## Follow-up

End-of-issue review confirmed the same `unwrap_or(1)` latent bug exists in the `Deletion` (line 230) and `Duplication` (line 261) arms of `analyze_na_edit` — canonical `c.100_102del` (parser sets `sequence: None, length: None`) reports `is_frameshift = true` because `1 % 3 != 0`. Out of scope for #394 (issue only flagged delins), but the `span_len_from_*_interval` helpers introduced here are the right primitive for that fix. Will file a follow-up issue.

## Test plan

- [ ] `cargo nextest run --features dev` — 5814 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences pre-existing on `origin/main`); no new failures.
- [ ] `cargo clippy --features dev -- -D warnings` clean.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo run --features dev --example generate_spec_fixture -- --check` clean.
- [ ] `cargo build --tests` (no features) clean — confirms the test file's feature gate works.
- [ ] All 16 new tests across the 3 new test files PASS.