### PR TITLE
omnibus follow-up: loader + diagnostics + ci polish (closes #397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
+      - name: Install packaging
+        # `packaging.specifiers.SpecifierSet` parses compound specs
+        # (`">=3.10,<4"`, `">=3.10rc1"`, etc.) per PEP 440/621 — more
+        # robust than regex matching the literal string form.
+        run: python -m pip install --no-cache-dir 'packaging>=24'
       - name: Assert Cargo.toml abi3-pyXY matches pyproject.toml requires-python
         # Cargo.toml's `abi3-pyXY` pyo3 feature sets the minimum Python
         # version the abi3 wheel can run on; pyproject.toml's
@@ -43,6 +48,8 @@ jobs:
           import re
           import sys
           from pathlib import Path
+          from packaging.specifiers import SpecifierSet
+          from packaging.version import Version
 
           cargo = Path("Cargo.toml").read_text()
           m = re.search(r'"abi3-py(\d+)"', cargo)
@@ -52,22 +59,35 @@ jobs:
           if not abi3_digits.startswith("3"):
               sys.exit(f"Unexpected abi3 minor in 'abi3-py{abi3_digits}'")
           # abi3-py310 → minor='10', abi3-py37 → minor='7'.
-          abi3_floor = f"3.{abi3_digits[1:]}"
+          abi3_floor = Version(f"3.{abi3_digits[1:]}")
 
           pyproject = Path("pyproject.toml").read_text()
-          m = re.search(r'requires-python\s*=\s*"\s*>=\s*([0-9.]+)\s*"', pyproject)
+          m = re.search(r'requires-python\s*=\s*"([^"]+)"', pyproject)
           if not m:
               sys.exit("Could not find requires-python in pyproject.toml")
-          requires_python = m.group(1)
+          spec_str = m.group(1)
+          spec = SpecifierSet(spec_str)
 
-          if abi3_floor != requires_python:
+          # The abi3 floor is correct iff the wheel's minimum CPython
+          # version is the lowest version the spec accepts. We test
+          # this by asserting (a) abi3_floor itself satisfies the spec
+          # and (b) the immediately-lower minor (3.{N-1}) does not.
+          minor = abi3_floor.minor
+          if not spec.contains(abi3_floor, prereleases=True):
               sys.exit(
-                  f"abi3 floor / requires-python drift:\n"
-                  f"  Cargo.toml `abi3-py{abi3_digits}` implies Python floor {abi3_floor}\n"
-                  f"  pyproject.toml `requires-python` is {requires_python!r}\n"
-                  f"Bump both together, or pin them in tandem here."
+                  f"abi3 floor / requires-python drift: Cargo.toml "
+                  f"`abi3-py{abi3_digits}` ({abi3_floor}) does not satisfy "
+                  f"pyproject.toml `requires-python = {spec_str!r}`."
               )
-          print(f"OK: abi3-py{abi3_digits} ↔ requires-python = >={requires_python}")
+          one_below = Version(f"3.{minor - 1}") if minor > 0 else None
+          if one_below is not None and spec.contains(one_below, prereleases=True):
+              sys.exit(
+                  f"abi3 floor / requires-python drift: pyproject.toml "
+                  f"`requires-python = {spec_str!r}` would accept Python "
+                  f"{one_below}, but the abi3 wheel from "
+                  f"`abi3-py{abi3_digits}` requires Python >= {abi3_floor}."
+              )
+          print(f"OK: abi3-py{abi3_digits} ({abi3_floor}) ↔ requires-python = {spec_str!r}")
           PY
 
   format:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-cargo-
+      - name: "Note: reference-aware tests are skipped without a manifest"
+        # `tests/mutalyzer_normalize_tests.rs` and the biocommons
+        # reference-aware suite both silently no-op when
+        # `FERRO_MANIFEST` is unset (PR CI does not provision the
+        # multi-GB reference manifest). Surface a GitHub annotation
+        # so reviewers see the skip explicitly in the PR check
+        # summary; the nightly `nightly-mutalyzer.yml` workflow runs
+        # the same suite with a real manifest. #397 item 6.
+        run: |
+          echo "::notice title=Reference-aware tests skipped on PR CI::PR CI does not provision FERRO_MANIFEST; the mutalyzer / biocommons reference-aware test suites silently skip. The nightly nightly-mutalyzer.yml workflow runs the full suite against a real manifest."
       - name: Run Rust tests
         run: cargo nextest run --features dev
       - name: Verify HGVS v21.0 fixture is up to date

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,58 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  abi3-floor-consistency:
+    name: abi3 floor ↔ requires-python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Assert Cargo.toml abi3-pyXY matches pyproject.toml requires-python
+        # Cargo.toml's `abi3-pyXY` pyo3 feature sets the minimum Python
+        # version the abi3 wheel can run on; pyproject.toml's
+        # `requires-python` declares the minimum Python pip will accept
+        # at install time. If they drift (e.g. a future bump on one
+        # side only), users hit either a runtime ABI mismatch
+        # (`abi3-py311` wheel on `requires-python = ">=3.10"` installs
+        # but fails to load on 3.10) or a silently-stale floor
+        # (`abi3-py310` wheel still permitted on a project that meant
+        # to drop 3.10 support). #397 item 5.
+        run: |
+          python <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          cargo = Path("Cargo.toml").read_text()
+          m = re.search(r'"abi3-py(\d+)"', cargo)
+          if not m:
+              sys.exit("Could not find abi3-pyXY feature in Cargo.toml")
+          abi3_digits = m.group(1)
+          if not abi3_digits.startswith("3"):
+              sys.exit(f"Unexpected abi3 minor in 'abi3-py{abi3_digits}'")
+          # abi3-py310 → minor='10', abi3-py37 → minor='7'.
+          abi3_floor = f"3.{abi3_digits[1:]}"
+
+          pyproject = Path("pyproject.toml").read_text()
+          m = re.search(r'requires-python\s*=\s*"\s*>=\s*([0-9.]+)\s*"', pyproject)
+          if not m:
+              sys.exit("Could not find requires-python in pyproject.toml")
+          requires_python = m.group(1)
+
+          if abi3_floor != requires_python:
+              sys.exit(
+                  f"abi3 floor / requires-python drift:\n"
+                  f"  Cargo.toml `abi3-py{abi3_digits}` implies Python floor {abi3_floor}\n"
+                  f"  pyproject.toml `requires-python` is {requires_python!r}\n"
+                  f"Bump both together, or pin them in tandem here."
+              )
+          print(f"OK: abi3-py{abi3_digits} ↔ requires-python = >={requires_python}")
+          PY
+
   format:
     name: Format
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -1,0 +1,116 @@
+name: Nightly reference-aware tests
+
+# Runs the mutalyzer / biocommons reference-aware test suites against a
+# real ferro-prepared manifest. PR CI silently skips these tests (see
+# the `::notice::` annotation in `ci.yml`) because provisioning a
+# multi-GB reference manifest would multiply PR CI time. This workflow
+# runs nightly so manifest-dependent regressions surface within 24h.
+#
+# Caching: the prepared reference directory is keyed on the Cargo.lock
+# hash (changes when the `prepare` crate's deps shift) + a fixed
+# version tag. First run takes ~30 min; subsequent runs reuse the
+# cache and finish in a few minutes.
+#
+# #397 item 6.
+
+on:
+  schedule:
+    # Daily at 04:00 UTC. Avoids contention with the weekly Sunday
+    # external-validation.yml run at 00:00 UTC.
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-mutalyzer-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Bump this tag whenever the manifest layout or `ferro prepare`
+  # invocation changes meaningfully, so stale caches are invalidated
+  # without manual purging.
+  MANIFEST_CACHE_VERSION: v1
+
+jobs:
+  reference-aware-tests:
+    name: Reference-aware mutalyzer / biocommons tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          submodules: true
+          lfs: true
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+
+      - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache prepared reference manifest
+        id: cache-manifest
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          # `benchmark-output/manifest.json` is one of the well-known
+          # paths the test harness probes (see `manifest_path()` in
+          # `tests/mutalyzer_normalize_tests.rs`); the surrounding
+          # `benchmark-output/` directory holds the FASTAs / cdot
+          # transcripts the manifest references.
+          path: benchmark-output/
+          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**') }}
+
+      - name: Build ferro (for prepare)
+        run: cargo build --release --bin ferro
+
+      - name: Run `ferro prepare` (cache miss only)
+        if: steps.cache-manifest.outputs.cache-hit != 'true'
+        run: |
+          ./target/release/ferro prepare \
+            --output benchmark-output \
+            --genome grch38
+
+      - name: Confirm manifest present
+        run: |
+          test -f benchmark-output/manifest.json || \
+            (echo "::error::manifest.json missing after prepare step"; exit 1)
+          echo "manifest size: $(stat -c%s benchmark-output/manifest.json) bytes"
+
+      - name: Run reference-aware tests
+        env:
+          FERRO_MANIFEST: ${{ github.workspace }}/benchmark-output/manifest.json
+        # Filter to the suites that require a manifest. Failures are
+        # NOT propagated to the step exit code via `|| true` — the
+        # purpose of the nightly is to surface drift in the xfail
+        # report, not to gate PRs. (PR CI's strict-mode test job
+        # already covers manifest-free correctness.)
+        run: |
+          cargo nextest run --features dev \
+            -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/)' \
+            || true
+
+      - name: Upload xfail reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ferro-xfail-${{ github.run_id }}
+          path: /tmp/ferro-xfail/
+          if-no-files-found: warn

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -76,7 +76,13 @@ jobs:
           # `benchmark-output/` directory holds the FASTAs / cdot
           # transcripts the manifest references.
           path: benchmark-output/
-          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**') }}
+          # Invalidation surface: lock file (downstream-dep changes),
+          # the `prepare` crate (manifest-output shape), and the CLI
+          # wiring at `src/bin/ferro.rs` (the `prepare` subcommand
+          # binding). If a future PR adds a `src/reference/**` dep
+          # that changes `ferro prepare` behavior, bump
+          # MANIFEST_CACHE_VERSION manually.
+          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs') }}
 
       - name: Build ferro (for prepare)
         run: cargo build --release --bin ferro
@@ -95,17 +101,19 @@ jobs:
           echo "manifest size: $(stat -c%s benchmark-output/manifest.json) bytes"
 
       - name: Run reference-aware tests
+        # Failures are NOT propagated to the workflow conclusion — the
+        # purpose of the nightly is to surface drift in the xfail report,
+        # not to gate PRs. (PR CI's strict-mode test job already covers
+        # manifest-free correctness.) Use step-level continue-on-error
+        # rather than `|| true` so the step's failure outcome remains
+        # visible in the GitHub Actions UI (steps.<id>.outcome stays
+        # `failure`), while the workflow conclusion stays `success`.
+        continue-on-error: true
         env:
           FERRO_MANIFEST: ${{ github.workspace }}/benchmark-output/manifest.json
-        # Filter to the suites that require a manifest. Failures are
-        # NOT propagated to the step exit code via `|| true` — the
-        # purpose of the nightly is to surface drift in the xfail
-        # report, not to gate PRs. (PR CI's strict-mode test job
-        # already covers manifest-free correctness.)
         run: |
           cargo nextest run --features dev \
-            -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/)' \
-            || true
+            -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/)'
 
       - name: Upload xfail reports
         if: always()

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -216,9 +216,60 @@ jobs:
           print(f"smoke ok: {v!r} cons={cons}")
           EOF
 
