### PR TITLE
feat(normalize,project,python,validate): four misc gaps from #395 (items 1, 4, 5, 6)

### DIFF
--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -311,6 +311,21 @@ pub enum ErrorType {
     /// variant; silent mode skips the check entirely. Intronic offsets
     /// remain out of scope (their bounds depend on intron size).
     PositionPastEnd,
+
+    /// Two or more cis-allele edits share identical reference bounds
+    /// (e.g. `g.[100A>C;100A>G]` — both substitutions at position 100).
+    /// The HGVS spec does not define a canonical form for this case;
+    /// ferro preserves the input verbatim and emits this warning.
+    /// Strict mode rejects with `FerroError::InvalidCoordinates`;
+    /// lenient and silent modes both accept and preserve the input,
+    /// with the warning still surfaced by `normalize_with_warnings`
+    /// (the emit site at `src/normalize/overlap.rs:88` is
+    /// unconditional — only strict-mode promotion is gated by mode).
+    /// Closes #395 item 6 — previously the warning was emitted but
+    /// strict mode did not reject, bypassing the registry's
+    /// `always_warn_if_not_rejected` policy table that declared
+    /// Strict→Reject.
+    OverlapConflictingEdits,
 }
 
 impl ErrorType {
@@ -350,6 +365,7 @@ impl ErrorType {
             ErrorType::SinglePositionRange => "W4003",
             ErrorType::PositionPastEnd => "W4004",
             ErrorType::RefSeqMismatch => "W5001",
+            ErrorType::OverlapConflictingEdits => "W5002",
             ErrorType::VariantExceedsReference => "W5003",
         }
     }
@@ -396,6 +412,7 @@ impl ErrorType {
         ErrorType::SinglePositionRange,
         ErrorType::PositionPastEnd,
         ErrorType::RefSeqMismatch,
+        ErrorType::OverlapConflictingEdits,
         ErrorType::VariantExceedsReference,
     ];
 
@@ -470,6 +487,9 @@ impl ErrorType {
                 "variant position range exceeds reference sequence"
             }
             ErrorType::PositionPastEnd => "position lies past CDS-end or transcript-end",
+            ErrorType::OverlapConflictingEdits => {
+                "two or more cis-allele edits share identical reference bounds"
+            }
         }
     }
 
@@ -537,6 +557,9 @@ impl ErrorType {
             // Past-end positions cannot be auto-corrected — there's no safe
             // way to guess the intended canonical position.
             ErrorType::PositionPastEnd => false,
+            // Coincident-bounds cis-allele edits have no spec-defined
+            // canonical form; ferro preserves the input verbatim.
+            ErrorType::OverlapConflictingEdits => false,
         }
     }
 
@@ -601,6 +624,10 @@ impl ErrorType {
                 "(no auto-correct; spec rejects per refseq.md \u{00A7}43)",
             ),
             ErrorType::PositionPastEnd => ("c.946G>C (CDS length 945)", "(no auto-correct)"),
+            ErrorType::OverlapConflictingEdits => (
+                "g.[100A>C;100A>G] (two cis edits at the same bound)",
+                "(no auto-correct)",
+            ),
         }
     }
 }
@@ -1000,6 +1027,7 @@ mod tests {
             ErrorType::SinglePositionRange,
             ErrorType::PositionPastEnd,
             ErrorType::RefSeqMismatch,
+            ErrorType::OverlapConflictingEdits,
             ErrorType::VariantExceedsReference,
         ];
         // Exhaustiveness probe: if a new variant is added to the enum,
@@ -1041,6 +1069,7 @@ mod tests {
                 | ErrorType::SinglePositionRange
                 | ErrorType::PositionPastEnd
                 | ErrorType::RefSeqMismatch
+                | ErrorType::OverlapConflictingEdits
                 | ErrorType::VariantExceedsReference => {}
             }
             assert!(

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -216,6 +216,22 @@ impl NormalizeConfig {
     pub fn should_warn_position_past_end(&self) -> bool {
         self.position_past_end_action().should_warn()
     }
+
+    /// Get the resolved action for `OverlapConflictingEdits` (W5002).
+    pub fn overlap_conflict_action(&self) -> ResolvedAction {
+        self.error_config
+            .action_for(ErrorType::OverlapConflictingEdits)
+    }
+
+    /// Returns true if cis-allele edits with coincident reference
+    /// bounds should be rejected (strict mode default). Closes #395
+    /// item 6 — previously the `overlap.rs:88` emit site unconditionally
+    /// pushed the warning, bypassing the registry's
+    /// `always_warn_if_not_rejected` policy table that declared
+    /// Strict→Reject.
+    pub fn should_reject_overlap_conflict(&self) -> bool {
+        self.overlap_conflict_action().should_reject()
+    }
 }
 
 #[cfg(test)]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -789,6 +789,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
+        // In strict mode, reject when two or more cis-allele edits
+        // share identical reference bounds (W5002). The registry
+        // already declared `ModeBehavior::always_warn_if_not_rejected`
+        // (Strict → Reject) but the emit site at `overlap.rs:88`
+        // unconditionally pushed the warning. Closes #395 item 6.
+        if self.config.should_reject_overlap_conflict() {
+            if let Some(err) = result.warnings.iter().find_map(|w| match w {
+                NormalizationWarning::OverlapConflict {
+                    accession,
+                    coordinate_system,
+                    location,
+                    edit_kinds,
+                    ..
+                } => Some(FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "{accession}:{coordinate_system}.{location} has \
+                         {n} coincident cis-allele edits ({kinds}); HGVS spec defines no \
+                         canonical form for this case (OverlapConflictingEdits / W5002)",
+                        n = edit_kinds.len(),
+                        kinds = edit_kinds.join(", "),
+                    ),
+                }),
+                _ => None,
+            }) {
+                return Err(err);
+            }
+        }
+
         Ok(result.result)
     }
 

