### PR TITLE
feat(parser): parse frameshift with alternative new residues (#544)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -1001,6 +1001,17 @@ pub enum ProteinEdit {
         ter: FrameshiftTer,
     },
 
+    /// Frameshift whose new residue is one of several alternatives joined by
+    /// `^` inside a wrapper (e.g. `p.Gly719(Ala^Ser)fsTer23`; HGVS
+    /// general.md). The position comes from the location; the alternative
+    /// new residues and the termination detail are stored here.
+    FrameshiftAlternatives {
+        /// The candidate new amino acids at the frameshift position.
+        alternatives: Vec<AminoAcid>,
+        /// Termination detail of the shifted reading frame.
+        ter: FrameshiftTer,
+    },
+
     /// Extension: extension beyond normal start/stop (e.g., p.Met1ext-5, p.Ter110Glnext*17)
     Extension {
         /// The new amino acid at the extension position (e.g., Gln in p.Ter110Glnext*17)
@@ -1167,6 +1178,24 @@ impl fmt::Display for ProteinEdit {
                 // Three-letter `Ter` is the spec-preferred form for the
                 // termination codon (`*` is an accepted input alternative);
                 // Display canonicalizes both to `Ter`.
+                match ter {
+                    FrameshiftTer::Unspecified => {}
+                    FrameshiftTer::Unknown => write!(f, "Ter?")?,
+                    FrameshiftTer::At(pos) => write!(f, "Ter{}", pos)?,
+                }
+                Ok(())
+            }
+            ProteinEdit::FrameshiftAlternatives { alternatives, ter } => {
+                // `(alt1^alt2)fs<ter>` — the new residue is one of the
+                // alternatives, wrapped in parens.
+                write!(f, "(")?;
+                for (i, aa) in alternatives.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "^")?;
+                    }
+                    write!(f, "{}", aa)?;
+                }
+                write!(f, ")fs")?;
                 match ter {
                     FrameshiftTer::Unspecified => {}
                     FrameshiftTer::Unknown => write!(f, "Ter?")?,

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -1653,6 +1653,45 @@ fn parse_protein_frameshift(input: &str) -> IResult<&str, ProteinEdit> {
     ))
 }
 
+/// Parse a frameshift whose new residue is one of several alternatives:
+/// `(aa^aa^...)fs[ter]` (e.g. `(Ala^Ser)fsTer23`). Requires at least two
+/// alternatives — a single `(aa)fs` is not this form.
+fn parse_protein_frameshift_alternatives(input: &str) -> IResult<&str, ProteinEdit> {
+    let (rest, _) = char('(').parse(input)?;
+    let (rest, first) = parse_amino_acid.parse(rest)?;
+    let mut alternatives = vec![first];
+    let mut rest = rest;
+    while let Some(after_caret) = rest.strip_prefix('^') {
+        let (next, aa) = parse_amino_acid.parse(after_caret)?;
+        alternatives.push(aa);
+        rest = next;
+    }
+    if alternatives.len() < 2 {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Tag,
+        )));
+    }
+    let rest = rest
+        .strip_prefix(')')
+        .ok_or_else(|| nom::Err::Error(nom::error::Error::new(rest, nom::error::ErrorKind::Tag)))?;
+    let (rest, _) = tag("fs").parse(rest)?;
+    let (rest, ter) = opt(alt((
+        map(tag("Ter?"), |_| FrameshiftTer::Unknown),
+        map(tag("*?"), |_| FrameshiftTer::Unknown),
+        preceded(tag("Ter"), map_res(digit1, parse_frameshift_ter_at)),
+        preceded(tag("*"), map_res(digit1, parse_frameshift_ter_at)),
+    )))
+    .parse(rest)?;
+    Ok((
+        rest,
+        ProteinEdit::FrameshiftAlternatives {
+            alternatives,
+            ter: ter.unwrap_or(FrameshiftTer::Unspecified),
+        },
+    ))
+}
+
 /// Parse the digits of a concrete frameshift termination position into
 /// [`FrameshiftTer::At`]. The position is 1-based (`docs/syntax.yaml`, `aa.fs`;
 /// the first changed amino acid is position 1), so `0` is rejected. Returning
@@ -1983,6 +2022,11 @@ pub fn parse_protein_edit(input: &str) -> IResult<&str, ProteinEdit> {
             // (N_?) uncertain extension annotation pattern (e.g., (41_?))
             // This indicates an uncertain C-terminal extension position
             if let Ok(result) = parse_uncertain_extension_annotation(input) {
+                return Ok(result);
+            }
+            // (aa^aa...)fs<ter> — frameshift whose new residue is one of
+            // several alternatives (e.g. `(Ala^Ser)fsTer23`).
+            if let Ok(result) = parse_protein_frameshift_alternatives(input) {
                 return Ok(result);
             }
             Err(nom::Err::Error(nom::error::Error::new(

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 327,
-      "preserved": 656
+      "parse-error": 326,
+      "preserved": 657
     },
     "by_coordinate_system": {
       "c": 464,
@@ -11027,19 +11027,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "p.Gly719(Ala^Ser)fsTer23",
-      "input_prefixed": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Ala^Ser)fsTer23\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/uncertain.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "p.Lys2_Leu3insTer12",
       "input_prefixed": "NP_003997.1:p.Lys2_Leu3insTer12",
       "current": "parse error: Parse error at position 29: Unexpected trailing characters: '12'",
@@ -12429,6 +12416,18 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/deletion.md"
+      ]
+    },
+    {
+      "input": "p.Gly719(Ala^Ser)fsTer23",
+      "input_prefixed": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
+      "current": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
+      "spec_expected": "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/uncertain.md"
       ]
     },
     {

--- a/tests/protein_frameshift_alternatives.rs
+++ b/tests/protein_frameshift_alternatives.rs
@@ -1,0 +1,18 @@
+//! Frameshift with alternative new residues (#544).
+//!
+//! `p.Gly719(Ala^Ser)fsTer23` — a frameshift at Gly719 whose new residue is
+//! Ala OR Ser (the `^` alternatives are wrapped in `(...)`), terminating at
+//! Ter23. HGVS general.md.
+
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn protein_frameshift_alternatives_round_trips() {
+    let s = "NP_003997.1:p.Gly719(Ala^Ser)fsTer23";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert!(
+        matches!(v, HgvsVariant::Protein(_)),
+        "expected Protein for `{s}`, got {v:?}"
+    );
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}


### PR DESCRIPTION
## Summary

Follow-up toward closing #544 (split from #550). Parses `p.Gly719(Ala^Ser)fsTer23` — a frameshift whose new residue is one of several alternatives joined by `^` inside `(...)`, before `fs`. Previously the parser rejected the parenthesized alternatives.

## What changed

- New `ProteinEdit::FrameshiftAlternatives { alternatives: Vec<AminoAcid>, ter }` (position from the location; alternatives + termination detail stored here), Display `(alt1^alt2)fs<ter>`. A new variant rather than a field on `Frameshift` keeps the 16 existing `Frameshift` construction sites untouched, and compiled clean against the codebase's wildcard `ProteinEdit` matches.
- The protein edit parser routes a `(aa^aa...)fs[ter]` shape (≥2 alternatives) from the `(` dispatch arm.

## Acceptance

One spec-fixture row moves off `parse-error` → `preserved`; no rows regress. New round-trip test. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544. Completes the residue-level `^` family (the substitution form is #550).