### PR TITLE
parser: trans-allele dedup, mixed phase reject, RNA whole-entity in brackets (closes #396)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1036,32 +1036,41 @@ fn parse_genome_variant(
     move |input: &str| {
         let (input, _) = tag("g.").parse(input)?;
 
-        // First try whole-genome identity (g.= or g.(=)) - no position
+        // First try whole-genome identity (g.= or g.(=)) - no position.
+        // Reject the probe when the remainder starts with `(;)` so that a
+        // bracketless unknown-phase compound (`g.=(;)123A>G`) reaches the
+        // `(;)` dispatcher below rather than getting silently consumed as
+        // a `g.=` whose trailing `(;)...` then fails far from the cause.
         if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Genome(GenomeVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Genome(GenomeVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
-        // Try whole-genome unknown (g.? or g.(?)) - no position
+        // Try whole-genome unknown (g.? or g.(?)) - no position. Same
+        // `(;)` guard as the identity probe above.
         if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Genome(GenomeVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Genome(GenomeVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Try trans-allele compact-prefix shorthand: g.[edit1];[edit2]
@@ -1642,21 +1651,20 @@ fn parse_genome_position_unknown_phase(
     ))
 }
 
-/// Parse a genomic trans-allele compact-prefix shorthand: `[edit1];[edit2]`
-/// (with the `g.` already consumed by the caller). Each bracketed group holds
-/// a single sub-variant rendered with this allele's accession. Mirrors
-/// `parse_cds_trans_allele_shorthand` and `parse_rna_trans_allele_shorthand`.
 /// Generic trans-allele shorthand parser shared by 6 of 7 axes (g., c., n.,
 /// m., r., o.). Owns the bracketed-member loop, the `[0]`/`[?]`
 /// cross-coordinate special-cases, the bracket-balance check, the
 /// `len < 2` guard, and the final `AlleleVariant::new(.., Trans)` wrap.
+/// Always emits `AllelePhase::Trans` — cis and unknown-phase shapes
+/// route through `parse_*_allele_shorthand` / `parse_*_compound_allele`
+/// upstream and never reach this function.
 ///
 /// Each axis-specific shim provides `parse_member`, a closure that
 /// consumes the bracket content and constructs the per-axis
-/// `HgvsVariant::<Axis>` (or returns a parse error). The closure also
-/// owns the post-parse "content fully consumed" check so axes are free
-/// to use their own bracket-member primitives without recomputing the
-/// remainder.
+/// `HgvsVariant::<Axis>` (or returns a parse error). The closure
+/// returns its own remainder so each axis is free to use its own
+/// bracket-member primitives; the generic checks the remainder is
+/// fully consumed.
 ///
 /// Protein keeps its own bespoke helper because it overrides the
 /// special-marker arm (`[0]`/`[0?]`/`[(0)]` → `ProteinEdit::NoProtein`
@@ -1703,8 +1711,24 @@ where
         variants.push(variant);
         remaining = &remaining[close_bracket + 1..];
 
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
+        // Enforce strict `[...];[...]` shape. A `;` is only valid if it
+        // separates the bracket we just consumed from another bracket; a
+        // dangling trailing `;` (e.g. `[A];[B];`) and a missing separator
+        // (e.g. `[A];[B][C]`) must both reject rather than silently
+        // build an extra-member or short AlleleVariant.
+        if let Some(after_semi) = remaining.strip_prefix(';') {
+            if !after_semi.starts_with('[') {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    after_semi,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+            remaining = after_semi;
+        } else if remaining.starts_with('[') {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            )));
         }
     }
 
@@ -2207,45 +2231,54 @@ fn parse_tx_variant(
         // First try whole-tx identity (n.= or n.(=)) - no position. #288.
         // Non-coding transcripts reuse the RNA whole-entity parsers
         // (`parse_whole_rna_*`, `parse_rna_no_product`) — those are pure
-        // tag-only parsers and don't depend on the coord system.
+        // tag-only parsers and don't depend on the coord system. Reject
+        // the probe when the remainder starts with `(;)` so a bracketless
+        // unknown-phase compound (`n.=(;)100A>G`) falls through to the
+        // `(;)` dispatcher rather than being silently consumed as `n.=`.
         if let Ok((remaining, edit)) = parse_whole_rna_identity(input) {
-            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
-            return Ok((
-                remaining,
-                HgvsVariant::Tx(TxVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+                return Ok((
+                    remaining,
+                    HgvsVariant::Tx(TxVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Try whole-tx unknown (n.? or n.(?)) - no position. #288.
         if let Ok((remaining, edit)) = parse_whole_rna_unknown(input) {
-            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
-            return Ok((
-                remaining,
-                HgvsVariant::Tx(TxVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+                return Ok((
+                    remaining,
+                    HgvsVariant::Tx(TxVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Try tx-specific no product pattern (n.0 or predicted n.(0)). #288.
         // `0` is a valid spec form for non-coding transcripts — they can
-        // fail to produce a transcript, exactly like `r.0`.
+        // fail to produce a transcript, exactly like `r.0`. Same `(;)` guard.
         if let Ok((remaining, edit)) = parse_rna_no_product(input) {
-            let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
-            return Ok((
-                remaining,
-                HgvsVariant::Tx(TxVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_interval = TxInterval::point(crate::hgvs::location::TxPos::new(1));
+                return Ok((
+                    remaining,
+                    HgvsVariant::Tx(TxVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Compact-prefix trans-allele shorthand: n.[a];[b]. Mirrors
@@ -2489,32 +2522,37 @@ fn parse_mt_variant(
 
         // First try whole-mtDNA identity (m.= or m.(=)) - no position. #288.
         // Mitochondrial DNA reuses the genome whole-entity parser because
-        // both share `GenomeInterval`.
+        // both share `GenomeInterval`. Reject when the remainder starts
+        // with `(;)` so `m.=(;)100A>G` reaches the unknown-phase dispatch.
         if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Mt(MtVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Mt(MtVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Try whole-mtDNA unknown (m.? or m.(?)) - no position. #288.
         if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Mt(MtVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Mt(MtVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Compact-prefix trans-allele shorthand: m.[a];[b]. Mirrors
@@ -2906,8 +2944,22 @@ fn parse_protein_trans_allele_shorthand(
         variants.push(variant);
         remaining = &remaining[close_bracket + 1..];
 
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
+        // Mirrors `parse_trans_allele_shorthand_generic`: enforce strict
+        // `[...];[...]` shape — reject both dangling trailing `;` and a
+        // missing separator between adjacent brackets.
+        if let Some(after_semi) = remaining.strip_prefix(';') {
+            if !after_semi.starts_with('[') {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    after_semi,
+                    nom::error::ErrorKind::Tag,
+                )));
+            }
+            remaining = after_semi;
+        } else if remaining.starts_with('[') {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                remaining,
+                nom::error::ErrorKind::Tag,
+            )));
         }
     }
 
@@ -3605,6 +3657,13 @@ fn parse_rna_bracket_member(
     // parsers so a bracket like `[(spl?)]` matches the predicted-splice
     // marker rather than being routed into `parse_rna_interval`. #396
     // item 3.
+    //
+    // Note: bare `[0]` / `[?]` in the trans-allele form are handled
+    // upstream by `parse_trans_allele_shorthand_generic`'s cross-coord
+    // short-circuits (→ `NullAllele` / `UnknownAllele`) and never reach
+    // this dispatcher. Only the cis/unknown-flat paths and predicted
+    // forms (`[(0)]`, `[(?)]`, `[(spl?)]`) plus splice markers
+    // (`[spl]`, `[spl?]`) flow through these probes.
     fn dummy_rna_interval() -> RnaInterval {
         RnaInterval::point(crate::hgvs::location::RnaPos {
             base: 1,
@@ -3796,31 +3855,37 @@ fn parse_circular_variant(
         // First try whole-circular identity (o.= or o.(=)) - no position. #288.
         // Circular DNA reuses the genome whole-entity parser because both
         // share `GenomeInterval`; SVD-WG006 inherits the DNA grammar.
+        // Reject when the remainder starts with `(;)` so `o.=(;)100A>G`
+        // reaches the unknown-phase dispatch below.
         if let Ok((remaining, edit)) = parse_whole_genome_identity(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Circular(CircularVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Circular(CircularVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Try whole-circular unknown (o.? or o.(?)) - no position. #288.
         if let Ok((remaining, edit)) = parse_whole_genome_unknown(input) {
-            let dummy_pos = crate::hgvs::location::GenomePos::new(1);
-            let dummy_interval = GenomeInterval::point(dummy_pos);
-            return Ok((
-                remaining,
-                HgvsVariant::Circular(CircularVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
-                }),
-            ));
+            if !remaining.starts_with("(;)") {
+                let dummy_pos = crate::hgvs::location::GenomePos::new(1);
+                let dummy_interval = GenomeInterval::point(dummy_pos);
+                return Ok((
+                    remaining,
+                    HgvsVariant::Circular(CircularVariant {
+                        accession: accession.clone(),
+                        gene_symbol: gene_symbol.clone(),
+                        loc_edit: LocEdit::with_uncertainty(dummy_interval, edit),
+                    }),
+                ));
+            }
         }
 
         // Compact-prefix trans-allele shorthand: o.[a];[b]. Mirrors
@@ -6558,7 +6623,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_mixed_phase_allele_shorthand_rejected() {
+    fn test_parse_mixed_phase_cds_allele_shorthand_rejected() {
         // Mixed `;`/`(;)` inside one bracket pair (e.g. `[A;B(;)C]`) has
         // no spec-defined HGVS shape: there is no way to express "A and
         // B are cis to each other, but unknown phase to C" in a single
@@ -6570,7 +6635,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_mixed_phase_allele_shorthand_complex_rejected() {
+    fn test_parse_mixed_phase_cds_allele_shorthand_complex_rejected() {
         // More complex mixed shape `[A;B;C(;)D;E]` rejects too.
         assert!(parse_variant("NM_000088.3:c.[100A>G;200C>T;300G>A(;)400del;500dup]").is_err());
     }

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1163,16 +1163,6 @@ enum GenomeKind {
 }
 
 impl GenomeKind {
-    fn build_variant(
-        self,
-        accession: Accession,
-        gene_symbol: Option<String>,
-        interval: GenomeInterval,
-        edit: crate::hgvs::edit::NaEdit,
-    ) -> HgvsVariant {
-        self.build_variant_with_loc_edit(accession, gene_symbol, LocEdit::new(interval, edit))
-    }
-
     /// Build a variant from a pre-constructed `LocEdit` (allowing
     /// `Mu::Uncertain` for the predicted-wrapper form). #243.
     fn build_variant_with_loc_edit(
@@ -1202,12 +1192,53 @@ impl GenomeKind {
 }
 
 /// Parse a single bracket-member position+edit (genome / m. / o.),
-/// recognising the predicted-wrapper form. Mirrors
-/// `parse_cds_bracket_member`. #243.
+/// recognising whole-entity edits (`=`, `?`, `(=)`, `(?)`) and the
+/// predicted-wrapper form. Mirrors `parse_cds_bracket_member` and
+/// `parse_rna_bracket_member`. #243; whole-entity dispatch added by
+/// #423 (follow-up to #396 item 3).
 fn parse_genome_bracket_member(
     part: &str,
     kind: GenomeKind,
 ) -> IResult<&str, LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>> {
+    // Whole-entity genome edits have no positional content, so attach
+    // a dummy interval at position 1 (mirrors `parse_genome_variant`'s
+    // handling of `g.=` / `g.?` at the top level). These probes run
+    // BEFORE the position-based predicted wrapper / bare-position
+    // parsers so a bracket like `[(=)]` matches the whole-entity
+    // identity marker rather than being routed into the position
+    // parser. Same shape applies to `m.` and `o.` — whole-entity edits
+    // don't carry a coordinate so the circular-vs-linear distinction
+    // is moot for these probes. #423, follow-up to #396 item 3.
+    //
+    // Note: bare `[0]` / `[?]` in the trans-allele form are handled
+    // upstream by `parse_trans_allele_shorthand_generic`'s cross-coord
+    // short-circuits (→ `NullAllele` / `UnknownAllele`) and never
+    // reach this dispatcher. Only cis/unknown-flat paths and
+    // predicted forms (`[(?)]`, `[(=)]`) plus bare `=` / `?` inside a
+    // cis bracket flow through these probes.
+    fn dummy_genome_interval() -> GenomeInterval {
+        GenomeInterval::point(crate::hgvs::location::GenomePos::new(1))
+    }
+
+    if let Ok((remaining, mu_edit)) = parse_whole_genome_identity(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_genome_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_whole_genome_unknown(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_genome_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+
     let is_circular = matches!(kind, GenomeKind::Mt | GenomeKind::Circular);
     // For `m.`/`o.` the circular variant allows the spec-authorised
     // reversed `<high>_<low>` forms; post-parse we still run
@@ -1617,25 +1648,26 @@ fn parse_genome_position_unknown_phase(
             )));
         }
 
-        let is_circular = matches!(kind, GenomeKind::Mt | GenomeKind::Circular);
-        let (edit_remaining, interval) = if is_circular {
-            parse_genome_interval_for_circular(part)?
-        } else {
-            parse_genome_interval(part)?
-        };
-        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
-
+        // Delegate to the bracket-member dispatcher so the same set of
+        // shapes (whole-entity `=`/`?`/`(=)`/`(?)`, predicted-wrapper
+        // `(<pos><edit>)`, bare position) is admitted here. This keeps
+        // the bracket form `g.[X(;)Y]` and the bracketless form
+        // `g.X(;)Y` symmetric — Display canonicalises one into the
+        // other, so accepting an asymmetric set on the parse side
+        // breaks round-trip. #423.
+        let (final_remaining, loc_edit) = parse_genome_bracket_member(part, kind)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
                 nom::error::ErrorKind::Tag,
             )));
         }
-        if is_circular {
-            check_circular_reversed_range(&interval, &edit, part)?;
-        }
 
-        variants.push(kind.build_variant(accession.clone(), gene_symbol.clone(), interval, edit));
+        variants.push(kind.build_variant_with_loc_edit(
+            accession.clone(),
+            gene_symbol.clone(),
+            loc_edit,
+        ));
     }
 
     if variants.len() < 2 {
@@ -2044,9 +2076,11 @@ fn parse_cds_position_unknown_phase(
             )));
         }
 
-        // Parse interval + edit
-        let (edit_remaining, interval) = parse_cds_interval(part)?;
-        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+        // Delegate to the bracket-member dispatcher so the same set of
+        // shapes is admitted here as in the bracketed cis/trans forms
+        // — keeps `c.[X(;)Y]` / `c.X(;)Y` round-trip-symmetric across
+        // Display's bracket-vs-bracketless canonicalisation. #423.
+        let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
 
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
@@ -2058,7 +2092,7 @@ fn parse_cds_position_unknown_phase(
         variants.push(HgvsVariant::Cds(CdsVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
+            loc_edit,
         }));
     }
 
@@ -2076,13 +2110,65 @@ fn parse_cds_position_unknown_phase(
 }
 
 /// Parse CDS allele shorthand: [145C>T;147C>G], [145C>T(;)147C>G], or [76A>C];[0]
-/// Parse a single bracket-member position+edit (CDS), recognising the
-/// predicted-wrapper form `(<pos><edit>)` and returning a `LocEdit`
-/// with `Mu::Uncertain` in that case. Falls back to `<pos>[<edit>]`
-/// (edit optional, defaults to identity). #243 follow-up to #241.
+/// Parse a single bracket-member position+edit (CDS), recognising
+/// whole-entity edits (`=`, `?`, `(=)`, `(?)`), the predicted-wrapper
+/// form `(<pos><edit>)`, and bare `<pos>[<edit>]` (edit optional,
+/// defaults to identity). #243 follow-up to #241; whole-entity dispatch
+/// added by #423 (follow-up to #396 item 3).
+///
+/// Note the intentional asymmetry with `parse_tx_bracket_member`: CDS
+/// does NOT probe `parse_rna_no_product`. `c.0` is not a CDS whole-entity
+/// form — bare `[0]` in trans-allele context is cross-coord-short-
+/// circuited to `NullAllele` upstream (see
+/// `parse_trans_allele_shorthand_generic`), and the spec does not
+/// define a `c.0` / `c.(0)` "no protein" form on the c. axis (that's
+/// what `p.0` / `p.(0)` are for). Non-coding transcripts `n.` DO use
+/// `parse_rna_no_product` because `n.0` is a valid spec form ("no
+/// transcript produced"), mirroring `r.0`.
 fn parse_cds_bracket_member(
     part: &str,
 ) -> IResult<&str, LocEdit<CdsInterval, crate::hgvs::edit::NaEdit>> {
+    // Whole-CDS edits have no positional content, so attach a dummy
+    // interval at position 1 (mirrors `parse_cds_variant`'s handling
+    // of `c.=` / `c.?` at the top level). These probes run BEFORE the
+    // position-based predicted wrapper / bare-position parsers so a
+    // bracket like `[(=)]` matches the whole-entity identity marker
+    // rather than being routed into `parse_cds_interval`. #423,
+    // follow-up to #396 item 3.
+    //
+    // Note: bare `[0]` / `[?]` in the trans-allele form are handled
+    // upstream by `parse_trans_allele_shorthand_generic`'s cross-coord
+    // short-circuits (→ `NullAllele` / `UnknownAllele`) and never
+    // reach this dispatcher. Only cis/unknown-flat paths and
+    // predicted forms (`[(?)]`, `[(=)]`) plus bare `=` / `?` inside a
+    // cis bracket flow through these probes.
+    fn dummy_cds_interval() -> CdsInterval {
+        CdsInterval::point(crate::hgvs::location::CdsPos {
+            base: 1,
+            offset: None,
+            utr3: false,
+        })
+    }
+
+    if let Ok((remaining, mu_edit)) = parse_whole_cds_identity(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_cds_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_whole_cds_unknown(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_cds_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+
     // Try predicted wrapper first
     if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
         if let Ok((remaining, (interval, edit))) =
@@ -2337,13 +2423,70 @@ fn parse_tx_variant(
 }
 
 /// Parse a single bracket-member position+edit (non-coding transcript /
-/// `n.`), recognising the predicted-wrapper form `(<pos><edit>)` and
-/// returning a `LocEdit` with `Mu::Uncertain` in that case. Falls back
-/// to `<pos>[<edit>]` (edit optional, defaults to identity). Mirrors
-/// `parse_cds_bracket_member`. #287 follow-up to #243 / PR #244.
+/// `n.`), recognising whole-entity edits (`=`, `?`, `(=)`, `(?)`, `0`,
+/// `(0)`), the predicted-wrapper form `(<pos><edit>)`, and bare
+/// `<pos>[<edit>]` (edit optional, defaults to identity). Mirrors
+/// `parse_cds_bracket_member` and `parse_rna_bracket_member`. #287
+/// follow-up to #243 / PR #244; whole-entity dispatch added by #423
+/// (follow-up to #396 item 3).
+///
+/// Whole-entity probes here reuse the RNA-named parsers
+/// (`parse_whole_rna_identity`, `parse_whole_rna_unknown`,
+/// `parse_rna_no_product`) — these are pure tag-only and don't depend
+/// on the coord system, so `parse_tx_variant` already shares them at
+/// the top level. The name is historical; functionally these are the
+/// shared NA whole-entity tag parsers for `n.` / `r.`.
 fn parse_tx_bracket_member(
     part: &str,
 ) -> IResult<&str, LocEdit<TxInterval, crate::hgvs::edit::NaEdit>> {
+    // Whole-tx edits have no positional content, so attach a dummy
+    // interval at position 1 (mirrors `parse_tx_variant`'s handling of
+    // `n.=` / `n.?` / `n.0` at the top level — which reuses the RNA
+    // whole-entity parsers because they're pure tag-only and don't
+    // depend on the coord system). These probes run BEFORE the
+    // position-based predicted wrapper / bare-position parsers so a
+    // bracket like `[(0)]` matches the no-product marker rather than
+    // being routed into `parse_tx_interval`. #423, follow-up to #396
+    // item 3.
+    //
+    // Note: bare `[0]` / `[?]` in the trans-allele form are handled
+    // upstream by `parse_trans_allele_shorthand_generic`'s cross-coord
+    // short-circuits (→ `NullAllele` / `UnknownAllele`) and never
+    // reach this dispatcher. Only cis/unknown-flat paths and
+    // predicted forms (`[(0)]`, `[(?)]`, `[(=)]`) plus bare `=` / `?`
+    // / `0` inside a cis bracket flow through these probes.
+    fn dummy_tx_interval() -> TxInterval {
+        TxInterval::point(crate::hgvs::location::TxPos::new(1))
+    }
+
+    if let Ok((remaining, mu_edit)) = parse_whole_rna_identity(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_tx_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_whole_rna_unknown(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_tx_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_rna_no_product(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_tx_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+
     // Try predicted wrapper first
     if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
         if let Ok((remaining, (interval, edit))) =
@@ -2484,8 +2627,10 @@ fn parse_tx_position_unknown_phase(
                 nom::error::ErrorKind::Verify,
             )));
         }
-        let (edit_remaining, interval) = parse_tx_interval(part)?;
-        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+        // Delegate to the bracket-member dispatcher so the same set of
+        // shapes is admitted here as in the bracketed cis/trans forms
+        // — keeps `n.[X(;)Y]` / `n.X(;)Y` round-trip-symmetric. #423.
+        let (final_remaining, loc_edit) = parse_tx_bracket_member(part)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
@@ -2495,7 +2640,7 @@ fn parse_tx_position_unknown_phase(
         variants.push(HgvsVariant::Tx(TxVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
+            loc_edit,
         }));
     }
 
@@ -3611,8 +3756,14 @@ fn parse_rna_position_unknown_phase(
             )));
         }
 
-        let (edit_remaining, interval) = parse_rna_interval(part)?;
-        let (final_remaining, edit) = parse_na_edit(edit_remaining)?;
+        // Delegate to the bracket-member dispatcher so whole-entity
+        // RNA forms (`=`, `?`, `0`, `spl`, `spl?`, `(=)`, `(?)`, `(0)`,
+        // `(spl)`, `(spl?)`) added in #396 item 3 are also admitted in
+        // the bracketless `r.X(;)Y` form. Keeps `r.[X(;)Y]` and
+        // `r.X(;)Y` round-trip-symmetric (Display canonicalises one
+        // into the other for unknown-phase). #423 sibling fix to #396
+        // item 3.
+        let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
 
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
@@ -3624,7 +3775,7 @@ fn parse_rna_position_unknown_phase(
         variants.push(HgvsVariant::Rna(RnaVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
+            loc_edit,
         }));
     }
 

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1546,11 +1546,28 @@ fn parse_genome_position_unknown_phase(
 /// (with the `g.` already consumed by the caller). Each bracketed group holds
 /// a single sub-variant rendered with this allele's accession. Mirrors
 /// `parse_cds_trans_allele_shorthand` and `parse_rna_trans_allele_shorthand`.
-fn parse_genome_trans_allele_shorthand(
+/// Generic trans-allele shorthand parser shared by 6 of 7 axes (g., c., n.,
+/// m., r., o.). Owns the bracketed-member loop, the `[0]`/`[?]`
+/// cross-coordinate special-cases, the bracket-balance check, the
+/// `len < 2` guard, and the final `AlleleVariant::new(.., Trans)` wrap.
+///
+/// Each axis-specific shim provides `parse_member`, a closure that
+/// consumes the bracket content and constructs the per-axis
+/// `HgvsVariant::<Axis>` (or returns a parse error). The closure also
+/// owns the post-parse "content fully consumed" check so axes are free
+/// to use their own bracket-member primitives without recomputing the
+/// remainder.
+///
+/// Protein keeps its own bespoke helper because it overrides the
+/// special-marker arm (`[0]`/`[0?]`/`[(0)]` → `ProteinEdit::NoProtein`
+/// rather than the cross-coordinate `NullAllele`).
+fn parse_trans_allele_shorthand_generic<F>(
     input: &str,
-    accession: Accession,
-    gene_symbol: Option<String>,
-) -> IResult<&str, HgvsVariant> {
+    mut parse_member: F,
+) -> IResult<&str, HgvsVariant>
+where
+    F: FnMut(&str) -> IResult<&str, HgvsVariant>,
+{
     let mut variants = Vec::with_capacity(2);
     let mut remaining = input;
 
@@ -1573,23 +1590,14 @@ fn parse_genome_trans_allele_shorthand(
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            // Route through parse_genome_bracket_member so the predicted-wrapper
-            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            let (final_remaining, loc_edit) =
-                parse_genome_bracket_member(content, GenomeKind::Genome)?;
-
+            let (final_remaining, variant) = parse_member(content)?;
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
                     final_remaining,
                     nom::error::ErrorKind::Tag,
                 )));
             }
-
-            HgvsVariant::Genome(GenomeVariant {
-                accession: accession.clone(),
-                gene_symbol: gene_symbol.clone(),
-                loc_edit,
-            })
+            variant
         };
 
         variants.push(variant);
@@ -1611,6 +1619,24 @@ fn parse_genome_trans_allele_shorthand(
         remaining,
         HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
     ))
+}
+
+fn parse_genome_trans_allele_shorthand(
+    input: &str,
+    accession: Accession,
+    gene_symbol: Option<String>,
+) -> IResult<&str, HgvsVariant> {
+    parse_trans_allele_shorthand_generic(input, |content| {
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Genome)?;
+        Ok((
+            rest,
+            HgvsVariant::Genome(GenomeVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit,
+            }),
+        ))
+    })
 }
 
 /// Parse whole-genome identity: g.=
@@ -2084,69 +2110,17 @@ fn parse_cds_trans_allele_shorthand(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
-    // Pre-allocate with capacity for trans alleles (typically 2)
-    let mut variants = Vec::with_capacity(2);
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        // Must start with [
-        if !remaining.starts_with('[') {
-            break;
-        }
-
-        // Find closing bracket
-        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
-            nom::Err::Error(nom::error::Error::new(
-                remaining,
-                nom::error::ErrorKind::Tag,
-            ))
-        })?;
-
-        let content = &remaining[1..close_bracket].trim();
-
-        // Check for special markers
-        let variant = if *content == "0" {
-            HgvsVariant::NullAllele
-        } else if *content == "?" {
-            HgvsVariant::UnknownAllele
-        } else {
-            // Parse as CDS variant (interval + edit, with predicted-wrapper support).
-            let (final_remaining, loc_edit) = parse_cds_bracket_member(content)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
+    parse_trans_allele_shorthand_generic(input, |content| {
+        let (rest, loc_edit) = parse_cds_bracket_member(content)?;
+        Ok((
+            rest,
             HgvsVariant::Cds(CdsVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit,
-            })
-        };
-
-        variants.push(variant);
-        remaining = &remaining[close_bracket + 1..];
-
-        // Check for more variants (semicolon separator)
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
-        }
-    }
-
-    if variants.len() < 2 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    Ok((
-        remaining,
-        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
-    ))
+            }),
+        ))
+    })
 }
 
 /// Parse transcript variant (n.)
@@ -2297,66 +2271,17 @@ fn parse_tx_trans_allele_shorthand(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
-    let mut variants = Vec::with_capacity(2);
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        if !remaining.starts_with('[') {
-            break;
-        }
-
-        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
-            nom::Err::Error(nom::error::Error::new(
-                remaining,
-                nom::error::ErrorKind::Tag,
-            ))
-        })?;
-
-        let content = remaining[1..close_bracket].trim();
-
-        let variant = if content == "0" {
-            HgvsVariant::NullAllele
-        } else if content == "?" {
-            HgvsVariant::UnknownAllele
-        } else {
-            // Route through parse_tx_bracket_member so the predicted-wrapper
-            // form `(<pos><edit>)` is recognised on trans-shorthand members
-            // too. #287.
-            let (final_remaining, loc_edit) = parse_tx_bracket_member(content)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
+    parse_trans_allele_shorthand_generic(input, |content| {
+        let (rest, loc_edit) = parse_tx_bracket_member(content)?;
+        Ok((
+            rest,
             HgvsVariant::Tx(TxVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit,
-            })
-        };
-
-        variants.push(variant);
-        remaining = &remaining[close_bracket + 1..];
-
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
-        }
-    }
-
-    if variants.len() < 2 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    Ok((
-        remaining,
-        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
-    ))
+            }),
+        ))
+    })
 }
 
 /// Parse a compound allele with `n.` (transcript) variants:
@@ -2602,67 +2527,19 @@ fn parse_mt_trans_allele_shorthand(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
-    let mut variants = Vec::with_capacity(2);
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        if !remaining.starts_with('[') {
-            break;
-        }
-
-        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
-            nom::Err::Error(nom::error::Error::new(
-                remaining,
-                nom::error::ErrorKind::Tag,
-            ))
-        })?;
-
-        let content = remaining[1..close_bracket].trim();
-
-        let variant = if content == "0" {
-            HgvsVariant::NullAllele
-        } else if content == "?" {
-            HgvsVariant::UnknownAllele
-        } else {
-            // Route through parse_genome_bracket_member so the predicted-wrapper
-            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            // Pass `GenomeKind::Mt` so the helper uses the circular interval
-            // parser + spec-authorised reversed-range validator (#129).
-            let (final_remaining, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Mt)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
+    parse_trans_allele_shorthand_generic(input, |content| {
+        // `GenomeKind::Mt` routes through the circular interval parser +
+        // spec-authorised reversed-range validator (#129).
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Mt)?;
+        Ok((
+            rest,
             HgvsVariant::Mt(MtVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit,
-            })
-        };
-
-        variants.push(variant);
-        remaining = &remaining[close_bracket + 1..];
-
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
-        }
-    }
-
-    if variants.len() < 2 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    Ok((
-        remaining,
-        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
-    ))
+            }),
+        ))
+    })
 }
 
 /// Parse whole-protein identity: p.= or p.(=)
