### PR TITLE
feat(parser): parse N-padded deletion over an uncertain range (#545)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -491,6 +491,15 @@ pub enum NaEdit {
         length: Option<u64>,
     },
 
+    /// N-padded deletion: a deletion whose removed size is given as a count of
+    /// unknown (`N`) bases — `delN[15]`, `delN[(150_180)]`. Used when a
+    /// fragment was amplified and only its size (not its sequence) was
+    /// determined, so the deletion is reported relative to the reference
+    /// fragment size. Spec: `recommendations/uncertain.md`,
+    /// `recommendations/DNA/repeated.md`. The matching insertion form is
+    /// `Insertion { InsertedSequence::Repeat { base: N, .. } }` (`insN[15]`).
+    NPaddedDeletion { count: RepeatCount },
+
     /// Insertion: addition of bases between two positions (e.g., insATG, ins10, insA[10])
     Insertion { sequence: InsertedSequence },
 
@@ -687,6 +696,7 @@ impl NaEdit {
                 }
                 s
             }
+            NaEdit::NPaddedDeletion { count } => format!("delN{}", count),
             NaEdit::Insertion { sequence } => {
                 format!("ins{}", sequence.to_rna_string())
             }
@@ -804,6 +814,7 @@ impl fmt::Display for NaEdit {
                 }
                 Ok(())
             }
+            NaEdit::NPaddedDeletion { count } => write!(f, "delN{}", count),
             NaEdit::Insertion { sequence } => {
                 write!(f, "ins{}", sequence)
             }

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -230,6 +230,15 @@ fn parse_deletion(input: &str) -> IResult<&str, NaEdit> {
         ));
     }
 
