### PR TITLE
perf(normalize): two no-functional-change normalize hot-path wins (shuffle-info + protein-length)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3201,61 +3201,28 @@ impl<P: ReferenceProvider> Normalizer<P> {
     }
 
     /// Discover the length of a protein via the `ReferenceProvider`
-    /// trait. The trait returns an out-of-range error rather than a
-    /// truncated string and has no separate length API, so we probe
-    /// with `get_protein_sequence(accession, 0, n)`.
+    /// trait's `get_protein_length` API.
     ///
-    /// Strategy: seed the upper probe at 64 KiB, which covers titin
-    /// (~35 kAA, the longest known human protein) and every realistic
-    /// protein. If 64 KiB already succeeds, walk up exponentially to a
-    /// 1 GiB safety cap. If the seed fails, the exact length is in
-    /// `[0, SEED)` — skip the exponential ramp and let the binary
-    /// search converge directly. Then binary-search between the last
-    /// known-good and first known-bad probes for the exact length.
+    /// The trait's default implementation derives the length by probing
+    /// `get_protein_sequence(accession, 0, n)` and binary-searching for
+    /// the largest accepted `n` (length-equals-largest-accepted-`n`
+    /// semantics), preserving the historical behavior. Providers that
+    /// store length metadata (e.g. `MockProvider`) override it to return
+    /// the length directly without cloning the sequence. Either way, an
+    /// empty protein or an accession the provider cannot resolve yields a
+    /// length of `0`.
+    ///
     /// Returns `None` for empty proteins or accessions the provider
     /// cannot resolve.
     fn discover_protein_length(&self, accession: &str) -> Option<u64> {
-        const SEED: u64 = 64 * 1024;
-        const CAP: u64 = 1 << 30;
-
-        let probe_ok = |n: u64| self.provider.get_protein_sequence(accession, 0, n).is_ok();
-
-        let (mut lo, mut hi) = if probe_ok(SEED) {
-            // Common case: the seed succeeded. Grow only if the protein
-            // is even longer (vanishingly rare).
-            let mut hi = SEED;
-            let mut lo = SEED;
-            while probe_ok(hi) {
-                lo = hi;
-                if hi >= CAP {
-                    break;
-                }
-                hi = hi.saturating_mul(2);
-            }
-            (lo, hi)
-        } else {
-            // Seed failed, so the exact length is in `[0, SEED)`.
-            // Hand `[0, SEED)` straight to the binary search below
-            // instead of re-doing a logarithmic exponential ramp from
-            // 1 (which would duplicate the work the failed seed
-            // already proved unnecessary). `lo = 0` is a valid lower
-            // bound — `probe_ok(0)` (empty slice) is accepted by the
-            // provider; only after the binary search converges to
-            // `lo = 0` do we conclude the protein is genuinely empty.
-            (0, SEED)
-        };
-        while lo + 1 < hi {
-            let mid = lo + (hi - lo) / 2;
-            if probe_ok(mid) {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
+        // A length of `0` — an empty protein or an accession the provider
+        // cannot resolve — maps to `None`, matching the prior behavior. The
+        // `Err(_)` arm is defensive: the trait contract maps unresolvable
+        // accessions to `Ok(0)`, but a provider may still surface an error.
+        match self.provider.get_protein_length(accession) {
+            Ok(0) | Err(_) => None,
+            Ok(len) => Some(len),
         }
-        if lo == 0 {
-            return None;
-        }
-        Some(lo)
     }
 
     /// Validate that the amino acids in a protein variant match the reference

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -905,7 +905,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// In strict mode (default), rejects variants with reference mismatches.
     /// Use `normalize_with_diagnostics` for lenient mode that corrects mismatches.
     pub fn normalize(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
-        let result = self.normalize_with_diagnostics(variant)?;
+        // `normalize()` returns only the variant and inspects warnings; it
+        // discards the diagnostic `infos` axis. Call `normalize_core`
+        // directly and wrap with empty infos, so the hot path skips the
+        // per-call `detect_shuffle_infos` work (use `normalize_with_diagnostics`
+        // when infos are actually needed). Behavior is unchanged.
+        let (normalized, warnings) = self.normalize_core(variant)?;
+        let result = NormalizeResult::with_warnings(normalized, warnings);
 
         // In strict mode, reject if there were reference mismatches.
         if self.config.should_reject_ref_mismatch() {
@@ -1070,7 +1076,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         variant: &HgvsVariant,
     ) -> Result<NormalizeResult, FerroError> {
-        let (result, warnings) = match variant {
+        let (result, warnings) = self.normalize_core(variant)?;
+        let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
+        Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
+    }
+
+    /// Core normalization: dispatch by variant kind and return the
+    /// normalized variant plus warnings, WITHOUT computing the diagnostic
+    /// `infos` axis. `normalize()` discards infos, so it calls this
+    /// directly to skip the per-call `detect_shuffle_infos` cost on the
+    /// hot path; `normalize_with_diagnostics` layers infos on top. The
+    /// (variant, warnings) output is identical to the previous inline match.
+    fn normalize_core(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        let result = match variant {
             // A `g.` variant on a mitochondrial reference (NC_012920 / NC_001807)
             // must be described with `m.` (#487). Coerce it to an `MtVariant`
             // — same accession/location/edit, only the coordinate system label
@@ -1106,9 +1127,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             HV::NullAllele => (HV::NullAllele, vec![]),
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
         };
-
-        let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
-        Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
+        Ok(result)
     }
 
     /// Normalize an allele (compound) variant
@@ -1162,9 +1181,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // variant and goes through the same pipeline as any direct input.
         let mut normalized: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
         for v in merged_split {
-            let r = self.normalize_with_diagnostics(&v)?;
-            all_warnings.extend(r.warnings);
-            normalized.push(r.result);
+            // `normalize()` discards the diagnostic `infos` axis, so allele
+            // members go through `normalize_core` (skipping the per-member
+            // `detect_shuffle_infos` cost) rather than `normalize_with_diagnostics`.
+            let (result, warnings) = self.normalize_core(&v)?;
+            all_warnings.extend(warnings);
+            normalized.push(result);
         }
 
         // Overlap detection runs post-shift so collisions caused by the

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -409,6 +409,27 @@ impl ReferenceProvider for MockProvider {
         Ok(protein_seq[start..end].to_string())
     }
 
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        // Mirror the accession resolution in `get_protein_sequence`:
+        // exact (versioned or stored) match first, then an unversioned
+        // base-accession fallback, returning the stored length directly.
+        if let Some(seq) = self.proteins.get(accession) {
+            return Ok(seq.len() as u64);
+        }
+        if !accession.contains('.') {
+            for (key, seq) in &self.proteins {
+                if key.split('.').next().unwrap_or(key) == accession {
+                    return Ok(seq.len() as u64);
+                }
+            }
+        }
+        // An accession this provider cannot resolve maps to length `0`,
+        // matching the trait contract (the default probe leaves `lo = 0`
+        // for an unresolvable protein). Returning an error here would
+        // diverge from that contract.
+        Ok(0)
+    }
+
     fn has_protein_data(&self) -> bool {
         !self.proteins.is_empty()
     }
@@ -564,6 +585,27 @@ mod tests {
         );
         assert!(provider.has_genomic_data());
         assert_eq!(provider.get_genomic_sequence("chr1", 0, 4).unwrap(), "ACGT");
+    }
+
+    #[test]
+    fn test_get_protein_length_resolves_and_falls_back() {
+        let mut provider = MockProvider::new();
+        provider.add_protein("NP_TEST.1", "MAPLE");
+
+        // Exact (versioned) match returns the stored length.
+        assert_eq!(provider.get_protein_length("NP_TEST.1").unwrap(), 5);
+        // Unversioned base accession falls back to the versioned entry.
+        assert_eq!(provider.get_protein_length("NP_TEST").unwrap(), 5);
+    }
+
+    #[test]
+    fn test_get_protein_length_unresolvable_is_zero() {
+        // Contract: an accession the provider cannot resolve maps to a
+        // length of `0` (matching the trait's default probe semantics),
+        // NOT an error — otherwise `normalize()` is not behavior-preserving
+        // when a provider switches from the probe loop to this API.
+        let provider = MockProvider::with_test_data();
+        assert_eq!(provider.get_protein_length("NP_NONEXISTENT.1").unwrap(), 0);
     }
 
     #[test]

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -138,6 +138,61 @@ pub trait ReferenceProvider {
         })
     }
 
