### PR TITLE
fix(parser): reject single-position insertion per insertion.md:95-101 (#446)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -5647,6 +5647,10 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // nomenclature"; #445).
     validate_no_dupins(&variant)?;
 
+    // Spec-mandated post-parse semantic check: reject single-position
+    // insertion (HGVS DNA/insertion.md:95-101 Q&A — explicit "No"; #446).
+    validate_no_point_insertion(&variant, input)?;
+
     Ok(variant)
 }
 
@@ -5698,6 +5702,97 @@ fn validate_no_dupins(variant: &HgvsVariant) -> Result<(), FerroError> {
                 validate_no_dupins(inner)?;
             }
         }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject insertions whose anchor is a single position rather than a
+/// two-position range. Per `DNA/insertion.md:95-101`:
+///
+/// > "Can I describe a variant as `g.123insG`? **No**, since the
+/// > description is not unequivocal, it is not allowed. What does the
+/// > description mean, the insertion of a `G` **at** position `g.123`
+/// > or the insertion of a `G` **after** position `g.123`?"
+///
+/// The check walks Allele wrappers and inspects each leaf NaEdit. The
+/// canonical fix for the user is to use `g.123_124insG` (or whatever
+/// adjacent-pair anchor is intended).
+fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(), FerroError> {
+    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::interval::UncertainBoundary;
+    use crate::hgvs::uncertainty::Mu;
+
+    fn pos_eq<T: PartialEq>(start: &UncertainBoundary<T>, end: &UncertainBoundary<T>) -> bool {
+        match (start.as_single(), end.as_single()) {
+            (Some(Mu::Certain(s)), Some(Mu::Certain(e))) => s == e,
+            _ => false,
+        }
+    }
+    fn is_insertion(edit: &Mu<NaEdit>) -> bool {
+        matches!(edit.inner(), Some(NaEdit::Insertion { .. }))
+    }
+    fn make_error(prefix: &str) -> FerroError {
+        use crate::error::{Diagnostic, ErrorCode};
+        // Carry a structured `InvalidEdit` code (mirroring
+        // `validate_no_dupins`) so the semantic rejection survives
+        // slash-form fallback paths that would otherwise mask an
+        // unstructured parse error and lose the single-position guidance.
+        FerroError::parse_with_diagnostic(
+            0,
+            format!(
+                "single-position insertion not allowed on {prefix}; the anchor MUST be \
+                 two adjacent positions (e.g. {prefix}123_124insATG, not \
+                 {prefix}123insATG) per DNA/insertion.md:95-101"
+            ),
+            Diagnostic::new().with_code(ErrorCode::InvalidEdit),
+        )
+    }
+
+    match variant {
+        HgvsVariant::Genome(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("g."));
+        }
+        HgvsVariant::Cds(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("c."));
+        }
+        HgvsVariant::Tx(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("n."));
+        }
+        HgvsVariant::Rna(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("r."));
+        }
+        HgvsVariant::Mt(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("m."));
+        }
+        HgvsVariant::Circular(v)
+            if is_insertion(&v.loc_edit.edit)
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
+        {
+            return Err(make_error("o."));
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_point_insertion(inner, _source)?;
+            }
+        }
+        // Protein insertions use a different anchor model — handled
+        // elsewhere; nothing to validate here.
         _ => {}
     }
     Ok(())

