### PR TITLE
feat(parser): parse and/or between bracketed alleles (#544)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -5905,6 +5905,10 @@ fn parse_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     }
 
     let mut variants: Vec<HgvsVariant> = Vec::with_capacity(chunks.len());
+    // The accession + coord-type stem of the first operand that carries one,
+    // inherited by bare bracketed operands (e.g. the `[(Asn158Val)]` in
+    // `ACC:p.[..]^[(Asn158Val)]`).
+    let mut anchor_prefix: Option<String> = None;
     for chunk in chunks {
         let chunk = chunk.trim();
         if chunk.is_empty() {
@@ -5914,7 +5918,53 @@ fn parse_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError> {
                 diagnostic: None,
             });
         }
-        variants.push(parse_variant(chunk)?);
+
+        if looks_like_accession_start(chunk) {
+            // Operand carries its own *leading* accession (incl. cross-reference
+            // forms). A `:` buried inside the chunk — e.g. an inner-accession
+            // edit like `[..delins[ACC:g.X_Y]]` — does *not* qualify the
+            // operand; only a leading accession stem does, so such bare
+            // bracketed operands fall through to the inherited-prefix path.
+            let variant = parse_variant(chunk)?;
+            if anchor_prefix.is_none() {
+                if let Some(leaf) = crate::hgvs::variant::first_leaf_with_accession(&variant) {
+                    if let Some(acc) = leaf.accession() {
+                        anchor_prefix = Some(format!("{}:{}.", acc.full(), leaf.variant_type()));
+                    }
+                }
+            }
+            variants.push(variant);
+            continue;
+        }
+
+        // Bare operand: inherit the accession + coord type from the first
+        // operand. Used for bracketed allele operands `[..]` that omit the
+        // shared accession.
+        let prefix = anchor_prefix.clone().ok_or_else(|| FerroError::Parse {
+            pos: 0,
+            msg: "And/or operand without an accession must follow one that has it".to_string(),
+            diagnostic: None,
+        })?;
+        let reconstructed = format!("{}{}", prefix, chunk);
+        match parse_variant(&reconstructed) {
+            Ok(variant) => variants.push(variant),
+            Err(e) => {
+                // A single-member bracket `[X]` is not a standalone allele
+                // (the spec uses it only as an operand). Parse the inner
+                // member with the inherited prefix and wrap it as a
+                // one-member allele so the `[..]` round-trips.
+                if chunk.starts_with('[') && chunk.ends_with(']') {
+                    let inner = chunk[1..chunk.len() - 1].trim();
+                    let member = parse_variant(&format!("{}{}", prefix, inner))?;
+                    variants.push(HgvsVariant::Allele(AlleleVariant::new(
+                        vec![member],
+                        AllelePhase::Cis,
+                    )));
+                } else {
+                    return Err(e);
+                }
+            }
+        }
     }
 
     Ok(HgvsVariant::Allele(AlleleVariant::new(

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1133,6 +1133,68 @@ fn write_trans_member(f: &mut fmt::Formatter<'_>, member: &HgvsVariant) -> fmt::
     }
 }
 
+/// The first leaf (non-allele) sub-variant that carries an accession,
+/// descending through nested allele members. Used to derive the shared
+/// accession + coord-type prefix of an and/or-of-alleles or to inherit it
+/// onto bare bracketed operands.
+pub(crate) fn first_leaf_with_accession(v: &HgvsVariant) -> Option<&HgvsVariant> {
+    match v {
+        HgvsVariant::Allele(a) => a.variants.iter().find_map(first_leaf_with_accession),
+        HgvsVariant::NullAllele | HgvsVariant::UnknownAllele | HgvsVariant::RnaFusion(_) => None,
+        other => {
+            if other.accession().is_some() {
+                Some(other)
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// True iff every operand of an and/or allele is itself an `Allele` and all
+/// their leaves share accession + coord type — the `ACC:p.[..]^[..]` form
+/// where the shared prefix is written once.
+fn andor_alleles_share_accession(variants: &[HgvsVariant]) -> bool {
+    let mut anchor: Option<&HgvsVariant> = None;
+    for member in variants {
+        let HgvsVariant::Allele(_) = member else {
+            return false;
+        };
+        let leaf = match first_leaf_with_accession(member) {
+            Some(l) => l,
+            None => return false,
+        };
+        match anchor {
+            None => anchor = Some(leaf),
+            Some(a) => {
+                if leaf.accession() != a.accession() || leaf.variant_type() != a.variant_type() {
+                    return false;
+                }
+            }
+        }
+    }
+    anchor.is_some()
+}
+
+/// Write the bracket-inner content of one and/or allele operand: each
+/// member's loc-edit, separated only between adjacent members — a
+/// one-member allele emits only that member's loc-edit with no separator.
+/// The separator is `(;)` for an unknown-phase group or `;` for cis.
+fn write_andor_allele_inner(f: &mut fmt::Formatter<'_>, allele: &AlleleVariant) -> fmt::Result {
+    let sep = if allele.phase == AllelePhase::Unknown {
+        "(;)"
+    } else {
+        ";"
+    };
+    for (i, member) in allele.variants.iter().enumerate() {
+        if i > 0 {
+            write!(f, "{}", sep)?;
+        }
+        member.fmt_loc_edit(f)?;
+    }
+    Ok(())
+}
+
 fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt::Result {
     let accession = first
         .accession()
@@ -1549,6 +1611,28 @@ impl fmt::Display for AlleleVariant {
                         write!(f, "{}", v)?;
                     }
                     write!(f, ")")
+                } else if andor_alleles_share_accession(&self.variants) {
+                    // And/or between bracketed alleles sharing an accession:
+                    // `ACC:p.[a(;)b]^[c]` — prefix once, then each operand as
+                    // a bracketed allele.
+                    let anchor = first_leaf_with_accession(&self.variants[0])
+                        .expect("andor_alleles_share_accession guarantees a leaf");
+                    write_compact_prefix(f, anchor)?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, "^")?;
+                        }
+                        write!(f, "[")?;
+                        if let HgvsVariant::Allele(a) = v {
+                            write_andor_allele_inner(f, a)?;
+                        } else {
+                            unreachable!(
+                                "andor_alleles_share_accession guarantees all operands are Alleles"
+                            )
+                        }
+                        write!(f, "]")?;
+                    }
+                    Ok(())
                 } else {
                     // And/or `^` join of full descriptions (possibly across
                     // references): render each in full — `ACC1:c.A^ACC2:c.B`.

--- a/tests/and_or_of_alleles.rs
+++ b/tests/and_or_of_alleles.rs
@@ -1,0 +1,65 @@
+//! And/or `^` joining bracketed allele operands (#544).
+//!
+//! `p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]` — an and/or (`^`) between
+//! two alleles: an unknown-phase predicted-protein group and a single-member
+//! predicted-protein bracket (which inherits the accession). HGVS general.md.
+//! Combines `^` (#547), predicted-protein members (#552), unknown-phase, and
+//! single-member bracket operands.
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn and_or_of_bracketed_alleles_round_trips() {
+    let s = "NP_003997.2:p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::AndOr, "phase");
+    assert_eq!(a.variants.len(), 2, "operand count");
+    assert_eq!(format!("{v}"), s, "round-trip");
+}
+
+/// A `c.` and/or form round-trips: a two-member cis bracket followed by a
+/// bare single-member bracket that inherits the accession.
+#[test]
+fn and_or_of_cds_bracketed_alleles_round_trips() {
+    let s = "NM_000088.3:c.[100A>G;200T>C]^[300del]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::AndOr, "phase");
+    assert_eq!(a.variants.len(), 2, "operand count");
+    assert_eq!(format!("{v}"), s, "round-trip");
+}
+
+/// A bare bracketed operand whose inner edit carries its *own* inner accession
+/// (a cross-reference `delins[ACC:g.X_Y]`) must still inherit the bracket's
+/// shared prefix. The chunk contains a `:` only via that inner accession, not a
+/// leading accession stem, so it must route through the inherited-prefix path
+/// rather than being misrouted to the fully-qualified parser.
+#[test]
+fn and_or_bare_operand_with_inner_accession_round_trips() {
+    let s = "NC_000022.10:g.[5_10del]^[10_15delins[NC_000022.10:g.20_25]]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::AndOr, "phase");
+    assert_eq!(a.variants.len(), 2, "operand count");
+    assert_eq!(format!("{v}"), s, "round-trip");
+}
+
+/// A bare bracketed operand appearing *first* in the `^` chain (no accession
+/// on the left-hand side) must produce a parse error — the guard at
+/// `parse_and_or_allele` requires at least one accession-bearing operand
+/// before any bare operand can inherit from it.
+#[test]
+fn and_or_bare_operand_first_is_rejected() {
+    assert!(
+        parse_hgvs("[100A>G]^[200T>C]").is_err(),
+        "bare first operand (no accession) must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

Parses `p.[(Asn158Asp)(;)(Asn158Ile)]^[(Asn158Val)]` — an and/or (`^`) between two **bracketed alleles** (an unknown-phase predicted-protein group and a single-member predicted-protein bracket). **This was the last `parse-error` row attributable to #544** — with it, every form the issue lists now parses.

## Stacking

Combines `^` (#547, **in main**) and predicted-protein members (#552, not yet merged), so it is built on an integration base `feat/issue-544-caret-trans-base` (= main + #552, linear). **Once #552 merges**, retarget this PR's base to `main` and rebase (the #552 commit drops out).

## What changed

- `parse_and_or_allele` accepts bracketed operands that omit the shared accession: a bare `[..]` operand inherits the accession + coord type from the first operand. A single-member bracket `[X]` (not a standalone allele) is parsed as its inner member wrapped in a one-member allele, so it round-trips with its brackets.
- Display gains an and/or-of-alleles compact branch: when every operand is an allele sharing the accession, the prefix is written once and each operand renders as `[..]` (`(;)`-joined for unknown-phase, `;` for cis). The existing cross-reference `^` join (`ACC1:c.A^ACC2:c.B`) is unchanged.

## Acceptance

One spec-fixture row moves off `parse-error` → `preserved`; no rows regress. New round-trip test. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544.