### PR TITLE
feat(parser): parse predicted + whole-entity mosaic =/ forms (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1541,6 +1541,46 @@ pub(crate) fn find_uncertain_and_or_group(input: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Detect a predicted (`(...)`-wrapped) mosaic group `<prefix>(<inner>)`
+/// where `<inner>` carries a top-level mosaic `/` (e.g. `p.(Val7=/del)`,
+/// `r.(=/6_8del)`). Returns `(prefix, inner)`. Mirrors
+/// `find_uncertain_and_or_group` but for the mosaic separator.
+pub(crate) fn find_uncertain_mosaic_group(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim();
+    let bytes = input.as_bytes();
+    if bytes.last() != Some(&b')') {
+        return None;
+    }
+    let mut depth: i32 = 0;
+    let mut open: Option<usize> = None;
+    for i in (0..bytes.len()).rev() {
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' => {
+                depth -= 1;
+                if depth == 0 {
+                    open = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    let prefix = &input[..open];
+    if !prefix.ends_with('.') {
+        return None;
+    }
+    let inner = &input[open + 1..input.len() - 1];
+    // A single top-level `/` is the mosaic separator (`=/`). Chimeric `//`
+    // inside a predicted wrapper is not a spec form handled here.
+    if find_top_level_slash(inner, false).is_some() {
+        Some((prefix, inner))
+    } else {
+        None
+    }
+}
+
 /// Result of `scan_allele_separators`: top-level depth-0 allele-separator
 /// flags plus the depth-aware members.
 #[derive(Debug)]
@@ -4758,6 +4798,31 @@ fn is_lhs_position_identity(variant: &HgvsVariant) -> bool {
     }
 }
 
+/// True iff `variant` carries a whole-entity identity edit (`r.=`, `c.=`,
+/// …). The mosaic LHS shape for `r.=/6_8del`, where the RHS carries its own
+/// position rather than inheriting the LHS's.
+fn lhs_is_whole_entity_identity(variant: &HgvsVariant) -> bool {
+    use crate::hgvs::edit::NaEdit;
+    let edit_is_whole = |edit: &Mu<NaEdit>| {
+        matches!(
+            edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: true,
+                ..
+            })
+        )
+    };
+    match variant {
+        HgvsVariant::Genome(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Cds(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Tx(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Rna(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Mt(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Circular(v) => edit_is_whole(&v.loc_edit.edit),
+        _ => false,
+    }
+}
+
 /// Create an identity variant based on the type of the reference variant.
 /// Used for mosaic/chimeric notation where "=" means reference allele.
 fn create_identity_variant_from(reference: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
@@ -5287,6 +5352,30 @@ fn parse_chimeric_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     parse_phase_allele(input, AllelePhase::Chimeric)
 }
 
+/// Parse a predicted (`(...)`-wrapped) mosaic `=/` group, e.g.
+/// `NP_003997.1:p.(Val7=/del)` or `LRG_199t1:r.(=/6_8del)`. Strips the
+/// uncertainty wrapper, parses the inner mosaic via the normal path, and
+/// marks the resulting allele uncertain so the `(...)` round-trips.
+fn parse_uncertain_mosaic_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let (prefix, inner) = find_uncertain_mosaic_group(input).ok_or_else(|| FerroError::Parse {
+        pos: 0,
+        msg: "Not an uncertain mosaic group".to_string(),
+        diagnostic: None,
+    })?;
+    let reconstructed = format!("{}{}", prefix, inner);
+    match parse_variant(&reconstructed)? {
+        HgvsVariant::Allele(mut allele) if allele.phase == AllelePhase::Mosaic => {
+            allele.uncertain = true;
+            Ok(HgvsVariant::Allele(allele))
+        }
+        _ => Err(FerroError::Parse {
+            pos: 0,
+            msg: "Predicted mosaic group did not resolve to a mosaic allele".to_string(),
+            diagnostic: None,
+        }),
+    }
+}
+
 /// Parse a top-level and/or allele: full descriptions joined by `^`
 /// (HGVS general.md, "variant A and/or variant B"). Each operand is a
 /// complete description and may carry its own accession (possibly
@@ -5576,41 +5665,65 @@ fn parse_phase_allele(input: &str, phase: AllelePhase) -> Result<HgvsVariant, Fe
                     match parse_variant_with_inherited_accession(chunk, acc, gs.as_ref()) {
                         Ok(v) => v,
                         Err(prefix_err) => {
+                            // Fallback 1.5: whole-entity identity LHS (`r.=`).
+                            // The RHS is a full position+edit lacking the
+                            // type prefix (`6_8del`); rebuild it as
+                            // `<acc>:<type>.<chunk>` and parse, so
+                            // `r.=/6_8del` (whole-entity mosaic) works.
+                            //
+                            // When the LHS is whole-entity identity the RHS is
+                            // unambiguously this rebuilt shape (the spec
+                            // compact bare-edit fallback below only applies to
+                            // a *position-bound* identity LHS, so it can never
+                            // recover a whole-entity-LHS chunk). So surface the
+                            // rebuilt parse's own error rather than swallowing
+                            // it with `.ok()` and falling through to the
+                            // generic `prefix_err` — otherwise a malformed RHS
+                            // like `g.=/6_8delQ` reports a misleading "Unknown
+                            // variant type prefix … found '6_8'" instead of the
+                            // real "Unexpected trailing characters: 'Q'".
+                            if lhs_is_whole_entity_identity(lhs) {
+                                let rebuilt =
+                                    format!("{}:{}.{}", acc.full(), lhs.variant_type(), chunk);
+                                parse_variant(&rebuilt)?
+                            } else
                             // Fallback 2: HGVS spec compact form — bare
                             // NaEdit RHS inheriting accession + coord
                             // type + position from `<pos>=` LHS.
-                            match parse_compact_mosaic_rhs(chunk, lhs)? {
-                                Some(v) => v,
-                                None => {
-                                    // Targeted diagnostic for the
-                                    // ClinVar-prose multi-allelic
-                                    // shorthand `m.<pos><ref>><alt>/<alt2>`
-                                    // (issue #278). Only fire on the
-                                    // recognizable bare-base RHS shape,
-                                    // when the LHS has already parsed
-                                    // (so this is genuinely a mosaic-RHS
-                                    // rejection), and when the LHS is a
-                                    // mitochondrial variant — the W3018
-                                    // diagnostic text and code are
-                                    // specifically for `m.` heteroplasmy
-                                    // prose; firing it on non-mito LHS
-                                    // would mislabel unrelated parse
-                                    // failures.
-                                    if matches!(lhs, HgvsVariant::Mt(_))
-                                        && is_prose_multi_allelic_rhs(chunk)
-                                    {
-                                        use crate::error::{Diagnostic, ErrorCode, SourceSpan};
-                                        let _w3018 = ErrorType::ClinVarProseMultiAllelic;
-                                        let diag = Diagnostic::new()
-                                            .with_code(ErrorCode::ClinVarProseMultiAllelic)
-                                            .with_span(SourceSpan::new(0, chunk.len()));
-                                        return Err(FerroError::parse_with_diagnostic(
-                                            0,
-                                            prose_multi_allelic_diagnostic_msg(chunk),
-                                            diag,
-                                        ));
+                            {
+                                match parse_compact_mosaic_rhs(chunk, lhs)? {
+                                    Some(v) => v,
+                                    None => {
+                                        // Targeted diagnostic for the
+                                        // ClinVar-prose multi-allelic
+                                        // shorthand `m.<pos><ref>><alt>/<alt2>`
+                                        // (issue #278). Only fire on the
+                                        // recognizable bare-base RHS shape,
+                                        // when the LHS has already parsed
+                                        // (so this is genuinely a mosaic-RHS
+                                        // rejection), and when the LHS is a
+                                        // mitochondrial variant — the W3018
+                                        // diagnostic text and code are
+                                        // specifically for `m.` heteroplasmy
+                                        // prose; firing it on non-mito LHS
+                                        // would mislabel unrelated parse
+                                        // failures.
+                                        if matches!(lhs, HgvsVariant::Mt(_))
+                                            && is_prose_multi_allelic_rhs(chunk)
+                                        {
+                                            use crate::error::{Diagnostic, ErrorCode, SourceSpan};
+                                            let _w3018 = ErrorType::ClinVarProseMultiAllelic;
+                                            let diag = Diagnostic::new()
+                                                .with_code(ErrorCode::ClinVarProseMultiAllelic)
+                                                .with_span(SourceSpan::new(0, chunk.len()));
+                                            return Err(FerroError::parse_with_diagnostic(
+                                                0,
+                                                prose_multi_allelic_diagnostic_msg(chunk),
+                                                diag,
+                                            ));
+                                        }
+                                        return Err(prefix_err);
                                     }
-                                    return Err(prefix_err);
                                 }
                             }
                         }
@@ -5775,6 +5888,14 @@ fn parse_unknown_phase_allele(input: &str) -> Result<HgvsVariant, FerroError> {
 /// Determine the type of allele from the input string
 fn detect_allele_type(input: &str) -> Option<&'static str> {
     let input = input.trim();
+
+    // Predicted (`(...)`-wrapped) mosaic `=/` must be checked BEFORE the
+    // bare top-level slash check below — the `/` lives inside the parens,
+    // which `find_top_level_slash` does not track, so it would otherwise be
+    // misclassified as a bare mosaic.
+    if find_uncertain_mosaic_group(input).is_some() {
+        return Some("uncertain_mosaic");
+    }
 
     // Top-level slash check happens BEFORE the bracket-wrapping checks
     // so that bracketed chimeric / mosaic forms like
@@ -6100,6 +6221,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
             "rna_fusion" => parse_rna_fusion(input)?,
             "and_or" => parse_and_or_allele(input)?,
             "uncertain_and_or" => parse_uncertain_and_or_allele(input)?,
+            "uncertain_mosaic" => parse_uncertain_mosaic_allele(input)?,
             _ => unreachable!(),
         }
     } else {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1048,12 +1048,17 @@ fn intervals_match_for_compact_mosaic(a: &HgvsVariant, b: &HgvsVariant) -> bool 
 
 /// Shared Display path for `Mosaic` (`/`) and `Chimeric` (`//`) phases.
 ///
-/// Three branches in priority order (mutually exclusive on each input):
+/// Four branches in priority order (mutually exclusive on each input):
 ///
 /// 1. **Spec compact mosaic / chimeric** — LHS is a position-bound `=`
 ///    identity edit, RHS shares accession + coord type + interval.
 ///    Emits `<lhs-full>=/<rhs-bare-edit>`. Per
 ///    `recommendations/DNA/{substitution,deletion,duplication}.md`.
+///
+/// 1b. **Whole-entity identity LHS** — LHS carries `r.=` / `c.=` / etc.
+///    (whole-entity, not position-bound); RHS carries its own position.
+///    Emits `<prefix>=/<rhs-loc-edit>`, optionally wrapped in `(...)` when
+///    `uncertain`. E.g. `r.=/6_8del` and `r.(=/6_8del)`.
 ///
 /// 2. **`var/=` shorthand cleanup** — LHS is a non-identity variant,
 ///    RHS is a whole-entity identity edit (the synthetic shape
@@ -1066,18 +1071,47 @@ fn write_mosaic_or_chimeric(
     f: &mut fmt::Formatter<'_>,
     variants: &[HgvsVariant],
     sep: &str,
+    uncertain: bool,
 ) -> fmt::Result {
     if variants.len() == 2 && use_compact_form(variants) {
         let lhs = &variants[0];
         let rhs = &variants[1];
 
-        // Branch 1: spec compact (LHS pos-identity, intervals match).
+        // Branch 1: spec compact (LHS pos-identity, intervals match). The
+        // prefix is written once; a predicted (`uncertain`) mosaic wraps the
+        // body — `<prefix>(<lhs-loc-edit>/<rhs-bare-edit>)` (e.g.
+        // `p.(Val7=/del)`).
         if is_position_identity_lhs(lhs) && intervals_match_for_compact_mosaic(lhs, rhs) {
-            write!(f, "{}", lhs)?;
+            write_compact_prefix(f, lhs)?;
+            if uncertain {
+                write!(f, "(")?;
+            }
+            lhs.fmt_loc_edit(f)?;
             write!(f, "{}", sep)?;
             // Emit the RHS edit alone (no accession, no type prefix, no
             // position) — that is the spec compact RHS shape.
-            return write_bare_edit(f, rhs);
+            write_bare_edit(f, rhs)?;
+            if uncertain {
+                write!(f, ")")?;
+            }
+            return Ok(());
+        }
+
+        // Branch 1b: whole-entity identity LHS (`r.=`); the RHS carries its
+        // own position. Compact form `<prefix>=/<rhs-loc-edit>` (e.g.
+        // `r.=/6_8del`), optionally predicted (`r.(=/6_8del)`).
+        if is_whole_entity_identity_rhs(lhs) {
+            write_compact_prefix(f, lhs)?;
+            if uncertain {
+                write!(f, "(")?;
+            }
+            write!(f, "=")?;
+            write!(f, "{}", sep)?;
+            rhs.fmt_loc_edit(f)?;
+            if uncertain {
+                write!(f, ")")?;
+            }
+            return Ok(());
         }
 
         // Branch 2: var/= cleanup. LHS must NOT be position-identity
@@ -1211,8 +1245,8 @@ impl fmt::Display for AlleleVariant {
                     write!(f, "]")
                 }
             }
-            AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/"),
-            AllelePhase::Chimeric => write_mosaic_or_chimeric(f, &self.variants, "//"),
+            AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/", self.uncertain),
+            AllelePhase::Chimeric => write_mosaic_or_chimeric(f, &self.variants, "//", false),
             AllelePhase::AndOr => {
                 if self.uncertain && use_compact_form(&self.variants) {
                     // Uncertainty-wrapped, shared accession + coord type:

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -13,8 +13,8 @@
       "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
-      "parse-error": 327,
-      "preserved": 656
+      "parse-error": 322,
+      "preserved": 661
     },
     "by_coordinate_system": {
       "c": 464,
@@ -10779,18 +10779,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:p.(Trp24=/Cys)",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(Trp24=\", code: Tag })",
-      "spec_expected": "LRG_199t1:p.(Trp24=/Cys)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/substitution.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
       "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"\", code: Digit })",
       "spec_expected": "NP_003997.1:p.(Gly56Ala^Ser^Cys)",
@@ -10811,30 +10799,6 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/insertion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.(Val7=/del)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val7=\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.(Val7=/del)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "NP_003997.1:p.(Val7=/dup)",
-      "current": "parse error: Parse error at position 12: Failed to parse variant: Error(Error { input: \"(Val7=\", code: Tag })",
-      "spec_expected": "NP_003997.1:p.(Val7=/dup)",
-      "status": "parse-error",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/duplication.md"
       ],
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
@@ -11186,6 +11150,17 @@
       ]
     },
     {
+      "input": "LRG_199t1:p.(Trp24=/Cys)",
+      "current": "LRG_199t1:p.(Trp24=/Cys)",
+      "spec_expected": "LRG_199t1:p.(Trp24=/Cys)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/substitution.md"
+      ]
+    },
+    {
       "input": "NP_000213.1:p.(Val559_Glu561del)",
       "current": "NP_000213.1:p.(Val559_Glu561del)",
       "spec_expected": "NP_000213.1:p.(Val559_Glu561del)",
@@ -11283,6 +11258,28 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/protein/insertion.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.(Val7=/del)",
+      "current": "NP_003997.1:p.(Val7=/del)",
+      "spec_expected": "NP_003997.1:p.(Val7=/del)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/deletion.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.(Val7=/dup)",
+      "current": "NP_003997.1:p.(Val7=/dup)",
+      "spec_expected": "NP_003997.1:p.(Val7=/dup)",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/duplication.md"
       ]
     },
     {
@@ -13159,30 +13156,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "LRG_199t1:r.(=/6_8del)",
-      "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(=\", code: Digit })",
-      "spec_expected": "LRG_199t1:r.(=/6_8del)",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
-      "input": "LRG_199t1:r.=/6_8del",
-      "current": "parse error: Parse error at position 0: Unknown variant type prefix: expected one of 'c.', 'g.', 'p.', 'n.', 'r.', 'm.', 'o.' but found '6_8'",
-      "spec_expected": "LRG_199t1:r.=/6_8del",
-      "status": "parse-error",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/deletion.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "LRG_199t1:r.[(578c>u;1339a>g;1680del)]",
       "current": "parse error: Parse error at position 10: Failed to parse variant: Error(Error { input: \"(578c>u;1339a>g;1680del)\", code: Digit })",
       "spec_expected": "LRG_199t1:r.[(578c>u;1339a>g;1680del)]",
@@ -14310,6 +14283,17 @@
       ]
     },
     {
+      "input": "LRG_199t1:r.(=/6_8del)",
+      "current": "LRG_199t1:r.(=/6_8del)",
+      "spec_expected": "LRG_199t1:r.(=/6_8del)",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
+      ]
+    },
+    {
       "input": "LRG_199t1:r.10del",
       "current": "LRG_199t1:r.10del",
       "spec_expected": "LRG_199t1:r.10del",
@@ -14373,6 +14357,17 @@
       "source_kind": "recommendation",
       "source_paths": [
         "docs/recommendations/RNA/alleles.md"
+      ]
+    },
+    {
+      "input": "LRG_199t1:r.=/6_8del",
+      "current": "LRG_199t1:r.=/6_8del",
+      "spec_expected": "LRG_199t1:r.=/6_8del",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/deletion.md"
       ]
     },
     {

--- a/tests/mosaic_paren_eq_slash.rs
+++ b/tests/mosaic_paren_eq_slash.rs
@@ -1,0 +1,84 @@
+//! Parenthesized (predicted) and whole-entity mosaic `=/` forms (#544).
+//!
+//! - `p.(Val7=/del)` — a predicted (`(...)`) mosaic `=/`.
+//! - `r.=/6_8del` and `r.(=/6_8del)` — mosaic with a whole-entity `r.=` LHS
+//!   and a position-bearing RHS.
+//!
+//! Builds on the protein `=/` (#548) and the `uncertain` wrapper (#547).
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn parenthesized_predicted_mosaic_eq_slash_round_trips() {
+    for s in [
+        "LRG_199t1:p.(Trp24=/Cys)",
+        "NP_003997.1:p.(Val7=/del)",
+        "NP_003997.1:p.(Val7=/dup)",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Mosaic, "phase for `{s}`");
+        assert!(a.uncertain, "uncertain flag for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+#[test]
+fn whole_entity_rna_mosaic_eq_slash_round_trips() {
+    for s in ["LRG_199t1:r.=/6_8del", "LRG_199t1:r.(=/6_8del)"] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// A whole-entity identity on *both* sides of the mosaic (`=/=`), including
+/// the predicted (`(=/=)`) wrapper, must round-trip. The predicted form is the
+/// load-bearing case: the Display "Branch 1b" path is the only branch that
+/// emits the `(...)` wrapper for a whole-entity-identity RHS, so it must keep
+/// handling this shape rather than deferring to the `var/=` cleanup branch
+/// (which drops the `uncertain` parens).
+#[test]
+fn whole_entity_identity_both_sides_mosaic_round_trips() {
+    for s in [
+        "NC_000001.11:g.=/=",
+        "NC_000001.11:g.(=/=)",
+        "NM_004006.2:c.=/=",
+        "NM_004006.2:c.(=/=)",
+        "LRG_199t1:r.=/=",
+        "LRG_199t1:r.(=/=)",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// A malformed RHS following a whole-entity identity LHS must surface the
+/// RHS's *own* parse diagnostic, not the generic "Unknown variant type prefix"
+/// fallback. `g.=/6_8delQ` rebuilds to `…:g.6_8delQ`, whose genuine failure is
+/// the trailing `Q`; the old `.ok()` swallowed it and reported a misleading
+/// "found '6_8'" prefix error instead.
+#[test]
+fn whole_entity_mosaic_malformed_rhs_surfaces_specific_error() {
+    let bad = "NC_000001.11:g.=/6_8delQ";
+    let err = parse_hgvs(bad).expect_err("malformed RHS must fail to parse");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("trailing") && msg.contains('Q'),
+        "expected the specific trailing-`Q` diagnostic for `{bad}`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Unknown variant type prefix"),
+        "must not fall through to the generic prefix error for `{bad}`, got: {msg}"
+    );
+
+    // Other malformed whole-entity-mosaic RHS shapes must also be rejected.
+    for bad in ["NC_000001.11:g.=/6_8xyz", "NM_004006.2:c.=/6_8delZ"] {
+        assert!(
+            parse_hgvs(bad).is_err(),
+            "malformed RHS `{bad}` must fail to parse"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Final follow-up for #544's `=/` family. Parses the parenthesized (predicted) and whole-entity-LHS mosaic `=/` forms:

- `p.(Trp24=/Cys)`, `p.(Val7=/del)`, `p.(Val7=/dup)` — predicted mosaic.
- `r.=/6_8del`, `r.(=/6_8del)` — whole-entity `r.=` LHS with a position-bearing RHS.

## Stacking note

This depends on **both** #547 (the `uncertain` flag — now **merged to main**) and #548 (protein `=/` parse — not yet merged). To present a clean diff it is built on an integration base (`feat/issue-544-eqslash-base` = #547 + #548, linear, no merge commit). **Once #548 merges**, retarget this PR's base to `main` and rebase — the redundant #547/#548 commits drop out, leaving just this change.

## What changed

- **Predicted mosaic**: `find_uncertain_mosaic_group` strips the outer `(...)`, parses the inner mosaic via the normal path, and marks the allele `uncertain` so the wrapper round-trips. Detected before the bare top-level-slash check (the `/` lives inside the parens, which `find_top_level_slash` doesn't track).
- **Whole-entity-LHS mosaic**: `parse_phase_allele` gains a fallback that rebuilds a bare RHS as `<acc>:<type>.<rhs>` when the LHS is a whole-entity identity (`r.=`), and the mosaic Display gains a whole-entity-LHS compact branch `<prefix>=/<rhs-loc-edit>`.
- The mosaic Display compact path is refactored to write the accession prefix once and wrap the body in `(...)` when uncertain — **byte-identical output for the existing non-predicted forms** (verified: all `mosaic_chimeric_compact` tests pass).

## Acceptance

Five spec-fixture rows move off `parse-error` → `preserved`; no rows regress. New round-trip tests. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544 — with this, the `^` / `=/` / trans / mosaic / repeat operator families from the issue are all parsed.