### PR TITLE
fix(project): report p.(Met1?) for initiation-codon variants (#498)

### DIFF
--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -4,12 +4,53 @@
 //! independently of the rest of the projector machinery.
 
 use crate::error::FerroError;
-use crate::hgvs::edit::{InsertedSequence, NaEdit};
-use crate::hgvs::location::AminoAcid;
+use crate::hgvs::edit::{InsertedSequence, NaEdit, ProteinEdit};
+use crate::hgvs::interval::ProtInterval;
+use crate::hgvs::location::{AminoAcid, ProtPos};
+use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
+use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
 use crate::sequence::reverse_complement;
 
 use super::substitution::translate_bytes;
+
+/// Does `edit` modify a base of the translation initiation codon (1-based CDS
+/// positions 1–3)?
+///
+/// An insertion places bases *between* `cds_pos_start` and the next position,
+/// so it disrupts the start codon only when the gap is strictly inside it
+/// (between c.1/c.2 or c.2/c.3, i.e. `cds_pos_start ∈ {1,2}`). Every other edit
+/// (substitution, deletion, delins, duplication, inversion) modifies the
+/// `[start,end]` span, so it disrupts the start codon whenever that span
+/// overlaps `[1,3]`.
+pub(crate) fn affects_initiation_codon(
+    edit: &NaEdit,
+    cds_pos_start: i64,
+    cds_pos_end: i64,
+) -> bool {
+    match edit {
+        NaEdit::Insertion { .. } => (1..=2).contains(&cds_pos_start),
+        _ => cds_pos_start <= 3 && cds_pos_end >= 1,
+    }
+}
+
+/// Build a predicted `p.(Met1?)` variant for a change affecting the translation
+/// initiation codon. Per HGVS (`recommendations/protein/substitution.md:51`,
+/// `deletion.md:62`) the protein consequence of an initiation-codon variant
+/// cannot be predicted, so it is reported as `Met1?`; emitting a concrete
+/// missense (`p.Met1Thr`-style) is explicitly disallowed by the spec. Protein
+/// residue 1 is the initiator `Met` regardless of the reference codon.
+pub(crate) fn build_initiator_unknown(
+    protein_accession: &str,
+    transcript: &Transcript,
+) -> HgvsVariant {
+    let loc = ProtInterval::point(ProtPos::new(AminoAcid::Met, 1));
+    HgvsVariant::Protein(ProteinVariant {
+        accession: parse_accession(protein_accession),
+        gene_symbol: transcript.gene_symbol.clone(),
+        loc_edit: LocEdit::new_predicted(loc, ProteinEdit::position_unknown()),
+    })
+}
 
 // ── CDS sequence readers ──────────────────────────────────────────────────────
 

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -10,9 +10,9 @@ use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
 
 use super::helpers::{
-    build_mutated_cds_with_ref, first_diff_position, net_length_change,
-    translate_full_cds_with_stop, translate_mutated_cds, translate_mutated_cds_inframe,
-    RefProteinBundle,
+    affects_initiation_codon, build_initiator_unknown, build_mutated_cds_with_ref,
+    first_diff_position, net_length_change, translate_full_cds_with_stop, translate_mutated_cds,
+    translate_mutated_cds_inframe, RefProteinBundle,
 };
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -33,6 +33,13 @@ pub(crate) fn predict_indel_protein(
     edit: &NaEdit,
     protein_accession: &str,
 ) -> Result<HgvsVariant, FerroError> {
+    // A change touching the translation initiation codon (CDS 1–3) has an
+    // unpredictable protein consequence — report p.(Met1?) up front rather
+    // than a concrete del/ins/delins, which the spec disallows (#498).
+    if affects_initiation_codon(edit, cds_pos_start, cds_pos_end) {
+        return Ok(build_initiator_unknown(protein_accession, transcript));
+    }
+
     // 1. The reference CDS + translation are pre-computed by the caller (and
     //    cached on `VariantProjector` so fan-out across many indels on the
     //    same transcript doesn't re-translate (or re-read+re-uppercase) the
@@ -915,29 +922,125 @@ mod tests {
     /// (ATG). HGVS recommendation: report as `p.(Met1?)` because we can't
     /// predict where translation actually starts on the altered transcript.
     ///
-    /// We accept either the strict `Met1?` form or any variant that flags
-    /// the first amino acid — what we require is that the prediction not
-    /// silently lose the start-codon edge case.
+    /// Deleting the initiation codon yields an unpredictable protein
+    /// consequence, reported as `p.(Met1?)` (HGVS deletion.md:62; #498) — not
+    /// a concrete `Met1del`.
     #[test]
     fn del_start_codon_initiator_met_loss() {
-        // CDS "ATGCGCTAA" → after del c.1_3, mut_cds = "CGCTAA".
-        // CDS-length change: -3 (in-frame at the AA level, but the new
-        // sequence starts with CGC = Arg — no Met at position 1).
+        // CDS "ATGCGCTAA"; del c.1_3 removes the entire start codon (ATG).
         let t = tx("ATGCGCTAA", 1, 9);
         let edit = NaEdit::Deletion {
             sequence: None,
             length: None,
         };
         let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Initiator Met loss via delins: replacing c.1_3 (the start codon) with
+    /// any sequence has an unpredictable protein consequence, reported as
+    /// `p.(Met1?)` rather than a concrete `Met1delins…` (#498). The
+    /// `[start,end]` span overlaps CDS 1–3 so the guard fires for delins.
+    #[test]
+    fn delins_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA"; delins c.1_3 (ATG → TCC) overwrites the start codon.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "TCC".parse().unwrap();
+        let edit = NaEdit::Delins {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
+        };
+        let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Initiator Met loss via duplication: duplicating c.1_3 (the start codon)
+    /// disrupts initiation, reported as `p.(Met1?)` rather than a concrete
+    /// `Met1dup` (#498). The `[start,end]` span overlaps CDS 1–3.
+    #[test]
+    fn dup_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA"; dup c.1_3 (ATG) overlaps the start codon.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Duplication {
+            sequence: None,
+            length: None,
+            uncertain_extent: None,
+        };
+        let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Initiator Met loss via inversion: inverting c.1_3 (the start codon)
+    /// disrupts initiation, reported as `p.(Met1?)` rather than a concrete
+    /// `Met1delins…` (#498). The `[start,end]` span overlaps CDS 1–3.
+    #[test]
+    fn inversion_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA"; inv c.1_3 (ATG → CAT) overwrites the start codon.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let edit = NaEdit::Inversion {
+            sequence: None,
+            length: None,
+        };
+        let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Initiator Met loss via insertion *inside* the start codon: an insertion
+    /// disrupts initiation only when the gap is strictly inside CDS 1–3, i.e.
+    /// `cds_pos_start ∈ {1,2}`. An insertion at c.1_2 (start=1) splits the
+    /// start codon and is reported as `p.(Met1?)` (#498).
+    #[test]
+    fn ins_within_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA"; insert "GGG" at c.1_2 (gap between c.1 and c.2,
+        // strictly inside the start codon ATG).
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 1, 1, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Initiator Met loss via insertion at the *second* interior gap of the
+    /// start codon (gap between c.2 and c.3, `cds_pos_start = 2`). The helper
+    /// treats both interior gaps (`cds_pos_start ∈ {1,2}`) as disrupting
+    /// initiation, so this also reports `p.(Met1?)` (#498). Pins the
+    /// `cds_pos_start == 2` branch that `ins_within_start_codon` (start=1) and
+    /// `ins_after_start_codon` (start=3) leave uncovered, guarding against an
+    /// off-by-one regression on the interior-gap range.
+    #[test]
+    fn ins_second_gap_within_start_codon_initiator_met_loss() {
+        // CDS "ATGCGCTAA"; insert "GGG" at c.2_3 (gap between c.2 and c.3,
+        // strictly inside the start codon ATG).
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 2, 2, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
+    }
+
+    /// Insertion boundary: an insertion *after* the start codon (gap between
+    /// c.3 and c.4, `cds_pos_start = 3`) does NOT disrupt initiation, so the
+    /// guard must NOT fire — the normal in-frame insertion consequence is
+    /// reported instead of `p.(Met1?)`. Pins the insertion-specific boundary
+    /// of `affects_initiation_codon` (#498).
+    #[test]
+    fn ins_after_start_codon_does_not_trigger_initiator_unknown() {
+        // CDS "ATGCGCTAA"; insert "GGG" at c.3_4 (gap just past the start
+        // codon). Same fixture as ins_three_bases_codon_aligned.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "GGG".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
-        // The codon-aligned in-frame deletion of codon 1 emits a Met1del
-        // (or some Met1-flagged form). Just assert the start codon was
-        // touched and the prediction succeeded.
-        assert!(
-            s.contains("Met1") || s.contains("M1"),
-            "expected Met1 reference in start-codon-loss prediction, got '{}'",
-            s
-        );
+        assert_ne!(s, "NP_TEST.1:p.(Met1?)", "guard must not fire past CDS 3");
+        assert_eq!(s, "NP_TEST.1:p.(Met1_Arg2insGly)");
     }
 
     /// Large multi-codon in-frame deletion (4 codons, 12 bases) — covers

--- a/src/project/protein/substitution.rs
+++ b/src/project/protein/substitution.rs
@@ -7,6 +7,7 @@ use crate::hgvs::interval::ProtInterval;
 use crate::hgvs::location::{AminoAcid, ProtPos};
 use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
 use crate::project::accession::parse_accession;
+use crate::project::protein::helpers::{affects_initiation_codon, build_initiator_unknown};
 use crate::reference::transcript::Transcript;
 use once_cell::sync::Lazy;
 
@@ -117,6 +118,12 @@ pub(crate) fn predict_substitution_protein(
             })
         }
     };
