### PR TITLE
docs: fix broken DOI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://docs.rs/ferro-hgvs/badge.svg)](https://docs.rs/ferro-hgvs)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/ferro-hgvs/README.html)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18703104.svg)](https://doi.org/10.5281/zenodo.18703104)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18703104-blue.svg)](https://doi.org/10.5281/zenodo.18703104)
 
 # ferro-hgvs
 


### PR DESCRIPTION
## Problem

The DOI badge image rendered broken on the GitHub README.

The badge URL itself is fine — the Zenodo SVG, the `doi.org` link, and the Zenodo record all resolve (HTTP 200). The breakage is on GitHub's side: GitHub proxies every README image through its `camo` cache, and Zenodo's `/badge/DOI/*.svg` endpoint returns `Cache-Control: no-cache, max-age=0` with a 120 req/min rate limit. Camo passes the `no-cache` straight through, so it re-fetches from Zenodo on every page view and gets rate-limited, intermittently rendering the image broken.

## Fix

Serve the badge from shields.io instead. shields.io sends `Cache-Control: max-age=432000` (5 days), so camo caches it reliably and never re-hits a rate-limited origin. The badge value (`10.5281/zenodo.18703104`), color, and the click-through `doi.org` link are unchanged — it renders the same `DOI | 10.5281/zenodo.18703104` badge.

```diff
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18703104.svg)](https://doi.org/10.5281/zenodo.18703104)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18703104-blue.svg)](https://doi.org/10.5281/zenodo.18703104)
```