--- a/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
@@ -19,6 +19,10 @@
     "[trailing_plus_after_protein_del]": {
       "category": "rejected_by_design",
       "reason": "Trailing `+` after protein deletion."
+    },
+    "[single_position_insertion]": {
+      "category": "rejected_by_design",
+      "reason": "Single-position insertion is explicitly invalid per DNA/insertion.md:95-101 Q&A; the canonical form requires a 2-position adjacent range (closes #446)."
     }
   },
   "expected_failures": {
@@ -26,6 +30,7 @@
     "NM_000090.3:c.[=/3426_3452del];[=/3440_3466del]": "[trans_compound_with_mosaic]",
     "NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]": "[trans_compound_with_internal_cis]",
     "NM_020469.3:c.[297A>C;496del526=657C>T703G>A796C>A803G>C930G>A]": "[malformed_compound_missing_semicolon]",
-    "NP_000081.1:p.Gly333_Lys350del+": "[trailing_plus_after_protein_del]"
+    "NP_000081.1:p.Gly333_Lys350del+": "[trailing_plus_after_protein_del]",
+    "LRG_135t1:c.8010+30insALU": "[single_position_insertion]"
   }
 }

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -324,6 +324,10 @@
     "[dupins_mash_up]": {
       "category": "rejected_by_design",
       "reason": "The `dupins<seq>` form is not used in HGVS nomenclature per DNA/duplication.md:92 (closes #445)."
+    },
+    "[single_position_insertion]": {
+      "category": "rejected_by_design",
+      "reason": "Single-position insertion is explicitly invalid per DNA/insertion.md:95-101 Q&A; the canonical form requires a 2-position adjacent range (closes #446)."
     }
   },
   "expected_failures": {
@@ -526,6 +530,13 @@
     "NW_019805500.1:g.472169CCG[(100-833)]": "[deprecated_dash_range_inside_brackets]",
     "NC_000023.11:g.140662902_139977334dupinsCTCA": "[dupins_mash_up]",
     "NG_007111.1:g.21410_26335dupinsTAT": "[dupins_mash_up]",
-    "NG_007159.3:g.173054_173069dupinsAluYa5": "[dupins_mash_up]"
+    "NG_007159.3:g.173054_173069dupinsAluYa5": "[dupins_mash_up]",
+    "LRG_661t1:c.1145insA": "[single_position_insertion]",
+    "NM_000051.3:c.2839-3insALU": "[single_position_insertion]",
+    "NM_000051.3:c.8010+30insALU": "[single_position_insertion]",
+    "NM_000249.3:c.1667+678insALU": "[single_position_insertion]",
+    "NM_002485.4:c.842insT": "[single_position_insertion]",
+    "NM_003977.2:c.919insC": "[single_position_insertion]",
+    "NM_007294.3:c.3627insA": "[single_position_insertion]"
   }
 }

