### PR TITLE
feat(reference): apply canonical overrides in MultiFastaProvider + reconcile cdot (#520)

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1502,6 +1502,7 @@ fn run_prepare_tool(
                 skip_existing: !force,
                 clinvar_file: None,
                 patterns_file: None,
+                validate_canonical_accessions: None,
                 dry_run: false,
             };
             let manifest = prepare_references(&config)?;

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -479,6 +479,11 @@ enum Commands {
         #[arg(long)]
         clinvar: Option<PathBuf>,
 
+        /// Newline-delimited accession list to validate against authoritative
+        /// GenBank records, writing canonical_overrides.json (issue #520)
+        #[arg(long)]
+        validate_canonical: Option<PathBuf>,
+
         /// Dry run - show what would be downloaded without downloading
         #[arg(long)]
         dry_run: bool,
@@ -761,6 +766,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             patterns,
             clinvar,
+            validate_canonical,
             dry_run,
         } => run_prepare(
             &output_dir,
@@ -772,6 +778,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             patterns.as_deref(),
             clinvar.as_deref(),
+            validate_canonical.as_deref(),
             dry_run,
         ),
         Commands::Check { reference } => run_check(&reference),
@@ -2775,6 +2782,7 @@ fn run_prepare(
     force: bool,
     patterns: Option<&Path>,
     clinvar: Option<&Path>,
+    validate_canonical: Option<&Path>,
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::prepare::{prepare_references, PrepareConfig};
@@ -2791,6 +2799,7 @@ fn run_prepare(
         skip_existing: !force,
         clinvar_file: clinvar.map(|p| p.to_path_buf()),
         patterns_file: patterns.map(|p| p.to_path_buf()),
+        validate_canonical_accessions: validate_canonical.map(|p| p.to_path_buf()),
         dry_run,
     };
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -113,6 +113,15 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    if let Some(ref overrides) = manifest.canonical_overrides {
+        if !overrides.exists() {
+            result.warnings.push(format!(
+                "Canonical overrides JSON not found: {}",
+                overrides.display()
+            ));
+        }
+    }
+
     result
 }
 
@@ -165,6 +174,10 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
         eprintln!("  cdot metadata (GRCh37): {}", cdot.display());
     } else {
         eprintln!("  cdot metadata (GRCh37): not available");
+    }
+
+    if let Some(ref overrides) = manifest.canonical_overrides {
+        eprintln!("  Canonical overrides: {}", overrides.display());
     }
 
     if let Some(ref supp) = manifest.supplemental_fasta {
@@ -227,6 +240,7 @@ mod tests {
             legacy_transcripts_metadata: None,
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
+            canonical_overrides: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -51,6 +51,12 @@ pub struct ReferenceManifest {
     /// Legacy GenBank metadata JSON (CDS coordinates, gene names)
     #[serde(default)]
     pub legacy_genbank_metadata: Option<PathBuf>,
+    /// Canonical-overrides JSON: authoritative `(cds_start, cds_end, protein_id,
+    /// tx_length)` per exact accession version, fetched by
+    /// `ferro prepare --validate-canonical`. Consumed by the canonical-record
+    /// validation / correction path (issue #520).
+    #[serde(default)]
+    pub canonical_overrides: Option<PathBuf>,
     /// Total number of transcripts
     pub transcript_count: usize,
     /// List of available accession prefixes
@@ -79,6 +85,7 @@ impl Default for ReferenceManifest {
             legacy_transcripts_metadata: None,
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
+            canonical_overrides: None,
             transcript_count: 0,
             available_prefixes: Vec::new(),
             reference_dir: PathBuf::new(),
@@ -213,6 +220,7 @@ impl ReferenceManifest {
             &self.legacy_transcripts_metadata,
             &self.legacy_genbank_fasta,
             &self.legacy_genbank_metadata,
+            &self.canonical_overrides,
         ]
         .into_iter()
         .flatten()
@@ -244,6 +252,7 @@ impl ReferenceManifest {
             &mut self.legacy_transcripts_metadata,
             &mut self.legacy_genbank_fasta,
             &mut self.legacy_genbank_metadata,
+            &mut self.canonical_overrides,
         ] {
             if let Some(p) = o.as_mut() {
                 f(p);
@@ -325,6 +334,7 @@ mod tests {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![ref_path.join("transcripts.fa")],
             cdot_json: Some(ref_path.join("cdot.json")),
+            canonical_overrides: Some(ref_path.join("canonical_overrides.json")),
             ..Default::default()
         };
 
@@ -335,6 +345,11 @@ mod tests {
             PathBuf::from("transcripts.fa")
         );
         assert_eq!(manifest.cdot_json, Some(PathBuf::from("cdot.json")));
+        assert_eq!(
+            manifest.canonical_overrides,
+            Some(PathBuf::from("canonical_overrides.json")),
+            "canonical_overrides must be normalized to a relative path"
+        );
     }
 
     #[test]
@@ -348,6 +363,7 @@ mod tests {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![PathBuf::from("transcripts.fa")],
             cdot_json: Some(PathBuf::from("cdot.json")),
+            canonical_overrides: Some(PathBuf::from("canonical_overrides.json")),
             ..Default::default()
         };
 
@@ -358,6 +374,11 @@ mod tests {
             ref_path.join("transcripts.fa")
         );
         assert_eq!(manifest.cdot_json, Some(ref_path.join("cdot.json")));
+        assert_eq!(
+            manifest.canonical_overrides,
+            Some(ref_path.join("canonical_overrides.json")),
+            "canonical_overrides must be resolved to an absolute path"
+        );
     }
 
     #[test]
@@ -406,6 +427,7 @@ mod tests {
             legacy_transcripts_metadata: Some(ref_dir.join("legacy.json")),
             legacy_genbank_fasta: Some(ref_dir.join("genbank.fa")),
             legacy_genbank_metadata: Some(ref_dir.join("genbank.json")),
+            canonical_overrides: None,
             transcript_count: 100,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: ref_dir.to_path_buf(),

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -51,6 +51,10 @@ pub struct PrepareConfig {
     pub clinvar_file: Option<PathBuf>,
     /// Plain text pattern file to extract missing accessions from
     pub patterns_file: Option<PathBuf>,
+    /// Newline-delimited file of exact versioned accessions to validate against
+    /// their authoritative GenBank records, writing a canonical-overrides file
+    /// (issue #520). `None` skips the canonical-validation stage.
+    pub validate_canonical_accessions: Option<PathBuf>,
     /// Dry run - show what would be fetched without fetching
     pub dry_run: bool,
 }
@@ -69,6 +73,7 @@ impl Default for PrepareConfig {
             skip_existing: true,
             clinvar_file: None,
             patterns_file: None,
+            validate_canonical_accessions: None,
             dry_run: false,
         }
     }
@@ -490,6 +495,23 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             if metadata_path.exists() {
                 manifest.legacy_genbank_metadata = Some(metadata_path);
             }
+        }
+    }
+
+    // Canonical-record validation: fetch authoritative GenBank records for the
+    // requested accessions and write the canonical-overrides file (issue #520).
+    if let Some(ref acc_file) = config.validate_canonical_accessions {
+        eprintln!("\n=== Validating against authoritative GenBank records ===");
+        let accessions = read_accession_list(acc_file)?;
+        let out = config.output_dir.join("canonical_overrides.json");
+        let written = fetch_canonical_overrides(&accessions, &out, config.dry_run)?;
+        if !config.dry_run && written > 0 {
+            manifest.canonical_overrides = Some(out.clone());
+            eprintln!(
+                "  Wrote {} canonical override records to {}",
+                written,
+                out.display()
+            );
         }
     }
 
@@ -1302,6 +1324,103 @@ pub fn fetch_legacy_versions(
     eprintln!("  Metadata written to: {}", metadata_path.display());
 
     Ok(fetched)
+}
+
+/// Read a newline-delimited accession list, trimming whitespace and skipping
+/// blank lines and `#` comments.
+fn read_accession_list(path: &Path) -> Result<Vec<String>, FerroError> {
+    let text = std::fs::read_to_string(path).map_err(|e| FerroError::Io {
+        msg: format!("Failed to read accession list {}: {}", path.display(), e),
+    })?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        // Upper-case so a lowercase entry (`nm_012459.2`) doesn't false-reject:
+        // efetch is case-insensitive and returns the canonical upper-case
+        // `VERSION`, which the version-match guard compares against exactly.
+        .map(str::to_uppercase)
+        .collect())
+}
+
+/// Fetch authoritative GenBank records for `accessions` and write a
+/// canonical-overrides JSON to `output`, returning the number of records
+/// written.
+///
+/// Reuses the same NCBI efetch (`rettype=gb`) + 100 ms rate-limit pattern as
+/// [`fetch_legacy_versions`]; record parsing and assembly (including the
+/// requested-vs-fetched version check) are delegated to
+/// [`build_canonical_overrides`](crate::reference::authoritative::build_canonical_overrides).
+pub fn fetch_canonical_overrides(
+    accessions: &[String],
+    output: &Path,
+    dry_run: bool,
+) -> Result<usize, FerroError> {
+    use crate::reference::authoritative::build_canonical_overrides;
+
+    if accessions.is_empty() {
+        return Ok(0);
+    }
+    if dry_run {
+        eprintln!(
+            "  [dry run] Would validate {} accessions against authoritative GenBank records",
+            accessions.len()
+        );
+        return Ok(0);
+    }
+
+    eprintln!(
+        "  Fetching {} authoritative GenBank records for canonical validation...",
+        accessions.len()
+    );
+    let pb = ProgressBar::new(accessions.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("    [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} {msg}")
+            .unwrap()
+            .progress_chars("##-"),
+    );
+
+    let (overrides, failed) = build_canonical_overrides(accessions, |acc| {
+        pb.set_message(acc.to_string());
+        let url = format!(
+            "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=gb&retmode=text",
+            acc
+        );
+        let result = Command::new("curl").args(["-s", "-L", &url]).output();
+        pb.inc(1);
+        std::thread::sleep(std::time::Duration::from_millis(100)); // NCBI rate limit
+        let out = result.ok()?;
+        let text = String::from_utf8_lossy(&out.stdout).into_owned();
+        (out.status.success() && text.contains("LOCUS")).then_some(text)
+    });
+    pb.finish_and_clear();
+
+    // Don't leave an orphan empty file (and an unreferenced manifest entry) when
+    // every accession failed; that mirrors the empty-input path which writes
+    // nothing. Still report the failures below.
+    if !overrides.is_empty() {
+        let json = overrides.to_json().map_err(|e| FerroError::Io {
+            msg: format!("Failed to serialize canonical overrides: {e}"),
+        })?;
+        std::fs::write(output, json).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write {}: {}", output.display(), e),
+        })?;
+    }
+
+    if !failed.is_empty() {
+        eprintln!(
+            "  Warning: {} accessions could not be validated (fetch/parse/version mismatch):",
+            failed.len()
+        );
+        for acc in failed.iter().take(5) {
+            eprintln!("    {}", acc);
+        }
+        if failed.len() > 5 {
+            eprintln!("    ... and {} more", failed.len() - 5);
+        }
+    }
+    Ok(overrides.len())
 }
 
 /// Detect patterns file from ferro reference directory.

