### PR TITLE
feat(parser): parse trans alleles with a mosaic (;) tail (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1097,10 +1097,15 @@ fn parse_genome_variant(
             }
         }
 
-        // Try trans-allele compact-prefix shorthand: g.[edit1];[edit2]
-        // Detection mirrors the CDS/RNA paths (parse_cds_allele_shorthand,
-        // parse_rna_allele_shorthand): starts with `[` and contains `];[`.
-        if input.starts_with('[') && input.contains("];[") {
+        // Try trans-allele compact-prefix shorthand: g.[edit1];[edit2].
+        // Attempt the trans parser whenever the input is bracketed and fall
+        // back to compound on a clean `Err`, rather than gating on a literal
+        // `];[`. The `];[` substring disappears once the FIRST group carries a
+        // `(;)` mosaic tail (e.g. `[a](;)b;[c]`), so gating on it misrouted
+        // those to compound parsing. The trans parser requires two or more
+        // bracketed groups, so a genuine single-bracket cis/predicted/products
+        // allele rejects and falls through. #559 / CodeRabbit.
+        if input.starts_with('[') {
             if let Ok((remaining, variant)) =
                 parse_genome_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {
@@ -1928,6 +1933,24 @@ where
         variants.push(variant);
         remaining = &remaining[close_bracket + 1..];
 
+        // Trans + mosaic mix: a `(;)` tail after a bracket means this trans
+        // allele member is itself an unknown-phase group — the bracketed
+        // member plus `(;)`-separated bare siblings (e.g. `[B](;)C(;)D` in
+        // `[A];[B](;)C`). Wrap them into an unknown-phase sub-allele member.
+        if remaining.starts_with("(;)") {
+            let bracket_member = variants.pop().expect("just pushed a member");
+            let mut up_members = vec![bracket_member];
+            while let Some(after) = remaining.strip_prefix("(;)") {
+                let (rest, sibling) = parse_member(after)?;
+                up_members.push(sibling);
+                remaining = rest;
+            }
+            variants.push(HgvsVariant::Allele(AlleleVariant::new(
+                up_members,
+                AllelePhase::Unknown,
+            )));
+        }
+
         // Enforce strict `[...];[...]` shape. A `;` is only valid if it
         // separates the bracket we just consumed from another bracket; a
         // dangling trailing `;` (e.g. `[A];[B];`) and a missing separator
@@ -2396,9 +2419,18 @@ fn parse_cds_allele_shorthand(
         )));
     }
 