+  smoke-test-musllinux:
+    # musllinux wheels (built by the `linux` job for both x86_64 and
+    # aarch64) ship to Alpine / musl-libc distros. The standard
+    # `smoke-test` matrix runs on glibc runners, so it cannot validate
+    # the musllinux wheel's pip-install + import flow. This job runs
+    # the same import + abi3 surface checks inside a python:<v>-alpine
+    # container on each supported Python version — installing the
+    # musllinux wheel via the same `pip install --no-index
+    # --only-binary :all: --find-links dist ferro-hgvs` call as the
+    # glibc smoke-test. #397 item 4.
+    name: Smoke musllinux ${{ matrix.arch_runner }} py${{ matrix.python-version }}
+    needs: [linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch_runner:
+          - runner: ubuntu-latest
+            container_platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            container_platform: linux/arm64
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    runs-on: ${{ matrix.arch_runner.runner }}
+    container:
+      image: python:${{ matrix.python-version }}-alpine
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Install built wheel
+        shell: sh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-index --only-binary :all: --find-links dist ferro-hgvs
+      - name: Smoke test (import + parse + eq_int pyclass)
+        shell: sh
+        # Same surface as the glibc smoke-test (parse + __eq__ +
+        # __hash__ + eq_int pyclass) so a musllinux ABI regression
+        # surfaces under the same checks.
+        run: |
+          python <<'EOF'
+          import ferro_hgvs
+          v = ferro_hgvs.parse("NM_000088.3:c.459A>G")
+          assert str(v) == "NM_000088.3:c.459A>G", f"str round-trip: {str(v)!r}"
+          assert v == ferro_hgvs.parse("NM_000088.3:c.459A>G"), "__eq__"
+          assert hash(v) == hash(ferro_hgvs.parse("NM_000088.3:c.459A>G")), "__hash__"
+          cons = ferro_hgvs.Consequence.CodingSequenceVariant
+          assert int(cons) == 18, f"eq_int: {int(cons)}"
+          print(f"musllinux smoke ok: {v!r} cons={cons}")
+          EOF
+
   upload:
     name: Upload to GitHub Release
-    needs: [check-metadata, smoke-test, sdist]
+    needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -237,7 +288,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [check-metadata, smoke-test, sdist]
+    needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
     runs-on: ubuntu-latest
     # Only publish on release events (not workflow_dispatch dry-runs)
     if: github.event_name == 'release'

--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -221,42 +221,43 @@ jobs:
     # aarch64) ship to Alpine / musl-libc distros. The standard
     # `smoke-test` matrix runs on glibc runners, so it cannot validate
     # the musllinux wheel's pip-install + import flow. This job runs
-    # the same import + abi3 surface checks inside a python:<v>-alpine
-    # container on each supported Python version — installing the
-    # musllinux wheel via the same `pip install --no-index
-    # --only-binary :all: --find-links dist ferro-hgvs` call as the
-    # glibc smoke-test. #397 item 4.
-    name: Smoke musllinux ${{ matrix.arch_runner }} py${{ matrix.python-version }}
+    # the same import + abi3 surface checks against a
+    # `python:<v>-alpine` image on each supported Python version.
+    #
+    # The runner stays on glibc Ubuntu (no `container:` key on the
+    # job) and the Alpine execution happens via `docker run` from a
+    # later step. This avoids the well-known footgun where
+    # GitHub-injected Node-based actions (`actions/download-artifact`
+    # etc.) cannot exec their glibc-linked Node binary inside an
+    # Alpine container. #397 item 4.
+    name: Smoke musllinux ${{ matrix.runner }} py${{ matrix.python-version }}
     needs: [linux]
     strategy:
       fail-fast: false
       matrix:
-        arch_runner:
-          - runner: ubuntu-latest
-            container_platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            container_platform: linux/arm64
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    runs-on: ${{ matrix.arch_runner.runner }}
-    container:
-      image: python:${{ matrix.python-version }}-alpine
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
-      - name: Install built wheel
-        shell: sh
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --no-index --only-binary :all: --find-links dist ferro-hgvs
-      - name: Smoke test (import + parse + eq_int pyclass)
-        shell: sh
+      - name: Smoke test (import + parse + eq_int pyclass) inside Alpine
         # Same surface as the glibc smoke-test (parse + __eq__ +
         # __hash__ + eq_int pyclass) so a musllinux ABI regression
-        # surfaces under the same checks.
+        # surfaces under the same checks. Runs under `docker run`
+        # from the glibc host so Node-based actions don't have to
+        # execute inside Alpine.
+        shell: bash
         run: |
-          python <<'EOF'
+          docker run --rm -v "$PWD/dist:/dist:ro" \
+            python:${{ matrix.python-version }}-alpine \
+            sh -c '
+              set -eu
+              python -m pip install --upgrade pip
+              python -m pip install --no-index --only-binary :all: --find-links /dist ferro-hgvs
+              python <<EOF
           import ferro_hgvs
           v = ferro_hgvs.parse("NM_000088.3:c.459A>G")
           assert str(v) == "NM_000088.3:c.459A>G", f"str round-trip: {str(v)!r}"
@@ -266,6 +267,7 @@ jobs:
           assert int(cons) == 18, f"eq_int: {int(cons)}"
           print(f"musllinux smoke ok: {v!r} cons={cons}")
           EOF
+            '
 
   upload:
     name: Upload to GitHub Release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # Pre-commit hooks for ferro-hgvs
 # Install: pip install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
+#
+# `default_install_hook_types` makes the bare `pre-commit install`
+# wire up BOTH `pre-commit` (per-commit fast checks) and `pre-push`
+# (the spec-fixture drift guard, which requires a Rust build and
+# would be too slow per commit).
+default_install_hook_types: [pre-commit, pre-push]
 
 repos:
   # Rust formatting
@@ -14,16 +20,20 @@ repos:
         pass_filenames: false
 
       # Spec-fixture drift guard (#397 item 7). CI already runs this
-      # check at `ci.yml:113` (`generate_spec_fixture --check`), but a
-      # push that drifts the fixture wastes a full CI cycle to discover
-      # the drift. The pre-push stage runs once per `git push` rather
-      # than per commit, so the build cost is paid only when actually
-      # pushing.
+      # check (search for `generate_spec_fixture --check` in
+      # `.github/workflows/ci.yml`), but a push that drifts the
+      # fixture wastes a full CI cycle to discover the drift. The
+      # pre-push stage runs once per `git push` rather than per
+      # commit, so the build cost is paid only when actually pushing.
       - id: generate-spec-fixture-check
         name: generate_spec_fixture --check
         entry: cargo run --features dev --example generate_spec_fixture -- --check
         language: system
-        types: [rust]
+        # always_run (not types: [rust]) — a push that only touches the
+        # spec submodule or test fixtures still needs the drift guard,
+        # and pre-commit otherwise skips type-filtered hooks when no
+        # matching files are staged in the push range.
+        always_run: true
         pass_filenames: false
         stages: [pre-push]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,20 @@ repos:
         types: [rust]
         pass_filenames: false
 
+      # Spec-fixture drift guard (#397 item 7). CI already runs this
+      # check at `ci.yml:113` (`generate_spec_fixture --check`), but a
+      # push that drifts the fixture wastes a full CI cycle to discover
+      # the drift. The pre-push stage runs once per `git push` rather
+      # than per commit, so the build cost is paid only when actually
+      # pushing.
+      - id: generate-spec-fixture-check
+        name: generate_spec_fixture --check
+        entry: cargo run --features dev --example generate_spec_fixture -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]
+
   # Rust linting (optional - can be slow)
   # Uncomment if you want clippy in pre-commit
   # - repo: local

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -794,7 +794,7 @@ mod runner {
     ) -> (String, bool, bool, Vec<String>) {
         match parse_hgvs(input) {
             Err(e) => (format!("parse error: {e}"), false, false, Vec::new()),
-            Ok(v) => match normalizer.normalize_with_warnings(&v) {
+            Ok(v) => match normalizer.normalize_with_diagnostics(&v) {
                 Err(e) => (format!("normalize error: {e}"), true, false, Vec::new()),
                 Ok(n) => {
                     let mut codes: Vec<String> =

--- a/src/benchmark/compare.rs
+++ b/src/benchmark/compare.rs
@@ -1476,8 +1476,8 @@ fn run_ferro_normalize(
 
             match parse_hgvs_lenient(&preprocessed) {
                 Ok(parse_result) => {
-                    // Use normalize_with_warnings to capture reference mismatches
-                    match normalizer.normalize_with_warnings(&parse_result.result) {
+                    // Use normalize_with_diagnostics to capture reference mismatches
+                    match normalizer.normalize_with_diagnostics(&parse_result.result) {
                         Ok(norm_result) => {
                             // Check if there were reference mismatches
                             let ref_mismatch = norm_result.warnings.iter().find_map(|w| match w {

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -333,7 +333,7 @@ pub enum ErrorType {
     /// ferro preserves the input verbatim and emits this warning.
     /// Strict mode rejects with `FerroError::InvalidCoordinates`;
     /// lenient and silent modes both accept and preserve the input,
-    /// with the warning still surfaced by `normalize_with_warnings`
+    /// with the warning still surfaced by `normalize_with_diagnostics`
     /// (the emit site at `src/normalize/overlap.rs:88` is
     /// unconditional — only strict-mode promotion is gated by mode).
     /// Closes #395 item 6 — previously the warning was emitted but

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -173,10 +173,6 @@ fn check_cds_pos_past_end(
         let abs_offset = offset.unsigned_abs();
         if abs_offset > intron_length {
             return Some(NormalizationWarning::PositionPastEnd {
-                message: format!(
-                    "{}:c.{} lies past the intron-end (intron length {})",
-                    accession, pos, intron_length
-                ),
                 accession: accession.to_string(),
                 coordinate_system: "c".to_string(),
                 position: pos.to_string(),
@@ -196,10 +192,6 @@ fn check_cds_pos_past_end(
         let utr3_len = transcript.utr3_length()?;
         if pos.base > 0 && (pos.base as u64) > utr3_len {
             return Some(NormalizationWarning::PositionPastEnd {
-                message: format!(
-                    "{}:c.*{} lies past the transcript-end (3'UTR length {})",
-                    accession, pos.base, utr3_len
-                ),
                 accession: accession.to_string(),
                 coordinate_system: "c".to_string(),
                 position: format!("*{}", pos.base),
@@ -216,10 +208,6 @@ fn check_cds_pos_past_end(
         let abs_n = pos.base.unsigned_abs();
         if abs_n > utr5_len {
             return Some(NormalizationWarning::PositionPastEnd {
-                message: format!(
-                    "{}:c.{} lies past the 5'UTR start (5'UTR length {})",
-                    accession, pos.base, utr5_len
-                ),
                 accession: accession.to_string(),
                 coordinate_system: "c".to_string(),
                 position: pos.base.to_string(),
@@ -233,10 +221,6 @@ fn check_cds_pos_past_end(
     let cds_len = transcript.cds_length()?;
     if (pos.base as u64) > cds_len {
         return Some(NormalizationWarning::PositionPastEnd {
-            message: format!(
-                "{}:c.{} lies past the CDS-end (CDS length {})",
-                accession, pos.base, cds_len
-            ),
             accession: accession.to_string(),
             coordinate_system: "c".to_string(),
             position: pos.base.to_string(),
@@ -298,10 +282,6 @@ fn check_tx_pos_past_end(
         let abs_offset = offset.unsigned_abs();
         if abs_offset > intron_length {
             return Some(NormalizationWarning::PositionPastEnd {
-                message: format!(
-                    "{}:n.{} lies past the intron-end (intron length {})",
-                    accession, pos, intron_length
-                ),
                 accession: accession.to_string(),
                 coordinate_system: "n".to_string(),
                 position: pos.to_string(),
@@ -317,10 +297,6 @@ fn check_tx_pos_past_end(
     let seq_len = transcript.sequence_length();
     if (pos.base as u64) > seq_len {
         return Some(NormalizationWarning::PositionPastEnd {
-            message: format!(
-                "{}:n.{} lies past the transcript-end (transcript length {})",
-                accession, pos.base, seq_len
-            ),
             accession: accession.to_string(),
             coordinate_system: "n".to_string(),
             position: pos.base.to_string(),
@@ -364,10 +340,6 @@ fn check_mt_pos_past_end(
     }
     if pos.base > contig_length {
         return Some(NormalizationWarning::PositionPastEnd {
-            message: format!(
-                "{}:m.{} lies past the contig-end (contig length {})",
-                accession, pos.base, contig_length
-            ),
             accession: accession.to_string(),
             coordinate_system: "m".to_string(),
             position: pos.base.to_string(),
@@ -412,15 +384,13 @@ fn edit_is_del_or_dup(edit: &NaEdit) -> bool {
 /// sites. Marked `#[non_exhaustive]` so downstream callers must include a
 /// wildcard arm when matching — adding a new variant is therefore not a
 /// breaking change. Mirrors the same attribute on
-/// [`NormalizationInfo`] / [`NormalizeResultWithWarnings`].
+/// [`NormalizationInfo`] / [`NormalizeResult`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum NormalizationWarning {
     /// Reference sequence mismatch. Stated ref bases in the HGVS expression
     /// do not match the actual reference sequence. Code: `REFSEQ_MISMATCH`.
     RefSeqMismatch {
-        /// Human-readable description
-        message: String,
         /// What the input claimed as reference
         stated_ref: String,
         /// What the actual reference sequence has
@@ -448,8 +418,6 @@ pub enum NormalizationWarning {
     /// ferro preserves the input verbatim and emits this warning.
     /// Code: `OVERLAP_CONFLICTING_EDITS`.
     OverlapConflict {
-        /// Human-readable description
-        message: String,
         /// Accession of the reference sequence
         accession: String,
         /// Coordinate system: "g" | "c" | "n" | "r" | "m"
@@ -470,8 +438,6 @@ pub enum NormalizationWarning {
     /// unchanged in lenient/silent modes.
     /// Closes-after: #354, #355. Code: `CANONICAL_SPLIT_SKIPPED`.
     CanonicalSplitSkipped {
-        /// Human-readable description
-        message: String,
         /// Accession of the reference sequence
         accession: String,
         /// HGVS span start (1-based inclusive). Carried so strict-mode
@@ -492,8 +458,6 @@ pub enum NormalizationWarning {
     /// preserves the canonical input position and emits this warning.
     /// Closes-after: #350. Code: `CROSS_AXIS_VARIANT_NOT_SHUFFLED`.
     CrossAxisVariantNotShuffled {
-        /// Human-readable description
-        message: String,
         /// Accession of the reference sequence
         accession: String,
         /// Axis of the start position: "5utr" | "cds" | "3utr"
@@ -506,8 +470,6 @@ pub enum NormalizationWarning {
     /// boundary, but the axis clamp constrained the result to the
     /// boundary. Closes-after: #349. Code: `AXIS_CLAMP_APPLIED`.
     AxisClampApplied {
-        /// Human-readable description
-        message: String,
         /// Accession of the reference sequence
         accession: String,
         /// Shuffle direction that was clamped: "5prime" | "3prime"
@@ -525,8 +487,6 @@ pub enum NormalizationWarning {
     /// rule for start-codon variants (substitution.md:45-65).
     /// Closes-after: #92. Code: `INITIATOR_MET_CANONICALIZATION`.
     InitiatorMetCanonicalization {
-        /// Human-readable description.
-        message: String,
         /// Accession of the reference sequence.
         accession: String,
         /// Final dup interval text, e.g. "Met1" or "Met1_Lys2".
@@ -538,8 +498,6 @@ pub enum NormalizationWarning {
     /// observability — callers can audit which inputs were canonicalized
     /// vs. preserved verbatim. Code: `INSERTED_SEQUENCE_EXPANDED`.
     InsertedSequenceExpanded {
-        /// Human-readable description
-        message: String,
         /// Accession of the outer variant
         accession: String,
         /// Original `ins[...]` payload as written (e.g. `[ATC]` or
@@ -560,8 +518,6 @@ pub enum NormalizationWarning {
     /// remain out of scope (they depend on intron-size alignment data
     /// this check does not consult).
     PositionPastEnd {
-        /// Human-readable description.
-        message: String,
         /// Transcript accession (e.g. `NM_001001656.1`).
         accession: String,
         /// Coordinate system: `"c"` for c. (cds-end / transcript-end /
@@ -595,17 +551,92 @@ impl NormalizationWarning {
         }
     }
 
-    /// Human-readable message for the warning.
-    pub fn message(&self) -> &str {
+    /// Human-readable message synthesized from the warning's structural
+    /// fields. Equivalent to `format!("{self}")` — preserved as a method
+    /// for ergonomics and back-compat with `.message()` call sites
+    /// (#397 item 3 dropped the per-variant `message: String` field).
+    pub fn message(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl std::fmt::Display for NormalizationWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::RefSeqMismatch { message, .. } => message,
-            Self::OverlapConflict { message, .. } => message,
-            Self::CanonicalSplitSkipped { message, .. } => message,
-            Self::CrossAxisVariantNotShuffled { message, .. } => message,
-            Self::AxisClampApplied { message, .. } => message,
-            Self::InitiatorMetCanonicalization { message, .. } => message,
-            Self::InsertedSequenceExpanded { message, .. } => message,
-            Self::PositionPastEnd { message, .. } => message,
+            Self::RefSeqMismatch {
+                stated_ref,
+                actual_ref,
+                position,
+                corrected,
+            } => write!(
+                f,
+                "reference sequence mismatch at {position}: stated {stated_ref:?}, actual {actual_ref:?} (corrected={corrected})",
+            ),
+            Self::OverlapConflict {
+                accession,
+                coordinate_system,
+                location,
+                edit_kinds,
+            } => write!(
+                f,
+                "{} cis edits share identical bounds at {}:{}.{}: {}",
+                edit_kinds.len(),
+                accession,
+                coordinate_system,
+                location,
+                edit_kinds.join(", "),
+            ),
+            Self::CanonicalSplitSkipped {
+                accession,
+                hgvs_start,
+                hgvs_end,
+                expected_span,
+                actual_bytes,
+            } => write!(
+                f,
+                "canonical split skipped at {accession}:{hgvs_start}_{hgvs_end}: expected {expected_span} bytes, got {actual_bytes}",
+            ),
+            Self::CrossAxisVariantNotShuffled {
+                accession,
+                start_axis,
+                end_axis,
+            } => write!(
+                f,
+                "{accession}: variant spans {start_axis} \u{2194} {end_axis} sub-axes; 3'-rule shuffle skipped",
+            ),
+            Self::AxisClampApplied {
+                accession,
+                direction,
+                clamp_kind,
+            } => write!(
+                f,
+                "{accession}: {direction} shuffle clamped at {clamp_kind} boundary",
+            ),
+            Self::InitiatorMetCanonicalization {
+                accession,
+                location,
+            } => write!(
+                f,
+                "{accession}: canonical form `p.{location}dup` includes the initiator methionine; the predicted protein consequence may also be described as `p.0?` or `p.(Met1?)` per HGVS Substitution recommendations",
+            ),
+            Self::InsertedSequenceExpanded {
+                accession,
+                original_payload,
+                expanded_literal,
+            } => write!(
+                f,
+                "{accession}: ins payload {original_payload} expanded to literal {expanded_literal}",
+            ),
+            Self::PositionPastEnd {
+                accession,
+                coordinate_system,
+                position,
+                bound_kind,
+                bound_value,
+            } => write!(
+                f,
+                "{accession}:{coordinate_system}.{position} lies past the {bound_kind} (bound {bound_value})",
+            ),
         }
     }
 }
@@ -635,8 +666,6 @@ pub enum NormalizationInfo {
     /// signal correctly. Code: `SHUFFLE_APPLIED`. Mutalyzer-equivalent:
     /// `ICORRECTEDPOINT` (mutalyzer only emits 3').
     ShuffleApplied {
-        /// Human-readable description of the shift.
-        message: String,
         /// Accession of the reference sequence.
         accession: String,
         /// Direction in which the shuffle ran for this normalization.
@@ -658,10 +687,26 @@ impl NormalizationInfo {
         }
     }
 
-    /// Human-readable message for the info.
-    pub fn message(&self) -> &str {
+    /// Human-readable message synthesized from the info's structural
+    /// fields. Equivalent to `format!("{self}")` (#397 item 3 dropped
+    /// the per-variant `message: String` field).
+    pub fn message(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl std::fmt::Display for NormalizationInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ShuffleApplied { message, .. } => message,
+            Self::ShuffleApplied {
+                accession,
+                direction,
+                original_position,
+                normalized_position,
+            } => write!(
+                f,
+                "{accession}: {direction:?} shuffle relocated variant from {original_position} to {normalized_position}",
+            ),
         }
     }
 }
@@ -673,7 +718,7 @@ impl NormalizationInfo {
 /// via struct literals.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct NormalizeResultWithWarnings {
+pub struct NormalizeResult {
     /// The normalized variant
     pub result: HgvsVariant,
     /// Warnings generated during normalization
@@ -684,7 +729,7 @@ pub struct NormalizeResultWithWarnings {
     pub infos: Vec<NormalizationInfo>,
 }
 
-impl NormalizeResultWithWarnings {
+impl NormalizeResult {
     /// Create a new result without warnings or infos
     pub fn new(result: HgvsVariant) -> Self {
         Self {
@@ -772,9 +817,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Normalize a variant
     ///
     /// In strict mode (default), rejects variants with reference mismatches.
-    /// Use `normalize_with_warnings` for lenient mode that corrects mismatches.
+    /// Use `normalize_with_diagnostics` for lenient mode that corrects mismatches.
     pub fn normalize(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
-        let result = self.normalize_with_warnings(variant)?;
+        let result = self.normalize_with_diagnostics(variant)?;
 
         // In strict mode, reject if there were reference mismatches.
         if self.config.should_reject_ref_mismatch() {
@@ -891,10 +936,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Returns the normalized variant along with any warnings generated during
     /// normalization (e.g., reference sequence mismatches that were auto-corrected).
     /// Use this method when you want to track what corrections were made.
-    pub fn normalize_with_warnings(
+    pub fn normalize_with_diagnostics(
         &self,
         variant: &HgvsVariant,
-    ) -> Result<NormalizeResultWithWarnings, FerroError> {
+    ) -> Result<NormalizeResult, FerroError> {
         let (result, warnings) = match variant {
             HV::Genome(v) => self.normalize_genome(v)?,
             HV::Cds(v) => self.normalize_cds(v)?,
@@ -920,9 +965,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         };
 
         let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
-        Ok(NormalizeResultWithWarnings::with_diagnostics(
-            result, warnings, infos,
-        ))
+        Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
     }
 
     /// Normalize an allele (compound) variant
@@ -976,7 +1019,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // variant and goes through the same pipeline as any direct input.
         let mut normalized: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
         for v in merged_split {
-            let r = self.normalize_with_warnings(&v)?;
+            let r = self.normalize_with_diagnostics(&v)?;
             all_warnings.extend(r.warnings);
             normalized.push(r.result);
         }
@@ -1042,7 +1085,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
             _ => return Ok(None),
         };
         let original_payload = format!("{}", original_inserted);
-        let original_edit_display = format!("{}", edit);
 
         let new_edit = match canonicalize_insertion_expand(edit, accession, kind, &self.provider)? {
             Some(e) => e,
@@ -1058,10 +1100,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // display keeps the field non-empty if invariants change.
             _ => {
                 let warning = NormalizationWarning::InsertedSequenceExpanded {
-                    message: format!(
-                        "ins[...] payload canonicalized to flat literal: {} -> {}",
-                        original_edit_display, new_edit
-                    ),
                     accession: accession.to_string(),
                     original_payload,
                     expanded_literal: format!("{}", new_edit),
@@ -1072,10 +1110,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let expanded_literal = format!("{}", new_inserted);
 
         let warning = NormalizationWarning::InsertedSequenceExpanded {
-            message: format!(
-                "ins[...] payload canonicalized to flat literal: {} -> {}",
-                original_edit_display, new_edit
-            ),
             accession: accession.to_string(),
             original_payload,
             expanded_literal,
@@ -1525,15 +1559,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
         {
             let acc = variant.accession.transcript_accession();
             let warning = NormalizationWarning::CrossAxisVariantNotShuffled {
-                message: format!(
-                    "{}:c.{}: range straddles {} and {} axes; \
-                     3'-rule shuffle is undefined across a CDS\u{2194}UTR \
-                     boundary, returning input unchanged",
-                    acc,
-                    variant.loc_edit.location,
-                    start_axis.label(),
-                    end_axis.label(),
-                ),
                 accession: acc,
                 start_axis: start_axis.label().to_string(),
                 end_axis: end_axis.label().to_string(),
@@ -1629,11 +1654,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
             if !direction_str.is_empty() {
                 let acc = variant.accession.transcript_accession();
                 warnings.push(NormalizationWarning::AxisClampApplied {
-                    message: format!(
-                        "{}:c.{}: {}-rule shuffle clamped at {} axis boundary; \
-                         canonical position was constrained by the CDS\u{2194}UTR sub-axis",
-                        acc, variant.loc_edit.location, direction_str, clamp_kind,
-                    ),
                     accession: acc,
                     direction: direction_str.to_string(),
                     clamp_kind: clamp_kind.to_string(),
@@ -2291,13 +2311,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         format!("{}{}_{}{}", s.aa, s.number, e.aa, e.number)
                     };
                     warnings.push(NormalizationWarning::InitiatorMetCanonicalization {
-                        message: format!(
-                            "canonical form `p.{}dup` includes the initiator \
-                             methionine; the predicted protein consequence may \
-                             also be described as `p.0?` or `p.(Met1?)` per HGVS \
-                             Substitution recommendations",
-                            location
-                        ),
                         accession: final_variant.accession.transcript_accession().to_string(),
                         location,
                     });
@@ -2343,7 +2356,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///
     /// Both entrypoints — `Normalizer::normalize` (the strict API,
     /// which rejects reference mismatches) and
-    /// `Normalizer::normalize_with_warnings` (the lenient API, which
+    /// `Normalizer::normalize_with_diagnostics` (the lenient API, which
     /// records mismatches as warnings) — share this shuffler via
     /// `normalize_protein`. They both treat `None` as "no shift" and
     /// return the input interval unchanged.
@@ -4150,7 +4163,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // Delins.
             let corrected = !matches!(edit, NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. });
             warnings.push(NormalizationWarning::RefSeqMismatch {
-                message: validation.warning.unwrap_or_default(),
                 stated_ref: validation.stated_ref.unwrap_or_default(),
                 actual_ref: validation.actual_ref.unwrap_or_default(),
                 position: format!("{}-{}", start, end),
@@ -5232,12 +5244,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if n != expected_span {
             let accession = variant_accession_string(&variant);
             let warning = NormalizationWarning::CanonicalSplitSkipped {
-                message: format!(
-                    "{}: variant span {}..{} ({} bp) exceeds provider's reference window \
-                     ({} bp). Per HGVS spec refseq.md \u{00A7}43, the variant must be \
-                     entirely encompassed by the reference. Strict mode rejects.",
-                    accession, hgvs_start, hgvs_end, expected_span, n,
-                ),
                 accession,
                 hgvs_start,
                 hgvs_end,
@@ -5434,7 +5440,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if extract_simple_delins(&v).is_none() {
             return vec![v];
         }
-        match self.normalize_with_warnings(&v) {
+        match self.normalize_with_diagnostics(&v) {
             Ok(r) => match r.result {
                 HgvsVariant::Allele(a) => a.variants,
                 other => vec![other],
@@ -5540,11 +5546,7 @@ fn single_variant_shift_info(
         .accession()
         .map(|a| format!("{}", a))
         .unwrap_or_default();
-    let message = format!(
-        "shuffle ({direction}) relocated variant from {original_position} to {normalized_position} on {accession}",
-    );
     Some(NormalizationInfo::ShuffleApplied {
-        message,
         accession,
         direction,
         original_position,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -411,6 +411,12 @@ pub enum NormalizationWarning {
         /// declaration is part of the user's variant description, and
         /// the normalizer declines to second-guess it. (Issue #280.)
         corrected: bool,
+        /// Free-form context from the validation layer (e.g. a
+        /// per-edit-kind explanation of the mismatch). When present,
+        /// the `Display` impl appends it to the synthesized message so
+        /// downstream consumers retain the nuance that previously
+        /// lived in the dropped `message` field.
+        details: Option<String>,
     },
 
     /// Two or more cis-allele edits share identical reference bounds.
@@ -568,10 +574,17 @@ impl std::fmt::Display for NormalizationWarning {
                 actual_ref,
                 position,
                 corrected,
-            } => write!(
-                f,
-                "reference sequence mismatch at {position}: stated {stated_ref:?}, actual {actual_ref:?} (corrected={corrected})",
-            ),
+                details,
+            } => {
+                write!(
+                    f,
+                    "reference sequence mismatch at {position}: stated {stated_ref:?}, actual {actual_ref:?} (corrected={corrected})",
+                )?;
+                if let Some(detail) = details.as_deref().filter(|s| !s.is_empty()) {
+                    write!(f, ": {detail}")?;
+                }
+                Ok(())
+            }
             Self::OverlapConflict {
                 accession,
                 coordinate_system,
@@ -594,7 +607,7 @@ impl std::fmt::Display for NormalizationWarning {
                 actual_bytes,
             } => write!(
                 f,
-                "canonical split skipped at {accession}:{hgvs_start}_{hgvs_end}: expected {expected_span} bytes, got {actual_bytes}",
+                "canonical split skipped at {accession}:{hgvs_start}_{hgvs_end}: expected {expected_span} bytes, got {actual_bytes} (HGVS refseq \u{00A7}43)",
             ),
             Self::CrossAxisVariantNotShuffled {
                 accession,
@@ -705,7 +718,7 @@ impl std::fmt::Display for NormalizationInfo {
                 normalized_position,
             } => write!(
                 f,
-                "{accession}: {direction:?} shuffle relocated variant from {original_position} to {normalized_position}",
+                "{accession}: {direction} shuffle relocated variant from {original_position} to {normalized_position}",
             ),
         }
     }
@@ -4167,6 +4180,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 actual_ref: validation.actual_ref.unwrap_or_default(),
                 position: format!("{}-{}", start, end),
                 corrected,
+                details: validation.warning,
             });
         }
 
@@ -5481,6 +5495,60 @@ fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
     }
 }
 
+/// Returns the underlying `NaEdit` for a shuffle-eligible variant so the
+/// shift detector can constrain `SHUFFLE_APPLIED` emission to genuine
+/// shuffle transitions (companion to `position_text_if_shuffleable`).
+/// `Mu::Uncertain` is unwrapped to the inner edit because shuffleability
+/// is determined by edit shape, not by the uncertainty wrapper.
+fn na_edit_if_shuffleable(variant: &HgvsVariant) -> Option<&NaEdit> {
+    let mu = match variant {
+        HV::Genome(v) => &v.loc_edit.edit,
+        HV::Cds(v) => &v.loc_edit.edit,
+        HV::Tx(v) => &v.loc_edit.edit,
+        HV::Rna(v) => &v.loc_edit.edit,
+        HV::Mt(v) => &v.loc_edit.edit,
+        HV::Circular(v) => &v.loc_edit.edit,
+        HV::Protein(_) | HV::Allele(_) | HV::RnaFusion(_) | HV::NullAllele | HV::UnknownAllele => {
+            return None
+        }
+    };
+    match mu {
+        crate::hgvs::Mu::Certain(e) | crate::hgvs::Mu::Uncertain(e) => Some(e),
+        // `Mu::Unknown` (Display: `?`) carries no edit — there is nothing
+        // for shuffle to act on, so the kind-compatibility gate skips it.
+        crate::hgvs::Mu::Unknown => None,
+    }
+}
+
+/// True if the (input, output) edit-kind transition is one the shuffle
+/// layer can produce. The shuffle algorithm rotates a deletion / insertion
+/// / duplication / delins span along its reference window and may
+/// canonicalize a single-base or homopolymer insertion into a duplication
+/// or repeat — every other kind transition (e.g. `delins → sub` from
+/// canonical-split, `delins → inv` from inversion decomposition,
+/// `delins → =` from identity rewrite, `ins → delins`) is a
+/// *canonicalization* and must not surface as `SHUFFLE_APPLIED`.
+///
+/// Closes the false-positive flagged on PR #426: `c.1_3delinsACG → c.2T>C`
+/// is canonical-split, not shuffle, and the original position-only
+/// post-hoc compare mislabeled it.
+fn shuffle_kind_compatible(input: &NaEdit, output: &NaEdit) -> bool {
+    use NaEdit::*;
+    matches!(
+        (input, output),
+        (Deletion { .. }, Deletion { .. })
+            | (Duplication { .. }, Duplication { .. })
+            | (Delins { .. }, Delins { .. })
+            | (Inversion { .. }, Inversion { .. })
+            | (
+                Insertion { .. },
+                Insertion { .. } | Duplication { .. } | Repeat { .. } | MultiRepeat { .. },
+            )
+            | (Repeat { .. }, Repeat { .. } | MultiRepeat { .. })
+            | (MultiRepeat { .. }, MultiRepeat { .. })
+    )
+}
+
 /// Detect shuffle infos by comparing the input variant to the normalized
 /// result.
 ///
@@ -5531,7 +5599,11 @@ fn detect_shuffle_infos(
 }
 
 /// Single-variant shift detector. Returns `Some(info)` iff the position
-/// text differs between input and output for a shuffle-eligible axis.
+/// text differs between input and output for a shuffle-eligible axis AND
+/// the (input, output) edit-kind transition is one the shuffle layer can
+/// produce (see [`shuffle_kind_compatible`]). The edit-kind gate excludes
+/// canonicalization that also moves positions — e.g. `delins → sub`,
+/// `delins → =`, `delins → inv` — from masquerading as shuffle.
 fn single_variant_shift_info(
     input: &HgvsVariant,
     output: &HgvsVariant,
@@ -5540,6 +5612,11 @@ fn single_variant_shift_info(
     let original_position = position_text_if_shuffleable(input)?;
     let normalized_position = position_text_if_shuffleable(output)?;
     if original_position == normalized_position {
+        return None;
+    }
+    let input_edit = na_edit_if_shuffleable(input)?;
+    let output_edit = na_edit_if_shuffleable(output)?;
+    if !shuffle_kind_compatible(input_edit, output_edit) {
         return None;
     }
     let accession = input

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -10,7 +10,6 @@
 //! boundary `[end, start]`, not a single-base location).
 
 use std::collections::BTreeMap;
-use std::fmt::Write as _;
 
 use crate::hgvs::edit::NaEdit;
 use crate::hgvs::interval::{Interval, UncertainBoundary};
@@ -63,30 +62,13 @@ pub(crate) fn detect_overlap_conflicts(
             .filter_map(|&i| edit_kind(&variants[i]).map(|s| s.to_string()))
             .collect();
         // group_key already filtered to variants with a known edit kind, so
-        // edit_kinds.len() == indices.len() in practice. Defensive equality
-        // keeps the message accurate if that invariant is ever loosened.
+        // edit_kinds.len() == indices.len() in practice. Preserved as a
+        // debug assert against future drift.
         debug_assert_eq!(edit_kinds.len(), indices.len());
         let location_str = location_for_variant(&variants[indices[0]])
             .expect("group_key established a renderable location");
 
-        let mut message = String::new();
-        let _ = write!(
-            message,
-            "{} cis edits share identical bounds at {}:{}.{}: ",
-            indices.len(),
-            key.accession,
-            key.coord_system,
-            location_str,
-        );
-        for (i, kind) in edit_kinds.iter().enumerate() {
-            if i > 0 {
-                message.push_str(", ");
-            }
-            message.push_str(kind);
-        }
-
         warnings.push(NormalizationWarning::OverlapConflict {
-            message,
             accession: key.accession.clone(),
             coordinate_system: key.coord_system.to_string(),
             location: location_str,
@@ -483,7 +465,9 @@ mod tests {
 
         let normalizer = Normalizer::new(MockProvider::new());
         let v = parse_hgvs("NC_000001.11:g.[100G>A;100A>C]").expect("parse");
-        let result = normalizer.normalize_with_warnings(&v).expect("normalize");
+        let result = normalizer
+            .normalize_with_diagnostics(&v)
+            .expect("normalize");
         assert!(
             result
                 .warnings

--- a/src/python.rs
+++ b/src/python.rs
@@ -558,7 +558,7 @@ impl PyNormalizer {
             .map_err(|e| PyValueError::new_err(format!("Parse error: {}", e)))?;
         let normalizer = Normalizer::with_config(self.provider.clone(), self.config.clone());
         let result = normalizer
-            .normalize_with_warnings(&variant)
+            .normalize_with_diagnostics(&variant)
             .map_err(|e| PyRuntimeError::new_err(format!("Normalization error: {}", e)))?;
         Ok(PyNormalizeResultWithWarnings {
             result: PyHgvsVariant {

--- a/src/reference/annotation/record.rs
+++ b/src/reference/annotation/record.rs
@@ -74,6 +74,18 @@ fn parse_phase<E>(nphase: Option<Result<Phase, E>>, trimmed: &str) -> Option<u8>
     }
 }
 
+/// Decode a GFF3 attribute value as a list of IDs. noodles-gff parses
+/// comma-separated values as `Value::Array` and single values as
+/// `Value::String`; both shapes flow into the same `Vec<String>` here.
+/// Used for both `Parent` and `Derives_from` parent-edge attributes.
+fn parse_gff_id_list(value: &noodles_gff::record::attributes::field::Value) -> Vec<String> {
+    use noodles_gff::record::attributes::field::Value as GffValue;
+    match value {
+        GffValue::String(s) => vec![s.to_string()],
+        GffValue::Array(arr) => arr.iter().map(|cow| cow.to_string()).collect(),
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum RecordParseError {
     #[error("invalid coordinate '{0}' in column {1}")]
@@ -145,9 +157,15 @@ impl Gff3Record {
         let strand = parse_strand(nrecord.strand(), trimmed)?;
         let phase = parse_phase(nrecord.phase(), trimmed);
 
-        // Extract ID, Parent, and remaining attributes.
+        // Extract ID, Parent (+ FlyBase `Derives_from`), and remaining
+        // attributes. `Derives_from` indicates a derives-from edge rather
+        // than the standard part-of relationship; for ferro's feature
+        // graph both establish a parent edge, so the two are merged into
+        // a single parent list (dedup'd, Parent values first, Derives_from
+        // values appended). #397 item 1.
         let mut id: Option<String> = None;
         let mut parents: Vec<String> = Vec::new();
+        let mut derives_from: Vec<String> = Vec::new();
         let mut attrs: AttributeMap = Vec::new();
 
         for result in nrecord.attributes().iter() {
@@ -159,18 +177,10 @@ impl Gff3Record {
                     id = Some(value.as_ref().to_string());
                 }
                 "Parent" => {
-                    // noodles-gff parses comma-separated values as Value::Array,
-                    // and single-parent lines as Value::String.
-                    use noodles_gff::record::attributes::field::Value as GffValue;
-                    match value {
-                        GffValue::String(s) => {
-                            // A single parent — the string itself (already URL-decoded).
-                            parents = vec![s.to_string()];
-                        }
-                        GffValue::Array(arr) => {
-                            parents = arr.iter().map(|cow| cow.to_string()).collect();
-                        }
-                    }
+                    parents = parse_gff_id_list(&value);
+                }
+                "Derives_from" => {
+                    derives_from = parse_gff_id_list(&value);
                 }
                 _ => {
                     // value.as_ref() gives &BStr; convert to str for SmolStr.
@@ -179,6 +189,14 @@ impl Gff3Record {
                         SmolStr::new(value.as_ref().to_string()),
                     ));
                 }
+            }
+        }
+
+        // Merge `Derives_from` IDs into `parents`, preserving order and
+        // de-duplicating against the existing parents.
+        for d in derives_from {
+            if !parents.contains(&d) {
+                parents.push(d);
             }
         }
 
@@ -404,6 +422,54 @@ mod tests {
             .expect("parse")
             .expect("not comment");
         assert_eq!(rec.parents(), &["tx1", "tx2"]);
+    }
+
+    #[test]
+    fn gff3_record_honors_derives_from_as_parent_edge() {
+        // FlyBase emits `Derives_from` for transcripts derived from
+        // pseudogenes / alleles. Treat it as an additional parent edge
+        // so the feature graph captures the part-of relationship. #397
+        // item 1.
+        let line = "2L\tFlyBase\tmRNA\t100\t200\t.\t+\t.\tID=FBtr0000001;Derives_from=FBgn0000001";
+        let rec = Gff3Record::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.parents(), &["FBgn0000001"]);
+    }
+
+    #[test]
+    fn gff3_record_merges_parent_and_derives_from() {
+        // Both attributes present — parent set is the union (Parent
+        // values first, Derives_from values appended). De-duplicate
+        // identical IDs.
+        let line = "2L\tFlyBase\tmRNA\t100\t200\t.\t+\t.\tID=FBtr0000001;Parent=FBgn0000001;Derives_from=FBgn0000002";
+        let rec = Gff3Record::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.parents(), &["FBgn0000001", "FBgn0000002"]);
+    }
+
+    #[test]
+    fn gff3_record_handles_multi_value_derives_from() {
+        // `Derives_from=A,B` (comma-separated multi-value) — both
+        // values flow into the parent set.
+        let line = "2L\tFlyBase\tmRNA\t100\t200\t.\t+\t.\tID=FBtr0000001;Derives_from=FBgn0000001,FBgn0000002";
+        let rec = Gff3Record::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.parents(), &["FBgn0000001", "FBgn0000002"]);
+    }
+
+    #[test]
+    fn gff3_record_dedups_identical_parent_and_derives_from() {
+        // If a record lists the same ID under both `Parent` and
+        // `Derives_from`, only one parent edge should land in the
+        // graph.
+        let line = "2L\tFlyBase\tmRNA\t100\t200\t.\t+\t.\tID=FBtr0000001;Parent=FBgn0000001;Derives_from=FBgn0000001";
+        let rec = Gff3Record::parse(line, 1)
+            .expect("parse")
+            .expect("not comment");
+        assert_eq!(rec.parents(), &["FBgn0000001"]);
     }
 
     #[test]

--- a/src/service/tools/ferro.rs
+++ b/src/service/tools/ferro.rs
@@ -293,7 +293,7 @@ impl FerroService {
                     let original_str = parse_result.result.to_string();
 
                     // Then normalize it
-                    match normalizer.normalize_with_warnings(&parse_result.result) {
+                    match normalizer.normalize_with_diagnostics(&parse_result.result) {
                         Ok(normalize_result) => {
                             let success = true;
                             let normalized_str = normalize_result.result.to_string();

--- a/tests/annotation_real_format_slices.rs
+++ b/tests/annotation_real_format_slices.rs
@@ -78,3 +78,22 @@ fn flybase_micro_loads_two_exon_protein_coding() {
         tx.exons[1].end
     );
 }
+
+/// FlyBase `Derives_from` parent edge survives end-to-end through the
+/// loader. The fixture's mRNA carries `Parent=FBgn0031208` *and*
+/// `Derives_from=FBgn0031208_pseudo`; with both edges in the feature
+/// graph, the transcript still loads cleanly and exon/CDS assembly
+/// completes (which it could not if a `Derives_from`-only ancestor
+/// were silently dropped). #397 item 1.
+#[test]
+fn flybase_derives_from_edge_survives_loader() {
+    let (db, _report) = load_annotations(
+        Path::new("tests/fixtures/annotation/flybase_micro.gff3"),
+        &LoaderConfig::new(),
+    )
+    .unwrap();
+    assert!(
+        db.get("FBtr0300689").is_some(),
+        "Derives_from-bearing mRNA must still load",
+    );
+}

--- a/tests/fixtures/annotation/flybase_micro.gff3
+++ b/tests/fixtures/annotation/flybase_micro.gff3
@@ -1,10 +1,13 @@
 ##gff-version 3
 # Hand-curated FlyBase-style GFF3 excerpt for unit testing.
 # FlyBase uses Derives_from in addition to Parent for transcripts derived from
-# pseudogenes / alleles. ferro-hgvs does not currently consume Derives_from
-# (the standard Parent edge still works), so this fixture documents that gap.
+# pseudogenes / alleles. ferro-hgvs honors Derives_from as a parent edge in
+# the feature graph (Parent values first, Derives_from values appended,
+# dedup'd) — see `Gff3Record::parse` in `src/reference/annotation/record.rs`
+# and tests gated by `gff3_record_honors_derives_from_*` / `_merges_*`.
 2L	FlyBase	gene	7529	9484	.	+	.	ID=FBgn0031208;Name=CG11023;gene_biotype=protein_coding
-2L	FlyBase	mRNA	7529	9484	.	+	.	ID=FBtr0300689;Parent=FBgn0031208;Name=CG11023-RA
+2L	FlyBase	pseudogene	7529	9484	.	+	.	ID=FBgn0031208_pseudo;Parent=FBgn0031208
+2L	FlyBase	mRNA	7529	9484	.	+	.	ID=FBtr0300689;Parent=FBgn0031208;Derives_from=FBgn0031208_pseudo;Name=CG11023-RA
 2L	FlyBase	exon	7529	8116	.	+	.	ID=FBex0_1;Parent=FBtr0300689
 2L	FlyBase	exon	8193	9484	.	+	.	ID=FBex0_2;Parent=FBtr0300689
 2L	FlyBase	CDS	7680	8116	.	+	0	ID=CDS_FBtr0300689_1;Parent=FBtr0300689

--- a/tests/hgvs_spec_normalization_tests.rs
+++ b/tests/hgvs_spec_normalization_tests.rs
@@ -55,7 +55,7 @@ fn fixture_path() -> PathBuf {
 fn observe(normalizer: &Normalizer<MockProvider>, input: &str) -> (String, Vec<String>) {
     match parse_hgvs(input) {
         Err(e) => (format!("parse error: {e}"), Vec::new()),
-        Ok(v) => match normalizer.normalize_with_warnings(&v) {
+        Ok(v) => match normalizer.normalize_with_diagnostics(&v) {
             Err(e) => (format!("normalize error: {e}"), Vec::new()),
             Ok(n) => {
                 let mut codes: Vec<String> =

--- a/tests/issue_129_mt_circular_wraparound.rs
+++ b/tests/issue_129_mt_circular_wraparound.rs
@@ -242,7 +242,7 @@ fn mt_wraparound_delins_normalize_does_not_emit_canonical_split_skipped() {
         parse_hgvs(&format!("{MT}:m.16569_1delinsT")).expect("wraparound delins must parse");
     let normalizer = Normalizer::new(MockProvider::new());
     let normalized = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize must succeed on no-reference fallback");
     assert_eq!(
         format!("{}", normalized.result),
@@ -270,7 +270,7 @@ fn mt_wraparound_del_normalize_does_not_emit_canonical_split_skipped() {
         parse_hgvs(&format!("{MT}:m.16563_13del")).expect("wraparound del must parse (SVD-WG006)");
     let normalizer = Normalizer::new(MockProvider::new());
     let normalized = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize must succeed on no-reference fallback");
     assert!(
         !normalized

--- a/tests/issue_214_repeat_unit_divides.rs
+++ b/tests/issue_214_repeat_unit_divides.rs
@@ -75,7 +75,7 @@ fn normalize_lenient_warnings(
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs(input).expect("parse failed");
     let r = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient normalize failed");
     (format!("{}", r.result), r.warnings)
 }

--- a/tests/issue_279_multirepeat_partial_validation.rs
+++ b/tests/issue_279_multirepeat_partial_validation.rs
@@ -79,7 +79,7 @@ fn normalize_lenient_warnings(
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs(input).expect("parse failed");
     let r = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient normalize failed");
     (format!("{}", r.result), r.warnings)
 }

--- a/tests/issue_280_refseqmismatch_corrected_flag.rs
+++ b/tests/issue_280_refseqmismatch_corrected_flag.rs
@@ -122,7 +122,7 @@ mod del_mismatched_stated_ref {
         let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
         let v = parse_hgvs("NM_TEST.1:c.5delG").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             corrected_flag(&r.warnings),
@@ -150,7 +150,7 @@ mod dup_mismatched_stated_ref {
         let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
         let v = parse_hgvs("NM_TEST.1:c.10dupA").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             corrected_flag(&r.warnings),
@@ -178,7 +178,7 @@ mod inv_mismatched_stated_ref {
         let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
         let v = parse_hgvs("NM_TEST.1:c.20_22invAAA").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             corrected_flag(&r.warnings),
@@ -213,7 +213,7 @@ mod repeat_single_consistency_mismatch {
         let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
         let v = parse_hgvs("NC_000001.11:g.257_263AC[3]").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             !corrected_flag(&r.warnings),
@@ -239,7 +239,7 @@ mod repeat_single_consistency_mismatch {
         let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
         let v = parse_hgvs("NC_000001.11:g.257_262AC[3]").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             !corrected_flag(&r.warnings),
@@ -260,7 +260,7 @@ mod repeat_single_consistency_mismatch {
         let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
         let v = parse_hgvs("NC_000001.11:g.257_260A[4]").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             !corrected_flag(&r.warnings),
@@ -295,7 +295,7 @@ mod multirepeat_consistency_mismatch {
         let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
         let v = parse_hgvs("NC_000001.11:g.257_280CTG[2]TTG[1]CTG[11]").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             !corrected_flag(&r.warnings),
@@ -319,7 +319,7 @@ mod multirepeat_consistency_mismatch {
         let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
         let v = parse_hgvs("NC_000001.11:g.257_298CTG[2]TTG[1]CTG[11]").expect("parse");
         let r = normalizer
-            .normalize_with_warnings(&v)
+            .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
         assert!(
             !corrected_flag(&r.warnings),

--- a/tests/issue_330_info_code_surface.rs
+++ b/tests/issue_330_info_code_surface.rs
@@ -218,6 +218,41 @@ fn normalize_without_warnings_discards_infos_by_design() {
     assert_eq!(detailed.infos.len(), 1);
 }
 
+/// Canonical-split (`delins → sub` via the same-base interior collapse
+/// at `apply_canonical_split`) moves the variant's position but is NOT a
+/// 3'-rule shuffle. Pin that the diagnostics surface no longer
+/// mislabels it: `c.12_13delinsAA` reduces to `c.13C>A` (the leading
+/// `A` matches c.12 and splits out, leaving a single-base substitution
+/// at c.13) and `infos` must stay empty.
+///
+/// Regression for PR #426 CR finding on `detect_shuffle_infos`: a
+/// post-hoc position-only compare emitted `SHUFFLE_APPLIED` whenever
+/// the position changed, mislabeling the canonical-split rewrite as a
+/// shuffle.
+#[test]
+fn canonical_split_delins_to_sub_does_not_emit_shuffle_info() {
+    let normalizer = Normalizer::new(provider_with_polya());
+    let variant = parse_hgvs("NM_POLYA.1:c.12_13delinsAA").expect("parse delins");
+
+    let result = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize delins");
+
+    let display = format!("{}", result.result);
+    assert!(
+        display.ends_with(":c.13C>A"),
+        "expected canonical-split to land on c.13C>A; got {display:?}",
+    );
+    // The output kind changed (Delins → Substitution) and the position
+    // moved; this is canonicalization, not shuffle. `infos` must be
+    // empty.
+    assert!(
+        result.infos.is_empty(),
+        "canonical-split must not emit SHUFFLE_APPLIED; got {:?}",
+        result.infos.iter().map(|i| i.code()).collect::<Vec<_>>(),
+    );
+}
+
 /// `NormalizationInfo::code()` returns a stable identifier suitable for
 /// programmatic dispatch. Pin the spelling so downstream callers can match
 /// on it without depending on `Debug` repr.

--- a/tests/issue_330_info_code_surface.rs
+++ b/tests/issue_330_info_code_surface.rs
@@ -7,7 +7,7 @@
 //! your variant per the 3' rule" from "ferro left it alone" without
 //! re-comparing strings. This pins the canonical contract:
 //!
-//! - `Normalizer::normalize_with_warnings` returns a result carrying both
+//! - `Normalizer::normalize_with_diagnostics` returns a result carrying both
 //!   `warnings: Vec<NormalizationWarning>` and `infos: Vec<NormalizationInfo>`.
 //! - Each [`NormalizationInfo`] exposes `code()` (a stable identifier such as
 //!   `"SHUFFLE_APPLIED"`) and `message()` (a human-readable description).
@@ -69,7 +69,7 @@ fn shuffle_emits_info_on_homopolymer_three_prime() {
     let variant = parse_hgvs("NM_POLYA.1:c.4del").expect("parse c.4del");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize c.4del");
 
     let display = format!("{}", result.result);
@@ -111,7 +111,7 @@ fn shuffle_info_carries_direction_under_five_prime_config() {
     let variant = parse_hgvs("NM_POLYA.1:c.12del").expect("parse c.12del");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize c.12del under 5'-shift");
 
     let display = format!("{}", result.result);
@@ -149,7 +149,7 @@ fn shuffle_info_for_multi_position_span() {
     let variant = parse_hgvs("NM_POLYA.1:c.4_5del").expect("parse c.4_5del");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize c.4_5del");
 
     let display = format!("{}", result.result);
@@ -180,7 +180,7 @@ fn no_info_when_variant_is_already_canonical() {
     let variant = parse_hgvs("NM_POLYA.1:c.3G>C").expect("parse c.3G>C");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize c.3G>C");
 
     assert!(
@@ -193,7 +193,7 @@ fn no_info_when_variant_is_already_canonical() {
 /// `Normalizer::normalize()` (the non-`with_warnings` entry point)
 /// returns only the normalized variant; infos are intentionally
 /// discarded. Callers that need the diagnostic surface must use
-/// `normalize_with_warnings`. Pin this contract so a future refactor
+/// `normalize_with_diagnostics`. Pin this contract so a future refactor
 /// doesn't accidentally surface infos through the bare `normalize()`
 /// return type.
 #[test]
@@ -213,8 +213,8 @@ fn normalize_without_warnings_discards_infos_by_design() {
     // And the with_warnings entry point is the only path that surfaces
     // the info.
     let detailed = normalizer
-        .normalize_with_warnings(&variant)
-        .expect("normalize_with_warnings c.4del");
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize_with_diagnostics c.4del");
     assert_eq!(detailed.infos.len(), 1);
 }
 
@@ -224,12 +224,17 @@ fn normalize_without_warnings_discards_infos_by_design() {
 #[test]
 fn info_code_is_stable_identifier() {
     let info = NormalizationInfo::ShuffleApplied {
-        message: "moved".to_string(),
         accession: "NM_POLYA.1".to_string(),
         direction: ShuffleDirection::ThreePrime,
         original_position: "4".to_string(),
         normalized_position: "12".to_string(),
     };
     assert_eq!(info.code(), "SHUFFLE_APPLIED");
-    assert_eq!(info.message(), "moved");
+    // `message()` synthesizes from structural fields (#397 item 3
+    // dropped the per-variant `message: String` field).
+    let msg = info.message();
+    assert!(
+        msg.contains("4") && msg.contains("12") && msg.contains("NM_POLYA.1"),
+        "synthesized message should mention positions and accession; got {msg:?}",
+    );
 }

--- a/tests/issue_336_position_past_end.rs
+++ b/tests/issue_336_position_past_end.rs
@@ -124,7 +124,7 @@ fn lenient_mode_warns_on_c_position_past_cds_end() {
     let variant = parse_hgvs("NM_TEST.1:c.10G>C").expect("parse");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error on past-end positions");
 
     assert!(
@@ -144,7 +144,7 @@ fn silent_mode_accepts_c_position_past_cds_end_without_warning() {
     let variant = parse_hgvs("NM_TEST.1:c.10G>C").expect("parse");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("silent mode must not error");
 
     assert!(
@@ -202,7 +202,7 @@ fn lenient_mode_emits_two_warnings_for_range_both_past_end() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs("NM_TEST.1:c.10_11del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     let past_end: Vec<_> = result
         .warnings
@@ -249,7 +249,7 @@ fn strict_mode_n_in_bounds_does_not_emit_warning() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
     let variant = parse_hgvs("NR_TEST.1:n.10G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("in-bounds n. variant must not error");
     assert!(
         !result
@@ -331,7 +331,7 @@ fn lenient_mode_warns_on_c_minus_position_past_5utr_start() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs("NM_5UTR.1:c.-6G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     assert!(
         result
@@ -408,7 +408,7 @@ fn lenient_mode_warns_on_n_position_past_transcript_end() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs("NR_TEST.1:n.21G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     assert!(
         result
@@ -454,7 +454,7 @@ fn silent_mode_accepts_c_minus_position_past_5utr_start_without_warning() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::silent());
     let variant = parse_hgvs("NM_5UTR.1:c.-6G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("silent mode must not error");
     assert!(
         !result
@@ -472,7 +472,7 @@ fn silent_mode_accepts_n_position_past_transcript_end_without_warning() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::silent());
     let variant = parse_hgvs("NR_TEST.1:n.21G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("silent mode must not error");
     assert!(
         !result
@@ -532,7 +532,7 @@ fn lenient_mode_skips_n_downstream_position() {
     // post-transcript region.
     let variant = parse_hgvs("NR_TEST.1:n.*5G>C").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("downstream n. must not error in lenient mode");
     assert!(
         !result
@@ -556,7 +556,7 @@ fn lenient_mode_preserves_downstream_n_indel_without_normalization() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs("NR_TEST.1:n.*5_*7del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("downstream n. indel must not error in lenient mode");
     assert!(
         !result

--- a/tests/issue_337_cds_start_clamp.rs
+++ b/tests/issue_337_cds_start_clamp.rs
@@ -183,7 +183,7 @@ fn cross_axis_5utr_to_cds_does_not_shuffle_and_warns() {
         let normalizer = Normalizer::with_config(provider_with_utr_padded_transcript(), config);
         let variant = parse_hgvs("NM_TEST.1:c.-1_1del").expect("parse");
         let result = normalizer
-            .normalize_with_warnings(&variant)
+            .normalize_with_diagnostics(&variant)
             .expect("normalize");
         assert_eq!(
             format!("{}", result.result),
@@ -214,7 +214,7 @@ fn cross_axis_cds_to_3utr_does_not_shuffle_and_warns() {
         let normalizer = Normalizer::with_config(provider_with_utr_padded_transcript(), config);
         let variant = parse_hgvs("NM_TEST.1:c.9_*1del").expect("parse");
         let result = normalizer
-            .normalize_with_warnings(&variant)
+            .normalize_with_diagnostics(&variant)
             .expect("normalize");
         assert_eq!(
             format!("{}", result.result),
@@ -241,7 +241,7 @@ fn within_axis_cds_variant_does_not_emit_cross_axis_warning() {
     );
     let variant = parse_hgvs("NM_TEST.1:c.1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert!(
         result
@@ -268,7 +268,7 @@ fn axis_clamp_emits_warning_when_constraining_5prime_shuffle() {
     );
     let variant = parse_hgvs("NM_TEST.1:c.1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_TEST.1:c.1del");
     assert!(
@@ -298,7 +298,7 @@ fn no_axis_clamp_when_upstream_utr_base_does_not_match() {
     );
     let variant = parse_hgvs("NM_INTRA.1:c.1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_INTRA.1:c.1del");
     assert!(
@@ -322,7 +322,7 @@ fn no_axis_clamp_when_5prime_shuffle_stays_within_axis() {
     );
     let variant = parse_hgvs("NM_TEST.1:c.6del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_TEST.1:c.4del");
     assert!(
@@ -492,7 +492,7 @@ fn axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuffle() {
     );
     let variant = parse_hgvs("NM_UTR3.1:c.*1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.*1del");
     assert!(
@@ -517,7 +517,7 @@ fn axis_clamp_emits_warning_when_constraining_5prime_c_star_1_dup_shuffle() {
     );
     let variant = parse_hgvs("NM_UTR3.1:c.*1dup").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.*1dup");
     assert!(
@@ -589,7 +589,7 @@ fn axis_clamp_emits_warning_when_constraining_3prime_c_cds_end_shuffle() {
     );
     let variant = parse_hgvs("NM_UTR3.1:c.9del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_UTR3.1:c.9del");
     assert!(
@@ -701,7 +701,7 @@ fn minus_strand_axis_clamp_emits_warning_when_constraining_5prime_shuffle() {
     );
     let variant = parse_hgvs("NM_MTEST.1:c.1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_MTEST.1:c.1del");
     assert!(
@@ -797,7 +797,7 @@ fn minus_strand_axis_clamp_emits_warning_when_constraining_5prime_c_star_1_shuff
     );
     let variant = parse_hgvs("NM_MUTR3.1:c.*1del").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize");
     assert_eq!(format!("{}", result.result), "NM_MUTR3.1:c.*1del");
     assert!(

--- a/tests/issue_339_alignment_gap_panic.rs
+++ b/tests/issue_339_alignment_gap_panic.rs
@@ -113,7 +113,7 @@ fn normalize_emits_canonical_split_skipped_warning_on_alignment_gap() {
     let variant = parse_hgvs("NG_032871.1:g.32476_53457delinsAATTAAGGTATA").expect("parse");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize must not panic on alignment-gap-spanning delins");
     assert_eq!(
         format!("{}", result.result),
@@ -137,7 +137,7 @@ fn normalize_emits_canonical_split_skipped_when_ref_longer_than_span() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::default());
     let variant = parse_hgvs("NC_000001.11:g.100_110delinsAAGCTT").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize must not panic on over-long ref window");
     assert!(
         result
@@ -222,7 +222,7 @@ fn lenient_mode_warns_and_preserves_when_variant_exceeds_reference() {
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs("NG_032871.1:g.32476_53457delinsAATTAAGGTATA").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode preserves the variant; rejection is strict-only");
     assert_eq!(
         format!("{}", result.result),

--- a/tests/issue_392_w4004_intronic_offsets.rs
+++ b/tests/issue_392_w4004_intronic_offsets.rs
@@ -234,7 +234,7 @@ fn position_past_end_fires(provider: MockProvider, input: &str) -> bool {
     let normalizer = Normalizer::with_config(provider, config);
     let variant =
         parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {:?}: {:?}", input, e));
-    match normalizer.normalize_with_warnings(&variant) {
+    match normalizer.normalize_with_diagnostics(&variant) {
         Ok(result) => result
             .warnings
             .iter()
@@ -360,7 +360,7 @@ fn intronic_offset_check_skips_when_genomic_coords_missing() {
 
 #[test]
 fn strict_mode_promotes_intronic_past_end_to_error() {
-    // Strict mode calls `normalize` (not `normalize_with_warnings`), which
+    // Strict mode calls `normalize` (not `normalize_with_diagnostics`), which
     // promotes a `PositionPastEnd` warning to `FerroError::InvalidCoordinates`.
     let provider = provider_with_intronic_transcript();
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());

--- a/tests/issue_393_mt_w4004.rs
+++ b/tests/issue_393_mt_w4004.rs
@@ -60,7 +60,7 @@ fn lenient_mode_warns_on_m_position_past_contig_end() {
     let variant = parse_hgvs("NC_012920.1:m.16570A>G").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error on past-end positions");
     assert!(
         result
@@ -77,7 +77,7 @@ fn silent_mode_accepts_m_position_past_contig_end_without_warning() {
     let variant = parse_hgvs("NC_012920.1:m.16570A>G").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::silent());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("silent mode must not error");
     assert!(
         !result
@@ -102,7 +102,7 @@ fn strict_mode_accepts_m_position_at_contig_end() {
     // match), so we use lenient mode here to isolate the bounds gate.
     let normalizer_lenient = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer_lenient
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("m.16569 must not error in lenient mode");
     assert!(
         !result
@@ -141,7 +141,7 @@ fn lenient_mode_no_w4004_on_wraparound_range_with_both_endpoints_in_bounds() {
     let variant = parse_hgvs("NC_012920.1:m.16569_1del").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("wraparound del must not error in lenient mode");
     assert!(
         !result
@@ -166,7 +166,7 @@ fn lenient_mode_warns_on_partial_wraparound_with_start_past_contig() {
     let variant = parse_hgvs("NC_012920.1:m.16570_5del").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     assert!(
         result
@@ -193,7 +193,7 @@ fn lenient_mode_w4004_when_only_offset_endpoint_distinguishes_positions() {
     let variant = parse_hgvs("NC_012920.1:m.16570+1_16570del").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     assert!(
         result
@@ -251,7 +251,7 @@ fn lenient_mode_canonicalizes_con_to_delins_even_when_past_contig_end() {
     let variant = parse_hgvs("NC_012920.1:m.16570conT").expect("parse must succeed");
     let normalizer = Normalizer::with_config(mt_provider(), NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error on past-end con");
     assert!(
         result

--- a/tests/issue_395_multirepeat_interleaved_resumption.rs
+++ b/tests/issue_395_multirepeat_interleaved_resumption.rs
@@ -58,7 +58,7 @@ fn normalize_lenient(provider: MockProvider, input: &str) -> (String, Vec<Normal
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs(input).expect("parse");
     let r = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient normalize");
     (format!("{}", r.result), r.warnings)
 }

--- a/tests/issue_395_overlap_conflict_strict_rejection.rs
+++ b/tests/issue_395_overlap_conflict_strict_rejection.rs
@@ -14,7 +14,7 @@
 //!   - Lenient mode preserves the input and emits the warning.
 //!   - Silent mode still emits the warning (the emit site at
 //!     `overlap.rs:88` is unconditional); only strict-mode promotion
-//!     to error was the gap. Callers using `normalize_with_warnings`
+//!     to error was the gap. Callers using `normalize_with_diagnostics`
 //!     get the warning in any mode, while `normalize` only differs
 //!     for strict (Err) vs lenient/silent (Ok with warning attached
 //!     to the dropped vec).
@@ -61,7 +61,7 @@ fn lenient_mode_emits_w5002_warning_and_preserves_input() {
     let normalizer = Normalizer::with_config(provider(), NormalizeConfig::lenient());
     let variant = parse_hgvs("NC_000001.11:g.[100A>C;100A>G]").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must accept coincident-bounds cis edits");
     let has_warning = result
         .warnings
@@ -99,13 +99,13 @@ fn silent_mode_still_emits_w5002_warning() {
     // The emit site at `src/normalize/overlap.rs:88` is unconditional —
     // silent mode does not suppress the warning, only changes
     // strict-mode behavior from Reject to WarnAccept. Callers using
-    // `normalize_with_warnings` get the warning regardless of mode;
+    // `normalize_with_diagnostics` get the warning regardless of mode;
     // `normalize` only differs by whether the warning is promoted
     // (strict → Err) or accepted (lenient/silent → Ok).
     let normalizer = Normalizer::with_config(provider(), NormalizeConfig::silent());
     let variant = parse_hgvs("NC_000001.11:g.[100A>C;100A>G]").expect("parse");
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("silent mode must accept coincident-bounds cis edits");
     let has_warning = result
         .warnings

--- a/tests/issue_428_multirepeat_middle_minimum.rs
+++ b/tests/issue_428_multirepeat_middle_minimum.rs
@@ -52,7 +52,7 @@ fn normalize_lenient(provider: MockProvider, input: &str) -> (String, Vec<Normal
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::lenient());
     let variant = parse_hgvs(input).expect("parse");
     let r = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient normalize");
     (format!("{}", r.result), r.warnings)
 }

--- a/tests/issue_92_protein_ins_to_dup.rs
+++ b/tests/issue_92_protein_ins_to_dup.rs
@@ -211,7 +211,7 @@ fn protein_met1_dup_emits_initiator_warning() {
     let variant = parse_hgvs("NP_TESTPROT.1:p.Met1_Lys2insMet").expect("parse p.Met1_Lys2insMet");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize p.Met1_Lys2insMet");
     let out = format!("{}", result.result);
     assert!(
@@ -242,7 +242,7 @@ fn protein_non_met1_dup_does_not_emit_initiator_warning() {
         parse_hgvs("NP_TESTPROT.1:p.Glu8_Leu9insLeuGlu").expect("parse p.Glu8_Leu9insLeuGlu");
 
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("normalize p.Glu8_Leu9insLeuGlu");
     assert!(
         !result

--- a/tests/merge_consecutive_edits_tests.rs
+++ b/tests/merge_consecutive_edits_tests.rs
@@ -14,7 +14,7 @@ fn normalize_to_string_and_warning_codes(input: &str) -> (String, Vec<String>) {
     let normalizer = Normalizer::new(MockProvider::new());
     let parsed = parse_hgvs(input).expect("parse");
     let r = normalizer
-        .normalize_with_warnings(&parsed)
+        .normalize_with_diagnostics(&parsed)
         .expect("normalize");
     let codes: Vec<String> = r.warnings.iter().map(|w| w.code().to_string()).collect();
     (r.result.to_string(), codes)
@@ -27,7 +27,7 @@ fn normalize_with_provider_and_warning_codes(
     let normalizer = Normalizer::new(provider);
     let parsed = parse_hgvs(input).expect("parse");
     let r = normalizer
-        .normalize_with_warnings(&parsed)
+        .normalize_with_diagnostics(&parsed)
         .expect("normalize");
     let codes: Vec<String> = r.warnings.iter().map(|w| w.code().to_string()).collect();
     (r.result.to_string(), codes)

--- a/tests/mito_circular_audit.rs
+++ b/tests/mito_circular_audit.rs
@@ -397,7 +397,7 @@ fn audit_mt_position_past_end_parses_but_normalize_fires_w4004() {
     p.add_genomic_sequence("NC_012920.1", "A".repeat(16569));
     let normalizer = Normalizer::with_config(p, ferro_hgvs::NormalizeConfig::lenient());
     let result = normalizer
-        .normalize_with_warnings(&variant)
+        .normalize_with_diagnostics(&variant)
         .expect("lenient mode must not error");
     assert!(
         result

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -901,7 +901,7 @@ fn axis_infos() {
 
             let v = parse_hgvs(&case.input).map_err(|e| format!("parse error: {e:?}"))?;
             let result = normalizer
-                .normalize_with_warnings(&v)
+                .normalize_with_diagnostics(&v)
                 .map_err(|e| format!("normalize error: {e:?}"))?;
             let emitted: Vec<&str> = result.infos.iter().map(|i| i.code()).collect();
 

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -221,22 +221,62 @@ struct AcceptedDivergence {
     note: Option<String>,
 }
 
+/// Closed enum of HGVS spec section identifiers cited from `cases.json`.
+/// Mirrors [`Policy`]'s shape: adding a new section requires a code
+/// change here, which forces deliberate review of every new citation
+/// rather than allowing ad-hoc string typing in `cases.json` (#430,
+/// follow-up to #397 item 2). The `#[serde(rename = "...")]` annotation
+/// keeps the JSON wire format stable.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum SpecSection {
+    /// HGVS §Prioritization — the spec's edit-prioritization rules (dup
+    /// over ins, etc.) that ferro applies during normalization. This is
+    /// a ferro-internal label, not a stable spec heading: the upstream
+    /// spec submodule (`assets/hgvs-nomenclature/docs/recommendations/`)
+    /// has no `Prioritization` anchor today, so binding to a path here
+    /// would create a brittle pointer. The human label is the stable
+    /// catalog key; the rename string preserves the byte sequence in
+    /// `cases.json`.
+    #[serde(rename = "HGVS §Prioritization")]
+    HgvsPrioritization,
+}
+
+impl SpecSection {
+    /// Stable identifier used in summary lines so reviewers can grep
+    /// across runs. Matches the `#[serde(rename)]` strings byte-for-byte
+    /// to preserve the pre-enum summary-line format.
+    fn as_str(self) -> &'static str {
+        match self {
+            SpecSection::HgvsPrioritization => "HGVS §Prioritization",
+        }
+    }
+}
+
+impl std::fmt::Display for SpecSection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Spec-citation annotation. Documentary only — does NOT affect tally
 /// bucketing. Used to record that the `cases.json` expected output for
 /// `axis` has been corrected to ferro's spec-correct value (versus
 /// mutalyzer's spec-incorrect output), with a citation to the relevant
 /// HGVS spec section.
 ///
-/// `axis` is a closed enum (see [`Axis`]); `section` remains a free-form
-/// string because HGVS spec section identifiers don't yet have a stable
-/// catalog worth pinning.
+/// `axis` and `section` are now closed enums (see [`Axis`], [`SpecSection`]);
+/// serde rejects unknown variants at fixture-parse time, so a misspelled
+/// section identifier surfaces as a hard parse error rather than silently
+/// losing cataloguability.
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 struct SpecCitation {
     /// Axis this citation applies to.
     axis: Axis,
-    /// HGVS spec section the citation references (e.g. `"HGVS §Prioritization"`).
-    section: String,
+    /// HGVS spec section the citation references (e.g.
+    /// `SpecSection::HgvsPrioritization`).
+    section: SpecSection,
     /// Optional human-readable note expanding on the citation.
     #[serde(default)]
     note: Option<String>,
@@ -416,7 +456,7 @@ impl AxisTally {
             if let Some(sc) = &case.spec_citation {
                 if sc.axis == self.axis {
                     self.spec_overridden
-                        .push((case.input.clone(), sc.section.clone()));
+                        .push((case.input.clone(), sc.section.to_string()));
                     return;
                 }
             }
@@ -1147,6 +1187,31 @@ mod comparator_tests {
         );
     }
 
+    /// Issue #430 closes `SpecCitation.section` to a [`SpecSection`] enum so
+    /// a misspelled section identifier surfaces as a hard parse error
+    /// rather than silently losing cataloguability in `cases.json`. Mirrors
+    /// `case_axis_typo_rejected_at_deserialization` and
+    /// `case_policy_typo_rejected_at_deserialization`.
+    #[test]
+    fn case_section_typo_rejected_at_deserialization() {
+        // Missing the `§` sigil — looks plausible but is not the
+        // canonical identifier.
+        let result: Result<Case, _> = serde_json::from_str(
+            r#"{
+                "input": "x",
+                "spec_citation": {
+                    "axis": "normalized",
+                    "section": "HGVS Prioritization"
+                }
+            }"#,
+        );
+        assert!(
+            result.is_err(),
+            "expected typo'd section (`HGVS Prioritization` vs `HGVS §Prioritization`) to be rejected; got {:?}",
+            result.ok(),
+        );
+    }
+
     // (2) `accepted_divergence` deserializes including the optional `note`.
     #[test]
     fn case_parses_with_accepted_divergence() {
@@ -1184,7 +1249,7 @@ mod comparator_tests {
         );
         let sc = case.spec_citation.as_ref().expect("spec_citation present");
         assert_eq!(sc.axis, Axis::Normalized);
-        assert_eq!(sc.section, "HGVS §Prioritization");
+        assert_eq!(sc.section, SpecSection::HgvsPrioritization);
         assert_eq!(sc.note.as_deref(), Some("dup over ins"));
     }
 
@@ -1294,7 +1359,7 @@ mod comparator_tests {
             None,
             Some(SpecCitation {
                 axis: Axis::Normalized,
-                section: "HGVS §Prioritization".to_string(),
+                section: SpecSection::HgvsPrioritization,
                 note: None,
             }),
         );
@@ -1318,7 +1383,7 @@ mod comparator_tests {
             None,
             Some(SpecCitation {
                 axis: Axis::Normalized,
-                section: "HGVS §Prioritization".to_string(),
+                section: SpecSection::HgvsPrioritization,
                 note: None,
             }),
         );
@@ -1341,7 +1406,7 @@ mod comparator_tests {
             None,
             Some(SpecCitation {
                 axis: Axis::Errors,
-                section: "HGVS §Prioritization".to_string(),
+                section: SpecSection::HgvsPrioritization,
                 note: None,
             }),
         );
@@ -1377,7 +1442,7 @@ mod comparator_tests {
                 None,
                 Some(SpecCitation {
                     axis: Axis::Normalized,
-                    section: "HGVS §Prioritization".to_string(),
+                    section: SpecSection::HgvsPrioritization,
                     note: None,
                 }),
             ),
@@ -1411,7 +1476,7 @@ mod comparator_tests {
             }),
             Some(SpecCitation {
                 axis: Axis::Normalized,
-                section: "HGVS §Prioritization".to_string(),
+                section: SpecSection::HgvsPrioritization,
                 note: None,
             }),
         );

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -123,25 +123,99 @@ struct Case {
     spec_citation: Option<SpecCitation>,
 }
 
+/// Closed enum of corpus-runner axes. Replaces the previous free-form
+/// `String` field on `AcceptedDivergence` and `SpecCitation` — serde
+/// deserialization rejects unknown variants, so a typo in `cases.json`
+/// surfaces as a hard parse error rather than silently no-op'ing the
+/// annotation (#397 item 2). The variants match the 8 `AxisTally::new`
+/// call sites; the lowercase serde rename keeps the JSON wire format
+/// stable.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+enum Axis {
+    Normalized,
+    Genomic,
+    ProteinDescription,
+    CodingProteinDescriptions,
+    RnaDescription,
+    Noncoding,
+    Errors,
+    Infos,
+}
+
+impl Axis {
+    /// Stable kebab-case string used in summary lines, file paths, and
+    /// log messages. Matches the lowercase strings the previous
+    /// `&'static str` axis carried.
+    fn as_str(self) -> &'static str {
+        match self {
+            Axis::Normalized => "normalized",
+            Axis::Genomic => "genomic",
+            Axis::ProteinDescription => "protein_description",
+            Axis::CodingProteinDescriptions => "coding_protein_descriptions",
+            Axis::RnaDescription => "rna_description",
+            Axis::Noncoding => "noncoding",
+            Axis::Errors => "errors",
+            Axis::Infos => "infos",
+        }
+    }
+}
+
+impl std::fmt::Display for Axis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Closed enum of accepted-divergence policies. Each policy identifier
+/// names a specific reason a mismatch is non-failing (e.g. ferro's spec
+/// arbitration on gene-symbol selectors). Adding a new policy requires
+/// a code change here, which is intentional: it forces deliberate
+/// review of every accepted divergence rather than allowing ad-hoc
+/// string typing in `cases.json` (#397 item 2).
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum Policy {
+    /// ferro's gene-symbol-selector handling per issue #121 (the
+    /// `NM_X(GENE):c.X` rendering and the related dispatcher
+    /// arbitration). See PR #146 for the spec arbitration trail.
+    #[serde(rename = "ferro-policy-121-gene-symbol-selector")]
+    GeneSymbolSelector121,
+}
+
+impl Policy {
+    /// Stable identifier used in summary lines so reviewers can grep
+    /// across runs.
+    fn as_str(self) -> &'static str {
+        match self {
+            Policy::GeneSymbolSelector121 => "ferro-policy-121-gene-symbol-selector",
+        }
+    }
+}
+
+impl std::fmt::Display for Policy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Accepted-divergence annotation. When attached to a `Case`, the
 /// corpus runner treats a mismatch on `axis` as a tracked-but-non-failing
 /// divergence (counted in `divergence_accepted`) rather than a hard FAIL.
 ///
-/// **Typo warning:** `axis` and `policy` are free-form strings, not
-/// validated enums. A misspelled `axis` (`"normalised"`, `"genomic_"`,
-/// etc.) silently makes the annotation a no-op — the case falls through
-/// to FAIL with no warning. Cross-check spelling against the `axis` arg
-/// passed to `AxisTally::new(...)` in each test in this file. (Tightening
-/// this to a closed enum is a follow-up.)
+/// `axis` and `policy` are now closed enums — `serde` rejects unknown
+/// variants at fixture-parse time, so misspellings surface as a hard
+/// parse error rather than silently no-op'ing the annotation.
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 struct AcceptedDivergence {
-    /// Axis name this annotation applies to (e.g. `"normalized"`).
-    axis: String,
-    /// Short policy identifier explaining *why* the divergence is acceptable
-    /// — e.g. `"ferro-policy-121-gene-symbol-selector"`. Surfaced in the
-    /// per-axis tally summary so reviewers can grep for the policy.
-    policy: String,
+    /// Axis this annotation applies to.
+    axis: Axis,
+    /// Closed policy identifier explaining *why* the divergence is
+    /// acceptable. Surfaced in the per-axis tally summary so reviewers
+    /// can grep for the policy.
+    policy: Policy,
     /// Optional human-readable note expanding on the policy.
     #[serde(default)]
     note: Option<String>,
@@ -152,11 +226,15 @@ struct AcceptedDivergence {
 /// `axis` has been corrected to ferro's spec-correct value (versus
 /// mutalyzer's spec-incorrect output), with a citation to the relevant
 /// HGVS spec section.
+///
+/// `axis` is a closed enum (see [`Axis`]); `section` remains a free-form
+/// string because HGVS spec section identifiers don't yet have a stable
+/// catalog worth pinning.
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 struct SpecCitation {
-    /// Axis name this citation applies to (e.g. `"normalized"`).
-    axis: String,
+    /// Axis this citation applies to.
+    axis: Axis,
     /// HGVS spec section the citation references (e.g. `"HGVS §Prioritization"`).
     section: String,
     /// Optional human-readable note expanding on the citation.
@@ -276,7 +354,7 @@ fn variant_projector() -> Option<VariantProjector<ArcProvider>> {
 
 #[derive(Debug)]
 struct AxisTally {
-    axis: &'static str,
+    axis: Axis,
     pass: usize,
     /// Mismatches gated by an `accepted_divergence` annotation whose
     /// `axis` matches this tally's axis. Tracked-but-non-failing; reported
@@ -297,7 +375,7 @@ struct AxisTally {
 }
 
 impl AxisTally {
-    fn new(axis: &'static str) -> Self {
+    fn new(axis: Axis) -> Self {
         Self {
             axis,
             pass: 0,
@@ -331,7 +409,7 @@ impl AxisTally {
             if let Some(ad) = &case.accepted_divergence {
                 if ad.axis == self.axis {
                     self.divergence_accepted
-                        .push((case.input.clone(), ad.policy.clone()));
+                        .push((case.input.clone(), ad.policy.to_string()));
                     return;
                 }
             }
@@ -511,7 +589,7 @@ fn axis_normalized() {
         return;
     };
 
-    let mut t = AxisTally::new("normalized");
+    let mut t = AxisTally::new(Axis::Normalized);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -545,7 +623,7 @@ fn axis_genomic() {
         return;
     };
 
-    let mut t = AxisTally::new("genomic");
+    let mut t = AxisTally::new(Axis::Genomic);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -582,7 +660,7 @@ fn axis_protein_description() {
         return;
     };
 
-    let mut t = AxisTally::new("protein_description");
+    let mut t = AxisTally::new(Axis::ProteinDescription);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -622,7 +700,7 @@ fn axis_coding_protein_descriptions() {
         return;
     };
 
-    let mut t = AxisTally::new("coding_protein_descriptions");
+    let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -680,7 +758,7 @@ fn axis_rna_description() {
         return;
     }
 
-    let mut t = AxisTally::new("rna_description");
+    let mut t = AxisTally::new(Axis::RnaDescription);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -707,7 +785,7 @@ fn axis_noncoding() {
         return;
     }
 
-    let mut t = AxisTally::new("noncoding");
+    let mut t = AxisTally::new(Axis::Noncoding);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -735,7 +813,7 @@ fn axis_errors() {
         return;
     };
 
-    let mut t = AxisTally::new("errors");
+    let mut t = AxisTally::new(Axis::Errors);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -794,7 +872,7 @@ fn axis_infos() {
         return;
     };
 
-    let mut t = AxisTally::new("infos");
+    let mut t = AxisTally::new(Axis::Infos);
     for case in &fixture().cases {
         if !case.to_test {
             continue;
@@ -1030,6 +1108,45 @@ mod comparator_tests {
         assert!(case.spec_citation.is_none());
     }
 
+    // (1b) Typo in `axis` or `policy` is rejected at deserialization
+    // (#397 item 2): the closed enums turn what used to be a silent
+    // no-op into a hard parse error during fixture load.
+    #[test]
+    fn case_axis_typo_rejected_at_deserialization() {
+        let result: Result<Case, _> = serde_json::from_str(
+            r#"{
+                "input": "x",
+                "accepted_divergence": {
+                    "axis": "normalised",
+                    "policy": "ferro-policy-121-gene-symbol-selector"
+                }
+            }"#,
+        );
+        assert!(
+            result.is_err(),
+            "expected typo'd axis (`normalised` vs `normalized`) to be rejected; got {:?}",
+            result.ok(),
+        );
+    }
+
+    #[test]
+    fn case_policy_typo_rejected_at_deserialization() {
+        let result: Result<Case, _> = serde_json::from_str(
+            r#"{
+                "input": "x",
+                "accepted_divergence": {
+                    "axis": "normalized",
+                    "policy": "ferro-policy-999-bogus"
+                }
+            }"#,
+        );
+        assert!(
+            result.is_err(),
+            "expected unknown policy to be rejected; got {:?}",
+            result.ok(),
+        );
+    }
+
     // (2) `accepted_divergence` deserializes including the optional `note`.
     #[test]
     fn case_parses_with_accepted_divergence() {
@@ -1047,8 +1164,8 @@ mod comparator_tests {
             .accepted_divergence
             .as_ref()
             .expect("accepted_divergence present");
-        assert_eq!(ad.axis, "normalized");
-        assert_eq!(ad.policy, "ferro-policy-121-gene-symbol-selector");
+        assert_eq!(ad.axis, Axis::Normalized);
+        assert_eq!(ad.policy, Policy::GeneSymbolSelector121);
         assert_eq!(ad.note.as_deref(), Some("ferro emits (COL1A1) per #121"));
     }
 
@@ -1066,7 +1183,7 @@ mod comparator_tests {
             }"#,
         );
         let sc = case.spec_citation.as_ref().expect("spec_citation present");
-        assert_eq!(sc.axis, "normalized");
+        assert_eq!(sc.axis, Axis::Normalized);
         assert_eq!(sc.section, "HGVS §Prioritization");
         assert_eq!(sc.note.as_deref(), Some("dup over ins"));
     }
@@ -1074,7 +1191,7 @@ mod comparator_tests {
     // (4) `record` PASSes when actual == expected, regardless of annotations.
     #[test]
     fn tally_pass_when_output_matches() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case("NM_000088.3:c.459A>G", None, None);
         t.record(&case, "X", Ok("X".to_string()));
         assert_eq!(t.pass, 1);
@@ -1085,12 +1202,12 @@ mod comparator_tests {
     // (5) Mismatch on the annotated axis goes into `divergence_accepted`.
     #[test]
     fn tally_divergence_accepted_on_matching_axis() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             Some(AcceptedDivergence {
-                axis: "normalized".to_string(),
-                policy: "ferro-policy-121-gene-symbol-selector".to_string(),
+                axis: Axis::Normalized,
+                policy: Policy::GeneSymbolSelector121,
                 note: None,
             }),
             None,
@@ -1111,12 +1228,12 @@ mod comparator_tests {
     // axis is still a FAIL — annotations are scoped strictly per-axis.
     #[test]
     fn tally_fail_when_annotation_axis_mismatches() {
-        let mut t = AxisTally::new("genomic");
+        let mut t = AxisTally::new(Axis::Genomic);
         let case = make_case(
             "in",
             Some(AcceptedDivergence {
-                axis: "normalized".to_string(),
-                policy: "ferro-policy-121-gene-symbol-selector".to_string(),
+                axis: Axis::Normalized,
+                policy: Policy::GeneSymbolSelector121,
                 note: None,
             }),
             None,
@@ -1135,12 +1252,12 @@ mod comparator_tests {
     // silenced by the annotation.
     #[test]
     fn tally_err_with_accepted_divergence_still_fails() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             Some(AcceptedDivergence {
-                axis: "normalized".to_string(),
-                policy: "ferro-policy-121-gene-symbol-selector".to_string(),
+                axis: Axis::Normalized,
+                policy: Policy::GeneSymbolSelector121,
                 note: None,
             }),
             None,
@@ -1158,7 +1275,7 @@ mod comparator_tests {
     // (7) Mismatch with no annotation is FAIL.
     #[test]
     fn tally_fail_when_no_annotation() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case("in", None, None);
         t.record(&case, "X", Ok("Y".to_string()));
         assert_eq!(t.pass, 0);
@@ -1171,12 +1288,12 @@ mod comparator_tests {
     // the `spec_overridden` bucket — non-failing, separately tracked.
     #[test]
     fn tally_spec_citation_routes_to_spec_overridden() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             None,
             Some(SpecCitation {
-                axis: "normalized".to_string(),
+                axis: Axis::Normalized,
                 section: "HGVS §Prioritization".to_string(),
                 note: None,
             }),
@@ -1195,12 +1312,12 @@ mod comparator_tests {
     // and must surface as FAIL — same contract as `accepted_divergence`.
     #[test]
     fn tally_err_with_spec_citation_still_fails() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             None,
             Some(SpecCitation {
-                axis: "normalized".to_string(),
+                axis: Axis::Normalized,
                 section: "HGVS §Prioritization".to_string(),
                 note: None,
             }),
@@ -1218,12 +1335,12 @@ mod comparator_tests {
     // route to `spec_overridden` — citations are axis-scoped.
     #[test]
     fn tally_spec_citation_other_axis_is_fail() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             None,
             Some(SpecCitation {
-                axis: "errors".to_string(),
+                axis: Axis::Errors,
                 section: "HGVS §Prioritization".to_string(),
                 note: None,
             }),
@@ -1237,7 +1354,7 @@ mod comparator_tests {
     // `spec_overridden` buckets in the documented stable format.
     #[test]
     fn tally_finish_summary_string_includes_new_bucket() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         // 1 pass, 1 divergence_accepted, 1 spec_overridden, 1 fail,
         // 0 skipped.
         t.record(&make_case("a", None, None), "X", Ok("X".to_string()));
@@ -1245,8 +1362,8 @@ mod comparator_tests {
             &make_case(
                 "b",
                 Some(AcceptedDivergence {
-                    axis: "normalized".to_string(),
-                    policy: "p".to_string(),
+                    axis: Axis::Normalized,
+                    policy: Policy::GeneSymbolSelector121,
                     note: None,
                 }),
                 None,
@@ -1259,7 +1376,7 @@ mod comparator_tests {
                 "d",
                 None,
                 Some(SpecCitation {
-                    axis: "normalized".to_string(),
+                    axis: Axis::Normalized,
                     section: "HGVS §Prioritization".to_string(),
                     note: None,
                 }),
@@ -1284,16 +1401,16 @@ mod comparator_tests {
     // co-attached `spec_citation`.
     #[test]
     fn tally_coexisting_annotations_route_by_accepted_divergence() {
-        let mut t = AxisTally::new("normalized");
+        let mut t = AxisTally::new(Axis::Normalized);
         let case = make_case(
             "in",
             Some(AcceptedDivergence {
-                axis: "normalized".to_string(),
-                policy: "ferro-policy-121-gene-symbol-selector".to_string(),
+                axis: Axis::Normalized,
+                policy: Policy::GeneSymbolSelector121,
                 note: None,
             }),
             Some(SpecCitation {
-                axis: "normalized".to_string(),
+                axis: Axis::Normalized,
                 section: "HGVS §Prioritization".to_string(),
                 note: None,
             }),

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -5194,7 +5194,7 @@ mod ins_bracketed_expansion {
         let variant =
             parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {}: {}", input, e));
         let outcome = normalizer
-            .normalize_with_warnings(&variant)
+            .normalize_with_diagnostics(&variant)
             .unwrap_or_else(|e| panic!("normalize failed for {}: {}", input, e));
         // Display round-trips identically.
         assert_eq!(format!("{}", outcome.result), input);
@@ -5226,7 +5226,7 @@ mod ins_bracketed_expansion {
         let variant =
             parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {}: {}", input, e));
         let outcome = normalizer
-            .normalize_with_warnings(&variant)
+            .normalize_with_diagnostics(&variant)
             .unwrap_or_else(|e| panic!("normalize failed for {}: {}", input, e));
         assert_eq!(
             format!("{}", outcome.result),


### PR DESCRIPTION
## Summary

Closes #397 — 7 small, scope-disparate follow-ups from PRs #137 / #195 / #197 / #323 / #359 / #373 / #381 across loader, diagnostics, and CI/packaging. Each item shipped as its own commit.

- **`feat(loader): honor FlyBase Derives_from as a parent edge (#397 item 1)`** — `Gff3Record::parse` previously only consumed `Parent`. FlyBase emits `Derives_from` for transcripts derived from pseudogenes / alleles, and the existing GFF3 path silently dropped that edge. Now reads both attributes, merging the two ID lists (Parent first, Derives_from appended, dedup'd). New `parse_gff_id_list` shares the GffValue::String / GffValue::Array handling between the arms. The `tests/fixtures/annotation/flybase_micro.gff3` fixture is updated to actually carry a `Derives_from` row. 4 in-module tests on `Gff3Record::parse` + 1 integration test on `load_annotations`.

- **`refactor(tests): close AcceptedDivergence/SpecCitation axis+policy to enums (#397 item 2)`** — Replace free-form `String` fields on `AcceptedDivergence` and `SpecCitation` with closed enums `Axis` (8 variants, `#[serde(rename_all = "snake_case")]`) and `Policy` (1 variant today, extensible via PR). A typo in `cases.json` is now a hard parse error instead of a silent no-op. `AxisTally::axis` flips from `&'static str` → `Axis`; 19 `AxisTally::new(...)` call sites converted; all in-module test fixture constructions updated. `SpecCitation.section` stays `String` (out of scope for #397). 2 new typo-rejection tests pin the strict-deserialize contract.

- **`refactor(normalize): rename NormalizeResult + drop message field from diagnostic variants (#397 item 3)`** — Two paired changes. (a) Rename `NormalizeResultWithWarnings` → `NormalizeResult` and `normalize_with_warnings` → `normalize_with_diagnostics`. After PR #373 added the `infos` channel, the `WithWarnings` / `with_warnings` suffix no longer reflects the type's scope; `NormalizeResult` matches Rust idiom (`std::io::Result`) and the struct is the canonical "result of normalization" type. (b) Drop the per-variant `message: String` field from all 7 `NormalizationWarning` variants + 1 `NormalizationInfo` variant. Replace with `impl Display` synthesizing the message from structural fields; keep `.message() -> String` as ergonomic delegator. Touched 17 files via mechanical search-replace + 10 hand-edits at construction/declaration sites.

- **`ci(release-wheels): add musllinux smoke-test matrix entry (#397 item 4)`** — musllinux_1_2 wheels were built for x86_64 + aarch64 but the existing smoke-test matrix only ran on glibc/macOS/Windows. New `smoke-test-musllinux` job runs the same import + parse + `__eq__` + `__hash__` + eq_int pyclass checks against `python:<v>-alpine` (Python 3.10..3.14) via `docker run` from glibc Ubuntu hosts. Wired into `upload` + `publish-testpypi` `needs:` so a musllinux ABI regression blocks the release.

- **`ci: assert Cargo.toml abi3 floor matches pyproject.toml requires-python (#397 item 5)`** — New `abi3-floor-consistency` CI job extracts the `abi3-pyXY` feature flag from `Cargo.toml` and the `requires-python` spec from `pyproject.toml`, then uses `packaging.specifiers.SpecifierSet` to assert both that the abi3 floor satisfies the spec and that the immediately-lower minor does not. Catches drift in either direction.

- **`ci: surface reference-aware skip + add nightly manifest workflow (#397 item 6)`** — Two paired changes. PR CI gains a `::notice::` annotation announcing that the reference-aware mutalyzer / biocommons suites are skipped without `FERRO_MANIFEST` (previously silent in CI logs). New `nightly-mutalyzer.yml` workflow runs daily at 04:00 UTC, caches `ferro prepare --genome grch38` output keyed on `Cargo.lock` + `src/prepare/**` + `src/bin/ferro.rs`, then exercises the manifest-aware suites with `FERRO_MANIFEST` set. Failures surface via uploaded xfail artifact rather than failing the workflow — the nightly's role is drift detection, not gate enforcement.

- **`chore(pre-commit): add spec-fixture drift guard at pre-push (#397 item 7)`** — Add a `pre-push` stage hook running the same `generate_spec_fixture --check` that CI runs. Pre-push (not pre-commit) is the right stage: the check requires a build, so paying that cost per commit would be prohibitive, but per push it's the right cost-vs-coverage trade. Top-level `default_install_hook_types: [pre-commit, pre-push]` makes the bare `pre-commit install` wire both stages automatically.

- **`fix(review): apply end-of-issue review findings (#397)`** — End-of-issue Opus review found 1 BLOCKING (Item 4 alpine container Node-action footgun), 2 MAJOR (Item 3 ShuffleApplied Debug instead of Display; RefSeqMismatch dropped validation-layer context), 4 MINOR (CanonicalSplitSkipped spec citation; Item 5 regex robustness; Item 6 cache key surface; Item 7 hook auto-install), 1 NIT (stale line ref). All applied.

## Test plan

- [x] `cargo nextest run --features dev` — 5906 pass + 9 baseline failures (mutalyzer/biocommons `axis_*` divergences pre-existing on `origin/main`); zero new failures.
- [x] `cargo clippy --features dev -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo run --features dev --example generate_spec_fixture -- --check` clean.
- [x] All new tests across items 1, 2 pass; item 3 reshapes one existing test (`tests/issue_330_info_code_surface.rs`) to assert structural content of the synthesized message instead of exact string equality.

## Notes for reviewers

- Item 3 is the most intrusive item by line count (17 files mostly via mechanical rename); the substantive code change is concentrated in `src/normalize/mod.rs` (Display impls + `details: Option<String>` on `RefSeqMismatch`).
- Items 4, 5, 6 are CI-only and won't run until merged; their YAML was validated locally with `python3 -c "import yaml; yaml.safe_load(...)"`. Item 5's SpecifierSet logic was verified against the current values in a local venv.
- Item 6 (nightly) and item 7 (pre-push hook) don't affect any merge gates today; they add coverage / dev-time guards.
- One commit (`8467ce2`) is unsigned because 1Password biometric approval failed mid-session (per the contributor guide's 3-attempt fallback). Will be re-signed after the next biometric session.
