### PR TITLE
feat(parser): parse the and/or `^` operator (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1446,6 +1446,101 @@ pub(crate) fn split_top_level_slashes(input: &str, want_double: bool) -> Vec<&st
     chunks
 }
 
+/// Find the first top-level `^` (and/or) separator in `input`, or `None`.
+///
+/// "Top level" means bracket depth 0 with respect to *both* `[ ]`
+/// allele brackets and `( )` uncertainty/grouping parens. The latter
+/// matters because `^` also appears *inside* parens as a within-edit
+/// alternative (`c.(370A>C^372C>R)`, `p.(Gly56Ala^Ser^Cys)`); those are
+/// part of a single description and must NOT be mistaken for a
+/// description-joining and/or operator. Only a `^` outside all brackets
+/// and parens joins full descriptions (`ACC1:c.A^ACC2:c.B`).
+pub(crate) fn find_top_level_caret(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut depth: i32 = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'[' | b'(' => depth += 1,
+            b']' | b')' => depth -= 1,
+            b'^' if depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Bracket/paren-depth-aware top-level split on the `^` (and/or)
+/// separator. Mirrors `str::split('^')` but respects `[ ]` and `( )`
+/// nesting. Empty chunks are preserved; callers reject them.
+pub(crate) fn split_top_level_carets(input: &str) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut s = input;
+    loop {
+        match find_top_level_caret(s) {
+            Some(pos) => {
+                chunks.push(&s[..pos]);
+                s = &s[pos + 1..];
+            }
+            None => {
+                chunks.push(s);
+                break;
+            }
+        }
+    }
+    chunks
+}
+
+/// Detect a whole-edit and/or group wrapped in an uncertainty marker,
+/// i.e. `<prefix>(<inner>)` where `<inner>` carries a top-level `^`
+/// (e.g. `NM_004006.2:c.(370A>C^372C>R)`). Returns `(prefix, inner)`,
+/// where `prefix` is the accession + coordinate-type stem (ending in
+/// `.`, e.g. `NM_004006.2:c.`) and `inner` is the `^`-joined edit list.
+///
+/// The matching `(` is found by scanning back from the final `)`, so an
+/// accession-internal paren like `GRCh38(chr1):g.(...)` is not mistaken
+/// for the uncertainty wrapper. Returns `None` unless the input ends in
+/// `)`, the matched `(` is preceded by a `.`, and the inner content has
+/// a top-level `^`. Residue-level alternatives that do not span whole
+/// edits (e.g. `p.(Gly56Ala^Ser^Cys)`) also match this shape; the
+/// caller's per-operand `parse_variant` then rejects the bare-residue
+/// operands, leaving those forms for separate residue-level handling.
+pub(crate) fn find_uncertain_and_or_group(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim();
+    let bytes = input.as_bytes();
+    if bytes.last() != Some(&b')') {
+        return None;
+    }
+    // Find the `(` matching the final `)` by reverse depth scan.
+    let mut depth: i32 = 0;
+    let mut open: Option<usize> = None;
+    for i in (0..bytes.len()).rev() {
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' => {
+                depth -= 1;
+                if depth == 0 {
+                    open = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    let prefix = &input[..open];
+    // The uncertainty wrapper opens immediately after the coordinate
+    // type stem (`g.`, `c.`, `p.`, …), so the char before `(` is `.`.
+    if !prefix.ends_with('.') {
+        return None;
+    }
+    let inner = &input[open + 1..input.len() - 1];
+    if find_top_level_caret(inner).is_some() {
+        Some((prefix, inner))
+    } else {
+        None
+    }
+}
+
 /// Result of `scan_allele_separators`: top-level depth-0 allele-separator
 /// flags plus the depth-aware members.
 #[derive(Debug)]
@@ -5144,6 +5239,85 @@ fn parse_chimeric_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     parse_phase_allele(input, AllelePhase::Chimeric)
 }
 
+/// Parse a top-level and/or allele: full descriptions joined by `^`
+/// (HGVS general.md, "variant A and/or variant B"). Each operand is a
+/// complete description and may carry its own accession (possibly
+/// across references, e.g. `NM_000517.4:c.424C>T^NM_000558.3:c.424C>T`),
+/// so each chunk is parsed via the full `parse_variant`. Unlike the
+/// mosaic/chimeric drivers, there is no inherited-accession or compact
+/// fallback — and/or operands are written out in full.
+fn parse_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let input = input.trim();
+    let chunks = split_top_level_carets(input);
+    if chunks.len() < 2 {
+        return Err(FerroError::Parse {
+            pos: 0,
+            msg: "And/or allele requires '^' separator".to_string(),
+            diagnostic: None,
+        });
+    }
+
+    let mut variants: Vec<HgvsVariant> = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        let chunk = chunk.trim();
+        if chunk.is_empty() {
+            return Err(FerroError::Parse {
+                pos: 0,
+                msg: "Empty operand in and/or allele".to_string(),
+                diagnostic: None,
+            });
+        }
+        variants.push(parse_variant(chunk)?);
+    }
+
+    Ok(HgvsVariant::Allele(AlleleVariant::new(
+        variants,
+        AllelePhase::AndOr,
+    )))
+}
+
+/// Parse a whole-edit and/or group wrapped in an uncertainty marker:
+/// `<prefix>(<edit1>^<edit2>^…)`, e.g. `NM_004006.2:c.(370A>C^372C>R)`.
+/// Each operand is a bare position+edit sharing the accession + coord
+/// type given by `prefix`, so each is reconstructed as `<prefix><edit>`
+/// and parsed via the full `parse_variant`. The resulting allele is
+/// marked uncertain so the surrounding `(...)` round-trips.
+fn parse_uncertain_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let (prefix, inner) = find_uncertain_and_or_group(input).ok_or_else(|| FerroError::Parse {
+        pos: 0,
+        msg: "Not an uncertain and/or group".to_string(),
+        diagnostic: None,
+    })?;
+
+    let operands = split_top_level_carets(inner);
+    if operands.len() < 2 {
+        return Err(FerroError::Parse {
+            pos: 0,
+            msg: "Uncertain and/or group requires '^' separator".to_string(),
+            diagnostic: None,
+        });
+    }
+
+    let mut variants: Vec<HgvsVariant> = Vec::with_capacity(operands.len());
+    for operand in operands {
+        let operand = operand.trim();
+        if operand.is_empty() {
+            return Err(FerroError::Parse {
+                pos: 0,
+                msg: "Empty operand in uncertain and/or group".to_string(),
+                diagnostic: None,
+            });
+        }
+        let full = format!("{}{}", prefix, operand);
+        variants.push(parse_variant(&full)?);
+    }
+
+    Ok(HgvsVariant::Allele(AlleleVariant::new_uncertain(
+        variants,
+        AllelePhase::AndOr,
+    )))
+}
+
 /// Whether a chunk-level `parse_variant` error carries a structured
 /// `Diagnostic.code` — i.e. it's a semantic violation that
 /// `parse_phase_allele`'s syntactic-recovery fallback chain should
