### PR TITLE
feat(error-handling): add W3023/W3024/W3025 for dup<N>/dup<seq>/del<seq> soft-prohibition forms (closes #460)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -966,6 +966,9 @@ class ErrorType(IntEnum):
     NonSpecMosaicForm = 34
     OverlapConflictingEdits = 35
     InitiatorMetCanonicalization = 36
+    DupSizeSuffix = 37
+    DupExplicitSeq = 38
+    DelExplicitSeq = 39
 
 class ErrorOverride(IntEnum):
     """Override behavior for a specific error type."""

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -2979,6 +2979,59 @@ pub fn detect_del_size_suffix(input: &str) -> Vec<DetectedCorrection> {
     hits
 }
 
+/// Detect duplications described with a size-count suffix (W3023).
+///
+/// Matches `dup` followed by one or more ASCII digits, terminated by a
+/// top-level boundary (`)`, `;`, `]`, whitespace, or end-of-input), inside
+/// a nucleic-acid coordinate segment. Per HGVS spec
+/// (`recommendations/DNA/duplication.md:140-143`), the canonical form names
+/// both endpoints, not a size; this detector is warn-only (mirrors W3011
+/// DelSizeSuffix; the position ambiguity prevents safe rewrite).
+pub fn detect_dup_size_suffix(input: &str) -> Vec<DetectedCorrection> {
+    let mut hits = Vec::new();
+    let bytes = input.as_bytes();
+    if !has_non_protein_description(bytes) {
+        return hits;
+    }
+
+    let mut i = 0usize;
+    while i + 3 <= bytes.len() {
+        if &bytes[i..i + 3] != b"dup" {
+            i += 1;
+            continue;
+        }
+        let digit_start = i + 3;
+        let mut j = digit_start;
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j == digit_start {
+            i += 3;
+            continue;
+        }
+        let end_byte = bytes.get(j).copied();
+        let is_terminator =
+            end_byte.is_none_or(|b| b == b')' || b == b';' || b == b']' || b.is_ascii_whitespace());
+        if !is_terminator {
+            i = j;
+            continue;
+        }
+        if !in_nucleic_acid_segment(input, i) {
+            i = j;
+            continue;
+        }
+        hits.push(DetectedCorrection::new(
+            ErrorType::DupSizeSuffix,
+            &input[i..j],
+            String::new(),
+            i,
+            j,
+        ));
+        i = j;
+    }
+    hits
+}
+
 /// Detect and correct deletion-insertions whose inserted sequence is empty
 /// (W3012, SVA-010).
 ///
@@ -4454,6 +4507,47 @@ mod tests {
         // (DNA/deletion) does not apply; protein has its own L2 track.
         let hits = detect_del_size_suffix("NP_000079.2:p.Lys100del32");
         assert!(hits.is_empty());
+    }
+
+    // --- W3023 DupSizeSuffix ---
+
+    #[test]
+    fn test_detect_dup_size_suffix_basic() {
+        let hits = detect_dup_size_suffix("NM_004006.2:c.20_21dup2");
+        assert_eq!(
+            hits.len(),
+            1,
+            "expected exactly one W3023 hit, got {hits:?}"
+        );
+        let h = &hits[0];
+        assert_eq!(h.error_type, ErrorType::DupSizeSuffix);
+        assert_eq!(h.original, "dup2");
+        assert_eq!(h.corrected, "");
+        assert_eq!(
+            &("NM_004006.2:c.20_21dup2".as_bytes())[h.start..h.end],
+            b"dup2"
+        );
+    }
+
+    #[test]
+    fn test_detect_dup_size_suffix_canonical_no_hit() {
+        let hits = detect_dup_size_suffix("NM_004006.2:c.20_21dup");
+        assert!(hits.is_empty(), "canonical dup must not fire W3023");
+    }
+
+    #[test]
+    fn test_detect_dup_size_suffix_skips_protein() {
+        let hits = detect_dup_size_suffix("NP_000079.2:p.Val7dup");
+        assert!(hits.is_empty(), "protein dup must not fire W3023");
+    }
+
+    #[test]
+    fn test_detect_dup_size_suffix_multiple() {
+        // Bracket allele with two dup<N> tokens.
+        let hits = detect_dup_size_suffix("NM_004006.2:c.[20dup2;30dup4]");
+        assert_eq!(hits.len(), 2, "expected two W3023 hits in bracket allele");
+        assert_eq!(hits[0].original, "dup2");
+        assert_eq!(hits[1].original, "dup4");
     }
 
     #[test]

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -3032,6 +3032,77 @@ pub fn detect_dup_size_suffix(input: &str) -> Vec<DetectedCorrection> {
     hits
 }
 
+/// Detect and correct duplications with an explicit duplicated sequence (W3024).
+///
+/// Matches `dup` followed by one or more ASCII nucleotide letters in
+/// `[ACGTUNacgtun]` (DNA upper-case + RNA lower-case; `U`/`u` for RNA),
+/// terminated by a top-level boundary, inside a nucleic-acid coordinate
+/// segment. Drops the trailing sequence in the rewritten output, emits one
+/// `DetectedCorrection` per occurrence with `original = "<seq>"` and
+/// `corrected = ""`.
+///
+/// Per HGVS spec (`recommendations/DNA/duplication.md:35-36`): the seq is
+/// redundant given the position range, and including it increases the
+/// chance of a typing error (`dupG` vs `dupT`). Safe to drop.
+pub fn correct_dup_explicit_seq(input: &str) -> (String, Vec<DetectedCorrection>) {
+    let mut hits = Vec::new();
+    let bytes = input.as_bytes();
+    if !has_non_protein_description(bytes) {
+        return (input.to_string(), hits);
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0usize;
+    while i + 3 <= bytes.len() {
+        if &bytes[i..i + 3] != b"dup" {
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+        let seq_start = i + 3;
+        let mut j = seq_start;
+        while j < bytes.len()
+            && matches!(
+                bytes[j],
+                b'A' | b'C' | b'G' | b'T' | b'U' | b'N' | b'a' | b'c' | b'g' | b't' | b'u' | b'n'
+            )
+        {
+            j += 1;
+        }
+        if j == seq_start {
+            out.push_str("dup");
+            i = seq_start;
+            continue;
+        }
+        let end_byte = bytes.get(j).copied();
+        let is_terminator =
+            end_byte.is_none_or(|b| b == b')' || b == b';' || b == b']' || b.is_ascii_whitespace());
+        if !is_terminator {
+            out.push_str(&input[i..j]);
+            i = j;
+            continue;
+        }
+        if !in_nucleic_acid_segment(input, i) {
+            out.push_str(&input[i..j]);
+            i = j;
+            continue;
+        }
+        out.push_str("dup");
+        hits.push(DetectedCorrection::new(
+            ErrorType::DupExplicitSeq,
+            &input[seq_start..j],
+            String::new(),
+            seq_start,
+            j,
+        ));
+        i = j;
+    }
+    if i < bytes.len() {
+        out.push_str(&input[i..]);
+    }
+    (out, hits)
+}
+
 /// Detect and correct deletion-insertions whose inserted sequence is empty
 /// (W3012, SVA-010).
 ///
@@ -5237,6 +5308,58 @@ mod tests {
         let input = "r.[1a>t;2t>g]";
         let (out, hits) = correct_rna_thymine(input);
         assert_eq!(out, "r.[1a>u;2u>g]");
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_basic() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:c.20_23dupTAGA");
+        assert_eq!(rewritten, "NM_004006.2:c.20_23dup");
+        assert_eq!(hits.len(), 1);
+        let h = &hits[0];
+        assert_eq!(h.error_type, ErrorType::DupExplicitSeq);
+        assert_eq!(h.original, "TAGA");
+        assert_eq!(h.corrected, "");
+        assert_eq!(
+            &("NM_004006.2:c.20_23dupTAGA".as_bytes())[h.start..h.end],
+            b"TAGA"
+        );
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_single_letter() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:c.20dupT");
+        assert_eq!(rewritten, "NM_004006.2:c.20dup");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].original, "T");
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_rna_lowercase() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:r.6_8dupugc");
+        assert_eq!(rewritten, "NM_004006.2:r.6_8dup");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].original, "ugc");
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_canonical_no_hit() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:c.20_23dup");
+        assert_eq!(rewritten, "NM_004006.2:c.20_23dup");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_skips_protein() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NP_000079.2:p.Val7_Lys23dup");
+        assert_eq!(rewritten, "NP_000079.2:p.Val7_Lys23dup");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_correct_dup_explicit_seq_bracket_allele() {
+        let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:c.[20_23dupTAGA;30_31dupGT]");
+        assert_eq!(rewritten, "NM_004006.2:c.[20_23dup;30_31dup]");
         assert_eq!(hits.len(), 2);
     }
 }

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -3103,6 +3103,81 @@ pub fn correct_dup_explicit_seq(input: &str) -> (String, Vec<DetectedCorrection>
     (out, hits)
 }
 