@@ -2843,10 +2720,19 @@ fn parse_protein_allele_shorthand(
 
 /// Parse a protein trans-allele compact-prefix shorthand:
 /// `[edit1];[edit2]` (with `p.` already consumed by the caller). Each
-/// bracketed group holds a single sub-variant. Mirrors
-/// `parse_genome_trans_allele_shorthand`, but parses protein intervals +
+/// bracketed group holds a single sub-variant. Parses protein intervals +
 /// edits and does NOT allow a bare-position (Identity) fallback — the
 /// protein grammar requires an edit.
+///
+/// Intentionally NOT routed through `parse_trans_allele_shorthand_generic`
+/// (used by the other 6 axes): protein has three special-case markers
+/// (`[0]`, `[0?]`, `[(0)]`) that resolve to `ProteinEdit::NoProtein` rather
+/// than the cross-coordinate `HgvsVariant::NullAllele`, because the `p.`
+/// compact prefix has already pinned the coordinate system. The generic
+/// helper hard-codes the cross-coordinate `[0]`/`[?]` →
+/// `NullAllele`/`UnknownAllele` mapping appropriate for the other 6 axes.
+/// See the inline comment at the `content == "0"` branch below for the
+/// full spec arbitration (#277, follow-up to PR #130).
 fn parse_protein_trans_allele_shorthand(
     input: &str,
     accession: Accession,
@@ -3782,66 +3668,17 @@ fn parse_rna_trans_allele_shorthand(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
-    let mut variants = Vec::with_capacity(2);
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        if !remaining.starts_with('[') {
-            break;
-        }
-
-        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
-            nom::Err::Error(nom::error::Error::new(
-                remaining,
-                nom::error::ErrorKind::Tag,
-            ))
-        })?;
-
-        let content = &remaining[1..close_bracket].trim();
-
-        let variant = if *content == "0" {
-            HgvsVariant::NullAllele
-        } else if *content == "?" {
-            HgvsVariant::UnknownAllele
-        } else {
-            // Route through parse_rna_bracket_member so the predicted-wrapper
-            // form `(<pos><edit>)` is recognised on trans-shorthand members
-            // too. #287.
-            let (final_remaining, loc_edit) = parse_rna_bracket_member(content)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
+    parse_trans_allele_shorthand_generic(input, |content| {
+        let (rest, loc_edit) = parse_rna_bracket_member(content)?;
+        Ok((
+            rest,
             HgvsVariant::Rna(RnaVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit,
-            })
-        };
-
-        variants.push(variant);
-        remaining = &remaining[close_bracket + 1..];
-
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
-        }
-    }
-
-    if variants.len() < 2 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    Ok((
-        remaining,
-        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
-    ))
+            }),
+        ))
+    })
 }
 
 /// Parse circular DNA variant (o.) - SVD-WG006
