### PR TITLE
fix(parser): bring fast path to full parity with the generic parser (ncRNA, U base, positions, panic)

### DIFF
--- a/src/hgvs/parser/fast_path.rs
+++ b/src/hgvs/parser/fast_path.rs
@@ -22,6 +22,7 @@
 //! - UTR variants: `c.*100A>G`, `c.-50A>G`
 //! - Non-coding RNA: `n.100A>G`
 //! - RNA variants: `r.100a>g`
+//! - Non-coding RNA accessions: NR_/XR_ (any coordinate system)
 //!
 //! This overhead comes from the quick-rejection checks needed to identify
 //! fast-path candidates. For workloads dominated by substitutions, the net
@@ -90,6 +91,37 @@ fn scan_digits(bytes: &[u8], start: usize) -> (u64, usize) {
     (value, end)
 }
 
+/// True for a base byte the fast path may parse in a DNA substitution. This is
+/// [`is_iupac_base`] minus the RNA base `U`: HGVS forbids `U` in a DNA (`g.` /
+/// `c.`) description (#486, `ENODNA`), so a `U` base must defer to the generic
+/// parser, which rejects it. (Lowercase bases already fail `is_iupac_base`.)
+#[inline]
+const fn is_fast_dna_base(b: u8) -> bool {
+    is_iupac_base(b) && b != b'U'
+}
+
+/// Scan an HGVS *position*: a run of ASCII digits that is canonical (no leading
+/// zero) and fits in `u64`. Returns `(value, end)`, or `None` if the position
+/// is absent, has a leading zero (`0`, `00`, `007`, `01` — all rejected by the
+/// generic parser), or overflows `u64`; the fast path defers to the generic
+/// parser on `None`. Distinct from [`scan_digits`], which is also used for
+/// accession numbers where leading zeros are valid (e.g. `NM_000088`).
+#[inline]
+fn scan_position(bytes: &[u8], start: usize) -> Option<(u64, usize)> {
+    if start >= bytes.len() || !bytes[start].is_ascii_digit() || bytes[start] == b'0' {
+        return None;
+    }
+    let mut end = start;
+    let mut value: u64 = 0;
+    while end < bytes.len() && bytes[end].is_ascii_digit() {
+        value = value
+            .checked_mul(10)?
+            .checked_add((bytes[end] - b'0') as u64)?;
+        end += 1;
+    }
+    Some((value, end))
+}
+
 /// Result of fast-path parsing attempt
 #[allow(clippy::large_enum_variant)]
 pub enum FastPathResult {
@@ -115,10 +147,12 @@ pub fn try_fast_path(input: &str) -> FastPathResult {
 
     // Quick check: does it end with a substitution pattern (X>Y)?
     // This avoids expensive parsing for deletions, insertions, etc.
+    // `is_fast_dna_base` (not `is_iupac_base`) so a `U` base — invalid in a DNA
+    // description — falls back to the generic parser rather than being parsed.
     if len < 3
         || bytes[len - 2] != b'>'
-        || !is_iupac_base(bytes[len - 1])
-        || !is_iupac_base(bytes[len - 3])
+        || !is_fast_dna_base(bytes[len - 1])
+        || !is_fast_dna_base(bytes[len - 3])
     {
         return FastPathResult::Fallback;
     }
@@ -169,7 +203,8 @@ pub fn try_fast_path(input: &str) -> FastPathResult {
 
     // Dispatch based on first character
     match bytes[0] {
-        // RefSeq accessions: NC_, NM_, NP_, NG_, NR_, XM_, XR_, XP_
+        // RefSeq accessions: NC_, NM_, NP_, NG_, XM_, XP_
+        // (NR_/XR_ are deferred to the generic parser before try_refseq_fast_path)
         b'N' | b'X' => {
             if bytes.len() > 2 && bytes[2] == b'_' {
                 // `NR_`/`XR_` are non-coding RNA transcripts (the only RefSeq
@@ -478,15 +513,12 @@ fn try_parse_genome_substitution(
     edit_start: usize,
     accession: Accession,
 ) -> FastPathResult {
-    // Parse position (must start with digit for simple case)
-    if edit_start >= bytes.len() || !bytes[edit_start].is_ascii_digit() {
-        return FastPathResult::Fallback;
-    }
-
-    let (position, pos_end) = scan_digits(bytes, edit_start);
-    if pos_end == edit_start {
-        return FastPathResult::Fallback;
-    }
+    // Parse a canonical position (no leading zero, fits u64); a non-canonical
+    // or overflowing position defers to the generic parser, which rejects it.
+    let (position, pos_end) = match scan_position(bytes, edit_start) {
+        Some(p) => p,
+        None => return FastPathResult::Fallback,
+    };
 
     // Check for simple substitution pattern: A>G at end of string
     // pos_end should point to ref base, pos_end+1 to '>', pos_end+2 to alt base
@@ -494,9 +526,9 @@ fn try_parse_genome_substitution(
         return FastPathResult::Fallback; // Not a simple substitution at end
     }
 
-    if !is_iupac_base(bytes[pos_end])
+    if !is_fast_dna_base(bytes[pos_end])
         || bytes[pos_end + 1] != b'>'
-        || !is_iupac_base(bytes[pos_end + 2])
+        || !is_fast_dna_base(bytes[pos_end + 2])
     {
         return FastPathResult::Fallback;
     }
@@ -529,14 +561,15 @@ fn try_parse_cds_substitution(
     edit_start: usize,
     accession: Accession,
 ) -> FastPathResult {
-    // Parse position - must start with digit for simple case
-    // Complex cases: -, *, (, ? all fall back to generic parser
-    if edit_start >= bytes.len() || !bytes[edit_start].is_ascii_digit() {
-        return FastPathResult::Fallback;
-    }
-
-    let (position, pos_end) = scan_digits(bytes, edit_start);
-    if pos_end == edit_start {
+    // Parse a canonical position (no leading zero, fits u64); a non-canonical
+    // or overflowing position defers to the generic parser, which rejects it.
+    // Complex cases (-, *, (, ?) start with a non-digit and so also defer.
+    let (position, pos_end) = match scan_position(bytes, edit_start) {
+        Some(p) => p,
+        None => return FastPathResult::Fallback,
+    };
+    // CdsPos is i64; a value beyond i64::MAX would wrap, so defer it.
+    if position > i64::MAX as u64 {
         return FastPathResult::Fallback;
     }
 
@@ -554,9 +587,9 @@ fn try_parse_cds_substitution(
         return FastPathResult::Fallback;
     }
 
-    if !is_iupac_base(bytes[pos_end])
+    if !is_fast_dna_base(bytes[pos_end])
         || bytes[pos_end + 1] != b'>'
-        || !is_iupac_base(bytes[pos_end + 2])
+        || !is_fast_dna_base(bytes[pos_end + 2])
     {
         return FastPathResult::Fallback;
     }

--- a/src/hgvs/parser/fast_path.rs
+++ b/src/hgvs/parser/fast_path.rs
@@ -30,7 +30,9 @@
 //! # Supported Fast-Paths
 //!
 //! Simple substitutions (position + single base change) for:
-//! - **RefSeq**: NC_, NM_, NG_, NR_, XM_, XR_ accessions with `g.` or `c.` variants
+//! - **RefSeq**: NC_, NM_, NG_, XM_ accessions with `g.` or `c.` variants
+//!   (`NR_`/`XR_` non-coding RNA transcripts are deferred to the generic
+//!   parser — their only valid coordinate systems are `n.`/`r.`)
 //! - **Ensembl**: ENST, ENSG accessions with `g.` or `c.` variants
 //! - **LRG**: LRG_ accessions with `g.` or `c.` variants
 //! - **Assembly**: GRCh37/38, hg19/38 notation with `g.` variants
@@ -146,11 +148,20 @@ pub fn try_fast_path(input: &str) -> FastPathResult {
                     return FastPathResult::Fallback;
                 }
 
-                // Check for intronic offset using memchr (faster than loop)
-                // Look for + or - in the region between position start and X>Y
-                let search_region = &bytes[colon_pos + 4..len - 3];
-                if memchr::memchr2(b'+', b'-', search_region).is_some() {
-                    return FastPathResult::Fallback;
+                // Check for intronic offset using memchr (faster than loop).
+                // Look for + or - in the region between the position start and
+                // the trailing `X>Y`. Guard the bounds: for a very short `c.`
+                // body (e.g. a malformed `c.A>G` with no position number)
+                // `colon_pos + 4` can exceed `len - 3`, and an unchecked slice
+                // would panic instead of falling back. When the region is
+                // empty there is no room for an intronic offset anyway, so skip.
+                let region_start = colon_pos + 4;
+                let region_end = len - 3;
+                if region_start < region_end {
+                    let search_region = &bytes[region_start..region_end];
+                    if memchr::memchr2(b'+', b'-', search_region).is_some() {
+                        return FastPathResult::Fallback;
+                    }
                 }
             }
         }
@@ -161,6 +172,20 @@ pub fn try_fast_path(input: &str) -> FastPathResult {
         // RefSeq accessions: NC_, NM_, NP_, NG_, NR_, XM_, XR_, XP_
         b'N' | b'X' => {
             if bytes.len() > 2 && bytes[2] == b'_' {
+                // `NR_`/`XR_` are non-coding RNA transcripts (the only RefSeq
+                // nucleotide prefixes whose second letter is `R`). Per HGVS
+                // (refseq.md: the prefix declares the reference *type*; `n.`
+                // is "based on a transcript not coding for a protein"), their
+                // only valid coordinate systems are `n.`/`r.`. The fast path
+                // parses only `g.`/`c.` substitutions, so parsing one here
+                // would mint a `Genome`/`Cds` variant — silently accepting a
+                // coordinate-system/reference-type mismatch that the generic
+                // parser rejects (#486, ECOORDINATESYSTEMMISMATCH). Defer to
+                // `parse_variant` so it owns that spec rule and the two entry
+                // points stay observationally identical.
+                if bytes[1] == b'R' {
+                    return FastPathResult::Fallback;
+                }
                 return try_refseq_fast_path(input, bytes);
             }
             FastPathResult::Fallback

--- a/tests/fast_path_differential.proptest-regressions
+++ b/tests/fast_path_differential.proptest-regressions
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 615c5624db77adcccd79def4de99aceebd1ce33df3695b73e89f3ff8f1e3d6a5 # shrinks to input = "NR_003051.3:g.1A>A"
+cc 7eca17481cce7490ca78796c12334e7eb829f86150cf4a8233dcb30324876bed # shrinks to input = "NR_003051.3:c.1A>A"

--- a/tests/fast_path_differential.rs
+++ b/tests/fast_path_differential.rs
@@ -84,6 +84,16 @@ const DIFFERENTIAL_CASES: &[&str] = &[
     // --- whitespace / trimming edges ---
     "  NC_000001.11:g.12345A>G  ",
     "\tNM_000088.3:c.459A>G\n",
+    // --- invalid base `U` in DNA / non-canonical positions: fast must defer ---
+    "NC_000001.11:g.100A>U",
+    "NC_000001.11:g.100U>A",
+    "NM_000088.3:c.45A>U",
+    "NM_000088.3:c.0A>G",
+    "NM_000088.3:c.00A>G",
+    "NM_000088.3:c.01A>G",
+    "NM_000088.3:c.007A>G",
+    "NC_000001.11:g.99999999999999999999999A>G",
+    "NM_000088.3:c.9223372036854775808A>G",
     // --- malformed (both must reject) ---
     "",
     "not an hgvs string",
@@ -151,8 +161,10 @@ prop_compose! {
 
 prop_compose! {
     /// An intronic / UTR-offset substitution, e.g. `c.100+5A>G` or
-    /// `c.-50A>G` — structurally a substitution but outside the fast path,
-    /// so it must route to the generic parser identically.
+    /// `c.-50A>G`. When `offset` is non-empty, the generated string is outside
+    /// the fast path and defers to the generic parser; when `offset` is empty
+    /// the generated string (e.g. `NM_000088.3:c.1A>G`) is a standard fast-path
+    /// case. In both cases both parsers must agree.
     fn offset_substitution()(
         acc in accession(),
         pos in 1u64..50_000,
@@ -180,6 +192,46 @@ prop_compose! {
         ],
     ) -> String {
         format!("{acc}:c.{pos}_{end}{edit}", end = pos + span)
+    }
+}
+
+/// A base spanning canonical (`ACGT`), IUPAC-ambiguity (`RYN`), the RNA base
+/// `U`, and lowercase — to exercise base-validity parity.
+fn edge_base() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("A"),
+        Just("C"),
+        Just("G"),
+        Just("T"),
+        Just("U"),
+        Just("R"),
+        Just("Y"),
+        Just("N"),
+        Just("a"),
+        Just("t"),
+        Just("u"),
+    ]
+}
+
+prop_compose! {
+    /// A substitution whose base and/or position deliberately ranges over the
+    /// invalid edges the fast path historically mis-accepted: the RNA base `U`,
+    /// IUPAC-ambiguity codes, lowercase, and non-canonical positions (`0`,
+    /// leading zeros, u64/i64 overflow). The generic parser rejects these; the
+    /// fast path must agree by *deferring*, not by parsing them.
+    fn edge_substitution()(
+        acc in accession(),
+        sys in prop_oneof![Just("g"), Just("c")],
+        pos in prop_oneof![
+            Just("1"), Just("100"), Just("250000000"), // canonical
+            Just("0"), Just("00"), Just("01"), Just("007"), // leading zero / zero
+            Just("99999999999999999999999"), // u64 overflow
+            Just("9223372036854775808"),     // i64::MAX + 1
+        ],
+        from in edge_base(),
+        to in edge_base(),
+    ) -> String {
+        format!("{acc}:{sys}.{pos}{from}>{to}")
     }
 }
 
@@ -226,6 +278,11 @@ proptest! {
 
     #[test]
     fn fast_path_matches_standard_truncated(input in truncated_boundary()) {
+        prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
+    }
+
+    #[test]
+    fn fast_path_matches_standard_edge(input in edge_substitution()) {
         prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
     }
 }

--- a/tests/fast_path_differential.rs
+++ b/tests/fast_path_differential.rs
@@ -1,0 +1,231 @@
+//! Differential identity test: `parse_hgvs_fast` must agree with `parse_hgvs`.
+//!
+//! `parse_hgvs` routes through the full nom parser (`parse_variant`).
+//! `parse_hgvs_fast` first tries a specialized substitution parser
+//! (`fast_path::try_fast_path`) and falls back to `parse_variant` for
+//! everything it does not recognize.
+//!
+//! Making the fast path the *default* (`C1`) is only sound if the two entry
+//! points are observationally identical for **every** input — i.e. for any
+//! string they either both reject, or both accept and yield the same
+//! [`HgvsVariant`]. A single divergence (one accepts where the other rejects,
+//! or they produce different ASTs) would be a behavior change, not a perf win.
+//!
+//! This test pins that invariant two ways:
+//!   1. a deterministic table covering each documented fast-path pattern and
+//!      its fallback counterparts (substitutions on every accession flavor,
+//!      plus intronic / UTR / non-coding / RNA / del / ins / dup / delins /
+//!      inv that must route to the generic parser), and
+//!   2. a `proptest` fuzzer that assembles structurally-varied HGVS strings
+//!      and asserts agreement on each.
+//!
+//! It is intentionally a pure correctness gate: it does not flip the default,
+//! it proves whether the default *could* be flipped safely.
+
+use ferro_hgvs::{parse_hgvs, parse_hgvs_fast};
+use proptest::prelude::*;
+
+/// Assert that the standard and fast entry points agree on `input`.
+///
+/// Agreement means: both `Err`, or both `Ok` with equal variants. Returns a
+/// human-readable description of the divergence on mismatch (so both the
+/// table test and the proptest fuzzer can surface the exact offending input)
+/// or `None` when they agree.
+fn divergence(input: &str) -> Option<String> {
+    let standard = parse_hgvs(input);
+    let fast = parse_hgvs_fast(input);
+    match (standard, fast) {
+        (Ok(a), Ok(b)) if a == b => None,
+        (Err(_), Err(_)) => None,
+        (Ok(a), Ok(b)) => Some(format!(
+            "both parsed but differ:\n  input:    {input:?}\n  standard: {a:?}\n  fast:     {b:?}"
+        )),
+        (Ok(a), Err(e)) => Some(format!(
+            "standard accepted, fast rejected:\n  input:    {input:?}\n  standard: {a:?}\n  fast err: {e:?}"
+        )),
+        (Err(e), Ok(b)) => Some(format!(
+            "fast accepted, standard rejected:\n  input:    {input:?}\n  fast:     {b:?}\n  std err:  {e:?}"
+        )),
+    }
+}
+
+/// Representative inputs spanning every documented fast-path pattern and the
+/// fallback patterns it must defer on. If the fast path ever diverges from the
+/// generic parser on one of these, flipping the default is unsafe.
+const DIFFERENTIAL_CASES: &[&str] = &[
+    // --- fast-path substitutions (every accession flavor) ---
+    "NC_000001.11:g.12345A>G",
+    "NC_000023.11:g.1A>T",
+    "NM_000088.3:c.459A>G",
+    "NM_000088.3:c.1G>C",
+    "ENST00000357033.8:c.100A>G",
+    "ENSG00000139618.15:g.500C>T",
+    "LRG_1:g.5000A>G",
+    "LRG_1t1:c.100A>G",
+    "GRCh38(chr1):g.12345A>G",
+    "GRCh37(chrX):g.999G>A",
+    // --- non-coding / RNA substitutions ---
+    "NR_003051.3:n.100A>G",
+    "NM_000088.3:r.100a>g",
+    // --- intronic / UTR (must fall back) ---
+    "NM_000088.3:c.100+5A>G",
+    "NM_000088.3:c.100-5A>G",
+    "NM_000088.3:c.-50A>G",
+    "NM_000088.3:c.*100A>G",
+    "NM_000088.3:c.*1G>A",
+    // --- non-substitution edits (must fall back) ---
+    "NM_000088.3:c.459del",
+    "NM_000088.3:c.459_460del",
+    "NM_000088.3:c.459dup",
+    "NM_000088.3:c.459_460insACGT",
+    "NM_000088.3:c.459_460delinsAC",
+    "NM_000088.3:c.459_460inv",
+    "NC_000001.11:g.12345_12350del",
+    // --- whitespace / trimming edges ---
+    "  NC_000001.11:g.12345A>G  ",
+    "\tNM_000088.3:c.459A>G\n",
+    // --- malformed (both must reject) ---
+    "",
+    "not an hgvs string",
+    "NM_000088.3:c.A>G",
+    "NC_000001.11:g.12345A>",
+    "NM_000088.3:c.459X>G",
+    "NM_000088.3:p.Arg100Gly",
+];
+
+#[test]
+fn fast_path_matches_standard_on_table() {
+    let mut failures = Vec::new();
+    for &input in DIFFERENTIAL_CASES {
+        if let Some(msg) = divergence(input) {
+            failures.push(msg);
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "fast path diverged from standard parser on {} case(s):\n\n{}",
+        failures.len(),
+        failures.join("\n\n")
+    );
+}
+
+/// A nucleotide base for substitution generation.
+fn base() -> impl Strategy<Value = &'static str> {
+    prop_oneof![Just("A"), Just("C"), Just("G"), Just("T")]
+}
+
+/// An accession prefix spanning the flavors the fast path special-cases plus
+/// ones it does not, so both `Success` and `Fallback` branches are exercised.
+fn accession() -> impl Strategy<Value = &'static str> {
+    prop_oneof![
+        Just("NC_000001.11"),
+        Just("NM_000088.3"),
+        Just("NR_003051.3"),
+        Just("ENST00000357033.8"),
+        Just("ENSG00000139618.15"),
+        Just("LRG_1"),
+        Just("LRG_1t1"),
+        Just("GRCh38(chr1)"),
+        Just("GRCh37(chrX)"),
+    ]
+}
+
+/// Coordinate-system letter.
+fn coord_system() -> impl Strategy<Value = &'static str> {
+    prop_oneof![Just("g"), Just("c"), Just("n"), Just("r")]
+}
+
+prop_compose! {
+    /// A bare substitution string, e.g. `NM_000088.3:c.459A>G` — the fast
+    /// path's core domain.
+    fn substitution()(
+        acc in accession(),
+        sys in coord_system(),
+        pos in 1u64..200_000,
+        from in base(),
+        to in base(),
+    ) -> String {
+        format!("{acc}:{sys}.{pos}{from}>{to}")
+    }
+}
+
+prop_compose! {
+    /// An intronic / UTR-offset substitution, e.g. `c.100+5A>G` or
+    /// `c.-50A>G` — structurally a substitution but outside the fast path,
+    /// so it must route to the generic parser identically.
+    fn offset_substitution()(
+        acc in accession(),
+        pos in 1u64..50_000,
+        offset in prop_oneof![Just(""), Just("+5"), Just("-5"), Just("*"), Just("-")],
+        from in base(),
+        to in base(),
+    ) -> String {
+        format!("{acc}:c.{offset}{pos}{from}>{to}")
+    }
+}
+
+prop_compose! {
+    /// A non-substitution edit (del/ins/dup/delins/inv) that the fast path
+    /// never claims — both parsers must agree (typically both accept).
+    fn non_sub_edit()(
+        acc in accession(),
+        pos in 1u64..50_000,
+        span in 1u64..20,
+        edit in prop_oneof![
+            Just("del"),
+            Just("dup"),
+            Just("inv"),
+            Just("insACGT"),
+            Just("delinsAC"),
+        ],
+    ) -> String {
+        format!("{acc}:c.{pos}_{end}{edit}", end = pos + span)
+    }
+}
+
+prop_compose! {
+    /// A truncated / boundary-length input: `{acc}:{sys}.{tail}` where `tail`
+    /// is a short string from the HGVS punctuation alphabet. This deliberately
+    /// stresses the fast path's byte-index arithmetic with bodies too short to
+    /// hold a position + edit (it is how the `c.A>G` slice-underflow panic was
+    /// found). The two entry points must still agree — and neither may panic.
+    fn truncated_boundary()(
+        acc in accession(),
+        sys in coord_system(),
+        tail in proptest::collection::vec(
+            prop_oneof![
+                Just('A'), Just('C'), Just('G'), Just('T'),
+                Just('0'), Just('1'), Just('9'),
+                Just('>'), Just('+'), Just('-'), Just('*'), Just('_'), Just('.'),
+            ],
+            0..6,
+        ),
+    ) -> String {
+        let tail: String = tail.into_iter().collect();
+        format!("{acc}:{sys}.{tail}")
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5000))]
+
+    #[test]
+    fn fast_path_matches_standard_substitution(input in substitution()) {
+        prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
+    }
+
+    #[test]
+    fn fast_path_matches_standard_offset(input in offset_substitution()) {
+        prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
+    }
+
+    #[test]
+    fn fast_path_matches_standard_non_sub(input in non_sub_edit()) {
+        prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
+    }
+
+    #[test]
+    fn fast_path_matches_standard_truncated(input in truncated_boundary()) {
+        prop_assert!(divergence(&input).is_none(), "{}", divergence(&input).unwrap());
+    }
+}

--- a/tests/fast_path_drift_scope.rs
+++ b/tests/fast_path_drift_scope.rs
@@ -1,0 +1,206 @@
+//! Scope-enumeration (not an assertion gate): bucket every way the fast path
+//! diverges from the standard parser, so we can size the parity gap before
+//! choosing a fix. Two diagnostics:
+//!
+//!   * `enumerate_fast_path_drift` — a widened accession x coord-system x edit
+//!     grid (mito / ncRNA / genomic-region / protein refs, UTR + intronic +
+//!     repeat edits).
+//!   * `replay_corpus_drift` — replays a real HGVS corpus (newline-delimited
+//!     text at `FERRO_DIFF_CORPUS_TXT`, e.g. the 500k ClinVar set) and
+//!     histograms the divergences by class and by the standard parser's
+//!     rejection reason.
+//!
+//! Run with:
+//!   cargo test --release --test fast_path_drift_scope --features dev -- \
+//!     --nocapture --ignored
+
+use ferro_hgvs::{parse_hgvs, parse_hgvs_fast};
+use std::collections::BTreeMap;
+
+/// Divergence class for a single input.
+enum Class {
+    Agree,
+    FastAcceptsStdRejects(String), // carries the standard parser's reason
+    StdAcceptsFastRejects,
+    BothOkDiffer,
+}
+
+fn classify(input: &str) -> Class {
+    match (parse_hgvs(input), parse_hgvs_fast(input)) {
+        (Ok(a), Ok(b)) if a == b => Class::Agree,
+        (Err(_), Err(_)) => Class::Agree,
+        (Err(e), Ok(_)) => {
+            // Normalize the reason to a stable bucket key: take the text up to
+            // the first reference-specific token so NR_/XR_/accession numbers
+            // collapse together.
+            let msg = e.to_string();
+            let key = msg
+                .split(" (")
+                .next()
+                .unwrap_or(&msg)
+                .replace("position 0: ", "")
+                .trim()
+                .to_string();
+            Class::FastAcceptsStdRejects(key)
+        }
+        (Ok(_), Err(_)) => Class::StdAcceptsFastRejects,
+        (Ok(_), Ok(_)) => Class::BothOkDiffer,
+    }
+}
+
+const ACCESSIONS: &[&str] = &[
+    "NC_000001.11", // genomic
+    "NC_012920.1",  // mitochondrial genome
+    "NG_012232.1",  // genomic region (RefSeqGene)
+    "NM_000088.3",  // mRNA
+    "NR_003051.3",  // non-coding RNA
+    "XR_001234.1",  // predicted non-coding RNA
+    "NP_000079.2",  // protein
+    "ENST00000357033.8",
+    "ENSG00000139618.15",
+    "ENSP00000369497.3", // Ensembl protein
+    "LRG_1",
+    "LRG_1t1",
+    "GRCh38(chr1)",
+];
+const SYSTEMS: &[&str] = &["g", "c", "n", "r", "m", "p"];
+const EDITS: &[&str] = &[
+    "100A>G",       // substitution
+    "100del",       // deletion
+    "100_101insAC", // insertion
+    "100dup",       // duplication
+    "100_101inv",   // inversion
+    "*100A>G",      // 3' UTR substitution
+    "-50A>G",       // 5' UTR substitution
+    "100+5A>G",     // intronic substitution
+    "100-5A>G",     // intronic substitution (acceptor side)
+    "100GT[3]",     // repeat
+    "Arg100Gly",    // protein substitution (3-letter)
+];
+
+#[test]
+#[ignore = "diagnostic enumeration, run explicitly with --ignored --nocapture"]
+fn enumerate_fast_path_drift() {
+    let mut total = 0usize;
+    let mut by_reason: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut std_accepts_fast_rejects = Vec::new();
+    let mut both_ok_differ = Vec::new();
+
+    for acc in ACCESSIONS {
+        for sys in SYSTEMS {
+            for edit in EDITS {
+                let input = format!("{acc}:{sys}.{edit}");
+                total += 1;
+                match classify(&input) {
+                    Class::Agree => {}
+                    Class::FastAcceptsStdRejects(reason) => {
+                        by_reason.entry(reason).or_default().push(input);
+                    }
+                    Class::StdAcceptsFastRejects => std_accepts_fast_rejects.push(input),
+                    Class::BothOkDiffer => both_ok_differ.push(input),
+                }
+            }
+        }
+    }
+
+    let diverged: usize = by_reason.values().map(Vec::len).sum::<usize>()
+        + std_accepts_fast_rejects.len()
+        + both_ok_differ.len();
+
+    println!("\n=== GRID drift: {diverged}/{total} inputs diverge ===\n");
+    println!("[A] fast ACCEPTS, standard REJECTS — grouped by standard's reason:");
+    for (reason, inputs) in &by_reason {
+        println!("  ({}) {reason}", inputs.len());
+        for input in inputs {
+            println!("        {input}");
+        }
+    }
+    println!(
+        "\n[B] standard ACCEPTS, fast REJECTS ({}):",
+        std_accepts_fast_rejects.len()
+    );
+    for input in &std_accepts_fast_rejects {
+        println!("        {input}");
+    }
+    println!("\n[C] both accept, ASTs DIFFER ({}):", both_ok_differ.len());
+    for input in &both_ok_differ {
+        println!("        {input}");
+    }
+    println!();
+}
+
+#[test]
+#[ignore = "corpus replay, run explicitly with --ignored --nocapture; needs FERRO_DIFF_CORPUS_TXT"]
+fn replay_corpus_drift() {
+    let Ok(path) = std::env::var("FERRO_DIFF_CORPUS_TXT") else {
+        println!(
+            "\nSKIP replay_corpus_drift: set FERRO_DIFF_CORPUS_TXT to a \
+             newline-delimited HGVS file (e.g. the 500k ClinVar inputs)\n"
+        );
+        return;
+    };
+    let text = std::fs::read_to_string(&path).expect("read corpus txt");
+
+    let mut total = 0usize;
+    let mut by_reason: BTreeMap<String, (usize, Vec<String>)> = BTreeMap::new();
+    let mut std_accepts_fast_rejects: (usize, Vec<String>) = (0, Vec::new());
+    let mut both_ok_differ: (usize, Vec<String>) = (0, Vec::new());
+
+    // Keep at most this many example inputs per bucket (count all of them).
+    const MAX_EXAMPLES: usize = 8;
+
+    for line in text.lines() {
+        let input = line.trim();
+        if input.is_empty() {
+            continue;
+        }
+        total += 1;
+        match classify(input) {
+            Class::Agree => {}
+            Class::FastAcceptsStdRejects(reason) => {
+                let entry = by_reason.entry(reason).or_insert((0, Vec::new()));
+                entry.0 += 1;
+                if entry.1.len() < MAX_EXAMPLES {
+                    entry.1.push(input.to_string());
+                }
+            }
+            Class::StdAcceptsFastRejects => {
+                std_accepts_fast_rejects.0 += 1;
+                if std_accepts_fast_rejects.1.len() < MAX_EXAMPLES {
+                    std_accepts_fast_rejects.1.push(input.to_string());
+                }
+            }
+            Class::BothOkDiffer => {
+                both_ok_differ.0 += 1;
+                if both_ok_differ.1.len() < MAX_EXAMPLES {
+                    both_ok_differ.1.push(input.to_string());
+                }
+            }
+        }
+    }
+
+    let diverged: usize = by_reason.values().map(|(n, _)| *n).sum::<usize>()
+        + std_accepts_fast_rejects.0
+        + both_ok_differ.0;
+
+    println!("\n=== CORPUS replay: {diverged}/{total} inputs diverge ===\n");
+    println!("[A] fast ACCEPTS, standard REJECTS — grouped by standard's reason:");
+    for (reason, (count, examples)) in &by_reason {
+        println!("  ({count}) {reason}");
+        for ex in examples {
+            println!("        e.g. {ex}");
+        }
+    }
+    println!(
+        "\n[B] standard ACCEPTS, fast REJECTS ({}):",
+        std_accepts_fast_rejects.0
+    );
+    for ex in &std_accepts_fast_rejects.1 {
+        println!("        e.g. {ex}");
+    }
+    println!("\n[C] both accept, ASTs DIFFER ({}):", both_ok_differ.0);
+    for ex in &both_ok_differ.1 {
+        println!("        e.g. {ex}");
+    }
+    println!();
+}


### PR DESCRIPTION
## What

Brings the fast-path substitution parser (`parse_hgvs_fast` / `try_fast_path`) to **full input-validation parity** with the canonical `parse_variant`, so the two are observationally identical for every input. A new differential identity test surfaced every gap; each fix defers the offending input to the generic parser (parity by construction). `parse_hgvs` (the default) is unchanged here — this is the prerequisite for a later PR that flips the default to the fast path (~1.7× on real ClinVar).

## The parity gaps (all "fast too lenient": fast accepts what generic rejects)

The differential test established the clean shape across a 13×6×11 grid, the 500k ClinVar corpus, and proptest fuzzers: **zero** cases where the fast path is stricter, **zero** AST mismatches on valid input — every divergence is the fast path accepting an input the generic parser rejects. Four classes, now all fixed:

1. **ncRNA coordinate system** — `g.`/`c.` on `NR_`/`XR_` non-coding transcripts (generic rejects, #486 `ECOORDINATESYSTEMMISMATCH`; per HGVS `refseq.md` the prefix declares the reference type and an ncRNA transcript's only valid systems are `n.`/`r.`). → defer `NR_`/`XR_`.
2. **`U` base in DNA** — `g.45A>U` (generic rejects, #486 `ENODNA`). → `is_fast_dna_base` = `is_iupac_base` minus `U` (all other IUPAC codes are accepted by both, so only `U` is excluded).
3. **non-canonical positions** — leading-zero / zero (`c.0`, `c.00`, `c.007`). → `scan_position` rejects a leading zero, kept separate from `scan_digits` (accession numbers like `NM_000088` legitimately have leading zeros).
4. **overflow positions** — `g.99999999999999999999999A>G` (u64) and `c.9223372036854775808A>G` (i64::MAX+1). → checked arithmetic in `scan_position` + an i64 guard for `CdsPos`.

Plus a robustness fix: a **slice-underflow panic** on too-short `c.` bodies (`c.A>G`) — the fast path crashed where the generic parser returns `Err`; bounds-guarded.

## Verification

- `tests/fast_path_differential.rs` — the identity gate: `parse_hgvs` (generic on this branch) vs `parse_hgvs_fast`, over a deterministic table plus proptest generators (substitutions, offset/UTR, non-sub edits, a boundary-length fuzzer, and an edge generator over the full IUPAC+`U`+lowercase base set × `{0, 01, 00, 007, u64-overflow, i64::MAX+1}` positions).
- `tests/fast_path_drift_scope.rs` — an ignored diagnostic bucketing divergences across a grid and an external corpus.
- After the fixes: grid `0/858`, 500k corpus `0/500004`, base/position enumeration `0`.
- Full `cargo nextest run --features dev` green except the pre-existing reference-gated conformance axes (verified identical on the unmodified baseline; stale local reference data, unrelated). `clippy -D warnings` + `fmt` clean.

## Scope / safety

The only production caller of `try_fast_path` is `parse_hgvs_fast`; the normalizer and conformance tests use `parse_hgvs`/`parse_variant` and never touch the fast path, so these changes cannot affect normalization or conformance.

## Reading order

1. `src/hgvs/parser/fast_path.rs` — `is_fast_dna_base`, `scan_position`, the ncRNA dispatch guard, the bounds guard
2. `tests/fast_path_differential.rs` — the identity gate + generators
3. `tests/fast_path_drift_scope.rs` — the characterization diagnostic