+    /// Return the length (in amino acids) of the named protein.
+    ///
+    /// # Arguments
+    ///
+    /// * `accession` - Protein accession (e.g., `"NP_000079.2"`)
+    ///
+    /// # Returns
+    ///
+    /// The protein length in amino acids, or `0` if the accession cannot be
+    /// resolved by this provider — matching the historical probe's semantics
+    /// (see below), so a missing protein behaves identically to before. (The
+    /// `Result` is retained for providers that surface genuine I/O errors.)
+    ///
+    /// The default implementation discovers the length by probing
+    /// [`get_protein_sequence`](Self::get_protein_sequence) with
+    /// `get_protein_sequence(accession, 0, n)` and binary-searching for
+    /// the largest accepted `n`, which equals the protein length. This
+    /// preserves the exact semantics of the historical probe: a protein
+    /// of length zero (or one the provider cannot resolve) yields a
+    /// length of `0`. Providers that store length metadata override this
+    /// to return the length directly without cloning the sequence.
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        const SEED: u64 = 64 * 1024;
+        const CAP: u64 = 1 << 30;
+
+        let probe_ok = |n: u64| self.get_protein_sequence(accession, 0, n).is_ok();
+
+        let (mut lo, mut hi) = if probe_ok(SEED) {
+            // Common case: the seed succeeded. Grow only if the protein
+            // is even longer (vanishingly rare).
+            let mut hi = SEED;
+            let mut lo = SEED;
+            while probe_ok(hi) {
+                lo = hi;
+                if hi >= CAP {
+                    break;
+                }
+                hi = hi.saturating_mul(2);
+            }
+            (lo, hi)
+        } else {
+            // Seed failed, so the exact length is in `[0, SEED)`.
+            (0, SEED)
+        };
+        while lo + 1 < hi {
+            let mid = lo + (hi - lo) / 2;
+            if probe_ok(mid) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        Ok(lo)
+    }
+
     /// Check if this provider has protein sequence data
     fn has_protein_data(&self) -> bool {
         false
@@ -204,6 +259,10 @@ impl ReferenceProvider for Box<dyn ReferenceProvider> {
         end: u64,
     ) -> Result<String, FerroError> {
         (**self).get_protein_sequence(accession, start, end)
+    }
+
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        (**self).get_protein_length(accession)
     }
 
     fn has_protein_data(&self) -> bool {


### PR DESCRIPTION
Two independent, behavior-preserving performance fixes on the `normalize()` hot path, found via a v0.4.0→HEAD performance sweep. Each is a "do the same work with less waste" change — no output changes.

## 1. Skip shuffle-info detection on the infos-discarding `normalize()` path (`a65b46e`)

`normalize()` returns only the variant and inspects warnings — it discards the diagnostic `infos` axis — yet `normalize_with_diagnostics()` ran `detect_shuffle_infos()` on every call, which renders position strings via `format!` for an info message `normalize()` immediately throws away. Profiling showed this is ~25% of normalize self-time.

Fix: extract `normalize_core` (variant + warnings, no infos); `normalize()` routes through it, and `detect_shuffle_infos` runs only in `normalize_with_diagnostics`, where infos are actually surfaced. Output of `normalize()` is byte-identical.

**Result:** `c.sub` normalize ~410 → ~296 ns (**~1.38×**), on every `normalize()` call.

## 2. `get_protein_length` to avoid the protein-length probe loop (`42703dd`)

`discover_protein_length()` learned a protein's length via a ~17-iteration binary search of `get_protein_sequence(acc, 0, n)` probes — each probe cloning the entire protein string — just to find a length the provider already knows.

Fix: add `ReferenceProvider::get_protein_length` with a default impl that runs the historical probe verbatim (so `MultiFastaProvider` and any non-overriding provider keep identical behavior), plus a `Box<dyn>` forward and a `MockProvider` override that returns the stored length directly. The override returns the same length the probe converged to (largest accepted `n` == `seq.len()`); an unresolvable accession maps to `None` exactly as before.

**Result:** `p.del` normalize ~3.5 µs → ~0.7 µs on the MockProvider microbench (**~5×**); the saving scales with real protein size, where the probe's per-iteration clones are far larger.

## Verification

Both changes are no-functional-change and are gated on the full `cargo nextest --features dev` suite **minus the reference-aware conformance tests** (`mutalyzer_normalize_tests` / `biocommons_normalize_tests`): **6600/6600 other tests pass**, clippy `-D warnings` and `fmt` clean.

The conformance suite is **not** included in that gate because it is currently red on `main` for an unrelated reason — the nightly's `ferro prepare` step uses a renamed CLI flag (fixed in #551), so the reference-aware suite has not actually run in ~a month. Both fixes here are behavior-preserving by construction (fix 1 only skips a discarded computation; fix 2 leaves `MultiFastaProvider` on the old probe via the trait default), so once #551 lands and the nightly is green again it will validate them against the conformance corpus.