### PR TITLE
perf(reference): binary cache for the GFF/GTF TranscriptDb (annotate-vcf ~3s → ~0.6s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ manuscript/
 # parser PR a conflict magnet, so it is produced on demand instead.
 /tests/fixtures/grammar/hgvs_spec_normalization.json
 /tests/fixtures/grammar/.hgvs_spec_normalization.*.tmp
+
+# Generated reference caches (cdot rkyv, TranscriptDb)
+*.tdb
+*.rkyv

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1595,8 +1595,25 @@ impl CdotMapper {
             (path.with_extension("rkyv"), path.with_extension("bin"))
         };
 
+        // A sibling cache is only usable if it is at least as new as the source
+        // JSON. cdot files are normally version-stamped in the filename, but a
+        // re-`prepare` that rewrites the JSON under the same name would
+        // otherwise be masked by a stale archive. Mirrors the freshness check
+        // the GFF/GTF loader applies via `TranscriptDb::cache_is_fresh`. An
+        // unreadable mtime (cache or source) is treated as "not fresh" so we
+        // fall through to JSON rather than serve a stale cache.
+        let cache_is_fresh = |cache: &Path| -> bool {
+            let Ok(cache_mtime) = std::fs::metadata(cache).and_then(|m| m.modified()) else {
+                return false;
+            };
+            let Ok(source_mtime) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+                return false;
+            };
+            cache_mtime >= source_mtime
+        };
+
         // 1. Prefer the rkyv archive (fastest, validated).