+/// Detect and correct deletions with an explicit deleted sequence (W3025).
+///
+/// Matches `del` followed by one or more ASCII nucleotide letters in
+/// `[ACGTUNacgtun]`, terminated by a top-level boundary, inside a
+/// nucleic-acid coordinate segment. EXCLUDES the `delins` keyword (the
+/// trailing seq there is canonical for the insertion).
+///
+/// Per HGVS spec (`recommendations/DNA/deletion.md:30-31`): the seq is
+/// redundant; including it increases the chance of a typing error
+/// (`delG` vs `delA`). Safe to drop.
+pub fn correct_del_explicit_seq(input: &str) -> (String, Vec<DetectedCorrection>) {
+    let mut hits = Vec::new();
+    let bytes = input.as_bytes();
+    if !has_non_protein_description(bytes) {
+        return (input.to_string(), hits);
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0usize;
+    while i + 3 <= bytes.len() {
+        if &bytes[i..i + 3] != b"del" {
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+        // Skip the `delins` keyword — that trailing seq is canonical.
+        if i + 6 <= bytes.len() && &bytes[i + 3..i + 6] == b"ins" {
+            out.push_str(&input[i..i + 6]);
+            i += 6;
+            continue;
+        }
+        let seq_start = i + 3;
+        let mut j = seq_start;
+        while j < bytes.len()
+            && matches!(
+                bytes[j],
+                b'A' | b'C' | b'G' | b'T' | b'U' | b'N' | b'a' | b'c' | b'g' | b't' | b'u' | b'n'
+            )
+        {
+            j += 1;
+        }
+        if j == seq_start {
+            out.push_str("del");
+            i = seq_start;
+            continue;
+        }
+        let end_byte = bytes.get(j).copied();
+        let is_terminator =
+            end_byte.is_none_or(|b| b == b')' || b == b';' || b == b']' || b.is_ascii_whitespace());
+        if !is_terminator {
+            out.push_str(&input[i..j]);
+            i = j;
+            continue;
+        }
+        if !in_nucleic_acid_segment(input, i) {
+            out.push_str(&input[i..j]);
+            i = j;
+            continue;
+        }
+        out.push_str("del");
+        hits.push(DetectedCorrection::new(
+            ErrorType::DelExplicitSeq,
+            &input[seq_start..j],
+            String::new(),
+            seq_start,
+            j,
+        ));
+        i = j;
+    }
+    if i < bytes.len() {
+        out.push_str(&input[i..]);
+    }
+    (out, hits)
+}
+
 /// Detect and correct deletion-insertions whose inserted sequence is empty
 /// (W3012, SVA-010).
 ///
@@ -5361,5 +5436,52 @@ mod tests {
         let (rewritten, hits) = correct_dup_explicit_seq("NM_004006.2:c.[20_23dupTAGA;30_31dupGT]");
         assert_eq!(rewritten, "NM_004006.2:c.[20_23dup;30_31dup]");
         assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_basic() {
+        let (rewritten, hits) = correct_del_explicit_seq("NC_000023.11:g.33344590_33344592delGAT");
+        assert_eq!(rewritten, "NC_000023.11:g.33344590_33344592del");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].error_type, ErrorType::DelExplicitSeq);
+        assert_eq!(hits[0].original, "GAT");
+        assert_eq!(hits[0].corrected, "");
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_single_letter() {
+        let (rewritten, hits) = correct_del_explicit_seq("NC_000023.11:g.33344591delA");
+        assert_eq!(rewritten, "NC_000023.11:g.33344591del");
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_excludes_delins() {
+        // `delinsATG` is canonical; must NOT be matched.
+        let (rewritten, hits) = correct_del_explicit_seq("NC_000001.11:g.123delinsATG");
+        assert_eq!(rewritten, "NC_000001.11:g.123delinsATG");
+        assert!(hits.is_empty(), "delins must not fire W3025");
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_rna_lowercase() {
+        let (rewritten, hits) = correct_del_explicit_seq("NM_004006.2:r.6_8deluug");
+        assert_eq!(rewritten, "NM_004006.2:r.6_8del");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].original, "uug");
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_canonical_no_hit() {
+        let (rewritten, hits) = correct_del_explicit_seq("NC_000023.11:g.33344591del");
+        assert_eq!(rewritten, "NC_000023.11:g.33344591del");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_correct_del_explicit_seq_skips_protein() {
+        let (rewritten, hits) = correct_del_explicit_seq("NP_000079.2:p.Val7del");
+        assert_eq!(rewritten, "NP_000079.2:p.Val7del");
+        assert!(hits.is_empty());
     }
 }

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -2462,6 +2462,45 @@ fn has_non_protein_description(bytes: &[u8]) -> bool {
     false
 }
 
+/// Returns true if byte index `pos` in `input` is inside a nucleic-acid
+/// coordinate segment (`g.`, `c.`, `n.`, `r.`, or `m.`), as opposed to a
+/// protein (`p.`) segment.
+///
+/// Lookback walks from `pos` toward the start of input, returning the
+/// boundary-most-recent coordinate prefix. The walk stops at the previous
+/// top-level boundary (`:` from a sequence-id boundary, `[` opening a
+/// bracket allele, `;` separating cis variants, or start-of-input).
+///
+/// Used to scope `del<seq>` / `dup<seq>` / `dup<N>` detection to nucleic
+/// acid contexts so we don't false-positive on protein descriptors where
+/// `del` / `dup` carry different semantics (amino-acid level edits).
+fn in_nucleic_acid_segment(input: &str, pos: usize) -> bool {
+    let bytes = input.as_bytes();
+    let end = pos.min(bytes.len());
+    // Walk backwards from `pos` looking for a `<coord>.` prefix preceded by
+    // a boundary character. The most-recent such prefix wins.
+    let mut i = end;
+    while i > 1 {
+        i -= 1;
+        if bytes[i] != b'.' {
+            continue;
+        }
+        let coord = bytes[i - 1];
+        let is_na = matches!(coord, b'g' | b'c' | b'n' | b'r' | b'm');
+        let is_protein = coord == b'p';
+        if !is_na && !is_protein {
+            continue;
+        }
+        // The byte before `coord` must be a top-level boundary, or the coord
+        // must be at the start of input.
+        let prev_ok = i == 1 || matches!(bytes[i - 2], b':' | b'(' | b'[' | b';');
+        if prev_ok {
+            return is_na;
+        }
+    }
+    false
+}
+
 /// Returns the byte index immediately after the UTF-8 character starting at
 /// `i` in `bytes`. Falls back to `i + 1` for malformed input.
 #[inline]
@@ -4415,6 +4454,22 @@ mod tests {
         // (DNA/deletion) does not apply; protein has its own L2 track.
         let hits = detect_del_size_suffix("NP_000079.2:p.Lys100del32");
         assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn test_in_nucleic_acid_segment() {
+        // Lookback finds g./c./n./r./m. at top-level boundaries.
+        assert!(in_nucleic_acid_segment("NC_000001.11:g.123del", 16));
+        assert!(in_nucleic_acid_segment("NM_004006.2:c.20_23dup", 14));
+        assert!(in_nucleic_acid_segment("NR_002196.2:n.123del", 14));
+        assert!(in_nucleic_acid_segment("NM_004006.2:r.6_8del", 14));
+        assert!(in_nucleic_acid_segment("NC_012920.1:m.3243del", 15));
+        // Protein segment returns false.
+        assert!(!in_nucleic_acid_segment("NP_000079.2:p.Arg97fs", 16));
+        // Inside a bracket-allele, the most-recent boundary determines context.
+        assert!(in_nucleic_acid_segment("NM_004006.2:c.[20del;30dup]", 18,));
+        // No coord-prefix at all → false.
+        assert!(!in_nucleic_acid_segment("just a string", 5));
     }
 
     // --- W3012 EmptyDelinsInsert ---

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -10,7 +10,7 @@ use super::corrections::{
     correct_old_substitution_syntax, correct_protein_arrow, correct_quote_characters,
     correct_redundant_repeat_label, correct_rna_thymine, correct_single_letter_aa_in_protein,
     correct_single_position_range, correct_swapped_positions, correct_whitespace,
-    detect_del_size_suffix, detect_deprecated_ivs, detect_length_mismatch,
+    detect_del_size_suffix, detect_deprecated_ivs, detect_dup_size_suffix, detect_length_mismatch,
     detect_length_mismatch_with_provider, detect_missing_versions, detect_position_zero,
     detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
 };
@@ -925,6 +925,44 @@ impl InputPreprocessor {
                 }
                 ResolvedAction::WarnCorrect => {
                     for c in &length_mismatch_hits {
+                        all_warnings.push(CorrectionWarning::from_correction(c));
+                    }
+                }
+                ResolvedAction::SilentCorrect | ResolvedAction::Accept => {}
+            }
+        }
+
+        // Phase 13b: Flag duplications described with a size-count suffix
+        // (W3023). `warn_accept` semantics: lenient warns without rewriting
+        // (the position is ambiguous between `<pos>_<pos+N-1>` and
+        // `<pos-N+1>_<pos>` per duplication.md:140-143); silent accepts;
+        // strict rejects.
+        let dup_size_hits = detect_dup_size_suffix(&current);
+        if !dup_size_hits.is_empty() {
+            let action = self.action_for(ErrorType::DupSizeSuffix);
+            match action {
+                ResolvedAction::Reject => {
+                    let first = &dup_size_hits[0];
+                    return PreprocessResult::failed(
+                        input.to_string(),
+                        FerroError::parse_with_diagnostic(
+                            first.start,
+                            format!(
+                                "Duplication '{}' uses size-count suffix; canonical form names both endpoints",
+                                first.original
+                            ),
+                            Diagnostic::new()
+                                .with_code(ErrorCode::InvalidEdit)
+                                .with_span(SourceSpan::new(first.start, first.end))
+                                .with_source(input)
+                                .with_hint(
+                                    "Write `g.<start>_<end>dup` instead of `g.<start>dup<size>`",
+                                ),
+                        ),
+                    );
+                }
+                ResolvedAction::WarnCorrect => {
+                    for c in &dup_size_hits {
                         all_warnings.push(CorrectionWarning::from_correction(c));
                     }
                 }

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -5,14 +5,14 @@
 
 use super::corrections::{
     correct_accession_prefix_case, correct_amino_acid_case_in_protein, correct_dash_characters,
-    correct_deprecated_con, correct_deprecated_protein_forms, correct_dup_explicit_seq,
-    correct_edit_type_case_full, correct_empty_delins, correct_missing_coordinate_prefix,
-    correct_old_allele_format, correct_old_substitution_syntax, correct_protein_arrow,
-    correct_quote_characters, correct_redundant_repeat_label, correct_rna_thymine,
-    correct_single_letter_aa_in_protein, correct_single_position_range, correct_swapped_positions,
-    correct_whitespace, detect_del_size_suffix, detect_deprecated_ivs, detect_dup_size_suffix,
-    detect_length_mismatch, detect_length_mismatch_with_provider, detect_missing_versions,
-    detect_position_zero,
+    correct_del_explicit_seq, correct_deprecated_con, correct_deprecated_protein_forms,
+    correct_dup_explicit_seq, correct_edit_type_case_full, correct_empty_delins,
+    correct_missing_coordinate_prefix, correct_old_allele_format, correct_old_substitution_syntax,
+    correct_protein_arrow, correct_quote_characters, correct_redundant_repeat_label,
+    correct_rna_thymine, correct_single_letter_aa_in_protein, correct_single_position_range,
+    correct_swapped_positions, correct_whitespace, detect_del_size_suffix, detect_deprecated_ivs,
+    detect_dup_size_suffix, detect_length_mismatch, detect_length_mismatch_with_provider,
+    detect_missing_versions, detect_position_zero,
     detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
 };
 use super::types::{ErrorType, ResolvedAction};
@@ -1009,6 +1009,47 @@ impl InputPreprocessor {
                 }
                 ResolvedAction::SilentCorrect => {
                     current = rewritten_dup_seq;
+                }
+                ResolvedAction::Accept => {}
+            }
+        }
+
+        // Phase 13d: Detect and rewrite deletions with explicit sequence
+        // (W3025). `standard_correctable` semantics — same shape as 13c.
+        // Excludes the `delins` keyword (its trailing seq is canonical).
+        let (rewritten_del_seq, del_seq_hits) = correct_del_explicit_seq(&current);
+        if !del_seq_hits.is_empty() {
+            let action = self.action_for(ErrorType::DelExplicitSeq);
+            match action {
+                ResolvedAction::Reject => {
+                    let first = &del_seq_hits[0];
+                    return PreprocessResult::failed(
+                        input.to_string(),
+                        FerroError::parse_with_diagnostic(
+                            first.start,
+                            format!(
+                                "Deletion includes explicit sequence '{}'; the position range already determines it",
+                                first.original
+                            ),
+                            Diagnostic::new()
+                                .with_code(ErrorCode::InvalidEdit)
+                                .with_span(SourceSpan::new(first.start, first.end))
+                                .with_source(input)
+                                .with_suggestion(rewritten_del_seq.clone())
+                                .with_hint(
+                                    "Drop the redundant sequence; write `g.<start>_<end>del` instead of `g.<start>_<end>del<seq>`",
+                                ),
+                        ),
+                    );
+                }
+                ResolvedAction::WarnCorrect => {
+                    for c in &del_seq_hits {
+                        all_warnings.push(CorrectionWarning::from_correction(c));
+                    }
+                    current = rewritten_del_seq;
+                }
+                ResolvedAction::SilentCorrect => {
+                    current = rewritten_del_seq;
                 }
                 ResolvedAction::Accept => {}
             }

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -5,13 +5,14 @@
 
 use super::corrections::{
     correct_accession_prefix_case, correct_amino_acid_case_in_protein, correct_dash_characters,
-    correct_deprecated_con, correct_deprecated_protein_forms, correct_edit_type_case_full,
-    correct_empty_delins, correct_missing_coordinate_prefix, correct_old_allele_format,
-    correct_old_substitution_syntax, correct_protein_arrow, correct_quote_characters,
-    correct_redundant_repeat_label, correct_rna_thymine, correct_single_letter_aa_in_protein,
-    correct_single_position_range, correct_swapped_positions, correct_whitespace,
-    detect_del_size_suffix, detect_deprecated_ivs, detect_dup_size_suffix, detect_length_mismatch,
-    detect_length_mismatch_with_provider, detect_missing_versions, detect_position_zero,
+    correct_deprecated_con, correct_deprecated_protein_forms, correct_dup_explicit_seq,
+    correct_edit_type_case_full, correct_empty_delins, correct_missing_coordinate_prefix,
+    correct_old_allele_format, correct_old_substitution_syntax, correct_protein_arrow,
+    correct_quote_characters, correct_redundant_repeat_label, correct_rna_thymine,
+    correct_single_letter_aa_in_protein, correct_single_position_range, correct_swapped_positions,
+    correct_whitespace, detect_del_size_suffix, detect_deprecated_ivs, detect_dup_size_suffix,
+    detect_length_mismatch, detect_length_mismatch_with_provider, detect_missing_versions,
+    detect_position_zero,
     detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
 };
 use super::types::{ErrorType, ResolvedAction};
@@ -967,6 +968,49 @@ impl InputPreprocessor {
                     }
                 }
                 ResolvedAction::SilentCorrect | ResolvedAction::Accept => {}
+            }
+        }
+
+        // Phase 13c: Detect and rewrite duplications with explicit sequence
+        // (W3024). `standard_correctable` semantics: strict rejects, lenient
+        // warns + drops the seq, silent drops silently. Mirrors Phase 6b
+        // (W3007-W3010 deprecated protein forms) per-correction dispatch
+        // because action_for resolves per ErrorType (here only one).
+        let (rewritten_dup_seq, dup_seq_hits) = correct_dup_explicit_seq(&current);
+        if !dup_seq_hits.is_empty() {
+            let action = self.action_for(ErrorType::DupExplicitSeq);
+            match action {
+                ResolvedAction::Reject => {
+                    let first = &dup_seq_hits[0];
+                    return PreprocessResult::failed(
+                        input.to_string(),
+                        FerroError::parse_with_diagnostic(
+                            first.start,
+                            format!(
+                                "Duplication includes explicit sequence '{}'; the position range already determines it",
+                                first.original
+                            ),
+                            Diagnostic::new()
+                                .with_code(ErrorCode::InvalidEdit)
+                                .with_span(SourceSpan::new(first.start, first.end))
+                                .with_source(input)
+                                .with_suggestion(rewritten_dup_seq.clone())
+                                .with_hint(
+                                    "Drop the redundant sequence; write `g.<start>_<end>dup` instead of `g.<start>_<end>dup<seq>`",
+                                ),
+                        ),
+                    );
+                }
+                ResolvedAction::WarnCorrect => {
+                    for c in &dup_seq_hits {
+                        all_warnings.push(CorrectionWarning::from_correction(c));
+                    }
+                    current = rewritten_dup_seq;
+                }
+                ResolvedAction::SilentCorrect => {
+                    current = rewritten_dup_seq;
+                }
+                ResolvedAction::Accept => {}
             }
         }
 

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -12,8 +12,8 @@ use super::corrections::{
     correct_rna_thymine, correct_single_letter_aa_in_protein, correct_single_position_range,
     correct_swapped_positions, correct_whitespace, detect_del_size_suffix, detect_deprecated_ivs,
     detect_dup_size_suffix, detect_length_mismatch, detect_length_mismatch_with_provider,
-    detect_missing_versions, detect_position_zero,
-    detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
+    detect_missing_versions, detect_position_zero, detect_protein_bracketed_aa_insertion,
+    strip_trailing_annotation, DetectedCorrection,
 };
 use super::types::{ErrorType, ResolvedAction};
 use super::ErrorConfig;

