### PR TITLE
feat(parser): parse trans alleles whose members are cis groups (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1849,14 +1849,49 @@ where
         } else if content == "?" {
             HgvsVariant::UnknownAllele
         } else {
-            let (final_remaining, variant) = parse_member(content)?;
-            if !final_remaining.trim().is_empty() {
-                return Err(nom::Err::Error(nom::error::Error::new(
-                    final_remaining,
-                    nom::error::ErrorKind::Tag,
-                )));
+            let scan = scan_allele_separators(content);
+            if scan.has_cis_separator && !scan.has_unknown_phase {
+                // A trans bracket whose content is itself a multi-variant
+                // cis group, e.g. `[296T>G;476T>C]` in `[a;b];[c]`
+                // (compound heterozygote). Parse each cis member and nest
+                // it as a `Cis` sub-allele member of the trans allele.
+                let mut cis_members = Vec::with_capacity(scan.members.len());
+                for member in scan.members {
+                    let member = member.trim();
+                    let (rest, v) = parse_member(member)?;
+                    if !rest.trim().is_empty() {
+                        return Err(nom::Err::Error(nom::error::Error::new(
+                            rest,
+                            nom::error::ErrorKind::Tag,
+                        )));
+                    }
+                    cis_members.push(v);
+                }
+                // HGVS DNA/alleles.md: the "not changed" `=` indication is
+                // used only when a single variant is identified per allele.
+                // Spelling the other allele's variant as `=` inside a
+                // multi-variant cis group is invalid (the spec flags
+                // `[2376G>C;3103=];[2376=;3103del]` as not correct). Reject a
+                // nested cis group that carries a position-identity member
+                // rather than accept the discouraged cross-spelled form.
+                // (The all-identity-allele edge `[a=;b=]` is deferred.)
+                if cis_members.iter().any(is_lhs_position_identity) {
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        content,
+                        nom::error::ErrorKind::Verify,
+                    )));
+                }
+                HgvsVariant::Allele(AlleleVariant::new(cis_members, AllelePhase::Cis))
+            } else {
+                let (final_remaining, variant) = parse_member(content)?;
+                if !final_remaining.trim().is_empty() {
+                    return Err(nom::Err::Error(nom::error::Error::new(
+                        final_remaining,
+                        nom::error::ErrorKind::Tag,
+                    )));
+                }
+                variant
             }
-            variant
         };
 
         variants.push(variant);

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -949,6 +949,65 @@ fn use_compact_form(variants: &[HgvsVariant]) -> bool {
         && !variants.iter().any(HgvsVariant::is_loc_edit_unknown)
 }
 
