### PR TITLE
test(biocommons): mirror the improvement conformance disposition (#503)

### DIFF
--- a/docs/CONFORMANCE_HARNESS_DESIGN.md
+++ b/docs/CONFORMANCE_HARNESS_DESIGN.md
@@ -57,14 +57,16 @@ Five pillars. (1) and (2) are the high-value core and are independently shippabl
 Each case in `cases.json` carries, **per axis** (direction × cross), an explicit disposition instead of a bare line in a side file:
 
 - `match` *(default)* — ferro must equal the upstream `normalized` value. A mismatch fails the test.
-- `accepted_divergence { reason, spec_citation, ferro_output }` — ferro is intentionally different. The harness asserts ferro produces **exactly `ferro_output`** (the divergence is *pinned*, not merely "anything ≠ upstream"), and surfaces `reason` + `spec_citation` in failure output.
+- `accepted_divergence { reason, spec_citation, ferro_output }` — ferro is intentionally and **terminally** different (both forms are spec-allowed); ferro will not converge. The harness asserts ferro produces **exactly `ferro_output`** (the divergence is *pinned*, not merely "anything ≠ upstream"), and surfaces `reason` + `spec_citation` in failure output.
 - `known_bug { tracking_issue, ferro_output }` — ferro is wrong, xfail until fixed. The harness asserts ferro still produces the recorded buggy `ferro_output`.
+- `improvement { tracking_issue, section, ferro_output }` — ferro's output is valid HGVS but not the spec-*preferred* canonical form; `normalize()` should converge once `tracking_issue` lands. The middle disposition between `accepted_divergence` (terminal) and `known_bug` (wrong). Like `known_bug` it is an xfail and XPASS-guarded, but it requires a `section` citation substantiating why ferro's current form is non-preferred. (Added in #501 for mutalyzer; mirrored into the biocommons harness in #503.)
+- `spec_citation { section }` *(mutalyzer harness; documentary)* — records that the upstream expected value in `cases.json` was corrected to ferro's spec-correct value, with the `section` that arbitrates it. Has no effect on tally bucketing (the corrected expectation makes the case a normal `match`).
 
 The flat `baseline-failures/*.txt` file is deleted (or becomes a generated, checked view — §5).
 
 ### 2. XPASS detection — the self-correcting mechanism
 
-For a `known_bug` axis, if ferro's output **starts matching** the upstream `normalized` value (or stops matching the recorded buggy `ferro_output`), the harness **fails loudly**:
+For a `known_bug` or `improvement` axis, if ferro's output **starts matching** the upstream `normalized` value (or stops matching the recorded `ferro_output`), the harness **fails loudly**:
 
 > `known_bug for NM_001166478.1:c.36_37insTC (#473) now matches upstream — the bug appears fixed. Remove the annotation and demote the row.`
 
@@ -149,8 +151,10 @@ The loader **validates each annotation against these invariants before any compa
   | `match` *(default; may be implicit — an axis with no annotation is `match`)* | none | `reason`, `spec_citation`, `ferro_output`, `tracking_issue` (a `match` axis has no divergence to describe) |
   | `accepted_divergence` | `reason`, `spec_citation`, `ferro_output` | `tracking_issue` (an accepted divergence is not a bug and has no owning issue) |
   | `known_bug` | `tracking_issue`, `ferro_output` | `reason`, `spec_citation` (the tracking issue is the source of truth for the why) |
+  | `improvement` | `tracking_issue`, `section`, `ferro_output` | `reason` (the `section` + tracking issue substantiate it) |
+  | `spec_citation` *(documentary)* | `section` | `ferro_output`, `tracking_issue` (no divergence is pinned — the corrected expectation makes it a `match`) |
 
-- **Types.** `tracking_issue` is a positive integer; `ferro_output`, `reason`, `spec_citation`, and `upstream` are non-empty strings; `disposition` is one of the three enum values above.
+- **Types.** `tracking_issue` is a positive integer; `ferro_output`, `reason`, `spec_citation`, `section`, and `upstream` are non-empty strings; `disposition` is one of the enum values above.
 - **Reference identity.** Each case's `reference` block requires `accession` and `length`; `spot_check.pos` (if present) is a pure **1-based sequence offset** into the pinned reference window — an index into the reference bases, independent of the HGVS `input` text and its coordinate system (it is *not* an interpretation of HGVS expressions, intronic forms, or offset coordinates). It must satisfy `1 <= pos <= length`, and the window's bases must fit: `pos + len(bases) - 1 <= length`. The provider's underlying string is indexed `0`-based, so the loader reads from offset `pos - 1`. `spot_check.pos` and the HGVS coordinates in `input` are independent; they often coincide for simple coding cases — e.g. `pos: 36` aligns with `c.36_37insTC` — but `spot_check.pos` is never derived from or interpreted as an HGVS token.
 
 `AxisTally::record` becomes annotation-aware: it looks up the disposition for `(case, axis)`, **validates the case entry against the invariants above**, compares ferro's actual output against the right expectation, and classifies the result as pass / fail / **xpass** (the §2 loud failure) — surfacing any validation error distinctly from a comparison failure.

--- a/src/conformance/biocommons.rs
+++ b/src/conformance/biocommons.rs
@@ -79,6 +79,17 @@ impl Fixture {
                         Some(*tracking_issue),
                         cluster.clone(),
                     ),
+                    Disposition::Improvement {
+                        ferro_output,
+                        tracking_issue,
+                        cluster,
+                        ..
+                    } => (
+                        DispositionKind::Improvement,
+                        Some(ferro_output.clone()),
+                        Some(*tracking_issue),
+                        cluster.clone(),
+                    ),
                 };
                 Some(MemberRow {
                     cluster,
@@ -163,6 +174,26 @@ pub enum Disposition {
         #[serde(default)]
         cluster: Option<String>,
     },
+    /// ferro's output is valid HGVS but not the spec-*preferred* canonical
+    /// form; `normalize()` should converge on the preferred form once
+    /// `tracking_issue` lands. The middle disposition between
+    /// `AcceptedDivergence` (terminal policy — both forms equally spec-allowed)
+    /// and `KnownBug` (ferro is wrong). Like `KnownBug` it is an xfail and
+    /// XPASS-guarded — if ferro converges to biocommons the harness fails
+    /// loudly — but unlike `KnownBug` it requires a `section` citation
+    /// substantiating why ferro's current form is non-preferred. Mirrors the
+    /// mutalyzer `improvement` disposition (#501).
+    Improvement {
+        /// Issue tracking the convergence to the spec-preferred form.
+        tracking_issue: u64,
+        /// HGVS spec section establishing ferro's current form as non-preferred.
+        section: String,
+        /// The (spec-non-preferred) output ferro currently produces.
+        ferro_output: String,
+        /// Root-cause cluster id (see the corpus `clusters` registry).
+        #[serde(default)]
+        cluster: Option<String>,
+    },
 }
 
 impl Disposition {
@@ -170,7 +201,8 @@ impl Disposition {
     pub fn cluster(&self) -> Option<&str> {
         match self {
             Disposition::AcceptedDivergence { cluster, .. }
-            | Disposition::KnownBug { cluster, .. } => cluster.as_deref(),
+            | Disposition::KnownBug { cluster, .. }
+            | Disposition::Improvement { cluster, .. } => cluster.as_deref(),
         }
     }
 }
@@ -208,6 +240,25 @@ mod tests {
         assert_eq!(row.ferro_output.as_deref(), Some("Z"));
         assert_eq!(row.tracking_issue, Some(472));
         assert_eq!(row.cluster.as_deref(), Some("panic"));
+    }
+
+    #[test]
+    fn improvement_cluster_ref_and_summary_are_preserved() {
+        let clusters = r#"{"id":"pref","title":"preferred form","spec_section":"x"}"#;
+        let disp = r#"{"kind":"improvement","tracking_issue":503,"section":"HGVS §x",
+                       "ferro_output":"Z","cluster":"pref"}"#;
+        let fixture = parse(clusters, disp);
+        assert_eq!(fixture.cluster_refs(), vec![("X", "pref")]);
+        assert!(fixture.validate_clusters().is_ok());
+
+        let summary = fixture.to_summary();
+        assert_eq!(summary.rows.len(), 1);
+        let row = &summary.rows[0];
+        assert_eq!(row.kind, DispositionKind::Improvement);
+        assert_eq!(row.axis, "normalized");
+        assert_eq!(row.ferro_output.as_deref(), Some("Z"));
+        assert_eq!(row.tracking_issue, Some(503));
+        assert_eq!(row.cluster.as_deref(), Some("pref"));
     }
 
     #[test]

--- a/tests/biocommons_normalize_tests.rs
+++ b/tests/biocommons_normalize_tests.rs
@@ -300,6 +300,8 @@ enum RecordOutcome {
     AcceptedDivergence,
     /// ferro diverges exactly as an annotated known bug (xfail).
     KnownBug,
+    /// ferro diverges exactly as an annotated tracked improvement (xfail).
+    Improvement,
     /// A failure that must break the suite.
     Fail(FailKind),
 }
@@ -312,6 +314,9 @@ enum FailKind {
     /// A `known_bug` row now matches biocommons — the bug appears fixed (XPASS);
     /// remove the annotation and demote the row.
     KnownBugFixed,
+    /// An `improvement` row now matches biocommons — ferro converged to the
+    /// spec-preferred form (XPASS); remove the annotation and demote the row.
+    ImprovementConverged,
     /// An `accepted_divergence` row now matches biocommons — the divergence is
     /// gone; remove the annotation.
     AcceptedDivergenceGone,
@@ -324,6 +329,7 @@ impl FailKind {
         match self {
             FailKind::Unannotated => "UNANNOTATED",
             FailKind::KnownBugFixed => "XPASS",
+            FailKind::ImprovementConverged => "XPASS",
             FailKind::AcceptedDivergenceGone => "XPASS",
             FailKind::AnnotationDrift => "DRIFT",
         }
@@ -359,6 +365,15 @@ fn classify_outcome(
                 RecordOutcome::Fail(FailKind::AnnotationDrift)
             }
         }
+        Some(Disposition::Improvement { ferro_output, .. }) => {
+            if matches_upstream {
+                RecordOutcome::Fail(FailKind::ImprovementConverged)
+            } else if actual_str == Some(ferro_output.as_str()) {
+                RecordOutcome::Improvement
+            } else {
+                RecordOutcome::Fail(FailKind::AnnotationDrift)
+            }
+        }
         Some(Disposition::AcceptedDivergence { ferro_output, .. }) => {
             if matches_upstream {
                 RecordOutcome::Fail(FailKind::AcceptedDivergenceGone)
@@ -379,6 +394,9 @@ struct AxisTally {
     accepted: usize,
     /// Annotated known bugs (xfail) still producing their recorded output.
     known_bug: usize,
+    /// Annotated tracked improvements (xfail) still producing their recorded
+    /// spec-non-preferred output.
+    improvement: usize,
     fail: Vec<(String, String)>,
     skipped: usize,
 }
@@ -390,6 +408,7 @@ impl AxisTally {
             pass: 0,
             accepted: 0,
             known_bug: 0,
+            improvement: 0,
             fail: Vec::new(),
             skipped: 0,
         }
@@ -406,6 +425,7 @@ impl AxisTally {
             RecordOutcome::Match => self.pass += 1,
             RecordOutcome::AcceptedDivergence => self.accepted += 1,
             RecordOutcome::KnownBug => self.known_bug += 1,
+            RecordOutcome::Improvement => self.improvement += 1,
             RecordOutcome::Fail(kind) => {
                 let got = match &actual {
                     Ok(s) => format!("got={s:?}"),
@@ -420,6 +440,13 @@ impl AxisTally {
                     ) => format!(
                         " — known_bug #{tracking_issue} now matches biocommons; the fix appears \
                          to have landed: remove the annotation and demote the row"
+                    ),
+                    (
+                        FailKind::ImprovementConverged,
+                        Some(Disposition::Improvement { tracking_issue, .. }),
+                    ) => format!(
+                        " — improvement #{tracking_issue} now matches biocommons; ferro converged \
+                         to the spec-preferred form: remove the annotation and demote the row"
                     ),
                     (
                         FailKind::AcceptedDivergenceGone,
@@ -458,12 +485,13 @@ impl AxisTally {
         let _ = fs::write(&tsv_path, &tsv);
 
         println!(
-            "{}: {} pass / {} accepted-divergence / {} known-bug / {} FAIL / {} skipped \
-             (FAIL inputs -> {})",
+            "{}: {} pass / {} accepted-divergence / {} known-bug / {} improvement / {} FAIL / \
+             {} skipped (FAIL inputs -> {})",
             self.axis,
             self.pass,
             self.accepted,
             self.known_bug,
+            self.improvement,
             self.fail.len(),
             self.skipped,
             report_path.display()
@@ -575,6 +603,15 @@ mod classify_outcome_tests {
         }
     }
 
+    fn improvement(ferro_output: &str) -> Disposition {
+        Disposition::Improvement {
+            tracking_issue: 500,
+            section: "HGVS §RefSeqGene transcript selection".to_string(),
+            ferro_output: ferro_output.to_string(),
+            cluster: None,
+        }
+    }
+
     #[test]
     fn no_disposition_match_is_match() {
         assert_eq!(
@@ -631,6 +668,47 @@ mod classify_outcome_tests {
     }
 
     #[test]
+    fn improvement_producing_recorded_output_is_improvement() {
+        // ferro still produces the recorded spec-non-preferred output →
+        // accounted xfail (tracked to convergence).
+        assert_eq!(
+            classify_outcome(
+                "c.12_13dup",
+                &ok("c.13_14dup"),
+                Some(&improvement("c.13_14dup"))
+            ),
+            RecordOutcome::Improvement
+        );
+    }
+
+    #[test]
+    fn improvement_now_matching_upstream_is_xpass_fail() {
+        // A converged improvement must fail loudly so it can't linger — the
+        // same XPASS keystone as known_bug.
+        assert_eq!(
+            classify_outcome(
+                "c.12_13dup",
+                &ok("c.12_13dup"),
+                Some(&improvement("c.13_14dup"))
+            ),
+            RecordOutcome::Fail(FailKind::ImprovementConverged)
+        );
+    }
+
+    #[test]
+    fn improvement_drifted_output_is_drift_fail() {
+        // ferro's output changed to a third value → annotation is stale.
+        assert_eq!(
+            classify_outcome(
+                "c.12_13dup",
+                &ok("c.11_12dup"),
+                Some(&improvement("c.13_14dup"))
+            ),
+            RecordOutcome::Fail(FailKind::AnnotationDrift)
+        );
+    }
+
+    #[test]
     fn accepted_divergence_producing_recorded_output_is_accepted() {
         assert_eq!(
             classify_outcome(
@@ -673,6 +751,18 @@ mod classify_outcome_tests {
         let err: Result<String, String> = Err("normalize error: boom".to_string());
         assert_eq!(
             classify_outcome("c.5dup", &err, Some(&known_bug("c.4_5dup"))),
+            RecordOutcome::Fail(FailKind::AnnotationDrift)
+        );
+    }
+
+    #[test]
+    fn improvement_error_is_drift_fail() {
+        // An annotated improvement that records a concrete ferro_output but now
+        // errors is drift — a normalize failure must not be silently absorbed
+        // into the improvement xfail bucket.
+        let err: Result<String, String> = Err("normalize error: boom".to_string());
+        assert_eq!(
+            classify_outcome("c.12_13dup", &err, Some(&improvement("c.13_14dup"))),
             RecordOutcome::Fail(FailKind::AnnotationDrift)
         );
     }


### PR DESCRIPTION
Closes #503. Mirrors the `improvement` conformance disposition — added to the **mutalyzer** harness in #501 — into the **biocommons** harness, so the two corpora keep a lockstep disposition vocabulary (#484 deliberately shares it).

> **Stacked on #538 (#509).** That PR moved the biocommons corpus schema into `src/conformance/biocommons.rs`; this PR builds on it. Review/merge #538 first. The diff here is against the #538 branch.

## What it adds

- **`Disposition::Improvement { tracking_issue, section, ferro_output, cluster }`** on the biocommons enum (`src/conformance/biocommons.rs`). Like the mutalyzer `improvement`, it requires both a `tracking_issue` and a `section` citation (the spec line establishing ferro's current form as non-preferred).
- Harness wiring in `tests/biocommons_normalize_tests.rs`, mirroring `known_bug`'s xfail mechanics exactly:
  - `RecordOutcome::Improvement` and `FailKind::ImprovementConverged` (XPASS).
  - The `classify_outcome` arm: still-diverging → `Improvement` (accounted xfail); converged to upstream → loud XPASS failure; drifted → `AnnotationDrift`.
  - `AxisTally` gains an `improvement` bucket, record routing, the actionable XPASS detail message, and a summary-line count.
- Three hermetic unit tests covering the accounted / XPASS / drift outcomes (run in CI, no manifest).
- The full disposition vocabulary (`accepted_divergence` / `known_bug` / `improvement` / `spec_citation`) is folded into `docs/CONFORMANCE_HARNESS_DESIGN.md` (the §1 list, the XPASS section, and the required/forbidden-fields table) — the doc previously described only the original three.

## Note on scope

No biocommons corpus row uses the `improvement` bucket yet — biocommons has zero seeded dispositions, and seeding is the manifest-gated follow-up tracked by #325. Per #503 this is the deliberate **proactive lockstep** addition (the issue allows either "first PR that needs it" or proactive parity); the bucket is exercised by the hermetic unit tests so it is not dead code.

## Verification

- `cargo nextest run --features dev -E 'binary(biocommons_normalize_tests) or test(conformance::)'` → all pass (incl. the 3 new tests)
- `cargo clippy --features dev --all-targets -- -D warnings` → clean
- `cargo fmt` → clean