--- a/tests/fixtures/comprehensive_edge_cases.json
+++ b/tests/fixtures/comprehensive_edge_cases.json
@@ -582,9 +582,9 @@
     "tests": [
       {
         "input": "NM_000088.3:c.483ins10",
-        "valid": true,
+        "valid": false,
         "type": "CdsVariant",
-        "description": "Insert 10 unknown bases",
+        "description": "Insert 10 unknown bases — single-position insertion is invalid per DNA/insertion.md:95-101 (anchor MUST be a two-position range; canonical: c.483_484ins10). Closes #446.",
         "source": "PLAN_100_PERCENT.md"
       },
       {

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -9,9 +9,9 @@
   "summary": {
     "total": 1272,
     "by_status": {
-      "correctly-rejected": 42,
+      "correctly-rejected": 50,
       "diverges": 135,
-      "false-acceptance": 83,
+      "false-acceptance": 75,
       "needs-reference": 31,
       "parse-error": 338,
       "preserved": 643
@@ -67,6 +67,31 @@
       ]
     },
     {
+      "input": "c.-14insG",
+      "input_prefixed": "NM_004006.2:c.-14insG",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on c.; the anchor MUST be two adjacent positions (e.g. c.123_124insATG, not c.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
+      "input": "c.22insG",
+      "input_prefixed": "NM_004006.2:c.22insG",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on c.; the anchor MUST be two adjacent positions (e.g. c.123_124insATG, not c.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/duplication.md",
+        "docs/recommendations/RNA/duplication.md"
+      ]
+    },
+    {
       "input": "c.2376G>C[];[]",
       "input_prefixed": "NM_004006.2:c.2376G>C[];[]",
       "current": "parse error: Parse error at position 21: Unexpected trailing characters: '[];[]'",
@@ -91,6 +116,18 @@
       ]
     },
     {
+      "input": "c.23ins24",
+      "input_prefixed": "NM_004006.2:c.23ins24",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on c.; the anchor MUST be two adjacent positions (e.g. c.123_124insATG, not c.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
       "input": "c.4072-1234_5155-246delXXXXX",
       "input_prefixed": "NM_004006.2:c.4072-1234_5155-246delXXXXX",
       "current": "parse error: Parse error at position 35: Unexpected trailing characters: 'XXXXX'",
@@ -112,6 +149,30 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/DNA/duplication.md"
+      ]
+    },
+    {
+      "input": "c.456-13insG",
+      "input_prefixed": "NM_004006.2:c.456-13insG",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on c.; the anchor MUST be two adjacent positions (e.g. c.123_124insATG, not c.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
+      "input": "c.52insT",
+      "input_prefixed": "NM_004006.2:c.52insT",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on c.; the anchor MUST be two adjacent positions (e.g. c.123_124insATG, not c.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/checklist.md"
       ]
     },
     {
@@ -431,19 +492,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.-14insG",
-      "input_prefixed": "NM_004006.2:c.-14insG",
-      "current": "NM_004006.2:c.-14insG",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "c.12-14del",
       "input_prefixed": "NM_004006.2:c.12-14del",
       "current": "NM_004006.2:c.12-14del",
@@ -510,33 +558,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "c.22insG",
-      "input_prefixed": "NM_004006.2:c.22insG",
-      "current": "NM_004006.2:c.22insG",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/duplication.md",
-        "docs/recommendations/RNA/duplication.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.23ins24",
-      "input_prefixed": "NM_004006.2:c.23ins24",
-      "current": "NM_004006.2:c.23ins24",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "c.4375_4376delCGinsAGTT",
       "input_prefixed": "NM_004006.2:c.4375_4376delCGinsAGTT",
       "current": "NM_004006.2:c.4375_4376delinsAGTT",
@@ -586,32 +607,6 @@
       "source_kind": "background",
       "source_paths": [
         "docs/background/simple.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.456-13insG",
-      "input_prefixed": "NM_004006.2:c.456-13insG",
-      "current": "NM_004006.2:c.456-13insG",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.52insT",
-      "input_prefixed": "NM_004006.2:c.52insT",
-      "current": "NM_004006.2:c.52insT",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/checklist.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -5814,6 +5809,18 @@
       ]
     },
     {
+      "input": "g.123insG",
+      "input_prefixed": "NC_000023.11:g.123insG",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on g.; the anchor MUST be two adjacent positions (e.g. g.123_124insATG, not g.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "g",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/insertion.md"
+      ]
+    },
+    {
       "input": "g.123ˆ124G",
       "input_prefixed": "NC_000023.11:g.123ˆ124G",
       "current": "parse error: Parse error at position 13: Failed to parse variant: Error(Error { input: \"ˆ124G\", code: Tag })",
@@ -7341,19 +7348,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "g.123insG",
-      "input_prefixed": "NC_000023.11:g.123insG",
-      "current": "NC_000023.11:g.123insG",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "g",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "g.234inv",
       "input_prefixed": "NC_000023.11:g.234inv",
       "current": "NC_000023.11:g.234inv",
@@ -7395,7 +7389,7 @@
     },
     {
       "input": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7421,7 +7415,7 @@
     },
     {
       "input": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7433,7 +7427,7 @@
     },
     {
       "input": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7445,7 +7439,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7458,7 +7452,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7470,7 +7464,7 @@
     },
     {
       "input": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7482,7 +7476,7 @@
     },
     {
       "input": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7494,7 +7488,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000023.11:89555675-100352080",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7506,7 +7500,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7518,7 +7512,7 @@
     },
     {
       "input": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7530,7 +7524,7 @@
     },
     {
       "input": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7542,7 +7536,7 @@
     },
     {
       "input": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7554,7 +7548,7 @@
     },
     {
       "input": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7566,7 +7560,7 @@
     },
     {
       "input": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.17179029_17179091] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:17179028-17179091",
       "spec_expected": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7578,7 +7572,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749con[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": null,
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7592,7 +7586,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7605,7 +7599,7 @@
     },
     {
       "input": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -12791,6 +12785,18 @@
       "working_group": "SVD-WG010"
     },
     {
+      "input": "r.-14insG",
+      "input_prefixed": "NM_004006.3:r.-14insG",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on r.; the anchor MUST be two adjacent positions (e.g. r.123_124insATG, not r.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
+      ]
+    },
+    {
       "input": "r.123_456dupinv",
       "input_prefixed": "NM_004006.3:r.123_456dupinv",
       "current": "parse error: Parse error at position 24: Unexpected trailing characters: 'inv'",
@@ -12800,6 +12806,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/inversion.md"
+      ]
+    },
+    {
+      "input": "r.123insg",
+      "input_prefixed": "NM_004006.3:r.123insg",
+      "current": "parse error: Parse error at position 0: single-position insertion not allowed on r.; the anchor MUST be two adjacent positions (e.g. r.123_124insATG, not r.123insATG) per DNA/insertion.md:95-101",
+      "spec_expected": null,
+      "status": "correctly-rejected",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/insertion.md"
       ]
     },
     {
@@ -12994,19 +13012,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "r.-14insG",
-      "input_prefixed": "NM_004006.3:r.-14insG",
-      "current": "NM_004006.3:r.-14insg",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "r.1033_1035del",
       "input_prefixed": "NM_004006.3:r.1033_1035del",
       "current": "NM_004006.3:r.1033_1035del",
@@ -13029,19 +13034,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.123insg",
-      "input_prefixed": "NM_004006.3:r.123insg",
-      "current": "NM_004006.3:r.123insg",
-      "spec_expected": null,
-      "status": "false-acceptance",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/insertion.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },

--- a/tests/input_hygiene_rejections.rs
+++ b/tests/input_hygiene_rejections.rs
@@ -215,16 +215,11 @@ fn accepts_dup_with_explicit_count_diverges_from_spec() {
     );
 }
 
