### PR TITLE
feat(parser): parse residue-level and/or `^` substitutions (#544)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -976,6 +976,13 @@ pub enum ProteinEdit {
         alternative: AminoAcid,
     },
 
+    /// Residue-level and/or substitution: one reference residue changed to
+    /// any of several alternatives, joined by `^` inside an uncertainty
+    /// wrapper (e.g. `p.(Gly56Ala^Ser^Cys)`; HGVS general.md). The
+    /// reference residue and position come from the location; only the
+    /// alternatives are stored here.
+    SubstitutionAlternatives { alternatives: Vec<AminoAcid> },
+
     /// Deletion: removal of amino acids (e.g., p.Lys23del, p.Lys228_Met259del32, p.Gln367_Gly372delQRGEPG)
     Deletion {
         /// Optional amino acid sequence that was deleted (e.g., Lys in p.Lys903delLys)
@@ -1146,6 +1153,17 @@ impl fmt::Display for ProteinEdit {
                 alternative,
             } => {
                 write!(f, "{}", alternative)
+            }
+            ProteinEdit::SubstitutionAlternatives { alternatives } => {
+                // Bare alternative residues joined by `^`; the reference +
+                // position are rendered by the location.
+                for (i, aa) in alternatives.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "^")?;
+                    }
+                    write!(f, "{}", aa)?;
+                }
+                Ok(())
             }
             ProteinEdit::Deletion { sequence, count } => {
                 write!(f, "del")?;

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -1522,6 +1522,21 @@ pub fn parse_na_edit(input: &str) -> IResult<&str, NaEdit> {
 /// Parse a protein substitution (e.g., Val600Glu after the position)
 fn parse_protein_substitution(input: &str) -> IResult<&str, ProteinEdit> {
     let (remaining, alternative) = parse_amino_acid.parse(input)?;
+
+    // Residue-level and/or: a `^`-joined list of alternative residues
+    // (e.g. `Ala^Ser^Cys`, used inside `p.(Gly56Ala^Ser^Cys)`). Each
+    // alternative is a bare amino acid sharing the reference + position.
+    if remaining.starts_with('^') {
+        let mut alternatives = vec![alternative];
+        let mut rest = remaining;
+        while let Some(after_caret) = rest.strip_prefix('^') {
+            let (next, aa) = parse_amino_acid.parse(after_caret)?;
+            alternatives.push(aa);
+            rest = next;
+        }
+        return Ok((rest, ProteinEdit::SubstitutionAlternatives { alternatives }));
+    }
+
     // Allow optional trailing number (e.g., p.Arg725Trp5) - appears in ClinVar data
     // This number is typically an annotation suffix and is ignored
     let remaining = if let Ok((rest, _)) = digit1::<_, nom::error::Error<&str>>.parse(remaining) {

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1500,10 +1500,15 @@ pub(crate) fn split_top_level_carets(input: &str) -> Vec<&str> {
 /// accession-internal paren like `GRCh38(chr1):g.(...)` is not mistaken
 /// for the uncertainty wrapper. Returns `None` unless the input ends in
 /// `)`, the matched `(` is preceded by a `.`, and the inner content has
-/// a top-level `^`. Residue-level alternatives that do not span whole
-/// edits (e.g. `p.(Gly56Ala^Ser^Cys)`) also match this shape; the
-/// caller's per-operand `parse_variant` then rejects the bare-residue
-/// operands, leaving those forms for separate residue-level handling.
+/// a top-level `^`.
+///
+/// The protein residue-level alternatives shorthand
+/// (`p.(Gly56Ala^Ser^Cys)`, protein/substitution.md) shares this outer
+/// shape but is NOT a whole-edit and/or group — its trailing `^`-operands
+/// are bare residues, not full edits. It is excluded here (see
+/// [`inner_is_protein_residue_alternatives`]) so it falls through to the
+/// substitution parser's `SubstitutionAlternatives` path; a whole-edit
+/// and/or operand always carries a position and is unaffected.
 pub(crate) fn find_uncertain_and_or_group(input: &str) -> Option<(&str, &str)> {
     let input = input.trim();
     let bytes = input.as_bytes();
@@ -1534,11 +1539,37 @@ pub(crate) fn find_uncertain_and_or_group(input: &str) -> Option<(&str, &str)> {
         return None;
     }
     let inner = &input[open + 1..input.len() - 1];
-    if find_top_level_caret(inner).is_some() {
+    if find_top_level_caret(inner).is_some()
+        && !inner_is_protein_residue_alternatives(prefix, inner)
+    {
         Some((prefix, inner))
     } else {
         None
     }
+}
+
+/// True iff `<prefix>(<inner>)` is the protein residue-level alternatives
+/// shorthand (`p.(Gly56Ala^Ser^Cys)` — "Gly56 is changed to an Ala, Ser,
+/// or Cys", protein/substitution.md) rather than a whole-edit and/or group.
+///
+/// The discriminator is positive (it matches the residue grammar) rather
+/// than "operand lacks a digit": every `^`-operand after the first must
+/// parse *completely* as a single amino-acid token. A whole-edit and/or
+/// operand (`Gly23CysfsTer26`) leaves a position remainder, and a
+/// whole-protein token (`=`, `?`, `0`) is not an amino acid at all — so
+/// neither is mistaken for a bare residue.
+fn inner_is_protein_residue_alternatives(prefix: &str, inner: &str) -> bool {
+    if !prefix.ends_with("p.") {
+        return false;
+    }
+    let operands = split_top_level_carets(inner);
+    if operands.len() < 2 {
+        return false;
+    }
+    operands[1..].iter().all(|op| {
+        let op = op.trim();
+        !op.is_empty() && matches!(parse_amino_acid(op), Ok((rest, _)) if rest.is_empty())
+    })
 }
 
 /// Result of `scan_allele_separators`: top-level depth-0 allele-separator
@@ -4982,6 +5013,22 @@ fn parse_compact_mosaic_rhs(
                     reference: start_pos.aa,
                     alternative,
                 }
+            }
+            // Residue-level alternatives (`Ala^Ser`) target a single residue
+            // too, so they carry the same point-LHS requirement as a plain
+            // substitution. The reference is rendered by the location, so the
+            // edit passes through unchanged once the guard holds.
+            ProteinEdit::SubstitutionAlternatives { alternatives } => {
+                let (Some(start_pos), Some(end_pos)) = (
+                    lhs_p.loc_edit.location.start.inner(),
+                    lhs_p.loc_edit.location.end.inner(),
+                ) else {
+                    return Ok(None);
+                };
+                if start_pos != end_pos {
+                    return Ok(None);
+                }
+                ProteinEdit::SubstitutionAlternatives { alternatives }
             }
             other => other,
         };

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 326,
-      "preserved": 657
+      "parse-error": 324,
+      "preserved": 659
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10790,18 +10790,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
-      "spec_expected": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.1:p.(Val582_Asn583insXaa[5])",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val582_Asn583insXaa[5])\", code: Tag })",
       "spec_expected": "NP_003997.1:p.(Val582_Asn583insXaa[5])",
@@ -10965,19 +10953,6 @@
       "input_prefixed": "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
       "current": "parse error: Parse error at position 35: Unexpected trailing characters: '[4]'",
       "spec_expected": "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.(Gly719Ala^Ser)",
-      "input_prefixed": "NP_003997.1:p.(Gly719Ala^Ser)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
-      "spec_expected": "NP_003997.1:p.(Gly719Ala^Ser)",
       "status": "parse-error",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -11215,6 +11190,17 @@
       "source_kind": "syntax_yaml",
       "source_paths": [
         "docs/syntax.yaml"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
+      "current": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
+      "spec_expected": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/substitution.md"
       ]
     },
     {
@@ -11991,6 +11977,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/checklist.md"
+      ]
+    },
+    {
+      "input": "p.(Gly719Ala^Ser)",
+      "input_prefixed": "NP_003997.1:p.(Gly719Ala^Ser)",
+      "current": "NP_003997.1:p.(Gly719Ala^Ser)",
+      "spec_expected": "NP_003997.1:p.(Gly719Ala^Ser)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ]
     },
     {

--- a/tests/protein_substitution_alternatives.rs
+++ b/tests/protein_substitution_alternatives.rs
@@ -1,0 +1,100 @@
+//! Residue-level and/or `^` on a protein substitution (#544).
+//!
+//! `p.(Gly56Ala^Ser^Cys)` means residue Gly56 is changed to Ala, Ser, OR Cys
+//! — one reference + position, multiple alternative residues
+//! (protein/substitution.md).
+//!
+//! This form shares its outer `p.(...^...)` shape with the whole-edit and/or
+//! operator from #547 (`p.(Gly23GlufsTer7^Gly23CysfsTer26)`, uncertain.md).
+//! The two are disambiguated by the operands: residue-alternatives have bare
+//! amino-acid trailing operands (no position), whole-edit and/or operands are
+//! full edits (each carries a position). These tests pin that boundary so the
+//! two `^` readings stay distinct.
+
+use ferro_hgvs::hgvs::variant::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn protein_substitution_alternatives_round_trip() {
+    for s in [
+        "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
+        "NP_003997.1:p.(Gly719Ala^Ser)",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert!(
+            matches!(v, HgvsVariant::Protein(_)),
+            "expected Protein (residue-alternatives) for `{s}`, got {v:?}"
+        );
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// The whole-edit and/or form (trailing operands are full edits carrying a
+/// position) must still route to #547's and/or allele, NOT the residue path.
+#[test]
+fn whole_edit_and_or_still_routes_to_allele() {
+    for s in [
+        "NP_003997.1:p.(Gly23GlufsTer7^Gly23CysfsTer26)",
+        // Two full substitutions at the same position — positioned trailing
+        // operand, so this is and/or, not residue-alternatives.
+        "NP_003997.1:p.(Gly56Ala^Gly56Ser)",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        match &v {
+            HgvsVariant::Allele(a) => {
+                assert_eq!(
+                    a.phase,
+                    AllelePhase::AndOr,
+                    "expected and/or phase for `{s}`"
+                )
+            }
+            other => panic!("expected and/or Allele for `{s}`, got {other:?}"),
+        }
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// The compact-mosaic somatic form (`<acc>:p.<pos>=/<bare-rhs>`) accepts a
+/// residue-alternatives RHS (`Ala^Ser`), but ONLY when the inherited identity
+/// LHS is a point. A range identity LHS would build a `SubstitutionAlternatives`
+/// spanning the whole interval, which breaks the single-residue contract, so it
+/// must be rejected rather than silently mis-parsed.
+#[test]
+fn compact_mosaic_residue_alternatives_rejects_range_lhs() {
+    // Point LHS: residue-alternatives RHS is accepted (mosaic somatic allele).
+    let point = "NP_003997.1:p.Trp24=/Ala^Ser";
+    let v = parse_hgvs(point).unwrap_or_else(|e| panic!("point LHS must parse `{point}`: {e}"));
+    match &v {
+        HgvsVariant::Allele(a) => {
+            assert_eq!(
+                a.phase,
+                AllelePhase::Mosaic,
+                "expected mosaic for `{point}`"
+            );
+            assert_eq!(a.variants.len(), 2, "expected 2 members for `{point}`");
+        }
+        other => panic!("expected mosaic Allele for `{point}`, got {other:?}"),
+    }
+
+    // Range LHS: must NOT produce a residue-alternatives edit on a range.
+    let range = "NP_003997.1:p.Trp24_Cys26=/Ala^Ser";
+    assert!(
+        parse_hgvs(range).is_err(),
+        "range identity LHS must be rejected for residue-alternatives RHS, got {:?}",
+        parse_hgvs(range)
+    );
+}
+
+/// Fail-safe pin: a trailing whole-protein token (`=`) is NOT an amino acid,
+/// so it is not mistaken for a residue alternative — the input routes to the
+/// and/or path rather than being swallowed (and mis-rejected) by the residue
+/// shorthand.
+#[test]
+fn trailing_non_residue_token_is_not_residue_alternatives() {
+    let s = "NP_003997.1:p.(Trp24Cys^=)";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert!(
+        matches!(v, HgvsVariant::Allele(_)),
+        "`{s}` must route to the and/or allele path, got {v:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up toward closing #544. Parses the **residue-level and/or** form `p.(Gly56Ala^Ser^Cys)` (and the two-alternative `p.(Gly719Ala^Ser)`), where one reference residue is changed to any of several alternatives joined by `^` inside an uncertainty wrapper (HGVS general.md). Distinct from the description-level `^` in #547 — here the operands are bare alternative residues sharing one reference + position.

## What changed

- New `ProteinEdit::SubstitutionAlternatives { alternatives: Vec<AminoAcid> }`. The reference residue and position come from the location (matching how `Substitution` already derives its reference); only the alternative residues are stored. Display renders the bare residues joined by `^`, so the location supplies `Gly56` and the edit supplies `Ala^Ser^Cys`.
- The protein substitution parser collects a `^`-joined list of alternative residues. (No existing exhaustive `ProteinEdit` match needed a new arm — the additive variant compiled clean against the codebase's wildcard arms.)

## Acceptance

Two spec-fixture rows move off `parse-error` → `preserved`; no rows regress to `false-acceptance`. New round-trip test. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

## Scope / follow-up

The frameshift new-residue form `p.Gly719(Ala^Ser)fsTer23` — where the `^` alternatives sit inside a frameshift's new residue rather than a plain substitution — needs `Frameshift.new_aa` to hold alternatives and is tracked as a separate small PR.