### PR TITLE
feat(parser): accept whole-entity edits in protein bracket members (closes #468)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -2844,6 +2844,70 @@ fn parse_whole_protein_unknown(input: &str) -> IResult<&str, ProteinEdit> {
     .parse(input)
 }
 
+/// Parse a single protein bracket-member `interval+edit`, recognising
+/// whole-entity protein edits (`=`, `(=)`, `(?)`) before the
+/// position-based `parse_prot_interval` + `parse_protein_edit` path.
+///
+/// This is the protein-axis analogue of `parse_cds_bracket_member` /
+/// `parse_genome_bracket_member` / `parse_rna_bracket_member`, but the
+/// protein axis does not share the `NaEdit` type: whole-entity protein
+/// edits are `ProteinEdit::Identity { whole_protein: true, .. }` /
+/// `ProteinEdit::Unknown { whole_protein: true, .. }` and carry no
+/// position, so we attach a dummy interval at `Met1` (mirroring
+/// `parse_protein_variant`'s top-level handling of `p.=` / `p.(?)`). The
+/// `predicted` flag lives inside the edit, so the returned `LocEdit` is
+/// `Mu::Certain` — matching the top-level dispatch. #468, follow-up to
+/// #423 (nucleic-acid axes) and #396 item 3 (`r.` axis).
+///
+/// Whole-entity protein forms admitted here, per HGVS v21
+/// `recommendations/protein/`:
+/// - `=` / `(=)` — whole-protein identity (`alleles.md` line 58-60:
+///   `p.[Ser68Arg];[=]` is valid and distinct from `[Ser68=]`;
+///   `substitution.md` "the description `p.=` means the **entire**
+///   protein coding region was analysed").
+/// - `(?)` — predicted whole-protein unknown (`alleles.md`:
+///   `p.[(Ser68Arg)];[?]` uses the bare `[?]` *trans whole-allele*
+///   marker; the parenthesised `p.(?)` is the per-member predicted form).
+///
+/// Bare `?` is intentionally NOT probed here: it is only the trans
+/// whole-allele marker (handled upstream in
+/// `parse_protein_trans_allele_shorthand` → `HgvsVariant::UnknownAllele`)
+/// and is not a valid cis / unknown-phase bracket member — `p.[?]`,
+/// `p.[?;X]`, `p.[X;?]` continue to reject (pinned by
+/// `tests/protein_unknown_roundtrip.rs`).
+///
+/// `0` / `0?` / `(0)` (whole-protein no-protein) is likewise NOT probed
+/// here: `[0]` is not a valid cis bracket member (issue #277), and the
+/// protein-coordinate trans-allele path handles `[0]` separately in
+/// `parse_protein_trans_allele_shorthand`.
+fn parse_protein_bracket_member(part: &str) -> IResult<&str, LocEdit<ProtInterval, ProteinEdit>> {
+    /// Whole-entity protein edits carry no position; attach a dummy
+    /// interval at `Met1` (mirrors `parse_protein_variant`).
+    fn dummy_prot_interval() -> ProtInterval {
+        ProtInterval::point(ProtPos::new(AminoAcid::Met, 1))
+    }
+
+    if let Ok((remaining, edit)) = parse_whole_protein_identity(part) {
+        return Ok((remaining, LocEdit::new(dummy_prot_interval(), edit)));
+    }
+    // Only the parenthesised predicted unknown `(?)` is admitted as a
+    // bracket member; bare `?` is reserved for the trans whole-allele
+    // marker and must not parse here (see the doc comment above).
+    if let Some(remaining) = part.strip_prefix("(?)") {
+        return Ok((
+            remaining,
+            LocEdit::new(
+                dummy_prot_interval(),
+                ProteinEdit::whole_protein_unknown_predicted(),
+            ),
+        ));
+    }
+
+    let (edit_remaining, interval) = parse_prot_interval(part)?;
+    let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
+    Ok((final_remaining, LocEdit::new(interval, edit)))
+}
+
 /// Parse a protein allele shorthand:
 ///   `p.[edit1;edit2;...]`     (cis)
 ///   `p.[edit1(;)edit2;...]`   (unknown phase)