+    // N-padded deletion: `delN[15]`, `delN[(150_180)]` — the deleted size is
+    // a count of unknown (`N`) bases (unsequenced amplicon size difference).
+    // Trigger only on `N` immediately followed by `[` so a literal `delNNN`
+    // stays an ordinary sequence deletion.
+    if bytes[0] == b'N' && bytes.get(1) == Some(&b'[') {
+        let (remaining, count) = parse_repeat_count(&input[1..])?;
+        return Ok((remaining, NaEdit::NPaddedDeletion { count }));
+    }
+
     match bytes[0] {
         b'0'..=b'9' => {
             // Length: del101

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -175,6 +175,9 @@ fn is_overlap_edit(edit: &NaEdit) -> bool {
         | NaEdit::Methylation { .. }
         | NaEdit::CopyNumber { .. }
         | NaEdit::Splice { .. }
+        // N-padded deletions sit over an uncertain `(start_end)` range with no
+        // definite reference span, so they are not overlap edits.
+        | NaEdit::NPaddedDeletion { .. }
         | NaEdit::NoProduct
         | NaEdit::PositionOnly => false,
     }

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -61,6 +61,7 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
         NaEdit::Substitution { .. } => "substitution",
         NaEdit::SubstitutionNoRef { .. } => "substitution",
         NaEdit::Deletion { .. } => "deletion",
+        NaEdit::NPaddedDeletion { .. } => "deletion",
         NaEdit::Duplication { .. } => "duplication",
         NaEdit::DupIns { .. } => "dupins",
         NaEdit::Insertion { .. } => "insertion",
@@ -384,6 +385,9 @@ pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
         | NaEdit::Inversion { .. }
         | NaEdit::Identity { .. } => Some(0),
         NaEdit::Deletion { .. } => Some(-compute_span(variant)?),
+        // N-padded deletion: size is a count of unknown bases — no deterministic
+        // indel length.
+        NaEdit::NPaddedDeletion { .. } => None,
         NaEdit::Duplication { .. } => Some(compute_span(variant)?),
         NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
@@ -435,6 +439,9 @@ pub fn get_indel_length_with_provider<P: ReferenceProvider + ?Sized>(
         | NaEdit::Inversion { .. }
         | NaEdit::Identity { .. } => Some(0),
         NaEdit::Deletion { .. } => Some(-compute_span_with_provider(variant, provider)?),
+        // N-padded deletion: size is a count of unknown bases — no deterministic
+        // indel length.
+        NaEdit::NPaddedDeletion { .. } => None,
         NaEdit::Duplication { .. } => Some(compute_span_with_provider(variant, provider)?),
         NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
@@ -625,6 +632,23 @@ mod tests {
             status: MethylationStatus::GainOfMethylation,
         };
         assert_eq!(na_edit_type_str(&edit), "methylation");
+    }
+
+    #[test]
+    fn test_na_edit_type_str_npadded_deletion() {
+        use crate::hgvs::edit::RepeatCount;
+        let edit = NaEdit::NPaddedDeletion {
+            count: RepeatCount::Exact(15),
+        };
+        assert_eq!(na_edit_type_str(&edit), "deletion");
+    }
+
+    #[test]
+    fn test_get_indel_length_npadded_deletion() {
+        // N-padded deletion has an uncertain count of deleted bases, so
+        // get_indel_length must return None (not Some(0) or any deterministic value).
+        let variant = parse_hgvs("NM_000333.3:c.(4_246)delN[15]").expect("must parse delN[15]");
+        assert_eq!(get_indel_length(&variant), None);
     }
 
     // ===== edit_type_from_debug Tests =====

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -450,6 +450,12 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
                 let ref_base = self.get_reference_base(chrom, start)?;
                 (start, ref_base.to_string(), vec![ref_base.to_string()])
             }
+            NaEdit::NPaddedDeletion { .. } => {
+                return Err(FerroError::ConversionError {
+                    msg: "N-padded deletions over an uncertain range cannot be converted to VCF"
+                        .to_string(),
+                });
+            }
             NaEdit::Conversion { .. } => {
                 return Err(FerroError::ConversionError {
                     msg: "Conversion variants cannot be directly converted to VCF".to_string(),

--- a/tests/repeat_deln_uncertain_range.rs
+++ b/tests/repeat_deln_uncertain_range.rs
@@ -1,0 +1,22 @@
+//! N-padded deletion over an uncertain range: `(start_end)delN[k]` (#545).
+//!
+//! A fragment containing a repeat was amplified and its size determined to be
+//! `k` nucleotides smaller than the reference, without sequencing — so the
+//! deleted size is `N[k]` (k unknown bases) over the uncertain amplified range
+//! `(start_end)`. Spec: `recommendations/uncertain.md` (lines 38-40),
+//! `recommendations/DNA/repeated.md` (line 51). The matching `insN[k]` form
+//! already parses; `delN[k]` was the gap.
+
+use ferro_hgvs::parse_hgvs;
+
+#[test]
+fn deln_over_uncertain_range_round_trips() {
+    for s in [
+        "NM_000333.3:c.(4_246)delN[15]",
+        "NC_000003.12:g.(63912602_63912844)delN[15]",
+        "NM_000333.3:c.(4_246)delN[(150_180)]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}


### PR DESCRIPTION
## Summary

First of three PRs for #545. Parses `delN[k]` — a deletion whose removed size is given as a count of unknown (`N`) bases, used when a fragment was amplified and only its **size** (not its sequence) was determined:

- `NM_000333.3:c.(4_246)delN[15]`, `NC_000003.12:g.(63912602_63912844)delN[15]` (spec: `uncertain.md:38–40`, `DNA/repeated.md:51`).

The matching `insN[k]` form already parsed; `delN[k]` was the gap — `del` consumed the `N` as a literal base and left `[15]` dangling, so the whole input failed.

## What changed

- Adds `NaEdit::NPaddedDeletion { count: RepeatCount }`, mirroring the insertion side's `InsertedSequence::Repeat { base: N, .. }` (`insN[15]`).
- `parse_deletion` recognizes `delN[<count>]` — triggered **only** on `N` immediately followed by `[`, so a literal `delNNN` stays an ordinary sequence deletion.
- Display renders `delN<count>`. The count reuses `RepeatCount`, so range/uncertain forms (`delN[15_30]`, `delN[(150_180)]`) round-trip for free.
- Three compiler-flagged exhaustive matches get arms: overlap detection treats it as non-definite-span (the range is uncertain); VCF conversion rejects it (uncertain size); the Python type maps to `"deletion"`.

## Acceptance

Four spec-fixture rows move off `parse-error` → `preserved` (the c./g. accession'd forms plus the bare-prefix `g.`/`r.` forms); no rows regress. New round-trip test. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #545. Independent of the two follow-ups (B: predicted cis allele `[(a;b)]`; C: comma transcript-products `[(a,b)]`).