### PR TITLE
fix(error-handling): provider-aware W3016 for mixed-shape intronic-endpoint ranges (closes #429)

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -4,6 +4,9 @@
 //! in HGVS input strings.
 
 use super::types::{ErrorType, ResolvedAction};
+use crate::convert::mapper::CoordinateMapper;
+use crate::hgvs::location::CdsPos;
+use crate::reference::provider::ReferenceProvider;
 use std::cmp::min;
 
 /// A detected correction with its details.
@@ -2495,6 +2498,48 @@ fn next_char_end(bytes: &[u8], i: usize) -> usize {
 /// involves an offset or marker — computing length requires a provider
 /// in those cases.
 pub fn detect_length_mismatch(input: &str) -> Vec<DetectedCorrection> {
+    detect_length_mismatch_inner(input, None)
+}
+
+/// Provider-aware variant of [`detect_length_mismatch`]. Handles the
+/// mixed-shape intronic endpoint cases that the no-provider scan
+/// deliberately skips:
+///
+/// - different anchor bases (`c.100+5_200-3del...`),
+/// - opposite-sign offsets at the same anchor (`c.100+5_100-3del...`,
+///   intron-internal range across the anchor),
+/// - one exonic + one intronic endpoint (`c.100_200+5del...`).
+///
+/// Resolution path: parse the accession prefix of each ranged segment
+/// (`<ACC>:c.X_Ydel...`), look up the transcript via the provider, and
+/// resolve each endpoint to a genomic position via
+/// [`crate::convert::mapper::CoordinateMapper::cds_to_genomic_with_intron`].
+/// The reference-frame span is then `|g_end - g_start| + 1` (absolute
+/// value handles minus-strand transcripts where genomic order is
+/// reversed relative to transcript order).
+///
+/// Falls back to the no-provider behavior when:
+/// - the input has no accession prefix (compound-allele inner members
+///   without a fresh accession),
+/// - the provider lookup fails,
+/// - either endpoint can't be resolved to a genomic position
+///   (transcript missing genomic coords, offset outside any intron),
+/// - the axis is anything other than `c.` (only c. has the
+///   exon/intron coordinate system that benefits from this path; g./m./o.
+///   ranges already use the exonic same-axis branch).
+///
+/// #429 (follow-up to #390 item 5).
+pub fn detect_length_mismatch_with_provider(
+    input: &str,
+    provider: &dyn ReferenceProvider,
+) -> Vec<DetectedCorrection> {
+    detect_length_mismatch_inner(input, Some(provider))
+}
+
+fn detect_length_mismatch_inner(
+    input: &str,
+    provider: Option<&dyn ReferenceProvider>,
+) -> Vec<DetectedCorrection> {
     let mut hits = Vec::new();
     let bytes = input.as_bytes();
     if !has_non_protein_description(bytes) {
@@ -2508,14 +2553,46 @@ pub fn detect_length_mismatch(input: &str) -> Vec<DetectedCorrection> {
     // prefix appears) are also scanned so `c.[100A>G;200_205delAAAA]`
     // catches the inner `200_205delAAAA` (#390 item 4). Multiple ranges
     // per input are handled by continuing past each match.
+    //
+    // `last_accession_span` tracks the most recent accession prefix
+    // seen (the `ACC:` before a coord marker); `last_axis` tracks the
+    // axis byte at that marker. Compound-allele inner members inherit
+    // both. Used for the provider-aware path (#429) — without correct
+    // axis tracking, a `g.[X;Y]` compound's inner `Y` would be
+    // erroneously mis-routed through the c.-axis provider path.
     let mut i = 0usize;
+    let mut last_accession_span: Option<(usize, usize)> = None;
+    let mut last_axis: Option<u8> = None;
     while i + 1 < bytes.len() {
         let prev_ok = i == 0 || matches!(bytes[i - 1], b':' | b'(' | b'[' | b';');
         let is_coord =
             matches!(bytes[i], b'c' | b'g' | b'n' | b'm' | b'o' | b'r') && bytes[i + 1] == b'.';
         if prev_ok && is_coord {
+            // If the coord marker was preceded by `:`, capture the
+            // accession span ending at that `:`. Walk back over
+            // non-separator bytes to find the accession start.
+            if i > 0 && bytes[i - 1] == b':' {
+                let acc_end = i - 1;
+                let mut acc_start = acc_end;
+                while acc_start > 0
+                    && !matches!(
+                        bytes[acc_start - 1],
+                        b':' | b'(' | b'[' | b';' | b' ' | b'\t' | b'\n'
+                    )
+                {
+                    acc_start -= 1;
+                }
+                if acc_start < acc_end {
+                    last_accession_span = Some((acc_start, acc_end));
+                }
+            }
+            let axis = bytes[i];
+            last_axis = Some(axis);
             let start_idx = i + 2;
-            if let Some(hit) = try_detect_length_mismatch_at(bytes, input, start_idx) {
+            let accession = last_accession_span.map_or("", |(s, e)| &input[s..e]);
+            if let Some(hit) =
+                try_detect_length_mismatch_at(bytes, input, start_idx, axis, provider, accession)
+            {
                 hits.push(hit);
             }
             i = start_idx;
@@ -2523,14 +2600,26 @@ pub fn detect_length_mismatch(input: &str) -> Vec<DetectedCorrection> {
         }
         // Compound-allele inner-member fast path: a digit right after
         // `[` or `;` is the start of a range that inherits the outer
-        // axis. `try_detect_length_mismatch_at` returns `None` for
+        // axis + accession (no fresh `<axis>.` marker on the inner
+        // member). `try_detect_length_mismatch_at` returns `None` for
         // anything that isn't a `<int>_<int><edit><refseq>` pattern,
         // so over-triggering is safe. The `i > 0` guard prevents an
-        // underflow on the `bytes[i - 1]` index at the very first
-        // byte (where there's no preceding separator to consider).
+        // underflow on the `bytes[i - 1]` index at the very first byte.
+        //
+        // The axis is the outer axis captured above (`last_axis`).
+        // Falling back to a hard-coded `b'c'` would mis-route a
+        // `g.[X;Y]` compound's inner `Y` into the c.-axis provider
+        // path. The axis-guard inside `try_detect_length_mismatch_at`
+        // ensures provider resolution only fires on the spec-supported
+        // c. axis; non-`c.` outer axes therefore correctly skip the
+        // provider path on inner members too.
         let prev_is_compound_separator = i > 0 && matches!(bytes[i - 1], b'[' | b';');
         if prev_is_compound_separator && bytes[i].is_ascii_digit() {
-            if let Some(hit) = try_detect_length_mismatch_at(bytes, input, i) {
+            let axis = last_axis.unwrap_or(b'c');
+            let accession = last_accession_span.map_or("", |(s, e)| &input[s..e]);
+            if let Some(hit) =
+                try_detect_length_mismatch_at(bytes, input, i, axis, provider, accession)
+            {
                 hits.push(hit);
             }
         }
@@ -2542,10 +2631,19 @@ pub fn detect_length_mismatch(input: &str) -> Vec<DetectedCorrection> {
 
 /// Try to detect a length-mismatch at `pos` (right after a coord marker
 /// like `.c.`). Returns the detection on success.
+///
+/// `axis` is the coord-system byte (`b'c'`, `b'g'`, etc.) so the
+/// provider-aware path knows whether to invoke `c.`-specific
+/// resolution. `accession` is the prefix accession (e.g. `NM_000088.3`)
+/// — empty when none is present; the provider-aware path only fires
+/// when both `provider` and a non-empty `accession` are available.
 fn try_detect_length_mismatch_at(
     bytes: &[u8],
     input: &str,
     pos: usize,
+    axis: u8,
+    provider: Option<&dyn ReferenceProvider>,
+    accession: &str,
 ) -> Option<DetectedCorrection> {
     // Endpoint 1: bare integer with optional `+offset` / `-offset`.
     let (start_base, start_off, mut j) = parse_endpoint_with_offset(bytes, pos)?;
@@ -2562,9 +2660,13 @@ fn try_detect_length_mismatch_at(
     //   (b) Both intronic with the same anchor base and same-sign
     //       offsets (`c.100+5_100+10` or `c.100-5_100-2`): the span
     //       is linear inside the intron, length = `|off2 - off1| + 1`.
-    // Anything else (one exonic + one intronic, mixed-sign offsets,
-    // different anchor bases) needs the intron length to resolve —
-    // the W3016 scan skips those cases rather than guess (#390 item 5).
+    //   (c) Mixed-shape (different anchors / opposite signs / one
+    //       exonic + one intronic): provider-aware resolution via the
+    //       transcript's c→g mapper. Only fires on the `c.` axis when
+    //       `provider` and `accession` are both available. #429
+    //       (follow-up to #390 item 5).
+    // Without a provider, mixed-shape inputs are skipped (no false
+    // positives, no panic).
     let range_len = match (start_off, end_off) {
         (0, 0) => {
             if end_base < start_base {
@@ -2578,7 +2680,24 @@ fn try_detect_length_mismatch_at(
             }
             (eo - so + 1) as usize
         }
-        _ => return None,
+        _ => {
+            // Mixed-shape: try provider-aware resolution. Only the
+            // `c.` axis carries the exon/intron coordinate system that
+            // the c→g mapper resolves; other axes fall through to the
+            // skip (per the issue's scoping).
+            if axis != b'c' || accession.is_empty() {
+                return None;
+            }
+            let provider = provider?;
+            let g_start =
+                resolve_cds_endpoint_to_genomic(provider, accession, start_base, start_off)?;
+            let g_end = resolve_cds_endpoint_to_genomic(provider, accession, end_base, end_off)?;
+            // Absolute difference handles both plus-strand (g_end >
+            // g_start) and minus-strand (g_start > g_end) transcripts;
+            // the W3016 length check only cares about the reference-frame
+            // span magnitude.
+            (g_start.max(g_end) - g_start.min(g_end) + 1) as usize
+        }
     };
 
     // Identify the edit keyword. Order matters: `delins` is a prefix of
@@ -2683,6 +2802,33 @@ fn parse_endpoint_with_offset(bytes: &[u8], pos: usize) -> Option<(i64, i64, usi
         j = o;
     }
     Some((base, offset, j))
+}
+
+/// Provider-aware resolver: convert a `c.` endpoint (`base`, `offset`)
+/// to a genomic position via the transcript's c→g mapper. Returns
+/// `None` when the transcript is missing genomic coords, the offset
+/// can't be located in any intron, or `cds_to_genomic_with_intron`
+/// otherwise fails. Used by the mixed-shape W3016 path (#429).
+fn resolve_cds_endpoint_to_genomic(
+    provider: &dyn ReferenceProvider,
+    accession: &str,
+    base: i64,
+    offset: i64,
+) -> Option<u64> {
+    // The backward accession scan stops at `(` / `[` / `;` separators but
+    // does not strip a trailing `)` left by a `NG_...(NM_...):c.` selector,
+    // so the captured span can be `NM_004006.2)`. Trim enclosing
+    // parentheses / whitespace before the provider lookup so the
+    // transcript id resolves cleanly (mixed-shape W3016, #429).
+    let accession = accession.trim_matches(|c| matches!(c, '(' | ')' | ' ' | '\t' | '\n'));
+    let transcript = provider.get_transcript(accession).ok()?;
+    let mapper = CoordinateMapper::new(&transcript);
+    let cds_pos = CdsPos {
+        base,
+        offset: if offset == 0 { None } else { Some(offset) },
+        utr3: false,
+    };
+    mapper.cds_to_genomic_with_intron(&cds_pos).ok()
 }
 
 /// Consume an IUPAC nucleotide run at `pos`. Returns the substring; empty

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -10,13 +10,14 @@ use super::corrections::{
     correct_old_substitution_syntax, correct_protein_arrow, correct_quote_characters,
     correct_redundant_repeat_label, correct_rna_thymine, correct_single_letter_aa_in_protein,
     correct_single_position_range, correct_swapped_positions, correct_whitespace,
-    detect_del_size_suffix, detect_deprecated_ivs, detect_length_mismatch, detect_missing_versions,
-    detect_position_zero, detect_protein_bracketed_aa_insertion, strip_trailing_annotation,
-    DetectedCorrection,
+    detect_del_size_suffix, detect_deprecated_ivs, detect_length_mismatch,
+    detect_length_mismatch_with_provider, detect_missing_versions, detect_position_zero,
+    detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
 };
 use super::types::{ErrorType, ResolvedAction};
 use super::ErrorConfig;
 use crate::error::{Diagnostic, ErrorCode, FerroError, SourceSpan};
+use crate::reference::provider::ReferenceProvider;
 
 /// Warning about a correction made during preprocessing.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +165,40 @@ impl InputPreprocessor {
     ///
     /// Applies corrections based on the configured error handling mode.
     pub fn preprocess(&self, input: &str) -> PreprocessResult {
+        self.preprocess_inner(input, None)
+    }
+
+    /// Preprocess the input string with a `ReferenceProvider` available
+    /// for provider-aware corrections.
+    ///
+    /// Identical to [`Self::preprocess`] except that the W3016
+    /// length-mismatch phase can resolve mixed-shape intronic-endpoint
+    /// ranges (e.g. `c.100+5_200-3del...`) via the provider's
+    /// transcript map. Without a provider those shapes silently skip
+    /// (per #390 item 5's "deliberately skipped" contract); with a
+    /// provider they're either flagged as mismatches or pass cleanly
+    /// based on the resolved genomic span (#429).
+    ///
+    /// Falls back to the no-provider behavior for every shape the
+    /// no-provider variant already handles — `preprocess_with_provider`
+    /// strictly extends, never replaces, the corrections surface.
+    pub fn preprocess_with_provider(
+        &self,
+        input: &str,
+        provider: &dyn ReferenceProvider,
+    ) -> PreprocessResult {
+        self.preprocess_inner(input, Some(provider))
+    }
+
+    /// Shared preprocessing implementation. `provider` is `Some` when
+    /// invoked via [`Self::preprocess_with_provider`], `None` otherwise.
+    /// Currently only the W3016 length-mismatch phase consults the
+    /// provider; every other correction phase ignores it.
+    fn preprocess_inner(
+        &self,
+        input: &str,
+        provider: Option<&dyn ReferenceProvider>,
+    ) -> PreprocessResult {
         // Start with the original input
         let mut current = input.to_string();
         let mut all_warnings = Vec::new();
@@ -857,7 +892,14 @@ impl InputPreprocessor {
         // (W3016 — HGVS spec recommendations/general.md range semantics).
         // `warn_accept` semantics: lenient warns without rewriting (no safe
         // auto-correction), strict rejects.
-        let length_mismatch_hits = detect_length_mismatch(&current);
+        // Provider-aware when available so mixed-shape intronic-endpoint
+        // ranges (`c.100+5_200-3del...`, `c.100_200+5del...`, etc.) are
+        // also length-checked. Without a provider, the same detector
+        // runs but silently skips those shapes (#429).
+        let length_mismatch_hits = match provider {
+            Some(p) => detect_length_mismatch_with_provider(&current, p),
+            None => detect_length_mismatch(&current),
+        };
         if !length_mismatch_hits.is_empty() {
             let action = self.action_for(ErrorType::LengthMismatch);
             match action {

--- a/tests/issue_429_w3016_mixed_endpoints.rs
+++ b/tests/issue_429_w3016_mixed_endpoints.rs
@@ -1,0 +1,358 @@
+//! Issue #429 — provider-aware W3016 length-mismatch detection for
+//! mixed-shape intronic-endpoint ranges.
+//!
+//! PR #406 (#390 item 5) added the same-anchor + same-sign intronic
+//! detection but explicitly skipped mixed-shape inputs because
+//! computing the actual span requires intron-length data only
+//! available through a `ReferenceProvider`. This file pins the
+//! provider-aware extension:
+//!
+//!   - `c.100+5_200-3del<refseq>`: both intronic, different anchors.
+//!   - `c.100+5_100-3del<refseq>`: same anchor, opposite signs.
+//!   - `c.100_200+5del<refseq>`: one exonic + one intronic.
+//!
+//! The no-provider variant (`detect_length_mismatch`) continues to
+//! silently skip these shapes — confirmed by the no-provider parity
+//! tests below.
+//!
+//! # Test fixture shape
+//!
+//! Two-exon transcript on the plus strand. Genomic layout:
+//!
+//!   ```text
+//!   genomic:  1000 ........ 1099  | 2000 ........ 2099
+//!             [-- exon 1 ---]      [-- exon 2 ---]
+//!   tx:       1 ........ 100       101 ........ 200
+//!   ```
+//!
+//! Intron between genomic [1100, 1999] (length 900). CDS spans the
+//! full transcript (cds_start=1, cds_end=200).
+
+use ferro_hgvs::error_handling::corrections::{
+    detect_length_mismatch, detect_length_mismatch_with_provider,
+};
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{
+    Exon, GenomeBuild, ManeStatus, Strand as TxStrand, Transcript,
+};
+
+const ACC: &str = "NM_TEST.1";
+
+/// Build a two-exon plus-strand transcript with a 900-bp intron.
+/// CDS spans the full transcript. Used by all provider-aware tests.
+fn two_exon_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    // Exon 1: tx 1..100 ↔ genomic 1000..1099.
+    let e1 = Exon::with_genomic(1, 1, 100, 1000, 1099);
+    // Exon 2: tx 101..200 ↔ genomic 2000..2099.
+    let e2 = Exon::with_genomic(2, 101, 200, 2000, 2099);
+    provider.add_transcript(Transcript::new(
+        ACC.to_string(),
+        Some("TEST".to_string()),
+        TxStrand::Plus,
+        None::<String>,
+        Some(1),
+        Some(200),
+        vec![e1, e2],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(2099),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    provider
+}
+
+// =============================================================================
+// No-provider parity: mixed-shape inputs continue to silently skip
+// =============================================================================
+
+#[test]
+fn no_provider_mixed_anchor_different_offsets_silently_skips() {
+    // `c.100+5_200-3delAAAA` — without a provider, the detector skips
+    // (per #390 item 5's "deliberately skipped" contract).
+    let input = format!("{ACC}:c.100+5_200-3delAAAA");
+    let hits = detect_length_mismatch(&input);
+    assert!(
+        hits.is_empty(),
+        "no-provider mixed-shape input must silently skip; got {hits:?}",
+    );
+}
+
+#[test]
+fn no_provider_mixed_axis_exonic_intronic_silently_skips() {
+    let input = format!("{ACC}:c.100_200+5delAAAA");
+    let hits = detect_length_mismatch(&input);
+    assert!(
+        hits.is_empty(),
+        "no-provider exonic-intronic input must silently skip; got {hits:?}",
+    );
+}
+
+// =============================================================================
+// Provider-aware detection: each mixed-shape pattern resolves cleanly
+// =============================================================================
+
+/// `c.100+5_101-3delAAAA`: both endpoints in the SAME intron
+/// (the intron between exon 1 and exon 2), referenced from different
+/// boundaries.
+///
+/// - `100+5`: 5 bp into intron from the 5' boundary (after exon 1).
+///   Genomic = intron_5'_start + 5 - 1 = 1100 + 5 - 1 = 1104.
+/// - `101-3`: 3 bp before the 3' boundary (before exon 2). Genomic =
+///   intron_3'_end - 3 + 1 = 1999 - 3 + 1 = 1997.
+///
+/// Span = 1997 - 1104 + 1 = 894 bp. Declared ref seq `AAAA` = 4 bp →
+/// mismatch (894 != 4).
+#[test]
+fn provider_mixed_anchor_different_intronic_offsets_detects_mismatch() {
+    let provider = two_exon_provider();
+    let input = format!("{ACC}:c.100+5_101-3delAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert_eq!(
+        hits.len(),
+        1,
+        "provider-aware mixed-shape mismatch must surface exactly one hit; got {hits:?}",
+    );
+    // The hit's `original` field captures the span from just after the
+    // `c.` marker through the end of the ref seq (matches the existing
+    // detector's span convention).
+    assert!(
+        hits[0].original.contains("100+5_101-3delAAAA"),
+        "hit should cover the mismatched range; got original={:?}",
+        hits[0].original,
+    );
+}
+
+/// Same input but the ref seq matches the resolved span: no hit.
+/// The intron is 900 bp; the declared range `100+5_101-3` is
+/// genomic 1104..1997 = 894 bp. A 894-bp explicit `delN...` ref would
+/// match (impractical to spell out — use a much smaller in-range
+/// example to confirm the no-mismatch path doesn't fire).
+#[test]
+fn provider_intron_internal_same_intron_consistent_no_hit() {
+    let provider = two_exon_provider();
+    // `c.100+1_100+3delAAA`: both intronic, same anchor (100), same
+    // sign (+). Span = 3 bp. Ref = 3 bp. Match — no hit. This shape
+    // is already handled by the same-anchor + same-sign branch, so
+    // the no-provider variant also returns empty. Asserted as a
+    // baseline that the provider path doesn't introduce false
+    // positives on the already-handled shape.
+    let input = format!("{ACC}:c.100+1_100+3delAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert!(
+        hits.is_empty(),
+        "consistent length on already-handled shape must not produce a hit; got {hits:?}",
+    );
+}
+
+/// One exonic + one intronic: `c.100_100+5delAAAA`.
+/// Start at exonic c.100 → genomic 1099 (end of exon 1).
+/// End at intronic 100+5 → genomic 1100 + 5 - 1 = 1104.
+/// Span = 1104 - 1099 + 1 = 6 bp. Ref AAAA = 4 bp → mismatch.
+#[test]
+fn provider_exonic_to_intronic_detects_mismatch() {
+    let provider = two_exon_provider();
+    let input = format!("{ACC}:c.100_100+5delAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert_eq!(
+        hits.len(),
+        1,
+        "exonic-to-intronic mixed-shape must surface a hit when ref length disagrees; got {hits:?}",
+    );
+}
+
+/// Exonic-to-intronic with a matching ref seq: no hit.
+#[test]
+fn provider_exonic_to_intronic_consistent_no_hit() {
+    let provider = two_exon_provider();
+    // `c.100_100+5delAAAAAA`: 6 bp ref = 6 bp span (genomic 1099..1104).
+    let input = format!("{ACC}:c.100_100+5delAAAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert!(
+        hits.is_empty(),
+        "matching ref length on exonic-to-intronic mixed-shape must not produce a hit; got {hits:?}",
+    );
+}
+
+/// Gene-in-parentheses transcript selector (`NG_...(NM_...):c.`): the
+/// backward accession scan stops at `(` but must not leave a trailing
+/// `)` on the captured id, or `get_transcript("NM_TEST.1)")` fails and
+/// the mixed-shape range is silently skipped. With the `)` trimmed, the
+/// provider lookup resolves and the mismatch is detected — same hit as
+/// the bare `NM_TEST.1:c.100+5_101-3delAAAA` form above.
+///
+/// Regression for the PR #436 CR finding on accession normalization.
+#[test]
+fn provider_gene_in_parens_selector_resolves_transcript() {
+    let provider = two_exon_provider();
+    let input = format!("NG_016465.4({ACC}):c.100+5_101-3delAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert_eq!(
+        hits.len(),
+        1,
+        "gene-in-parens selector must resolve the inner transcript and detect the mismatch; got {hits:?}",
+    );
+}
+
+// =============================================================================
+// Existing shapes continue to work under the provider-aware entry point
+// =============================================================================
+
+/// All-exonic `c.100_105delAAAA`: declared 4 bp, span is 6 bp → mismatch.
+/// The all-exonic path is handled by both no-provider and provider-aware
+/// variants (same branch). Pin that the provider entry point doesn't
+/// regress the existing shapes.
+#[test]
+fn provider_all_exonic_same_axis_detects_mismatch() {
+    let provider = two_exon_provider();
+    let input = format!("{ACC}:c.100_105delAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert_eq!(
+        hits.len(),
+        1,
+        "all-exonic mismatch must still surface; got {hits:?}"
+    );
+}
+
+/// Same-anchor same-sign intronic `c.100+5_100+10delAAAA`: declared
+/// 4 bp, span is 6 bp → mismatch. Handled by the (b) branch in the
+/// no-provider path; pin that provider-aware path also handles it.
+#[test]
+fn provider_same_anchor_same_sign_intronic_still_detects_mismatch() {
+    let provider = two_exon_provider();
+    let input = format!("{ACC}:c.100+5_100+10delAAAA");
+    let hits = detect_length_mismatch_with_provider(&input, &provider);
+    assert_eq!(
+        hits.len(),
+        1,
+        "same-anchor same-sign intronic mismatch must still surface; got {hits:?}",
+    );
+}
+
+// =============================================================================
+// Graceful fallback: unknown accession / no transcript → silent skip
+// =============================================================================
+
+#[test]
+fn provider_unknown_accession_silently_skips_mixed_shape() {
+    let provider = two_exon_provider();
+    // Accession not in provider — `get_transcript` returns Err →
+    // `resolve_cds_endpoint_to_genomic` returns None → mixed-shape
+    // path returns None → no hit. Crucially: no panic, no false
+    // positive.
+    let input = "NM_UNKNOWN.1:c.100+5_200-3delAAAA";
+    let hits = detect_length_mismatch_with_provider(input, &provider);
+    assert!(
+        hits.is_empty(),
+        "unknown accession must silently skip the mixed-shape path; got {hits:?}",
+    );
+}
+
+#[test]
+fn provider_g_axis_mixed_offsets_skipped_per_scope() {
+    // The provider-aware path is scoped to the `c.` axis. A g.-axis
+    // input with intronic-looking offsets (which would be malformed
+    // HGVS in practice but exercises the scope guard) silently skips.
+    let provider = two_exon_provider();
+    let input = "NC_000001.11:g.100+5_200-3delAAAA";
+    let hits = detect_length_mismatch_with_provider(input, &provider);
+    assert!(
+        hits.is_empty(),
+        "non-`c.` axis must skip the provider path; got {hits:?}",
+    );
+}
+
+/// Compound-allele inner member axis tracking: a `g.[X;Y]` compound's
+/// inner member must NOT be routed through the c.-axis provider path
+/// just because the outer accession is non-empty. Pre-fix, the inner
+/// dispatch always used a hardcoded `b'c'` axis byte, creating a
+/// latent false-positive risk on `g.` compounds. This test pins the
+/// fix that propagates the outer axis to inner members.
+#[test]
+fn provider_g_axis_compound_inner_member_skipped_per_scope() {
+    let provider = two_exon_provider();
+    // Outer axis is `g.`; the inner member `100+5_200-3delAAAA` would
+    // otherwise be a mixed-shape intronic range that the provider path
+    // could erroneously process. The axis guard (now correctly using
+    // the outer `g.` axis) must keep it out of the provider path.
+    let input = "NC_000001.11:g.[100A>G;100+5_200-3delAAAA]";
+    let hits = detect_length_mismatch_with_provider(input, &provider);
+    // The inner mixed-shape intronic range must not be processed via
+    // the provider path. The hit list may be empty or contain only the
+    // outer-axis exonic hit (none here). Crucially, NO mixed-shape hit
+    // appears that would imply c.-axis resolution against `NC_000001.11`.
+    for hit in &hits {
+        assert!(
+            !hit.original.contains("100+5_200-3delAAAA"),
+            "g.-compound inner member must not be c.-axis-resolved; \
+             got hit on the mixed-shape inner: {:?}",
+            hit.original,
+        );
+    }
+}
+
+// =============================================================================
+// Minus-strand resolution
+// =============================================================================
+
+/// Build a minus-strand two-exon transcript. Exon ordering follows
+/// transcript direction, but genomic coordinates are reversed:
+///
+///   ```text
+///   genomic:  1000 ........ 1099  | 2000 ........ 2099
+///                                     [-- exon 1 ---]      <- minus
+///             [-- exon 2 ---]                              <- minus
+///   tx:                                1 ........ 100
+///                                                  101 ........ 200
+///   ```
+///
+/// Equivalently: on minus strand, transcript 5' end maps to the
+/// HIGHER genomic position. Exon 1 (tx 1..100) maps to genomic
+/// 2000..2099 reversed; exon 2 (tx 101..200) maps to genomic
+/// 1000..1099 reversed.
+fn minus_strand_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let e1 = Exon::with_genomic(1, 1, 100, 2000, 2099);
+    let e2 = Exon::with_genomic(2, 101, 200, 1000, 1099);
+    provider.add_transcript(Transcript::new(
+        "NM_MINUS.1".to_string(),
+        Some("MTEST".to_string()),
+        TxStrand::Minus,
+        None::<String>,
+        Some(1),
+        Some(200),
+        vec![e1, e2],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(2099),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Minus-strand exonic-to-intronic span: detection must not break on
+/// the genomic-order-reversed case. The `|g_end - g_start| + 1`
+/// absolute-value formula handles minus strand transparently because
+/// the W3016 length check only cares about span magnitude.
+#[test]
+fn provider_minus_strand_exonic_to_intronic_detects_mismatch() {
+    let provider = minus_strand_provider();
+    let input = "NM_MINUS.1:c.100_100+5delAAAA";
+    let hits = detect_length_mismatch_with_provider(input, &provider);
+    // Whether the hit fires depends on the resolved span. The point
+    // here is that the call does not panic and produces a consistent
+    // shape (either a hit or an empty list, but never an error). The
+    // resolved span should be the same magnitude as the plus-strand
+    // case (6 bp) — declared 4 bp → mismatch.
+    assert_eq!(
+        hits.len(),
+        1,
+        "minus-strand exonic-to-intronic mismatch must surface a hit; got {hits:?}",
+    );
+}


### PR DESCRIPTION
## Summary

Closes #429. PR #406 (#390 item 5) added W3016 length-mismatch detection for intronic endpoint ranges in two shapes: both exonic, and both intronic with the same anchor base + same-sign offsets. Mixed-shape endpoints (different anchors, opposite-sign offsets, or one exonic + one intronic) were deliberately skipped because computing the actual span requires intron-length data only available through a `ReferenceProvider`. This PR completes the W3016 surface.

## New public API

* `detect_length_mismatch_with_provider(input, &dyn ReferenceProvider)` — same return shape as the existing `detect_length_mismatch`, but resolves mixed-shape `c.`-axis endpoints to genomic positions via `CoordinateMapper::cds_to_genomic_with_intron`. Reference-frame span is `|g_end - g_start| + 1` (absolute value handles minus-strand transcripts).
* Existing `detect_length_mismatch(input)` is unchanged — delegates to the shared inner with `provider = None`, preserving the "deliberately skipped" contract.

## Scope

* Provider-aware path fires only on `c.` axis with non-empty accession prefix. Other axes use the existing exonic same-axis branch.
* Falls back to skip (no panic, no false positive) when:
  - provider lookup fails (unknown accession);
  - either endpoint can't be resolved to a genomic position;
  - input has no accession prefix.

## Internal changes

`detect_length_mismatch_inner` now tracks the most recent accession span and the axis byte at each `c.`/`g.`/etc. marker, plumbed into `try_detect_length_mismatch_at` via two new parameters. The same-anchor + same-sign branch and the all-exonic branch are unchanged — only the previous `_ => return None` arm gained a provider-aware fallback.

## Test plan

- [x] New `tests/issue_429_w3016_mixed_endpoints.rs` — 10 cases covering provider-aware mixed-shape (different-anchor different-sign intronic, exonic-to-intronic mismatch + matching), regression for existing all-exonic + same-anchor same-sign shapes, no-provider parity (still skips), unknown accession fallback, non-`c.` axis scope guard.
- [x] Existing 32 tests in `issue_266_length_mismatch` + `issue_390_*` pass.
- [x] `cargo nextest run --features dev --test 'issue_*'` — 1300/1300 pass.
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.

## Spec basis

`assets/hgvs-nomenclature/docs/recommendations/general.md` range semantics — explicit reference-sequence forms `del<ref>` / `dup<ref>` / `inv<ref>` must satisfy `len(ref) == end - start + 1` in the reference frame. For c.-axis ranges that cross intron boundaries, the reference frame is the underlying genomic span (intron sequence is part of the deleted ref).