@@ -3963,68 +3800,19 @@ fn parse_circular_trans_allele_shorthand(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
-    let mut variants = Vec::with_capacity(2);
-    let mut remaining = input;
-
-    while !remaining.is_empty() {
-        if !remaining.starts_with('[') {
-            break;
-        }
-
-        let close_bracket = find_top_level_close_bracket(remaining).ok_or_else(|| {
-            nom::Err::Error(nom::error::Error::new(
-                remaining,
-                nom::error::ErrorKind::Tag,
-            ))
-        })?;
-
-        let content = remaining[1..close_bracket].trim();
-
-        let variant = if content == "0" {
-            HgvsVariant::NullAllele
-        } else if content == "?" {
-            HgvsVariant::UnknownAllele
-        } else {
-            // Route through parse_genome_bracket_member so the predicted-wrapper
-            // form `(<pos><edit>)` is recognised on trans-shorthand members too.
-            // Pass `GenomeKind::Circular` so the helper uses the circular
-            // interval parser + spec-authorised reversed-range validator (#129).
-            let (final_remaining, loc_edit) =
-                parse_genome_bracket_member(content, GenomeKind::Circular)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
+    parse_trans_allele_shorthand_generic(input, |content| {
+        // `GenomeKind::Circular` routes through the circular interval parser
+        // + spec-authorised reversed-range validator (#129).
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Circular)?;
+        Ok((
+            rest,
             HgvsVariant::Circular(CircularVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
                 loc_edit,
-            })
-        };
-
-        variants.push(variant);
-        remaining = &remaining[close_bracket + 1..];
-
-        if remaining.starts_with(';') {
-            remaining = &remaining[1..];
-        }
-    }
-
-    if variants.len() < 2 {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    Ok((
-        remaining,
-        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
-    ))
+            }),
+        ))
+    })
 }
 
 /// Parse a single variant (not an allele) from input

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1382,6 +1382,109 @@ pub(crate) fn split_top_level_slashes(input: &str, want_double: bool) -> Vec<&st
     chunks
 }
 
+/// Result of `scan_allele_separators`: top-level depth-0 allele-separator
+/// flags plus the depth-aware members.
+#[derive(Debug)]
+pub(crate) struct AlleleSeparatorScan<'a> {
+    /// True iff `content` contains at least one top-level `(;)` (unknown phase).
+    pub has_unknown_phase: bool,
+    /// True iff `content` contains at least one top-level standalone `;`
+    /// that is not part of a `(;)`.
+    pub has_cis_separator: bool,
+    /// `content` split at whichever separator is present. If only `(;)` is
+    /// present, splits at top-level `(;)`. If only `;` is present, splits
+    /// at top-level `;`. If neither is present, returns `[content]`.
+    /// If both are present (mixed phase), splits at top-level `(;)` —
+    /// callers reject mixed-phase before consuming this field, so the
+    /// exact split for the mixed shape is not meaningful.
+    pub members: Vec<&'a str>,
+}
+
+/// Scan `content` — the inside of an outer `[...]` allele bracket pair,
+/// with the surrounding `[`/`]` already stripped — for top-level
+/// (depth-0) allele-phase separators and split into members at the same
+/// depth.
+///
+/// "Top level" means bracket depth 0 with respect to nested `[...]`
+/// inside an edit (`delins[A;T]`, `delins[ACC:g.x_y]`, `TG[14]`, ...).
+/// `(;)` and `;` inside such nested brackets are part of the edit, not
+/// allele separators, and must not be counted here.
+///
+/// The pair of `parens` characters `(` / `)` is also tracked so that a
+/// member written as a predicted-wrapper form like `(100A>G;200del)`
+/// is treated as a single member (the inner `;` is at parens-depth 1,
+/// not at the allele top level). Without this, a single predicted
+/// member could be mis-split into multiple bogus members.
+///
+/// Used by every `parse_*_compound_allele` / `parse_*_allele_shorthand`
+/// that drives the in-bracket cis (`;`) vs. unknown-phase (`(;)`)
+/// distinction so the mixed-phase reject path and the member split both
+/// scan only at the outer allele level.
+pub(crate) fn scan_allele_separators(content: &str) -> AlleleSeparatorScan<'_> {
+    let bytes = content.as_bytes();
+    let mut bracket_depth: i32 = 0;
+    let mut paren_depth: i32 = 0;
+    // Positions and lengths of top-level (depth-0 for both brackets and
+    // parens) separators. `len` is 3 for `(;)` and 1 for `;`.
+    let mut seps: Vec<(usize, usize)> = Vec::new();
+    let mut has_unknown_phase = false;
+    let mut has_cis_separator = false;
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'[' => bracket_depth += 1,
+            b']' if bracket_depth > 0 => bracket_depth -= 1,
+            b'(' if bracket_depth == 0 => {
+                // Check for a `(;)` separator at allele top level — only
+                // when we are not already inside any other parens or
+                // brackets.
+                if paren_depth == 0
+                    && i + 2 < bytes.len()
+                    && bytes[i + 1] == b';'
+                    && bytes[i + 2] == b')'
+                {
+                    has_unknown_phase = true;
+                    seps.push((i, 3));
+                    i += 3;
+                    continue;
+                }
+                paren_depth += 1;
+            }
+            b')' if bracket_depth == 0 && paren_depth > 0 => paren_depth -= 1,
+            b';' if bracket_depth == 0 && paren_depth == 0 => {
+                has_cis_separator = true;
+                seps.push((i, 1));
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    // Build the member slices. If both unknown and cis separators are
+    // present (mixed phase), prefer the `(;)` split — callers reject
+    // before consuming `members`, so the exact split is moot.
+    let split_kind_len = if has_unknown_phase { 3 } else { 1 };
+    let mut members: Vec<&str> = Vec::new();
+    let mut start = 0;
+    for (pos, len) in &seps {
+        if *len != split_kind_len {
+            // Skip the "other" separator kind in the mixed case.
+            continue;
+        }
+        members.push(&content[start..*pos]);
+        start = *pos + *len;
+    }
+    members.push(&content[start..]);
+
+    AlleleSeparatorScan {
+        has_unknown_phase,
+        has_cis_separator,
+        members,
+    }
+}
+
 /// Parse a compound allele with genomic variants:
 ///   `[pos1edit1;pos2edit2;...]`   (cis)
 ///   `[pos1edit1(;)pos2edit2;...]` (unknown phase)
