### PR TITLE
ci: lint feature-gated code with a `clippy --all-features` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,42 @@ jobs:
             ${{ runner.os }}-cargo-
       - run: cargo clippy --features dev --all-targets -- -D warnings
 
+  clippy-all-features:
+    # Lints the feature-gated code that `--features dev` never compiles —
+    # notably `python` (pyo3) and `hgvs-rs`, whose `#[cfg(test)]` modules are
+    # otherwise unbuilt in CI and silently rot when the production API they
+    # construct changes. Complements (does not replace) the `clippy` job
+    # above: that one lints the `#[cfg(not(feature = ...))]` slice and the
+    # default-features-off code most consumers compile, which `--all-features`
+    # cannot see.
+    name: Clippy (all features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          submodules: true
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+          components: clippy
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-all-features
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
+      - run: cargo clippy --all-features --all-targets -- -D warnings
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/src/python.rs
+++ b/src/python.rs
@@ -3717,17 +3717,16 @@ mod tests {
         let cases: Vec<(crate::normalize::NormalizationWarning, &str)> = vec![
             (
                 crate::normalize::NormalizationWarning::RefSeqMismatch {
-                    message: "stated A but reference is T".to_string(),
                     stated_ref: "A".to_string(),
                     actual_ref: "T".to_string(),
                     position: "100".to_string(),
                     corrected: true,
+                    details: Some("stated A but reference is T".to_string()),
                 },
                 "REFSEQ_MISMATCH",
             ),
             (
                 crate::normalize::NormalizationWarning::OverlapConflict {
-                    message: "two coincident edits".to_string(),
                     accession: "NC_000001.11".to_string(),
                     coordinate_system: "g".to_string(),
                     location: "100".to_string(),
@@ -3737,7 +3736,6 @@ mod tests {
             ),
             (
                 crate::normalize::NormalizationWarning::PositionPastEnd {
-                    message: "past cds-end".to_string(),
                     accession: "NM_X.1".to_string(),
                     coordinate_system: "c".to_string(),
                     position: "946".to_string(),

--- a/src/service/tools/hgvs_rs.rs
+++ b/src/service/tools/hgvs_rs.rs
@@ -206,9 +206,9 @@ mod tests {
         // With hgvs-rs feature, this might fail due to missing database, but shouldn't panic
         #[cfg(feature = "hgvs-rs")]
         {
-            let result = HgvsRsService::new(&config);
-            // This may succeed or fail depending on whether the database is available
-            // But it shouldn't panic
+            // This may succeed or fail depending on whether the database is available,
+            // but it must not panic — the binding is discarded deliberately.
+            let _result = HgvsRsService::new(&config);
         }
     }
 


### PR DESCRIPTION
Adds a `Clippy (all features)` job to `ci.yml` running `cargo clippy --all-features --all-targets -- -D warnings`.

## Why

The existing `clippy` and `test` jobs build with `--features dev`, which excludes `python` (needs maturin/pyo3) and `hgvs-rs` (needs postgres/seqrepo deps). Code behind those gates — including `#[cfg(test)]` modules — is never compiled in CI and rots silently when the production API it references changes. This is exactly the class of bug fixed in #580 (a `NormalizationWarning` field rename that only broke under `--features python`).

## Notes

- **Stacked on #580** (base = `fix/all-features-build-drift`). The new job is red on `main` until #580 lands, so this is targeted at the fix branch; GitHub will auto-retarget it to `main` once #580 merges. Merge #580 first.
- Sets up Python so pyo3's build script can locate an interpreter. The deps `--all-features` pulls (`postgres`, `seqrepo`, etc.) are pure-Rust, so no system libraries or live database are needed — clippy type-checks the gated code without running it.
- **Complements, does not replace, the `--features dev` clippy job.** The two configs compile different slices: `--all-features` enables every `#[cfg(feature)]` branch but hides the `#[cfg(not(feature))]` ones the dev build lints, and `dev` is closer to the default-features-off form most library consumers compile.

## Out of scope

A nightly `cargo hack --feature-powerset` would additionally catch single-feature-in-isolation breakage that `--all-features` cannot. Deliberately left out per request to keep this to the `--all-features` job.