### PR TITLE
docs(mutalyzer-normalize): regenerate failure-patterns from live run + arbitration

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -1,117 +1,69 @@
 # Mutalyzer-normalize failure patterns
 
-This document groups the **479 FAILs** that ferro-hgvs surfaces today against
-the imported mutalyzer normalizer fixtures (320 active cases × 8 output axes,
-many cases hitting multiple axes). Each section is one root-cause pattern, not
-one input — burn-down PRs fix the root cause and demote rows from the
-per-axis `baseline-failures/<axis>.txt` files.
+Per-axis root-cause analysis of the divergences ferro-hgvs surfaces against the
+imported mutalyzer normalizer fixtures (320 active cases × 8 output axes; many
+cases hit multiple axes). The authoritative, continuously-updated tracker is
+[#326](https://github.com/fulcrumgenomics/ferro-hgvs/issues/326); this file is
+the in-repo snapshot.
 
-**Comparator-driven demotion via #335 (recorded here for reviewability):**
-16 inputs on the `normalized` axis are no longer FAILs as of #335:
-14 gene-symbol-selector cases are tallied as `divergence_accepted` (per
-ferro policy #121); 2 dup-vs-ins cases had their `cases.json` `normalized`
-field corrected to ferro's HGVS-spec-correct value and carry a
-`spec_citation` annotation. Neither set required changing ferro behavior.
-Pre-#335 the `normalized`-axis FAIL count was 149; post-#335 it is 133.
+> **Regenerated 2026-05-29 from a live `FERRO_MANIFEST` run.** This supersedes
+> the earlier version, whose "479 FAILs" header and per-pattern dispositions
+> predated the spec arbitration and were optimistic (e.g. it assumed exposing
+> the c→g projection API would clear the `genomic` axis; in fact that API emits
+> invalid coordinates — see #480).
 
-Raw per-axis FAIL data is rebuilt by running
+## Important: "FAIL" means "differs from mutalyzer", not "ferro is wrong"
 
-    rm -rf /tmp/ferro-xfail
-    cargo nextest run --features dev --test mutalyzer_normalize_tests \
-      -E 'test(/^axis_/)' --no-capture --no-fail-fast
+Mutalyzer is **not** HGVS ground truth. Every divergence must be arbitrated
+against the spec (`assets/hgvs-nomenclature`) into one of:
 
-against a `cases.json` whose `xfail` arrays are empty. The test runner writes
-`/tmp/ferro-xfail/<axis>.tsv` (input \t diagnostic) and `<axis>.txt` (input
-per line). `scripts/group-mutalyzer-failures.py` (next PR) will re-generate
-this Markdown from those TSVs.
+- **(a) ferro bug** — fix ferro.
+- **(b) ferro spec-correct / mutalyzer diverges** — annotate `accepted_divergence`
+  in `cases.json` (the #335 mechanism); no ferro change.
+- **(c) missing feature** — ferro doesn't implement this surface yet.
+- **(d) both spec-allowed** — policy call.
 
-## Per-pattern summary
+## Live run (origin/main, 2026-05-29)
 
-| # | Pattern | Count | Axes | Existing GH refs | Arbitration verdict | Burn-down disposition |
-|---|---|---:|---|---|---|---|
-| 1 | `c→g API not exposed` | 83 | genomic | (none) | **ferro gap** — c./n. → g. projection is not exposed; HGVS spec requires reverse projection support to back the `equivalent_descriptions["g"]` shape | **new issue**: "expose c./n. → g. projection in `VariantProjector`"; once landed, re-run axis and the 83 fall to 0 |
-| 2 | `VariantProjector only accepts g. variants` (`project: error` / `project_all: error`) | 83 (65+18) | protein_description, coding_protein_descriptions | **#310** ([PR #313](https://github.com/fulcrumgenomics/ferro-hgvs/pull/313) in flight) covers non-RefSeq protein prediction; the g.-only restriction is a separate adjacent gap | **ferro gap** — projector should accept c./n. inputs by first projecting back to g., then forward to p. | **new issue**: "VariantProjector::project should accept c./n./r. inputs"; possibly subsumed if c→g API (#1) ships first |
-| 3 | `output divergence: other` | 101 | normalized, genomic | many — needs per-row spec arbitration | mixed | **bulk arbitration** below (split into sub-patterns 3a–3e) |
-| 4 | `error-code mapping missing` | 50 | errors | **resolved via #329** | mapping table now lives in `error_handling::mutalyzer_map`; the runner delegates via `mutalyzer_to_ferro(code).map(\|t\| t.debug_tag())` | **resolved** — 3 inputs (ESYNTAXUEOF / ECOORDINATESYSTEMINVALID / ESYNTAXNESTED) now pass; the remaining 47 are no longer "mapping missing" but a single semantic gap — ferro accepts inputs mutalyzer rejects, surfacing as `ferro produced no error; mutalyzer expected …`. That's #87 / over-permissive-validation territory (tighten parser/validator to reject what mutalyzer rejects). Tracked under rows 6 / 14, not this row. |
-| 5 | `output divergence: coding_protein pair missing` | 33 | coding_protein_descriptions | **#310** / #313 — the gene-symbol-in-selector issue accounts for most of these once c→g exists | **ferro policy** — #121 closed deliberately *preserving* gene-symbol selector; mutalyzer uses `(NM_legacy_alias)`. The pair shape is the same; only the selector spelling differs | **partially resolved via comparator (#335)** on the `normalized` axis; the same selector-spelling divergence on `coding_protein_descriptions` still FAILs and needs either #310/#313 protein-prediction fixes or comparator extension to that axis |
-| 6 | `parse error` | 23 | normalized, genomic, protein_description | check #87 / #83 trackers — likely uncovered spec gaps | **needs per-row spec arbitration** — these are inputs ferro cannot parse at all | Triage each: if parseable per spec → **new issue** under #87; if intentionally rejected → move expected to `errors` axis with spec citation |
-| 7 | `info-code surface not wired` | 22 | infos | (none) | ferro doesn't yet emit structured `info` codes the way mutalyzer's `IINFO_*` does | **new issue**: "structured info-code surface in normalize output (mirror W##### warnings)" |
-| 8 | `gene-symbol vs alias selector (#121)` | 14 | normalized | **#121** (closed, ferro policy explicitly preserves gene-symbol selector); see also #310/#313 | **ferro policy** — these are *not bugs*. mutalyzer emits `(BRCA2_v001)`, ferro emits `(BRCA2)` | **resolved via `accepted_divergence` comparator (#335)**: 14 cases on the `normalized` axis carry `accepted_divergence: "ferro-policy-121-gene-symbol-selector"`. The comparator tracks them in the `divergence_accepted` tally bucket instead of FAIL. **No issue filed; no ferro change.** Original eyeballed estimate was ~21; the strict selector-only-divergence count (expected vs got differ exclusively in the `(…)` token) is 14. |
-| 9 | `3' shift differs by N bases` | 20 | normalized | overlaps **#161**, **#11**, and adjacent intronic/repeat-shift work | **needs per-row spec arbitration** — some are real ferro bugs in 3' rule, some are mutalyzer over-shifts | Triage each against HGVS §SVD-WG009; cluster into 2-4 sub-issues per shape (intronic-boundary, repeat-region, etc.) |
-| 10 | `r. prediction not wired` | 16 | rna_description | **#283** (open, [PR #301](https://github.com/fulcrumgenomics/ferro-hgvs/pull/301)) audits c.→r.; **#291** (open, [PR #304](https://github.com/fulcrumgenomics/ferro-hgvs/pull/304)) related r. branch fix | **ferro gap** — runner uses a stub. After #301/#304 merge, wire the runner to ferro's r. prediction surface | Wire runner: replace the `Err("not wired")` stub with real call once those PRs merge |
-| 11 | `no chromosome mapping for intronic normalization` | 12 | normalized, genomic | adjacent to **#172** (E3006 intronic ranges) and the recently-closed #98/#100 family | **ferro bug** — when input is `NG_xxx(NM_yyy):c.123-5_…`, ferro requires a chromosome mapping but the cdot mapper has the NG-based projection | **new issue**: "intronic boundary normalization with NG-prefixed transcript inputs" |
-| 12 | `panic: arithmetic overflow in normalize` | 9 | normalized, genomic, protein_description | adjacent to **#87** "insertion form" rules and shuffle.rs:86 (called out in #87 body) | **ferro bug** — `c.123insG` (single-pos insertion) panics in `Normalizer::normalize` at `normalize/shuffle.rs:86` per #87's call-out | This is already documented in #87. **No new issue needed.** Add to #87 checklist if not there; demote when fixed. |
-| 13 | `n. projection not wired` | 8 | noncoding | same family as #10 (r. prediction) | **ferro gap** — runner stub | Wire runner once n. projection API is settled |
-| 14 | `error expected but ferro succeeded` | 7 | errors | needs per-row spec arbitration | **needs per-row spec arbitration** — mutalyzer rejects these as errors; should ferro? | Triage 7 inputs; per-row spec citation; either tighten ferro validation (new issue) or accept divergence |
-| 15 | `no chromosome for boundary normalization` | 2 | normalized, genomic | same family as #11 | **ferro bug** | Subsumed into #11's new issue |
-| 16 | `normalize: other error` | 2 | normalized, genomic | per-row triage | **needs per-row spec arbitration** | Triage |
-| 17 | `could not infer transcript_id` | 2 | protein_description | runner-side issue, not ferro | **runner bug** — for `NG_…:g.…` style inputs the runner can't infer which transcript to project against | Fix in the runner: use `project_all` for protein axis when input has no embedded transcript |
-| 18 | `output divergence: expected empty string` | 1 | normalized | upstream fixture quirk | **upstream fixture quirk** — one mutalyzer case has `"normalized": ""` which mutalyzer treats as "no normalized form" | Document in `cases.json` as accepted divergence |
+| Axis | FAIL | Verdict | Tracking |
+|---|---:|---|---|
+| `normalized` | 105 | mostly (a): `ins`→`dup`, tandem-repeat & allele-collapse detection, mito `m.`, 3′ off-by-one; plus panics. ~8–10 (b) `(GENE_v001)` selector (#121). | **#487** (edit-form), **#488** (panics) |
+| `genomic` | 100 | (a)/scope: `project_to_genomic` emits **chromosome coords under the `NG_`/`LRG_` accession** — invalid HGVS regardless of mutalyzer. Axis is 100% NG/LRG-relative; cdot has no NM→NG alignment. | **#480** |
+| `protein_description` | 71 → **64** | (a): routes c→g→CDS (`projector.rs`), so it sits on top of #480 and needs a `genomic_context` parent. NP accession was wrong (NM→NP inference). 7 wrapper-only cases now spec-correct (bare `NP_`); ~10 genuine prediction divergences + ~54 bare-`NM_` remain. | **PR #483** (NP fix, merged) + **PR #495** (7 bare-NP) |
+| `coding_protein_descriptions` | 51 | (a): same projection path; many `got []`. | as above |
+| `errors` | 54 | mostly (a): ferro **over-permissively accepts** invalid HGVS (U-in-DNA, single-pos `ins`, coord-system mismatch on `NR_`, seq/length/repeat mismatch, out-of-bounds, intronic-on-bare-`NM_`). ~7 (b) Ensembl/complex-repeat/selector. | **#486** |
+| `infos` | 22 → **11** | (b): the `I*` codes are mutalyzer **internal** diagnostics, absent from the HGVS spec. Accepted; 11 genuine divergences remain (`SHUFFLE_APPLIED` over/under-emit, parse failures). | **PR #481** (shipped 22→11) |
+| `rna_description` | 16 | (c): no public c.→r. consequence-prediction surface exists. | **#485** |
+| `noncoding` | 8 | (c): no public c.→n. surface. | **#485** |
+| **Total** | **427** | | |
 
-**Total burn-down work:** 13 new ferro issues (rows 1, 2, 4, 6, 7, 9, 10, 11, 13, 14, 17, plus #3 splits + child issues), minus rows that map to existing in-flight PRs (#310/#313, #283/#301, #291/#304, #87, #121).
+Merged demotions: **PR #479** removed 49 already-passing `ins[...]` rows
+(`normalized` 133→105, `genomic` 120→99); **PR #481** reclassified the 11
+non-spec `infos` rows (22→11); **PR #483** fixed the protein NP accession.
+In flight: **PR #495** (7 spec-correct bare-`NP_` protein cases). Committed
+baseline total is now **415** (→ 408 once #495 merges).
 
-## Sub-patterns inside `output divergence: other` (101 FAILs)
+## Regenerating this snapshot
 
-This pattern is too generic to act on as-is. Eyeballing the diagnostics:
+The per-axis FAIL lists under `/tmp/ferro-xfail/<axis>.{txt,tsv}` are produced
+by the single-process `regenerate_baselines` test (the per-axis `axis_*` gates
+no longer write files):
 
-### 3a. `ins[…]` → `ins<seq>` collapse (~30)
-**Examples:**
-- `NG_007485.1(NM_000077.4):c.161_162ins[ATC]` → expected `c.161_162insATC`
-- `NG_008939.1:g.5207_5208ins[GTCCTGTGCTC;ATTATCTGGC]` → expected `c.…insGTCCTGTGCTCATTATCTGGC`
-- `NG_008939.1:g.5207_5208ins[4300_4320]` → expected `c.…insGTCCTGTGCTCATTATCTGGC` (range→sequence lookup)
+```sh
+FERRO_MANIFEST=/path/to/manifest.json \
+  cargo nextest run --features dev -E 'test(regenerate_baselines)' \
+  --run-ignored only --no-capture
+```
 
-**Verdict:** **ferro gap** — bracketed and range-form inserts should be canonicalized to a single concatenated sequence. The range-form `ins[start_end]` needs reference-sequence lookup, which is a separate feature.
+Then refresh the committed `baseline-failures/<axis>.txt` from those outputs.
+A future `scripts/group-mutalyzer-failures.py` may auto-generate the table
+above from the `.tsv` files; the **verdict** column is human spec arbitration
+and is maintained by hand (mirrored in #326).
 
-**Disposition:** new issue: "canonicalize bracketed `ins[…]` and range-form `ins[start_end]` to flat sequence form".
+## Background
 
-### 3b. dup-vs-ins canonicalization at coding-region boundary (2)
-**Examples:**
-- `NM_000143.3:c.1_2insCAT` → expected `c.1_2insCAT`, got `c.-1_2dup`
-- `NM_000143.3:c.-1_1insCAT` → expected `c.-1_1insCAT`, got `c.-1_2dup`
-
-**Verdict:** **HGVS spec §Prioritization** mandates `dup` over `ins` when both descriptions are valid. ferro applies this rule; mutalyzer left these in `ins` form.
-
-**Disposition:** **resolved via `spec_citation` + corrected expected output (#335)**. The `cases.json` `normalized` field for both inputs was updated to ferro's spec-correct value, and a `spec_citation: HGVS §Prioritization` was attached. Both cases now PASS the standard match check; the citation makes the divergence reviewable. Original estimate was ~5; the actual count of `ins[bases]` → `dup` divergences on the `normalized` axis is 2.
-
-### 3c. Gene-symbol-vs-alias selector in `normalized` axis (~20)
-Spillover from row 8 — gene-symbol selector preservation by ferro vs alias in mutalyzer.
-
-**Disposition:** same as row 8 — `accepted_divergence` field in `cases.json`.
-
-### 3d. 5' UTR boundary delins (~15)
-**Examples:** several `NM_…:c.<positive>_<positive>delins…` where ferro produces a slightly different position pair than mutalyzer.
-
-**Disposition:** **needs spec arbitration** + likely 1 new issue.
-
-### 3e. Other (~30)
-Tail of single-occurrence divergences that need 1:1 spec arbitration.
-
-**Disposition:** spec-arbitrate batch; expected outcome is small (~1-3) new issues plus some `accepted_divergence` entries.
-
-## Cross-reference matrix: existing GH refs ↔ patterns
-
-| GH ref | State | Patterns it touches |
-|---|---|---|
-| **#310** / [PR #313](https://github.com/fulcrumgenomics/ferro-hgvs/pull/313) | issue open / PR open | rows 2, 5 (protein prediction, gene-symbol selector) |
-| **#311** / [PR #312](https://github.com/fulcrumgenomics/ferro-hgvs/pull/312) | open / open | possibly handful of row 3e cases |
-| **#121** | closed | row 8 (ferro policy precedent) |
-| **#283** / [PR #301](https://github.com/fulcrumgenomics/ferro-hgvs/pull/301) | open / open | row 10 |
-| **#291** / [PR #304](https://github.com/fulcrumgenomics/ferro-hgvs/pull/304) | open / open | row 10 |
-| **#275** / [PR #292](https://github.com/fulcrumgenomics/ferro-hgvs/pull/292) | open / open | possibly row 9 |
-| **#280** / [PR #297](https://github.com/fulcrumgenomics/ferro-hgvs/pull/297) | open / open | row 14 |
-| **#83** | open, umbrella | rows 6, 9 (spec-driven gaps) |
-| **#87** | open, umbrella | row 12 (explicitly documents the shuffle.rs:86 overflow) |
-| **#172** | open | row 11 (intronic ranges adjacent) |
-| **#129** | open | possibly m. axis cases (none surfaced so far) |
-| **#10** | closed | reference: "Conflicting Mutalyzer outputs" — first ferro/mutalyzer divergence ticket; useful template |
-| **#11** | closed | adjacent to row 9 (intron-spanning insertion numbering) |
-
-## After this PR lands
-
-1. File **one** umbrella tracking issue ("tracking: ferro-hgvs ↔ mutalyzer normalize parity") in `fulcrumgenomics/ferro-hgvs`. Body lists rows 1–18 with the disposition column above as the burn-down checklist.
-2. File child issues for rows requiring new ferro work (1, 2, 4, 7, 11, 13 — and the 3a/3b/3d sub-issues). **Each child issue gets title + body approval before filing per the project's GitHub guardrail.**
-3. Burn-down PRs: one per child issue. Each:
-   - Drives a TDD case in `tests/normalize_tests.rs` (CI-runnable, `MockProvider`-backed)
-   - Removes the corresponding inputs from `baseline-failures/<axis>.txt`
-   - Cross-links the umbrella issue
-4. Re-run the runner; demoted inputs become passes; XPASS guard ensures any forgotten demotions are loud.
+- Corpus: 320 active cases × 8 output axes, ported from `mutalyzer/mutalyzer`
+  `tests/variants_set.py` at the pinned upstream commit.
+- Refresh the corpus: `pixi run python scripts/refresh-mutalyzer-fixtures.py refresh`.
+  Bumping the pinned SHA is a deliberate per-PR action; never blind.
+- Layout convention: `tests/fixtures/CORPUS_LAYOUT.md`.


### PR DESCRIPTION
The committed `failure-patterns.md` was stale: a "479 FAILs" header and per-pattern dispositions that predated the HGVS-spec arbitration and were optimistic (e.g. it assumed exposing the c→g projection API would clear the `genomic` axis; that API actually emits invalid coordinates — #480).

Regenerated from a live `FERRO_MANIFEST` run (**427** FAILs across 8 axes) and the spec arbitration in #326:

- Leads with the **(a) bug / (b) accepted-divergence / (c) feature / (d) policy** framing and the "differs from mutalyzer ≠ ferro is wrong" caveat.
- Per-axis verdict + tracking issue/PR: #480 (genomic), PR #481 (infos), PR #483 (protein NP), #485 (rna/noncoding), #486 (errors), #487 (normalize edit-form), #488 (panics); in-flight demotions #479/#481/#483.
- Documents the single-process `regenerate_baselines` workflow (PR #491) that produces the `/tmp/ferro-xfail` artifacts.

Doc-only change. The authoritative live tracker remains #326; this is the in-repo snapshot.

Refs #326.