### PR TITLE
fix(edit): drop brackets on single-payload InsertedSequence::Complex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(edit)* drop brackets on single-payload `InsertedSequence::Complex` `Display` so e.g. `delins[78185355_78199419inv]` round-trips as `delins78185355_78199419inv`, matching HGVS v21 (`DNA/insertion.md:22`, `DNA/inversion.md:39`).
 - *(normalize)* extend HGVS codon-frame exception beyond the two-`c.`-SNV case (closes #275, follow-up to #79 / #104): the spec's "two variants separated by one nucleotide, together affecting one amino acid" carve-out now also covers (1) `r.` coding regions, (2) chains of 3+ SNVs where a strict-adjacency merge leaves `prev_a` as a multi-base delins, and (3) `sub`+`del` and `del`+`sub` pairs separated by one unchanged nucleotide.
 
 ## [0.6.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.5.0...v0.6.0) - 2026-05-16

--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -272,6 +272,24 @@ impl fmt::Display for InsertedPart {
     }
 }
 
+/// Render a `Complex` payload as `[a;b;c]`, joining each part via `fmt_part`.
+/// Always emits brackets — single-part wrapping is the caller's choice.
+fn join_complex_parts<F: Fn(&InsertedPart) -> String>(
+    parts: &[InsertedPart],
+    fmt_part: F,
+) -> String {
+    let mut s = String::with_capacity(parts.len() * 8 + 2);
+    s.push('[');
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            s.push(';');
+        }
+        s.push_str(&fmt_part(part));
+    }
+    s.push(']');
+    s
+}
+
 impl fmt::Display for InsertedSequence {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -283,14 +301,15 @@ impl fmt::Display for InsertedSequence {
                 write!(f, "{}{}", sequence, count)
             }
             InsertedSequence::Complex(parts) => {
-                write!(f, "[")?;
-                for (i, part) in parts.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, ";")?;
-                    }
-                    write!(f, "{}", part)?;
+                // Per HGVS v21 (DNA/insertion.md:22, DNA/inversion.md:39),
+                // brackets are reserved for compositions with two or more
+                // parts. A single-part insertion (e.g. `ins123_234inv`,
+                // `ins858_895`, `insATG`) must not be bracketed.
+                if parts.len() == 1 {
+                    write!(f, "{}", parts[0])
+                } else {
+                    write!(f, "{}", join_complex_parts(parts, |p| format!("{}", p)))
                 }
-                write!(f, "]")
             }
             InsertedSequence::Named(name) => write!(f, "{}", name),
             InsertedSequence::Reference(reference) => write!(f, "[{}]", reference),