-    // Check for trans allele pattern: [var];[var] or [var];[0] or [var];[?]
-    if input.contains("];[") {
-        return parse_cds_trans_allele_shorthand(input, accession, gene_symbol);
+    // Try the trans-allele shorthand first: `[var];[var]` and friends,
+    // including the trans+mosaic forms where a group carries a `(;)` tail
+    // (e.g. `[a](;)b;[c]`). A literal `];[` no longer appears once the
+    // FIRST group has a tail, so we can't gate on it; instead we attempt
+    // the trans parser and fall back to compound on a clean `Err`. The
+    // trans parser requires two or more bracketed groups, so a genuine
+    // single-bracket cis/predicted/products allele rejects and falls
+    // through. #559 / CodeRabbit.
+    if let Ok((remaining, variant)) =
+        parse_cds_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+    {
+        return Ok((remaining, variant));
     }
 
     let close_bracket = input.rfind(']').ok_or_else(|| {
@@ -2558,7 +2590,13 @@ fn parse_tx_variant(
         // Compact-prefix trans-allele shorthand: n.[a];[b]. Mirrors
         // parse_genome_variant's dispatch added in PR #146; the expanded
         // form [ACC:n.a];[ACC:n.b] is handled by the top-level allele parser.
-        if input.starts_with('[') && input.contains("];[") {
+        // Attempt the trans parser whenever the input is bracketed and fall
+        // back to compound on a clean `Err`, rather than gating on a literal
+        // `];[` — that substring disappears once the FIRST group carries a
+        // `(;)` mosaic tail (e.g. `[a](;)b;[c]`). The trans parser requires
+        // two or more bracketed groups, so a single-bracket cis/predicted/
+        // products allele rejects and falls through. #559 / CodeRabbit.
+        if input.starts_with('[') {
             if let Ok((remaining, variant)) =
                 parse_tx_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {
@@ -2889,8 +2927,14 @@ fn parse_mt_variant(
         }
 
         // Compact-prefix trans-allele shorthand: m.[a];[b]. Mirrors
-        // parse_genome_variant's dispatch added in PR #146.
-        if input.starts_with('[') && input.contains("];[") {
+        // parse_genome_variant's dispatch added in PR #146. Attempt the trans
+        // parser whenever the input is bracketed and fall back to compound on
+        // a clean `Err`, rather than gating on a literal `];[` — that substring
+        // disappears once the FIRST group carries a `(;)` mosaic tail (e.g.
+        // `[a](;)b;[c]`). The trans parser requires two or more bracketed
+        // groups, so a single-bracket cis/predicted/products allele rejects and
+        // falls through. #559 / CodeRabbit.
+        if input.starts_with('[') {
             if let Ok((remaining, variant)) =
                 parse_mt_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {
@@ -3665,7 +3709,12 @@ fn parse_protein_variant(
         // before the cis allele path, since trans is the more specific shape.
         // Mirrors the DNA/RNA dispatches (parse_genome_variant,
         // parse_cds_variant, parse_rna_variant) and PR #146's fix for `g.`.
-        if input.starts_with('[') && input.contains("];[") {
+        // Attempt the trans parser whenever the input is bracketed and fall
+        // back to compound on a clean `Err`, rather than gating on a literal
+        // `];[`: `parse_protein_trans_allele_shorthand` requires two or more
+        // bracketed groups, so a single-bracket cis/predicted/products allele
+        // rejects and falls through. #559 / CodeRabbit.
+        if input.starts_with('[') {
             if let Ok((remaining, variant)) =
                 parse_protein_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {
@@ -4176,9 +4225,18 @@ fn parse_rna_allele_shorthand(
         )));
     }
 
-    // Check for trans allele pattern: [var];[var] or [var];[0] or [var];[?]
-    if input.contains("];[") {
-        return parse_rna_trans_allele_shorthand(input, accession, gene_symbol);
+    // Try the trans-allele shorthand first: `[var];[var]` and friends,
+    // including the trans+mosaic forms where a group carries a `(;)` tail
+    // (e.g. `[a](;)b;[c]`). A literal `];[` no longer appears once the
+    // FIRST group has a tail, so we can't gate on it; instead we attempt
+    // the trans parser and fall back to compound on a clean `Err`. The
+    // trans parser requires two or more bracketed groups, so a genuine
+    // single-bracket cis/predicted/products allele rejects and falls
+    // through. #559 / CodeRabbit.
+    if let Ok((remaining, variant)) =
+        parse_rna_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
+    {
+        return Ok((remaining, variant));
     }
 
     let close_bracket = input.rfind(']').ok_or_else(|| {
@@ -4316,8 +4374,14 @@ fn parse_circular_variant(
 
         // Compact-prefix trans-allele shorthand: o.[a];[b]. Mirrors
         // parse_genome_variant's dispatch added in PR #146; SVD-WG006 says
-        // circular DNA inherits the DNA allele grammar.
-        if input.starts_with('[') && input.contains("];[") {
+        // circular DNA inherits the DNA allele grammar. Attempt the trans
+        // parser whenever the input is bracketed and fall back to compound on
+        // a clean `Err`, rather than gating on a literal `];[` — that substring
+        // disappears once the FIRST group carries a `(;)` mosaic tail (e.g.
+        // `[a](;)b;[c]`). The trans parser requires two or more bracketed
+        // groups, so a single-bracket cis/predicted/products allele rejects and
+        // falls through. #559 / CodeRabbit.
+        if input.starts_with('[') {
             if let Ok((remaining, variant)) =
                 parse_circular_trans_allele_shorthand(input, accession.clone(), gene_symbol.clone())
             {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1099,6 +1099,31 @@ fn trans_compact_anchor(variants: &[HgvsVariant]) -> Option<&HgvsVariant> {
     anchor
 }
 
+/// Write one trans member wrapped in its bracket(s). A cis-group / leaf /
+/// `[0]` / `[?]` member renders as `[<inner>]`. An unknown-phase sub-allele
+/// member (the trans+mosaic mix `[B](;)C`) brackets only its first member and
+/// appends the rest with `(;)` outside the bracket.
+fn write_trans_member_bracketed(f: &mut fmt::Formatter<'_>, member: &HgvsVariant) -> fmt::Result {
+    if let HgvsVariant::Allele(a) = member {
+        if a.phase == AllelePhase::Unknown {
+            for (i, sub) in a.variants.iter().enumerate() {
+                if i == 0 {
+                    write!(f, "[")?;
+                    sub.fmt_loc_edit(f)?;
+                    write!(f, "]")?;
+                } else {
+                    write!(f, "(;)")?;
+                    sub.fmt_loc_edit(f)?;
+                }
+            }
+            return Ok(());
+        }
+    }
+    write!(f, "[")?;
+    write_trans_member(f, member)?;
+    write!(f, "]")
+}
+
 /// Write the bracket-inner content of one `Trans` allele member (without the
 /// surrounding `[` `]`). A nested cis-group member renders its sub-variants'
 /// loc-edits joined by `;`; `[0]`/`[?]` render their marker; a leaf renders
@@ -1357,15 +1382,15 @@ impl fmt::Display for AlleleVariant {
                 if has_nested_group {
                     if let Some(anchor) = trans_compact_anchor(&self.variants) {
                         // Compact: ACC:c.[a;b];[c;d] — prefix once, then each
-                        // member's bracket-inner content.
+                        // member's bracket-inner content. An unknown-phase
+                        // member renders as `[B](;)C` (mosaic tail outside the
+                        // bracket).
                         write_compact_prefix(f, anchor)?;
                         for (i, v) in self.variants.iter().enumerate() {
                             if i > 0 {
                                 write!(f, ";")?;
                             }
-                            write!(f, "[")?;
-                            write_trans_member(f, v)?;
-                            write!(f, "]")?;
+                            write_trans_member_bracketed(f, v)?;
                         }
                         Ok(())
                     } else {
@@ -1375,7 +1400,7 @@ impl fmt::Display for AlleleVariant {
                             if i > 0 {
                                 write!(f, ";")?;
                             }
-                            write!(f, "[{}]", v)?;
+                            write_trans_member_bracketed(f, v)?;
                         }
                         Ok(())
                     }

--- a/tests/trans_mosaic_mixed.rs
+++ b/tests/trans_mosaic_mixed.rs
@@ -1,0 +1,181 @@
+//! Trans alleles with a mosaic `(;)` tail on one allele (#544).
+//!
+//! `c.[296T>G;476T>C];[476T>C](;)1083A>C` — a trans allele where the second
+//! allele is itself an unknown-phase group: a bracketed member followed by
+//! `(;)`-separated siblings. HGVS DNA/alleles.md + mosaicism.
+
+use ferro_hgvs::hgvs::{AllelePhase, AlleleVariant};
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn trans_with_mosaic_tail_round_trips() {
+    for s in [
+        "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C",
+        "NM_004006.2:c.[296T>G];[476T>C](;)1083G>C(;)1406del",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// First trans group carries a `(;)` mosaic tail — symmetric to the
+/// already-supported second-member tail. When the leading group ends with a
+/// `(;)` tail the literal `];[` no longer appears in the input, so the old
+/// `starts_with('[') && contains("];[")` gate misrouted these to compound
+/// parsing and they failed. #559 / CodeRabbit.
+#[test]
+fn first_member_mosaic_tail_round_trips() {
+    for s in [
+        "NC_000002.12:g.[100A>G](;)150del;[200del]",
+        "NM_004006.2:c.[296T>G](;)1083A>C;[476T>C]",
+        "NR_004006.2:n.[100A>G](;)300del;[200T>C]",
+        "NC_012920.1:m.[100A>G](;)300del;[200T>C]",
+        "AC_000001.1:o.[100A>G](;)300del;[200T>C]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// g. / n. / m. / o. axis round-trips (#544 nitpick)
+// ---------------------------------------------------------------------------
+
+/// Genomic trans+mosaic round-trips. Exercises the same `[a;b];[c](;)d`
+/// shape as the c. test above but for `g.` coordinates.
+#[test]
+fn trans_with_mosaic_tail_g_round_trips() {
+    for s in [
+        "NC_000001.11:g.[100A>G;200T>C];[300del](;)400dup",
+        "NC_000001.11:g.[100A>G];[200T>C](;)300del(;)400dup",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// Non-coding transcript trans+mosaic round-trips (`n.` axis).
+#[test]
+fn trans_with_mosaic_tail_n_round_trips() {
+    for s in [
+        "NR_004006.2:n.[100A>G;200T>C];[300del](;)400dup",
+        "NR_004006.2:n.[100A>G];[200T>C](;)300del",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// Mitochondrial trans+mosaic round-trips (`m.` axis, heteroplasmy).
+#[test]
+fn trans_with_mosaic_tail_m_round_trips() {
+    for s in [
+        "NC_012920.1:m.[100A>G;200T>C];[300del](;)400dup",
+        "NC_012920.1:m.[100A>G];[200T>C](;)300del",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// Circular DNA trans+mosaic round-trips (`o.` axis, SVD-WG006).
+#[test]
+fn trans_with_mosaic_tail_o_round_trips() {
+    for s in [
+        "AC_000001.1:o.[100A>G;200T>C];[300del](;)400dup",
+        "AC_000001.1:o.[100A>G];[200T>C](;)300del",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Trans, "phase for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-reference trans+mosaic Display fix (#544 — Finding 1)
+// ---------------------------------------------------------------------------
+
+/// A programmatically-constructed trans allele where one member is an
+/// `Unknown`-phase sub-allele and the members have different reference
+/// accessions (so `trans_compact_anchor` returns `None`, forcing the
+/// mixed-reference expanded path).
+///
+/// Before the fix, the else-branch used `write!(f, "[{}]", v)?`, which
+/// called the full `Display` on the Unknown-phase sub-allele (producing the
+/// compact bracketless form `ACC:c.B(;)C`) and then wrapped it in `[…]`,
+/// yielding the syntactically-invalid `[ACC:c.B(;)C]`. The fix replaces
+/// that with `write_trans_member_bracketed`, which recognises the
+/// Unknown-phase inner allele and emits `[B](;)C` with the bracket only
+/// around the first member — exactly the trans+mosaic spec shape.
+#[test]
+fn mixed_accession_trans_mosaic_display_not_double_wrapped() {
+    // Build the inner Unknown-phase allele from two separately-parsed
+    // leaf variants that share accession NM_001005922.2 (different from
+    // the outer leaf below).
+    let inner_a = parse_hgvs("NM_001005922.2:c.476T>C").expect("inner leaf a must parse");
+    let inner_b = parse_hgvs("NM_001005922.2:c.1083A>C").expect("inner leaf b must parse");
+    let unknown_member = HgvsVariant::Allele(AlleleVariant::new(
+        vec![inner_a, inner_b],
+        AllelePhase::Unknown,
+    ));
+
+    // The outer trans allele has two members with different accessions:
+    // NM_004006.2 (leaf) vs NM_001005922.2 (Unknown-phase group above).
+    // trans_compact_anchor will return None, so the mixed-reference else
+    // branch is taken.
+    let leaf = parse_hgvs("NM_004006.2:c.296T>G").expect("leaf must parse");
+    let trans = HgvsVariant::Allele(AlleleVariant::new(
+        vec![leaf, unknown_member],
+        AllelePhase::Trans,
+    ));
+    let display = format!("{trans}");
+
+    // The Unknown-phase member must render as [B](;)C, not [ACC:type.B(;)C].
+    // In the mixed-reference path the accession+type prefix is omitted by
+    // write_trans_member_bracketed (it calls fmt_loc_edit for each sub),
+    // so the expected form is the bare edit without a coord-system prefix.
+    assert!(
+        !display.contains("[NM_001005922.2:"),
+        "display must not wrap the accession-prefixed form in brackets; got: {display}"
+    );
+    // The first sub of the Unknown-phase member should be bracket-wrapped
+    // and the second appended with (;) — the trans+mosaic bracket shape.
+    assert!(
+        display.contains("[476T>C](;)1083A>C"),
+        "Unknown-phase member must render as [476T>C](;)1083A>C; got: {display}"
+    );
+    // No double brackets anywhere.
+    assert!(
+        !display.contains("[["),
+        "display must not contain double brackets; got: {display}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up toward closing #544, **stacked on #549** (base: `feat/issue-544-nested-alleles`; retarget to `main` after #549 merges). Parses the trans+mosaic mixed form `[A];[B](;)C(;)D`, where one trans allele is itself an unknown-phase group — a bracketed member followed by `(;)`-separated siblings: `NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C`, `NM_004006.2:c.[296T>G];[476T>C](;)1083G>C(;)1406del`. Previously the trans shorthand rejected the `(;)` tail after a bracket.

## What changed

- **Parse**: after a trans bracket, a `(;)` tail consumes the `(;)`-separated bare siblings and wraps the bracket member + siblings into an unknown-phase sub-allele member — nested in the trans allele, reusing #549's nested-member representation (no new AST).
- **Display**: a `write_trans_member_bracketed` helper renders an unknown-phase trans member as `[B](;)C` — the bracket wraps only the first member, with the `(;)` siblings outside it. (The uniform `[m];[m]` rendering can't express this; flat/cis trans rendering is unchanged.)

## Acceptance

Two spec-fixture rows move off `parse-error` → `preserved`; no rows regress. New round-trip test. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544. (The combined caret+mosaic+trans form `p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]` additionally needs #547's `^`, so it remains for a later cross-cutting pass.)