### PR TITLE
feat(parser): parse comma products allele [a,b] (#545)

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1490,6 +1490,117 @@ pub(crate) fn split_top_level_carets(input: &str) -> Vec<&str> {
     chunks
 }
 
+/// Index of the first top-level (bracket/paren depth 0) `,` separator —
+/// the "different transcripts/proteins from one allele" relationship.
+pub(crate) fn find_top_level_comma(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut depth: i32 = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'[' | b'(' => depth += 1,
+            b']' | b')' => depth -= 1,
+            b',' if depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Bracket/paren-depth-aware top-level split on the `,` (products) separator.
+pub(crate) fn split_top_level_commas(input: &str) -> Vec<&str> {
+    let mut chunks = Vec::new();
+    let mut s = input;
+    loop {
+        match find_top_level_comma(s) {
+            Some(pos) => {
+                chunks.push(&s[..pos]);
+                s = &s[pos + 1..];
+            }
+            None => {
+                chunks.push(s);
+                break;
+            }
+        }
+    }
+    chunks
+}
+
+/// Detect a products allele `<prefix>[a,b]` (or predicted `<prefix>[(a,b)]`):
+/// the outermost allele bracket carries a top-level `,`. Returns
+/// `(prefix_through_open_bracket, inner, uncertain)` where `inner` is the
+/// bracket content with any whole-group `(...)` wrapper stripped.
+///
+/// The matched `[` must open the allele (preceded by the coord stem `.` or at
+/// the start), so the inner bracket of a trans form `[a,b];[c,d]` is not
+/// mistaken for it.
+pub(crate) fn find_products_bracket(input: &str) -> Option<(&str, &str, bool)> {
+    let input = input.trim();
+    if !input.ends_with(']') {
+        return None;
+    }
+    let bytes = input.as_bytes();
+    let mut depth: i32 = 0;
+    let mut open: Option<usize> = None;
+    for i in (0..bytes.len()).rev() {
+        match bytes[i] {
+            b']' => depth += 1,
+            b'[' => {
+                depth -= 1;
+                if depth == 0 {
+                    open = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    // The comma (products) relationship — different transcripts/proteins
+    // derived from one allele — applies only to the r./p. axes. It is never
+    // used on a g./c. DNA-source description, so require the allele bracket to
+    // open right after an `r.`/`p.` coordinate stem. This keeps invalid
+    // `c.[a,b]` / `g.[a,b]` comma forms rejected. The stem is either bare
+    // (`r.[`) or accession-qualified (`<acc>:r.[`); matching on `:r.`/`:p.`
+    // (or the bare-prefix start) avoids a false hit on an accession that
+    // merely ends in `r`/`p` before the dot.
+    let stem = &input[..open];
+    let is_rna_or_protein =
+        stem == "r." || stem == "p." || stem.ends_with(":r.") || stem.ends_with(":p.");
+    if !is_rna_or_protein {
+        return None;
+    }
+    let content = &input[open + 1..input.len() - 1];
+    // Strip a whole-group `(...)` predicted wrapper if present.
+    let (inner, uncertain) = if content.starts_with('(') && content.ends_with(')') {
+        // confirm the opening `(` matches the final `)`
+        let cb = content.as_bytes();
+        let mut d: i32 = 0;
+        let mut matched_at_end = false;
+        for (j, &b) in cb.iter().enumerate() {
+            match b {
+                b'(' => d += 1,
+                b')' => {
+                    d -= 1;
+                    if d == 0 {
+                        matched_at_end = j == cb.len() - 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if matched_at_end {
+            (&content[1..content.len() - 1], true)
+        } else {
+            (content, false)
+        }
+    } else {
+        (content, false)
+    };
+    // Must carry a top-level `,` to be a products allele.
+    find_top_level_comma(inner)?;
+    Some((&input[..=open], inner, uncertain))
+}
+
 /// Detect a whole-edit and/or group wrapped in an uncertainty marker,
 /// i.e. `<prefix>(<inner>)` where `<inner>` carries a top-level `^`
 /// (e.g. `NM_004006.2:c.(370A>C^372C>R)`). Returns `(prefix, inner)`,
@@ -5484,6 +5595,56 @@ fn parse_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError> {
     )))
 }
 
+/// Parse a products allele `[a,b]` / predicted `[(a,b)]` — different
+/// transcripts/proteins derived from one allele (HGVS general.md,
+/// RNA/splicing.md). Members are `,`-separated; each is parsed with the
+/// shared accession + coord-type stem inherited from the bracket prefix
+/// (or its own accession in the expanded multi-transcript form). The
+/// `(...)` whole-group wrapper sets the `uncertain` flag.
+fn parse_products_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let (prefix, inner, uncertain) =
+        find_products_bracket(input).ok_or_else(|| FerroError::Parse {
+            pos: 0,
+            msg: "Not a products allele".to_string(),
+            diagnostic: None,
+        })?;
+    // `prefix` runs through the opening `[`; drop it to get the coord stem.
+    let coord_prefix = &prefix[..prefix.len() - 1];
+    let members = split_top_level_commas(inner);
+    if members.len() < 2 {
+        return Err(FerroError::Parse {
+            pos: 0,
+            msg: "Products allele requires at least two `,`-separated members".to_string(),
+            diagnostic: None,
+        });
+    }
+    let mut variants: Vec<HgvsVariant> = Vec::with_capacity(members.len());
+    for member in members {
+        let member = member.trim();
+        if member.is_empty() {
+            return Err(FerroError::Parse {
+                pos: 0,
+                msg: "Empty member in products allele".to_string(),
+                diagnostic: None,
+            });
+        }
+        // A member may carry its own accession (expanded multi-transcript
+        // form) or be bare and inherit the shared accession + coord type.
+        let variant = if member.contains(':') {
+            parse_variant(member)?
+        } else {
+            parse_variant(&format!("{}{}", coord_prefix, member))?
+        };
+        variants.push(variant);
+    }
+    let allele = if uncertain {
+        AlleleVariant::new_uncertain(variants, AllelePhase::Products)
+    } else {
+        AlleleVariant::new(variants, AllelePhase::Products)
+    };
+    Ok(HgvsVariant::Allele(allele))
+}
+
 /// Parse a whole-edit and/or group wrapped in an uncertainty marker:
 /// `<prefix>(<edit1>^<edit2>^…)`, e.g. `NM_004006.2:c.(370A>C^372C>R)`.
 /// Each operand is a bare position+edit sharing the accession + coord
@@ -5936,6 +6097,15 @@ fn parse_unknown_phase_allele(input: &str) -> Result<HgvsVariant, FerroError> {
 fn detect_allele_type(input: &str) -> Option<&'static str> {
     let input = input.trim();
 
+    // Products allele `[a,b]` / predicted `[(a,b)]`: the outer allele bracket
+    // carries a top-level `,` (different transcripts/proteins from one
+    // allele). Checked before the cis `;` / bare-bracket checks so a comma
+    // bracket is never misread as cis, and so a mixed `[a,b;c]` routes here
+    // and is then rejected when a member fails to parse.
+    if find_products_bracket(input).is_some() {
+        return Some("products");
+    }
+
     // Top-level slash check happens BEFORE the bracket-wrapping checks
     // so that bracketed chimeric / mosaic forms like
     // `[a;b]//[c;d]` and `[a;b]/[c;d]` route to chimeric / mosaic
@@ -6300,6 +6470,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
             "unknown_phase" => parse_unknown_phase_allele(input)?,
             "rna_fusion" => parse_rna_fusion(input)?,
             "and_or" => parse_and_or_allele(input)?,
+            "products" => parse_products_allele(input)?,
             "uncertain_and_or" => parse_uncertain_and_or_allele(input)?,
             _ => unreachable!(),
         }

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -489,7 +489,10 @@ impl<L: fmt::Display, E: fmt::Display> fmt::Display for LocEdit<L, E> {
 
 /// Main HGVS variant enum
 ///
-/// Phase of allele variants (cis vs trans vs mosaic vs chimeric)
+/// The relationship/separator kind among the sub-descriptions of a single
+/// allele bracket. Most variants are true *phase* (cis/trans/mosaic/chimeric),
+/// but the enum also carries non-phase relationships expressed with the same
+/// `[...]` machinery: `AndOr` (`^`) and `Products` (`,`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AllelePhase {
     /// Same chromosome (cis): [var1;var2]
@@ -507,6 +510,12 @@ pub enum AllelePhase {
     /// And/or - alternatives joined by `^`: var1^var2
     /// ("variant A and/or variant B"; HGVS general.md)
     AndOr,
+    /// Products - different transcripts/proteins derived from one allele,
+    /// joined by `,`: `r.[a,b]` (HGVS general.md, RNA/splicing.md,
+    /// RNA/alleles.md). Not a phase: the members are downstream products of a
+    /// single DNA-level event (e.g. alternative splicing), not co-occurrence
+    /// relationships. Only meaningful on the r./p. axes.
+    Products,
 }
 
 impl fmt::Display for AllelePhase {
@@ -518,6 +527,7 @@ impl fmt::Display for AllelePhase {
             AllelePhase::Mosaic => write!(f, "mosaic"),
             AllelePhase::Chimeric => write!(f, "chimeric"),
             AllelePhase::AndOr => write!(f, "and/or"),
+            AllelePhase::Products => write!(f, "products"),
         }
     }
 }
@@ -1342,6 +1352,34 @@ impl fmt::Display for AlleleVariant {
                         write!(f, "{}", v)?;
                     }
                     write!(f, "]")
+                }
+            }
+            AllelePhase::Products => {
+                // `[a,b]` — different transcripts/proteins from one allele.
+                // Mirrors the cis compact/expanded split (members may carry
+                // distinct transcript accessions, so do not assume shared),
+                // joining with `,`. A predicted group wraps the members in
+                // `(...)` inside the bracket: `[(a,b)]`.
+                let (lp, rp) = if self.uncertain { ("(", ")") } else { ("", "") };
+                if use_compact_form(&self.variants) {
+                    write_compact_prefix(f, &self.variants[0])?;
+                    write!(f, "[{}", lp)?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ",")?;
+                        }
+                        v.fmt_loc_edit(f)?;
+                    }
+                    write!(f, "{}]", rp)
+                } else {
+                    write!(f, "[{}", lp)?;
+                    for (i, v) in self.variants.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ",")?;
+                        }
+                        write!(f, "{}", v)?;
+                    }
+                    write!(f, "{}]", rp)
                 }
             }
             AllelePhase::Trans => {
@@ -2697,12 +2735,16 @@ mod tests {
         assert!(!AllelePhase::Unknown.is_mosaic());
         assert!(AllelePhase::Mosaic.is_mosaic());
         assert!(!AllelePhase::Chimeric.is_mosaic());
+        assert!(!AllelePhase::AndOr.is_mosaic());
+        assert!(!AllelePhase::Products.is_mosaic());
 
         assert!(!AllelePhase::Cis.is_chimeric());
         assert!(!AllelePhase::Trans.is_chimeric());
         assert!(!AllelePhase::Unknown.is_chimeric());
         assert!(!AllelePhase::Mosaic.is_chimeric());
         assert!(AllelePhase::Chimeric.is_chimeric());
+        assert!(!AllelePhase::AndOr.is_chimeric());
+        assert!(!AllelePhase::Products.is_chimeric());
     }
 
     // ============== Accession Tests ==============
@@ -2973,6 +3015,8 @@ mod tests {
         assert_eq!(format!("{}", AllelePhase::Unknown), "unknown");
         assert_eq!(format!("{}", AllelePhase::Mosaic), "mosaic");
         assert_eq!(format!("{}", AllelePhase::Chimeric), "chimeric");
+        assert_eq!(format!("{}", AllelePhase::AndOr), "and/or");
+        assert_eq!(format!("{}", AllelePhase::Products), "products");
     }
 
     // ============== AlleleVariant Tests ==============

--- a/tests/comma_products_allele.rs
+++ b/tests/comma_products_allele.rs
@@ -1,0 +1,86 @@
+//! Comma allele `[a,b]` — different transcripts/proteins derived from one
+//! allele (#545). Spec: `general.md`, `RNA/splicing.md`, `RNA/alleles.md`
+//! ("two different transcripts ... derive from one variant on the DNA level").
+//!
+//! Distinct from cis (`;`), trans (`];[`), and-or (`^`), mosaic/chimeric
+//! (`/`/`//`): the comma members are downstream products of a single DNA
+//! event, modeled as `AllelePhase::Products`.
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn comma_products_allele_round_trips() {
+    // Accession-bearing forms. The bare-prefix examples (`r.[123a>u,...]`)
+    // depend on bare-RNA-without-accession member parsing, which ferro does
+    // not support — a limitation orthogonal to the comma relationship.
+    for s in [
+        "LRG_199t1:r.[897u>g,832_960del]",
+        "NM_004006.3:r.[897u>g,832_960del]",
+        "NP_003997.1:p.[Lys31Asn,Val25_Lys31del]",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        let HgvsVariant::Allele(a) = &v else {
+            panic!("expected Allele for `{s}`, got {v:?}");
+        };
+        assert_eq!(a.phase, AllelePhase::Products, "phase for `{s}`");
+        assert!(!a.uncertain, "must not be uncertain for `{s}`");
+        assert_eq!(a.variants.len(), 2, "member count for `{s}`");
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+/// Predicted comma allele `[(a,b)]`: the `(...)` wraps all members inside the
+/// bracket (whole-group uncertainty) — `[(` ... `)]`.
+#[test]
+fn predicted_comma_products_allele_round_trips() {
+    let s = "LRG_199t1:r.[(2603_2622del,2622g>c)]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = &v else {
+        panic!("expected Allele for `{s}`, got {v:?}");
+    };
+    assert_eq!(a.phase, AllelePhase::Products);
+    assert!(a.uncertain, "predicted form must set uncertain");
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+/// A bracket may not mix the comma (product) separator with `;` (cis) —
+/// they answer orthogonal questions, and the grammar admits only one
+/// separator kind per bracket.
+#[test]
+fn mixed_comma_and_semicolon_separators_reject() {
+    assert!(
+        parse_hgvs("LRG_199t1:r.[897u>g,832_960del;900a>c]").is_err(),
+        "mixing `,` and `;` in one bracket must reject"
+    );
+}
+
+/// The comma (products) relationship is r./p.-only — different
+/// transcripts/proteins derived from one allele. It is never valid on a
+/// g./c. DNA-source description, so `c.[a,b]` / `g.[a,b]` must reject. This
+/// guards the `find_products_bracket` axis restriction that keeps real
+/// ClinVar/CMRG `c.[a,b]` inputs out of the products path. HGVS general.md,
+/// RNA/alleles.md.
+#[test]
+fn comma_on_dna_axes_reject() {
+    assert!(
+        parse_hgvs("NM_014762.3:c.[881A>C,918G>C]").is_err(),
+        "comma allele on the c. (CDS) axis must reject"
+    );
+    assert!(
+        parse_hgvs("NC_000001.11:g.[100A>G,200C>T]").is_err(),
+        "comma allele on the g. (genomic) axis must reject"
+    );
+}
+
+/// A products allele requires an outer `r.`/`p.` coordinate stem; the
+/// fully-expanded cross-accession bracket form `[ACC1:r.a,ACC2:r.b]` (no
+/// shared outer stem) is out of spec scope and must reject rather than parse
+/// into a shape that would not round-trip.
+#[test]
+fn bare_expanded_cross_accession_products_reject() {
+    assert!(
+        parse_hgvs("[NM_004006.3:r.897u>g,NM_004006.3:r.832_960del]").is_err(),
+        "fully-expanded bare-bracket products form must reject"
+    );
+}


### PR DESCRIPTION
## Summary

Third of three PRs for #545. Parses the **comma** allele `[a,b]` — different transcripts/proteins derived from one allele (HGVS `general.md`, `RNA/splicing.md`, `RNA/alleles.md`: *"two different transcripts ... derive from one variant on the DNA level"*):

- `LRG_199t1:r.[897u>g,832_960del]`, `NM_004006.3:r.[897u>g,832_960del]`, `NC_000023.11(NM_004006.2):r.[897u>g,832_960del]`, `r.[123a>u,122_154del]`, `NP_003997.1:p.[Lys31Asn,Val25_Lys31del]`, and the predicted `r.[(2603_2622del,2622g>c)]`.

## Design (Opus design-reviewed)

The comma is a *distinct relationship* from cis (`;`), trans, and/or (`^`), and mosaic/chimeric (`/`/`//`) — the members are downstream **products** of a single DNA-level event, not co-occurrence relationships. Modeled as a new `AllelePhase::Products` (the enum already carries the non-phase `AndOr`; its doc is updated to "relationship/separator kind — phase *or* product").

- **`find_products_bracket`** detects the outer allele bracket carrying a top-level `,`, **restricted to the r./p. axes** — the comma is never valid on a g./c. DNA-source description, so `c.[a,b]`/`g.[a,b]` stay correctly rejected. (This restriction was added after the benchmark caught two real-world `c.[a,b]` ClinVar/CMRG inputs being falsely accepted.) A whole-group `(...)` wrapper sets `uncertain` (`[(a,b)]`).
- **`parse_products_allele`** splits on the top-level `,`, parsing each member with the inherited (or its own) accession. Mixing `,` with `;` in one bracket rejects.
- **Display** mirrors the cis compact/expanded split with `,`, wrapping in `[(...)]` when uncertain. **Normalize** needs no change — the cis-only merge/split/overlap guards already exclude `Products`.

## Acceptance

Nine spec-fixture rows move off `parse-error` (eight `preserved`; the `*`-stop protein form `p.[(Ser868Argfs*2,Ser868=)]` `diverges` via the canonical `Ter` rendering). No rows regress; **clinvar/cmrg failure-expectation snapshots are unchanged** (the r./p. restriction keeps invalid `c.[a,b]` forms rejected). `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and the spec-fixture `--check` gate are clean. Full suite: only the pre-existing, environment-dependent mutalyzer/biocommons normalize-divergence tests fail.

Part of #545. Built on current `main` (includes #548). Independent of PR-A (#568, delN) and PR-B (#569, predicted cis).