### PR TITLE
feat(reference): authoritative GenBank record parsing + canonical-overrides schema (#520)

### DIFF
--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -1,0 +1,475 @@
+//! Authoritative transcript records and the canonical-overrides schema.
+//!
+//! The canonical-record validation effort (issue #520) needs the *authoritative*
+//! RefSeq record for an exact accession version — its CDS coordinates, the
+//! paired protein accession, and the transcript length — to detect (and later
+//! correct) transcript records whose cdot-derived metadata disagrees with the
+//! canonical record (e.g. `NM_012459.2` cdot-paired with `NP_036591.3` instead
+//! of the canonical `NP_036591.2`).
+//!
+//! This module provides:
+//!
+//! - [`AuthoritativeRecord`] — the fields we compare against, parsed from a
+//!   GenBank flat-file record ([`parse_authoritative_genbank`]). Parsing is
+//!   pure and network-free; the actual NCBI efetch that produces the GenBank
+//!   text lives in the `prepare` pipeline.
+//! - [`CanonicalOverrides`] — a serialisable accession→record map, the
+//!   "authoritative-overrides" file written by `ferro prepare` and consumed by
+//!   the later validation / correction phases.
+//!
+//! All coordinates here are **1-based inclusive** (as written in the GenBank
+//! `CDS` feature). cdot stores CDS as 0-based; callers comparing the two must
+//! convert.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The authoritative facts about a transcript at an exact accession version,
+/// taken from its canonical RefSeq (GenBank) record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AuthoritativeRecord {
+    /// The exact versioned accession from the record's `VERSION` line
+    /// (e.g. `NM_012459.2`).
+    pub accession: String,
+    /// Transcript length in nucleotides (the length of the `ORIGIN` sequence).
+    pub tx_length: u64,
+    /// CDS start, 1-based inclusive, in transcript coordinates. `None` for a
+    /// non-coding record.
+    pub cds_start: Option<u64>,
+    /// CDS end, 1-based inclusive. `None` for a non-coding record.
+    pub cds_end: Option<u64>,
+    /// The protein accession paired with the CDS (`/protein_id`, e.g.
+    /// `NP_036591.2`). `None` for a non-coding record or one without the
+    /// qualifier.
+    pub protein_id: Option<String>,
+}
+
+/// Parse the authoritative facts out of a single GenBank flat-file record.
+///
+/// Extracts the `VERSION` accession, the transcript length (counted from the
+/// `ORIGIN` sequence), and — from the first `CDS` feature — the 1-based CDS
+/// coordinates and the `/protein_id`. Returns `None` if the record has no
+/// `VERSION` line or no `ORIGIN` sequence (i.e. it is not a usable record).
+///
+/// Location parsing handles the common RefSeq mRNA shapes: a plain `a..b`
+/// range and a `join(a..b,...)` (including one that wraps onto continuation
+/// lines), `complement(...)`, and the `<`/`>` partial-boundary markers.
+/// Compound multi-segment CDS spans collapse to their outer bounds (first
+/// segment start, last segment end), which is sufficient for length/pairing
+/// validation.
+///
+/// Parses the **first** GenBank record only (it stops at the first `//`), so
+/// callers should efetch one accession per call rather than a concatenated
+/// multi-record batch.
+pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord> {
+    let mut accession: Option<String> = None;
+    let mut cds_start: Option<u64> = None;
+    let mut cds_end: Option<u64> = None;
+    let mut protein_id: Option<String> = None;
+    let mut tx_length: u64 = 0;
+
+    let mut in_origin = false;
+    // True while reading the `CDS` feature's qualifier lines (so a stray
+    // `/protein_id` under another feature isn't captured).
+    let mut in_cds_feature = false;
+    // The CDS location string, accumulated across any continuation lines (a
+    // long `join(...)` wraps onto qualifier-indented lines) until the first
+    // `/qualifier`; parsed once after the loop.
+    let mut cds_loc = String::new();
+    let mut collecting_loc = false;
+    // Only the first CDS feature is used (its bounds and protein_id). A second
+    // CDS (rare in mRNA records) must not overwrite the first's bounds while
+    // keeping the first's protein_id.
+    let mut seen_cds = false;
+
+    for line in genbank.lines() {
+        if line.starts_with("ORIGIN") {
+            in_origin = true;
+            in_cds_feature = false;
+            collecting_loc = false;
+            continue;
+        }
+
+        if in_origin {
+            if line.starts_with("//") {
+                break;
+            }
+            // Sequence lines: "        1 acgtacgt acgt...". Count alphabetic
+            // bases only (the leading number and spaces are not sequence).
+            tx_length += line.bytes().filter(|b| b.is_ascii_alphabetic()).count() as u64;
+            continue;
+        }
+
+        if accession.is_none() {
+            if let Some(rest) = line.strip_prefix("VERSION") {
+                accession = rest.split_whitespace().next().map(str::to_string);
+            }
+        }
+
+        // Feature keys sit at column 6 (exactly 5 leading spaces); qualifier
+        // and location-continuation lines are indented further (~21 spaces).
+        let trimmed = line.trim_start();
+        let is_feature_key_line = line.starts_with("     ") && !line.starts_with("      ");
+        if is_feature_key_line {
+            // Accept only the first CDS feature; later features (CDS or not)
+            // end the CDS block.
+            let is_cds = !seen_cds && trimmed.split_whitespace().next() == Some("CDS");
+            in_cds_feature = is_cds;
+            collecting_loc = is_cds;
+            if is_cds {
+                seen_cds = true;
+                cds_loc.clear();
+                if let Some(loc) = trimmed.split_whitespace().nth(1) {
+                    cds_loc.push_str(loc);
+                }
+            }
+        } else if collecting_loc {
+            // Inside the CDS feature, before the first qualifier: either a
+            // wrapped continuation of the location, or the first `/qualifier`.
+            if trimmed.starts_with('/') {
+                collecting_loc = false;
+                if protein_id.is_none() {
+                    if let Some(pid) = extract_qualifier(trimmed, "protein_id") {
+                        protein_id = Some(pid);
+                    }
+                }
+            } else {
+                cds_loc.push_str(trimmed); // wrapped location segment
+            }
+        } else if in_cds_feature && protein_id.is_none() {
+            if let Some(pid) = extract_qualifier(trimmed, "protein_id") {
+                protein_id = Some(pid);
+            }
+        }
+    }
+
+    if !cds_loc.is_empty() {
+        if let Some((s, e)) = parse_cds_bounds(&cds_loc) {
+            cds_start = Some(s);
+            cds_end = Some(e);
+        }
+    }
+
+    let accession = accession?;
+    if tx_length == 0 {
+        return None;
+    }
+    Some(AuthoritativeRecord {
+        accession,
+        tx_length,
+        cds_start,
+        cds_end,
+        protein_id,
+    })
+}
+
+/// Parse the outer 1-based bounds of a GenBank CDS location string.
+///
+/// Handles `a..b` and `join(a..b,...)`; tolerates `<`/`>` partial markers and
+/// `complement(...)` wrappers. Returns `None` if no `..` range is present.
+fn parse_cds_bounds(loc: &str) -> Option<(u64, u64)> {
+    let inner = loc
+        .strip_prefix("complement(")
+        .map(|s| s.trim_end_matches(')'))
+        .unwrap_or(loc);
+    let inner = inner
+        .strip_prefix("join(")
+        .map(|s| s.trim_end_matches(')'))
+        .unwrap_or(inner);
+
+    // For join(...), the outer CDS bounds are the start of the first segment
+    // and the end of the last segment. Each segment is a single `x..y` range.
+    let first = inner.split(',').next()?;
+    let last = inner.rsplit(',').next()?; // char pattern → reverse-iterable
+    let start = first.split_once("..")?.0;
+    let end = last.split_once("..")?.1;
+
+    let start = start
+        .trim_matches(|c: char| !c.is_ascii_digit())
+        .parse()
+        .ok()?;
+    let end = end
+        .trim_matches(|c: char| !c.is_ascii_digit())
+        .parse()
+        .ok()?;
+    Some((start, end))
+}
+
+/// Extract a quoted GenBank qualifier value, e.g. `/protein_id="NP_036591.2"`
+/// → `NP_036591.2`.
+fn extract_qualifier(line: &str, name: &str) -> Option<String> {
+    let needle = format!("/{name}=\"");
+    let start = line.find(&needle)? + needle.len();
+    let rest = &line[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Current on-disk schema version for [`CanonicalOverrides`].
+pub const CANONICAL_OVERRIDES_SCHEMA_VERSION: u32 = 1;
+
+/// An accession→[`AuthoritativeRecord`] map: the "authoritative-overrides" file
+/// written by `ferro prepare --validate-canonical` and consumed by the
+/// validation / correction phases. Keyed by exact versioned accession.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CanonicalOverrides {
+    /// On-disk schema version, so a future reader can detect a format change.
+    /// Defaults to 0 when reading a file written before the field existed.
+    #[serde(default)]
+    pub schema_version: u32,
+    /// Authoritative records keyed by exact versioned accession.
+    pub records: BTreeMap<String, AuthoritativeRecord>,
+}
+
+impl Default for CanonicalOverrides {
+    fn default() -> Self {
+        Self {
+            schema_version: CANONICAL_OVERRIDES_SCHEMA_VERSION,
+            records: BTreeMap::new(),
+        }
+    }
+}
+
+impl CanonicalOverrides {
+    /// Look up the authoritative record for an exact versioned accession.
+    pub fn get(&self, accession: &str) -> Option<&AuthoritativeRecord> {
+        self.records.get(accession)
+    }
+
+    /// Insert (or replace) a record, keyed by its own accession.
+    pub fn insert(&mut self, record: AuthoritativeRecord) {
+        self.records.insert(record.accession.clone(), record);
+    }
+
+    /// Number of records.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Serialise to pretty JSON.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Parse from JSON (the on-disk overrides file).
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal but realistic GenBank record: NM_012459.2-shaped, with the
+    /// canonical CDS `31..327` paired with `NP_036591.2`, total length 30
+    /// (sequence below) — the values matter, not biological realism.
+    const FIXTURE: &str = "\
+LOCUS       NM_012459                 30 bp    mRNA    linear   PRI 01-JAN-2020
+DEFINITION  Homo sapiens translocase (TIMM8B), mRNA.
+ACCESSION   NM_012459
+VERSION     NM_012459.2
+FEATURES             Location/Qualifiers
+     source          1..30
+                     /organism=\"Homo sapiens\"
+     gene            1..30
+                     /gene=\"TIMM8B\"
+     CDS             4..30
+                     /gene=\"TIMM8B\"
+                     /codon_start=1
+                     /product=\"mitochondrial import inner membrane translocase\"
+                     /protein_id=\"NP_036591.2\"
+                     /translation=\"MAEL\"
+ORIGIN
+        1 acgatggcag agctgtaagg ccacgagcct
+//
+";
+
+    #[test]
+    fn parses_version_length_cds_and_protein_id() {
+        let rec = parse_authoritative_genbank(FIXTURE).expect("record should parse");
+        assert_eq!(rec.accession, "NM_012459.2");
+        assert_eq!(rec.tx_length, 30, "should count the 30 sequence bases");
+        assert_eq!(rec.cds_start, Some(4));
+        assert_eq!(rec.cds_end, Some(30));
+        assert_eq!(rec.protein_id.as_deref(), Some("NP_036591.2"));
+    }
+
+    #[test]
+    fn parses_join_location_outer_bounds() {
+        let gb = "\
+VERSION     NM_TEST.1
+FEATURES             Location/Qualifiers
+     CDS             join(10..20,31..45)
+                     /protein_id=\"NP_TEST.1\"
+ORIGIN
+        1 acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.cds_start, Some(10));
+        assert_eq!(rec.cds_end, Some(45), "outer end of the last join segment");
+        assert_eq!(rec.protein_id.as_deref(), Some("NP_TEST.1"));
+    }
+
+    #[test]
+    fn parses_wrapped_join_location() {
+        // A join() that wraps onto a continuation line (the CDS key line ends
+        // with a trailing comma) must still yield outer bounds, not None.
+        let gb = "\
+VERSION     NM_WRAP.1
+FEATURES             Location/Qualifiers
+     CDS             join(1..100,200..300,
+                     400..567)
+                     /protein_id=\"NP_WRAP.1\"
+ORIGIN
+        1 acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.cds_start, Some(1));
+        assert_eq!(
+            rec.cds_end,
+            Some(567),
+            "outer end of the wrapped last segment"
+        );
+        assert_eq!(rec.protein_id.as_deref(), Some("NP_WRAP.1"));
+    }
+
+    #[test]
+    fn parses_complement_join_location() {
+        let gb = "\
+VERSION     NM_CJ.1
+     CDS             complement(join(10..20,31..45))
+                     /protein_id=\"NP_CJ.1\"
+ORIGIN
+        1 acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.cds_start, Some(10));
+        assert_eq!(rec.cds_end, Some(45));
+    }
+
+    #[test]
+    fn first_cds_wins_over_a_second_cds() {
+        // The first CDS's bounds AND protein_id are kept; a second CDS must not
+        // overwrite the bounds.
+        let gb = "\
+VERSION     NM_TWO.1
+     CDS             1..9
+                     /protein_id=\"NP_FIRST.1\"
+     CDS             10..30
+                     /protein_id=\"NP_SECOND.2\"
+ORIGIN
+        1 acgtacgtac acgtacgtac acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.cds_start, Some(1));
+        assert_eq!(
+            rec.cds_end,
+            Some(9),
+            "second CDS must not overwrite the first's bounds"
+        );
+        assert_eq!(rec.protein_id.as_deref(), Some("NP_FIRST.1"));
+    }
+
+    #[test]
+    fn legacy_overrides_without_schema_version_default_to_zero() {
+        // A file written before the schema_version field existed reads as 0.
+        let ov = CanonicalOverrides::from_json(r#"{"records":{}}"#).unwrap();
+        assert_eq!(ov.schema_version, 0);
+        assert!(ov.is_empty());
+    }
+
+    #[test]
+    fn tolerates_partial_boundary_markers() {
+        let gb = "\
+VERSION     NM_PARTIAL.1
+     CDS             <1..>27
+                     /protein_id=\"NP_PARTIAL.1\"
+ORIGIN
+        1 acgtacgtac acgtacgtac acgtacg
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.cds_start, Some(1));
+        assert_eq!(rec.cds_end, Some(27));
+    }
+
+    #[test]
+    fn noncoding_record_has_no_cds_or_protein() {
+        let gb = "\
+VERSION     NR_TEST.1
+FEATURES             Location/Qualifiers
+     gene            1..10
+                     /gene=\"LINC\"
+ORIGIN
+        1 acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.accession, "NR_TEST.1");
+        assert_eq!(rec.tx_length, 10);
+        assert_eq!(rec.cds_start, None);
+        assert_eq!(rec.cds_end, None);
+        assert_eq!(rec.protein_id, None);
+    }
+
+    #[test]
+    fn returns_none_without_version_or_sequence() {
+        assert!(parse_authoritative_genbank("LOCUS only, no version or origin\n").is_none());
+        let no_seq = "VERSION     NM_X.1\nORIGIN\n//\n";
+        assert!(
+            parse_authoritative_genbank(no_seq).is_none(),
+            "a record with no sequence bases is not usable"
+        );
+    }
+
+    #[test]
+    fn does_not_capture_protein_id_outside_the_cds_feature() {
+        // A /protein_id appearing under a non-CDS feature must be ignored.
+        let gb = "\
+VERSION     NM_TEST.1
+     misc_feature    1..10
+                     /protein_id=\"NP_WRONG.9\"
+     CDS             1..9
+                     /protein_id=\"NP_RIGHT.1\"
+ORIGIN
+        1 acgtacgtac
+//
+";
+        let rec = parse_authoritative_genbank(gb).expect("record should parse");
+        assert_eq!(rec.protein_id.as_deref(), Some("NP_RIGHT.1"));
+    }
+
+    #[test]
+    fn canonical_overrides_roundtrips_through_json() {
+        let mut ov = CanonicalOverrides::default();
+        assert_eq!(ov.schema_version, CANONICAL_OVERRIDES_SCHEMA_VERSION);
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_012459.2".to_string(),
+            tx_length: 327,
+            cds_start: Some(31),
+            cds_end: Some(327),
+            protein_id: Some("NP_036591.2".to_string()),
+        });
+        assert_eq!(ov.len(), 1);
+        let json = ov.to_json().unwrap();
+        let back = CanonicalOverrides::from_json(&json).unwrap();
+        assert_eq!(back, ov);
+        assert_eq!(
+            back.get("NM_012459.2")
+                .and_then(|r| r.protein_id.as_deref()),
+            Some("NP_036591.2")
+        );
+    }
+}

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -3,6 +3,7 @@
 //! Provides traits and implementations for accessing reference sequence data.
 
 pub mod annotation;