+/// For a `Trans` allele, return the first concrete leaf sub-variant if the
+/// compact form `ACC:c.[..];[..]` applies. Every concrete leaf — descending
+/// one level into nested cis-group members — must share accession, coord
+/// type, and gene selector; there must be at least one; and none may carry
+/// the per-variant unknown form. `[0]`/`[?]` members contribute no leaves
+/// and are permitted alongside concrete members (this is what keeps
+/// `ACC:c.[X];[?]` / `;[0]` in compact form).
+fn trans_compact_anchor(variants: &[HgvsVariant]) -> Option<&HgvsVariant> {
+    let mut anchor: Option<&HgvsVariant> = None;
+    for member in variants {
+        let leaves: &[HgvsVariant] = match member {
+            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => &[],
+            HgvsVariant::Allele(a) => &a.variants,
+            other => std::slice::from_ref(other),
+        };
+        for leaf in leaves {
+            if leaf.accession().is_none()
+                || matches!(leaf.variant_type(), "allele" | "null" | "unknown" | "r::r")
+                || leaf.is_loc_edit_unknown()
+            {
+                return None;
+            }
+            match anchor {
+                None => anchor = Some(leaf),
+                Some(a) => {
+                    if leaf.accession() != a.accession()
+                        || leaf.variant_type() != a.variant_type()
+                        || leaf.gene_symbol() != a.gene_symbol()
+                    {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+    anchor
+}
+
+/// Write the bracket-inner content of one `Trans` allele member (without the
+/// surrounding `[` `]`). A nested cis-group member renders its sub-variants'
+/// loc-edits joined by `;`; `[0]`/`[?]` render their marker; a leaf renders
+/// its loc-edit.
+fn write_trans_member(f: &mut fmt::Formatter<'_>, member: &HgvsVariant) -> fmt::Result {
+    match member {
+        HgvsVariant::NullAllele => write!(f, "0"),
+        HgvsVariant::UnknownAllele => write!(f, "?"),
+        HgvsVariant::Allele(a) => {
+            for (i, sub) in a.variants.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ";")?;
+                }
+                sub.fmt_loc_edit(f)?;
+            }
+            Ok(())
+        }
+        other => other.fmt_loc_edit(f),
+    }
+}
+
 fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt::Result {
     let accession = first
         .accession()
@@ -1174,7 +1233,41 @@ impl fmt::Display for AlleleVariant {
                 }
             }
             AllelePhase::Trans => {
-                if use_compact_form(&self.variants) {
+                // A trans member that is itself a nested cis group (`[a;b]`)
+                // needs dedicated rendering; the existing flat-trans paths
+                // (which `fmt_loc_edit` a single leaf per bracket) can't
+                // express it. Only take the nested path when a nested member
+                // is actually present, so flat trans Display is unchanged.
+                let has_nested_group = self
+                    .variants
+                    .iter()
+                    .any(|v| matches!(v, HgvsVariant::Allele(_)));
+                if has_nested_group {
+                    if let Some(anchor) = trans_compact_anchor(&self.variants) {
+                        // Compact: ACC:c.[a;b];[c;d] — prefix once, then each
+                        // member's bracket-inner content.
+                        write_compact_prefix(f, anchor)?;
+                        for (i, v) in self.variants.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ";")?;
+                            }
+                            write!(f, "[")?;
+                            write_trans_member(f, v)?;
+                            write!(f, "]")?;
+                        }
+                        Ok(())
+                    } else {
+                        // Mixed-reference nested trans (not a spec target):
+                        // expanded, each member rendered in full.
+                        for (i, v) in self.variants.iter().enumerate() {
+                            if i > 0 {
+                                write!(f, ";")?;
+                            }
+                            write!(f, "[{}]", v)?;
+                        }
+                        Ok(())
+                    }
+                } else if use_compact_form(&self.variants) {
                     // Compact form: ACC:g.[edit1];[edit2]
                     write_compact_prefix(f, &self.variants[0])?;
                     for (i, v) in self.variants.iter().enumerate() {

--- a/tests/allele_trans_phase.rs
+++ b/tests/allele_trans_phase.rs
@@ -91,6 +91,51 @@ fn test_trans_spec_example_round_trip() {
     );
 }
 
+/// Trans alleles whose members are themselves multi-variant CIS groups:
+/// `[a;b;c];[d;e]` (HGVS DNA alleles.md, compound heterozygote).
+#[test]
+fn test_trans_of_cis_groups_round_trips() {
+    let s = "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]";
+    assert_eq!(parse_to_string(s), s, "round-trip for `{s}`");
+    assert_eq!(parse_phase(s), AllelePhase::Trans, "phase for `{s}`");
+}
+
+/// The spec (DNA/alleles.md) marks the redundant cross-spelled `=` form as
+/// invalid: "do not use `c.[2376G>C;3103=];[2376=;3103del]`". A multi-variant
+/// cis group containing a position-identity (`=`) member must stay rejected
+/// rather than round-trip the discouraged form.
+#[test]
+fn test_trans_of_cis_with_identity_member_is_rejected() {
+    for s in [
+        "LRG_199t1:c.[2376G>C;3103=];[2376=;3103del]",
+        "NM_004006.2:c.[2376G>C;3103=];[2376=;3103del]",
+    ] {
+        assert!(
+            parse_hgvs(s).is_err(),
+            "spec-invalid cross-spelled `=` trans form must reject: `{s}`"
+        );
+    }
+}
+
+/// Inner members of a trans-of-cis allele are nested cis sub-alleles.
+#[test]
+fn test_trans_of_cis_nesting_shape() {
+    let v = parse_hgvs("NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]").unwrap();
+    let HgvsVariant::Allele(trans) = &v else {
+        panic!("expected Allele, got {v:?}");
+    };
+    assert_eq!(trans.phase, AllelePhase::Trans);
+    assert_eq!(trans.variants.len(), 2);
+    let HgvsVariant::Allele(cis0) = &trans.variants[0] else {
+        panic!(
+            "expected nested cis allele member, got {:?}",
+            trans.variants[0]
+        );
+    };
+    assert_eq!(cis0.phase, AllelePhase::Cis);
+    assert_eq!(cis0.variants.len(), 3);
+}
+
 /// Genomic trans round-trip — exercises the `g.` parser path.
 #[test]
 fn test_trans_genomic_round_trip() {

--- a/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_500k_failure_expectations.json
@@ -8,10 +8,6 @@
       "category": "spec_not_yet_supported",
       "reason": "Trans-phase compound `[a];[b]` with mosaic `=/` in each allele. Spec form per recommendations/DNA/alleles.md (compound) and deletion.md (mosaic `=/`)."
     },
-    "[trans_compound_with_internal_cis]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans `[a];[b;c]` \u2014 first allele a single del, second allele a cis pair. Spec recommendations/DNA/alleles.md."
-    },
     "[malformed_compound_missing_semicolon]": {
       "category": "malformed_input",
       "reason": "Compound missing `;`."
@@ -28,7 +24,6 @@
   "expected_failures": {
     "NC_000005.9:g.(?_13922436_13923774del": "[malformed_unbalanced_paren_three_positions]",
     "NM_000090.3:c.[=/3426_3452del];[=/3440_3466del]": "[trans_compound_with_mosaic]",
-    "NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]": "[trans_compound_with_internal_cis]",
     "NM_020469.3:c.[297A>C;496del526=657C>T703G>A796C>A803G>C930G>A]": "[malformed_compound_missing_semicolon]",
     "NP_000081.1:p.Gly333_Lys350del+": "[trailing_plus_after_protein_del]",
     "LRG_135t1:c.8010+30insALU": "[single_position_insertion]"

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -261,10 +261,6 @@
       "category": "spec_not_yet_supported",
       "reason": "Chimeric compound `[a,b]`."
     },
-    "[trans_compound_with_internal_cis]": {
-      "category": "spec_not_yet_supported",
-      "reason": "Trans `[a];[b;c]` \u2014 first allele a single del, second allele a cis pair. Spec recommendations/DNA/alleles.md."
-    },
     "[malformed_trailing_word_annotation]": {
       "category": "malformed_input",
       "reason": "Trailing word `transition` is annotation, not HGVS."
@@ -493,7 +489,6 @@
     "NM_013236.2:c.1173+54822_1173+54826ATTCT(400_760)": "[deprecated_repeat_paren_no_brackets]",
     "NM_013236.2:c.1173+54822_1173+54826ATTCT(800_4500)": "[deprecated_repeat_paren_no_brackets]",
     "NM_014762.3:c.[881A>C,918G>C]": "[chimeric_compound_comma]",
-    "NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]": "[trans_compound_with_internal_cis]",
     "NM_016124.4:c.[186G>T;410C>T455A>C667T>G]": "[malformed_compound_missing_semicolon]",
     "NM_016124.4:c.[410C>T;455A>C509T>C667T>G]": "[malformed_compound_missing_semicolon]",
     "NM_016124.6:c.[186G>T;410C>T455A>C602C>G604G>A733G>C]": "[malformed_compound_missing_semicolon]",

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 327,
-      "preserved": 656
+      "parse-error": 326,
+      "preserved": 657
     },
     "by_coordinate_system": {
       "c": 464,
@@ -35,7 +35,7 @@
   "rows": [
     {
       "input": "LRG_199t1:c.[2376G>C;3103=];[2376=;3103del]",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \";3103=\", code: Tag })",
+      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"2376G>C;3103=\", code: Verify })",
       "spec_expected": null,
       "status": "correctly-rejected",
       "coordinate_system": "c",
@@ -250,7 +250,7 @@
     {
       "input": "c.[2376G>C;3103=];[2376=;3103del]",
       "input_prefixed": "NM_004006.2:c.[2376G>C;3103=];[2376=;3103del]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \";3103=\", code: Tag })",
+      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"2376G>C;3103=\", code: Verify })",
       "spec_expected": null,
       "status": "correctly-rejected",
       "coordinate_system": "c",
@@ -817,7 +817,7 @@
     },
     {
       "input": "LRG_199t1:c.[633A>G];[531_648=;961_1149=]",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \";961_1149=\", code: Tag })",
+      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"531_648=;961_1149=\", code: Verify })",
       "spec_expected": "LRG_199t1:c.[633A>G];[531_648=;961_1149=]",
       "status": "parse-error",
       "coordinate_system": "c",
@@ -879,20 +879,8 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \";476T>C;1083A>C\", code: Tag })",
-      "spec_expected": "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]",
-      "status": "parse-error",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \";476T>C\", code: Tag })",
+      "current": "parse error: Parse error at position 38: Unexpected trailing characters: '(;)1083A>C'",
       "spec_expected": "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C",
       "status": "parse-error",
       "coordinate_system": "c",
@@ -4017,6 +4005,17 @@
       "input": "NM_004006.2:c.[2376G>C];[3103del]",
       "current": "NM_004006.2:c.[2376G>C];[3103del]",
       "spec_expected": "NM_004006.2:c.[2376G>C];[3103del]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]",
+      "current": "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]",
+      "spec_expected": "NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",


### PR DESCRIPTION
## Summary

Third PR toward closing #544. Parses the compound-heterozygote **trans-of-cis** form `[a;b;c];[d;e]`, where each `[...]` bracket is itself a multi-variant cis group — e.g. `NM_004006.2:c.[296T>G;476T>C;1083A>C];[296T>G;1083A>C]`. Previously the trans shorthand parsed exactly one edit per bracket and rejected an inner `;` (the most common clinical compound-het description).

## Design (Option A — no AST change)

`AlleleVariant.variants` is `Vec<HgvsVariant>` and `HgvsVariant::Allele` is a variant of the enum, so a cis-group member is represented by **nesting** `HgvsVariant::Allele(AlleleVariant{phase: Cis, ..})` inside the trans allele's existing vector — no new type, derives (Serde/Eq/Hash) nest for free, and the blast radius is benign (every `allele.variants` consumer either recurses or skips non-leaf members; no panic sites).

- **Parser**: in the trans shorthand, a bracket whose content has a top-level `;` is parsed as a nested cis sub-allele.
- **Display**: a dedicated path renders nested members as `ACC:c.[a;b];[c;d]` (shared accession written once). It is taken **only when a nested member is present**, so flat-trans Display (including the established `[?]`/`[0]` expanded rendering) is byte-for-byte unchanged.

## Spec-invalid forms stay rejected

DNA/alleles.md flags the redundant cross-spelled `=` form `[2376G>C;3103=];[2376=;3103del]` as `<code class="invalid">` ("the 'not changed' indication is used only when one variant was identified"). A nested cis group carrying a position-identity (`=`) member is therefore **refused** rather than round-tripped — these inputs remain `correctly-rejected` (no false-acceptance).

## Acceptance

- One `hgvs_spec_normalization.json` row moves off `parse-error` → `preserved`; no rows regress to `false-acceptance`.
- One ClinVar bulk-fixture input (`NM_016035.4:c.[23_33delTCCTCCGTCGG];[331G>T;356C>T]`) now parses, so it is removed from both `clinvar_hgvs_*_failure_expectations.json` snapshots (surgical removal of the single now-passing entry + its now-orphaned `kind`; the curated taxonomy is otherwise untouched). The bulk benchmarks report **0 new failures**.
- New round-trip + nesting-shape + reject tests. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail (same set with or without this change).

> Note: this commit is currently **unsigned** (`--no-gpg-sign`) due to 1Password being unavailable; it will be re-signed before merge.

## Scope / follow-ups (same issue)

Tracked as separate PRs: protein predicted-wrapper trans (`p.[(Ser68Arg)];[(Ser73Arg)]`), repeat-count trans (`p.Ala2[10];[11]`), trans+mosaic mixes (`[a];[b](;)c`), and the rare all-identity-allele edge (`[633A>G];[531_648=;961_1149=]`) which needs precise cross-spell validation to distinguish it from the invalid form above.