### PR TITLE
feat(tool-support): single source of truth for the tool-comparison tables

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Tool-support matrix is the single source of truth for the comparison tables.
+/docs/tool_support_matrix.json  @nh13

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,8 @@ jobs:
         run: cargo nextest run --features dev
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
+      - name: Tool-support tables up to date
+        run: cargo run --features dev --example generate_tool_support_tables -- --check
       - name: Install dev dependencies
         run: uv sync --group dev --locked --no-install-project
       - name: Run Python tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,19 @@ override file.
    - re-validate the default-prefix table above against the new spec corpus
    - regenerate the fixture and review the diff
 
+## Tool-support comparison tables
+
+The ferro/mutalyzer/biocommons/hgvs-rs support tables in `README.md`,
+`docs/BENCHMARK_GUIDE.md`, and the web help tab are **generated**. To change a
+cell, edit `docs/tool_support_matrix.json` and run:
+
+```bash
+cargo run --features dev --example generate_tool_support_tables
+```
+
+Do not edit the tables in those files directly — CI (`… -- --check`) will fail.
+See `docs/tool_support_matrix.json` for the full schema and inline `_comment` field for authoring notes.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,10 @@ pulldown-cmark = { version = "0.13", default-features = false }
 serde_yaml = "0.9"
 anyhow = "1"
 
+[[example]]
+name = "generate_tool_support_tables"
+required-features = ["dev"]
+
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 
 ### Normalization Capabilities Comparison
 
+<!-- DO NOT EDIT — generated from docs/tool_support_matrix.json by `generate_tool_support_tables`. -->
+<!-- BEGIN tool-support:normalization_capabilities -->
 | Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |
 |--------------|:-----:|:---------:|:----------:|:-------:|
 | Genomic (g.) | ✓ | ✓ | ✓ | ✓ |
@@ -206,10 +208,11 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 | Coding (c.) intronic | ✓ | ✓* | ✗ | ✗ |
 | Non-coding (n.) | ✓ | ✓ | ✓ | ✓ |
 | RNA (r.) | ✓ | ✓ | ✓ | ✓ |
-| Protein (p.) | ✓ | Net** | ✗ | ✓ |
+| Protein (p.) | ✓ | Net** | ✗ | ✗ |
 
-\* mutalyzer intronic support requires genomic context rewriting (enabled by default)
-\** mutalyzer protein normalization requires network access for NP_→NM_ lookups
+\* mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.
+\*\* mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally).
+<!-- END tool-support:normalization_capabilities -->
 
 ### Performance Comparison
 

--- a/docs/BENCHMARK_GUIDE.md
+++ b/docs/BENCHMARK_GUIDE.md
@@ -65,19 +65,20 @@ Results in this guide were generated with:
 
 ### Normalization Capabilities by Tool
 
-| Pattern Type | ferro | hgvs-rs | biocommons | mutalyzer |
-|--------------|:-----:|:-------:|:----------:|:---------:|
+<!-- DO NOT EDIT — generated from docs/tool_support_matrix.json by `generate_tool_support_tables`. -->
+<!-- BEGIN tool-support:normalization_capabilities -->
+| Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |
+|--------------|:-----:|:---------:|:----------:|:-------:|
 | Genomic (g.) | ✓ | ✓ | ✓ | ✓ |
 | Coding (c.) exonic | ✓ | ✓ | ✓ | ✓ |
-| Coding (c.) intronic | ✓ | ✗ | ✗ | ✓* |
+| Coding (c.) intronic | ✓ | ✓* | ✗ | ✗ |
 | Non-coding (n.) | ✓ | ✓ | ✓ | ✓ |
 | RNA (r.) | ✓ | ✓ | ✓ | ✓ |
-| Protein (p.) | ✓ | ✓ | ✗ | Net** |
+| Protein (p.) | ✓ | Net** | ✗ | ✗ |
 
-\* mutalyzer intronic support enabled by default via genomic context rewriting.
-Use `--no-rewrite-intronic` to disable.
-
-\** mutalyzer protein normalization requires network access for NP_→NM_ lookups (see Design Limitations).
+\* mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.
+\*\* mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally).
+<!-- END tool-support:normalization_capabilities -->
 
 ### Design Limitations
 