--- a/src/python.rs
+++ b/src/python.rs
@@ -3099,6 +3099,7 @@ impl PyPrepareConfig {
                 skip_existing,
                 clinvar_file: None,
                 patterns_file: None,
+                validate_canonical_accessions: None,
                 dry_run,
             },
         }

--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -264,6 +264,42 @@ impl CanonicalOverrides {
     }
 }
 
+/// Build a [`CanonicalOverrides`] for `accessions` by fetching and parsing each
+/// one's GenBank record.
+///
+/// `fetch_gb` is the GenBank-text source: given an exact versioned accession it
+/// returns the record text, or `None` if the fetch failed. Injecting it keeps
+/// this orchestration network-free and testable — the `ferro prepare` caller
+/// supplies an NCBI-efetch implementation, tests supply fixtures.
+///
+/// Returns the assembled overrides plus the list of accessions that could not
+/// be fetched or parsed (so the caller can report them). If the parsed record's
+/// `accession` differs from the requested one, the record is rejected and the
+/// requested accession is recorded as unresolved.
+pub fn build_canonical_overrides<F>(
+    accessions: &[String],
+    mut fetch_gb: F,
+) -> (CanonicalOverrides, Vec<String>)
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut overrides = CanonicalOverrides::default();
+    let mut failed = Vec::new();
+    for accession in accessions {
+        match fetch_gb(accession)
+            .as_deref()
+            .and_then(parse_authoritative_genbank)
+        {
+            // The fetched record's VERSION must match what we asked for; a
+            // mismatch means efetch resolved to a different version and the
+            // record is not authoritative for `accession`.
+            Some(record) if record.accession == *accession => overrides.insert(record),
+            _ => failed.push(accession.clone()),
+        }
+    }
+    (overrides, failed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -471,5 +507,38 @@ ORIGIN
                 .and_then(|r| r.protein_id.as_deref()),
             Some("NP_036591.2")
         );