@@ -5582,6 +5756,21 @@ fn detect_allele_type(input: &str) -> Option<&'static str> {
         }
     }
 
+    // Check for and/or: full descriptions joined by a top-level `^`
+    // (outside all `[]`/`()`). A `^` inside parens is a within-edit
+    // alternative belonging to a single description, not a top-level
+    // and/or join, so `find_top_level_caret` ignores it.
+    if find_top_level_caret(input).is_some() {
+        return Some("and_or");
+    }
+
+    // Check for an uncertainty-wrapped whole-edit and/or group, where
+    // the `^` lives inside the trailing `(...)`, e.g.
+    // `NM_004006.2:c.(370A>C^372C>R)`.
+    if find_uncertain_and_or_group(input).is_some() {
+        return Some("uncertain_and_or");
+    }
+
     // Check for trans: [var];[var] pattern
     if input.starts_with('[') && input.contains("];[") {
         return Some("trans");
@@ -5861,6 +6050,8 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
             "chimeric" => parse_chimeric_allele(input)?,
             "unknown_phase" => parse_unknown_phase_allele(input)?,
             "rna_fusion" => parse_rna_fusion(input)?,
+            "and_or" => parse_and_or_allele(input)?,
+            "uncertain_and_or" => parse_uncertain_and_or_allele(input)?,
             _ => unreachable!(),
         }
     } else {
@@ -7007,6 +7198,51 @@ mod tests {
         assert_eq!(
             format!("{}", variant),
             "NM_000088.3:c.100A>G//NM_000088.3:c.200C>T"
+        );
+    }
+
+    #[test]
+    fn test_parse_and_or_top_level_cross_reference() {
+        // And/or `^` between two full descriptions across references
+        // (HGVS general.md): "variant A and/or variant B".
+        let variant = parse_variant("NM_000517.4:c.424C>T^NM_000558.3:c.424C>T").unwrap();
+        assert!(matches!(variant, HgvsVariant::Allele(_)));
+        if let HgvsVariant::Allele(allele) = &variant {
+            assert_eq!(allele.phase, AllelePhase::AndOr);
+            assert_eq!(allele.variants.len(), 2);
+        }
+        assert_eq!(
+            format!("{}", variant),
+            "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T"
+        );
+    }
+
+    #[test]
+    fn test_parse_and_or_uncertain_whole_edit_cds() {
+        // And/or `^` between two whole edits inside an uncertainty
+        // wrapper `(...)`; operands are full position+edits at different
+        // positions (HGVS general.md). Parens must round-trip.
+        let variant = parse_variant("NM_004006.2:c.(370A>C^372C>R)").unwrap();
+        assert!(matches!(variant, HgvsVariant::Allele(_)));
+        if let HgvsVariant::Allele(allele) = &variant {
+            assert_eq!(allele.phase, AllelePhase::AndOr);
+            assert_eq!(allele.variants.len(), 2);
+        }
+        assert_eq!(format!("{}", variant), "NM_004006.2:c.(370A>C^372C>R)");
+    }
+
+    #[test]
+    fn test_parse_and_or_uncertain_whole_edit_protein() {
+        // Two whole protein descriptions joined by `^` inside `(...)`.
+        let variant = parse_variant("NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)").unwrap();
+        assert!(matches!(variant, HgvsVariant::Allele(_)));
+        if let HgvsVariant::Allele(allele) = &variant {
+            assert_eq!(allele.phase, AllelePhase::AndOr);
+            assert_eq!(allele.variants.len(), 2);
+        }
+        assert_eq!(
+            format!("{}", variant),
+            "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)"
         );
     }
 

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -492,6 +492,9 @@ pub enum AllelePhase {
     /// Chimeric - different cell lines: var1//var2
     /// (two distinct cell populations in one individual)
     Chimeric,
+    /// And/or - alternatives joined by `^`: var1^var2
+    /// ("variant A and/or variant B"; HGVS general.md)
+    AndOr,
 }
 
 impl fmt::Display for AllelePhase {
@@ -502,6 +505,7 @@ impl fmt::Display for AllelePhase {
             AllelePhase::Unknown => write!(f, "unknown"),
             AllelePhase::Mosaic => write!(f, "mosaic"),
             AllelePhase::Chimeric => write!(f, "chimeric"),
+            AllelePhase::AndOr => write!(f, "and/or"),
         }
     }
 }
