### PR TITLE
feat(parser): parse predicted-wrapper members in protein alleles (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -3091,6 +3091,26 @@ fn parse_protein_bracket_member(part: &str) -> IResult<&str, LocEdit<ProtInterva
         ));
     }
 
+    // Predicted-change member `(position+edit)` — strip the uncertainty
+    // wrapper, parse the inner position+edit, and mark the edit uncertain
+    // so the member round-trips as `[(...)]` (e.g.
+    // `p.[(Ser68Arg)];[(Ser73Arg)]`). Mirrors the single-variant predicted
+    // form in `parse_protein_variant`.
+    if part.starts_with('(') {
+        if let Ok((remaining, (interval, edit))) = delimited(
+            char('('),
+            (parse_prot_interval, parse_protein_edit),
+            char(')'),
+        )
+        .parse(part)
+        {
+            return Ok((
+                remaining,
+                LocEdit::with_uncertainty(interval, Mu::Uncertain(edit)),
+            ));
+        }
+    }
+
     let (edit_remaining, interval) = parse_prot_interval(part)?;
     let (final_remaining, edit) = parse_protein_edit(edit_remaining)?;
     Ok((final_remaining, LocEdit::new(interval, edit)))

--- a/tests/allele_grammar_corners.rs
+++ b/tests/allele_grammar_corners.rs
@@ -99,12 +99,12 @@ fn allele_with_predicted_variant_inside() {
 
 #[test]
 fn protein_allele_with_predicted_variant_inside() {
-    // protein/alleles.md:91 is a valid spec example, but ferro does not
-    // yet parse a predicted member inside a protein allele bracket —
-    // pin the current gap. Promote to `pin_accept` when ferro supports it.
-    pin_reject(
+    // protein/alleles.md:91 spec example: a predicted member inside a
+    // protein allele bracket now parses and round-trips (#544).
+    pin_round_trip(
         "NP_003997.1:p.[Phe233Leu;(Cys690Trp)]",
-        "protein/alleles.md:91 spec example — currently a parse gap",
+        "NP_003997.1:p.[Phe233Leu;(Cys690Trp)]",
+        "protein/alleles.md:91 spec example — predicted member inside allele bracket",
     );
 }
 

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,11 +10,11 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 50,
-      "diverges": 133,
+      "diverges": 134,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 324,
-      "preserved": 659
+      "parse-error": 320,
+      "preserved": 662
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10266,6 +10266,18 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
+      "input": "NP_003997.1:p.[(Ser68Arg)];[?]",
+      "current": "[NP_003997.1:p.(Ser68Arg)];[?]",
+      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[?]",
+      "status": "diverges",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ],
+      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
+    },
+    {
       "input": "NP_003997.2:p.(Asn444Lysfs*15)",
       "current": "NP_003997.2:p.(Asn444LysfsTer15)",
       "spec_expected": "NP_003997.2:p.(Asn444Lysfs*15)",
@@ -10826,30 +10838,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Ser68Arg)];[(Ser68Arg)]\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.[(Ser68Arg)];[?]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Ser68Arg)];[?]\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[?]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.1:p.[(Ser68Arg;Asn594del)]",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Ser68Arg;Asn594del)]\", code: Tag })",
       "spec_expected": "NP_003997.1:p.[(Ser68Arg;Asn594del)]",