--- a/docs/tool_support_matrix.json
+++ b/docs/tool_support_matrix.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "_comment": "SOURCE OF TRUTH for tool-support tables. Edit cells here, then run: cargo run --features dev --example generate_tool_support_tables. Cells with a 'carried' note are inherited from the prior web table and not source-verified.",
+  "tools": [
+    { "id": "ferro", "name": "ferro", "version": "0.6.0", "url": "https://github.com/fulcrumgenomics/ferro-hgvs" },
+    { "id": "mutalyzer", "name": "mutalyzer", "version": "3.1.1", "url": "https://mutalyzer.nl/" },
+    { "id": "biocommons", "name": "biocommons", "version": "main @ fa02ca5 (post-1.5.3)", "url": "https://github.com/biocommons/hgvs" },
+    { "id": "hgvs-rs", "name": "hgvs-rs", "version": "0.20.2", "url": "https://github.com/varfish-org/hgvs-rs" }
+  ],
+  "footnotes": {
+    "rewrite": "mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.",
+    "net": "mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally)."
+  },
+  "categories": [
+    {
+      "id": "reference_types",
+      "title": "Reference Types",
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "rows": [
+        { "key": "NM_", "label": "Coding transcript (mRNA)", "example": "NM_000088.3", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "NR_", "label": "Non-coding transcript", "example": "NR_024540.1", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "NC_", "label": "Genomic chromosome", "example": "NC_000001.11", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "NG_", "label": "Genomic gene region", "example": "NG_007400.1", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "NP_", "label": "Protein", "example": "NP_000079.2", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"network_only","footnote":"net"}, "biocommons": {"validate":"yes","normalize":"unsupported_by_design"}, "hgvs-rs": {"validate":"permissive","normalize":"errors","note":"permissive: accepts protein syntax but performs no semantic validation; normalization errors"} } },
+        { "key": "LRG_", "label": "Locus Reference Genomic", "example": "LRG_1", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "ENST", "label": "Ensembl transcript", "example": "ENST00000357033", "last_reviewed": "2026-06-10",
+          "support": { "ferro": {"validate":"yes","normalize":"no","note":"parses ENST (ensembl_style flag) but ferro downloads RefSeq-only cdot, so ENST c./n. is returned unchanged"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"no","note":"parses ENST; c./n. mapping requires an Ensembl-populated provider — the default RefSeq UTA lacks ENST alignments (HGVSDataNotAvailableError)"}, "hgvs-rs": {"validate":"permissive","normalize":"no","note":"accession parser accepts any prefix incl. ENST; no Ensembl data in default UTA-style provider"} } }
+      ]
+    },
+    {
+      "id": "coordinate_types",
+      "title": "Coordinate Types",
+      "rows": [
+        { "key": "c", "label": "Coding DNA (relative to CDS)", "example": "c.589G>T", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "g", "label": "Genomic (absolute position)", "example": "g.12345A>G", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "n", "label": "Non-coding transcript", "example": "n.100del", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "p", "label": "Protein", "example": "p.Gly12Val", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/protein/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"network_only","footnote":"net"}, "biocommons": {"validate":"yes","normalize":"unsupported_by_design"}, "hgvs-rs": {"validate":"permissive","normalize":"errors","note":"permissive: accepts protein syntax but performs no semantic validation; normalization errors"} } },
+        { "key": "m", "label": "Mitochondrial", "example": "m.8993T>G", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "r", "label": "RNA", "example": "r.76a>u", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/RNA/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "intronic", "label": "Intronic positions", "example": "c.100+5G>A", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full","footnote":"rewrite"}, "biocommons": {"validate":"yes","normalize":"no"}, "hgvs-rs": {"validate":"permissive","normalize":"unsupported_by_design"} } }
+      ]
+    },
+    {
+      "id": "variant_types",
+      "title": "Variant Types",
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/",
+      "rows": [
+        { "key": "substitution", "label": "Substitution", "example": "c.589G>T", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "deletion", "label": "Deletion", "example": "c.589del", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/deletion/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "insertion", "label": "Insertion", "example": "c.589_590insA", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/insertion/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "duplication", "label": "Duplication", "example": "c.589dup", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/duplication/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "delins", "label": "Delins", "example": "c.589delinsAT", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/delins/", "last_reviewed": "2026-06-09",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "inversion", "label": "Inversion", "example": "c.589_600inv", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/inversion/", "last_reviewed": "2026-06-10",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"yes","normalize":"full"}, "hgvs-rs": {"validate":"permissive","normalize":"full"} } },
+        { "key": "repeat", "label": "Repeat", "example": "c.589CAG[23]", "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/repeated/", "last_reviewed": "2026-06-10",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"full"}, "biocommons": {"validate":"no","normalize":"no","note":"grammar has no [N] repeat rule; raises HGVSParseError (the Repeat Edit class is unreachable dead code)"}, "hgvs-rs": {"validate":"no","normalize":"unsupported_by_design","note":"no repeat AST node or parser"} } },
+        { "key": "conversion", "label": "Conversion", "example": "c.589_600con", "last_reviewed": "2026-06-10",
+          "support": { "ferro": {"validate":"yes","normalize":"full"}, "mutalyzer": {"validate":"yes","normalize":"unsupported_by_design","note":"parses con and lowers to delins, but there is no delins->con round-trip, so con is never re-emitted"}, "biocommons": {"validate":"yes","normalize":"unsupported_by_design","note":"normalize() raises HGVSUnsupportedOperationError for con"}, "hgvs-rs": {"validate":"no","normalize":"unsupported_by_design","note":"no con AST node; explicit 'once we support gene conversions' TODO in normalizer"} } }
+      ]
+    }
+  ],
+  "views": [
+    {
+      "id": "normalization_capabilities",
+      "title": "Normalization Capabilities",
+      "row_label_header": "Pattern Type",
+      "select": [
+        { "category": "coordinate_types", "key": "g", "label": "Genomic (g.)" },
+        { "category": "coordinate_types", "key": "c", "label": "Coding (c.) exonic" },
+        { "category": "coordinate_types", "key": "intronic", "label": "Coding (c.) intronic" },
+        { "category": "coordinate_types", "key": "n", "label": "Non-coding (n.)" },
+        { "category": "coordinate_types", "key": "r", "label": "RNA (r.)" },
+        { "category": "coordinate_types", "key": "p", "label": "Protein (p.)" }
+      ]
+    }
+  ]
+}

--- a/examples/generate_tool_support_tables.rs
+++ b/examples/generate_tool_support_tables.rs
@@ -1,0 +1,167 @@
+//! Generator for the tool-support comparison tables.
+//!
+//! Reads `docs/tool_support_matrix.json` (the single source of truth) and
+//! renders:
+//!   - the "Normalization Capabilities" markdown table into README.md and
+//!     docs/BENCHMARK_GUIDE.md (between `tool-support:<view>` markers), and
+//!   - the render-ready website JSON into
+//!     src/service/web/static/data/tool_support_matrix.json.
+//!
+//! Modes:
+//!   - default:  rewrite the targets in place.
+//!   - --check:  re-render in memory; exit non-zero if any target differs.
+//!
+//! Run:   cargo run --features dev --example generate_tool_support_tables
+//! Check: cargo run --features dev --example generate_tool_support_tables -- --check
+//!
+//! See: docs/superpowers/specs/2026-06-09-tool-support-matrix-design.md
+
+use std::path::Path;
+use std::process::ExitCode;
+
+use clap::Parser;
+use ferro_hgvs::tool_support::Matrix;
+
+/// `today` is injected (not read from the clock) so the staleness check is
+/// reproducible; CI passes the commit date or leaves the default.
+#[derive(Parser, Debug)]
+#[command(about = "Generate tool-support comparison tables")]
+struct Cli {
+    /// Re-render in memory and fail if on-disk output differs.
+    #[arg(long)]
+    check: bool,
+    /// Path to the source matrix.
+    #[arg(long, default_value = "docs/tool_support_matrix.json")]
+    matrix: String,
+    /// Staleness reference date (YYYY-MM-DD); warnings only. Frozen at the
+    /// matrix authoring date so output is reproducible; pass --today=$(date +%F)
+    /// (or the commit date) to check staleness against the present.
+    #[arg(long, default_value = "2026-06-09")]
+    today: String,
+    /// Staleness window in months.
+    #[arg(long, default_value_t = 6)]
+    stale_months: i64,
+}
+
+const VIEW: &str = "normalization_capabilities";
+const README: &str = "README.md";
+const GUIDE: &str = "docs/BENCHMARK_GUIDE.md";
+const WEB_JSON: &str = "src/service/web/static/data/tool_support_matrix.json";
+
+fn marker_begin() -> String {
+    format!("<!-- BEGIN tool-support:{VIEW} -->")
+}
+fn marker_end() -> String {
+    format!("<!-- END tool-support:{VIEW} -->")
+}
+
+/// Replace the text between the begin/end markers with `body`. Returns the new
+/// file content, or an error if markers are missing/disordered.
+fn splice(content: &str, body: &str) -> Result<String, String> {
+    let begin = marker_begin();
+    let end = marker_end();
+    let b = content
+        .find(&begin)
+        .ok_or_else(|| format!("missing {begin}"))?;
+    let after_begin = b + begin.len();
+    let e = content[after_begin..]
+        .find(&end)
+        .ok_or_else(|| format!("missing {end} after {begin}"))?
+        + after_begin;
+    let mut out = String::new();
+    out.push_str(&content[..after_begin]);
+    out.push('\n');
+    out.push_str(body.trim_end());
+    out.push('\n');
+    out.push_str(&content[e..]);
+    Ok(out)
+}
+
+/// One generated target: path + desired content.
+struct Target {
+    path: String,
+    content: String,
+}
+
+fn compute_targets(m: &Matrix) -> Result<Vec<Target>, String> {
+    let body = m.render_markdown_view(VIEW)?;
+    let mut targets = Vec::new();
+    for path in [README, GUIDE] {
+        let cur = std::fs::read_to_string(path).map_err(|e| format!("read {path}: {e}"))?;
+        targets.push(Target {
+            path: path.to_string(),
+            content: splice(&cur, &body)?,
+        });
+    }
+    let web = serde_json::to_string_pretty(&m.render_website_json())
+        .map_err(|e| format!("serialize web json: {e}"))?;
+    targets.push(Target {
+        path: WEB_JSON.to_string(),
+        content: format!("{web}\n"),
+    });
+    Ok(targets)
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let m = match Matrix::load(&cli.matrix) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(e) = m.validate_invariants() {
+        eprintln!("error: matrix invariants: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    // Staleness warnings (never fail).
+    for s in m.stale_cells(&cli.today, cli.stale_months) {
+        eprintln!(
+            "warning: stale tool-support cell {s} (>{} months)",
+            cli.stale_months
+        );
+    }
+
+    let targets = match compute_targets(&m) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut drift = false;
+    for t in &targets {
+        let on_disk = std::fs::read_to_string(&t.path).unwrap_or_default();
+        if cli.check {
+            if on_disk != t.content {
+                drift = true;
+                eprintln!("error: {} is out of date", t.path);
+            }
+        } else if on_disk != t.content {
+            if let Some(parent) = Path::new(&t.path).parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    eprintln!("error: create dir {}: {e}", parent.display());
+                    return ExitCode::FAILURE;
+                }
+            }
+            if let Err(e) = std::fs::write(&t.path, &t.content) {
+                eprintln!("error: write {}: {e}", t.path);
+                return ExitCode::FAILURE;
+            }
+            println!("updated {}", t.path);
+        }
+    }
+
+    if cli.check && drift {
+        eprintln!(
+            "tool-support tables are out of date; rerun: \
+             cargo run --features dev --example generate_tool_support_tables \
+             (edit docs/tool_support_matrix.json, not the generated files)"
+        );
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,10 @@ pub mod sequence;
 #[cfg(feature = "web-service")]
 pub mod service;
 pub mod spdi;
+/// Tool-support matrix types + table generation (used by the
+/// `generate_tool_support_tables` example and its tests).
+#[cfg(feature = "dev")]
+pub mod tool_support;
 pub mod vcf;
 
 // Re-export commonly used types

--- a/src/service/server.rs
+++ b/src/service/server.rs
@@ -132,6 +132,10 @@ pub fn create_app(config: ServiceConfig) -> Result<(Router, AppState), ServiceEr
         .route("/", get(index_handler))
         .route("/static/css/styles.css", get(styles_css_handler))
         .route("/static/js/main.js", get(main_js_handler))
+        .route(
+            "/static/data/tool_support_matrix.json",
+            get(tool_support_matrix_handler),
+        )
         // Health endpoints
         .route("/health", get(handlers::health::health_check))
         .route(
@@ -215,6 +219,14 @@ async fn main_js_handler() -> impl IntoResponse {
             "application/javascript; charset=utf-8",
         )],
         include_str!("web/static/js/main.js"),
+    )
+}
+
+/// Serve the generated tool-support matrix consumed by the help tab.
+async fn tool_support_matrix_handler() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "application/json")],
+        include_str!("web/static/data/tool_support_matrix.json"),
     )
 }
 