@@ -1419,36 +1522,33 @@ fn parse_genome_kind_compound_allele(
     let content = &input[1..close_bracket];
     let remaining = &input[close_bracket + 1..];
 
-    // Distinguish unknown phase from cis based on `(;)` presence.
-    let has_unknown_phase = content.contains("(;)");
-    let has_cis_separator = {
-        // Any `;` that isn't part of `(;)`.
-        let temp = content.replace("(;)", "\x00");
-        temp.contains(';')
-    };
+    // Scan for top-level (depth-0) allele separators. Any `(;)` / `;`
+    // inside a nested edit bracket (`delins[A;T]`) or a predicted-wrapper
+    // member (`(100A>G;200del)`) is part of the edit, not an allele
+    // separator. See `scan_allele_separators` for the depth rules.
+    let scan = scan_allele_separators(content);
 
     // Mixed `;` and `(;)` inside a single bracket pair is not spec-valid
     // (HGVS `recommendations/{DNA,protein}/alleles.md` only mixes `;`/`(;)` at
     // the top level via `[a;b];[c](;)d`, not inside one `[...]`). Reject
     // rather than silently flatten the cis subgroup boundary into a single
     // `phase: Unknown` allele.
-    if has_unknown_phase && has_cis_separator {
+    if scan.has_unknown_phase && scan.has_cis_separator {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Verify,
         )));
     }
 
-    let phase = if has_unknown_phase {
+    let phase = if scan.has_unknown_phase {
         AllelePhase::Unknown
     } else {
         AllelePhase::Cis
     };
 
-    let separator = if has_unknown_phase { "(;)" } else { ";" };
     let mut variants = Vec::with_capacity(4);
 
-    for part in content.split(separator) {
+    for part in scan.members {
         let part = part.trim();
         if part.is_empty() {
             // Empty parts (e.g. `[a;;b]`, `[a(;)(;)b]`, or trailing `[a(;)]`)
@@ -2010,85 +2110,58 @@ fn parse_cds_allele_shorthand(
     let content = &input[1..close_bracket];
     let remaining = &input[close_bracket + 1..];
 
-    // Check for mixed phase: contains both ; and (;)
-    // We need to check for ; that's NOT part of (;)
-    let has_unknown_phase = content.contains("(;)");
-    let has_cis_separator = {
-        // Replace (;) temporarily to check for standalone ;
-        let temp = content.replace("(;)", "\x00");
-        temp.contains(';')
-    };
+    // Scan for top-level (depth-0) allele separators. Inner `;` / `(;)`
+    // belonging to a nested edit (`delins[A;T]`) or a predicted-wrapper
+    // member must NOT drive phase detection or member splitting. See
+    // `scan_allele_separators`.
+    let scan = scan_allele_separators(content);
 
-    // Determine phase and parsing strategy
-    let phase = if has_unknown_phase {
-        // If there's any unknown phase, the overall phase is unknown
+    // Mixed `;`/`(;)` inside one bracket pair is not spec-valid — HGVS
+    // does not provide a way to express "subgroup A;B is cis to each
+    // other but unknown phase to C" inside a single bracket. Reject
+    // rather than silently flattening to AllelePhase::Unknown (#396
+    // item 2). Mirrors `parse_protein_allele_shorthand`.
+    if scan.has_unknown_phase && scan.has_cis_separator {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    let phase = if scan.has_unknown_phase {
         AllelePhase::Unknown
     } else {
         AllelePhase::Cis
     };
 
-    // Parse variants - handle mixed separators
     // Pre-allocate with estimated capacity (most alleles have 2-4 variants)
     let mut variants = Vec::with_capacity(4);
 
-    if has_unknown_phase && has_cis_separator {
-        // Mixed phase: split on (;) first, then on ;
-        for unknown_group in content.split("(;)") {
-            for part in unknown_group.split(';') {
-                let part = part.trim();
-                if part.is_empty() {
-                    return Err(nom::Err::Error(nom::error::Error::new(
-                        input,
-                        nom::error::ErrorKind::Verify,
-                    )));
-                }
-
-                let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
-
-                if !final_remaining.trim().is_empty() {
-                    return Err(nom::Err::Error(nom::error::Error::new(
-                        final_remaining,
-                        nom::error::ErrorKind::Tag,
-                    )));
-                }
-
-                variants.push(HgvsVariant::Cds(CdsVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit,
-                }));
-            }
+    for part in scan.members {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
         }
-    } else {
-        // Single separator type
-        let separator = if has_unknown_phase { "(;)" } else { ";" };
 
-        for part in content.split(separator) {
-            let part = part.trim();
-            if part.is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    input,
-                    nom::error::ErrorKind::Verify,
-                )));
-            }
+        // Parse interval + edit (e.g., "145C>T" or "100_200del" or
+        // predicted "(145C>T)").
+        let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
 
-            // Parse interval + edit (e.g., "145C>T" or "100_200del" or
-            // predicted "(145C>T)").
-            let (final_remaining, loc_edit) = parse_cds_bracket_member(part)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
-            variants.push(HgvsVariant::Cds(CdsVariant {
-                accession: accession.clone(),
-                gene_symbol: gene_symbol.clone(),
-                loc_edit,
-            }));
+        if !final_remaining.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                final_remaining,
+                nom::error::ErrorKind::Tag,
+            )));
         }
+
+        variants.push(HgvsVariant::Cds(CdsVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit,
+        }));
     }
 
     if variants.is_empty() {
@@ -2306,31 +2379,28 @@ fn parse_tx_compound_allele(
     let content = &input[1..close_bracket];
     let remaining = &input[close_bracket + 1..];
 
-    let has_unknown_phase = content.contains("(;)");
-    let has_cis_separator = {
-        let temp = content.replace("(;)", "\x00");
-        temp.contains(';')
-    };
+    // Scan for top-level (depth-0) allele separators. See
+    // `scan_allele_separators` for the depth rules; inner `;` / `(;)`
+    // from a nested edit must not drive phase detection or splitting.
+    let scan = scan_allele_separators(content);
 
     // Mixed `;`/`(;)` inside one bracket pair is not spec-valid — see
     // `parse_genome_kind_compound_allele` for the spec citation.
-    if has_unknown_phase && has_cis_separator {
+    if scan.has_unknown_phase && scan.has_cis_separator {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Verify,
         )));
     }
 
