### PR TITLE
refactor(parser): drop dead 0? clause in protein trans-allele shorthand (closes #424)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -2885,6 +2885,18 @@ fn parse_protein_trans_allele_shorthand(
         // (`[ACC:p.X];[0]`), where `NullAllele` / `UnknownAllele` remain
         // correct — see the pin
         // `protein_no_protein_roundtrip::bare_bracketed_zero_is_null_allele_not_no_protein`.
+        //
+        // Arm routing for the three protein no-protein input shapes inside a
+        // `p.`-prefixed trans-allele bracket (see the preamble block above
+        // for why the protein-coord context overrides the cross-coord
+        // `NullAllele` default for `[0]`):
+        // - `[0]`  → first arm, `NoProtein { predicted: false }` (certain
+        //   no-protein; the protein-coord override of the cross-coord
+        //   `NullAllele` shape pinned in `bare_bracketed_zero_is_null_allele_not_no_protein`).
+        // - `[0?]` → first arm, `NoProtein { predicted: true }` (canonical
+        //   spec form; Display emits this).
+        // - `[(0)]` → third arm, `NoProtein { predicted: true }` (tolerated
+        //   alternate input from #289; Display canonicalises to `[0?]`).
         let variant = if content == "0" || content == "0?" {
             let predicted = content == "0?";
             let dummy_pos = ProtPos::new(AminoAcid::Met, 1);
@@ -2896,22 +2908,21 @@ fn parse_protein_trans_allele_shorthand(
             })
         } else if content == "?" {
             HgvsVariant::UnknownAllele
-        } else if content == "(0)" || content == "0?" {
-            // `[(0)]` and `[0?]` are the predicted-no-protein forms inside a
-            // protein-coordinate compact-form trans-allele bracket. Both route
-            // to `ProteinEdit::NoProtein { predicted: true }` and Display
+        } else if content == "(0)" {
+            // `[(0)]` is the tolerated alternate input for predicted no-protein
+            // inside a protein-coordinate compact-form trans-allele bracket
+            // (issue #289), mirroring the bare dispatcher's
+            // `parse_whole_protein_no_protein` arm. Routes to
+            // `ProteinEdit::NoProtein { predicted: true }`; Display
             // canonicalises to `[0?]` (the HGVS spec form, per
-            // `recommendations/protein/deletion.md`).
+            // `recommendations/protein/deletion.md`). Without this arm,
+            // `parse_prot_interval` would try to consume `(0)` as a position
+            // and reject.
             //
-            // `[(0)]` is the tolerated alternate input from issue #289 (mirrors
-            // the dispatcher's `parse_whole_protein_no_protein` arm); `[0?]`
-            // is the canonical Display output and must parse back round-trip.
-            // Without these arms, `parse_prot_interval` would try to consume
-            // `(0)` / `0?` as a position and reject.
-            //
-            // Bare `[0]` keeps its cross-coordinate `NullAllele` meaning (per
-            // `protein_no_protein_roundtrip::bare_bracketed_zero_is_null_allele_not_no_protein`);
-            // `[(0)]` / `[0?]` are unambiguously protein no-protein forms.
+            // `[0?]` is handled by the first arm above (the canonical spec
+            // form) — see the arm-routing summary block above. Bare `[0]`
+            // keeps its cross-coordinate `NullAllele` meaning (per
+            // `protein_no_protein_roundtrip::bare_bracketed_zero_is_null_allele_not_no_protein`).
             let dummy_pos = ProtPos::new(AminoAcid::Met, 1);
             let dummy_interval = ProtInterval::point(dummy_pos);
             HgvsVariant::Protein(ProteinVariant {

--- a/tests/issue_289_protein_zero_predicted.rs
+++ b/tests/issue_289_protein_zero_predicted.rs
@@ -316,3 +316,64 @@ fn p_paren_zero_in_trans_allele_parses_and_displays() {
         "Display is a fixed point on the canonical trans form"
     );
 }
+
+/// Regression for issue #424: the canonical spec form `p.[0?];[X]` must route
+/// to `ProteinEdit::NoProtein { predicted: true }`. This is the first-arm
+/// path through `parse_protein_trans_allele_shorthand` (the arm that handles
+/// both `[0]` and `[0?]`, distinguishing them by `predicted`). The
+/// `[(0)]` form is covered by `p_paren_zero_in_trans_allele_parses_and_displays`
+/// above and routes through the third arm.
+///
+/// Pinning both arms as separate tests guards against a future refactor that
+/// collapses them and loses one of the input shapes — the third arm used to
+/// carry a dead `|| content == "0?"` clause that masked exactly this kind of
+/// loss.
+#[test]
+fn p_zero_question_in_trans_allele_parses_and_displays() {
+    use ferro_hgvs::hgvs::variant::AllelePhase;
+
+    let parsed = parse_hgvs("NP_000088.3:p.[0?];[Arg97Trp]")
+        .expect("NP_000088.3:p.[0?];[Arg97Trp] must parse — issue #424 first-arm regression");
+
+    let allele = match &parsed {
+        HgvsVariant::Allele(a) => a,
+        other => panic!("expected Allele, got {:?}", other),
+    };
+    assert_eq!(allele.phase, AllelePhase::Trans);
+    assert_eq!(allele.variants.len(), 2);
+
+    match protein_edit(&allele.variants[0]) {
+        ProteinEdit::NoProtein { predicted } => assert!(
+            *predicted,
+            "trans-allele [0?] arm must carry predicted=true"
+        ),
+        other => panic!(
+            "trans-allele [0?] arm did not route to NoProtein; got {:?}",
+            other
+        ),
+    }
+
+    // Spec form Displays back to itself byte-for-byte.
+    assert_eq!(format!("{}", parsed), "NP_000088.3:p.[0?];[Arg97Trp]");
+}
+
+/// Negative guard for issue #424: with the third arm now tightened to
+/// `content == "(0)"` (exact match), the double-marked shape `p.[(0?)];[X]`
+/// must reject — `(0?)` matches neither the first arm (exact `0` / `0?`),
+/// the second arm (`?`), nor the third arm (`(0)`), and falls through to
+/// the generic `parse_prot_interval` path which rejects the parens. The
+/// bare-form `p.(0?)` rejection is already pinned at
+/// `double_marked_p_paren_zero_question_rejects` above; this is the
+/// trans-allele bracket sibling.
+#[test]
+fn p_paren_zero_question_in_trans_allele_rejects() {
+    for bad in &[
+        "NP_000088.3:p.[(0?)];[Arg97Trp]",
+        "NP_000088.3:p.[Arg97Trp];[(0?)]",
+    ] {
+        assert!(
+            parse_hgvs(bad).is_err(),
+            "{bad:?} must reject (double-marked predicted in trans-allele bracket is not a spec form)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #424. Drops the unreachable `|| content == "0?"` clause from the third arm of `parse_protein_trans_allele_shorthand` (`src/hgvs/parser/variant.rs`). The first arm already matches `content == "0" || content == "0?"`, so the third arm's `0?` clause was dead code.

Pure cleanup — no behavior change. The third arm still matches `[(0)]` via `content == "(0)"`, and `[0?]` still routes through the first arm with `predicted` set from `content == "0?"`.

## Changes

- `src/hgvs/parser/variant.rs`: drop dead clause; add an arm-routing summary doc block above the if/else cascade documenting which input shape (`[0]`, `[0?]`, `[(0)]`) goes through which arm.
- `tests/issue_289_protein_zero_predicted.rs`: add `p_zero_question_in_trans_allele_parses_and_displays` next to the existing `p_paren_zero_in_trans_allele_parses_and_displays`. The pair pins both the first-arm (`[0?]`) and third-arm (`[(0)]`) routes to `ProteinEdit::NoProtein { predicted: true }`, guarding against a future refactor that collapses arms and silently loses one input shape — exactly the latent failure mode the dead clause was masking.

## Spec basis

`recommendations/protein/deletion.md` (no-protein forms). HGVS arbitration in #277 (follow-up to PR #130) determined `[0]` is `NullAllele` while `[0?]` / `[(0)]` are `NoProtein { predicted: true }`. This PR does not change that arbitration — only the redundant pattern match.

## Test plan

- [x] `cargo nextest run --features dev --test issue_289_protein_zero_predicted` — 14/14 pass (includes the new test)
- [x] `cargo nextest run --features dev --test issue_277_trans_allele_protein_zero --test protein_no_protein_roundtrip` — 22/22 pass
- [x] `cargo nextest run --features dev --test 'issue_*'` — 1291/1291 pass
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean