### PR TITLE
fix(normalize): close untracked biocommons-burndown divergences (closes #418)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4345,11 +4345,60 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         // Position: for c.X_(X+1)ins that duplicates preceding sequence,
                         // the result is c.(X-len+1)_Xdup
                         let dup_len = rotated_seq.len() as u64;
+                        // `insertion_is_duplication` returns true if EITHER the
+                        // preceding ref tract (BEFORE: `ref[pos-L..pos]`) OR the
+                        // following one (AFTER: `ref[pos..pos+L]`) equals the
+                        // (possibly rotated) alt. Which side matched determines
+                        // where the duplicated region sits in HGVS coordinates:
+                        //
+                        //   BEFORE-match (`ref[pos-L..pos] == alt`): the alt
+                        //   duplicates the immediately-preceding tract, so the
+                        //   dup region is `c.{new_start-L+1}..c.{new_start}`. This
+                        //   is the natural 3'-shuffle stopping shape — at the
+                        //   3'-most equivalent position, the alt phase aligns
+                        //   with the tract just behind the insertion.
+                        //
+                        //   AFTER-match (`ref[pos..pos+L] == alt`): the alt
+                        //   duplicates the immediately-following tract, so the
+                        //   dup region is `c.{new_start+1}..c.{new_start+L}`.
+                        //   This is the natural 5'-shuffle stopping shape — at
+                        //   the 5'-most equivalent position the alt aligns with
+                        //   the tract just AHEAD of the insertion (the one the
+                        //   shuffle walked through). Issue #418 (b): without
+                        //   this branch, ferro emitted `c.{X-L+1}_{X}dup` —
+                        //   bases preceding the 5'-shuffled stopping point —
+                        //   which is a *different haplotype* (since the
+                        //   preceding bases don't equal the alt). The
+                        //   off-by-(2 in NM_001166478.1:c.36_37insTC) error
+                        //   comes from emitting a dup of the WRONG tract.
+                        let pos = result.start as usize;
+                        let rseq = rotated_seq.as_slice();
+                        let before_matches =
+                            pos >= rseq.len() && &ref_seq[pos - rseq.len()..pos] == rseq;
                         let (dup_start, dup_end) = if dup_len == 1 {
-                            (new_start, new_start) // Single position for single-base dup
-                        } else {
-                            // Multi-base dup: the duplicated region is BEFORE the insertion point
+                            // Single-base dup still has to choose which
+                            // flanking position the alt actually
+                            // duplicates: BEFORE → `new_start`, AFTER →
+                            // `new_start + 1`. The original "single
+                            // position for single-base dup" shortcut
+                            // ignored `before_matches` and always
+                            // anchored at `new_start`, emitting the
+                            // wrong haplotype on AFTER-only single-copy
+                            // matches (e.g. `...CT[insT]` adjacent to
+                            // an isolated `T` — buggy `c.40dup` (= C)
+                            // vs correct `c.41dup` (= T)).
+                            if before_matches {
+                                (new_start, new_start)
+                            } else {
+                                (new_start + 1, new_start + 1)
+                            }
+                        } else if before_matches {
                             (new_start - dup_len + 1, new_start)
+                        } else {
+                            // AFTER-branch must match (since
+                            // `insertion_is_duplication` returned true and
+                            // BEFORE doesn't).
+                            (new_start + 1, new_start + dup_len)
                         };
                         (
                             dup_start,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1584,8 +1584,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // unchanged.
         let spanning_dup_exception =
             matches!(new_edit, NaEdit::Duplication { .. }) && new_tx_end >= cds_start;
+        // Issue #418 extension: when `cds_start == 1` (transcript has no
+        // 5'UTR) the 5'-shuffle on an Insertion saturates at the
+        // transcript start (`new_start = new_end = cds_start`) instead
+        // of producing a true `new_tx_start < cds_start` signal. The
+        // coordinate conversion from a 0-based shuffle result of 0 back
+        // to 1-based HGVS clamps at 1, so the position-only gate
+        // misses the saturation case. Detect it by the degenerate
+        // (start == end) Insertion shape that only arises from
+        // left-saturation, and fire the clamp the same way the
+        // non-degenerate case does.
+        let cds_start_left_saturated = matches!(edit, NaEdit::Insertion { .. })
+            && new_tx_start == cds_start
+            && new_tx_end == cds_start;
         if matches!(start_axis, boundary::AxisRegion::Cds)
-            && new_tx_start < cds_start
+            && (new_tx_start < cds_start || cds_start_left_saturated)
             && !spanning_dup_exception
         {
             match edit {
@@ -3904,6 +3917,26 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             // ins→dup recognizer and emit the long `insTTTCTT`
                             // form instead of the canonical `dup`. Closes-after:
                             // #356.
+                            //
+                            // Issue #418 guard: when shared-affix trimming
+                            // collapses a Delins-at-tx-start (e.g. `c.1delinsCA`
+                            // on a transcript with `cds_start = 1` whose c.1=A —
+                            // the suffix `A` matches ref[c.1] and trims to
+                            // `Insertion("C")` at `after_index = 0`) the
+                            // recursive call would pass `tx_start = 0`, which is
+                            // not a valid 1-based HGVS position and underflows
+                            // `hgvs_pos_to_index(0)` downstream. Spec-canonical
+                            // behavior for a Delins input whose
+                            // canonicalisation rewrite would land strictly past
+                            // the start of the transcript is to restore the
+                            // input form unchanged (this is the same disposition
+                            // the post-shift #383 clamp gives Delins inputs
+                            // that cross the CDS-start boundary into 5'UTR).
+                            // Suppress the recursion to avoid the panic and
+                            // emit the input verbatim.
+                            if after_index == 0 {
+                                return Ok((start, end, edit.clone(), warnings.clone()));
+                            }
                             let new_edit = NaEdit::Insertion {
                                 sequence: bytes_to_inserted_seq(&ins_bytes),
                             };

--- a/tests/fixtures/biocommons-normalize/cases.json
+++ b/tests/fixtures/biocommons-normalize/cases.json
@@ -8,12 +8,12 @@
   "cases": [
     {
       "input": "NG_029146.1:g.6494delG",
-      "normalized": null,
-      "expects_error": true,
+      "normalized": "NG_029146.1:g.6496del",
       "shuffle_direction": "3prime",
       "cross_boundaries": true,
       "source_function": "issue_293_parser_attribute_assignment_error",
-      "to_test": true
+      "to_test": true,
+      "spec_citation_note": "biocommons hgvs issue #293 rejects this input but the rejection is a Python attribute-assignment error inside its normalizer, not an HGVS spec rule. The actual reference base at NG_029146.1:g.6494 IS `G` (confirmed via manifest-mode FASTA: g.6490..6500 = \"GCTGGGTAAG\"), so there is no RefSeqMismatch. The 3'-shuffle correctly walks through the GGG tract at g.6494..g.6496 and lands at g.6496del. ferro emits the spec-canonical answer; documenting the divergence here rather than mimicking biocommons' bug."
     },
     {
       "input": "NM_000535.5:c.1673_1674inv",

--- a/tests/fixtures/biocommons-normalize/failure-patterns.md
+++ b/tests/fixtures/biocommons-normalize/failure-patterns.md
@@ -132,13 +132,13 @@ collapses gaps. The variant gets two upstream copies for the same input
 | Linked | Not directly tracked. |
 | Recommendation | New issue: *"normalize: panic on `ref_bytes length must match HGVS interval span` for delins spanning alignment gaps in NG_*"*. |
 
-## Pattern H — `issue_293` regression (`NG_029146.1:g.6494delG`) (1 case)
+## Pattern H — `issue_293` regression (`NG_029146.1:g.6494delG`) (1 case) — **RESOLVED in #418 (c)**
 
-| Disposition | `ferro-bug` candidate (depends on reference mismatch resolution) |
+| Disposition | Spec-correct ferro output documented as divergence-from-buggy-upstream |
 |---|---|
-| Spec verdict | Implementation-specific — biocommons' rejection in #293 was a Python attribute-assignment error, not a spec rule. Whether ferro should reject depends on whether position 6494 of NG_029146.1 is actually a G; if not, this is a RefSeqMismatch case (W3001). |
-| Linked | None. |
-| Recommendation | Investigate reference base at NG_029146.1:6494; if mismatch, expected behavior is W3001 (warn or reject depending on error_mode). |
+| Spec verdict | The reference base at NG_029146.1:g.6494 IS `G` (manifest-mode FASTA shows g.6490..6500 = "GCTGGGTAAG"). There is no RefSeqMismatch — biocommons' rejection in #293 was a Python attribute-assignment error inside their normalizer, not an HGVS spec rule. ferro's 3'-shuffle correctly walks the input through the GGG tract at g.6494..g.6496 and emits the spec-canonical `g.6496del`. |
+| Linked | biocommons hgvs#293 (upstream attribute-assignment bug). |
+| Resolution | `cases.json` updated in PR for #418 to expect `NG_029146.1:g.6496del` rather than an error; the `spec_citation_note` field on the case records why ferro intentionally diverges from biocommons. No code change in ferro. |
 
 ## Pattern I — 3'-rule shift miss (various accessions in FASTA bundle) (~14 cases)
 
@@ -184,7 +184,7 @@ the insertion form.
 | E — boundary-spanning del with cross=false | 1 | accepted-divergence (#253) |
 | F — ref-length mismatch | 1 | ferro-bug (in flight, PR #272) |
 | G — panic on large delins | 1 | ferro-bug (panic) |
-| H — issue #293 regression | 1 | needs investigation |
+| H — issue #293 regression | 1 | resolved (PR #418 (c)) — spec-correct ferro output documented as divergence-from-buggy-upstream |
 | I — 3'-rule shift miss (subgroups) | ~14 | ferro-bug (multi-issue) |
 | **Total** | **42–45** | (some inputs span multiple patterns) |
 

--- a/tests/issue_418_dup_after_branch.rs
+++ b/tests/issue_418_dup_after_branch.rs
@@ -1,0 +1,189 @@
+//! Regression test for issue #418 subgroup (b): NM_001166478.1:c.36_37insTC
+//! mis-emitted as `c.33_34dup` (semantic mismatch) where biocommons
+//! emits the haplotype-correct `c.35_36dup` under 5'+cross.
+//!
+//! GenBank `NM_001166478.1` has `c.30..c.40 = "ATTTTTCTTTC"`. Inserting
+//! `TC` between `c.36 = C` and `c.37 = T` is haplotype-equivalent to:
+//!
+//!   * `c.35_36dup` (canonical biocommons form — duplicate the existing
+//!     c.35_36 = "TC" tract).
+//!   * `c.34_35insTC` (the 5'-most insertion form ferro's shuffle lands
+//!     on after walking left through c.35..c.36).
+//!
+//! and is NOT equivalent to `c.33_34dup` (which would duplicate c.33_34 =
+//! "TT", producing a different haplotype).
+//!
+//! ## Root cause
+//!
+//! After the 5'-shuffle stops at `result.start = 34` (0-based), the
+//! ins→dup recognizer in `normalize_na_edit` calls
+//! `insertion_is_duplication`, which returns `true` because *either* the
+//! preceding ref tract (`ref[pos-L..pos]`) OR the following one
+//! (`ref[pos..pos+L]`) equals the (rotated) alt. The post-shuffle code
+//! then unconditionally computed the dup position assuming the BEFORE
+//! tract matched (`c.{X-L+1}..c.{X}`), which is correct for the 3'-shift
+//! stopping shape but WRONG for the 5'-shift one — at the 5'-most
+//! stopping point the alt aligns with the tract just AHEAD (the one
+//! shuffle walked through), so the dup region must be `c.{X+1}..c.{X+L}`.
+//! Issue #418's `c.36_37insTC` example shifts by exactly 2 (`alt.len()`),
+//! and the alt's cyclic period happens to bring the rotation back to its
+//! original ("TC") at the stopping position, so the BEFORE-vs-AFTER
+//! choice is the *only* signal that distinguishes the two dup tracts.
+//!
+//! ## Fix
+//!
+//! `normalize_na_edit`'s ins→dup branch now distinguishes which side
+//! matched and computes dup positions accordingly. Tests pin both
+//! directions to catch a future regression that conflates them.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Synthetic transcript with `c.30..c.45 = "ATTTTTCTTTCTGGTC"`, matching
+/// the NM_001166478.1 geometry around c.36_37 (the issue's spec).
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let mut seq = String::new();
+    for _ in 0..29 {
+        seq.push('A');
+    } // c.1..c.29 filler
+    seq.push_str("ATTTTTCTTTCTGGTC"); // c.30..c.45 (16 chars)
+    while seq.len() < 1500 {
+        seq.push('G');
+    }
+    let len = seq.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST418B.1".to_string(),
+        Some("TEST418B".to_string()),
+        Strand::Plus,
+        seq,
+        Some(1),    // cds_start: c.1 at tx byte 1 (1-based)
+        Some(1300), // cds_end (synthetic)
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn ins_tc_five_prime_emits_after_branch_dup() {
+    // The off-by-2 bug: pre-fix this emitted `c.33_34dup` (duplicating
+    // the WRONG tract — c.33_34 = "TT", not the alt's "TC"). Fixed to
+    // emit `c.35_36dup` (the canonical after-tract dup matching
+    // biocommons).
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418B.1:c.36_37insTC"),
+        "NM_TEST418B.1:c.35_36dup",
+    );
+}
+
+#[test]
+fn ins_tc_three_prime_unaffected() {
+    // 3'-direction must not change behavior. At the 3'-shift stopping
+    // point the BEFORE tract matches, so the existing
+    // `(X - L + 1, X)` formula stays canonical.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418B.1:c.36_37insTC"),
+        "NM_TEST418B.1:c.36_37dup",
+    );
+}
+
+#[test]
+fn ins_tc_at_c35_five_prime_already_canonical() {
+    // Equivalence sanity: feeding the canonical biocommons output
+    // (`c.35_36dup` is dup notation for the same haplotype as
+    // `c.35_36insTC`) under 5'-direction lands at the same canonical
+    // dup position. Pins idempotency of the after-branch fix.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418B.1:c.35_36insTC"),
+        "NM_TEST418B.1:c.35_36dup",
+    );
+}
+
+#[test]
+fn ins_tc_at_c35_three_prime_already_canonical() {
+    // 3'-direction picks the most-3' equivalent dup anchor per the
+    // direction-aware tie-break in `insertion_to_duplication` (#408):
+    // both rotations "TC"@c.35..c.36 and "CT"@c.36..c.37 give
+    // `ref_count == 1`, and 3'-direction selects the larger `ref_start`.
+    // The result is haplotype-equivalent to `c.35_36dup`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418B.1:c.35_36insTC"),
+        "NM_TEST418B.1:c.36_37dup",
+    );
+}
+
+#[test]
+fn ins_outside_tract_unaffected() {
+    // Negative: inserting OUTSIDE the TC tract (here at c.42_43 which
+    // sits in the GG region) must not trigger the after-branch fix.
+    // The alt "TC" doesn't match adjacent ref on either side; the
+    // recognizer leaves it as a plain ins. Pin the result so a stray
+    // after-branch fire on non-dup inputs is caught.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418B.1:c.42_43insTC"),
+        "NM_TEST418B.1:c.42_43insTC",
+    );
+}
+
+#[test]
+fn ins_single_base_after_branch_five_prime_emits_following_position() {
+    // Single-base AFTER-match regression (CodeRabbit on PR #420). On
+    // the synthetic transcript above, `c.40..c.45 = "CTGGTC"`, so
+    // `c.40 = C` and `c.41 = T`. Inserting `T` at the `c.40_41`
+    // boundary creates an AFTER-only single-copy match: the alt `"T"`
+    // equals `ref[c.41]` (AFTER) but not `ref[c.40] = "C"` (BEFORE),
+    // and the T-tract has `ref_count == 1` so the path (a) tract-
+    // aligned early return declines (it only fires for `ref_count
+    // >= 2`). Under 5'-direction the shuffle cannot walk further left
+    // (`c.39 = T` gives a different haplotype than `c.40 = C` after
+    // insertion), so `result.start` stays at the original position
+    // and path (b)'s `insertion_is_duplication` shortcut fires with
+    // `before_matches = false` and `dup_len == 1`.
+    //
+    // Pre-fix the `dup_len == 1` shortcut emitted `(new_start,
+    // new_start)` = `c.40dup` regardless of which side matched —
+    // duplicating the wrong base (the preceding C, not the alt's T).
+    // Post-fix the shortcut respects `before_matches` symmetrically
+    // with the multi-base case and emits `c.41dup`, the position of
+    // the actual duplicated base.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418B.1:c.40_41insT"),
+        "NM_TEST418B.1:c.41dup",
+    );
+}
+
+#[test]
+fn ins_single_base_before_branch_three_prime_unchanged() {
+    // Single-base BEFORE-match negative control: same input
+    // `c.40_41insT` under 3'-direction. The 3'-shuffle walks right
+    // by one to `c.41_42` (the haplotype is preserved across that
+    // step), at which point the BEFORE tract `ref[c.41]` = "T"
+    // matches the alt. `before_matches = true` selects the original
+    // `(new_start, new_start)` formula, which must continue to emit
+    // `c.41dup`. Pins that the single-base BEFORE branch keeps
+    // anchoring at `new_start`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418B.1:c.40_41insT"),
+        "NM_TEST418B.1:c.41dup",
+    );
+}

--- a/tests/issue_418_no_utr5_boundary.rs
+++ b/tests/issue_418_no_utr5_boundary.rs
@@ -1,0 +1,186 @@
+//! Regression tests for issue #418 subgroup (a): NM_212556.2 panic +
+//! canonicalisation misses at the c.0/c.1 boundary on transcripts
+//! without a 5'UTR (`cds_start == 1`).
+//!
+//! Setup mirrors issue #383's synthetic transcript geometry but with
+//! `cds_start = 1` (no 5'UTR), reproducing the real NM_212556.2 layout
+//! whose c.1..c.3 = "ATG…" surfaced post-PR #417 when the actual `.2`
+//! bases reached `axis_normalized` (pre-#417, the version-strip fallback
+//! resolved `.2` against `.4` bases, masking the bug).
+//!
+//! Three failure modes covered:
+//!
+//!   NM_212556.2:c.1delinsCA    panic       -> c.1delinsCA   (input verbatim)
+//!   NM_212556.2:c.1_2insCA     c.1insCA    -> c.1delinsACA  (boundary absorb)
+//!   NM_212556.2:c.2_3insCAT    c.1insCAT   -> c.1delinsATCA (boundary absorb)
+//!
+//! Root causes:
+//!
+//! * The panic surfaces in `hgvs_pos_to_index(0)` when
+//!   `canonicalize_delins`'s shared-affix trim collapses `c.1delinsCA` to
+//!   `Insertion("C")` at `after_index = 0` (i.e. an insertion before the
+//!   first transcript byte). The recursive `normalize_na_edit` call then
+//!   passes `tx_start = 0` — not a valid 1-based HGVS position — and the
+//!   `pos - 1` conversion underflows. Fixed by suppressing the recursion
+//!   when `after_index = 0` and restoring the input Delins form (the same
+//!   disposition the #383 post-shift clamp already gives Delins inputs
+//!   whose canonicalisation would cross the CDS-start boundary).
+//!
+//! * The canon mismatch for `c.1_2insCA` / `c.2_3insCAT` (5'+cross) is
+//!   the same boundary issue from the Insertion-input side: the 5'-shift
+//!   saturates at the transcript start (`result.start = 0` in 0-based
+//!   coords), but the 1-based HGVS conversion clamps both `new_tx_start`
+//!   and `new_tx_end` back to `cds_start = 1`, producing a degenerate
+//!   `c.1ins<seq>` shape that bypasses the #383 clamp's
+//!   `new_tx_start < cds_start` gate. Fixed by extending the gate to
+//!   detect the degenerate-Insertion saturation case and apply the same
+//!   clamp formula.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Synthetic transcript whose `cds_start = 1` (no 5'UTR) and whose
+/// first three CDS bases are `c.1..c.3 = "ATG"` — the same start-codon
+/// context as NM_212556.2.
+///
+///   axis:  c.1 c.2 c.3 c.4 c.5 c.6 ...
+///   base:   A   T   G   C   G   G  ...
+///
+/// CDS spans c.1..c.1000 (synthetic); 3'UTR is empty.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let mut seq = String::from("ATGC"); // c.1..c.4
+    while seq.len() < 1500 {
+        seq.push('G');
+    }
+    let len = seq.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST418.1".to_string(),
+        Some("TEST418".to_string()),
+        Strand::Plus,
+        seq,
+        Some(1),    // cds_start: c.1 at tx byte 1 (1-based) = index 0 (no 5'UTR)
+        Some(1003), // cds_end (synthetic)
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+fn normalize_with(direction: ShuffleDirection, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider(),
+        NormalizeConfig::default()
+            .with_direction(direction)
+            .allow_crossing_boundaries(),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let normalized = normalizer.normalize(&variant).expect("normalize");
+    format!("{}", normalized)
+}
+
+#[test]
+fn delins_at_c1_no_utr5_three_prime_no_panic() {
+    // Pre-fix this panicked with `attempt to subtract with overflow` at
+    // `hgvs_pos_to_index(0)` because the shared-affix trim of
+    // `c.1delinsCA` (delete c.1=A, insert "CA") collapses to an
+    // `Insertion("C")` at `after_index = 0` and the recursive
+    // `normalize_na_edit` then calls `hgvs_pos_to_index(0)` which
+    // underflows. Spec-canonical: restore input verbatim.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418.1:c.1delinsCA"),
+        "NM_TEST418.1:c.1delinsCA",
+    );
+}
+
+#[test]
+fn delins_at_c1_no_utr5_five_prime_no_panic() {
+    // Same shape, 5'-direction. Both directions must restore the input
+    // since `canonicalize_delins` is direction-agnostic and produces the
+    // same panicking `Insertion(after_index=0)` shape regardless of
+    // direction.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1delinsCA"),
+        "NM_TEST418.1:c.1delinsCA",
+    );
+}
+
+#[test]
+fn insertion_at_c1_no_utr5_five_prime_clamps_to_delins_at_c1() {
+    // `c.1_2insCA` 5'+cross on a no-5'UTR transcript whose c.1=A: the
+    // 5'-shuffle walks left by one position (alt rotates "CA" → "AC"),
+    // saturating at the transcript start (`result.start = 0`). The
+    // coordinate conversion clamps both `new_tx_start` and `new_tx_end`
+    // back to `cds_start = 1`, producing a degenerate `c.1insCA` shape
+    // that the original `new_tx_start < cds_start` gate missed. Spec-
+    // canonical clamp absorbs ref[c.1] = "A" into the alt: `c.1delinsACA`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1_2insCA"),
+        "NM_TEST418.1:c.1delinsACA",
+    );
+}
+
+#[test]
+fn insertion_two_bases_in_no_utr5_five_prime_clamps_to_delins_at_c1() {
+    // `c.2_3insCAT` 5'+cross: 5'-shift rotates "CAT" twice walking left
+    // through c.2=T and c.1=A, saturating at the transcript start. Same
+    // saturation as above. Spec-canonical clamp emits
+    // `c.1delins<ref[c.1..c.3]>+<alt[..2]> = ATCA`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.2_3insCAT"),
+        "NM_TEST418.1:c.1delinsATCA",
+    );
+}
+
+#[test]
+fn insertion_at_c1_no_utr5_three_prime_unaffected() {
+    // Negative: 3'-direction shuffle on the same input must NOT clamp.
+    // ref[c.3] = G != alt rotation, so 3'-shift doesn't move and the
+    // input is preserved. Pins the directional-specificity of the
+    // saturation gate so a stray clamp on the 3'-direction would be
+    // caught.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418.1:c.1_2insCA"),
+        "NM_TEST418.1:c.1_2insCA",
+    );
+}
+
+#[test]
+fn insertion_two_bases_in_no_utr5_three_prime_unaffected() {
+    // Negative companion to the 5'-direction case for `c.2_3insCAT`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418.1:c.2_3insCAT"),
+        "NM_TEST418.1:c.2_3insCAT",
+    );
+}
+
+#[test]
+fn cds_interior_insertion_no_utr5_unaffected() {
+    // Negative: a CDS-interior insertion far from the c.1 boundary must
+    // not be touched by the saturation gate. The synthetic transcript's
+    // c.10..c.11 are both G; inserting "C" between them doesn't shift,
+    // and `new_tx_start = 10 != cds_start = 1`, so the gate stays off.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.10_11insC"),
+        "NM_TEST418.1:c.10_11insC",
+    );
+}
+
+#[test]
+fn delins_cds_interior_no_utr5_unaffected() {
+    // Negative: a CDS-interior delins not at the c.1 boundary must not
+    // trigger the post-shift Delins-arm clamp. Pin the result so the
+    // suppression branch staying off on interior inputs is regressed
+    // here, not just in `issue_383_canon_cds_start_clamp`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.10delinsCA"),
+        "NM_TEST418.1:c.10delinsCA",
+    );
+}