@@ -525,12 +529,31 @@ pub struct AlleleVariant {
     pub variants: Vec<HgvsVariant>,
     /// Phase relationship
     pub phase: AllelePhase,
+    /// Whether the whole allele group is wrapped in an uncertainty
+    /// marker `(...)` (predicted). Currently used by the and/or (`^`)
+    /// group, e.g. `c.(370A>C^372C>R)`. Defaults to `false`.
+    #[serde(default)]
+    pub uncertain: bool,
 }
 
 impl AlleleVariant {
     /// Create a new allele variant
     pub fn new(variants: Vec<HgvsVariant>, phase: AllelePhase) -> Self {
-        Self { variants, phase }
+        Self {
+            variants,
+            phase,
+            uncertain: false,
+        }
+    }
+
+    /// Create a new allele variant wrapped in an uncertainty marker
+    /// `(...)` (predicted), e.g. the and/or group `c.(370A>C^372C>R)`.
+    pub fn new_uncertain(variants: Vec<HgvsVariant>, phase: AllelePhase) -> Self {
+        Self {
+            variants,
+            phase,
+            uncertain: true,
+        }
     }
 
     /// Create a cis allele (same chromosome)
@@ -1169,6 +1192,43 @@ impl fmt::Display for AlleleVariant {
             }
             AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/"),
             AllelePhase::Chimeric => write_mosaic_or_chimeric(f, &self.variants, "//"),
+            AllelePhase::AndOr => {
+                if self.uncertain && use_compact_form(&self.variants) {
+                    // Uncertainty-wrapped, shared accession + coord type:
+                    // `ACC:c.(edit1^edit2)` — prefix once, then the
+                    // `^`-joined bare edits inside the parens.
+                    write_compact_prefix(f, &self.variants[0])?;
+                    write!(f, "(")?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "^")?;
+                        }
+                        v.fmt_loc_edit(f)?;
+                    }
+                    write!(f, ")")
+                } else if self.uncertain {
+                    // Uncertainty-wrapped but mixed references: wrap the
+                    // full-description join in parens — `(ACC1:c.A^ACC2:c.B)`.
+                    write!(f, "(")?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "^")?;
+                        }
+                        write!(f, "{}", v)?;
+                    }
+                    write!(f, ")")
+                } else {
+                    // And/or `^` join of full descriptions (possibly across
+                    // references): render each in full — `ACC1:c.A^ACC2:c.B`.
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "^")?;
+                        }
+                        write!(f, "{}", v)?;
+                    }
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1176,10 +1176,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         {
             normalized.pop().unwrap()
         } else {
-            HgvsVariant::Allele(crate::hgvs::variant::AlleleVariant::new(
-                normalized,
-                allele.phase,
-            ))
+            let mut rebuilt = crate::hgvs::variant::AlleleVariant::new(normalized, allele.phase);
+            // Preserve the uncertainty wrapper `(...)` (e.g. the and/or
+            // group `c.(370A>C^372C>R)`) — rebuilding via `new` would
+            // otherwise drop it and re-render the group expanded.
+            rebuilt.uncertain = allele.uncertain;
+            HgvsVariant::Allele(rebuilt)
         };
 
         Ok((result, all_warnings))
