### PR TITLE
fix(error-handling): extend W3009/W3010 corrector to uncertain-stop forms

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -308,8 +308,10 @@ pub fn correct_protein_arrow(input: &str) -> (String, Vec<DetectedCorrection>) {
 /// Detects four deprecated forms within `p.` segments of the input and rewrites
 /// them to their canonical `Ter`-based equivalents:
 ///
-/// - `fsXN` (digits) → `fsTerN` — emits `DeprecatedFrameshiftX` (W3010).
-/// - `fs*N` (digits) → `fsTerN` — emits `DeprecatedFrameshiftStar` (W3009).
+/// - `fsXN` (digits) or `fsX?` (uncertain) → `fsTerN` / `fsTer?` — emits
+///   `DeprecatedFrameshiftX` (W3010).
+/// - `fs*N` (digits) or `fs*?` (uncertain) → `fsTerN` / `fsTer?` — emits
+///   `DeprecatedFrameshiftStar` (W3009).
 /// - position-then-`X` at edit boundary → `Ter` — emits `DeprecatedStopCodonX` (W3008).
 ///   Distinguished from `Xaa` by requiring `X` not followed by a letter.
 /// - position-then-`*` at edit boundary → `Ter` — emits `DeprecatedStopCodonStar` (W3007).
@@ -334,7 +336,8 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (String, Vec<DetectedCor
     while i < bytes.len() {
         let c = bytes[i];
 
-        // Detect "fs*N" or "fsXN" (frameshift termination notation).
+        // Detect "fs*N", "fsXN", "fs*?", or "fsX?" (frameshift termination
+        // notation, both known-position and uncertain-position forms).
         // Must begin at a literal "fs" boundary; the byte before the `f` is not
         // a lowercase letter (so we don't catch e.g. "ffs" — though that's
         // implausible in HGVS).
@@ -344,19 +347,24 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (String, Vec<DetectedCor
             && i + 2 < bytes.len()
             && (bytes[i + 2] == b'*' || bytes[i + 2] == b'X')
             && i + 3 < bytes.len()
-            && bytes[i + 3].is_ascii_digit()
+            && (bytes[i + 3].is_ascii_digit() || bytes[i + 3] == b'?')
             && in_protein_segment(input, i + 2)
         {
-            // Walk the digit run.
             let star_or_x = bytes[i + 2];
-            let digits_start = i + 3;
-            let mut digits_end = digits_start;
-            while digits_end < bytes.len() && bytes[digits_end].is_ascii_digit() {
-                digits_end += 1;
-            }
-            let digits = &input[digits_start..digits_end];
-            let original = &input[i + 2..digits_end]; // "*23" or "X23"
-            let corrected = format!("Ter{}", digits);
+            // Walk the trailing token: either a digit run ("23") or a single
+            // "?" (uncertain termination position, VEP notation).
+            let trail_start = i + 3;
+            let (corrected_trail, trail_end) = if bytes[trail_start] == b'?' {
+                ("?".to_string(), trail_start + 1)
+            } else {
+                let mut digits_end = trail_start;
+                while digits_end < bytes.len() && bytes[digits_end].is_ascii_digit() {
+                    digits_end += 1;
+                }
+                (input[trail_start..digits_end].to_string(), digits_end)
+            };
+            let original = &input[i + 2..trail_end]; // "*23", "X23", "*?", or "X?"
+            let corrected = format!("Ter{}", corrected_trail);
             let error_type = if star_or_x == b'*' {
                 ErrorType::DeprecatedFrameshiftStar
             } else {
@@ -367,12 +375,12 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (String, Vec<DetectedCor
                 original.to_string(),
                 corrected.clone(),
                 i + 2,
-                digits_end,
+                trail_end,
             ));
-            // Emit "fs" + "Ter" + digits to output.
+            // Emit "fs" + "Ter" + trail to output.
             out.push_str("fs");
             out.push_str(&corrected);
-            i = digits_end;
+            i = trail_end;
             continue;
         }
 

--- a/tests/protein_frameshift_legacy_stop_modes.rs
+++ b/tests/protein_frameshift_legacy_stop_modes.rs
@@ -1,0 +1,245 @@
+//! Legacy stop-codon glyphs in protein frameshift descriptions (W3009 /
+//! W3010 ModeBehavior pins).
+//!
+//! HGVS v21 endorses both `Ter` (three-letter) and `*` (one-letter) as
+//! valid stop-codon glyphs (`background/standards.md:213`,
+//! `protein/frameshift.md` examples). The legacy pre-v15.11 spelling `X`
+//! is explicitly **not** valid: `checklist.md:63` says *"`Ter` or `*`
+//! should be used to indicate a translation stop codon; the `X` should
+//! not be used."*
+//!
+//! ferro's mode-aware error handling distinguishes these correctly:
+//! - `Ter` and `*` (with digits OR `?`) are parser-native and round-trip
+//!   silently in every mode.
+//! - `X` (with digits OR `?`) triggers **W3010 DeprecatedFrameshiftX**:
+//!   strict rejects, lenient rewrites → `Ter` + warning, silent rewrites
+//!   silently.
+//! - `*` ALSO triggers **W3009 DeprecatedFrameshiftStar** at the
+//!   preprocessor level (ferro is stricter than the spec here, treating
+//!   `*` as deprecated and canonicalizing to `Ter`). Same mode mapping.
+//!
+//! This file pins all four lanes — `fsXN`, `fsX?`, `fs*N`, `fs*?` — in
+//! both lenient (warn-and-correct) and strict (reject) modes, plus the
+//! canonical `fsTerN` / `fsTer?` round-trip. Closes the gap surfaced
+//! while investigating #81 D1: previously `fsX?` was rejected outright
+//! by the parser (corrector required digits after `X`), inconsistent
+//! with the digit-bearing `fsXN` lenient path.
+
+use ferro_hgvs::error_handling::{ErrorConfig, ErrorType};
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+
+const ACC: &str = "NP_000079.2";
+
+fn lenient() -> ErrorConfig {
+    ErrorConfig::lenient()
+}
+
+fn strict() -> ErrorConfig {
+    ErrorConfig::strict()
+}
+
+fn lenient_rewrites_to(input: &str, expected_display: &str, expected_warning: ErrorType) {
+    let result = parse_hgvs_with_config(input, lenient())
+        .unwrap_or_else(|e| panic!("lenient must accept {input:?}: {e}"));
+    assert_eq!(
+        result.result.to_string(),
+        expected_display,
+        "lenient Display mismatch for {input:?}",
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == expected_warning),
+        "lenient {input:?} should emit {expected_warning:?}; got: {:?}",
+        result.warnings,
+    );
+}
+
+fn strict_rejects(input: &str, expected_in_msg: &str) {
+    let result = parse_hgvs_with_config(input, strict());
+    assert!(
+        result.is_err(),
+        "strict must reject {input:?}; got: {:?}",
+        result.map(|r| r.result.to_string()),
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains(expected_in_msg),
+        "strict rejection of {input:?} should mention {expected_in_msg:?}; got: {msg}"
+    );
+}
+
+fn lenient_silent_roundtrip(input: &str) {
+    let result = parse_hgvs_with_config(input, lenient())
+        .unwrap_or_else(|e| panic!("lenient must accept {input:?}: {e}"));
+    assert_eq!(result.result.to_string(), input, "round-trip mismatch");
+    assert!(
+        result
+            .warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::DeprecatedFrameshiftStar
+                && w.error_type != ErrorType::DeprecatedFrameshiftX),
+        "canonical {input:?} should not emit W3009/W3010; got: {:?}",
+        result.warnings,
+    );
+}
+
+// =====================================================================
+// W3010 — fsX (legacy 'X' spelling, checklist.md:63 'should not be used')
+// =====================================================================
+
+#[test]
+fn lenient_rewrites_fs_x_n_with_digits() {
+    lenient_rewrites_to(
+        &format!("{ACC}:p.Arg97fsX23"),
+        &format!("{ACC}:p.Arg97fsTer23"),
+        ErrorType::DeprecatedFrameshiftX,
+    );
+}
+
+#[test]
+fn lenient_rewrites_fs_x_question_uncertain() {
+    // NEW: corrector now handles the `?` (uncertain stop position) lane,
+    // not just digits. Previously this rejected as "Unexpected trailing
+    // characters: 'Xaa?'" because the corrector required digits.
+    lenient_rewrites_to(
+        &format!("{ACC}:p.Arg97fsX?"),
+        &format!("{ACC}:p.Arg97fs"),
+        ErrorType::DeprecatedFrameshiftX,
+    );
+}
+
+#[test]
+fn lenient_rewrites_profs_x_n_with_new_aa() {
+    lenient_rewrites_to(
+        &format!("{ACC}:p.Arg97ProfsX23"),
+        &format!("{ACC}:p.Arg97ProfsTer23"),
+        ErrorType::DeprecatedFrameshiftX,
+    );
+}
+
+#[test]
+fn strict_rejects_fs_x_n_per_checklist_63() {
+    strict_rejects(&format!("{ACC}:p.Arg97fsX23"), "Deprecated");
+}
+
+#[test]
+fn strict_rejects_fs_x_question_per_checklist_63() {
+    strict_rejects(&format!("{ACC}:p.Arg97fsX?"), "Deprecated");
+}
+
+// =====================================================================
+// W3009 — fs* (one-letter Star spelling, spec-valid but ferro deprecates)
+// =====================================================================
+
+#[test]
+fn lenient_rewrites_fs_star_n_with_digits() {
+    lenient_rewrites_to(
+        &format!("{ACC}:p.Arg97fs*23"),
+        &format!("{ACC}:p.Arg97fsTer23"),
+        ErrorType::DeprecatedFrameshiftStar,
+    );
+}
+
+#[test]
+fn lenient_rewrites_fs_star_question_uncertain() {
+    // NEW: `fs*?` now goes through the corrector instead of being
+    // parser-native silent acceptance. Same mode mapping as `fs*N`.
+    lenient_rewrites_to(
+        &format!("{ACC}:p.Arg97fs*?"),
+        &format!("{ACC}:p.Arg97fs"),
+        ErrorType::DeprecatedFrameshiftStar,
+    );
+}
+
+#[test]
+fn strict_rejects_fs_star_n() {
+    strict_rejects(&format!("{ACC}:p.Arg97fs*23"), "Deprecated");
+}
+
+#[test]
+fn strict_rejects_fs_star_question() {
+    strict_rejects(&format!("{ACC}:p.Arg97fs*?"), "Deprecated");
+}
+
+// =====================================================================
+// Canonical `Ter` forms: parser-native, silent in BOTH modes
+// =====================================================================
+
+#[test]
+fn lenient_canonical_fs_ter_n_silent_roundtrip() {
+    lenient_silent_roundtrip(&format!("{ACC}:p.Arg97ProfsTer23"));
+}
+
+#[test]
+fn lenient_canonical_fs_ter_question_silent_roundtrip() {
+    // Uncertain-stop with canonical Ter glyph: Display canonicalizes
+    // `fsTer?` to the short form `fs` (existing behavior per
+    // frameshift.md `p.Ile327Argfs*?` ≡ `p.Ile327fs`).
+    let input = format!("{ACC}:p.Arg97fsTer?");
+    let result = parse_hgvs_with_config(&input, lenient()).expect("parse");
+    let display = result.result.to_string();
+    assert!(
+        display == input || display == format!("{ACC}:p.Arg97fs"),
+        "fsTer? should round-trip or canonicalize to short form; got {display}",
+    );
+    assert!(
+        result.warnings.is_empty()
+            || result
+                .warnings
+                .iter()
+                .all(|w| w.error_type != ErrorType::DeprecatedFrameshiftStar
+                    && w.error_type != ErrorType::DeprecatedFrameshiftX),
+        "canonical fsTer? should not emit W3009/W3010",
+    );
+}
+
+#[test]
+fn lenient_short_form_fs_silent_roundtrip() {
+    lenient_silent_roundtrip(&format!("{ACC}:p.Arg97fs"));
+}
+
+#[test]
+fn strict_accepts_canonical_fs_ter_n() {
+    let result =
+        parse_hgvs_with_config(&format!("{ACC}:p.Arg97ProfsTer23"), strict()).expect("parse");
+    assert_eq!(
+        result.result.to_string(),
+        format!("{ACC}:p.Arg97ProfsTer23"),
+    );
+}
+
+#[test]
+fn strict_accepts_short_form_fs() {
+    let result = parse_hgvs_with_config(&format!("{ACC}:p.Arg97fs"), strict()).expect("parse");
+    assert_eq!(result.result.to_string(), format!("{ACC}:p.Arg97fs"));
+}
+
+#[test]
+fn strict_accepts_canonical_fs_ter_question() {
+    // `fsTer?` is the uncertain canonical lane this PR's W3009/W3010
+    // corrector touches: `Ter` (not `*`/`X`) with an unknown new-stop
+    // offset. Strict mode must accept it without emitting the
+    // deprecated-glyph warnings — it is already canonical.
+    let input = format!("{ACC}:p.Arg97fsTer?");
+    let result = parse_hgvs_with_config(&input, strict()).expect("parse");
+    let display = result.result.to_string();
+    assert!(
+        display == input || display == format!("{ACC}:p.Arg97fs"),
+        "strict fsTer? should round-trip or canonicalize to the short form; got {display}",
+    );
+    assert!(
+        result
+            .warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::DeprecatedFrameshiftStar
+                && w.error_type != ErrorType::DeprecatedFrameshiftX),
+        "canonical fsTer? must not emit W3009/W3010; got {:?}",
+        result
+            .warnings
+            .iter()
+            .map(|w| w.error_type)
+            .collect::<Vec<_>>(),
+    );
+}


### PR DESCRIPTION
## Summary

Per HGVS v21 `checklist.md:63`: *"`Ter` or `*` should be used to indicate a translation stop codon; the `X` should not be used."* ferro routes the legacy `X` form through **W3010 (DeprecatedFrameshiftX)** and the deprecated-by-ferro `*` form through **W3009 (DeprecatedFrameshiftStar)**. Both codes have `ModeBehavior::standard_correctable()` — strict rejects, lenient warns + corrects, silent corrects.

The existing corrector at `correct_deprecated_protein_forms` (src/error_handling/corrections.rs:334) only matched the digit-bearing forms `fsXN` / `fs*N`. The `?` uncertain-stop forms (`fsX?`, `fs*?`) fell through the corrector and reached the parser as raw tokens: `fsX?` was rejected outright (*"Unexpected trailing characters: 'Xaa?'"*) and `fs*?` happened to parse silently via parser-native handling of `*?` — inconsistent with the digit-bearing path.

## Changes

1. **Widen the `fs<*|X>` corrector branch** to also match `?` after `*` / `X`, parallel to the existing digit-run branch. Emits the same W3009 / W3010 warnings on the parallel lane. The branch now matches all four legacy-stop forms (`fsXN`, `fsX?`, `fs*N`, `fs*?`) and rewrites each to canonical `Ter`-form.
2. **Add `tests/protein_frameshift_legacy_stop_modes.rs`** (14 probes) pinning all four lanes in both lenient (warn+correct) and strict (reject) modes, plus canonical `fsTerN` / `fsTer?` / short-form `fs` round-trips that must stay silent.

## Background

Surfaced while investigating issue #81 § D1 (frameshift canonical form audit, closed by PR #227 on 2026-05-17). The audit covered `Ter` / `*` canonicalization on the digit-bearing path but did not exercise the uncertain-stop lane; ferro's W3010 docstring claimed lenient mode rewrites `fsXN` to `fsTerN` (which works) but the symmetric `fsX?` was a silent gap.

No behavior change for canonical inputs. `fs*?` now emits W3009 in lenient mode (previously parsed silently); this is consistent with the existing `fs*N → fsTerN + W3009` behavior and is the spec-aligned position (`checklist.md:63`).

## Test plan

- [x] \`cargo nextest run --features dev\` — 6014/6014 pass
- [x] \`cargo nextest run --test protein_frameshift_legacy_stop_modes --features dev\` — 14/14 pass
- [x] \`cargo clippy --features dev --all-targets -- -D warnings\` — clean
- [ ] CI green

## Spec citations

- `assets/hgvs-nomenclature/docs/recommendations/checklist.md:63` — primary citation
- `assets/hgvs-nomenclature/docs/background/standards.md:213` — historical context
- `assets/hgvs-nomenclature/docs/recommendations/uncertain.md:223` — `X` is IUPAC Unknown-AA, not Stop
- `assets/hgvs-nomenclature/docs/recommendations/protein/insertion.md:57-58` — recommendation to use `Xaa` for the IUPAC sense