### PR TITLE
feat(display): render trans alleles with [0]/[?] markers in compact form (#544)

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1177,49 +1177,21 @@ impl fmt::Display for AlleleVariant {
                 }
             }
             AllelePhase::Trans => {
-                // A trans member that is itself a nested cis group (`[a;b]`)
-                // needs dedicated rendering; the existing flat-trans paths
-                // (which `fmt_loc_edit` a single leaf per bracket) can't
-                // express it. Only take the nested path when a nested member
-                // is actually present, so flat trans Display is unchanged.
-                let has_nested_group = self
-                    .variants
-                    .iter()
-                    .any(|v| matches!(v, HgvsVariant::Allele(_)));
-                if has_nested_group {
-                    if let Some(anchor) = trans_compact_anchor(&self.variants) {
-                        // Compact: ACC:c.[a;b];[c;d] — prefix once, then each
-                        // member's bracket-inner content.
-                        write_compact_prefix(f, anchor)?;
-                        for (i, v) in self.variants.iter().enumerate() {
-                            if i > 0 {
-                                write!(f, ";")?;
-                            }
-                            write!(f, "[")?;
-                            write_trans_member(f, v)?;
-                            write!(f, "]")?;
-                        }
-                        Ok(())
-                    } else {
-                        // Mixed-reference nested trans (not a spec target):
-                        // expanded, each member rendered in full.
-                        for (i, v) in self.variants.iter().enumerate() {
-                            if i > 0 {
-                                write!(f, ";")?;
-                            }
-                            write!(f, "[{}]", v)?;
-                        }
-                        Ok(())
-                    }
-                } else if use_compact_form(&self.variants) {
-                    // Compact form: ACC:g.[edit1];[edit2]
-                    write_compact_prefix(f, &self.variants[0])?;
+                // `trans_compact_anchor` returns the anchoring leaf when the
+                // concrete members share an accession + coord type — nested
+                // cis groups (`[a;b]`), `[0]`/`[?]` markers (which contribute
+                // no anchor), and plain leaves all qualify. The shared
+                // accession is written once and each member is rendered as
+                // its bracket-inner content via `write_trans_member`, giving
+                // the compact `ACC:c.[a;b];[c;d]` / `ACC:c.[X];[?]` forms.
+                if let Some(anchor) = trans_compact_anchor(&self.variants) {
+                    write_compact_prefix(f, anchor)?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, ";")?;
                         }
                         write!(f, "[")?;
-                        v.fmt_loc_edit(f)?;
+                        write_trans_member(f, v)?;
                         write!(f, "]")?;
                     }
                     Ok(())

