### PR TITLE
fix(reference): decline protein prediction for non-version-exact transcripts (#505)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1026,6 +1026,20 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let Some(prot_acc) = prot_acc else {
             return Ok(None);
         };
+        // Issue #505: protein prediction below reads this transcript's CDS
+        // bases directly and translates them. If the reference only carries a
+        // *different* version of the transcript (a silent version-strip
+        // substitution), those bases may pair with a different CDS/exon
+        // structure, so the prediction would be wrong yet attributed to the
+        // requested version. Decline to predict rather than emit a wrong
+        // protein — this gates *all* downstream prediction, including the
+        // initiation-codon short-circuit below, whose CDS positions are
+        // likewise mapped against the requested-version transcript. The
+        // predicate still permits exact-version cdot-genome synthesis — it
+        // rejects only cross-version substitution.
+        if !self.provider.has_transcript_version_exact(transcript_id) {
+            return Ok(None);
+        }
         // An initiation-codon-affecting edit short-circuits to `p.(Met1?)`
         // here, before edit-type dispatch, so boundary-spanning edits whose
         // 5' end is in the 5'UTR (which the per-edit paths reject via their
@@ -3775,6 +3789,36 @@ mod tests {
         // c.4C>A: codon 2 CGC(Arg) → AGC(Ser) ⇒ p.(Arg2Ser).
         let protein = proj.protein.expect("protein should be predicted");
         assert_eq!(format!("{protein}"), "NP_TEST.1:p.(Arg2Ser)");
+    }
+
+    #[test]
+    fn project_declines_protein_when_transcript_not_version_exact() {
+        // Issue #505: the protein path reads the transcript's CDS bases
+        // directly. When the reference only carries a *different* version of
+        // the requested transcript (a silent version-strip substitution),
+        // translating those bases would emit a wrong protein attributed to the
+        // requested version. The protein path must decline to predict rather
+        // than lie. The non-protein axes (coding) are unaffected.
+        let (projector, mut provider) = make_test_provider_and_projector();
+        // Same input as `project_bare_nm_substitution_predicts_protein_without_genome`,
+        // but the provider now reports NM_TEST.1 as not available at the exact
+        // requested version (e.g. only a sibling version's bases are present).
+        provider.mark_non_version_exact("NM_TEST.1");
+        let vp = VariantProjector::new(projector, provider);
+        let variant = make_coding_variant("NM_TEST.1", None);
+        let proj = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .expect("projection should still succeed; only protein prediction declines");
+        assert!(
+            proj.protein.is_none(),
+            "protein must be declined for a non-version-exact transcript, got {:?}",
+            proj.protein
+        );
+        // The protein-only gate must not suppress the coding axis.
+        assert!(
+            proj.coding.is_some(),
+            "coding form should still be present despite the protein gate"
+        );
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -105,6 +105,16 @@ impl ReferenceProvider for PyProvider {
             PyProvider::MultiFasta(p) => p.has_protein_data(),
         }
     }
+
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        // Forward to the inner provider so the protein version-exact gate (#505)
+        // is enforced on the Python path; otherwise this falls through to the
+        // trait default `true` and the gate is inert for Python consumers.
+        match self {
+            PyProvider::Mock(p) => p.has_transcript_version_exact(id),
+            PyProvider::MultiFasta(p) => p.has_transcript_version_exact(id),
+        }
+    }
 }
 
 impl PyProvider {

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -601,6 +601,15 @@ impl ReferenceProvider for CachedFastaProvider {
         self.inner.get_transcript(id)
     }
 
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        // Delegate to the inner provider so the protein version-exact gate
+        // (#505) reflects the underlying verdict rather than the trait default
+        // `true`. Inert today (the inner `FastaProvider` keeps the default),
+        // but forwarding here prevents a silently-dropped gate if it ever
+        // gains the override.
+        self.inner.has_transcript_version_exact(id)
+    }
+
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
         // Create cache key
         let key = (id.to_string(), start, end);

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -3,7 +3,7 @@
 use crate::error::FerroError;
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::OnceLock;
 
