### PR TITLE
perf(bench): broaden microbenchmark suite + tag-sweep runner (perf-effort foundation)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,6 +207,10 @@ required-features = ["web-service"]
 name = "benchmarks"
 harness = false
 
+[[bench]]
+name = "projection"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,10 @@ harness = false
 name = "projection"
 harness = false
 
+[[bench]]
+name = "baseline_head"
+harness = false
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/benches/baseline_head.rs
+++ b/benches/baseline_head.rs
@@ -1,0 +1,179 @@
+//! Performance benchmarks for ferro-hgvs features added after v0.4.0.
+//!
+//! VERSION FLOOR: post-v0.4.0 — HEAD BASELINE target (NOT swept). These exercise features added after v0.4.0: enriched genomic/intronic normalization (Transcript::new signature drift makes it uncompilable at v0.4.0), W30xx correctors (the swapped-position corrector errors at v0.4.0), and trans-allele parsing (errors at v0.4.0). No v0.4.0 baseline exists, so this establishes a forward floor at HEAD only. Run: cargo bench --bench baseline_head
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ferro_hgvs::reference::{Exon, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+// =============================================================================
+// Enriched normalization benchmarks (genomic + intronic)
+// =============================================================================
+
+/// `with_test_data()` plus a genome-mapped contig and two intron-bearing
+/// transcripts (one per strand), so `g.` and intronic normalization run on
+/// the real path. Uses the post-v0.4.0 `Transcript::new` signature
+/// (`Option<String>` gene name), so this only compiles at HEAD.
+fn enriched_provider() -> MockProvider {
+    use ferro_hgvs::reference::transcript::{GenomeBuild, ManeStatus};
+    let mut p = MockProvider::with_test_data();
+
+    // Plus-strand, two-exon coding transcript with a real intron, mapped to
+    // NC_000001.11. Exon1 genome[1000,1009] tx[1,10]; intron genome[1010,1999];
+    // exon2 genome[2000,2009] tx[11,20]. CDS tx[1,18]; tx[19,20] is a 2-nt 3'UTR tail.
+    p.add_transcript(Transcript::new(
+        "NM_INTR.1".to_string(),
+        Some("INTRGENE".to_string()),
+        Strand::Plus,
+        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
+        Some(1),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 10, 1000, 1009),
+            Exon::with_genomic(2, 11, 20, 2000, 2009),
+        ],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(2009),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+
+    // Minus-strand counterpart for the #497 minus-strand intronic shuffle path.
+    // On minus strand exons are listed 5'→3' in transcript coordinates, but
+    // their genomic coords are reversed: exon1 (tx 1..10) maps to genome 2000..2009,
+    // exon2 (tx 11..20) maps to genome 1000..1009.
+    p.add_transcript(Transcript::new(
+        "NM_INTRM.1".to_string(),
+        Some("INTRGENM".to_string()),
+        Strand::Minus,
+        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
+        Some(1),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 10, 2000, 2009),
+            Exon::with_genomic(2, 11, 20, 1000, 1009),
+        ],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(2009),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+
+    // Genomic sequence for NC_000001.11: 999 N's + exon1 + 990 N intron +
+    // exon2 + 100 N's, so positions 1000..2009 carry the modeled bases.
+    let prefix = "N".repeat(999);
+    let exon1 = "ATGCGCAAAG"; // genome 1000..1009
+    let intron = "N".repeat(990); // genome 1010..1999
+    let exon2 = "GGTAACCCNN"; // genome 2000..2009
+    let suffix = "N".repeat(100);
+    p.add_genomic_sequence(
+        "NC_000001.11",
+        format!("{prefix}{exon1}{intron}{exon2}{suffix}"),
+    );
+    p
+}
+
+/// Benchmark genomic + intronic normalization on the enriched provider.
+fn bench_normalization_enriched(c: &mut Criterion) {
+    let provider = enriched_provider();
+    let normalizer = Normalizer::new(provider);
+
+    let test_cases = vec![
+        // c. intronic (enriched fixture; #497 shuffle path)
+        ("c.intronic_plus_del", "NM_INTR.1:c.10+2del"),
+        ("c.intronic_minus_del", "NM_INTRM.1:c.10+2del"),
+        // g. (enriched fixture, NC_000001.11)
+        ("g.sub", "NC_000001.11:g.1000A>G"),
+        ("g.del", "NC_000001.11:g.1001del"),
+        ("g.ins", "NC_000001.11:g.1001_1002insTT"),
+        ("g.delins", "NC_000001.11:g.1001_1003delinsTT"),
+        ("g.inv", "NC_000001.11:g.1001_1003inv"),
+    ];
+
+    // Guard: every case must parse AND normalize on the real path. A case
+    // that errors here (bad coordinate, missing accession) would otherwise be
+    // timed on the error path. Fail loud.
+    for (name, s) in &test_cases {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("normalize bench {name:?} parse: {e}"));
+        normalizer
+            .normalize(&v)
+            .unwrap_or_else(|e| panic!("normalize bench {name:?} ({s:?}) errored: {e}"));
+    }
+
+    let mut group = c.benchmark_group("normalization_enriched");
+    for (name, variant_str) in &test_cases {
+        let variant = parse_hgvs(variant_str).unwrap();
+        group.bench_function(*name, |b| {
+            b.iter(|| normalizer.normalize(black_box(&variant)))
+        });
+    }
+    group.finish();
+}
+
+// =============================================================================
+// Corrector benchmarks (W30xx machinery)
+// =============================================================================
+
+/// Parse-path timing for inputs that exercise the W30xx correction/diagnostic
+/// machinery (swapped positions, dup/del soft-prohibition suffix forms).
+fn bench_correctors(c: &mut Criterion) {
+    // These inputs exercise the W30xx correction/diagnostic machinery:
+    //   swapped_positions (W3026): Ok-with-warning in WarnCorrect mode, Err in Reject mode.
+    //   dup_count_suffix / del_seq_suffix / dup_seq_suffix: Ok-with-warning under the lenient default.
+    // We time the full parse path regardless of Ok/Err — that is intentional, so there is no is_ok guard.
+    let cases = vec![
+        ("swapped_positions", "NC_000001.11:g.200_100del"),
+        ("dup_count_suffix", "NM_000088.3:c.100_102dup3"),
+        ("del_seq_suffix", "NM_000088.3:c.100delA"),
+        ("dup_seq_suffix", "NM_000088.3:c.100_102dupATG"),
+    ];
+    let mut group = c.benchmark_group("correctors");
+    for (name, input) in &cases {
+        group.bench_with_input(BenchmarkId::new("parse", name), input, |b, v| {
+            b.iter(|| parse_hgvs(black_box(v)))
+        });
+    }
+    group.finish();
+}
+
+// =============================================================================
+// Parsing benchmarks for post-v0.4.0 grammar
+// =============================================================================
+
+/// Parse-path timing for grammar constructs that error at v0.4.0.
+fn bench_parsing_baseline(c: &mut Criterion) {
+    let variants = vec![("allele_trans", "NC_000001.11:g.[100A>G];[200del]")];
+
+    // Guard: every benched string must actually parse. A typo or grammar
+    // drift that turns a case into a parse error would otherwise be timed
+    // on the error path and silently misreport. Fail loud instead.
+    for (name, v) in &variants {
+        assert!(
+            parse_hgvs(v).is_ok(),
+            "parsing bench case {name:?} ({v:?}) did not parse"
+        );
+    }
+
+    let mut group = c.benchmark_group("parsing_baseline");
+    for (name, variant) in &variants {
+        group.bench_with_input(BenchmarkId::new("type", name), variant, |b, v| {
+            b.iter(|| parse_hgvs(black_box(v)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    baseline_head,
+    bench_normalization_enriched,
+    bench_correctors,
+    bench_parsing_baseline,
+);
+
+criterion_main!(baseline_head);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -122,6 +122,7 @@ fn bench_parsing_by_length(c: &mut Criterion) {
 struct BulkFixture {
     test_cases: Vec<BulkCase>,
 }
+
 #[derive(Deserialize)]
 struct BulkCase {
     input: String,
@@ -188,12 +189,12 @@ fn enriched_provider() -> MockProvider {
 
     // Plus-strand, two-exon coding transcript with a real intron, mapped to
     // NC_000001.11. Exon1 genome[1000,1009] tx[1,10]; intron genome[1010,1999];
-    // exon2 genome[2000,2009] tx[11,20]. CDS tx[1,18].
+    // exon2 genome[2000,2009] tx[11,20]. CDS tx[1,18]; tx[19,20] is a 2-nt 3'UTR tail.
     p.add_transcript(Transcript::new(
         "NM_INTR.1".to_string(),
         Some("INTRGENE".to_string()),
         Strand::Plus,
-        Some("ATGCGCAAAGGGTAACCC".to_string()), // 18 bp
+        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
         Some(1),
         Some(18),
         vec![
@@ -217,7 +218,7 @@ fn enriched_provider() -> MockProvider {
         "NM_INTRM.1".to_string(),
         Some("INTRGENM".to_string()),
         Strand::Minus,
-        Some("ATGCGCAAAGGGTAACCC".to_string()),
+        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
         Some(1),
         Some(18),
         vec![
@@ -496,7 +497,7 @@ fn consecutive_subs_allele(n: usize) -> String {
     s
 }
 
-/// Build non-adjacent subs (5 nt apart): worst case for the adjacency loop —
+/// Build non-adjacent subs (stride 5 (positions 1000, 1005, 1010, …)): worst case for the adjacency loop —
 /// every pair is checked and rejected.
 fn non_adjacent_subs_allele(n: usize) -> String {
     let mut s = String::from("NC_000001.11:g.[");
@@ -530,6 +531,8 @@ fn non_adjacent_delins_allele(n: usize) -> String {
 }
 
 fn bench_allele_scaling(c: &mut Criterion) {
+    // Uses MockProvider::new() (no sequences), so this measures allele-merge
+    // scaling, not sequence-dependent 3' shift.
     let normalizer = Normalizer::new(MockProvider::new());
     let mut group = c.benchmark_group("allele_scaling");
 
@@ -558,6 +561,10 @@ fn bench_allele_scaling(c: &mut Criterion) {
 /// Parse-path timing for inputs that exercise the W30xx correction/diagnostic
 /// machinery (swapped positions, dup/del soft-prohibition suffix forms).
 fn bench_correctors(c: &mut Criterion) {
+    // These inputs exercise the W30xx correction/diagnostic machinery:
+    //   swapped_positions (W3026): Ok-with-warning in WarnCorrect mode, Err in Reject mode.
+    //   dup_count_suffix / del_seq_suffix / dup_seq_suffix: Ok-with-warning under the lenient default.
+    // We time the full parse path regardless of Ok/Err — that is intentional, so there is no is_ok guard.
     let cases = vec![
         ("swapped_positions", "NC_000001.11:g.200_100del"),
         ("dup_count_suffix", "NM_000088.3:c.100_102dup3"),

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -461,6 +461,83 @@ fn bench_error_handling(c: &mut Criterion) {
     group.finish();
 }
 
+/// Build `g.[1000G>A;1001A>C;…]` — strictly consecutive subs that all collapse.
+fn consecutive_subs_allele(n: usize) -> String {
+    let mut s = String::from("NC_000001.11:g.[");
+    for i in 0..n {
+        if i > 0 {
+            s.push(';');
+        }
+        let (r, a) = match i % 3 {
+            0 => ('G', 'A'),
+            1 => ('A', 'C'),
+            _ => ('C', 'T'),
+        };
+        s.push_str(&format!("{}{}>{}", 1000 + i, r, a));
+    }
+    s.push(']');
+    s
+}
+
+/// Build non-adjacent subs (5 nt apart): worst case for the adjacency loop —
+/// every pair is checked and rejected.
+fn non_adjacent_subs_allele(n: usize) -> String {
+    let mut s = String::from("NC_000001.11:g.[");
+    for i in 0..n {
+        if i > 0 {
+            s.push(';');
+        }
+        let (r, a) = match i % 3 {
+            0 => ('G', 'A'),
+            1 => ('A', 'C'),
+            _ => ('C', 'T'),
+        };
+        s.push_str(&format!("{}{}>{}", 1000 + i * 5, r, a));
+    }
+    s.push(']');
+    s
+}
+
+/// Non-adjacent delins: worst case for the eager alt-clone in the merge loop.
+fn non_adjacent_delins_allele(n: usize) -> String {
+    let mut s = String::from("NC_000001.11:g.[");
+    for i in 0..n {
+        if i > 0 {
+            s.push(';');
+        }
+        let start = 1000 + i * 10;
+        s.push_str(&format!("{}_{}delinsACGTA", start, start + 4));
+    }
+    s.push(']');
+    s
+}
+
+fn bench_allele_scaling(c: &mut Criterion) {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let mut group = c.benchmark_group("allele_scaling");
+
+    for n in [10usize, 100, 1000] {
+        for (label, input) in [
+            ("consecutive_subs", consecutive_subs_allele(n)),
+            ("non_adjacent_subs", non_adjacent_subs_allele(n)),
+            ("non_adjacent_delins", non_adjacent_delins_allele(n)),
+        ] {
+            // Guard: must parse + normalize on the real path.
+            let v = parse_hgvs(&input)
+                .unwrap_or_else(|e| panic!("allele bench {label} n={n} parse: {e}"));
+            normalizer
+                .normalize(&v)
+                .unwrap_or_else(|e| panic!("allele bench {label} n={n} normalize: {e}"));
+
+            group.throughput(Throughput::Elements(n as u64));
+            group.bench_with_input(BenchmarkId::new(label, n), &v, |b, v| {
+                b.iter(|| normalizer.normalize(black_box(v)))
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parsing,
@@ -472,6 +549,7 @@ criterion_group!(
     bench_clinical_variants,
     bench_fast_path,
     bench_error_handling,
+    bench_allele_scaling,
 );
 
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -5,6 +5,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ferro_hgvs::hgvs::parser::parse_hgvs_fast;
+use ferro_hgvs::reference::{Exon, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
 
 // =============================================================================
@@ -160,31 +161,127 @@ fn bench_parsing_throughput(c: &mut Criterion) {
 // Normalization benchmarks
 // =============================================================================
 
+/// `with_test_data()` plus a genome-mapped contig and two intron-bearing
+/// transcripts (one per strand), so `g.` and intronic normalization run on
+/// the real path. Uses only reference APIs present since v0.4.0, so this
+/// file overlays onto every release tag during the sweep.
+fn enriched_provider() -> MockProvider {
+    use ferro_hgvs::reference::transcript::{GenomeBuild, ManeStatus};
+    let mut p = MockProvider::with_test_data();
+
+    // Plus-strand, two-exon coding transcript with a real intron, mapped to
+    // NC_000001.11. Exon1 genome[1000,1009] tx[1,10]; intron genome[1010,1999];
+    // exon2 genome[2000,2009] tx[11,20]. CDS tx[1,18].
+    p.add_transcript(Transcript::new(
+        "NM_INTR.1".to_string(),
+        Some("INTRGENE".to_string()),
+        Strand::Plus,
+        Some("ATGCGCAAAGGGTAACCC".to_string()), // 18 bp
+        Some(1),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 10, 1000, 1009),
+            Exon::with_genomic(2, 11, 20, 2000, 2009),
+        ],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(2009),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+
+    // Minus-strand counterpart for the #497 minus-strand intronic shuffle path.
+    // On minus strand exons are listed 5'→3' in transcript coordinates, but
+    // their genomic coords are reversed: exon1 (tx 1..10) maps to genome 2000..2009,
+    // exon2 (tx 11..20) maps to genome 1000..1009.
+    p.add_transcript(Transcript::new(
+        "NM_INTRM.1".to_string(),
+        Some("INTRGENM".to_string()),
+        Strand::Minus,
+        Some("ATGCGCAAAGGGTAACCC".to_string()),
+        Some(1),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 10, 2000, 2009),
+            Exon::with_genomic(2, 11, 20, 1000, 1009),
+        ],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(2009),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+
+    // Genomic sequence for NC_000001.11: 999 N's + exon1 + 990 N intron +
+    // exon2 + 100 N's, so positions 1000..2009 carry the modeled bases.
+    let prefix = "N".repeat(999);
+    let exon1 = "ATGCGCAAAG"; // genome 1000..1009
+    let intron = "N".repeat(990); // genome 1010..1999
+    let exon2 = "GGTAACCCNN"; // genome 2000..2009
+    let suffix = "N".repeat(100);
+    p.add_genomic_sequence(
+        "NC_000001.11",
+        format!("{prefix}{exon1}{intron}{exon2}{suffix}"),
+    );
+    p
+}
+
 /// Benchmark normalization performance for different variant types
 fn bench_normalization(c: &mut Criterion) {
-    let provider = MockProvider::with_test_data();
+    let provider = enriched_provider();
     let normalizer = Normalizer::new(provider);
 
     let test_cases = vec![
+        // c. plus-strand (NM_000088.3, NM_888888.1 for 3'-shift dup)
         ("c.sub", "NM_000088.3:c.10A>G"),
         ("c.del", "NM_000088.3:c.10del"),
         ("c.del_range", "NM_000088.3:c.10_15del"),
-        ("c.dup", "NM_000088.3:c.10dup"),
         ("c.ins", "NM_000088.3:c.10_11insATG"),
-        ("g.sub", "NC_000001.11:g.12345A>G"),
-        ("g.del", "NC_000001.11:g.12345del"),
-        ("p.sub", "NP_000079.2:p.Val10Glu"),
+        ("c.delins", "NM_000088.3:c.10_12delinsAT"),
+        ("c.inv", "NM_000088.3:c.10_15inv"),
+        ("c.dup", "NM_000088.3:c.10dup"),
+        ("c.dup_3shift", "NM_888888.1:c.8dup"),
+        // c. minus-strand (NM_999999.1)
+        ("c.sub_minus", "NM_999999.1:c.5A>G"),
+        ("c.del_minus", "NM_999999.1:c.5del"),
+        ("c.ins_minus", "NM_999999.1:c.5_6insAT"),
+        // c. intronic (enriched fixture; #497 shuffle path)
+        ("c.intronic_plus_del", "NM_INTR.1:c.10+2del"),
+        ("c.intronic_minus_del", "NM_INTRM.1:c.10+2del"),
+        // protein (NP_000079.2: M1, R97, V600)
+        ("p.sub", "NP_000079.2:p.Val600Glu"),
+        ("p.del", "NP_000079.2:p.Val600del"),
+        ("p.fs", "NP_000079.2:p.Arg97fs"),
+        ("p.fsTer", "NP_000079.2:p.Arg97fsTer15"),
+        // g. (enriched fixture, NC_000001.11)
+        ("g.sub", "NC_000001.11:g.1000A>G"),
+        ("g.del", "NC_000001.11:g.1001del"),
+        ("g.ins", "NC_000001.11:g.1001_1002insTT"),
+        ("g.delins", "NC_000001.11:g.1001_1003delinsTT"),
+        ("g.inv", "NC_000001.11:g.1001_1003inv"),
     ];
 
-    let mut group = c.benchmark_group("normalization");
+    // Guard: every case must parse AND normalize on the real path. A case
+    // that errors here (bad coordinate, missing accession) would otherwise be
+    // timed on the error path. Fail loud.
+    for (name, s) in &test_cases {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("normalize bench {name:?} parse: {e}"));
+        normalizer
+            .normalize(&v)
+            .unwrap_or_else(|e| panic!("normalize bench {name:?} ({s:?}) errored: {e}"));
+    }
 
-    for (name, variant_str) in test_cases {
+    let mut group = c.benchmark_group("normalization");
+    for (name, variant_str) in &test_cases {
         let variant = parse_hgvs(variant_str).unwrap();
-        group.bench_function(name, |b| {
+        group.bench_function(*name, |b| {
             b.iter(|| normalizer.normalize(black_box(&variant)))
         });
     }
-
     group.finish();
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,10 +2,11 @@
 //!
 //! Run with: cargo bench
 //! Run specific benchmark: cargo bench -- parsing
+//!
+//! VERSION FLOOR: v0.4.0 — SWEPT target. Every group/case here parses and normalizes at v0.4.0 (verified by probe), so scripts/perf/sweep_tags.sh overlays this file onto all release tags for regression detection. Do NOT add cases that don't compile+resolve at v0.4.0 — put those in baseline_head.rs.
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ferro_hgvs::hgvs::parser::parse_hgvs_fast;
-use ferro_hgvs::reference::{Exon, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
 use flate2::read::GzDecoder;
 use serde::Deserialize;
@@ -53,7 +54,6 @@ fn bench_parsing(c: &mut Criterion) {
         // --- coverage gap-fills (churned grammar) ---
         ("m.sub", "NC_012920.1:m.8993T>G"),
         ("allele_cis", "NC_000001.11:g.[100A>G;200del]"),
-        ("allele_trans", "NC_000001.11:g.[100A>G];[200del]"),
         ("c.compound_repeat", "NM_000088.3:c.5GA[10]"),
         ("c.uncertain", "NM_000088.3:c.(100_200)del"),
         ("p.predicted", "NP_000079.2:p.(Val600Glu)"),
@@ -179,78 +179,9 @@ fn bench_parsing_throughput(c: &mut Criterion) {
 // Normalization benchmarks
 // =============================================================================
 
-/// `with_test_data()` plus a genome-mapped contig and two intron-bearing
-/// transcripts (one per strand), so `g.` and intronic normalization run on
-/// the real path. Uses only reference APIs present since v0.4.0, so this
-/// file overlays onto every release tag during the sweep.
-fn enriched_provider() -> MockProvider {
-    use ferro_hgvs::reference::transcript::{GenomeBuild, ManeStatus};
-    let mut p = MockProvider::with_test_data();
-
-    // Plus-strand, two-exon coding transcript with a real intron, mapped to
-    // NC_000001.11. Exon1 genome[1000,1009] tx[1,10]; intron genome[1010,1999];
-    // exon2 genome[2000,2009] tx[11,20]. CDS tx[1,18]; tx[19,20] is a 2-nt 3'UTR tail.
-    p.add_transcript(Transcript::new(
-        "NM_INTR.1".to_string(),
-        Some("INTRGENE".to_string()),
-        Strand::Plus,
-        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
-        Some(1),
-        Some(18),
-        vec![
-            Exon::with_genomic(1, 1, 10, 1000, 1009),
-            Exon::with_genomic(2, 11, 20, 2000, 2009),
-        ],
-        Some("NC_000001.11".to_string()),
-        Some(1000),
-        Some(2009),
-        GenomeBuild::default(),
-        ManeStatus::default(),
-        None,
-        None,
-    ));
-
-    // Minus-strand counterpart for the #497 minus-strand intronic shuffle path.
-    // On minus strand exons are listed 5'→3' in transcript coordinates, but
-    // their genomic coords are reversed: exon1 (tx 1..10) maps to genome 2000..2009,
-    // exon2 (tx 11..20) maps to genome 1000..1009.
-    p.add_transcript(Transcript::new(
-        "NM_INTRM.1".to_string(),
-        Some("INTRGENM".to_string()),
-        Strand::Minus,
-        Some("ATGCGCAAAGGGTAACCCNN".to_string()), // 20 bp (18 bp CDS + 2 nt 3'UTR tail)
-        Some(1),
-        Some(18),
-        vec![
-            Exon::with_genomic(1, 1, 10, 2000, 2009),
-            Exon::with_genomic(2, 11, 20, 1000, 1009),
-        ],
-        Some("NC_000001.11".to_string()),
-        Some(1000),
-        Some(2009),
-        GenomeBuild::default(),
-        ManeStatus::default(),
-        None,
-        None,
-    ));
-
-    // Genomic sequence for NC_000001.11: 999 N's + exon1 + 990 N intron +
-    // exon2 + 100 N's, so positions 1000..2009 carry the modeled bases.
-    let prefix = "N".repeat(999);
-    let exon1 = "ATGCGCAAAG"; // genome 1000..1009
-    let intron = "N".repeat(990); // genome 1010..1999
-    let exon2 = "GGTAACCCNN"; // genome 2000..2009
-    let suffix = "N".repeat(100);
-    p.add_genomic_sequence(
-        "NC_000001.11",
-        format!("{prefix}{exon1}{intron}{exon2}{suffix}"),
-    );
-    p
-}
-
 /// Benchmark normalization performance for different variant types
 fn bench_normalization(c: &mut Criterion) {
-    let provider = enriched_provider();
+    let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
     let test_cases = vec![
@@ -267,20 +198,11 @@ fn bench_normalization(c: &mut Criterion) {
         ("c.sub_minus", "NM_999999.1:c.5A>G"),
         ("c.del_minus", "NM_999999.1:c.5del"),
         ("c.ins_minus", "NM_999999.1:c.5_6insAT"),
-        // c. intronic (enriched fixture; #497 shuffle path)
-        ("c.intronic_plus_del", "NM_INTR.1:c.10+2del"),
-        ("c.intronic_minus_del", "NM_INTRM.1:c.10+2del"),
         // protein (NP_000079.2: M1, R97, V600)
         ("p.sub", "NP_000079.2:p.Val600Glu"),
         ("p.del", "NP_000079.2:p.Val600del"),
         ("p.fs", "NP_000079.2:p.Arg97fs"),
         ("p.fsTer", "NP_000079.2:p.Arg97fsTer15"),
-        // g. (enriched fixture, NC_000001.11)
-        ("g.sub", "NC_000001.11:g.1000A>G"),
-        ("g.del", "NC_000001.11:g.1001del"),
-        ("g.ins", "NC_000001.11:g.1001_1002insTT"),
-        ("g.delins", "NC_000001.11:g.1001_1003delinsTT"),
-        ("g.inv", "NC_000001.11:g.1001_1003inv"),
     ];
 
     // Guard: every case must parse AND normalize on the real path. A case
@@ -558,28 +480,6 @@ fn bench_allele_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-/// Parse-path timing for inputs that exercise the W30xx correction/diagnostic
-/// machinery (swapped positions, dup/del soft-prohibition suffix forms).
-fn bench_correctors(c: &mut Criterion) {
-    // These inputs exercise the W30xx correction/diagnostic machinery:
-    //   swapped_positions (W3026): Ok-with-warning in WarnCorrect mode, Err in Reject mode.
-    //   dup_count_suffix / del_seq_suffix / dup_seq_suffix: Ok-with-warning under the lenient default.
-    // We time the full parse path regardless of Ok/Err — that is intentional, so there is no is_ok guard.
-    let cases = vec![
-        ("swapped_positions", "NC_000001.11:g.200_100del"),
-        ("dup_count_suffix", "NM_000088.3:c.100_102dup3"),
-        ("del_seq_suffix", "NM_000088.3:c.100delA"),
-        ("dup_seq_suffix", "NM_000088.3:c.100_102dupATG"),
-    ];
-    let mut group = c.benchmark_group("correctors");
-    for (name, input) in &cases {
-        group.bench_with_input(BenchmarkId::new("parse", name), input, |b, v| {
-            b.iter(|| parse_hgvs(black_box(v)))
-        });
-    }
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_parsing,
@@ -592,7 +492,6 @@ criterion_group!(
     bench_fast_path,
     bench_error_handling,
     bench_allele_scaling,
-    bench_correctors,
 );
 
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -46,7 +46,36 @@ fn bench_parsing(c: &mut Criterion) {
         ("r.sub", "NM_000088.3:r.100a>g"),
         // Ensembl
         ("enst.sub", "ENST00000357033:c.100A>G"),
+        // --- coverage gap-fills (churned grammar) ---
+        ("m.sub", "NC_012920.1:m.8993T>G"),
+        ("allele_cis", "NC_000001.11:g.[100A>G;200del]"),
+        ("allele_trans", "NC_000001.11:g.[100A>G];[200del]"),
+        ("c.compound_repeat", "NM_000088.3:c.5GA[10]"),
+        ("c.uncertain", "NM_000088.3:c.(100_200)del"),
+        ("p.predicted", "NP_000079.2:p.(Val600Glu)"),
+        ("p.three_letter", "NP_000079.2:p.Val600Glufs*15"),
+        ("c.utr3", "NM_000088.3:c.*5A>G"),
+        ("c.utr5", "NM_000088.3:c.-5A>G"),
+        ("c.deep_intronic", "NM_000088.3:c.100+2000A>G"),
+        (
+            "g.long_ins",
+            "NC_000001.11:g.100_101insATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAT",
+        ),
+        (
+            "g.delins_long",
+            "NC_000001.11:g.100_120delinsACGTACGTACGTACGTACGT",
+        ),
     ];
+
+    // Guard: every benched string must actually parse. A typo or grammar
+    // drift that turns a case into a parse error would otherwise be timed
+    // on the error path and silently misreport. Fail loud instead.
+    for (name, v) in &variants {
+        assert!(
+            parse_hgvs(v).is_ok(),
+            "parsing bench case {name:?} ({v:?}) did not parse"
+        );
+    }
 
     let mut group = c.benchmark_group("parsing");
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -538,6 +538,24 @@ fn bench_allele_scaling(c: &mut Criterion) {
     group.finish();
 }
 
+/// Parse-path timing for inputs that exercise the W30xx correction/diagnostic
+/// machinery (swapped positions, dup/del soft-prohibition suffix forms).
+fn bench_correctors(c: &mut Criterion) {
+    let cases = vec![
+        ("swapped_positions", "NC_000001.11:g.200_100del"),
+        ("dup_count_suffix", "NM_000088.3:c.100_102dup3"),
+        ("del_seq_suffix", "NM_000088.3:c.100delA"),
+        ("dup_seq_suffix", "NM_000088.3:c.100_102dupATG"),
+    ];
+    let mut group = c.benchmark_group("correctors");
+    for (name, input) in &cases {
+        group.bench_with_input(BenchmarkId::new("parse", name), input, |b, v| {
+            b.iter(|| parse_hgvs(black_box(v)))
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_parsing,
@@ -550,6 +568,7 @@ criterion_group!(
     bench_fast_path,
     bench_error_handling,
     bench_allele_scaling,
+    bench_correctors,
 );
 
 criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -7,6 +7,9 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use ferro_hgvs::hgvs::parser::parse_hgvs_fast;
 use ferro_hgvs::reference::{Exon, Strand, Transcript};
 use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use std::io::Read;
 
 // =============================================================================
 // Parsing benchmarks
@@ -115,45 +118,59 @@ fn bench_parsing_by_length(c: &mut Criterion) {
 // Throughput benchmarks
 // =============================================================================
 
-/// Benchmark parsing throughput (variants per second)
+#[derive(Deserialize)]
+struct BulkFixture {
+    test_cases: Vec<BulkCase>,
+}
+#[derive(Deserialize)]
+struct BulkCase {
+    input: String,
+}
+
+/// Load up to `limit` HGVS strings from the 500k ClinVar corpus. The path is
+/// taken from `FERRO_BENCH_CORPUS` (absolute path, set by the sweep so all
+/// tags read identical input) and falls back to the in-tree fixture.
+fn load_corpus(limit: usize) -> Vec<String> {
+    let path = std::env::var("FERRO_BENCH_CORPUS")
+        .unwrap_or_else(|_| "tests/fixtures/bulk/clinvar_hgvs_500k.json.gz".to_string());
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(), // bench reports empty corpus; see guard below
+    };
+    let mut buf = Vec::new();
+    GzDecoder::new(file)
+        .read_to_end(&mut buf)
+        .expect("decompress corpus");
+    let fixture: BulkFixture = serde_json::from_slice(&buf).expect("parse corpus json");
+    fixture
+        .test_cases
+        .into_iter()
+        .take(limit)
+        .map(|c| c.input)
+        .collect()
+}
+
+/// Parse throughput over a real ClinVar corpus slice (decoded once, outside
+/// the timed loop).
 fn bench_parsing_throughput(c: &mut Criterion) {
-    let variants: Vec<&str> = vec![
-        "NC_000001.11:g.12345A>G",
-        "NM_000088.3:c.459A>G",
-        "NM_000088.3:c.100+5G>A",
-        "NP_000079.2:p.Val600Glu",
-        "NC_000001.11:g.100del",
-        "NM_000088.3:c.100_102dup",
-        "NC_000001.11:g.100_101insATG",
-        "NP_000079.2:p.Val600fs",
-    ];
+    const N: usize = 50_000;
+    let corpus = load_corpus(N);
+    assert!(
+        !corpus.is_empty(),
+        "throughput corpus empty: set FERRO_BENCH_CORPUS or ensure \
+         tests/fixtures/bulk/clinvar_hgvs_500k.json.gz exists (git lfs)"
+    );
 
     let mut group = c.benchmark_group("throughput");
-
-    // Batch of 100 variants
-    group.throughput(Throughput::Elements(100));
-    group.bench_function("parse_100", |b| {
+    group.throughput(Throughput::Elements(corpus.len() as u64));
+    group.sample_size(10); // each iter parses N strings; keep wall-time sane
+    group.bench_function("parse_corpus", |b| {
         b.iter(|| {
-            for _ in 0..100 / variants.len() + 1 {
-                for variant in &variants {
-                    let _ = parse_hgvs(black_box(variant));
-                }
+            for s in &corpus {
+                let _ = parse_hgvs(black_box(s));
             }
         })
     });
-
-    // Batch of 1000 variants
-    group.throughput(Throughput::Elements(1000));
-    group.bench_function("parse_1000", |b| {
-        b.iter(|| {
-            for _ in 0..1000 / variants.len() + 1 {
-                for variant in &variants {
-                    let _ = parse_hgvs(black_box(variant));
-                }
-            }
-        })
-    });
-
     group.finish();
 }
 

--- a/benches/projection.rs
+++ b/benches/projection.rs
@@ -1,5 +1,7 @@
 //! Projection benchmarks (v0.6.0+ subsystem). Establishes a HEAD baseline.
 //! Run with: cargo bench --bench projection
+//!
+//! VERSION FLOOR: v0.6.0 — HEAD BASELINE target (NOT swept). The project module is new in v0.6.0. Run: cargo bench --bench projection
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};

--- a/benches/projection.rs
+++ b/benches/projection.rs
@@ -1,0 +1,158 @@
+//! Projection benchmarks (v0.6.0+ subsystem). Establishes a HEAD baseline.
+//! Run with: cargo bench --bench projection
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::project::VariantProjector;
+use ferro_hgvs::reference::transcript::{GenomeBuild, ManeStatus};
+use ferro_hgvs::reference::{Exon, MockProvider, Strand, Transcript};
+
+/// Plus-strand 9bp CDS "ATGCGCTAA" on chr1 [1000,1009), with NP_TEST.1 protein.
+///
+/// Layout (0-based, half-open):
+///   genome chr1[999,1008) = ATGCGCTAA (genome g.1000..g.1008, HGVS 1-based inclusive)
+///   single exon: tx[1,9], genome[1000,1008]
+///   CDS: tx.cds_start=1 (Transcript, 1-based) / cdot.cds_start=0 (CdotTranscript, 0-based); cds_end=9
+fn plus_projector() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            // [genome_start(incl), genome_end(excl), tx_start(0-based), tx_end(0-based excl)]
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let mut provider = MockProvider::new();
+    provider.add_transcript(
+        Transcript::new(
+            "NM_TEST.1".to_string(),
+            Some("TESTGENE".to_string()),
+            Strand::Plus,
+            Some("ATGCGCTAA".to_string()),
+            Some(1),
+            Some(9),
+            // Exon tx[1,9] maps to genome[1000,1008] (1-based inclusive)
+            vec![Exon::with_genomic(1, 1, 9, 1000, 1008)],
+            Some("chr1".to_string()),
+            Some(1000),
+            Some(1008),
+            GenomeBuild::default(),
+            ManeStatus::default(),
+            None,
+            None,
+        )
+        .with_protein_id(Some("NP_TEST.1".to_string())),
+    );
+    provider.add_protein("NP_TEST.1", "MR*");
+    // chr1 sequence: 999 N's + ATGCGCTAA + 100 N's
+    // HGVS positions g.1000..g.1008 = ATGCGCTAA
+    provider.add_genomic_sequence(
+        "chr1",
+        format!("{}{}{}", "N".repeat(999), "ATGCGCTAA", "N".repeat(100)),
+    );
+    VariantProjector::new(Projector::new(cdot), provider)
+}
+
+/// Two-exon transcript with a 990bp intron on chr1, for intronic g→c projection.
+///
+/// Layout (1-based, HGVS inclusive):
+///   exon1: tx[1,10], genome g.1000..g.1009
+///   intron: genome g.1010..g.1999
+///   exon2: tx[11,20], genome g.2000..g.2009
+///   CDS: tx.cds_start=1 (Transcript, 1-based) / cdot.cds_start=0 (CdotTranscript, 0-based); cds_end=18 (exon1[1..10] + exon2[11..18])
+///
+/// Intronic input g.1015A>G maps to c.10+6A>G (6bp into the intron after exon1).
+/// Note: the intron is N-filled, so the stated `A` reference base isn't real. The
+/// projector does coordinate-only g→c mapping and does not validate the intronic
+/// reference allele here, so the `A` is unchecked by design (the input string works as-is).
+fn intronic_projector() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_INTR.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("INTRGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            // [genome_start(incl), genome_end(excl), tx_start(0-based), tx_end(0-based excl)]
+            exons: vec![[1000, 1010, 0, 10], [2000, 2010, 10, 20]],
+            cds_start: Some(0),
+            cds_end: Some(18),
+            gene_id: None,
+            protein: Some("NP_INTR.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_INTR.1".to_string(),
+        Some("INTRGENE".to_string()),
+        Strand::Plus,
+        Some("ATGCGCAAAGGGTAACCC".to_string()),
+        Some(1),
+        Some(18),
+        vec![
+            Exon::with_genomic(1, 1, 10, 1000, 1009),
+            Exon::with_genomic(2, 11, 20, 2000, 2009),
+        ],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(2009),
+        GenomeBuild::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // chr1 sequence: 999 N's + exon1(10bp) + intron(990bp N's) + exon2(10bp) + 100 N's
+    let exon1 = "ATGCGCAAAG"; // genome g.1000..g.1009
+    let intron = "N".repeat(990); // genome g.1010..g.1999
+    let exon2 = "GGTAACCCNN"; // genome g.2000..g.2009
+    provider.add_genomic_sequence(
+        "chr1",
+        format!(
+            "{}{}{}{}{}",
+            "N".repeat(999),
+            exon1,
+            intron,
+            exon2,
+            "N".repeat(100)
+        ),
+    );
+    VariantProjector::new(Projector::new(cdot), provider)
+}
+
+fn bench_projection(c: &mut Criterion) {
+    let plus = plus_projector();
+    let intr = intronic_projector();
+
+    // Guard: each input must project on the real path.
+    // plus:    g.1003C>A is position 4 of ATGCGCTAA (0-indexed 3 = 'C') → c.4C>A
+    // intronic: g.1015A>G is 6bp into the intron after exon1 (c.10+6A>G)
+    let cases: Vec<(&str, &VariantProjector<MockProvider>, &str, &str)> = vec![
+        ("g_to_c_plus", &plus, "chr1:g.1003C>A", "NM_TEST.1"),
+        ("g_to_c_intronic", &intr, "chr1:g.1015A>G", "NM_INTR.1"),
+    ];
+    for (name, vp, input, tx) in &cases {
+        vp.project(input, tx)
+            .unwrap_or_else(|e| panic!("projection bench {name:?} ({input:?}) errored: {e}"));
+    }
+
+    let mut group = c.benchmark_group("projection");
+    for (name, vp, input, tx) in &cases {
+        group.bench_with_input(BenchmarkId::new("project", name), input, |b, i| {
+            b.iter(|| vp.project(black_box(i), black_box(tx)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(projection, bench_projection);
+criterion_main!(projection);

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,0 +1,25 @@
+# Performance sweep
+
+`sweep_tags.sh` overlays the expanded `benches/benchmarks.rs` onto each release
+tag (v0.4.0 → HEAD), runs `cargo bench --save-baseline <tag>` into a shared
+target dir, and prints a `critcmp` table localizing any regression to a release
+window. Corpus is pinned via `FERRO_BENCH_CORPUS` so all tags parse identical
+input.
+
+## Run
+```
+cargo install critcmp        # once
+git lfs pull                 # ensure the 500k corpus is real, not a pointer
+scripts/perf/sweep_tags.sh   # ~5 release builds (LTO); run on a quiet machine
+```
+
+## Projection (HEAD only)
+Projection is v0.6.0-new and not part of the sweep:
+```
+cargo bench --bench projection
+```
+
+## Reading output
+`critcmp` columns are tags; rows are bench ids. A row whose time jumps between
+two adjacent tag columns points at the PRs merged in that window. Investigate
+those, not the whole range.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1,22 +1,41 @@
 # Performance sweep
 
-`sweep_tags.sh` overlays the expanded `benches/benchmarks.rs` onto each release
+`sweep_tags.sh` overlays the swept `benches/benchmarks.rs` onto each release
 tag (v0.4.0 → HEAD), runs `cargo bench --save-baseline <tag>` into a shared
 target dir, and prints a `critcmp` table localizing any regression to a release
 window. Corpus is pinned via `FERRO_BENCH_CORPUS` so all tags parse identical
 input.
 
+## Version-floor contract — which bench runs against which tags
+
+Each bench target declares a version floor in its header doc-comment. The rule:
+**the sweep only measures operations that existed at v0.4.0**, so a slowdown is a
+real regression. Anything added after v0.4.0 has no v0.4.0 baseline (it cannot
+"regress"), so it lives in a HEAD-only baseline target that just establishes a
+forward floor.
+
+| Bench target | Floor | Role | Run |
+|---|---|---|---|
+| `benches/benchmarks.rs` | **v0.4.0** | **SWEPT** — regression detection (parsing, c./p. normalize on `with_test_data`, allele scaling, real-corpus throughput) | `sweep_tags.sh` (all tags) |
+| `benches/baseline_head.rs` | post-v0.4.0 | HEAD baseline — enriched genomic/intronic normalize (`Transcript::new` signature drift), W30xx correctors, trans-allele parsing | `cargo bench --bench baseline_head` |
+| `benches/projection.rs` | v0.6.0 | HEAD baseline — `project` module is new in v0.6.0 | `cargo bench --bench projection` |
+
+When adding a case: if it does not both **compile and resolve at v0.4.0** (verify
+with the overlay check in `benchmarks.rs`'s header), it belongs in a baseline
+target, not the swept one.
+
 ## Run
-```
+```bash
 cargo install critcmp        # once
 git lfs pull                 # ensure the 500k corpus is real, not a pointer
 scripts/perf/sweep_tags.sh   # ~5 release builds (LTO); run on a quiet machine
 ```
 
-## Projection (HEAD only)
-Projection is v0.6.0-new and not part of the sweep:
-```
-cargo bench --bench projection
+## HEAD baseline targets (not swept)
+These cover post-v0.4.0 features; run them at HEAD to establish a forward floor:
+```bash
+cargo bench --bench baseline_head   # enriched g./intronic normalize, correctors, trans-allele
+cargo bench --bench projection      # g→c projection (v0.6.0+)
 ```
 
 ## Reading output

--- a/scripts/perf/sweep_tags.sh
+++ b/scripts/perf/sweep_tags.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Five-tag A/B sweep of the portable microbench suite (benches/benchmarks.rs).
+# Overlays the current branch's benchmarks.rs onto each tag, runs cargo bench
+# with a per-tag criterion baseline into a shared target dir, then critcmp.
+#
+# Projection (benches/projection.rs) is NOT swept — run it at HEAD only:
+#   cargo bench --bench projection
+#
+# Prereqs: critcmp (cargo install critcmp), git lfs (corpus), a quiet machine.
+set -euo pipefail
+
+# Fail fast on a missing dependency before spending minutes on benchmark
+# builds: a missing `critcmp` would otherwise only surface after every tag's
+# `cargo bench` run has already completed.
+for cmd in git cargo critcmp; do
+    command -v "$cmd" >/dev/null 2>&1 || { echo "missing required command: $cmd"; exit 1; }
+done
+
+TAGS=(v0.4.0 v0.4.1 v0.5.0 v0.6.0 HEAD)
+ROOT="$(git rev-parse --show-toplevel)"
+WORK="$(mktemp -d)"
+SHARED_TARGET="${ROOT}/target/perf-sweep"          # shared so critcmp sees all baselines
+CORPUS="${ROOT}/tests/fixtures/bulk/clinvar_hgvs_500k.json.gz"  # pinned corpus
+BENCH_SRC="${ROOT}/benches/benchmarks.rs"          # the expanded portable suite
+
+# Track the currently-live worktree so an abnormal exit (Ctrl-C, SIGTERM)
+# between `git worktree add` and `git worktree remove` doesn't leave a stale
+# registration under .git/worktrees that `git worktree list` would then show.
+CURRENT_WT=""
+
+# Clean up WORK on exit (normal or error) so temp dirs never accumulate.
+cleanup() {
+    [[ -n "${CURRENT_WT:-}" ]] && git worktree remove --force "$CURRENT_WT" 2>/dev/null || true
+    git worktree prune 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+[ -f "$CORPUS" ] || { echo "missing corpus: $CORPUS (git lfs pull?)"; exit 1; }
+cp "$BENCH_SRC" "${WORK}/benchmarks.rs"
+export FERRO_BENCH_CORPUS="$CORPUS"
+export CARGO_TARGET_DIR="$SHARED_TARGET"
+
+for tag in "${TAGS[@]}"; do
+    echo "=== $tag ==="
+    wt="${WORK}/wt-${tag/\//_}"
+    git worktree add --detach "$wt" "$tag" >/dev/null
+    CURRENT_WT="$wt"
+    # Overlay the portable suite (projection target is not present pre-branch; skip it).
+    cp "${WORK}/benchmarks.rs" "${wt}/benches/benchmarks.rs"
+    if ( cd "$wt" && cargo bench --bench benchmarks -- --save-baseline "$tag" ); then
+        git worktree remove --force "$wt"
+        CURRENT_WT=""
+    else
+        echo "bench failed at $tag"
+        git worktree remove --force "$wt"
+        CURRENT_WT=""
+        exit 1
+    fi
+done
+
+echo "=== critcmp (all tags) ==="
+critcmp "${TAGS[@]}"
+echo "Baselines in: ${SHARED_TARGET}/criterion"

--- a/scripts/perf/sweep_tags.sh
+++ b/scripts/perf/sweep_tags.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Five-tag A/B sweep of the portable microbench suite (benches/benchmarks.rs).
+# Five-tag A/B sweep of the v0.4.0-SWEPT microbench target (benches/benchmarks.rs).
 # Overlays the current branch's benchmarks.rs onto each tag, runs cargo bench
 # with a per-tag criterion baseline into a shared target dir, then critcmp.
 #
-# Projection (benches/projection.rs) is NOT swept — run it at HEAD only:
-#   cargo bench --bench projection
+# Only `benchmarks` is swept (it is v0.4.0-clean: compiles + resolves at every tag).
+# The HEAD-baseline targets cover post-v0.4.0 features and are NOT swept — run at HEAD:
+#   cargo bench --bench baseline_head   # enriched g./intronic normalize, correctors, trans-allele
+#   cargo bench --bench projection      # g→c projection (v0.6.0+)
+# See scripts/perf/README.md for the full version-floor contract.
 #
 # Prereqs: critcmp (cargo install critcmp), git lfs (corpus), a quiet machine.
 set -euo pipefail


### PR DESCRIPTION
## What

Foundation PR for the renewed performance effort: a broadened criterion microbenchmark suite plus a tag-sweep runner. This is the measurement substrate the v0.4.0-gap investigation was built on, and the baseline that subsequent perf PRs (e.g. #553) are measured against. **No functional changes to library code** — only `benches/`, `scripts/perf/`, and bench-target wiring in `Cargo.toml`.

## Why

Correctness work since v0.4.0 (200+ commits) was never benchmarked end-to-end. The existing benches didn't cover the normalization paths that matter most (CDS/protein/intronic, both strands), allele scaling, the W30xx correction path, or g→c projection — so regressions could hide. This suite closes those gaps and is structured so it can be swept across historical release tags to localize where a regression entered.

## Suite structure

Two deliberately separate target families:

- **`benchmarks` — v0.4.0-swept.** Uses only API present at the v0.4.0 floor, so the same target compiles and runs across every tag from v0.4.0 to HEAD. This is what the sweep runner drives. Groups: `parsing`, the normalization matrix (`c`/`p`/`g`/intronic, both strands), `allele_scaling` (consecutive-collapse + worst-case adjacency), `correctors` (W30xx correction path), and a `throughput` group over a real 500k-variant ClinVar corpus (pinned via `FERRO_BENCH_CORPUS`).
- **`baseline_head` + `projection` — HEAD-baseline.** Exercise current-API-only surfaces (enriched provider matrix, g→c projection plus/intronic) that can't compile against older tags. HEAD-only, not swept.

`scripts/perf/sweep_tags.sh` runs the swept target across a set of tags and collects criterion output; `scripts/perf/README.md` documents the version-floor split and how to read the results.

## Running

```bash
# HEAD microbenchmarks
cargo bench --bench benchmarks --features dev
cargo bench --bench projection  --features dev
cargo bench --bench baseline_head --features dev

# throughput over the committed 500k ClinVar corpus
FERRO_BENCH_CORPUS=tests/fixtures/bulk/clinvar_hgvs_500k.json.gz \
  cargo bench --bench benchmarks --features dev -- throughput

# sweep the v0.4.0-swept target across tags
scripts/perf/sweep_tags.sh
```

## Validation

All three bench targets compile against current `main` and run clean in criterion `--test` mode (one iteration per benchmark, all `Success`). Rebased onto current `main` with no conflicts.

## Reading order

1. `scripts/perf/README.md` — the version-floor split and methodology
2. `benches/benchmarks.rs` — the swept target (groups described above)
3. `benches/baseline_head.rs`, `benches/projection.rs` — HEAD-only targets
4. `scripts/perf/sweep_tags.sh` — the sweep runner
