### PR TITLE
feat(parser): extend mosaic `=/` to protein + fix RNA case (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -4873,7 +4873,90 @@ fn parse_compact_mosaic_rhs(
     lhs: &HgvsVariant,
 ) -> Result<Option<HgvsVariant>, FerroError> {
     use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::interval::Interval;
     use crate::hgvs::parser::edit::parse_na_edit;
+
+    /// A single-base substitution targets one position, so the inherited
+    /// compact-mosaic LHS identity must be a point (`c.85=`), not a range
+    /// (`c.79_80=`). True only when both boundaries are present and equal;
+    /// a complex / unknown boundary is not a point.
+    fn interval_is_point<T: PartialEq>(interval: &Interval<T>) -> bool {
+        matches!(
+            (interval.start.inner(), interval.end.inner()),
+            (Some(start), Some(end)) if start == end
+        )
+    }
+
+    // Protein LHS: `<acc>:p.<pos>=` identity (the `=/` somatic and/or
+    // form). The bare RHS is either a protein edit (`del`, `dup`,
+    // `delins…`) or a bare alternative amino acid (`Cys`); the latter
+    // forms a substitution inheriting the LHS reference amino acid and
+    // position.
+    if let HgvsVariant::Protein(lhs_p) = lhs {
+        use crate::hgvs::edit::ProteinEdit;
+        use crate::hgvs::parser::edit::parse_protein_edit;
+        use crate::hgvs::parser::position::parse_amino_acid;
+
+        // Eligible only for a position-bound protein identity LHS.
+        if !matches!(
+            lhs_p.loc_edit.edit.inner(),
+            Some(ProteinEdit::Identity {
+                whole_protein: false,
+                ..
+            })
+        ) {
+            return Ok(None);
+        }
+
+        // Prefer a fully-consumed protein edit (`del`/`dup`/`delins…`);
+        // otherwise treat a fully-consumed bare amino acid as the
+        // alternative of a substitution at the inherited position. A bare
+        // amino acid (`Cys`) is also accepted by `parse_protein_edit` as a
+        // `Substitution { reference: Xaa, .. }` — the edit syntax alone
+        // carries no reference — so both arms funnel into the same
+        // substitution-reference fix-up below.
+        let prot_edit = match parse_protein_edit(rhs) {
+            Ok((rem, e)) if rem.trim().is_empty() => e,
+            _ => match parse_amino_acid(rhs) {
+                Ok((rem, alt)) if rem.trim().is_empty() => ProteinEdit::Substitution {
+                    reference: AminoAcid::Xaa,
+                    alternative: alt,
+                },
+                _ => return Ok(None),
+            },
+        };
+
+        // A substitution targets a single residue, and its reference amino
+        // acid comes from the inherited LHS position. Require a point identity
+        // LHS (`p.Trp24=`), not a range (`p.Trp24_Cys26=`) — a range would
+        // build a malformed substitution spanning the whole interval — and
+        // inherit the reference AA from that point. Non-substitution edits
+        // (`del`/`dup`/`delins…`) legitimately span a range, so leave them be.
+        let prot_edit = match prot_edit {
+            ProteinEdit::Substitution { alternative, .. } => {
+                let (Some(start_pos), Some(end_pos)) = (
+                    lhs_p.loc_edit.location.start.inner(),
+                    lhs_p.loc_edit.location.end.inner(),
+                ) else {
+                    return Ok(None);
+                };
+                if start_pos != end_pos {
+                    return Ok(None);
+                }
+                ProteinEdit::Substitution {
+                    reference: start_pos.aa,
+                    alternative,
+                }
+            }
+            other => other,
+        };
+
+        return Ok(Some(HgvsVariant::Protein(ProteinVariant {
+            accession: lhs_p.accession.clone(),
+            gene_symbol: lhs_p.gene_symbol.clone(),
+            loc_edit: LocEdit::new(lhs_p.loc_edit.location.clone(), prot_edit),
+        })));
+    }
 
     // Eligibility: LHS must carry a position-bound (not whole-entity)
     // identity edit on a NA coord system.
@@ -4940,6 +5023,29 @@ fn parse_compact_mosaic_rhs(
             ),
             diagnostic: None,
         });