-    let phase = if has_unknown_phase {
+    let phase = if scan.has_unknown_phase {
         AllelePhase::Unknown
     } else {
         AllelePhase::Cis
     };
 
-    let separator = if has_unknown_phase { "(;)" } else { ";" };
-
     let mut variants = Vec::with_capacity(4);
-    for part in content.split(separator) {
+    for part in scan.members {
         let part = part.trim();
         if part.is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
@@ -2620,16 +2690,15 @@ fn parse_protein_allele_shorthand(
     let content = &input[1..close_bracket];
     let after_bracket = &input[close_bracket + 1..];
 
-    let has_unknown_phase = content.contains("(;)");
+    // Scan for top-level (depth-0) allele separators. See
+    // `scan_allele_separators` for the depth rules; inner `;` / `(;)`
+    // from a nested edit must not drive phase detection or splitting.
+    let scan = scan_allele_separators(content);
 
-    if has_unknown_phase {
-        let has_cis_separator = {
-            let temp = content.replace("(;)", "\x00");
-            temp.contains(';')
-        };
+    if scan.has_unknown_phase {
         // Mixed `;`/`(;)` inside one bracket pair is not spec-valid — see
         // `parse_genome_kind_compound_allele` for the spec citation.
-        if has_cis_separator {
+        if scan.has_cis_separator {
             return Err(nom::Err::Error(nom::error::Error::new(
                 input,
                 nom::error::ErrorKind::Verify,
@@ -2637,7 +2706,7 @@ fn parse_protein_allele_shorthand(
         }
 
         let mut variants = Vec::with_capacity(4);
-        for part in content.split("(;)") {
+        for part in scan.members {
             let part = part.trim();
             if part.is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3578,14 +3647,24 @@ fn parse_rna_allele_shorthand(
     let content = &input[1..close_bracket];
     let remaining = &input[close_bracket + 1..];
 
-    // Check for mixed phase: contains both ; and (;)
-    let has_unknown_phase = content.contains("(;)");
-    let has_cis_separator = {
-        let temp = content.replace("(;)", "\x00");
-        temp.contains(';')
-    };
+    // Scan for top-level (depth-0) allele separators. Inner `;` / `(;)`
+    // from a nested edit (`delins[a;u]`) or predicted-wrapper member
+    // must not drive phase detection or splitting. See
+    // `scan_allele_separators`.
+    let scan = scan_allele_separators(content);
 
-    let phase = if has_unknown_phase {
+    // Mixed `;`/`(;)` inside one bracket pair is not spec-valid (#396
+    // item 2; mirrors `parse_protein_allele_shorthand` and the new
+    // cds-axis reject path). Reject rather than silently flattening to
+    // AllelePhase::Unknown.
+    if scan.has_unknown_phase && scan.has_cis_separator {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    let phase = if scan.has_unknown_phase {
         AllelePhase::Unknown
     } else {
         AllelePhase::Cis
@@ -3593,60 +3672,29 @@ fn parse_rna_allele_shorthand(
 
     let mut variants = Vec::with_capacity(4);
 
-    if has_unknown_phase && has_cis_separator {
-        for unknown_group in content.split("(;)") {
-            for part in unknown_group.split(';') {
-                let part = part.trim();
-                if part.is_empty() {
-                    return Err(nom::Err::Error(nom::error::Error::new(
-                        input,
-                        nom::error::ErrorKind::Verify,
-                    )));
-                }
-
-                let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
-
-                if !final_remaining.trim().is_empty() {
-                    return Err(nom::Err::Error(nom::error::Error::new(
-                        final_remaining,
-                        nom::error::ErrorKind::Tag,
-                    )));
-                }
-
-                variants.push(HgvsVariant::Rna(RnaVariant {
-                    accession: accession.clone(),
-                    gene_symbol: gene_symbol.clone(),
-                    loc_edit,
-                }));
-            }
+    for part in scan.members {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
         }
-    } else {
-        let separator = if has_unknown_phase { "(;)" } else { ";" };
 
-        for part in content.split(separator) {
-            let part = part.trim();
-            if part.is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    input,
-                    nom::error::ErrorKind::Verify,
-                )));
-            }
+        let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
 
-            let (final_remaining, loc_edit) = parse_rna_bracket_member(part)?;
-
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
-            }
-
-            variants.push(HgvsVariant::Rna(RnaVariant {
-                accession: accession.clone(),
-                gene_symbol: gene_symbol.clone(),
-                loc_edit,
-            }));
+        if !final_remaining.trim().is_empty() {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                final_remaining,
+                nom::error::ErrorKind::Tag,
+            )));
         }
+
+        variants.push(HgvsVariant::Rna(RnaVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit,
+        }));
     }
 
     if variants.is_empty() {
@@ -6454,28 +6502,21 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_mixed_phase_allele_shorthand() {
-        // Mixed phase allele: some cis (;) and some unknown ((;))
-        // Pattern: [123A>G;456C>T(;)789G>A] means 123 and 456 are cis, unknown phase with 789
-        let variant = parse_variant("NM_000088.3:c.[123A>G;456C>T(;)789G>A]").unwrap();
-        assert!(matches!(variant, HgvsVariant::Allele(_)));
-        if let HgvsVariant::Allele(allele) = &variant {
-            // Overall phase is Unknown when there's any unknown phase
-            assert_eq!(allele.phase, AllelePhase::Unknown);
-            assert_eq!(allele.variants.len(), 3);
-        }
+    fn test_parse_mixed_phase_allele_shorthand_rejected() {
+        // Mixed `;`/`(;)` inside one bracket pair (e.g. `[A;B(;)C]`) has
+        // no spec-defined HGVS shape: there is no way to express "A and
+        // B are cis to each other, but unknown phase to C" in a single
+        // bracket. Item 2 of #396 replaced the previous silent-flatten
+        // (which used to produce a flat `AllelePhase::Unknown` over all
+        // members) with an explicit reject. Mirrors
+        // `parse_protein_allele_shorthand`.
+        assert!(parse_variant("NM_000088.3:c.[123A>G;456C>T(;)789G>A]").is_err());
     }
 
     #[test]
-    fn test_parse_mixed_phase_allele_shorthand_complex() {
-        // More complex mixed phase: [A;B;C(;)D;E]
-        let variant =
-            parse_variant("NM_000088.3:c.[100A>G;200C>T;300G>A(;)400del;500dup]").unwrap();
-        assert!(matches!(variant, HgvsVariant::Allele(_)));
-        if let HgvsVariant::Allele(allele) = &variant {
-            assert_eq!(allele.phase, AllelePhase::Unknown);
-            assert_eq!(allele.variants.len(), 5);
-        }
+    fn test_parse_mixed_phase_allele_shorthand_complex_rejected() {
+        // More complex mixed shape `[A;B;C(;)D;E]` rejects too.
+        assert!(parse_variant("NM_000088.3:c.[100A>G;200C>T;300G>A(;)400del;500dup]").is_err());
     }
 
     #[test]

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -3589,15 +3589,71 @@ fn parse_rna_position_unknown_phase(
     ))
 }
 
-/// Parse a single bracket-member position+edit (RNA), recognising the
-/// predicted-wrapper form `(<pos><edit>)` and returning a `LocEdit`
-/// with `Mu::Uncertain` in that case. Falls back to `<pos>[<edit>]`
-/// (edit optional, defaults to identity). Mirrors
-/// `parse_cds_bracket_member`. #287 follow-up to #243 / PR #244.
+/// Parse a single bracket-member position+edit (RNA), recognising
+/// whole-entity edits (`=`, `?`, `0`, `spl`, `spl?`, `(spl)`,
+/// `(spl?)`), the predicted-wrapper form `(<pos><edit>)`, and bare
+/// `<pos><edit>` (edit optional, defaults to identity). Mirrors
+/// `parse_cds_bracket_member`. #287 follow-up to #243 / PR #244;
+/// whole-entity dispatch added by #396 item 3.
 fn parse_rna_bracket_member(
     part: &str,
 ) -> IResult<&str, LocEdit<RnaInterval, crate::hgvs::edit::NaEdit>> {
-    // Try predicted wrapper first
+    // Whole-entity RNA edits have no positional content, so attach a
+    // dummy interval at position 1 (mirrors `parse_rna_variant`'s
+    // handling of the same forms at the top level). These probes run
+    // BEFORE the position-based predicted wrapper / bare-position
+    // parsers so a bracket like `[(spl?)]` matches the predicted-splice
+    // marker rather than being routed into `parse_rna_interval`. #396
+    // item 3.
+    fn dummy_rna_interval() -> RnaInterval {
+        RnaInterval::point(crate::hgvs::location::RnaPos {
+            base: 1,
+            offset: None,
+            utr3: false,
+        })
+    }
+
+    if let Ok((remaining, mu_edit)) = parse_whole_rna_identity(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_rna_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_whole_rna_unknown(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_rna_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, mu_edit)) = parse_rna_no_product(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_rna_interval(),
+                edit: mu_edit,
+            },
+        ));
+    }
+    if let Ok((remaining, edit)) = parse_whole_rna_predicted_splice(part) {
+        return Ok((
+            remaining,
+            LocEdit {
+                location: dummy_rna_interval(),
+                edit: Mu::Uncertain(edit),
+            },
+        ));
+    }
+    if let Ok((remaining, edit)) = parse_rna_splice(part) {
+        return Ok((remaining, LocEdit::new(dummy_rna_interval(), edit)));
+    }
+
+    // Position-based predicted wrapper: `(<pos><edit>)`.
     if part.starts_with('(') && !part.starts_with("(?") && !part.starts_with("(=)") {
         if let Ok((remaining, (interval, edit))) =
             delimited(char('('), (parse_rna_interval, parse_na_edit), char(')')).parse(part)

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -153,10 +153,6 @@
       "category": "rejected_by_design",
       "reason": "`[ins<coords>;<seq>]` \u2014 compound brackets used to combine insertion-with-coords and a literal sequence. Not a current-spec form."
     },
-    "[complex_ins_inside_compound]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Three-allele cis compound `[a;b;c]` whose middle allele uses complex-insertion payload `ins[<seq>;<refrange>]` (multi-segment insertion concatenation per recommendations/DNA/insertion.md). Each form is spec-valid; the combined nested structure is not yet parsed."
-    },
     "[redundant_g_prefix_inside_compound]": {
       "category": "rejected_by_design",
       "reason": "Redundant `g.` prefix on second allele inside compound bracket."
@@ -335,7 +331,6 @@
     "LRG_311t1:c.-(903_882)dup": "[malformed_5utr_paren_reversed_no_minus]",
     "LRG_485:g.4900_4911CCCCGCCCCGCG(2_3)": "[deprecated_repeat_paren_no_brackets]",
     "LRG_486:g.37978T(27_30)": "[deprecated_repeat_paren_no_brackets]",
-    "LRG_501:g.[83418_83419insN;83419_83420ins[TAGCTTTGCTAGGTGTTAAATAGTAATGTAATTATATTTCCTATAATACAGCAATATA;84466_84575];83423_83424insAT]": "[complex_ins_inside_compound]",
     "LRG_555:g.70398_70399insL170382_70398dup": "[ins_with_LINE1_coords_then_dup]",
     "LRG_555t1:c.3065_3066insL13054_3065dup": "[ins_with_LINE1_coords_then_dup]",
     "LRG_556t1:.c.(391+1_392-1)insN[?]": "[leading_dot_before_prefix]",

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13237,7 +13237,7 @@
     },
     {
       "input": "LRG_199t1:r.[(578c>u;1339a>g;1680del)]",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(578c>u\", code: Digit })",
+      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(578c>u;1339a>g;1680del)\", code: Digit })",
       "spec_expected": "LRG_199t1:r.[(578c>u;1339a>g;1680del)]",
       "status": "parse-error",
       "coordinate_system": "r",

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 135,
       "false-acceptance": 83,
       "needs-reference": 31,
-      "parse-error": 338,
-      "preserved": 643
+      "parse-error": 334,
+      "preserved": 647
     },
     "by_coordinate_system": {
       "c": 464,
@@ -867,18 +867,6 @@
       "source_kind": "background",
       "source_paths": [
         "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:c.2376G>C(;)(2376G>C)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(2376G>C)\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.2376G>C(;)(2376G>C)",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -2782,19 +2770,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.[2376G>C];[=]",
-      "input_prefixed": "NM_004006.2:c.[2376G>C];[=]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"=\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.[2376G>C];[=]",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "class=\"invalid\">NM_000109.3:c.-401C>T</code>",
       "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"class=\\\"invalid\\\">NM_000109.3:c.-401C>T<\", code: Alpha })",
       "spec_expected": "class=\"invalid\">NM_000109.3:c.-401C>T</code>",
@@ -3853,6 +3828,17 @@
       "source_paths": [
         "docs/recommendations/DNA/duplication.md",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
+      ]
+    },
+    {
+      "input": "NM_004006.2:c.2376G>C(;)(2376G>C)",
+      "current": "NM_004006.2:c.2376G>C(;)(2376G>C)",
+      "spec_expected": "NM_004006.2:c.2376G>C(;)(2376G>C)",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
       ]
     },
     {
@@ -5720,6 +5706,18 @@
       "working_group": "SVD-WG010"
     },
     {
+      "input": "c.[2376G>C];[=]",
+      "input_prefixed": "NM_004006.2:c.[2376G>C];[=]",
+      "current": "NM_004006.2:c.[2376G>C];[=]",
+      "spec_expected": "NM_004006.2:c.[2376G>C];[=]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
       "input": "c.[2376_2377insGT];[2376_2377=]",
       "input_prefixed": "NM_004006.2:c.[2376_2377insGT];[2376_2377=]",
       "current": "NM_004006.2:c.[2376_2377insGT];[2376_2377=]",
@@ -7395,7 +7393,7 @@
     },
     {
       "input": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7421,7 +7419,7 @@
     },
     {
       "input": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7433,7 +7431,7 @@
     },
     {
       "input": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7445,7 +7443,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7458,7 +7456,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7470,7 +7468,7 @@
     },
     {
       "input": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7482,7 +7480,7 @@
     },
     {
       "input": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7494,7 +7492,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000023.11:89555675-100352080",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7506,7 +7504,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7518,7 +7516,7 @@
     },
     {
       "input": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7530,7 +7528,7 @@
     },
     {
       "input": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7542,7 +7540,7 @@
     },
     {
       "input": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7554,7 +7552,7 @@
     },
     {
       "input": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7566,7 +7564,7 @@
     },
     {
       "input": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.17179029_17179091] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:17179028-17179091",
       "spec_expected": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7578,7 +7576,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749con[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": null,
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7592,7 +7590,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7605,7 +7603,7 @@
     },
     {
       "input": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -13212,18 +13210,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:r.76a>u(;)(76a>u)",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(76a>u)\", code: Digit })",
-      "spec_expected": "LRG_199t1:r.76a>u(;)(76a>u)",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "LRG_199t1:r.=/6_8del",
       "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found '6_8'",
       "spec_expected": "LRG_199t1:r.=/6_8del",
@@ -14339,19 +14325,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.[76a>u];[=]",
-      "input_prefixed": "NM_004006.3:r.[76a>u];[=]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"=\", code: Digit })",
-      "spec_expected": "NM_004006.3:r.[76a>u];[=]",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "r.[83g>u,73_93del]",
       "input_prefixed": "NM_004006.3:r.[83g>u,73_93del]",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \",73_93del\", code: Tag })",
@@ -14428,6 +14401,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/insertion.md"
+      ]
+    },
+    {
+      "input": "LRG_199t1:r.76a>u(;)(76a>u)",
+      "current": "LRG_199t1:r.76a>u(;)(76a>u)",
+      "spec_expected": "LRG_199t1:r.76a>u(;)(76a>u)",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
       ]
     },
     {
@@ -15726,6 +15710,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/delins.md"
+      ]
+    },
+    {
+      "input": "r.[76a>u];[=]",
+      "input_prefixed": "NM_004006.3:r.[76a>u];[=]",
+      "current": "NM_004006.3:r.[76a>u];[=]",
+      "spec_expected": "NM_004006.3:r.[76a>u];[=]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
       ]
     },
     {

--- a/tests/issue_396_mixed_phase_separators.rs
+++ b/tests/issue_396_mixed_phase_separators.rs
@@ -1,0 +1,164 @@
+//! Issue #396 item 2 — `parse_cds_allele_shorthand` and
+//! `parse_rna_allele_shorthand` silently flatten genuinely mixed
+//! `;` / `(;)` separators into a single `AllelePhase::Unknown` flat
+//! list. There is no spec-defined HGVS shape that says "subgroup A;B
+//! is cis to each other but unknown phase to C", so the parser must
+//! reject the mixed form, not silently flatten it.
+//!
+//! `parse_protein_allele_shorthand` already does this (see
+//! `parse_protein_allele_shorthand` line ~2755 in
+//! `src/hgvs/parser/variant.rs` for the existing reject path); item 2
+//! brings cds + rna in line.
+//!
+//! # Spec basis
+//!
+//! `assets/hgvs-nomenclature/docs/recommendations/DNA/alleles.md` and
+//! `recommendations/RNA/alleles.md`: phase is either fully cis (`;`),
+//! fully trans (`];[`), or fully unknown (`(;)`). The grammar does not
+//! provide a way to express partial cis-within-unknown nesting in a
+//! single bracket pair. A mix is malformed.
+//!
+//! # Negative controls
+//!
+//! Pure cis (`a;b`) and pure unknown-phase (`a(;)b`) must continue to
+//! parse — only the mixed shape rejects.
+
+use ferro_hgvs::parse_hgvs;
+
+fn assert_parse_err(input: &str) {
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "expected mixed-separator input to be rejected but it parsed: {input:?} → {:?}",
+        result.ok().map(|v| v.to_string()),
+    );
+}
+
+fn assert_parse_ok(input: &str) {
+    parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input:?}) must succeed; got {e:?}"));
+}
+
+// =============================================================================
+// CDS axis (c.)
+// =============================================================================
+
+#[test]
+fn cds_mixed_cis_then_unknown_rejected() {
+    // `[A;B(;)C]` — A and B written as cis, then unknown phase before C.
+    // No spec form for this nesting; must reject.
+    assert_parse_err("NM_000088.3:c.[1A>G;2T>C(;)3G>A]");
+}
+
+#[test]
+fn cds_mixed_unknown_then_cis_rejected() {
+    // `[A(;)B;C]` — unknown phase between A and B, then cis B+C.
+    assert_parse_err("NM_000088.3:c.[1A>G(;)2T>C;3G>A]");
+}
+
+#[test]
+fn cds_mixed_three_groupings_rejected() {
+    // `[A;B(;)C;D]`
+    assert_parse_err("NM_000088.3:c.[1A>G;2T>C(;)3G>A;4C>T]");
+}
+
+#[test]
+fn cds_pure_cis_still_accepted() {
+    assert_parse_ok("NM_000088.3:c.[1A>G;2T>C]");
+}
+
+#[test]
+fn cds_pure_unknown_phase_still_accepted() {
+    assert_parse_ok("NM_000088.3:c.[1A>G(;)2T>C]");
+}
+
+// =============================================================================
+// RNA axis (r.)
+// =============================================================================
+
+#[test]
+fn rna_mixed_cis_then_unknown_rejected() {
+    assert_parse_err("NM_004006.2:r.[100a>g;200u>c(;)300g>a]");
+}
+
+#[test]
+fn rna_mixed_unknown_then_cis_rejected() {
+    assert_parse_err("NM_004006.2:r.[100a>g(;)200u>c;300g>a]");
+}
+
+#[test]
+fn rna_pure_cis_still_accepted() {
+    assert_parse_ok("NM_004006.2:r.[100a>g;200u>c]");
+}
+
+#[test]
+fn rna_pure_unknown_phase_still_accepted() {
+    assert_parse_ok("NM_004006.2:r.[100a>g(;)200u>c]");
+}
+
+// =============================================================================
+// Cross-axis: protein already rejects (regression — keep that working)
+// =============================================================================
+
+#[test]
+fn protein_mixed_still_rejected() {
+    assert_parse_err("NP_000079.2:p.[Ala1Val;Ser2Thr(;)Gly3Ala]");
+}
+
+// =============================================================================
+// Nested-bracket members: the mixed-phase reject and the cis/unknown-phase
+// splitter must scan separators at the OUTER bracket depth only. A member
+// like `delins[A;T]` carries an inner `;` that is part of the edit, not
+// an allele separator, so:
+//   - `[X;<delins[A;T]>]`     → cis 2-member (inner `;` not a separator)
+//   - `[X(;)<delins[A;T]>]`   → unknown-phase 2-member (no top-level `;`)
+//   - `[X;<delins[A;T]>(;)Y]` → MUST reject as mixed-phase only when the
+//      top-level depth-0 scan finds both `;` and `(;)`.
+// See `parse_*_compound_allele` / `parse_*_allele_shorthand` and the
+// `scan_allele_separators` helper for the depth rules.
+// =============================================================================
+
+#[test]
+fn cds_cis_with_nested_delins_bracket_member() {
+    // Inner `;` lives inside `delins[A;T]` and must NOT be treated as an
+    // allele-level cis separator. The outer form is pure cis (one top-level `;`).
+    assert_parse_ok("NM_000088.3:c.[100_200delins[A;T];300del]");
+}
+
+#[test]
+fn cds_unknown_phase_with_nested_delins_bracket_member() {
+    // Inner `;` inside `delins[A;T]`; outer separator is `(;)`. Pure
+    // unknown-phase, NOT mixed-phase.
+    assert_parse_ok("NM_000088.3:c.[100_200delins[A;T](;)300del]");
+}
+
+#[test]
+fn cds_mixed_with_nested_delins_bracket_member_rejected() {
+    // Top-level scan finds both `;` and `(;)`. Genuine mixed-phase even
+    // though there's also a nested `;` inside `delins[A;T]`.
+    assert_parse_err("NM_000088.3:c.[1A>G;100_200delins[A;T](;)300del]");
+}
+
+#[test]
+fn rna_cis_with_nested_delins_bracket_member() {
+    assert_parse_ok("NM_004006.2:r.[100_200delins[a;u];300del]");
+}
+
+#[test]
+fn rna_unknown_phase_with_nested_delins_bracket_member() {
+    assert_parse_ok("NM_004006.2:r.[100_200delins[a;u](;)300del]");
+}
+
+#[test]
+fn rna_mixed_with_nested_delins_bracket_member_rejected() {
+    assert_parse_err("NM_004006.2:r.[100a>g;100_200delins[a;u](;)300del]");
+}
+
+#[test]
+fn genome_unknown_phase_with_nested_delins_bracket_member() {
+    assert_parse_ok("NC_000001.11:g.[100_200delins[A;T](;)300del]");
+}
+
+#[test]
+fn tx_unknown_phase_with_nested_delins_bracket_member() {
+    assert_parse_ok("NM_002001.2:n.[100_200delins[A;T](;)300del]");
+}

--- a/tests/issue_396_rna_bracket_whole_entity.rs
+++ b/tests/issue_396_rna_bracket_whole_entity.rs
@@ -41,7 +41,10 @@ fn rna_trans_spl_question_then_spl_roundtrip() {
     // The exact case pinned by `rna_spl_marker.rs:246`.
     let s = parse_ok("NM_004006.2:r.[spl?];[spl]");
     assert!(s.contains("spl?"), "expected 'spl?' in {s}");
-    assert!(s.contains("spl"), "expected 'spl' in {s}");
+    // Assert the exact `[spl]` member token, not a bare `contains("spl")`
+    // which `spl?` already satisfies and would hide a regression in the
+    // second bracket member.
+    assert!(s.contains("[spl]"), "expected '[spl]' member in {s}");
     assert!(s.contains("];["), "expected trans-form display, got {s}");
 }
 

--- a/tests/issue_396_rna_bracket_whole_entity.rs
+++ b/tests/issue_396_rna_bracket_whole_entity.rs
@@ -1,0 +1,121 @@
+//! Issue #396 item 3 — `parse_rna_bracket_member` only knew about
+//! position-based edits and the predicted-wrapper `(pos edit)`. Inside
+//! an RNA allele bracket (`r.[X];[Y]` or `r.[X;Y]` or `r.[X(;)Y]`),
+//! whole-entity edits like `=`, `?`, `0`, `spl`, `spl?`, `(spl)`,
+//! `(spl?)` were rejected because they have no positional content.
+//!
+//! Item 3 dispatches to the whole-entity RNA parsers
+//! (`parse_whole_rna_identity`, `parse_whole_rna_unknown`,
+//! `parse_rna_no_product`, `parse_rna_splice`,
+//! `parse_whole_rna_predicted_splice`) inside the bracket member,
+//! attaching a dummy interval at position 1 (mirroring the
+//! `parse_rna_variant` dispatcher's handling of the same forms).
+//!
+//! The two existing trans-allele special cases `[0]` → `NullAllele`
+//! and `[?]` → `UnknownAllele` are preserved at the
+//! `parse_rna_trans_allele_shorthand` layer (above this bracket
+//! member), so a bare `r.[X];[0]` still routes to the
+//! cross-coordinate `NullAllele`. Only the cis/unknown-flat paths and
+//! members that look like `(0)` / `spl` / `spl?` / `=` / `?` (which
+//! never short-circuited in the trans helper) flow into this new
+//! bracket-member dispatch.
+//!
+//! When item 3 lands, `tests/rna_spl_marker.rs:246`
+//! (`rna_spl_allele_compound_currently_rejected`) is flipped from a
+//! "rejects today" pin to an explicit success assertion.
+
+use ferro_hgvs::parse_hgvs;
+
+fn parse_ok(input: &str) -> String {
+    parse_hgvs(input)
+        .unwrap_or_else(|e| panic!("parse({input:?}) must succeed; got {e:?}"))
+        .to_string()
+}
+
+// =============================================================================
+// Trans form: `r.[A];[B]` with whole-entity edits as one member
+// =============================================================================
+
+#[test]
+fn rna_trans_spl_question_then_spl_roundtrip() {
+    // The exact case pinned by `rna_spl_marker.rs:246`.
+    let s = parse_ok("NM_004006.2:r.[spl?];[spl]");
+    assert!(s.contains("spl?"), "expected 'spl?' in {s}");
+    assert!(s.contains("spl"), "expected 'spl' in {s}");
+    assert!(s.contains("];["), "expected trans-form display, got {s}");
+}
+
+#[test]
+fn rna_trans_spl_pair_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[spl];[spl]");
+    assert!(s.contains("];["));
+}
+
+#[test]
+fn rna_trans_identity_with_substitution_roundtrip() {
+    // `[=];[edit]` — identity (no change) on one strand, edit on the other.
+    let s = parse_ok("NM_004006.2:r.[=];[100a>g]");
+    assert!(s.contains("];["));
+    assert!(s.contains("=") || s.contains("=]"));
+}
+
+#[test]
+fn rna_trans_predicted_spl_with_substitution_roundtrip() {
+    // `[(spl?)];[edit]` — predicted-uncertain splice on one strand.
+    let s = parse_ok("NM_004006.2:r.[(spl?)];[100a>g]");
+    assert!(s.contains("(spl?)"), "expected '(spl?)' in {s}");
+}
+
+#[test]
+fn rna_trans_predicted_no_product_with_substitution_roundtrip() {
+    // `[(0)];[edit]` — predicted no product (parens form).
+    // Bare `[0]` is the cross-coord NullAllele short-circuit upstream;
+    // `[(0)]` flows into the bracket member.
+    let s = parse_ok("NM_004006.2:r.[(0)];[100a>g]");
+    assert!(s.contains("(0)"), "expected '(0)' in {s}");
+}
+
+// =============================================================================
+// Cis form: `r.[A;B]` with whole-entity edits as a member
+// =============================================================================
+
+#[test]
+fn rna_cis_spl_question_with_substitution_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[100a>g;spl?]");
+    assert!(s.contains("spl?"));
+    assert!(s.contains("100a>g"));
+}
+
+#[test]
+fn rna_cis_spl_then_substitution_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[spl;100a>g]");
+    assert!(s.contains("spl"));
+    assert!(s.contains("100a>g"));
+}
+
+// =============================================================================
+// Unknown-phase form: `r.[A(;)B]` with whole-entity edits as a member
+// =============================================================================
+
+#[test]
+fn rna_unknown_phase_spl_with_substitution_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[100a>g(;)spl?]");
+    assert!(s.contains("spl?"));
+    assert!(s.contains("(;)"), "expected unknown-phase '(;)' in {s}");
+}
+
+// =============================================================================
+// Negative controls: invalid whole-entity-like content must still reject
+// =============================================================================
+
+#[test]
+fn rna_bracket_garbage_still_rejected() {
+    // `spline` is not `spl` or `spl?` — trailing chars must fail.
+    assert!(parse_hgvs("NM_004006.2:r.[spline];[100a>g]").is_err());
+}
+
+#[test]
+fn rna_bracket_uppercase_spl_rejected() {
+    // RNA is lowercase per spec.
+    assert!(parse_hgvs("NM_004006.2:r.[SPL];[100a>g]").is_err());
+}