--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -1120,6 +1120,85 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
         },
     );
 
+    map.insert(
+        "W3023",
+        CodeInfo {
+            code: "W3023",
+            name: "DupSizeSuffix",
+            summary: "Duplication described with a size-count suffix instead of a position range.",
+            explanation:
+                "HGVS recommends naming both endpoints of a multi-residue duplication. The legacy \
+                form `g.123dup6` (size 6 starting at position 123) is non-canonical; the canonical \
+                form lists the first and last residue duplicated, e.g. `g.123_128dup`. ferro cannot \
+                auto-synthesize the end position safely (`g.123dup6` is ambiguous between `g.123_128dup` \
+                and `g.124_129dup` per the spec Q&A), so this warning is emitted but not auto-corrected.",
+            category: CodeCategory::Format,
+            bad_examples: &["NM_004006.2:c.20_21dup2", "NC_000023.11:g.123dup6"],
+            good_examples: &["NM_004006.2:c.20_21dup", "NC_000023.11:g.123_124dup"],
+            mode_behavior: Some(ModeBehavior::warn_accept()),
+            hgvs_spec_url: Some(
+                "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
+            ),
+            related_codes: &["W3011", "W3016", "W3024"],
+        },
+    );
+
+    map.insert(
+        "W3024",
+        CodeInfo {
+            code: "W3024",
+            name: "DupExplicitSeq",
+            summary: "Duplication described with the explicit duplicated nucleotide sequence.",
+            explanation:
+                "Per HGVS recommendations (`DNA/duplication.md`), the duplicated sequence should \
+                NOT be appended after `dup` because (1) the description is longer, (2) it contains \
+                redundant information already implied by the position range, and (3) the chances \
+                to make an error increase (e.g. writing `dupG` when the reference is `T`). The \
+                canonical form is `c.20_23dup`, not `c.20_23dupTAGA`. ferro rewrites the explicit \
+                form to the canonical form in lenient and silent modes; strict mode rejects.",
+            category: CodeCategory::Format,
+            bad_examples: &["NM_004006.2:c.20_23dupTAGA", "NM_004006.2:c.20dupT"],
+            good_examples: &["NM_004006.2:c.20_23dup", "NM_004006.2:c.20dup"],
+            mode_behavior: Some(ModeBehavior::standard_correctable()),
+            hgvs_spec_url: Some(
+                "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
+            ),
+            related_codes: &["W3011", "W3016", "W3023", "W3025"],
+        },
+    );
+
+    map.insert(
+        "W3025",
+        CodeInfo {
+            code: "W3025",
+            name: "DelExplicitSeq",
+            summary: "Deletion described with the explicit deleted nucleotide sequence.",
+            explanation:
+                "Per HGVS recommendations (`DNA/deletion.md`), the deleted sequence should NOT \
+                be appended after `del` because (1) the description is longer, (2) it contains \
+                redundant information already implied by the position range, and (3) the chances \
+                to make an error increase (e.g. writing `delG` when the reference is `A`). The \
+                canonical form is `g.33344590_33344592del`, not `g.33344590_33344592delGAT`. \
+                ferro rewrites the explicit form to the canonical form in lenient and silent \
+                modes; strict mode rejects. This warning applies only to pure deletions; \
+                deletion-insertions (`delins`) are excluded from this check.",
+            category: CodeCategory::Format,
+            bad_examples: &[
+                "NC_000023.11:g.33344590_33344592delGAT",
+                "NC_000023.11:g.33344591delA",
+            ],
+            good_examples: &[
+                "NC_000023.11:g.33344590_33344592del",
+                "NC_000023.11:g.33344591del",
+            ],
+            mode_behavior: Some(ModeBehavior::standard_correctable()),
+            hgvs_spec_url: Some(
+                "https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/",
+            ),
+            related_codes: &["W3011", "W3016", "W3023", "W3024"],
+        },
+    );
+
     // --- Position/Range Warnings (W4xxx) ---
 
     map.insert(

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -297,6 +297,36 @@ pub enum ErrorType {
     /// Closes-after: #92. Code: `W3022`.
     InitiatorMetCanonicalization,
 
+    /// Duplication described with a size-count suffix instead of a position
+    /// range (e.g. `g.123dup6` instead of `g.123_128dup`).
+    ///
+    /// Per HGVS spec (`recommendations/DNA/duplication.md:140-143` Q&A):
+    /// "a duplication of more than one nucleotide should give the position
+    /// of the first and last nucleotide duplicated, separated using the
+    /// range symbol (`_`, underscore), e.g., `g.123_128dup`." Position
+    /// ambiguity ("at" vs "after") prevents safe rewrite.
+    DupSizeSuffix,
+
+    /// Duplication described with an explicit duplicated sequence (e.g.
+    /// `c.20_23dupTAGA` instead of `c.20_23dup`).
+    ///
+    /// Per HGVS spec (`recommendations/DNA/duplication.md:35-36, 50-51`):
+    /// "the recommendation is not to describe the variant as
+    /// `c.20_23dupTAGA`. This description is longer, it contains redundant
+    /// information, and chances to make an error increases." Sequence is
+    /// safely droppable since the position range fully determines it.
+    DupExplicitSeq,
+
+    /// Deletion described with an explicit deleted sequence (e.g.
+    /// `g.33344590_33344592delGAT` instead of `g.33344590_33344592del`).
+    ///
+    /// Per HGVS spec (`recommendations/DNA/deletion.md:30-31, 45-46`):
+    /// "the recommendation is not to describe the variant as
+    /// `NC_000023.11:g.33344590_33344592delGAT`. This description is
+    /// longer, it contains redundant information, and chances to make an
+    /// error increases." Sequence is safely droppable.
+    DelExplicitSeq,
+
     /// Variant position range exceeds the reference sequence the
     /// provider returned (`fetch_ref_for_canonical_split` got fewer
     /// bytes than the HGVS interval span).
@@ -377,6 +407,9 @@ impl ErrorType {
             ErrorType::RnaThymineCanonicalized => "W3020",
             ErrorType::ProteinBracketedAaInsertion => "W3021",
             ErrorType::InitiatorMetCanonicalization => "W3022",
+            ErrorType::DupSizeSuffix => "W3023",
+            ErrorType::DupExplicitSeq => "W3024",
+            ErrorType::DelExplicitSeq => "W3025",
             ErrorType::SwappedPositions => "W4001",
             ErrorType::SinglePositionRange => "W4003",
             ErrorType::PositionPastEnd => "W4004",
@@ -425,6 +458,9 @@ impl ErrorType {
         ErrorType::RnaThymineCanonicalized,
         ErrorType::ProteinBracketedAaInsertion,
         ErrorType::InitiatorMetCanonicalization,
+        ErrorType::DupSizeSuffix,
+        ErrorType::DupExplicitSeq,
+        ErrorType::DelExplicitSeq,
         ErrorType::SwappedPositions,
         ErrorType::SinglePositionRange,
         ErrorType::PositionPastEnd,

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -946,6 +946,13 @@ mod tests {
         // InitiatorMetCanonicalization is informational only — the dup
         // form is kept; no rewrite back to ins or to p.0?/p.(Met1?).
         assert!(!ErrorType::InitiatorMetCanonicalization.is_correctable());
+        // DupSizeSuffix (W3023) uses warn_accept — the input is preserved as-is,
+        // so there is no rewrite to apply.
+        assert!(!ErrorType::DupSizeSuffix.is_correctable());
+        // DupExplicitSeq (W3024) and DelExplicitSeq (W3025) use
+        // standard_correctable — the redundant sequence suffix is stripped.
+        assert!(ErrorType::DupExplicitSeq.is_correctable());
+        assert!(ErrorType::DelExplicitSeq.is_correctable());
     }
 
     // ErrorOverride tests

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -539,6 +539,9 @@ impl ErrorType {
             ErrorType::InitiatorMetCanonicalization => {
                 "canonical form `p.Met1dup` (or analogous) includes the initiator methionine"
             }
+            ErrorType::DupSizeSuffix => "duplication described with a size-count suffix",
+            ErrorType::DupExplicitSeq => "duplication with explicit duplicated sequence",
+            ErrorType::DelExplicitSeq => "deletion with explicit deleted sequence",
             ErrorType::VariantExceedsReference => {
                 "variant position range exceeds reference sequence"
             }
@@ -610,6 +613,13 @@ impl ErrorType {
             // is purely informational. We do not rewrite the canonical output
             // back to ins or to p.0?/p.(Met1?) — that is the consumer's call.
             ErrorType::InitiatorMetCanonicalization => false,
+            // Lenient mode warns without rewriting (warn_accept); strict rejects.
+            // Position ambiguity ("at" vs "after") prevents safe synthesis.
+            ErrorType::DupSizeSuffix => false,
+            // Sequence is redundant given the position range; lenient mode
+            // drops it (standard_correctable).
+            ErrorType::DupExplicitSeq => true,
+            ErrorType::DelExplicitSeq => true,
             // Variant exceeds reference: no safe auto-correction — the
             // variant references positions past the provider's window
             // and we cannot conjure missing bases.
@@ -680,6 +690,9 @@ impl ErrorType {
                 ("p.Arg97_Trp98ins[Ala;Pro]", "p.Arg97_Trp98insAlaPro")
             }
             ErrorType::InitiatorMetCanonicalization => ("p.Met1_Lys2insMet", "p.Met1dup"),
+            ErrorType::DupSizeSuffix => ("g.123dup6", "g.123_128dup"),
+            ErrorType::DupExplicitSeq => ("c.20_23dupTAGA", "c.20_23dup"),
+            ErrorType::DelExplicitSeq => ("g.33344590_33344592delGAT", "g.33344590_33344592del"),
             ErrorType::VariantExceedsReference => (
                 "NG_032871.1:g.32476_53457delinsAATTAAGGTATA (ref shorter than 53457)",
                 "(no auto-correct; spec rejects per refseq.md \u{00A7}43)",
@@ -1090,6 +1103,9 @@ mod tests {
             ErrorType::RnaThymineCanonicalized,
             ErrorType::ProteinBracketedAaInsertion,
             ErrorType::InitiatorMetCanonicalization,
+            ErrorType::DupSizeSuffix,
+            ErrorType::DupExplicitSeq,
+            ErrorType::DelExplicitSeq,
             ErrorType::SwappedPositions,
             ErrorType::SinglePositionRange,
             ErrorType::PositionPastEnd,
@@ -1133,6 +1149,9 @@ mod tests {
                 | ErrorType::RnaThymineCanonicalized
                 | ErrorType::ProteinBracketedAaInsertion
                 | ErrorType::InitiatorMetCanonicalization
+                | ErrorType::DupSizeSuffix
+                | ErrorType::DupExplicitSeq
+                | ErrorType::DelExplicitSeq
                 | ErrorType::SwappedPositions
                 | ErrorType::SinglePositionRange
                 | ErrorType::PositionPastEnd

--- a/src/python.rs
+++ b/src/python.rs
@@ -2270,6 +2270,11 @@ pub enum PyErrorType {
     NonSpecMosaicForm = 34,
     OverlapConflictingEdits = 35,
     InitiatorMetCanonicalization = 36,
+    // 37 is W3023 DupSizeSuffix, 38 is W3024 DupExplicitSeq, 39 is W3025
+    // DelExplicitSeq — soft-prohibition warnings for dup<N>/dup<seq>/del<seq>.
+    DupSizeSuffix = 37,
+    DupExplicitSeq = 38,
+    DelExplicitSeq = 39,
 }
 
 impl From<ErrorType> for PyErrorType {
@@ -2311,6 +2316,9 @@ impl From<ErrorType> for PyErrorType {
             ErrorType::PositionPastEnd => PyErrorType::PositionPastEnd,
             ErrorType::OverlapConflictingEdits => PyErrorType::OverlapConflictingEdits,
             ErrorType::InitiatorMetCanonicalization => PyErrorType::InitiatorMetCanonicalization,
+            ErrorType::DupSizeSuffix => PyErrorType::DupSizeSuffix,
+            ErrorType::DupExplicitSeq => PyErrorType::DupExplicitSeq,
+            ErrorType::DelExplicitSeq => PyErrorType::DelExplicitSeq,
         }
     }
 }
@@ -2354,6 +2362,9 @@ impl From<PyErrorType> for ErrorType {
             PyErrorType::PositionPastEnd => ErrorType::PositionPastEnd,
             PyErrorType::OverlapConflictingEdits => ErrorType::OverlapConflictingEdits,
             PyErrorType::InitiatorMetCanonicalization => ErrorType::InitiatorMetCanonicalization,
+            PyErrorType::DupSizeSuffix => ErrorType::DupSizeSuffix,
+            PyErrorType::DupExplicitSeq => ErrorType::DupExplicitSeq,
+            PyErrorType::DelExplicitSeq => ErrorType::DelExplicitSeq,
         }
     }
 }

--- a/src/service/handlers/validate.rs
+++ b/src/service/handlers/validate.rs
@@ -442,12 +442,14 @@ mod tests {
 
     #[test]
     fn test_extract_na_edit_info_deletion() {
+        // W3025 (DelExplicitSeq) strips the explicit sequence in lenient mode,
+        // so the parsed NaEdit::Deletion has sequence=None after preprocessing.
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350delC").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
                 let (vtype, deleted, inserted) = extract_na_edit_info(edit);
                 assert_eq!(vtype, "deletion");
-                assert_eq!(deleted, Some("C".to_string()));
+                assert_eq!(deleted, None);
                 assert!(inserted.is_none());
             }
         }
@@ -510,12 +512,14 @@ mod tests {
 
     #[test]
     fn test_extract_na_edit_info_duplication() {
+        // W3024 (DupExplicitSeq) strips the explicit sequence in lenient mode,
+        // so the parsed NaEdit::Duplication has sequence=None after preprocessing.
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350dupC").unwrap();
         if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
             if let Some(edit) = v.loc_edit.edit.inner() {
                 let (vtype, deleted, _inserted) = extract_na_edit_info(edit);
                 assert_eq!(vtype, "duplication");
-                assert_eq!(deleted, Some("C".to_string()));
+                assert_eq!(deleted, None);
             }
         }
     }

--- a/tests/error_mode_tests.rs
+++ b/tests/error_mode_tests.rs
@@ -1318,6 +1318,60 @@ mod w3011_del_size_suffix_emission {
     }
 }
 
+mod w3023_dup_size_suffix_emission {
+    use super::*;
+    use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};
+
+    #[test]
+    fn lenient_warns_without_rewrite() {
+        let result = parse_hgvs_lenient("NM_004006.2:c.20_21dup2").unwrap();
+        assert!(result.has_warnings());
+        assert_eq!(
+            result
+                .warnings
+                .iter()
+                .filter(|w| w.error_type == ErrorType::DupSizeSuffix)
+                .count(),
+            1
+        );
+        // warn_accept: input is unchanged.
+        assert_eq!(result.preprocessed_input, "NM_004006.2:c.20_21dup2");
+    }
+
+    #[test]
+    fn strict_rejects() {
+        let result = parse_hgvs_with_config("NM_004006.2:c.20_21dup2", ErrorConfig::strict());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn silent_accepts_without_warning() {
+        let result = parse_hgvs_silent("NM_004006.2:c.20_21dup2").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupSizeSuffix));
+        assert_eq!(result.preprocessed_input, "NM_004006.2:c.20_21dup2");
+    }
+
+    #[test]
+    fn canonical_input_does_not_warn() {
+        let result = parse_hgvs_lenient("NM_004006.2:c.20_21dup").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupSizeSuffix));
+    }
+
+    #[test]
+    fn idempotent_re_pass() {
+        let r1 = parse_hgvs_lenient("NM_004006.2:c.20_21dup2").unwrap();
+        let r2 = parse_hgvs_lenient(&r1.preprocessed_input).unwrap();
+        assert_eq!(r1.preprocessed_input, r2.preprocessed_input);
+        assert!(r2.has_warnings());
+    }
+}
+
 mod w4003_single_position_range_emission {
     use super::*;
     use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};

--- a/tests/error_mode_tests.rs
+++ b/tests/error_mode_tests.rs
@@ -1431,6 +1431,82 @@ mod w3024_dup_explicit_seq_emission {
     }
 }
 
