### PR TITLE
feat(parser): support inverted insertion of an uncertain-boundary range (#546)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -219,6 +219,19 @@ pub enum InsertedSequence {
     PositionRange { start: u64, end: u64 },
     /// Position range with inversion (e.g., delins86116_86422inv)
     PositionRangeInv { start: u64, end: u64 },
+    /// Inserted copy of a single region with uncertain (parenthesized) start
+    /// and end boundaries, inserted in inverted orientation
+    /// (e.g., `ins(127300001_131500000)_(131500001_136400000)inv`). This is the
+    /// HGVS-sanctioned way to describe an orientation-reversed duplication whose
+    /// breakpoints are not sequenced (DNA/complex.md) — the spec rejects the
+    /// shorthand `dupinv` (DNA/inversion.md:19). Each boundary is itself an
+    /// uncertain range `(min_max)`.
+    UncertainRangeInv {
+        /// Uncertain start position `(min, max)`.
+        start: (u64, u64),
+        /// Uncertain end position `(min, max)`.
+        end: (u64, u64),
+    },
     /// Uncertain sequence (e.g., delins(?))
     Uncertain,
     /// Empty insertion (e.g., just "ins" without sequence - rare but valid)
@@ -317,6 +330,9 @@ impl fmt::Display for InsertedSequence {
             InsertedSequence::PositionRangeInv { start, end } => {
                 write!(f, "{}_{}inv", start, end)
             }
+            InsertedSequence::UncertainRangeInv { start, end } => {
+                write!(f, "({}_{})_({}_{})inv", start.0, start.1, end.0, end.1)
+            }
             InsertedSequence::Uncertain => write!(f, "(?)"),
             InsertedSequence::Empty => Ok(()),
         }
@@ -386,7 +402,8 @@ impl InsertedSequence {
             InsertedSequence::Reference(_) => None, // Requires lookup
             InsertedSequence::PositionRange { start, end } => Some((end - start + 1) as usize),
             InsertedSequence::PositionRangeInv { start, end } => Some((end - start + 1) as usize),
-            InsertedSequence::Uncertain => None, // Unknown
+            InsertedSequence::UncertainRangeInv { .. } => None, // Boundaries uncertain
+            InsertedSequence::Uncertain => None,                // Unknown
             InsertedSequence::Empty => Some(0),
         }
     }
