### PR TITLE
perf(parser): route the default parse_hgvs through the fast path (~1.7x on ClinVar)

### DIFF
--- a/src/hgvs/parser/fast_path.rs
+++ b/src/hgvs/parser/fast_path.rs
@@ -5,11 +5,16 @@
 //!
 //! # Performance
 //!
-//! The fast-path parser provides **45-58% speedup** for simple substitution patterns,
-//! which represent ~87% of variants in clinical databases like ClinVar:
+//! The fast-path parser provides a **~1.7x end-to-end speedup** on the full ClinVar
+//! corpus. It handles ~72% of real ClinVar variants (RefSeq / Ensembl / LRG /
+//! Assembly `g.`/`c.` SNVs); everything else falls back to the generic parser.
+//! The per-pattern micro-benchmark speedup (fast path alone vs. generic parser) is
+//! higher — roughly 45-58% faster for the patterns listed below — but the corpus-level
+//! figure accounts for the fallback fraction and the fast-path overhead on
+//! non-eligible inputs.
 //!
-//! | Pattern | Speedup |
-//! |---------|---------|
+//! | Pattern | Micro-benchmark speedup |
+//! |---------|------------------------|
 //! | `NC_000001.11:g.12345A>G` (RefSeq genomic) | ~50% faster |
 //! | `NM_000088.3:c.459A>G` (RefSeq coding) | ~57% faster |
 //! | `ENST00000357033.8:c.100A>G` (Ensembl) | ~54% faster |
@@ -40,15 +45,13 @@
 //!
 //! # When to Use
 //!
-//! Use [`super::parse_hgvs_fast`] when:
-//! - Your data is primarily simple substitutions (SNVs)
-//! - You're processing large batches from clinical databases
-//! - Performance is critical
+//! Call [`super::parse_hgvs`] for all new code — the fast path is now the
+//! default, so callers get the performance benefit automatically without
+//! selecting a separate entry point.
 //!
-//! Use [`super::parse_hgvs`] when:
-//! - Your data has many complex variants (indels, intronic, UTR)
-//! - You need consistent performance across all variant types
-//! - You're unsure of your data composition
+//! [`super::parse_hgvs_fast`] is retained for backward compatibility only; it
+//! delegates unconditionally to [`super::parse_hgvs`] and offers no additional
+//! performance over calling [`super::parse_hgvs`] directly.
 
 use crate::hgvs::edit::{Base, NaEdit};
 use crate::hgvs::interval::{CdsInterval, GenomeInterval};

--- a/src/hgvs/parser/mod.rs
+++ b/src/hgvs/parser/mod.rs
@@ -30,6 +30,18 @@ use crate::hgvs::HgvsVariant;
 /// Uses strict error handling mode by default. For configurable error handling,
 /// use [`parse_hgvs_with_config`] instead.
 ///
+/// # Performance
+///
+/// Common substitution patterns (RefSeq / Ensembl / LRG / Assembly `g.`/`c.`
+/// SNVs — ~72% of real ClinVar) take a specialized fast path that is ~1.7x
+/// faster end-to-end over the full ClinVar corpus; everything else falls back
+/// to the full [`variant::parse_variant`] parser. The fast path is
+/// observationally identical to the generic parser — both accept the same
+/// inputs and produce the same [`HgvsVariant`] (guarded by the differential
+/// test in `tests/fast_path_differential.rs`) — so it is transparent to
+/// callers. To force the generic parser, call [`variant::parse_variant`]
+/// directly.
+///
 /// # Example
 ///
 /// ```
@@ -39,68 +51,34 @@ use crate::hgvs::HgvsVariant;
 /// println!("Parsed: {}", variant);
 /// ```
 pub fn parse_hgvs(input: &str) -> Result<HgvsVariant, FerroError> {
-    variant::parse_variant(input)
+    let trimmed = input.trim();
+    match fast_path::try_fast_path(trimmed) {
+        fast_path::FastPathResult::Success(variant) => Ok(variant),
+        // Fall back on the original (untrimmed) input so the generic parser
+        // sees exactly what it did before the fast path existed.
+        fast_path::FastPathResult::Fallback => variant::parse_variant(input),
+    }
 }
 
-/// Parse an HGVS string with fast-path optimization for common patterns
+/// Parse an HGVS string using the fast path for common patterns.
 ///