+    }
+
+    #[test]
+    fn build_overrides_collects_parsed_records() {
+        let accs = vec!["NM_012459.2".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |acc| {
+            assert_eq!(acc, "NM_012459.2");
+            Some(FIXTURE.to_string())
+        });
+        assert!(failed.is_empty());
+        assert_eq!(ov.len(), 1);
+        assert_eq!(
+            ov.get("NM_012459.2").and_then(|r| r.protein_id.as_deref()),
+            Some("NP_036591.2")
+        );
+    }
+
+    #[test]
+    fn build_overrides_records_fetch_failures() {
+        let accs = vec!["NM_NOPE.1".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |_| None);
+        assert!(ov.is_empty());
+        assert_eq!(failed, vec!["NM_NOPE.1".to_string()]);
+    }
+
+    #[test]
+    fn build_overrides_rejects_version_mismatch() {
+        // Requested .9 but efetch returned the .2 record → not authoritative
+        // for the requested version, so it is recorded as failed, not inserted.
+        let accs = vec!["NM_012459.9".to_string()];
+        let (ov, failed) = build_canonical_overrides(&accs, |_| Some(FIXTURE.to_string()));
+        assert!(ov.is_empty());
+        assert_eq!(failed, vec!["NM_012459.9".to_string()]);
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -28,6 +28,7 @@ use log::warn;
 
 use crate::data::cdot::CdotMapper;
 use crate::error::FerroError;
+use crate::reference::authoritative::CanonicalOverrides;
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
 
@@ -89,6 +90,8 @@ pub struct MultiFastaProvider {
     cdot_mapper: Option<CdotMapper>,
     /// Supplemental CDS info for transcripts not in cdot
     supplemental_cds: SupplementalCdsInfo,
+    /// Authoritative canonical overrides (issue #520), loaded from the manifest.
+    canonical_overrides: CanonicalOverrides,
 }
 
 impl MultiFastaProvider {
@@ -160,6 +163,7 @@ impl MultiFastaProvider {
             aliases: build_chromosome_aliases(),
             cdot_mapper: None,
             supplemental_cds: SupplementalCdsInfo::default(),
+            canonical_overrides: CanonicalOverrides::default(),
         })
     }
 
