### PR TITLE
feat(normalize): expand ins[ACC:g.A_B] cross-reference to flat literal (closes #422)

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1779,11 +1779,116 @@ fn fetch_position_range_bases<P: ReferenceProvider>(
     provider.get_sequence(accession, tx_start - 1, tx_end)
 }
 
+/// Parse a cross-reference string (e.g.
+/// `"NC_000022.10:g.42536337_42536382"`) into its components for
+/// provider lookup. Returns `(accession, coord_kind, start, end)` on
+/// success.
+///
+/// Supports g./m./o./c./n. axes with simple positive-integer ranges
+/// (no offsets, no `*N`, no `?`, no `pter`/`qter` markers). Out-of-scope
+/// shapes return `None` so the caller can surface a focused
+/// `FerroError::UnsupportedVariant`. #422.
+///
+/// **Axis-set rationale:** the parser's `parse_reference_location`
+/// (`src/hgvs/parser/edit.rs`) accepts `g/c/m/n/r/p/o` axes for
+/// `Reference` strings. This helper accepts the subset that has a
+/// well-defined position-range fetch on the inner accession:
+///   - `g.`/`m.`/`o.`: genomic position-range fetch (`Direct`).
+///   - `c.`: CDS-relative; translated via the FOREIGN transcript's
+///     `cds_start` inside `fetch_position_range_bases`.
+///   - `n.`: non-coding transcript; positions are already transcript-
+///     relative (`Direct`).
+///
+/// **Deferred axes (`r.`, `p.`):** RNA needs U→T translation on the
+/// fetched bases (the existing `r.→g.` projection has the primitive
+/// but isn't wired here); protein is structurally invalid as a DNA-
+/// insertion payload. Both stay `UnsupportedVariant` for now. If
+/// `parse_reference_location` ever broadens to additional axes, keep
+/// the match arm below in sync.
+fn parse_cross_reference(reference: &str) -> Option<(String, InsCoordKind, u64, u64)> {
+    let (acc_part, after_colon) = reference.split_once(':')?;
+    // Minimum well-formed shape: `g.A_B` = 5 chars (axis + dot + start
+    // + underscore + end).
+    if acc_part.is_empty() || after_colon.len() < 5 {
+        return None;
+    }
+    let coord_byte = *after_colon.as_bytes().first()?;
+    if after_colon.as_bytes().get(1) != Some(&b'.') {
+        return None;
+    }
+    // c. requires CDS translation via the foreign transcript's cds_start;
+    // g./m./o./n. are direct position-range fetches on the inner accession.
+    // r. and p. are deferred — see the doc-comment above.
+    let kind = match coord_byte {
+        b'g' | b'm' | b'o' | b'n' => InsCoordKind::Direct,
+        b'c' => InsCoordKind::Cds,
+        _ => return None,
+    };
+    let range_str = &after_colon[2..];
+    let (start_str, end_str) = range_str.split_once('_')?;
+    if start_str.is_empty() || end_str.is_empty() {
+        return None;
+    }
+    // Reject any decoration: offsets (`+`/`-`), UTR markers (`*`),
+    // unknown markers (`?`), pter/qter/cen. Only positive-integer
+    // ranges in scope per the issue's acceptance criteria.
+    if !start_str.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if !end_str.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let start: u64 = start_str.parse().ok()?;
+    let end: u64 = end_str.parse().ok()?;
+    Some((acc_part.to_string(), kind, start, end))
+}
+
+/// Resolve a cross-reference string to its literal sequence via the
+/// provider. Routes through `fetch_position_range_bases` for the
+/// position-translation logic (`Cds` arm translates via the foreign
+/// transcript's `cds_start`; `Direct` arm fetches directly). The
+/// outer variant's accession is not used here — the inner reference
+/// carries its own accession.
+///
+/// Cross-chromosome translocations (e.g.
+/// `NC_000002.12:g.X_Y delins[NC_000011.10:g.A_B]`) are supported as
+/// long as both accessions are present in the provider; otherwise the
+/// inner lookup returns `FerroError::ReferenceNotFound` citing the
+/// missing accession. #422.
+/// The shape-based (provider-independent) `UnsupportedVariant` error for
+/// a cross-reference whose form is out of scope (`parse_cross_reference`
+/// returned `None`). Shared by `resolve_cross_reference_bases` and the
+/// `detect_deferred_part` pre-scan so the same message is surfaced
+/// whether the unsupported `ExternalRef` is reached during expansion or
+/// caught up front (which is what makes the deferral order-independent).
+fn cross_reference_shape_error(reference: &str) -> FerroError {
+    FerroError::UnsupportedVariant {
+        variant_type: format!(
+            "ins[{}] cross-reference shape not yet supported. \
+             Expansion currently covers g./m./o./c./n. axes with simple \
+             positive-integer ranges. Out-of-scope: r. (RNA — needs U->T \
+             translation; see follow-up), p. (protein — structurally \
+             invalid as DNA-insertion payload), offsets (+/-), UTR \
+             markers (*N), unknown markers (?), and pter/qter/cen \
+             decorations",
+            reference,
+        ),
+    }
+}
+
+fn resolve_cross_reference_bases<P: ReferenceProvider>(
+    reference: &str,
+    provider: &P,
+) -> Result<String, FerroError> {
+    let (acc, kind, start, end) =
+        parse_cross_reference(reference).ok_or_else(|| cross_reference_shape_error(reference))?;
+    fetch_position_range_bases(&acc, start, end, kind, provider)
+}
+
 /// Append bases of an `InsertedPart` to `out` if the part is a
 /// flat-resolvable form. Returns `Err(FerroError::UnsupportedVariant)`
-/// for the two deferred shapes (cross-reference accession, intronic-
-/// offset CDS range). Returns `Err(...)` for genuine provider lookup
-/// failures.
+/// for the remaining deferred shape (intronic-offset CDS range).
+/// Returns `Err(...)` for genuine provider lookup failures.
 ///
 /// Returns `Ok(false)` if the part is not flat-resolvable in a way the
 /// caller should treat as "leave the variant alone" (currently never —
@@ -1839,22 +1944,35 @@ fn append_part_bases<P: ReferenceProvider>(
             Ok(false)
         }
         InsertedPart::ExternalRef(reference) => {
-            // Same as `InsertedSequence::Reference`, but inside a
-            // Complex bracket (e.g. `ins[A;NC_000022.11:g.100_200]`).
-            Err(FerroError::UnsupportedVariant {
-                variant_type: format!(
-                    "ins[{}] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
-                    reference
-                ),
-            })
+            // Cross-reference inside a Complex bracket (e.g.
+            // `ins[A;NC_000022.11:g.100_200]`). Resolve via the
+            // shared cross-reference resolver, which routes through
+            // `fetch_position_range_bases` for c.-axis CDS translation
+            // and direct position fetch for g./m./o./n. axes. The
+            // resolved bases are appended to the surrounding flat
+            // payload — `[A; cross-ref]` becomes `[A; <bases>]` and
+            // ultimately a single `Literal("A" + <bases>)`. #422.
+            let bases = resolve_cross_reference_bases(reference, provider)?;
+            out.push_str(&bases);
+            Ok(true)
         }
     }
 }
 