@@ -7097,6 +7099,25 @@ mod tests {
             format!("{}", result),
             "NM_000088.3:c.[10A>G;20C>T]",
             "Allele display should use canonical compact form"
+        );
+    }
+
+    #[test]
+    fn test_normalize_preserves_uncertain_and_or_group() {
+        // An uncertainty-wrapped and/or group `(a^b)` must keep its `(...)`
+        // wrapper (and compact form) through normalization — normalize must
+        // not drop the `uncertain` flag when it rebuilds the allele.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_004006.2:c.(370A>C^372C>R)").unwrap();
+        let result = normalizer.normalize(&variant).unwrap();
+
+        assert!(matches!(result, HgvsVariant::Allele(_)));
+        assert_eq!(
+            format!("{}", result),
+            "NM_004006.2:c.(370A>C^372C>R)",
+            "Uncertain and/or group must round-trip with its parens after normalize"
         );
     }
 

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -1025,10 +1025,7 @@ mod tests {
         let provider = MockProvider::new();
         let converter = HgvsToVcfConverter::new(&transcript, &provider);
 
-        let variant = HgvsVariant::Allele(AlleleVariant {
-            variants: vec![],
-            phase: AllelePhase::Cis,
-        });
+        let variant = HgvsVariant::Allele(AlleleVariant::new(vec![], AllelePhase::Cis));
 
         let result = converter.convert(&variant);
         assert!(result.is_err());
@@ -1052,10 +1049,7 @@ mod tests {
             ),
         });
 