@@ -14,6 +14,12 @@ pub struct MockProvider {
     proteins: HashMap<String, String>,
     /// Genomic sequences keyed by contig name
     genomic_sequences: HashMap<String, String>,
+    /// Transcript ids this provider should report as *not* version-exact from
+    /// [`ReferenceProvider::has_transcript_version_exact`]. Lets tests exercise
+    /// the protein path's cross-version gate (#505) without a full FASTA/cdot
+    /// manifest. Empty by default, so an unconfigured mock reports every
+    /// transcript as version-exact (matching the trait default).
+    non_version_exact: HashSet<String>,
 }
 
 impl MockProvider {
@@ -23,7 +29,15 @@ impl MockProvider {
             transcripts: HashMap::new(),
             proteins: HashMap::new(),
             genomic_sequences: HashMap::new(),
+            non_version_exact: HashSet::new(),
         }
+    }
+
+    /// Mark `id` as not available at its exact requested version, so
+    /// [`ReferenceProvider::has_transcript_version_exact`] returns `false` for
+    /// it. Simulates a reference that only carries a sibling version's bases.
+    pub fn mark_non_version_exact(&mut self, id: impl Into<String>) {
+        self.non_version_exact.insert(id.into());
     }
 
     /// Load reference data from a JSON file.
@@ -79,6 +93,7 @@ impl MockProvider {
             transcripts: map,
             proteins,
             genomic_sequences,
+            non_version_exact: HashSet::new(),
         })
     }
 
@@ -440,6 +455,10 @@ impl ReferenceProvider for MockProvider {
             .map(|s| s.len() as u64)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })
     }
+
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        !self.non_version_exact.contains(id)
+    }
 }
 
 #[cfg(test)]
@@ -489,6 +508,24 @@ mod tests {
         let provider = MockProvider::with_test_data();
         assert!(provider.has_transcript("NM_000088.3"));
         assert!(!provider.has_transcript("NONEXISTENT"));
+    }
+
+    #[test]
+    fn boxed_provider_forwards_has_transcript_version_exact() {
+        // The protein gate (#505) is consulted through the provider type the
+        // production CLI/benchmark paths use: `Box<dyn ReferenceProvider>`. If
+        // the blanket boxed impl does not forward `has_transcript_version_exact`,
+        // it silently falls through to the trait default `true` and the gate is
+        // inert in production. Pin the forwarding here.
+        let mut inner = MockProvider::new();
+        inner.mark_non_version_exact("NM_TEST.1");
+        let boxed: Box<dyn ReferenceProvider> = Box::new(inner);
+        assert!(
+            !boxed.has_transcript_version_exact("NM_TEST.1"),
+            "boxed provider must forward to the inner provider's verdict (false), \
+             not the trait default (true)"
+        );
+        assert!(boxed.has_transcript_version_exact("NM_OTHER.1"));
     }
 
     #[test]

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1221,6 +1221,40 @@ impl ReferenceProvider for MultiFastaProvider {
         }
     }
 
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        // Version-exact = the bases the read path would actually serve for
+        // `id` correspond to the *exact* requested version, with no
+        // cross-version substitution. Two ways that holds:
+        //
+        //  1. The FASTA/supplemental index ships the exact versioned accession.
+        //  2. The FASTA index has no entry that `resolve_name` would resolve to
+        //     (so no version-strip sibling shadows `id`) AND cdot stores the
+        //     exon alignment at the exact version — then `get_transcript_on_build`
+        //     reconstructs the bases from the genome at the exact version (#331).
+        //
+        // Condition 2 must check `resolve_name(id).is_none()`: the read path
+        // resolves the FASTA (including a version-strip sibling) BEFORE it ever
+        // reaches cdot synthesis, so a cdot-exact record shadowed by a FASTA
+        // sibling would NOT be the bases actually served. Omitting that check
+        // would green-light translating the sibling's bases as `id` — the exact
+        // wrong-protein attribution #505 exists to prevent.
+        //
+        // Scope: the cdot arm consults the *primary-build* transcript map
+        // (`CdotMapper::has_transcript_exact`). The bare-transcript protein path
+        // (no NG/NC parent) routes through `get_transcript_on_build(id, None)`,
+        // which is exactly the primary-build view this models. An NG/NC-parented
+        // variant can probe alt-build maps that carry their own version-strip
+        // fallback; covering that path's exactness is left to follow-up work.
+        if self.has_transcript_exact(id) {
+            return true;
+        }
+        self.resolve_name(id).is_none()
+            && self
+                .cdot_mapper
+                .as_ref()
+                .is_some_and(|cdot| cdot.has_transcript_exact(id))
+    }
+
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
         let resolved = self
             .resolve_name(id)