+pub mod authoritative;
 pub mod fasta;
 pub mod loader;
 pub mod mock;

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -1,14 +1,23 @@
-//! Offline structural validation of transcript reference records.
+//! Validation of transcript reference records (issue #520).
 //!
-//! These checks are **self-contained**: they look only at a single
-//! [`Transcript`]'s own sequence, CDS coordinates, and exon alignment, with no
-//! network access and no authoritative external record. They catch a class of
-//! reference-data corruption where the served bases and the alignment/CDS
-//! metadata disagree, or the CDS does not translate as a sane open reading
-//! frame.
+//! Two tiers, both reporting [`TranscriptAnomaly`] tagged with an
+//! [`AnomalyConfidence`]:
 //!
-//! Scope (issue #520, phase 0): this is the cheap, offline tier. Anomalies are
-//! tagged with an [`AnomalyConfidence`]:
+//! 1. **Offline structural** ([`validate_transcript_record`]) — self-contained
+//!    checks over a single [`Transcript`]'s own sequence, CDS coordinates, and
+//!    exon alignment; no network, no external record.
+//! 2. **Authoritative comparison** ([`validate_against_authoritative`]) —
+//!    compares the served transcript's length, CDS bounds, and paired protein
+//!    against the canonical RefSeq record for the exact accession version (an
+//!    [`AuthoritativeRecord`], parsed from GenBank in
+//!    [`crate::reference::authoritative`]). This is the precise tier that
+//!    catches the mis-pairing / non-canonical-length cases the offline tier
+//!    cannot (e.g. `NM_012459.2` paired with `NP_036591.3`; `NM_000193.2`
+//!    served at 4650 nt vs the canonical 1576 nt).
+//!
+//! ## Offline structural tier
+//!
+//! Anomalies are tagged:
 //!
 //! - **`Corruption`** — high-confidence structural problems: the served
 //!   sequence is *shorter* than the exon alignment needs (missing bases), the
