### PR TITLE
fix(build): repair test code that broke under non-`dev` feature flags

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -3717,17 +3717,16 @@ mod tests {
         let cases: Vec<(crate::normalize::NormalizationWarning, &str)> = vec![
             (
                 crate::normalize::NormalizationWarning::RefSeqMismatch {
-                    message: "stated A but reference is T".to_string(),
                     stated_ref: "A".to_string(),
                     actual_ref: "T".to_string(),
                     position: "100".to_string(),
                     corrected: true,
+                    details: Some("stated A but reference is T".to_string()),
                 },
                 "REFSEQ_MISMATCH",
             ),
             (
                 crate::normalize::NormalizationWarning::OverlapConflict {
-                    message: "two coincident edits".to_string(),
                     accession: "NC_000001.11".to_string(),
                     coordinate_system: "g".to_string(),
                     location: "100".to_string(),
@@ -3737,7 +3736,6 @@ mod tests {
             ),
             (
                 crate::normalize::NormalizationWarning::PositionPastEnd {
-                    message: "past cds-end".to_string(),
                     accession: "NM_X.1".to_string(),
                     coordinate_system: "c".to_string(),
                     position: "946".to_string(),

--- a/src/service/tools/hgvs_rs.rs
+++ b/src/service/tools/hgvs_rs.rs
@@ -206,9 +206,9 @@ mod tests {
         // With hgvs-rs feature, this might fail due to missing database, but shouldn't panic
         #[cfg(feature = "hgvs-rs")]
         {
-            let result = HgvsRsService::new(&config);
-            // This may succeed or fail depending on whether the database is available
-            // But it shouldn't panic
+            // This may succeed or fail depending on whether the database is available,
+            // but it must not panic — the binding is discarded deliberately.
+            let _result = HgvsRsService::new(&config);
         }
     }
 


### PR DESCRIPTION
The `python` and `hgvs-rs` features are not part of `dev`, so CI — which builds and lints with `--features dev` — never compiles their `#[cfg(test)]` modules. Two production refactors drifted the gated test code out of sync, breaking `cargo clippy --all-features` (and `--features python` / `--features hgvs-rs`) locally:

- **`NormalizationWarning` lost its per-variant `message` field.** `RefSeqMismatch` now carries `details: Option<String>`, and `OverlapConflict` / `PositionPastEnd` synthesize their message via `Display` (`message()` just calls `to_string()`). The PyO3 round-trip test in `src/python.rs` still constructed all three variants with a `message:` field, failing to compile with `E0559`. Updated to drop the removed fields and move the `RefSeqMismatch` text into `details`.
- **The `hgvs-rs`-gated service test bound an unused `result`** in `src/service/tools/hgvs_rs.rs`, tripping `-D unused-variables`. Renamed to `_result` (the call is kept for its must-not-panic intent, the value discarded).

Both are test-only changes — no production behavior changes.

## Verification

- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo test --features python --lib py_normalization_warning_carries_code_and_message` — passes
- Standalone `--features python` / `--features hgvs-rs` / `--features dhat-heap` clippy — all clean
- `cargo fmt --check` — clean

## Root cause / follow-up

CI lints and tests with `--features dev`, which deliberately excludes `python` (needs maturin) and `hgvs-rs` (needs postgres/seqrepo system libs). Test code behind those gates can therefore rot undetected. A durable guard would be a CI job running `cargo clippy --features python` (and, where the toolchain allows, `hgvs-rs`); left out of this PR to keep it focused on the immediate breakage.