+mod w3025_del_explicit_seq_emission {
+    use super::*;
+    use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};
+
+    #[test]
+    fn lenient_corrects_drops_seq() {
+        let result = parse_hgvs_lenient("NC_000023.11:g.33344590_33344592delGAT").unwrap();
+        assert_eq!(
+            result.preprocessed_input,
+            "NC_000023.11:g.33344590_33344592del"
+        );
+        assert_eq!(
+            result
+                .warnings
+                .iter()
+                .filter(|w| w.error_type == ErrorType::DelExplicitSeq)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn strict_rejects() {
+        let result = parse_hgvs_with_config(
+            "NC_000023.11:g.33344590_33344592delGAT",
+            ErrorConfig::strict(),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn silent_corrects_without_warning() {
+        let result = parse_hgvs_silent("NC_000023.11:g.33344591delA").unwrap();
+        assert_eq!(result.preprocessed_input, "NC_000023.11:g.33344591del");
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DelExplicitSeq));
+    }
+
+    #[test]
+    fn delins_unaffected() {
+        // delins<seq> is canonical for delins; W3025 must NOT fire.
+        let result = parse_hgvs_lenient("NC_000001.11:g.123delinsATG").unwrap();
+        assert_eq!(result.preprocessed_input, "NC_000001.11:g.123delinsATG");
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DelExplicitSeq));
+    }
+
+    #[test]
+    fn rna_lowercase_corrected() {
+        let result = parse_hgvs_lenient("NM_004006.2:r.6_8deluug").unwrap();
+        assert_eq!(result.preprocessed_input, "NM_004006.2:r.6_8del");
+    }
+
+    #[test]
+    fn canonical_input_does_not_warn() {
+        let result = parse_hgvs_lenient("NC_000023.11:g.33344591del").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DelExplicitSeq));
+    }
+
+    #[test]
+    fn protein_del_unaffected() {
+        let result = parse_hgvs_lenient("NP_003997.2:p.Val7del").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DelExplicitSeq));
+    }
+}
+
 mod w4003_single_position_range_emission {
     use super::*;
     use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};

