### PR TITLE
ci(test): fix recurring linker disk-exhaustion crash on the Test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,25 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      # The Test job builds and LINKS ~179 separate integration-test
+      # binaries (tests/*.rs). With full debuginfo (dev/test profile
+      # default `debug = true`) the linked `target/` exhausts the stock
+      # runner's ~14 GB free disk, and the linker dies with
+      # `ld terminated with signal 7 (Bus error)` — a write past a full
+      # disk. Stripping test-binary debuginfo in CI removes the bulk of
+      # each binary's size. CI-only (not in Cargo.toml), so local dev
+      # keeps full debuginfo for backtraces.
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
+      - name: Free up runner disk space
+        # Reclaim large preinstalled toolchains ferro's build never uses
+        # (~25-30 GB), as a second guard against the disk-exhaustion link
+        # crash above. Inline removal avoids adding a third-party action.
+        run: |
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
+            /usr/local/lib/android /opt/hostedtoolcache/CodeQL
+          df -h /
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
@@ -175,10 +193,15 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test
+          # `-nodebug` suffix: with CARGO_PROFILE_TEST_DEBUG=0 the test
+          # artifacts are much smaller. A fresh key prevents restoring the
+          # old debuginfo-laden `target/` (which would refill the disk and
+          # defeat the size reduction). Don't fall back to the generic
+          # `-cargo-` caches for the same reason — only reuse a Cargo.lock-
+          # matched nodebug cache.
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-test-nodebug
       - name: "Note: reference-aware tests are skipped without a manifest"
         # `tests/mutalyzer_normalize_tests.rs` and the biocommons
         # reference-aware suite both silently no-op when


### PR DESCRIPTION
## Problem

The `Test` job has been failing on essentially every PR (and the untouched release PR), surfacing two ways:

- `ld terminated with signal 7 (Bus error)` during linking, and
- the job dying mid-setup with no test output.

Both are the **same root cause**, not flakiness: the Test job builds and **links ~179 separate integration-test binaries** (`tests/*.rs`), each with full debuginfo (dev/test profile defaults to `debug = true`). On a stock `ubuntu-latest` runner (~14 GB free disk) the linked `target/` — plus a cache-restored `target/` — exhausts the disk. `ld ... signal 7` is the textbook signature of the linker writing past a full disk (SIGBUS on an mmap'd output past EOF). It looks flaky only because cache size / disk headroom varies run to run.

## Fix (CI-only, no behavior change)

1. **`CARGO_PROFILE_TEST_DEBUG=0`** on the Test job — strips debuginfo from the 179 test binaries, which is the bulk of their on-disk size. Scoped to the CI env (not `Cargo.toml`), so local dev keeps full debuginfo for backtraces.
2. **Free up runner disk space** — a first step that removes large preinstalled toolchains ferro never uses (dotnet/ghc/android/CodeQL), reclaiming ~25–30 GB as a second guard. Inline `rm` avoids adding a third-party action.
3. **Bump the Test job's cargo cache key** to `-test-nodebug` (and drop the generic restore-key fallbacks) so the smaller artifacts get a fresh cache instead of restoring the old debuginfo-laden `target/` that would refill the disk.

Only the `Test` job links all 179 binaries (Clippy `--all-targets` doesn't codegen/link; Build uses the release profile), so the change is scoped there.

## Test plan

- [x] `ci.yml` validated as well-formed YAML
- [ ] This PR's own `Test` job runs to completion (the real proof) — should now link without SIGBUS and the `Free up runner disk space` step prints `df -h /` headroom