+    }
+
+    // A single-base substitution (`A>G` / `>G`) targets one position, so the
+    // inherited LHS identity must be a point (`c.85=`), not a range
+    // (`c.79_80=`) — a range would build a malformed substitution spanning the
+    // whole interval. del / dup / ins / inv / delins legitimately span a
+    // range, so leave them be. Reject so the caller falls to its error path.
+    if matches!(
+        edit,
+        NaEdit::Substitution { .. } | NaEdit::SubstitutionNoRef { .. }
+    ) {
+        let lhs_is_point = match lhs {
+            HgvsVariant::Genome(v) => interval_is_point(&v.loc_edit.location),
+            HgvsVariant::Cds(v) => interval_is_point(&v.loc_edit.location),
+            HgvsVariant::Tx(v) => interval_is_point(&v.loc_edit.location),
+            HgvsVariant::Rna(v) => interval_is_point(&v.loc_edit.location),
+            HgvsVariant::Mt(v) => interval_is_point(&v.loc_edit.location),
+            HgvsVariant::Circular(v) => interval_is_point(&v.loc_edit.location),
+            _ => false,
+        };
+        if !lhs_is_point {
+            return Ok(None);
+        }
     }
 
     // Build the RHS variant by cloning LHS's accession + gene_symbol +

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -998,6 +998,15 @@ fn is_position_identity_lhs(variant: &HgvsVariant) -> bool {
         HgvsVariant::Rna(v) => edit_is_pos_identity(&v.loc_edit.edit),
         HgvsVariant::Mt(v) => edit_is_pos_identity(&v.loc_edit.edit),
         HgvsVariant::Circular(v) => edit_is_pos_identity(&v.loc_edit.edit),
+        // Protein position-bound identity (`p.Trp24=`) — the LHS of the
+        // protein `=/` compact mosaic form.
+        HgvsVariant::Protein(v) => matches!(
+            v.loc_edit.edit.inner(),
+            Some(crate::hgvs::edit::ProteinEdit::Identity {
+                whole_protein: false,
+                ..
+            })
+        ),
         _ => false,
     }
 }
@@ -1040,6 +1049,9 @@ fn intervals_match_for_compact_mosaic(a: &HgvsVariant, b: &HgvsVariant) -> bool 
         (HgvsVariant::Rna(x), HgvsVariant::Rna(y)) => x.loc_edit.location == y.loc_edit.location,
         (HgvsVariant::Mt(x), HgvsVariant::Mt(y)) => x.loc_edit.location == y.loc_edit.location,
         (HgvsVariant::Circular(x), HgvsVariant::Circular(y)) => {
+            x.loc_edit.location == y.loc_edit.location
+        }
+        (HgvsVariant::Protein(x), HgvsVariant::Protein(y)) => {
             x.loc_edit.location == y.loc_edit.location
         }
         _ => false,
@@ -1112,9 +1124,18 @@ fn write_bare_edit(f: &mut fmt::Formatter<'_>, variant: &HgvsVariant) -> fmt::Re
         HgvsVariant::Genome(v) => write!(f, "{}", v.loc_edit.edit),
         HgvsVariant::Cds(v) => write!(f, "{}", v.loc_edit.edit),
         HgvsVariant::Tx(v) => write!(f, "{}", v.loc_edit.edit),
-        HgvsVariant::Rna(v) => write!(f, "{}", v.loc_edit.edit),
+        // RNA renders nucleotides in lowercase per the HGVS spec. The bare
+        // edit must go through `to_rna_string()` — the plain `NaEdit`
+        // `Display` is uppercase and would corrupt the case here.
+        HgvsVariant::Rna(v) => match v.loc_edit.edit.inner() {
+            Some(edit) => write!(f, "{}", edit.to_rna_string()),
+            None => write!(f, "{}", v.loc_edit.edit),
+        },
         HgvsVariant::Mt(v) => write!(f, "{}", v.loc_edit.edit),
         HgvsVariant::Circular(v) => write!(f, "{}", v.loc_edit.edit),
+        // Protein substitution Display renders just the alternative AA, and
+        // del/dup render their keyword — exactly the bare-edit RHS shape.
+        HgvsVariant::Protein(v) => write!(f, "{}", v.loc_edit.edit),
         _ => write!(f, "{}", variant),
     }
 }

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,11 +10,11 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 50,
-      "diverges": 135,
+      "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 330,
-      "preserved": 651
+      "parse-error": 327,
+      "preserved": 656
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10779,18 +10779,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199p1:p.Trp24=/Cys",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found 'Cys'",
-      "spec_expected": "LRG_199p1:p.Trp24=/Cys",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "LRG_199t1:p.(Trp24=/Cys)",
       "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(Trp24=\", code: Tag })",
       "spec_expected": "LRG_199t1:p.(Trp24=/Cys)",
@@ -10842,30 +10830,6 @@
       "input": "NP_003997.1:p.(Val7=/dup)",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val7=\", code: Tag })",
       "spec_expected": "NP_003997.1:p.(Val7=/dup)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/duplication.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.Val7=/del",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found 'del'",
