### PR TITLE
feat(reference): ingest protein FASTAs + get_protein_sequence + translation check (#520)

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1493,6 +1493,7 @@ fn run_prepare_tool(
             let config = PrepareConfig {
                 output_dir: output_dir.to_path_buf(),
                 download_transcripts: true,
+                download_proteins: false,
                 download_genome: matches!(genome, GenomeOption::Grch38 | GenomeOption::All),
                 download_genome_grch37: matches!(genome, GenomeOption::Grch37 | GenomeOption::All),
                 download_refseqgene: !no_refseqgene,

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -455,6 +455,11 @@ enum Commands {
         #[arg(long)]
         no_transcripts: bool,
 
+        /// Also download companion protein FASTAs (~2GB) for the canonical
+        /// translation check (issue #520); off by default
+        #[arg(long)]
+        proteins: bool,
+
         /// Skip cdot transcript metadata
         #[arg(long)]
         no_cdot: bool,
@@ -760,6 +765,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir,
             genome,
             no_transcripts,
+            proteins,
             no_cdot,
             no_refseqgene,
             no_lrg,
@@ -772,6 +778,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &output_dir,
             &genome,
             no_transcripts,
+            proteins,
             no_cdot,
             no_refseqgene,
             no_lrg,
@@ -2776,6 +2783,7 @@ fn run_prepare(
     output_dir: &Path,
     genome: &str,
     no_transcripts: bool,
+    proteins: bool,
     no_cdot: bool,
     no_refseqgene: bool,
     no_lrg: bool,
@@ -2790,6 +2798,7 @@ fn run_prepare(
     let config = PrepareConfig {
         output_dir: output_dir.to_path_buf(),
         download_transcripts: !no_transcripts,
+        download_proteins: proteins,
         download_genome: genome == "grch38" || genome == "all",
         download_genome_grch37: genome == "grch37" || genome == "all",
         download_refseqgene: !no_refseqgene,

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -176,6 +176,10 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
         eprintln!("  cdot metadata (GRCh37): not available");
     }
 
+    if !manifest.protein_fastas.is_empty() {
+        eprintln!("  Protein FASTA files: {}", manifest.protein_fastas.len());
+    }
+
     if let Some(ref overrides) = manifest.canonical_overrides {
         eprintln!("  Canonical overrides: {}", overrides.display());
     }
@@ -227,6 +231,7 @@ mod tests {
         let mut manifest = ReferenceManifest {
             prepared_at: "2024-01-01T00:00:00Z".to_string(),
             transcript_fastas: vec![transcript_fasta.clone()],
+            protein_fastas: Vec::new(),
             genome_fasta: None,
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -14,6 +14,10 @@ pub struct ReferenceManifest {
     pub prepared_at: String,
     /// Transcript FASTA files
     pub transcript_fastas: Vec<PathBuf>,
+    /// Protein FASTA files (`*.protein.faa`, NP_/XP_ accessions) for the
+    /// translated-CDS-vs-canonical-protein check (issue #520).
+    #[serde(default)]
+    pub protein_fastas: Vec<PathBuf>,
     /// GRCh38 genome FASTA file (if downloaded)
     pub genome_fasta: Option<PathBuf>,
     /// GRCh37 genome FASTA file (if downloaded)
@@ -72,6 +76,7 @@ impl Default for ReferenceManifest {
             // Empty string by default; `save()` populates this with the current time.
             prepared_at: String::new(),
             transcript_fastas: Vec::new(),
+            protein_fastas: Vec::new(),
             genome_fasta: None,
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),
@@ -203,6 +208,7 @@ impl ReferenceManifest {
         for p in self
             .transcript_fastas
             .iter()
+            .chain(self.protein_fastas.iter())
             .chain(self.refseqgene_fastas.iter())
             .chain(self.lrg_fastas.iter())
             .chain(self.lrg_xmls.iter())
@@ -233,6 +239,7 @@ impl ReferenceManifest {
     fn for_each_path_mut(&mut self, mut f: impl FnMut(&mut PathBuf)) {
         for v in [
             &mut self.transcript_fastas,
+            &mut self.protein_fastas,
             &mut self.refseqgene_fastas,
             &mut self.lrg_fastas,
             &mut self.lrg_xmls,
@@ -293,6 +300,7 @@ impl ReferenceManifest {
     fn deduplicate_paths(&mut self) {
         for v in [
             &mut self.transcript_fastas,
+            &mut self.protein_fastas,
             &mut self.refseqgene_fastas,
             &mut self.lrg_fastas,
             &mut self.lrg_xmls,
@@ -333,6 +341,7 @@ mod tests {
         let mut manifest = ReferenceManifest {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![ref_path.join("transcripts.fa")],
+            protein_fastas: vec![ref_path.join("proteins.faa")],
             cdot_json: Some(ref_path.join("cdot.json")),
             canonical_overrides: Some(ref_path.join("canonical_overrides.json")),
             ..Default::default()
@@ -343,6 +352,11 @@ mod tests {
         assert_eq!(
             manifest.transcript_fastas[0],
             PathBuf::from("transcripts.fa")
+        );
+        assert_eq!(
+            manifest.protein_fastas[0],
+            PathBuf::from("proteins.faa"),
+            "protein_fastas must be normalized to a relative path"
         );
         assert_eq!(manifest.cdot_json, Some(PathBuf::from("cdot.json")));
         assert_eq!(
@@ -362,6 +376,7 @@ mod tests {
         let mut manifest = ReferenceManifest {
             reference_dir: ref_path.clone(),
             transcript_fastas: vec![PathBuf::from("transcripts.fa")],
+            protein_fastas: vec![PathBuf::from("proteins.faa")],
             cdot_json: Some(PathBuf::from("cdot.json")),
             canonical_overrides: Some(PathBuf::from("canonical_overrides.json")),
             ..Default::default()
@@ -372,6 +387,11 @@ mod tests {
         assert_eq!(
             manifest.transcript_fastas[0],
             ref_path.join("transcripts.fa")
+        );
+        assert_eq!(
+            manifest.protein_fastas[0],
+            ref_path.join("proteins.faa"),
+            "protein_fastas must be resolved to an absolute path"
         );
         assert_eq!(manifest.cdot_json, Some(ref_path.join("cdot.json")));
         assert_eq!(
@@ -389,6 +409,11 @@ mod tests {
                 PathBuf::from("a.fa"),
                 PathBuf::from("b.fa"),
             ],
+            protein_fastas: vec![
+                PathBuf::from("q.faa"),
+                PathBuf::from("p.faa"),
+                PathBuf::from("q.faa"),
+            ],
             lrg_fastas: vec![PathBuf::from("lrg.fa"), PathBuf::from("lrg.fa")],
             ..Default::default()
         };
@@ -398,6 +423,10 @@ mod tests {
         assert_eq!(
             manifest.transcript_fastas,
             vec![PathBuf::from("a.fa"), PathBuf::from("b.fa")]
+        );
+        assert_eq!(
+            manifest.protein_fastas,
+            vec![PathBuf::from("p.faa"), PathBuf::from("q.faa")]
         );
         assert_eq!(manifest.lrg_fastas, vec![PathBuf::from("lrg.fa")]);
     }
@@ -414,6 +443,7 @@ mod tests {
         let mut manifest = ReferenceManifest {
             prepared_at: "2024-01-01T00:00:00Z".to_string(),
             transcript_fastas: vec![ref_dir.join("transcripts.fa")],
+            protein_fastas: Vec::new(),
             genome_fasta: Some(ref_dir.join("genome.fa")),
             genome_grch37_fasta: Some(ref_dir.join("genome37.fa")),
             refseqgene_fastas: vec![ref_dir.join("ng.fa")],

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -33,6 +33,10 @@ pub struct PrepareConfig {
     pub output_dir: PathBuf,
     /// Download RefSeq transcripts
     pub download_transcripts: bool,
+    /// Download companion RefSeq protein FASTAs (`*.protein.faa.gz`, ~same size
+    /// as the transcript set) for the translated-CDS-vs-canonical-protein check
+    /// (issue #520). Off by default — opt in only when you need the check.
+    pub download_proteins: bool,
     /// Download GRCh38 genome (large ~3GB)
     pub download_genome: bool,
     /// Download GRCh37 genome (large ~3GB) - for older ClinVar patterns
@@ -64,6 +68,7 @@ impl Default for PrepareConfig {
         Self {
             output_dir: PathBuf::from("ferro-reference"),
             download_transcripts: true,
+            download_proteins: false,
             download_genome: true,
             download_genome_grch37: false,
             download_refseqgene: false,
@@ -227,6 +232,62 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
         manifest.transcript_count = count;
         manifest.available_prefixes = prefixes;
         eprintln!("\n  Total transcripts: {}", count);
+    }
+
+    // Companion RefSeq protein FASTAs (`*.protein.faa.gz`) for the
+    // translated-CDS-vs-canonical-protein check (issue #520, edge 3). Opt-in:
+    // the protein set is roughly the size of the RNA set, so it is NOT pulled
+    // by a default `ferro prepare`. Same `mRNA_Prot/human.N.` base as the RNA
+    // files. Discover the available `.gz` files first (break on the first 404
+    // past #1), then decompress + index + record each by its `.faa` path.
+    if config.download_proteins {
+        eprintln!("\n=== Downloading RefSeq proteins ===");
+        let protein_dir = config.output_dir.join("transcripts");
+        fs::create_dir_all(&protein_dir).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create directory: {}", e),
+        })?;
+
+        let mut gz_paths: Vec<PathBuf> = Vec::new();
+        for i in 1..=urls::REFSEQ_RNA_COUNT {
+            let gz_name = format!("human.{}.protein.faa.gz", i);
+            let gz_path = protein_dir.join(&gz_name);
+            if config.skip_existing && gz_path.exists() {
+                eprintln!("  Skipping {} (exists)", gz_name);
+                gz_paths.push(gz_path);
+                continue;
+            }
+            let url = format!("{}{}.protein.faa.gz", urls::REFSEQ_RNA_BASE, i);
+            match download_file(&url, &gz_path) {
+                Ok(_) => {
+                    eprintln!("  Downloaded {}", gz_name);
+                    gz_paths.push(gz_path);
+                }
+                Err(e) => {
+                    if i > 1 {
+                        eprintln!(
+                            "  No more protein files after human.{}.protein.faa.gz",
+                            i - 1
+                        );
+                        break;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        for gz_path in &gz_paths {
+            let faa_path = gz_path.with_extension("").with_extension("faa");
+            if !(config.skip_existing && faa_path.exists()) {
+                decompress_gzip(gz_path, &faa_path)?;
+            }
+            let fai_path = PathBuf::from(format!("{}.fai", faa_path.display()));
+            if !(config.skip_existing && fai_path.exists()) {
+                index_fasta(&faa_path)?;
+            }
+            if !manifest.protein_fastas.contains(&faa_path) {
+                manifest.protein_fastas.push(faa_path);
+            }
+        }
     }
 
     // Download genome

--- a/src/python.rs
+++ b/src/python.rs
@@ -3090,6 +3090,7 @@ impl PyPrepareConfig {
             inner: PrepareConfig {
                 output_dir: std::path::PathBuf::from(output_dir),
                 download_transcripts,
+                download_proteins: false,
                 download_genome,
                 download_genome_grch37,
                 download_refseqgene,

--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -43,6 +43,13 @@ pub struct AuthoritativeRecord {
     /// `NP_036591.2`). `None` for a non-coding record or one without the
     /// qualifier.
     pub protein_id: Option<String>,
+    /// The canonical transcript bases (upper-cased `ORIGIN` sequence). When
+    /// present, the correction path can *replace* a served non-canonical
+    /// sequence (the wrong-sequence class, e.g. `NM_000193.2`) and detect a
+    /// same-length-but-edited sequence — not just flag a length mismatch.
+    /// Optional because carrying full sequences enlarges the overrides file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequence: Option<String>,
 }
 
 /// Parse the authoritative facts out of a single GenBank flat-file record.
@@ -67,7 +74,9 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
     let mut cds_start: Option<u64> = None;
     let mut cds_end: Option<u64> = None;
     let mut protein_id: Option<String> = None;
-    let mut tx_length: u64 = 0;
+    // The full transcript bases, accumulated (upper-cased) from the ORIGIN
+    // block; `tx_length` is derived from it.
+    let mut sequence = String::new();
 
     let mut in_origin = false;
     // True while reading the `CDS` feature's qualifier lines (so a stray
@@ -95,9 +104,12 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
             if line.starts_with("//") {
                 break;
             }
-            // Sequence lines: "        1 acgtacgt acgt...". Count alphabetic
-            // bases only (the leading number and spaces are not sequence).
-            tx_length += line.bytes().filter(|b| b.is_ascii_alphabetic()).count() as u64;
+            // Sequence lines: "        1 acgtacgt acgt...". Keep alphabetic
+            // bases only (the leading residue number and spaces are not
+            // sequence), upper-cased.
+            for b in line.bytes().filter(u8::is_ascii_alphabetic) {
+                sequence.push(b.to_ascii_uppercase() as char);
+            }
             continue;
         }
 
@@ -152,15 +164,16 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
     }
 
     let accession = accession?;
-    if tx_length == 0 {
+    if sequence.is_empty() {
         return None;
     }
     Some(AuthoritativeRecord {
         accession,
-        tx_length,
+        tx_length: sequence.len() as u64,
         cds_start,
         cds_end,
         protein_id,
+        sequence: Some(sequence),
     })
 }
 
@@ -336,6 +349,11 @@ ORIGIN
         assert_eq!(rec.cds_start, Some(4));
         assert_eq!(rec.cds_end, Some(30));
         assert_eq!(rec.protein_id.as_deref(), Some("NP_036591.2"));
+        // The full ORIGIN bases are captured, upper-cased.
+        assert_eq!(
+            rec.sequence.as_deref(),
+            Some("ACGATGGCAGAGCTGTAAGGCCACGAGCCT")
+        );
     }
 
     #[test]
@@ -497,6 +515,7 @@ ORIGIN
             cds_start: Some(31),
             cds_end: Some(327),
             protein_id: Some("NP_036591.2".to_string()),
+            sequence: None,
         });
         assert_eq!(ov.len(), 1);
         let json = ov.to_json().unwrap();
@@ -506,6 +525,26 @@ ORIGIN
             back.get("NM_012459.2")
                 .and_then(|r| r.protein_id.as_deref()),
             Some("NP_036591.2")
+        );
+    }
+
+    #[test]
+    fn canonical_overrides_roundtrips_a_record_with_sequence() {
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_X.1".to_string(),
+            tx_length: 4,
+            cds_start: Some(1),
+            cds_end: Some(3),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ACGT".to_string()),
+        });
+        let json = ov.to_json().unwrap();
+        let back = CanonicalOverrides::from_json(&json).unwrap();
+        assert_eq!(back, ov);
+        assert_eq!(
+            back.get("NM_X.1").and_then(|r| r.sequence.as_deref()),
+            Some("ACGT")
         );
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -92,6 +92,8 @@ pub struct MultiFastaProvider {
     supplemental_cds: SupplementalCdsInfo,
     /// Authoritative canonical overrides (issue #520), loaded from the manifest.
     canonical_overrides: CanonicalOverrides,
+    /// Protein FASTA index (NP_/XP_ accessions) for get_protein_sequence (#520).
+    protein_index: HashMap<String, FastaIndexEntry>,
 }
 
 impl MultiFastaProvider {
@@ -164,6 +166,7 @@ impl MultiFastaProvider {
             cdot_mapper: None,
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
+            protein_index: HashMap::new(),
         })
     }
 
@@ -196,6 +199,7 @@ impl MultiFastaProvider {
             cdot_mapper: None,
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
+            protein_index: HashMap::new(),
         })
     }
 
@@ -387,6 +391,33 @@ impl MultiFastaProvider {
             }
         }
 
+        // Protein FASTAs (issue #520, edge 3): index NP_/XP_ sequences for
+        // get_protein_sequence — the translated-CDS-vs-canonical-protein check.
+        if let Some(protein_paths) = manifest.get("protein_fastas").and_then(|v| v.as_array()) {
+            for p in protein_paths.iter().filter_map(|v| v.as_str()) {
+                let path = resolve_path(p);
+                let fai = PathBuf::from(format!("{}.fai", path.display()));
+                if !path.exists() || !fai.exists() {
+                    eprintln!(
+                        "Warning: protein FASTA or its .fai is missing: {}",
+                        path.display()
+                    );
+                    continue;
+                }
+                match load_fai_index(&path, &fai) {
+                    Ok(idx) => provider.protein_index.extend(idx),
+                    Err(e) => eprintln!(
+                        "Warning: Failed to index protein FASTA {}: {}",
+                        path.display(),
+                        e
+                    ),
+                }
+            }
+            if !provider.protein_index.is_empty() {
+                eprintln!("Loaded {} protein sequences", provider.protein_index.len());
+            }
+        }
+
         // Canonical overrides (issue #520): load the authoritative-overrides
         // file and reconcile it into the cdot metadata so both the served
         // transcript and the projection path see the corrected CDS/protein.
@@ -476,6 +507,7 @@ impl MultiFastaProvider {
             cdot_mapper: Some(cdot_mapper),
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
+            protein_index: HashMap::new(),
         })
     }
 
@@ -1283,6 +1315,34 @@ impl MultiFastaProvider {
         // FASTA-backed branch and never the cdot-synthesis fallback.
         self.get_transcript_on_build(id, None)
     }
+
+    /// Run the translated-CDS-vs-canonical-protein check (#520, the strategy-B
+    /// depth tier) for each `(transcript_id, protein_accession)` pair, fetching
+    /// the served transcript and the canonical protein from this provider's
+    /// ingested protein FASTAs. Pairs whose transcript or protein is
+    /// unavailable are skipped — translation validation is best-effort
+    /// defense-in-depth, and protein data may not be ingested.
+    pub fn validate_translations(
+        &self,
+        pairs: &[(String, String)],
+    ) -> Vec<crate::reference::validate::TranscriptAnomaly> {
+        use crate::reference::validate::validate_translation_against_protein;
+        let mut anomalies = Vec::new();
+        for (tx_id, protein_acc) in pairs {
+            let Ok(tx) = self.get_transcript(tx_id) else {
+                continue;
+            };
+            // `0, u64::MAX` fetches the full protein (the index read clamps the
+            // end to the sequence length).
+            let Ok(protein) = self.get_protein_sequence(protein_acc, 0, u64::MAX) else {
+                continue;
+            };
+            if let Some(anomaly) = validate_translation_against_protein(&tx, &protein) {
+                anomalies.push(anomaly);
+            }
+        }
+        anomalies
+    }
 }
 
 impl ReferenceProvider for MultiFastaProvider {
@@ -1429,6 +1489,30 @@ impl ReferenceProvider for MultiFastaProvider {
     fn get_sequence_length(&self, id: &str) -> Result<u64, FerroError> {
         self.sequence_length(id)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })
+    }
+
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        // Exact versioned lookup only (no base-accession fallback) — a protein
+        // accession is version-specific and callers supply versioned accessions.
+        // (`MockProvider` does an unversioned fallback for testing; this
+        // provider deliberately does not.)
+        let entry = self.protein_index.get(accession).ok_or_else(|| {
+            FerroError::ProteinReferenceNotAvailable {
+                accession: accession.to_string(),
+                start,
+                end,
+            }
+        })?;
+        self.get_sequence_from_index(entry, start, end)
+    }
+
+    fn has_protein_data(&self) -> bool {
+        !self.protein_index.is_empty()
     }
 }
 
@@ -2862,5 +2946,53 @@ mod tests {
         let tx = provider.get_transcript_for_variant(&variant).unwrap();
         assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
         assert_eq!(tx.protein_id.as_deref(), Some("NP_OV.2"));
+    }
+
+    // --- protein FASTA ingestion (issue #520, edge 3) -----------------------
+
+    #[test]
+    fn get_protein_sequence_reads_from_protein_index() {
+        // build a FASTA entry, then move it into the protein index (a real file
+        // on disk backs it, so get_sequence_from_index can read it).
+        let (mut provider, _kept) = build_provider_with_transcripts(&[("NP_TEST.1", "MWAPLE")]);
+        let entry = provider.index.get("NP_TEST.1").unwrap().clone();
+        provider
+            .protein_index
+            .insert("NP_TEST.1".to_string(), entry);
+
+        assert!(provider.has_protein_data());
+        // `0, u64::MAX` fetches the full protein (read clamps end to length).
+        assert_eq!(
+            provider
+                .get_protein_sequence("NP_TEST.1", 0, u64::MAX)
+                .unwrap(),
+            "MWAPLE"
+        );
+        assert!(provider.get_protein_sequence("NP_NOPE.9", 0, 10).is_err());
+    }
+
+    #[test]
+    fn validate_translations_flags_mismatch_end_to_end() {
+        use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
+        use crate::reference::validate::AnomalyKind;
+        // NM_T.1 = ATG|TGG|TAA → "MW"; the canonical protein NP_T.1 = "MV".
+        let (mut provider, _kept) =
+            build_provider_with_transcripts(&[("NM_T.1", "ATGTGGTAA"), ("NP_T.1", "MV")]);
+        let np = provider.index.get("NP_T.1").unwrap().clone();
+        provider.protein_index.insert("NP_T.1".to_string(), np);
+        // The override gives NM_T.1 its CDS so the served transcript is coding.
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_T.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_T.1".to_string()),
+        });
+        provider.canonical_overrides = ov;
+
+        let found = provider.validate_translations(&[("NM_T.1".to_string(), "NP_T.1".to_string())]);
+        assert_eq!(found.len(), 1, "translated MW vs canonical MV → mismatch");
+        assert_eq!(found[0].kind, AnomalyKind::TranslationMismatch);
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -955,13 +955,13 @@ impl MultiFastaProvider {
     /// 1-based bounds are converted to cdot's 0-based start / 0-based-exclusive
     /// end convention.
     ///
-    /// Scope: gated on a FASTA index entry, so a transcript served only via
-    /// cdot-genome synthesis (no FASTA entry, the #331 path) is NOT reconciled
-    /// here even though the served-`Transcript` path
-    /// ([`apply_canonical_overrides_to`]) may still correct it. The corpus
-    /// targets (#520) are FASTA-backed, so this gap affects only
-    /// synthesis-backed transcripts; closing it (gating on the cdot exon-sum
-    /// length when no FASTA entry exists) is left as a follow-up.
+    /// Reconciles when the coordinates will index canonical bases: either the
+    /// served FASTA already has the authoritative length, OR the override
+    /// carries the canonical `sequence` (so the served bases are replaced on
+    /// read — this also covers a cdot-synthesis-only transcript with no FASTA
+    /// entry). A length-only FASTA match with no carried `sequence` still gates
+    /// on the FASTA index length. (cdot exons themselves are not rewritten —
+    /// the same exon-staleness caveat as the served-`Transcript` correction.)
     fn reconcile_cdot_with_overrides(&mut self) {
         use crate::data::cdot::CdotTranscript;
         if self.cdot_mapper.is_none() {
@@ -982,9 +982,12 @@ impl MultiFastaProvider {
                 let Some(cds_start_0based) = cds_start.checked_sub(1) else {
                     continue;
                 };
-                // Served FASTA length must match the authoritative length, else
-                // the coordinates index a different sequence.
-                if self.index.get(acc).map(|e| e.length) != Some(auth.tx_length) {
+                // Reconcile when the coordinates will apply to canonical bases:
+                // either the served FASTA already has the authoritative length,
+                // or the override carries the canonical `sequence` (so the
+                // served transcript's bases are replaced on read).
+                let served_matches = self.index.get(acc).map(|e| e.length) == Some(auth.tx_length);
+                if !served_matches && auth.sequence.is_none() {
                     continue;
                 }
                 // Require an *exact* cdot record for `acc`: `get_transcript`
@@ -2750,6 +2753,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2790,6 +2794,7 @@ mod tests {
             cds_start: Some(1), // authoritative 1-based
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2837,6 +2842,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2884,6 +2890,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2920,6 +2927,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
         let tx = provider.get_transcript_strict("NM_OV.2").unwrap();
@@ -2940,6 +2948,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
         let variant = crate::parse_hgvs("NM_OV.2:c.4C>A").unwrap();
@@ -2988,6 +2997,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_T.1".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -47,7 +47,7 @@ use crate::backtranslate::codon::{Codon, CodonTable};
 use crate::error::FerroError;
 use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
 use crate::reference::provider::ReferenceProvider;
-use crate::reference::transcript::Transcript;
+use crate::reference::transcript::{Exon, Transcript};
 
 /// The kind of structural anomaly found in a transcript record.
 ///
@@ -460,11 +460,20 @@ pub enum Correction {
         /// The authoritative `protein_id`.
         to: String,
     },
-    /// The served sequence length disagrees with the authoritative record, so
-    /// CDS/protein were **not** overridden — the authoritative coordinates
-    /// index a different-length sequence. The served *bases* themselves need
-    /// re-ingestion from the canonical record, which [`CanonicalOverrides`]
-    /// does not carry.
+    /// The served bases were **replaced** with the authoritative sequence — the
+    /// served sequence was the wrong length, or a same-length edit. Only
+    /// possible when the override carries the canonical `sequence`.
+    SequenceCorrected {
+        /// Served sequence length before correction (0 if coordinate-only).
+        from: u64,
+        /// Authoritative sequence length.
+        to: u64,
+    },
+    /// The served sequence length disagrees with the authoritative record AND
+    /// the override carries no canonical `sequence` to replace it with, so
+    /// CDS/protein were **not** overridden (the coordinates index a
+    /// different-length sequence). Fetch the canonical bases (carry `sequence`
+    /// in the overrides) to make this correctable.
     SequenceReingestionRequired {
         /// Served sequence length.
         served: u64,
@@ -483,14 +492,16 @@ pub enum Correction {
 /// authoritative record so downstream protein prediction translates the
 /// canonical reading frame.
 ///
-/// It deliberately does **not** touch the bases. When the served length
-/// disagrees with the authoritative length (the **wrong-sequence** class, e.g.
-/// `NM_000193.2` served at 4650 nt vs the canonical 1576), the authoritative
-/// coordinates do not apply to the served sequence, so no override is made and
-/// a [`Correction::SequenceReingestionRequired`] is reported instead — fixing
-/// that case needs the authoritative *bases*, which the overrides file does not
-/// carry. The served length is the sequence byte length, or, for a
-/// coordinate-only record, the exon-sum length.
+/// It also fixes the **wrong-sequence** class (e.g. `NM_000193.2` served at
+/// 4650 nt vs the canonical 1576) when the override carries the canonical
+/// `sequence`: the served bases are replaced ([`Correction::SequenceCorrected`])
+/// — this also catches a same-length-but-edited sequence (byte comparison, not
+/// just length). When the override carries **no** `sequence` and the served
+/// length disagrees with the authoritative length, the coordinates can't be
+/// applied safely, so nothing is overridden and a
+/// [`Correction::SequenceReingestionRequired`] is reported instead (carry the
+/// canonical bases to make it correctable). The served length is the sequence
+/// byte length, or, for a coordinate-only record, the exon-sum length.
 ///
 /// CDS and `protein_id` are corrected **together or not at all**: a corrected
 /// reading frame paired with a stale protein label (or vice versa) is more
@@ -500,9 +511,13 @@ pub enum Correction {
 ///
 /// # Limitations
 ///
-/// - **Same-length-but-edited** sequences are not detected: length equality is
-///   a proxy for base identity (the overrides carry no checksum), so a
-///   canonical-length sequence with point edits passes through as if canonical.
+/// - **Same-length-but-edited** sequences are only caught when the override
+///   carries the canonical `sequence` (byte comparison); without it, length
+///   equality is the only proxy and a same-length edit passes as canonical.
+/// - Replacing the bases does **not** rewrite the exon structure (the
+///   authoritative exon layout isn't carried). Protein prediction reads the CDS
+///   bases via `cds_start`/`cds_end`, so it is correct; genomic projection on a
+///   sequence-corrected transcript may be inconsistent with the stale exons.
 /// - This corrects only the served [`Transcript`]. The projection path also
 ///   reads the **cdot mapper's** parallel `protein`/CDS fields and prefers them,
 ///   so for full effect the wiring must reconcile the cdot record too (or route
@@ -530,27 +545,62 @@ pub fn apply_canonical_overrides(
     }
     let mut corrections = Vec::new();
 
-    // Served length: sequence byte length, else the exon-sum length for a
-    // coordinate-only record. If the served length disagrees with the
-    // authoritative length, the authoritative CDS coordinates index a
-    // different-length sequence — applying them would corrupt the reading
-    // frame (and could place `cds_end` out of range). Report that the sequence
-    // needs re-ingestion and leave the record untouched.
-    let served_len = tx.sequence.as_deref().map(|s| s.len() as u64).or_else(|| {
-        let sum: u64 = tx
-            .exons
-            .iter()
-            .map(|e| e.end.saturating_sub(e.start) + 1)
-            .sum();
-        (sum > 0).then_some(sum)
-    });
-    if let Some(served) = served_len {
-        if served != auth.tx_length {
-            corrections.push(Correction::SequenceReingestionRequired {
-                served,
-                authoritative: auth.tx_length,
+    // Sequence reconciliation:
+    // - If the override carries canonical bases, replace a non-canonical served
+    //   sequence (wrong-length OR same-length-but-edited) so the authoritative
+    //   coordinates apply to the right bases.
+    // - Otherwise fall back to the length gate: only proceed when the served
+    //   length matches the authoritative length (the coordinates would
+    //   otherwise index a different-length sequence); if not, report that the
+    //   canonical bases need to be carried/re-ingested and stop.
+    match auth.sequence.as_deref() {
+        Some(canonical) => {
+            // Compare case-insensitively: a soft-masked (lowercase) served
+            // sequence that is otherwise canonical is NOT a real edit, so don't
+            // report a spurious correction. Only genuine base differences (or a
+            // length difference) trigger a replacement.
+            let differs = tx
+                .sequence
+                .as_deref()
+                .is_none_or(|s| !s.eq_ignore_ascii_case(canonical));
+            if differs {
+                let from = tx.sequence.as_deref().map_or(0, |s| s.len() as u64);
+                let to = canonical.len() as u64;
+                corrections.push(Correction::SequenceCorrected { from, to });
+                tx.sequence = Some(canonical.to_string());
+                // A length-changing replacement leaves the exon structure (which
+                // tiled the old length) stale — e.g. it would trip the offline
+                // `LengthMismatch` check (served shorter than the exon extent).
+                // The authoritative exon layout isn't carried, and was wrong for
+                // a wrong-length record anyway, so collapse to a single exon
+                // spanning the corrected transcript (mRNA is contiguous in
+                // transcript space). Genomic projection on such a record is
+                // already out of scope (see the doc caveat).
+                if from != to {
+                    tx.exons = vec![Exon::new(1, 1, to)];
+                }
+            }
+        }
+        None => {
+            // Served length: sequence byte length, else the exon-sum length for
+            // a coordinate-only record.
+            let served_len = tx.sequence.as_deref().map(|s| s.len() as u64).or_else(|| {
+                let sum: u64 = tx
+                    .exons
+                    .iter()
+                    .map(|e| e.end.saturating_sub(e.start) + 1)
+                    .sum();
+                (sum > 0).then_some(sum)
             });
-            return corrections;
+            if let Some(served) = served_len {
+                if served != auth.tx_length {
+                    corrections.push(Correction::SequenceReingestionRequired {
+                        served,
+                        authoritative: auth.tx_length,
+                    });
+                    return corrections;
+                }
+            }
         }
     }
 
@@ -1011,6 +1061,7 @@ mod tests {
             cds_start: cds.map(|(s, _)| s),
             cds_end: cds.map(|(_, e)| e),
             protein_id: protein.map(str::to_string),
+            sequence: None,
         }
     }
 
@@ -1197,6 +1248,101 @@ mod tests {
         // Untouched: coordinates for the canonical 1576 nt would be wrong here.
         assert_eq!((tx.cds_start, tx.cds_end), (Some(342), Some(1730)));
         assert_eq!(tx.protein_id.as_deref(), Some("NP_000184.1"));
+    }
+
+    #[test]
+    fn correction_replaces_wrong_length_sequence_when_canonical_present() {
+        // Wrong-sequence class WITH canonical bases carried: the served 12 nt is
+        // replaced by the canonical 9 nt, then CDS/protein applied.
+        let mut tx = coding_tx("ATGAAATAAGGG", 1, 12);
+        tx.id = "NM_X.2".to_string();
+        tx.protein_id = Some("NP_OLD.1".to_string());
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_X.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_NEW.2".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(corrections
+            .iter()
+            .any(|c| matches!(c, Correction::SequenceCorrected { from: 12, to: 9 })));
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+        assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_NEW.2"));
+    }
+
+    #[test]
+    fn correction_replaces_same_length_edited_sequence() {
+        // Same length (9) but a point edit vs canonical → replaced (byte
+        // comparison, not just length).
+        let mut tx = coding_tx("ATGCAATAA", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(corrections
+            .iter()
+            .any(|c| matches!(c, Correction::SequenceCorrected { from: 9, to: 9 })));
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+    }
+
+    #[test]
+    fn sequence_corrected_transcript_has_no_self_inflicted_length_mismatch() {
+        // Served 12 nt (exons tile [1,12]); canonical is 9 nt. After correction
+        // the sequence is 9 nt; the offline length check must NOT flag a
+        // LengthMismatch (the exons are collapsed to the corrected length).
+        let mut tx = coding_tx("ATGAAATAAGGG", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        apply_canonical_overrides(&mut tx, &ov);
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+        let anomalies = validate_transcript_record(&tx);
+        assert!(
+            !anomalies
+                .iter()
+                .any(|a| a.kind == AnomalyKind::LengthMismatch),
+            "sequence-corrected transcript must not self-trip LengthMismatch: {anomalies:?}"
+        );
+    }
+
+    #[test]
+    fn lowercase_served_sequence_is_not_spuriously_corrected() {
+        // Served bases are canonical except for case (soft-masked); this must
+        // NOT be reported as a SequenceCorrected.
+        let mut tx = coding_tx("atgaaataa", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(
+            !corrections
+                .iter()
+                .any(|c| matches!(c, Correction::SequenceCorrected { .. })),
+            "case-only difference must not be a SequenceCorrected: {corrections:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Edge 3** of the canonical-validation effort (#520) — the **strategy-B depth tier**: translate the served CDS and compare it to the canonical protein, catching base-level non-canonical sequences (e.g. a same-length CDS with point edits) that the coordinate / length / `protein_id` checks miss. **Stacked on #528** (Edge 2).

- **`ferro prepare`** downloads the companion RefSeq `*.protein.faa.gz` files (same `mRNA_Prot/human.N` base as the RNA files), decompresses + indexes them, and records them in the manifest's new `protein_fastas` field.
- **`MultiFastaProvider`** gains a `protein_index` (loaded from `protein_fastas` in `from_manifest`) and implements **`get_protein_sequence`** / `has_protein_data` over it, reusing the existing FASTA index reader.
- **`MultiFastaProvider::validate_translations(pairs)`** makes Phase 4's `validate_translation_against_protein` *live*: fetches the served transcript + the canonical protein and reports `TranslationMismatch` (Advisory) on a divergence. `ferro check` displays the new manifest entry.

## Testing

2 new tests: `get_protein_sequence` reads from the protein index (real file-backed read); end-to-end translation mismatch (an override sets the CDS so the transcript is coding, the canonical protein differs → `TranslationMismatch`). `ferro`/`python`/`benchmark` compile; module suite green (56); `clippy --all-targets -D warnings` clean.

The `*.protein.faa.gz` **download** is the on-host network piece (gated inside `download_transcripts`); the ingestion, `get_protein_sequence`, and the translation wiring are unit-tested here.

Refs #520, #505.