@@ -305,6 +324,20 @@ impl fmt::Display for InsertedSequence {
 }
 
 impl InsertedSequence {
+    /// Format as `Display` would, but always wrap a [`InsertedSequence::Complex`]
+    /// payload in `[...]` even for a single part. For non-`Complex` variants
+    /// the result is identical to `Display`.
+    ///
+    /// Used by callers (e.g. normalization warnings) that need to preserve
+    /// the bracketed input shape regardless of `Display`'s spec-canonical
+    /// single-payload unbracketing.
+    pub fn to_bracketed_string(&self) -> String {
+        match self {
+            InsertedSequence::Complex(parts) => join_complex_parts(parts, |p| format!("{}", p)),
+            other => format!("{}", other),
+        }
+    }
+
     /// Create a literal sequence insertion
     pub fn literal(seq: Sequence) -> Self {
         InsertedSequence::Literal(seq)
@@ -381,15 +414,12 @@ impl InsertedSequence {
                 format!("{}{}", sequence.to_lowercase_string(), count)
             }
             InsertedSequence::Complex(parts) => {
-                let mut s = String::from("[");
-                for (i, part) in parts.iter().enumerate() {
-                    if i > 0 {
-                        s.push(';');
-                    }
-                    s.push_str(&part.to_rna_string());
+                // Single-part insertion: no brackets, per HGVS v21 spec.
+                if parts.len() == 1 {
+                    parts[0].to_rna_string()
+                } else {
+                    join_complex_parts(parts, |p| p.to_rna_string())
                 }
-                s.push(']');
-                s
             }
             InsertedSequence::Named(name) => name.clone(),
             InsertedSequence::Reference(reference) => format!("[{}]", reference),

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7034,13 +7034,16 @@ mod tests {
         assert!(matches!(variant, HgvsVariant::Genome(_)));
         assert_eq!(format!("{}", variant), "NC_000007.14:g.45043702_46521017delins[AGAAGGAAATTT;45310743_46521014;45043709_45310738inv]");
 
-        // Simple complex delins with just inversion
+        // Simple complex delins with just inversion. The spec-canonical
+        // form for a single-payload inv is unbracketed (DNA/insertion.md:22,
+        // DNA/inversion.md:39 — examples like `c.849_850ins850_900inv`);
+        // ferro now drops brackets on Display for single-element Complex.
         let variant =
             parse_variant("NC_000016.9:g.78179358_78219143delins[78185355_78199419inv]").unwrap();
         assert!(matches!(variant, HgvsVariant::Genome(_)));
         assert_eq!(
             format!("{}", variant),
-            "NC_000016.9:g.78179358_78219143delins[78185355_78199419inv]"
+            "NC_000016.9:g.78179358_78219143delins78185355_78199419inv"
         );
     }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1097,7 +1097,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
             | NaEdit::DupIns { sequence } => sequence,
             _ => return Ok(None),
         };
-        let original_payload = format!("{}", original_inserted);
+        // The warning is specifically about a bracketed payload being
+        // expanded — by construction `canonicalize_insertion_expand`
+        // only acts on `InsertedSequence::Complex`. `to_bracketed_string`
+        // forces the bracketed form so the warning preserves the user's
+        // input shape (`[ATC]`, `[A;100_110]`) even though `Display` on
+        // `InsertedSequence::Complex` now drops brackets for single-element
+        // vectors (spec-canonical form).
+        let original_payload = original_inserted.to_bracketed_string();
 
         let new_edit = match canonicalize_insertion_expand(edit, accession, kind, &self.provider)? {
             Some(e) => e,

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,11 +10,11 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 42,
-      "diverges": 146,
+      "diverges": 135,
       "false-acceptance": 83,
       "needs-reference": 31,
       "parse-error": 338,
-      "preserved": 632
+      "preserved": 643
     },
     "by_coordinate_system": {
       "c": 464,
@@ -12897,114 +12897,6 @@
       ]
     },
     {
-      "input": "LRG_199t1:r.186_187ins186+1_186+4",
-      "current": "LRG_199t1:r.186_187ins[186+1_186+4]",
-      "spec_expected": "LRG_199t1:r.186_187ins186+1_186+4",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/numbering.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
-      "current": "NC_000023.10(NM_004006.2):r.186_187ins[186+1_186+4]",
-      "spec_expected": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/numbering.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
-      "current": "NC_000023.10(NM_004006.2):r.357_358ins[357+1_357+12]",
-      "spec_expected": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268",
-      "current": "NC_000023.11(NM_004006.2):r.649_650ins[650-1400_650-1268]",
-      "spec_expected": "NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1",
-      "current": "NC_000023.11(NM_004006.2):r.649_650ins[650-50_650-1]",
-      "spec_expected": "NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67",
-      "current": "NC_000023.11(NM_004006.2):r.831_832ins[831+1_831+67]",
-      "spec_expected": "NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/splicing.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
-      "current": "NG_012232.1(NM_004006.2):r.186_187ins[186+1_186+4]",
-      "spec_expected": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/numbering.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
-      "current": "NG_012232.1(NM_004006.2):r.357_358ins[357+1_357+12]",
-      "spec_expected": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "background",
-      "source_paths": [
-        "docs/background/refseq.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.2:r.2623_2803delins2804_2949",
-      "current": "NM_004006.2:r.2623_2803delins[2804_2949]",
-      "spec_expected": "NM_004006.2:r.2623_2803delins2804_2949",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/delins.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_004006.2:r.[76a>u];[?]",
       "current": "[NM_004006.2:r.76a>u];[?]",
       "spec_expected": "NM_004006.2:r.[76a>u];[?]",
@@ -13037,34 +12929,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.234_235ins123_234inv",
-      "input_prefixed": "NM_004006.3:r.234_235ins123_234inv",
-      "current": "NM_004006.3:r.234_235ins[123_234inv]",
-      "spec_expected": "NM_004006.3:r.234_235ins123_234inv",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/duplication.md",
-        "docs/recommendations/RNA/insertion.md",
-        "docs/recommendations/RNA/inversion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.849_850ins858_895",
-      "input_prefixed": "NM_004006.3:r.849_850ins858_895",
-      "current": "NM_004006.3:r.849_850ins[858_895]",
-      "spec_expected": "NM_004006.3:r.849_850ins858_895",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -13210,7 +13074,7 @@
     {
       "input": "r.456_457ins123_456",
       "input_prefixed": "NM_004006.3:r.456_457ins123_456",
-      "current": "NM_004006.3:r.456_457ins[123_456]",
+      "current": "NM_004006.3:r.456_457ins123_456",
       "spec_expected": null,
       "status": "false-acceptance",
       "coordinate_system": "r",
@@ -14534,6 +14398,17 @@
       ]
     },
     {
+      "input": "LRG_199t1:r.186_187ins186+1_186+4",
+      "current": "LRG_199t1:r.186_187ins186+1_186+4",
+      "spec_expected": "LRG_199t1:r.186_187ins186+1_186+4",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:r.426_427insa",
       "current": "LRG_199t1:r.426_427insa",
       "spec_expected": "LRG_199t1:r.426_427insa",
@@ -14600,9 +14475,53 @@
       ]
     },
     {
+      "input": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
+      "current": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
+      "spec_expected": "NC_000023.10(NM_004006.2):r.186_187ins186+1_186+4",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
+      "current": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
+      "spec_expected": "NC_000023.10(NM_004006.2):r.357_358ins357+1_357+12",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
+      ]
+    },
+    {
       "input": "NC_000023.11(NM_004006.2):r.(76a>c)",
       "current": "NC_000023.11(NM_004006.2):r.(76a>c)",
       "spec_expected": "NC_000023.11(NM_004006.2):r.(76a>c)",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268",
+      "current": "NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268",
+      "spec_expected": "NC_000023.11(NM_004006.2):r.649_650ins650-1400_650-1268",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1",
+      "current": "NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1",
+      "spec_expected": "NC_000023.11(NM_004006.2):r.649_650ins650-50_650-1",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",
@@ -14655,6 +14574,17 @@
       ]
     },
     {
+      "input": "NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67",
+      "current": "NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67",
+      "spec_expected": "NC_000023.11(NM_004006.2):r.831_832ins831+1_831+67",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
       "input": "NC_000023.11(NM_004006.2):r.831_832ins[ga;831+3_831+60]",
       "current": "NC_000023.11(NM_004006.2):r.831_832ins[ga;831+3_831+60]",
       "spec_expected": "NC_000023.11(NM_004006.2):r.831_832ins[ga;831+3_831+60]",
@@ -14685,6 +14615,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/splicing.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
+      "current": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
+      "spec_expected": "NG_012232.1(NM_004006.2):r.186_187ins186+1_186+4",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/numbering.md"
+      ]
+    },
+    {
+      "input": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
+      "current": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
+      "spec_expected": "NG_012232.1(NM_004006.2):r.357_358ins357+1_357+12",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "background",
+      "source_paths": [
+        "docs/background/refseq.md"
       ]
     },
     {
@@ -14756,6 +14708,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/insertion.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:r.2623_2803delins2804_2949",
+      "current": "NM_004006.2:r.2623_2803delins2804_2949",
+      "spec_expected": "NM_004006.2:r.2623_2803delins2804_2949",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/delins.md"
       ]
     },
     {
@@ -15507,6 +15470,20 @@
       ]
     },
     {
+      "input": "r.234_235ins123_234inv",
+      "input_prefixed": "NM_004006.3:r.234_235ins123_234inv",
+      "current": "NM_004006.3:r.234_235ins123_234inv",
+      "spec_expected": "NM_004006.3:r.234_235ins123_234inv",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/duplication.md",
+        "docs/recommendations/RNA/insertion.md",
+        "docs/recommendations/RNA/inversion.md"
+      ]
+    },
+    {
       "input": "r.4567_4569=",
       "input_prefixed": "NM_004006.3:r.4567_4569=",
       "current": "NM_004006.3:r.4567_4569=",
@@ -15650,6 +15627,18 @@
         "docs/recommendations/RNA/alleles.md",
         "docs/recommendations/RNA/splicing.md",
         "docs/recommendations/RNA/substitution.md"
+      ]
+    },
+    {
+      "input": "r.849_850ins858_895",
+      "input_prefixed": "NM_004006.3:r.849_850ins858_895",
+      "current": "NM_004006.3:r.849_850ins858_895",
+      "spec_expected": "NM_004006.3:r.849_850ins858_895",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
       ]
     },
     {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -265,9 +265,12 @@ fn test_verified_roundtrip(#[case] input: &str) {
     "NG_016862.1:g.4732_10560delins[AC010542.7:g.65062_65110]",
     "NG_016862.1:g.4732_10560delins[AC010542.7:g.65062_65110]"
 )]