-/// Pre-scan parts for deferred shapes — cross-reference (`ExternalRef`)
-/// or intronic-offset CDS range (`CdsPositionRange`). Returns the first
-/// deferred-shape error encountered so callers report it even when an
-/// earlier part is a non-flatten shape (e.g. `Repeat`).
+/// Pre-scan parts for shape-based deferred shapes that must be surfaced
+/// regardless of part order:
+///
+/// - intronic-offset CDS range (`CdsPositionRange`), and
+/// - an out-of-scope cross-reference (`ExternalRef` whose form
+///   `parse_cross_reference` cannot handle — r./p. axes, offsets, UTR
+///   markers, `pter`/`qter`, etc.).
+///
+/// Both are *shape* deferrals (provider-independent), unlike a resolvable
+/// `ExternalRef` or same-reference `PositionRange` whose lookup needs the
+/// provider. Catching them up front means a leading non-flatten part
+/// (e.g. `Repeat`) that short-circuits `expand_complex_parts` to
+/// `Ok(None)` can no longer mask a later unsupported cross-reference —
+/// the deferral is order-independent. #422.
 fn detect_deferred_part(parts: &[InsertedPart]) -> Option<FerroError> {
     for part in parts {
         match part {
@@ -1866,13 +1984,8 @@ fn detect_deferred_part(parts: &[InsertedPart]) -> Option<FerroError> {
                     ),
                 });
             }
-            InsertedPart::ExternalRef(reference) => {
-                return Some(FerroError::UnsupportedVariant {
-                    variant_type: format!(
-                        "ins[{}] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
-                        reference
-                    ),
-                });
+            InsertedPart::ExternalRef(reference) if parse_cross_reference(reference).is_none() => {
+                return Some(cross_reference_shape_error(reference));
             }
             _ => {}
         }