--- a/src/service/web/static/data/tool_support_matrix.json
+++ b/src/service/web/static/data/tool_support_matrix.json
@@ -1,0 +1,597 @@
+{
+  "categories": [
+    {
+      "footnotes": [
+        {
+          "marker": "*",
+          "text": "mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally)."
+        }
+      ],
+      "id": "reference_types",
+      "rows": [
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "NM_000088.3",
+          "key": "NM_",
+          "label": "Coding transcript (mRNA)",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "NR_024540.1",
+          "key": "NR_",
+          "label": "Non-coding transcript",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "NC_000001.11",
+          "key": "NC_",
+          "label": "Genomic chromosome",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "NG_007400.1",
+          "key": "NG_",
+          "label": "Genomic gene region",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "*",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            }
+          ],
+          "example": "NP_000079.2",
+          "key": "NP_",
+          "label": "Protein",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "LRG_1",
+          "key": "LRG_",
+          "label": "Locus Reference Genomic",
+          "spec_url": null
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            }
+          ],
+          "example": "ENST00000357033",
+          "key": "ENST",
+          "label": "Ensembl transcript",
+          "spec_url": null
+        }
+      ],
+      "spec_url": "https://hgvs-nomenclature.org/stable/background/refseq/",
+      "title": "Reference Types"
+    },
+    {
+      "footnotes": [
+        {
+          "marker": "*",
+          "text": "mutalyzer protein normalization requires network access for NP_→NM_ lookups (cannot be cached locally)."
+        },
+        {
+          "marker": "**",
+          "text": "mutalyzer intronic support is enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic."
+        }
+      ],
+      "id": "coordinate_types",
+      "rows": [
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589G>T",
+          "key": "c",
+          "label": "Coding DNA (relative to CDS)",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "g.12345A>G",
+          "key": "g",
+          "label": "Genomic (absolute position)",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "n.100del",
+          "key": "n",
+          "label": "Non-coding transcript",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "*",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            }
+          ],
+          "example": "p.Gly12Val",
+          "key": "p",
+          "label": "Protein",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/protein/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "m.8993T>G",
+          "key": "m",
+          "label": "Mitochondrial",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "r.76a>u",
+          "key": "r",
+          "label": "RNA",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/RNA/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "**",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            }
+          ],
+          "example": "c.100+5G>A",
+          "key": "intronic",
+          "label": "Intronic positions",
+          "spec_url": null
+        }
+      ],
+      "spec_url": null,
+      "title": "Coordinate Types"
+    },
+    {
+      "footnotes": [],
+      "id": "variant_types",
+      "rows": [
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589G>T",
+          "key": "substitution",
+          "label": "Substitution",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589del",
+          "key": "deletion",
+          "label": "Deletion",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/deletion/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589_590insA",
+          "key": "insertion",
+          "label": "Insertion",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/insertion/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589dup",
+          "key": "duplication",
+          "label": "Duplication",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/duplication/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589delinsAT",
+          "key": "delins",
+          "label": "Delins",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/delins/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            }
+          ],
+          "example": "c.589_600inv",
+          "key": "inversion",
+          "label": "Inversion",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/inversion/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "-"
+            },
+            {
+              "footnote": "",
+              "glyph": "-"
+            }
+          ],
+          "example": "c.589CAG[23]",
+          "key": "repeat",
+          "label": "Repeat",
+          "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/repeated/"
+        },
+        {
+          "cells": [
+            {
+              "footnote": "",
+              "glyph": "V/N"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "V"
+            },
+            {
+              "footnote": "",
+              "glyph": "-"
+            }
+          ],
+          "example": "c.589_600con",
+          "key": "conversion",
+          "label": "Conversion",
+          "spec_url": null
+        }
+      ],
+      "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/",
+      "title": "Variant Types"
+    }
+  ],
+  "schema_version": 1,
+  "tools": [
+    {
+      "id": "ferro",
+      "name": "ferro",
+      "url": "https://github.com/fulcrumgenomics/ferro-hgvs",
+      "version": "0.6.0"
+    },
+    {
+      "id": "mutalyzer",
+      "name": "mutalyzer",
+      "url": "https://mutalyzer.nl/",
+      "version": "3.1.1"
+    },
+    {
+      "id": "biocommons",
+      "name": "biocommons",
+      "url": "https://github.com/biocommons/hgvs",
+      "version": "main @ fa02ca5 (post-1.5.3)"
+    },
+    {
+      "id": "hgvs-rs",
+      "name": "hgvs-rs",
+      "url": "https://github.com/varfish-org/hgvs-rs",
+      "version": "0.20.2"
+    }
+  ]
+}