--- a/tests/error_mode_tests.rs
+++ b/tests/error_mode_tests.rs
@@ -1372,6 +1372,65 @@ mod w3023_dup_size_suffix_emission {
     }
 }
 
+mod w3024_dup_explicit_seq_emission {
+    use super::*;
+    use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};
+
+    #[test]
+    fn lenient_corrects_drops_seq() {
+        let result = parse_hgvs_lenient("NM_004006.2:c.20_23dupTAGA").unwrap();
+        assert_eq!(result.preprocessed_input, "NM_004006.2:c.20_23dup");
+        assert_eq!(
+            result
+                .warnings
+                .iter()
+                .filter(|w| w.error_type == ErrorType::DupExplicitSeq)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn strict_rejects() {
+        let result = parse_hgvs_with_config("NM_004006.2:c.20_23dupTAGA", ErrorConfig::strict());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn silent_corrects_without_warning() {
+        let result = parse_hgvs_silent("NM_004006.2:c.20_23dupTAGA").unwrap();
+        assert_eq!(result.preprocessed_input, "NM_004006.2:c.20_23dup");
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupExplicitSeq));
+    }
+
+    #[test]
+    fn rna_lowercase_corrected() {
+        let result = parse_hgvs_lenient("NM_004006.2:r.6_8dupugc").unwrap();
+        assert_eq!(result.preprocessed_input, "NM_004006.2:r.6_8dup");
+    }
+
+    #[test]
+    fn canonical_input_does_not_warn() {
+        let result = parse_hgvs_lenient("NM_004006.2:c.20_23dup").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupExplicitSeq));
+    }
+
+    #[test]
+    fn protein_dup_unaffected() {
+        let result = parse_hgvs_lenient("NP_003997.2:p.Val7dup").unwrap();
+        assert!(!result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupExplicitSeq));
+    }
+}
+
 mod w4003_single_position_range_emission {
     use super::*;
     use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};