-      "spec_expected": "NP_003997.1:p.Val7=/del",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.Val7=/dup",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found 'dup'",
-      "spec_expected": "NP_003997.1:p.Val7=/dup",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -11189,6 +11153,17 @@
       ]
     },
     {
+      "input": "LRG_199p1:p.Trp24=/Cys",
+      "current": "LRG_199p1:p.Trp24=/Cys",
+      "spec_expected": "LRG_199p1:p.Trp24=/Cys",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
       "input": "LRG_199p1:p.Trp24Cys",
       "current": "LRG_199p1:p.Trp24Cys",
       "spec_expected": "LRG_199p1:p.Trp24Cys",
@@ -11388,6 +11363,28 @@
       "source_paths": [
         "docs/syntax.yaml",
         "tests/hgvs_spec_compliance_tests.rs (legacy)"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.Val7=/del",
+      "current": "NP_003997.1:p.Val7=/del",
+      "spec_expected": "NP_003997.1:p.Val7=/del",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/deletion.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.Val7=/dup",
+      "current": "NP_003997.1:p.Val7=/dup",
+      "spec_expected": "NP_003997.1:p.Val7=/dup",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/duplication.md"
       ]
     },
     {
@@ -12917,30 +12914,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.3:r.85=//u>c",
-      "current": "NM_004006.3:r.85=//U>C",
-      "spec_expected": "NM_004006.3:r.85=//u>c",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NM_004006.3:r.85=/u>c",
-      "current": "NM_004006.3:r.85=/U>C",
-      "spec_expected": "NM_004006.3:r.85=/u>c",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/substitution.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -14901,6 +14874,28 @@
       "input": "NM_004006.3:r.76a>c",
       "current": "NM_004006.3:r.76a>c",
       "spec_expected": "NM_004006.3:r.76a>c",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/substitution.md"
+      ]
+    },
+    {
+      "input": "NM_004006.3:r.85=//u>c",
+      "current": "NM_004006.3:r.85=//u>c",
+      "spec_expected": "NM_004006.3:r.85=//u>c",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/substitution.md"
+      ]
+    },
+    {
+      "input": "NM_004006.3:r.85=/u>c",
+      "current": "NM_004006.3:r.85=/u>c",
+      "spec_expected": "NM_004006.3:r.85=/u>c",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",

--- a/tests/mosaic_chimeric_compact.rs
+++ b/tests/mosaic_chimeric_compact.rs
@@ -56,10 +56,9 @@ fn compact_form_round_trips_across_coord_systems() {
         "NM_000088.3:c.85=//T>C",
         "NR_002196.2:n.100=/A>G",
         "NR_002196.2:n.100=//A>G",
-        // RNA: ferro normalizes case on Display (input lowercase / output
-        // uppercase is observed in the wider test suite).
-        "NR_002196.2:r.100=/A>G",
-        "NR_002196.2:r.100=//A>G",
+        // RNA renders nucleotides in lowercase per the HGVS spec.
+        "NR_002196.2:r.100=/a>g",
+        "NR_002196.2:r.100=//a>g",
         "NC_012920.1:m.3243=/A>G",
         "NC_012920.1:m.3243=//A>G",
         // Deletion — mosaic + chimeric.
@@ -84,6 +83,89 @@ fn compact_form_round_trips_across_coord_systems() {
             format!("{parsed}"),
             input,
             "round-trip mismatch for `{input}`"
+        );
+    }
+}
+
+/// Protein compact mosaic `<acc>:p.<pos>=/<edit>` (the `=/` somatic
+/// and/or form, HGVS general.md). The bare RHS is either an alternative
+/// amino acid (a substitution inheriting the LHS reference + position) or
+/// a bare protein edit (`del`, `dup`).
+#[test]
+fn protein_compact_mosaic_round_trips() {
+    for input in [
+        "LRG_199p1:p.Trp24=/Cys",
+        "NP_003997.1:p.Val7=/del",
+        "NP_003997.1:p.Val7=/dup",
+    ] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("must parse `{input}`: {e}"));
+        assert!(
+            matches!(parsed, HgvsVariant::Allele(_)),
+            "expected Allele for `{input}`, got {parsed:?}"
+        );
+        assert_eq!(format!("{parsed}"), input, "round-trip for `{input}`");
+    }
+}
+
+/// A bare alternative amino acid RHS only forms a substitution when the LHS
+/// is a single point. A range identity LHS (`p.Trp24_Cys26=`) must not be
+/// coerced into a substitution carrying the whole interval — the bare-AA
+/// compact form is rejected so the caller falls through to its error path.
+#[test]
+fn protein_compact_mosaic_bare_aa_requires_point_lhs() {
+    for input in [
+        "NP_003997.1:p.Trp24_Cys26=/Gly",
+        "NP_003997.1:p.Val7_Leu9=/Cys",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "range-LHS bare-AA compact form must be rejected, but `{input}` parsed"
+        );
+    }
+}
+
+/// A single-base substitution RHS (`A>G`) only forms a compact mosaic when
+/// the inherited LHS identity is a point. A range identity LHS
+/// (`c.79_80=`) must not be coerced into a substitution spanning the whole
+/// interval — the compact form is rejected. del / dup span ranges fine.
+#[test]
+fn na_compact_mosaic_substitution_requires_point_lhs() {
+    for input in [
+        "NM_000088.3:c.79_80=/A>G",
+        "NM_000088.3:c.79_80=//A>G",
+        "NC_000023.11:g.33344590_33344592=/A>G",
+        "NC_012920.1:m.8470_8482=/A>G",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "range-LHS substitution compact form must be rejected, but `{input}` parsed"
+        );
+    }
+    // Range del / dup remain valid (they legitimately span the interval).
+    for input in ["NM_000088.3:c.79_80=/del", "NM_000088.3:c.79_80=/dup"] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "range-LHS del/dup compact form must still parse: `{input}`"
+        );
+    }
+}
+
+/// RNA compact mosaic/chimeric forms must preserve lowercase bases on the
+/// bare-edit RHS — HGVS renders RNA in lowercase. Previously the bare-edit
+/// RHS routed through `NaEdit`'s uppercase `Display`, losing the RNA case.
+#[test]
+fn rna_compact_mosaic_chimeric_preserves_lowercase() {
+    for input in [
+        "NM_004006.3:r.85=/u>c",
+        "NM_004006.3:r.85=//u>c",
+        "NR_002196.2:r.100=/a>g",
+        "NR_002196.2:r.100=//a>g",
+    ] {
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("must parse `{input}`: {e}"));
+        assert_eq!(
+            format!("{parsed}"),
+            input,
+            "RNA case round-trip for `{input}`"
         );
     }
 }


