### PR TITLE
fix: make HashMap-ordered output deterministic (VCF INFO + benchmark reports)

### DIFF
--- a/src/benchmark/report.rs
+++ b/src/benchmark/report.rs
@@ -10,6 +10,15 @@ use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
 use std::path::Path;
 
+/// Iterate a map's entries in a deterministic (key-sorted) order. Report tables
+/// are written to files, so iterating the `HashMap` directly would emit dataset
+/// rows in a per-run-random order.
+fn sorted_by_key<V>(map: &HashMap<String, V>) -> Vec<(&String, &V)> {
+    let mut entries: Vec<(&String, &V)> = map.iter().collect();
+    entries.sort_by_key(|e| e.0);
+    entries
+}
+
 /// Generate a full benchmark summary from comparison files.
 pub fn generate_summary<P: AsRef<Path>>(
     parsing_dir: P,
@@ -182,7 +191,7 @@ pub fn generate_report<P: AsRef<Path>>(
             "|---------|------:|:-------------:|:---------:|--------:|"
         )?;
 
-        for (name, comp) in &summary.parsing {
+        for (name, comp) in sorted_by_key(&summary.parsing) {
             let mut_rate = comp
                 .mutalyzer
                 .as_ref()
@@ -219,7 +228,7 @@ pub fn generate_report<P: AsRef<Path>>(
             "|---------|------------:|:-------------:|:---------:|:---------:|"
         )?;
 
-        for (name, comp) in &summary.normalization {
+        for (name, comp) in sorted_by_key(&summary.normalization) {
             let mut_rate = comp
                 .mutalyzer
                 .as_ref()
@@ -348,7 +357,7 @@ pub fn generate_readme_tables<P: AsRef<Path>>(
         let mut total = 0usize;
         let mut total_success = 0usize;
 
-        for (name, comp) in &summary.parsing {
+        for (name, comp) in sorted_by_key(&summary.parsing) {
             writeln!(
                 writer,
                 "| {} | {} | {:.4}% |",

--- a/src/benchmark/runner.rs
+++ b/src/benchmark/runner.rs
@@ -267,7 +267,11 @@ pub fn run_benchmark(config: &MutalyzerBenchmarkConfig) -> Result<BenchmarkSumma
             "Copying {} successful results from existing file...",
             existing.successful_count()
         );
-        for result in existing.successful.values() {
+        // Sort by key so the copied results land in the output file in a
+        // deterministic order (`successful` is a HashMap).
+        let mut successful: Vec<_> = existing.successful.iter().collect();
+        successful.sort_by(|a, b| a.0.cmp(b.0));
+        for (_, result) in successful {
             writer.write(result)?;
             copied_successful += 1;
         }
@@ -278,7 +282,9 @@ pub fn run_benchmark(config: &MutalyzerBenchmarkConfig) -> Result<BenchmarkSumma
                 "Copying {} failed results from existing file (skip_failed=true)...",
                 existing.failed_count()
             );
-            for result in existing.failed.values() {
+            let mut failed: Vec<_> = existing.failed.iter().collect();
+            failed.sort_by(|a, b| a.0.cmp(b.0));
+            for (_, result) in failed {
                 writer.write(result)?;
                 copied_failed += 1;
             }

--- a/src/vcf/record.rs
+++ b/src/vcf/record.rs
@@ -272,7 +272,10 @@ impl fmt::Display for VcfRecord {
         if self.info.is_empty() {
             write!(f, "\t.")?;
         } else {
-            let info_str: Vec<String> = self
+            // `info` is a HashMap, whose iteration order is randomized per run.
+            // Emit fields sorted by key so VCF output is deterministic and
+            // diffable (the field order is not semantically meaningful).
+            let mut info_str: Vec<String> = self
                 .info
                 .iter()
                 .map(|(k, v)| {
@@ -283,6 +286,11 @@ impl fmt::Display for VcfRecord {
                     }
                 })
                 .collect();
+            info_str.sort_by(|a, b| {
+                let key_a = a.split('=').next().unwrap_or(a.as_str());
+                let key_b = b.split('=').next().unwrap_or(b.as_str());
+                key_a.cmp(key_b)
+            });
             write!(f, "\t{}", info_str.join(";"))?;
         }
 
@@ -422,6 +430,46 @@ mod tests {
         assert!(s.contains("rs123"));
         assert!(s.contains("A"));
         assert!(s.contains("G"));
+    }
+
+    #[test]
+    fn test_display_info_fields_are_key_sorted() {
+        // INFO is a HashMap; insertion order is irrelevant and iteration order
+        // is randomized per run. The Display output must be key-sorted so VCFs
+        // are reproducible/diffable regardless of insert order.
+        let mut record = VcfRecord::snv("chr1", 100, 'A', 'G');
+        record.info.insert(
+            "TRANSCRIPT".to_string(),
+            InfoValue::String("NM_1".to_string()),
+        );
+        record
+            .info
+            .insert("GENE".to_string(), InfoValue::String("BRCA1".to_string()));
+        record.info.insert(
+            "CONSEQUENCE".to_string(),
+            InfoValue::String("missense".to_string()),
+        );
+        record.info.insert("DB".to_string(), InfoValue::Flag);
+
+        let s = format!("{}", record);
+        let info_col = s.split('\t').nth(7).expect("INFO column");
+        assert_eq!(
+            info_col,
+            "CONSEQUENCE=missense;DB;GENE=BRCA1;TRANSCRIPT=NM_1"
+        );
+
+        // A non-flag key whose name is a prefix of a flag key must still sort
+        // before it: "AF" (with value) < "AF1" (flag). The bare-key sort avoids
+        // comparing the '=' separator against the digit '1', which would
+        // otherwise place "AF1" before "AF=0.5".
+        let mut record2 = VcfRecord::snv("chr1", 100, 'A', 'G');
+        record2.info.insert("AF1".to_string(), InfoValue::Flag);
+        record2
+            .info
+            .insert("AF".to_string(), InfoValue::String("0.5".to_string()));
+        let s2 = format!("{}", record2);
+        let info_col2 = s2.split('\t').nth(7).expect("INFO column");
+        assert_eq!(info_col2, "AF=0.5;AF1");
     }
 
     #[test]


### PR DESCRIPTION
Rust's `HashMap` iterates in a per-process-random order, so any code that turns HashMap iteration into observable output produces different results every run. This is **(a)** a fix for the VCF INFO ordering I found while building the annotate cache (#593), plus **(b)** a systematic sweep for the rest of the class.

## (a) VCF INFO field order
`VcfRecord`'s `Display` built the INFO column by iterating `info: HashMap`, so `ferro annotate-vcf` emitted INFO fields (`TRANSCRIPT`, `GENE`, `CONSEQUENCE`, `HGVS_C`, …) in a **random order** — two runs over the same input diverged in the INFO column. Fixed by sorting INFO fields by key (order is not semantically meaningful in VCF). Verified end-to-end: annotate output is now **byte-identical run-to-run**. Adds a unit test pinning key-sorted INFO output.

## (b) Systematic sweep — benchmark report/file output
A focused search for HashMap-iteration-into-output turned up 4 more, all in `src/benchmark/` writing to files:
- `report.rs` (3 sites): markdown comparison tables (`summary.parsing`, `summary.normalization`) iterated `HashMap`s → dataset rows in random order. Added a `sorted_by_key` helper.
- `runner.rs` (2 sites): copied `successful`/`failed` results into the JSONL output by iterating `HashMap`s → records in random order. Sorted by key.

The FORMAT/sample VCF columns were checked and are already deterministic (they iterate the ordered FORMAT string and look up each key, not the HashMap).

## Context
These join the same class of bug fixed earlier this effort: the cdot and FASTA `base_to_versioned` maps, which picked a *random transcript version* from HashMap iteration order (causing run-to-run coordinate flips). That makes **three subsystems** where `HashMap` order leaked into results — worth keeping in mind as a pattern (a `clippy`-style lint or a `BTreeMap`/`IndexMap` convention for output-bound maps could prevent recurrence).

Full suite passes except the 9 pre-existing reference-gated axes; clippy clean.

> Committed `--no-gpg-sign` (1Password biometric unavailable); will re-sign.