### PR TITLE
feat(parser): parse predicted compound cis allele [(a;b)] (#545)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1810,6 +1810,83 @@ pub(crate) fn find_products_bracket(input: &str) -> Option<(&str, &str, bool)> {
     Some((&input[..=open], inner, uncertain))
 }
 
+/// Detect a predicted/uncertain compound cis allele `<prefix>[(<inner>)]`,
+/// where `<inner>` is a `;`-separated cis group wrapped in `(...)` inside the
+/// allele bracket (e.g. `NP_003997.1:p.[(Ser68Arg;Asn594del)]`). Returns
+/// `(prefix, inner)` where `prefix` runs through the opening `[` and `inner`
+/// is the cis content with the wrapping parens stripped.
+///
+/// Requires a top-level `;` (depth 0 w.r.t. nested edit brackets / parens,
+/// via [`scan_allele_separators`]) so it stays distinct from the comma
+/// transcript-product form `[(a,b)]`, from a single predicted member, and
+/// from an edit carrying a nested `;` (`ins[A;T]`). The matched `[` must be
+/// the whole-allele bracket (at the start or right after the coordinate-type
+/// stem), not a nested edit suffix like `...ins[(A;T)]`.
+pub(crate) fn find_predicted_cis_bracket(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim();
+    if !input.ends_with(")]") {
+        return None;
+    }
+    // Find the allele `[` matching the final `]` by reverse depth scan.
+    let bytes = input.as_bytes();
+    let mut depth: i32 = 0;
+    let mut open: Option<usize> = None;
+    for i in (0..bytes.len()).rev() {
+        match bytes[i] {
+            b']' => depth += 1,
+            b'[' => {
+                depth -= 1;
+                if depth == 0 {
+                    open = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    // The matched `[` must be the whole-allele bracket, not a nested edit
+    // suffix (`...ins[(A;T)]`). The allele bracket opens at the very start
+    // or immediately after the coordinate-type stem (`g.`, `c.`, `p.`, …),
+    // so the char before `[` is `.`. A nested `ins[...]` / `delins[...]`
+    // bracket is preceded by a letter, so it is rejected here.
+    if open != 0 && !input[..open].ends_with('.') {
+        return None;
+    }
+    let content = &input[open + 1..input.len() - 1];
+    // The content must be a single `(...)` group: starts with `(`, and the
+    // `)` matching that opening `(` is the final character.
+    if !content.starts_with('(') {
+        return None;
+    }
+    let cbytes = content.as_bytes();
+    let mut d: i32 = 0;
+    for (j, &b) in cbytes.iter().enumerate() {
+        match b {
+            b'(' => d += 1,
+            b')' => {
+                d -= 1;
+                if d == 0 && j != cbytes.len() - 1 {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    if d != 0 {
+        return None;
+    }
+    let inner = &content[1..content.len() - 1];
+    // Require a *top-level* `;` cis separator — depth 0 with respect to
+    // nested edit brackets (`ins[A;T]`) and parens. A `;` buried inside an
+    // edit is part of that edit, not an allele-level cis separator, so a
+    // single member like `100_101ins[A;T]` is not a `;`-separated cis group.
+    if !scan_allele_separators(inner).has_cis_separator {
+        return None;
+    }
+    Some((&input[..=open], inner))
+}
+
 /// Detect a whole-edit and/or group wrapped in an uncertainty marker,
 /// i.e. `<prefix>(<inner>)` where `<inner>` carries a top-level `^`
 /// (e.g. `NM_004006.2:c.(370A>C^372C>R)`). Returns `(prefix, inner)`,
@@ -5973,6 +6050,30 @@ fn parse_products_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     Ok(HgvsVariant::Allele(allele))
 }
 
+/// Parse a predicted/uncertain compound cis allele `<prefix>[(<inner>)]`.
+/// Strips the inner `(...)`, parses `<prefix>[<inner>]` as an ordinary cis
+/// allele, and marks it uncertain so the `(...)` round-trips.
+fn parse_predicted_cis_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let (prefix, inner) = find_predicted_cis_bracket(input).ok_or_else(|| FerroError::Parse {
+        pos: 0,
+        msg: "Not a predicted cis allele".to_string(),
+        diagnostic: None,
+    })?;
+    // `prefix` includes the opening `[`.
+    let reconstructed = format!("{}{}]", prefix, inner);
+    match parse_variant(&reconstructed)? {
+        HgvsVariant::Allele(mut allele) if allele.phase == AllelePhase::Cis => {
+            allele.uncertain = true;
+            Ok(HgvsVariant::Allele(allele))
+        }
+        _ => Err(FerroError::Parse {
+            pos: 0,
+            msg: "Predicted cis bracket did not resolve to a cis allele".to_string(),
+            diagnostic: None,
+        }),
+    }
+}
+
 /// Parse a whole-edit and/or group wrapped in an uncertainty marker:
 /// `<prefix>(<edit1>^<edit2>^…)`, e.g. `NM_004006.2:c.(370A>C^372C>R)`.
 /// Each operand is a bare position+edit sharing the accession + coord
@@ -6434,6 +6535,15 @@ fn detect_allele_type(input: &str) -> Option<&'static str> {
         return Some("products");
     }
 
+    // Predicted/uncertain compound cis allele `[(a;b)]`: a `(...)` wrapping a
+    // `;`-separated cis group inside the allele bracket. Checked first — the
+    // inner `(` would otherwise confuse the bare-bracket cis check below, and
+    // the required top-level `;` keeps it distinct from the comma
+    // transcript-product form `[(a,b)]`.
+    if find_predicted_cis_bracket(input).is_some() {
+        return Some("predicted_cis");
+    }
+
     // Top-level slash check happens BEFORE the bracket-wrapping checks
     // so that bracketed chimeric / mosaic forms like
     // `[a;b]//[c;d]` and `[a;b]/[c;d]` route to chimeric / mosaic
@@ -6814,6 +6924,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
             "and_or" => parse_and_or_allele(input)?,
             "products" => parse_products_allele(input)?,
             "uncertain_and_or" => parse_uncertain_and_or_allele(input)?,
+            "predicted_cis" => parse_predicted_cis_allele(input)?,
             _ => unreachable!(),
         }
     } else {

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1358,32 +1358,40 @@ impl fmt::Display for AlleleVariant {
         // Per HGVS spec, `[var]` denotes a multi-variant allele; a singleton
         // is just the inner variant. (Mosaic/chimeric already emit bare via
         // their separator-only loops; this unifies cis/trans/unknown.)
+        // A valid predicted cis allele always has ≥2 members — enforced by the
+        // ';' guard in `find_predicted_cis_bracket` — so this singleton
+        // short-circuit never fires for `[(a;b)]` inputs.  The normalizer
+        // also guards `allele.uncertain` before collapsing a cis allele to a
+        // singleton, keeping this invariant intact through the normalize path.
         if self.variants.len() == 1 {
             return self.variants[0].fmt(f);
         }
         match self.phase {
             AllelePhase::Cis => {
+                // A predicted/uncertain cis allele wraps the bracket content in
+                // `(...)`: `[(a;b)]` (recommendations/uncertain.md).
+                let (lp, rp) = if self.uncertain { ("(", ")") } else { ("", "") };
                 if use_compact_form(&self.variants) {
-                    // Compact form: ACC:g.[edit1;edit2]
+                    // Compact form: ACC:g.[edit1;edit2] / ACC:p.[(edit1;edit2)]
                     write_compact_prefix(f, &self.variants[0])?;
-                    write!(f, "[")?;
+                    write!(f, "[{}", lp)?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, ";")?;
                         }
                         v.fmt_loc_edit(f)?;
                     }
-                    write!(f, "]")
+                    write!(f, "{}]", rp)
                 } else {
                     // Expanded form: [ACC:g.edit1;ACC:g.edit2]
-                    write!(f, "[")?;
+                    write!(f, "[{}", lp)?;
                     for (i, v) in self.variants.iter().enumerate() {
                         if i > 0 {
                             write!(f, ";")?;
                         }
                         write!(f, "{}", v)?;
                     }
-                    write!(f, "]")
+                    write!(f, "{}]", rp)
                 }
             }
             AllelePhase::Products => {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1209,7 +1209,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // pre-existing singleton alleles must round-trip with the Allele
         // wrapper intact for programmatic callers (Display already renders
         // singletons in bare form regardless).
+        // Never unwrap a predicted/uncertain cis allele (`[(a;b)]`): even if
+        // the members merge down to one, the `uncertain` flag and the `[(...)]`
+        // notation must be preserved.  Dropping the wrapper would silently
+        // change semantics and break round-trip fidelity.
         let result = if allele.phase == crate::hgvs::variant::AllelePhase::Cis
+            && !allele.uncertain
             && original_len > 1
             && normalized.len() == 1
         {

--- a/tests/predicted_cis_allele.rs
+++ b/tests/predicted_cis_allele.rs
@@ -1,0 +1,140 @@
+//! Predicted / uncertain compound cis allele `[(a;b)]` (#545).
+//!
+//! `(...)` wraps a `;`-separated cis group inside the allele bracket, marking
+//! the whole cis allele as predicted/uncertain — e.g.
+//! `NP_003997.1:p.[(Ser68Arg;Asn594del)]`. Spec: `recommendations/uncertain.md`,
+//! `recommendations/<axis>/alleles.md`.
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+#[test]
+fn predicted_cis_allele_round_trips() {
+    for s in [
+        "NP_003997.1:p.[(Ser68Arg;Asn594del)]",
+        "NP_003997.1:p.[(Ser73Arg;Asn103del)]",
+        "LRG_199t1:r.[(578c>u;1339a>g;1680del)]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Cis, "phase for `{s}`");
+        assert!(a.uncertain, "uncertain flag for `{s}`");
+        assert!(a.variants.len() >= 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// `p.[(Lys79*;Lys79Asn)]` parses as a predicted cis allele too; only the
+/// `*` stop renders in its canonical `Ter` form (a pre-existing protein-stop
+/// canonicalization, independent of the `(...)` wrapper). It moves off
+/// `parse-error` to `diverges`, not `preserved`.
+#[test]
+fn predicted_cis_allele_with_stop_parses_ter_canonical() {
+    let v = parse_hgvs("NP_003997.1:p.[(Lys79*;Lys79Asn)]").expect("must parse");
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::Cis);
+    assert!(a.uncertain);
+    assert_eq!(format!("{v}"), "NP_003997.1:p.[(Lys79Ter;Lys79Asn)]");
+}
+
+/// Normalize must be idempotent on predicted cis alleles: two consecutive
+/// passes must produce identical output, and the `uncertain` flag and `Cis`
+/// phase must survive both passes.  Mirrors `test_trans_normalize_is_idempotent`
+/// in `allele_trans_phase.rs`.
+///
+/// This also pins the normalizer's singleton-merge branch: if normalization
+/// were to collapse the two protein variants to one and then drop the
+/// `uncertain` wrapper via the cis-unwrap path, `pass1.uncertain` would be
+/// `false` and the Display would lose the `[(…)]` notation.
+#[test]
+fn predicted_cis_allele_normalize_is_idempotent() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let parsed = parse_hgvs("NP_003997.1:p.[(Ser68Arg;Asn594del)]").expect("must parse");
+    let pass1 = normalizer
+        .normalize(&parsed)
+        .expect("normalize pass1 failed");
+    let pass2 = normalizer
+        .normalize(&pass1)
+        .expect("normalize pass2 failed");
+    assert_eq!(
+        format!("{}", pass1),
+        format!("{}", pass2),
+        "normalize must be idempotent on predicted cis alleles",
+    );
+    let HgvsVariant::Allele(a) = pass2 else {
+        panic!("expected Allele after second normalize");
+    };
+    assert_eq!(
+        a.phase,
+        AllelePhase::Cis,
+        "phase must be Cis after normalize"
+    );
+    assert!(a.uncertain, "uncertain flag must survive normalize");
+}
+
+/// A single-member uncertain compound allele whose only member is an edit
+/// containing a *nested* `;` (e.g. an insertion with a multi-segment inserted
+/// allele `ins[A;T]`) must NOT be misclassified as a predicted cis allele.
+///
+/// `find_predicted_cis_bracket` requires a *top-level* `;` separator (depth 0
+/// w.r.t. nested edit brackets / parens), not just any `;` anywhere in the
+/// payload. The `;` in `ins[A;T]` is part of the inserted allele, at bracket
+/// depth 1, so the input is not a `;`-separated cis group. Misclassifying it
+/// reconstructs a single-member cis that collapses to a bare insertion,
+/// dropping the `[(…)]` wrapper entirely (a round-trip failure).
+///
+/// Here the input is therefore a single-member compound allele that round-trips
+/// to the bare insertion form, exactly as the non-predicted route already does
+/// for `p.[(Ser68Arg)]` → `p.(Ser68Arg)`.
+#[test]
+fn nested_semicolon_in_edit_is_not_predicted_cis() {
+    let s = "NM_004006.2:c.[(100_101ins[A;T])]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    // Not a predicted cis allele: a single member whose nested `;` is part of
+    // the inserted allele, not an allele-level cis separator.
+    assert!(
+        !(a.phase == AllelePhase::Cis && a.uncertain && a.variants.len() >= 2),
+        "`{s}` must not be classified as a predicted cis allele, got {a:?}",
+    );
+    // Legit two-member predicted cis alleles still round-trip.
+    for ok in [
+        "NP_003997.1:p.[(Ser68Arg;Asn594del)]",
+        "NM_004006.2:c.[(100A>G;200T>C)]",
+    ] {
+        let v = parse_hgvs(ok).unwrap_or_else(|e| panic!("must parse `{ok}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{ok}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Cis, "phase for `{ok}`");
+        assert!(a.uncertain, "uncertain flag for `{ok}`");
+        assert_eq!(format!("{v}"), ok, "round-trip for `{ok}`");
+    }
+}
+
+/// Predicted cis alleles round-trip correctly on the DNA coordinate axes
+/// (`g.`, `c.`, `n.`).  All three axes route through the same
+/// `find_predicted_cis_bracket` helper and must preserve the `[(…)]` wrapper.
+#[test]
+fn predicted_cis_allele_dna_axes_round_trip() {
+    for s in [
+        "NC_000001.11:g.[(100A>G;200T>C)]",
+        "NM_000088.3:c.[(100A>G;200T>C)]",
+        "NR_024540.1:n.[(100A>G;200T>C)]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Cis, "phase for `{s}`");
+        assert!(a.uncertain, "uncertain flag for `{s}`");
+        assert!(a.variants.len() >= 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}


### PR DESCRIPTION
## Summary

Second of three PRs for #545. Parses the predicted/uncertain compound **cis** allele `[(a;b)]` — a `(...)` wrapping a `;`-separated cis group inside the allele bracket, marking the whole cis allele as predicted:

- `NP_003997.1:p.[(Ser68Arg;Asn594del)]`, `NP_003997.1:p.[(Ser73Arg;Asn103del)]`, `LRG_199t1:r.[(578c>u;1339a>g;1680del)]` (spec: `uncertain.md`, `<axis>/alleles.md`).

## What changed

- `find_predicted_cis_bracket` detects `<prefix>[(<inner>)]` where the inner content is a single `(...)` group with a **top-level `;`** — the `;` requirement keeps it distinct from the comma transcript-product form `[(a,b)]` (PR-C) and from a single predicted member.
- `detect_allele_type` routes it to `parse_predicted_cis_allele`, which strips the inner `(...)`, parses `<prefix>[<inner>]` as an ordinary cis allele (delegation → axis-agnostic, works for p./r./c./g.), and sets the `uncertain` flag.
- The Cis `Display` arm wraps the bracket content in `(...)` when `uncertain` — byte-identical for non-predicted cis alleles.

## Acceptance

Three spec-fixture rows move off `parse-error` → `preserved`. `NP_003997.1:p.[(Lys79*;Lys79Asn)]` moves to `diverges` — it parses as a predicted cis allele, but the `*` stop renders in its canonical `Ter` form (a pre-existing protein-stop canonicalization, independent of this PR). No rows regress. `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #545. Built on current `main` (includes #548). The third follow-up (C: comma transcript-products `[(a,b)]`) is independent.