--- a/tests/allele_trans_phase.rs
+++ b/tests/allele_trans_phase.rs
@@ -468,8 +468,11 @@ fn test_trans_p_homozygous_round_trip() {
 /// "second allele unknown" semantics).
 #[test]
 fn test_trans_c_with_unknown_allele_round_trip() {
-    let input = "[NM_000088.3:c.100A>G];[?]";
+    // Canonical (compact) form writes the shared accession once; the
+    // expanded spelling normalizes to it.
+    let input = "NM_000088.3:c.[100A>G];[?]";
     assert_eq!(parse_to_string(input), input);
+    assert_eq!(parse_to_string("[NM_000088.3:c.100A>G];[?]"), input);
     assert_eq!(parse_phase(input), AllelePhase::Trans);
     let parsed = parse_hgvs(input).expect("parse failed");
     if let HgvsVariant::Allele(a) = parsed {
@@ -486,8 +489,11 @@ fn test_trans_c_with_unknown_allele_round_trip() {
 /// `recommendations/DNA/alleles.md`). Lowers to `NullAllele`.
 #[test]
 fn test_trans_c_with_null_allele_round_trip() {
-    let input = "[NM_000088.3:c.100A>G];[0]";
+    // Canonical (compact) form writes the shared accession once; the
+    // expanded spelling normalizes to it.
+    let input = "NM_000088.3:c.[100A>G];[0]";
     assert_eq!(parse_to_string(input), input);
+    assert_eq!(parse_to_string("[NM_000088.3:c.100A>G];[0]"), input);
     assert_eq!(parse_phase(input), AllelePhase::Trans);
     let parsed = parse_hgvs(input).expect("parse failed");
     if let HgvsVariant::Allele(a) = parsed {
@@ -525,23 +531,26 @@ fn test_trans_c_with_wildtype_second_allele_round_trip() {
 /// asserts both special-token branches in that helper.
 #[test]
 fn test_trans_g_with_special_tokens_round_trip() {
-    let unknown = "[NC_000001.11:g.100G>A];[?]";
+    let unknown = "NC_000001.11:g.[100G>A];[?]";
     assert_eq!(parse_to_string(unknown), unknown);
+    assert_eq!(parse_to_string("[NC_000001.11:g.100G>A];[?]"), unknown);
     assert_eq!(parse_phase(unknown), AllelePhase::Trans);
 
-    let null = "[NC_000001.11:g.100G>A];[0]";
+    let null = "NC_000001.11:g.[100G>A];[0]";
     assert_eq!(parse_to_string(null), null);
+    assert_eq!(parse_to_string("[NC_000001.11:g.100G>A];[0]"), null);
     assert_eq!(parse_phase(null), AllelePhase::Trans);
 }
 
 /// `n.[a];[?]`: special tokens reach the new n.-trans helper added above.
-/// The compact form parses; Display emits the expanded form for the [?]
-/// branch (the Allele Display logic detects mixed-variant-kinds and falls
-/// back). The Display→parse round-trip closes the loop.
+/// The compact form parses and Display emits the compact form (shared
+/// accession written once, `[?]` marker after). The Display→parse round-trip
+/// closes the loop.
 #[test]
 fn test_trans_n_with_unknown_allele_round_trip() {
     let parsed = parse_hgvs("NR_X.1:n.[100A>G];[?]").expect("parse failed");
     let displayed = format!("{}", parsed);
+    assert_eq!(displayed, "NR_X.1:n.[100A>G];[?]");
     assert_eq!(parse_to_string(&displayed), displayed);
     if let HgvsVariant::Allele(a) = parsed {
         assert_eq!(a.variants.len(), 2);

--- a/tests/compound_cross_reference.rs
+++ b/tests/compound_cross_reference.rs
@@ -19,10 +19,12 @@
 //!    the relative order of sub-variants.
 //! 2. Phase is preserved (cis `[a;b]`, trans `[a];[b]`, mosaic `a/b`,
 //!    chimeric `a//b`, unknown `[a(;)b]`).
-//! 3. Display falls back to the *expanded* form (each sub-variant prints
-//!    its own `ACC:type.` prefix) whenever the sub-variants do not share
-//!    both accession and coordinate type. The compact form
-//!    (`ACC:type.[edit;edit]`) is a strict optimization for the common case.
+//! 3. Display uses the compact form (`ACC:type.[edit];[edit]` for trans,
+//!    `ACC:type.[edit;edit]` for cis) whenever the concrete members share
+//!    both accession and coordinate type. `[0]`/`[?]` markers in a trans
+//!    allele contribute no accession and are permitted alongside concrete
+//!    members without breaking the compact form. Display falls back to the
+//!    expanded form only when concrete members disagree on accession or type.
 //! 4. Each sub-variant normalizes independently against its own reference;
 //!    a c. dup with a transcript provider 3'-shifts even when its
 //!    cis-companion is a g. variant on a different (un-resolvable) accession.
@@ -795,7 +797,8 @@ fn test_spec_discouraged_cross_reference_trans_accepted() {
 
 #[test]
 fn test_trans_cross_reference_with_null_allele() {
-    let input = "[NM_000088.3:c.1A>G];[0]";
+    // Single shared accession + `[0]` marker -> compact canonical form.
+    let input = "NM_000088.3:c.[1A>G];[0]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Trans, 2);
     assert!(matches!(allele.variants[0], HgvsVariant::Cds(_)));
@@ -804,7 +807,8 @@ fn test_trans_cross_reference_with_null_allele() {
 
 #[test]
 fn test_trans_cross_reference_with_unknown_allele() {
-    let input = "[NM_000088.3:c.1A>G];[?]";
+    // Single shared accession + `[?]` marker -> compact canonical form.
+    let input = "NM_000088.3:c.[1A>G];[?]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Trans, 2);
     assert!(matches!(allele.variants[0], HgvsVariant::Cds(_)));
@@ -813,12 +817,13 @@ fn test_trans_cross_reference_with_unknown_allele() {
 
 #[test]
 fn test_trans_cross_reference_marker_normalize_preserves_shape() {
-    // Markers ride through normalize untouched; the c. partner
-    // normalizes (or no-ops) but the marker leg stays as `[0]` / `[?]`.
+    // Markers ride through normalize untouched; the c. partner normalizes
+    // (or no-ops) but the marker leg stays as `[0]` / `[?]`. Output is the
+    // compact canonical form (shared accession written once).
     let null_normalized = normalize_to_string("[NM_000088.3:c.1A>G];[0]");
-    assert_eq!(null_normalized, "[NM_000088.3:c.1A>G];[0]");
+    assert_eq!(null_normalized, "NM_000088.3:c.[1A>G];[0]");
     let unk_normalized = normalize_to_string("[NM_000088.3:c.1A>G];[?]");
-    assert_eq!(unk_normalized, "[NM_000088.3:c.1A>G];[?]");
+    assert_eq!(unk_normalized, "NM_000088.3:c.[1A>G];[?]");
 }
 
 #[test]

--- a/tests/fixtures/grammar/hgvs_spec_normalization.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization.json
@@ -10,11 +10,11 @@
     "total": 1272,
     "by_status": {
       "correctly-rejected": 50,
-      "diverges": 136,
+      "diverges": 133,
       "false-acceptance": 75,
       "needs-reference": 31,
       "parse-error": 329,
-      "preserved": 651
+      "preserved": 654
     },
     "by_coordinate_system": {
       "c": 464,
@@ -282,18 +282,6 @@
       "source_paths": [
         "docs/recommendations/DNA/alleles.md"
       ]
-    },
-    {
-      "input": "NM_004006.2:c.[2376G>C];[?]",
-      "current": "[NM_004006.2:c.2376G>C];[?]",
-      "spec_expected": "NM_004006.2:c.[2376G>C];[?]",
-      "status": "diverges",
-      "coordinate_system": "c",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/DNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
       "input": "c.35delG",
@@ -4019,6 +4007,17 @@
       "input": "NM_004006.2:c.[2376G>C];[3103del]",
       "current": "NM_004006.2:c.[2376G>C];[3103del]",
       "spec_expected": "NM_004006.2:c.[2376G>C];[3103del]",
+      "status": "preserved",
+      "coordinate_system": "c",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/DNA/alleles.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:c.[2376G>C];[?]",
+      "current": "NM_004006.2:c.[2376G>C];[?]",
+      "spec_expected": "NM_004006.2:c.[2376G>C];[?]",
       "status": "preserved",
       "coordinate_system": "c",
       "source_kind": "recommendation",
@@ -10268,18 +10267,6 @@
       "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
-      "input": "NP_003997.1:p.[(Ser68Arg)];[?]",
-      "current": "[NP_003997.1:p.(Ser68Arg)];[?]",
-      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[?]",
-      "status": "diverges",
-      "coordinate_system": "p",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/protein/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
-    },
-    {
       "input": "NP_003997.2:p.(Asn444Lysfs*15)",
       "current": "NP_003997.2:p.(Asn444LysfsTer15)",
       "spec_expected": "NP_003997.2:p.(Asn444Lysfs*15)",
@@ -11384,6 +11371,17 @@
       "input": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
       "current": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
       "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[(Ser68Arg)]",
+      "status": "preserved",
+      "coordinate_system": "p",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/protein/alleles.md"
+      ]
+    },
+    {
+      "input": "NP_003997.1:p.[(Ser68Arg)];[?]",
+      "current": "NP_003997.1:p.[(Ser68Arg)];[?]",
+      "spec_expected": "NP_003997.1:p.[(Ser68Arg)];[?]",
       "status": "preserved",
       "coordinate_system": "p",
       "source_kind": "recommendation",
@@ -12907,18 +12905,6 @@
       "source_paths": [
         "docs/recommendations/RNA/alleles.md"
       ]
-    },
-    {
-      "input": "NM_004006.2:r.[76a>u];[?]",
-      "current": "[NM_004006.2:r.76a>u];[?]",
-      "spec_expected": "NM_004006.2:r.[76a>u];[?]",
-      "status": "diverges",
-      "coordinate_system": "r",
-      "source_kind": "recommendation",
-      "source_paths": [
-        "docs/recommendations/RNA/alleles.md"
-      ],
-      "todo": "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83"
     },
     {
       "input": "NM_004006.3:r.85=//u>c",
@@ -14741,6 +14727,17 @@
       "input": "NM_004006.2:r.[76a>u];[76a>u]",
       "current": "NM_004006.2:r.[76a>u];[76a>u]",
       "spec_expected": "NM_004006.2:r.[76a>u];[76a>u]",
+      "status": "preserved",
+      "coordinate_system": "r",
+      "source_kind": "recommendation",
+      "source_paths": [
+        "docs/recommendations/RNA/alleles.md"
+      ]
+    },
+    {
+      "input": "NM_004006.2:r.[76a>u];[?]",
+      "current": "NM_004006.2:r.[76a>u];[?]",
+      "spec_expected": "NM_004006.2:r.[76a>u];[?]",
       "status": "preserved",
       "coordinate_system": "r",
       "source_kind": "recommendation",

--- a/tests/issue_207_multi_repeat_compound_roundtrip.rs
+++ b/tests/issue_207_multi_repeat_compound_roundtrip.rs
@@ -235,25 +235,22 @@ fn delins_reference_with_nested_repeat_count_parses_and_defers() {
 fn trans_compound_repeat_alongside_null_allele() {
     // `[0]` is the spec's "no allele" marker. The trans helper has a
     // dedicated branch for it (`content == "0"`); confirm it still
-    // works when the *other* allele contains a nested repeat
-    // count's `[N]`. The Display path falls back to the
-    // fully-qualified form `[ACC:variant];[0]` (compact-prefix is
-    // only used when both alleles are real variants sharing an
-    // accession).
-    let input = "NC_000001.11:g.[100_105TG[3]];[0]";
-    let canonical = "[NC_000001.11:g.100_105TG[3]];[0]";
-    assert_eq!(round_trip(input), canonical);
+    // works when the *other* allele contains a nested repeat count's
+    // `[N]`. Display uses the compact form: the marker contributes no
+    // accession, so the single real allele's accession anchors the
+    // shared prefix written once — `ACC:g.[variant];[0]`.
+    let canonical = "NC_000001.11:g.[100_105TG[3]];[0]";
     assert_eq!(round_trip(canonical), canonical);
+    assert_eq!(round_trip("[NC_000001.11:g.100_105TG[3]];[0]"), canonical);
 }
 
 #[test]
 fn trans_compound_repeat_alongside_unknown_allele() {
-    // `[?]` is the spec's "unknown allele" marker. Same Display shape
-    // as the null-allele test above.
-    let input = "NC_000001.11:g.[100_105TG[3]];[?]";
-    let canonical = "[NC_000001.11:g.100_105TG[3]];[?]";
-    assert_eq!(round_trip(input), canonical);
+    // `[?]` is the spec's "unknown allele" marker. Same compact Display
+    // shape as the null-allele test above.
+    let canonical = "NC_000001.11:g.[100_105TG[3]];[?]";
     assert_eq!(round_trip(canonical), canonical);
+    assert_eq!(round_trip("[NC_000001.11:g.100_105TG[3]];[?]"), canonical);
 }
 
 // =============================================================================

--- a/tests/protein_unknown_roundtrip.rs
+++ b/tests/protein_unknown_roundtrip.rs
@@ -632,8 +632,9 @@ fn protein_unknown_bracket_marker_is_unknown_allele_not_protein_edit() {
     // The spec's canonical heterozygous example (alleles.md:43):
     //   NP_003997.1:p.[(Ser68Arg)];[?]
     // Arm 0 is a predicted protein substitution, arm 1 is the bare
-    // `[?]` whole-allele marker.
-    let input = "[NP_003997.1:p.(Ser68Arg)];[?]";
+    // `[?]` whole-allele marker. Compact form: the shared accession is
+    // written once (the `[?]` marker contributes none).
+    let input = "NP_003997.1:p.[(Ser68Arg)];[?]";
     let parsed = parse_hgvs(input).unwrap();
 
     let allele = match &parsed {


### PR DESCRIPTION
## Summary

A trans allele pairing a real variant with a `[0]` (no allele) or `[?]` (unknown allele) marker now renders in the spec-preferred **compact** form — shared accession written once: `ACC:c.[X];[?]` rather than the expanded `[ACC:c.X];[?]`. This moves the last `diverges` rows attributable to #544 to `preserved`.

## Stacking

This needs **#549** (the `trans_compact_anchor` Display) and **#552** (predicted-protein bracket members — so the protein compact form `p.[(Ser68Arg)];[?]` re-parses). Built on an integration base `feat/issue-544-trans-unknown-base` (= #549 + #552, linear). **Once #549 and #552 merge**, retarget this PR's base to `main` and rebase.

## What changed

#549 deliberately gated its compact path to nested cis groups only, to avoid a broad Display change rippling through pinned tests. This removes that gate: `trans_compact_anchor` already treats `[0]`/`[?]` markers as contributing no accession, so the single real allele anchors the shared prefix. The Trans Display arm is unified on that one path (compact when an anchor exists, expanded otherwise).

Pinned tests that asserted the old expanded spelling are updated to assert the compact canonical form **and** that the expanded spelling normalizes to it (testing the behavior, not the old shape): 3 in `allele_trans_phase`, 3 in `compound_cross_reference`, 2 in `issue_207_multi_repeat_compound_roundtrip`, 1 in `protein_unknown_roundtrip`.

## Acceptance

Three spec-fixture rows move off `diverges` → `preserved` (`c.[2376G>C];[?]`, `r.[76a>u];[?]`, `p.[(Ser68Arg)];[?]`); no rows regress; ClinVar benchmarks unaffected. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #544.