--- a/tests/issue_396_trans_allele_consolidation.rs
+++ b/tests/issue_396_trans_allele_consolidation.rs
@@ -1,0 +1,228 @@
+//! Issue #396 item 1 — behavior-preserving regression net for the 7
+//! `parse_*_trans_allele_shorthand` helpers.
+//!
+//! Each axis must round-trip the compact-prefix trans-allele forms:
+//!
+//! - `[var1];[var2]` (two member variants)
+//! - `[var1];[0]`   (paired with NullAllele)
+//! - `[var1];[?]`   (paired with UnknownAllele)
+//!
+//! and reject malformed inputs (missing close bracket, fewer than 2
+//! members) the same way they do today. These tests must pass on
+//! `origin/main` before the refactor and continue passing after — the
+//! refactor is behavior-preserving by design.
+//!
+//! Protein has 3 additional special-case markers (`[0]`, `[0?]`,
+//! `[(0)]`) that resolve to `ProteinEdit::NoProtein` inside the
+//! compact `p.` form. Those are exercised here too so the refactor
+//! doesn't accidentally relax that protein-specific routing.
+
+use ferro_hgvs::parse_hgvs;
+
+fn parse_ok(input: &str) -> String {
+    parse_hgvs(input)
+        .unwrap_or_else(|e| panic!("parse({input:?}) failed: {e:?}"))
+        .to_string()
+}
+
+fn parse_err(input: &str) -> ferro_hgvs::error::FerroError {
+    parse_hgvs(input).expect_err(&format!("parse({input:?}) unexpectedly succeeded"))
+}
+
+// =============================================================================
+// Axis: genome (g.)
+// =============================================================================
+
+#[test]
+fn genome_trans_two_members_roundtrip() {
+    let s = parse_ok("NC_000001.11:g.[100A>G];[200T>C]");
+    assert!(s.contains("];["), "expected split brackets, got {s}");
+    assert!(s.contains("100A>G"));
+    assert!(s.contains("200T>C"));
+}
+
+#[test]
+fn genome_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NC_000001.11:g.[100A>G];[0]");
+    assert!(s.contains(";[0]"), "expected NullAllele segment, got {s}");
+}
+
+#[test]
+fn genome_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NC_000001.11:g.[100A>G];[?]");
+    assert!(
+        s.contains(";[?]"),
+        "expected UnknownAllele segment, got {s}"
+    );
+}
+
+// =============================================================================
+// Axis: cds (c.)
+// =============================================================================
+
+#[test]
+fn cds_trans_two_members_roundtrip() {
+    let s = parse_ok("NM_000088.3:c.[1A>G];[2T>C]");
+    assert!(s.contains("];["), "got {s}");
+    assert!(s.contains("1A>G") && s.contains("2T>C"));
+}
+
+#[test]
+fn cds_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NM_000088.3:c.[1A>G];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn cds_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NM_000088.3:c.[1A>G];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+// =============================================================================
+// Axis: tx (n.)
+// =============================================================================
+
+#[test]
+fn tx_trans_two_members_roundtrip() {
+    let s = parse_ok("NR_000001.1:n.[1A>G];[2T>C]");
+    assert!(s.contains("];["), "got {s}");
+}
+
+#[test]
+fn tx_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NR_000001.1:n.[1A>G];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn tx_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NR_000001.1:n.[1A>G];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+// =============================================================================
+// Axis: mt (m.)
+// =============================================================================
+
+#[test]
+fn mt_trans_two_members_roundtrip() {
+    let s = parse_ok("NC_012920.1:m.[100A>G];[200T>C]");
+    assert!(s.contains("];["), "got {s}");
+}
+
+#[test]
+fn mt_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NC_012920.1:m.[100A>G];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn mt_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NC_012920.1:m.[100A>G];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+// =============================================================================
+// Axis: rna (r.)
+// =============================================================================
+
+#[test]
+fn rna_trans_two_members_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[100a>g];[200u>c]");
+    assert!(s.contains("];["), "got {s}");
+}
+
+#[test]
+fn rna_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[100a>g];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn rna_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NM_004006.2:r.[100a>g];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+// =============================================================================
+// Axis: circular (o.)
+// =============================================================================
+
+#[test]
+fn circular_trans_two_members_roundtrip() {
+    let s = parse_ok("NC_011083.1:o.[100A>G];[200T>C]");
+    assert!(s.contains("];["), "got {s}");
+}
+
+#[test]
+fn circular_trans_with_null_allele_roundtrip() {
+    let s = parse_ok("NC_011083.1:o.[100A>G];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn circular_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NC_011083.1:o.[100A>G];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+// =============================================================================
+// Axis: protein (p.) — keeps its 3 special markers
+// =============================================================================
+
+#[test]
+fn protein_trans_two_members_roundtrip() {
+    let s = parse_ok("NP_000079.2:p.[Ala1Val];[Ser2Thr]");
+    assert!(s.contains("];["), "got {s}");
+}
+
+#[test]
+fn protein_trans_with_no_protein_zero_roundtrip() {
+    // `p.[X];[0]` → second member is ProteinEdit::NoProtein (NOT NullAllele).
+    let s = parse_ok("NP_000079.2:p.[Ala1Val];[0]");
+    assert!(s.contains(";[0]"), "got {s}");
+}
+
+#[test]
+fn protein_trans_with_unknown_allele_roundtrip() {
+    let s = parse_ok("NP_000079.2:p.[Ala1Val];[?]");
+    assert!(s.contains(";[?]"), "got {s}");
+}
+
+#[test]
+fn protein_trans_with_predicted_no_protein_roundtrip() {
+    // `p.[X];[0?]` → second member is ProteinEdit::NoProtein { predicted: true }.
+    let s = parse_ok("NP_000079.2:p.[Ala1Val];[0?]");
+    assert!(s.contains(";[0?]"), "got {s}");
+}
+
+// =============================================================================
+// Negative: malformed forms must still reject across all axes
+// =============================================================================
+
+#[test]
+fn trans_single_bracket_rejected_across_axes() {
+    // Only one bracket member — must reject (less than 2 alleles for trans).
+    // A trailing `;` with no second bracket is not a spec-defined allele
+    // shape: the inner singleton parses but the dangling `;` becomes
+    // unexpected trailing input. The trans-allele code path must NOT
+    // produce a 1-element AlleleVariant from this form.
+    for input in [
+        "NC_000001.11:g.[100A>G];", // trailing semicolon, no second bracket
+        "NM_000088.3:c.[1A>G];",
+    ] {
+        parse_err(input);
+    }
+}
+
+#[test]
+fn trans_truncated_bracket_rejected() {
+    // Missing close bracket on second member.
+    for input in [
+        "NC_000001.11:g.[100A>G];[200T>C",
+        "NM_000088.3:c.[1A>G];[2T>C",
+    ] {
+        let _ = parse_err(input);
+    }
+}

--- a/tests/issue_396_trans_allele_consolidation.rs
+++ b/tests/issue_396_trans_allele_consolidation.rs
@@ -226,3 +226,42 @@ fn trans_truncated_bracket_rejected() {
         let _ = parse_err(input);
     }
 }
+
+#[test]
+fn trans_missing_separator_between_brackets_rejected() {
+    // `[A];[B][C]` (no `;` between the second and third brackets) is not a
+    // spec-defined trans-allele shape: each member must be separated by a
+    // single `;`. The parser must reject this rather than silently building
+    // a 3-element AlleleVariant.
+    for input in [
+        "NC_000001.11:g.[100A>G];[200T>C][300A>G]",
+        "NM_000088.3:c.[1A>G];[2T>C][3A>G]",
+        "NR_000001.1:n.[1A>G];[2T>C][3A>G]",
+        "NC_012920.1:m.[100A>G];[200T>C][300A>G]",
+        "NM_004006.2:r.[100a>g];[200u>c][300a>g]",
+        "NC_011083.1:o.[100A>G];[200T>C][300A>G]",
+        "NP_000079.2:p.[Ala1Val];[Ser2Thr][Cys3Trp]",
+    ] {
+        parse_err(input);
+    }
+}
+
+#[test]
+fn trans_dangling_trailing_semicolon_rejected() {
+    // `[A];[B];` (trailing `;` with no following bracket) is not a
+    // spec-defined trans-allele shape. The parser must reject rather than
+    // silently stripping the dangling `;`. Mirrors the single-bracket
+    // rejection (`[A];`) but covers the post-second-bracket case where the
+    // `variants.len() < 2` guard does not catch it.
+    for input in [
+        "NC_000001.11:g.[100A>G];[200T>C];",
+        "NM_000088.3:c.[1A>G];[2T>C];",
+        "NR_000001.1:n.[1A>G];[2T>C];",
+        "NC_012920.1:m.[100A>G];[200T>C];",
+        "NM_004006.2:r.[100a>g];[200u>c];",
+        "NC_011083.1:o.[100A>G];[200T>C];",
+        "NP_000079.2:p.[Ala1Val];[Ser2Thr];",
+    ] {
+        parse_err(input);
+    }
+}

--- a/tests/issue_423_bracket_whole_entity.rs
+++ b/tests/issue_423_bracket_whole_entity.rs
@@ -1,0 +1,234 @@
+//! Issue #423 — `parse_cds_bracket_member`, `parse_tx_bracket_member`,
+//! and `parse_genome_bracket_member` only knew about position-based
+//! edits and the predicted-wrapper `(pos edit)`. Inside a c./n./g./m./o.
+//! allele bracket (`c.[X];[Y]` or `c.[X;Y]` or `c.[X(;)Y]`), whole-entity
+//! edits like `=`, `?` (and `0` for `n.`) were rejected because they
+//! have no positional content.
+//!
+//! This issue closes the symmetry gap with PR #396 item 3 (which added
+//! the same dispatch for `r.`). Each dispatcher now probes the
+//! axis-specific whole-entity parsers (`parse_whole_cds_*`,
+//! `parse_whole_rna_*`, `parse_whole_genome_*`, plus `parse_rna_no_product`
+//! for the `n.0` tx form) before the position-based parsers, attaching
+//! a dummy interval at position 1 (mirroring the top-level dispatchers'
+//! handling of the same forms).
+//!
+//! Bare `[0]` / `[?]` in the trans-allele form `[X];[Y]` continue to
+//! cross-coord-short-circuit to `NullAllele` / `UnknownAllele` via the
+//! shared `parse_trans_allele_shorthand_generic`. Only cis/unknown-flat
+//! paths and predicted-form members (`[(?)]`, `[(=)]`, `[(0)]`) plus
+//! bare whole-entity tokens inside cis brackets flow into the new
+//! probes.
+//!
+//! **Display-shape note:** for some inputs (e.g. `c.[100A>G(;)=]`,
+//! `c.[(?)];[100A>G]`) the existing pre-#423 Display logic re-emits the
+//! variant in the expanded `[ACC:c.X];[ACC:c.Y]` form rather than the
+//! compact-prefix `c.[X];[Y]` form. That re-emission is pre-existing
+//! behavior on this axis pair, not introduced here, so the assertions
+//! below pin the actual canonical Display output (re-parse-stable) for
+//! each input rather than expecting a byte-identical echo. Re-parse of
+//! every canonical Display is asserted as a fixed point at the end of
+//! each test.
+
+use ferro_hgvs::parse_hgvs;
+
+/// Parse, Display, and re-parse the input. Asserts:
+/// 1. parse(`input`) succeeds and Displays to `expected_canonical`.
+/// 2. parse(`expected_canonical`) succeeds.
+/// 3. Display of the re-parsed variant equals `expected_canonical`
+///    (Display is a fixed point on the canonical form).
+fn assert_canonical(input: &str, expected_canonical: &str) {
+    let parsed =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input:?}) must succeed; got {e:?}"));
+    let displayed = parsed.to_string();
+    assert_eq!(
+        displayed, expected_canonical,
+        "Display({input:?}) must equal {expected_canonical:?}; got {displayed:?}",
+    );
+    let reparsed = parse_hgvs(&displayed).unwrap_or_else(|e| {
+        panic!("re-parse of canonical Display {displayed:?} must succeed; got {e:?}")
+    });
+    let redisplayed = reparsed.to_string();
+    assert_eq!(
+        redisplayed, expected_canonical,
+        "Display must be a fixed point on the canonical form for {input:?}; got {redisplayed:?}",
+    );
+}
+
+// =============================================================================
+// CDS (c.) axis
+// =============================================================================
+
+#[test]
+fn cds_cis_substitution_then_identity_roundtrip() {
+    assert_canonical("NM_000088.3:c.[100A>G;=]", "NM_000088.3:c.[100A>G;=]");
+}
+
+#[test]
+fn cds_unknown_phase_substitution_with_identity_roundtrip() {
+    // Unknown-phase brackets (`(;)`) get re-emitted in the bracketless
+    // form `c.X(;)Y` per the pre-#423 Display logic. Re-parse stable.
+    assert_canonical("NM_000088.3:c.[100A>G(;)=]", "NM_000088.3:c.100A>G(;)=");
+}
+
+#[test]
+fn cds_trans_identity_then_substitution_roundtrip() {
+    // `c.[=];[100A>G]` — whole-CDS identity on one arm, substitution
+    // on the other. The `[=]` arm flows through the bracket-member
+    // dispatcher (NOT the cross-coord short-circuit, which only fires
+    // for bare `[0]` / `[?]`).
+    assert_canonical("NM_000088.3:c.[=];[100A>G]", "NM_000088.3:c.[=];[100A>G]");
+}
+
+#[test]
+fn cds_trans_predicted_unknown_with_substitution_roundtrip() {
+    // `c.[(?)];[100A>G]` — predicted-uncertain whole-CDS unknown on
+    // one arm. Display re-emits in expanded form per pre-#423 behavior.
+    assert_canonical(
+        "NM_000088.3:c.[(?)];[100A>G]",
+        "[NM_000088.3:c.(?)];[NM_000088.3:c.100A>G]",
+    );
+}
+
+#[test]
+fn cds_cis_unknown_with_substitution_roundtrip() {
+    // `c.[100A>G;?]` — bare `?` inside a cis bracket flows through
+    // the bracket member (not short-circuited because the
+    // short-circuit only fires in the trans `[X];[Y]` shape).
+    // Display re-emits in expanded form per pre-#423 behavior.
+    assert_canonical(
+        "NM_000088.3:c.[100A>G;?]",
+        "[NM_000088.3:c.100A>G;NM_000088.3:c.?]",
+    );
+}
+
+// =============================================================================
+// Non-coding tx (n.) axis — includes the `0` / `(0)` no-product forms
+// =============================================================================
+
+#[test]
+fn tx_cis_substitution_then_identity_roundtrip() {
+    assert_canonical("NR_001234.1:n.[100A>G;=]", "NR_001234.1:n.[100A>G;=]");
+}
+
+#[test]
+fn tx_trans_identity_with_substitution_roundtrip() {
+    assert_canonical("NR_001234.1:n.[=];[100A>G]", "NR_001234.1:n.[=];[100A>G]");
+}
+
+#[test]
+fn tx_trans_predicted_no_product_with_substitution_roundtrip() {
+    // `n.[(0)];[100A>G]` — predicted no transcript on one arm.
+    // Bare `[0]` short-circuits to `NullAllele`; `[(0)]` is the
+    // tx-specific predicted no-product form (mirrors `r.(0)`).
+    assert_canonical(
+        "NR_001234.1:n.[(0)];[100A>G]",
+        "NR_001234.1:n.[(0)];[100A>G]",
+    );
+}
+
+#[test]
+fn tx_trans_pure_whole_entity_pair_roundtrip() {
+    // Both arms whole-entity: `n.[=];[?]`. Bare `[?]` cross-coord-short-
+    // circuits to `UnknownAllele` upstream of the bracket member, so
+    // this exercises the new `=` probe on the first arm AND the
+    // upstream short-circuit on the second.
+    let v = parse_hgvs("NR_001234.1:n.[=];[?]")
+        .expect("NR_001234.1:n.[=];[?] must parse — pure whole-entity trans pair");
+    // The displayed form depends on how UnknownAllele Displays inside
+    // an Allele — pin re-parse stability rather than the exact bytes.
+    let displayed = v.to_string();
+    let reparsed = parse_hgvs(&displayed)
+        .unwrap_or_else(|e| panic!("re-parse of {displayed:?} must succeed; got {e:?}"));
+    assert_eq!(
+        reparsed.to_string(),
+        displayed,
+        "Display must be a fixed point for the canonical form",
+    );
+}
+
+// =============================================================================
+// Genome (g./m./o.) axis
+// =============================================================================
+
+#[test]
+fn genome_cis_substitution_then_identity_roundtrip() {
+    assert_canonical("NC_000001.11:g.[100A>G;=]", "NC_000001.11:g.[100A>G;=]");
+}
+
+#[test]
+fn genome_trans_identity_with_substitution_roundtrip() {
+    assert_canonical("NC_000001.11:g.[=];[100A>G]", "NC_000001.11:g.[=];[100A>G]");
+}
+
+#[test]
+fn mito_cis_substitution_then_identity_roundtrip() {
+    assert_canonical("NC_012920.1:m.[100A>G;=]", "NC_012920.1:m.[100A>G;=]");
+}
+
+#[test]
+fn mito_trans_predicted_unknown_with_substitution_roundtrip() {
+    // `m.[(?)];[100A>G]` — predicted-uncertain whole-mito unknown on
+    // one arm. Same shape as `g.[(?)]`, routed through the same
+    // dispatcher with `kind = Mt`. Display expansion mirrors c.[(?)]
+    // (pre-#423 trans-allele Display behavior).
+    assert_canonical(
+        "NC_012920.1:m.[(?)];[100A>G]",
+        "[NC_012920.1:m.(?)];[NC_012920.1:m.100A>G]",
+    );
+}
+
+// =============================================================================
+// Protein bracket-member dispatch is intentionally out of scope here.
+// `p.[=];[X]` and the protein cis-form whole-entity members
+// (`p.[Arg97Cys;=]`, etc.) are not currently a supported protein
+// bracket-member shape — the issue body's claim that the protein
+// dispatcher already accepts `[=]` is true only for the
+// position-bearing form `[pos=]` (e.g. `[Arg97=];[X]`), which has
+// always worked. Closing the "whole-protein identity in a bracket" gap
+// is its own follow-up because protein needs a different dummy-interval
+// shape (no `1`-base dummy makes sense for `p.`) and a different
+// round-trip story.
+//
+// =============================================================================
+// Negative controls: spec-malformed inputs must reject
+// =============================================================================
+
+#[test]
+fn cds_bracket_trailing_junk_after_identity_rejected() {
+    // `=garbage` is not a whole-entity edit; trailing chars must fail
+    // the `final_remaining.trim().is_empty()` check.
+    assert!(parse_hgvs("NM_000088.3:c.[=garbage];[100A>G]").is_err());
+}
+
+#[test]
+fn cds_bracket_double_identity_rejected() {
+    // `==` is not a spec form. The first `=` is consumed by the
+    // whole-entity-identity probe, leaving `=` as the remainder —
+    // which fails the bracket member's
+    // `final_remaining.trim().is_empty()` guard.
+    assert!(parse_hgvs("NM_000088.3:c.[==];[100A>G]").is_err());
+}
+
+#[test]
+fn cds_bracket_identity_then_unknown_concat_rejected() {
+    // `=?` is not a spec form — same shape as `==` but exercising the
+    // "first probe wins, second token leaks" failure path.
+    assert!(parse_hgvs("NM_000088.3:c.[=?];[100A>G]").is_err());
+}
+
+#[test]
+fn tx_bracket_double_marked_no_product_rejected() {
+    // `(0?)` is the spec-malformed double-marked form for `n.` no
+    // product (the protein-axis analog `p.(0?)` is pinned in
+    // `tests/issue_289_protein_zero_predicted.rs::double_marked_p_paren_zero_question_rejects`).
+    // Must reject in trans-allele context too.
+    assert!(parse_hgvs("NR_001234.1:n.[(0?)];[100A>G]").is_err());
+}
+
+#[test]
+fn genome_bracket_uppercase_position_letter_rejected() {
+    // `X` is not a base or whole-entity marker; the position parser
+    // refuses it and the bracket member returns an error.
+    assert!(parse_hgvs("NC_000001.11:g.[100A>G;X]").is_err());
+}

