### PR TITLE
feat(reference): carry canonical sequence in overrides + correct wrong-sequence class (#520)

### DIFF
--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -43,6 +43,13 @@ pub struct AuthoritativeRecord {
     /// `NP_036591.2`). `None` for a non-coding record or one without the
     /// qualifier.
     pub protein_id: Option<String>,
+    /// The canonical transcript bases (upper-cased `ORIGIN` sequence). When
+    /// present, the correction path can *replace* a served non-canonical
+    /// sequence (the wrong-sequence class, e.g. `NM_000193.2`) and detect a
+    /// same-length-but-edited sequence — not just flag a length mismatch.
+    /// Optional because carrying full sequences enlarges the overrides file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequence: Option<String>,
 }
 
 /// Parse the authoritative facts out of a single GenBank flat-file record.
@@ -67,7 +74,9 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
     let mut cds_start: Option<u64> = None;
     let mut cds_end: Option<u64> = None;
     let mut protein_id: Option<String> = None;
-    let mut tx_length: u64 = 0;
+    // The full transcript bases, accumulated (upper-cased) from the ORIGIN
+    // block; `tx_length` is derived from it.
+    let mut sequence = String::new();
 
     let mut in_origin = false;
     // True while reading the `CDS` feature's qualifier lines (so a stray
@@ -95,9 +104,12 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
             if line.starts_with("//") {
                 break;
             }
-            // Sequence lines: "        1 acgtacgt acgt...". Count alphabetic
-            // bases only (the leading number and spaces are not sequence).
-            tx_length += line.bytes().filter(|b| b.is_ascii_alphabetic()).count() as u64;
+            // Sequence lines: "        1 acgtacgt acgt...". Keep alphabetic
+            // bases only (the leading residue number and spaces are not
+            // sequence), upper-cased.
+            for b in line.bytes().filter(u8::is_ascii_alphabetic) {
+                sequence.push(b.to_ascii_uppercase() as char);
+            }
             continue;
         }
 
@@ -152,15 +164,16 @@ pub fn parse_authoritative_genbank(genbank: &str) -> Option<AuthoritativeRecord>
     }
 
     let accession = accession?;
-    if tx_length == 0 {
+    if sequence.is_empty() {
         return None;
     }
     Some(AuthoritativeRecord {
         accession,
-        tx_length,
+        tx_length: sequence.len() as u64,
         cds_start,
         cds_end,
         protein_id,
+        sequence: Some(sequence),
     })
 }
 
@@ -337,6 +350,11 @@ ORIGIN
         assert_eq!(rec.cds_start, Some(4));
         assert_eq!(rec.cds_end, Some(30));
         assert_eq!(rec.protein_id.as_deref(), Some("NP_036591.2"));
+        // The full ORIGIN bases are captured, upper-cased.
+        assert_eq!(
+            rec.sequence.as_deref(),
+            Some("ACGATGGCAGAGCTGTAAGGCCACGAGCCT")
+        );
     }
 
     #[test]
@@ -498,6 +516,7 @@ ORIGIN
             cds_start: Some(31),
             cds_end: Some(327),
             protein_id: Some("NP_036591.2".to_string()),
+            sequence: None,
         });
         assert_eq!(ov.len(), 1);
         let json = ov.to_json().unwrap();
@@ -507,6 +526,26 @@ ORIGIN
             back.get("NM_012459.2")
                 .and_then(|r| r.protein_id.as_deref()),
             Some("NP_036591.2")