@@ -2432,5 +2466,66 @@ mod tests {
             synthesized.sequence.as_deref(),
             Some("GGTTTTAAAACCCCGGGGTT")
         );
+    }
+
+    #[test]
+    fn has_transcript_version_exact_true_for_exact_fasta() {
+        // The exact requested version is shipped in the FASTA → version-exact.
+        let (provider, _kept) = build_provider_with_transcripts(&[("NM_212556.2", "ACGTACGTAC")]);
+        assert!(provider.has_transcript_version_exact("NM_212556.2"));
+    }
+
+    #[test]
+    fn has_transcript_version_exact_false_for_sibling_only() {
+        // Only the .4 sibling is shipped; a request for .2 would be served by
+        // the lenient version-strip substitution. The protein gate (#505) must
+        // see this as NOT version-exact so it declines to translate the wrong
+        // bases — even though the lenient `get_transcript` still substitutes.
+        let (provider, _kept) = build_provider_with_transcripts(&[("NM_212556.4", "TTTTGGGGCC")]);
+        assert!(!provider.has_transcript_version_exact("NM_212556.2"));
+        // The exact sibling itself is version-exact.
+        assert!(provider.has_transcript_version_exact("NM_212556.4"));
+    }
+
+    #[test]
+    fn has_transcript_version_exact_true_for_exact_cdot_synthesis() {
+        use crate::reference::transcript::Strand;
+        // NM_TEST.1 is absent from the transcript FASTA but cdot carries it at
+        // the exact version, so the lenient path reconstructs its bases from
+        // the genome. Those bases DO correspond to the requested version, so it
+        // is version-exact and the gate must permit protein prediction — unlike
+        // strict resolution, which refuses all synthesis. This pins the #331
+        // (exact-version synthesis) regression guard called out in the #505
+        // design review.
+        let (mut provider, _kept) = build_provider_with_test_genome();
+        let tx = build_single_exon_synthetic_tx(Strand::Plus);
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts(std::iter::once(&tx)));
+        // Not in the FASTA index...
+        assert!(!provider.has_transcript_exact("NM_TEST.1"));
+        // ...but cdot carries the exact version, so it is version-exact.
+        assert!(provider.has_transcript_version_exact("NM_TEST.1"));
+    }
+
+    #[test]
+    fn has_transcript_version_exact_false_when_fasta_sibling_shadows_cdot_exact() {
+        use crate::reference::transcript::Strand;
+        // The FASTA ships only the .2 sibling; cdot carries the exact .1. The
+        // read path (`get_transcript_on_build`) resolves the FASTA sibling via
+        // `resolve_name`'s version-strip BEFORE it would ever reach cdot
+        // synthesis, so a request for .1 is actually served the .2 bases. The
+        // gate must therefore report .1 as NOT version-exact even though cdot
+        // has an exact .1 record — otherwise it green-lights translating .2
+        // bases as .1, the exact wrong-protein attribution #505 targets.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_TEST.2", "ACGTACGTAC")]);
+        let tx = build_single_exon_synthetic_tx(Strand::Plus); // id NM_TEST.1
+        provider.cdot_mapper = Some(CdotMapper::from_transcripts(std::iter::once(&tx)));
+        // Precondition: cdot really does carry the exact .1 record...
+        assert!(provider
+            .cdot_mapper()
+            .unwrap()
+            .has_transcript_exact("NM_TEST.1"));
+        // ...but a FASTA sibling (.2) shadows it on the read path, so .1 is not
+        // reachable at its exact version.
+        assert!(!provider.has_transcript_version_exact("NM_TEST.1"));
     }
 }

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -53,6 +53,28 @@ pub trait ReferenceProvider {
         self.get_transcript(id).is_ok()
     }
 