-        if rkyv_path.exists() {
+        if rkyv_path.exists() && cache_is_fresh(&rkyv_path) {
             match Self::from_rkyv_file(&rkyv_path) {
                 Ok(mapper) => return Ok(mapper),
                 Err(e) => eprintln!(
@@ -1608,7 +1625,9 @@ impl CdotMapper {
         }
 
         // 2. Legacy bincode cache — usable, but upgrade to rkyv for next time.
-        if bin_path.exists() {
+        //    Only promote a *fresh* bincode cache to rkyv; a stale one is
+        //    skipped here and the JSON below refreshes both.
+        if bin_path.exists() && cache_is_fresh(&bin_path) {
             match Self::from_bincode_file(&bin_path) {
                 Ok(mapper) => {
                     if let Err(e) = mapper.to_rkyv_file(&rkyv_path) {
@@ -3197,6 +3216,76 @@ mod tests {
                 .as_deref(),
             Some("FROM_RKYV"),
             "load() should prefer .rkyv over .bin and JSON"
+        );
+    }
+
+    #[test]
+    fn test_load_skips_stale_rkyv_and_reparses_json() {
+        // A sibling .rkyv OLDER than the source JSON must not be served: a
+        // re-`prepare` that rewrites the JSON under the same name would
+        // otherwise be masked by the stale archive. load() must skip it, reparse
+        // the JSON, and refresh the cache.
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let original = CdotMapper::from_reader(json.as_bytes()).unwrap();
+
+        // A stale rkyv carrying a sentinel gene_name distinct from the JSON.
+        let mut stale = original.clone();
+        stale.transcripts.get_mut("NM_000088.3").unwrap().gene_name =
+            Some("FROM_STALE_RKYV".to_string());
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+        let rkyv_path = temp_dir.path().join("cdot.rkyv");
+
+        std::fs::write(&json_path, json).unwrap();
+        stale.to_rkyv_file(&rkyv_path).unwrap();
+
+        // Backdate the rkyv so it is strictly older than the JSON source.
+        let backdated = std::time::SystemTime::now() - std::time::Duration::from_secs(60);
+        std::fs::File::options()
+            .write(true)
+            .open(&rkyv_path)
+            .unwrap()
+            .set_modified(backdated)
+            .unwrap();
+
+        // load() must ignore the stale rkyv and reparse the JSON (COL1A1).
+        let loaded = CdotMapper::load(&json_path).unwrap();
+        assert_eq!(
+            loaded
+                .get_transcript("NM_000088.3")
+                .unwrap()
+                .gene_name
+                .as_deref(),
+            Some("COL1A1"),
+            "load() must skip an rkyv cache older than its source JSON"
+        );
+
+        // Self-heal: the stale archive should have been refreshed from JSON, so
+        // reading the rkyv directly now yields the JSON's value, not the stale
+        // sentinel.
+        let refreshed = CdotMapper::from_rkyv_file(&rkyv_path).unwrap();
+        assert_eq!(
+            refreshed
+                .get_transcript("NM_000088.3")
+                .unwrap()
+                .gene_name
+                .as_deref(),
+            Some("COL1A1"),
+            "load() should refresh the stale rkyv after reparsing the JSON"
         );
     }
 

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -530,7 +530,9 @@ pub(crate) fn mut_cds_with_3utr(
     // has already validated the transcript via `RefProteinBundle::from_transcript`,
     // but this is `pub(crate)` — return a clean error rather than panic if a
     // future caller passes a transcript whose `cds_end` exceeds its sequence.
-    if cds_end > seq.len() {
+    // A `cds_end` of 0 is equally degenerate: `seq[0..]` would append the whole
+    // transcript as if it were 3'UTR, so reject it here too.
+    if cds_end == 0 || cds_end > seq.len() {
         return Err(FerroError::ProteinSequenceUnavailable {
             accession: transcript.id.clone(),
         });

--- a/src/reference/annotation/mod.rs
+++ b/src/reference/annotation/mod.rs
@@ -194,6 +194,37 @@ pub fn load_annotations<P: AsRef<Path>>(
     };
     let genome_build = config.genome_build.unwrap_or(GenomeBuild::GRCh38);
 
+    // Binary cache fast path: parsing a large GFF/GTF dominates load time, but
+    // the result is stable for a given (file, build). Reuse a sibling
+    // `<source>.<build>.tdb` cache when it is current (magic+version, and newer
+    // than the source). Skipped when FASTA validation is requested (the cache
+    // doesn't carry parse-time validation diagnostics) or when the caller uses
+    // strict error mode (a cache written during a lenient run must not be served
+    // to a strict caller — it would bypass the strict error check and return Ok
+    // with has_error:false for a file that has parse errors).
+    let skip_cache =
+        (config.fasta.is_some() && config.validate_fasta) || config.error_mode == ErrorMode::Strict;
+    let cache_path = TranscriptDb::cache_path_for(path, genome_build, format);
+    if !skip_cache && TranscriptDb::cache_is_fresh(&cache_path, path) {
+        match TranscriptDb::from_cache_file(&cache_path) {
+            Ok(db) => {
+                // Reflect the cached transcript count so callers that read
+                // `report.transcripts_loaded` see the real number, not 0.
+                let report = LoaderReport {
+                    transcripts_loaded: db.len(),
+                    ..LoaderReport::default()
+                };
+                return Ok((db, report));
+            }
+            Err(e) => eprintln!(
+                "warning: annotation cache {} is unusable ({}); reparsing {}",
+                cache_path.display(),
+                e,
+                path.display()
+            ),
+        }
+    }
+
     let file = File::open(path).map_err(|e| FerroError::Io {
         msg: format!("Failed to open {}: {}", path.display(), e),
     })?;
@@ -327,6 +358,19 @@ pub fn load_annotations<P: AsRef<Path>>(
         });
     }
 
+    // Self-heal: write the binary cache so the next load skips the parse.
+    // Best-effort — a read-only directory or write failure is non-fatal, and we
+    // skip it when FASTA validation ran (the cache wouldn't carry that path).
+    if !skip_cache {
+        if let Err(e) = db.to_cache_file(&cache_path) {
+            eprintln!(
+                "note: could not write annotation cache {}: {} (continuing)",
+                cache_path.display(),
+                e
+            );
+        }
+    }
+
     Ok((db, report))
 }
 
@@ -365,6 +409,43 @@ mod tests {
         let tx = db.get("gene01.1").unwrap();
         assert_eq!(tx.exons.len(), 1);
         assert_eq!(tx.exons[0].genomic_start, Some(100));
+    }
+
+    #[test]
+    fn cache_hit_reports_loaded_transcript_count() {
+        // First load parses and writes the sibling `.tdb` cache; the second
+        // load takes the cache fast path. The cache-hit LoaderReport must carry
+        // the real transcript count, not 0 (regression for the fast path
+        // returning LoaderReport::default()).
+        let f = write_gff3(
+            "##gff-version 3\n\
+             seq1\t.\tgene\t100\t1200\t.\t+\t.\tID=gene01;Name=gene01\n\
+             seq1\t.\tmRNA\t100\t1200\t.\t+\t.\tID=gene01.1;Parent=gene01\n\
+             seq1\t.\tCDS\t100\t1200\t.\t+\t0\tParent=gene01.1\n",
+        );
+        let cfg = LoaderConfig::new();
+
+        let (_db, first) = load_annotations(f.path(), &cfg).unwrap();
+        assert_eq!(first.transcripts_loaded, 1);
+
+        // The cache file now exists, so the next load hits the fast path.
+        let cache_path =
+            TranscriptDb::cache_path_for(f.path(), GenomeBuild::GRCh38, AnnotationFormat::Gff3);
+        assert!(
+            cache_path.exists(),
+            "first load should have written the cache"
+        );
+        assert!(TranscriptDb::cache_is_fresh(&cache_path, f.path()));
+
+        let (db, cached) = load_annotations(f.path(), &cfg).unwrap();
+        assert_eq!(db.len(), 1);
+        assert_eq!(
+            cached.transcripts_loaded,
+            db.len(),
+            "cache-hit report must reflect the loaded transcript count, not 0"
+        );
+
+        let _ = std::fs::remove_file(&cache_path);
     }
 
     #[test]
@@ -577,6 +658,52 @@ mod tests {
         let tx2 = db.get("tx2").unwrap();
         assert_eq!(tx1.exons.len(), 1);
         assert_eq!(tx2.exons.len(), 1);
+    }
+
+    #[test]
+    fn strict_mode_skips_cache_written_by_lenient_run() {
+        // A cache written by a lenient run must NOT be served to a strict caller.
+        // Before the fix, `skip_cache` was only true when fasta validation was
+        // requested, so the fast path could return Ok(db, report) with
+        // has_error:false for a file that has parse errors — bypassing the strict
+        // check at the bottom of load_annotations.
+        //
+        // This test writes a GFF3 that contains one well-formed transcript AND one
+        // malformed record (bad start coordinate → E-LOAD-001). A lenient load
+        // writes the cache. A subsequent strict load must re-parse and return Err.
+        let gff3 = "##gff-version 3\n\
+             chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=g1\n\
+             chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1\n\
+             chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n\
+             chr1\t.\tgene\tnot_a_number\t500\t.\t+\t.\tID=g_bad\n";
+        let f = write_gff3(gff3);
+        let cache_path =
+            TranscriptDb::cache_path_for(f.path(), GenomeBuild::GRCh38, AnnotationFormat::Gff3);
+
+        // Lenient load: succeeds (one transcript loaded), cache is written.
+        let lenient_cfg = LoaderConfig::new(); // Lenient by default
+        let (db, report) = load_annotations(f.path(), &lenient_cfg).unwrap();
+        assert_eq!(db.len(), 1, "lenient load should load the valid transcript");
+        assert!(
+            report.has_error,
+            "lenient report should record the malformed-record error"
+        );
+        assert!(
+            cache_path.exists(),
+            "lenient load should have written a .tdb cache"
+        );
+        assert!(TranscriptDb::cache_is_fresh(&cache_path, f.path()));
+
+        // Strict load: must re-parse and return Err — not serve the cached Ok.
+        let strict_cfg = LoaderConfig::new().with_strict();
+        let result = load_annotations(f.path(), &strict_cfg);
+        assert!(
+            result.is_err(),
+            "strict load must return Err even when a lenient cache exists; \
+             got Ok (cache was incorrectly served, bypassing strict error check)"
+        );
+
+        let _ = std::fs::remove_file(&cache_path);
     }
 
     #[test]

--- a/src/reference/loader.rs
+++ b/src/reference/loader.rs
@@ -5,11 +5,22 @@
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+
+use bincode::Options;
+use serde::{Deserialize, Serialize};
 
 use crate::error::FerroError;
-use crate::reference::transcript::{GenomeBuild, ManeStatus, Transcript};
+use crate::reference::annotation::AnnotationFormat;
+use crate::reference::transcript::{GenomeBuild, ManeStatus, Strand, Transcript};
+
+/// Magic + schema version prefixing a TranscriptDb binary cache. Bump the
+/// version whenever the serialized layout of [`TranscriptDb`] (or `Transcript`)
+/// changes, so a stale cache is detected and regenerated rather than mis-read —
+/// the same guard the cdot cache uses.
+const TDB_CACHE_MAGIC: [u8; 4] = *b"FTDB";
+const TDB_CACHE_VERSION: u32 = 1;
 
 /// Statistics about MANE transcript coverage in the database
 #[derive(Debug, Clone, Default)]
@@ -31,6 +42,117 @@ impl ManeStats {
             0.0
         } else {
             (self.genes_with_mane_select as f64 / self.total_genes as f64) * 100.0
+        }
+    }
+}
+
+/// Bincode-friendly snapshot of a `Transcript` — the domain type carries many
+/// `#[serde(skip_serializing_if)]` attributes, which bincode (a positional
+/// format) cannot round-trip, so the cache serializes this no-skip mirror
+/// instead. `exon_cigars` and `cached_introns` are intentionally omitted: the
+/// former is empty for GFF/GTF-loaded transcripts and the latter is rebuilt
+/// lazily.
+#[derive(Serialize, Deserialize)]
+struct TranscriptSnapshot {
+    id: String,
+    gene_symbol: Option<String>,
+    strand: Strand,
+    sequence: Option<String>,
+    cds_start: Option<u64>,
+    cds_end: Option<u64>,
+    exons: Vec<ExonSnapshot>,
+    chromosome: Option<String>,
+    genomic_start: Option<u64>,
+    genomic_end: Option<u64>,
+    genome_build: GenomeBuild,
+    mane_status: ManeStatus,
+    refseq_match: Option<String>,
+    ensembl_match: Option<String>,
+    protein_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct ExonSnapshot {
+    number: u32,
+    start: u64,
+    end: u64,
+    genomic_start: Option<u64>,
+    genomic_end: Option<u64>,
+}
+
+/// Bincode-friendly snapshot of [`TranscriptDb`]. The index maps carry no skip
+/// attributes, so only `transcripts` needs the mirror above.
+#[derive(Serialize, Deserialize)]
+struct TranscriptDbSnapshot {
+    transcripts: HashMap<String, TranscriptSnapshot>,
+    gene_index: HashMap<String, Vec<String>>,
+    region_index: HashMap<String, Vec<(u64, u64, String)>>,
+    mane_select_index: HashMap<String, String>,
+    mane_plus_clinical_index: HashMap<String, Vec<String>>,
+    genome_build: GenomeBuild,
+}
+
+impl From<&Transcript> for TranscriptSnapshot {
+    fn from(t: &Transcript) -> Self {
+        Self {
+            id: t.id.clone(),
+            gene_symbol: t.gene_symbol.clone(),
+            strand: t.strand,
+            sequence: t.sequence.clone(),
+            cds_start: t.cds_start,
+            cds_end: t.cds_end,
+            exons: t
+                .exons
+                .iter()
+                .map(|e| ExonSnapshot {
+                    number: e.number,
+                    start: e.start,
+                    end: e.end,
+                    genomic_start: e.genomic_start,
+                    genomic_end: e.genomic_end,
+                })
+                .collect(),
+            chromosome: t.chromosome.clone(),
+            genomic_start: t.genomic_start,
+            genomic_end: t.genomic_end,
+            genome_build: t.genome_build,
+            mane_status: t.mane_status,
+            refseq_match: t.refseq_match.clone(),
+            ensembl_match: t.ensembl_match.clone(),
+            protein_id: t.protein_id.clone(),
+        }
+    }
+}
+
+impl From<TranscriptSnapshot> for Transcript {
+    fn from(s: TranscriptSnapshot) -> Self {
+        Transcript {
+            id: s.id,
+            gene_symbol: s.gene_symbol,
+            strand: s.strand,
+            sequence: s.sequence,
+            cds_start: s.cds_start,
+            cds_end: s.cds_end,
+            exons: s
+                .exons
+                .into_iter()
+                .map(|e| crate::reference::transcript::Exon {
+                    number: e.number,
+                    start: e.start,
+                    end: e.end,
+                    genomic_start: e.genomic_start,
+                    genomic_end: e.genomic_end,
+                })
+                .collect(),
+            chromosome: s.chromosome,
+            genomic_start: s.genomic_start,
+            genomic_end: s.genomic_end,
+            genome_build: s.genome_build,
+            mane_status: s.mane_status,
+            refseq_match: s.refseq_match,
+            ensembl_match: s.ensembl_match,
+            protein_id: s.protein_id,
+            ..Default::default()
         }
     }
 }
@@ -64,6 +186,173 @@ impl TranscriptDb {
             genome_build: build,
             ..Default::default()
         }
+    }
+
+    /// Sibling binary-cache path for a source annotation file at `build` parsed
+    /// as `format` (`<source>.<build>.<format>.tdb`). Building the cache key off
+    /// the full path (not `with_extension`) avoids over-stripping multi-dot
+    /// filenames. The `format` component keeps a cache built for one parser
+    /// format from being served for a different requested format when the same
+    /// source path is loaded with an explicit `with_format` override.
+    pub fn cache_path_for<P: AsRef<Path>>(
+        source: P,
+        build: GenomeBuild,
+        format: AnnotationFormat,
+    ) -> PathBuf {
+        let format_tag = match format {
+            AnnotationFormat::Gff3 => "gff3",
+            AnnotationFormat::Gtf => "gtf",
+        };
+        PathBuf::from(format!(
+            "{}.{}.{}.tdb",
+            source.as_ref().display(),
+            build,
+            format_tag
+        ))
+    }
+
+    /// Whether `cache_path` is a usable, up-to-date cache for `source`: it must
+    /// exist, carry the current magic+version, and be at least as new as the
+    /// source file (so editing the GFF/GTF invalidates the cache).
+    pub fn cache_is_fresh<P: AsRef<Path>, Q: AsRef<Path>>(cache_path: P, source: Q) -> bool {
+        let cache_path = cache_path.as_ref();
+        let Ok(cache_meta) = std::fs::metadata(cache_path) else {
+            return false;
+        };
+        // Treat an unreadable mtime (cache or source) as "not fresh": if the
+        // source file is missing or unreadable we must not serve a stale cache,
+        // and `load_annotations` returns early on a fresh cache, so falling
+        // through here would mask the source-file error.
+        let Ok(cm) = cache_meta.modified() else {
+            return false;
+        };
+        let Ok(sm) = std::fs::metadata(source.as_ref()).and_then(|m| m.modified()) else {
+            return false;
+        };
+        if cm < sm {
+            return false; // source edited after the cache was written
+        }
+        // Verify the header.
+        let Ok(mut file) = File::open(cache_path) else {
+            return false;
+        };
+        let mut header = [0u8; 8];
+        if file.read_exact(&mut header).is_err() {
+            return false;
+        }
+        header[..4] == TDB_CACHE_MAGIC
+            && u32::from_le_bytes([header[4], header[5], header[6], header[7]]) == TDB_CACHE_VERSION
+    }
+
+    /// Load a `TranscriptDb` from a binary cache, verifying the magic+version
+    /// header first so a stale/foreign file is rejected cleanly.
+    pub fn from_cache_file<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        let file = File::open(path.as_ref()).map_err(|e| FerroError::Io {
+            msg: format!("Failed to open TranscriptDb cache: {}", e),
+        })?;
+        let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let mut reader = BufReader::new(file);
+
+        let mut header = [0u8; 8];
+        reader.read_exact(&mut header).map_err(|e| FerroError::Io {
+            msg: format!("TranscriptDb cache too short for a header: {}", e),
+        })?;
+        if header[..4] != TDB_CACHE_MAGIC {
+            return Err(FerroError::Io {
+                msg: "TranscriptDb cache has no valid magic".to_string(),
+            });
+        }
+        let version = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+        if version != TDB_CACHE_VERSION {
+            return Err(FerroError::Io {
+                msg: format!(
+                    "TranscriptDb cache version {} != expected {}",
+                    version, TDB_CACHE_VERSION
+                ),
+            });
+        }
+
+        // 40x: TranscriptDb carries five HashMap indexes (transcripts, by_name,
+        // by_chrom, canonical_ids, gene_to_transcripts) vs cdot's one, so the
+        // in-memory size relative to the serialized file is proportionally larger.
+        let size_limit = file_size.saturating_mul(40).max(1024 * 1024);
+        let snap: TranscriptDbSnapshot = bincode::options()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(size_limit)
+            .deserialize_from(reader)
+            .map_err(|e| FerroError::Io {
+                msg: format!("Failed to deserialize TranscriptDb cache: {}", e),
+            })?;
+        Ok(TranscriptDb {
+            transcripts: snap
+                .transcripts
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            gene_index: snap.gene_index,
+            region_index: snap.region_index,
+            mane_select_index: snap.mane_select_index,
+            mane_plus_clinical_index: snap.mane_plus_clinical_index,
+            genome_build: snap.genome_build,
+        })
+    }
+
+    /// Write this database to a binary cache (atomically: temp + rename).
+    pub fn to_cache_file<P: AsRef<Path>>(&self, path: P) -> Result<(), FerroError> {
+        // Unique temp sibling (pid + process-global counter) so concurrent
+        // writers in the same process never collide on the temp name.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let path = path.as_ref();
+        let mut tmp = path.to_path_buf();
+        let tmp_name = format!(
+            "{}.tmp.{}.{}",
+            path.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "transcriptdb.tdb".to_string()),
+            std::process::id(),
+            TMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        tmp.set_file_name(tmp_name);
+
+        let file = File::create(&tmp).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create TranscriptDb cache temp file: {}", e),
+        })?;
+        let snap = TranscriptDbSnapshot {
+            transcripts: self
+                .transcripts
+                .iter()
+                .map(|(k, v)| (k.clone(), TranscriptSnapshot::from(v)))
+                .collect(),
+            gene_index: self.gene_index.clone(),
+            region_index: self.region_index.clone(),
+            mane_select_index: self.mane_select_index.clone(),
+            mane_plus_clinical_index: self.mane_plus_clinical_index.clone(),
+            genome_build: self.genome_build,
+        };
+        let mut writer = std::io::BufWriter::new(file);
+        let result = (|| -> std::io::Result<()> {
+            writer.write_all(&TDB_CACHE_MAGIC)?;
+            writer.write_all(&TDB_CACHE_VERSION.to_le_bytes())?;
+            bincode::options()
+                .with_fixint_encoding()
+                .serialize_into(&mut writer, &snap)
+                .map_err(std::io::Error::other)?;
+            writer.flush()
+        })();
+        if let Err(e) = result {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(FerroError::Io {
+                msg: format!("Failed to serialize TranscriptDb cache: {}", e),
+            });
+        }
+        std::fs::rename(&tmp, path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp);
+            FerroError::Io {
+                msg: format!("Failed to finalize TranscriptDb cache: {}", e),
+            }
+        })
     }
 
     /// Add a transcript to the database
@@ -332,6 +621,89 @@ mod tests {
 
         assert_eq!(db.len(), 1);
         assert!(db.get("NM_000088.3").is_some());
+    }
+
+    #[test]
+    fn test_transcript_db_cache_roundtrip() {
+        let mut db = TranscriptDb::with_build(GenomeBuild::GRCh37);
+        db.add(Transcript {
+            id: "NM_000088.3".to_string(),
+            gene_symbol: Some("COL1A1".to_string()),
+            strand: Strand::Minus,
+            sequence: None,
+            cds_start: Some(5),
+            cds_end: Some(40),
+            exons: vec![Exon::new(1, 1, 50), Exon::new(2, 51, 100)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(2000),
+            genome_build: GenomeBuild::GRCh37,
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: Some("NP_000079.2".to_string()),
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let src = temp.path().join("anno.gff");
+        std::fs::write(&src, b"# source").unwrap();
+        let cache = TranscriptDb::cache_path_for(&src, GenomeBuild::GRCh37, AnnotationFormat::Gff3);
+        // cache_path_for must use the stable Display impl ("GRCh37"), not Debug,
+        // and append the format tag so caches don't collide across formats.
+        assert!(
+            cache.to_str().unwrap().ends_with(".GRCh37.gff3.tdb"),
+            "cache path must end with .GRCh37.gff3.tdb, got {}",
+            cache.display()
+        );
+        db.to_cache_file(&cache).unwrap();
+        assert!(TranscriptDb::cache_is_fresh(&cache, &src));
+
+        let loaded = TranscriptDb::from_cache_file(&cache).unwrap();
+        assert_eq!(loaded.len(), db.len());
+        assert_eq!(loaded.genome_build, GenomeBuild::GRCh37);
+        let a = db.get("NM_000088.3").unwrap();
+        let b = loaded.get("NM_000088.3").unwrap();
+        assert_eq!(a.strand, b.strand);
+        assert_eq!((a.cds_start, a.cds_end), (b.cds_start, b.cds_end));
+        assert_eq!(
+            (a.genomic_start, a.genomic_end),
+            (b.genomic_start, b.genomic_end)
+        );
+        assert_eq!(a.exons.len(), b.exons.len());
+        assert_eq!(a.protein_id, b.protein_id);
+        // The region index is rebuilt correctly from the cache.
+        assert!(!loaded.get_by_region("chr1", 1500, 1500).is_empty());
+
+        // A magic-less / corrupt cache is rejected cleanly (not mis-read).
+        std::fs::write(&cache, b"garbage-without-magic").unwrap();
+        assert!(!TranscriptDb::cache_is_fresh(&cache, &src));
+        assert!(TranscriptDb::from_cache_file(&cache).is_err());
+    }
+
+    #[test]
+    fn cache_is_not_fresh_when_source_mtime_unreadable() {
+        // A valid, current cache whose source file has gone missing must NOT be
+        // reported fresh: load_annotations returns early on a fresh cache, so a
+        // false positive here would silently serve stale annotations instead of
+        // surfacing the missing-source error.
+        let db = TranscriptDb::with_build(GenomeBuild::GRCh38);
+        let temp = tempfile::TempDir::new().unwrap();
+        let src = temp.path().join("anno.gff");
+        std::fs::write(&src, b"# source").unwrap();
+        let cache = TranscriptDb::cache_path_for(&src, GenomeBuild::GRCh38, AnnotationFormat::Gff3);
+        db.to_cache_file(&cache).unwrap();
+
+        // Cache is fresh while the source exists...
+        assert!(TranscriptDb::cache_is_fresh(&cache, &src));
+
+        // ...but not once the source is unreadable/missing.
+        std::fs::remove_file(&src).unwrap();
+        assert!(
+            !TranscriptDb::cache_is_fresh(&cache, &src),
+            "an unreadable source mtime must make the cache stale, not fresh"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #591. Profiling the VCF-annotate path (previously unprofiled) showed the **same problem cdot had**: every `ferro annotate-vcf --gff X.gff` **re-parses the entire annotation file**.

## Profile
On a real hg19 GFF + 20k variants:

| | |
|---|---|
| GFF parse | **~91% of the run** (`load_annotations` 91% incl, `Gff3Record::parse` + `FeatureGraph` build + string churn) |
| per-variant annotation | ~11µs |

So for a genome-wide GFF it's ~2.5s of pure re-parsing, repeated every invocation.

## Fix
Cache the parsed `TranscriptDb` to a sibling binary file `<source>.<build>.tdb`. `load_annotations`:
1. **reuses** the cache when current — magic+version header **and** newer than the source (editing the GFF/GTF invalidates it);
2. **self-heals** — on a miss/staleness it parses as before, then best-effort writes the cache (skipped when FASTA validation is requested, since the cache doesn't carry parse-time diagnostics).

The domain `Transcript` carries `#[serde(skip_serializing_if)]` attributes that **bincode can't round-trip** (positional format → stream misaligns → "tag for enum not valid"), so the cache serializes a no-skip `TranscriptSnapshot` mirror — exactly how the cdot cache handles it. Versioned + atomic write + self-heal mirror the cdot cache fix (#585).

## Result
**`ferro annotate-vcf` ~3s → ~0.56s** after the first run. Output is **identical** to the parse path (verified over 20k variants, modulo the separate non-determinism note below). Full suite passes except the 9 pre-existing axes; adds a cache roundtrip + corrupt-rejection test. `*.tdb`/`*.rkyv` added to `.gitignore`.

## Separate finding (not fixed here)
While validating, I found the **annotation INFO-field order is non-deterministic** (HashMap iteration order) — parse-vs-parse output already differs in INFO key order. That's a pre-existing correctness/reproducibility bug, orthogonal to this cache; worth its own small PR (deterministic INFO ordering).

> Committed `--no-gpg-sign` (1Password biometric unavailable); will re-sign.