--- a/src/normalize/validate.rs
+++ b/src/normalize/validate.rs
@@ -215,14 +215,19 @@ fn validate_repeat_tract(
 /// - **All units `Exact`** — full validation. The expanded
 ///   concatenation has a deterministic length; we check both the
 ///   span-vs-sum length invariant and the base-by-base content match.
-/// - **Leading `Exact` prefix followed by a non-`Exact` unit (Range /
-///   MinUncertain / MaxUncertain / Unknown)** — *partial validation*
-///   (issue #279). The prefix bases at `[start, start + prefix_len)`
-///   are known; we validate just those against the reference and
-///   skip the length check and the ambiguous tail. A prefix mismatch
-///   surfaces as `RefSeqMismatch`.
-/// - **First unit non-`Exact`** — no validation. There is no known
-///   prefix to check; the description is accepted unchanged.
+/// - **Mixed Exact / non-Exact** — *anchored partial validation*
+///   (issue #279 + #395 item 1). The leading-`Exact` prefix and the
+///   trailing-`Exact` suffix are deterministic (left-anchored and
+///   right-anchored respectively); we validate both against the
+///   reference and skip the ambiguous middle. If `prefix_len +
+///   suffix_len > span_len`, that's a content/length mismatch — the
+///   suffix would overlap the prefix or run off the start of the
+///   tract, which is incompatible with any combination of middle-unit
+///   counts.
+/// - **First AND last unit non-`Exact`** — no validation. Neither end
+///   is anchored.
+///
+/// Mismatches surface as `RefSeqMismatch`.
 ///
 /// Missing reference data (out-of-range span, inverted range) is
 /// handled defensively: those cases short-circuit to `ok()` so other
@@ -241,14 +246,13 @@ fn validate_multirepeat_tract(
 
     // Walk units left-to-right, building the deterministic prefix from
     // the leading `Exact` runs. Stop at the first non-`Exact` unit;
-    // everything from there on is the ambiguous tail and is skipped.
+    // everything from there to the right anchor is the ambiguous middle.
     let mut prefix_bytes: Vec<u8> = Vec::new();
     let mut prefix_str = String::new();
     let mut prefix_units = 0usize;
     for u in units {
         let n = match u.count {
             RepeatCount::Exact(n) => n,
-            // First non-Exact ends the validated prefix.
             _ => break,
         };
         let unit_bytes: Vec<u8> = u.sequence.bases().iter().map(|b| b.to_u8()).collect();
@@ -260,13 +264,48 @@ fn validate_multirepeat_tract(
         prefix_units += 1;
     }
 
-    // First-unit-non-Exact case: no known prefix → no validation.
-    // Preserves the pre-#279 behavior for these descriptions.
-    if prefix_units == 0 {
-        return ValidationResult::ok();
+    let all_exact = prefix_units == units.len();
+
+    // Walk units right-to-left for the trailing-`Exact` suffix
+    // (closes #395 item 1). Only meaningful when the left walk did not
+    // consume every unit; otherwise the whole tract is the prefix and
+    // there is no separate suffix to validate.
+    let mut suffix_bytes: Vec<u8> = Vec::new();
+    let mut suffix_str = String::new();
+    let mut suffix_units = 0usize;
+    if !all_exact {
+        // Bound the right walk so prefix and suffix never overlap on
+        // the same `Exact` units (would happen if the units in between
+        // were all `Exact` too, but we've already established at least
+        // one non-`Exact` unit exists in `[prefix_units, units.len())`).
+        for u in units[prefix_units..].iter().rev() {
+            let n = match u.count {
+                RepeatCount::Exact(n) => n,
+                _ => break,
+            };
+            let unit_bytes: Vec<u8> = u.sequence.bases().iter().map(|b| b.to_u8()).collect();
+            let unit_str: String = u.sequence.bases().iter().map(|b| b.to_char()).collect();
+            // Build suffix_str in left-to-right order so the diagnostic
+            // reads naturally despite the right-to-left walk.
+            suffix_str.insert_str(0, &format!("{}[{}]", unit_str, n));
+            // Prepend bytes for the same reason — earlier units in the
+            // tract appear earlier in the byte vector.
+            let mut new_bytes =
+                Vec::with_capacity(suffix_bytes.len() + unit_bytes.len() * n as usize);
+            for _ in 0..n {
+                new_bytes.extend_from_slice(&unit_bytes);
+            }
+            new_bytes.extend_from_slice(&suffix_bytes);
+            suffix_bytes = new_bytes;
+            suffix_units += 1;
+        }
     }
 
-    let all_exact = prefix_units == units.len();
+    // No anchored units on either side → no validation. Preserves the
+    // pre-#279 behavior for these descriptions.
+    if prefix_units == 0 && suffix_units == 0 {
+        return ValidationResult::ok();
+    }
 
     let start_idx = hgvs_pos_to_index(start);
     let end_idx = end as usize;
@@ -309,52 +348,87 @@ fn validate_multirepeat_tract(
         );
     }
 
-    // Partial validation (issue #279): only the known Exact prefix is
-    // checked. The ambiguous tail starts at `prefix_bytes.len()` in
-    // `actual_bytes` and is skipped entirely.
-    //
-    // If the reference span is shorter than the Exact prefix the
-    // description claims, that itself is a content/length mismatch —
-    // surface it. (Without this the slice below would silently truncate
-    // the comparison.)
-    if actual_bytes.len() < prefix_bytes.len() {
+    // Anchored partial validation: check prefix and/or suffix; skip
+    // the ambiguous middle.
+
+    // If prefix + suffix together exceed the actual span, the suffix
+    // can't fit at the right edge without overlapping the prefix.
+    // That's a length mismatch incompatible with any middle-count
+    // assignment.
+    if prefix_bytes.len() + suffix_bytes.len() > actual_bytes.len() {
+        let combined_str = if prefix_units == 0 {
+            suffix_str.clone()
+        } else if suffix_units == 0 {
+            prefix_str.clone()
+        } else {
+            format!("{}…{}", prefix_str, suffix_str)
+        };
         let actual_str: String = actual_bytes
             .iter()
             .map(|&b| (b as char).to_ascii_uppercase())
             .collect();
         return ValidationResult::mismatch(
             format!(
-                "{} ({} bp from declared Exact prefix)",
-                prefix_str,
-                prefix_bytes.len()
+                "{} ({} bp from declared anchored units)",
+                combined_str,
+                prefix_bytes.len() + suffix_bytes.len()
             ),
             format!(
-                "{} ({} bp; reference span too short for prefix)",
+                "{} ({} bp; reference span too short for prefix+suffix)",
                 actual_str,
                 actual_bytes.len()
             ),
         );
     }
-    let prefix_actual = &actual_bytes[..prefix_bytes.len()];
-    let matches = prefix_bytes
-        .iter()
-        .zip(prefix_actual.iter())
-        .all(|(a, b)| a.eq_ignore_ascii_case(b));
-    if matches {
-        return ValidationResult::ok();
+
+    // Left-anchored prefix check (no-op when prefix_units == 0).
+    if !prefix_bytes.is_empty() {
+        let prefix_actual = &actual_bytes[..prefix_bytes.len()];
+        let matches = prefix_bytes
+            .iter()
+            .zip(prefix_actual.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b));
+        if !matches {
+            let expected_bases_str: String = prefix_bytes
+                .iter()
+                .map(|&b| (b as char).to_ascii_uppercase())
+                .collect();
+            let prefix_actual_str: String = prefix_actual
+                .iter()
+                .map(|&b| (b as char).to_ascii_uppercase())
+                .collect();
+            return ValidationResult::mismatch(
+                format!("{} ({})", prefix_str, expected_bases_str),
+                prefix_actual_str,
+            );
+        }
     }
-    let expected_bases_str: String = prefix_bytes
-        .iter()
-        .map(|&b| (b as char).to_ascii_uppercase())
-        .collect();
-    let prefix_actual_str: String = prefix_actual
-        .iter()
-        .map(|&b| (b as char).to_ascii_uppercase())
-        .collect();
-    ValidationResult::mismatch(
-        format!("{} ({})", prefix_str, expected_bases_str),
-        prefix_actual_str,
-    )
+
+    // Right-anchored suffix check (no-op when suffix_units == 0).
+    if !suffix_bytes.is_empty() {
+        let suffix_start = actual_bytes.len() - suffix_bytes.len();
+        let suffix_actual = &actual_bytes[suffix_start..];
+        let matches = suffix_bytes
+            .iter()
+            .zip(suffix_actual.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b));
+        if !matches {
+            let expected_bases_str: String = suffix_bytes
+                .iter()
+                .map(|&b| (b as char).to_ascii_uppercase())
+                .collect();
+            let suffix_actual_str: String = suffix_actual
+                .iter()
+                .map(|&b| (b as char).to_ascii_uppercase())
+                .collect();
+            return ValidationResult::mismatch(
+                format!("{} ({})", suffix_str, expected_bases_str),
+                suffix_actual_str,
+            );
+        }
+    }
+
+    ValidationResult::ok()
 }
 
 /// Validate a single base against the reference

--- a/src/normalize/validate.rs
+++ b/src/normalize/validate.rs
@@ -352,9 +352,21 @@ fn validate_multirepeat_tract(
     // the ambiguous middle.
 
     // If prefix + suffix together exceed the actual span, the suffix
-    // can't fit at the right edge without overlapping the prefix.
-    // That's a length mismatch incompatible with any middle-count
-    // assignment.
+    // can't fit at the right edge without overlapping the prefix —
+    // length mismatch incompatible with any middle-count assignment.
+    //
+    // Note: the `==` case (prefix + suffix exactly equal to span) is
+    // intentionally accepted here. The middle would need 0 copies of
+    // each non-Exact unit, which is only possible for non-Exact
+    // counts that admit a 0-count interpretation (`Unknown`,
+    // `MaxUncertain`, `UncertainRange(0, _)`). A tighter check that
+    // computes the minimum middle length from each non-Exact unit's
+    // count would reject `==` for inputs like `[Exact(2), Range(1,3),
+    // Exact(2)]` over a 12-bp span; that's left as a future
+    // tightening pass and pinned by `interleaved_prefix_and_trailing_
+    // exact_consistent_accepted_strict` (which uses a 15-bp span =
+    // prefix(6) + middle(3) + suffix(6)) as the lax-acceptance
+    // contract.
     if prefix_bytes.len() + suffix_bytes.len() > actual_bytes.len() {
         let combined_str = if prefix_units == 0 {
             suffix_str.clone()

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -1,16 +1,25 @@
-//! Strand-aware transformation of `NaEdit` from g. to c./n.
+//! Strand-aware transformation of `NaEdit` between g. and c./n./r.
 
 use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
 use crate::reference::Strand;
 
-/// Transform a g.-coordinate edit into the equivalent edit on the transcript strand.
+/// Transform an edit between the genomic axis and the transcript axis.
 ///
-/// On the plus strand, the edit is returned unchanged. On the minus strand, the
-/// ref/alt bases (and any embedded sequences) are reverse-complemented so the
-/// resulting edit reads correctly on the transcript's sense strand.
-pub(crate) fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
+/// On the **plus strand**, no reverse-complement is needed — the
+/// transcript reads the same as the genome. However, r. inputs carry
+/// `Base::U` which is not a valid DNA letter; when projecting
+/// r.→g. we still need to translate every `U` to `T` so the output
+/// is valid DNA. Closes #395 item 4: previously the plus-strand path
+/// returned the edit unchanged, which left RNA `u` substitutions
+/// emitting invalid `g.<N>U>A` shapes. Non-U bases are passed
+/// through unchanged.
+///
+/// On the **minus strand**, ref/alt bases (and any embedded sequences)
+/// are reverse-complemented. The `Base::U → Base::A` complement in
+/// `complement_base` already handles RNA `u` correctly on this path.
+pub fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
     if strand == Strand::Plus {
-        return edit.clone();
+        return u_to_t_edit(edit);
     }
     match edit {
         NaEdit::Substitution {
@@ -98,6 +107,88 @@ fn revcomp_sequence(s: &Sequence) -> Sequence {
 fn revcomp_inserted(ins: &InsertedSequence) -> InsertedSequence {
     match ins {
         InsertedSequence::Literal(seq) => InsertedSequence::Literal(revcomp_sequence(seq)),
+        other => other.clone(),
+    }
+}
+
+/// U→T translation for an edit, used by `transform_edit_for_strand` on
+/// `Strand::Plus`. Translates RNA `U` to DNA `T` in single bases and
+/// embedded sequences without reversing or complementing other bases.
+/// Closes #395 item 4.
+fn u_to_t_edit(edit: &NaEdit) -> NaEdit {
+    match edit {
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => NaEdit::Substitution {
+            reference: u_to_t_base(*reference),
+            alternative: u_to_t_base(*alternative),
+        },
+        NaEdit::SubstitutionNoRef { alternative } => NaEdit::SubstitutionNoRef {
+            alternative: u_to_t_base(*alternative),
+        },
+        NaEdit::Deletion { sequence, length } => NaEdit::Deletion {
+            sequence: sequence.as_ref().map(u_to_t_sequence),
+            length: *length,
+        },
+        NaEdit::Insertion { sequence } => NaEdit::Insertion {
+            sequence: u_to_t_inserted(sequence),
+        },
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => NaEdit::Delins {
+            sequence: u_to_t_inserted(sequence),
+            deleted: deleted.as_ref().map(u_to_t_sequence),
+            deleted_length: *deleted_length,
+        },
+        NaEdit::Duplication {
+            sequence,
+            length,
+            uncertain_extent,
+        } => NaEdit::Duplication {
+            sequence: sequence.as_ref().map(u_to_t_sequence),
+            length: *length,
+            uncertain_extent: uncertain_extent.clone(),
+        },
+        NaEdit::DupIns { sequence } => NaEdit::DupIns {
+            sequence: u_to_t_inserted(sequence),
+        },
+        NaEdit::Inversion { sequence, length } => NaEdit::Inversion {
+            sequence: sequence.as_ref().map(u_to_t_sequence),
+            length: *length,
+        },
+        // Other edit shapes have no embedded sequence to translate.
+        other => other.clone(),
+    }
+}
+
+fn u_to_t_base(b: Base) -> Base {
+    match b {
+        Base::U => Base::T,
+        other => other,
+    }
+}
+
+fn u_to_t_sequence(s: &Sequence) -> Sequence {
+    let translated: String = s
+        .to_string()
+        .chars()
+        .map(|c| match c {
+            'U' => 'T',
+            'u' => 't',
+            other => other,
+        })
+        .collect();
+    translated
+        .parse()
+        .expect("U→T translation produces only valid IUPAC bases")
+}
+
+fn u_to_t_inserted(ins: &InsertedSequence) -> InsertedSequence {
+    match ins {
+        InsertedSequence::Literal(seq) => InsertedSequence::Literal(u_to_t_sequence(seq)),
         other => other.clone(),
     }
 }

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -172,6 +172,10 @@ fn u_to_t_base(b: Base) -> Base {
 }
 
 fn u_to_t_sequence(s: &Sequence) -> Sequence {
+    // `Base::to_char()` emits uppercase, so `s.to_string()` is always
+    // uppercase. The lowercase `'u'` arm is defensive only — kept in
+    // case a future `Sequence::from_str` accepts lowercase input
+    // without normalizing.
     let translated: String = s
         .to_string()
         .chars()
@@ -204,7 +208,10 @@ mod tests {
     }
 
     #[test]
-    fn substitution_plus_strand_unchanged() {
+    fn substitution_plus_strand_non_u_unchanged() {
+        // A>G has no U, so plus-strand pass-through is bit-identical.
+        // (With U the plus-strand path translates U→T — covered by
+        // `tests/issue_395_rna_u_to_t_plus_strand.rs`.)
         let edit = NaEdit::Substitution {
             reference: Base::A,
             alternative: Base::G,

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,7 +1,7 @@
 //! Variant-level projection: g. variants → c./p. equivalents on a target transcript.
 
 mod accession;
-mod edit;
+pub mod edit;
 mod projector;
 mod protein;
 mod result;

--- a/src/python.rs
+++ b/src/python.rs
@@ -539,6 +539,103 @@ impl PyNormalizer {
 
         Ok(normalized.to_string())
     }
+
+    /// Parse and normalize an HGVS string, surfacing any warnings.
+    ///
+    /// Closes #395 item 5: previously `NormalizationWarning` was Rust-only;
+    /// Python callers had no access to RefSeqMismatch, OverlapConflict,
+    /// PositionPastEnd, AxisClampApplied, or the other warning codes the
+    /// normalizer emits.
+    ///
+    /// Strict-mode rejections still raise `RuntimeError` (matching the
+    /// existing `normalize` method). Lenient/silent return a result
+    /// with the warnings vec, which may be empty.
+    fn normalize_with_warnings(
+        &self,
+        hgvs_string: &str,
+    ) -> PyResult<PyNormalizeResultWithWarnings> {
+        let variant = parse_hgvs(hgvs_string)
+            .map_err(|e| PyValueError::new_err(format!("Parse error: {}", e)))?;
+        let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
+        let result = normalizer
+            .normalize_with_warnings(&variant)
+            .map_err(|e| PyRuntimeError::new_err(format!("Normalization error: {}", e)))?;
+        Ok(PyNormalizeResultWithWarnings {
+            result: PyHgvsVariant {
+                inner: result.result,
+            },
+            warnings: result
+                .warnings
+                .iter()
+                .map(PyNormalizationWarning::from)
+                .collect(),
+        })
+    }
+}
+
+/// Warning emitted by the normalizer.
+///
+/// Mirrors `crate::normalize::NormalizationWarning` but flattened for
+/// Python: only the code, message, and a `String` representation of the
+/// variant-specific fields are surfaced. Callers can pattern-match on
+/// `code` for downstream branching (matches the convention used by the
+/// W4004/W5001/W5002/etc. SVA codes).
+#[pyclass(name = "NormalizationWarning", from_py_object)]
+#[derive(Clone)]
+pub struct PyNormalizationWarning {
+    /// SVA code, e.g. `"REFSEQ_MISMATCH"` / `"OVERLAP_CONFLICTING_EDITS"` /
+    /// `"POSITION_PAST_END"` / `"AXIS_CLAMP_APPLIED"` /
+    /// `"CROSS_AXIS_VARIANT_NOT_SHUFFLED"` /
+    /// `"CANONICAL_SPLIT_SKIPPED"`.
+    #[pyo3(get)]
+    pub code: String,
+    /// Human-readable message.
+    #[pyo3(get)]
+    pub message: String,
+}
+
+impl From<&crate::normalize::NormalizationWarning> for PyNormalizationWarning {
+    fn from(w: &crate::normalize::NormalizationWarning) -> Self {
+        Self {
+            code: w.code().to_string(),
+            message: w.message().to_string(),
+        }
+    }
+}
+
+#[pymethods]
+impl PyNormalizationWarning {
+    fn __repr__(&self) -> String {
+        format!("NormalizationWarning({}: {})", self.code, self.message)
+    }
+}
+
+/// Result of `Normalizer.normalize_with_warnings`: the normalized
+/// variant plus the warnings emitted during normalization.
+#[pyclass(name = "NormalizeResultWithWarnings")]
+pub struct PyNormalizeResultWithWarnings {
+    /// The normalized variant.
+    #[pyo3(get)]
+    pub result: PyHgvsVariant,
+    /// Warnings emitted during normalization (may be empty).
+    #[pyo3(get)]
+    pub warnings: Vec<PyNormalizationWarning>,
+}
+
+#[pymethods]
+impl PyNormalizeResultWithWarnings {
+    /// Returns true if any warnings were emitted.
+    fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "NormalizeResultWithWarnings({} warning{})",
+            self.warnings.len(),
+            if self.warnings.len() == 1 { "" } else { "s" },
+        )
+    }
 }
 
 // ============================================================================
@@ -2170,6 +2267,8 @@ pub enum PyErrorType {
     PositionPastEnd = 32,
     VariantExceedsReference = 33,
     NonSpecMosaicForm = 34,
+    // 35 is W5002 OverlapConflictingEdits (closes #395 item 6).
+    OverlapConflictingEdits = 35,
 }
 
 impl From<ErrorType> for PyErrorType {
@@ -2209,6 +2308,7 @@ impl From<ErrorType> for PyErrorType {
             ErrorType::NonSpecMosaicForm => PyErrorType::NonSpecMosaicForm,
             ErrorType::VariantExceedsReference => PyErrorType::VariantExceedsReference,
             ErrorType::PositionPastEnd => PyErrorType::PositionPastEnd,
+            ErrorType::OverlapConflictingEdits => PyErrorType::OverlapConflictingEdits,
         }
     }
 }
@@ -2250,6 +2350,7 @@ impl From<PyErrorType> for ErrorType {
             PyErrorType::NonSpecMosaicForm => ErrorType::NonSpecMosaicForm,
             PyErrorType::VariantExceedsReference => ErrorType::VariantExceedsReference,
             PyErrorType::PositionPastEnd => ErrorType::PositionPastEnd,
+            PyErrorType::OverlapConflictingEdits => ErrorType::OverlapConflictingEdits,
         }
     }
 }
@@ -3517,6 +3618,8 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCorrectionWarning>()?;
     m.add_class::<PyErrorConfig>()?;
     m.add_class::<PyParseResultWithWarnings>()?;
+    m.add_class::<PyNormalizationWarning>()?;
+    m.add_class::<PyNormalizeResultWithWarnings>()?;
 
     // Backtranslation classes
     m.add_class::<PyCodonChange>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -3653,3 +3653,54 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Closes #395 item 5 — verifies the `From<&NormalizationWarning>
+    /// for PyNormalizationWarning` converter at the Rust level.
+    /// Complements `tests/python/test_issue_395_normalization_warnings.py`
+    /// which exercises the Python-facing surface (under maturin develop).
+    #[test]
+    fn py_normalization_warning_carries_code_and_message() {
+        let cases: Vec<(crate::normalize::NormalizationWarning, &str)> = vec![
+            (
+                crate::normalize::NormalizationWarning::RefSeqMismatch {
+                    message: "stated A but reference is T".to_string(),
+                    stated_ref: "A".to_string(),
+                    actual_ref: "T".to_string(),
+                    position: "100".to_string(),
+                    corrected: true,
+                },
+                "REFSEQ_MISMATCH",
+            ),
+            (
+                crate::normalize::NormalizationWarning::OverlapConflict {
+                    message: "two coincident edits".to_string(),
+                    accession: "NC_000001.11".to_string(),
+                    coordinate_system: "g".to_string(),
+                    location: "100".to_string(),
+                    edit_kinds: vec!["sub".to_string(), "sub".to_string()],
+                },
+                "OVERLAP_CONFLICTING_EDITS",
+            ),
+            (
+                crate::normalize::NormalizationWarning::PositionPastEnd {
+                    message: "past cds-end".to_string(),
+                    accession: "NM_X.1".to_string(),
+                    coordinate_system: "c".to_string(),
+                    position: "946".to_string(),
+                    bound_kind: "cds-end".to_string(),
+                    bound_value: 945,
+                },
+                "POSITION_PAST_END",
+            ),
+        ];
+        for (w, expected_code) in cases {
+            let py: PyNormalizationWarning = (&w).into();
+            assert_eq!(py.code, expected_code, "code mismatch for {expected_code}");
+            assert_eq!(py.message, w.message(), "message round-trip mismatch");
+        }
+    }
+}

--- a/tests/issue_279_multirepeat_partial_validation.rs
+++ b/tests/issue_279_multirepeat_partial_validation.rs
@@ -20,12 +20,18 @@
 //!      against the reference; do NOT validate length or tail bases.
 //!      A mismatch in the prefix surfaces as `RefSeqMismatch` (strict
 //!      reject / lenient warn) using the same flow as PR #215.
-//!   3. First unit non-`Exact` — no validation at all (no known
-//!      prefix), identical to today's skip behavior.
-//!   4. Mismatch in the unvalidated tail bases does NOT fire — the
-//!      tail is genuinely ambiguous and the normalizer cannot tell a
-//!      "wrong" tail from a tail whose count happens to be at the
+//!   3. First AND last unit non-`Exact` — no validation at all (no
+//!      anchored end), identical to today's skip behavior.
+//!   4. Mismatch in the unvalidated middle bases does NOT fire — the
+//!      middle is genuinely ambiguous and the normalizer cannot tell a
+//!      "wrong" middle from one whose count happens to be at the
 //!      lower bound of the declared range.
+//!
+//! Issue #395 item 1 extended this contract: a trailing-`Exact`
+//! suffix is now also right-anchored validated. The
+//! "first-unit-non-Exact-but-last-is-Exact" case (previously skipped
+//! per (3)) is now covered by
+//! `tests/issue_395_multirepeat_interleaved_resumption.rs`.
 
 use ferro_hgvs::error::FerroError;
 use ferro_hgvs::normalize::NormalizationWarning;
@@ -277,34 +283,38 @@ mod exact_prefix_unknown_tail {
 mod first_unit_non_exact {
     use super::*;
 
-    /// First unit is `Range` — there is no known prefix to validate.
+    /// First AND last unit non-Exact — neither end is anchored.
     /// Validation must be skipped entirely. A genuinely WRONG-looking
-    /// reference must still be accepted in strict mode, consistent
-    /// with today's behavior.
+    /// reference must still be accepted in strict mode.
+    ///
+    /// (Pre-#395 this also held for `[Range, Exact]` shapes; #395
+    /// item 1 added right-anchored validation, so the trailing-Exact
+    /// variant is now covered by
+    /// `issue_395_multirepeat_interleaved_resumption`.)
     #[test]
-    fn first_unit_range_no_validation_strict() {
+    fn first_and_last_unit_range_no_validation_strict() {
         // Reference has CAG triplets — clearly not CTG repeated — but
-        // because the first unit's count is uncertain, no prefix
-        // exists to validate and the description is accepted.
+        // because neither end is anchored, no validation fires.
         let core = "CAGCAGCAGCAGCAG";
         let padded_seq = padded(core);
         let provider = g_provider("NC_000001.11", &padded_seq);
         let end = CORE_START + (core.len() as u64) - 1;
-        let input = format!("NC_000001.11:g.{}_{}CTG[(2_5)]TTG[2]", CORE_START, end);
-        let _ = normalize_strict(provider, &input)
-            .expect("first-unit-non-Exact must skip validation (no known prefix to check)");
+        let input = format!("NC_000001.11:g.{}_{}CTG[(2_5)]TTG[(1_3)]", CORE_START, end);
+        let _ = normalize_strict(provider, &input).expect(
+            "first-and-last-unit-non-Exact must skip validation (no anchored end to check)",
+        );
     }
 
-    /// First unit `Unknown` count — same skip.
+    /// Both ends `Unknown` count — same skip.
     #[test]
-    fn first_unit_unknown_no_validation_strict() {
+    fn first_and_last_unit_unknown_no_validation_strict() {
         let core = "CAGCAGCAGCAGCAG";
         let padded_seq = padded(core);
         let provider = g_provider("NC_000001.11", &padded_seq);
         let end = CORE_START + (core.len() as u64) - 1;
-        let input = format!("NC_000001.11:g.{}_{}CTG[?]TTG[2]", CORE_START, end);
-        let _ =
-            normalize_strict(provider, &input).expect("first-unit Unknown must skip validation");
+        let input = format!("NC_000001.11:g.{}_{}CTG[?]TTG[?]", CORE_START, end);
+        let _ = normalize_strict(provider, &input)
+            .expect("first-and-last-unit Unknown must skip validation (no anchored end to check)");
     }
 }
 

--- a/tests/issue_395_multirepeat_interleaved_resumption.rs
+++ b/tests/issue_395_multirepeat_interleaved_resumption.rs
@@ -1,0 +1,223 @@
+//! Issue #395 item 1 — extend `validate_multirepeat_tract` to validate
+//! trailing `Exact` units after a non-`Exact` middle unit, by
+//! right-anchoring a suffix walk in addition to the existing
+//! left-anchored prefix walk.
+//!
+//! # Current behavior (pre-PR)
+//!
+//! `src/normalize/validate.rs::validate_multirepeat_tract` walks units
+//! left-to-right and `break`s at the first non-`Exact` count. For
+//! `[Exact(3), Range(1,5), Exact(2)]`, the trailing `Exact(2)` is
+//! never validated even though its bases at the *right* edge of the
+//! reference tract are deterministic.
+//!
+//! # New behavior
+//!
+//! - Leading-`Exact` prefix is still validated left-anchored.
+//! - **New:** trailing-`Exact` suffix is validated right-anchored
+//!   (last `sum(trailing_exact_lens)` bytes of the ref span).
+//! - The non-`Exact` middle is still skipped.
+//! - When the declared prefix + suffix lengths would together exceed
+//!   the reference span, that's a content/length mismatch (the suffix
+//!   would overlap the prefix or run off the start of the tract).
+//!
+//! # Spec basis
+//!
+//! `assets/hgvs-nomenclature/docs/recommendations/DNA/repeated.md`:
+//! every unit's bases are part of the reference tract. Validating
+//! *any* deterministic prefix/suffix matches the spec; what's added
+//! here is the symmetric right-anchored case.
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
+
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{}{}{}", PAD, core, PAD)
+}
+const CORE_START: u64 = PAD.len() as u64 + 1;
+
+fn g_provider(accession: &str, padded_seq: &str) -> MockProvider {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence(accession, padded_seq);
+    p
+}
+
+fn normalize_strict(provider: MockProvider, input: &str) -> Result<String, FerroError> {
+    let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
+    let variant = parse_hgvs(input).expect("parse");
+    normalizer.normalize(&variant).map(|v| format!("{}", v))
+}
+
+fn normalize_lenient(provider: MockProvider, input: &str) -> (String, Vec<NormalizationWarning>) {
+    let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
+    let variant = parse_hgvs(input).expect("parse");
+    let r = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("lenient normalize");
+    (format!("{}", r.result), r.warnings)
+}
+
+fn has_refseq_mismatch(warnings: &[NormalizationWarning]) -> bool {
+    warnings
+        .iter()
+        .any(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. }))
+}
+
+fn is_ref_mismatch(err: &FerroError) -> bool {
+    matches!(err, FerroError::ReferenceMismatch { .. })
+}
+
+// =============================================================================
+// Trailing-Exact suffix validation (the new behavior)
+// =============================================================================
+
+/// Reference matches both prefix AND suffix: must accept.
+///
+/// `[CTG[2], TTG[1..3], ACG[2]]` declared over a 15 bp tract whose
+/// content is `CTGCTG.TTGTTG.ACGACG` (rendered with the middle's actual
+/// count = 2). Prefix CTGCTG (6 bp) matches the start; suffix ACGACG
+/// (6 bp) matches the end; the middle 3 bp `TTG` is in the declared
+/// range and skipped.
+#[test]
+fn interleaved_prefix_and_trailing_exact_consistent_accepted_strict() {
+    // 2 CTG (6) + 1 TTG (3) + 2 ACG (6) = 15 bp.
+    let core = "CTGCTGTTGACGACG";
+    assert_eq!(core.len(), 15);
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]ACG[2]", CORE_START, end);
+    let out =
+        normalize_strict(provider, &input).expect("matching prefix + matching suffix must accept");
+    // Just sanity that it produced something parseable.
+    assert!(out.contains("CTG[2]") && out.contains("ACG[2]"));
+}
+
+/// Suffix bases DON'T match the reference: must reject in strict mode
+/// (the new validation path catches this).
+#[test]
+fn trailing_exact_suffix_mismatch_rejected_strict() {
+    // Declared: CTG[2] (6) + TTG[1_3] (skip) + ACG[2] (6 expected at right end).
+    // Actual end: GGGGGG (not ACGACG) → suffix mismatch.
+    let core = "CTGCTGTTGGGGGGG"; // 15 bp: 6 CTG + 3 TTG + 6 G
+    assert_eq!(core.len(), 15);
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]ACG[2]", CORE_START, end);
+    let err = normalize_strict(provider, &input)
+        .expect_err("trailing-Exact suffix mismatch must reject in strict mode");
+    assert!(
+        is_ref_mismatch(&err),
+        "expected ReferenceMismatch from trailing-Exact suffix check; got: {err:?}",
+    );
+}
+
+/// Lenient mode: suffix mismatch emits a `RefSeqMismatch` warning.
+#[test]
+fn trailing_exact_suffix_mismatch_warns_lenient() {
+    let core = "CTGCTGTTGGGGGGG";
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]ACG[2]", CORE_START, end);
+    let (_, warnings) = normalize_lenient(provider, &input);
+    assert!(
+        has_refseq_mismatch(&warnings),
+        "expected RefSeqMismatch warning in lenient mode; got: {:?}",
+        warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+/// Prefix matches but the span is too short to fit both prefix +
+/// suffix simultaneously: that's a length mismatch (the suffix would
+/// overlap the prefix). Must reject.
+#[test]
+fn prefix_plus_suffix_overflow_span_rejected_strict() {
+    // Declare CTG[2] (6 bp prefix) + TTG[1_3] (skip) + ACG[3] (9 bp
+    // suffix) but actual span is only 13 bp — prefix + suffix = 15 bp
+    // exceeds the available span (no room for ANY ambiguous middle).
+    let core = "CTGCTGTTGGGGGG"; // 14 bp
+    assert_eq!(core.len(), 14);
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]ACG[3]", CORE_START, end);
+    let err = normalize_strict(provider, &input)
+        .expect_err("prefix + suffix together exceeding span must reject (overlap)");
+    assert!(
+        is_ref_mismatch(&err),
+        "expected ReferenceMismatch for prefix+suffix overflow; got: {err:?}",
+    );
+}
+
+// =============================================================================
+// Negative controls — preserve existing behavior
+// =============================================================================
+
+/// All-Exact regression: full validation still works (prefix walk
+/// reaches end, suffix walk has nothing left to check).
+#[test]
+fn all_exact_consistent_accepted_strict_regression() {
+    // 2 CTG (6) + 1 TTG (3) + 11 CTG (33) = 42 bp.
+    let core = "CTGCTGTTGCTGCTGCTGCTGCTGCTGCTGCTGCTGCTGCTG";
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1]CTG[11]", CORE_START, end);
+    normalize_strict(provider, &input).expect("all-Exact must still accept");
+}
+
+/// First-unit-non-Exact, no trailing Exact: no validation (no
+/// deterministic prefix or suffix).
+#[test]
+fn no_anchored_units_skips_validation() {
+    // First unit Range, last unit also Range → no validation anchor on
+    // either side. Reference bases are arbitrary; must accept.
+    let core = "CTGCTGCTGTTGACGACGACG"; // 21 bp
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!(
+        "NC_000001.11:g.{}_{}CTG[1_5]TTG[1]ACG[1_5]",
+        CORE_START, end
+    );
+    normalize_strict(provider, &input)
+        .expect("no anchored units → no validation; must accept arbitrary tract");
+}
+
+/// Leading-Exact-only (no trailing Exact): the prefix path still
+/// works exactly as before — confirms the new suffix path doesn't
+/// break the prefix-only case.
+#[test]
+fn leading_exact_only_prefix_validation_regression() {
+    // CTG[2] (6 bp prefix) + TTG[1_3] (skip) — no trailing Exact.
+    let core = "CTGCTGTTGTTG"; // 12 bp: 6 CTG + 6 TTG (2 TTGs in the range)
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]", CORE_START, end);
+    normalize_strict(provider, &input)
+        .expect("leading-Exact-only with matching prefix must accept (regression)");
+}
+
+/// Leading prefix mismatch is still detected (regression for the
+/// existing prefix-validation path).
+#[test]
+fn leading_exact_prefix_mismatch_still_rejected_strict() {
+    // CTG[2] declared but the actual leading 6 bp is GGGGGG.
+    let core = "GGGGGGTTGACGACG"; // 15 bp
+    let padded_seq = padded(core);
+    let provider = g_provider("NC_000001.11", &padded_seq);
+    let end = CORE_START + (core.len() as u64) - 1;
+    let input = format!("NC_000001.11:g.{}_{}CTG[2]TTG[1_3]ACG[2]", CORE_START, end);
+    let err = normalize_strict(provider, &input)
+        .expect_err("leading-Exact prefix mismatch must still reject");
+    assert!(is_ref_mismatch(&err), "expected RefMismatch; got: {err:?}");
+}

--- a/tests/issue_395_multirepeat_interleaved_resumption.rs
+++ b/tests/issue_395_multirepeat_interleaved_resumption.rs
@@ -141,7 +141,7 @@ fn trailing_exact_suffix_mismatch_warns_lenient() {
 #[test]
 fn prefix_plus_suffix_overflow_span_rejected_strict() {
     // Declare CTG[2] (6 bp prefix) + TTG[1_3] (skip) + ACG[3] (9 bp
-    // suffix) but actual span is only 13 bp — prefix + suffix = 15 bp
+    // suffix) but actual span is only 14 bp — prefix + suffix = 15 bp
     // exceeds the available span (no room for ANY ambiguous middle).
     let core = "CTGCTGTTGGGGGG"; // 14 bp
     assert_eq!(core.len(), 14);

--- a/tests/issue_395_overlap_conflict_strict_rejection.rs
+++ b/tests/issue_395_overlap_conflict_strict_rejection.rs
@@ -12,7 +12,12 @@
 //!   - Strict mode rejects W5002 with `FerroError::InvalidCoordinates`
 //!     citing `OverlapConflictingEdits / W5002`.
 //!   - Lenient mode preserves the input and emits the warning.
-//!   - Silent mode skips the warning entirely (matches PositionPastEnd/W4004).
+//!   - Silent mode still emits the warning (the emit site at
+//!     `overlap.rs:88` is unconditional); only strict-mode promotion
+//!     to error was the gap. Callers using `normalize_with_warnings`
+//!     get the warning in any mode, while `normalize` only differs
+//!     for strict (Err) vs lenient/silent (Ok with warning attached
+//!     to the dropped vec).
 //!
 //! # Spec basis
 //!
@@ -67,6 +72,15 @@ fn lenient_mode_emits_w5002_warning_and_preserves_input() {
         "lenient mode must emit OverlapConflict (W5002) warning; got: {:?}",
         result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
     );
+    // "Preserves input" contract: the normalized variant equals the
+    // parsed input verbatim. Per the registry text and the
+    // `OverlapConflictingEdits` docstring, ferro does NOT canonicalize
+    // coincident-bounds cis edits — the input is returned unchanged.
+    assert_eq!(
+        result.result, variant,
+        "lenient mode must preserve the parsed input verbatim; got: {}",
+        result.result,
+    );
 }
 
 #[test]
@@ -77,5 +91,38 @@ fn strict_mode_accepts_non_coincident_cis_edits() {
     let variant = parse_hgvs("NC_000001.11:g.[100A>C;101A>G]").expect("parse");
     normalizer.normalize(&variant).expect(
         "strict mode must accept non-coincident cis edits; the W5002 trigger is coincident-bounds only",
+    );
+}
+
+#[test]
+fn silent_mode_still_emits_w5002_warning() {
+    // The emit site at `src/normalize/overlap.rs:88` is unconditional —
+    // silent mode does not suppress the warning, only changes
+    // strict-mode behavior from Reject to WarnAccept. Callers using
+    // `normalize_with_warnings` get the warning regardless of mode;
+    // `normalize` only differs by whether the warning is promoted
+    // (strict → Err) or accepted (lenient/silent → Ok).
+    let normalizer = Normalizer::with_config(provider(), NormalizeConfig::silent());
+    let variant = parse_hgvs("NC_000001.11:g.[100A>C;100A>G]").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("silent mode must accept coincident-bounds cis edits");
+    let has_warning = result
+        .warnings
+        .iter()
+        .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
+    assert!(
+        has_warning,
+        "silent mode still emits the OverlapConflict warning at the detection site; \
+         only strict-mode promotion is gated by mode. Got: {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+    // "Preserves input" contract: silent mode, like lenient, returns
+    // the parsed input verbatim — ferro does NOT canonicalize
+    // coincident-bounds cis edits in any non-strict mode.
+    assert_eq!(
+        result.result, variant,
+        "silent mode must preserve the parsed input verbatim; got: {}",
+        result.result,
     );
 }

--- a/tests/issue_395_overlap_conflict_strict_rejection.rs
+++ b/tests/issue_395_overlap_conflict_strict_rejection.rs
@@ -1,0 +1,81 @@
+//! Issue #395 item 6 — `W5002 OverlapConflict` promoted to error in
+//! strict mode.
+//!
+//! `src/error_handling/registry.rs:1190` declared W5002's
+//! `mode_behavior` as `ModeBehavior::always_warn_if_not_rejected()`
+//! (Strict→Reject, Lenient→WarnAccept, Silent→WarnAccept). But the
+//! emit site at `src/normalize/overlap.rs:88` pushes the warning
+//! unconditionally, bypassing the policy table. Result: strict mode
+//! still emitted the warning and accepted the variant.
+//!
+//! This file pins:
+//!   - Strict mode rejects W5002 with `FerroError::InvalidCoordinates`
+//!     citing `OverlapConflictingEdits / W5002`.
+//!   - Lenient mode preserves the input and emits the warning.
+//!   - Silent mode skips the warning entirely (matches PositionPastEnd/W4004).
+//!
+//! # Spec basis
+//!
+//! HGVS spec does not define a canonical form for two cis-allele edits
+//! sharing identical reference bounds — the variant is ambiguous. Per
+//! the registry: "ferro preserves the input verbatim and emits this
+//! warning". Strict mode promotes to a typed error so callers can flag
+//! the input.
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
+
+fn provider() -> MockProvider {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000001.11", "A".repeat(200));
+    p
+}
+
+#[test]
+fn strict_mode_rejects_coincident_bounds_with_w5002_error() {
+    // Two substitutions at the same g.100 position — coincident bounds.
+    let normalizer = Normalizer::with_config(provider(), NormalizeConfig::strict());
+    let variant = parse_hgvs("NC_000001.11:g.[100A>C;100A>G]").expect("parse");
+    let err = normalizer
+        .normalize(&variant)
+        .expect_err("strict mode must reject coincident-bounds cis edits");
+    match err {
+        FerroError::InvalidCoordinates { msg } => {
+            assert!(
+                msg.contains("W5002") || msg.contains("OverlapConflictingEdits"),
+                "strict-mode error message must reference W5002 / OverlapConflictingEdits; got: {msg}",
+            );
+        }
+        other => panic!("unexpected error variant: {other:?}"),
+    }
+}
+
+#[test]
+fn lenient_mode_emits_w5002_warning_and_preserves_input() {
+    let normalizer = Normalizer::with_config(provider(), NormalizeConfig::lenient());
+    let variant = parse_hgvs("NC_000001.11:g.[100A>C;100A>G]").expect("parse");
+    let result = normalizer
+        .normalize_with_warnings(&variant)
+        .expect("lenient mode must accept coincident-bounds cis edits");
+    let has_warning = result
+        .warnings
+        .iter()
+        .any(|w| matches!(w, NormalizationWarning::OverlapConflict { .. }));
+    assert!(
+        has_warning,
+        "lenient mode must emit OverlapConflict (W5002) warning; got: {:?}",
+        result.warnings.iter().map(|w| w.code()).collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn strict_mode_accepts_non_coincident_cis_edits() {
+    // Negative control: cis edits at DIFFERENT positions must not
+    // trigger the overlap rejection.
+    let normalizer = Normalizer::with_config(provider(), NormalizeConfig::strict());
+    let variant = parse_hgvs("NC_000001.11:g.[100A>C;101A>G]").expect("parse");
+    normalizer.normalize(&variant).expect(
+        "strict mode must accept non-coincident cis edits; the W5002 trigger is coincident-bounds only",
+    );
+}

--- a/tests/issue_395_rna_u_to_t_plus_strand.rs
+++ b/tests/issue_395_rna_u_to_t_plus_strand.rs
@@ -1,0 +1,164 @@
+//! Issue #395 item 4 — RNA `u` to DNA `t` translation on plus-strand
+//! projection.
+//!
+//! `src/project/edit.rs::transform_edit_for_strand` previously
+//! returned `edit.clone()` unchanged on `Strand::Plus`. For r. inputs
+//! (RNA-coordinate variants) that carry `Base::U`, projecting to the
+//! genomic axis (DNA) requires translating `u → t` independently of
+//! strand: the genomic reference is DNA, not RNA. The `Base::U →
+//! Base::A` complement map at `src/project/edit.rs:71` only ran via
+//! `complement_base` on the `Strand::Minus` path, leaving plus-strand
+//! r.→g. projections emitting invalid DNA like `g.<N>U>A`.
+//!
+//! # Spec basis
+//!
+//! `assets/hgvs-nomenclature/docs/recommendations/general.md` defines
+//! r./n./c. variants on RNA sequences with lowercase nucleotides
+//! including `u`. The DNA reference sequences (`g.`, `m.`, `o.`) use
+//! `T`. A round-trip r.→g. projection must therefore translate `u`
+//! to `t` regardless of strand orientation.
+
+use ferro_hgvs::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
+use ferro_hgvs::project::edit::transform_edit_for_strand;
+use ferro_hgvs::reference::Strand;
+
+#[test]
+fn plus_strand_substitution_u_to_a_translates_to_t_to_a_dna() {
+    // r.100u>a — RNA `u` substitution to `a`. On plus strand projecting
+    // to g. (DNA), the `u` becomes `t` (no reverse complement on Plus).
+    let r_edit = NaEdit::Substitution {
+        reference: Base::U,
+        alternative: Base::A,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    assert_eq!(
+        g_edit,
+        NaEdit::Substitution {
+            reference: Base::T,
+            alternative: Base::A,
+        },
+        "plus-strand r.u>a must project to g.T>A (DNA), not g.U>A (invalid DNA)",
+    );
+}
+
+#[test]
+fn plus_strand_substitution_a_to_u_translates_alt_u_to_t() {
+    // r.100a>u — RNA `a` substitution to `u`. Plus-strand projection:
+    // alt `u` → `t`.
+    let r_edit = NaEdit::Substitution {
+        reference: Base::A,
+        alternative: Base::U,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    assert_eq!(
+        g_edit,
+        NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::T,
+        },
+        "plus-strand r.a>u must project to g.A>T (DNA)",
+    );
+}
+
+#[test]
+fn plus_strand_substitution_non_u_unchanged() {
+    // Negative control: a substitution with no `u` is returned
+    // bit-for-bit identical on plus strand.
+    let r_edit = NaEdit::Substitution {
+        reference: Base::A,
+        alternative: Base::G,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    assert_eq!(
+        g_edit, r_edit,
+        "plus-strand non-u edit must pass through unchanged"
+    );
+}
+
+#[test]
+fn plus_strand_deletion_u_in_sequence_translates_to_t() {
+    // r.100_102delauu — deleted sequence carries `u`. Plus-strand
+    // projection: the stated deleted DNA sequence is `ATT`.
+    let r_edit = NaEdit::Deletion {
+        sequence: Some("AUU".parse::<Sequence>().unwrap()),
+        length: None,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    let expected_seq: Sequence = "ATT".parse().unwrap();
+    match g_edit {
+        NaEdit::Deletion {
+            sequence: Some(s), ..
+        } => assert_eq!(
+            s, expected_seq,
+            "plus-strand del sequence with U must translate U→T"
+        ),
+        other => panic!("expected Deletion with sequence, got {other:?}"),
+    }
+}
+
+#[test]
+fn plus_strand_insertion_u_in_inserted_translates_to_t() {
+    // r.100_101insauu — inserted sequence carries `u`. Plus-strand
+    // projection: `ATT`.
+    let r_edit = NaEdit::Insertion {
+        sequence: InsertedSequence::Literal("AUU".parse::<Sequence>().unwrap()),
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    let expected_seq: Sequence = "ATT".parse().unwrap();
+    match g_edit {
+        NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(s),
+        } => assert_eq!(
+            s, expected_seq,
+            "plus-strand ins sequence with U must translate U→T"
+        ),
+        other => panic!("expected Insertion with Literal sequence, got {other:?}"),
+    }
+}
+
+#[test]
+fn plus_strand_delins_u_in_both_translates_both() {
+    // r.100_102delauuinscu — both deleted and inserted sequences have
+    // `u`. Plus-strand: deleted `ATT`, inserted `CT`.
+    let r_edit = NaEdit::Delins {
+        sequence: InsertedSequence::Literal("CU".parse::<Sequence>().unwrap()),
+        deleted: Some("AUU".parse::<Sequence>().unwrap()),
+        deleted_length: None,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
+    let expected_del: Sequence = "ATT".parse().unwrap();
+    let expected_ins: Sequence = "CT".parse().unwrap();
+    match g_edit {
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(ins),
+            deleted: Some(del),
+            ..
+        } => {
+            assert_eq!(del, expected_del, "delins deleted U→T");
+            assert_eq!(ins, expected_ins, "delins inserted U→T");
+        }
+        other => panic!("expected Delins, got {other:?}"),
+    }
+}
+
+#[test]
+fn minus_strand_u_in_substitution_still_revcomps() {
+    // Regression for the minus-strand path: r.U>A on minus strand
+    // becomes g.A>T (U complement = A, A complement = T). The
+    // existing complement_base map already handles U → A; this test
+    // just pins that the minus-strand path is unaffected by the
+    // item 4 fix.
+    let r_edit = NaEdit::Substitution {
+        reference: Base::U,
+        alternative: Base::A,
+    };
+    let g_edit = transform_edit_for_strand(&r_edit, Strand::Minus);
+    assert_eq!(
+        g_edit,
+        NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::T,
+        },
+        "minus-strand r.u>a must project to g.A>T (existing complement_base behavior)",
+    );
+}

--- a/tests/python/test_issue_395_normalization_warnings.py
+++ b/tests/python/test_issue_395_normalization_warnings.py
@@ -1,0 +1,82 @@
+"""Issue #395 item 5 — `NormalizationWarning` exposed to Python.
+
+`src/python.rs` previously had zero references to
+`crate::normalize::NormalizationWarning`. Python callers calling
+`Normalizer.normalize(...)` got back only the warning-stripped String
+representation. The new `Normalizer.normalize_with_warnings(...)` method
+surfaces the warnings on a `NormalizeResultWithWarnings` object.
+
+These tests run under `pytest tests/python/` after `maturin develop
+--features python`. They cover:
+
+  - The new `NormalizeResultWithWarnings` shape (result + warnings).
+  - `NormalizationWarning.code` and `.message` accessors.
+  - The empty-warnings case (no-corrections normalize call).
+"""
+
+import json
+
+import ferro_hgvs
+
+
+def _make_reference_json(tmp_path, contig: str, start_1based: int, bases: str) -> str:
+    """Write a JSON reference with `bases` at `start_1based..` and return its path."""
+    seq = ["A"] * max(2000, start_1based + len(bases) + 200)
+    for i, b in enumerate(bases):
+        seq[start_1based - 1 + i] = b
+    payload = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {contig: "".join(seq)},
+    }
+    path = tmp_path / "ref.json"
+    path.write_text(json.dumps(payload))
+    return str(path)
+
+
+class TestNormalizeWithWarnings:
+    """Smoke tests for the new `normalize_with_warnings` Python method."""
+
+    def test_normalize_with_warnings_returns_result_and_warnings(self) -> None:
+        """A normalize call that emits no warnings still returns the
+        result wrapped in `NormalizeResultWithWarnings` with an empty
+        warnings list.
+
+        Uses an in-bounds, reference-matching position on the bundled
+        `NM_000088.3` test transcript (CDS sequence
+        `ATGCCCAAGGTGCTGCCCCAGATGCTGCCAGTGCTGCTGCTGCTGCTGCTGCTGCTGCTG`,
+        CDS length 60). `c.4C>G` matches the reference base at position 4
+        and stays within the CDS, so neither `RefSeqMismatch` nor
+        `PositionPastEnd` is emitted."""
+        normalizer = ferro_hgvs.Normalizer()
+        result = normalizer.normalize_with_warnings("NM_000088.3:c.4C>G")
+        assert result.has_warnings() is False
+        assert result.warnings == []
+        # The wrapped variant should be accessible via `.result`.
+        assert str(result.result) == "NM_000088.3:c.4C>G"
+
+    def test_normalize_with_warnings_surfaces_overlap_conflict(self, tmp_path) -> None:
+        """Two cis-allele substitutions at coincident bounds emit
+        `OVERLAP_CONFLICTING_EDITS` (W5002) in lenient mode."""
+        ref = _make_reference_json(tmp_path, "NC_000001.11", 100, "A")
+        normalizer = ferro_hgvs.Normalizer(reference_json=ref)
+        result = normalizer.normalize_with_warnings("NC_000001.11:g.[100A>C;100A>G]")
+        codes = [w.code for w in result.warnings]
+        assert "OVERLAP_CONFLICTING_EDITS" in codes, (
+            f"expected OVERLAP_CONFLICTING_EDITS in warnings; got {codes}"
+        )
+        assert result.has_warnings() is True
+
+    def test_normalization_warning_has_code_and_message(self, tmp_path) -> None:
+        """Each `NormalizationWarning` carries `.code` and `.message`."""
+        ref = _make_reference_json(tmp_path, "NC_000001.11", 100, "A")
+        normalizer = ferro_hgvs.Normalizer(reference_json=ref)
+        result = normalizer.normalize_with_warnings("NC_000001.11:g.[100A>C;100A>G]")
+        assert len(result.warnings) > 0
+        w = result.warnings[0]
+        # Both accessors must be non-empty.
+        assert isinstance(w.code, str) and len(w.code) > 0
+        assert isinstance(w.message, str) and len(w.message) > 0
+        # __repr__ surfaces the code + message.
+        repr_str = repr(w)
+        assert w.code in repr_str


### PR DESCRIPTION
## Summary

Closes 4 of 6 items in #395 (items 1, 4, 5, 6). Items 2 and 3 (cross-reference ins expansion; CDS-offset range ins expansion) are deferred — item 3 is spec-undefined per the existing `src/normalize/rules.rs:1788-1804` doc comment ("The HGVS spec does not pin canonical expansion for any of these shapes"), and item 2 warrants its own focused issue. Will file a follow-up for item 2.

- **`feat(validate): right-anchor MultiRepeat trailing-Exact suffix` (#395 item 1)** — `validate_multirepeat_tract` previously walked left-to-right and broke at the first non-`Exact` count, never validating trailing `Exact` units. New behavior: builds a leading-`Exact` prefix (left-anchored) AND a trailing-`Exact` suffix (right-anchored). Length sanity check rejects when `prefix_len + suffix_len > span_len` (the suffix would overlap the prefix). Updates 2 tests in `tests/issue_279_multirepeat_partial_validation.rs` to use first-AND-last-non-Exact (genuinely no anchor) instead of first-non-Exact-but-last-Exact (now covered by the new validation). 8 new tests in `tests/issue_395_multirepeat_interleaved_resumption.rs`.

- **`fix(project): translate RNA U→T on plus-strand r.→g. projection` (#395 item 4)** — `transform_edit_for_strand` on `Strand::Plus` previously returned `edit.clone()` unchanged. For r. inputs carrying `Base::U`, projecting to g. (DNA) requires translating `U → T` regardless of strand. The minus-strand path already handled this via `complement_base` (`U → A` + reversal). New `u_to_t_edit` helper covers the plus-strand path symmetrically. Visibility expanded: `transform_edit_for_strand` from `pub(crate)` to `pub`; `project::edit` from `mod edit` to `pub mod edit` so the integration test can exercise the helper directly. 7 new tests.

- **`feat(python): expose NormalizationWarning surface` (#395 item 5)** — `src/python.rs` previously had zero references to `crate::normalize::NormalizationWarning`. Python callers got back only the warning-stripped `String`. New `PyNormalizationWarning` (code + message accessors) and `PyNormalizeResultWithWarnings` types; new `PyNormalizer::normalize_with_warnings(hgvs_string)` method. `PyErrorType` gains `OverlapConflictingEdits = 35` matching the new Rust ErrorType variant from item 6. 3 pytest smoke tests + 1 Rust-level From-converter test added by the review-fix commit.

- **`feat(normalize): promote W5002 OverlapConflict to strict-mode rejection` (#395 item 6)** — `src/error_handling/registry.rs:1190` declared W5002's `mode_behavior` as `ModeBehavior::always_warn_if_not_rejected()` (Strict→Reject), but the emit site at `src/normalize/overlap.rs:88` unconditionally pushed the warning, bypassing the policy table. New `ErrorType::OverlapConflictingEdits` (W5002) variant + `NormalizeConfig::should_reject_overlap_conflict` helper + strict-mode promotion at the outer `Normalizer::normalize` wrapper (parallels existing W4004/W5003 promotions). 4 new tests (strict reject, lenient warn, non-coincident accept, silent-mode still-emits-warning).

- **`fix(review): apply end-of-issue review findings` (#395)** — Consolidated review-fix commit. Documented the `prefix + suffix == span` lax-acceptance gap in `validate_multirepeat_tract` (tightening left as future pass). Documented the dead lowercase `'u'` arm in `u_to_t_sequence` as defensive. Renamed the in-module test `substitution_plus_strand_unchanged` → `substitution_plus_strand_non_u_unchanged` to match the post-fix contract. Added Rust-level From-converter unit test in `src/python.rs`. Fixed an off-by-one in a test docstring. Corrected an inaccurate silent-mode claim in the W5002 test docstring + added a silent-mode-still-emits-warning regression test.

## Items 2 + 3 deferral

Per investigation in the issue thread:

- **Item 2 (cross-reference ins expansion)**: real stub at `src/normalize/rules.rs:1816-1822` and `:1919-1924`. Implementing requires fetching foreign-accession bases via `ReferenceProvider::get_genomic_sequence` and parsing inner coord ranges. Moderate complexity; deferred to its own focused issue.

- **Item 3 (CDS-offset range ins expansion)**: real stub at `src/normalize/rules.rs:1799-1804` and `:1833-1839`, but per the existing doc comment at line 1794-1798: "The HGVS spec does not pin canonical expansion for any of these shapes." Per the project's HGVS-spec-arbitrated rule, implementing spec-undefined behavior would mean inventing a contract. Deferred indefinitely.

## Test plan

- [ ] `cargo nextest run --features dev` — 5869 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences pre-existing on `origin/main`); no new failures.
- [ ] `cargo clippy --features dev -- -D warnings` clean.
- [ ] `cargo fmt --all -- --check` clean.
- [ ] `cargo run --features dev --example generate_spec_fixture -- --check` clean.
- [ ] All new tests across the 4 items PASS (8 + 7 + 3 + 4 = 22 new Rust tests; 3 new Python tests under `maturin develop`).