### PR TITLE
fix(project): emit nonsense (not fsTer1) for an immediate-stop frameshift

### DIFF
--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -1259,4 +1259,21 @@ mod tests {
         let result = predict_indel(&t, 4, 4, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Lys2ArgfsTer5)");
     }
+
+    /// Spec (frameshift.md:22, 36-39): a frameshift whose first changed residue
+    /// is immediately a stop is a NONSENSE substitution (`p.(<aa><pos>Ter)`),
+    /// never `fsTer1` — `fsTer1` is an illegal count (the minimum is `fsTer2`).
+    /// `c.3_4insT` on Met-Lys-Ter shifts the frame so codon 2 reads TAA: the
+    /// mutated CDS "ATGTAAATAA" translates Met then an immediate stop at the
+    /// first changed codon ⇒ `p.(Lys2Ter)`, not `p.(Lys2fsTer1)`.
+    #[test]
+    fn frameshift_immediate_stop_is_nonsense_not_fster1() {
+        let t = tx("ATGAAATAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "T".parse().unwrap();
+        let edit = NaEdit::Insertion {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+        };
+        let result = predict_indel(&t, 3, 3, &edit, "NP_TEST.1").unwrap();
+        assert_eq!(prot_str(&result), "NP_TEST.1:p.(Lys2Ter)");
+    }
 }

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -613,6 +613,25 @@ fn build_frameshift_variant(
         FrameshiftTer::Unknown
     };
 
+    // Spec (frameshift.md:22, 36-39): `fsTer1` is illegal — the minimum
+    // frameshift count is `fsTer2`. A shifted frame whose first changed codon
+    // is immediately a stop is a NONSENSE substitution `p.(<aa><pos>Ter)`, not
+    // a frameshift. Emit the nonsense form (mirrors `predict_substitution`'s
+    // `Ter` substitution) rather than the invalid `fsTer1`.
+    if matches!(ter, FrameshiftTer::At(1)) {
+        let nonsense_edit = ProteinEdit::Substitution {
+            reference: ref_aa,
+            alternative: AminoAcid::Ter,
+        };
+        let loc = ProtInterval::point(ProtPos::new(ref_aa, aa_pos));
+        let accession = parse_accession(protein_accession);
+        return Ok(HgvsVariant::Protein(ProteinVariant {
+            accession,
+            gene_symbol: transcript.gene_symbol.clone(),
+            loc_edit: LocEdit::new_predicted(loc, nonsense_edit),
+        }));
+    }
+
     let protein_edit = ProteinEdit::Frameshift { new_aa, ter };
     let loc = ProtInterval::point(ProtPos::new(ref_aa, aa_pos));
     let accession = parse_accession(protein_accession);


### PR DESCRIPTION
## Summary

A frameshift whose **first changed residue is immediately a stop** was emitting `p.(…fsTer1)` — but `fsTer1` is illegal per HGVS (frameshift.md:22, 36-39; the minimum frameshift count is `fsTer2`). An immediate stop is a **nonsense substitution** `p.(<aa><pos>Ter)`. Found by the `p.`-form characterization spike following #587.

Example: `c.3_4insT` on `Met-Lys-Ter` shifts the frame so codon 2 reads `TAA` → was `p.(Lys2fsTer1)`, now `p.(Lys2Ter)`.

## Changes

- `indel.rs`: in `build_frameshift_variant`, when the new stop is at shifted-position 1 (`ter == FrameshiftTer::At(1)`), emit a nonsense `ProteinEdit::Substitution { reference, alternative: Ter }` instead of the invalid `fsTer1` (mirrors `predict_substitution`'s nonsense form).
- Regression test (`frameshift_immediate_stop_is_nonsense_not_fster1`).

## Test plan

- [x] New test fails before (`p.(Lys2fsTer1)`), passes after (`p.(Lys2Ter)`).
- [x] All 44 indel tests + full CI-equivalent suite (6752 passed, 0 failed); fmt + clippy clean.

## Context

Stacked on #587 (frameshift 3'UTR fix) — both are frameshift-consequence correctness fixes in `build_frameshift_variant`, surfaced by the projection-engine `p.`-form characterization. The other characterization findings: ferro's `c→p` is otherwise already spec-correct (extension, nonsense, synonymous, start-loss, stop→stop); the splice-region `p.?` and intronic cases are known divergences deferred to later layers (#485/#480).