-/// This function attempts to use specialized fast-path parsers for the most
-/// common HGVS patterns (RefSeq, Ensembl, LRG, Assembly substitutions).
-/// Falls back to the standard parser for complex or unusual patterns.
-///
-/// # Performance
-///
-/// For simple substitution patterns (which represent ~87% of ClinVar variants),
-/// this provides **45-58% speedup**:
-///
-/// | Pattern Type | Example | Speedup |
-/// |--------------|---------|---------|
-/// | RefSeq genomic | `NC_000001.11:g.12345A>G` | ~50% |
-/// | RefSeq coding | `NM_000088.3:c.459A>G` | ~57% |
-/// | Ensembl | `ENST00000357033.8:c.100A>G` | ~54% |
-/// | Assembly | `GRCh38(chr1):g.12345A>G` | ~47% |
-///
-/// # Tradeoffs
-///
-/// The fast-path adds a small overhead (~3-6%) for patterns it cannot optimize:
-/// - Intronic variants (`c.100+5G>A`)
-/// - UTR variants (`c.*100A>G`, `c.-50A>G`)
-/// - Non-coding RNA (`n.100A>G`)
-/// - RNA variants (`r.100a>g`)
-/// - All deletions, insertions, duplications, etc.
-///
-/// # When to Use
-///
-/// **Recommended for:**
-/// - Clinical variant databases (ClinVar, gnomAD)
-/// - Batch processing of SNV-heavy datasets
-/// - Performance-critical pipelines
-///
-/// **Use standard [`parse_hgvs`] instead when:**
-/// - Data contains many complex variants (indels, intronic)
-/// - Consistent performance across all variant types is needed
-/// - Data composition is unknown
+/// **Equivalent to [`parse_hgvs`].** The fast path is now the default, so this
+/// is a thin synonym retained for backward compatibility; new code should call
+/// [`parse_hgvs`]. See [`parse_hgvs`] for the performance characteristics and
+/// the identity guarantee versus the generic parser.
 ///
 /// # Example
 ///
 /// ```
 /// use ferro_hgvs::parse_hgvs_fast;
 ///
-/// // Fast path for RefSeq substitution (~2x faster)
 /// let variant = parse_hgvs_fast("NC_000001.11:g.12345A>G").unwrap();
-///
-/// // Falls back to standard parser for complex patterns
+/// // Complex patterns transparently fall back to the full parser.
 /// let variant = parse_hgvs_fast("NM_000088.3:c.100+5A>G").unwrap();
 /// ```
 #[inline]
 pub fn parse_hgvs_fast(input: &str) -> Result<HgvsVariant, FerroError> {
-    let trimmed = input.trim();
-
-    // Try fast path first
-    match fast_path::try_fast_path(trimmed) {
-        fast_path::FastPathResult::Success(variant) => Ok(variant),
-        fast_path::FastPathResult::Fallback => variant::parse_variant(input),
-    }
+    parse_hgvs(input)
 }
 
 /// Parse an HGVS string with configurable error handling.

--- a/tests/fast_path_differential.rs
+++ b/tests/fast_path_differential.rs
@@ -1,15 +1,15 @@
-//! Differential identity test: `parse_hgvs_fast` must agree with `parse_hgvs`.
+//! Differential identity test: the default `parse_hgvs` (which now routes
+//! through the fast path) must agree with the generic `parse_variant`.
 //!
-//! `parse_hgvs` routes through the full nom parser (`parse_variant`).
-//! `parse_hgvs_fast` first tries a specialized substitution parser
-//! (`fast_path::try_fast_path`) and falls back to `parse_variant` for
-//! everything it does not recognize.
+//! `parse_variant` is the full nom parser — the source of truth. `parse_hgvs`
+//! first tries a specialized substitution parser (`fast_path::try_fast_path`)
+//! and falls back to `parse_variant` for everything it does not recognize.
 //!
-//! Making the fast path the *default* (`C1`) is only sound if the two entry
-//! points are observationally identical for **every** input — i.e. for any
-//! string they either both reject, or both accept and yield the same
-//! [`HgvsVariant`]. A single divergence (one accepts where the other rejects,
-//! or they produce different ASTs) would be a behavior change, not a perf win.
+//! The fast path being the default is only sound if it is observationally
+//! identical to the generic parser for **every** input — i.e. for any string
+//! they either both reject, or both accept and yield the same [`HgvsVariant`].
+//! A single divergence (one accepts where the other rejects, or they produce
+//! different ASTs) would be a behavior change, not a perf win.
 //!
 //! This test pins that invariant two ways:
 //!   1. a deterministic table covering each documented fast-path pattern and
