### PR TITLE
feat(prepare): canonical-overrides acquisition — ferro prepare --validate-canonical (#520)

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1502,6 +1502,7 @@ fn run_prepare_tool(
                 skip_existing: !force,
                 clinvar_file: None,
                 patterns_file: None,
+                validate_canonical_accessions: None,
                 dry_run: false,
             };
             let manifest = prepare_references(&config)?;

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -479,6 +479,11 @@ enum Commands {
         #[arg(long)]
         clinvar: Option<PathBuf>,
 
+        /// Newline-delimited accession list to validate against authoritative
+        /// GenBank records, writing canonical_overrides.json (issue #520)
+        #[arg(long)]
+        validate_canonical: Option<PathBuf>,
+
         /// Dry run - show what would be downloaded without downloading
         #[arg(long)]
         dry_run: bool,
@@ -761,6 +766,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             patterns,
             clinvar,
+            validate_canonical,
             dry_run,
         } => run_prepare(
             &output_dir,
@@ -772,6 +778,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             patterns.as_deref(),
             clinvar.as_deref(),
+            validate_canonical.as_deref(),
             dry_run,
         ),
         Commands::Check { reference } => run_check(&reference),
@@ -2775,6 +2782,7 @@ fn run_prepare(
     force: bool,
     patterns: Option<&Path>,
     clinvar: Option<&Path>,
+    validate_canonical: Option<&Path>,
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::prepare::{prepare_references, PrepareConfig};
@@ -2791,6 +2799,7 @@ fn run_prepare(
         skip_existing: !force,
         clinvar_file: clinvar.map(|p| p.to_path_buf()),
         patterns_file: patterns.map(|p| p.to_path_buf()),
+        validate_canonical_accessions: validate_canonical.map(|p| p.to_path_buf()),
         dry_run,
     };
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -113,6 +113,15 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    if let Some(ref overrides) = manifest.canonical_overrides {
+        if !overrides.exists() {
+            result.warnings.push(format!(
+                "Canonical overrides JSON not found: {}",
+                overrides.display()
+            ));
+        }
+    }
+
     result
 }
 
@@ -165,6 +174,10 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
         eprintln!("  cdot metadata (GRCh37): {}", cdot.display());
     } else {
         eprintln!("  cdot metadata (GRCh37): not available");
+    }
+
+    if let Some(ref overrides) = manifest.canonical_overrides {
+        eprintln!("  Canonical overrides: {}", overrides.display());
     }
 
     if let Some(ref supp) = manifest.supplemental_fasta {
@@ -227,6 +240,7 @@ mod tests {
             legacy_transcripts_metadata: None,
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
+            canonical_overrides: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -51,6 +51,12 @@ pub struct ReferenceManifest {
     /// Legacy GenBank metadata JSON (CDS coordinates, gene names)
     #[serde(default)]
     pub legacy_genbank_metadata: Option<PathBuf>,
+    /// Canonical-overrides JSON: authoritative `(cds_start, cds_end, protein_id,
+    /// tx_length)` per exact accession version, fetched by
+    /// `ferro prepare --validate-canonical`. Consumed by the canonical-record
+    /// validation / correction path (issue #520).
+    #[serde(default)]
+    pub canonical_overrides: Option<PathBuf>,
     /// Total number of transcripts
     pub transcript_count: usize,
     /// List of available accession prefixes
@@ -79,6 +85,7 @@ impl Default for ReferenceManifest {
             legacy_transcripts_metadata: None,
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
+            canonical_overrides: None,
             transcript_count: 0,
             available_prefixes: Vec::new(),
             reference_dir: PathBuf::new(),
@@ -213,6 +220,7 @@ impl ReferenceManifest {
             &self.legacy_transcripts_metadata,
             &self.legacy_genbank_fasta,
             &self.legacy_genbank_metadata,
+            &self.canonical_overrides,
         ]
         .into_iter()
         .flatten()
@@ -244,6 +252,7 @@ impl ReferenceManifest {
             &mut self.legacy_transcripts_metadata,
             &mut self.legacy_genbank_fasta,
             &mut self.legacy_genbank_metadata,
+            &mut self.canonical_overrides,
         ] {
             if let Some(p) = o.as_mut() {
                 f(p);
@@ -325,6 +334,7 @@ mod tests {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![ref_path.join("transcripts.fa")],
             cdot_json: Some(ref_path.join("cdot.json")),
+            canonical_overrides: Some(ref_path.join("canonical_overrides.json")),
             ..Default::default()
         };
 
@@ -335,6 +345,11 @@ mod tests {
             PathBuf::from("transcripts.fa")
         );
         assert_eq!(manifest.cdot_json, Some(PathBuf::from("cdot.json")));
+        assert_eq!(
+            manifest.canonical_overrides,
+            Some(PathBuf::from("canonical_overrides.json")),
+            "canonical_overrides must be normalized to a relative path"
+        );
     }
 
     #[test]
@@ -348,6 +363,7 @@ mod tests {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![PathBuf::from("transcripts.fa")],
             cdot_json: Some(PathBuf::from("cdot.json")),
+            canonical_overrides: Some(PathBuf::from("canonical_overrides.json")),
             ..Default::default()
         };
 
@@ -358,6 +374,11 @@ mod tests {
             ref_path.join("transcripts.fa")
         );
         assert_eq!(manifest.cdot_json, Some(ref_path.join("cdot.json")));
+        assert_eq!(
+            manifest.canonical_overrides,
+            Some(ref_path.join("canonical_overrides.json")),
+            "canonical_overrides must be resolved to an absolute path"
+        );
     }
 
     #[test]
@@ -406,6 +427,7 @@ mod tests {
             legacy_transcripts_metadata: Some(ref_dir.join("legacy.json")),
             legacy_genbank_fasta: Some(ref_dir.join("genbank.fa")),
             legacy_genbank_metadata: Some(ref_dir.join("genbank.json")),
+            canonical_overrides: None,
             transcript_count: 100,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: ref_dir.to_path_buf(),

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -51,6 +51,10 @@ pub struct PrepareConfig {
     pub clinvar_file: Option<PathBuf>,
     /// Plain text pattern file to extract missing accessions from
     pub patterns_file: Option<PathBuf>,
+    /// Newline-delimited file of exact versioned accessions to validate against
+    /// their authoritative GenBank records, writing a canonical-overrides file
+    /// (issue #520). `None` skips the canonical-validation stage.
+    pub validate_canonical_accessions: Option<PathBuf>,
     /// Dry run - show what would be fetched without fetching
     pub dry_run: bool,
 }
@@ -69,6 +73,7 @@ impl Default for PrepareConfig {
             skip_existing: true,
             clinvar_file: None,
             patterns_file: None,
+            validate_canonical_accessions: None,
             dry_run: false,
         }
     }
@@ -490,6 +495,23 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             if metadata_path.exists() {
                 manifest.legacy_genbank_metadata = Some(metadata_path);
             }
+        }
+    }
+
+    // Canonical-record validation: fetch authoritative GenBank records for the
+    // requested accessions and write the canonical-overrides file (issue #520).
+    if let Some(ref acc_file) = config.validate_canonical_accessions {
+        eprintln!("\n=== Validating against authoritative GenBank records ===");
+        let accessions = read_accession_list(acc_file)?;
+        let out = config.output_dir.join("canonical_overrides.json");
+        let written = fetch_canonical_overrides(&accessions, &out, config.dry_run)?;
+        if !config.dry_run && written > 0 {
+            manifest.canonical_overrides = Some(out.clone());
+            eprintln!(
+                "  Wrote {} canonical override records to {}",
+                written,
+                out.display()
+            );
         }
     }
 
@@ -1302,6 +1324,103 @@ pub fn fetch_legacy_versions(
     eprintln!("  Metadata written to: {}", metadata_path.display());
 
     Ok(fetched)
+}
+
+/// Read a newline-delimited accession list, trimming whitespace and skipping
+/// blank lines and `#` comments.
+fn read_accession_list(path: &Path) -> Result<Vec<String>, FerroError> {
+    let text = std::fs::read_to_string(path).map_err(|e| FerroError::Io {
+        msg: format!("Failed to read accession list {}: {}", path.display(), e),
+    })?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        // Upper-case so a lowercase entry (`nm_012459.2`) doesn't false-reject:
+        // efetch is case-insensitive and returns the canonical upper-case
+        // `VERSION`, which the version-match guard compares against exactly.
+        .map(str::to_uppercase)
+        .collect())
+}
+
+/// Fetch authoritative GenBank records for `accessions` and write a
+/// canonical-overrides JSON to `output`, returning the number of records
+/// written.
+///
+/// Reuses the same NCBI efetch (`rettype=gb`) + 100 ms rate-limit pattern as
+/// [`fetch_legacy_versions`]; record parsing and assembly (including the
+/// requested-vs-fetched version check) are delegated to
+/// [`build_canonical_overrides`](crate::reference::authoritative::build_canonical_overrides).
+pub fn fetch_canonical_overrides(
+    accessions: &[String],
+    output: &Path,
+    dry_run: bool,
+) -> Result<usize, FerroError> {
+    use crate::reference::authoritative::build_canonical_overrides;
+
+    if accessions.is_empty() {
+        return Ok(0);
+    }
+    if dry_run {
+        eprintln!(
+            "  [dry run] Would validate {} accessions against authoritative GenBank records",
+            accessions.len()
+        );
+        return Ok(0);
+    }
+
+    eprintln!(
+        "  Fetching {} authoritative GenBank records for canonical validation...",
+        accessions.len()
+    );
+    let pb = ProgressBar::new(accessions.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("    [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}")
+            .unwrap()
+            .progress_chars("##-"),
+    );
+
+    let (overrides, failed) = build_canonical_overrides(accessions, |acc| {
+        pb.set_message(acc.to_string());
+        let url = format!(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=gb&retmode=text",
+            acc
+        );
+        let result = Command::new("curl").args(["-s", "-L", &url]).output();
+        pb.inc(1);
+        std::thread::sleep(std::time::Duration::from_millis(100)); // NCBI rate limit
+        let out = result.ok()?;
+        let text = String::from_utf8_lossy(&out.stdout).into_owned();
+        (out.status.success() && text.contains("LOCUS")).then_some(text)
+    });
+    pb.finish_and_clear();
+
+    // Don't leave an orphan empty file (and an unreferenced manifest entry) when
+    // every accession failed; that mirrors the empty-input path which writes
+    // nothing. Still report the failures below.
+    if !overrides.is_empty() {
+        let json = overrides.to_json().map_err(|e| FerroError::Io {
+            msg: format!("Failed to serialize canonical overrides: {e}"),
+        })?;
+        std::fs::write(output, json).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write {}: {}", output.display(), e),
+        })?;
+    }
+
+    if !failed.is_empty() {
+        eprintln!(
+            "  Warning: {} accessions could not be validated (fetch/parse/version mismatch):",
+            failed.len()
+        );
+        for acc in failed.iter().take(5) {
+            eprintln!("    {}", acc);
+        }
+        if failed.len() > 5 {
+            eprintln!("    ... and {} more", failed.len() - 5);
+        }
+    }
+    Ok(overrides.len())
 }
 
 /// Detect patterns file from ferro reference directory.