@@ -21,19 +30,21 @@
 //!   start codons, stop-codon readthrough exists, and `partial` RefSeq records
 //!   legitimately lack a start or stop. Treat these as "review", not proof.
 //!
-//! Deliberately out of scope here:
+//! Deliberately out of scope for the **offline** tier (handled by the
+//! authoritative tier instead):
 //!
-//! - A served sequence *longer* than the alignment is **not** flagged — a
-//!   poly-A tail or unaligned 3' bases routinely make the transcript FASTA
-//!   longer than the genome-derived exon alignment. Detecting an
-//!   implausibly-long sequence precisely (e.g. issue #505's `NM_000193.2`,
-//!   served ~3× too long) needs the authoritative transcript length, which is
-//!   the authoritative-comparison phase, not this offline tier.
-//! - A sequence that is internally consistent but non-canonical or mis-paired
-//!   to the wrong protein version (e.g. `NM_012459.2`) — also a later phase,
-//!   since it requires the authoritative RefSeq record for the exact version.
+//! - A served sequence *longer* than the exon alignment is **not** flagged
+//!   offline — a poly-A tail or unaligned 3' bases routinely make the
+//!   transcript FASTA longer than the genome-derived alignment. The precise
+//!   over-length check (e.g. `NM_000193.2`) lives in
+//!   [`validate_against_authoritative`], which compares against the canonical
+//!   transcript length.
+//! - A sequence internally consistent but mis-paired to the wrong protein
+//!   version (e.g. `NM_012459.2`) is invisible offline; the authoritative tier
+//!   catches it via the CDS / protein_id comparison.
 
 use crate::error::FerroError;