--- a/src/service/web/static/js/main.js
+++ b/src/service/web/static/js/main.js
@@ -56,42 +56,7 @@ class HelpSystem {
                 <p>This matrix shows which features each tool supports: <strong>V/N</strong> = Validate &amp; Normalize,
                 <strong>V</strong> = Validate only, <strong>N</strong> = Normalize only, <strong>-</strong> = Not supported.</p>
 
-                <h5>Reference Types <a href="https://hgvs-nomenclature.org/stable/background/refseq/" target="_blank" rel="noopener">[Spec]</a></h5>
-                <table>
-                    <tr><th>Reference</th><th>Description</th><th>Example</th><th>ferro</th><th>mutalyzer</th><th>biocommons</th><th>hgvs-rs</th></tr>
-                    <tr><td><code>NM_</code></td><td>Coding transcript (mRNA)</td><td><code>NM_000088.3</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>NR_</code></td><td>Non-coding transcript</td><td><code>NR_024540.1</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>NC_</code></td><td>Genomic chromosome</td><td><code>NC_000001.11</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>NG_</code></td><td>Genomic gene region</td><td><code>NG_007400.1</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>NP_</code></td><td>Protein</td><td><code>NP_000079.2</code></td><td>V</td><td>V/N</td><td>V/N</td><td>-</td></tr>
-                    <tr><td><code>LRG_</code></td><td>Locus Reference Genomic</td><td><code>LRG_1</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>ENST</code></td><td>Ensembl transcript</td><td><code>ENST00000357033</code></td><td>-</td><td>V/N</td><td>V/N</td><td>-</td></tr>
-                </table>
-
-                <h5>Coordinate Types</h5>
-                <table>
-                    <tr><th>Coordinate</th><th>Description</th><th>Example</th><th>ferro</th><th>mutalyzer</th><th>biocommons</th><th>hgvs-rs</th></tr>
-                    <tr><td><code>c.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/" target="_blank" rel="noopener">Coding DNA</a> (relative to CDS)</td><td><code>c.589G>T</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>g.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/" target="_blank" rel="noopener">Genomic</a> (absolute position)</td><td><code>g.12345A>G</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>n.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/" target="_blank" rel="noopener">Non-coding transcript</a></td><td><code>n.100del</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>p.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/protein/" target="_blank" rel="noopener">Protein</a></td><td><code>p.Gly12Val</code></td><td>V</td><td>V/N</td><td>V/N</td><td>-</td></tr>
-                    <tr><td><code>m.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/" target="_blank" rel="noopener">Mitochondrial</a></td><td><code>m.8993T>G</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><code>r.</code></td><td><a href="https://hgvs-nomenclature.org/stable/recommendations/RNA/" target="_blank" rel="noopener">RNA</a></td><td><code>r.76a>u</code></td><td>V</td><td>V/N</td><td>V/N</td><td>-</td></tr>
-                    <tr><td><code>+/-</code></td><td>Intronic positions</td><td><code>c.100+5G>A</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V</td></tr>
-                </table>
-
-                <h5>Variant Types <a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/" target="_blank" rel="noopener">[Spec]</a></h5>
-                <table>
-                    <tr><th>Type</th><th>Description</th><th>Example</th><th>ferro</th><th>mutalyzer</th><th>biocommons</th><th>hgvs-rs</th></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/substitution/" target="_blank" rel="noopener">Substitution</a></td><td>Single nucleotide change</td><td><code>c.589G>T</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/deletion/" target="_blank" rel="noopener">Deletion</a></td><td>Nucleotide(s) removed</td><td><code>c.589del</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/insertion/" target="_blank" rel="noopener">Insertion</a></td><td>Nucleotide(s) added</td><td><code>c.589_590insA</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/duplication/" target="_blank" rel="noopener">Duplication</a></td><td>Sequence copied in tandem</td><td><code>c.589dup</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/delins/" target="_blank" rel="noopener">Delins</a></td><td>Deletion + insertion</td><td><code>c.589delinsAT</code></td><td>V/N</td><td>V/N</td><td>V/N</td><td>V/N</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/inversion/" target="_blank" rel="noopener">Inversion</a></td><td>Sequence reversed</td><td><code>c.589_600inv</code></td><td>V</td><td>V/N</td><td>V/N</td><td>V</td></tr>
-                    <tr><td><a href="https://hgvs-nomenclature.org/stable/recommendations/DNA/variant/repeated/" target="_blank" rel="noopener">Repeat</a></td><td>Tandem repeat expansion</td><td><code>c.589CAG[23]</code></td><td>V</td><td>V/N</td><td>V</td><td>-</td></tr>
-                    <tr><td>Conversion</td><td>Gene conversion event</td><td><code>c.589_600con</code></td><td>-</td><td>V/N</td><td>V</td><td>-</td></tr>
-                </table>
+                <div id="support-matrix" data-loaded="false">Loading support matrix…</div>
 
                 <p><em>Note: Actual support may vary by tool version and configuration. "Validate" = parsing/syntax checking,
                 "Normalize" = 3' shifting and HGVS-compliant formatting.</em></p>
@@ -301,6 +266,7 @@ Content-Type: application/json
         const container = document.getElementById('help-tab-content');
         if (container && this.content[tabId]) {
             container.innerHTML = this.content[tabId];
+            if (tabId === 'support') renderSupportMatrix();
         }
     }
 }
@@ -314,6 +280,65 @@ document.addEventListener('DOMContentLoaded', () => {
     // (Server runs actual health checks every 15 minutes in background)
     setInterval(refreshHealth, 60000);
 });