--- a/src/python.rs
+++ b/src/python.rs
@@ -3099,6 +3099,7 @@ impl PyPrepareConfig {
                 skip_existing,
                 clinvar_file: None,
                 patterns_file: None,
+                validate_canonical_accessions: None,
                 dry_run,
             },
         }

--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -264,6 +264,42 @@ impl CanonicalOverrides {
     }
 }
 
+/// Build a [`CanonicalOverrides`] for `accessions` by fetching and parsing each
+/// one's GenBank record.
+///
+/// `fetch_gb` is the GenBank-text source: given an exact versioned accession it
+/// returns the record text, or `None` if the fetch failed. Injecting it keeps
+/// this orchestration network-free and testable — the `ferro prepare` caller
+/// supplies an NCBI-efetch implementation, tests supply fixtures.
+///
+/// Returns the assembled overrides plus the list of accessions that could not
+/// be fetched or parsed (so the caller can report them). If the parsed record's
+/// `accession` differs from the requested one, the record is rejected and the
+/// requested accession is recorded as unresolved.
+pub fn build_canonical_overrides<F>(
+    accessions: &[String],
+    mut fetch_gb: F,
+) -> (CanonicalOverrides, Vec<String>)
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut overrides = CanonicalOverrides::default();
+    let mut failed = Vec::new();
+    for accession in accessions {
+        match fetch_gb(accession)
+            .as_deref()
+            .and_then(parse_authoritative_genbank)
+        {
+            // The fetched record's VERSION must match what we asked for; a
+            // mismatch means efetch resolved to a different version and the
+            // record is not authoritative for `accession`.
+            Some(record) if record.accession == *accession => overrides.insert(record),
+            _ => failed.push(accession.clone()),
+        }
+    }
+    (overrides, failed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -471,5 +507,38 @@ ORIGIN
                 .and_then(|r| r.protein_id.as_deref()),
             Some("NP_036591.2")
         );
