### PR TITLE
ci: fix nightly reference-aware tests (`ferro prepare --output-dir`) + add nightly badge

### DIFF
--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -91,7 +91,7 @@ jobs:
         if: steps.cache-manifest.outputs.cache-hit != 'true'
         run: |
           ./target/release/ferro prepare \
-            --output benchmark-output \
+            --output-dir benchmark-output \
             --genome grch38
 
       - name: Confirm manifest present

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CI](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/ci.yml/badge.svg)](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/ci.yml)
+[![Nightly reference-aware tests](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml)
 [![Codecov](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs)
 [![Crates.io](https://img.shields.io/crates/v/ferro-hgvs.svg)](https://crates.io/crates/ferro-hgvs)
 [![Documentation](https://docs.rs/ferro-hgvs/badge.svg)](https://docs.rs/ferro-hgvs)


### PR DESCRIPTION
## What

The nightly `nightly-mutalyzer.yml` workflow has been **red for 30+ consecutive runs** (no success in the last 30+ nightly runs). The failure is in manifest provisioning, before any test runs: the workflow calls `ferro prepare --output benchmark-output`, but the `prepare` CLI flag was renamed to `--output-dir`. On a manifest cache miss the step fails with `error: unexpected argument '--output' found` (exit code 2), so the reference-aware mutalyzer / biocommons conformance suite has not actually executed in a month.

This is purely a stale CI invocation — not a normalize/correctness regression.

## Changes

- **Fix the flag:** `ferro prepare --output benchmark-output` → `--output-dir benchmark-output` (matches the current `prepare` CLI, which exposes `-o, --output-dir`).
- **Add a nightly status badge** to the README, next to the CI badge, so a broken nightly surfaces immediately instead of silently rotting (this is what let it stay red for a month — PR CI skips these tests by design, so nothing else flagged it).

## Notes

Fixing the flag unblocks *provisioning*. Because the suite hasn't run in ~a month, the first green-provisioning nightly may surface genuine divergences or disposition drift that accumulated in the meantime; if so, those are a separate follow-up. The point of this PR is to get the gate executing again and make its status visible.