### PR DESCRIPTION
## Summary

Second PR toward closing #544. Extends the existing mosaic compact form `<acc>:<type>.<pos>=/<edit>` (the `=/` somatic *and/or* notation) to the **protein** axis, and fixes RNA bases being uppercased on the bare-edit RHS.

`=/` is already parsed as a mosaic `AllelePhase::Mosaic` for DNA (`NC_012920.1:m.3243=/A>G`); this PR widens the same compact machinery rather than introducing a new construct.

## What changed

- **Protein `=/`** (`parse_compact_mosaic_rhs`): a protein position-identity LHS (`p.Trp24=`) now accepts a bare RHS that is either
  - an **alternative amino acid** (`Cys`) → a `Substitution` inheriting the LHS reference AA + position (`p.Trp24=/Cys`), or
  - a **bare protein edit** (`del`, `dup`) → `p.Val7=/del`, `p.Val7=/dup`.
  The Display helpers `is_position_identity_lhs`, `intervals_match_for_compact_mosaic`, and `write_bare_edit` gain protein arms so the compact form round-trips.
- **RNA lowercase fix**: the compact bare-edit RHS rendered through `NaEdit`'s uppercase `Display`, corrupting RNA case. `write_bare_edit` now routes RNA through `to_rna_string()`, so `r.85=/u>c` and `r.85=//u>c` round-trip lowercase (the canonical HGVS RNA form). The pre-existing `tests/mosaic_chimeric_compact.rs` RNA rows are corrected from the buggy uppercase to lowercase.

## Acceptance

Five spec-fixture rows reach `preserved`: three protein off `parse-error` (`p.Trp24=/Cys`, `p.Val7=/del`, `p.Val7=/dup`), two RNA off `diverges` (`r.85=/u>c`, `r.85=//u>c`); no rows regress to `false-acceptance`. New round-trip tests for the protein and RNA forms. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. (The 9 mutalyzer/biocommons normalize-divergence tests fail locally with or without this change — pre-existing and environment-dependent.)

## Scope / follow-ups (same issue)

Deferred to a follow-up PR:

- Whole-entity-LHS RNA form `r.=/6_8del` — needs a new whole-entity-LHS compact Display branch.
- Parenthesized / predicted `=/` forms (`p.(Trp24=/Cys)`, `p.(Val7=/del)`, `r.(=/6_8del)`) — depend on the `AlleleVariant.uncertain` flag added in #547 (this branch is off `main`), plus an outer-paren strip pre-pass.

Independent of #547; can merge in either order.