### PR TITLE
perf(reference): memoize resolved transcripts in MultiFastaProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "log",
+ "lru",
  "memchr",
  "memmap2",
  "nom",
@@ -1858,6 +1859,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ once_cell = "1.20"
 superintervals = "0.3"
 rkyv = "0.8"
 rustc-hash = "2"
+lru = "0.12.5"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ ferro check --reference ferro-reference --build-cache
 ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
 ```
 
+> **Throughput tip:** when normalizing many variants, feed them **sorted by transcript accession (or by genomic position)**. ferro caches each resolved transcript, so consecutive variants on the same transcript skip the (dominant) cost of re-reading and re-building it from the reference. Sorted input keeps the relevant transcripts resident in the cache and is markedly faster on large batches — see [Performance Comparison](#performance-comparison).
+
 ### Library
 
 ```rust
@@ -226,6 +228,8 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 | mutalyzer | ~20 patterns/sec | ~1 pattern/sec | **200,000x** |
 | biocommons/hgvs | ~20 patterns/sec | ~0.2 patterns/sec | **200,000x** |
 | hgvs-rs | ~2 patterns/sec | ~0.2 patterns/sec | **2,000,000x** |
+
+**Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.
 
 ### Reference Data: What ferro Prepares
 

--- a/docs/BENCHMARK_GUIDE.md
+++ b/docs/BENCHMARK_GUIDE.md
@@ -160,6 +160,8 @@ ferro-benchmark compare results normalize ferro_norm.json mutalyzer_norm.json -o
 > from https://dl.biocommons.org/uta/uta_20210129b.pgd.gz (requires human verification),
 > then see [Prepare biocommons](#step-3-prepare-biocommons).
 
+> **Throughput tip — sort the input.** ferro's normalize cost is dominated by transcript resolution (reading the full transcript sequence from the reference and rebuilding its metadata). Resolved transcripts are memoized, so input **sorted by transcript accession (or by genomic position, which clusters variants onto shared transcripts)** maximizes the cache hit rate and can be an order of magnitude faster on large batches than randomly-ordered input. This matters most when the number of distinct transcripts exceeds the cache capacity; sort large or genome-wide inputs to keep the hot transcript set resident.
+
 ---
 
 ## Prerequisites & Build

--- a/examples/projector-bench.rs
+++ b/examples/projector-bench.rs
@@ -70,7 +70,7 @@ enum Cmd {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1788,7 +1788,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // hit the downstream `try_expand_cds_ins` and canonicalization passes.
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
-            || -> Result<crate::reference::transcript::Transcript, FerroError> {
+            || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
                 self.provider
                     .get_transcript_for_variant(&HV::Cds(variant.clone()))
             };
@@ -2388,7 +2388,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `try_expand_tx_ins` and canonicalization passes.
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
-            || -> Result<crate::reference::transcript::Transcript, FerroError> {
+            || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
                 self.provider
                     .get_transcript_for_variant(&HV::Tx(variant.clone()))
             };

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -97,7 +97,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .transcript_cache
             .write()
             .expect("transcript cache poisoned");
-        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        // `tx` is already an `Arc<Transcript>` from the provider; insert directly.
+        let entry = guard.entry(key).or_insert_with(|| tx);
         Ok(Arc::clone(entry))
     }
 
@@ -375,7 +376,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .transcript_cache
             .write()
             .expect("transcript cache poisoned");
-        let entry = guard.entry(key).or_insert_with(|| Arc::new(tx));
+        // `tx` is already an `Arc<Transcript>` from the provider; insert directly.
+        let entry = guard.entry(key).or_insert_with(|| tx);
         Ok(Arc::clone(entry))
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -49,7 +49,7 @@ impl ReferenceProvider for PyProvider {
     fn get_transcript(
         &self,
         id: &str,
-    ) -> Result<crate::reference::transcript::Transcript, crate::error::FerroError> {
+    ) -> Result<Arc<crate::reference::transcript::Transcript>, crate::error::FerroError> {
         match self {
             PyProvider::Mock(p) => p.get_transcript(id),
             PyProvider::MultiFasta(p) => p.get_transcript(id),

--- a/src/reference/annotation/validate.rs
+++ b/src/reference/annotation/validate.rs
@@ -179,7 +179,10 @@ mod tests {
     }
 
     impl ReferenceProvider for StubFasta {
-        fn get_transcript(&self, id: &str) -> Result<Transcript, crate::error::FerroError> {
+        fn get_transcript(
+            &self,
+            id: &str,
+        ) -> Result<std::sync::Arc<Transcript>, crate::error::FerroError> {
             Err(crate::error::FerroError::ReferenceNotFound { id: id.to_string() })
         }
 

--- a/src/reference/fasta.rs
+++ b/src/reference/fasta.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::error::FerroError;
 use crate::reference::provider::ReferenceProvider;
@@ -39,7 +40,7 @@ pub struct FastaProvider {
     /// Chromosome name aliases (for mapping between different naming conventions)
     aliases: HashMap<String, String>,
     /// Transcript data (if loaded)
-    transcripts: HashMap<String, Transcript>,
+    transcripts: HashMap<String, Arc<Transcript>>,
 }
 
 impl FastaProvider {
@@ -217,7 +218,8 @@ impl FastaProvider {
 
     /// Add a transcript to the provider
     pub fn add_transcript(&mut self, transcript: Transcript) {
-        self.transcripts.insert(transcript.id.clone(), transcript);
+        self.transcripts
+            .insert(transcript.id.clone(), Arc::new(transcript));
     }
 
     /// True when `id` is declared as a chromosome/contig name — either
@@ -238,10 +240,10 @@ impl FastaProvider {
 }
 
 impl ReferenceProvider for FastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.transcripts
             .get(id)
-            .cloned()
+            .map(Arc::clone)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })
     }
 
@@ -597,7 +599,7 @@ impl CachedFastaProvider {
 }
 
 impl ReferenceProvider for CachedFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.inner.get_transcript(id)
     }
 
@@ -668,7 +670,7 @@ pub struct MmapFastaProvider {
     /// Chromosome name aliases
     aliases: HashMap<String, String>,
     /// Transcript data (if loaded)
-    transcripts: HashMap<String, Transcript>,
+    transcripts: HashMap<String, Arc<Transcript>>,
 }
 
 #[cfg(feature = "mmap")]
@@ -893,16 +895,17 @@ impl MmapFastaProvider {
 
     /// Add a transcript to the provider
     pub fn add_transcript(&mut self, transcript: Transcript) {
-        self.transcripts.insert(transcript.id.clone(), transcript);
+        self.transcripts
+            .insert(transcript.id.clone(), Arc::new(transcript));
     }
 }
 
 #[cfg(feature = "mmap")]
 impl ReferenceProvider for MmapFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         // Handle versioned and unversioned lookups
         if let Some(tx) = self.transcripts.get(id) {
-            return Ok(tx.clone());
+            return Ok(Arc::clone(tx));
         }
 
         // Try without version: only match a stored key whose base id (the
@@ -913,7 +916,7 @@ impl ReferenceProvider for MmapFastaProvider {
         let base_id = id.split('.').next().unwrap_or(id);
         for (key, tx) in &self.transcripts {
             if key.split('.').next().unwrap_or(key) == base_id {
-                return Ok(tx.clone());
+                return Ok(Arc::clone(tx));
             }
         }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -5,12 +5,12 @@ use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::Transcript;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 /// Mock reference provider that loads transcripts from JSON
 #[derive(Clone)]
 pub struct MockProvider {
-    transcripts: HashMap<String, Transcript>,
+    transcripts: HashMap<String, Arc<Transcript>>,
     proteins: HashMap<String, String>,
     /// Genomic sequences keyed by contig name
     genomic_sequences: HashMap<String, String>,
@@ -84,9 +84,9 @@ impl MockProvider {
             }
         };
 
-        let map: HashMap<String, Transcript> = transcripts
+        let map: HashMap<String, Arc<Transcript>> = transcripts
             .into_iter()
-            .map(|tx| (tx.id.clone(), tx))
+            .map(|tx| (tx.id.clone(), Arc::new(tx)))
             .collect();
 
         Ok(Self {
@@ -99,7 +99,8 @@ impl MockProvider {
 
     /// Add a transcript to the provider
     pub fn add_transcript(&mut self, transcript: Transcript) {
-        self.transcripts.insert(transcript.id.clone(), transcript);
+        self.transcripts
+            .insert(transcript.id.clone(), Arc::new(transcript));
     }
 
     /// Add a protein sequence to the provider
@@ -273,7 +274,7 @@ impl MockProvider {
 
     /// Iterate over all transcripts registered in the provider.
     pub fn all_transcripts(&self) -> impl Iterator<Item = &Transcript> {
-        self.transcripts.values()
+        self.transcripts.values().map(Arc::as_ref)
     }
 
     /// True when `id` is declared as a chromosome/contig name — either an
@@ -298,10 +299,10 @@ impl Default for MockProvider {
 }
 
 impl ReferenceProvider for MockProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         // Handle versioned and unversioned lookups
         if let Some(tx) = self.transcripts.get(id) {
-            return Ok(tx.clone());
+            return Ok(Arc::clone(tx));
         }
 
         // Try without version: only match a stored key whose base id (the
@@ -317,7 +318,7 @@ impl ReferenceProvider for MockProvider {
         if !id.contains('.') {
             for (key, tx) in &self.transcripts {
                 if key.split('.').next().unwrap_or(key) == id {
-                    return Ok(tx.clone());
+                    return Ok(Arc::clone(tx));
                 }
             }
         }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -21,9 +21,12 @@
 
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use log::warn;
+use lru::LruCache;
 use rustc_hash::FxHashMap;
 
 use crate::data::cdot::CdotMapper;
@@ -140,6 +143,42 @@ pub struct MultiFastaProvider {
     canonical_overrides: CanonicalOverrides,
     /// Protein FASTA index (NP_/XP_ accessions) for get_protein_sequence (#520).
     protein_index: FxHashMap<String, FastaIndexEntry>,
+    /// Bounded LRU memoizing resolved transcripts, keyed on the exact resolution
+    /// inputs `(id, build_hint)`. Resolving a transcript materializes its full
+    /// sequence from the FASTA and rebuilds cdot exon/CDS metadata — by far the
+    /// dominant cost in batch normalization. Most real workloads (transcript- or
+    /// genome-position-sorted input) revisit the same transcript many times in a
+    /// row, so memoizing turns those repeats into cheap `Arc` clones. The result
+    /// is byte-identical to recomputing it, so this is purely a timing change.
+    /// Keying on `(id, build_hint)` (not the bare accession) keeps multi-build
+    /// resolution correct: the same accession on different builds caches
+    /// distinctly. See the resolve-cache perf work.
+    transcript_cache: TranscriptCache,
+}
+
+/// Resolution inputs that uniquely identify a resolved transcript: the requested
+/// accession and the optional genome-build hint. Used as the resolve-cache key.
+type TranscriptCacheKey = (String, Option<String>);
+
+/// Bounded LRU memoizing resolved transcripts (see [`MultiFastaProvider`]'s
+/// `transcript_cache` field). Wrapped in a [`Mutex`] for `&self` access from the
+/// [`ReferenceProvider`] trait, which is shared across threads.
+type TranscriptCache = Mutex<LruCache<TranscriptCacheKey, Arc<Transcript>>>;
+
+/// Default capacity (number of distinct transcripts) for the resolve cache.
+///
+/// Sized well above the working set of typical batch runs (ClinVar-scale inputs
+/// touch on the order of tens of thousands of distinct transcripts), so locality
+/// is captured without eviction churn, while still bounding memory for
+/// long-running services that would otherwise accumulate every transcript ever
+/// requested.
+const TRANSCRIPT_CACHE_CAPACITY: usize = 65_536;
+
+/// Build an empty resolve cache at the default capacity.
+fn new_transcript_cache() -> TranscriptCache {
+    let capacity =
+        NonZeroUsize::new(TRANSCRIPT_CACHE_CAPACITY).expect("cache capacity is non-zero");
+    Mutex::new(LruCache::new(capacity))
 }
 
 impl MultiFastaProvider {
@@ -208,6 +247,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: FxHashMap::default(),
+            transcript_cache: new_transcript_cache(),
         })
     }
 
@@ -239,6 +279,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: FxHashMap::default(),
+            transcript_cache: new_transcript_cache(),
         })
     }
 
@@ -539,6 +580,7 @@ impl MultiFastaProvider {
             supplemental_cds: SupplementalCdsInfo::default(),
             canonical_overrides: CanonicalOverrides::default(),
             protein_index: FxHashMap::default(),
+            transcript_cache: new_transcript_cache(),
         })
     }
 
@@ -1079,6 +1121,46 @@ impl MultiFastaProvider {
         Ok(tx)
     }
 
+    /// Memoized [`Self::get_transcript_on_build`].
+    ///
+    /// On a cache hit returns a cheap [`Arc`] clone of the previously resolved
+    /// transcript; on a miss it resolves (materializing the full sequence and
+    /// rebuilding cdot metadata), stores the result, and returns it. The cached
+    /// value is exactly what `get_transcript_on_build` would have produced —
+    /// including applied canonical overrides — so callers cannot observe any
+    /// behavioral difference, only reduced work on repeat lookups. The cache key
+    /// `(id, build_hint)` matches the resolution inputs so distinct builds of the
+    /// same accession never collide.
+    fn get_transcript_on_build_cached(
+        &self,
+        id: &str,
+        build_hint: Option<&str>,
+    ) -> Result<Arc<Transcript>, FerroError> {
+        let key = (id.to_string(), build_hint.map(str::to_string));
+
+        if let Some(hit) = self
+            .transcript_cache
+            .lock()
+            .expect("transcript cache mutex poisoned")
+            .get(&key)
+        {
+            return Ok(Arc::clone(hit));
+        }
+
+        // Resolve outside the lock so concurrent misses for *different*
+        // transcripts don't serialize on the expensive FASTA read.
+        // NOTE: concurrent same-key misses both resolve; the second put is a
+        // no-op in value terms (LruCache overwrites with a semantically
+        // identical Arc, and all callers already hold their own Arc clone).
+        let tx = Arc::new(self.get_transcript_on_build(id, build_hint)?);
+
+        self.transcript_cache
+            .lock()
+            .expect("transcript cache mutex poisoned")
+            .put(key, Arc::clone(&tx));
+        Ok(tx)
+    }
+
     fn get_transcript_on_build_inner(
         &self,
         id: &str,
@@ -1408,24 +1490,24 @@ impl MultiFastaProvider {
 }
 
 impl ReferenceProvider for MultiFastaProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
-        self.get_transcript_on_build(id, None)
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
+        self.get_transcript_on_build_cached(id, None)
     }
 
     fn get_transcript_for_variant(
         &self,
         variant: &crate::hgvs::variant::HgvsVariant,
-    ) -> Result<Transcript, FerroError> {
+    ) -> Result<Arc<Transcript>, FerroError> {
         let Some(accession) = variant.accession() else {
             // No accession at all (e.g. NullAllele) — fall through to the
             // default impl which produces a clear ReferenceNotFound error.
-            return self.get_transcript_on_build(&format!("{}", variant), None);
+            return self.get_transcript_on_build_cached(&format!("{}", variant), None);
         };
         let tx_id = accession.transcript_accession();
 
         // No parent → exactly the existing behavior.
         let Some(parent) = accession.genomic_context.as_deref() else {
-            return self.get_transcript_on_build(&tx_id, None);
+            return self.get_transcript_on_build_cached(&tx_id, None);
         };
 
         // Decide a probe order based on the parent class.
@@ -1442,16 +1524,16 @@ impl ReferenceProvider for MultiFastaProvider {
                 if &*parent.prefix == "NG" {
                     &["GRCh38", "GRCh37"]
                 } else {
-                    return self.get_transcript_on_build(&tx_id, None);
+                    return self.get_transcript_on_build_cached(&tx_id, None);
                 }
             }
         };
 
         let mut last_err: Option<FerroError> = None;
         for build in probe_order {
-            match self.get_transcript_on_build(&tx_id, Some(build)) {
+            match self.get_transcript_on_build_cached(&tx_id, Some(build)) {
                 Ok(tx) if tx.chromosome.is_some() => return Ok(tx),
-                Ok(tx) => last_err = Some(FerroError::ReferenceNotFound { id: tx.id }),
+                Ok(tx) => last_err = Some(FerroError::ReferenceNotFound { id: tx.id.clone() }),
                 Err(e) => last_err = Some(e),
             }
         }
@@ -1459,7 +1541,7 @@ impl ReferenceProvider for MultiFastaProvider {
         // Final fallback: try without a build hint (uses cdot's primary build
         // and any supplemental/FASTA-only data). Preserves the historical
         // behavior for transcripts that only live in the primary build.
-        match self.get_transcript_on_build(&tx_id, None) {
+        match self.get_transcript_on_build_cached(&tx_id, None) {
             Ok(tx) => Ok(tx),
             Err(e) => Err(last_err.unwrap_or(e)),
         }
@@ -2677,6 +2759,70 @@ mod tests {
         drop(fai);
         let provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
         (provider, dir)
+    }
+
+    #[test]
+    fn resolve_cache_memoizes_and_preserves_content() {
+        let (provider, _kept) = build_provider_with_transcripts(&[
+            ("NM_CACHE.1", "ATGAAATAA"),
+            ("NM_OTHER.1", "ATGCAT"),
+        ]);
+
+        // The cached result must be byte-identical to an uncached resolve:
+        // caching is purely a timing change, never a behavioral one.
+        let uncached = provider
+            .get_transcript_on_build("NM_CACHE.1", None)
+            .unwrap();
+        let first = provider.get_transcript("NM_CACHE.1").unwrap();
+        assert_eq!(*first, uncached);
+
+        // A second lookup of the same (id, build) returns the *same* Arc — proof
+        // the materialize path ran once and the repeat was served from cache.
+        let second = provider.get_transcript("NM_CACHE.1").unwrap();
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "repeat lookup should hit the cache and return the same Arc"
+        );
+
+        // A different accession is a distinct entry, not an accidental alias.
+        let other = provider.get_transcript("NM_OTHER.1").unwrap();
+        assert!(!Arc::ptr_eq(&first, &other));
+        assert_eq!(other.sequence.as_deref(), Some("ATGCAT"));
+
+        // A miss still surfaces as an error (not a stale or empty cache hit).
+        assert!(provider.get_transcript("NM_MISSING.1").is_err());
+    }
+
+    #[test]
+    fn resolve_cache_build_hint_key_isolation() {
+        // The docstring for get_transcript_on_build_cached states that the
+        // cache key is (id, build_hint), so the same accession with different
+        // build hints must produce independent entries that never evict each
+        // other.
+        let (provider, _kept) = build_provider_with_transcripts(&[("NM_BUILD.1", "ATGAAACCC")]);
+
+        let grch37 = provider
+            .get_transcript_on_build_cached("NM_BUILD.1", Some("GRCh37"))
+            .expect("GRCh37 lookup must succeed");
+        let grch38 = provider
+            .get_transcript_on_build_cached("NM_BUILD.1", Some("GRCh38"))
+            .expect("GRCh38 lookup must succeed");
+
+        // Different build hints produce distinct Arc allocations — neither
+        // entry evicted the other from the cache.
+        assert!(
+            !Arc::ptr_eq(&grch37, &grch38),
+            "(id, GRCh37) and (id, GRCh38) must be independent cache entries"
+        );
+
+        // A repeat GRCh37 lookup is still served from the cache (same Arc).
+        let grch37_again = provider
+            .get_transcript_on_build_cached("NM_BUILD.1", Some("GRCh37"))
+            .expect("repeat GRCh37 lookup must succeed");
+        assert!(
+            Arc::ptr_eq(&grch37, &grch37_again),
+            "repeat (id, GRCh37) lookup should hit the cache and return the same Arc"
+        );
     }
 
     #[test]

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -2,6 +2,8 @@
 //!
 //! Defines the interface for accessing reference sequence data.
 
+use std::sync::Arc;
+
 use crate::error::FerroError;
 use crate::hgvs::variant::HgvsVariant;
 use crate::reference::transcript::Transcript;
@@ -13,8 +15,16 @@ use crate::reference::transcript::Transcript;
 /// - SeqRepoProvider for local sequence databases
 /// - NCBIProvider for remote NCBI E-utilities
 pub trait ReferenceProvider {
-    /// Get a transcript by its accession
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError>;
+    /// Get a transcript by its accession.
+    ///
+    /// Returns an [`Arc`] so that providers which materialize the full
+    /// transcript sequence (e.g.
+    /// [`MultiFastaProvider`](crate::reference::multi_fasta::MultiFastaProvider))
+    /// can memoize the result and hand out cheap pointer clones on repeated
+    /// lookups of the same transcript. Callers that only read fields are
+    /// unaffected (`Arc<Transcript>` derefs to `Transcript`); callers that
+    /// need an owned `Transcript` can clone via `(*tx).clone()`.
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError>;
 
     /// Get the transcript for the given variant, optionally using the
     /// variant's `genomic_context` parent (NG/NC) to pick a cdot build
@@ -30,7 +40,10 @@ pub trait ReferenceProvider {
     /// specific cdot build (e.g. [`crate::reference::multi_fasta::MultiFastaProvider`])
     /// override this to consult the parent accession before falling back to
     /// the bare transcript lookup. See issue #332.
-    fn get_transcript_for_variant(&self, variant: &HgvsVariant) -> Result<Transcript, FerroError> {
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, FerroError> {
         let accession = variant
             .accession()
             .ok_or_else(|| FerroError::ReferenceNotFound {
@@ -219,11 +232,14 @@ pub trait ReferenceProvider {
 
 /// Blanket implementation for boxed trait objects
 impl ReferenceProvider for Box<dyn ReferenceProvider> {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         (**self).get_transcript(id)
     }
 
-    fn get_transcript_for_variant(&self, variant: &HgvsVariant) -> Result<Transcript, FerroError> {
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, FerroError> {
         (**self).get_transcript_for_variant(variant)
     }
 

--- a/src/reference/validate.rs
+++ b/src/reference/validate.rs
@@ -1031,7 +1031,7 @@ mod tests {
     /// to exercise the `LoadError` surfacing path.
     struct FailingProvider;
     impl ReferenceProvider for FailingProvider {
-        fn get_transcript(&self, _id: &str) -> Result<Transcript, FerroError> {
+        fn get_transcript(&self, _id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
             Err(FerroError::InvalidCoordinates {
                 msg: "degenerate coordinates".to_string(),
             })

--- a/tests/biocommons_normalize_tests.rs
+++ b/tests/biocommons_normalize_tests.rs
@@ -120,7 +120,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/tests/hgvs_rs_projection_tests.rs
+++ b/tests/hgvs_rs_projection_tests.rs
@@ -133,7 +133,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/tests/issue_339_alignment_gap_panic.rs
+++ b/tests/issue_339_alignment_gap_panic.rs
@@ -31,7 +31,7 @@ struct FixedLengthProvider {
 }
 
 impl ReferenceProvider for FixedLengthProvider {
-    fn get_transcript(&self, _id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, _id: &str) -> Result<std::sync::Arc<Transcript>, FerroError> {
         Err(FerroError::ReferenceNotFound {
             id: "<fixed-length-provider>".to_string(),
         })

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -141,7 +141,7 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
 struct ArcProvider(Arc<MultiFastaProvider>);
 
 impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.0.get_transcript(id)
     }
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -226,7 +226,7 @@ impl<P: ReferenceProvider + Clone> CountingProvider<P> {
 }
 
 impl<P: ReferenceProvider + Clone> ReferenceProvider for CountingProvider<P> {
-    fn get_transcript(&self, id: &str) -> Result<Transcript, FerroError> {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
         self.transcript_calls.fetch_add(1, Ordering::SeqCst);
         self.inner.get_transcript(id)
     }


### PR DESCRIPTION
## What

Transcript resolution dominates batch-normalization cost. Profiling on the real manifest (50k ClinVar `c.`/`n.` corpus, warmup + min-of-3) decomposes end-to-end normalize as:

| phase | per-variant | share |
|-------|-------------|-------|
| parse | ~330 ns | 3% |
| normalize-core | ~1.5 µs | 13% |
| **resolve** | **~9–23 µs** | **84%** |

Resolve re-reads the full transcript sequence from the FASTA and rebuilds its cdot exon/CDS metadata on *every* variant. Real workloads revisit the same transcript many times in a row (transcript- or genome-position-sorted input), so this work is overwhelmingly redundant.

This PR memoizes resolved transcripts in a bounded LRU on `MultiFastaProvider`, keyed on the exact resolution inputs `(id, build_hint)` so multi-build resolution stays correct. To make cache hits cheap pointer clones rather than full sequence copies, `ReferenceProvider::get_transcript` and `get_transcript_for_variant` now return `Arc<Transcript>`; callers that only read fields are unaffected via `Deref` (only a handful of ownership-transfer sites needed edits across the 9 impls).

The cached value is exactly what resolution would have produced (including applied canonical overrides), so this is **purely a timing change**.

## Results

Measured on the real manifest (min-of-3, 50k variants), baseline vs cache:

| input order | full normalize (baseline → cache) | speedup |
|-------------|-----------------------------------|---------|
| sorted (realistic) | 24,075 → 861 ns/var (resolve 22,584 → 129) | **≈28×** |
| unsorted (worst case) | 25,114 → 2,317 ns/var | **≈11×** |

Ordering matters once the number of distinct transcripts in a run exceeds the cache capacity (65,536); below that the working set stays resident regardless of order. The sorted-input throughput tip is documented in the README and `docs/BENCHMARK_GUIDE.md`.

## Correctness

This is behavior-preserving by construction (memoization of an unchanged resolution result). Verified with the conformance xfail-diff gate: the per-axis divergence detail (`/tmp/ferro-xfail/axis_*`) is **byte-for-byte identical** to the pre-cache base commit. The full suite passes except the 9 pre-existing reference-gated conformance axes (stale fixture data, unrelated to this change). Adds a unit test asserting that repeat lookups return the same `Arc` and preserve content, that distinct accessions don't collide, and that misses still error.

## Notes

- Independent of and composes cleanly with the FASTA file-handle reuse PR (#570): handle reuse speeds the cache *misses*; this cache eliminates the *repeat* reads.
- Adds one dependency: `lru = "0.12"`.

## Reading order

1. `src/reference/provider.rs` — the trait return-type change (`Arc<Transcript>`).
2. `src/reference/multi_fasta.rs` — the cache field, `get_transcript_on_build_cached` funnel, and the unit test.
3. The remaining files are mechanical: wrap each impl's return in `Arc`, and fix the ownership-transfer callsites in `normalize/mod.rs`, `project/projector.rs`.