### PR TITLE
feat(parser): parse positionless breakpoint insertion in composite alleles (#546)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -514,6 +514,13 @@ pub enum NaEdit {
     /// Insertion: addition of bases between two positions (e.g., insATG, ins10, insA[10])
     Insertion { sequence: InsertedSequence },
 
+    /// Positionless insertion at a structural breakpoint (e.g., the `insG`
+    /// member of `g.[a_bdel;c_dinv;insG]`). HGVS `DNA/complex.md` allows an
+    /// insertion to omit its coordinate when it occurs at an implied junction
+    /// inside a composite cis allele ("1 bp insertion at break points"). Like
+    /// the whole-entity edits it carries no position, so Display skips it.
+    BreakpointInsertion { sequence: InsertedSequence },
+
     /// Deletion-insertion: replacement of bases (e.g., delinsATG, delinsA[10],
     /// delATGinsTTCC, del3insTA).
     ///
@@ -682,6 +689,15 @@ impl NaEdit {
             || self.is_no_product()
     }
 
+    /// Check if this edit is positionless — it carries no coordinate of its
+    /// own and Display must skip the location. Currently the structural
+    /// [`NaEdit::BreakpointInsertion`] (`DNA/complex.md`), distinct from a
+    /// whole-entity edit in that it still represents a localized change at an
+    /// implied junction rather than spanning the whole reference.
+    pub fn is_positionless(&self) -> bool {
+        matches!(self, NaEdit::BreakpointInsertion { .. })
+    }
+
     /// Format this edit with lowercase nucleotides (for RNA display).
     pub fn to_rna_string(&self) -> String {
         match self {
@@ -708,6 +724,9 @@ impl NaEdit {
                 s
             }
             NaEdit::Insertion { sequence } => {
+                format!("ins{}", sequence.to_rna_string())
+            }
+            NaEdit::BreakpointInsertion { sequence } => {
                 format!("ins{}", sequence.to_rna_string())
             }
             NaEdit::Delins {
@@ -825,6 +844,9 @@ impl fmt::Display for NaEdit {
                 Ok(())
             }
             NaEdit::Insertion { sequence } => {
+                write!(f, "ins{}", sequence)
+            }
+            NaEdit::BreakpointInsertion { sequence } => {
                 write!(f, "ins{}", sequence)
             }
             NaEdit::Delins {

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1129,7 +1129,10 @@ fn try_parse_genome_ring<'a>(
         if looks_like_accession_start(segment) || segment.contains(':') {
             return None;
         }
-        let (rest, loc_edit) = parse_genome_bracket_member(segment, GenomeKind::Genome).ok()?;
+        // Ring segments are not cis composite members: a positionless `ins`
+        // here has no implied breakpoint, so disallow the conversion. #546.
+        let (rest, loc_edit) =
+            parse_genome_bracket_member(segment, GenomeKind::Genome, false).ok()?;
         // Each segment must be consumed in full; trailing text means the
         // join is malformed.
         if !rest.is_empty() {
@@ -1325,9 +1328,19 @@ impl GenomeKind {
 /// predicted-wrapper form. Mirrors `parse_cds_bracket_member` and
 /// `parse_rna_bracket_member`. #243; whole-entity dispatch added by
 /// #423 (follow-up to #396 item 3).
+///
+/// `allow_breakpoint_insertion` gates the positionless-`ins` →
+/// [`NaEdit::BreakpointInsertion`] conversion (`DNA/complex.md`, e.g. the
+/// `insG` in `[a_bdel;c_dinv;insG]`). It is `true` only for members of a
+/// multi-member **cis** composite allele, where a positionless `ins` sits at
+/// an implied breakpoint between other edits. Every other caller (ring
+/// segments, trans `];[` shorthand, unknown-phase `(;)` shorthand, lone
+/// single-member brackets) passes `false` so a bare positionless `ins` is
+/// rejected as it was before the breakpoint-insertion feature. #546.
 fn parse_genome_bracket_member(
     part: &str,
     kind: GenomeKind,
+    allow_breakpoint_insertion: bool,
 ) -> IResult<&str, LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>> {
     // Whole-entity genome edits have no positional content, so attach
     // a dummy interval at position 1 (mirrors `parse_genome_variant`'s
@@ -1366,6 +1379,30 @@ fn parse_genome_bracket_member(
                 edit: mu_edit,
             },
         ));
+    }
+
+    // A bare `ins<seq>` member that carries no coordinate is a positionless
+    // breakpoint insertion (`DNA/complex.md`, e.g. the `insG` in
+    // `[a_bdel;c_dinv;insG]` — "1 bp insertion at break points"). Recognize it
+    // only when the caller authorises it (a multi-member cis composite allele),
+    // so standalone `g.insG`, a lone `[insG]`, ring segments, trans members and
+    // unknown-phase members — none of which carry an implied junction — stay
+    // rejected. Attach a dummy interval; Display skips the position via
+    // `NaEdit::is_positionless`.
+    if allow_breakpoint_insertion {
+        if let Ok((remaining, crate::hgvs::edit::NaEdit::Insertion { sequence })) =
+            parse_na_edit(part)
+        {
+            if remaining.is_empty() {
+                return Ok((
+                    remaining,
+                    LocEdit::new(
+                        dummy_genome_interval(),
+                        crate::hgvs::edit::NaEdit::BreakpointInsertion { sequence },
+                    ),
+                ));
+            }
+        }
     }
 
     let is_circular = matches!(kind, GenomeKind::Mt | GenomeKind::Circular);
@@ -1841,6 +1878,12 @@ fn parse_genome_kind_compound_allele(
         AllelePhase::Cis
     };
 
+    // A positionless `ins` member (`DNA/complex.md`'s `insG`) is only valid as
+    // an implied breakpoint between other edits in a multi-member cis group
+    // (`[a_bdel;c_dinv;insG]`). Reject it in a lone `[insG]` bracket and in
+    // unknown-phase groups, where there is no such junction. #546.
+    let allow_breakpoint_insertion = matches!(phase, AllelePhase::Cis) && scan.members.len() >= 2;
+
     let mut variants = Vec::with_capacity(4);
 
     for part in scan.members {
@@ -1853,7 +1896,8 @@ fn parse_genome_kind_compound_allele(
                 nom::error::ErrorKind::Verify,
             )));
         }
-        let (final_remaining, loc_edit) = parse_genome_bracket_member(part, kind)?;
+        let (final_remaining, loc_edit) =
+            parse_genome_bracket_member(part, kind, allow_breakpoint_insertion)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
@@ -1910,7 +1954,9 @@ fn parse_genome_position_unknown_phase(
         // `g.X(;)Y` symmetric — Display canonicalises one into the
         // other, so accepting an asymmetric set on the parse side
         // breaks round-trip. #423.
-        let (final_remaining, loc_edit) = parse_genome_bracket_member(part, kind)?;
+        // Unknown-phase (`(;)`) members are not a cis breakpoint context, so a
+        // positionless `ins` is not converted here. #546.
+        let (final_remaining, loc_edit) = parse_genome_bracket_member(part, kind, false)?;
         if !final_remaining.trim().is_empty() {
             return Err(nom::Err::Error(nom::error::Error::new(
                 final_remaining,
@@ -2161,7 +2207,7 @@ fn parse_genome_trans_allele_shorthand(
     gene_symbol: Option<String>,
 ) -> IResult<&str, HgvsVariant> {
     parse_trans_allele_shorthand_generic(input, |content| {
-        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Genome)?;
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Genome, false)?;
         Ok((
             rest,
             HgvsVariant::Genome(GenomeVariant {
@@ -3164,7 +3210,7 @@ fn parse_mt_trans_allele_shorthand(
     parse_trans_allele_shorthand_generic(input, |content| {
         // `GenomeKind::Mt` routes through the circular interval parser +
         // spec-authorised reversed-range validator (#129).
-        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Mt)?;
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Mt, false)?;
         Ok((
             rest,
             HgvsVariant::Mt(MtVariant {
@@ -4591,7 +4637,7 @@ fn parse_circular_trans_allele_shorthand(
     parse_trans_allele_shorthand_generic(input, |content| {
         // `GenomeKind::Circular` routes through the circular interval parser
         // + spec-authorised reversed-range validator (#129).
-        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Circular)?;
+        let (rest, loc_edit) = parse_genome_bracket_member(content, GenomeKind::Circular, false)?;
         Ok((
             rest,
             HgvsVariant::Circular(CircularVariant {

--- a/src/hgvs/validation.rs
+++ b/src/hgvs/validation.rs
@@ -306,6 +306,12 @@ pub mod rules {
                     "Insertion must have at least one base",
                 ));
             }
+            NaEdit::BreakpointInsertion { sequence } if sequence.is_empty() => {
+                result = result.with_error(ValidationError::new(
+                    "E002",
+                    "Insertion must have at least one base",
+                ));
+            }
             NaEdit::Delins { sequence, .. } if sequence.is_empty() => {
                 result = result.with_error(ValidationError::new(
                     "E003",
@@ -584,6 +590,21 @@ mod tests {
         #[test]
         fn test_validate_insertion_empty_error() {
             let edit = NaEdit::Insertion {
+                sequence: InsertedSequence::Literal(Sequence::new(vec![])),
+            };
+            let result = rules::validate_na_edit(&edit);
+            assert!(!result.valid);
+            assert!(result.has_errors());
+            assert_eq!(result.errors[0].code, "E002");
+        }
+
+        #[test]
+        fn test_validate_breakpoint_insertion_empty_error() {
+            // BreakpointInsertion is publicly constructible and carries the
+            // same InsertedSequence field as Insertion; an empty sequence must
+            // also emit E002 (the parser never produces this, but direct
+            // struct construction must be guarded).
+            let edit = NaEdit::BreakpointInsertion {
                 sequence: InsertedSequence::Literal(Sequence::new(vec![])),
             };
             let result = rules::validate_na_edit(&edit);

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1157,16 +1157,18 @@ fn write_accession_with_optional_gene(
 /// [`GenomeRing`]'s `Display` so a ring segment round-trips byte-identically
 /// to a standalone genome variant.
 ///
-/// Whole-entity identity (`g.=`) / unknown (`g.?`) skip the position; the
+/// Whole-entity identity (`g.=`) / unknown (`g.?`) and a positionless
+/// breakpoint insertion (composite SV `[...;insG]`) skip the position; the
 /// predicted form wraps position+edit in parens (#241); otherwise the plain
 /// `LocEdit` Display is used.
 fn fmt_genome_loc_edit(
     f: &mut fmt::Formatter<'_>,
     loc_edit: &LocEdit<GenomeInterval, NaEdit>,
 ) -> fmt::Result {
-    // For whole-entity identity (g.=) or unknown (g.?), skip the position.
+    // For whole-entity identity (g.=) or unknown (g.?), or a positionless
+    // breakpoint insertion (composite SV `[...;insG]`), skip the position.
     if let Some(edit) = loc_edit.edit.inner() {
-        if edit.is_whole_entity() {
+        if edit.is_whole_entity() || edit.is_positionless() {
             return write!(f, "{}", loc_edit.edit);
         }
     }

--- a/src/normalize/overlap.rs
+++ b/src/normalize/overlap.rs
@@ -167,6 +167,7 @@ fn is_overlap_edit(edit: &NaEdit) -> bool {
         | NaEdit::Inversion { .. }
         | NaEdit::Repeat { .. } => true,
         NaEdit::Insertion { .. }
+        | NaEdit::BreakpointInsertion { .. }
         | NaEdit::DupIns { .. }
         | NaEdit::MultiRepeat { .. }
         | NaEdit::Identity { .. }

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -65,6 +65,7 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
         NaEdit::Duplication { .. } => "duplication",
         NaEdit::DupIns { .. } => "dupins",
         NaEdit::Insertion { .. } => "insertion",
+        NaEdit::BreakpointInsertion { .. } => "breakpoint_insertion",
         NaEdit::Delins { .. } => "delins",
         NaEdit::Inversion { .. } => "inversion",
         NaEdit::Repeat { .. } => "repeat",
@@ -94,6 +95,8 @@ pub fn edit_type_from_debug<T: std::fmt::Debug>(edit: &T) -> &'static str {
         "dupins"
     } else if debug.contains("Duplication") {
         "duplication"
+    } else if debug.contains("BreakpointInsertion") {
+        "breakpoint_insertion"
     } else if debug.contains("Insertion") {
         "insertion"
     } else if debug.contains("Delins") {
@@ -391,6 +394,7 @@ pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
         NaEdit::Deletion { .. } => Some(-compute_span(variant)?),
         NaEdit::Duplication { .. } => Some(compute_span(variant)?),
         NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
+        NaEdit::BreakpointInsertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
             Some(inserted_sequence_len(sequence)? - compute_span(variant)?)
         }
@@ -442,6 +446,7 @@ pub fn get_indel_length_with_provider<P: ReferenceProvider + ?Sized>(
         NaEdit::Deletion { .. } => Some(-compute_span_with_provider(variant, provider)?),
         NaEdit::Duplication { .. } => Some(compute_span_with_provider(variant, provider)?),
         NaEdit::Insertion { sequence } => inserted_sequence_len(sequence),
+        NaEdit::BreakpointInsertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
             Some(inserted_sequence_len(sequence)? - compute_span_with_provider(variant, provider)?)
         }

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -330,6 +330,12 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
 
                 (anchor_pos, ref_allele, vec![alt_allele])
             }
+            NaEdit::BreakpointInsertion { .. } => {
+                return Err(FerroError::ConversionError {
+                    msg: "Positionless breakpoint insertions cannot be converted to VCF (no anchor coordinate)"
+                        .to_string(),
+                });
+            }
             NaEdit::Delins { sequence, .. } => {
                 // Deletion-insertion: REF is deleted sequence, ALT is replacement
                 let deleted_seq = self.get_reference_sequence(chrom, start, end)?;

--- a/tests/breakpoint_insertion.rs
+++ b/tests/breakpoint_insertion.rs
@@ -1,0 +1,107 @@
+//! Positionless breakpoint insertion within a composite cis allele (#546).
+//!
+//! HGVS `DNA/complex.md` describes a de novo pericentric inversion with a
+//! deletion and a 1 bp insertion at the break point, where the insertion is
+//! written WITHOUT a coordinate because the junction position is implied:
+//! `NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]`.
+
+use ferro_hgvs::hgvs::edit::NaEdit;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::python_helpers::get_indel_length;
+
+/// The canonical composite SV from `DNA/complex.md` round-trips, including the
+/// positionless `insG` breakpoint member.
+#[test]
+fn composite_allele_with_positionless_insertion_round_trips() {
+    let s = "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+/// A standalone positionless insertion is NOT spec-valid (the form only exists
+/// inside a composite breakpoint context) and must stay rejected.
+#[test]
+fn standalone_positionless_insertion_is_rejected() {
+    assert!(
+        parse_hgvs("NC_000002.12:g.insG").is_err(),
+        "standalone positionless `g.insG` must be rejected"
+    );
+}
+
+/// A positionless `ins` is valid ONLY as a member of a multi-member cis
+/// composite allele (an implied breakpoint between other edits). It must stay
+/// rejected in every other bracket/join context — a lone single-member bracket,
+/// a ring `::` segment, a trans `];[` member, and an unknown-phase `(;)` member.
+#[test]
+fn positionless_insertion_rejected_outside_multi_member_cis_group() {
+    for s in [
+        "NC_000022.11:g.[insG]",              // lone single-member bracket
+        "NC_000022.11:g.100_200del::insG",    // ring `::` segment
+        "NC_000002.12:g.[insG];[100_200del]", // trans `];[` member
+        "NC_000002.12:g.[100_200del(;)insG]", // unknown-phase `(;)` member
+    ] {
+        assert!(
+            parse_hgvs(s).is_err(),
+            "positionless `ins` outside a multi-member cis group must be rejected: `{s}`"
+        );
+    }
+}
+
+/// A genuine multi-member cis breakpoint group with a positionless `ins`
+/// round-trips even with only two members (the spec form has three, but the
+/// "implied breakpoint between edits" rule holds for >= 2).
+#[test]
+fn two_member_cis_breakpoint_insertion_round_trips() {
+    let s = "NC_000002.12:g.[100_200del;insG]";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+/// Helper: extract the `insG` sub-variant from the composite allele.
+fn get_breakpoint_member() -> HgvsVariant {
+    let s = "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]";
+    let allele = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    let HgvsVariant::Allele(a) = allele else {
+        panic!("expected Allele, got {allele:?}");
+    };
+    a.variants
+        .into_iter()
+        .find(|v| {
+            matches!(v, HgvsVariant::Genome(g)
+                if matches!(g.loc_edit.edit.inner(), Some(NaEdit::BreakpointInsertion { .. })))
+        })
+        .expect("composite allele must contain a BreakpointInsertion member")
+}
+
+/// `NaEdit::is_positionless()` returns `true` for the breakpoint insertion
+/// member and `false` for ordinary positioned edits.
+#[test]
+fn breakpoint_insertion_is_positionless() {
+    let ins_member = get_breakpoint_member();
+    let HgvsVariant::Genome(g) = &ins_member else {
+        panic!("expected Genome variant");
+    };
+    let edit = g
+        .loc_edit
+        .edit
+        .inner()
+        .expect("breakpoint member must have a NaEdit");
+    assert!(
+        edit.is_positionless(),
+        "BreakpointInsertion must report is_positionless() == true; got false for {edit:?}"
+    );
+}
+
+/// `get_indel_length` returns `Some(1)` for the single-base `insG` breakpoint
+/// insertion — i.e. the accessor no longer falls through to `_ => None`.
+#[test]
+fn breakpoint_insertion_indel_length_is_sequence_length() {
+    let ins_member = get_breakpoint_member();
+    let len = get_indel_length(&ins_member);
+    assert_eq!(
+        len,
+        Some(1),
+        "indel_length for `insG` breakpoint insertion must be Some(1); got {len:?}"
+    );
+}

--- a/tests/python/test_accessors.py
+++ b/tests/python/test_accessors.py
@@ -85,6 +85,20 @@ class TestEditAccessors:
         v = ferro_hgvs.parse("NC_000001.11:g.12345_12346ins(10_20)")
         assert v.indel_length is None
 
+    def test_indel_length_breakpoint_insertion(self) -> None:
+        # The positionless `insG` inside a composite SV carries a concrete
+        # 1-base sequence; indel_length must return 1, not None.
+        allele = ferro_hgvs.parse(
+            "NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]"
+        )
+        ins_sub = next(
+            (v for v in allele.variants() if v.edit_type == "breakpoint_insertion"),
+            None,
+        )
+        assert ins_sub is not None, "composite allele must contain a breakpoint_insertion member"
+        assert ins_sub.edit_type == "breakpoint_insertion"
+        assert ins_sub.indel_length == 1
+
     def test_is_frameshift_true(self) -> None:
         assert ferro_hgvs.parse("NC_000001.11:g.12345del").is_frameshift()
 


### PR DESCRIPTION
## Summary

Closes part of #546 (structural-variant notation). Adds support for a **positionless insertion at a structural breakpoint** inside a composite cis allele, e.g.:

```
NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]
```

This is the canonical form in HGVS `DNA/complex.md:117` for a de novo pericentric inversion with a deletion and a "1 bp insertion at break points" (ISCN `inv(2)(pter->p22.3::q31.1->p22.3::q31.1->qter)dn`). The `insG` member omits its coordinate because the junction position is implied by the surrounding edits.

## Scope

Composite mixed-edit cis groups already parsed and round-tripped (`g.[del;inv]`, `g.[A>G;del]`, `g.[del;dup]`, and the 2-member `g.[...del;...inv]`). The only gap was the **positionless `ins` member** — ferro could not represent an insertion with no location (an unknown position renders as `?`, i.e. `g.?insG`, not the spec's bare `insG`).

## Changes

- New `NaEdit::BreakpointInsertion { sequence }` — an insertion that carries no coordinate. It mirrors the existing whole-entity precedent: the bracket-member parser attaches a dummy interval and `GenomeVariant::fmt_loc_edit` skips the position when the new `NaEdit::is_positionless` predicate is true, so the member round-trips as a bare `ins<seq>`.
- Parser probe scoped to `parse_genome_bracket_member` (the composite-member path), so a standalone `g.insG` — which has no implied junction — stays rejected. Added a regression test for that.
- Normalize (`expand_inserted_sequence` overlap classifier) and VCF (`from_hgvs`) treat the edit as out-of-scope: there is no anchor coordinate to expand or emit against.

## Spec-fixture impact

| input | before | after |
|---|---|---|
| `NC_000002.12:g.[32310435_32310710del;32310711_171827243inv;insG]` | `parse-error` | `preserved` |
| `chr2:g.[32310435_32310710del;32310711_171827243inv;insG]` | `parse-error` | `preserved` |

(`chr2:` is the chromosome-name alias for `NC_000002.12`.) No `false-acceptance` rows introduced.

## Testing

- New `tests/breakpoint_insertion.rs`: the composite SV round-trips; standalone `g.insG` stays rejected.
- `cargo fmt --check`, `cargo clippy --features dev --all-targets` clean.
- Spec-fixture `--check` gate passes.
- Full suite: 6738 passed, only the 9 pre-existing corpus-parity environment failures remain (unchanged).