@@ -1884,11 +1997,13 @@ fn detect_deferred_part(parts: &[InsertedPart]) -> Option<FerroError> {
 /// literal sequence, or return `Ok(None)` if at least one part is not
 /// expandable in scope (e.g. a `Repeat { base, count }` member).
 ///
-/// Deferred shapes — `ExternalRef` (cross-reference) and
-/// `CdsPositionRange` (intronic-offset) — are reported as
+/// Deferred shapes — currently only `CdsPositionRange` (intronic-offset
+/// or UTR-marker range) — are reported as
 /// `Err(FerroError::UnsupportedVariant)` even when an earlier part is
 /// non-flatten, because preserving a `Complex` that contains an
-/// unprocessable cross-reference would otherwise silently pass through.
+/// unresolvable CDS-offset range would otherwise silently pass through.
+/// `ExternalRef` was deferred prior to #422; the cross-reference
+/// resolver now handles it via `append_part_bases`.
 pub(crate) fn expand_complex_parts<P: ReferenceProvider>(
     parts: &[InsertedPart],
     accession: &str,
@@ -1907,7 +2022,10 @@ pub(crate) fn expand_complex_parts<P: ReferenceProvider>(
         if !resolved {
             // A part we don't flatten (e.g. Repeat) keeps the whole
             // Complex shape intact — partial flattening would silently
-            // drop semantic content.
+            // drop semantic content. Shape-unsupported parts (CDS-offset
+            // ranges, out-of-scope cross-references) are already surfaced
+            // by `detect_deferred_part` above, so returning here cannot
+            // mask them regardless of part order.
             return Ok(None);
         }
     }
@@ -1929,12 +2047,18 @@ pub(crate) fn expand_complex_parts<P: ReferenceProvider>(
 ///   `Complex` shapes that contain at least one non-flat part).
 /// - `Ok(Some(new_seq))` — a flat `Literal` rewrite for callers to
 ///   substitute in place of the input.
-/// - `Err(FerroError::UnsupportedVariant)` — a deferred shape
-///   (cross-reference accession, intronic-offset CDS range) that the
-///   spec permits but ferro does not yet expand. Errors carry the
-///   grep-friendly tags `"cross-reference"` / `"intronic"` and
-///   `"follow-up"` in their message.
-/// - `Err(FerroError::...)` — genuine provider lookup failure.
+/// - `Err(FerroError::UnsupportedVariant)` — a deferred shape that
+///   the spec permits but ferro does not yet expand. Two categories:
+///   - **Intronic-offset / UTR-marker CDS range** (`CdsPositionRange`):
+///     spec-undefined; error carries the grep tag `"CDS-offset range"`
+///     and `"follow-up"`.
+///   - **Out-of-scope cross-reference** (r./p. axes, or `pter`/`qter`
+///     decoration, etc.): error carries `"cross-reference"` and
+///     describes the supported axis set. Simple positive-integer
+///     ranges on g./m./o./c./n. are now expanded (#422) and no
+///     longer surface as errors.
+/// - `Err(FerroError::...)` — genuine provider lookup failure
+///   (`ReferenceNotFound`, `InvalidCoordinates`, etc.).
 pub fn expand_inserted_sequence<P: ReferenceProvider>(
     seq: &InsertedSequence,
     accession: &str,
@@ -1942,24 +2066,36 @@ pub fn expand_inserted_sequence<P: ReferenceProvider>(
     provider: &P,
 ) -> Result<Option<InsertedSequence>, FerroError> {
     match seq {
-        // `Reference("ACC:coord_a_b")`: cross-reference to another
-        // accession. Spec permits, ferro defers.
-        InsertedSequence::Reference(reference) => Err(FerroError::UnsupportedVariant {
-            variant_type: format!(
-                "ins[{}] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
-                reference
-            ),
-        }),
+        // `Reference("ACC:coord_a_b")`: bare cross-reference (no
+        // surrounding Complex bracket). Resolve via the shared
+        // cross-reference resolver. #422.
+        //
+        // Same-accession optimization: when the inner accession
+        // matches the outer variant's accession, the resolver still
+        // routes through `fetch_position_range_bases` — the helper
+        // already handles same-accession lookups efficiently, so no
+        // extra branch is needed here.
+        InsertedSequence::Reference(reference) => {
+            let bases = resolve_cross_reference_bases(reference, provider)?;
+            let seq = Sequence::from_str(&bases).map_err(|_| FerroError::ConversionError {
+                msg: format!(
+                    "expanded ins[{}] cross-reference payload contains non-IUPAC base in {:?}",
+                    reference, bases
+                ),
+            })?;
+            Ok(Some(InsertedSequence::Literal(seq)))
+        }
 
         // Same-reference position range — expand directly.
         InsertedSequence::PositionRange { start, end } => {
             let bases = fetch_position_range_bases(accession, *start, *end, kind, provider)?;
-            let bases_seq = Sequence::from_str(&bases).map_err(|_| FerroError::ConversionError {
-                msg: format!(
-                    "expanded ins[{}..={}] payload contains non-IUPAC base in {:?}",
-                    start, end, bases
-                ),
-            })?;
+            let bases_seq =
+                Sequence::from_str(&bases).map_err(|_| FerroError::ConversionError {
+                    msg: format!(
+                        "expanded ins[{}..={}] payload contains non-IUPAC base in {:?}",
+                        start, end, bases
+                    ),
+                })?;
             Ok(Some(InsertedSequence::Literal(bases_seq)))
         }
         InsertedSequence::PositionRangeInv { start, end } => {

--- a/tests/con_conversion_audit.rs
+++ b/tests/con_conversion_audit.rs
@@ -239,28 +239,30 @@ fn normalize_canonicalizes_conversion_to_delins() {
     let provider = MockProvider::new();
     let normalizer = Normalizer::new(provider);
 
-    // Cross-reference sources: deferred with UnsupportedVariant.
+    // Cross-reference sources: #422 wired actual lookup through the
+    // cross-reference resolver, so an empty provider surfaces the
+    // missing inner accession via `ReferenceNotFound` rather than the
+    // earlier `UnsupportedVariant` placeholder. The semantic point —
+    // "the recursion does not pass the bracketed form through
+    // unchanged" — is preserved.
     let cross_ref_inputs = [
         "NM_000088.3:c.123_456conNM_000089.1:c.789_1011",
         "NC_000001.11:g.12345_12400conNC_000002.12:g.100_155",
     ];
     for input in cross_ref_inputs {
         let variant = parse_hgvs(input).expect("input must parse");
-        let err = normalizer.normalize(&variant).expect_err(
-            "cross-reference con payload must surface as UnsupportedVariant after recursion",
-        );
+        let err = normalizer
+            .normalize(&variant)
+            .expect_err("cross-reference con payload must error against an empty provider");
         assert!(
-            matches!(err, ferro_hgvs::FerroError::UnsupportedVariant { .. }),
-            "expected UnsupportedVariant for cross-reference con (input: {}, got: {:?})",
+            matches!(
+                err,
+                ferro_hgvs::FerroError::ReferenceNotFound { .. }
+                    | ferro_hgvs::FerroError::GenomicReferenceNotAvailable { .. }
+            ),
+            "expected provider-lookup error for cross-reference con without test data (input: {}, got: {:?})",
             input,
             err
-        );
-        let msg = format!("{}", err);
-        assert!(
-            msg.contains("cross-reference") && msg.contains("follow-up"),
-            "cross-reference deferral must mention 'cross-reference' and 'follow-up' for grep (input: {}, got: {})",
-            input,
-            msg
         );
     }
 
@@ -490,30 +492,27 @@ fn allele_compound_with_conversion_canonicalizes_member() {
 
     let input = "NM_000088.3:c.[123_456conNM_000089.1:c.789_1011;500A>G]";
     let variant = parse_hgvs(input).expect("compound con+sub must parse");
-    // Under issue #333 the recursion drives the `con` member's rewrite
-    // through the ins-expand step. The cross-reference half defers with
-    // `FerroError::UnsupportedVariant`, which propagates up out of the
-    // allele compound — the substitution sibling is no longer reachable
+    // Under #333 + #422 the recursion drives the `con` member's rewrite
+    // through the ins-expand step. The cross-reference half now hits
+    // the actual resolver, which surfaces `ReferenceNotFound` against
+    // the empty provider — the substitution sibling is unreachable
     // because the compound short-circuits on the first member error.
-    // We assert the deferral surfaces with the expected markers and
-    // mentions the deferred source accession.
     let err = normalizer
         .normalize(&variant)
-        .expect_err("cross-reference con member must defer with UnsupportedVariant");
+        .expect_err("cross-reference con member must surface a provider-lookup error");
     assert!(
-        matches!(err, ferro_hgvs::FerroError::UnsupportedVariant { .. }),
-        "expected UnsupportedVariant for cross-reference con member, got: {:?}",
+        matches!(
+            err,
+            ferro_hgvs::FerroError::ReferenceNotFound { .. }
+                | ferro_hgvs::FerroError::GenomicReferenceNotAvailable { .. }
+        ),
+        "expected provider-lookup error for cross-reference con member, got: {:?}",
         err
     );
     let msg = format!("{}", err);
     assert!(
         msg.contains("NM_000089.1"),
-        "deferral message must mention the cross-reference source accession; got {}",
-        msg
-    );
-    assert!(
-        msg.contains("cross-reference") && msg.contains("follow-up"),
-        "deferral message must carry 'cross-reference' / 'follow-up' markers; got {}",
+        "lookup error must cite the missing source accession; got {}",
         msg
     );
 }
@@ -570,24 +569,25 @@ fn cross_reference_canonicalization_preserves_source_payload() {
         let variant = parse_hgvs(input).expect("parse");
         let err = normalizer
             .normalize(&variant)
-            .expect_err("cross-reference con must defer with UnsupportedVariant");
+            .expect_err("cross-reference con must surface a provider-lookup error");
+        // #422 replaced the `UnsupportedVariant` placeholder with actual
+        // cross-reference resolution; an empty provider surfaces
+        // `ReferenceNotFound` against the missing inner accession.
         assert!(
-            matches!(err, ferro_hgvs::FerroError::UnsupportedVariant { .. }),
-            "expected UnsupportedVariant (input: {}, got: {:?})",
+            matches!(
+                err,
+                ferro_hgvs::FerroError::ReferenceNotFound { .. }
+                    | ferro_hgvs::FerroError::GenomicReferenceNotAvailable { .. }
+            ),
+            "expected provider-lookup error (input: {}, got: {:?})",
             input,
             err
         );
         let msg = format!("{}", err);
         assert!(
             msg.contains(expected_source_accession),
-            "deferral message must mention the source accession {} (input: {}, got: {})",
+            "lookup error must cite the missing source accession {} (input: {}, got: {})",
             expected_source_accession,
-            input,
-            msg
-        );
-        assert!(
-            msg.contains("cross-reference") && msg.contains("follow-up"),
-            "deferral message must carry 'cross-reference' / 'follow-up' markers (input: {}, got: {})",
             input,
             msg
         );

--- a/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
@@ -167,7 +167,7 @@ NG_012337.1(SDHD):c.274G>T	NG_012337.1(SDHD):c.274G>T
 NG_012337.1(10683):c.274G>T	NG_012337.1(10683):c.274G>T
 NG_009299.1(NM_017668.3):c.41A>C	NG_009299.1(NM_017668.3):c.41A>C
 NG_012337.1(NM_012459.2):c.5_6delinsTAG	NG_012337.1(NM_012459.2):c.5_6delinsTAG
-LRG_303t1:c.10_11insLRG_1t1:c.100_101	normalize error: Unsupported variant type: ins[LRG_1t1:c.100_101] cross-reference is valid HGVS but not yet supported by ferro; see follow-up
+LRG_303t1:c.10_11insLRG_1t1:c.100_101	normalize error: Reference not found: LRG_1t1
 LRG_303:g.[105_106del;6681G>C;6883_6884insTTTCGCCCCTTTCGCCCC]	LRG_303:g.[105_106del;6681G>C;6883_6884insTTTCGCCCCTTTCGCCCC]
 NG_012337.1:g.13124_13125del	NG_012337.1:g.13124_13125del
 NG_012337.1(NM_012459.2):c.[10del;23_25del;36_37insAAT]	NG_012337.1(NM_012459.2):c.[10del;23_25del;36_37insAAT]
@@ -210,7 +210,7 @@ NM_003002.2:c.pterdel	parse error: Parse error at position 12: Failed to parse v
 NM_003002.2:c.qterdel	parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: "qterdel", code: Tag })
 LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.pter_-51'
 LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.*835_qter'
-LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up
+LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations
 LRG_24t1:c.pter_qterdelinspter_qter	parse error: Parse error at position 9: Failed to parse variant: Error(Error { input: "pter_qterdelinspter_qter", code: Tag })
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]	parse error: Parse error at position 9: Failed to parse variant: Error(Error { input: "pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]", code: Tag })
 NG_012337.1(NM_003002.2):c.[274=;275del]	NG_012337.1(NM_003002.2):c.[274=;275del]

--- a/tests/issue_207_multi_repeat_compound_roundtrip.rs
+++ b/tests/issue_207_multi_repeat_compound_roundtrip.rs
@@ -188,12 +188,21 @@ fn delins_reference_with_nested_repeat_count_parses_and_defers() {
     // depth-aware variant of the helper used by the trans-allele
     // parsers above.
     //
-    // Issue #333 changes the *normalize* contract for cross-reference
-    // payloads: ferro now defers the cross-coord lookup as
-    // `FerroError::UnsupportedVariant`. The parser pin survives —
-    // depth-aware bracket scanning still works — but `normalize` no
-    // longer round-trips this shape unchanged. The deferral message
-    // carries `cross-reference` / `follow-up` for grep.
+    // # Cross-reference contract evolution
+    //
+    // Issue #333 deferred ALL cross-reference payloads as
+    // `FerroError::UnsupportedVariant`. Issue #422 then closed the
+    // common-case deferral: simple positive-integer ranges like
+    // `NC_000022.11:g.100_200` now expand to a flat literal when the
+    // inner accession is in the provider.
+    //
+    // What remains deferred (this test's input) is the COMPLEX
+    // cross-reference shape — a reference range followed by a repeat
+    // extension (`TG[3]`). `parse_cross_reference` only accepts simple
+    // positive-integer ranges, so this shape returns `None` and the
+    // resolver surfaces `UnsupportedVariant`. The parser pin (depth-
+    // aware bracket scanning) is unchanged; only the normalize-time
+    // outcome differs from simple cross-references.
     use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
     let s = "NC_000001.11:g.100_105delins[NC_000022.11:g.100_200TG[3]]";
     let variant =
@@ -201,19 +210,19 @@ fn delins_reference_with_nested_repeat_count_parses_and_defers() {
     let normalizer = Normalizer::new(MockProvider::new());
     let err = normalizer
         .normalize(&variant)
-        .expect_err("cross-reference payload normalization must defer");
+        .expect_err("complex cross-reference payload (range + repeat) normalization must defer");
     // Pin the concrete error variant so the message-text grep below
     // can't accidentally pass on a different error type that happens
     // to contain the same words.
     assert!(
         matches!(err, ferro_hgvs::FerroError::UnsupportedVariant { .. }),
-        "expected UnsupportedVariant for cross-reference deferral (got: {:?})",
+        "expected UnsupportedVariant for complex cross-reference deferral (got: {:?})",
         err
     );
     let msg = format!("{}", err);
     assert!(
-        msg.contains("cross-reference") && msg.contains("follow-up"),
-        "deferral message must mention 'cross-reference' and 'follow-up' (got: {})",
+        msg.contains("cross-reference"),
+        "deferral message must mention 'cross-reference' (got: {})",
         msg
     );
 }

--- a/tests/issue_422_cross_reference_ins.rs
+++ b/tests/issue_422_cross_reference_ins.rs
@@ -1,0 +1,305 @@
+//! Issue #422 — expand cross-reference `ins[ACC:g.A_B]` payloads to
+//! their literal sequence.
+//!
+//! `InsertedSequence::Reference` (bare cross-reference) and
+//! `InsertedPart::ExternalRef` (cross-reference inside a Complex
+//! bracket) are valid per the HGVS spec but ferro previously returned
+//! `FerroError::UnsupportedVariant` instead of expanding them. This
+//! file pins the new behavior:
+//!
+//!   - Same-accession bracketed range (the spec example
+//!     `NC_000022.10:g.42522624_42522669delins[NC_000022.10:g.42536337_42536382]`).
+//!   - Cross-chromosome translocation
+//!     (`NC_000002.12:g.X_Y delins[NC_000011.10:g.A_B]`).
+//!   - Complex brackets mixing literal and ExternalRef parts
+//!     (`ins[A;NC_000022.11:g.100_200]`).
+//!   - Graceful error when an inner accession isn't in the provider.
+//!
+//! Spec basis: `assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md`
+//! (same-accession bracketed range conversion in CYP2D6; cross-chromosome
+//! translocation example pter_X delins[pter_Y]).
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// Build a MockProvider with two genomic contigs preloaded. The
+/// sequences are arbitrary IUPAC bases — only their lengths matter for
+/// the position-range fetch.
+fn two_genomic_provider() -> MockProvider {
+    let mut p = MockProvider::new();
+    // NC_000022.10 has bases "ACGTACGT..." padded to 50000+ positions
+    // so the spec example's coordinates resolve. We don't need full
+    // length — only enough for the range we'll query.
+    p.add_genomic_sequence(
+        "NC_000022.10",
+        // 100 bp: positions 1..100 cyclic ACGT.
+        "ACGT".repeat(25),
+    );
+    p.add_genomic_sequence("NC_000011.10", "GGGGTTTTAAAACCCC".repeat(10));
+    p
+}
+
+fn normalize(input: &str, provider: MockProvider) -> Result<String, FerroError> {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input)?;
+    normalizer.normalize(&variant).map(|v| format!("{}", v))
+}
+
+// =============================================================================
+// Same-accession bare cross-reference (the spec CYP2D6 shape, simplified
+// to coords that fit in our fixture).
+// =============================================================================
+
+/// `NC_000022.10:g.10_15delins[NC_000022.10:g.20_25]`: the inner range
+/// at positions 20..25 spans 6 bases (1-based inclusive HGVS
+/// semantics, `TACGTA` from cyclic `ACGTACGT...`); the outer delins
+/// flattens to a literal `delins<6 chars>`. The exact bases depend on
+/// the cyclic sequence at position 20.
+#[test]
+fn same_accession_bare_cross_reference_expands_to_literal() {
+    let provider = two_genomic_provider();
+    let out = normalize("NC_000022.10:g.10_15delins[NC_000022.10:g.20_25]", provider)
+        .expect("must normalize cleanly with both accessions in provider");
+    // Expanded form should contain `delins` followed by a literal IUPAC
+    // run (the inner range), NOT a `[NC_` bracket reference. Check
+    // exhaustively that the cross-ref bracket is gone.
+    assert!(
+        !out.contains("[NC_"),
+        "cross-reference bracket must be flattened to a literal; got {out}",
+    );
+    assert!(
+        out.contains("delins"),
+        "expanded form should still have the `delins` keyword; got {out}",
+    );
+}
+
+// =============================================================================
+// Cross-chromosome translocation
+// =============================================================================
+
+/// `NC_000002.12:g.X_Y delins[NC_000011.10:g.A_B]` style. Both
+/// chromosomes are in the provider, so the inner reference is
+/// resolved against `NC_000011.10`.
+#[test]
+fn cross_chromosome_cross_reference_expands_to_literal() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000002.12", "A".repeat(100));
+    p.add_genomic_sequence("NC_000011.10", "GGGGTTTTAAAA".repeat(10));
+    let out = normalize("NC_000002.12:g.5_10delins[NC_000011.10:g.20_25]", p)
+        .expect("must normalize cleanly with both contigs in provider");
+    assert!(
+        !out.contains("[NC_"),
+        "cross-chromosome reference must be flattened; got {out}",
+    );
+    assert!(out.contains("delins"));
+}
+
+// =============================================================================
+// Complex bracket mixing literal and ExternalRef
+// =============================================================================
+
+/// `ins[A;NC_000022.11:g.100_200]` style — literal `A` followed by a
+/// cross-reference range. Both parts flatten into a single
+/// `Literal("A" + <bases>)`.
+#[test]
+fn complex_bracket_literal_then_cross_ref_expands_to_single_literal() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    let out = normalize("NC_000022.10:g.5_6ins[A;NC_000022.10:g.10_15]", p)
+        .expect("Complex with literal + ExternalRef must expand");
+    // The Complex bracket must be gone — either flattened into a
+    // literal ins/delins, or further normalized into a `dup` if the
+    // resolved bases happen to duplicate the preceding ref bases.
+    // Either outcome means the cross-reference is no longer deferred.
+    assert!(
+        !out.contains("[A;"),
+        "Complex bracket must be flattened to a single literal; got {out}",
+    );
+    assert!(
+        !out.contains("NC_000022.10:g.10_15"),
+        "the inner cross-reference range must be expanded away; got {out}",
+    );
+}
+
+// =============================================================================
+// Graceful error: inner accession not in provider
+// =============================================================================
+
+#[test]
+fn cross_reference_unknown_inner_accession_surfaces_reference_not_found() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    // Inner `NC_999999.99` is not registered. The expansion path
+    // calls `provider.get_sequence(inner_acc, ...)` which returns
+    // `Err(FerroError::ReferenceNotFound | InvalidCoordinates)`. The
+    // error must surface — not silently leave the cross-ref intact.
+    let result = normalize("NC_000022.10:g.10_15delins[NC_999999.99:g.20_25]", p);
+    assert!(
+        result.is_err(),
+        "unknown inner accession must surface as an error; got Ok({:?})",
+        result.ok(),
+    );
+}
+
+// =============================================================================
+// Regression: existing same-reference bracketed shape (no cross-ref)
+// =============================================================================
+
+/// `ins[start_end]` with no foreign accession is the existing
+/// `InsertedSequence::PositionRange` shape (issue #333). It must
+/// continue to expand as before — the #422 changes are strictly
+/// additive on the cross-reference paths.
+#[test]
+fn same_reference_position_range_still_expands() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    let out = normalize("NC_000022.10:g.5_6ins[10_15]", p)
+        .expect("same-reference bracketed range must still expand");
+    assert!(
+        !out.contains("[10_15]"),
+        "same-reference position range must flatten; got {out}",
+    );
+}
+
+// =============================================================================
+// Out-of-scope shapes continue to defer (spec-undefined / decoration)
+// =============================================================================
+
+/// `pter`/`qter` markers inside the cross-reference are out of scope
+/// per the issue's "Out of scope" section. The resolver returns
+/// `Unsupported` with a clear message.
+#[test]
+fn pter_marker_in_cross_reference_stays_deferred() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    p.add_genomic_sequence("NC_000011.10", "ACGT".repeat(50));
+    // `pter` decoration → the inner reference isn't a simple
+    // positive-integer range, so `parse_cross_reference` returns
+    // `None` and the resolver surfaces `UnsupportedVariant`.
+    let result = normalize("NC_000022.10:g.10_15delins[NC_000011.10:g.pter_25]", p);
+    assert!(
+        result.is_err(),
+        "pter-marker cross-reference must continue to defer; got Ok({:?})",
+        result.ok(),
+    );
+}
+
+/// CDS-offset range inside a Complex bracket (`InsertedPart::CdsPositionRange`)
+/// remains spec-undefined and continues to defer with the
+/// `cross-reference is valid HGVS but not yet supported by ferro` /
+/// `CDS-offset range` error message.
+#[test]
+fn cds_offset_range_part_still_deferred() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    // `244-8_249` is a CDS-offset range. Must continue to error.
+    let result = normalize("NC_000022.10:g.5_6ins[N[2800];244-8_249]", p);
+    assert!(
+        result.is_err(),
+        "CDS-offset range must continue to defer; got Ok({:?})",
+        result.ok(),
+    );
+}
+
+// =============================================================================
+// Additional axis coverage: m. (mito) routed through `Direct`
+// =============================================================================
+
+#[test]
+fn mito_cross_reference_expands_to_literal() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_012920.1", "ACGT".repeat(50));
+    let out = normalize("NC_012920.1:m.5_6ins[NC_012920.1:m.10_15]", p)
+        .expect("mito cross-reference must expand");
+    assert!(
+        !out.contains("[NC_"),
+        "mito cross-reference must be flattened; got {out}",
+    );
+}
+
+// =============================================================================
+// Out-of-scope axis: r. (RNA) — should defer with a clear message
+// =============================================================================
+
+#[test]
+fn rna_cross_reference_continues_to_defer() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    // Inner is r. axis — needs U->T translation; deferred until that's
+    // wired through the cross-reference path.
+    let result = normalize("NC_000022.10:g.10_15delins[NR_001234.1:r.10_15]", p);
+    assert!(
+        result.is_err(),
+        "r.-axis cross-reference must defer; got Ok({:?})",
+        result.ok(),
+    );
+    let err = result.unwrap_err();
+    let msg = format!("{}", err);
+    assert!(
+        msg.contains("cross-reference"),
+        "deferral message must mention 'cross-reference'; got {msg}",
+    );
+}
+
+// =============================================================================
+// Out-of-scope axis: p. (protein) — structurally invalid as DNA payload
+// =============================================================================
+
+#[test]
+fn protein_cross_reference_continues_to_defer() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    let result = normalize("NC_000022.10:g.10_15delins[NP_000079.2:p.10_15]", p);
+    assert!(
+        result.is_err(),
+        "p.-axis cross-reference is structurally invalid as DNA-insertion \
+         payload and must defer; got Ok({:?})",
+        result.ok(),
+    );
+}
+
+// =============================================================================
+// Cross-reference with offset (`+N`/`-N`) continues to defer
+// =============================================================================
+
+#[test]
+fn cross_reference_with_offset_continues_to_defer() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    p.add_genomic_sequence("NC_000011.10", "ACGT".repeat(50));
+    // `+5` offset on the inner end position — out of scope per the
+    // issue (offsets need exon/intron context the simple
+    // position-range fetch doesn't provide).
+    let result = normalize("NC_000022.10:g.10_15delins[NC_000011.10:g.20_25+5]", p);
+    assert!(
+        result.is_err(),
+        "offset-bearing cross-reference must defer; got Ok({:?})",
+        result.ok(),
+    );
+}
+
+// =============================================================================
+// Order-independence: an unsupported cross-reference must defer even when
+// it follows a non-flattenable part (e.g. a Repeat). Regression for the
+// order-dependent masking flagged on PR #437: a leading non-flatten part
+// used to short-circuit `expand_complex_parts` to `Ok(None)` before the
+// later `ExternalRef` arm was validated, silently passing the variant
+// through instead of erroring on the unsupported cross-reference.
+// =============================================================================
+
+#[test]
+fn unsupported_cross_reference_after_repeat_part_still_defers() {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    // `N[2800]` is a non-flattenable Repeat part; the trailing
+    // `NR_001234.1:r.10_15` is an out-of-scope r.-axis cross-reference.
+    // The r.-axis member must still surface an error regardless of its
+    // position after the Repeat.
+    let result = normalize("NC_000022.10:g.5_6ins[N[2800];NR_001234.1:r.10_15]", p);
+    assert!(
+        result.is_err(),
+        "unsupported cross-reference after a Repeat part must defer; got Ok({:?})",
+        result.ok(),
+    );
+}

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -1295,41 +1295,54 @@ mod clinvar_normalization {
     }
 
     // Embedded-accession `ins[ACC:...]` / `delins[ACC:...]` payloads are
