### PR TITLE
feat(project): add the c↔n (non-coding transcript) axis to VariantProjection

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1462,6 +1462,16 @@ class VariantProjection:
         ...
 
     @property
+    def n_name(self) -> str | None:
+        """The n. (transcript-relative) variant as an HGVS string.
+
+        Populated for both coding transcripts (derived genome-free from the c.
+        form) and non-coding transcripts; None when no transcript coordinate is
+        available (e.g. an empty allele).
+        """
+        ...
+
+    @property
     def p_name(self) -> str | None:
         """The p. variant as an HGVS string, or None for intronic/UTR/non-coding variants."""
         ...

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -5,6 +5,7 @@ pub mod edit;
 mod projector;
 mod protein;
 mod result;
+mod transcript_axis;
 
 pub use projector::VariantProjector;
 pub use result::VariantProjection;

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1209,10 +1209,28 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         )?;
 
         let frameshift = is_frameshift(normalized);
+
+        // c↔n axis: derive the n. (transcript-relative) form genome-free from
+        // the resolved CDS positions. Best-effort — never fail the whole
+        // projection if the n. derivation hits an edge (e.g. legacy c.0); log
+        // and leave None.
+        let noncoding = match self.cached_get_transcript_for_variant(normalized, transcript_id) {
+            Ok(tx) => crate::project::transcript_axis::noncoding_from_coding(
+                &cds_start,
+                &cds_end,
+                &tx,
+                &edit,
+                transcript_id,
+                gene_symbol.clone(),
+            )
+            .ok(),
+            Err(_) => None,
+        };
+
         Ok(VariantProjection {
             genomic: None,
             coding: Some(normalized.clone()),
-            noncoding: None,
+            noncoding,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,
@@ -3868,6 +3886,40 @@ mod tests {
         // c.4C>A: codon 2 CGC(Arg) → AGC(Ser) ⇒ p.(Arg2Ser).
         let protein = proj.protein.expect("protein should be predicted");
         assert_eq!(format!("{protein}"), "NP_TEST.1:p.(Arg2Ser)");
+    }
+
+    #[test]
+    fn project_bare_nm_substitution_populates_noncoding_axis() {
+        // c↔n axis: a bare-NM_ c. SNV carries an n. (transcript-relative) form
+        // even with no genome alignment. The n. edit matches the c. edit; only
+        // the coordinate frame reframes.
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // NM_TEST.1:c.4C>A — bare, no genomic_context parent.
+        let variant = make_coding_variant("NM_TEST.1", None);
+        let proj = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .expect("bare-NM_ projection should succeed");
+        assert!(proj.coding.is_some(), "coding (c.) form should be present");
+        let n = proj
+            .noncoding
+            .as_ref()
+            .expect("noncoding (n.) axis should be populated for a coding transcript");
+        assert!(
+            matches!(n, HgvsVariant::Tx(_)),
+            "noncoding form should be an n. (Tx) variant, got {n:?}"
+        );
+        let n_str = n.to_string();
+        assert!(
+            n_str.starts_with("NM_TEST.1"),
+            "n. form should render on the transcript accession, got {n_str}"
+        );
+        // NM_TEST.1's CDS begins at transcript position 1 (sequence ATGCGCTAA,
+        // no 5'UTR), so c.4 → n.4 and the edit is unchanged.
+        assert!(
+            n_str.contains(":n.4C>A"),
+            "c.4C>A should reframe to n.4C>A (cds_start at tx pos 1), got {n_str}"
+        );
     }
 
     #[test]

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -898,6 +898,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let coding = coding_variants
             .map(|variants| HgvsVariant::Allele(AlleleVariant::new(variants, allele.phase)));
 
+        // Build the n. (transcript-relative) allele the same all-or-nothing way:
+        // only when EVERY member carries an n. form (mirrors the coding rule).
+        let noncoding_variants: Option<Vec<HgvsVariant>> = inner_projections
+            .iter()
+            .map(|p| p.noncoding.clone())
+            .collect();
+        let noncoding = noncoding_variants
+            .map(|variants| HgvsVariant::Allele(AlleleVariant::new(variants, allele.phase)));
+
         // Build the protein allele only if ALL inner projections have a protein.
         let all_have_protein = inner_projections.iter().all(|p| p.protein.is_some());
         let protein = if all_have_protein {
@@ -937,7 +946,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(VariantProjection {
             genomic,
             coding,
-            noncoding: None,
+            noncoding,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,
@@ -2661,6 +2670,32 @@ mod tests {
                 av.variants.len(),
                 2,
                 "expected 2 inner c. variants in cis allele"
+            );
+        }
+    }
+
+    #[test]
+    fn project_cis_allele_aggregates_noncoding_axis() {
+        // c↔n axis: every inner member carries an n. form, so the allele
+        // projection exposes a cis n. allele mirroring the c. allele.
+        let result = project_cis_allele();
+        let noncoding = result
+            .noncoding
+            .as_ref()
+            .expect("n. allele should be aggregated");
+        assert!(
+            matches!(noncoding, HgvsVariant::Allele(av) if av.phase == AllelePhase::Cis),
+            "expected Cis noncoding allele, got: {noncoding}"
+        );
+        if let HgvsVariant::Allele(av) = noncoding {
+            assert_eq!(
+                av.variants.len(),
+                2,
+                "expected 2 inner n. variants in cis allele"
+            );
+            assert!(
+                av.variants.iter().all(|v| matches!(v, HgvsVariant::Tx(_))),
+                "every inner member of the n. allele should be an n. (Tx) variant"
             );
         }
     }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -866,6 +866,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 // already `None` for the empty allele (#508 review).
                 genomic: None,
                 coding: None,
+                // Empty allele: no inner member to derive an n. form from.
+                noncoding: None,
                 protein: None,
                 transcript_id: transcript_id.to_string(),
                 gene_symbol,
@@ -935,6 +937,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(VariantProjection {
             genomic,
             coding,
+            noncoding: None,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,
@@ -1209,6 +1212,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(VariantProjection {
             genomic: None,
             coding: Some(normalized.clone()),
+            noncoding: None,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,
@@ -1484,6 +1488,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(VariantProjection {
             genomic: Some(projected_genome),
             coding: Some(coding),
+            noncoding: None,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1498,6 +1498,32 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         )?;
 
         let frameshift = is_frameshift(&coding);
+
+        // c↔n axis. For a coding transcript derive the n. form genome-free from
+        // the resolved CDS positions (same edit, reframed coordinates);
+        // best-effort — never fail the whole projection on an n.-derivation
+        // edge. For a non-coding transcript `coding` already IS the n. (Tx)
+        // form, so reuse it (forward-compatible: the non-coding full-projection
+        // path is currently pinned unsupported — see
+        // `tests/issue_328_projector_accepts_cnr.rs` — so this arm is not yet
+        // reached, but carries the correct semantics for when it is).
+        let noncoding = if is_coding {
+            match self.cached_get_transcript_for_variant(&cache_variant, transcript_id) {
+                Ok(tx) => crate::project::transcript_axis::noncoding_from_coding(
+                    &cds_start,
+                    &cds_end,
+                    &tx,
+                    &c_edit,
+                    transcript_id,
+                    gene_symbol.clone(),
+                )
+                .ok(),
+                Err(_) => None,
+            }
+        } else {
+            Some(coding.clone())
+        };
+
         // `.genomic` is always the canonical g. representation. For g.
         // input that's the (normalized) input itself; for c./n./r.
         // input that's the variant produced by `project_to_genomic`.
@@ -1506,7 +1532,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Ok(VariantProjection {
             genomic: Some(projected_genome),
             coding: Some(coding),
-            noncoding: None,
+            noncoding,
             protein,
             transcript_id: transcript_id.to_string(),
             gene_symbol,
@@ -2031,6 +2057,35 @@ mod tests {
         assert!(!result.is_frameshift);
         assert!(!result.is_intronic);
         assert!(!result.is_utr);
+    }
+
+    #[test]
+    fn project_genome_pivot_coding_populates_noncoding_axis() {
+        // c↔n axis: a g. SNV projected onto a coding transcript carries BOTH
+        // the c. form and the n. form, in distinct coordinate frames.
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "NM_TEST.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. present");
+        assert!(
+            matches!(c, HgvsVariant::Cds(_)),
+            "coding should be a c. (Cds) variant, got {c:?}"
+        );
+        let n = result
+            .noncoding
+            .as_ref()
+            .expect("n. axis populated for coding tx");
+        assert!(
+            matches!(n, HgvsVariant::Tx(_)),
+            "noncoding should be an n. (Tx) variant, got {n:?}"
+        );
+        // NM_TEST.1's CDS begins at transcript position 1, so c.4 → n.4.
+        assert!(
+            n.to_string().contains(":n.4C>A"),
+            "expected n.4C>A, got {n}"
+        );
     }
 
     #[test]
@@ -2753,6 +2808,15 @@ mod tests {
             provider.add_genomic_sequence("chr1", format!("{}{}{}", prefix, "ATGCGCTAA", suffix));
             (projector, provider)
         }
+
+        // Note: the non-coding (`else`) branch of `project_single_inner` — where
+        // `noncoding` mirrors the `coding` `Tx` form — is currently unreachable
+        // via full projection: the downstream g.→c. path errors with
+        // `TranscriptNotOverlapping` for non-coding transcripts, pinned in
+        // `tests/issue_328_projector_accepts_cnr.rs`. When that path is expanded
+        // to support non-coding tx, add a `noncoding == coding` regression test
+        // here. The branch stays for forward-compatibility (correct semantics
+        // the moment the path is reachable).
 
         // -- 1: plus-strand substitution ---------------------------------------
 

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1219,20 +1219,27 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         let frameshift = is_frameshift(normalized);
 
-        // c↔n axis: derive the n. (transcript-relative) form genome-free from
-        // the resolved CDS positions. Best-effort — never fail the whole
-        // projection if the n. derivation hits an edge (e.g. legacy c.0); log
-        // and leave None.
+        // c↔n axis: derive the n. (transcript-relative) form from the resolved
+        // CDS positions via the exon/CIGAR-aware mapper. Carry the *input's*
+        // gene symbol (`cds.gene_symbol`) so the n. form matches the `coding`
+        // form (which is the raw input here) rather than disagreeing on the
+        // gene tag. Best-effort — a derivation edge (e.g. legacy c.0) is logged
+        // and leaves the axis None rather than failing the whole projection.
         let noncoding = match self.cached_get_transcript_for_variant(normalized, transcript_id) {
-            Ok(tx) => crate::project::transcript_axis::noncoding_from_coding(
+            Ok(tx) => match crate::project::transcript_axis::noncoding_from_coding(
                 &cds_start,
                 &cds_end,
                 &tx,
                 &edit,
                 transcript_id,
-                gene_symbol.clone(),
-            )
-            .ok(),
+                cds.gene_symbol.clone(),
+            ) {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    log::trace!("c→n derivation failed for {transcript_id}: {e}");
+                    None
+                }
+            },
             Err(_) => None,
         };
 
@@ -1518,15 +1525,20 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // reached, but carries the correct semantics for when it is).
         let noncoding = if is_coding {
             match self.cached_get_transcript_for_variant(&cache_variant, transcript_id) {
-                Ok(tx) => crate::project::transcript_axis::noncoding_from_coding(
+                Ok(tx) => match crate::project::transcript_axis::noncoding_from_coding(
                     &cds_start,
                     &cds_end,
                     &tx,
                     &c_edit,
                     transcript_id,
                     gene_symbol.clone(),
-                )
-                .ok(),
+                ) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        log::trace!("c→n derivation failed for {transcript_id}: {e}");
+                        None
+                    }
+                },
                 Err(_) => None,
             }
         } else {
@@ -2696,6 +2708,18 @@ mod tests {
             assert!(
                 av.variants.iter().all(|v| matches!(v, HgvsVariant::Tx(_))),
                 "every inner member of the n. allele should be an n. (Tx) variant"
+            );
+            // The fixture's inner members are g.1003→c.4 and g.1006→c.7 on
+            // NM_TEST.1 (CDS at tx pos 1), so the aggregated n. coordinates are
+            // n.4 and n.7 — pin them so an off-by-one in the derivation fails.
+            let rendered: Vec<String> = av.variants.iter().map(|v| v.to_string()).collect();
+            assert!(
+                rendered.iter().any(|s| s.contains(":n.4")),
+                "expected an n.4 member, got {rendered:?}"
+            );
+            assert!(
+                rendered.iter().any(|s| s.contains(":n.7")),
+                "expected an n.7 member, got {rendered:?}"
             );
         }
     }

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -15,6 +15,16 @@ use crate::hgvs::variant::HgvsVariant;
 pub struct VariantProjection {
     pub genomic: Option<HgvsVariant>,
     pub coding: Option<HgvsVariant>,
+    /// The `n.` (transcript-relative) representation on this transcript, when
+    /// derivable. Populated for both coding transcripts (derived genome-free
+    /// from the `c.` form via CDS-offset arithmetic) and non-coding transcripts
+    /// (the same `Tx` form also carried in `coding`). `None` when no transcript
+    /// coordinate is available (e.g. an empty allele).
+    ///
+    /// Note: for a non-coding (`NR_`) transcript `coding` *also* holds this
+    /// `Tx` form — a pre-existing quirk of the `coding` field's name. This axis
+    /// gives callers a single field that always means "the `n.` form".
+    pub noncoding: Option<HgvsVariant>,
     pub protein: Option<HgvsVariant>,
     pub transcript_id: String,
     pub gene_symbol: Option<String>,

--- a/src/project/transcript_axis.rs
+++ b/src/project/transcript_axis.rs
@@ -1,0 +1,147 @@
+//! The `c↔n` axis: derive the `n.` (transcript-relative) representation of a
+//! coding (`c.`) variant, genome-free, via CDS-offset arithmetic.
+//!
+//! `c→n` is pure transcript-local arithmetic (CDS position → transcript
+//! position through [`crate::convert::coding::cds_to_transcript_pos`]), so it is
+//! defined even for intronic positions — unlike `c→p`, which needs the spliced
+//! CDS.
+#![forbid(unsafe_code)]
+
+use crate::convert::coding::cds_to_transcript_pos;
+use crate::error::FerroError;
+use crate::hgvs::edit::NaEdit;
+use crate::hgvs::interval::TxInterval;
+use crate::hgvs::location::{CdsPos, TxPos};
+use crate::hgvs::variant::{HgvsVariant, LocEdit, TxVariant};
+use crate::project::accession::parse_accession;
+use crate::reference::transcript::Transcript;
+
+/// Convert one `c.` position to its `n.` (transcript-relative) [`TxPos`].
+///
+/// `n.base` is the transcript-frame position from `cds_to_transcript_pos`
+/// (where `c.1 → cds_start`), and any intronic `CdsPos.offset` is carried over
+/// verbatim. A coding 3'UTR base (`c.*N`) maps to a plain positive `n.`
+/// coordinate (not `n.*N`), matching `cds_to_transcript_pos`'s `cds_end + N`.
+fn cds_pos_to_tx_pos(pos: &CdsPos, transcript: &Transcript) -> Result<TxPos, FerroError> {
+    let base = cds_to_transcript_pos(pos, transcript)? as i64;
+    Ok(match pos.offset {
+        Some(offset) => TxPos::with_offset(base, offset),
+        None => TxPos::new(base),
+    })
+}
+
+/// Derive the `n.` form ([`HgvsVariant::Tx`]) of a coding variant from its
+/// resolved `c.` start/end CDS positions and transcript-axis edit.
+///
+/// The edit is identical to the one carried in the `c.` form — only the
+/// coordinate frame reframes from CDS-relative to transcript-relative.
+pub(crate) fn noncoding_from_coding(
+    cds_start: &CdsPos,
+    cds_end: &CdsPos,
+    transcript: &Transcript,
+    c_edit: &NaEdit,
+    transcript_id: &str,
+    gene_symbol: Option<String>,
+) -> Result<HgvsVariant, FerroError> {
+    let n_start = cds_pos_to_tx_pos(cds_start, transcript)?;
+    let n_end = cds_pos_to_tx_pos(cds_end, transcript)?;
+    Ok(HgvsVariant::Tx(TxVariant {
+        accession: parse_accession(transcript_id),
+        gene_symbol,
+        loc_edit: LocEdit::new(TxInterval::new(n_start, n_end), c_edit.clone()),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hgvs::edit::{Base, NaEdit};
+    use crate::reference::transcript::{Exon, ManeStatus, Strand};
+    use std::sync::OnceLock;
+
+    fn make_test_transcript() -> Transcript {
+        Transcript {
+            id: "NM_TEST.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: Some("AAAAATGCCCAAAGGGTTTTAAAAAA".to_string()), // 26 bases
+            cds_start: Some(6),
+            cds_end: Some(20),
+            exons: vec![Exon::new(1, 1, 26)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    fn sub_a_g() -> NaEdit {
+        // A>G substitution; exact bases are irrelevant to coordinate reframing.
+        // `Base` is an enum (src/hgvs/edit.rs) — construct variants directly.
+        NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        }
+    }
+
+    #[test]
+    fn cds_first_base_maps_to_cds_start_offset() {
+        // c.1 (first CDS base) → n.6 (cds_start), per cds_to_transcript_pos.
+        let tx = make_test_transcript();
+        let p = cds_pos_to_tx_pos(&CdsPos::new(1), &tx).unwrap();
+        assert_eq!(p.base, 6);
+        assert_eq!(p.offset, None);
+        assert!(!p.downstream);
+    }
+
+    #[test]
+    fn five_utr_maps_below_cds_start() {
+        // c.-1 → n.5 (cds_start - 1).
+        let tx = make_test_transcript();
+        let p = cds_pos_to_tx_pos(&CdsPos::new(-1), &tx).unwrap();
+        assert_eq!(p.base, 5);
+    }
+
+    #[test]
+    fn three_utr_maps_past_cds_end_as_plain_positive() {
+        // c.*1 → n.21 (cds_end + 1), plain positive (NOT n.* notation).
+        let tx = make_test_transcript();
+        let p = cds_pos_to_tx_pos(&CdsPos::utr3(1), &tx).unwrap();
+        assert_eq!(p.base, 21);
+        assert!(!p.downstream);
+    }
+
+    #[test]
+    fn intronic_offset_is_carried() {
+        // c.3+5 → n.8+5 : base from cds_to_transcript_pos(c.3)=8, offset +5 kept.
+        let tx = make_test_transcript();
+        let mut pos = CdsPos::new(3);
+        pos.offset = Some(5);
+        let p = cds_pos_to_tx_pos(&pos, &tx).unwrap();
+        assert_eq!(p.base, 8);
+        assert_eq!(p.offset, Some(5));
+    }
+
+    #[test]
+    fn builds_tx_variant_rendering_as_n_dot() {
+        // c.1A>G on NM_TEST.1 → n.6A>G.
+        let tx = make_test_transcript();
+        let v = noncoding_from_coding(
+            &CdsPos::new(1),
+            &CdsPos::new(1),
+            &tx,
+            &sub_a_g(),
+            "NM_TEST.1",
+            None,
+        )
+        .unwrap();
+        assert!(matches!(v, HgvsVariant::Tx(_)));
+        assert_eq!(v.to_string(), "NM_TEST.1:n.6A>G");
+    }
+}

--- a/src/project/transcript_axis.rs
+++ b/src/project/transcript_axis.rs
@@ -1,40 +1,33 @@
 //! The `c↔n` axis: derive the `n.` (transcript-relative) representation of a
-//! coding (`c.`) variant, genome-free, via CDS-offset arithmetic.
+//! coding (`c.`) variant.
 //!
-//! `c→n` is pure transcript-local arithmetic (CDS position → transcript
-//! position through [`crate::convert::coding::cds_to_transcript_pos`]), so it is
-//! defined even for intronic positions — unlike `c→p`, which needs the spliced
-//! CDS.
+//! The CDS→transcript conversion is routed through the projector's authoritative
+//! [`CoordinateMapper::cds_to_tx`] — the **same** exon- and CIGAR-aware mapping
+//! that `genome_to_cds` / `project_single_inner` already trust. A flat
+//! CDS-offset shift (`cds_start + base - 1`) would silently diverge on
+//! multi-exon transcripts with tx-coordinate gaps or on transcripts whose
+//! genome alignment carries CIGAR insertions, producing an `n.` base that
+//! disagrees with the `c.` form's true transcript position. Routing through the
+//! mapper keeps the two axes consistent and makes `c→n` defined even for
+//! intronic positions (the mapper carries the offset).
 #![forbid(unsafe_code)]
 
-use crate::convert::coding::cds_to_transcript_pos;
+use crate::convert::mapper::CoordinateMapper;
 use crate::error::FerroError;
 use crate::hgvs::edit::NaEdit;
 use crate::hgvs::interval::TxInterval;
-use crate::hgvs::location::{CdsPos, TxPos};
+use crate::hgvs::location::CdsPos;
 use crate::hgvs::variant::{HgvsVariant, LocEdit, TxVariant};
 use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
-
-/// Convert one `c.` position to its `n.` (transcript-relative) [`TxPos`].
-///
-/// `n.base` is the transcript-frame position from `cds_to_transcript_pos`
-/// (where `c.1 → cds_start`), and any intronic `CdsPos.offset` is carried over
-/// verbatim. A coding 3'UTR base (`c.*N`) maps to a plain positive `n.`
-/// coordinate (not `n.*N`), matching `cds_to_transcript_pos`'s `cds_end + N`.
-fn cds_pos_to_tx_pos(pos: &CdsPos, transcript: &Transcript) -> Result<TxPos, FerroError> {
-    let base = cds_to_transcript_pos(pos, transcript)? as i64;
-    Ok(match pos.offset {
-        Some(offset) => TxPos::with_offset(base, offset),
-        None => TxPos::new(base),
-    })
-}
 
 /// Derive the `n.` form ([`HgvsVariant::Tx`]) of a coding variant from its
 /// resolved `c.` start/end CDS positions and transcript-axis edit.
 ///
 /// The edit is identical to the one carried in the `c.` form — only the
-/// coordinate frame reframes from CDS-relative to transcript-relative.
+/// coordinate frame reframes from CDS-relative to transcript-relative, via the
+/// exon/CIGAR-aware [`CoordinateMapper::cds_to_tx`]. Intronic offsets and the
+/// 3'UTR (`c.*N` → a plain positive `n.`, not `n.*N`) are handled by the mapper.
 pub(crate) fn noncoding_from_coding(
     cds_start: &CdsPos,
     cds_end: &CdsPos,
@@ -43,8 +36,9 @@ pub(crate) fn noncoding_from_coding(
     transcript_id: &str,
     gene_symbol: Option<String>,
 ) -> Result<HgvsVariant, FerroError> {
-    let n_start = cds_pos_to_tx_pos(cds_start, transcript)?;
-    let n_end = cds_pos_to_tx_pos(cds_end, transcript)?;
+    let mapper = CoordinateMapper::new(transcript);
+    let n_start = mapper.cds_to_tx(cds_start)?;
+    let n_end = mapper.cds_to_tx(cds_end)?;
     Ok(HgvsVariant::Tx(TxVariant {
         accession: parse_accession(transcript_id),
         gene_symbol,
@@ -55,10 +49,13 @@ pub(crate) fn noncoding_from_coding(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hgvs::edit::{Base, NaEdit};
+    use crate::data::cdot::CigarOp;
+    use crate::hgvs::edit::Base;
     use crate::reference::transcript::{Exon, ManeStatus, Strand};
     use std::sync::OnceLock;
 
+    /// Single-exon coding transcript: `cds_start = 6`, `cds_end = 20`, no CIGAR.
+    /// `n.` coordinates equal plain transcript offsets and are hand-checkable.
     fn make_test_transcript() -> Transcript {
         Transcript {
             id: "NM_TEST.1".to_string(),
@@ -90,47 +87,55 @@ mod tests {
         }
     }
 
-    #[test]
-    fn cds_first_base_maps_to_cds_start_offset() {
-        // c.1 (first CDS base) → n.6 (cds_start), per cds_to_transcript_pos.
-        let tx = make_test_transcript();
-        let p = cds_pos_to_tx_pos(&CdsPos::new(1), &tx).unwrap();
-        assert_eq!(p.base, 6);
-        assert_eq!(p.offset, None);
-        assert!(!p.downstream);
+    /// Render the `n.` form of a single-position coding variant for assertions.
+    fn n_string(cds: CdsPos, tx: &Transcript, id: &str) -> String {
+        noncoding_from_coding(&cds, &cds, tx, &sub_a_g(), id, None)
+            .unwrap()
+            .to_string()
     }
 
     #[test]
-    fn five_utr_maps_below_cds_start() {
+    fn cds_first_base_renders_as_cds_start_offset() {
+        // c.1 (first CDS base) → n.6 (cds_start).
+        let tx = make_test_transcript();
+        assert_eq!(
+            n_string(CdsPos::new(1), &tx, "NM_TEST.1"),
+            "NM_TEST.1:n.6A>G"
+        );
+    }
+
+    #[test]
+    fn five_utr_renders_below_cds_start() {
         // c.-1 → n.5 (cds_start - 1).
         let tx = make_test_transcript();
-        let p = cds_pos_to_tx_pos(&CdsPos::new(-1), &tx).unwrap();
-        assert_eq!(p.base, 5);
+        assert_eq!(
+            n_string(CdsPos::new(-1), &tx, "NM_TEST.1"),
+            "NM_TEST.1:n.5A>G"
+        );
     }
 
     #[test]
-    fn three_utr_maps_past_cds_end_as_plain_positive() {
-        // c.*1 → n.21 (cds_end + 1), plain positive (NOT n.* notation).
+    fn three_utr_renders_plain_positive_not_star() {
+        // c.*1 → n.21 (cds_end + 1), plain positive — NOT n.*1 (which would mean
+        // past the transcript 3' end).
         let tx = make_test_transcript();
-        let p = cds_pos_to_tx_pos(&CdsPos::utr3(1), &tx).unwrap();
-        assert_eq!(p.base, 21);
-        assert!(!p.downstream);
+        assert_eq!(
+            n_string(CdsPos::utr3(1), &tx, "NM_TEST.1"),
+            "NM_TEST.1:n.21A>G"
+        );
     }
 
     #[test]
     fn intronic_offset_is_carried() {
-        // c.3+5 → n.8+5 : base from cds_to_transcript_pos(c.3)=8, offset +5 kept.
+        // c.3+5 → n.8+5 : base 8 (cds_start 6 + 2), intronic offset +5 carried.
         let tx = make_test_transcript();
         let mut pos = CdsPos::new(3);
         pos.offset = Some(5);
-        let p = cds_pos_to_tx_pos(&pos, &tx).unwrap();
-        assert_eq!(p.base, 8);
-        assert_eq!(p.offset, Some(5));
+        assert_eq!(n_string(pos, &tx, "NM_TEST.1"), "NM_TEST.1:n.8+5A>G");
     }
 
     #[test]
-    fn builds_tx_variant_rendering_as_n_dot() {
-        // c.1A>G on NM_TEST.1 → n.6A>G.
+    fn builds_tx_variant_not_cds() {
         let tx = make_test_transcript();
         let v = noncoding_from_coding(
             &CdsPos::new(1),
@@ -141,7 +146,50 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(matches!(v, HgvsVariant::Tx(_)));
-        assert_eq!(v.to_string(), "NM_TEST.1:n.6A>G");
+        assert!(
+            matches!(v, HgvsVariant::Tx(_)),
+            "expected an n. (Tx) variant"
+        );
+    }
+
+    #[test]
+    fn cigar_insertion_shifts_n_coordinate_vs_flat() {
+        // M1 regression: the n. derivation must route through the exon/CIGAR-aware
+        // `cds_to_tx`, not a flat CDS-offset shift. With a CIGAR insertion of 2
+        // bases before the variant, c.6 maps to n.8 — a flat `cds_start + base -
+        // 1` (= 6) would be wrong and would disagree with the c. form's true
+        // transcript position.
+        let tx = Transcript {
+            id: "NM_CIGAR.1".to_string(),
+            gene_symbol: None,
+            strand: Strand::Plus,
+            sequence: Some("A".repeat(20)),
+            cds_start: Some(1),
+            cds_end: Some(20),
+            exons: vec![Exon::new(1, 1, 20)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            // 3 matched, 2 inserted (tx bases not in genome), then 15 matched.
+            exon_cigars: vec![Some(vec![
+                CigarOp::Match(3),
+                CigarOp::Insertion(2),
+                CigarOp::Match(15),
+            ])],
+            cached_introns: OnceLock::new(),
+        };
+        // Exon/CIGAR-aware: c.6 → n.8 (the 2 inserted bases shift it up by 2).
+        assert_eq!(
+            n_string(CdsPos::new(6), &tx, "NM_CIGAR.1"),
+            "NM_CIGAR.1:n.8A>G"
+        );
+        // Consistency: matches the authoritative mapper exactly.
+        let mapper = CoordinateMapper::new(&tx);
+        assert_eq!(mapper.cds_to_tx(&CdsPos::new(6)).unwrap().base, 8);
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -673,6 +673,15 @@ impl PyVariantProjection {
         self.inner.coding.as_ref().map(|v| v.to_string())
     }
 
+    /// The n. (transcript-relative) variant as an HGVS string. Populated for
+    /// both coding transcripts (derived genome-free from the c. form) and
+    /// non-coding transcripts; None when no transcript coordinate is available
+    /// (e.g. an empty allele).
+    #[getter]
+    fn n_name(&self) -> Option<String> {
+        self.inner.noncoding.as_ref().map(|v| v.to_string())
+    }
+
     /// The p. variant as an HGVS string (None for intronic, UTR, non-coding,
     /// or non-substitution edits).
     #[getter]
@@ -707,9 +716,10 @@ impl PyVariantProjection {
 
     fn __repr__(&self) -> String {
         format!(
-            "VariantProjection(g={:?}, c={:?}, p={:?}, transcript={:?})",
+            "VariantProjection(g={:?}, c={:?}, n={:?}, p={:?}, transcript={:?})",
             self.g_name(),
             self.c_name(),
+            self.n_name(),
             self.p_name(),
             self.transcript_id()
         )


### PR DESCRIPTION
Adds a first-class `n.` (transcript-relative) axis to projection results, the next step in the axis-symmetric projection program (#507), Cycle 1b-ii.

`VariantProjection` gains a `noncoding: Option<HgvsVariant>` field carrying the `n.` form of the variant on the transcript. It's populated for coding transcripts by reframing the resolved `c.` CDS positions into transcript coordinates via the projector's existing exon- and CIGAR-aware `CoordinateMapper::cds_to_tx` — the same conversion `genome_to_cds`/`project_single_inner` already trust — so the `c.` and `n.` axes never disagree, including on multi-exon transcripts with tx-coordinate gaps or CIGAR insertions. The derivation is genome-free and is therefore defined even for intronic positions. Allele projections aggregate an `n.` allele the same all-or-nothing way as the existing `coding`/`protein` axes. Python gains a uniform `n_name` accessor.

The change is additive: `coding`'s existing semantics are unchanged (it still holds the `Tx`/`n.` form for non-coding transcripts — a pre-existing quirk left as documented debt). No existing field value, test expectation, or conformance baseline shifts.

For a non-coding (`NR_`) transcript the genome-pivot branch sets `noncoding = Some(coding.clone())`, but that branch is currently unreachable via full projection (non-coding transcript projection is pinned unsupported in `tests/issue_328_projector_accepts_cnr.rs`). It is kept as forward-compatible, documented code that carries the correct semantics the moment that path is enabled.

## Tests
- `c↔n` boundary matrix: `c.1`, `c.-N`, `c.*N` (→ a plain positive `n.`, not `n.*N`), intronic offset carry.
- CIGAR-insertion regression: `c.6 → n.8`, which a flat `cds_start + base - 1` conversion would get wrong (it would yield `n.6` and disagree with the `c.` form's true transcript position).
- Genome-pivot and bare-`NM_` integration tests asserting both `c.` and `n.` forms.
- Allele aggregation with pinned inner `n.` coordinates.

## Verification
- `cargo clippy --features dev --all-targets -- -D warnings`: clean.
- `cargo fmt --all`: clean.
- `cargo check --features python`: clean.
- Full suite minus the `FERRO_MANIFEST`-gated conformance dashboards: 6707/6707 pass. The 9 conformance-dashboard failures are pre-existing and reproduce identically on the base commit (they fail locally where the manifest is present and are skipped in CI).