@@ -2897,8 +2961,7 @@ fn parse_protein_allele_shorthand(
                     nom::error::ErrorKind::Verify,
                 )));
             }
-            let (edit_remaining, interval) = parse_prot_interval(part)?;
-            let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
+            let (final_remaining, loc_edit) = parse_protein_bracket_member(part)?;
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
                     final_remaining,
@@ -2908,7 +2971,7 @@ fn parse_protein_allele_shorthand(
             variants.push(HgvsVariant::Protein(ProteinVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             }));
         }
 
@@ -2934,14 +2997,14 @@ fn parse_protein_allele_shorthand(
     let mut current = remaining;
 
     loop {
-        // Parse interval and edit
-        let (rest, interval) = parse_prot_interval(current)?;
-        let (rest, edit) = parse_protein_edit(rest)?;
+        // Parse interval and edit, admitting whole-entity members
+        // (`=`, `(=)`, `(?)`) alongside position-based edits. #468.
+        let (rest, loc_edit) = parse_protein_bracket_member(current)?;
 
         variants.push(HgvsVariant::Protein(ProteinVariant {
             accession: accession.clone(),
             gene_symbol: gene_symbol.clone(),
-            loc_edit: LocEdit::new(interval, edit),
+            loc_edit,
         }));
 
         // Check for more variants (semicolon separator) or end of allele
@@ -3069,8 +3132,12 @@ fn parse_protein_trans_allele_shorthand(
                 loc_edit: LocEdit::new(dummy_interval, ProteinEdit::NoProtein { predicted: true }),
             })
         } else {
-            let (edit_remaining, interval) = parse_prot_interval(content)?;
-            let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
+            // All other members (position-based edits plus whole-entity
+            // identity `=` / `(=)` and unknown `(?)`) flow through the
+            // shared bracket-member dispatcher. Bare `?` and the `0`
+            // forms are handled by the arms above, so they never reach
+            // here. #468.
+            let (final_remaining, loc_edit) = parse_protein_bracket_member(content)?;
 
             if !final_remaining.trim().is_empty() {
                 return Err(nom::Err::Error(nom::error::Error::new(
@@ -3082,7 +3149,7 @@ fn parse_protein_trans_allele_shorthand(
             HgvsVariant::Protein(ProteinVariant {
                 accession: accession.clone(),
                 gene_symbol: gene_symbol.clone(),
-                loc_edit: LocEdit::new(interval, edit),
+                loc_edit,
             })
         };
 

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 135,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 334,
-      "preserved": 647
+      "parse-error": 333,
+      "preserved": 648
     },
     "by_coordinate_system": {
       "c": 464,
@@ -11159,19 +11159,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.[Ser68Arg];[=]",
-      "input_prefixed": "NP_003997.1:p.[Ser68Arg];[=]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[=]'",
-      "spec_expected": "NP_003997.1:p.[Ser68Arg];[=]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "LRG_199p1:p.(Met1?)",
       "current": "LRG_199p1:p.(Met1?)",
       "spec_expected": "LRG_199p1:p.(Met1?)",
@@ -12731,6 +12718,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md"
+      ]
+    },
+    {
+      "input": "p.[Ser68Arg];[=]",
+      "input_prefixed": "NP_003997.1:p.[Ser68Arg];[=]",
+      "current": "NP_003997.1:p.[Ser68Arg];[=]",
+      "spec_expected": "NP_003997.1:p.[Ser68Arg];[=]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
       ]
     },
     {

--- a/tests/issue_468_protein_bracket_whole_entity.rs
+++ b/tests/issue_468_protein_bracket_whole_entity.rs
@@ -1,0 +1,342 @@
+//! Issue #468 — protein bracket-member dispatch for whole-entity edits.
+//!
+//! PR #433 (closes #423) extended whole-entity bracket-member dispatch
+//! (`=`, `?`, `0`, splice markers) to the nucleic-acid axes
+//! (`c.`/`n.`/`g.`/`m.`/`o.`), mirroring PR #396 item 3 for `r.`. The
+//! protein axis (`p.`) was intentionally left out of #433 because `p.`
+//! does not share the `NaEdit` type and `p.[=];[X]` needs a different
+//! dummy-interval/edit shape (a `ProtInterval` at position `Met1` carrying
+//! a `ProteinEdit` rather than a `NaEdit`).
+//!
+//! This file pins the protein-axis behavior. The spec-clear whole-entity
+//! protein bracket member is `[=]` → whole-protein identity (`p.=`):
+//!
+//! - HGVS v21 `recommendations/protein/alleles.md` line 58-60:
+//!   `NP_003997.1:p.[Ser68Arg];[=]` is a valid description and is
+//!   explicitly *different* from `p.[Ser68Arg];[Ser68=]` — the `[=]`
+//!   member means "the entire protein reference sequence was analysed".
+//! - HGVS v21 `recommendations/protein/substitution.md` line 43:
+//!   `p.=` means the **entire** protein coding region was analysed and no
+//!   sequence-changing variant was found.
+//!
+//! For input tolerance (mirroring the established `p.(=)` / `p.(0)`
+//! handling from PR #246 / #289 and PR #433's bracket probes), the
+//! parenthesised predicted forms `[(=)]` and `[(?)]` are also accepted in
+//! bracket-member position. The certain `[(=)]` Displays back as `[(=)]`.
+//!
+//! Pre-existing, unchanged behavior (NOT introduced here):
+//!   - bare `[0]` / `[0?]` / `[(0)]` in a `p.`-prefixed trans-allele
+//!     bracket → `ProteinEdit::NoProtein` (issue #277 / #289).
+//!   - bare `[?]` in a `p.`-prefixed trans-allele bracket →
+//!     `HgvsVariant::UnknownAllele` (cross-coord short-circuit).
+//!   - bare `[?]` inside a cis bracket → position-unknown interval.
+
+use ferro_hgvs::hgvs::edit::ProteinEdit;
+use ferro_hgvs::hgvs::uncertainty::Mu;
+use ferro_hgvs::hgvs::variant::{AllelePhase, ProteinVariant};
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+/// Parse, Display, and re-parse the input. Asserts:
+/// 1. parse(`input`) succeeds and Displays to `expected_canonical`.
+/// 2. parse(`expected_canonical`) succeeds.
+/// 3. Display of the re-parsed variant equals `expected_canonical`
+///    (Display is a fixed point on the canonical form).
+fn assert_canonical(input: &str, expected_canonical: &str) {
+    let parsed =
+        parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input:?}) must succeed; got {e:?}"));
+    let displayed = parsed.to_string();
+    assert_eq!(
+        displayed, expected_canonical,
+        "Display({input:?}) must equal {expected_canonical:?}; got {displayed:?}",
+    );
+    let reparsed = parse_hgvs(&displayed).unwrap_or_else(|e| {
+        panic!("re-parse of canonical Display {displayed:?} must succeed; got {e:?}")
+    });
+    let redisplayed = reparsed.to_string();
+    assert_eq!(
+        redisplayed, expected_canonical,
+        "Display must be a fixed point on the canonical form for {input:?}; got {redisplayed:?}",
+    );
+}
+
+/// Extract the `(AllelePhase, &[HgvsVariant])` from a parsed allele.
+fn allele_parts(variant: &HgvsVariant) -> (AllelePhase, &[HgvsVariant]) {
+    match variant {
+        HgvsVariant::Allele(a) => (a.phase, a.variants.as_slice()),
+        other => panic!("expected HgvsVariant::Allele, got {other:?}"),
+    }
+}
+
+/// Assert that the given allele arm is a protein variant carrying
+/// `ProteinEdit::Identity { whole_protein: true, predicted }`.
+fn assert_whole_protein_identity_arm(arm: &HgvsVariant, predicted: bool) {
+    let pv: &ProteinVariant = match arm {
+        HgvsVariant::Protein(pv) => pv,
+        other => panic!("expected Protein arm, got {other:?}"),
+    };
+    let edit = match &pv.loc_edit.edit {
+        Mu::Certain(e) => e,
+        Mu::Uncertain(e) => e,
+        other => panic!("expected Certain/Uncertain protein edit, got {other:?}"),
+    };
+    match edit {
+        ProteinEdit::Identity {
+            whole_protein: true,
+            predicted: p,
+        } => assert_eq!(
+            *p, predicted,
+            "predicted flag mismatch on whole-protein identity arm"
+        ),
+        other => panic!("expected whole-protein Identity, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// Trans phase: `p.[X];[=]`
+// =============================================================================
+
+/// The canonical spec example (alleles.md:58-60): one allele carries a
+/// substitution, the other carries whole-protein identity (`p.=`).
+#[test]
+fn trans_substitution_then_whole_protein_identity_roundtrips() {
+    assert_canonical(
+        "NP_003997.1:p.[Ser68Arg];[=]",
+        "NP_003997.1:p.[Ser68Arg];[=]",
+    );
+}
+
+/// Whole-protein identity on the *first* arm parses symmetrically.
+#[test]
+fn trans_whole_protein_identity_first_arm_roundtrips() {
+    assert_canonical(
+        "NP_003997.1:p.[=];[Ser68Arg]",
+        "NP_003997.1:p.[=];[Ser68Arg]",
+    );
+}
+
+/// Structural check: the `[=]` arm is a Protein variant carrying
+/// whole-protein identity, NOT a `NullAllele`/`UnknownAllele`.
+#[test]
+fn trans_whole_protein_identity_arm_is_protein_identity() {
+    let parsed = parse_hgvs("NP_003997.1:p.[Ser68Arg];[=]")
+        .expect("parse trans allele with whole-protein identity");
+    let (phase, arms) = allele_parts(&parsed);
+    assert_eq!(phase, AllelePhase::Trans);
+    assert_eq!(arms.len(), 2);
+    assert!(
+        matches!(&arms[0], HgvsVariant::Protein(_)),
+        "first arm must be Protein, got {:?}",
+        arms[0]
+    );
+    assert_whole_protein_identity_arm(&arms[1], false);
+}
+
+// =============================================================================
+// Cis phase: `p.[X;=]`
+// =============================================================================
+
+/// Whole-protein identity as a trailing cis bracket member.
+#[test]
+fn cis_substitution_then_whole_protein_identity_roundtrips() {
+    assert_canonical("NP_003997.1:p.[Ser68Arg;=]", "NP_003997.1:p.[Ser68Arg;=]");
+}
+
+/// Whole-protein identity as a leading cis bracket member.
+#[test]
+fn cis_whole_protein_identity_then_substitution_roundtrips() {
+    assert_canonical("NP_003997.1:p.[=;Ser68Arg]", "NP_003997.1:p.[=;Ser68Arg]");
+}
+
+// =============================================================================
+// Unknown phase: `p.[X(;)=]`
+// =============================================================================
+
+/// Whole-protein identity as an unknown-phase *bracket* member.
+///
+/// In-scope behavior for #468 is that the bracketed unknown-phase form
+/// `p.[X(;)=]` parses symmetrically with the nucleic-acid axes and yields
+/// an `AllelePhase::Unknown` allele whose second arm is whole-protein
+/// identity.
+///
+/// We deliberately do NOT assert a Display round-trip fixed point here.
+/// The protein unknown-phase Display canonicalises the bracketed form to
+/// the bare compact form (`p.Ser68Arg(;)=`), and re-parsing that compact
+/// form is a *pre-existing* protein-axis gap unrelated to whole-entity
+/// members: even `p.[Ser68Arg(;)Asn594del]` → `p.Ser68Arg(;)Asn594del`
+/// fails to re-parse on `main` (the bracketless unknown-phase protein
+/// parser only admits fully parenthesised members `(X)(;)(Y)`). Fixing
+/// that broad Display/parse asymmetry is out of scope for #468.
+#[test]
+fn unknown_phase_substitution_then_whole_protein_identity_parses() {
+    let parsed = parse_hgvs("NP_003997.1:p.[Ser68Arg(;)=]")
+        .expect("parse unknown-phase allele with whole-protein identity");
+    let (phase, arms) = allele_parts(&parsed);
+    assert_eq!(phase, AllelePhase::Unknown);
+    assert_eq!(arms.len(), 2);
+    assert!(
+        matches!(&arms[0], HgvsVariant::Protein(_)),
+        "first arm must be Protein, got {:?}",
+        arms[0]
+    );
+    assert_whole_protein_identity_arm(&arms[1], false);
+}
+
+// =============================================================================
+// Predicted-wrapper whole-entity members: `[(=)]`, `[(?)]`
+// =============================================================================
+
+/// Parenthesised predicted whole-protein identity in trans bracket
+/// position. Tolerated input mirroring `p.(=)` (#246) and PR #433's
+/// bracket probes. The certain Display of `(=)` keeps the parens.
+#[test]
+fn trans_predicted_whole_protein_identity_parses() {
+    let parsed = parse_hgvs("NP_003997.1:p.[Ser68Arg];[(=)]")
+        .expect("parse trans allele with predicted whole-protein identity");
+    let (phase, arms) = allele_parts(&parsed);
+    assert_eq!(phase, AllelePhase::Trans);
+    assert_eq!(arms.len(), 2);
+    assert_whole_protein_identity_arm(&arms[1], true);
+
+    // Display is a re-parse fixed point.
+    let displayed = parsed.to_string();
+    let reparsed = parse_hgvs(&displayed)
+        .unwrap_or_else(|e| panic!("re-parse of {displayed:?} must succeed; got {e:?}"));
+    assert_eq!(reparsed.to_string(), displayed, "Display must be stable");
+}
+
+/// Parenthesised predicted whole-protein unknown (`p.(?)`) in trans
+/// bracket position. Spec example alleles.md:55-56 uses bare `[?]` for
+/// this; the explicit `[(?)]` is the tolerated parenthesised input.
+#[test]
+fn trans_predicted_whole_protein_unknown_parses() {
+    let parsed = parse_hgvs("NP_003997.1:p.[Ser68Arg];[(?)]")
+        .expect("parse trans allele with predicted whole-protein unknown");
+    let (phase, arms) = allele_parts(&parsed);
+    assert_eq!(phase, AllelePhase::Trans);
+    assert_eq!(arms.len(), 2);
+    let pv = match &arms[1] {
+        HgvsVariant::Protein(pv) => pv,
+        other => panic!("expected Protein arm, got {other:?}"),
+    };
+    let edit = match &pv.loc_edit.edit {
+        Mu::Certain(e) | Mu::Uncertain(e) => e,
+        other => panic!("expected protein edit, got {other:?}"),
+    };
+    assert!(
+        matches!(
+            edit,
+            ProteinEdit::Unknown {
+                whole_protein: true,
+                predicted: true
+            }
+        ),
+        "expected predicted whole-protein Unknown, got {edit:?}"
+    );
+
+    let displayed = parsed.to_string();
+    let reparsed = parse_hgvs(&displayed)
+        .unwrap_or_else(|e| panic!("re-parse of {displayed:?} must succeed; got {e:?}"));
+    assert_eq!(reparsed.to_string(), displayed, "Display must be stable");
+}
+
+// =============================================================================
+// Singleton bracket: `p.[=]`
+// =============================================================================
+
+/// A singleton bracketed whole-protein identity `p.[=]` unwraps to the
+/// spec-sanctioned `p.=`, exactly as every other singleton bracket
+/// unwraps its sole member (`p.[Ser68Arg]` → `p.Ser68Arg`). This is a
+/// consequence of admitting whole-entity members in bracket position;
+/// the prior `tests/protein_silent_eq.rs` pin that rejected `p.[=]` is
+/// updated accordingly.
+#[test]
+fn singleton_bracket_whole_protein_identity_unwraps() {
+    assert_canonical("NP_003997.1:p.[=]", "NP_003997.1:p.=");
+}
+
+// =============================================================================
+// Pre-existing behavior preserved (regression guards)
+// =============================================================================
+
+/// `[0]` in a protein trans-allele bracket still routes to
+/// `ProteinEdit::NoProtein` (issue #277), NOT changed by this work.
+#[test]
+fn trans_bracket_zero_still_no_protein() {
+    let parsed =
+        parse_hgvs("NP_003997.1:p.[Ser68Arg];[0]").expect("parse trans allele with bracketed zero");
+    let (_, arms) = allele_parts(&parsed);
+    let pv = match &arms[1] {
+        HgvsVariant::Protein(pv) => pv,
+        other => panic!("expected Protein arm for [0], got {other:?}"),
+    };
+    assert!(
+        matches!(
+            pv.loc_edit.edit,
+            Mu::Certain(ProteinEdit::NoProtein { predicted: false })
+        ),
+        "[0] must remain NoProtein, got {:?}",
+        pv.loc_edit.edit
+    );
+}
+
+/// `[?]` in a protein trans-allele bracket still routes to
+/// `HgvsVariant::UnknownAllele` (cross-coord short-circuit), unchanged.
+#[test]
+fn trans_bracket_question_still_unknown_allele() {
+    let parsed = parse_hgvs("NP_003997.1:p.[Ser68Arg];[?]")
+        .expect("parse trans allele with bracketed question");
+    let (_, arms) = allele_parts(&parsed);
+    assert!(
+        matches!(&arms[1], HgvsVariant::UnknownAllele),
+        "[?] must remain UnknownAllele, got {:?}",
+        arms[1]
+    );
+}
+
+/// Position-bound identity `[Ser68=]` is distinct from whole-protein
+/// `[=]` and continues to parse as a position-bound identity (alleles.md
+/// explicitly contrasts the two).
+#[test]
+fn trans_position_bound_identity_still_distinct() {
+    assert_canonical(
+        "NP_003997.1:p.[Ser68Arg];[Ser68=]",
+        "NP_003997.1:p.[Ser68Arg];[Ser68=]",
+    );
+}
+
+// =============================================================================
+// Negative controls (spec-disallowed forms must still reject)
+// =============================================================================
+
+/// `p.[=;0]` mixes whole-protein identity with no-protein inside a single
+/// cis bracket. `[0]` is not a valid cis bracket member (issue #277 pins
+/// `p.[X;0]` as forbidden), so this must reject.
+#[test]
+fn cis_bracket_with_zero_member_rejects() {
+    for input in [
+        "NP_003997.1:p.[=;0]",
+        "NP_003997.1:p.[0;=]",
+        "NP_003997.1:p.[Ser68Arg;0]",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "{input:?} must reject ([0] is not a valid cis bracket member)"
+        );
+    }
+}
+
+/// A whole-entity edit followed by trailing garbage in bracket position
+/// must reject rather than silently consuming the prefix.
+#[test]
+fn whole_entity_member_with_trailing_garbage_rejects() {
+    for input in [
+        "NP_003997.1:p.[=X];[Ser68Arg]",
+        "NP_003997.1:p.[Ser68Arg];[=foo]",
+        "NP_003997.1:p.[Ser68Arg;=bar]",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "{input:?} must reject (trailing chars after whole-entity edit)"
+        );
+    }
+}

--- a/tests/protein_silent_eq.rs
+++ b/tests/protein_silent_eq.rs
@@ -469,9 +469,6 @@ fn silent_eq_rejects_malformed_adjacent_inputs() {
         "p.(=)",
         "p.Leu54=",
         "p.(Leu54=)",
-        // Cis-bracket forms — bare `[=]` is NOT a sanctioned NullAllele-like
-        // marker (only `[0]` and `[?]` are special-cased at variant.rs:1383).
-        "NP_000079.2:p.[=]",
     ];
 
     for input in &rejects {
@@ -482,6 +479,26 @@ fn silent_eq_rejects_malformed_adjacent_inputs() {
             result.ok()
         );
     }
+}
+
+/// Since #468, whole-entity protein edits (`=`, `(=)`, `(?)`) are
+/// admitted as bracket members so compound forms like `p.[Ser68Arg];[=]`
+/// parse (HGVS v21 `recommendations/protein/alleles.md`). Bare `?` is
+/// NOT admitted here — it remains the trans whole-allele unknown marker
+/// (`UnknownAllele`), handled outside `parse_protein_bracket_member`. As a
+/// consequence, a *singleton* bracketed whole-protein identity `p.[=]`
+/// now parses too — unwrapping to the spec-sanctioned `p.=`, exactly as
+/// every other singleton bracket unwraps its sole member
+/// (`p.[Ser68Arg]` → `p.Ser68Arg`). This replaces the prior pin that
+/// rejected `p.[=]` outright (the rejection was an artifact of
+/// whole-entity members not being admitted in bracket position at all).
+#[test]
+fn silent_eq_singleton_bracket_unwraps_to_whole_protein_identity() {
+    let parsed = parse_hgvs("NP_000079.2:p.[=]").expect("p.[=] must parse since #468");
+    assert_eq!(parsed.to_string(), "NP_000079.2:p.=");
+    // Re-parse fixed point on the canonical (unwrapped) form.
+    let reparsed = parse_hgvs("NP_000079.2:p.=").expect("p.= must parse");
+    assert_eq!(reparsed.to_string(), "NP_000079.2:p.=");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #468. Extends protein bracket-member parsing to accept whole-entity edits (`=`, `(=)`, `(?)`) in bracket-member position, so compound forms like `NP_003997.1:p.[Ser68Arg];[=]` parse. This is the protein-axis analogue of the nucleic-acid bracket-member whole-entity dispatch (#423 / PR #433) and the `r.` axis (#396 item 3).

The protein axis does not share the `NaEdit` type the nucleic-acid axes use, so this adds a dedicated `parse_protein_bracket_member` helper: whole-entity protein edits are `ProteinEdit::Identity { whole_protein: true, .. }` / `ProteinEdit::Unknown { whole_protein: true, .. }`, carry no position, and are attached to a dummy `Met1` interval (mirroring `parse_protein_variant`'s top-level handling of `p.=` / `p.(?)`). The helper is routed into all three protein bracket paths: cis (`p.[X;Y]`), unknown-phase (`p.[X(;)Y]`), and trans (`p.[X];[Y]`).

## What is and isn't admitted

- **Admitted:** `=` / `(=)` (whole-protein identity) and `(?)` (predicted whole-protein unknown).
- **Not admitted (unchanged):** bare `?` is reserved for the trans whole-allele marker (`p.[(Ser68Arg)];[?]` → `UnknownAllele`); `0` / `0?` / `(0)` are not valid cis members (#277). The existing reject pins in `tests/protein_unknown_roundtrip.rs` are preserved.

## Spec basis

- `recommendations/protein/alleles.md` (lines 58–60): `p.[Ser68Arg];[=]` is a valid description, explicitly distinct from `[Ser68=]`; `[=]` means the entire protein reference sequence was analysed.
- `recommendations/protein/substitution.md`: `p.=` means the entire protein coding region was analysed.

## Note for reviewers

- Touches the spec fixture `tests/fixtures/grammar/hgvs_spec_normalization.json` (regenerated via the generator): the spec's own example `p.[Ser68Arg];[=]` moves from `parse-error` to `preserved` (−1 parse-error, +1 preserved) — a spec-compliance improvement. No other rows change.
- Updates one pin in `tests/protein_silent_eq.rs`: `p.[=]` previously rejected outright; it now unwraps to the spec-sanctioned `p.=`, exactly as every other singleton bracket unwraps its sole member. The prior rejection was an artifact of whole-entity members not being admitted in bracket position at all.
- The sibling nucleic-acid work (#433) is currently stacked on the open #425 branch, not yet on `main`, so this lands the protein axis somewhat ahead of the NA symmetry reaching `main`. The implementation is independent (separate parser paths) and spec-justified on its own.

## Tests

New `tests/issue_468_protein_bracket_whole_entity.rs` (14 cases): cis / trans / unknown-phase / predicted whole-entity members, plus regression guards (`[0]` still no-protein, `[?]` still UnknownAllele, position-bound identity still distinct) and negative controls.

## Test plan

- [x] `cargo test --features dev` — full suite green (new test 14/14)
- [x] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