+    }
+
+    #[test]
+    fn build_overrides_collects_parsed_records() {
+        let accs = vec!["NM_012459.2".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |acc| {
+            assert_eq!(acc, "NM_012459.2");
+            Some(FIXTURE.to_string())
+        });
+        assert!(failed.is_empty());
+        assert_eq!(ov.len(), 1);
+        assert_eq!(
+            ov.get("NM_012459.2").and_then(|r| r.protein_id.as_deref()),
+            Some("NP_036591.2")
+        );
+    }
+
+    #[test]
+    fn build_overrides_records_fetch_failures() {
+        let accs = vec!["NM_NOPE.1".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |_| None);
+        assert!(ov.is_empty());
+        assert_eq!(failed, vec!["NM_NOPE.1".to_string()]);
+    }
+
+    #[test]
+    fn build_overrides_rejects_version_mismatch() {
+        // Requested .9 but efetch returned the .2 record → not authoritative
+        // for the requested version, so it is recorded as failed, not inserted.
+        let accs = vec!["NM_012459.9".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |_| Some(FIXTURE.to_string()));
+        assert!(ov.is_empty());
+        assert_eq!(failed, vec!["NM_012459.9".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

**Edge 1** of the canonical-validation integration (#520) — the acquisition stage that populates the `CanonicalOverrides` file the validate/correct path consumes. **Stacked on #525** (Phase 4); review the phase stack (#521→#525) first.

- **`build_canonical_overrides(accessions, fetch_fn)`** (`reference::authoritative`) — network-free orchestration: parses each fetched GenBank record via `parse_authoritative_genbank`, keys it by its own `VERSION` accession, and records as **failed** any accession that can't be fetched/parsed **or whose fetched record resolves to a different version** (efetch version drift). Injecting `fetch_fn` keeps it unit-testable.
- **`fetch_canonical_overrides(accessions, out, dry_run)`** (`prepare`) — the network wrapper, reusing the existing NCBI efetch (`rettype=gb`) + 100 ms rate-limit pattern from `fetch_legacy_versions`; delegates assembly to `build_canonical_overrides` and writes the JSON.
- **`ferro prepare --validate-canonical <accessions-file>`** — reads a newline-delimited accession list (skips blanks/`#` comments), runs the fetch, writes `canonical_overrides.json`, and records it in the manifest (new `canonical_overrides` field).

## Scope / verification

The efetch **network call** is the on-host part. The orchestration (`build_canonical_overrides`), the version-drift rejection, the manifest schema, and the accession-list parsing are unit-tested (3 new tests: collects parsed records, records fetch failures, rejects version mismatch). `ferro` / `python` / `benchmark` all compile; full suite **6583 pass**; clippy clean.

To run it on-host: `ferro prepare --validate-canonical accessions.txt` (one accession per line) → writes `canonical_overrides.json` next to the manifest.

Refs #520, #505.
