### PR TITLE
feat(parser): parse shared-position repeat trans alleles (#544)

### DIFF
--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -1055,7 +1055,7 @@ fn scan_digits(bytes: &[u8]) -> (u64, usize) {
 /// Parse a repeat count (e.g., [12], [10_15], [?], [?_?], [10_?], [?_10])
 /// Optimized with byte-based dispatch to avoid alt() backtracking
 #[inline]
-fn parse_repeat_count(input: &str) -> IResult<&str, RepeatCount> {
+pub(crate) fn parse_repeat_count(input: &str) -> IResult<&str, RepeatCount> {
     let bytes = input.as_bytes();
 
     // Must start with '['

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -6200,6 +6200,47 @@ fn prose_multi_allelic_diagnostic_msg(rhs: &str) -> String {
     )
 }
 
+/// Build the error for a single variant with un-consumed trailing input that
+/// is *not* a valid shared-position repeat-trans continuation.
+///
+/// `remaining` is the un-consumed tail of `input`. Trailing allele-fraction /
+/// heteroplasmy annotations such as `[level=70%]`, `[heteroplasmy=70%]`,
+/// `[mosaic=80%]`, or `(80%)` are out-of-spec but appear in real-world
+/// submissions. Emit the dedicated SVA code (W3017 /
+/// `ErrorType::AlleleFractionAnnotation`) so downstream tooling can recognize
+/// the intent rather than seeing a generic trailing-character parse error. See
+/// issue #278 (follow-up to #133 work-item 4). Any other trailing input gets
+/// the generic "unexpected trailing characters" parse error.
+fn repeat_trans_or_trailing_error(input: &str, remaining: &str) -> FerroError {
+    if is_allele_fraction_annotation(remaining) {
+        use crate::error::{Diagnostic, ErrorCode, SourceSpan};
+        // Bind the SVA `ErrorType::*` here so the audit's emission-site scan
+        // (see tests/error_code_audit.rs) sees a real reference for this
+        // W-code in the parser path.
+        let _w3017 = ErrorType::AlleleFractionAnnotation;
+        let pos = input.len() - remaining.len();
+        let diag = Diagnostic::new()
+            .with_code(ErrorCode::AlleleFractionAnnotation)
+            .with_span(SourceSpan::new(pos, input.len()));
+        return FerroError::parse_with_diagnostic(
+            pos,
+            format!(
+                "Allele-fraction / heteroplasmy annotation '{}' is not part of the HGVS \
+                 spec; allele fraction belongs in accompanying metadata (VCF \
+                 FORMAT/AF, ClinVar's heteroplasmy field, etc.), not in the HGVS \
+                 expression. Strip the annotation and record the fraction separately.",
+                remaining
+            ),
+            diag,
+        );
+    }
+    FerroError::Parse {
+        pos: input.len() - remaining.len(),
+        msg: format!("Unexpected trailing characters: '{}'", remaining),
+        diagnostic: None,
+    }
+}
+
 /// Parse a complete HGVS variant string
 ///
 /// The parser is optimized with:
@@ -6266,43 +6307,56 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
         // Parse as single variant
         let (remaining, v) = parse_single_variant(input)?;
         if !remaining.is_empty() {
-            // Trailing allele-fraction / heteroplasmy annotations such as
-            // `[level=70%]`, `[heteroplasmy=70%]`, `[mosaic=80%]`, or
-            // `(80%)` are out-of-spec but appear in real-world
-            // submissions. Emit the dedicated SVA code (W3017 /
-            // `ErrorType::AlleleFractionAnnotation`) so downstream
-            // tooling can recognize the intent rather than seeing a
-            // generic trailing-character parse error. See issue #278
-            // (follow-up to #133 work-item 4).
-            if is_allele_fraction_annotation(remaining) {
-                use crate::error::{Diagnostic, ErrorCode, SourceSpan};
-                // Bind the SVA `ErrorType::*` here so the audit's
-                // emission-site scan (see tests/error_code_audit.rs) sees
-                // a real reference for this W-code in the parser path.
-                let _w3017 = ErrorType::AlleleFractionAnnotation;
-                let pos = input.len() - remaining.len();
-                let diag = Diagnostic::new()
-                    .with_code(ErrorCode::AlleleFractionAnnotation)
-                    .with_span(SourceSpan::new(pos, input.len()));
-                return Err(FerroError::parse_with_diagnostic(
-                    pos,
-                    format!(
-                        "Allele-fraction / heteroplasmy annotation '{}' is not part of the HGVS \
-                         spec; allele fraction belongs in accompanying metadata (VCF \
-                         FORMAT/AF, ClinVar's heteroplasmy field, etc.), not in the HGVS \
-                         expression. Strip the annotation and record the fraction separately.",
-                        remaining
-                    ),
-                    diag,
-                ));
+            // Shared-position repeat trans allele: `<repeat>[c1];[c2]...`
+            // where the first variant is a single-count repeat and each
+            // `;[cN]` is another allele's count inheriting the same
+            // position + unit (HGVS repeated.md). Only engages when the
+            // whole remainder is consumed as `;[count]` continuations.
+            //
+            // The built allele falls through to the end-of-function
+            // validators (`validate_coordinate_system`, `validate_no_u_in_dna`,
+            // etc.) rather than returning early — a `c.` coordinate on an NR_
+            // reference, or a `U` in a DNA repeat, must still be rejected when
+            // written in this shorthand (#486 / #544).
+            if remaining.starts_with(';') {
+                let mut members = vec![v.clone()];
+                let mut rest = remaining;
+                let mut consumed_ok = true;
+                while let Some(after_semi) = rest.strip_prefix(';') {
+                    match crate::hgvs::parser::edit::parse_repeat_count(after_semi) {
+                        Ok((next, count)) => {
+                            let mut sibling = v.clone();
+                            if crate::hgvs::variant::set_repeat_count(&mut sibling, count) {
+                                members.push(sibling);
+                                rest = next;
+                            } else {
+                                consumed_ok = false;
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            consumed_ok = false;
+                            break;
+                        }
+                    }
+                }
+                if consumed_ok && rest.is_empty() && members.len() >= 2 {
+                    HgvsVariant::Allele(AlleleVariant::new(members, AllelePhase::Trans))
+                } else {
+                    // Report the post-loop tail (`rest`), not the pre-loop
+                    // `remaining`: after consuming one or more `;[count]`
+                    // members the actual leftover is what follows them (e.g.
+                    // `(80%)`), so the diagnostic — including W3017 allele-
+                    // fraction detection — keys off the real trailing text.
+                    // `rest == remaining` when nothing was consumed.
+                    return Err(repeat_trans_or_trailing_error(input, rest));
+                }
+            } else {
+                return Err(repeat_trans_or_trailing_error(input, remaining));
             }
-            return Err(FerroError::Parse {
-                pos: input.len() - remaining.len(),
-                msg: format!("Unexpected trailing characters: '{}'", remaining),
-                diagnostic: None,
-            });
+        } else {
+            v
         }
-        v
     };
 
     // Spec-mandated post-parse semantic check: reject self-cancelling alleles

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -938,6 +938,118 @@ fn ranges_overlap(a: SelfCancellingRange, b: SelfCancellingRange) -> bool {
     lo <= hi
 }
 
+/// Set the count of a single-count `Repeat` edit on `v` to `new_count`,
+/// returning `true` on success. Used to build the sibling alleles of a
+/// shared-position repeat trans allele (`p.Ala2[10];[11]`): clone the first
+/// variant and swap in each subsequent allele's count. Variants that are
+/// not single-count repeats are left unchanged and return `false`.
+pub(crate) fn set_repeat_count(
+    v: &mut HgvsVariant,
+    new_count: crate::hgvs::edit::RepeatCount,
+) -> bool {
+    fn na(edit: &mut Mu<NaEdit>, c: crate::hgvs::edit::RepeatCount) -> bool {
+        match edit {
+            Mu::Certain(NaEdit::Repeat {
+                count,
+                additional_counts,
+                trailing,
+                ..
+            })
+            | Mu::Uncertain(NaEdit::Repeat {
+                count,
+                additional_counts,
+                trailing,
+                ..
+            }) if additional_counts.is_empty() && trailing.is_none() => {
+                *count = c;
+                true
+            }
+            _ => false,
+        }
+    }
+    match v {
+        HgvsVariant::Genome(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Cds(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Tx(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Rna(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Mt(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Circular(x) => na(&mut x.loc_edit.edit, new_count),
+        HgvsVariant::Protein(x) => match &mut x.loc_edit.edit {
+            Mu::Certain(ProteinEdit::Repeat { count, .. })
+            | Mu::Uncertain(ProteinEdit::Repeat { count, .. }) => {
+                *count = new_count;
+                true
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+/// The count of a single-count `Repeat` edit on `v`, if any. Used by the
+/// shared-position repeat trans Display.
+fn repeat_count_of(v: &HgvsVariant) -> Option<&crate::hgvs::edit::RepeatCount> {
+    fn na(edit: &Mu<NaEdit>) -> Option<&crate::hgvs::edit::RepeatCount> {
+        match edit.inner() {
+            Some(NaEdit::Repeat {
+                count,
+                additional_counts,
+                trailing,
+                ..
+            }) if additional_counts.is_empty() && trailing.is_none() => Some(count),
+            _ => None,
+        }
+    }
+    match v {
+        HgvsVariant::Genome(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Cds(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Tx(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Rna(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Mt(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Circular(x) => na(&x.loc_edit.edit),
+        HgvsVariant::Protein(x) => match x.loc_edit.edit.inner() {
+            Some(ProteinEdit::Repeat { count, .. }) => Some(count),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// True iff `variants` is a shared-position repeat trans allele: 2+ members
+/// that are single-count repeats sharing accession, coord type, position,
+/// and repeat unit — differing only in count. Such an allele renders in the
+/// compact `<pos><unit>[c1];[c2]` form (HGVS repeated.md) rather than the
+/// generic `[m1];[m2]`.
+fn is_shared_repeat_trans(variants: &[HgvsVariant]) -> bool {
+    if variants.len() < 2 || !HgvsVariant::all_share_accession_and_type(variants) {
+        return false;
+    }
+    // The compact `<pos><unit>[c1];[c2]` form is the spec canonical for RNA
+    // and protein (`recommendations/{protein,DNA}/repeated.md`); the DNA
+    // axes (g./c./m./o.) spell each allele out in full (`[member];[member]`,
+    // DNA/repeated.md:33). Gate the compact rendering to RNA + protein so
+    // DNA repeat trans alleles keep their explicit spec form.
+    if !variants
+        .iter()
+        .all(|v| matches!(v, HgvsVariant::Rna(_) | HgvsVariant::Protein(_)))
+    {
+        return false;
+    }
+    // Key = the full Display with the count normalized out; equal keys mean
+    // the members differ only in their repeat count.
+    let key = |v: &HgvsVariant| -> Option<String> {
+        let mut probe = v.clone();
+        set_repeat_count(&mut probe, crate::hgvs::edit::RepeatCount::Exact(0))
+            .then(|| format!("{}", probe))
+    };
+    match key(&variants[0]) {
+        Some(first) => variants
+            .iter()
+            .all(|v| key(v).as_deref() == Some(first.as_str())),
+        None => false,
+    }
+}
+
 /// Write the `ACC:<type>.` prefix for compact allele form.
 ///
 /// Per HGVS spec, bracketed `?` is only valid as a whole-allele marker (`[?]`),
@@ -1267,6 +1379,30 @@ impl fmt::Display for AlleleVariant {
                         }
                         Ok(())
                     }
+                } else if is_shared_repeat_trans(&self.variants) {
+                    // Shared-position repeat trans: `ACC:p.Ala2[10];[11]` —
+                    // the position+unit is written once (first member in
+                    // full), then each allele's count `;[cN]`. A shared-repeat
+                    // group has no nested-cis members, so it is disjoint from
+                    // the `has_nested_group` arm above.
+                    write_compact_prefix(f, &self.variants[0])?;
+                    self.variants[0].fmt_loc_edit(f)?;
+                    for v in &self.variants[1..] {
+                        write!(f, ";")?;
+                        // `repeat_count_of` cannot be `None` here: every member
+                        // is a single-count repeat (the same invariant
+                        // `is_shared_repeat_trans` keyed on). The `if let`
+                        // stays defensive — a missing count would otherwise
+                        // emit a malformed bare `;`.
+                        debug_assert!(
+                            repeat_count_of(v).is_some(),
+                            "is_shared_repeat_trans guarantees a single-count repeat per member"
+                        );
+                        if let Some(count) = repeat_count_of(v) {
+                            write!(f, "{}", count)?;
+                        }
+                    }
+                    Ok(())
                 } else if use_compact_form(&self.variants) {
                     // Compact form: ACC:g.[edit1];[edit2]
                     write_compact_prefix(f, &self.variants[0])?;

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 134,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 320,
-      "preserved": 662
+      "parse-error": 316,
+      "preserved": 666
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10886,18 +10886,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_0123456.1:p.Ala2[10];[11]",
-      "current": "parse error: Parse error at position 23: Unexpected trailing characters: ';[11]'",
-      "spec_expected": "NP_0123456.1:p.Ala2[10];[11]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "syntax_yaml",
-      "source_paths": [
-        "docs/syntax.yaml"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_060250.2:p.Gln746_Lys747ins*63",
       "current": "parse error: Parse error at position 31: Unexpected trailing characters: '63'",
       "spec_expected": "NP_060250.2:p.Gln746_Lys747ins*63",
@@ -10934,19 +10922,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "p.Ala2[10];[11]",
-      "input_prefixed": "NP_003997.1:p.Ala2[10];[11]",
-      "current": "parse error: Parse error at position 22: Unexpected trailing characters: ';[11]'",
-      "spec_expected": "NP_003997.1:p.Ala2[10];[11]",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/repeated.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -11644,6 +11619,17 @@
       ]
     },
     {
+      "input": "NP_0123456.1:p.Ala2[10];[11]",
+      "current": "NP_0123456.1:p.Ala2[10];[11]",
+      "spec_expected": "NP_0123456.1:p.Ala2[10];[11]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "syntax_yaml",
+      "source_paths": [
+        "docs/syntax.yaml"
+      ]
+    },
+    {
       "input": "NP_0123456.1:p.Arg65_Ser67[12]",
       "current": "NP_0123456.1:p.Arg65_Ser67[12]",
       "spec_expected": "NP_0123456.1:p.Arg65_Ser67[12]",
@@ -12176,6 +12162,18 @@
       "input_prefixed": "NP_003997.1:p.Ala2[10]",
       "current": "NP_003997.1:p.Ala2[10]",
       "spec_expected": "NP_003997.1:p.Ala2[10]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/repeated.md"
+      ]
+    },
+    {
+      "input": "p.Ala2[10];[11]",
+      "input_prefixed": "NP_003997.1:p.Ala2[10];[11]",
+      "current": "NP_003997.1:p.Ala2[10];[11]",
+      "spec_expected": "NP_003997.1:p.Ala2[10];[11]",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -13340,32 +13338,6 @@
       "input_prefixed": "NM_004006.3:r.-124",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: TakeWhile1 })",
       "spec_expected": "NM_004006.3:r.-124",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.-124_-123[14];[18]",
-      "input_prefixed": "NM_004006.3:r.-124_-123[14];[18]",
-      "current": "parse error: Parse error at position 27: Unexpected trailing characters: ';[18]'",
-      "spec_expected": "NM_004006.3:r.-124_-123[14];[18]",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/repeated.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "r.-124ug[14];[18]",
-      "input_prefixed": "NM_004006.3:r.-124ug[14];[18]",
-      "current": "parse error: Parse error at position 24: Unexpected trailing characters: ';[18]'",
-      "spec_expected": "NM_004006.3:r.-124ug[14];[18]",
       "status": "parse-error",
       "coordinate_system": "r",
       "source_kind": "recommendation",
@@ -15178,10 +15150,34 @@
       ]
     },
     {
+      "input": "r.-124_-123[14];[18]",
+      "input_prefixed": "NM_004006.3:r.-124_-123[14];[18]",
+      "current": "NM_004006.3:r.-124_-123[14];[18]",
+      "spec_expected": "NM_004006.3:r.-124_-123[14];[18]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
       "input": "r.-124ug[14]",
       "input_prefixed": "NM_004006.3:r.-124ug[14]",
       "current": "NM_004006.3:r.-124ug[14]",
       "spec_expected": "NM_004006.3:r.-124ug[14]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/repeated.md"
+      ]
+    },
+    {
+      "input": "r.-124ug[14];[18]",
+      "input_prefixed": "NM_004006.3:r.-124ug[14];[18]",
+      "current": "NM_004006.3:r.-124ug[14];[18]",
+      "spec_expected": "NM_004006.3:r.-124ug[14];[18]",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",

--- a/tests/issue_207_multi_repeat_compound_roundtrip.rs
+++ b/tests/issue_207_multi_repeat_compound_roundtrip.rs
@@ -81,9 +81,13 @@ fn noncoding_trans_compound_repeat() {
 #[test]
 fn rna_trans_compound_repeat_lowercase() {
     // RNA spec requires lowercase bases; the compound trans form must
-    // preserve case end-to-end.
-    let s = "NM_000088.3:r.[10_15ug[3]];[10_15ug[5]]";
-    assert_eq!(round_trip(s), s);
+    // preserve case end-to-end. Unlike the DNA axes (which spell each
+    // allele out in full, DNA/repeated.md:33), RNA's spec canonical form
+    // for a shared-locus repeat trans is the compact `<pos><unit>[c1];[c2]`
+    // (RNA/repeated.md:36), so the explicit `[..];[..]` input normalizes to
+    // the compact shape (lowercase preserved). See #544.
+    let input = "NM_000088.3:r.[10_15ug[3]];[10_15ug[5]]";
+    assert_eq!(round_trip(input), "NM_000088.3:r.10_15ug[3];[5]");
 }
 
 #[test]

--- a/tests/repeat_count_trans.rs
+++ b/tests/repeat_count_trans.rs
@@ -1,0 +1,118 @@
+//! Trans alleles written as shared-position repeat counts (#544).
+//!
+//! `p.Ala2[10];[11]` is a trans allele where both alleles repeat the same
+//! unit at the same position, differing only in count — the position+unit is
+//! written once and each allele's count is bracketed (`[10];[11]`). HGVS
+//! repeated.md. Distinct from `p.[a];[b]` (which brackets whole members).
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn repeat_count_trans_round_trips() {
+    for s in [
+        "NP_003997.1:p.Ala2[10];[11]",
+        "NM_004006.3:r.-124_-123[14];[18]",
+        "NM_004006.3:r.-124ug[14];[18]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// Three or more alleles exercise the N-member parse loop and the `[1..]`
+/// Display loop, not just the two-member base case.
+#[test]
+fn repeat_count_trans_three_members() {
+    let s = "NP_003997.1:p.Ala2[10];[11];[12]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+    assert_eq!(a.variants.len(), 3, "member count for `{s}`");
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+/// The shared-position repeat-trans path must still run `parse_variant`'s
+/// post-parse validators rather than short-circuiting with an early `return`.
+/// Both validators the reviewer flagged as bypassed (#544) are exercised:
+///
+/// - `validate_coordinate_system` (#486): a `c.` (coding) coordinate on an
+///   `NR_` non-coding RNA reference is a coordinate-system mismatch.
+/// - `validate_no_u_in_dna`: a `U` (RNA base) in a DNA-context repeat unit.
+///
+/// Each must be rejected even when written in the compact repeat-trans
+/// shorthand, not silently accepted by a path that skips the validators.
+#[test]
+fn repeat_count_trans_runs_post_parse_validators() {
+    let coord_mismatch = "NR_003051.3:c.100_102CAG[10];[11]";
+    let err = parse_hgvs(coord_mismatch).expect_err(
+        "c. coordinate on an NR_ non-coding RNA must be rejected even in repeat-trans shorthand",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("non-coding RNA"),
+        "expected coordinate-system-mismatch error, got: {msg}"
+    );
+
+    let u_in_dna = "NC_000001.11:g.123_124AU[10];[11]";
+    let err = parse_hgvs(u_in_dna).expect_err(
+        "U in a DNA-context repeat unit must be rejected even in repeat-trans shorthand",
+    );
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("RNA base") && msg.contains("not valid in a DNA"),
+        "expected U-in-DNA rejection, got: {msg}"
+    );
+}
+
+/// When trailing text follows the `;[count]` continuations, the diagnostic
+/// must point at the *post-loop* leftover, not the pre-loop tail (#544 review).
+/// After consuming `;[11]`, the real leftover of `…[10];[11](80%)` is `(80%)`,
+/// an allele-fraction annotation (W3017) — surfacing that requires passing the
+/// loop's `rest`, not the original `remaining` (which still starts with `;[11]`
+/// and would only yield a generic trailing-characters error).
+#[test]
+fn repeat_count_trans_trailing_diagnostic_uses_post_loop_tail() {
+    let input = "NP_003997.1:p.Ala2[10];[11](80%)";
+    let err =
+        parse_hgvs(input).expect_err("trailing (80%) after a repeat-trans member must be rejected");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("Allele-fraction") && msg.contains("(80%)"),
+        "expected the W3017 allele-fraction diagnostic on the post-loop tail, got: {msg}"
+    );
+    assert!(
+        !msg.contains(";[11]"),
+        "diagnostic should point at the leftover `(80%)`, not the consumed `;[11]`: {msg}"
+    );
+}
+
+/// The compact `<pos><unit>[c1];[c2]` Display is gated to RNA and protein
+/// (`recommendations/{RNA,protein}/repeated.md`); the DNA axes spell each
+/// allele out in full (`DNA/repeated.md:33`). A `g.` shared-repeat trans is
+/// still *accepted* by the parser, but it must normalize to the expanded
+/// `[member];[member]` spec form rather than the compact shape — pinning that
+/// the RNA/protein Display gate keeps DNA on its explicit form.
+#[test]
+fn repeat_count_trans_dna_axis_renders_expanded() {
+    let input = "NC_000001.11:g.123_124AC[10];[11]";
+    let expanded = "NC_000001.11:g.[123_124AC[10]];[123_124AC[11]]";
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("must parse `{input}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{input}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::Trans, "phase for `{input}`");
+    assert_eq!(a.variants.len(), 2, "member count for `{input}`");
+    assert_eq!(
+        format!("{v}"),
+        expanded,
+        "DNA shared-repeat trans must render expanded, not compact"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up toward closing #544. Parses the compact repeat trans form `<pos><unit>[c1];[c2]`, where both alleles repeat the same unit at the same position and only the count differs — `NP_003997.1:p.Ala2[10];[11]`, `NM_004006.3:r.-124_-123[14];[18]`, `NM_004006.3:r.-124ug[14];[18]`. Previously the parser finished at the first `]` and rejected the `;[..]` continuation.

## What changed

- **Parse**: after a single-count repeat variant, each `;[count]` continuation builds a sibling allele inheriting the same position + unit with the new count (`set_repeat_count`), assembled into a trans allele. Engages only when the whole remainder is consumed as `;[count]` continuations on a repeat variant.
- **Display**: RNA and protein render the compact spec form (`recommendations/{RNA,protein}/repeated.md` — e.g. RNA/repeated.md:36), gated so the **DNA axes keep their explicit `[member];[member]` form** (DNA/repeated.md:33). This axis split is exactly what the spec uses, and it means the existing DNA repeat-trans rows are unaffected.

## Acceptance

Four spec-fixture rows move off `parse-error` → `preserved`; no rows regress (the explicit DNA `g.[X[14]];[X[18]]` row stays `preserved`). One existing RNA test (`rna_trans_compound_repeat_lowercase`) pinned the explicit form as canonical; it is updated to the compact spec canonical with a citation — its lowercase-preservation intent is unchanged, and DNA's explicit form is untouched.

`cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544.