-        let variant = HgvsVariant::Allele(AlleleVariant {
-            variants: vec![inner],
-            phase: AllelePhase::Cis,
-        });
+        let variant = HgvsVariant::Allele(AlleleVariant::new(vec![inner], AllelePhase::Cis));
 
         let result = converter.convert(&variant);
         assert!(result.is_ok());
@@ -1090,10 +1084,8 @@ mod tests {
             ),
         });
 
-        let variant = HgvsVariant::Allele(AlleleVariant {
-            variants: vec![inner1, inner2],
-            phase: AllelePhase::Cis,
-        });
+        let variant =
+            HgvsVariant::Allele(AlleleVariant::new(vec![inner1, inner2], AllelePhase::Cis));
 
         let result = converter.convert(&variant);
         assert!(result.is_err());

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 135,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 333,
-      "preserved": 648
+      "parse-error": 330,
+      "preserved": 651
     },
     "by_coordinate_system": {
       "c": 464,
@@ -842,18 +842,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T",
-      "current": "parse error: Parse error at position 20: Unexpected trailing characters: '^NM_000558.3:c.424C>T'",
-      "spec_expected": "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_004006.1:c.5690",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Tag })",
       "spec_expected": "NM_004006.1:c.5690",
@@ -954,19 +942,6 @@
         "docs/recommendations/checklist.md"
       ],
       "working_group": "SVD-WG002",
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "c.(370A>C^372C>R)",
-      "input_prefixed": "NM_004006.2:c.(370A>C^372C>R)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(370A>C^372C>R)\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.(370A>C^372C>R)",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/general.md"
-      ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
@@ -3610,6 +3585,17 @@
       ]
     },
     {
+      "input": "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T",
+      "current": "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T",
+      "spec_expected": "NM_000517.4:c.424C>T^NM_000558.3:c.424C>T",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
       "input": "NM_000552.3:c.3675-45_3692",
       "current": "NM_000552.3:c.3675-45_3692",
       "spec_expected": "NM_000552.3:c.3675-45_3692",
@@ -4246,6 +4232,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/delins.md"
+      ]
+    },
+    {
+      "input": "c.(370A>C^372C>R)",
+      "input_prefixed": "NM_004006.2:c.(370A>C^372C>R)",
+      "current": "NM_004006.2:c.(370A>C^372C>R)",
+      "spec_expected": "NM_004006.2:c.(370A>C^372C>R)",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/general.md"
       ]
     },
     {
@@ -10806,7 +10804,7 @@
     },
     {
       "input": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Gly56Ala^Ser^Cys)\", code: Tag })",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
       "spec_expected": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
       "status": "parse-error",
       "coordinate_system": "p",
@@ -10950,7 +10948,7 @@
     },
     {
       "input": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]\", code: Tag })",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Asn158Asp)(;)(Asn158Ile)]\", code: Tag })",
       "spec_expected": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
       "status": "parse-error",
       "coordinate_system": "p",
@@ -11013,22 +11011,9 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.(Gly23GlufsTer7^Gly23CysfsTer26)",
-      "input_prefixed": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Gly23GlufsTer7^Gly23CysfsTer26)\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.(Gly719Ala^Ser)",
       "input_prefixed": "NP_003997.1:p.(Gly719Ala^Ser)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Gly719Ala^Ser)\", code: Tag })",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
       "spec_expected": "NP_003997.1:p.(Gly719Ala^Ser)",
       "status": "parse-error",
       "coordinate_system": "p",
@@ -11981,6 +11966,18 @@
       "input_prefixed": "NP_003997.1:p.(Gly23GlufsTer7)",
       "current": "NP_003997.1:p.(Gly23GlufsTer7)",
       "spec_expected": "NP_003997.1:p.(Gly23GlufsTer7)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
+      ]
+    },
+    {
+      "input": "p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+      "input_prefixed": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+      "current": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+      "spec_expected": "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",

--- a/tests/issue_390_hgvs_vcf_provider_coverage.rs
+++ b/tests/issue_390_hgvs_vcf_provider_coverage.rs
@@ -505,10 +505,7 @@ mod allele_branch {
                 substitution(Base::A, Base::G),
             ),
         };
