### PR TITLE
feat(parser): accept all-identity trans alleles via cross-spell check (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -20,6 +20,8 @@ use crate::hgvs::variant::{
     LocEdit, MtVariant, ProteinVariant, RnaFusionBreakpoint, RnaFusionVariant, RnaVariant,
     TxVariant,
 };
+use std::collections::HashSet;
+
 use nom::{
     branch::alt,
     bytes::complete::tag,
@@ -1898,20 +1900,6 @@ where
                     }
                     cis_members.push(v);
                 }
-                // HGVS DNA/alleles.md: the "not changed" `=` indication is
-                // used only when a single variant is identified per allele.
-                // Spelling the other allele's variant as `=` inside a
-                // multi-variant cis group is invalid (the spec flags
-                // `[2376G>C;3103=];[2376=;3103del]` as not correct). Reject a
-                // nested cis group that carries a position-identity member
-                // rather than accept the discouraged cross-spelled form.
-                // (The all-identity-allele edge `[a=;b=]` is deferred.)
-                if cis_members.iter().any(is_lhs_position_identity) {
-                    return Err(nom::Err::Error(nom::error::Error::new(
-                        content,
-                        nom::error::ErrorKind::Verify,
-                    )));
-                }
                 HgvsVariant::Allele(AlleleVariant::new(cis_members, AllelePhase::Cis))
             } else {
                 let (final_remaining, variant) = parse_member(content)?;
@@ -1956,10 +1944,112 @@ where
         )));
     }
 
+    // HGVS DNA/alleles.md: the "not changed" `=` indication is used only
+    // when a single variant is identified per allele. Spelling the *other*
+    // allele's variant position as `=` is the invalid "cross-spelled" form
+    // (`[2376G>C;3103=];[2376=;3103del]`). Reject precisely that: a position
+    // that carries a concrete edit in one place and a position-identity (`=`)
+    // in another. An all-identity allele (`[a=;b=]`) paired with a variant at
+    // a *different* position is valid and accepted.
+    if trans_has_cross_spelled_identity(&variants) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
     Ok((
         remaining,
         HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Trans)),
     ))