+// Spec-canonical form drops brackets for single-payload inserted-sequence
+// (DNA/insertion.md:22, DNA/inversion.md:39). Input may include brackets;
+// Display normalizes to the unbracketed form.
 #[case(
     "NC_000016.9:g.78179358_78219143delins[78185355_78199419inv]",
-    "NC_000016.9:g.78179358_78219143delins[78185355_78199419inv]"
+    "NC_000016.9:g.78179358_78219143delins78185355_78199419inv"
 )]
 // Self-reference insertions (ferro preserves N[count], mutalyzer expands)
 #[case(

--- a/tests/spec_canonical_locks.rs
+++ b/tests/spec_canonical_locks.rs
@@ -102,30 +102,28 @@ fn large_inversion_round_trips() {
 // the inverted-copy and complex-rearrangement cases.
 
 /// Inverted-copy at 5' boundary of original. Source: dna-inversion:C-C1.
-/// Spec canonical: `ins123_234inv`. ferro currently wraps the inv payload
-/// in brackets on Display (`ins[123_234inv]`). Pin the current shape so
-/// the divergence is visible; both forms are semantically equivalent.
+/// Spec canonical: `ins123_234inv` without brackets (DNA/insertion.md:18,
+/// DNA/inversion.md:39). Locks the fix for the single-payload Display.
 #[test]
-fn ins_inverted_copy_5prime_boundary_pins_bracketed_display() {
+fn ins_inverted_copy_5prime_boundary_round_trips() {
     let input = "NC_000023.11:g.122_123ins123_234inv";
     let parsed = parse_hgvs(input).expect("must parse");
     assert_eq!(
         parsed.to_string(),
-        "NC_000023.11:g.122_123ins[123_234inv]",
-        "ferro currently brackets the inv payload; spec uses {input:?}"
+        input,
+        "single-payload ins<range>inv must not be bracketed (spec form)"
     );
 }
 
 /// Inverted-copy at 3' boundary of original. Source: dna-inversion:C-C2.
-/// Same brackets-added divergence as C-C1.
 #[test]
-fn ins_inverted_copy_3prime_boundary_pins_bracketed_display() {
+fn ins_inverted_copy_3prime_boundary_round_trips() {
     let input = "NC_000023.11:g.234_235ins123_234inv";
     let parsed = parse_hgvs(input).expect("must parse");
     assert_eq!(
         parsed.to_string(),
-        "NC_000023.11:g.234_235ins[123_234inv]",
-        "ferro currently brackets the inv payload; spec uses {input:?}"
+        input,
+        "single-payload ins<range>inv must not be bracketed (spec form)"
     );
 }
 

--- a/tests/spec_canonical_locks.rs
+++ b/tests/spec_canonical_locks.rs
@@ -1,0 +1,198 @@
+//! Regression locks for canonical HGVS v21 spec examples that aren't yet
+//! pinned by ferro's test suite.
+//!
+//! Source: phase4_final_triage.md families F3 + F4 + F5 (13 net-new corners,
+//! all POS-style — the spec gives an explicit canonical form and we want a
+//! test to catch any future drift). Each test names the construct,
+//! coordinate system, and the originating axes-doc corner; the spec citation
+//! is in the per-test comment.
+//!
+//! Every test in this file pins parse + Display round-trip against the
+//! spec-canonical form. If a future change regresses any input to a parse
+//! error or to a non-canonical Display, the corresponding test fails — that
+//! is the entire point of the file.
+
+use ferro_hgvs::parse_hgvs;
+
+// =====================================================================
+// F3 — CNV / large-range / uncertain endpoint pairs (7 corners)
+// =====================================================================
+//
+// `DNA/duplication.md` gives several canonical-shape examples that combine
+// intronic offsets, uncertain endpoints, and large ranges. SVD-WG003
+// proposed the nested-paren uncertain endpoint form
+// `(A+1_B-1)_(C+1_D-1)dup`; ferro parses + round-trips it.
+
+/// Exon/intron border duplication: spec uses `c.1704+1dup` (the intronic
+/// `+1` position), NOT `c.1704dup`. Source: dna-duplication:C-C3.
+#[test]
+fn dup_exon_intron_border_round_trips() {
+    let input = "NM_000088.3:c.1704+1dup";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse spec-canonical {input:?}: {e}"),
+    }
+}
+
+/// Intron/exon border duplication: spec uses `c.1813dup`, NOT
+/// `c.1813-1dup`. Source: dna-duplication:C-C4.
+#[test]
+fn dup_intron_exon_border_round_trips() {
+    let input = "NM_000088.3:c.1813dup";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse spec-canonical {input:?}: {e}"),
+    }
+}
+
+/// Two-exon-spanning duplication with intronic endpoints. Source:
+/// dna-duplication:C-C5.
+#[test]
+fn dup_two_exon_spanning_intronic_endpoints_round_trips() {
+    let input = "NM_000088.3:c.4072-1234_5155-246dup";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(parsed.to_string(), input, "round-trip mismatch");
+}
+
+/// SVD-WG003 uncertain endpoint pair form. Source: dna-duplication:C-C6.
+#[test]
+fn dup_uncertain_endpoint_pairs_svd_wg003_round_trips() {
+    let input = "NM_000088.3:c.(4071+1_4072-1)_(5154+1_5155-1)dup";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(
+        parsed.to_string(),
+        input,
+        "round-trip mismatch for SVD-WG003 uncertain endpoint pair"
+    );
+}
+
+/// Triplication CNV with uncertain endpoint pairs. Source:
+/// dna-duplication:C-C7.
+#[test]
+fn cnv_triplication_uncertain_endpoints_round_trips() {
+    let input = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)[3]";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(parsed.to_string(), input, "round-trip mismatch");
+}
+
+/// Whole-gene CNV duplication form. Source: dna-duplication:C-C8.
+#[test]
+fn cnv_whole_gene_dup_round_trips() {
+    let input = "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(parsed.to_string(), input, "round-trip mismatch");
+}
+
+/// Very large inversion (megabase scale). Source: dna-inversion:C-C6.
+#[test]
+fn large_inversion_round_trips() {
+    let input = "NC_000023.11:g.111754331_111966764inv";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input),
+        Err(e) => panic!("ferro should parse large inversion {input:?}: {e}"),
+    }
+}
+
+// =====================================================================
+// F4 — Combined-insertion bracketed forms (4 corners)
+// =====================================================================
+//
+// `DNA/inversion.md` shows insertions whose payload is a bracketed
+// composition of inv / sub / del. These are spec-canonical for describing
+// the inverted-copy and complex-rearrangement cases.
+
+/// Inverted-copy at 5' boundary of original. Source: dna-inversion:C-C1.
+/// Spec canonical: `ins123_234inv`. ferro currently wraps the inv payload
+/// in brackets on Display (`ins[123_234inv]`). Pin the current shape so
+/// the divergence is visible; both forms are semantically equivalent.
+#[test]
+fn ins_inverted_copy_5prime_boundary_pins_bracketed_display() {
+    let input = "NC_000023.11:g.122_123ins123_234inv";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(
+        parsed.to_string(),
+        "NC_000023.11:g.122_123ins[123_234inv]",
+        "ferro currently brackets the inv payload; spec uses {input:?}"
+    );
+}
+
+/// Inverted-copy at 3' boundary of original. Source: dna-inversion:C-C2.
+/// Same brackets-added divergence as C-C1.
+#[test]
+fn ins_inverted_copy_3prime_boundary_pins_bracketed_display() {
+    let input = "NC_000023.11:g.234_235ins123_234inv";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(
+        parsed.to_string(),
+        "NC_000023.11:g.234_235ins[123_234inv]",
+        "ferro currently brackets the inv payload; spec uses {input:?}"
+    );
+}
+
+/// Combination inserted form: two inversions + an inserted A.
+/// Source: dna-inversion:C-C3.
+#[test]
+fn ins_combination_inv_sub_inv_round_trips() {
+    let input = "NM_004006.2:c.940_941ins[885_940inv;A;851_883inv]";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(parsed.to_string(), input, "round-trip mismatch");
+}
+
+/// Combination inserted form: two inversions composed.
+/// Source: dna-inversion:C-C4.
+#[test]
+fn ins_combination_two_inversions_round_trips() {
+    let input = "NM_004006.2:c.940_941ins[903_940inv;851_885inv]";
+    let parsed = parse_hgvs(input).expect("must parse");
+    assert_eq!(parsed.to_string(), input, "round-trip mismatch");
+}
+
+// =====================================================================
+// F5 — Boundary-stacking subs (UTR ∩ intronic) (2 corners)
+// =====================================================================
+//
+// Substitutions at positions that span two boundary classes simultaneously
+// (e.g. 5' UTR + intronic donor). `numbering.md` defines the position
+// kinds; the substitution doc doesn't cross them with a worked example.
+
+/// Substitution at 5' UTR intronic donor. Source: dna-substitution:C-C3.
+#[test]
+fn sub_5utr_intronic_donor_round_trips() {
+    let input = "NM_004006.2:c.-85+1A>G";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse 5'UTR-intronic sub {input:?}: {e}"),
+    }
+}
+
+/// Substitution at 5' UTR intronic donor (variant position).
+/// Source: dna-substitution:C-C3.
+#[test]
+fn sub_5utr_intronic_donor_variant_round_trips() {
+    let input = "NM_004006.2:c.-15+1A>G";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse {input:?}: {e}"),
+    }
+}
+
+/// Substitution at first intronic nt of intron immediately after stop.
+/// Source: dna-substitution:C-C8.
+#[test]
+fn sub_stop_plus_1_intronic_acceptor_round_trips() {
+    let input = "NM_004006.2:c.*1-1A>G";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse stop+1 intronic sub {input:?}: {e}"),
+    }
+}
+
+/// Substitution at deep 3'UTR intronic. Source: dna-substitution:C-C8.
+#[test]
+fn sub_3utr_deep_intronic_round_trips() {
+    let input = "NM_004006.2:c.*639-1G>A";
+    match parse_hgvs(input) {
+        Ok(v) => assert_eq!(v.to_string(), input, "round-trip mismatch"),
+        Err(e) => panic!("ferro should parse 3'UTR deep intronic {input:?}: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary

Per HGVS v21 (`DNA/insertion.md:22`, `DNA/inversion.md:39`), brackets in an `ins<...>` payload are reserved for compositions with two or more parts. A single-part insertion such as `ins123_234inv`, `ins858_895`, or `insATG` must not be bracketed. ferro previously emitted `ins[123_234inv]` for the single-payload inv case; this PR aligns Display with the spec.

Surfaced by the phase4 spec-coverage triage (family F4 — combined-insertion bracketed forms). Mutalyzer emits the same unbracketed form for these inputs, so the change also closes a small ferro-vs-Mutalyzer divergence.

Spec examples that now round-trip cleanly:
- `c.849_850ins850_900inv` (inversion.md:39)
- `c.900_901ins850_900inv` (inversion.md:42)
- `g.234_235ins123_234inv` (insertion.md:18 — inverted-dup-as-ins canonical form)

Composite payloads with two or more parts are unchanged: `c.940_941ins[885_940inv;A;851_883inv]`, `c.419_420ins[T;401_419]`, etc.

## What changed

- `src/hgvs/edit.rs` — `InsertedSequence::Complex` Display (and `to_rna_string`) emit the single part directly when `parts.len() == 1`; multi-part composition stays bracketed.
- `src/normalize/mod.rs` — `try_expand_ins_edit` explicitly brackets the warning's `original_payload` field so `InsertedSequenceExpanded` still records the user's bracketed input shape.
- `src/hgvs/parser/variant.rs` — `test_parse_complex_delins_array` updated to assert the spec-canonical unbracketed Display.
- `tests/parser_tests.rs` case 28 — same update.
- `tests/fixtures/grammar/hgvs_spec_normalization.json` — regenerated via `cargo run --features dev --example generate_spec_fixture`. 12 rows flipped from the bracketed pin to the unbracketed canonical.
- `tests/spec_canonical_locks.rs` — new file with 15 regression-lock probes for F3 + F4 + F5 (CNV / SVD-WG003 uncertain endpoint pairs / combined-insertion bracketed forms / UTR∩intronic boundary-stacking subs).

Net diff: +231 test LOC + ~30 LOC src + 12-row fixture flip.

## Test plan
- [x] `cargo nextest run --features dev --test spec_canonical_locks` — 15/15 pass
- [x] Touched-test regression: `cargo nextest run -E 'test(test_parse_complex_delins_array) or test(pinned_v21_normalization_behavior) or test(ins_bracketed_expansion_emits_warning) or test(test_mismatch_parses)'` — 54/54 pass
- [x] Full suite: 5990 pass, 0 new failures (9 remaining failures are pre-existing axis_normalized / axis_coding_protein_descriptions / etc. divergences also present on `origin/main`)
- [x] `cargo fmt` + `cargo clippy --features dev --all-targets -- -D warnings` clean