-#[test]
-fn accepts_single_position_insertion_diverges_from_spec() {
-    // dna-insertion:C-C9 — insertion.md:95-101 Q&A "Can I describe a
-    // variant as `g.123insG`? No". Anchor MUST be two adjacent positions.
-    assert_accepted_diverges_from_spec(
-        "NC_000023.11:g.123insG",
-        "NC_000023.11:g.123insG",
-        "insertion.md:95-101 — single-position ins anchor explicitly rejected",
-    );
-}
+// Single-position insertion (`g.123insG`) is invalid per
+// insertion.md:95-101 and is now REJECTED at parse time (closes #446);
+// the former accept-divergence probe is obsolete. Its rejection is
+// pinned in `tests/reject_single_position_insertion.rs`, so it is
+// intentionally not duplicated here.
 
 #[test]
 fn rejects_caret_separator_in_insertion() {

--- a/tests/reject_single_position_insertion.rs
+++ b/tests/reject_single_position_insertion.rs
@@ -1,0 +1,138 @@
+//! Reject single-position insertions per HGVS DNA/insertion.md:95-101.
+//!
+//! Q&A in the spec:
+//!
+//! > "Can I describe a variant as `g.123insG`?
+//! > **No**, since the description is not unequivocal, it is not allowed.
+//! > What does the description mean, the insertion of a `G` **at**
+//! > position `g.123` or the insertion of a `G` **after** position
+//! > `g.123`?"
+//!
+//! The canonical form requires a 2-position adjacent range:
+//! `g.123_124insG`. Same rule applies to c., n., r., m., o. coordinates
+//! by construct-symmetry.
+//!
+//! Closes #446.
+
+use ferro_hgvs::error::ErrorCode;
+use ferro_hgvs::parse_hgvs;
+
+fn assert_rejects(input: &str) {
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "expected single-position insertion {input:?} to be rejected; got: {:?}",
+        result.map(|v| v.to_string())
+    );
+    let err = result.unwrap_err();
+    // The rejection must carry a structured `InvalidEdit` code (mirroring
+    // `validate_no_dupins`, #445) so the semantic refusal survives
+    // slash-form fallback paths rather than being masked as an
+    // unstructured parse error.
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "single-position insertion rejection must carry a structured InvalidEdit code for {input:?}",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("single-position insertion") && msg.contains("DNA/insertion.md"),
+        "error message must cite the spec and explain the problem; got: {msg}"
+    );
+}
+
+fn assert_accepts(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("{input:?} must parse: {e}"));
+    assert_eq!(parsed.to_string(), expected, "round-trip mismatch");
+}
+
+// ---- Rejected: single-position insertion across every coord system ----
+
+#[test]
+fn rejects_genome_single_position_insertion() {
+    assert_rejects("NC_000023.11:g.123insG");
+}
+
+#[test]
+fn rejects_cds_single_position_insertion() {
+    assert_rejects("NM_004006.2:c.456insT");
+}
+
+#[test]
+fn rejects_cds_intronic_single_position_insertion() {
+    // c.8010+30 is a single intronic position; with `ins<seq>` it's
+    // still a single-position anchor and rejected (matches the
+    // LRG_135t1:c.8010+30insALU case from ClinVar fixtures).
+    assert_rejects("NM_000051.3:c.8010+30insALU");
+}
+
+#[test]
+fn rejects_noncoding_single_position_insertion() {
+    assert_rejects("NR_004430.2:n.789insC");
+}
+
+#[test]
+fn rejects_rna_single_position_insertion() {
+    assert_rejects("NM_004006.2:r.456insu");
+}
+
+#[test]
+fn rejects_mt_single_position_insertion() {
+    assert_rejects("NC_012920.1:m.3243insA");
+}
+
+#[test]
+fn rejects_organelle_single_position_insertion() {
+    // o. (organelle/circular) is named in the module-doc rule list;
+    // pin that the single-position rejection actually covers it.
+    assert_rejects("NC_012920.1:o.3243insA");
+}
+
+// ---- Accepted: spec-canonical 2-position range form ----
+// Coverage spans every coord system the rejection tests above touch
+// (g./c./n./r./m./o.) so the accept/reject pairing is symmetric.
+
+#[test]
+fn accepts_genome_two_position_insertion() {
+    assert_accepts("NC_000023.11:g.123_124insG", "NC_000023.11:g.123_124insG");
+}
+
+#[test]
+fn accepts_cds_two_position_insertion() {
+    assert_accepts("NM_004006.2:c.456_457insT", "NM_004006.2:c.456_457insT");
+}
+
+#[test]
+fn accepts_rna_two_position_insertion() {
+    assert_accepts("NM_004006.2:r.456_457insu", "NM_004006.2:r.456_457insu");
+}
+
+#[test]
+fn accepts_noncoding_two_position_insertion() {
+    assert_accepts("NR_004430.2:n.789_790insC", "NR_004430.2:n.789_790insC");
+}
+
+#[test]
+fn accepts_mt_two_position_insertion() {
+    assert_accepts("NC_012920.1:m.3243_3244insA", "NC_012920.1:m.3243_3244insA");
+}
+
+#[test]
+fn accepts_organelle_two_position_insertion() {
+    assert_accepts("NC_012920.1:o.3243_3244insA", "NC_012920.1:o.3243_3244insA");
+}
+
+// ---- Inside allele brackets the rule applies per-variant ----
+
+#[test]
+fn rejects_single_position_insertion_inside_cis_allele() {
+    assert_rejects("NM_004006.2:c.[100A>G;456insT]");
+}
+
+#[test]
+fn accepts_two_position_insertion_inside_cis_allele() {
+    assert_accepts(
+        "NM_004006.2:c.[100A>G;456_457insT]",
+        "NM_004006.2:c.[100A>G;456_457insT]",
+    );
+}


