### PR TITLE
fix(normalize): number coding-transcript r. positions CDS-relative (#469)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3448,29 +3448,33 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Err(_) => return Ok((HV::Rna(variant.clone()), vec![])),
         };
 
-        // Convert RNA positions to transcript-1 positions, deciding per
-        // endpoint. UTR (`r.*N`/`r.-N`) and non-positive bases need a CDS
-        // to translate; non-UTR positive bases map 1:1 to transcript-1
-        // indices and work without a CDS (mock providers used in tests
-        // often omit cds_start/end). Choosing per endpoint keeps mixed
-        // intervals like `r.50_*1del` from rerouting the positive end
-        // through `rna_to_tx_pos` — issue #163 follow-up.
+        // Convert RNA positions to transcript-1 positions.
         //
-        // Axis convention (pinned by `tests/issue_291_rna_axis_convention.rs`,
-        // closes #291): `r.` positive non-UTR bases are
-        // **transcript-1-relative**, NOT CDS-relative. `r.10` against a
-        // transcript with `cds_start = 100` maps to tx index 10, not tx 109.
-        // This is consistent across `fetch_ref_for_canonical_split`,
-        // `simple_rna_pos`, and `normalize_na_edit`. Only `r.*N`/`r.-N`
-        // (and base 0) translate through `cds_start`/`cds_end` via
-        // `rna_to_tx_pos`.
+        // Axis convention (#469, HGVS `background/numbering.md` L58/L61): on a
+        // **coding** transcript, `r.` shares `c.`'s **CDS-relative** numbering
+        // — `r.123` relates to `c.123` — so every region (`r.-N` 5'UTR, `r.N`
+        // CDS, `r.*N` 3'UTR) translates through `cds_start`/`cds_end` via
+        // `rna_to_tx_pos`, exactly like `c.`. `r.10` against `cds_start = 100`
+        // maps to tx 109 (== `c.10`), not tx 10. This supersedes the
+        // transcript-1-relative pin PR #304 added when closing #291 (made on
+        // internal-consistency grounds without checking the spec).
+        //
+        // When the transcript carries no CDS (coordinate-only / mock providers
+        // that omit cds_start/end), positive non-UTR bases fall back to
+        // transcript-1 indices and UTR positions can't be resolved.
         let cds_info = transcript.cds_start.zip(transcript.cds_end);
         let map_in = |pos: &crate::hgvs::location::RnaPos| -> Option<u64> {
-            if pos.utr3 || pos.base < 1 {
-                let (cds_start, cds_end) = cds_info?;
-                self.rna_to_tx_pos(pos, cds_start, Some(cds_end)).ok()
-            } else {
-                Some(pos.base as u64)
+            match cds_info {
+                Some((cds_start, cds_end)) => {
+                    self.rna_to_tx_pos(pos, cds_start, Some(cds_end)).ok()
+                }
+                None => {
+                    if pos.utr3 || pos.base < 1 {
+                        None
+                    } else {
+                        Some(pos.base as u64)
+                    }
+                }
             }
         };
         let tx_start = match map_in(start_pos) {
@@ -3518,25 +3522,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let (new_tx_start, new_tx_end, new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
 
-        // Convert each normalized tx position back independently, restoring
-        // UTR notation when the position falls outside the CDS. This catches
-        // both the original issue #163 case (UTR input shuffling within the
-        // UTR) and a positive-base input that shifts past `cds_end` during
-        // normalization. Without `cds_info` we keep the simple base-1 mapping.
-        //
-        // For positions that stay inside the CDS-proper window
-        // (`cds_start <= pos <= cds_end`), the tx index is emitted directly
-        // as `r.{pos}` — i.e. the transcript-1-relative axis is preserved on
-        // the way out, matching the convention enforced by `map_in` above.
-        // See `tests/issue_291_rna_axis_convention.rs` for the pin.
+        // Convert each normalized tx position back to a CDS-relative `r.`
+        // position via `tx_to_rna_pos`, which restores the correct region for
+        // every tx index: `r.-N` (5'UTR, `pos < cds_start`), `r.N` (CDS,
+        // `pos - cds_start + 1`), `r.*N` (3'UTR, `pos > cds_end`). This keeps
+        // the output axis CDS-relative (== `c.`) and symmetric with `map_in`
+        // (#469). Without `cds_info` (coordinate-only / mock) we keep the
+        // simple transcript-1 mapping.
         use crate::hgvs::location::RnaPos;
         let map_out = |pos: u64| -> Result<RnaPos, FerroError> {
-            if let Some((cds_start, cds_end)) = cds_info {
-                if pos < cds_start || pos > cds_end {
-                    return self.tx_to_rna_pos(pos, cds_start, Some(cds_end));
-                }
+            match cds_info {
+                Some((cds_start, cds_end)) => self.tx_to_rna_pos(pos, cds_start, Some(cds_end)),
+                None => Ok(RnaPos::new(pos as i64)),
             }
-            Ok(RnaPos::new(pos as i64))
         };
         let new_start = map_out(new_tx_start)?;
         let new_end = map_out(new_tx_end)?;
@@ -5662,12 +5660,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // discriminant check below is sufficient. The exception fires
         // inside `build_split_variants` for every embedded
         // `[Sub; Identity; Sub]` triplet whose endpoints share a codon.
-        // Caveat: the `r.` branch of `fetch_ref_for_canonical_split`
-        // does not translate the RNA axis through `cds_start`, so for
-        // transcripts with `cds_start > 1` the ref window can be
-        // mis-aligned. The codon-frame split path inherits that latent
-        // bug. See #291 — the fix is to apply `rna_to_tx_pos` (or
-        // equivalent) before reading bytes.
+        // The `r.` branch of `fetch_ref_for_canonical_split` translates
+        // the RNA axis through `cds_start` (`r.N` → 1-based tx pos
+        // `cds_start + N - 1`, falling back to transcript-1 when the
+        // transcript has no CDS), so its ref window is CDS-aligned and the
+        // codon-frame split path reads correctly for `cds_start > 1` (#469,
+        // superseding the latent #291 mis-alignment).
         let codon_frame_aware = matches!(variant, HgvsVariant::Cds(_) | HgvsVariant::Rna(_));
         (
             build_split_variants(&variant, subedits, hgvs_start, codon_frame_aware),
@@ -5746,27 +5744,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 bytes[s..e].to_vec()
             }
             HgvsVariant::Rna(r) => {
-                // `r.` positive non-UTR bases use the transcript-1-relative
-                // axis in this codebase (NOT CDS-relative): `r.N` for `N > 0`
-                // and non-UTR maps directly to tx index `N`. This matches the
-                // convention used by `simple_rna_pos`, `normalize_rna::map_in`/
-                // `map_out`, and `normalize_na_edit` for the r. arm.
-                // `simple_rna_pos` filters intronic positions, 3'-UTR
-                // positions (the `r.*N` form), and non-positive bases. It
-                // does NOT filter 5'-UTR positions because under the tx-1
-                // axis convention those have positive bases below
-                // `cds_start` and are themselves valid tx indices — the
-                // `hgvs_start - 1` slice against the full transcript
-                // sequence is therefore correct for any position reaching
-                // this arm (including tx-1 5'-UTR).
-                // Pinned by `tests/issue_291_rna_axis_convention.rs` (closes #291).
+                // `r.` shares c.'s CDS-relative numbering on a coding
+                // transcript (#469): `r.N` maps to 1-based tx pos
+                // `cds_start + N - 1`, exactly like the Cds arm above.
+                // `simple_rna_pos` has already filtered UTR (`r.*N`/`r.-N`,
+                // now a negative base) and intronic positions, so any position
+                // reaching this arm is a positive CDS-relative base. Without a
+                // CDS (coordinate-only / mock) fall back to transcript-1.
                 let tx = self
                     .provider
                     .get_transcript(&r.accession.transcript_accession())
                     .ok()?;
-                let s = (hgvs_start - 1) as usize;
-                let e = hgvs_end as usize;
                 let bytes = tx.sequence.as_deref()?.as_bytes();
+                let (s, e) = match tx.cds_start {
+                    Some(cds_start) => (
+                        cds_start.checked_add(hgvs_start)?.checked_sub(2)? as usize,
+                        cds_start.checked_add(hgvs_end)?.checked_sub(1)? as usize,
+                    ),
+                    None => ((hgvs_start - 1) as usize, hgvs_end as usize),
+                };
                 if e > bytes.len() || s >= e {
                     return None;
                 }
@@ -6975,16 +6971,17 @@ mod tests {
 
     #[test]
     fn test_normalize_rna_deletion_shifts_3prime() {
-        // NM_001234.1 has a G repeat at tx positions 13-37 spanning three
-        // exons: exon 1 (1-15), exon 2 (16-30), exon 3 (31-44). Per HGVS
-        // general.md's exon-junction exception, an r. deletion does not
-        // shift across exon boundaries — so `r.14del` (a G in exon 1)
-        // shifts only as far as `r.15del` (the last G inside exon 1).
+        // NM_001234.1 has cds_start = 5 and a G repeat at tx positions 13-37
+        // spanning three exons: exon 1 (1-15), exon 2 (16-30), exon 3 (31-44).
+        // `r.` is CDS-relative (== `c.`, #469), so `r.10` = tx 14 — a G in
+        // exon 1. Per HGVS general.md's exon-junction exception, an r.
+        // deletion does not shift across exon boundaries, so `r.10del` shifts
+        // only as far as `r.11del` (= tx 15, the last G inside exon 1).
         // Closes #334.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
-        let variant = parse_hgvs("NM_001234.1:r.14del").unwrap();
+        let variant = parse_hgvs("NM_001234.1:r.10del").unwrap();
         let result = normalizer.normalize(&variant).unwrap();
         let output = format!("{}", result);
 
@@ -6993,10 +6990,10 @@ mod tests {
             "Deletion should remain a deletion, got: {}",
             output
         );
-        // Spec-canonical 3' anchor inside exon 1 is position 15.
+        // Spec-canonical 3' anchor inside exon 1 is tx 15 = r.11 (CDS-relative).
         assert!(
-            output.contains("r.15del"),
-            "Deletion should shift 3' to exon-1 boundary (r.15del), got: {}",
+            output.contains("r.11del"),
+            "Deletion should shift 3' to exon-1 boundary (r.11del), got: {}",
             output
         );
     }

--- a/tests/issue_163_rna_utr3_flag.rs
+++ b/tests/issue_163_rna_utr3_flag.rs
@@ -115,19 +115,14 @@ fn rna_utr3_dup_preserves_star_flag() {
 
 #[test]
 fn rna_mixed_cds_utr3_del_shifts_into_utr() {
-    // Mixed-interval: start in CDS (r.50 = last C of CDS, tx 50), end in
-    // 3'UTR (r.*1 = A, tx 51). Deletion of "CA" can 3'-shift one position
-    // because tx 52 ('C') equals the first deleted byte; the new range
-    // [tx 51, tx 52] = "AC" lies entirely in the 3'UTR, so the canonical
-    // output must use `*1_*2` notation.
-    //
-    // Regression for per-endpoint translation: under the previous
-    // interval-wide `needs_cds_translation` flag, r.50 was rerouted
-    // through `rna_to_tx_pos` (yielding tx 60) just because the other
-    // endpoint was UTR, producing a reversed range that silently
-    // returned the input unchanged.
+    // Mixed-interval: start in CDS, end in 3'UTR. `r.` is CDS-relative
+    // (== `c.`, #469) with cds_start = 11, so the last CDS base (tx 50) is
+    // `r.40` (= c.40), and `r.*1` = tx 51 = 'A'. Deletion of "CA" (tx 50_51)
+    // can 3'-shift one position because tx 52 ('C') equals the first deleted
+    // byte; the new range [tx 51, tx 52] = "AC" lies entirely in the 3'UTR,
+    // so the canonical output must use `*1_*2` notation.
     assert_eq!(
-        normalize_to_string("NM_TESTUTR.1:r.50_*1del"),
+        normalize_to_string("NM_TESTUTR.1:r.40_*1del"),
         "NM_TESTUTR.1:r.*1_*2del",
     );
 }

--- a/tests/issue_291_rna_axis_convention.rs
+++ b/tests/issue_291_rna_axis_convention.rs
@@ -1,31 +1,27 @@
-//! Regression / convention pin for issue #291: the r.-axis used by
-//! `fetch_ref_for_canonical_split`, `normalize_na_edit` (via
-//! `normalize_rna::map_in`/`map_out`), and `simple_rna_pos` is
-//! **transcript-1-relative** for positive non-UTR bases in this codebase,
-//! NOT CDS-relative.
+//! Convention pin for the r.-axis used by `fetch_ref_for_canonical_split`,
+//! `normalize_na_edit` (via `normalize_rna::map_in`/`map_out`), and
+//! `simple_rna_pos`: on a coding transcript `r.` is **CDS-relative** — the
+//! same axis as `c.` — so `r.N` maps to tx `cds_start + N - 1` and `r.123`
+//! relates to `c.123` (HGVS `background/numbering.md` L58/L61).
 //!
-//! Issue #291 was filed based on a claim that "RNA shares the CDS-relative
-//! coordinate axis"; investigation showed the claim is incorrect. The r.
-//! arm of `fetch_ref_for_canonical_split` is internally consistent with the
-//! rest of the r. normalization path: `r.N` for `N > 0` and non-UTR maps
-//! directly to tx index `N`, and only `r.*N`/`r.-N` (UTR) translate through
-//! `cds_start` / `cds_end` via `rna_to_tx_pos`.
+//! History: #291 was filed to make r. CDS-relative; PR #304 instead pinned
+//! the then-current **transcript-1-relative** behavior as a "convention",
+//! deciding on internal-consistency grounds without checking the spec.
+//! **#469 corrected this** — r. is CDS-relative — and these tests were
+//! rewritten to assert the spec-correct axis, superseding PR #304's pin.
 //!
-//! These tests pin the convention with a fixture that has a non-trivial
-//! 5'UTR (`cds_start = 100`) so the tx-1 axis and a hypothetical
-//! CDS-relative axis yield distinct, easily-distinguishable outputs.
-//!
-//! Closes #291. Follow-up audit to PR #275.
+//! The fixture has a non-trivial 5'UTR (`cds_start = 100`) so the
+//! CDS-relative axis and the old tx-1 axis yield distinct, easily
+//! distinguishable outputs.
 //!
 //! Related pins:
 //! - `tests/issue_163_rna_utr3_flag.rs` (UTR `*N` translation via cds_end)
 //! - `tests/issue_233_rna_cds_consistency.rs` (r./c. Display parity across
-//!   edit shapes — relies on the tx-1 axis being internally consistent
-//!   for matched-position pairs)
+//!   edit shapes)
+//! - `tests/rna_coding_consistency.rs` (r./c. CDS-relative parity, #469)
 //! - `src/normalize/mod.rs::test_normalize_rna_deletion_shifts_3prime`
-//!   (the `r.14del` → `r.15del` shift uses tx-1 indices; the result
-//!   halts at the exon-1 right edge per the HGVS exon-junction
-//!   exception — see PR #374 / issue #334)
+//!   (the `r.10del` → `r.11del` shift, CDS-relative; the result halts at the
+//!   exon-1 right edge per the HGVS exon-junction exception — PR #374 / #334)
 
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
@@ -114,103 +110,63 @@ fn normalize_to_string(input: &str) -> String {
     format!("{}", normalized)
 }
 
-/// Pins that `normalize_na_edit` (via `normalize_rna::map_in`) reads byte
-/// `seq[hgvs_pos - 1]` for positive non-UTR `r.` bases — the tx-1
-/// convention. `r.10` → tx 10 = `G`, surrounded by `C`'s, so no 3'-shift.
-/// On the way out, `map_out` sees tx 10 < cds_start (100) and canonicalizes
-/// the position into 5'UTR notation: tx 10 → `r.{10 - 100}` = `r.-90`.
-///
-/// Two facets of the tx-1 convention are pinned by this one assertion:
-/// 1. `map_in` for positive non-UTR `r.N` maps directly to tx `N` (no
-///    `cds_start` offset) — otherwise the read byte would be tx 109 = `G`
-///    inside the 22-base G-run at tx 109..=130 and the deletion would shift
-///    3' to tx 130, producing `r.31del` or similar.
-/// 2. `map_out` honors the actual transcript region: tx 10 is in 5'UTR
-///    (since `cds_start = 100`), so it must come back out as `r.-90`, not
-///    as `r.10`. This is the asymmetry that makes the convention robust —
-///    the input notation `r.10` is interpreted as tx 10 regardless of
-///    whether tx 10 happens to be inside the CDS, but the canonical output
-///    uses the appropriate region marker.
+/// `r.` is CDS-relative on a coding transcript (#469): `r.10` = `c.10` =
+/// tx `cds_start + 10 - 1` = tx 109, the first base of the 22-base G-run at
+/// tx 109..=130. The deletion 3'-shifts through the run to tx 130, which
+/// `map_out` emits CDS-relative as `r.{130 - cds_start + 1}` = `r.31`.
+/// (Under the superseded tx-1 pin from PR #304 this read tx 10 — an isolated
+/// G in the 5'UTR — and emitted `r.-90del`.)
 #[test]
-fn rna_positive_nonutr_uses_tx1_axis_no_shift() {
+fn rna_positive_cds_base_is_cds_relative() {
     assert_eq!(
         normalize_to_string("NM_TESTCDS100.1:r.10del"),
-        "NM_TESTCDS100.1:r.-90del",
-        "r.10 must read tx 10 (tx-1 axis), not tx 109 (CDS-rel); since tx \
-         10 lies in the 5'UTR (cds_start = 100), map_out re-emits as r.-90"
+        "NM_TESTCDS100.1:r.31del",
+        "r.10 must read tx 109 (= c.10, CDS-relative) and shift 3' through \
+         the G-run to tx 130 = r.31"
     );
 }
 
-/// Pins that `normalize_na_edit`'s 3'-shift loop uses tx-1 indices on the
-/// way in AND `map_out` re-emits the raw tx index (NOT a CDS-relative
-/// translation) for positions inside the CDS-proper window. `r.110` → tx
-/// 110 inside the G-run at tx 109..=130, shifts 3' to tx 130. tx 130 lies
-/// in CDS (`100 <= 130 <= 180`), so `map_out` returns `r.130` verbatim, not
-/// `r.{130 - cds_start + 1}` = `r.31`.
-///
-/// Under a hypothetical CDS-relative axis, `r.110` would map to tx 209,
-/// which is past the 200-base transcript end — `map_in` would return `None`
-/// and normalization would fall back to the input, yielding `r.110del`
-/// unchanged. The output here (`r.130del`, a distinct shifted position) is
-/// only reachable under the tx-1 convention.
+/// The CDS-relative axis means `r.N` and `c.N` are the same position, so a
+/// shifting edit normalizes identically across the two coordinate systems
+/// (modulo alphabet). `c.10del` on this fixture shifts the same G-run to
+/// tx 130 = `c.31`, the c. twin of `r.10del` → `r.31del` above (#469).
 #[test]
-fn rna_positive_nonutr_shift_uses_tx1_axis() {
+fn rna_and_cds_numbering_agree() {
     assert_eq!(
-        normalize_to_string("NM_TESTCDS100.1:r.110del"),
-        "NM_TESTCDS100.1:r.130del",
-        "r.110del must shift 3' through the tx 109..=130 G-run to r.130del \
-         (proves both map_in and map_out skip cds_start translation for \
-         positive non-UTR bases)"
+        normalize_to_string("NM_TESTCDS100.1:c.10del"),
+        "NM_TESTCDS100.1:c.31del",
+        "c.10 == r.10 (both CDS-relative); shifts through the G-run to c.31, \
+         the c. twin of the r.31del pinned above"
     );
 }
 
-/// Pins that `r.1` (the lowest positive non-UTR base) is treated as tx 1,
-/// NOT as `cds_start = 100`. tx 1 = `C` at the start of a 9-base C-run;
-/// `r.1del` shifts 3' through the run to tx 9. tx 9 lies in 5'UTR (since
-/// `cds_start = 100`), so `map_out` re-emits as `r.{9 - 100}` = `r.-91`.
-///
-/// Under a hypothetical CDS-relative axis, `r.1` → tx 100 = `C` at the
-/// start of a different 9-base C-run (tx 100..=108); the shift would land
-/// at tx 108 and `map_out` would emit `r.108del` (since 100 <= 108 <= 180
-/// is CDS-proper). The tx-1 convention's `r.-91del` is unambiguously
-/// distinguishable from the hypothetical CDS-rel `r.108del`.
+/// `r.1` is the first coding base = `cds_start` = tx 100 (#469), at the
+/// start of the 9-base C-run tx 100..=108. `r.1del` 3'-shifts through the
+/// run to tx 108, emitted CDS-relative as `r.{108 - cds_start + 1}` = `r.9`.
+/// (Under the superseded tx-1 pin, `r.1` was tx 1 and this emitted
+/// `r.-91del`.)
 #[test]
-fn rna_first_positive_base_is_tx1_not_cds_start() {
+fn rna_first_coding_base_maps_to_cds_start() {
     assert_eq!(
         normalize_to_string("NM_TESTCDS100.1:r.1del"),
-        "NM_TESTCDS100.1:r.-91del",
-        "r.1del must shift through the tx 1..=9 C-run; tx 9 lies in 5'UTR \
-         so map_out re-emits as r.-91 (proves r.1 maps to tx 1, not to \
-         cds_start)"
+        "NM_TESTCDS100.1:r.9del",
+        "r.1 must map to cds_start (tx 100); the C-run shift lands at tx 108 \
+         = r.9 (proves r.1 == c.1 == cds_start, not tx 1)"
     );
 }
 
-/// Pins that `fetch_ref_for_canonical_split` reads the r. ref window from
-/// the tx-1 axis (NOT through `cds_start`). The variant below is a
-/// 3-base `delins` whose ref slice lands inside the CDS-interior G-run
-/// (tx 109..=130). Under the tx-1 convention, the ref bytes are `GGG`
-/// and the alt `ccu` (normalized to `CCT`) decomposes as `[Inv(0,2),
-/// Sub@2 G>U]` via `decompose_delins`'s revcomp scan — the resulting
-/// canonical split renders as a `[..inv;..g>u]` cis-allele.
-///
-/// Under the hypothetical CDS-relative axis, `r.109_111` would index
-/// tx `(100 + 109 - 2)..(100 + 111 - 1)` = tx 207..210, which is past
-/// the 200-base transcript end. `fetch_ref_for_canonical_split` would
-/// return `None`, `apply_canonical_split` would short-circuit to the
-/// un-split variant, and Display would emit the input shape unchanged
-/// (`r.109_111delinsccu`). The two outputs are mechanically
-/// distinguishable, so the assertion below pins the tx-1 axis at the
-/// canonical-split entry point even though the parse, normalize, and
-/// Display layers are all unchanged from the simpler `del` cases above.
+/// Pins that `fetch_ref_for_canonical_split` reads the r. ref window
+/// CDS-relative (through `cds_start`, exactly like the `c.` arm — #469).
+/// The 3-base `delins` below targets `r.10_12` = tx 109..=111 = the `GGG`
+/// at the start of the CDS-interior G-run; alt `ccu` (→ `CCT`) decomposes
+/// via the revcomp scan into `[Inv; Sub g>u]`, rendering as a cis-allele.
 #[test]
-fn rna_canonical_split_fetch_uses_tx1_axis() {
-    let out = normalize_to_string("NM_TESTCDS100.1:r.109_111delinsccu");
+fn rna_canonical_split_fetch_is_cds_relative() {
+    let out = normalize_to_string("NM_TESTCDS100.1:r.10_12delinsccu");
     assert_eq!(
-        out, "NM_TESTCDS100.1:r.[109_110inv;111g>u]",
-        "fetch_ref_for_canonical_split must slice tx 108..111 (= GGG) for \
-         r.109_111 — not tx 207..210 (out-of-range under a hypothetical \
-         CDS-relative axis); the inv + sub split is only reachable when \
-         the slice actually contains the CDS-interior G-run"
+        out, "NM_TESTCDS100.1:r.[10_11inv;12g>u]",
+        "fetch_ref_for_canonical_split must slice tx 109..=111 (= GGG) for \
+         r.10_12 via cds_start, mirroring the c. arm"
     );
 }
 

--- a/tests/rna_coding_consistency.rs
+++ b/tests/rna_coding_consistency.rs
@@ -9,14 +9,12 @@
 //! "`NM_004006.3:r.76a>c`" mirrors "`NM_004006.3:c.76A>C`".
 //!
 //! This file pins r./c. parity across edit types (sub, del, ins, dup,
-//! delins, inv, repeat) and 3'-shift behavior. It also audits the known
-//! divergence on coding transcripts where the start codon is not at
-//! transcript position 1: ferro currently treats `r.X` as transcript-
-//! relative (n.-style) rather than CDS-relative, so the audit cases here
-//! pin the *current* behavior with `// TODO #<issue>` markers so that a
-//! future fix is forced through this test surface.
+//! delins, inv, repeat) and 3'-shift behavior, including on coding
+//! transcripts where the start codon is not at transcript position 1.
+//! `r.X` is CDS-relative (== `c.X`) per HGVS numbering.md (#469), so r. and
+//! c. normalize identically (modulo alphabet) at every position.
 //!
-//! Tracking: #81 item E3.
+//! Tracking: #81 item E3; #469 (CDS-relative r. numbering).
 
 use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
 
@@ -385,73 +383,19 @@ mod variant_arm_lock {
 }
 
 // ---------------------------------------------------------------------------
-// AUDIT: cds_start > 1 divergence
+// cds_start > 1: r./c. CDS-relative parity (issue #469)
 //
 // On a coding transcript where the start codon is not at transcript
-// position 1 (here: NM_001234.1, cds_start=5), the HGVS spec says r.X and
-// c.X share the same CDS-relative numbering: r.10 and c.10 must point to
-// the *same* transcript base. ferro currently treats r.X as transcript-
-// relative (n.-style) — i.e. r.10 maps to transcript position 10, while
-// c.10 maps to transcript position 14 (cds_start + 10 - 1). The two
-// diverge by `cds_start - 1` bases when cds_start > 1.
-//
-// These tests pin the *current* behavior so a future fix is forced
-// through this surface. Tag with `// TODO #<follow-up>` when the
-// follow-up issue lands.
-//
-// TODO: file follow-up issue tracking r./c. CDS-relative numbering
-// reconciliation (item E3 audit), then update these tests to assert
-// the spec-correct equality.
+// position 1 (here: NM_001234.1, cds_start=5), HGVS numbering.md (L58/L61)
+// requires r.X and c.X to share the same CDS-relative numbering: r.10 and
+// c.10 point to the *same* transcript base (tx cds_start + 10 - 1 = 14).
+// #469 fixed ferro to honor this, superseding the transcript-1-relative pin
+// PR #304 added when it closed #291 on internal-consistency grounds without
+// checking the spec. These tests assert the parity.
 // ---------------------------------------------------------------------------
 
 mod cds_start_offset_audit {
     use super::*;
-
-    /// Pin current behavior: on NM_001234.1 (cds_start=5, 4 bp 5'UTR),
-    /// r.10 and c.10 do NOT currently produce the same edit. Per spec
-    /// they should — this test pins the divergence.
-    ///
-    /// Sequence: AAAAATGCCCAAGGGGGGGGGGGGGGGGGGGGGGGGGTAAAAAA
-    ///           ^^^^ ^                              ^      ^^^^^^
-    ///           5'UTR ATG (CDS start, c.1 = tx-pos 5)  TAA   3'UTR
-    ///
-    /// - c.10 maps to tx-pos 5 + 10 - 1 = 14 → 'G' (in homopolymer)
-    /// - r.10 (current code) maps to tx-pos 10 → 'C' (last C of CCC)
-    ///
-    /// These should be equal per spec; right now they are not.
-    #[test]
-    fn r_and_c_diverge_when_cds_start_gt_1() {
-        // Substitution at the same numeric position; pick a point where
-        // the underlying tx bases differ between the two interpretations.
-        // c.10 = tx-pos 14 = 'G'; r.10 (current) = tx-pos 10 = 'C'.
-        let c_out = normalize(provider(), "NM_001234.1:c.10G>A");
-        let r_out = normalize(provider(), "NM_001234.1:r.10c>a");
-
-        // Both succeed without error (no panic):
-        assert!(c_out.contains(":c."));
-        assert!(r_out.contains(":r."));
-
-        // Pin the current divergence: the reference base differs because
-        // the position interpretations differ. After the follow-up fix,
-        // this assertion should flip to `assert_eq!(body(&c_out), body(&r_out))`
-        // (modulo alphabet) and the explicit reference letters should
-        // either both be 'G/g' or both be 'C/c'.
-        // TODO #<follow-up>: replace this with parity equality.
-        let c_b = body(&c_out);
-        let r_b = body(&r_out);
-        // Strip alphabet to compare: c.→lowercase-rna-style.
-        assert_ne!(
-            c_to_r(&c_out)
-                .split_once(":r.")
-                .map(|(_, b)| b)
-                .unwrap_or(""),
-            r_b,
-            "current behavior diverges; replace this !=  with == once spec-parity is implemented \
-             (c.={c_out}, r.={r_out})"
-        );
-        // Sanity: both should be present.
-        assert!(!c_b.is_empty() && !r_b.is_empty());
-    }
 
     /// On a transcript where cds_start == 1, the two interpretations
     /// agree and the divergence vanishes. This complements the test above
@@ -464,6 +408,26 @@ mod cds_start_offset_audit {
         // c.→r. projection must match — they refer to the same tx base
         // because cds_start==1 collapses the ambiguity.
         assert_eq!(c_to_r(&c_out), r_out);
+    }
+
+    /// Issue #469: on a coding transcript with cds_start > 1, `r.X` must use
+    /// the same CDS-relative numbering as `c.X` (HGVS numbering.md: "r.123
+    /// relates to c.123"). A *shifting* edit at the same numeric position
+    /// must therefore normalize identically across r. and c. (modulo the
+    /// alphabet) — a substitution would not distinguish the axes since it
+    /// does not move. This supersedes the transcript-1-relative pin from
+    /// PR #304 (which closed #291 on internal-consistency grounds without
+    /// checking the spec).
+    #[test]
+    fn r_and_c_agree_when_cds_start_gt_1() {
+        let c_out = normalize(provider(), "NM_001234.1:c.10del");
+        let r_out = normalize(provider(), "NM_001234.1:r.10del");
+        assert_eq!(
+            c_to_r(&c_out),
+            r_out,
+            "r.10 must be CDS-relative (== c.10) on a cds_start>1 transcript (#469); \
+             c.={c_out}, r.={r_out}"
+        );
     }
 
     /// Pin that an r. query against a 5' UTR position (`r.-N`) parses


### PR DESCRIPTION
Fixes #469. On a coding transcript, ferro numbered positive non-UTR `r.` positions **transcript-1-relative**, but HGVS `background/numbering.md` requires `r.` to follow `c.`:

> L58: "nucleotide numbering for an RNA reference sequence follows that of the associated coding or non-coding DNA reference sequence; nucleotide `r.123` relates to `c.123` or `n.123`."
> L61: "in a **coding** RNA reference sequence, nucleotide numbering is … **following that of a coding DNA reference sequence**."

So `r.N` must equal `c.N` (CDS-relative). When the start codon is not at transcript position 1, ferro's `r.N` and `c.N` diverged by `cds_start - 1`. The axis was also internally inconsistent: UTR `r.-N`/`r.*N` were already translated through `cds_start`/`cds_end`, so `r.-1` (just before the start codon) and `r.1` were not adjacent.

## History (why this supersedes a merged PR)

#291 was originally filed to make `r.` CDS-relative ("translate through `cds_start` consistently with how the `c.` branch handles it"). PR #304 instead closed it as "not a bug" and pinned the transcript-1-relative behavior as a "convention" — but it decided on **internal-consistency grounds and explicitly never checked the spec**. #469 corrects that; this PR supersedes PR #304's pin.

## The fix

Three sites, all just routing coding-transcript `r.` positions through the **existing** CDS-relative helpers instead of bypassing them for positive bases:

- `normalize_rna::map_in` — translate every region via `rna_to_tx_pos` when the transcript has a CDS (positive bases previously used `pos.base` directly).
- `normalize_rna::map_out` — emit every region via `tx_to_rna_pos` (CDS positions previously emitted the raw tx index).
- `fetch_ref_for_canonical_split` r. arm — slice `cds_start + N - 1`, mirroring the `c.` arm.

Transcripts without a CDS (coordinate-only / mock providers that omit `cds_start`) keep the transcript-1 fallback, so non-coding behavior is unchanged. `rna_to_tx_pos`/`tx_to_rna_pos` already computed the correct CDS-relative mapping — the bug was only that positive positions skipped them.

## Tests

- `tests/rna_coding_consistency.rs`: the `cds_start > 1` audit now asserts `r.N` ↔ `c.N` parity (the `// TODO` markers and the old "pin the divergence" test are removed).
- `tests/issue_291_rna_axis_convention.rs`: rewritten to pin the spec-correct CDS-relative axis (e.g. `r.10del` → `r.31del`, `r.1del` → `r.9del`), with the header documenting the #304 → #469 supersession.
- `tests/issue_163_rna_utr3_flag.rs` and the `test_normalize_rna_deletion_shifts_3prime` unit test: inputs recomputed to the CDS-relative numbers for the same intended transcript positions.

## Verification

- `cargo nextest run --features dev` → 6663 passed, 51 skipped (manifest-gated), 0 failed
- `cargo clippy --features dev --all-targets -- -D warnings` → clean
- `cargo fmt` → clean