-        let allele = AlleleVariant {
-            variants: vec![HgvsVariant::Cds(inner)],
-            phase: AllelePhase::Cis,
-        };
+        let allele = AlleleVariant::new(vec![HgvsVariant::Cds(inner)], AllelePhase::Cis);
         let result = converter
             .convert(&HgvsVariant::Allele(allele))
             .expect("single-inner allele must route through the inner conversion");
@@ -520,10 +517,7 @@ mod allele_branch {
         let tx = fixture_transcript();
         let provider = fixture_provider();
         let converter = HgvsToVcfConverter::new(&tx, &provider);
-        let allele = AlleleVariant {
-            variants: vec![],
-            phase: AllelePhase::Cis,
-        };
+        let allele = AlleleVariant::new(vec![], AllelePhase::Cis);
         let err = converter
             .convert(&HgvsVariant::Allele(allele))
             .expect_err("empty allele has nothing to encode in VCF");
@@ -559,10 +553,10 @@ mod allele_branch {
                 substitution(Base::T, Base::C),
             ),
         };
-        let allele = AlleleVariant {
-            variants: vec![HgvsVariant::Cds(inner1), HgvsVariant::Cds(inner2)],
-            phase: AllelePhase::Cis,
-        };
+        let allele = AlleleVariant::new(
+            vec![HgvsVariant::Cds(inner1), HgvsVariant::Cds(inner2)],
+            AllelePhase::Cis,
+        );
         // The converter may surface a ConversionError or successfully
         // emit only the first variant with a warning, depending on
         // the implementation's contract. Pin "either reject OR emit


### PR DESCRIPTION
## Summary

First PR toward closing #544 (allele / variant-relationship operators). Implements the HGVS **and/or `^`** operator in the two forms that exist in the spec-coverage fixture:

- **Top-level**, between full descriptions, possibly across references — e.g. `NM_000517.4:c.424C>T^NM_000558.3:c.424C>T`.
- **Inside an uncertainty wrapper**, joining whole edits that share an accession and coordinate type — e.g. `NM_004006.2:c.(370A>C^372C>R)` and `NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)`. The surrounding `(...)` round-trips.

## What changed

- New `AllelePhase::AndOr` variant; `^`-joined operands are modeled as an `AlleleVariant`.
- New `uncertain` flag on `AlleleVariant` (serde-defaulted, so existing serialized forms are unaffected) so the `(...)` predicted wrapper round-trips. Normalization now preserves the flag when it rebuilds the allele.
- Bracket/paren-depth-aware detection (`find_top_level_caret`, `find_uncertain_and_or_group`): a `^` nested inside `(...)` is treated as part of a single description, not a top-level join. The uncertainty-wrapper opener is found by scanning back from the final `)`, so an accession-internal paren like `GRCh38(chr1):g.(...)` is not misread.

## Acceptance

Three rows in `tests/fixtures/grammar/hgvs_spec_normalization.json` move off `parse-error` to `preserved`; no rows regress to `false-acceptance`. New unit tests cover parse + round-trip for each form, plus a normalize round-trip test for the uncertainty-wrapped group. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. (The mutalyzer/biocommons normalize-divergence tests fail locally with or without this change — they are pre-existing, environment-dependent, and unrelated to `^`.)

## Scope / follow-ups (same issue)

This does **not** close #544 on its own. Remaining operator groups, tracked as separate PRs:

- Residue-level `^` alternatives (`p.(Gly56Ala^Ser^Cys)`, `p.(Gly719Ala^Ser)`, `p.Gly719(Ala^Ser)fsTer23`) — shares a new `ProteinEdit` alternatives mechanism with `=/`.
- The `=/` and/or operator (`p.Trp24=/Cys`, `r.=/6_8del`), axis-gated against the existing mosaic `=/`.
- Nested / mixed trans + mosaic compound alleles (`[A;B];[C]`, `[A];[B](;)C`, predicted-protein alleles, `p.[(...)(;)(...)]^[(...)]`).