@@ -425,6 +442,9 @@ impl InsertedSequence {
             InsertedSequence::Reference(reference) => format!("[{}]", reference),
             InsertedSequence::PositionRange { start, end } => format!("{}_{}", start, end),
             InsertedSequence::PositionRangeInv { start, end } => format!("{}_{}inv", start, end),
+            InsertedSequence::UncertainRangeInv { start, end } => {
+                format!("({}_{})_({}_{})inv", start.0, start.1, end.0, end.1)
+            }
             InsertedSequence::Uncertain => String::from("(?)"),
             InsertedSequence::Empty => String::new(),
         }

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -767,6 +767,25 @@ fn parse_parenthesized_count(input: &str) -> IResult<&str, InsertedSequence> {
                             {
                                 let start2: u64 = start2_str.parse().unwrap_or(0);
                                 let end2: u64 = end2_str.parse().unwrap_or(0);
+
+                                // A trailing `inv` marks an orientation-reversed
+                                // insertion of the single uncertain-boundary
+                                // region — the HGVS-sanctioned form for what the
+                                // spec rejects as `dupinv` (DNA/complex.md,
+                                // DNA/inversion.md:19). Preserve it verbatim
+                                // rather than splitting into two bracket parts.
+                                if let Ok((rest, _)) =
+                                    tag::<_, _, nom::error::Error<&str>>("inv").parse(rest)
+                                {
+                                    return Ok((
+                                        rest,
+                                        InsertedSequence::UncertainRangeInv {
+                                            start: (start1, end1),
+                                            end: (start2, end2),
+                                        },
+                                    ));
+                                }
+
                                 return Ok((
                                     rest,
                                     InsertedSequence::Complex(vec![

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -2116,12 +2116,16 @@ pub fn expand_inserted_sequence<P: ReferenceProvider>(
         InsertedSequence::Complex(parts) => expand_complex_parts(parts, accession, kind, provider),
 
         // Already flat or out-of-scope for this canonicalization.
+        // `UncertainRangeInv` has uncertain (parenthesized) breakpoints that
+        // are not sequenced, so there are no exact bases to fetch — leave it
+        // as-is (DNA/complex.md).
         InsertedSequence::Literal(_)
         | InsertedSequence::Count(_)
         | InsertedSequence::Range(_, _)
         | InsertedSequence::Repeat { .. }
         | InsertedSequence::SequenceRepeat { .. }
         | InsertedSequence::Named(_)
+        | InsertedSequence::UncertainRangeInv { .. }
         | InsertedSequence::Uncertain
         | InsertedSequence::Empty => Ok(None),
     }

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -29,6 +29,10 @@
     "g.456_457ins123_456": {
       "status": "needs-reference",
       "note": "Spec has no canonical output (`spec_expected: null`); auto-classification yields `false-acceptance`. Same-reference ins-from-range payload requires provider sequence to expand; with the empty MockProvider the normalizer surfaces a provider-lookup error. That is a `needs-reference` outcome (#365)."
+    },
+    "chr8:g.128746677_128749160dupinv": {
+      "spec_expected": null,
+      "note": "Harvested from the SVD-WG004 consultation proposal, which is banner-flagged `not updated` and superseded by DNA/complex.md. The adopted recommendation rejects `dupinv` (`<code class=\"invalid\">` at DNA/inversion.md:19, RNA/inversion.md:19) and re-expresses this exact orientation-reversed duplication as an inverted insertion (`NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv`, DNA/complex.md). The seeded `spec_expected` was a fixture bug; force spec-rejects so ferro correctly rejecting `dupinv` reads as `correctly-rejected`, not `parse-error`. ferro supports the spec-correct `ins(...)_(...)inv` form instead (#546)."
     }
   }
 }

--- a/tests/inverted_uncertain_range_insertion.rs
+++ b/tests/inverted_uncertain_range_insertion.rs
@@ -1,0 +1,56 @@
+//! Inverted insertion of an uncertain-boundary range — the spec-sanctioned way
+//! (HGVS DNA/complex.md) to describe an orientation-reversed duplication. HGVS
+//! writes this as `ins(a_b)_(c_d)inv`, NOT as the invalid `dupinv`
+//! (DNA/inversion.md:19 marks `dupinv` `class="invalid"`). Issue #546.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer};
+
+/// The canonical orientation-reversed intra-chromosomal duplication from
+/// `DNA/complex.md` (ISCN `dup(8)(q24.22q24.21)`, breakpoint not sequenced).
+#[test]
+fn inverted_uncertain_range_insertion_round_trips() {
+    let s = "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+/// Guard: the bare (non-`inv`) compound paren range keeps its established
+/// canonical bracket form (`[a_b;c_d]`) — the `inv` support must not disturb it.
+#[test]
+fn bare_compound_paren_insertion_keeps_bracket_canonical_form() {
+    let s = "NG_007406.1:g.?_?ins(23632682_23625413)_(23625324_23619334)";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(
+        format!("{v}"),
+        "NG_007406.1:g.?ins[23632682_23625413;23625324_23619334]",
+        "bare compound paren insertion canonicalizes to brackets"
+    );
+}
+
+/// The normalizer must pass the `UncertainRangeInv` form through unchanged:
+/// `expand_inserted_sequence` returns `Ok(None)`, and `normalize_na_edit`'s
+/// `Insertion` arm bails early when `sequence.bases()` returns `None`.
+#[test]
+fn inverted_uncertain_range_insertion_normalizes_idempotently() {
+    let s = "NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let provider = MockProvider::new();
+    let normalizer = Normalizer::with_config(provider, NormalizeConfig::default());
+    let result = normalizer.normalize(&v).expect("normalize");
+    assert_eq!(
+        format!("{result}"),
+        s,
+        "normalize must pass through unchanged for `{s}`"
+    );
+}
+
+/// `delins` with an `UncertainRangeInv` inserted payload — both `ins` and
+/// `delins` share `parse_parenthesized_count` as the entry point, so the new
+/// variant parses and round-trips for `delins` too.
+#[test]
+fn delins_uncertain_range_inv_round_trips() {
+    let s =
+        "NC_000008.11:g.(131500001_136400000)delins(127300001_131500000)_(131500001_136400000)inv";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}


### PR DESCRIPTION
## Summary

Closes part of #546 (structural-variant notation). Adds parse + round-trip support for the HGVS-sanctioned notation for an **orientation-reversed duplication whose breakpoints are not sequenced**, e.g.:

```
NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv
```

This is the form the adopted recommendation `DNA/complex.md` uses for ISCN `dup(8)(q24.22q24.21)`.

## Why not `dupinv`?

Issue #546 was seeded from the `SVD-WG004` consultation proposal, which uses the shorthand `chr8:g.128746677_128749160dupinv`. On review against the spec, `dupinv` is **explicitly invalid**:

- `DNA/inversion.md:19` and `RNA/inversion.md:19` render `dupinv` as `<code class="invalid">` and direct inverted duplications to the inverted-insertion form.
- `SVD-WG004.md` carries a banner: *"not updated … To see the current recommendations, please check Complex (HGVS/ISCN)"*, and was accepted only as a named extension.
- `DNA/complex.md` re-expresses that exact orientation-reversed duplication as `NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv` — an inverted insertion on a RefSeq accession, not `dupinv`.

So this PR implements the spec-correct `ins(…)_(…)inv` form and treats the seeded `dupinv` fixture row as a fixture bug.

## Changes

- New `InsertedSequence::UncertainRangeInv { start: (u64, u64), end: (u64, u64) }` variant — preserves the `(a_b)_(c_d)inv` shape verbatim (Display, `to_rna_string`, `len`).
- Parser: `parse_parenthesized_count` recognizes a trailing `inv` after the compound parenthesized range. The `inv` suffix is **only** consumed in that position, so the established canonical bracket form for the bare `ins(a_b)_(c_d)` insertion (rendered `[a_b;c_d]`, locked by existing tests) is unchanged.
- `expand_inserted_sequence`: `UncertainRangeInv` is a no-op — its breakpoints are uncertain/unsequenced, so there are no exact bases to fetch.
- Spec fixture: an override pins `spec_expected: null` on `chr8:g.128746677_128749160dupinv` so ferro's correct rejection of `dupinv` classifies as `correctly-rejected` rather than `parse-error`.

## Spec-fixture impact

| input | before | after |
|---|---|---|
| `NC_000008.11:g.(131500001_136400000)ins(127300001_131500000)_(131500001_136400000)inv` | `parse-error` | `preserved` |
| `chr8:g.128746677_128749160dupinv` | `parse-error` | `correctly-rejected` |

No `false-acceptance` rows introduced; the three normative `dupinv` rows (`g.123_234dupinv`, `g.123_456dupinv`, `r.123_456dupinv`) remain `correctly-rejected`.

## Testing

- New `tests/inverted_uncertain_range_insertion.rs`: the `complex.md` form round-trips; a guard test pins the bare compound-paren insertion to its existing bracket canonical form.
- `cargo fmt --check`, `cargo clippy --features dev --all-targets` clean.
- Spec-fixture `--check` gate passes.
- Full suite: 6729 passed, only the 9 pre-existing corpus-parity environment failures remain (unchanged).
