### PR TITLE
ci(fixture): regenerate spec-fixture after #435/#437/#443/#454/#458 batch merge

### DIFF
--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -7395,7 +7395,7 @@
     },
     {
       "input": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.47643464_47643465ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7421,7 +7421,7 @@
     },
     {
       "input": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.35788169_35788352] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:35788168-35788352",
       "spec_expected": "NC_000002.11:g.?_?ins[NC_000022.10:g.35788169_35788352]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7433,7 +7433,7 @@
     },
     {
       "input": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.108111987_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.17450009_qterdelins[NC_000011.10:g.108111987_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7445,7 +7445,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825266] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825266]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7458,7 +7458,7 @@
     },
     {
       "input": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000011.10:g.pter_15825272] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000002.12:g.pter_8247756delins[NC_000011.10:g.pter_15825272]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7470,7 +7470,7 @@
     },
     {
       "input": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000008.11:g.(128534000_128546000)_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.158573187_qterdelins[NC_000008.11:g.(128534000_128546000)_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7482,7 +7482,7 @@
     },
     {
       "input": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000014.9:g.29745314_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000003.12:g.pter_36969141delins[CATTTGTTCAAATTTAGTTCAAATGA;NC_000014.9:g.29745314_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7494,7 +7494,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000023.11:89555675-100352080",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7506,7 +7506,7 @@
     },
     {
       "input": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000023.11:g.89555676_100352080inv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000004.12:g.134850793_134850794ins[NC_000023.11:g.89555676_100352080inv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7518,7 +7518,7 @@
     },
     {
       "input": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000010.11:g.67539995_qterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000005.10:g.29658442delins[NC_000010.11:g.67539995_qterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7530,7 +7530,7 @@
     },
     {
       "input": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000004.11:g.106370094_106370420;A[26]] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000006.11:g.10791926_10791927ins[NC_000004.11:g.106370094_106370420;A[26]]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7542,7 +7542,7 @@
     },
     {
       "input": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.17450009_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.108111982_qterdelins[NC_000002.12:g.17450009_qter]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7554,7 +7554,7 @@
     },
     {
       "input": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000002.12:g.pter_8247756] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000011.10:g.pter_5825272delins[NC_000002.12:g.pter_8247756]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7566,7 +7566,7 @@
     },
     {
       "input": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.10:g.17179029_17179091] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.10:17179028-17179091",
       "spec_expected": "NC_000012.11:g.6128892_6128954delins[NC_000022.10:g.17179029_17179091]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7578,7 +7578,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749con[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": null,
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7592,7 +7592,7 @@
     },
     {
       "input": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000022.11:g.17178616_17178886] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Genomic reference not available for NC_000022.11:17178615-17178886",
       "spec_expected": "NC_000012.12:g.6128479_6128749delins[NC_000022.11:g.17178616_17178886]",
       "status": "needs-reference",
       "coordinate_system": "g",
@@ -7605,7 +7605,7 @@
     },
     {
       "input": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
-      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference is valid HGVS but not yet supported by ferro; see follow-up",
+      "current": "normalize error: Unsupported variant type: ins[NC_000003.12:g.36969141_pterinv] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations",
       "spec_expected": "NC_000014.9:g.29745314_qterdelins[NC_000003.12:g.36969141_pterinv]",
       "status": "needs-reference",
       "coordinate_system": "g",


### PR DESCRIPTION
## Problem

\`main\`'s CI is failing on \`Verify HGVS v21.0 fixture is up to date\`:

\`\`\`
fixture tests/fixtures/grammar/hgvs_spec_normalization.json is out of date;
rerun: cargo run --features dev --example generate_spec_fixture
error: fixture out of date
\`\`\`

Five PRs landed together at \`fc2ce22\` (#435/#437/#443/#454/#458). Each regenerated the spec fixture against its own merge base and saw a green local \`--check\`, but the combined merge order left \`tests/fixtures/grammar/hgvs_spec_normalization.json\` 17 lines out of sync with what the generator now produces. This is the same red-main pattern #463 fixed for the dupins / single-position-insertion test collision: an inter-PR regeneration race that no individual PR's CI could detect.

## Fix

\`cargo run --features dev --example generate_spec_fixture\` on top of \`fc2ce22\`, commit the regenerated fixture. No production-code changes.

## Test plan

- [x] \`cargo nextest run --features dev\` — 6299 passed, 51 skipped
- [x] \`cargo run --features dev --example generate_spec_fixture -- --check\` — clean