+    // A substitution in the translation initiation codon (CDS 1–3) has an
+    // unpredictable protein consequence — report p.(Met1?) rather than a
+    // concrete missense, which the spec disallows (#498).
+    if affects_initiation_codon(edit, cds_pos, cds_pos) {
+        return Ok(build_initiator_unknown(protein_accession, transcript));
+    }
     let (ref_codon, frame) = read_ref_codon(transcript, cds_pos)?;
     let alt_codon = apply_substitution(&ref_codon, frame, alt);
     let ref_aa = translate(&ref_codon).unwrap_or(AminoAcid::Xaa);
@@ -340,49 +347,78 @@ mod tests {
 
     #[test]
     fn substitution_missense_arg_to_gly() {
-        // CDS "CGGGGG": codon 1 = CGG = Arg. c.1C>G → codon 1 = GGG = Gly.
-        let tx = tx_with_seq("CGGGGG", 1, 6);
+        // CDS "ATGCGGGGG": codon 2 = CGG = Arg. c.4C>G → codon 2 = GGG = Gly.
+        // (Codon 2, not 1, so the initiation-codon guard does not apply.)
+        let tx = tx_with_seq("ATGCGGGGG", 1, 9);
         let edit = NaEdit::Substitution {
             reference: Base::C,
             alternative: Base::G,
         };
-        let pv = predict_substitution_protein(&tx, 1, &edit, "NP_000288.1").unwrap();
+        let pv = predict_substitution_protein(&tx, 4, &edit, "NP_000288.1").unwrap();
         let s = match &pv {
             HgvsVariant::Protein(p) => p.to_string(),
             _ => panic!("expected Protein variant"),
         };
-        assert_eq!(s, "NP_000288.1:p.(Arg1Gly)");
+        assert_eq!(s, "NP_000288.1:p.(Arg2Gly)");
     }
 
     #[test]
     fn substitution_synonymous_arg_arg() {
-        // CGG (Arg) → CGC (Arg). Frame 2 of codon 1, alt C.
-        let tx = tx_with_seq("CGGGGG", 1, 6);
+        // codon 2 = CGG (Arg) → CGC (Arg). Frame 2 of codon 2 (c.6), alt C.
+        let tx = tx_with_seq("ATGCGGGGG", 1, 9);
         let edit = NaEdit::Substitution {
             reference: Base::G,
             alternative: Base::C,
         };
-        let pv = predict_substitution_protein(&tx, 3, &edit, "NP_000288.1").unwrap();
+        let pv = predict_substitution_protein(&tx, 6, &edit, "NP_000288.1").unwrap();
         let s = match &pv {
             HgvsVariant::Protein(p) => p.to_string(),
             _ => panic!("expected Protein variant"),
         };
-        assert_eq!(s, "NP_000288.1:p.(Arg1=)");
+        assert_eq!(s, "NP_000288.1:p.(Arg2=)");
+    }
+
+    #[test]
+    fn substitution_in_initiation_codon_is_met1_unknown() {
+        // A substitution anywhere in the initiation codon (CDS 1–3) has an
+        // unpredictable protein consequence → p.(Met1?), NOT a concrete
+        // missense (HGVS substitution.md:51; #498). Sequence codon 1 = CTG
+        // (Leu) — protein residue 1 is still the initiator Met.
+        let tx = tx_with_seq("CTGGGGTAA", 1, 9);
+        // Reference base differs per position in codon CTG, so build a
+        // position-specific substitution for each rather than reusing one
+        // edit — every case is a true substitution against the actual base.
+        for (pos, reference, alternative) in [
+            (1, Base::C, Base::G),
+            (2, Base::T, Base::G),
+            (3, Base::G, Base::A),
+        ] {
+            let edit = NaEdit::Substitution {
+                reference,
+                alternative,
+            };
+            let pv = predict_substitution_protein(&tx, pos, &edit, "NP_TEST.1").unwrap();
+            let s = match &pv {
+                HgvsVariant::Protein(p) => p.to_string(),
+                _ => panic!("expected Protein variant"),
+            };
+            assert_eq!(s, "NP_TEST.1:p.(Met1?)", "cds_pos {pos}");
+        }
     }
 
     #[test]
     fn substitution_nonsense_arg_ter() {
-        // CGA (Arg) → TGA (Ter). Frame 0 of codon 1, alt T.
-        let tx = tx_with_seq("CGAAAA", 1, 6);
+        // codon 2 = CGA (Arg) → TGA (Ter). Frame 0 of codon 2 (c.4), alt T.
+        let tx = tx_with_seq("ATGCGAAAA", 1, 9);
         let edit = NaEdit::Substitution {
             reference: Base::C,
             alternative: Base::T,
         };
-        let pv = predict_substitution_protein(&tx, 1, &edit, "NP_000288.1").unwrap();
+        let pv = predict_substitution_protein(&tx, 4, &edit, "NP_000288.1").unwrap();
         let s = match &pv {
             HgvsVariant::Protein(p) => p.to_string(),
             _ => panic!("expected Protein variant"),
         };
-        assert_eq!(s, "NP_000288.1:p.(Arg1Ter)");
+        assert_eq!(s, "NP_000288.1:p.(Arg2Ter)");
     }
 }