-    // cross-reference shapes. Per issue #333, ferro defers expansion of
-    // those — normalize must surface the deferral as a
-    // `FerroError::UnsupportedVariant` carrying the grep-friendly
-    // `cross-reference` / `follow-up` markers. The round-trip pin moves
-    // to that error contract; the bracketed payload no longer survives
-    // normalize unchanged.
+    // cross-reference shapes. Per issue #422 the resolver looks up the
+    // inner accession through the provider; against an empty provider
+    // each surfaces `ReferenceNotFound` citing the missing accession.
+    // Successful-expansion coverage lives in
+    // `tests/issue_422_cross_reference_ins.rs`.
     #[rstest]
-    #[case("NC_000008.11:g.86688947_86688948ins[MF045863.1:g.1_36978]")]
-    #[case("NC_000008.11:g.86711345_86711346ins[MF045864.2:g.1_98770]")]
-    #[case("NG_016167.1:g.21559097_21559098ins[PP887427.1:g.1_1518]")]
-    #[case("LRG_1293:g.21559097_21559098ins[PP887427.1:g.1_1518]")]
-    #[case("NC_000008.11:g.86587460_86650711delins[KY923049.1:g.1_466]")]
-    fn test_embedded_accession_variants_defer_with_unsupported(#[case] input: &str) {
+    #[case(
+        "NC_000008.11:g.86688947_86688948ins[MF045863.1:g.1_36978]",
+        "MF045863.1"
+    )]
+    #[case(
+        "NC_000008.11:g.86711345_86711346ins[MF045864.2:g.1_98770]",
+        "MF045864.2"
+    )]
+    #[case(
+        "NG_016167.1:g.21559097_21559098ins[PP887427.1:g.1_1518]",
+        "PP887427.1"
+    )]
+    #[case("LRG_1293:g.21559097_21559098ins[PP887427.1:g.1_1518]", "PP887427.1")]
+    #[case(
+        "NC_000008.11:g.86587460_86650711delins[KY923049.1:g.1_466]",
+        "KY923049.1"
+    )]
+    fn test_embedded_accession_variants_defer_with_unsupported(
+        #[case] input: &str,
+        #[case] expected_missing_accession: &str,
+    ) {
         let provider = MockProvider::new();
         let normalizer = Normalizer::new(provider);
         let variant = parse_hgvs(input).expect("Failed to parse");
         let err = normalizer
             .normalize(&variant)
-            .expect_err("cross-reference payload must surface as UnsupportedVariant");
-        // Pin the concrete error variant so a different error type
-        // (e.g. a future provider-lookup failure) can't accidentally
-        // satisfy the message-text assertion below.
+            .expect_err("cross-reference payload must surface a provider-lookup error");
         assert!(
             matches!(
                 err,
-                ferro_hgvs::error::FerroError::UnsupportedVariant { .. }
+                ferro_hgvs::error::FerroError::ReferenceNotFound { .. }
+                    | ferro_hgvs::error::FerroError::GenomicReferenceNotAvailable { .. }
             ),
-            "expected UnsupportedVariant for cross-reference deferral (input: {}, got: {:?})",
+            "expected provider-lookup error for cross-reference (input: {}, got: {:?})",
             input,
             err
         );
         let msg = format!("{}", err);
         assert!(
-            msg.contains("cross-reference") && msg.contains("follow-up"),
-            "cross-reference deferral must mention both 'cross-reference' and 'follow-up' for grep (input: {}, got: {})",
+            msg.contains(expected_missing_accession),
+            "lookup error must cite the missing inner accession {} (input: {}, got: {})",
+            expected_missing_accession,
             input,
             msg
         );
@@ -5304,30 +5317,31 @@ mod ins_bracketed_expansion {
     }
 
     // -------------------------------------------------------------------
-    // 12. Cross-reference accession in the payload is deferred — error
-    //    with a grep-friendly message mentioning "cross-reference" and
-    //    "follow-up" so users can find the tracking issue.
+    // 12. Cross-reference accession in the payload is resolved against
+    //    the provider (#422). Against an empty provider the inner
+    //    lookup surfaces `ReferenceNotFound` citing the missing
+    //    accession; exhaustive expansion coverage lives in
+    //    `tests/issue_422_cross_reference_ins.rs`.
     // -------------------------------------------------------------------
     #[test]
-    fn ins_cross_reference_returns_unsupported_error() {
+    fn ins_cross_reference_missing_provider_returns_reference_not_found() {
         let err = normalize_err(
             MockProvider::new(),
             "NC_000001.11:g.5207_5208ins[NC_000022.11:g.100_200]",
         );
-        let msg = format!("{}", err);
         assert!(
-            matches!(err, FerroError::UnsupportedVariant { .. }),
-            "expected UnsupportedVariant, got {:?}",
+            matches!(
+                err,
+                FerroError::ReferenceNotFound { .. }
+                    | FerroError::GenomicReferenceNotAvailable { .. }
+            ),
+            "expected provider-lookup error against empty provider, got {:?}",
             err
         );
+        let msg = format!("{}", err);
         assert!(
-            msg.contains("cross-reference"),
-            "error message must mention 'cross-reference' for grep, got: {}",
-            msg
-        );
-        assert!(
-            msg.contains("follow-up"),
-            "error message must mention 'follow-up' for grep, got: {}",
+            msg.contains("NC_000022.11"),
+            "lookup error must cite the missing inner accession; got: {}",
             msg
         );
     }


### PR DESCRIPTION
## Summary

Closes #422. `InsertedSequence::Reference` (bare cross-reference, e.g. `ins[NC_000022.10:g.42536337_42536382]`) and `InsertedPart::ExternalRef` (cross-reference inside a Complex bracket, e.g. `ins[A;NC_000022.11:g.100_200]`) are valid per the HGVS spec but ferro previously returned `FerroError::UnsupportedVariant` instead of expanding them. This PR expands the common-case shapes via the existing provider lookup machinery.

**Stacked on #421** (`fix/issue-395-misc-gaps`). Base will revert to `main` once #421 lands.

## Design

New helpers in `src/normalize/rules.rs`:
* `parse_cross_reference(reference) -> Option<(accession, InsCoordKind, start, end)>` — parses the inner reference string. Accepts g./m./o./c./n. axes with simple positive-integer ranges only.
* `resolve_cross_reference_bases(reference, provider) -> Result<String, FerroError>` — routes through the existing `fetch_position_range_bases` (handles both `Direct` and `Cds` coord kinds, including the CDS-translation path).

Three stub sites updated:
* `expand_inserted_sequence` — `InsertedSequence::Reference` arm.
* `append_part_bases` — `InsertedPart::ExternalRef` arm.
* `detect_deferred_part` — drops `ExternalRef` from the pre-scan (kept for `CdsPositionRange` which remains spec-undefined).

## Acceptance criteria

- [x] Same-accession bracketed range expands to literal.
- [x] Cross-chromosome translocation expands when both contigs are present.
- [x] Complex brackets mixing literal and ExternalRef parts expand to single flat `Literal`.
- [x] Existing same-reference bracketed shape `delins[start_end]` is unchanged.
- [x] Inner accession not in provider → clear Err.
- [x] Spec-undefined `CdsPositionRange` shapes remain deferred.
- [x] `pter`/`qter` decoration markers continue to defer (out of scope).

## Test plan

- New `tests/issue_422_cross_reference_ins.rs` — 7 cases.
- Updated `tests/issue_207_multi_repeat_compound_roundtrip.rs::delins_reference_with_nested_repeat_count_parses_and_defers` to reflect the new contract.
- `cargo nextest run --features dev --test 'issue_*'` — 1316/1316 pass.
- `cargo clippy` + `cargo fmt --check` — clean.

## Spec basis

`assets/hgvs-nomenclature/docs/recommendations/DNA/delins.md` — same-accession bracketed range conversion in CYP2D6 and cross-chromosome translocation examples.