+    /// Whether `id`'s bases are available at the *exact* requested versioned
+    /// accession — i.e. not via a silent version-strip substitution to a
+    /// sibling version.
+    ///
+    /// Protein prediction reads a transcript's CDS bases directly and
+    /// translates them. If the reference only carries a *different* version of
+    /// the transcript, those bases may pair with a different CDS/exon
+    /// structure, so the prediction would be wrong yet attributed to the
+    /// requested version (issue #505). The protein path consults this before
+    /// the CDS read and declines to predict when it returns `false`.
+    ///
+    /// The default is `true`: providers that do not track multiple versions of
+    /// a transcript (e.g. test doubles) never trigger the gate, so existing
+    /// behavior is preserved. Version-aware providers (e.g.
+    /// `MultiFastaProvider`) override this to mean "the exact version is
+    /// directly present, or can be reconstructed at the exact version" — which
+    /// deliberately still permits exact-version cdot-genome synthesis and only
+    /// rejects cross-version substitution.
+    fn has_transcript_version_exact(&self, _id: &str) -> bool {
+        true
+    }
+
     /// Get genomic sequence for a contig/chromosome
     ///
     /// This is used for normalizing intronic variants which require access
@@ -156,6 +178,10 @@ impl ReferenceProvider for Box<dyn ReferenceProvider> {
 
     fn has_transcript(&self, id: &str) -> bool {
         (**self).has_transcript(id)
+    }
+
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        (**self).has_transcript_version_exact(id)
     }
 
     fn get_genomic_sequence(


### PR DESCRIPTION
## Summary

Closes part of #505 (the cross-version-substitution failure mode).

Protein prediction reads a transcript's CDS bases directly and translates them. The lenient reference lookup silently substitutes a *different version* of a transcript when the exact requested version is absent (version-strip fallback), so prediction could translate wrong-version bases and emit a wrong protein attributed to the requested version.

This adds a `ReferenceProvider::has_transcript_version_exact` predicate (default `true`) and gates the shared protein chokepoint `predict_protein_consequence` on it: when the requested transcript version is not exactly available, protein prediction declines (`Ok(None)`) rather than translating substituted bases. The coding and genomic axes are unaffected (the gate is protein-only).

## Design

`MultiFastaProvider` implements the predicate as "the FASTA ships the exact version, **or** no FASTA sibling shadows it **and** cdot carries the exact version". This keeps exact-version cdot-genome synthesis (#331) eligible for protein prediction while rejecting cross-version substitution. The `resolve_name(id).is_none()` guard exactly matches the read path, which serves a FASTA version-strip sibling before it ever reaches cdot synthesis — so the gate's verdict agrees with the bases actually served.

The predicate is forwarded through the delegating providers (`Box<dyn ReferenceProvider>`, `PyProvider`, `CachedFastaProvider`) so the gate is enforced on the boxed-CLI and Python paths, not only on direct providers.

## Scope

This PR closes the **cross-version-substitution** silent-wrong class. It does **not** address the issue's "mode 2b": a sequence ingested under the *correct* version label but whose bases/CDS are non-canonical (e.g. `NM_012459.2` paired with the `NP_036591.3` short-isoform CDS; `NM_000193.2` served as 4650 nt vs canonical 1576 nt). That requires reference-data validation (translate served CDS vs the pinned `NP_`; check transcript length vs the canonical record) plus version-exact ingestion, and is tracked separately under #505.

Known residual (documented in the predicate's doc comment): the cdot arm consults the **primary-build** transcript map. The bare-transcript protein path routes through the primary-build view this models; an NG/NC-parented variant can probe alt-build maps with their own version-strip fallback, whose exactness this predicate does not yet cover. Follow-up.

## Testing

- TDD throughout; 6 new tests covering: gate declines protein for a non-version-exact transcript (projector end-to-end); FASTA-exact → true; sibling-only → false; exact-version cdot synthesis → true (the #331 allowance); FASTA-sibling shadows cdot-exact → false; `Box<dyn>` forwards the predicate.
- Full suite: 6540 passed, 51 skipped. `clippy --all-targets -D warnings` clean. `--features python` compiles.

## Suggested reading order

1. `src/reference/provider.rs` — the new trait method (default `true`) + `Box<dyn>` forward.
2. `src/reference/multi_fasta.rs` — the real predicate + its three unit tests.
3. `src/project/projector.rs` — the one-line gate in `predict_protein_consequence` + the projector test.
4. `src/reference/mock.rs`, `src/python.rs`, `src/reference/fasta.rs` — test knob and delegating-provider forwards.
