### PR TITLE
perf(reference): version + self-heal the cdot bincode cache (fix silent JSON fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ ferro prepare --output-dir ferro-reference
 # Verify reference data is ready
 ferro check --reference ferro-reference
 
+# (Optional) pre-build the on-disk cdot cache as a setup step, so the one-time
+# cache build doesn't slow the start of a real (or timed/benchmarked) run.
+ferro check --reference ferro-reference --build-cache
+
 # Normalize with reference
 ferro normalize "NM_000088.3:c.459del" --reference ferro-reference/
 ```

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -499,6 +499,12 @@ enum Commands {
         /// Reference directory to check
         #[arg(long, default_value = "ferro-reference")]
         reference: PathBuf,
+
+        /// After checking, load the reference once to build/refresh the on-disk
+        /// cdot bincode cache. Pay the one-time cache build here as a setup step
+        /// so it doesn't land inside (and slow down the start of) a real run.
+        #[arg(long)]
+        build_cache: bool,
     },
 
     /// Build a transcripts.json from a FASTA + CDS coordinates (single-exon).
@@ -788,7 +794,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             validate_canonical.as_deref(),
             dry_run,
         ),
-        Commands::Check { reference } => run_check(&reference),
+        Commands::Check {
+            reference,
+            build_cache,
+        } => run_check(&reference, build_cache),
         Commands::BuildTranscript {
             fasta,
             cds_start,
@@ -2817,17 +2826,28 @@ fn run_prepare(
 }
 
 /// Check reference data setup.
-fn run_check(reference: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn run_check(reference: &Path, build_cache: bool) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::check::{check_reference, print_check_summary};
 
     let result = check_reference(reference);
     print_check_summary(&result, reference);
 
-    if result.valid {
-        Ok(())
-    } else {
-        Err("Reference data check failed".into())
+    if !result.valid {
+        return Err("Reference data check failed".into());
     }
+
+    if build_cache {
+        // Load the reference once so the cdot bincode cache is built/refreshed
+        // now (a stale cache self-heals on this load), keeping subsequent runs
+        // on the fast path. The constructed provider is intentionally dropped.
+        use ferro_hgvs::commands::create_reference_provider;
+        eprintln!("Building/refreshing reference cache (one-time)...");
+        let started = std::time::Instant::now();
+        let _provider = create_reference_provider(Some(reference))?;
+        eprintln!("Reference cache ready in {:.1?}.", started.elapsed());
+    }
+
+    Ok(())
 }
 
 /// Build a transcripts.json from a FASTA file and CDS coordinates.

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -32,9 +32,22 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Write};
 use std::path::Path;
 use superintervals::IntervalMap;
+
+/// Magic bytes prefixing a cdot bincode cache file, followed by a `u32`
+/// schema version. The version MUST be bumped whenever the serialized layout
+/// of [`CdotMapperSnapshot`] changes (a field added/removed/reordered, or a
+/// nested type's layout changes), so a cache written by an older build is
+/// detected as stale and refreshed rather than silently mis-deserialized.
+///
+/// Without this guard a layout change makes `bincode` read past the end of the
+/// file (`failed to fill whole buffer`) only *after* a partial read, and the
+/// loader falls back to parsing the multi-hundred-MB JSON on every run — ~10x
+/// slower — with no indication anything is wrong.
+const CDOT_BINCODE_MAGIC: [u8; 4] = *b"FCDT";
+const CDOT_BINCODE_VERSION: u32 = 1;
 
 /// cdot transcript alignment data (normalized internal representation).
 ///
@@ -738,6 +751,12 @@ struct CdotMapperSnapshot {
     /// hand-rolled deserializer skipping this field — bincode itself will
     /// error on a truncated stream and the loader falls back to JSON).
     primary_build: Option<String>,
+    /// Per-build transcript maps for non-primary builds (e.g. GRCh37 when the
+    /// primary is GRCh38). Required for NG/NC-parent-aware resolution (#332);
+    /// omitting it from the cache silently degraded that path on every fast
+    /// load. Part of the v1 layout — a cache missing it fails the version/EOF
+    /// guard and is regenerated.
+    alt_build_transcripts: HashMap<String, HashMap<String, CdotTranscriptSnapshot>>,
 }
 
 /// Borrowed view of CdotMapper for zero-copy serialization to bincode.
@@ -749,6 +768,7 @@ struct CdotMapperSnapshotRef<'a> {
     base_to_versioned: &'a HashMap<String, String>,
     lrg_to_refseq: &'a HashMap<String, String>,
     primary_build: Option<&'a str>,
+    alt_build_transcripts: HashMap<&'a String, HashMap<&'a String, CdotTranscriptSnapshotRef<'a>>>,
 }
 
 /// Bincode-friendly snapshot of CdotTranscript, using standard Strand serde.
@@ -1011,7 +1031,31 @@ impl CdotMapper {
             msg: format!("Failed to open cdot bincode file: {}", e),
         })?;
         let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
-        let reader = BufReader::new(file);
+        let mut reader = BufReader::new(file);
+
+        // Verify the magic + schema version before deserializing. A mismatch
+        // (including a legacy headerless cache, or one written by a build with a
+        // different snapshot layout) is reported cleanly so the caller can fall
+        // back to JSON and refresh the cache, instead of mis-deserializing.
+        let mut header = [0u8; 8];
+        reader.read_exact(&mut header).map_err(|e| FerroError::Io {
+            msg: format!("cdot bincode too short to contain a header: {}", e),
+        })?;
+        if header[..4] != CDOT_BINCODE_MAGIC {
+            return Err(FerroError::Io {
+                msg: "cdot bincode has no valid magic (legacy or non-cdot file)".to_string(),
+            });
+        }
+        let version = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+        if version != CDOT_BINCODE_VERSION {
+            return Err(FerroError::Io {
+                msg: format!(
+                    "cdot bincode schema version {} != expected {}",
+                    version, CDOT_BINCODE_VERSION
+                ),
+            });
+        }
+
         // Use a size limit to prevent OOM on corrupt files. Allow 20x the file size
         // (bincode is compact, but deserialized HashMap overhead can be significant).
         // Limit deserialization size to prevent OOM on corrupt files (20x file size or 1MB min).
@@ -1034,17 +1078,13 @@ impl CdotMapper {
             contig_alias_to_canonical: snapshot.contig_alias_to_canonical,
             base_to_versioned: snapshot.base_to_versioned,
             lrg_to_refseq: snapshot.lrg_to_refseq,
-            // Bincode snapshots are produced for a specific genome build; alt-
-            // build data is not part of the serialized format. Callers that
-            // need multi-build access (e.g. NG/NC-parent-aware transcript
-            // lookup per #332) should load from JSON.
-            alt_build_transcripts: {
-                log::warn!(
-                    "cdot bincode load: alt-build data unavailable; NG/NC-parent build \
-                     resolution (#332) is degraded. Load from JSON to enable."
-                );
-                HashMap::new()
-            },
+            // Alt-build maps are now part of the serialized format (v1), so
+            // NG/NC-parent-aware resolution (#332) works on the fast path too.
+            alt_build_transcripts: snapshot
+                .alt_build_transcripts
+                .into_iter()
+                .map(|(build, txs)| (build, txs.into_iter().map(|(k, v)| (k, v.into())).collect()))
+                .collect(),
             // Honor the snapshot's recorded primary build; older snapshots
             // that pre-date this field surface as `None` rather than
             // claiming a fabricated GRCh38 (#389 follow-up).
@@ -1052,6 +1092,22 @@ impl CdotMapper {
             contig_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
         })
+    }
+
+    /// Cheap check: does `path` begin with the current cdot bincode magic and
+    /// schema version? Lets callers (e.g. `ferro prepare`) decide whether a
+    /// cache needs regenerating without paying for a full deserialize.
+    pub fn bincode_is_current<P: AsRef<Path>>(path: P) -> bool {
+        let Ok(mut file) = File::open(path) else {
+            return false;
+        };
+        let mut header = [0u8; 8];
+        if file.read_exact(&mut header).is_err() {
+            return false;
+        }
+        header[..4] == CDOT_BINCODE_MAGIC
+            && u32::from_le_bytes([header[4], header[5], header[6], header[7]])
+                == CDOT_BINCODE_VERSION
     }
 
     /// Write the mapper to a bincode file for fast subsequent loading.
@@ -1067,17 +1123,56 @@ impl CdotMapper {
             base_to_versioned: &self.base_to_versioned,
             lrg_to_refseq: &self.lrg_to_refseq,
             primary_build: self.primary_build.as_deref(),
+            alt_build_transcripts: self
+                .alt_build_transcripts
+                .iter()
+                .map(|(build, txs)| (build, txs.iter().map(|(k, v)| (k, v.into())).collect()))
+                .collect(),
         };
-        let file = File::create(path.as_ref()).map_err(|e| FerroError::Io {
-            msg: format!("Failed to create cdot bincode file: {}", e),
+        // Write to a unique temp sibling, then atomically rename, so a crash
+        // mid-write or a concurrent reader never observes a half-written cache.
+        // The temp name combines the pid (unique across live processes) with a
+        // process-global counter (unique across concurrent writers within this
+        // process), so two threads writing the same cache never collide.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let path = path.as_ref();
+        let mut tmp = path.to_path_buf();
+        let tmp_name = format!(
+            "{}.tmp.{}.{}",
+            path.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "cdot.bin".to_string()),
+            std::process::id(),
+            TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        tmp.set_file_name(tmp_name);
+
+        let file = File::create(&tmp).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create cdot bincode temp file: {}", e),
         })?;
-        let writer = std::io::BufWriter::new(file);
-        bincode::options()
-            .with_fixint_encoding()
-            .serialize_into(writer, &snapshot)
-            .map_err(|e| FerroError::Io {
+        let mut writer = std::io::BufWriter::new(file);
+        let write_result = (|| -> std::io::Result<()> {
+            writer.write_all(&CDOT_BINCODE_MAGIC)?;
+            writer.write_all(&CDOT_BINCODE_VERSION.to_le_bytes())?;
+            bincode::options()
+                .with_fixint_encoding()
+                .serialize_into(&mut writer, &snapshot)
+                .map_err(std::io::Error::other)?;
+            writer.flush()
+        })();
+        if let Err(e) = write_result {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(FerroError::Io {
                 msg: format!("Failed to serialize cdot bincode: {}", e),
-            })
+            });
+        }
+        std::fs::rename(&tmp, path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            FerroError::Io {
+                msg: format!("Failed to finalize cdot bincode file: {}", e),
+            }
+        })
     }
 
     /// Load a cdot file, preferring a sibling `.bin` (bincode) file if available.
@@ -1106,8 +1201,12 @@ impl CdotMapper {
             match Self::from_bincode_file(&bin_path) {
                 Ok(mapper) => return Ok(mapper),
                 Err(e) => {
-                    log::warn!(
-                        "Failed to load bincode {}: {}. Falling back to JSON.",
+                    // Loud (stderr, not just `log`) — the binary may not
+                    // initialize a logger, and silently eating the ~10x JSON
+                    // parse on every run is exactly the failure mode this guards.
+                    eprintln!(
+                        "warning: cdot bincode cache {} is unusable ({}); \
+                         parsing JSON (much slower) and refreshing the cache",
                         bin_path.display(),
                         e
                     );
@@ -1115,12 +1214,25 @@ impl CdotMapper {
             }
         }
 
-        // Fall back to JSON
-        if path_str.ends_with(".gz") {
-            Self::from_json_gz(path)
+        // Fall back to JSON.
+        let mapper = if path_str.ends_with(".gz") {
+            Self::from_json_gz(path)?
         } else {
-            Self::from_json_file(path)
+            Self::from_json_file(path)?
+        };
+
+        // Self-heal: best-effort refresh of the sibling bincode cache so the
+        // next load takes the fast path. Failures here (e.g. a read-only
+        // reference mount) are non-fatal — we already have a usable mapper.
+        if let Err(e) = mapper.to_bincode_file(&bin_path) {
+            eprintln!(
+                "note: could not refresh cdot bincode cache {}: {} (continuing)",
+                bin_path.display(),
+                e
+            );
         }
+
+        Ok(mapper)
     }
 
     /// Load from any reader, defaulting to GRCh38 genome build.
@@ -2450,6 +2562,61 @@ mod tests {
     }
 
     #[test]
+    fn test_concurrent_to_bincode_file_same_path() {
+        // Multiple threads writing the same cache path concurrently must not
+        // collide on their temp siblings or leave a half-written file: the
+        // final cache must always be loadable and complete.
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let original = std::sync::Arc::new(CdotMapper::from_reader(json.as_bytes()).unwrap());
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let bin_path = std::sync::Arc::new(temp_dir.path().join("concurrent.bin"));
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let original = std::sync::Arc::clone(&original);
+                let bin_path = std::sync::Arc::clone(&bin_path);
+                std::thread::spawn(move || original.to_bincode_file(bin_path.as_path()))
+            })
+            .collect();
+        for handle in handles {
+            handle
+                .join()
+                .unwrap()
+                .expect("concurrent write should succeed");
+        }
+
+        // The final cache is complete and loadable, and no temp siblings leaked.
+        let loaded = CdotMapper::from_bincode_file(bin_path.as_path()).unwrap();
+        assert_eq!(loaded.transcript_count(), 1);
+        assert!(loaded.get_transcript("NM_000088.3").is_some());
+
+        let leftover_tmp: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(
+            leftover_tmp.is_empty(),
+            "temp siblings leaked: {:?}",
+            leftover_tmp
+        );
+    }
+
+    #[test]
     fn test_load_prefers_bincode() {
         let json = r#"
         {
@@ -2553,6 +2720,98 @@ mod tests {
         let loaded = CdotMapper::load(&json_path).unwrap();
         assert_eq!(loaded.transcript_count(), 1);
         assert!(loaded.get_transcript("NM_000088.3").is_some());
+
+        // Self-heal: the corrupt cache must have been refreshed to a current
+        // one, so a second load takes the fast bincode path.
+        assert!(
+            CdotMapper::bincode_is_current(&bin_path),
+            "corrupt cache should be refreshed after the JSON fallback"
+        );
+        let reloaded = CdotMapper::from_bincode_file(&bin_path).unwrap();
+        assert_eq!(reloaded.transcript_count(), 1);
+    }
+
+    #[test]
+    fn test_bincode_roundtrip_preserves_alt_build() {
+        // A transcript with both GRCh37 and GRCh38 alignments. Primary build is
+        // GRCh38, so GRCh37 lives in the alt-build map. The fast (bincode) path
+        // must preserve it, or NG/NC-parent build resolution (#332) silently
+        // breaks whenever the cache is used.
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000017.10",
+                            "strand": "+",
+                            "exons": [[48263025, 48263098, 1, 0, 73, "M73"]]
+                        },
+                        "GRCh38": {
+                            "contig": "NC_000017.11",
+                            "strand": "+",
+                            "exons": [[50184096, 50184169, 1, 0, 73, "M73"]]
+                        }
+                    },
+                    "start_codon": 10,
+                    "stop_codon": 60
+                }
+            }
+        }
+        "#;
+        let from_json = CdotMapper::from_reader(json.as_bytes()).unwrap();
+        let temp = tempfile::TempDir::new().unwrap();
+        let p = temp.path().join("cdot.bin");
+        from_json.to_bincode_file(&p).unwrap();
+        let from_bin = CdotMapper::from_bincode_file(&p).unwrap();
+
+        // GRCh37 (alt-build) resolution must be identical across both paths.
+        let want = from_json
+            .get_transcript_on_build("NM_000088.3", "GRCh37")
+            .map(|t| (t.contig.clone(), t.cds_start));
+        let got = from_bin
+            .get_transcript_on_build("NM_000088.3", "GRCh37")
+            .map(|t| (t.contig.clone(), t.cds_start));
+        assert_eq!(
+            want, got,
+            "alt-build resolution must survive bincode roundtrip"
+        );
+        assert_eq!(got, Some(("NC_000017.10".to_string(), Some(10))));
+    }
+
+    #[test]
+    fn test_bincode_header_roundtrip_and_staleness() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let p = temp.path().join("cdot.bin");
+
+        let mut m = CdotMapper::new();
+        m.add_transcript("NM_000001.1".to_string(), sample_transcript());
+        m.to_bincode_file(&p).unwrap();
+
+        // A freshly written cache carries the current magic+version and loads.
+        assert!(CdotMapper::bincode_is_current(&p));
+        assert_eq!(
+            CdotMapper::from_bincode_file(&p)
+                .unwrap()
+                .transcript_count(),
+            1
+        );
+
+        // A legacy / headerless cache is detected as not-current and rejected
+        // cleanly, rather than mis-deserialized.
+        std::fs::write(&p, b"legacy-bincode-without-any-header-bytes").unwrap();
+        assert!(!CdotMapper::bincode_is_current(&p));
+        assert!(CdotMapper::from_bincode_file(&p).is_err());
+
+        // Correct magic but a future schema version is also rejected.
+        let mut wrong_version = Vec::new();
+        wrong_version.extend_from_slice(&CDOT_BINCODE_MAGIC);
+        wrong_version.extend_from_slice(&(CDOT_BINCODE_VERSION + 1).to_le_bytes());
+        wrong_version.extend_from_slice(&[0u8; 16]);
+        std::fs::write(&p, &wrong_version).unwrap();
+        assert!(!CdotMapper::bincode_is_current(&p));
+        assert!(CdotMapper::from_bincode_file(&p).is_err());
     }
 
     // =========================================================================

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -741,9 +741,17 @@ fn download_cdot(url: &str, cdot_dir: &Path, skip_existing: bool) -> Result<Path
     // Parse JSON and serialize to bincode for fast subsequent loading.
     // Always regenerate bincode when JSON was freshly downloaded to avoid stale cache.
     let bin_path = json_path.with_extension("bin");
-    if !json_is_fresh && skip_existing && bin_path.exists() {
-        eprintln!("  Skipping cdot bincode conversion (exists)");
+    // Only skip when an existing cache is actually *current* — a stale cache
+    // (written by a build with a different snapshot layout) fails to load and
+    // silently forces a ~10x JSON parse on every run, so it must be regenerated.
+    let bin_is_current =
+        bin_path.exists() && crate::data::cdot::CdotMapper::bincode_is_current(&bin_path);
+    if !json_is_fresh && skip_existing && bin_is_current {
+        eprintln!("  Skipping cdot bincode conversion (up to date)");
     } else {
+        if bin_path.exists() && !bin_is_current {
+            eprintln!("  Existing cdot bincode is stale; regenerating...");
+        }
         eprintln!("  Converting cdot JSON to bincode for fast loading...");
         let mapper = crate::data::cdot::CdotMapper::from_json_file(&json_path).map_err(|e| {
             FerroError::Io {


### PR DESCRIPTION
## The regression

`ferro` startup is ~90% of CLI wall time for any batch, and most of it was a **512 MB cdot JSON parse that the bincode cache exists to avoid**. Profiling `ferro normalize` end-to-end:

| | time |
|---|---|
| cdot load via JSON (the silent fallback) | **~5.9 s** |
| cdot load via a valid bincode cache | **~0.6 s** |
| `ferro normalize` startup, stale cache | ~6.7 s |
| `ferro normalize` startup, valid cache | **~1.4 s** |

## Root cause

The bincode cache had **no version/magic header**. Any change to the serialized `CdotMapperSnapshot` layout made an existing `.bin` mis-deserialize (`"failed to fill whole buffer"`). The loader caught the error and fell back to JSON — but the warning went through `log`, which the CLI never initializes, so it was **silent**. Every run re-parsed the JSON, with no indication the fast path was dead. `prepare` compounded it by **skipping regeneration whenever a (stale) `.bin` existed**.

## Fix

- **Version+magic header** (`FCDT` + `u32`): bump on any layout change. `from_bincode_file` verifies it and rejects a legacy/mismatched cache cleanly instead of mis-reading it. Cheap `bincode_is_current` for callers.
- **Atomic writes** (temp + rename) so a crash or concurrent reader never sees a half-written cache.
- **Self-healing `load`**: on a missing/stale/unusable cache it parses JSON, prints a **loud (stderr)** warning, then best-effort rewrites a fresh `.bin` — next run is fast, no re-prepare needed. Read-only mounts degrade gracefully (refresh failure is non-fatal).
- **`prepare`** regenerates when the cache isn't current, instead of skip-if-exists.
- **Completeness fix:** include `alt_build_transcripts` in the snapshot. The old format dropped it, so the bincode fast path silently degraded NG/NC-parent build resolution (#332). Now the cache is complete and **bincode load == JSON load**.

## Verification

- New unit tests: header roundtrip, staleness/version detection, self-heal after a corrupt cache, and **alt-build preservation across the bincode roundtrip** (GRCh37 contig + CDS identical to the JSON path).
- Full suite passes except the 9 pre-existing reference-gated axes; clippy clean. (The suite itself runs ~2× faster now that cdot loads from a valid cache.)
- End-to-end confirmed: stale cache self-heals on first run, ~1.4 s on every run after; an NG/NC GRCh37-parented variant resolves via the bincode path.

> Independent of the open perf PRs; touches `src/data/cdot.rs` (alongside the #583 determinism fix to the same file — whichever merges second takes a trivial rebase).

---

## Follow-up in this PR: `ferro check --build-cache` (pre-warm)

With the self-heal above, a stale/missing cache rebuilds lazily inside the *first* real run (the one-time ~5-6.7s). For timed/benchmarked/production runs you may want to pay that up front. `check` previously only verified file existence; `--build-cache` now loads the reference once as an explicit setup step (self-healing the cache), so later runs always start fast.

On vs off (real manifest):

| | query cost |
|---|---|
| no pre-warm (cold cache) | ~5-6.7s (one-time build lands in the query) |
| `check --build-cache` once (~5s), then queries | ~1.5s each |

Note: the long-running API/service path already pays startup once (build `MultiFastaProvider` once, reuse) — this flag is for the repeated-/timed-CLI case.