### PR TITLE
perf(normalize): resolve intronic transcripts by accession, not a cloned variant

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1789,8 +1789,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
             || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
+                // Resolve directly from the accession — the build-aware lookup
+                // only needs the accession, so we avoid cloning the whole
+                // variant just to satisfy the by-variant signature.
                 self.provider
-                    .get_transcript_for_variant(&HV::Cds(variant.clone()))
+                    .get_transcript_for_accession(&variant.accession)
             };
         let transcript_opt = self.provider.get_transcript(&accession).ok();
         if self.config.should_reject_position_past_end()
@@ -1877,8 +1880,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
         // Handle intronic variants specially
         if start_pos.is_intronic() || end_pos.is_intronic() {
-            // Switch to the variant-aware lookup so an NG/NC-parented input
-            // gets the build-correct chromosome. If the variant-aware lookup
+            // Switch to the accession-aware lookup so an NG/NC-parented input
+            // gets the build-correct chromosome. If the accession-aware lookup
             // fails, fall back to the plain transcript we already fetched.
             let transcript = transcript_for_intronic().unwrap_or(transcript);
             // Check if both positions are intronic and in the same intron
@@ -2389,8 +2392,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let accession = variant.accession.transcript_accession();
         let transcript_for_intronic =
             || -> Result<std::sync::Arc<crate::reference::transcript::Transcript>, FerroError> {
+                // Resolve directly from the accession — avoids cloning the
+                // whole variant just to call the by-variant lookup.
                 self.provider
-                    .get_transcript_for_variant(&HV::Tx(variant.clone()))
+                    .get_transcript_for_accession(&variant.accession)
             };
         let transcript_opt = self.provider.get_transcript(&accession).ok();
         if self.config.should_reject_position_past_end()
@@ -2471,7 +2476,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         if start_pos.is_intronic() || end_pos.is_intronic() {
-            // Switch to the variant-aware lookup so an NG/NC-parented input
+            // Switch to the accession-aware lookup so an NG/NC-parented input
             // gets the build-correct chromosome.
             let transcript = transcript_for_intronic().unwrap_or(transcript);
             // Route intronic tx variants to the intronic normalization path

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1503,6 +1503,13 @@ impl ReferenceProvider for MultiFastaProvider {
             // default impl which produces a clear ReferenceNotFound error.
             return self.get_transcript_on_build_cached(&format!("{}", variant), None);
         };
+        self.get_transcript_for_accession(accession)
+    }
+
+    fn get_transcript_for_accession(
+        &self,
+        accession: &crate::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, FerroError> {
         let tx_id = accession.transcript_accession();
 
         // No parent → exactly the existing behavior.
@@ -3184,6 +3191,47 @@ mod tests {
         let tx = provider.get_transcript_for_variant(&variant).unwrap();
         assert_eq!((tx.cds_start, tx.cds_end), (Some(1), Some(9)));
         assert_eq!(tx.protein_id.as_deref(), Some("NP_OV.2"));
+    }
+
+    // --- get_transcript_for_accession (issue #582) ---------------------------
+
+    #[test]
+    fn get_transcript_for_accession_with_ng_context() {
+        use crate::hgvs::variant::Accession;
+        use crate::reference::ReferenceProvider;
+        // FASTA-only provider: no cdot, so chromosome is None for all transcripts.
+        // With an NG_* genomic_context the implementation probes GRCh38 then
+        // GRCh37 (no cdot → no chromosome hit), then falls back to the
+        // no-build-hint path, which succeeds because the transcript is in the
+        // FASTA index.
+        let (provider, _kept) = build_provider_with_transcripts(&[("NM_ACC.1", "ATGAAATAA")]);
+        let inner = Accession::new("NM", "ACC", Some(1));
+        let context = Accession::new("NG", "012345", Some(1));
+        let accession = inner.with_genomic_context(context);
+        let tx = provider
+            .get_transcript_for_accession(&accession)
+            .expect("NG_* context must not prevent transcript lookup");
+        assert_eq!(tx.id, "NM_ACC.1");
+        assert_eq!(tx.sequence.as_deref(), Some("ATGAAATAA"));
+    }
+
+    #[test]
+    fn get_transcript_for_accession_with_nc_context() {
+        use crate::hgvs::variant::Accession;
+        use crate::reference::ReferenceProvider;
+        // NC_000023.11 → infer_build_from_parent returns GRCh38, so the probe
+        // order is [GRCh38, GRCh37].  In a FASTA-only provider neither probe
+        // finds a chromosome-bearing transcript, so we fall back to the plain
+        // no-build-hint lookup, which still succeeds via the FASTA index.
+        let (provider, _kept) = build_provider_with_transcripts(&[("NM_ACC.2", "ATGTGGTAA")]);
+        let inner = Accession::new("NM", "ACC", Some(2));
+        let context = Accession::new("NC", "000023", Some(11));
+        let accession = inner.with_genomic_context(context);
+        let tx = provider
+            .get_transcript_for_accession(&accession)
+            .expect("NC_* context must not prevent transcript lookup");
+        assert_eq!(tx.id, "NM_ACC.2");
+        assert_eq!(tx.sequence.as_deref(), Some("ATGTGGTAA"));
     }
 
     // --- protein FASTA ingestion (issue #520, edge 3) -----------------------

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use crate::error::FerroError;
-use crate::hgvs::variant::HgvsVariant;
+use crate::hgvs::variant::{Accession, HgvsVariant};
 use crate::reference::transcript::Transcript;
 
 /// Trait for providing reference sequence data
@@ -49,6 +49,28 @@ pub trait ReferenceProvider {
             .ok_or_else(|| FerroError::ReferenceNotFound {
                 id: format!("{}", variant),
             })?;
+        self.get_transcript_for_accession(accession)
+    }
+
+    /// Get the transcript for the given accession, using its `genomic_context`
+    /// parent (NG/NC) to pick a cdot build that has the transcript with a
+    /// chromosome populated.
+    ///
+    /// This is the build-aware resolution that backs
+    /// [`get_transcript_for_variant`](Self::get_transcript_for_variant), exposed
+    /// directly so callers that already hold an [`Accession`] (e.g. the intronic
+    /// normalization path) can resolve without cloning a whole variant just to
+    /// satisfy the by-variant signature.
+    ///
+    /// The default implementation delegates to
+    /// [`get_transcript`](Self::get_transcript), preserving existing behavior
+    /// for inputs that do not carry a `genomic_context`. Build-aware providers
+    /// (e.g. [`crate::reference::multi_fasta::MultiFastaProvider`]) override this
+    /// to consult the parent accession first. See issue #332.
+    fn get_transcript_for_accession(
+        &self,
+        accession: &Accession,
+    ) -> Result<Arc<Transcript>, FerroError> {
         self.get_transcript(&accession.transcript_accession())
     }
 
@@ -241,6 +263,13 @@ impl ReferenceProvider for Box<dyn ReferenceProvider> {
         variant: &HgvsVariant,
     ) -> Result<Arc<Transcript>, FerroError> {
         (**self).get_transcript_for_variant(variant)
+    }
+
+    fn get_transcript_for_accession(
+        &self,
+        accession: &Accession,
+    ) -> Result<Arc<Transcript>, FerroError> {
+        (**self).get_transcript_for_accession(accession)
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {


### PR DESCRIPTION
## What

The intronic `c.`/`n.` normalization paths re-resolve the transcript with the build-aware lookup `get_transcript_for_variant(&HgvsVariant)`. Because that method takes a whole variant, each intronic variant paid a full `variant.clone()` + `HgvsVariant::Cds`/`Tx` wrap **just to satisfy the signature** — even though the build-aware resolution only ever reads the variant's `Accession` (transcript accession + `genomic_context` parent).

This adds `ReferenceProvider::get_transcript_for_accession(&Accession)`, moves the build-aware logic there, has `get_transcript_for_variant` delegate to it, and calls it directly from the two intronic paths with a **borrow** — no clone, no wrapper.

## Why

Profiling the normalize hot path (after the resolve-cache + handle-reuse work) showed intronic normalization dominates per-variant cost, and a chunk of it is allocation/drop churn. Intronic variants are ~18% of a typical ClinVar batch, and this clone fired on every one of them. The default impl and the `MultiFastaProvider` override are a **straight relocation** of the existing resolution logic, so this is a pure allocation-elision refactor.

## Correctness

Behavior-preserving by construction — `get_transcript_for_variant(&HV::Cds(v.clone()))` and `get_transcript_for_accession(&v.accession)` resolve from the identical `Accession`. Verified with the conformance xfail-diff gate: **identical** to the base commit once the single pre-existing non-deterministic transcript (`NM_003002.2`) is excluded.

> Note: `NM_003002.2` exhibits a run-to-run ±49-base `sequence_length` flake (poly-A) that shifts its pter/qter/intronic/cis-allele results **with unchanged code** — I reproduced the same flip across two runs of this branch and of the base. All gate differences are confined to that one transcript; filtering it out yields a byte-identical gate. The non-determinism is pre-existing and orthogonal to this PR (worth a separate look).

Full suite passes except the 9 pre-existing reference-gated conformance axes.

## Notes
- Touches the same `get_transcript_for_variant` method as #578 (which changes its return to `Arc<Transcript>`); whichever merges second takes a trivial rebase to combine the `Arc` return with the new delegation.