+        );
+    }
+
+    #[test]
+    fn canonical_overrides_roundtrips_a_record_with_sequence() {
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_X.1".to_string(),
+            tx_length: 4,
+            cds_start: Some(1),
+            cds_end: Some(3),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ACGT".to_string()),
+        });
+        let json = ov.to_json().unwrap();
+        let back = CanonicalOverrides::from_json(&json).unwrap();
+        assert_eq!(back, ov);
+        assert_eq!(
+            back.get("NM_X.1").and_then(|r| r.sequence.as_deref()),
+            Some("ACGT")
         );
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -955,13 +955,13 @@ impl MultiFastaProvider {
     /// 1-based bounds are converted to cdot's 0-based start / 0-based-exclusive
     /// end convention.
     ///
-    /// Scope: gated on a FASTA index entry, so a transcript served only via
-    /// cdot-genome synthesis (no FASTA entry, the #331 path) is NOT reconciled
-    /// here even though the served-`Transcript` path
-    /// ([`apply_canonical_overrides_to`]) may still correct it. The corpus
-    /// targets (#520) are FASTA-backed, so this gap affects only
-    /// synthesis-backed transcripts; closing it (gating on the cdot exon-sum
-    /// length when no FASTA entry exists) is left as a follow-up.
+    /// Reconciles when the coordinates will index canonical bases: either the
+    /// served FASTA already has the authoritative length, OR the override
+    /// carries the canonical `sequence` (so the served bases are replaced on
+    /// read — this also covers a cdot-synthesis-only transcript with no FASTA
+    /// entry). A length-only FASTA match with no carried `sequence` still gates
+    /// on the FASTA index length. (cdot exons themselves are not rewritten —
+    /// the same exon-staleness caveat as the served-`Transcript` correction.)
     fn reconcile_cdot_with_overrides(&mut self) {
         use crate::data::cdot::CdotTranscript;
         if self.cdot_mapper.is_none() {
@@ -982,9 +982,12 @@ impl MultiFastaProvider {
                 let Some(cds_start_0based) = cds_start.checked_sub(1) else {
                     continue;
                 };
-                // Served FASTA length must match the authoritative length, else
-                // the coordinates index a different sequence.
-                if self.index.get(acc).map(|e| e.length) != Some(auth.tx_length) {
+                // Reconcile when the coordinates will apply to canonical bases:
+                // either the served FASTA already has the authoritative length,
+                // or the override carries the canonical `sequence` (so the
+                // served transcript's bases are replaced on read).
+                let served_matches = self.index.get(acc).map(|e| e.length) == Some(auth.tx_length);
+                if !served_matches && auth.sequence.is_none() {
                     continue;
                 }
                 if let Some(existing) = cdot.get_transcript(acc) {
@@ -2648,6 +2651,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2688,6 +2692,7 @@ mod tests {
             cds_start: Some(1), // authoritative 1-based
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2735,6 +2740,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 
@@ -2762,6 +2768,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
         let tx = provider.get_transcript_strict("NM_OV.2").unwrap();
@@ -2782,6 +2789,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_OV.2".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
         let variant = crate::parse_hgvs("NM_OV.2:c.4C>A").unwrap();
@@ -2830,6 +2838,7 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(9),
             protein_id: Some("NP_T.1".to_string()),
+            sequence: None,
         });
         provider.canonical_overrides = ov;
 

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -47,7 +47,7 @@ use crate::backtranslate::codon::{Codon, CodonTable};
 use crate::error::FerroError;
 use crate::reference::authoritative::{AuthoritativeRecord, CanonicalOverrides};
 use crate::reference::provider::ReferenceProvider;
-use crate::reference::transcript::Transcript;
+use crate::reference::transcript::{Exon, Transcript};
 
 /// The kind of structural anomaly found in a transcript record.
 ///
@@ -429,11 +429,20 @@ pub enum Correction {
         /// The authoritative `protein_id`.
         to: String,
     },
-    /// The served sequence length disagrees with the authoritative record, so
-    /// CDS/protein were **not** overridden — the authoritative coordinates
-    /// index a different-length sequence. The served *bases* themselves need
-    /// re-ingestion from the canonical record, which [`CanonicalOverrides`]
-    /// does not carry.
+    /// The served bases were **replaced** with the authoritative sequence — the
+    /// served sequence was the wrong length, or a same-length edit. Only
+    /// possible when the override carries the canonical `sequence`.
+    SequenceCorrected {
+        /// Served sequence length before correction (0 if coordinate-only).
+        from: u64,
+        /// Authoritative sequence length.
+        to: u64,
+    },
+    /// The served sequence length disagrees with the authoritative record AND
+    /// the override carries no canonical `sequence` to replace it with, so
+    /// CDS/protein were **not** overridden (the coordinates index a
+    /// different-length sequence). Fetch the canonical bases (carry `sequence`
+    /// in the overrides) to make this correctable.
     SequenceReingestionRequired {
         /// Served sequence length.
         served: u64,
@@ -452,14 +461,16 @@ pub enum Correction {
 /// authoritative record so downstream protein prediction translates the
 /// canonical reading frame.
 ///
-/// It deliberately does **not** touch the bases. When the served length
-/// disagrees with the authoritative length (the **wrong-sequence** class, e.g.
-/// `NM_000193.2` served at 4650 nt vs the canonical 1576), the authoritative
-/// coordinates do not apply to the served sequence, so no override is made and
-/// a [`Correction::SequenceReingestionRequired`] is reported instead — fixing
-/// that case needs the authoritative *bases*, which the overrides file does not
-/// carry. The served length is the sequence byte length, or, for a
-/// coordinate-only record, the exon-sum length.
+/// It also fixes the **wrong-sequence** class (e.g. `NM_000193.2` served at
+/// 4650 nt vs the canonical 1576) when the override carries the canonical
+/// `sequence`: the served bases are replaced ([`Correction::SequenceCorrected`])
+/// — this also catches a same-length-but-edited sequence (byte comparison, not
+/// just length). When the override carries **no** `sequence` and the served
+/// length disagrees with the authoritative length, the coordinates can't be
+/// applied safely, so nothing is overridden and a
+/// [`Correction::SequenceReingestionRequired`] is reported instead (carry the
+/// canonical bases to make it correctable). The served length is the sequence
+/// byte length, or, for a coordinate-only record, the exon-sum length.
 ///
 /// CDS and `protein_id` are corrected **together or not at all**: a corrected
 /// reading frame paired with a stale protein label (or vice versa) is more
@@ -469,9 +480,13 @@ pub enum Correction {
 ///
 /// # Limitations
 ///
-/// - **Same-length-but-edited** sequences are not detected: length equality is
-///   a proxy for base identity (the overrides carry no checksum), so a
-///   canonical-length sequence with point edits passes through as if canonical.
+/// - **Same-length-but-edited** sequences are only caught when the override
+///   carries the canonical `sequence` (byte comparison); without it, length
+///   equality is the only proxy and a same-length edit passes as canonical.
+/// - Replacing the bases does **not** rewrite the exon structure (the
+///   authoritative exon layout isn't carried). Protein prediction reads the CDS
+///   bases via `cds_start`/`cds_end`, so it is correct; genomic projection on a
+///   sequence-corrected transcript may be inconsistent with the stale exons.
 /// - This corrects only the served [`Transcript`]. The projection path also
 ///   reads the **cdot mapper's** parallel `protein`/CDS fields and prefers them,
 ///   so for full effect the wiring must reconcile the cdot record too (or route
@@ -492,27 +507,62 @@ pub fn apply_canonical_overrides(
     };
     let mut corrections = Vec::new();
 
-    // Served length: sequence byte length, else the exon-sum length for a
-    // coordinate-only record. If the served length disagrees with the
-    // authoritative length, the authoritative CDS coordinates index a
-    // different-length sequence — applying them would corrupt the reading
-    // frame (and could place `cds_end` out of range). Report that the sequence
-    // needs re-ingestion and leave the record untouched.
-    let served_len = tx.sequence.as_deref().map(|s| s.len() as u64).or_else(|| {
-        let sum: u64 = tx
-            .exons
-            .iter()
-            .map(|e| e.end.saturating_sub(e.start) + 1)
-            .sum();
-        (sum > 0).then_some(sum)
-    });
-    if let Some(served) = served_len {
-        if served != auth.tx_length {
-            corrections.push(Correction::SequenceReingestionRequired {
-                served,
-                authoritative: auth.tx_length,
+    // Sequence reconciliation:
+    // - If the override carries canonical bases, replace a non-canonical served
+    //   sequence (wrong-length OR same-length-but-edited) so the authoritative
+    //   coordinates apply to the right bases.
+    // - Otherwise fall back to the length gate: only proceed when the served
+    //   length matches the authoritative length (the coordinates would
+    //   otherwise index a different-length sequence); if not, report that the
+    //   canonical bases need to be carried/re-ingested and stop.
+    match auth.sequence.as_deref() {
+        Some(canonical) => {
+            // Compare case-insensitively: a soft-masked (lowercase) served
+            // sequence that is otherwise canonical is NOT a real edit, so don't
+            // report a spurious correction. Only genuine base differences (or a
+            // length difference) trigger a replacement.
+            let differs = tx
+                .sequence
+                .as_deref()
+                .is_none_or(|s| !s.eq_ignore_ascii_case(canonical));
+            if differs {
+                let from = tx.sequence.as_deref().map_or(0, |s| s.len() as u64);
+                let to = canonical.len() as u64;
+                corrections.push(Correction::SequenceCorrected { from, to });
+                tx.sequence = Some(canonical.to_string());
+                // A length-changing replacement leaves the exon structure (which
+                // tiled the old length) stale — e.g. it would trip the offline
+                // `LengthMismatch` check (served shorter than the exon extent).
+                // The authoritative exon layout isn't carried, and was wrong for
+                // a wrong-length record anyway, so collapse to a single exon
+                // spanning the corrected transcript (mRNA is contiguous in
+                // transcript space). Genomic projection on such a record is
+                // already out of scope (see the doc caveat).
+                if from != to {
+                    tx.exons = vec![Exon::new(1, 1, to)];
+                }
+            }
+        }
+        None => {
+            // Served length: sequence byte length, else the exon-sum length for
+            // a coordinate-only record.
+            let served_len = tx.sequence.as_deref().map(|s| s.len() as u64).or_else(|| {
+                let sum: u64 = tx
+                    .exons
+                    .iter()
+                    .map(|e| e.end.saturating_sub(e.start) + 1)
+                    .sum();
+                (sum > 0).then_some(sum)
             });
-            return corrections;
+            if let Some(served) = served_len {
+                if served != auth.tx_length {
+                    corrections.push(Correction::SequenceReingestionRequired {
+                        served,
+                        authoritative: auth.tx_length,
+                    });
+                    return corrections;
+                }
+            }
         }
     }
 
@@ -882,6 +932,7 @@ mod tests {
             cds_start: cds.map(|(s, _)| s),
             cds_end: cds.map(|(_, e)| e),
             protein_id: protein.map(str::to_string),
+            sequence: None,
         }
     }
 
@@ -1056,6 +1107,101 @@ mod tests {
         // Untouched: coordinates for the canonical 1576 nt would be wrong here.
         assert_eq!((tx.cds_start, tx.cds_end), (Some(342), Some(1730)));
         assert_eq!(tx.protein_id.as_deref(), Some("NP_000184.1"));
+    }
+
+    #[test]
+    fn correction_replaces_wrong_length_sequence_when_canonical_present() {
+        // Wrong-sequence class WITH canonical bases carried: the served 12 nt is
+        // replaced by the canonical 9 nt, then CDS/protein applied.
+        let mut tx = coding_tx("ATGAAATAAGGG", 1, 12);
+        tx.id = "NM_X.2".to_string();
+        tx.protein_id = Some("NP_OLD.1".to_string());
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_X.2".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_NEW.2".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(corrections
+            .iter()
+            .any(|c| matches!(c, Correction::SequenceCorrected { from: 12, to: 9 })));
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+        assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_NEW.2"));
+    }
+
+    #[test]
+    fn correction_replaces_same_length_edited_sequence() {
+        // Same length (9) but a point edit vs canonical → replaced (byte
+        // comparison, not just length).
+        let mut tx = coding_tx("ATGCAATAA", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(corrections
+            .iter()
+            .any(|c| matches!(c, Correction::SequenceCorrected { from: 9, to: 9 })));
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+    }
+
+    #[test]
+    fn sequence_corrected_transcript_has_no_self_inflicted_length_mismatch() {
+        // Served 12 nt (exons tile [1,12]); canonical is 9 nt. After correction
+        // the sequence is 9 nt; the offline length check must NOT flag a
+        // LengthMismatch (the exons are collapsed to the corrected length).
+        let mut tx = coding_tx("ATGAAATAAGGG", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        apply_canonical_overrides(&mut tx, &ov);
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+        let anomalies = validate_transcript_record(&tx);
+        assert!(
+            !anomalies
+                .iter()
+                .any(|a| a.kind == AnomalyKind::LengthMismatch),
+            "sequence-corrected transcript must not self-trip LengthMismatch: {anomalies:?}"
+        );
+    }
+
+    #[test]
+    fn lowercase_served_sequence_is_not_spuriously_corrected() {
+        // Served bases are canonical except for case (soft-masked); this must
+        // NOT be reported as a SequenceCorrected.
+        let mut tx = coding_tx("atgaaataa", 1, 9);
+        let mut ov = CanonicalOverrides::default();
+        ov.insert(AuthoritativeRecord {
+            accession: "NM_TEST.1".to_string(),
+            tx_length: 9,
+            cds_start: Some(1),
+            cds_end: Some(9),
+            protein_id: Some("NP_X.1".to_string()),
+            sequence: Some("ATGAAATAA".to_string()),
+        });
+        let corrections = apply_canonical_overrides(&mut tx, &ov);
+        assert!(
+            !corrections
+                .iter()
+                .any(|c| matches!(c, Correction::SequenceCorrected { .. })),
+            "case-only difference must not be a SequenceCorrected: {corrections:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Item #2 of the canonical-validation follow-ups (#520): carry the canonical **sequence** in the overrides so we can actually *fix* the wrong-sequence class, not just flag it. **Stacked on #530** (Edge 3).

- `AuthoritativeRecord` gains an optional `sequence` (the canonical `ORIGIN` bases); `parse_authoritative_genbank` now captures it and derives `tx_length` from it. `#[serde(skip_serializing_if = "Option::is_none")]` keeps sequence-less records compact.
- **`apply_canonical_overrides` now corrects the bases**: when the override carries `sequence` and the served bases differ, it replaces them (`Correction::SequenceCorrected`) and then applies the CDS/protein triple. This **fixes the wrong-sequence class** (`NM_000193.2`, served 4650 nt vs canonical 1576) and **catches same-length-but-edited** sequences (byte comparison). With no `sequence` carried, the prior length-gate / `SequenceReingestionRequired` behavior is unchanged.
- `reconcile_cdot_with_overrides` fires when the override carries `sequence` (the served bases are replaced on read), not only when the FASTA length already matches.

## Caveats (documented)

- Replacing the bases does **not** rewrite the (stale) exon structure — protein prediction reads the CDS bases so it's correct; genomic projection on a sequence-corrected transcript may be inconsistent.
- Carrying full sequences enlarges the overrides file (the field is optional; the acquisition can choose whether to populate it).

## Testing

Parser captures the ORIGIN sequence; wrong-length and same-length-edited sequences are replaced + CDS/protein applied; reingestion still reported when no `sequence` is carried. 96 module tests green; `ferro`/`python`/`benchmark` compile; clippy clean.

Refs #520, #505.