--- a/tests/rna_spl_marker.rs
+++ b/tests/rna_spl_marker.rs
@@ -242,7 +242,7 @@ fn rna_spl_question_mark_not_equal_to_rna_unknown() {
 /// `r.[spl?];[spl]` must round-trip after #396 item 3. Replaces the older
 /// "currently rejected" pin.
 #[test]
-fn rna_spl_allele_compound_roundtrip() {
+fn rna_spl_allele_compound_round_trip() {
     let variant = parse_hgvs("NM_004006.2:r.[spl?];[spl]")
         .expect("r.[spl?];[spl] must parse after #396 item 3");
     // Exact-string equality so a regression that drops the `?` (yielding

--- a/tests/rna_spl_marker.rs
+++ b/tests/rna_spl_marker.rs
@@ -17,8 +17,8 @@
 //! - hash + Eq distinctness across the four forms,
 //! - non-equivalence with `r.?` (whole-RNA unknown),
 //! - rejection of malformed inputs (`r.spl??`, `r.spline`, `r.SPL`, whitespace),
-//! - current rejection of whole-entity edits inside allele brackets
-//!   (`r.[spl?];[spl]`) — pre-existing parser limitation, out of E2 scope.
+//! - round-trip of whole-entity edits inside allele brackets
+//!   (`r.[spl?];[spl]`) as of #396 item 3.
 
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
 
@@ -228,31 +228,28 @@ fn rna_spl_question_mark_not_equal_to_rna_unknown() {
 }
 
 // ---------------------------------------------------------------------------
-// Allele compounds — pinned to current behavior.
+// Allele compounds — supported as of #396 item 3.
 //
-// ferro's RNA allele bracket parsers (`parse_rna_allele_shorthand` and
-// `parse_rna_trans_allele_shorthand`) require an interval before each segment's
-// edit, so today they reject all whole-entity splicing markers — including the
-// pre-existing `r.[spl];[spl]`. This is independent of #126 (which scopes
-// standalone `r.spl?` / `r.(spl?)`); allowing whole-entity edits inside allele
-// brackets is its own change. Pin the current behavior so any future allele
-// parser refactor surfaces it.
+// `parse_rna_bracket_member` (the per-bracket dispatcher used by both
+// `parse_rna_allele_shorthand` cis/unknown paths and
+// `parse_rna_trans_allele_shorthand`) now recognises the whole-entity RNA
+// edits `=` / `?` / `0` / `spl` / `spl?` / `(spl)` / `(spl?)` in addition to
+// the previously-supported position-based edits and predicted-wrapper form.
+// Whole-entity members attach a dummy interval at position 1 (mirroring
+// `parse_rna_variant`'s top-level handling).
 // ---------------------------------------------------------------------------
 
-/// `r.[spl?];[spl]` is currently rejected by the allele bracket parser. When/if
-/// support for whole-entity RNA edits inside allele brackets is added, flip this
-/// pin to assert successful round-trip.
+/// `r.[spl?];[spl]` must round-trip after #396 item 3. Replaces the older
+/// "currently rejected" pin.
 #[test]
-fn rna_spl_allele_compound_currently_rejected() {
-    let result = parse_hgvs("NM_004006.2:r.[spl?];[spl]");
-    assert!(
-        result.is_err(),
-        "r.[spl?];[spl] is expected to be rejected today (pre-existing limitation \
-         of the RNA allele bracket parser, independent of this PR's scope); got \
-         Ok({:?}). When support for whole-entity edits inside allele brackets is \
-         added, flip this pin to assert successful round-trip.",
-        result.ok().map(|v| v.to_string()),
-    );
+fn rna_spl_allele_compound_roundtrip() {
+    let variant = parse_hgvs("NM_004006.2:r.[spl?];[spl]")
+        .expect("r.[spl?];[spl] must parse after #396 item 3");
+    // Exact-string equality so a regression that drops the `?` (yielding
+    // `[spl];[spl]`) or that loses the trans-form split (`[spl?];[spl]` →
+    // `[spl?;spl]`) is caught — a `contains("spl")` check would silently
+    // match `spl?` and miss either regression.
+    assert_eq!(variant.to_string(), "NM_004006.2:r.[spl?];[spl]");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #396 — three parser items surfaced by CodeRabbit on PRs #146 / #148 / #134 that never got follow-up fixes. All three items shipped.

- **`refactor(parser): dedup 7 trans-allele shorthand helpers into generic (#396 item 1)`** — `parse_*_trans_allele_shorthand` for `genome`, `cds`, `tx`, `mt`, `rna`, `circular` were 7 near-identical scaffolds (bracket-balance scan, `[0]`/`[?]` cross-coordinate special-cases, content-fully-consumed check, `len<2` guard, `AlleleVariant::Trans` wrap). Extract the scaffolding into `parse_trans_allele_shorthand_generic<F>(input, parse_member)`; each axis becomes a 12-line closure. Protein intentionally stays solo: it has three special-case markers (`[0]`, `[0?]`, `[(0)]`) that resolve to `ProteinEdit::NoProtein` rather than the cross-coordinate `NullAllele`, because the `p.` compact prefix has already pinned the coordinate system. The protein helper's doc comment now explicitly explains why it does not use the generic. Behavior-preserving: net -212 lines, no functional change. 24-test regression net in `tests/issue_396_trans_allele_consolidation.rs` pins the shared contract across all 7 axes.

- **`fix(parser): reject mixed ;/(;) in cds/rna allele shorthand (#396 item 2)`** — `parse_cds_allele_shorthand` and `parse_rna_allele_shorthand` previously silent-flattened the mixed-separator form `[A;B(;)C]` into a flat `AllelePhase::Unknown` allele over all members. There is no spec-defined HGVS shape that says "subgroup A;B is cis to each other but unknown phase to C" inside a single bracket pair, so silently emitting a flat Unknown allele drops the user's intent. `parse_protein_allele_shorthand` already returned an error on this mixed form; this commit brings cds and rna in line. Pure cis (`[A;B]`) and pure unknown (`[A(;)B]`) still parse — only the mixed form rejects. Two in-module pin tests for the old silent-flatten contract are reshaped to pin the new reject contract; 10 new tests in `tests/issue_396_mixed_phase_separators.rs` cover both axes plus protein-axis regression.

- **`feat(parser): support whole-entity RNA edits inside allele brackets (#396 item 3)`** — `parse_rna_bracket_member` (the per-bracket dispatcher used by both `parse_rna_allele_shorthand` cis/unknown paths and `parse_rna_trans_allele_shorthand`) previously only recognised the predicted-wrapper form `(<pos><edit>)` and bare `<pos><edit>` — whole-entity RNA edits like `=`, `?`, `0`, `spl`, `spl?`, `(spl)`, `(spl?)` were rejected because they carry no positional content. Dispatch to the existing whole-entity RNA parsers (`parse_whole_rna_identity`, `parse_whole_rna_unknown`, `parse_rna_no_product`, `parse_whole_rna_predicted_splice`, `parse_rna_splice`) before falling through to the position-based parsers. Whole-entity members attach a dummy interval at position 1 (mirrors `parse_rna_variant`'s top-level handling). Un-pinned `tests/rna_spl_marker.rs::rna_spl_allele_compound_currently_rejected` and replaced it with a positive round-trip assertion. Regenerated `tests/fixtures/grammar/hgvs_spec_normalization.json` (`r.[76a>u];[=]` moves from `parse-error` to `preserved`). 10 new tests in `tests/issue_396_rna_bracket_whole_entity.rs`.

- **`fix(review): apply end-of-issue review findings (#396)`** — Drop an orphan doc paragraph that sat above `parse_trans_allele_shorthand_generic` (pre-refactor it described the genome shim, post-refactor it was stranded and misleading); make the Trans-only contract explicit in the generic's doc; add a precedence note to `parse_rna_bracket_member` explaining how upstream cross-coord short-circuits handle `[0]` / `[?]` before this dispatcher; rename in-module `test_parse_mixed_phase_allele_shorthand_rejected{,_complex}` to `_cds_` variants for axis disambiguation against the RNA-axis counterparts in the new integration test.

## Follow-ups filed

- #423 — `parse_cds_bracket_member` / `parse_tx_bracket_member` / `parse_genome_bracket_member` lack the whole-entity dispatch that RNA now has. Out of scope for #396 (RNA-scoped); shapes like `c.[100A>G;=]` still reject today.
- #424 — Pre-existing dead `0?` clause in `parse_protein_trans_allele_shorthand`'s third arm; not introduced by this PR but worth a cleanup pass.

## Test plan

- [x] `cargo nextest run --features dev` — 5895 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences pre-existing on `origin/main`); zero new failures.
- [x] `cargo clippy --features dev -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run --features dev --example generate_spec_fixture -- --check` clean (after regenerating `hgvs_spec_normalization.json`).
- [x] All new tests across the 3 items PASS (24 + 10 + 10 = 44 new Rust tests).
