### PR TITLE
test(parser): fix red main — drop obsolete dupins-accept probe (contradicts #445)

### DIFF
--- a/tests/input_hygiene_rejections.rs
+++ b/tests/input_hygiene_rejections.rs
@@ -13,10 +13,12 @@
 //! accept-and-warn is caught.
 //!
 //! Policy decisions in `phase4_final_triage.md`:
-//! - D1 — `dupins` (absolute) and `dupT`/`dupSEQ`/`dupN` (soft) all
-//!   currently ACCEPTED by ferro at the API level; spec says reject.
-//!   Tracked as divergence; lenient mode may later accept soft forms
-//!   with a W code while rejecting absolute forms outright.
+//! - D1 — `dupT`/`dupSEQ`/`dupN` (soft) are currently ACCEPTED by ferro
+//!   at the API level; spec says reject. Tracked as divergence; lenient
+//!   mode may later accept these soft forms with a W code. The `dupins`
+//!   (absolute) form is now REJECTED outright per `DNA/duplication.md:92`
+//!   (#445) — its rejection is pinned in `tests/reject_dupins.rs`, so it
+//!   is intentionally not duplicated here.
 //! - D2 — whitespace inside variant body rejected per `general.md:96`;
 //!   ferro currently accepts spaces inside allele brackets (stripped on
 //!   Display).
@@ -190,16 +192,6 @@ fn accepts_dup_size_suffix_pre_2016_diverges_from_spec() {
         "NC_000023.11:g.123del3",
         "NC_000023.11:g.123del3",
         "checklist.md:49 — pre-2016 size-suffix form, must be g.123_125del",
-    );
-}
-
-#[test]
-fn accepts_dupins_mash_up_diverges_from_spec() {
-    // dna-duplication:C-C17 — "a format not used" (strong prohibition).
-    assert_accepted_diverges_from_spec(
-        "NM_004006.2:c.20_21dupinsATG",
-        "NM_004006.2:c.20_21dupinsATG",
-        "DNA/duplication.md — dupins is a format not used",
     );
 }
 


### PR DESCRIPTION
## Summary

`main` is red: every open PR's `Test` job fails (including the untouched release PR #212). Root cause is a merge-order collision between two PRs that landed ~7 minutes apart:

- **#445/#451** (merged 21:48) made the parser reject `dupins<seq>` per `DNA/duplication.md:92` — the spec lists it `class="invalid"` ("a format not used in HGVS nomenclature").
- **#444** (merged 21:55) added `accepts_dupins_mash_up_diverges_from_spec`, which asserts `NM_004006.2:c.20_21dupinsATG` is **accepted** (pinning the pre-#445 divergent behavior).

The #444 probe was written before #445 landed, so it now contradicts the merged, spec-aligned rejection and fails on every branch that includes current `main`.

## Fix (spec-aligned)

`dupins` is invalid per the HGVS spec and is correctly rejected by ferro, so the accept-probe is obsolete. Its exact input is already covered by `tests/reject_dupins.rs::rejects_cds_dupins`, which pins the rejection with the structured `InvalidEdit` diagnostic. This PR:

- deletes the contradicting `accepts_dupins_mash_up_diverges_from_spec` probe, and
- updates the D1 policy note in the module doc to record that `dupins` is now rejected (rejection coverage lives in `reject_dupins.rs`), while leaving the still-accurate soft-prohibition probes (`dupGT`, `dup2`) untouched.

## Test plan

- [x] `cargo nextest run --features dev` — 6188 passed, 51 skipped (was 1 failed on `main`)
- [x] `cargo nextest run --features dev --test input_hygiene_rejections --test reject_dupins` — 27 passed
- [x] `cargo fmt --all --check` — clean