+
+// Fetch and render the tool-support matrix tables in the help tab.
+// Runs once per page load; subsequent calls are no-ops (data-loaded guard).
+async function renderSupportMatrix() {
+    const host = document.getElementById('support-matrix');
+    if (!host || host.dataset.loaded === 'true') return;
+    try {
+        const res = await fetch('/static/data/tool_support_matrix.json');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        host.innerHTML = '';
+        for (const cat of data.categories) {
+            const h = document.createElement('h5');
+            h.textContent = cat.title;
+            host.appendChild(h);
+
+            const table = document.createElement('table');
+            const head = document.createElement('tr');
+            for (const col of ['', 'Example', ...data.tools.map(t => t.name)]) {
+                const th = document.createElement('th');
+                th.scope = 'col';
+                th.textContent = col;
+                head.appendChild(th);
+            }
+            table.appendChild(head);
+
+            for (const row of cat.rows) {
+                const tr = document.createElement('tr');
+                const label = document.createElement('th');
+                label.scope = 'row';
+                label.textContent = row.label;
+                tr.appendChild(label);
+
+                const ex = document.createElement('td');
+                if (row.example) { const c = document.createElement('code'); c.textContent = row.example; ex.appendChild(c); }
+                tr.appendChild(ex);
+
+                for (const cell of row.cells) {
+                    const td = document.createElement('td');
+                    td.textContent = (cell.glyph === '-' ? '—' : cell.glyph) + (cell.footnote || '');
+                    if (cell.glyph === '-') td.setAttribute('aria-label', 'not supported');
+                    tr.appendChild(td);
+                }
+                table.appendChild(tr);
+            }
+            host.appendChild(table);
+
+            if (cat.footnotes && cat.footnotes.length) {
+                const fn = document.createElement('p');
+                fn.className = 'support-footnotes';
+                fn.innerHTML = cat.footnotes.map(f => `<small>${escapeHtml(f.marker)} ${escapeHtml(f.text)}</small>`).join('<br>');
+                host.appendChild(fn);
+            }
+        }
+        host.dataset.loaded = 'true';
+    } catch (e) {
+        host.textContent = `Failed to load support matrix: ${e.message}`;
+    }
+}
 
 // Refresh health status (quick check)
 async function refreshHealth() {

--- a/src/tool_support/mod.rs
+++ b/src/tool_support/mod.rs
@@ -1,0 +1,621 @@
+//! Tool-support matrix: types + table projection.
+//!
+//! Source of truth is `docs/tool_support_matrix.json`. This module loads it
+//! and renders deterministic projections (markdown tables, website JSON). See
+//! `docs/superpowers/specs/2026-06-09-tool-support-matrix-design.md`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Whether a tool parses/validates a pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Validate {
+    /// Parses and performs semantic validation.
+    Yes,
+    /// Parses/round-trips but does no semantic validation (permissive stub).
+    Permissive,
+    /// Does not accept the pattern.
+    No,
+}
+
+/// Whether/how a tool normalizes a pattern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Normalize {
+    /// Genuinely canonicalizes / 3'-shifts.
+    Full,
+    /// Works but requires network access (cannot be cached).
+    NetworkOnly,
+    /// Deliberately unsupported (explicit design decision).
+    UnsupportedByDesign,
+    /// Parses but normalization errors out.
+    Errors,
+    /// Parses but normalization is a no-op by design.
+    No,
+}
+
+/// One (tool × pattern) support claim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Cell {
+    pub validate: Validate,
+    pub normalize: Normalize,
+    /// Key into [`Matrix::footnotes`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub footnote: Option<String>,
+    /// Free-text rationale / provenance note (not rendered into tables).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl Cell {
+    /// True when the tool accepts the pattern (renders the `V` component).
+    pub fn validate_active(&self) -> bool {
+        !matches!(self.validate, Validate::No)
+    }
+
+    /// True when the tool produces a normalized result (renders the `N`
+    /// component). `network_only` counts as active.
+    pub fn normalize_active(&self) -> bool {
+        matches!(self.normalize, Normalize::Full | Normalize::NetworkOnly)
+    }
+
+    /// Website glyph: `V/N`, `V`, `N`, or `-`.
+    pub fn website_glyph(&self) -> &'static str {
+        match (self.validate_active(), self.normalize_active()) {
+            (true, true) => "V/N",
+            (true, false) => "V",
+            (false, true) => "N",
+            (false, false) => "-",
+        }
+    }
+
+    /// Markdown glyph for the normalization-capabilities view: `✓`, `Net`, `✗`.
+    pub fn markdown_glyph(&self) -> &'static str {
+        match self.normalize {
+            Normalize::Full => "✓",
+            Normalize::NetworkOnly => "Net",
+            Normalize::UnsupportedByDesign | Normalize::Errors | Normalize::No => "✗",
+        }
+    }
+}
+
+/// A pattern row within a category.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Row {
+    pub key: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub example: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec_url: Option<String>,
+    /// Keyed by tool id; must contain exactly the ids in [`Matrix::tools`].
+    pub support: BTreeMap<String, Cell>,
+    pub last_reviewed: String,
+}
+
+/// A group of rows (reference types, coordinate types, variant types).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Category {
+    pub id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec_url: Option<String>,
+    pub rows: Vec<Row>,
+}
+
+/// One compared tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tool {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub url: String,
+}
+
+/// One selected row within a view (with an optional relabel).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ViewSelect {
+    pub category: String,
+    pub key: String,
+    pub label: String,
+}
+
+/// A markdown projection (e.g. README "Normalization Capabilities").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct View {
+    pub id: String,
+    pub title: String,
+    pub row_label_header: String,
+    pub select: Vec<ViewSelect>,
+}
+
+/// The whole matrix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Matrix {
+    pub schema_version: u32,
+    pub tools: Vec<Tool>,
+    pub footnotes: BTreeMap<String, String>,
+    pub categories: Vec<Category>,
+    #[serde(default)]
+    pub views: Vec<View>,
+}
+
+impl Matrix {
+    /// Parse from a JSON string.
+    pub fn from_json_str(s: &str) -> Result<Self, String> {
+        serde_json::from_str(s).map_err(|e| format!("parse tool_support_matrix: {e}"))
+    }
+
+    /// Load from a file path.
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+        let p = path.as_ref();
+        let s = std::fs::read_to_string(p).map_err(|e| format!("read {}: {e}", p.display()))?;
+        Self::from_json_str(&s)
+    }
+
+    /// Tool ids in declared order.
+    pub fn tool_ids(&self) -> Vec<&str> {
+        self.tools.iter().map(|t| t.id.as_str()).collect()
+    }
+
+    /// Fail if any row is missing a tool, references an unknown tool, or cites
+    /// an undefined footnote; or a view selects a missing (category, key).
+    pub fn validate_invariants(&self) -> Result<(), String> {
+        let ids: Vec<&str> = self.tool_ids();
+        for cat in &self.categories {
+            for row in &cat.rows {
+                for id in &ids {
+                    if !row.support.contains_key(*id) {
+                        return Err(format!(
+                            "category {} row {} missing tool {id}",
+                            cat.id, row.key
+                        ));
+                    }
+                }
+                for (id, cell) in &row.support {
+                    if !ids.contains(&id.as_str()) {
+                        return Err(format!(
+                            "category {} row {} has unknown tool {id}",
+                            cat.id, row.key
+                        ));
+                    }
+                    if let Some(f) = &cell.footnote {
+                        if !self.footnotes.contains_key(f) {
+                            return Err(format!(
+                                "category {} row {} tool {id} cites unknown footnote {f}",
+                                cat.id, row.key
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        for view in &self.views {
+            for sel in &view.select {
+                if self.find_row(&sel.category, &sel.key).is_none() {
+                    return Err(format!(
+                        "view {} selects missing row {}/{}",
+                        view.id, sel.category, sel.key
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Find a row by (category id, row key).
+    pub fn find_row(&self, category: &str, key: &str) -> Option<&Row> {
+        self.categories
+            .iter()
+            .find(|c| c.id == category)?
+            .rows
+            .iter()
+            .find(|r| r.key == key)
+    }
+
+    /// Render a markdown view (selected rows, relabeled) into a GitHub-flavored
+    /// table plus a footnote legend. Column order follows [`Matrix::tools`].
+    ///
+    /// Returns `Err` if the view is not found, a row is missing a tool entry,
+    /// or a cell cites an unknown footnote. Call
+    /// [`Matrix::validate_invariants`] first to catch those conditions early.
+    pub fn render_markdown_view(&self, view_id: &str) -> Result<String, String> {
+        let view = self
+            .views
+            .iter()
+            .find(|v| v.id == view_id)
+            .ok_or_else(|| format!("unknown view {view_id}"))?;
+
+        let mut fa = FootnoteAssigner::new();
+        let mut out = String::new();
+
+        // Header row.
+        out.push_str(&format!("| {} |", view.row_label_header));
+        for t in &self.tools {
+            out.push_str(&format!(" {} |", t.name));
+        }
+        out.push('\n');
+
+        // Alignment row: left-align the label column, center the tool columns,
+        // widths matching the header cell text for stable diffs.
+        out.push_str(&format!(
+            "|{}|",
+            "-".repeat(view.row_label_header.len() + 2)
+        ));
+        for t in &self.tools {
+            out.push_str(&format!(":{}:|", "-".repeat(t.name.len())));
+        }
+        out.push('\n');
+
+        // Body rows.
+        for sel in &view.select {
+            let row = self.find_row(&sel.category, &sel.key).ok_or_else(|| {
+                format!("view {view_id} row {}/{} missing", sel.category, sel.key)
+            })?;
+            out.push_str(&format!("| {} |", sel.label));
+            for t in &self.tools {
+                let cell = row.support.get(&t.id).ok_or_else(|| {
+                    format!("category/view row {} missing tool {}", row.key, t.id)
+                })?;
+                let mut g = cell.markdown_glyph().to_string();
+                if let Some(f) = &cell.footnote {
+                    g.push_str(&fa.marker(f));
+                }
+                out.push_str(&format!(" {g} |"));
+            }
+            out.push('\n');
+        }
+
+        // Footnote legend (escaped `*` so markdown doesn't italicize).
+        let used = fa.used();
+        if !used.is_empty() {
+            out.push('\n');
+            for (marker, key) in used {
+                let text = self
+                    .footnotes
+                    .get(key)
+                    .ok_or_else(|| format!("view {view_id} cites unknown footnote {key}"))?;
+                let escaped = marker.replace('*', "\\*");
+                out.push_str(&format!("{escaped} {text}\n"));
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Build the render-ready website projection consumed by `main.js`.
+    /// Glyphs and footnote markers are pre-computed; JS only builds the DOM.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the matrix has not passed [`Matrix::validate_invariants`]
+    /// (a row missing a tool, or a cell citing an unknown footnote).
+    pub fn render_website_json(&self) -> serde_json::Value {
+        let tools: Vec<serde_json::Value> = self
+            .tools
+            .iter()
+            .map(|t| json!({"id": t.id, "name": t.name, "version": t.version, "url": t.url}))
+            .collect();
+
+        let categories: Vec<serde_json::Value> = self
+            .categories
+            .iter()
+            .map(|cat| {
+                let mut fa = FootnoteAssigner::new();
+                let rows: Vec<serde_json::Value> = cat
+                    .rows
+                    .iter()
+                    .map(|row| {
+                        let cells: Vec<serde_json::Value> = self
+                            .tools
+                            .iter()
+                            .map(|t| {
+                                let cell = row.support.get(&t.id).expect(
+                                    "row missing a tool; call Matrix::validate_invariants() before rendering",
+                                );
+                                let marker = cell
+                                    .footnote
+                                    .as_ref()
+                                    .map(|f| fa.marker(f))
+                                    .unwrap_or_default();
+                                json!({"glyph": cell.website_glyph(), "footnote": marker})
+                            })
+                            .collect();
+                        json!({
+                            "key": row.key,
+                            "label": row.label,
+                            "example": row.example,
+                            "spec_url": row.spec_url,
+                            "cells": cells,
+                        })
+                    })
+                    .collect();
+                let legend: Vec<serde_json::Value> = fa
+                    .used()
+                    .into_iter()
+                    .map(|(marker, key)| {
+                        json!({"marker": marker, "text": self.footnotes.get(key).cloned().expect("cell cites unknown footnote; call Matrix::validate_invariants() before rendering")})
+                    })
+                    .collect();
+                json!({"id": cat.id, "title": cat.title, "spec_url": cat.spec_url, "rows": rows, "footnotes": legend})
+            })
+            .collect();
+
+        json!({
+            "schema_version": self.schema_version,
+            "tools": tools,
+            "categories": categories,
+        })
+    }
+
+    /// Return human-readable identifiers of cells whose row `last_reviewed` is
+    /// older than `months` before `today` (both `YYYY-MM-DD`). Non-failing.
+    pub fn stale_cells(&self, today: &str, months: i64) -> Vec<String> {
+        let cutoff = months_before(today, months);
+        let mut out = Vec::new();
+        for cat in &self.categories {
+            for row in &cat.rows {
+                if row.last_reviewed.as_str() < cutoff.as_str() {
+                    out.push(format!(
+                        "{}/{} (last_reviewed {})",
+                        cat.id, row.key, row.last_reviewed
+                    ));
+                }
+            }
+        }
+        out
+    }
+}
+
+/// Assigns `*`, `**`, `***`, … to footnote keys in first-appearance order
+/// within one rendered table.
+struct FootnoteAssigner {
+    order: Vec<String>,
+}
+
+impl FootnoteAssigner {
+    fn new() -> Self {
+        Self { order: Vec::new() }
+    }
+
+    /// Return the marker for a key, registering it on first use.
+    fn marker(&mut self, key: &str) -> String {
+        let idx = match self.order.iter().position(|k| k == key) {
+            Some(i) => i,
+            None => {
+                self.order.push(key.to_string());
+                self.order.len() - 1
+            }
+        };
+        "*".repeat(idx + 1)
+    }
+
+    /// Markers used so far, in assignment order, as (marker, key).
+    fn used(&self) -> Vec<(String, &str)> {
+        self.order
+            .iter()
+            .enumerate()
+            .map(|(i, k)| ("*".repeat(i + 1), k.as_str()))
+            .collect()
+    }
+}
+
+/// Subtract `months` from a `YYYY-MM-DD` date lexically (string comparison is
+/// valid for ISO dates). Clamps the day implicitly by keeping it; only the
+/// year/month are shifted, which is sufficient for a coarse staleness check.
+fn months_before(today: &str, months: i64) -> String {
+    let mut parts = today.splitn(3, '-');
+    let (y, m, d) = (
+        parts
+            .next()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(0),
+        parts
+            .next()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(1),
+        parts.next().unwrap_or("01"),
+    );
+    let total = y * 12 + (m - 1) - months;
+    let ny = total.div_euclid(12);
+    let nm = total.rem_euclid(12) + 1;
+    format!("{ny:04}-{nm:02}-{d}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cell(v: Validate, n: Normalize) -> Cell {
+        Cell {
+            validate: v,
+            normalize: n,
+            footnote: None,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn website_glyphs() {
+        assert_eq!(cell(Validate::Yes, Normalize::Full).website_glyph(), "V/N");
+        assert_eq!(
+            cell(Validate::Yes, Normalize::NetworkOnly).website_glyph(),
+            "V/N"
+        );
+        assert_eq!(
+            cell(Validate::Permissive, Normalize::Errors).website_glyph(),
+            "V"
+        );
+        assert_eq!(cell(Validate::Yes, Normalize::No).website_glyph(), "V");
+        assert_eq!(
+            cell(Validate::Yes, Normalize::UnsupportedByDesign).website_glyph(),
+            "V"
+        );
+        assert_eq!(cell(Validate::No, Normalize::No).website_glyph(), "-");
+        assert_eq!(cell(Validate::No, Normalize::Full).website_glyph(), "N");
+    }
+
+    #[test]
+    fn markdown_glyphs() {
+        assert_eq!(cell(Validate::Yes, Normalize::Full).markdown_glyph(), "✓");
+        assert_eq!(
+            cell(Validate::Yes, Normalize::NetworkOnly).markdown_glyph(),
+            "Net"
+        );
+        assert_eq!(
+            cell(Validate::Permissive, Normalize::Errors).markdown_glyph(),
+            "✗"
+        );
+        assert_eq!(
+            cell(Validate::Yes, Normalize::UnsupportedByDesign).markdown_glyph(),
+            "✗"
+        );
+        assert_eq!(cell(Validate::Yes, Normalize::No).markdown_glyph(), "✗");
+    }
+
+    const SAMPLE: &str = r#"{
+      "schema_version": 1,
+      "tools": [
+        {"id":"ferro","name":"ferro","version":"0.6.0","url":"https://x"},
+        {"id":"hgvs-rs","name":"hgvs-rs","version":"0.20.2","url":"https://y"}
+      ],
+      "footnotes": {"net":"needs network"},
+      "categories": [
+        {"id":"coordinate_types","title":"Coordinate Types","rows":[
+          {"key":"p","label":"Protein","example":"p.Gly12Val","last_reviewed":"2026-06-09",
+           "support":{"ferro":{"validate":"yes","normalize":"full"},"hgvs-rs":{"validate":"permissive","normalize":"errors"}}}
+        ]}
+      ],
+      "views": []
+    }"#;
+
+    #[test]
+    fn loads_and_validates() {
+        let m = Matrix::from_json_str(SAMPLE).expect("parse");
+        m.validate_invariants().expect("invariants");
+        assert_eq!(m.tools.len(), 2);
+    }
+
+    #[test]
+    fn rejects_missing_tool_in_row() {
+        // Drop the hgvs-rs cell -> invariant must fail.
+        let bad = SAMPLE.replace(
+            r#","hgvs-rs":{"validate":"permissive","normalize":"errors"}"#,
+            "",
+        );
+        let m = Matrix::from_json_str(&bad).expect("parse");
+        assert!(m.validate_invariants().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_footnote() {
+        let bad = SAMPLE.replace(
+            r#""normalize":"full"}"#,
+            r#""normalize":"full","footnote":"nope"}"#,
+        );
+        let m = Matrix::from_json_str(&bad).expect("parse");
+        assert!(m.validate_invariants().is_err());
+    }
+
+    fn view_matrix() -> Matrix {
+        let json = r#"{
+          "schema_version":1,
+          "tools":[
+            {"id":"ferro","name":"ferro","version":"0","url":"u"},
+            {"id":"mutalyzer","name":"mutalyzer","version":"0","url":"u"},
+            {"id":"biocommons","name":"biocommons","version":"0","url":"u"},
+            {"id":"hgvs-rs","name":"hgvs-rs","version":"0","url":"u"}
+          ],
+          "footnotes":{
+            "rewrite":"enabled by default via genomic-context rewriting; disable with --no-rewrite-intronic.",
+            "net":"requires network access for NP_->NM_ lookups."
+          },
+          "categories":[{"id":"coordinate_types","title":"Coordinate Types","rows":[
+            {"key":"intronic","label":"Intronic","last_reviewed":"2026-06-09","support":{
+              "ferro":{"validate":"yes","normalize":"full"},
+              "mutalyzer":{"validate":"yes","normalize":"full","footnote":"rewrite"},
+              "biocommons":{"validate":"yes","normalize":"no"},
+              "hgvs-rs":{"validate":"permissive","normalize":"unsupported_by_design"}
+            }},
+            {"key":"p","label":"Protein","last_reviewed":"2026-06-09","support":{
+              "ferro":{"validate":"yes","normalize":"full"},
+              "mutalyzer":{"validate":"yes","normalize":"network_only","footnote":"net"},
+              "biocommons":{"validate":"yes","normalize":"unsupported_by_design"},
+              "hgvs-rs":{"validate":"permissive","normalize":"errors"}
+            }}
+          ]}],
+          "views":[{"id":"normalization_capabilities","title":"Normalization Capabilities",
+            "row_label_header":"Pattern Type","select":[
+              {"category":"coordinate_types","key":"intronic","label":"Coding (c.) intronic"},
+              {"category":"coordinate_types","key":"p","label":"Protein (p.)"}
+            ]}]
+        }"#;
+        Matrix::from_json_str(json).unwrap()
+    }
+
+    #[test]
+    fn renders_markdown_view() {
+        let m = view_matrix();
+        let out = m
+            .render_markdown_view("normalization_capabilities")
+            .unwrap();
+        // Header + alignment.
+        assert!(out.contains("| Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |"));
+        assert!(out.contains("|--------------|:-----:|:---------:|:----------:|:-------:|"));
+        // Intronic row: ferro ✓, mutalyzer ✓ with first footnote (*), biocommons ✗, hgvs-rs ✗.
+        assert!(out.contains("| Coding (c.) intronic | ✓ | ✓* | ✗ | ✗ |"));
+        // Protein row: mutalyzer Net with second footnote (**).
+        assert!(out.contains("| Protein (p.) | ✓ | Net** | ✗ | ✗ |"));
+        // Footnote legend, in assignment order.
+        assert!(out.contains("\\* enabled by default via genomic-context rewriting"));
+        assert!(out.contains("\\*\\* requires network access"));
+    }
+
+    #[test]
+    fn renders_website_json() {
+        let m = view_matrix();
+        let v = m.render_website_json();
+        assert_eq!(v["tools"][0]["name"], "ferro");
+        let cats = v["categories"].as_array().unwrap();
+        let coord = &cats[0];
+        assert_eq!(coord["title"], "Coordinate Types");
+        let rows = coord["rows"].as_array().unwrap();
+        // Intronic row glyphs in tool order.
+        assert_eq!(rows[0]["label"], "Intronic");
+        assert_eq!(rows[0]["cells"][0]["glyph"], "V/N"); // ferro
+        assert_eq!(rows[0]["cells"][2]["glyph"], "V"); // biocommons (no normalize)
+        assert_eq!(rows[0]["cells"][3]["glyph"], "V"); // hgvs-rs (unsupported)
+                                                       // Protein: hgvs-rs errors -> V, biocommons unsupported -> V.
+        assert_eq!(rows[1]["cells"][3]["glyph"], "V");
+    }
+
+    #[test]
+    fn staleness_scan_flags_old() {
+        let mut m = view_matrix();
+        m.categories[0].rows[0].last_reviewed = "2000-01-01".into();
+        let stale = m.stale_cells("2026-06-09", 6);
+        assert_eq!(stale.len(), 1);
+        assert!(stale[0].contains("intronic"));
+    }
+
+    #[test]
+    fn months_before_wraps_year() {
+        assert_eq!(months_before("2026-01-15", 1), "2025-12-15");
+        assert_eq!(months_before("2026-06-09", 6), "2025-12-09");
+    }
+
+    /// `stale_cells` is documented "Non-failing": malformed `today` strings must
+    /// not panic — they should yield a degenerate cutoff and return normally.
+    #[test]
+    fn stale_cells_non_failing_on_malformed_today() {
+        let m = view_matrix();
+        // Empty string, year-only, and year+month all must return without panicking.
+        let _ = m.stale_cells("", 6);
+        let _ = m.stale_cells("2026", 6);
+        let _ = m.stale_cells("2026-06", 6);
+    }
+}

--- a/tests/tool_support_matrix.rs
+++ b/tests/tool_support_matrix.rs
@@ -1,0 +1,87 @@
+//! Golden/contract tests for the curated tool-support matrix.
+#![cfg(feature = "dev")]
+
+use ferro_hgvs::tool_support::{Matrix, Normalize, Validate};
+
+fn matrix() -> Matrix {
+    Matrix::load("docs/tool_support_matrix.json").expect("load matrix")
+}
+
+#[test]
+fn matrix_invariants_hold() {
+    matrix().validate_invariants().expect("invariants");
+}
+
+#[test]
+fn adjudicated_cells_are_correct() {
+    let m = matrix();
+    let p = m.find_row("coordinate_types", "p").unwrap();
+    assert_eq!(p.support["ferro"].normalize, Normalize::Full);
+    assert_eq!(p.support["hgvs-rs"].normalize, Normalize::Errors);
+    assert_eq!(p.support["hgvs-rs"].validate, Validate::Permissive);
+    assert_eq!(
+        p.support["biocommons"].normalize,
+        Normalize::UnsupportedByDesign
+    );
+    assert_eq!(p.support["mutalyzer"].normalize, Normalize::NetworkOnly);
+
+    let intronic = m.find_row("coordinate_types", "intronic").unwrap();
+    assert_eq!(intronic.support["ferro"].normalize, Normalize::Full);
+    assert_eq!(intronic.support["biocommons"].normalize, Normalize::No);
+    assert_eq!(
+        intronic.support["hgvs-rs"].normalize,
+        Normalize::UnsupportedByDesign
+    );
+
+    let r = m.find_row("coordinate_types", "r").unwrap();
+    assert_eq!(r.support["hgvs-rs"].normalize, Normalize::Full);
+
+    let conv = m.find_row("variant_types", "conversion").unwrap();
+    assert_eq!(conv.support["ferro"].normalize, Normalize::Full);
+}
+
+#[test]
+fn normalization_view_renders_expected() {
+    let m = matrix();
+    let out = m
+        .render_markdown_view("normalization_capabilities")
+        .unwrap();
+    let expected = "\
+| Pattern Type | ferro | mutalyzer | biocommons | hgvs-rs |
+|--------------|:-----:|:---------:|:----------:|:-------:|
+| Genomic (g.) | ✓ | ✓ | ✓ | ✓ |
+| Coding (c.) exonic | ✓ | ✓ | ✓ | ✓ |
+| Coding (c.) intronic | ✓ | ✓* | ✗ | ✗ |
+| Non-coding (n.) | ✓ | ✓ | ✓ | ✓ |
+| RNA (r.) | ✓ | ✓ | ✓ | ✓ |
+| Protein (p.) | ✓ | Net** | ✗ | ✗ |
+";
+    // Compare the table portion (ignore the trailing footnote legend, which is
+    // asserted separately to avoid coupling to exact footnote prose).
+    let table: String = out.lines().take(8).collect::<Vec<_>>().join("\n");
+    assert_eq!(table, expected.trim_end());
+    assert!(out.contains("\\* mutalyzer intronic support is enabled by default"));
+    assert!(out.contains("\\*\\* mutalyzer protein normalization requires network access"));
+}
+
+#[test]
+fn newly_verified_cells() {
+    let m = matrix();
+
+    let inversion = m.find_row("variant_types", "inversion").unwrap();
+    assert_eq!(inversion.support["hgvs-rs"].normalize, Normalize::Full);
+
+    let conversion = m.find_row("variant_types", "conversion").unwrap();
+    assert_eq!(
+        conversion.support["mutalyzer"].normalize,
+        Normalize::UnsupportedByDesign
+    );
+
+    let repeat = m.find_row("variant_types", "repeat").unwrap();
+    assert_eq!(repeat.support["biocommons"].validate, Validate::No);
+
+    let enst = m.find_row("reference_types", "ENST").unwrap();
+    assert_eq!(enst.support["ferro"].validate, Validate::Yes);
+    assert_eq!(enst.support["mutalyzer"].normalize, Normalize::Full);
+    assert_eq!(enst.support["biocommons"].normalize, Normalize::No);
+}


### PR DESCRIPTION
## Summary

The ferro/mutalyzer/biocommons/hgvs-rs feature-support tables were hand-maintained in three places — `README.md`, `docs/BENCHMARK_GUIDE.md`, and the web help tab (`src/service/web/static/js/main.js`) — and had drifted out of sync with each other and with reality. This replaces all three with a single curated source of truth plus a generator, and refreshes the tables against the tools' actual behavior.

- `docs/tool_support_matrix.json` is the single source of truth: 4 tools × 3 categories (reference types, coordinate types, variant types), each cell a fine-grained `{validate, normalize}` pair (closed enums) with footnotes, per-tool versions, and `last_reviewed` dates.
- `src/tool_support/` (dev-gated) holds the serde types and projection logic (enum → glyph), with unit + golden tests.
- `examples/generate_tool_support_tables.rs` renders the README and BENCHMARK_GUIDE tables (between `<!-- BEGIN/END tool-support -->` markers) and a render-ready web JSON. `--check` mode fails CI on any drift, and is wired into the `test` job alongside the existing generator checks.
- The web help tab now builds its tables at runtime from the generated JSON (served via `include_str!`), instead of hardcoded HTML.
- Governance: CI `--check`, `.github/CODEOWNERS` for the matrix file, and a CONTRIBUTING note.

## Data corrections in this refresh

The cells were adjudicated against the tools' source code (ferro `src/normalize/`, hgvs-rs `normalizer.rs` at v0.20.2):

- **hgvs-rs protein**: `✓` → `✗`. hgvs-rs parses `p.` but its normalizer explicitly returns `Error::ProteinVariant`.
- **ferro** protein, RNA, inversion, repeat, conversion: corrected to full normalization. The prior web table understated ferro as validate-only / unsupported for these.
- **biocommons** protein and intronic: `V/N` → `V` (parses/validates but does not normalize, by design).
- **mutalyzer** protein: now carries the network-only footnote.
- README and BENCHMARK_GUIDE tables are now generated from one source, so they share column order and can no longer disagree.

External-tool cells that were not independently source-verified (ENST; mutalyzer/biocommons/hgvs-rs inversion/repeat/conversion) are carried from the prior table and explicitly marked with a `"carried … not source-verified"` note in the JSON, to be confirmed in a future refresh.

## How to refresh in future

Edit `docs/tool_support_matrix.json`, then run `cargo run --features dev --example generate_tool_support_tables`. CI `--check` enforces that the generated tables stay in sync.

## Test plan

- [ ] `cargo nextest run --features dev` — new `tool_support` unit + golden tests pass (the 9 `axis_*` failures are pre-existing live-upstream conformance tests, unchanged by this PR)
- [ ] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [ ] `cargo run --features dev --example generate_tool_support_tables -- --check` — exits 0
- [ ] `cargo build --features web-service` — succeeds
- [ ] Manual: open the web Help → "HGVS Support" tab and confirm the three tables render (ferro `V/N` across protein/RNA/inversion/repeat/conversion; hgvs-rs protein `V`)