--- a/tests/error_mode_tests.rs
+++ b/tests/error_mode_tests.rs
@@ -318,8 +318,10 @@ mod w2003_extra_whitespace {
 
     #[test]
     fn test_lenient_strips_whitespace_inside_uncertain_position() {
+        // Use `dup` (no explicit sequence) so W3025 (DelExplicitSeq) does not
+        // interfere with the whitespace-stripping assertion.
         use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
-        let result = parse_hgvs_lenient("NM_000088.3:c.( 123 _ 127 )delA");
+        let result = parse_hgvs_lenient("NM_000088.3:c.( 123 _ 127 )dup");
         assert!(
             result.is_ok(),
             "lenient parse should accept whitespace inside uncertain position: {:?}",
@@ -327,7 +329,19 @@ mod w2003_extra_whitespace {
         );
         let parsed = result.unwrap();
         assert!(parsed.has_warnings());
-        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.(123_127)delA");
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.error_type == ErrorType::ExtraWhitespace),
+            "expected ExtraWhitespace warning; got {:?}",
+            parsed
+                .warnings
+                .iter()
+                .map(|w| w.error_type.code())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(parsed.preprocessed_input, "NM_000088.3:c.(123_127)dup");
     }
 
     #[test]

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -419,7 +419,7 @@
       "spec_section": "recommendations/DNA/duplication.md (position range recommended; size-suffix form is legacy non-canonical)",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
       "status": "enforced",
-      "spec_section_notes": "Detected by validate_dup_size_suffix in src/error_handling/mod.rs. ferro cannot auto-synthesize the end position safely because g.123dup6 is ambiguous (could be g.123_128dup or g.124_129dup per spec Q&A). mode_behavior is warn_accept (Reject in strict, WarnAndAccept in lenient/silent) — warning is emitted but the input is not auto-corrected."
+      "spec_section_notes": "Detected by detect_dup_size_suffix in src/error_handling/corrections.rs. Wired as InputPreprocessor in Phase 13b. ferro cannot auto-synthesize the end position safely because g.123dup6 is ambiguous (could be g.123_128dup or g.124_129dup per spec Q&A). mode_behavior is warn_accept (Reject in strict, WarnAndAccept in lenient, Accept in silent) — a warning is emitted in lenient mode only (silent mode accepts without warning), and the input is not auto-corrected."
     },
     {
       "code": "W3024",
@@ -427,7 +427,7 @@
       "spec_section": "recommendations/DNA/duplication.md (explicit sequence not recommended: longer, redundant, error-prone)",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
       "status": "enforced",
-      "spec_section_notes": "Detected by validate_dup_explicit_seq in src/error_handling/mod.rs. Wired as InputPreprocessor in Phase 16 via rewrite_dup_explicit_seq. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
+      "spec_section_notes": "Detected and rewritten by correct_dup_explicit_seq in src/error_handling/corrections.rs. Wired as InputPreprocessor in Phase 13c. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
     },
     {
       "code": "W3025",
@@ -435,7 +435,7 @@
       "spec_section": "recommendations/DNA/deletion.md (explicit sequence not recommended: longer, redundant, error-prone)",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/",
       "status": "enforced",
-      "spec_section_notes": "Detected by validate_del_explicit_seq in src/error_handling/mod.rs. Wired as InputPreprocessor in Phase 16 via rewrite_del_explicit_seq. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
+      "spec_section_notes": "Detected and rewritten by correct_del_explicit_seq in src/error_handling/corrections.rs. Wired as InputPreprocessor in Phase 13d. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
     },
     {
       "code": "W4001",

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -414,6 +414,30 @@
       "spec_section_notes": "Emitted by try_protein_ins_to_dup / try_protein_delins_canonicalize in src/normalize/mod.rs when the resulting dup interval includes position 1. mode_behavior is warn_accept (Reject in strict, WarnAndAccept in lenient/silent) — the warning is purely informational (consumers should consider the p.0/p.0? substitution-rule interpretation); the runtime does not attempt to auto-correct the input to an alternative form. Closes #92."
     },
     {
+      "code": "W3023",
+      "description": "DupSizeSuffix — duplication described with a size-count suffix instead of a position range, e.g. g.123dup6 instead of g.123_128dup.",
+      "spec_section": "recommendations/DNA/duplication.md (position range recommended; size-suffix form is legacy non-canonical)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
+      "status": "enforced",
+      "spec_section_notes": "Detected by validate_dup_size_suffix in src/error_handling/mod.rs. ferro cannot auto-synthesize the end position safely because g.123dup6 is ambiguous (could be g.123_128dup or g.124_129dup per spec Q&A). mode_behavior is warn_accept (Reject in strict, WarnAndAccept in lenient/silent) — warning is emitted but the input is not auto-corrected."
+    },
+    {
+      "code": "W3024",
+      "description": "DupExplicitSeq — duplication described with the explicit duplicated nucleotide sequence appended after dup, e.g. c.20_23dupTAGA instead of c.20_23dup.",
+      "spec_section": "recommendations/DNA/duplication.md (explicit sequence not recommended: longer, redundant, error-prone)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/duplication/",
+      "status": "enforced",
+      "spec_section_notes": "Detected by validate_dup_explicit_seq in src/error_handling/mod.rs. Wired as InputPreprocessor in Phase 16 via rewrite_dup_explicit_seq. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
+    },
+    {
+      "code": "W3025",
+      "description": "DelExplicitSeq — deletion described with the explicit deleted nucleotide sequence appended after del, e.g. g.33344590_33344592delGAT instead of g.33344590_33344592del.",
+      "spec_section": "recommendations/DNA/deletion.md (explicit sequence not recommended: longer, redundant, error-prone)",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/deletion/",
+      "status": "enforced",
+      "spec_section_notes": "Detected by validate_del_explicit_seq in src/error_handling/mod.rs. Wired as InputPreprocessor in Phase 16 via rewrite_del_explicit_seq. mode_behavior is standard_correctable (Reject in strict, WarnAndRewrite in lenient, silently rewrite in silent) — ferro rewrites the explicit form to the canonical form in lenient/silent modes."
+    },
+    {
       "code": "W4001",
       "description": "SwappedPositions — 'c.200_100del' corrected to 'c.100_200del'.",
       "spec_section": "recommendations/general.md line 65 (range semantics: start <= end implied by underscore range syntax)",

--- a/tests/issue_268_mixed_case_edit_type.rs
+++ b/tests/issue_268_mixed_case_edit_type.rs
@@ -61,7 +61,25 @@ mod nucleotide {
 
     #[test]
     fn cds_uppercase_dup() {
-        assert_rewrites_with_w1004("NM_000088.3:c.100_102DUPATG", "NM_000088.3:c.100_102dupATG");
+        // W3024 (DupExplicitSeq) strips the explicit seq after case-folding,
+        // so the canonical output is `dup` without the trailing bases. Assert
+        // both warnings fire (W1004 case-fold + W3024 seq-strip), mirroring the
+        // chained-warning pattern in `cds_uppercase_con_chains_to_delins`.
+        let r = parse_hgvs_lenient("NM_000088.3:c.100_102DUPATG").unwrap();
+        let codes: Vec<_> = r
+            .warnings
+            .iter()
+            .map(|w| w.error_type.code().to_string())
+            .collect();
+        assert!(
+            codes.iter().any(|c| c == "W1004"),
+            "expected W1004; got {codes:?}"
+        );
+        assert!(
+            codes.iter().any(|c| c == "W3024"),
+            "expected W3024; got {codes:?}"
+        );
+        assert_eq!(format!("{}", r.result), "NM_000088.3:c.100_102dup");
     }
 
     #[test]
@@ -97,10 +115,25 @@ mod nucleotide {
     /// Genomic accession also lowercases.
     #[test]
     fn genomic_uppercase_del() {
-        assert_rewrites_with_w1004(
-            "NC_000001.11:g.100_102DELAcg",
-            "NC_000001.11:g.100_102delACG",
+        // W3025 (DelExplicitSeq) strips the explicit seq after case-folding,
+        // so the canonical output is `del` without the trailing bases. Assert
+        // both warnings fire (W1004 case-fold + W3025 seq-strip), mirroring the
+        // chained-warning pattern in `cds_uppercase_con_chains_to_delins`.
+        let r = parse_hgvs_lenient("NC_000001.11:g.100_102DELAcg").unwrap();
+        let codes: Vec<_> = r
+            .warnings
+            .iter()
+            .map(|w| w.error_type.code().to_string())
+            .collect();
+        assert!(
+            codes.iter().any(|c| c == "W1004"),
+            "expected W1004; got {codes:?}"
         );
+        assert!(
+            codes.iter().any(|c| c == "W3025"),
+            "expected W3025; got {codes:?}"
+        );
+        assert_eq!(format!("{}", r.result), "NC_000001.11:g.100_102del");
     }
 }
 

--- a/tests/issue_282_rna_thymine_policy.rs
+++ b/tests/issue_282_rna_thymine_policy.rs
@@ -81,6 +81,43 @@ fn assert_strict_rejects_with_w3019(input: &str) {
     );
 }
 
+/// Parse with lenient mode; assert success, the given warning code fired, and
+/// the rewritten `Display` output equals `expected` (pins the seq-strip rewrite).
+#[track_caller]
+fn assert_lenient_strips_to(input: &str, code: &str, expected: &str) {
+    let parsed = parse_hgvs_with_config(input, ErrorConfig::lenient())
+        .unwrap_or_else(|e| panic!("lenient parse {input:?} failed: {e}"));
+    let warnings = &parsed.warnings;
+    assert!(
+        warnings.iter().any(|w| w.error_type.code() == code),
+        "expected {code} on {input:?}, got warnings: {:?}",
+        warnings
+            .iter()
+            .map(|w| w.error_type.code())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        format!("{}", parsed.result),
+        expected,
+        "rewrite mismatch for {input:?}"
+    );
+}
+
+/// Strict mode must reject; the error display must mention the given code or keyword.
+#[track_caller]
+fn assert_strict_rejects_with_code(input: &str, code: &str, keyword: &str) {
+    let result = parse_hgvs_with_config(input, ErrorConfig::strict());
+    let err = match result {
+        Ok(_) => panic!("strict parse {input:?} succeeded, expected rejection"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(
+        msg.contains(code) || msg.to_lowercase().contains(keyword),
+        "strict rejection for {input:?} did not surface {code} / {keyword}: {msg}"
+    );
+}
+
 // =============================================================================
 // SECTION 1 — Substitution (sub)
 // =============================================================================
@@ -127,28 +164,45 @@ mod deletion {
 
     #[test]
     fn stated_ref_with_t_canonicalizes_to_u_with_w3019() {
-        assert_canonicalizes_with_w3019(
+        // W3025 (DelExplicitSeq) fires before W3020 (RnaThymineCanonicalized):
+        // the explicit sequence is stripped in Phase 13d before the thymine
+        // check in Phase 13e can see the `t` bytes. W3025 supersedes W3020.
+        // Pin the rewritten output too: the explicit seq is dropped entirely.
+        assert_lenient_strips_to(
             &format!("{ACC}:r.123_125delaut"),
-            &format!("{ACC}:r.123_125delauu"),
+            "W3025",
+            &format!("{ACC}:r.123_125del"),
         );
     }
 
     #[test]
     fn uppercase_stated_ref_with_t_canonicalizes() {
-        assert_canonicalizes_with_w3019(
+        // Same ordering as above: W3025 strips the seq (after case-folding),
+        // so W3020 (thymine) never fires. The surfacing warning is W3025.
+        assert_lenient_strips_to(
             &format!("{ACC}:r.123_125delAUT"),
-            &format!("{ACC}:r.123_125delauu"),
+            "W3025",
+            &format!("{ACC}:r.123_125del"),
         );
     }
 
     #[test]
-    fn lowercase_canonical_aug_no_warning() {
+    // The explicit-sequence form fires W3025 (DelExplicitSeq), but this test
+    // specifically validates that canonical RNA bases (`u`, not `t`) do not
+    // trigger the thymine warning W3020.
+    fn lowercase_canonical_aug_no_thymine_warning() {
         assert_no_w3019(&format!("{ACC}:r.123_125delaug"));
     }
 
     #[test]
     fn strict_mode_rejects_t_in_del_ref() {
-        assert_strict_rejects_with_w3019(&format!("{ACC}:r.123_125delaut"));
+        // Strict mode rejects with W3025 (DelExplicitSeq) because the explicit
+        // sequence check in Phase 13d fires before the thymine check (Phase 13e).
+        assert_strict_rejects_with_code(
+            &format!("{ACC}:r.123_125delaut"),
+            "W3025",
+            "explicit sequence",
+        );
     }
 }
 
@@ -190,17 +244,25 @@ mod duplication {
 
     #[test]
     fn stated_ref_with_t_canonicalizes_to_u_with_w3019() {
-        assert_canonicalizes_with_w3019(
+        // W3024 (DupExplicitSeq) fires before W3020 (RnaThymineCanonicalized):
+        // the explicit sequence is stripped in Phase 13c before the thymine
+        // check can see the `t` bytes. W3024 supersedes W3020.
+        // Pin the rewritten output too: the explicit seq is dropped entirely.
+        assert_lenient_strips_to(
             &format!("{ACC}:r.123_125dupaut"),
-            &format!("{ACC}:r.123_125dupauu"),
+            "W3024",
+            &format!("{ACC}:r.123_125dup"),
         );
     }
 
     #[test]
     fn uppercase_dup_t_canonicalizes() {
-        assert_canonicalizes_with_w3019(
+        // Same ordering: W3024 strips the seq (after case-folding),
+        // so W3020 (thymine) never fires. The surfacing warning is W3024.
+        assert_lenient_strips_to(
             &format!("{ACC}:r.123_125dupAUT"),
-            &format!("{ACC}:r.123_125dupauu"),
+            "W3024",
+            &format!("{ACC}:r.123_125dup"),
         );
     }
 }

--- a/tests/strict_explicit_seq_size_modes.rs
+++ b/tests/strict_explicit_seq_size_modes.rs
@@ -91,6 +91,22 @@ fn lenient_warns_but_preserves_dup_size_suffix() {
     assert_eq!(result.result.to_string(), "NM_004006.2:c.20_21dup2");
 }
 
+#[test]
+fn silent_accepts_dup_size_suffix_without_warning() {
+    use ferro_hgvs::hgvs::parser::parse_hgvs_silent;
+    let result = parse_hgvs_silent("NM_004006.2:c.20_21dup2").expect("silent must accept");
+    assert!(
+        !result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DupSizeSuffix),
+        "silent mode must not emit W3023; got: {:?}",
+        result.warnings,
+    );
+    // Display preserves the legacy form (silent accepts, no rewrite).
+    assert_eq!(result.result.to_string(), "NM_004006.2:c.20_21dup2");
+}
+
 // =====================================================================
 // W3024 DupExplicitSeq — standard_correctable (rewrite drops seq)
 // =====================================================================
@@ -237,4 +253,30 @@ fn lenient_with_dup_explicit_seq_override_rejects() {
         "override should reject {:?}",
         result.map(|r| r.result.to_string())
     );
+}
+
+// =====================================================================
+// Axis coverage: m. (mito) and n. (non-coding transcript)
+// =====================================================================
+
+#[test]
+fn strict_rejects_dup_explicit_seq_mito() {
+    assert_strict_rejects("NC_012920.1:m.3243_3245dupAGC", "explicit sequence");
+}
+
+#[test]
+fn strict_rejects_del_explicit_seq_noncoding() {
+    assert_strict_rejects("NR_002196.2:n.123_125delTAA", "explicit sequence");
+}
+
+#[test]
+fn lenient_rewrites_dup_size_suffix_noncoding_preserved() {
+    // warn_accept on n. axis: Display preserves the legacy form.
+    let result = parse_hgvs_with_config("NR_002196.2:n.20_21dup2", lenient())
+        .expect("lenient must accept dup<N>");
+    assert!(result
+        .warnings
+        .iter()
+        .any(|w| w.error_type == ErrorType::DupSizeSuffix));
+    assert_eq!(result.result.to_string(), "NR_002196.2:n.20_21dup2");
 }

--- a/tests/strict_explicit_seq_size_modes.rs
+++ b/tests/strict_explicit_seq_size_modes.rs
@@ -1,0 +1,240 @@
+//! Strict-mode rejection + lenient-mode warn/correct for the soft-prohibition
+//! forms `dup<N>`, `dup<seq>`, `del<seq>` (#460).
+//!
+//! Per HGVS v21 spec:
+//! - `dup<N>` (e.g. `c.20_21dup2`): non-canonical per `duplication.md:140-143`
+//!   Q&A "No, a duplication of more than one nucleotide should give the
+//!   position of the first and last nucleotide duplicated". W3023 (DupSizeSuffix)
+//!   uses `warn_accept` — strict rejects, lenient warns without rewrite,
+//!   silent accepts.
+//! - `dup<seq>` (e.g. `c.20_23dupTAGA`): non-canonical per
+//!   `duplication.md:35-36` "the recommendation is not to ... chances to
+//!   make an error increases". W3024 (DupExplicitSeq) uses
+//!   `standard_correctable` — strict rejects, lenient rewrites + warns,
+//!   silent rewrites silently.
+//! - `del<seq>` (e.g. `g.33344590_33344592delGAT`): same register per
+//!   `deletion.md:30-31`. W3025 (DelExplicitSeq), same mapping as W3024.
+//!
+//! ferro's existing W3011 (DelSizeSuffix) is pinned by
+//! `tests/strict_del_size_suffix_mode.rs` (PR #459). This file pins the
+//! three new sibling codes. Closes #460.
+
+use ferro_hgvs::error_handling::{ErrorConfig, ErrorOverride, ErrorType};
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+
+fn strict() -> ErrorConfig {
+    ErrorConfig::strict()
+}
+
+fn lenient() -> ErrorConfig {
+    ErrorConfig::lenient()
+}
+
+fn assert_strict_rejects(input: &str, expected_in_msg: &str) {
+    let result = parse_hgvs_with_config(input, strict());
+    assert!(
+        result.is_err(),
+        "strict must reject {input:?}; got: {:?}",
+        result.map(|r| r.result.to_string())
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.to_lowercase().contains(&expected_in_msg.to_lowercase()),
+        "strict rejection of {input:?} should mention {expected_in_msg:?}; got: {msg}"
+    );
+}
+
+fn assert_lenient_emits(input: &str, expected_display: &str, kind: ErrorType) {
+    let result = parse_hgvs_with_config(input, lenient())
+        .unwrap_or_else(|e| panic!("lenient must accept {input:?}: {e}"));
+    assert_eq!(
+        result.result.to_string(),
+        expected_display,
+        "lenient Display mismatch for {input:?}",
+    );
+    assert!(
+        result.warnings.iter().any(|w| w.error_type == kind),
+        "lenient {input:?} should emit {kind:?}; got: {:?}",
+        result.warnings,
+    );
+}
+
+// =====================================================================
+// W3023 DupSizeSuffix — warn_accept (no rewrite)
+// =====================================================================
+
+#[test]
+fn strict_rejects_dup_size_suffix_genomic() {
+    assert_strict_rejects("NC_000023.11:g.123dup6", "size-count suffix");
+}
+
+#[test]
+fn strict_rejects_dup_size_suffix_cds() {
+    assert_strict_rejects("NM_004006.2:c.20_21dup2", "size-count suffix");
+}
+
+#[test]
+fn strict_rejects_dup_size_suffix_rna() {
+    assert_strict_rejects("NM_004006.2:r.20_21dup2", "size-count suffix");
+}
+
+#[test]
+fn lenient_warns_but_preserves_dup_size_suffix() {
+    // warn_accept: input is preserved through to Display.
+    let result = parse_hgvs_with_config("NM_004006.2:c.20_21dup2", lenient())
+        .expect("lenient must accept dup<N>");
+    assert!(result
+        .warnings
+        .iter()
+        .any(|w| w.error_type == ErrorType::DupSizeSuffix));
+    // Display preserves the legacy form (NaEdit::Duplication.length is populated).
+    assert_eq!(result.result.to_string(), "NM_004006.2:c.20_21dup2");
+}
+
+// =====================================================================
+// W3024 DupExplicitSeq — standard_correctable (rewrite drops seq)
+// =====================================================================
+
+#[test]
+fn strict_rejects_dup_explicit_seq_cds() {
+    assert_strict_rejects("NM_004006.2:c.20_23dupTAGA", "explicit sequence");
+}
+
+#[test]
+fn strict_rejects_dup_explicit_seq_single_base() {
+    assert_strict_rejects("NM_004006.2:c.20dupT", "explicit sequence");
+}
+
+#[test]
+fn strict_rejects_dup_explicit_seq_rna() {
+    assert_strict_rejects("NM_004006.2:r.6_8dupugc", "explicit sequence");
+}
+
+#[test]
+fn lenient_rewrites_dup_explicit_seq_dna() {
+    assert_lenient_emits(
+        "NM_004006.2:c.20_23dupTAGA",
+        "NM_004006.2:c.20_23dup",
+        ErrorType::DupExplicitSeq,
+    );
+}
+
+#[test]
+fn lenient_rewrites_dup_explicit_seq_rna() {
+    assert_lenient_emits(
+        "NM_004006.2:r.6_8dupugc",
+        "NM_004006.2:r.6_8dup",
+        ErrorType::DupExplicitSeq,
+    );
+}
+
+// =====================================================================
+// W3025 DelExplicitSeq — standard_correctable (rewrite drops seq)
+// =====================================================================
+
+#[test]
+fn strict_rejects_del_explicit_seq_genomic() {
+    assert_strict_rejects(
+        "NC_000023.11:g.33344590_33344592delGAT",
+        "explicit sequence",
+    );
+}
+
+#[test]
+fn strict_rejects_del_explicit_seq_single_base() {
+    assert_strict_rejects("NC_000023.11:g.33344591delA", "explicit sequence");
+}
+
+#[test]
+fn strict_rejects_del_explicit_seq_rna() {
+    assert_strict_rejects("NM_004006.2:r.6_8deluug", "explicit sequence");
+}
+
+#[test]
+fn lenient_rewrites_del_explicit_seq_dna() {
+    assert_lenient_emits(
+        "NC_000023.11:g.33344590_33344592delGAT",
+        "NC_000023.11:g.33344590_33344592del",
+        ErrorType::DelExplicitSeq,
+    );
+}
+
+#[test]
+fn lenient_rewrites_del_explicit_seq_rna() {
+    assert_lenient_emits(
+        "NM_004006.2:r.6_8deluug",
+        "NM_004006.2:r.6_8del",
+        ErrorType::DelExplicitSeq,
+    );
+}
+
+#[test]
+fn strict_does_not_reject_delins() {
+    // delins<seq> is canonical for delins; must NOT fire W3025.
+    let result = parse_hgvs_with_config("NC_000001.11:g.123delinsATG", strict())
+        .expect("strict must accept canonical delins");
+    assert_eq!(result.result.to_string(), "NC_000001.11:g.123delinsATG");
+}
+
+// =====================================================================
+// Canonical inputs pass cleanly in both modes
+// =====================================================================
+
+#[test]
+fn strict_accepts_canonical_dup() {
+    let out = parse_hgvs_with_config("NM_004006.2:c.20_21dup", strict())
+        .expect("canonical c.20_21dup must pass strict");
+    assert_eq!(out.result.to_string(), "NM_004006.2:c.20_21dup");
+}
+
+#[test]
+fn strict_accepts_canonical_del() {
+    let out = parse_hgvs_with_config("NC_000023.11:g.33344591del", strict())
+        .expect("canonical g.33344591del must pass strict");
+    assert_eq!(out.result.to_string(), "NC_000023.11:g.33344591del");
+}
+
+#[test]
+fn lenient_accepts_canonical_silent() {
+    let out = parse_hgvs_with_config("NM_004006.2:c.20_23dup", lenient())
+        .expect("canonical c.20_23dup must pass lenient silently");
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::DupExplicitSeq
+                && w.error_type != ErrorType::DupSizeSuffix),
+        "canonical must not emit W3023/W3024",
+    );
+}
+
+// =====================================================================
+// Diagnostic surface check
+// =====================================================================
+
+#[test]
+fn diagnostic_includes_canonical_hint() {
+    let result = parse_hgvs_with_config("NC_000023.11:g.33344591delA", strict());
+    let err = result.unwrap_err();
+    let formatted = format!("{err:?}");
+    assert!(
+        formatted.contains("Drop the redundant sequence")
+            || formatted.contains("g.<start>_<end>del"),
+        "diagnostic should hint at canonical form; got: {formatted}"
+    );
+}
+
+// =====================================================================
+// User can opt into strict-only behavior via per-error override
+// =====================================================================
+
+#[test]
+fn lenient_with_dup_explicit_seq_override_rejects() {
+    let cfg =
+        ErrorConfig::lenient().with_override(ErrorType::DupExplicitSeq, ErrorOverride::Reject);
+    let result = parse_hgvs_with_config("NM_004006.2:c.20_23dupTAGA", cfg);
+    assert!(
+        result.is_err(),
+        "override should reject {:?}",
+        result.map(|r| r.result.to_string())
+    );
+}

--- a/tests/web_service_tests.rs
+++ b/tests/web_service_tests.rs
@@ -547,7 +547,9 @@ fn test_vcf_extract_alleles_substitution() {
 fn test_vcf_extract_alleles_deletion_with_sequence() {
     use ferro_hgvs::hgvs::edit::NaEdit;
 
-    // Test allele extraction for deletion with explicit sequence
+    // W3025 (DelExplicitSeq) strips the explicit sequence in lenient mode,
+    // so the parsed NaEdit::Deletion has sequence=None after preprocessing.
+    // The test verifies the edit type is Deletion and that sequence is None.
     let input = "NC_000007.14:g.117559593delG";
     let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
 
@@ -555,9 +557,8 @@ fn test_vcf_extract_alleles_deletion_with_sequence() {
         if let Some(edit) = v.loc_edit.edit.inner() {
             match edit {
                 NaEdit::Deletion { sequence, .. } => {
-                    // Deletion should have the deleted sequence
-                    assert!(sequence.is_some());
-                    assert_eq!(sequence.as_ref().unwrap().to_string(), "G");
+                    // After W3025 preprocessing the explicit sequence is stripped.
+                    assert!(sequence.is_none());
                 }
                 _ => panic!("Expected deletion"),
             }
@@ -589,7 +590,9 @@ fn test_vcf_extract_alleles_insertion() {
 fn test_vcf_extract_alleles_duplication() {
     use ferro_hgvs::hgvs::edit::NaEdit;
 
-    // Test allele extraction for duplication
+    // W3024 (DupExplicitSeq) strips the explicit sequence in lenient mode,
+    // so the parsed NaEdit::Duplication has sequence=None after preprocessing.
+    // The test verifies the edit type is Duplication and that sequence is None.
     let input = "NC_000007.14:g.117559593_117559595dupATG";
     let result = ferro_hgvs::hgvs::parser::parse_hgvs_lenient(input).unwrap();
 
@@ -597,9 +600,8 @@ fn test_vcf_extract_alleles_duplication() {
         if let Some(edit) = v.loc_edit.edit.inner() {
             match edit {
                 NaEdit::Duplication { sequence, .. } => {
-                    // Dup should provide the duplicated sequence
-                    assert!(sequence.is_some());
-                    assert_eq!(sequence.as_ref().unwrap().to_string(), "ATG");
+                    // After W3024 preprocessing the explicit sequence is stripped.
+                    assert!(sequence.is_none());
                 }
                 _ => panic!("Expected duplication"),
             }


### PR DESCRIPTION
## Summary

Three new W30xx codes detecting the spec-non-canonical edit forms surfaced while triaging #447:

| Code | Form | Mode Behavior | Strict | Lenient | Silent |
|---|---|---|---|---|---|
| W3023 | \`dup<N>\` (\`c.20_21dup2\`) | \`warn_accept\` | Reject | Warn (no rewrite) | Accept |
| W3024 | \`dup<seq>\` (\`c.20_23dupTAGA\`) | \`standard_correctable\` | Reject | Warn + drop seq | Drop seq silently |
| W3025 | \`del<seq>\` (\`g.33344590_33344592delGAT\`) | \`standard_correctable\` | Reject | Warn + drop seq | Drop seq silently |

Parallel to the existing W3011 (DelSizeSuffix, `del<N>`) handling pinned in PR #459.

## Spec basis

HGVS v21 `syntax.yaml` defines `del`/`dup` grammar as `position_or_range "del"` / `"dup"` — **no trailing size or sequence productions**. The four forms are grammatically out-of-spec. Register stratification:

- `<N>` forms: `duplication.md:140-143` Q&A **"No"** + position ambiguity ("at" vs "after") → `warn_accept` (no safe rewrite).
- `<seq>` forms: `deletion.md:30,45` / `duplication.md:35,50` *"recommendation is not to ... chances to make an error increases"* → `standard_correctable` (sequence redundant; safe to drop; matches Mutalyzer).

Scope: nucleic-acid coordinates (g./c./n./r./m.). Protein out of scope (no `<seq>` analogue in the protein grammar).

## Implementation

- Three new `ErrorType` variants + registry entries
- New `in_nucleic_acid_segment` lookback helper (position-aware analogue of `has_non_protein_description`)
- One detector (`detect_dup_size_suffix`) + two correctors (`correct_dup_explicit_seq`, `correct_del_explicit_seq`)
- Three new preprocessor phases (13b, 13c, 13d) wired after Phase 13a (W3016 LengthMismatch) so W3016 still fires on the explicit-seq form before W3024/W3025 drop the seq

## Test plan

- [x] Full suite: `cargo nextest run --features dev` — 6055 passed, 51 skipped
- [x] Clippy: `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] New test file `tests/strict_explicit_seq_size_modes.rs` — 20 cross-cutting probes
- [x] Three new emission test modules in `tests/error_mode_tests.rs` (w3023/w3024/w3025_*_emission)
- [x] 12 existing tests across multiple files (service::handlers::validate, issue_268, issue_282, error_mode_tests::w2003, web_service_tests) updated to reflect the new canonical behavior (W3024/W3025 strip the redundant seq)
- [ ] CI green

Closes #460.