### PR TITLE
fix(parser): reject `dupins<seq>` per duplication.md:92 (#445)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -5624,7 +5624,65 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // (HGVS recommendations/general.md line 47, tracked under issue #115).
     validate_no_self_cancelling(&variant, input)?;
 
+    // Spec-mandated post-parse semantic check: reject `dupins` mash-up
+    // (HGVS DNA/duplication.md:92 — "a format not used in HGVS
+    // nomenclature"; #445).
+    validate_no_dupins(&variant)?;
+
     Ok(variant)
+}
+
+/// Reject `dupins` edits per `DNA/duplication.md:92`:
+///
+/// > "the variant is not described using `dupins`, a format not used in
+/// > HGVS nomenclature."
+///
+/// `<code class="invalid">` markup in the spec — the strongest
+/// prohibition register. ferro previously parsed `dupins<seq>` into the
+/// `NaEdit::DupIns` variant and round-tripped it; this validation
+/// rejects at parse time with a diagnostic pointing the user at the
+/// canonical alternatives (`del` followed by `ins`, or `delins`).
+///
+/// The `NaEdit::DupIns` variant is kept in the data model for now (no
+/// data-type refactor) — this check just ensures it is never produced
+/// by the parser's user-facing entry point. Internal code that
+/// constructs `DupIns` for normalization intermediates is unaffected.
+fn validate_no_dupins(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::uncertainty::Mu;
+
+    fn is_dupins(edit: &Mu<NaEdit>) -> bool {
+        matches!(edit.inner(), Some(NaEdit::DupIns { .. }))
+    }
+    fn make_error() -> FerroError {
+        use crate::error::{Diagnostic, ErrorCode};
+        // Carry a structured `InvalidEdit` code so the semantic rejection
+        // survives slash-form fallback paths that would otherwise mask an
+        // unstructured parse error and lose the `dupins` guidance.
+        FerroError::parse_with_diagnostic(
+            0,
+            "the `dupins<seq>` form is not used in HGVS nomenclature \
+             (DNA/duplication.md:92). Describe as `del` followed by \
+             `ins`, or as `delins` if the edit is contiguous.",
+            Diagnostic::new().with_code(ErrorCode::InvalidEdit),
+        )
+    }
+
+    match variant {
+        HgvsVariant::Genome(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Cds(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Tx(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Rna(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Mt(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Circular(v) if is_dupins(&v.loc_edit.edit) => return Err(make_error()),
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_dupins(inner)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Pre-parse rejection for `p.…ins[Ala;Pro]` — W3021

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -320,6 +320,10 @@
     "[non_canonical_paren_around_single_count]": {
       "category": "rejected_by_design",
       "reason": "`[(3)]` paren around single count is non-canonical; spec form is `[3]` for fixed and `[(N_M)]` for ranges."
+    },
+    "[dupins_mash_up]": {
+      "category": "rejected_by_design",
+      "reason": "The `dupins<seq>` form is not used in HGVS nomenclature per DNA/duplication.md:92 (closes #445)."
     }
   },
   "expected_failures": {
@@ -519,6 +523,9 @@
     "NP_009225.1:p.Phe1036_Lys1037delinsPheTerArgfs": "[trailing_fs_after_delins]",
     "NP_612422.2:p.Ala278Alabutlastnucleotideofexon.": "[malformed_clinical_comment_text]",
     "NR_002717.2:n.894CTA[(3)]CTG[(317_330)]": "[non_canonical_paren_around_single_count]",
-    "NW_019805500.1:g.472169CCG[(100-833)]": "[deprecated_dash_range_inside_brackets]"
+    "NW_019805500.1:g.472169CCG[(100-833)]": "[deprecated_dash_range_inside_brackets]",
+    "NC_000023.11:g.140662902_139977334dupinsCTCA": "[dupins_mash_up]",
+    "NG_007111.1:g.21410_26335dupinsTAT": "[dupins_mash_up]",
+    "NG_007159.3:g.173054_173069dupinsAluYa5": "[dupins_mash_up]"
   }
 }

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -5288,10 +5288,19 @@ mod ins_bracketed_expansion {
     // -------------------------------------------------------------------
     // 11. The same canonicalization applies to a `dupins` payload.
     // -------------------------------------------------------------------
+    /// `dupins<seq>` is rejected at parse time per
+    /// `DNA/duplication.md:92` (#445). The normalize-time expansion of
+    /// the bracketed `dupins[ATC]` payload never fires because the
+    /// parser refuses the form. Pin the rejection diagnostic.
     #[test]
-    fn dupins_bracketed_payload_expands() {
-        let result = normalize_ok(MockProvider::new(), "NC_000001.11:g.5207_5208dupins[ATC]");
-        assert_eq!(result, "NC_000001.11:g.5207_5208dupinsATC");
+    fn dupins_bracketed_payload_rejected_at_parse() {
+        let result = parse_hgvs("NC_000001.11:g.5207_5208dupins[ATC]");
+        let err = result.expect_err("dupins should be rejected at parse");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("dupins") && msg.contains("DNA/duplication.md"),
+            "expected dupins-rejection diagnostic, got: {msg}"
+        );
     }
 
     // -------------------------------------------------------------------

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -953,6 +953,11 @@ fn test_reference_insertions(#[case] input: &str, #[case] _description: &str) {
 
 // =============================================================================
 // Dupins (combined duplication + insertion)
+//
+// HGVS v21 (`DNA/duplication.md:92`) rejects this form: "a format not
+// used in HGVS nomenclature." ferro now rejects at parse time per #445.
+// The test was previously asserting acceptance; flipped to assert
+// rejection with the canonical alternatives in the diagnostic.
 // =============================================================================
 
 #[rstest]
@@ -961,11 +966,16 @@ fn test_reference_insertions(#[case] input: &str, #[case] _description: &str) {
 fn test_dupins(#[case] input: &str, #[case] _description: &str) {
     let result = parse_hgvs(input);
     assert!(
-        result.is_ok(),
-        "Failed to parse {} ({}): {:?}",
+        result.is_err(),
+        "expected ferro to reject `dupins` form {} ({}); got: {:?}",
         input,
         _description,
-        result.err()
+        result.map(|v| v.to_string())
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("dupins") && msg.contains("DNA/duplication.md"),
+        "diagnostic must cite the spec and the form: {msg}"
     );
 }
 

--- a/tests/reject_dupins.rs
+++ b/tests/reject_dupins.rs
@@ -1,0 +1,102 @@
+//! Reject `dupins<seq>` per HGVS DNA/duplication.md:92.
+//!
+//! The spec says:
+//!
+//! > "the variant is not described using `dupins`, a format not used in
+//! > HGVS nomenclature."
+//!
+//! Marked `class="invalid"` in the spec — the strongest prohibition
+//! register. Canonical alternatives:
+//! - describe `del` and `ins` as separate edits,
+//! - use `delins` for a contiguous deletion-insertion.
+//!
+//! Closes #445.
+
+use ferro_hgvs::error::ErrorCode;
+use ferro_hgvs::parse_hgvs;
+
+fn assert_rejects(input: &str) {
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "expected `dupins` form {input:?} to be rejected; got: {:?}",
+        result.map(|v| v.to_string())
+    );
+    let err = result.unwrap_err();
+    // The rejection must carry a structured `InvalidEdit` code so the
+    // semantic refusal survives slash-form fallback paths rather than
+    // being masked as an unstructured parse error.
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "dupins rejection must carry a structured InvalidEdit code for {input:?}",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("dupins") && msg.contains("DNA/duplication.md"),
+        "diagnostic must cite the spec; got: {msg}"
+    );
+}
+
+fn assert_accepts(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("{input:?} must parse: {e}"));
+    assert_eq!(parsed.to_string(), expected, "round-trip mismatch");
+}
+
+// ---- Rejected: `dupins<seq>` across coord systems ----
+
+#[test]
+fn rejects_genome_dupins() {
+    assert_rejects("NC_000001.11:g.5207_5208dupinsATC");
+}
+
+#[test]
+fn rejects_genome_single_position_dupins() {
+    // The combination of `dupins` + single-position is doubly invalid;
+    // reject for the dupins reason (#445), not for the single-position
+    // reason (#446).
+    let result = parse_hgvs("NC_000001.11:g.1000dupinsTAG");
+    assert!(result.is_err());
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("dupins"),
+        "diagnostic must mention dupins first; got: {msg}"
+    );
+}
+
+#[test]
+fn rejects_cds_dupins() {
+    assert_rejects("NM_004006.2:c.20_21dupinsATG");
+}
+
+#[test]
+fn rejects_rna_dupins() {
+    assert_rejects("NM_004006.2:r.20_21dupinsacg");
+}
+
+#[test]
+fn rejects_dupins_with_bracketed_payload() {
+    assert_rejects("NC_000001.11:g.5207_5208dupins[ATC]");
+}
+
+// ---- Inside allele brackets ----
+
+#[test]
+fn rejects_dupins_inside_cis_allele() {
+    assert_rejects("NM_004006.2:c.[100A>G;20_21dupinsATG]");
+}
+
+// ---- Canonical alternatives stay accepted ----
+
+#[test]
+fn accepts_canonical_delins_alternative() {
+    assert_accepts(
+        "NC_000001.11:g.5207_5208delinsATC",
+        "NC_000001.11:g.5207_5208delinsATC",
+    );
+}
+
+#[test]
+fn accepts_canonical_dup_alone() {
+    assert_accepts("NC_000001.11:g.5207_5208dup", "NC_000001.11:g.5207_5208dup");
+}


### PR DESCRIPTION
Closes #445.

## Summary

Per HGVS v21 `DNA/duplication.md:92`:

> "the variant is not described using `dupins`, a format not used in HGVS nomenclature."

Marked `class=\"invalid\"` in the spec — the strongest prohibition register. ferro previously parsed `dupins<seq>` into the `NaEdit::DupIns` variant and round-tripped it. This PR adds a post-parse semantic check that rejects at the user-facing parse entry point with a diagnostic pointing at canonical alternatives.

## Implementation

`validate_no_dupins` is a post-parse semantic check in `parse_variant`, run after the self-cancelling and single-position-insertion checks (#446). Walks Allele wrappers and rejects any leaf variant whose edit is `NaEdit::DupIns`.

The `NaEdit::DupIns` variant is kept in the data model — internal normalization code that constructs `DupIns` as a canonicalization intermediate is unaffected. Only the user-facing `parse_hgvs` entry point rejects.

## Test + fixture updates

- `tests/reject_dupins.rs` (new) — 8 probes (5 reject across coord systems + 1 allele-bracket recursion + 2 accept-canonical alternatives).
- `tests/parser_tests.rs::test_dupins` — flipped from \"must parse\" to \"must reject with spec citation\".
- `tests/normalize_tests.rs::dupins_bracketed_payload_expands` → `dupins_bracketed_payload_rejected_at_parse`.
- `tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json` — added `[dupins_mash_up]` kind; recategorized 3 real ClinVar inputs (`NC_000023.11:g.140662902_139977334dupinsCTCA`, `NG_007111.1:g.21410_26335dupinsTAT`, `NG_007159.3:g.173054_173069dupinsAluYa5`) as `rejected_by_design`.
- `tests/fixtures/grammar/hgvs_spec_normalization.json` regenerated.

## Test plan
- [x] \`cargo nextest run --features dev --test reject_dupins\` — 8/8 pass
- [x] Full suite: 5977 pass, 9 failed (all 9 are pre-existing \`axis_*\` failures on \`origin/main\`, unrelated)
- [x] \`cargo fmt\` + \`cargo clippy --features dev --all-targets -- -D warnings\` clean