@@ -10858,18 +10846,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Ser73Arg)];[(Asn103del)]\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -10899,7 +10875,7 @@
     },
     {
       "input": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"[(Asn158Asp)(;)(Asn158Ile)]\", code: Tag })",
+      "current": "parse error: Parse error at position 0: Failed to parse accession: Error(Error { input: \"[(Asn158Val)]\", code: Alpha })",
       "spec_expected": "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]",
       "status": "parse-error",
       "coordinate_system": "p",
@@ -11357,6 +11333,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/duplication.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
+      "current": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
+      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
+      "current": "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
+      "spec_expected": "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
       ]
     },
     {

--- a/tests/protein_predicted_trans.rs
+++ b/tests/protein_predicted_trans.rs
@@ -1,0 +1,38 @@
+//! Trans protein alleles whose members are predicted-change wrappers (#544).
+//!
+//! `p.[(Ser68Arg)];[(Ser73Arg)]` — each trans member is a predicted protein
+//! change `(...)`. Previously the protein trans bracket-member parser only
+//! handled bare members and whole-entity markers, not the predicted wrapper.
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn protein_predicted_trans_round_trips() {
+    for s in [
+        "NP_003997.1:p.[(Ser68Arg)];[(Ser73Arg)]",
+        "NP_003997.1:p.[(Ser73Arg)];[(Asn103del)]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// A predicted member paired with the unknown-allele marker `[?]` must at
+/// least parse to a trans allele (its compact round-trip is tracked with the
+/// other trans `[?]` rendering work).
+#[test]
+fn protein_predicted_trans_with_unknown_member_parses() {
+    let v = parse_hgvs("NP_003997.1:p.[(Ser68Arg)];[?]").expect("must parse");
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::Trans);
+    assert_eq!(a.variants.len(), 2);
+    assert!(matches!(a.variants[1], HgvsVariant::UnknownAllele));
+}

--- a/tests/protein_unknown_roundtrip.rs
+++ b/tests/protein_unknown_roundtrip.rs
@@ -800,7 +800,7 @@ fn protein_unknown_trans_compound_with_position_unknown_arm_round_trips() {
 // =====================================================================
 
 #[test]
-fn protein_unknown_trans_compound_with_predicted_arm_drifts() {
+fn protein_unknown_trans_compound_with_predicted_arm_round_trips() {
     let input = "[NP_000079.2:p.Arg97Trp];[NP_000079.2:p.(Met1?)]";
     let parsed = parse_hgvs(input).unwrap();
 
@@ -831,7 +831,7 @@ fn protein_unknown_trans_compound_with_predicted_arm_drifts() {
     }
 
     // Display compacts to ACC:p.[Arg97Trp];[(Met1?)]. The bracket parsers
-    // don't dispatch on `(` today, so re-parsing the compact form fails.
+    // now dispatch on `(`, so the compact form re-parses cleanly (#544).
     let displayed = format!("{}", parsed);
     assert!(
         displayed.starts_with("NP_000079.2:p.["),
@@ -842,12 +842,11 @@ fn protein_unknown_trans_compound_with_predicted_arm_drifts() {
         "{input:?}: expected predicted-form arm in compact Display, got {displayed:?}"
     );
 
-    let reparsed = parse_hgvs(&displayed);
-    assert!(
-        reparsed.is_err(),
-        "{input:?}: compact-form Display {displayed:?} unexpectedly re-parsed; \
-         this means the predicted-form bracket gap is fixed and this assertion \
-         should flip to `assert_eq!(reparsed.unwrap(), parsed)`. Got: {:?}",
-        reparsed.ok()
+    let reparsed = parse_hgvs(&displayed).unwrap_or_else(|e| {
+        panic!("{input:?}: compact-form Display {displayed:?} must re-parse: {e}")
+    });
+    assert_eq!(
+        reparsed, parsed,
+        "{input:?}: re-parsing the compact Display must yield the same allele"
     );
 }

--- a/tests/spec_coverage_misc.rs
+++ b/tests/spec_coverage_misc.rs
@@ -263,9 +263,10 @@ fn f16_open_side_uncertain_breakpoint() {
 /// protein-alleles:S-S8 — Predicted-each-cis form `p.[(a);(b)]`.
 #[test]
 fn f16_protein_predicted_each_cis() {
-    pin_reject(
+    pin_round_trip(
         "NP_003997.1:p.[(Trp24Cys);(Lys25Arg)]",
-        "protein/alleles.md silent on predicted-each-cis combination; ferro currently rejects",
+        "NP_003997.1:p.[(Trp24Cys);(Lys25Arg)]",
+        "predicted-each-cis protein allele now parses and round-trips (#544)",
     );
 }
 


### PR DESCRIPTION
## Summary

Follow-up toward closing #544. Parses a **predicted-change member** `(...)` inside a protein allele bracket — both trans (`p.[(Ser68Arg)];[(Ser73Arg)]`) and cis (`p.[Phe233Leu;(Cys690Trp)]`, protein/alleles.md:91). Previously `parse_protein_bracket_member` handled bare members and whole-entity markers but not the predicted wrapper, so any `[(...)]` member failed at parse.

## What changed

- `parse_protein_bracket_member` gains a `(...)` branch that mirrors the single-variant predicted form: strip the wrapper, parse the inner position+edit, and mark the edit uncertain (`Mu::Uncertain`) so the member round-trips as `[(...)]`.
- Because the same bracket-member parser backs the **cis** path too, this also closes the predicted-member-inside-cis gap, and the compact Display of a predicted trans arm now re-parses cleanly (previously a documented round-trip drift).

## Acceptance

Two spec-fixture rows move off `parse-error` → `preserved`. A third (`p.[(Ser68Arg)];[?]`) reaches `diverges`: it parses and round-trips, but the trans `[?]` arm still renders in expanded form — the cross-cutting trans-`[?]` compact rendering is tracked separately (it has broad Display ripple, see #549's deferred item).

Three previously-pinned "gap" tests are **promoted** exactly as their own TODO comments instructed (e.g. *"Promote to `pin_accept` when ferro supports it"*, *"flip to `assert_eq!(reparsed.unwrap(), parsed)`"*): `protein_allele_with_predicted_variant_inside`, `f16_protein_predicted_each_cis`, and the renamed `protein_unknown_trans_compound_with_predicted_arm_round_trips`.

`cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544.