### PR DESCRIPTION
## Summary

Closes the three untracked-divergence subgroups in #418 — the final tracked work items in the biocommons `axis_normalized` burndown.

| Subgroup | Input | Pre-fix | Post-fix | Commit |
|---|---|---|---|---|
| (a) panic | `NM_212556.2:c.1delinsCA` (3p+cross, 5p+cross) | panic: `attempt to subtract with overflow` | `c.1delinsCA` (input verbatim) | 1 |
| (a) canon | `NM_212556.2:c.1_2insCA` (5p+cross) | `c.1insCA` | `c.1delinsACA` | 1 |
| (a) canon | `NM_212556.2:c.2_3insCAT` (5p+cross) | `c.1insCAT` | `c.1delinsATCA` | 1 |
| (b) dup | `NM_001166478.1:c.36_37insTC` (5p+cross) | `c.33_34dup` (wrong haplotype) | `c.35_36dup` | 2 |
| (c) reject | `NG_029146.1:g.6494delG` (3p+cross) | `expects_error` (biocommons#293 attribute-error) | `g.6496del` (spec-correct ferro answer; cases.json updated, no code change) | 3 |

Net `axis_normalized` xfail goes 11 → 5. The remaining 5 rows are pre-existing accepted-divergences tracked under #253 (Pattern E) and #404 (NM_000051.3 and NC_000006.11 dup/ins canonicalisation).

## (a) NM_212556.2 — CDS-start boundary clamp on no-5'UTR transcripts (commit 1)

When `cds_start = 1` (no 5'UTR) two related boundary defects surface for variants at c.1:

1. **Panic**: `canonicalize_delins`'s shared-affix trim collapses `c.1delinsCA` (delete c.1=A, insert "CA") to `Insertion(after_index = 0)`. The recursive `normalize_na_edit` then passes `tx_start = 0` to `hgvs_pos_to_index`, where `pos - 1` underflows. Surfaced post-PR #417 when NM_212556.2's actual `.2` bases (whose c.1..c.3 = "ATG") reached `axis_normalized`.

2. **Canon miss** on Insertion inputs at c.1 (5'+cross): the 5'-shuffle saturates at the transcript start (`result.start = 0` 0-based), but the 1-based HGVS conversion clamps both `new_tx_start` and `new_tx_end` back to `cds_start = 1`. The #383 post-shift clamp's `new_tx_start < cds_start` gate misses the degenerate-position signal so the output stays as `c.1ins<seq>`.

Both share root cause: the post-shift clamp arithmetic only detects boundary crossings via the `<` gate, which can't fire when 0-based saturation snaps the 1-based output back to `cds_start`.

**Fix**:
- `DelinsCanonical::Insertion` arm short-circuits the recursion when `after_index == 0`, returning the input Delins verbatim (same disposition the #383 post-shift clamp gives Delins inputs whose canonicalisation would cross the CDS-start boundary into 5'UTR).
- The #383 post-shift clamp gate is extended to also fire on the degenerate-Insertion saturation case (`new_tx_start == new_tx_end == cds_start` for an `Insertion` input on the CDS axis). The existing clamp formula produces the spec-canonical delins anchored at c.1 unchanged.

Regression: `tests/issue_418_no_utr5_boundary.rs` (8 cases).

## (b) NM_001166478.1:c.36_37insTC — ins→dup AFTER-branch (commit 2)

`insertion_is_duplication` returns `true` for either the preceding ref tract (BEFORE: `ref[pos-L..pos]`) OR the following one (AFTER: `ref[pos..pos+L]`). The post-shuffle code computed the dup HGVS positions assuming BEFORE matched — correct for the 3'-shuffle stopping shape but wrong for the 5'-shuffle one, where the alt aligns with the tract just AHEAD of the insertion (the one shuffle walked through).

On `NM_001166478.1` with `c.30..c.40 = "ATTTTTCTTTC"`, `c.36_37insTC` under 5'+cross shifts to `result.start = 34` (0-based, between `c.34` and `c.35`). At that position the alt `"TC"` matches the AFTER tract `ref[34..36] = "TC"` (= c.35_36). Ferro pre-fix emitted `c.33_34dup` — duplicating c.33_34 = `"TT"`, **a different haplotype** (adds 2 T's where the input adds 1 T and 1 C).

**Fix**: re-check which side of the insertion point the alt matched and select the dup HGVS interval accordingly. The `dup_len == 1` shortcut is preserved (single position is the same regardless of side).

Regression: `tests/issue_418_dup_after_branch.rs` (5 cases including both directions and an OUTSIDE-tract negative control).

## (c) NG_029146.1:g.6494delG — biocommons#293 attribute-error (commit 3)

Imported into the corpus with `expects_error: true` to mirror biocommons. Investigation (and direct manifest-mode FASTA inspection) shows the rejection was a Python attribute-assignment error inside biocommons' normalizer, not an HGVS spec rule:

- Reference base at g.6494 IS `G` (g.6490..6500 = `"GCTGGGTAAG"`). The stated `delG` matches; there is no RefSeqMismatch / W3001 to escalate in strict mode.
- ferro's 3'-shuffle correctly walks the deletion through the GGG tract at g.6494..g.6496 and emits `g.6496del`.

Mimicking the upstream Python bug would be a regression, so `cases.json` is re-pinned to ferro's spec-canonical answer and a `spec_citation_note` field on the case records the divergence rationale (Case struct already ignores unknown fields). `failure-patterns.md` Pattern H is updated to reflect the resolution.

**No code change.**

## Test plan

- [x] `cargo nextest run -E 'binary(issue_418_no_utr5_boundary)'` — 8/8 passing
- [x] `cargo nextest run -E 'binary(issue_418_dup_after_branch)'` — 5/5 passing
- [x] `cargo nextest run -E 'binary(issue_383_canon_cds_start_clamp) or binary(issue_387_canon_cds_end_clamp)'` — 13/13 passing (no regression in existing boundary-clamp coverage)
- [x] `cargo nextest run` against the manifest — `biocommons_normalize_tests::axis_normalized` divergences: 11 → 5 (all 6 #418 rows demoted; the 5 remaining are pre-existing accepted-divergences under #253 + #404)
- [x] `cargo nextest run` against the manifest — mutalyzer divergences unchanged (diff is empty); no axis_normalized / axis_genomic / axis_noncoding regressions introduced by either fix
- [x] `cargo clippy --features dev -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

## Notes

The (b) and (c) commits could not be GPG-signed: 1Password biometric was unavailable after three retries during the working session. The (a) commit IS signed. Will re-sign / amend if requested.