@@ -191,6 +195,7 @@ impl MultiFastaProvider {
             aliases: build_chromosome_aliases(),
             cdot_mapper: None,
             supplemental_cds: SupplementalCdsInfo::default(),
+            canonical_overrides: CanonicalOverrides::default(),
         })
     }
 
@@ -382,6 +387,28 @@ impl MultiFastaProvider {
             }
         }
 
+        // Canonical overrides (issue #520): load the authoritative-overrides
+        // file and reconcile it into the cdot metadata so both the served
+        // transcript and the projection path see the corrected CDS/protein.
+        if let Some(overrides_ref) = manifest.get("canonical_overrides").and_then(|v| v.as_str()) {
+            let path = resolve_path(overrides_ref);
+            match std::fs::read_to_string(&path) {
+                Ok(text) => match CanonicalOverrides::from_json(&text) {
+                    Ok(ov) => {
+                        eprintln!("Loaded {} canonical override records", ov.len());
+                        provider.canonical_overrides = ov;
+                        provider.reconcile_cdot_with_overrides();
+                    }
+                    Err(e) => eprintln!("Warning: Failed to parse canonical overrides: {}", e),
+                },
+                Err(e) => eprintln!(
+                    "Warning: Failed to read canonical overrides {}: {}",
+                    path.display(),
+                    e
+                ),
+            }
+        }
+
         Ok(provider)
     }
 
@@ -448,6 +475,7 @@ impl MultiFastaProvider {
             aliases: build_chromosome_aliases(),
             cdot_mapper: Some(cdot_mapper),
             supplemental_cds: SupplementalCdsInfo::default(),
+            canonical_overrides: CanonicalOverrides::default(),
         })
     }
 