### PR DESCRIPTION
> **Stacked on #508** (base = `feat/issue-498-direct-cdot-protein`). The bare-`NM_` start-loss row reaches protein prediction only via #508's direct c.→p. path. Retarget to `main` once #508 merges.

## Summary

A variant affecting the **translation initiation codon** (CDS positions 1–3) has an unpredictable protein consequence. ferro previously emitted a concrete missense — `NM_024426.4:c.1C>G` → `p.(Leu1Val)` — which the HGVS spec **explicitly disallows**: *"Do not use descriptions like `p.Met1Thr`"* (`recommendations/protein/substitution.md:51`).

This fix reports such variants as **`p.(Met1?)`** (consequence unknown; `substitution.md:51`, `deletion.md:62`). Protein residue 1 is the initiator `Met` regardless of the reference codon.

## Changes
- `helpers::affects_initiation_codon` — substitution/del/delins/dup/inversion disrupt the start codon when their span overlaps CDS 1–3; an insertion only when the gap is strictly inside the codon.
- `helpers::build_initiator_unknown` → `p.(Met1?)`.
- Guard both protein entry points (`predict_substitution_protein`, `predict_indel_protein`) up front.
- Three existing substitution tests used codon-1 positions *incidentally* to test general missense/nonsense/synonymous rendering — moved them to codon 2 (prepend `ATG`) so they still test that without tripping the guard. Strengthened the del-start-codon indel test to assert the exact `p.(Met1?)`.

## Scope — output correctness, not corpus parity
Like #510, this is an **output-correctness** fix (no more spec-forbidden `p.Met1Thr`-style missense) that demotes **0** rows by itself. The target row also differs from mutalyzer on the bare-`NP_` wrapper **and** on `p.(Met1?)` vs mutalyzer's coarser `p.?` — both reconciliations are tracked under #498. **No regressions** (`protein_description` unchanged at 60; no codon-1 row broke).

## Test plan
- New unit tests: substitution in the initiation codon (c.1/c.2/c.3) → `p.(Met1?)`; del of the start codon → `p.(Met1?)`.
- `cargo fmt --all -- --check` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — 0 warnings
- `cargo nextest run --features dev` — 6523 passed, 51 skipped
- Manifest protein axes: target row now emits `p.(Met1?)`; no regressions.

Refs #498, #326.