@@ -18,22 +18,20 @@
 //!      inv that must route to the generic parser), and
 //!   2. a `proptest` fuzzer that assembles structurally-varied HGVS strings
 //!      and asserts agreement on each.
-//!
-//! It is intentionally a pure correctness gate: it does not flip the default,
-//! it proves whether the default *could* be flipped safely.
 
-use ferro_hgvs::{parse_hgvs, parse_hgvs_fast};
+use ferro_hgvs::hgvs::parser::variant::parse_variant;
+use ferro_hgvs::parse_hgvs;
 use proptest::prelude::*;
 
-/// Assert that the standard and fast entry points agree on `input`.
+/// Assert that the generic parser and the (fast-path) default agree on `input`.
 ///
 /// Agreement means: both `Err`, or both `Ok` with equal variants. Returns a
 /// human-readable description of the divergence on mismatch (so both the
 /// table test and the proptest fuzzer can surface the exact offending input)
 /// or `None` when they agree.
 fn divergence(input: &str) -> Option<String> {
-    let standard = parse_hgvs(input);
-    let fast = parse_hgvs_fast(input);
+    let standard = parse_variant(input);
+    let fast = parse_hgvs(input);
     match (standard, fast) {
         (Ok(a), Ok(b)) if a == b => None,
         (Err(_), Err(_)) => None,

--- a/tests/fast_path_drift_scope.rs
+++ b/tests/fast_path_drift_scope.rs
@@ -14,7 +14,8 @@
 //!   cargo test --release --test fast_path_drift_scope --features dev -- \
 //!     --nocapture --ignored
 
-use ferro_hgvs::{parse_hgvs, parse_hgvs_fast};
+use ferro_hgvs::hgvs::parser::variant::parse_variant;
+use ferro_hgvs::parse_hgvs;
 use std::collections::BTreeMap;
 
 /// Divergence class for a single input.
@@ -26,7 +27,9 @@ enum Class {
 }
 
 fn classify(input: &str) -> Class {
-    match (parse_hgvs(input), parse_hgvs_fast(input)) {
+    // Compare the generic parser (source of truth) against the default
+    // `parse_hgvs`, which now routes through the fast path.
+    match (parse_variant(input), parse_hgvs(input)) {
         (Ok(a), Ok(b)) if a == b => Class::Agree,
         (Err(_), Err(_)) => Class::Agree,
         (Err(e), Ok(_)) => {

--- a/tests/fast_path_flip_bench.rs
+++ b/tests/fast_path_flip_bench.rs
@@ -1,0 +1,90 @@
+//! Measurement (ignored): how much does routing the default through the fast
+//! path save on a representative corpus? Times the forced-generic
+//! `parse_variant` against the default `parse_hgvs` (now fast-path) over
+//! `FERRO_DIFF_CORPUS_TXT` (newline-delimited, e.g. the 500k ClinVar inputs),
+//! min-of-reps.
+//!
+//!   cargo test --release --test fast_path_flip_bench --features dev -- \
+//!     --nocapture --ignored
+
+use ferro_hgvs::hgvs::parser::variant::parse_variant;
+use ferro_hgvs::parse_hgvs;
+use std::hint::black_box;
+use std::time::Instant;
+
+#[test]
+#[ignore = "measurement, run explicitly with --release --ignored --nocapture; needs FERRO_DIFF_CORPUS_TXT"]
+fn measure_flip_net_effect() {
+    let Ok(path) = std::env::var("FERRO_DIFF_CORPUS_TXT") else {
+        println!("\nSKIP: set FERRO_DIFF_CORPUS_TXT to a newline-delimited HGVS file\n");
+        return;
+    };
+    let inputs: Vec<String> = std::fs::read_to_string(&path)
+        .expect("read corpus")
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    if inputs.is_empty() {
+        println!("\nSKIP: corpus file {path} has no non-empty lines\n");
+        return;
+    }
+    println!("\ncorpus: {} inputs", inputs.len());
+
+    // Count how many the fast path actually claims (the rest fall back), so we
+    // can interpret the net number.
+    let mut fast_claimed = 0usize;
+    for s in &inputs {
+        if matches!(
+            ferro_hgvs::hgvs::parser::fast_path::try_fast_path(s),
+            ferro_hgvs::hgvs::parser::fast_path::FastPathResult::Success(_)
+        ) {
+            fast_claimed += 1;
+        }
+    }
+    println!(
+        "fast-path claims {fast_claimed}/{} ({:.1}%); rest fall back to generic",
+        inputs.len(),
+        100.0 * fast_claimed as f64 / inputs.len() as f64
+    );
+
+    let reps = 5;
+    let mut best_generic = f64::MAX;
+    let mut best_fast = f64::MAX;
+    // Interleave reps so transient system load hits both equally.
+    for _ in 0..reps {
+        let t = Instant::now();
+        let mut ok = 0usize;
+        for s in &inputs {
+            ok += black_box(parse_variant(s)).is_ok() as usize;
+        }
+        black_box(ok);
+        best_generic = best_generic.min(t.elapsed().as_secs_f64());
+
+        let t = Instant::now();
+        let mut ok = 0usize;
+        for s in &inputs {
+            ok += black_box(parse_hgvs(s)).is_ok() as usize;
+        }
+        black_box(ok);
+        best_fast = best_fast.min(t.elapsed().as_secs_f64());
+    }
+
+    let n = inputs.len() as f64;
+    println!("\n=== flip net effect (min of {reps} reps) ===");
+    println!(
+        "  forced-generic parse_variant: {:.3} s   ({:.2} M/s)",
+        best_generic,
+        n / best_generic / 1e6
+    );
+    println!(
+        "  default parse_hgvs (fast):    {:.3} s   ({:.2} M/s)",
+        best_fast,
+        n / best_fast / 1e6
+    );
+    println!(
+        "  speedup (generic/fast):  {:.3}x   ({:+.1}%)\n",
+        best_generic / best_fast,
+        100.0 * (best_generic / best_fast - 1.0)
+    );
+}


### PR DESCRIPTION
## What

Makes the substitution fast path the **default**: `parse_hgvs` now tries `try_fast_path` first and falls back to the generic `parse_variant`, instead of always running the generic parser.

**Stacked on #560** (base = `perf/default-fast-path`). #560 brings the fast path to full input-validation parity with the generic parser; this PR is the one-function flip that turns that parity into a speedup. Review #560 first — the diff here is just `parse_hgvs`/`parse_hgvs_fast` plus the test re-pointing.

## Result

Over the full 500k ClinVar corpus (laptop, min of 5 reps):

```
forced-generic parse_variant: 0.169 s   (2.96 M/s)
default parse_hgvs (fast):    0.099 s   (5.03 M/s)
speedup:                      1.70×     (+70.1%)
```

The fast path claims ~72% of real variants; even counting the ~28% that fall back (paying the probe overhead), the net is **1.70×**. `tests/fast_path_flip_bench.rs` is the ignored measurement.

## Why it's safe

The flip is sound only because the fast path is now observationally identical to the generic parser (the whole point of #560). Verification on this branch:

- The differential test now compares the generic `parse_variant` against the fast-default `parse_hgvs` (since `parse_hgvs_fast` is now a synonym) over a table + proptest generators spanning IUPAC/`U`/lowercase bases and canonical/leading-zero/overflow positions — **green**.
- Full `cargo nextest run --features dev`: **6717 passed, 9 failed**, where the 9 are exactly the pre-existing reference-gated conformance axes (identical on the baseline; stale local reference data, unrelated). Crucially, the tests that *would* catch a regression — `reject_u_in_dna`, `spec_coverage_misc::f11_c_zero_not_valid_position`, `comprehensive_edge_case_tests::test_invalid_patterns` — all pass *because* they exercise `parse_hgvs`, which now routes through the (parity-correct) fast path.
- `clippy -D warnings`, `fmt`, doctests clean.

## API

`parse_hgvs_fast` becomes a thin synonym of `parse_hgvs`, retained for backward compatibility. To force the generic parser, call `variant::parse_variant` directly.

## Reading order

1. `src/hgvs/parser/mod.rs` — `parse_hgvs` (the flip) and `parse_hgvs_fast` (now a synonym)
2. `tests/fast_path_differential.rs` — re-pointed to generic-vs-default
3. `tests/fast_path_flip_bench.rs` — the net-effect measurement