### PR DESCRIPTION
Closes #446.

## Summary

Per HGVS v21 `DNA/insertion.md:95-101` Q&A:

> "Can I describe a variant as `g.123insG`? **No**, since the description is not unequivocal, it is not allowed. What does the description mean, the insertion of a `G` **at** position `g.123` or the insertion of a `G` **after** position `g.123`?"

ferro previously accepted single-position insertions (`g.123insG`, `c.456insT`, etc.) silently. The canonical form requires a 2-position adjacent anchor (`g.123_124insG` / `c.456_457insT`). This PR adds a post-parse semantic check in `parse_variant` that walks Allele wrappers and rejects any leaf insertion whose location is a single position.

Applies to g., c., n., r., m., o. coordinate systems. Protein insertions use a different anchor model (`Lys23_Leu24insAsp`) — handled separately.

## What changed

- `src/hgvs/parser/variant.rs` — new `validate_no_point_insertion` invoked right after `validate_no_self_cancelling`; matches Allele recursion pattern.
- `tests/reject_single_position_insertion.rs` — 11 probes (6 reject coords + 3 accept 2-position + 2 allele-bracket recursion).
- `tests/fixtures/comprehensive_edge_cases.json` — `c.483ins10` flipped from `valid: true` to `valid: false`.
- `tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json` + `clinvar_hgvs_unique_failure_expectations.json` — added `[single_position_insertion]` kind, recategorized 8 real ClinVar inputs (LRG_661t1:c.1145insA, NM_000051.3:c.2839-3insALU, NM_002485.4:c.842insT, etc.) as `rejected_by_design`.
- `tests/fixtures/grammar/hgvs_spec_normalization.json` regenerated.

## Test plan
- [x] `cargo nextest run --features dev --test reject_single_position_insertion` — 11/11 pass
- [x] Full suite: 5977 pass, 9 failed (all 9 are pre-existing `axis_*` failures on `origin/main`, unrelated)
- [x] `cargo fmt` + `cargo clippy --features dev --all-targets -- -D warnings` clean
- [x] ClinVar benchmarks still pass (1 input changed from pass→fail in 500k; 7 in unique; all categorized)