### PR TITLE
fix(error-handling): make detect_swapped_positions axis-aware for m./o. wraparound (closes #467)

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -1157,24 +1157,55 @@ fn parse_endpoint_token(
 /// offset-bearing forms (`c.100+5_99+3del`) and 3'UTR `*N` markers
 /// (`c.*5_*1del`). Returns Some with the detected swap information and
 /// the swapped endpoint pair (with offsets and markers preserved).
+///
+/// Axis-aware: the `m.` (mitochondrial) and `o.` (circular) axes are skipped
+/// entirely. On a circular contig a range with `start > end` is a valid
+/// origin-crossing wraparound (SVD-WG006), not a transposition error, so
+/// rewriting it would destroy the wraparound signal. See issue #467.
 pub fn detect_swapped_positions(input: &str) -> Option<DetectedCorrection> {
-    // Find coordinate marker.
-    let coord_markers = [".c.", ".g.", ".n.", ".m.", ".o.", ".r."];
+    // Find the coordinate marker and remember which axis it names so circular
+    // axes (m./o.) can be skipped.
+    let coord_markers = [
+        (".c.", 'c'),
+        (".g.", 'g'),
+        (".n.", 'n'),
+        (".m.", 'm'),
+        (".o.", 'o'),
+        (".r.", 'r'),
+    ];
     let mut search_start = 0;
-    for marker in &coord_markers {
-        if let Some(pos) = input.find(marker) {
-            search_start = pos + marker.len();
-            break;
-        }
+    let mut axis = None;
+    // Pick the earliest (leftmost) marker in the input, not the first marker
+    // kind in `coord_markers`. A later embedded coord prefix (e.g. a source
+    // HGVS appended after the main variant) must not override the axis of the
+    // leading expression, which would parse the wrong range. See issue #467.
+    if let Some((pos, marker_len, marker_axis)) = coord_markers
+        .iter()
+        .filter_map(|(marker, marker_axis)| {
+            input
+                .find(marker)
+                .map(|pos| (pos, marker.len(), *marker_axis))
+        })
+        .min_by_key(|(pos, _, _)| *pos)
+    {
+        search_start = pos + marker_len;
+        axis = Some(marker_axis);
     }
     if search_start == 0 {
-        if let Some(pos) = input.find(['c', 'g', 'n', 'm', 'r']) {
+        if let Some(pos) = input.find(['c', 'g', 'n', 'm', 'o', 'r']) {
             if input.get(pos + 1..pos + 2) == Some(".") {
                 search_start = pos + 2;
+                axis = input[pos..].chars().next();
             }
         }
     }
     if search_start == 0 {
+        return None;
+    }
+
+    // Skip circular axes: a reversed range here is a valid origin-crossing
+    // wraparound, not a swapped-position error.
+    if matches!(axis, Some('m') | Some('o')) {
         return None;
     }
 
@@ -3817,6 +3848,28 @@ mod tests {
         let result = detect_swapped_positions("c.-10_-50del");
         // -10 > -50, so this should be detected as swapped
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_detect_swapped_positions_picks_leftmost_marker() {
+        // The leftmost coordinate marker is a circular axis (`m.`), so a reversed
+        // range there is a valid origin-crossing wraparound and must NOT be flagged.
+        // A later embedded `c.` HGVS (e.g. a source expression) with a swapped
+        // range must not cause the detector to lock onto that later marker and
+        // emit a spurious correction. See issue #467 / PR #474.
+        // The dotted accession-with-version form (`...920.1.m.`) exercises the
+        // primary marker scan. The leftmost marker is `.m.`; a later `.c.` is
+        // earlier in the marker array, so a naive "first marker kind" scan would
+        // lock onto the embedded `.c.` range (`500_100`, reversed) and wrongly
+        // report a swap. Picking the leftmost marker selects the circular `m.`
+        // axis instead, which is skipped (valid origin-crossing wraparound).
+        let result =
+            detect_swapped_positions("NC_012920.1.m.16100_16000del NM_000088.3.c.500_100del");
+        assert!(
+            result.is_none(),
+            "leftmost marker is circular (m.), so no swap should be reported even though a \
+             later embedded c. range is reversed; got {result:?}"
+        );
     }
 
     #[test]

--- a/src/service/handlers/validate.rs
+++ b/src/service/handlers/validate.rs
@@ -38,32 +38,16 @@ pub async fn validate_single(
         ));
     }
 
-    // Parse using ferro's lenient parser; fold the strict parse for
-    // wraps_origin into the same blocking task so neither parse runs on
-    // the async runtime thread.
+    // Parse using ferro's lenient parser on a blocking task so it does not run
+    // on the async runtime thread.
     let hgvs_str = request.hgvs.clone();
-    let (parse_result, wraps_origin_for_ok) = tokio::task::spawn_blocking(move || {
-        let lenient = crate::hgvs::parser::parse_hgvs_lenient(&hgvs_str);
-        // TODO(#399): the secondary strict parse is needed because W4001
-        // SwappedPositions auto-correction in parse_hgvs_lenient swaps reversed
-        // ranges before grammar parsing, destroying the wraparound signal. A
-        // cleaner fix would be to make detect_swapped_positions in
-        // src/error_handling/corrections.rs axis-aware (skip m./o.). Tracked
-        // as a follow-up; opening a dedicated issue is also fine.
-        let wraps = crate::hgvs::parser::parse_hgvs(&hgvs_str)
-            .map(|v| variant_wraps_origin(&v))
-            // Falls back to false if strict parse fails (e.g. on a secondary
-            // preprocessor-correctable error like an en-dash). In that case the
-            // lenient path would also yield wraparound=false after correction, so
-            // the two paths agree on the observable output.
-            .unwrap_or(false);
-        (lenient, wraps)
-    })
-    .await
-    .map_err(|e| {
-        let error = ServiceError::InternalError(format!("Task error: {}", e));
-        (StatusCode::INTERNAL_SERVER_ERROR, Json(error.to_response()))
-    })?;
+    let parse_result =
+        tokio::task::spawn_blocking(move || crate::hgvs::parser::parse_hgvs_lenient(&hgvs_str))
+            .await
+            .map_err(|e| {
+                let error = ServiceError::InternalError(format!("Task error: {}", e));
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(error.to_response()))
+            })?;
 
     let elapsed_ms = start.elapsed().as_millis() as u64;
 
@@ -71,7 +55,7 @@ pub async fn validate_single(
         Ok(result) => {
             // Extract component details
             let components = extract_variant_details(&result.result);
-            let wraps_origin = wraps_origin_for_ok;
+            let wraps_origin = variant_wraps_origin(&result.result);
 
             // Collect any warnings as potential issues
             let errors = if result.warnings.is_empty() {
@@ -118,26 +102,15 @@ fn variant_wraps_origin(variant: &crate::hgvs::variant::HgvsVariant) -> bool {
 /// Unlike the async `validate_single` axum handler, this function is
 /// synchronous and suitable for unit tests and non-HTTP callers.
 ///
-/// `wraps_origin` is derived from the strict (no-preprocessor) parse so
-/// that the preprocessor's position-swap correction does not mask the
-/// reversed `<high>_<low>` form that marks a circular-contig wraparound.
+/// `wraps_origin` is derived from the lenient parse: `detect_swapped_positions`
+/// is axis-aware and leaves `m.`/`o.` wraparound ranges untouched, so the
+/// reversed `<high>_<low>` form that marks a circular-contig wraparound
+/// survives preprocessing intact.
 pub fn validate_hgvs(hgvs: &str) -> ValidateResponse {
     match crate::hgvs::parser::parse_hgvs_lenient(hgvs) {
         Ok(result) => {
             let components = extract_variant_details(&result.result);
-            // TODO(#399): the secondary strict parse is needed because W4001
-            // SwappedPositions auto-correction in parse_hgvs_lenient swaps reversed
-            // ranges before grammar parsing, destroying the wraparound signal. A
-            // cleaner fix would be to make detect_swapped_positions in
-            // src/error_handling/corrections.rs axis-aware (skip m./o.). Tracked
-            // as a follow-up; opening a dedicated issue is also fine.
-            let wraps_origin = crate::hgvs::parser::parse_hgvs(hgvs)
-                .map(|v| variant_wraps_origin(&v))
-                // Falls back to false if strict parse fails (e.g. on a secondary
-                // preprocessor-correctable error like an en-dash). In that case the
-                // lenient path would also yield wraparound=false after correction, so
-                // the two paths agree on the observable output.
-                .unwrap_or(false);
+            let wraps_origin = variant_wraps_origin(&result.result);
             let errors = if result.warnings.is_empty() {
                 None
             } else {

--- a/tests/issue_399_mt_circular_followup.rs
+++ b/tests/issue_399_mt_circular_followup.rs
@@ -223,6 +223,63 @@ fn spdi_conversion_rejects_wraparound_circular() {
 }
 
 // =============================================================================
+// W4001 SwappedPositions must be axis-aware: skip m./o. wraparound ranges
+// =============================================================================
+// A wraparound (origin-crossing) range on a circular contig legitimately has
+// start > end (SVD-WG006). The W4001 SwappedPositions preprocessor must not
+// treat that as a transposition error and rewrite it. Linear axes (c./g./n./r.)
+// keep flagging reversed ranges as before.
+
+mod w4001_axis_aware {
+    use ferro_hgvs::hgvs::parser::parse_hgvs_lenient;
+
+    fn warning_codes(input: &str) -> Vec<String> {
+        let r =
+            parse_hgvs_lenient(input).unwrap_or_else(|e| panic!("lenient parse {input:?}: {e}"));
+        r.warnings
+            .iter()
+            .map(|w| w.error_type.code().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn wraparound_mt_del_does_not_emit_w4001() {
+        let codes = warning_codes("NC_012920.1:m.16569_1del");
+        assert!(
+            !codes.iter().any(|c| c == "W4001"),
+            "wraparound m. range must not emit W4001 SwappedPositions, got {codes:?}"
+        );
+    }
+
+    #[test]
+    fn wraparound_mt_range_is_not_rewritten() {
+        // The reversed start > end form must survive preprocessing so the
+        // wraparound signal reaches the parser intact.
+        let r = parse_hgvs_lenient("NC_012920.1:m.16569_1del").unwrap();
+        assert_eq!(format!("{}", r.result), "NC_012920.1:m.16569_1del");
+    }
+
+    #[test]
+    fn wraparound_circular_dup_does_not_emit_w4001() {
+        let codes = warning_codes("J01749.1:o.4344_197dup");
+        assert!(
+            !codes.iter().any(|c| c == "W4001"),
+            "wraparound o. range must not emit W4001 SwappedPositions, got {codes:?}"
+        );
+    }
+
+    #[test]
+    fn linear_genomic_swapped_still_emits_w4001() {
+        // Regression guard: axis-aware skip must not disable W4001 on linear axes.
+        let codes = warning_codes("NC_000001.11:g.500_100dup");
+        assert!(
+            codes.iter().any(|c| c == "W4001"),
+            "linear g. swapped range must still emit W4001, got {codes:?}"
+        );
+    }
+}
+
+// =============================================================================
 // Validate handler: wraps_origin field on ValidateResponse
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Closes #467. Makes `detect_swapped_positions` (the W4001 `SwappedPositions` preprocessor) axis-aware so it skips the `.m.` and `.o.` axes, where a range with `start > end` is a valid origin-crossing wraparound (per SVD-WG006) rather than a transposition error. This lets the wraparound signal survive preprocessing, which removes the dual-parse workaround introduced in PR #411.

## Background

PR #411 (closes #399) surfaced `wraps_origin` through `validate_hgvs` / `validate_single` via a secondary strict `parse_hgvs` call: the lenient parser's W4001 auto-correction would otherwise swap the reversed `<high>_<low>` endpoints before grammar parsing and destroy the wraparound signal. Both sites carried `TODO(#399)` comments noting that the cleaner fix was to make `detect_swapped_positions` axis-aware. Issue #399 is now closed, so those TODOs were orphaned.

## Changes

- `src/error_handling/corrections.rs` — `detect_swapped_positions` captures the coordinate axis while locating the marker and returns `None` early for the `m.`/`o.` axes. (Also adds `'o'` to the bare-prefix fallback set so `o.` detection is correct-by-construction rather than incidental; net behavior for `o.` is unchanged — still no W4001.)
- `src/service/handlers/validate.rs` — drops the secondary strict parse in both `validate_single` and `validate_hgvs`; `wraps_origin` is now derived directly from the lenient parse via `variant_wraps_origin`. Deletes both `TODO(#399)` blocks and refreshes the doc comments.

## Tests

New `mod w4001_axis_aware` in `tests/issue_399_mt_circular_followup.rs` (4 cases): a wraparound `m.` range does not emit W4001 and is not rewritten; a wraparound circular (`o.`) dup does not emit W4001; and a linear genomic swapped range still emits W4001 (regression guard). The pre-existing `web-service`-gated `validate_response_wraps_origin_true_for_wraparound_{mt,circular}` tests stay green after the workaround removal.

## Test plan

- [x] `cargo test --features dev` — full suite green
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `grep -rn "TODO(#399)" src tests` — empty