+use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
 
@@ -64,6 +75,15 @@ pub enum AnomalyKind {
     /// The record failed to load from the provider for a reason other than
     /// "not found" (e.g. degenerate coordinates rejected during construction).
     LoadError,
+    /// The served transcript length disagrees with the authoritative RefSeq
+    /// record for the exact accession version.
+    AuthoritativeLengthMismatch,
+    /// The served CDS coordinates disagree with the authoritative record.
+    AuthoritativeCdsMismatch,
+    /// The served paired protein accession disagrees with the authoritative
+    /// record (e.g. `NM_012459.2` served with `NP_036591.3` instead of the
+    /// canonical `NP_036591.2`).
+    AuthoritativeProteinIdMismatch,
 }
 
 /// How much confidence an anomaly carries that the record is genuinely corrupt.
@@ -260,6 +280,115 @@ pub fn validate_transcripts<P: ReferenceProvider>(
             Err(FerroError::ReferenceNotFound { .. }) => {} // unknown accession: not our concern
             Err(e) => anomalies.push(TranscriptAnomaly::new(
                 id,
+                AnomalyKind::LoadError,
+                AnomalyConfidence::Corruption,
+                format!("transcript failed to load: {e}"),
+            )),
+        }
+    }
+    anomalies
+}
+
+/// Compare a served transcript against the authoritative RefSeq record for its
+/// exact accession version, returning a [`TranscriptAnomaly`] for each
+/// disagreement.
+///
+/// Unlike the offline structural checks ([`validate_transcript_record`]), these
+/// are precise: the authoritative record is the canonical truth for the exact
+/// version, so a disagreement is high-confidence corruption (`Corruption`). All
+/// comparisons are in **1-based** coordinates (the served `Transcript`'s CDS is
+/// already 1-based; the [`AuthoritativeRecord`] is 1-based by construction).
+///
+/// Checks:
+/// - **length**: served sequence length vs `tx_length`;
+/// - **CDS**: served `(cds_start, cds_end)` vs the authoritative bounds;
+/// - **protein_id**: served paired protein vs the authoritative `/protein_id`.
+///
+/// CDS and protein_id are compared only when **both** sides carry the value. A
+/// served `None` is deliberately NOT treated as a "non-coding / no-protein vs
+/// coding" mismatch: the provider commonly leaves these fields unpopulated for
+/// reasons unrelated to corruption (e.g. the cdot-synthesis path sets
+/// `protein_id: None`), so flagging a presence difference would be
+/// false-positive-prone. A presence-aware check belongs to a richer
+/// authoritative ingestion, not this comparison.
+pub fn validate_against_authoritative(
+    tx: &Transcript,
+    auth: &AuthoritativeRecord,
+) -> Vec<TranscriptAnomaly> {
+    let mut anomalies = Vec::new();
+    let id = &tx.id;
+
+    if let Some(seq) = tx.sequence.as_deref() {
+        let served = seq.len() as u64;
+        if served != auth.tx_length {
+            anomalies.push(TranscriptAnomaly::new(
+                id,
+                AnomalyKind::AuthoritativeLengthMismatch,
+                AnomalyConfidence::Corruption,
+                format!(
+                    "served sequence is {served} nt but the authoritative record \
+                     {} is {} nt",
+                    auth.accession, auth.tx_length
+                ),
+            ));
+        }
+    }
+
+    // Both sides are 1-based inclusive. `Transcript.cds_end` needs no
+    // conversion from cdot because cdot's 0-based *exclusive* end is
+    // numerically identical to a 1-based inclusive end (see cdot.rs and
+    // multi_fasta.rs CDS construction); the authoritative `cds_end` is the
+    // GenBank `a..b` value, also 1-based inclusive.
+    if let (Some(ts), Some(te), Some(as_), Some(ae)) =
+        (tx.cds_start, tx.cds_end, auth.cds_start, auth.cds_end)
+    {
+        if (ts, te) != (as_, ae) {
+            anomalies.push(TranscriptAnomaly::new(
+                id,
+                AnomalyKind::AuthoritativeCdsMismatch,
+                AnomalyConfidence::Corruption,
+                format!(
+                    "served CDS {ts}..{te} (1-based) disagrees with the authoritative \
+                     {as_}..{ae}"
+                ),
+            ));
+        }
+    }
+
+    if let (Some(tp), Some(ap)) = (tx.protein_id.as_deref(), auth.protein_id.as_deref()) {
+        if tp != ap {
+            anomalies.push(TranscriptAnomaly::new(
+                id,
+                AnomalyKind::AuthoritativeProteinIdMismatch,
+                AnomalyConfidence::Corruption,
+                format!("served protein {tp} disagrees with the authoritative {ap}"),
+            ));
+        }
+    }
+
+    anomalies
+}
+
+/// Validate every transcript named in `overrides` against its authoritative
+/// record, pulling the served transcript from `provider`.
+///
+/// As in [`validate_transcripts`], an accession the provider does not have is
+/// skipped (`ReferenceNotFound`); any other load error surfaces as a
+/// [`AnomalyKind::LoadError`] anomaly. The skip is deliberate even though we
+/// hold authoritative data for the accession: "we have the canonical record
+/// but the reference does not ship this transcript" is an inventory/coverage
+/// concern for the prepare/check layer, not a corruption of a served record.
+pub fn validate_against_overrides<P: ReferenceProvider>(
+    provider: &P,
+    overrides: &CanonicalOverrides,
+) -> Vec<TranscriptAnomaly> {
+    let mut anomalies = Vec::new();
+    for (accession, auth) in &overrides.records {
+        match provider.get_transcript(accession) {
+            Ok(tx) => anomalies.extend(validate_against_authoritative(&tx, auth)),
+            Err(FerroError::ReferenceNotFound { .. }) => {}
+            Err(e) => anomalies.push(TranscriptAnomaly::new(
+                accession,
                 AnomalyKind::LoadError,
                 AnomalyConfidence::Corruption,
                 format!("transcript failed to load: {e}"),
@@ -493,5 +622,132 @@ mod tests {
         assert_eq!(kinds(&found), vec![AnomalyKind::LoadError]);
         assert_eq!(found[0].transcript_id, "NM_BROKEN.1");
         assert_eq!(found[0].confidence, AnomalyConfidence::Corruption);
+    }
+
+    // --- authoritative comparison (phase 2) ---------------------------------
+
+    fn auth(
+        accession: &str,
+        tx_length: u64,
+        cds: Option<(u64, u64)>,
+        protein: Option<&str>,
+    ) -> AuthoritativeRecord {
+        AuthoritativeRecord {
+            accession: accession.to_string(),
+            tx_length,
+            cds_start: cds.map(|(s, _)| s),
+            cds_end: cds.map(|(_, e)| e),
+            protein_id: protein.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn authoritative_match_yields_no_anomalies() {
+        let mut tx = coding_tx("ATGAAATAA", 1, 9);
+        tx.protein_id = Some("NP_X.1".to_string());
+        let a = auth("NM_TEST.1", 9, Some((1, 9)), Some("NP_X.1"));
+        assert!(validate_against_authoritative(&tx, &a).is_empty());
+    }
+
+    #[test]
+    fn authoritative_protein_and_cds_mismatch_are_corruption() {
+        // NM_012459.2 shape: served pairs the short isoform (NP_036591.3, CDS
+        // 34..285); the authoritative record is NP_036591.2, CDS 31..327.
+        let s = "A".repeat(327);
+        let mut tx = coding_tx(&s, 34, 285);
+        tx.protein_id = Some("NP_036591.3".to_string());
+        let a = auth("NM_012459.2", 327, Some((31, 327)), Some("NP_036591.2"));
+        let found = validate_against_authoritative(&tx, &a);
+        let ks = kinds(&found);
+        assert!(
+            ks.contains(&AnomalyKind::AuthoritativeCdsMismatch),
+            "got {ks:?}"
+        );
+        assert!(
+            ks.contains(&AnomalyKind::AuthoritativeProteinIdMismatch),
+            "got {ks:?}"
+        );
+        assert!(found
+            .iter()
+            .all(|x| x.confidence == AnomalyConfidence::Corruption));
+    }
+
+    #[test]
+    fn authoritative_length_mismatch_is_flagged() {
+        // NM_000193.2 shape: served 4650 nt vs authoritative 1576 nt.
+        let s = "A".repeat(4650);
+        let mut tx = coding_tx(&s, 342, 1730);
+        tx.protein_id = Some("NP_000184.1".to_string());
+        let a = auth("NM_000193.2", 1576, Some((152, 1540)), Some("NP_000184.1"));
+        let ks = kinds(&validate_against_authoritative(&tx, &a));
+        assert!(
+            ks.contains(&AnomalyKind::AuthoritativeLengthMismatch),
+            "got {ks:?}"
+        );
+        assert!(
+            ks.contains(&AnomalyKind::AuthoritativeCdsMismatch),
+            "got {ks:?}"
+        );
+    }
+
+    #[test]
+    fn validate_against_overrides_pulls_served_transcript_from_provider() {
+        use crate::reference::mock::MockProvider;
+        let mut provider = MockProvider::new();
+        let mut tx = coding_tx("ATGAAATAA", 1, 9);
+        tx.protein_id = Some("NP_WRONG.9".to_string());
+        provider.add_transcript(tx);
+
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(auth("NM_TEST.1", 9, Some((1, 9)), Some("NP_RIGHT.1")));
+        ov.insert(auth("NM_ABSENT.1", 100, Some((1, 99)), Some("NP_ABSENT.1"))); // skipped
+
+        let found = validate_against_overrides(&provider, &ov);
+        assert_eq!(
+            kinds(&found),
+            vec![AnomalyKind::AuthoritativeProteinIdMismatch]
+        );
+        assert_eq!(found[0].transcript_id, "NM_TEST.1");
+    }
+
+    #[test]
+    fn missing_served_protein_or_cds_is_not_a_presence_mismatch() {
+        // A served record that leaves protein_id/CDS unpopulated must NOT be
+        // flagged against a coding authoritative record (a provider `None`
+        // means "not populated", not "non-coding").
+        let mut tx = coding_tx("ATGAAATAA", 1, 9);
+        tx.protein_id = None;
+        tx.cds_start = None;
+        tx.cds_end = None;
+        let a = auth("NM_TEST.1", 9, Some((1, 9)), Some("NP_X.1"));
+        assert!(
+            validate_against_authoritative(&tx, &a).is_empty(),
+            "presence-only differences must not be flagged"
+        );
+    }
+
+    #[test]
+    fn coordinate_only_served_record_skips_length_check() {
+        // No served sequence → length check skipped despite a differing length.
+        let tx = Transcript {
+            id: "NM_TEST.1".to_string(),
+            sequence: None,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            exons: vec![Exon::new(1, 1, 9)],
+            ..Default::default()
+        };
+        let a = auth("NM_TEST.1", 9999, Some((1, 9)), Some("NP_X.1"));
+        assert!(validate_against_authoritative(&tx, &a).is_empty());
+    }
+
+    #[test]
+    fn validate_against_overrides_surfaces_non_not_found_load_errors() {
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(auth("NM_BROKEN.1", 9, Some((1, 9)), Some("NP_X.1")));
+        let found = validate_against_overrides(&FailingProvider, &ov);
+        assert_eq!(kinds(&found), vec![AnomalyKind::LoadError]);
+        assert_eq!(found[0].transcript_id, "NM_BROKEN.1");
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #520 (canonical-record validation). **Stacked on #521** (Phase 0) — base is `feat/issue-505-canonical-validation`; review #521 first.

Adds the network-free core the later phases compare cdot-derived metadata against:

- **`parse_authoritative_genbank(&str) -> Option<AuthoritativeRecord>`** — extracts from a GenBank flat-file record: the `VERSION` accession, transcript length (counted from the `ORIGIN` sequence), and the first `CDS` feature's **1-based** bounds and `/protein_id`. Location parsing handles `a..b`, `join(...)` (including a join that **wraps** onto continuation lines), `complement(...)`, and `<`/`>` partial markers. Only the first CDS feature is used; only the first record is parsed (one accession per efetch call).
- **`AuthoritativeRecord`** and **`CanonicalOverrides`** — a serde accession→record map (with an on-disk `schema_version`) = the "authoritative-overrides" artifact `ferro prepare` will write and the validate/correct phases consume.

`protein_id` is the field that lets a later phase catch the `NM_012459.2` mis-pairing (`.2` transcript canonically pairs with `NP_036591.2`, not the `.3` short isoform cdot records). Coordinates are 1-based inclusive (GenBank); cdot is 0-based, so the compare phase converts.

## Review

Opus + CodeRabbit-style review before opening. Fixes folded in:
- **Wrapped `join(...)` CDS location** — the original read the location only from the CDS key line, so a join wrapping onto continuation lines parsed to `None` (CDS silently dropped). Now the location is accumulated across continuation lines until the first `/qualifier`.
- **First-CDS-wins** — a second CDS feature no longer overwrites the first's bounds while keeping the first's `protein_id` (`seen_cds` guard).
- **On-disk `schema_version`** on `CanonicalOverrides` (+ `#[non_exhaustive]`) for format longevity; legacy files without the field read as `0`.
- Documented: parses the first record only; `complement(join(...))` correctness.

## Scope / verification

This PR is the **parsing + schema core**, unit-tested (11 tests) with synthetic GenBank fixtures: VERSION/length/CDS/`protein_id` extraction, wrapped + `complement(join())` locations, partial markers, first-CDS-wins, non-coding, JSON round-trip, legacy-schema default. `clippy --all-targets -D warnings` clean.

The NCBI **efetch** that produces the GenBank text (the `ferro prepare --validate-canonical` stage) is the network edge and is **not** in this PR — it's wired and verified on a prepared host / in CI, where a real reference manifest exists.

Refs #520, #505.
