### PR TITLE
perf(reference): get_transcript -> Arc<Transcript> + bounded provider cache (resolve transcript once)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,6 +949,7 @@ dependencies = [
  "dhat",
  "flate2",
  "futures-util",
+ "hashlink",
  "hgvs",
  "indexmap",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ url = "2.4"
 regex = "1.10"
 once_cell = "1.20"
 superintervals = "0.3"
+hashlink = "0.9"
 
 [features]
 default = []
@@ -205,6 +206,10 @@ required-features = ["web-service"]
 
 [[bench]]
 name = "benchmarks"
+harness = false
+
+[[bench]]
+name = "normalize_e2e"
 harness = false
 
 [profile.release]

--- a/benches/normalize_e2e.rs
+++ b/benches/normalize_e2e.rs
@@ -1,0 +1,76 @@
+//! End-to-end normalize benchmark over a real `MultiFastaProvider`.
+//!
+//! This is the surface that actually shows the A2 win (transcript resolved
+//! once and shared as an `Arc` instead of rebuilt on every `get_transcript`).
+//! The `MockProvider` microbench in `benchmarks.rs` cannot show it — its
+//! `get_transcript` is trivially cheap and never rebuilds.
+//!
+//! Guarded: it skips unless BOTH env vars are set, so it is inert in normal
+//! `cargo bench` runs and only measures where real reference data exists
+//! (e.g. the nightly, which builds the manifest via `ferro prepare`):
+//!   FERRO_BENCH_MANIFEST  = path to a `ferro prepare` manifest.json
+//!   FERRO_NORM_CORPUS_TXT = newline-delimited HGVS inputs (one per line)
+//!
+//! Run:
+//!   FERRO_BENCH_MANIFEST=/path/manifest.json \
+//!   FERRO_NORM_CORPUS_TXT=/path/inputs.txt \
+//!     cargo bench --bench normalize_e2e --features dev
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MultiFastaProvider, Normalizer};
+use std::hint::black_box;
+
+/// Parse up to `limit` HGVS inputs from `FERRO_NORM_CORPUS_TXT`. Unparseable
+/// lines are skipped — the benchmark measures `normalize`, not parsing.
+fn load_variants(limit: usize) -> Vec<HgvsVariant> {
+    let Ok(path) = std::env::var("FERRO_NORM_CORPUS_TXT") else {
+        return Vec::new();
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    text.lines()
+        .filter_map(|line| parse_hgvs(line.trim()).ok())
+        .take(limit)
+        .collect()
+}
+
+fn bench_normalize_e2e(c: &mut Criterion) {
+    let Ok(manifest) = std::env::var("FERRO_BENCH_MANIFEST") else {
+        eprintln!(
+            "SKIP normalize_e2e: set FERRO_BENCH_MANIFEST (manifest.json) and \
+             FERRO_NORM_CORPUS_TXT (newline-delimited HGVS) to measure"
+        );
+        return;
+    };
+    let provider = match MultiFastaProvider::from_manifest(&manifest) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("SKIP normalize_e2e: could not load manifest {manifest}: {e}");
+            return;
+        }
+    };
+    let normalizer = Normalizer::new(provider);
+
+    let variants = load_variants(50_000);
+    if variants.is_empty() {
+        eprintln!("SKIP normalize_e2e: no parseable inputs (set FERRO_NORM_CORPUS_TXT)");
+        return;
+    }
+
+    let mut group = c.benchmark_group("normalize_e2e");
+    group.throughput(Throughput::Elements(variants.len() as u64));
+    group.bench_function("normalize_corpus", |b| {
+        b.iter(|| {
+            let mut ok = 0usize;
+            for variant in &variants {
+                ok += black_box(normalizer.normalize(black_box(variant))).is_ok() as usize;
+            }
+            black_box(ok);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_normalize_e2e);
+criterion_main!(benches);

--- a/examples/projector-bench.rs
+++ b/examples/projector-bench.rs
@@ -70,7 +70,7 @@ enum Cmd {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3210,47 +3210,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Returns `None` for empty proteins or accessions the provider
     /// cannot resolve.
     fn discover_protein_length(&self, accession: &str) -> Option<u64> {
-        const SEED: u64 = 64 * 1024;
-        const CAP: u64 = 1 << 30;
-
-        let probe_ok = |n: u64| self.provider.get_protein_sequence(accession, 0, n).is_ok();
-
-        let (mut lo, mut hi) = if probe_ok(SEED) {
-            // Common case: the seed succeeded. Grow only if the protein
-            // is even longer (vanishingly rare).
-            let mut hi = SEED;
-            let mut lo = SEED;
-            while probe_ok(hi) {
-                lo = hi;
-                if hi >= CAP {
-                    break;
-                }
-                hi = hi.saturating_mul(2);
-            }
-            (lo, hi)
-        } else {
-            // Seed failed, so the exact length is in `[0, SEED)`.
-            // Hand `[0, SEED)` straight to the binary search below
-            // instead of re-doing a logarithmic exponential ramp from
-            // 1 (which would duplicate the work the failed seed
-            // already proved unnecessary). `lo = 0` is a valid lower
-            // bound — `probe_ok(0)` (empty slice) is accepted by the
-            // provider; only after the binary search converges to
-            // `lo = 0` do we conclude the protein is genuinely empty.
-            (0, SEED)
-        };
-        while lo + 1 < hi {
-            let mid = lo + (hi - lo) / 2;
-            if probe_ok(mid) {
-                lo = mid;
-            } else {
-                hi = mid;
-            }
+        // Ask the provider directly. The trait's default implementation
+        // still performs the historical probe + binary search (preserving
+        // its exact, length-equals-largest-accepted-`n` semantics), while
+        // providers that store length metadata (e.g. `MockProvider`)
+        // override it to return the length without cloning the sequence.
+        //
+        // A length of `0` — an empty protein or an accession the provider
+        // cannot resolve (the default probe leaves `lo = 0`; overrides
+        // return `Err`) — maps to `None`, matching the prior behavior.
+        match self.provider.get_protein_length(accession) {
+            Ok(0) | Err(_) => None,
+            Ok(len) => Some(len),
         }
-        if lo == 0 {
-            return None;
-        }
-        Some(lo)
     }
 
     /// Validate that the amino acids in a protein variant match the reference

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1779,7 +1779,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // hit the downstream `try_expand_cds_ins` and canonicalization passes.
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
-            || -> Result<crate::reference::transcript::Transcript, FerroError> {
+            || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
                 self.provider
                     .get_transcript_for_variant(&HV::Cds(variant.clone()))
             };
@@ -2379,7 +2379,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `try_expand_tx_ins` and canonicalization passes.
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
-            || -> Result<crate::reference::transcript::Transcript, FerroError> {
+            || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
                 self.provider
                     .get_transcript_for_variant(&HV::Tx(variant.clone()))
             };

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -905,7 +905,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// In strict mode (default), rejects variants with reference mismatches.
     /// Use `normalize_with_diagnostics` for lenient mode that corrects mismatches.
     pub fn normalize(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
-        let result = self.normalize_with_diagnostics(variant)?;
+        // `normalize()` returns only the variant and inspects warnings; it
+        // discards the diagnostic `infos` axis. Call `normalize_core`
+        // directly and wrap with empty infos, so the hot path skips the
+        // per-call `detect_shuffle_infos` work (use `normalize_with_diagnostics`
+        // when infos are actually needed). Behavior is unchanged.
+        let (normalized, warnings) = self.normalize_core(variant)?;
+        let result = NormalizeResult::with_warnings(normalized, warnings);
 
         // In strict mode, reject if there were reference mismatches.
         if self.config.should_reject_ref_mismatch() {
@@ -1070,7 +1076,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         variant: &HgvsVariant,
     ) -> Result<NormalizeResult, FerroError> {
-        let (result, warnings) = match variant {
+        let (result, warnings) = self.normalize_core(variant)?;
+        let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
+        Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
+    }
+
+    /// Core normalization: dispatch by variant kind and return the
+    /// normalized variant plus warnings, WITHOUT computing the diagnostic
+    /// `infos` axis. `normalize()` discards infos, so it calls this
+    /// directly to skip the per-call `detect_shuffle_infos` cost on the
+    /// hot path; `normalize_with_diagnostics` layers infos on top. The
+    /// (variant, warnings) output is identical to the previous inline match.
+    fn normalize_core(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        let result = match variant {
             // A `g.` variant on a mitochondrial reference (NC_012920 / NC_001807)
             // must be described with `m.` (#487). Coerce it to an `MtVariant`
             // — same accession/location/edit, only the coordinate system label
@@ -1106,9 +1127,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             HV::NullAllele => (HV::NullAllele, vec![]),
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
         };
-
-        let infos = detect_shuffle_infos(variant, &result, self.config.shuffle_direction);
-        Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
+        Ok(result)
     }
 
     /// Normalize an allele (compound) variant

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -97,7 +97,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .transcript_cache
             .write()
             .expect("transcript cache poisoned");
-        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        let entry = guard.entry(key).or_insert_with(|| tx);
         Ok(Arc::clone(entry))
     }
 
@@ -369,7 +369,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .transcript_cache
             .write()
             .expect("transcript cache poisoned");
-        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        let entry = guard.entry(key).or_insert_with(|| tx);
         Ok(Arc::clone(entry))
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -49,7 +49,8 @@ impl ReferenceProvider for PyProvider {
     fn get_transcript(
         &self,
         id: &str,
-    ) -> Result<crate::reference::transcript::Transcript, crate::error::FerroError> {
+    ) -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, crate::error::FerroError>
+    {
         match self {
             PyProvider::Mock(p) => p.get_transcript(id),
             PyProvider::MultiFasta(p) => p.get_transcript(id),

--- a/src/reference/annotation/validate.rs
+++ b/src/reference/annotation/validate.rs
@@ -179,7 +179,10 @@ mod tests {
     }
 
     impl ReferenceProvider for StubFasta {
-        fn get_transcript(&self, id: &str) -> Result<Transcript, crate::error::FerroError> {
+        fn get_transcript(
+            &self,
+            id: &str,
+        ) -> Result<std::sync::Arc<Transcript>, crate::error::FerroError> {
             Err(crate::error::FerroError::ReferenceNotFound { id: id.to_string() })
         }
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::error::FerroError;
 use crate::reference::provider::ReferenceProvider;
@@ -238,10 +239,11 @@ impl FastaProvider {
 }
 
 impl ReferenceProvider for FastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.transcripts
             .get(id)
             .cloned()
+            .map(Arc::new)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })
     }
 
@@ -597,7 +599,7 @@ impl CachedFastaProvider {
 }
 
 impl ReferenceProvider for CachedFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.inner.get_transcript(id)
     }
 
@@ -899,10 +901,10 @@ impl MmapFastaProvider {
 
 #[cfg(feature = "mmap")]
 impl ReferenceProvider for MmapFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         // Handle versioned and unversioned lookups
         if let Some(tx) = self.transcripts.get(id) {
-            return Ok(tx.clone());
+            return Ok(Arc::new(tx.clone()));
         }
 
         // Try without version: only match a stored key whose base id (the
@@ -913,7 +915,7 @@ impl ReferenceProvider for MmapFastaProvider {
         let base_id = id.split('.').next().unwrap_or(id);
         for (key, tx) in &self.transcripts {
             if key.split('.').next().unwrap_or(key) == base_id {
-                return Ok(tx.clone());
+                return Ok(Arc::new(tx.clone()));
             }
         }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -409,6 +409,27 @@ impl ReferenceProvider for MockProvider {
         Ok(protein_seq[start..end].to_string())
     }
 
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        // Mirror the accession resolution in `get_protein_sequence`:
+        // exact (versioned or stored) match first, then an unversioned
+        // base-accession fallback, returning the stored length directly.
+        if let Some(seq) = self.proteins.get(accession) {
+            return Ok(seq.len() as u64);
+        }
+        if !accession.contains('.') {
+            for (key, seq) in &self.proteins {
+                if key.split('.').next().unwrap_or(key) == accession {
+                    return Ok(seq.len() as u64);
+                }
+            }
+        }
+        Err(FerroError::ProteinReferenceNotAvailable {
+            accession: accession.to_string(),
+            start: 0,
+            end: 0,
+        })
+    }
+
     fn has_protein_data(&self) -> bool {
         !self.proteins.is_empty()
     }

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -5,7 +5,7 @@ use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 /// Mock reference provider that loads transcripts from JSON
 #[derive(Clone)]
@@ -298,10 +298,10 @@ impl Default for MockProvider {
 }
 
 impl ReferenceProvider for MockProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         // Handle versioned and unversioned lookups
         if let Some(tx) = self.transcripts.get(id) {
-            return Ok(tx.clone());
+            return Ok(Arc::new(tx.clone()));
         }
 
         // Try without version: only match a stored key whose base id (the
@@ -317,7 +317,7 @@ impl ReferenceProvider for MockProvider {
         if !id.contains('.') {
             for (key, tx) in &self.transcripts {
                 if key.split('.').next().unwrap_or(key) == id {
-                    return Ok(tx.clone());
+                    return Ok(Arc::new(tx.clone()));
                 }
             }
         }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -23,7 +23,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
+use hashlink::LruCache;
 use log::warn;
 
 use crate::data::cdot::CdotMapper;
@@ -94,7 +96,28 @@ pub struct MultiFastaProvider {
     canonical_overrides: CanonicalOverrides,
     /// Protein FASTA index (NP_/XP_ accessions) for get_protein_sequence (#520).
     protein_index: HashMap<String, FastaIndexEntry>,
+    /// Memoization cache of built transcripts, keyed by (accession, cdot build
+    /// hint). `get_transcript_on_build` rebuilds the full transcript (sequence
+    /// read + cdot conversion + exon construction) on every miss, and callers
+    /// like `normalize_cds` resolve the *same* transcript many times per variant
+    /// (bounds check, intronic, special-position, the 3' shuffle, plus each
+    /// recursion); the cache turns those repeats into shared `Arc` clones.
+    /// Bounded (LRU) so a long batch's working set stays in memory without
+    /// unbounded growth. Transcripts are immutable for the provider's lifetime,
+    /// so this is pure memoization — no invalidation.
+    transcript_cache: Mutex<TranscriptCache>,
 }
+
+/// Cache key for a built transcript: (accession as requested, cdot build hint).
+type TranscriptCacheKey = (String, Option<String>);
+
+/// Bounded LRU of built transcripts shared as `Arc`.
+type TranscriptCache = LruCache<TranscriptCacheKey, Arc<Transcript>>;
+
+/// LRU capacity for the built-transcript cache. Comfortably exceeds the working
+/// set of a single normalize call (one transcript for a simple variant, a
+/// handful for a compound allele) while bounding memory for long batches.
+const TRANSCRIPT_CACHE_CAPACITY: usize = 512;
 
 impl MultiFastaProvider {
     /// Create a new multi-FASTA provider from a directory of FASTA files
@@ -167,6 +190,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: HashMap::new(),
+            transcript_cache: Mutex::new(LruCache::new(TRANSCRIPT_CACHE_CAPACITY)),
         })
     }
 
@@ -200,6 +224,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: HashMap::new(),
+            transcript_cache: Mutex::new(LruCache::new(TRANSCRIPT_CACHE_CAPACITY)),
         })
     }
 
@@ -508,6 +533,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: HashMap::new(),
+            transcript_cache: Mutex::new(LruCache::new(TRANSCRIPT_CACHE_CAPACITY)),
         })
     }
 
@@ -1042,9 +1068,29 @@ impl MultiFastaProvider {
         &self,
         id: &str,
         build_hint: Option<&str>,
-    ) -> Result<Transcript, FerroError> {
+    ) -> Result<Arc<Transcript>, FerroError> {
+        // Memoize on (accession, build hint): the inner builder reads the full
+        // sequence and reconstructs cdot metadata on every call, and callers
+        // resolve the same transcript repeatedly. Key by the raw `id` so the
+        // repeated same-accession lookups in one normalize share an entry;
+        // version-fallback siblings simply get their own entry.
+        let key = (id.to_string(), build_hint.map(str::to_string));
+        if let Some(cached) = self
+            .transcript_cache
+            .lock()
+            .expect("transcript cache mutex poisoned")
+            .get(&key)
+            .cloned()
+        {
+            return Ok(cached);
+        }
         let mut tx = self.get_transcript_on_build_inner(id, build_hint)?;
         self.apply_canonical_overrides_to(&mut tx);
+        let tx = Arc::new(tx);
+        self.transcript_cache
+            .lock()
+            .expect("transcript cache mutex poisoned")
+            .insert(key, tx.clone());
         Ok(tx)
     }
 
@@ -1326,7 +1372,7 @@ impl MultiFastaProvider {
     /// version-exactness of the served *bases*, while a canonical override
     /// corrects CDS/`protein` *metadata* on the exact-version record — the two
     /// are orthogonal, so a strict caller still gets the canonical metadata.
-    pub fn get_transcript_strict(&self, id: &str) -> Result<Transcript, FerroError> {
+    pub fn get_transcript_strict(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         if !self.has_transcript_exact(id) {
             return Err(FerroError::TranscriptVersionNotExact {
                 requested: id.to_string(),
@@ -1377,14 +1423,14 @@ impl MultiFastaProvider {
 }
 
 impl ReferenceProvider for MultiFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.get_transcript_on_build(id, None)
     }
 
     fn get_transcript_for_variant(
         &self,
         variant: &crate::hgvs::variant::HgvsVariant,
-    ) -> Result<Transcript, FerroError> {
+    ) -> Result<Arc<Transcript>, FerroError> {
         let Some(accession) = variant.accession() else {
             // No accession at all (e.g. NullAllele) — fall through to the
             // default impl which produces a clear ReferenceNotFound error.
@@ -1420,7 +1466,7 @@ impl ReferenceProvider for MultiFastaProvider {
         for build in probe_order {
             match self.get_transcript_on_build(&tx_id, Some(build)) {
                 Ok(tx) if tx.chromosome.is_some() => return Ok(tx),
-                Ok(tx) => last_err = Some(FerroError::ReferenceNotFound { id: tx.id }),
+                Ok(tx) => last_err = Some(FerroError::ReferenceNotFound { id: tx.id.clone() }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -2045,6 +2091,20 @@ mod tests {
         }
         let provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
         (provider, dir)
+    }
+
+    /// Repeated `get_transcript` for the same accession returns the *same*
+    /// cached `Arc` rather than rebuilding the transcript (the A2 win:
+    /// `normalize_cds` resolves the same transcript many times per variant).
+    #[test]
+    fn get_transcript_returns_shared_cached_arc() {
+        let (provider, _dir) = build_provider_with_test_genome();
+        let first = provider.get_transcript("NC_TEST.1").unwrap();
+        let second = provider.get_transcript("NC_TEST.1").unwrap();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "repeated get_transcript must return the same cached Arc (no rebuild)"
+        );
     }
 
     /// Build a single-exon synthetic `Transcript` over NC_TEST.1[10..30]

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -138,6 +138,59 @@ pub trait ReferenceProvider {
         })
     }
 
+    /// Return the length (in amino acids) of the named protein.
+    ///
+    /// # Arguments
+    ///
+    /// * `accession` - Protein accession (e.g., `"NP_000079.2"`)
+    ///
+    /// # Returns
+    ///
+    /// The protein length in amino acids, or an error if the accession
+    /// cannot be resolved by this provider.
+    ///
+    /// The default implementation discovers the length by probing
+    /// [`get_protein_sequence`](Self::get_protein_sequence) with
+    /// `get_protein_sequence(accession, 0, n)` and binary-searching for
+    /// the largest accepted `n`, which equals the protein length. This
+    /// preserves the exact semantics of the historical probe: a protein
+    /// of length zero (or one the provider cannot resolve) yields a
+    /// length of `0`. Providers that store length metadata override this
+    /// to return the length directly without cloning the sequence.
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        const SEED: u64 = 64 * 1024;
+        const CAP: u64 = 1 << 30;
+
+        let probe_ok = |n: u64| self.get_protein_sequence(accession, 0, n).is_ok();
+
+        let (mut lo, mut hi) = if probe_ok(SEED) {
+            // Common case: the seed succeeded. Grow only if the protein
+            // is even longer (vanishingly rare).
+            let mut hi = SEED;
+            let mut lo = SEED;
+            while probe_ok(hi) {
+                lo = hi;
+                if hi >= CAP {
+                    break;
+                }
+                hi = hi.saturating_mul(2);
+            }
+            (lo, hi)
+        } else {
+            // Seed failed, so the exact length is in `[0, SEED)`.
+            (0, SEED)
+        };
+        while lo + 1 < hi {
+            let mid = lo + (hi - lo) / 2;
+            if probe_ok(mid) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        Ok(lo)
+    }
+
     /// Check if this provider has protein sequence data
     fn has_protein_data(&self) -> bool {
         false
@@ -204,6 +257,10 @@ impl ReferenceProvider for Box<dyn ReferenceProvider> {
         end: u64,
     ) -> Result<String, FerroError> {
         (**self).get_protein_sequence(accession, start, end)
+    }
+
+    fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
+        (**self).get_protein_length(accession)
     }
 
     fn has_protein_data(&self) -> bool {

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -5,6 +5,7 @@
 use crate::error::FerroError;
 use crate::hgvs::variant::HgvsVariant;
 use crate::reference::transcript::Transcript;
+use std::sync::Arc;
 
 /// Trait for providing reference sequence data
 ///
@@ -13,8 +14,14 @@ use crate::reference::transcript::Transcript;
 /// - SeqRepoProvider for local sequence databases
 /// - NCBIProvider for remote NCBI E-utilities
 pub trait ReferenceProvider {
-    /// Get a transcript by its accession
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError>;
+    /// Get a transcript by its accession.
+    ///
+    /// Returns an [`Arc`] so providers can hand out a shared, immutable handle
+    /// to a cached transcript instead of rebuilding or deep-cloning the full
+    /// sequence on every call. Callers that only read (the common case) use it
+    /// transparently via `Deref`; a caller needing an owned `Transcript`
+    /// clones via `(*tx).clone()`.
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError>;
 
     /// Get the transcript for the given variant, optionally using the
     /// variant's `genomic_context` parent (NG/NC) to pick a cdot build
@@ -30,7 +37,10 @@ pub trait ReferenceProvider {
     /// specific cdot build (e.g. [`crate::reference::multi_fasta::MultiFastaProvider`])
     /// override this to consult the parent accession before falling back to
     /// the bare transcript lookup. See issue #332.
-    fn get_transcript_for_variant(&self, variant: &HgvsVariant) -> Result<Transcript, FerroError> {
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, FerroError> {
         let accession = variant
             .accession()
             .ok_or_else(|| FerroError::ReferenceNotFound {
@@ -217,11 +227,14 @@ pub trait ReferenceProvider {
 
 /// Blanket implementation for boxed trait objects
 impl ReferenceProvider for Box<dyn ReferenceProvider> {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         (**self).get_transcript(id)
     }
 
-    fn get_transcript_for_variant(&self, variant: &HgvsVariant) -> Result<Transcript, FerroError> {
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, FerroError> {
         (**self).get_transcript_for_variant(variant)
     }
 

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -1031,7 +1031,7 @@ mod tests {
     /// to exercise the `LoadError` surfacing path.
     struct FailingProvider;
     impl ReferenceProvider for FailingProvider {
-        fn get_transcript(&self, _id: &str) -> Result<Transcript, FerroError> {
+        fn get_transcript(&self, _id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
             Err(FerroError::InvalidCoordinates {
                 msg: "degenerate coordinates".to_string(),
             })

--- a/tests/biocommons_normalize_tests.rs
+++ b/tests/biocommons_normalize_tests.rs
@@ -120,7 +120,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/tests/issue_339_alignment_gap_panic.rs
+++ b/tests/issue_339_alignment_gap_panic.rs
@@ -31,7 +31,7 @@ struct FixedLengthProvider {
 }
 
 impl ReferenceProvider for FixedLengthProvider {
-    fn get_transcript(&self, _id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, _id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         Err(FerroError::ReferenceNotFound {
             id: "<fixed-length-provider>".to_string(),
         })

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -140,7 +140,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -226,7 +226,7 @@ impl<P: ReferenceProvider + Clone> CountingProvider<P> {
 }
 
 impl<P: ReferenceProvider + Clone> ReferenceProvider for CountingProvider<P> {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         self.transcript_calls.fetch_add(1, Ordering::SeqCst);
         self.inner.get_transcript(id)
     }


### PR DESCRIPTION
## What

Makes `ReferenceProvider::get_transcript` (and `get_transcript_for_variant`) return `Arc<Transcript>` instead of `Transcript` by value, and gives `MultiFastaProvider` a bounded LRU cache of built transcripts. Repeated resolutions now return a shared `Arc` instead of rebuilding the full transcript every call.

**Stacked on #553** (base = `perf/skip-unused-normalize-infos`) because it edits `normalize/mod.rs`, which #553 also touches. Review #553 first.

## The problem

`get_transcript` → `get_transcript_on_build` does real work on *every* call: reads the full transcript sequence from the index, looks up cdot metadata, reconstructs the exon vector, applies canonical overrides. There was no cache. And `normalize_cds` resolves the *same* transcript many times for one variant — the past-end bounds check, the intronic lookup, the special-position branch, the 3′ shuffle in `rules.rs`, and once more on each recursion (`con`→`delins`, `ins[...]` expansion, special-position). Each was a full rebuild.

## The fix (the principled one)

A transcript is a large, immutable, provider-owned resource; callers want to *read* it, not own a fresh copy. Returning `Arc<Transcript>` from a memoizing provider models exactly that and eliminates both the rebuild and the deep clone (handoff is a refcount bump). The cache is keyed by `(accession, cdot build hint)`, bounded (LRU, capacity 512) so a long batch's working set stays in memory without unbounded growth, and needs no invalidation (transcripts are immutable for the provider's lifetime).

This is a breaking change to the public `ReferenceProvider` trait — taken deliberately now, while pre-1.0, before more code depends on the by-value semantics. Fallout was mechanical: most call sites read via `Deref` and compile unchanged; a couple needed `(*tx).clone()`; `projector.rs` (which already cached `Arc<Transcript>`) dropped a now-redundant `Arc::new` wrap.

## Verification

- **Cache correctness (runnable):** a `multi_fasta` unit test asserts that two `get_transcript` calls for the same accession return the *same* `Arc` (`Arc::ptr_eq`) — i.e. the second is a cache hit, not a rebuild.
- **Behavior preserved:** full `cargo nextest run --features dev` is green except the pre-existing reference-gated conformance axes, which fail *identically* on the #553 baseline (stale local reference data, unrelated). Pure memoization of immutable transcripts ⇒ identical results.
- **Measurement surface:** `benches/normalize_e2e.rs` is a guarded end-to-end normalize bench over a real `MultiFastaProvider`. It skips unless `FERRO_BENCH_MANIFEST` + `FERRO_NORM_CORPUS_TXT` are set, because the `MockProvider` microbench *cannot* show this win (its `get_transcript` is trivially cheap and never rebuilds). This is the surface to measure on — e.g. the nightly, which builds the manifest via `ferro prepare`.
- `clippy --all-targets -D warnings`, `fmt`, and `cargo check --features python` all clean.

## Honest caveat

The headline win is **not measured locally** in this PR — it requires real reference data (the manifest), the same stale-local blocker that gates the conformance suite. The cache unit test proves the *mechanism* (no rebuild); the e2e bench is wired to quantify the end-to-end speedup once it runs against the manifest (nightly).

## Dependency

Adds `hashlink` (already in the tree) for the bounded LRU.

## Reading order

1. `src/reference/provider.rs` — the trait change
2. `src/reference/multi_fasta.rs` — the cache + `get_transcript_on_build`, and the cache test
3. `src/normalize/mod.rs` — the two intronic closures (the only normalize edits: closure return type)
4. the remaining files — mechanical impl/call-site updates
5. `benches/normalize_e2e.rs` — the measurement surface