+}
+
+/// True iff a trans allele cross-spells a position: a concrete edit at some
+/// position in one place and a position-identity (`=`) at the *same* position
+/// inside a multi-variant cis group elsewhere. This is the spec-invalid
+/// redundant-`=` form (`[A;B=];[A=;B]`, DNA/alleles.md).
+///
+/// Only `=` members of a multi-variant *cis group* count as cross-spell
+/// identities — a standalone single-variant `=` allele (`[A];[A=]`) is the
+/// spec's sanctioned "not changed when one variant is identified" form and
+/// must NOT be rejected. Concrete edits count from any member. The position
+/// key is the leaf's location rendering (positions compared as written).
+fn trans_has_cross_spelled_identity(members: &[HgvsVariant]) -> bool {
+    let mut concrete: HashSet<String> = HashSet::new();
+    let mut group_identity: HashSet<String> = HashSet::new();
+    for member in members {
+        // Only a *multi-variant* cis group's `=` counts as a cross-spell
+        // identity. A single-member cis group (`[A=]`) is the spec's
+        // sanctioned "not changed when one variant is identified" form and
+        // must not be rejected. The compact-prefix path unwraps single
+        // members to bare variants, but the fully-qualified path
+        // (`parse_trans_allele`) keeps them wrapped in a one-member
+        // `Allele`, so gate on `len() > 1` to stay spelling-independent.
+        let (leaves, in_cis_group): (&[HgvsVariant], bool) = match member {
+            HgvsVariant::Allele(a) => (&a.variants, a.variants.len() > 1),
+            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => (&[], false),
+            other => (std::slice::from_ref(other), false),
+        };
+        for leaf in leaves {
+            if let Some((pos_key, is_identity)) = leaf_position_and_identity(leaf) {
+                if is_identity {
+                    if in_cis_group {
+                        group_identity.insert(pos_key);
+                    }
+                } else {
+                    concrete.insert(pos_key);
+                }
+            }
+        }
+    }
+    concrete.intersection(&group_identity).next().is_some()
+}
+
+/// For a leaf variant, return `(position-key, is_position_identity)` where the
+/// position key is the location rendering. `None` for non-leaf / non-coord
+/// variants. Used by [`trans_has_cross_spelled_identity`].
+///
+/// For NA arms, `is_position_identity` delegates to [`is_lhs_position_identity`]
+/// to avoid duplicating the `NaEdit::Identity { whole_entity: false, .. }` predicate.
+fn leaf_position_and_identity(v: &HgvsVariant) -> Option<(String, bool)> {
+    use crate::hgvs::edit::ProteinEdit;
+    match v {
+        HgvsVariant::Genome(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Cds(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Tx(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Rna(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Mt(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Circular(x) => Some((
+            format!("{}", x.loc_edit.location),
+            is_lhs_position_identity(v),
+        )),
+        HgvsVariant::Protein(x) => {
+            let is_identity = matches!(
+                x.loc_edit.edit.inner(),
+                Some(ProteinEdit::Identity {
+                    whole_protein: false,
+                    ..
+                })
+            );
+            Some((format!("{}", x.loc_edit.location), is_identity))
+        }
+        _ => None,
+    }
 }
 
 fn parse_genome_trans_allele_shorthand(
@@ -4800,6 +4890,19 @@ fn parse_trans_allele(input: &str) -> Result<HgvsVariant, FerroError> {
         return Err(FerroError::Parse {
             pos: 0,
             msg: "Trans allele requires at least two variants".to_string(),
+            diagnostic: None,
+        });
+    }
+
+    // Reject the spec-invalid cross-spelled `=` form regardless of spelling:
+    // this fully-qualified entrypoint must reject the same allele that the
+    // compact-prefix path rejects via `trans_has_cross_spelled_identity`
+    // (e.g. `[NM_000088.3:c.[2376G>C;3103=]];[NM_000088.3:c.[2376=;3103del]]`).
+    // See `parse_trans_allele_shorthand_generic` for the rationale.
+    if trans_has_cross_spelled_identity(&variants) {
+        return Err(FerroError::Parse {
+            pos: 0,
+            msg: "Invalid cross-spelled `=` in trans allele".to_string(),
             diagnostic: None,
         });
     }

--- a/tests/allele_trans_phase.rs
+++ b/tests/allele_trans_phase.rs
@@ -103,17 +103,62 @@ fn test_trans_of_cis_groups_round_trips() {
 /// The spec (DNA/alleles.md) marks the redundant cross-spelled `=` form as
 /// invalid: "do not use `c.[2376G>C;3103=];[2376=;3103del]`". A multi-variant
 /// cis group containing a position-identity (`=`) member must stay rejected
-/// rather than round-trip the discouraged form.
+/// rather than round-trip the discouraged form. Rejection must not depend on
+/// spelling: both the compact-prefix form and the fully-qualified form (each
+/// arm a bracketed, accession-qualified cis group) describe the same invalid
+/// cross-spelled allele and must reject alike.
 #[test]
 fn test_trans_of_cis_with_identity_member_is_rejected() {
     for s in [
         "LRG_199t1:c.[2376G>C;3103=];[2376=;3103del]",
         "NM_004006.2:c.[2376G>C;3103=];[2376=;3103del]",
+        "[NM_000088.3:c.[2376G>C;3103=]];[NM_000088.3:c.[2376=;3103del]]",
     ] {
         assert!(
             parse_hgvs(s).is_err(),
             "spec-invalid cross-spelled `=` trans form must reject: `{s}`"
         );
+    }
+}
+
+/// A trans allele where one allele is described as reference across regions
+/// (all-identity cis group) is valid — no position is cross-spelled (variant
+/// in one allele, `=` in the other). `[633A>G];[531_648=;961_1149=]` must
+/// parse and round-trip (HGVS DNA/alleles.md). Contrast with the rejected
+/// cross-spelled form above.
+///
+/// Both the compact-prefix spelling and the fully-qualified spelling (each arm
+/// a bracketed, accession-qualified cis group) must be accepted and round-trip
+/// to the canonical compact form. This pins the `parse_trans_allele` code path
+/// for the all-identity acceptance case alongside `parse_trans_allele_shorthand_generic`.
+#[test]
+fn test_trans_of_cis_all_identity_allele_round_trips() {
+    let canonical = "LRG_199t1:c.[633A>G];[531_648=;961_1149=]";
+    for s in [
+        canonical,
+        "[LRG_199t1:c.[633A>G]];[LRG_199t1:c.[531_648=;961_1149=]]",
+    ] {
+        assert_eq!(parse_to_string(s), canonical, "round-trip for `{s}`");
+        assert_eq!(parse_phase(s), AllelePhase::Trans, "phase for `{s}`");
+    }
+}
+
+/// The cross-spell validator must only reject a *multi-variant* cis group's
+/// `=`. A single-variant `=` arm (`[2376G>C];[2376=]`, the spec's "not changed
+/// when one variant is identified" form) is valid in *both* spellings: the
+/// compact-prefix form and the fully-qualified form where each arm repeats the
+/// accession and brackets a single member. Both must round-trip to the compact
+/// canonical form. Guards against the validator keying off the `[...]` wrapper
+/// rather than the member count.
+#[test]
+fn test_trans_single_variant_identity_arm_round_trips_either_spelling() {
+    let canonical = "NM_004006.2:c.[2376G>C];[2376=]";
+    for s in [
+        canonical,
+        "[NM_004006.2:c.[2376G>C]];[NM_004006.2:c.[2376=]]",
+    ] {
+        assert_eq!(parse_to_string(s), canonical, "round-trip for `{s}`");
+        assert_eq!(parse_phase(s), AllelePhase::Trans, "phase for `{s}`");
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up toward closing #544, **stacked on #549** (base: `feat/issue-544-nested-alleles`; retarget to `main` after #549 merges). Refines #549's trans-of-cis identity handling so the valid all-identity allele parses while the spec-invalid cross-spelled form stays rejected.

## What changed

#549 rejected *any* cis group containing a position-identity (`=`) member — a deliberately conservative blanket reject to avoid false-accepting `[2376G>C;3103=];[2376=;3103del]` (flagged `<code class="invalid">` in DNA/alleles.md). That also rejected the **valid** `LRG_199t1:c.[633A>G];[531_648=;961_1149=]` (one allele described as reference across regions).

This replaces the blanket reject with a **precise cross-spell check**: reject only when a position carries a concrete edit in one place and a `=` inside a *multi-variant cis group* at the same position elsewhere. Distinctions preserved:

- `[A];[A=]` (standalone single-variant `=` allele) — the spec's sanctioned "not changed when one variant is identified" form → **accepted**.
- `[633A>G];[531_648=;961_1149=]` (all-identity allele, variant at a different position) → **accepted**.
- `[2376G>C;3103=];[2376=;3103del]` (cross-spelled `=` inside cis groups) → **rejected**.

## Acceptance

One spec-fixture row moves off `parse-error` → `preserved`; the cross-spelled invalid form stays rejected; the existing single-variant-`=` tests still pass. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544.