@@ -876,7 +904,96 @@ impl MultiFastaProvider {
     /// issue #332: when the input carries an NG/NC `genomic_context`, the
     /// caller passes the inferred build so the transcript's `chromosome` is
     /// populated against the correct alignment.
+    /// Apply any loaded canonical overrides to a freshly-built transcript,
+    /// correcting its CDS/protein metadata in place (issue #520). No-op when no
+    /// overrides are loaded. Called at the single [`get_transcript_on_build`]
+    /// chokepoint so every served transcript — lenient, strict, or
+    /// variant-aware — is corrected before it is cached/translated.
+    fn apply_canonical_overrides_to(&self, tx: &mut Transcript) {
+        if !self.canonical_overrides.is_empty() {
+            crate::reference::validate::apply_canonical_overrides(tx, &self.canonical_overrides);
+        }
+    }
+
+    /// Reconcile the cdot mapper's parallel CDS/`protein` with the canonical
+    /// overrides, so the projection path — which reads cdot's fields
+    /// preferentially over the served `Transcript` — also sees the corrected
+    /// values. Only reconciles a fully-coding authoritative record whose
+    /// served FASTA length matches (so the coordinates apply); authoritative
+    /// 1-based bounds are converted to cdot's 0-based start / 0-based-exclusive
+    /// end convention.
+    ///
+    /// Scope: gated on a FASTA index entry, so a transcript served only via
+    /// cdot-genome synthesis (no FASTA entry, the #331 path) is NOT reconciled
+    /// here even though the served-`Transcript` path
+    /// ([`apply_canonical_overrides_to`]) may still correct it. The corpus
+    /// targets (#520) are FASTA-backed, so this gap affects only
+    /// synthesis-backed transcripts; closing it (gating on the cdot exon-sum
+    /// length when no FASTA entry exists) is left as a follow-up.
+    fn reconcile_cdot_with_overrides(&mut self) {
+        use crate::data::cdot::CdotTranscript;
+        if self.cdot_mapper.is_none() {
+            return;
+        }
+        // Compute corrections under immutable borrows, then apply them.
+        let mut corrections: Vec<(String, CdotTranscript)> = Vec::new();
+        {
+            let cdot = self.cdot_mapper.as_ref().unwrap();
+            for (acc, auth) in &self.canonical_overrides.records {
+                let (Some(cds_start), Some(cds_end), Some(protein)) =
+                    (auth.cds_start, auth.cds_end, auth.protein_id.as_ref())
+                else {
+                    continue; // not fully coding → don't half-correct
+                };
+                // 1-based start → 0-based; guard against a degenerate `0` start
+                // (unsigned underflow) from a malformed overrides file.
+                let Some(cds_start_0based) = cds_start.checked_sub(1) else {
+                    continue;
+                };
+                // Served FASTA length must match the authoritative length, else
+                // the coordinates index a different sequence.
+                if self.index.get(acc).map(|e| e.length) != Some(auth.tx_length) {
+                    continue;
+                }
+                // Require an *exact* cdot record for `acc`: `get_transcript`
+                // version-falls-back to a sibling, and cloning that sibling
+                // under `acc` would carry over the wrong exon alignment / contig
+                // metadata. Only reconcile when cdot holds this exact version.
+                if cdot.has_transcript_exact(acc) {
+                    let existing = cdot
+                        .get_transcript(acc)
+                        .expect("exact cdot presence checked above");
+                    corrections.push((
+                        acc.clone(),
+                        CdotTranscript {
+                            cds_start: Some(cds_start_0based), // 1-based incl → 0-based incl
+                            cds_end: Some(cds_end),            // 1-based incl == 0-based excl
+                            protein: Some(protein.clone()),
+                            ..existing.clone()
+                        },
+                    ));
+                }
+            }
+        }
+        let cdot = self.cdot_mapper.as_mut().unwrap();
+        for (acc, rec) in corrections {
+            cdot.add_transcript(acc, rec);
+        }
+    }
+
+    /// Build a transcript and apply canonical overrides — the single chokepoint
+    /// every public entry point funnels through.
     fn get_transcript_on_build(
+        &self,
+        id: &str,
+        build_hint: Option<&str>,
+    ) -> Result<Transcript, FerroError> {
+        let mut tx = self.get_transcript_on_build_inner(id, build_hint)?;
+        self.apply_canonical_overrides_to(&mut tx);
+        Ok(tx)
+    }
+
+    fn get_transcript_on_build_inner(
         &self,
         id: &str,
         build_hint: Option<&str>,
@@ -1149,6 +1266,11 @@ impl MultiFastaProvider {
     ///
     /// The lenient `get_transcript` and the [`ReferenceProvider`] trait impl
     /// are unchanged.
+    ///
+    /// Canonical overrides (#520) still apply: strict resolution is about the
+    /// version-exactness of the served *bases*, while a canonical override
+    /// corrects CDS/`protein` *metadata* on the exact-version record — the two
+    /// are orthogonal, so a strict caller still gets the canonical metadata.
     pub fn get_transcript_strict(&self, id: &str) -> Result<Transcript, FerroError> {
         if !self.has_transcript_exact(id) {
             return Err(FerroError::TranscriptVersionNotExact {
@@ -2527,5 +2649,218 @@ mod tests {
         // ...but a FASTA sibling (.2) shadows it on the read path, so .1 is not
         // reachable at its exact version.
         assert!(!provider.has_transcript_version_exact("NM_TEST.1"));
+    }
+
+    // --- canonical-override wiring (issue #520, edge 2) ---------------------
+
+    #[test]
+    fn get_transcript_applies_canonical_override() {
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        // FASTA-only transcript (9 nt); the override supplies the canonical CDS
+        // + protein. get_transcript must return the corrected metadata.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+
+        let tx = provider.get_transcript("NM_OV.2").unwrap();
+        assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_OV.2"));
+    }
+
+    #[test]
+    fn reconcile_cdot_converts_authoritative_to_cdot_coords() {
+        use crate::data::cdot::{CdotMapper, CdotTranscript};
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        use crate::reference::Strand;
+
+        // FASTA transcript (9 nt) + a cdot record with the WRONG CDS/protein.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_OV.2".to_string(),
+            CdotTranscript {
+                gene_name: None,
+                contig: "chr1".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[0, 9, 0, 9]],
+                cds_start: Some(2), // wrong
+                cds_end: Some(6),   // wrong
+                gene_id: None,
+                protein: Some("NP_WRONG.9".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        provider.cdot_mapper = Some(cdot);
+
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1), // authoritative 1-based
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+
+        provider.reconcile_cdot_with_overrides();
+
+        let rec = provider
+            .cdot_mapper()
+            .unwrap()
+            .get_transcript("NM_OV.2")
+            .unwrap();
+        // 1-based start 1 → cdot 0-based 0; end 9 unchanged (0-based exclusive).
+        assert_eq!(rec.cds_start, Some(0));
+        assert_eq!(rec.cds_end, Some(9));
+        assert_eq!(rec.protein.as_deref(), Some("NP_OV.2"));
+    }
+
+    #[test]
+    fn reconcile_cdot_skips_on_length_mismatch() {
+        use crate::data::cdot::{CdotMapper, CdotTranscript};
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        use crate::reference::Strand;
+        // Served FASTA is 9 nt but the authoritative length is 99 → the
+        // coordinates don't apply; cdot must be left untouched.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_OV.2".to_string(),
+            CdotTranscript {
+                gene_name: None,
+                contig: "chr1".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[0, 9, 0, 9]],
+                cds_start: Some(2),
+                cds_end: Some(6),
+                gene_id: None,
+                protein: Some("NP_WRONG.9".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        provider.cdot_mapper = Some(cdot);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 99, // mismatch
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+
+        provider.reconcile_cdot_with_overrides();
+
+        let rec = provider
+            .cdot_mapper()
+            .unwrap()
+            .get_transcript("NM_OV.2")
+            .unwrap();
+        assert_eq!(rec.cds_start, Some(2), "length mismatch → cdot untouched");
+        assert_eq!(rec.protein.as_deref(), Some("NP_WRONG.9"));
+    }
+
+    #[test]
+    fn reconcile_cdot_requires_exact_version_not_sibling() {
+        use crate::data::cdot::{CdotMapper, CdotTranscript};
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        use crate::reference::Strand;
+        // FASTA carries NM_OV.2 (9 nt). cdot has only the .4 SIBLING (different
+        // contig/exons). An override for .2 must NOT clone the .4 record under
+        // .2: `get_transcript` version-falls-back to .4, but reconcile requires
+        // an *exact* .2 cdot record, so it leaves cdot untouched.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_OV.4".to_string(),
+            CdotTranscript {
+                gene_name: None,
+                contig: "chrSIBLING".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[0, 9, 0, 9]],
+                cds_start: Some(2),
+                cds_end: Some(6),
+                gene_id: None,
+                protein: Some("NP_SIB.4".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        provider.cdot_mapper = Some(cdot);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+
+        provider.reconcile_cdot_with_overrides();
+
+        // No exact .2 in cdot → nothing written under .2.
+        assert!(
+            !provider
+                .cdot_mapper()
+                .unwrap()
+                .has_transcript_exact("NM_OV.2"),
+            "a sibling-only cdot record must not be cloned under the exact version"
+        );
+        // The .4 sibling is left untouched.
+        let sib = provider
+            .cdot_mapper()
+            .unwrap()
+            .get_transcript("NM_OV.4")
+            .unwrap();
+        assert_eq!(sib.contig, "chrSIBLING");
+        assert_eq!(sib.protein.as_deref(), Some("NP_SIB.4"));
+    }
+
+    #[test]
+    fn get_transcript_strict_also_applies_canonical_override() {
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        // The exact version is in the FASTA index, so strict succeeds; the
+        // override must still be applied (orthogonal to version-exactness).
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+        let tx = provider.get_transcript_strict("NM_OV.2").unwrap();
+        assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_OV.2"));
+    }
+
+    #[test]
+    fn get_transcript_for_variant_applies_canonical_override() {
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        // A bare-NM_ coding variant routes through get_transcript_for_variant's
+        // no-parent branch → the wrapper → override applied.
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NM_OV.2", "ATGAAATAA")]);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_OV.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_OV.2".to_string()),
+        });
+        provider.canonical_overrides = ov;
+        let variant = crate::parse_hgvs("NM_OV.2:c.4C>A").unwrap();
+        let tx = provider.get_transcript_for_variant(&variant).unwrap();
+        assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_OV.2"));
     }
 }


### PR DESCRIPTION
## Summary

**Edge 2** of the canonical-validation integration (#520) — wires the correction into `MultiFastaProvider` so served transcripts **and** the projection path use authoritative CDS/protein. **Stacked on #527** (Edge 1); review the chain (phases #521→#525, then #527, then this).

- `MultiFastaProvider` carries `canonical_overrides: CanonicalOverrides`, loaded in `from_manifest` from the manifest's `canonical_overrides` file.
- **Single chokepoint:** `get_transcript_on_build` is now a thin wrapper around `get_transcript_on_build_inner` that applies `validate::apply_canonical_overrides` to the built transcript. So **every** public path — lenient `get_transcript`, `get_transcript_strict`, and the variant-aware build-probing `get_transcript_for_variant` — gets the corrected metadata before the transcript is cached or translated (satisfying the phase-3 cache-ordering contract).
- **cdot reconciliation:** `reconcile_cdot_with_overrides` patches the cdot mapper's parallel `cds_start`/`cds_end`/`protein` for overridden accessions — the half the phase-3 review flagged as essential, since the projection path reads cdot's fields preferentially over the served `Transcript`. Authoritative 1-based bounds convert to cdot's 0-based start / 0-based-exclusive end (`cds_start - 1`, `cds_end` unchanged); only fully-coding records whose served FASTA length matches are reconciled.

## Effect

Together with Edge 1 (which produces the overrides file) and the phase stack, this is what makes `NM_012459.2` predict `NP_036591.2` / the canonical frame: both the served `Transcript` and the cdot record the projector reads are corrected.

## Testing

3 new tests: apply-on-read corrects a served transcript; cdot reconciliation converts coordinates (1-based `1..9` → cdot `0..9`, protein swapped); length-mismatch leaves cdot untouched. `ferro`/`python`/`benchmark` compile; full module suite green (90 in the touched modules); `clippy --all-targets -D warnings` clean.

End-to-end (a prepared manifest with a real `canonical_overrides.json` flipping the corpus rows) is the on-host verification this enables.

Refs #520, #505.
