### PR TITLE
feat(parser): parse same-chromosome ring `::` deletion-join (#546)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -243,7 +243,8 @@ class HgvsVariant:
     """A parsed HGVS variant.
 
     Attributes:
-        variant_type: The type of variant (genomic, coding, non_coding, protein, rna, mitochondrial)
+        variant_type: The type of variant (genomic, coding, non_coding, protein, rna, mitochondrial,
+            circular, rna_fusion, genome_ring, allele, null_allele, unknown_allele)
         reference: The reference accession (e.g., "NM_000088.3")
         edit_type: The type of edit (substitution, deletion, duplication, insertion, delins, etc.)
     """
@@ -270,8 +271,8 @@ class HgvsVariant:
         Returns the base position (without intronic offset) for genomic, coding,
         non-coding, RNA, mitochondrial, and circular variants. For single-element
         alleles, delegates to the sub-variant. Returns None for protein variants,
-        RNA fusions, null/unknown alleles, and alleles with multiple sub-variants
-        (whose start is ambiguous).
+        RNA fusions, genome ring variants, null/unknown alleles, and alleles with
+        multiple sub-variants (whose start is ambiguous).
 
         Note: 5' UTR (``c.-5A>G``) and 3' UTR (``c.*5A>G``) positions are returned
         as raw base values and are indistinguishable from CDS positions at the same
@@ -285,7 +286,8 @@ class HgvsVariant:
 
         For point variants, end equals start. For single-element alleles,
         delegates to the sub-variant. Returns None for protein variants, RNA
-        fusions, null/unknown alleles, and alleles with multiple sub-variants.
+        fusions, genome ring variants, null/unknown alleles, and alleles with
+        multiple sub-variants.
         """
         ...
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -424,6 +424,7 @@ fn variant_type_name(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Mt(_) => "Mitochondrial (m.)",
         HgvsVariant::Circular(_) => "Circular DNA (o.)",
         HgvsVariant::RnaFusion(_) => "RNA Fusion (::)",
+        HgvsVariant::GenomeRing(_) => "Genome Ring (::)",
         HgvsVariant::Allele(_) => "Allele/Compound",
         HgvsVariant::NullAllele => "Null Allele [0]",
         HgvsVariant::UnknownAllele => "Unknown Allele [?]",

--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -388,7 +388,7 @@ fn parse_standard_accession(input: &str) -> IResult<&str, Accession> {
 
 /// Check if the input starts with something that looks like an accession
 /// (not a gene symbol). Accessions have patterns like NC_, NM_, ENST, LRG_, etc.
-fn looks_like_accession_start(input: &str) -> bool {
+pub(crate) fn looks_like_accession_start(input: &str) -> bool {
     let bytes = input.as_bytes();
     if bytes.len() < 3 {
         return false;

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -9,16 +9,18 @@ use crate::hgvs::interval::{
     CdsInterval, GenomeInterval, Interval, ProtInterval, RnaInterval, TxInterval, UncertainBoundary,
 };
 use crate::hgvs::location::{AminoAcid, CdsPos, ProtPos};
-use crate::hgvs::parser::accession::{parse_accession, parse_gene_symbol};
+use crate::hgvs::parser::accession::{
+    looks_like_accession_start, parse_accession, parse_gene_symbol,
+};
 use crate::hgvs::parser::edit::{parse_na_edit, parse_protein_edit};
 use crate::hgvs::parser::position::{
     parse_amino_acid, parse_cds_pos, parse_genome_pos, parse_prot_pos, parse_rna_pos, parse_tx_pos,
 };
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
-    Accession, AllelePhase, AlleleVariant, CdsVariant, CircularVariant, GenomeVariant, HgvsVariant,
-    LocEdit, MtVariant, ProteinVariant, RnaFusionBreakpoint, RnaFusionVariant, RnaVariant,
-    TxVariant,
+    Accession, AllelePhase, AlleleVariant, CdsVariant, CircularVariant, GenomeRing, GenomeVariant,
+    HgvsVariant, LocEdit, MtVariant, ProteinVariant, RnaFusionBreakpoint, RnaFusionVariant,
+    RnaVariant, TxVariant,
 };
 use nom::{
     branch::alt,
@@ -210,8 +212,11 @@ fn parse_genome_boundary(
         )));
     }
 
-    // Fast path: if starts with digit, it's a simple certain position
-    if bytes[0].is_ascii_digit() {
+    // Fast path: if starts with a digit or a special telomere/centromere
+    // marker (pter/qter/cen), it's a simple certain position. Special markers
+    // are needed so a complex boundary like `pter_(a_b)` or `(a_b)_qter`
+    // (ring-chromosome notation, #546) parses each end correctly.
+    if bytes[0].is_ascii_digit() || starts_with_special_pos(bytes) {
         return map(parse_genome_pos, UncertainBoundary::certain).parse(input);
     }
 
@@ -1053,12 +1058,110 @@ fn parse_rna_interval(input: &str) -> IResult<&str, RnaInterval> {
 }
 
 /// Parse genomic variant (g.)
+/// Split `input` on top-level `::` separators, scanning at both bracket (`[]`)
+/// and paren (`()`) depth 0. Ring segments themselves contain parens (e.g.
+/// `(12200001_14700000)`), so a naive `split("::")` would be safe here, but
+/// depth tracking keeps the split robust against bracketed inner forms and
+/// guards against `::` that appears inside a sub-expression. Returns the list
+/// of segment slices (always at least one element).
+fn split_top_level_double_colon(input: &str) -> Vec<&str> {
+    let bytes = input.as_bytes();
+    let mut segments: Vec<&str> = Vec::new();
+    let mut bracket_depth: i32 = 0;
+    let mut paren_depth: i32 = 0;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'[' => bracket_depth += 1,
+            b']' => bracket_depth -= 1,
+            b'(' => paren_depth += 1,
+            b')' => paren_depth -= 1,
+            b':' if bracket_depth == 0
+                && paren_depth == 0
+                && i + 1 < bytes.len()
+                && bytes[i + 1] == b':' =>
+            {
+                segments.push(&input[start..i]);
+                i += 2;
+                start = i;
+                continue;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    segments.push(&input[start..]);
+    segments
+}
+
+/// Try to parse a same-chromosome ring `::` deletion-join (#546). Returns
+/// `Some((remaining, HgvsVariant::GenomeRing(..)))` when `input` (the text
+/// after the `accession:g.` prefix) is a top-level `::`-joined sequence of two
+/// or more genome loc-edits on the single `accession`. Returns `None` (so the
+/// caller falls through to the ordinary single-variant path) when there is no
+/// top-level `::`. Returns `None` for any malformed join (a segment that fails
+/// to parse, leaves trailing input, or contains an inner `:` accession) so that
+/// cross-chromosome `::` is rejected rather than mis-parsed as a ring.
+fn try_parse_genome_ring<'a>(
+    input: &'a str,
+    accession: &Accession,
+    gene_symbol: Option<&str>,
+) -> Option<(&'a str, HgvsVariant)> {
+    let segments = split_top_level_double_colon(input);
+    // No top-level `::` → not a ring; let the single-variant path handle it.
+    if segments.len() < 2 {
+        return None;
+    }
+
+    let mut parsed_segments: Vec<LocEdit<GenomeInterval, crate::hgvs::edit::NaEdit>> =
+        Vec::with_capacity(segments.len());
+    for segment in segments {
+        // Reject a segment that names another accession: a cross-chromosome
+        // `::` (`::NC_…:g.…`) is ISCN2016, removed in ISCN2020, and spec-invalid.
+        // `looks_like_accession_start` self-documents that intent for the
+        // RefSeq/Ensembl/LRG accession shapes. We also keep the coarse
+        // `contains(':')` guard as a fallback, because bare chromosome names
+        // (`chrN:`, `1:`, contigs) do not match those shapes yet still carry an
+        // inner `:` accession separator that must be rejected.
+        if looks_like_accession_start(segment) || segment.contains(':') {
+            return None;
+        }
+        let (rest, loc_edit) = parse_genome_bracket_member(segment, GenomeKind::Genome).ok()?;
+        // Each segment must be consumed in full; trailing text means the
+        // join is malformed.
+        if !rest.is_empty() {
+            return None;
+        }
+        parsed_segments.push(loc_edit);
+    }
+
+    let ring = GenomeRing::new(
+        accession.clone(),
+        gene_symbol.map(str::to_string),
+        parsed_segments,
+    )?;
+    Some(("", HgvsVariant::GenomeRing(ring)))
+}
+
 fn parse_genome_variant(
     accession: Accession,
     gene_symbol: Option<String>,
 ) -> impl FnMut(&str) -> IResult<&str, HgvsVariant> {
     move |input: &str| {
         let (input, _) = tag("g.").parse(input)?;
+
+        // Same-chromosome ring `::` deletion-join (#546; HGVS DNA/complex.md:127).
+        // Two or more genome edits on this one accession joined by top-level
+        // `::` describe a ring chromosome. Cross-chromosome `::` (an inner
+        // accession after a `::`) is ISCN2016, removed in ISCN2020, and is
+        // rejected here by requiring every segment to parse as a bare genome
+        // loc-edit with no inner `:` accession.
+        if let Some((remaining, ring)) =
+            try_parse_genome_ring(input, &accession, gene_symbol.as_deref())
+        {
+            return Ok((remaining, ring));
+        }
 
         // First try whole-genome identity (g.= or g.(=)) - no position.
         // Reject the probe when the remainder starts with `(;)` so that a

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1078,7 +1078,10 @@ fn trans_compact_anchor(variants: &[HgvsVariant]) -> Option<&HgvsVariant> {
         };
         for leaf in leaves {
             if leaf.accession().is_none()
-                || matches!(leaf.variant_type(), "allele" | "null" | "unknown" | "r::r")
+                || matches!(
+                    leaf.variant_type(),
+                    "allele" | "null" | "unknown" | "r::r" | "g::g"
+                )
                 || leaf.is_loc_edit_unknown()
             {
                 return None;
@@ -1147,6 +1150,33 @@ fn write_accession_with_optional_gene(
         write!(f, "({})", gene)?;
     }
     Ok(())
+}
+
+/// Format the position+edit portion of a genome loc-edit (without the
+/// `accession:g.` prefix). Shared by [`GenomeVariant::fmt_loc_edit`] and
+/// [`GenomeRing`]'s `Display` so a ring segment round-trips byte-identically
+/// to a standalone genome variant.
+///
+/// Whole-entity identity (`g.=`) / unknown (`g.?`) skip the position; the
+/// predicted form wraps position+edit in parens (#241); otherwise the plain
+/// `LocEdit` Display is used.
+fn fmt_genome_loc_edit(
+    f: &mut fmt::Formatter<'_>,
+    loc_edit: &LocEdit<GenomeInterval, NaEdit>,
+) -> fmt::Result {
+    // For whole-entity identity (g.=) or unknown (g.?), skip the position.
+    if let Some(edit) = loc_edit.edit.inner() {
+        if edit.is_whole_entity() {
+            return write!(f, "{}", loc_edit.edit);
+        }
+    }
+    // Predicted form: wrap position+edit in parens. #241.
+    if loc_edit.edit.is_uncertain() {
+        if let Some(edit) = loc_edit.edit.inner() {
+            return write!(f, "({}{})", loc_edit.location, edit);
+        }
+    }
+    write!(f, "{}", loc_edit)
 }
 
 /// True iff `variant` carries a position-bound (not whole-entity)
@@ -1523,6 +1553,9 @@ pub enum HgvsVariant {
     Circular(CircularVariant),
     /// RNA Fusion variant (::) - SVD-WG007
     RnaFusion(RnaFusionVariant),
+    /// Ring chromosome: two or more genome edits on a single accession joined
+    /// by `::` break junctions (HGVS DNA/complex.md:127/130).
+    GenomeRing(GenomeRing),
     /// Allele/compound variant
     Allele(AlleleVariant),
     /// Null allele marker [0] - indicates no variant on this chromosome (hemizygous)
@@ -1547,6 +1580,7 @@ impl HgvsVariant {
             HgvsVariant::Mt(v) => Some(&v.accession),
             HgvsVariant::Circular(v) => Some(&v.accession),
             HgvsVariant::RnaFusion(v) => Some(&v.five_prime.accession),
+            HgvsVariant::GenomeRing(g) => Some(&g.accession),
             HgvsVariant::Allele(a) => a.variants.first().and_then(|v| v.accession()),
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => None,
         }
@@ -1569,6 +1603,7 @@ impl HgvsVariant {
             HgvsVariant::Protein(v) => v.gene_symbol.as_deref(),
             HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
             HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
+            HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
             HgvsVariant::RnaFusion(_)
             | HgvsVariant::Allele(_)
             | HgvsVariant::NullAllele
@@ -1587,6 +1622,7 @@ impl HgvsVariant {
             HgvsVariant::Mt(_) => "m",
             HgvsVariant::Circular(_) => "o",
             HgvsVariant::RnaFusion(_) => "r::r",
+            HgvsVariant::GenomeRing(_) => "g::g",
             HgvsVariant::Allele(_) => "allele",
             HgvsVariant::NullAllele => "null",
             HgvsVariant::UnknownAllele => "unknown",
@@ -1628,6 +1664,7 @@ impl HgvsVariant {
             HgvsVariant::Circular(v) => v.fmt_loc_edit(f),
             // These types have no compact form — fall back to full Display.
             HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
+            HgvsVariant::GenomeRing(g) => write!(f, "{}", g),
             HgvsVariant::Allele(a) => write!(f, "{}", a),
             HgvsVariant::NullAllele => write!(f, "0"),
             HgvsVariant::UnknownAllele => write!(f, "?"),
@@ -1654,6 +1691,7 @@ impl HgvsVariant {
                 Mu::Certain(e) | Mu::Uncertain(e) => e.is_whole_protein_unknown(),
             },
             HgvsVariant::RnaFusion(_)
+            | HgvsVariant::GenomeRing(_)
             | HgvsVariant::Allele(_)
             | HgvsVariant::NullAllele
             | HgvsVariant::UnknownAllele => false,
@@ -1681,7 +1719,9 @@ impl HgvsVariant {
 
         // Don't use compact form for types that aren't simple coordinate-based variants,
         // or when the first variant has no accession (e.g. NullAllele, UnknownAllele)
-        if first_acc.is_none() || matches!(first_type, "allele" | "null" | "unknown" | "r::r") {
+        if first_acc.is_none()
+            || matches!(first_type, "allele" | "null" | "unknown" | "r::r" | "g::g")
+        {
             return false;
         }
 
@@ -1713,6 +1753,7 @@ impl fmt::Display for HgvsVariant {
             HgvsVariant::Mt(v) => write!(f, "{}", v),
             HgvsVariant::Circular(v) => write!(f, "{}", v),
             HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
+            HgvsVariant::GenomeRing(g) => write!(f, "{}", g),
             HgvsVariant::Allele(a) => write!(f, "{}", a),
             HgvsVariant::NullAllele => write!(f, "0"),
             HgvsVariant::UnknownAllele => write!(f, "?"),
@@ -1731,19 +1772,7 @@ pub struct GenomeVariant {
 impl GenomeVariant {
     /// Format just the position+edit portion (without `accession:g.` prefix).
     fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // For whole-entity identity (g.=) or unknown (g.?), skip the position
-        if let Some(edit) = self.loc_edit.edit.inner() {
-            if edit.is_whole_entity() {
-                return write!(f, "{}", self.loc_edit.edit);
-            }
-        }
-        // Predicted form: wrap position+edit in parens. #241.
-        if self.loc_edit.edit.is_uncertain() {
-            if let Some(edit) = self.loc_edit.edit.inner() {
-                return write!(f, "({}{})", self.loc_edit.location, edit);
-            }
-        }
-        write!(f, "{}", self.loc_edit)
+        fmt_genome_loc_edit(f, &self.loc_edit)
     }
 }
 
@@ -1752,6 +1781,51 @@ impl fmt::Display for GenomeVariant {
         write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
         write!(f, ":g.")?;
         self.fmt_loc_edit(f)
+    }
+}
+
+/// A ring chromosome described as two or more genome edits on a single
+/// accession joined by `::` break junctions (HGVS DNA/complex.md:127/130 —
+/// the ISCN2020 meaning of `::`). Each segment is a normal genome loc-edit
+/// (typically a `del`); `Display` joins them with `::`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct GenomeRing {
+    pub accession: Accession,
+    pub gene_symbol: Option<String>,
+    pub segments: Vec<LocEdit<GenomeInterval, NaEdit>>,
+}
+
+impl GenomeRing {
+    /// Build a ring from its segments. Requires at least two segments joined
+    /// by `::` (a ring needs >= 2 break junctions on one accession); returns
+    /// `None` otherwise, since a 0/1-segment ring would not round-trip.
+    pub fn new(
+        accession: Accession,
+        gene_symbol: Option<String>,
+        segments: Vec<LocEdit<GenomeInterval, NaEdit>>,
+    ) -> Option<Self> {
+        if segments.len() < 2 {
+            return None;
+        }
+        Some(Self {
+            accession,
+            gene_symbol,
+            segments,
+        })
+    }
+}
+
+impl fmt::Display for GenomeRing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":g.")?;
+        for (i, segment) in self.segments.iter().enumerate() {
+            if i > 0 {
+                write!(f, "::")?;
+            }
+            fmt_genome_loc_edit(f, segment)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1123,6 +1123,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ),
             // RNA fusions pass through unchanged (no normalization needed for fusions)
             HV::RnaFusion(v) => (HV::RnaFusion(v.clone()), vec![]),
+            // Genome rings pass through unchanged (not normalized; #546)
+            HV::GenomeRing(g) => (HV::GenomeRing(g.clone()), vec![]),
             // Null and unknown allele markers pass through unchanged
             HV::NullAllele => (HV::NullAllele, vec![]),
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
@@ -5844,9 +5846,12 @@ fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
         HV::Rna(v) => Some(format!("{}", v.loc_edit.location)),
         HV::Mt(v) => Some(format!("{}", v.loc_edit.location)),
         HV::Circular(v) => Some(format!("{}", v.loc_edit.location)),
-        HV::Protein(_) | HV::Allele(_) | HV::RnaFusion(_) | HV::NullAllele | HV::UnknownAllele => {
-            None
-        }
+        HV::Protein(_)
+        | HV::Allele(_)
+        | HV::RnaFusion(_)
+        | HV::GenomeRing(_)
+        | HV::NullAllele
+        | HV::UnknownAllele => None,
     }
 }
 
@@ -5863,9 +5868,12 @@ fn na_edit_if_shuffleable(variant: &HgvsVariant) -> Option<&NaEdit> {
         HV::Rna(v) => &v.loc_edit.edit,
         HV::Mt(v) => &v.loc_edit.edit,
         HV::Circular(v) => &v.loc_edit.edit,
-        HV::Protein(_) | HV::Allele(_) | HV::RnaFusion(_) | HV::NullAllele | HV::UnknownAllele => {
-            return None
-        }
+        HV::Protein(_)
+        | HV::Allele(_)
+        | HV::RnaFusion(_)
+        | HV::GenomeRing(_)
+        | HV::NullAllele
+        | HV::UnknownAllele => return None,
     };
     match mu {
         crate::hgvs::Mu::Certain(e) | crate::hgvs::Mu::Uncertain(e) => Some(e),

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -327,6 +327,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             HgvsVariant::RnaFusion(_) => Err(FerroError::UnsupportedProjection {
                 reason: "project_all does not accept RNA fusion inputs".to_string(),
             }),
+            HgvsVariant::GenomeRing(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept genome ring inputs".to_string(),
+            }),
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
                 Err(FerroError::UnsupportedProjection {
                     reason: "project_all does not accept null/unknown allele inputs".to_string(),
@@ -545,6 +548,11 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             HgvsVariant::RnaFusion(_) => {
                 return Err(FerroError::UnsupportedProjection {
                     reason: "project_to_genomic does not support RNA fusion inputs".to_string(),
+                })
+            }
+            HgvsVariant::GenomeRing(_) => {
+                return Err(FerroError::UnsupportedProjection {
+                    reason: "project_to_genomic does not support genome ring inputs".to_string(),
                 })
             }
             HgvsVariant::Allele(_) => {

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -37,6 +37,7 @@ pub fn variant_type_str(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Mt(_) => "mitochondrial",
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
+        HgvsVariant::GenomeRing(_) => "genome_ring",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",
@@ -160,6 +161,7 @@ pub fn get_variant_reference(variant: &HgvsVariant) -> Result<String, &'static s
         HgvsVariant::Mt(v) => Ok(v.accession.to_string()),
         HgvsVariant::Circular(v) => Ok(v.accession.to_string()),
         HgvsVariant::RnaFusion(v) => Ok(v.five_prime.accession.to_string()),
+        HgvsVariant::GenomeRing(g) => Ok(g.accession.to_string()),
         HgvsVariant::Allele(a) => {
             if let Some(first) = a.variants.first() {
                 get_variant_reference(first)
@@ -196,6 +198,7 @@ pub fn get_variant_edit_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(v) => mu_na_edit_type_str(&v.loc_edit.edit),
         HgvsVariant::Protein(_) => "protein",
         HgvsVariant::RnaFusion(_) => "fusion",
+        HgvsVariant::GenomeRing(_) => "ring",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null",
         HgvsVariant::UnknownAllele => "unknown",
@@ -269,6 +272,7 @@ pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
         },
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
+        | HgvsVariant::GenomeRing(_)
         | HgvsVariant::NullAllele
         | HgvsVariant::UnknownAllele => None,
     }
@@ -294,6 +298,7 @@ pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
         },
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
+        | HgvsVariant::GenomeRing(_)
         | HgvsVariant::NullAllele
         | HgvsVariant::UnknownAllele => None,
     }

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -252,6 +252,7 @@ pub fn determine_consequence(ann: &HgvsAnnotation) -> Consequence {
         HgvsVariant::Mt(_) => Consequence::Unknown,
         HgvsVariant::Circular(_) => Consequence::Unknown,
         HgvsVariant::RnaFusion(_) => Consequence::Unknown, // Fusion transcripts - complex structural consequence
+        HgvsVariant::GenomeRing(_) => Consequence::Unknown, // Ring chromosome - complex structural consequence
         HgvsVariant::Allele(_) => Consequence::Unknown,
         HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => Consequence::Unknown,
     }

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -149,6 +149,11 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
                 msg: "RNA fusion (::) conversion to VCF not supported (complex structural variant)"
                     .to_string(),
             }),
+            HgvsVariant::GenomeRing(_) => Err(FerroError::ConversionError {
+                msg:
+                    "genome ring (::) conversion to VCF not supported (complex structural variant)"
+                        .to_string(),
+            }),
         }
     }
 

--- a/tests/api_comparison_tests.rs
+++ b/tests/api_comparison_tests.rs
@@ -133,6 +133,7 @@ fn get_variant_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Mt(_) => "mt",
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
+        HgvsVariant::GenomeRing(_) => "genome_ring",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",

--- a/tests/biocommons_tests.rs
+++ b/tests/biocommons_tests.rs
@@ -67,6 +67,7 @@ fn test_biocommons_valid_variants() {
                         HgvsVariant::Mt(_) => "Mt",
                         HgvsVariant::Circular(_) => "Circular",
                         HgvsVariant::RnaFusion(_) => "RnaFusion",
+                        HgvsVariant::GenomeRing(_) => "GenomeRing",
                         HgvsVariant::Allele(_) => "Allele",
                         HgvsVariant::NullAllele => "NullAllele",
                         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/clinvar_tests.rs
+++ b/tests/clinvar_tests.rs
@@ -554,6 +554,7 @@ fn get_variant_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Mt(_) => "Mt",
         HgvsVariant::Circular(_) => "Circular",
         HgvsVariant::RnaFusion(_) => "RnaFusion",
+        HgvsVariant::GenomeRing(_) => "GenomeRing",
         HgvsVariant::Allele(_) => "Allele",
         HgvsVariant::NullAllele => "NullAllele",
         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/dbsnp_tests.rs
+++ b/tests/dbsnp_tests.rs
@@ -124,6 +124,7 @@ fn get_variant_type_name(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Mt(_) => "mt",
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
+        HgvsVariant::GenomeRing(_) => "genome_ring",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",

--- a/tests/gene_selector_display_preserve.rs
+++ b/tests/gene_selector_display_preserve.rs
@@ -38,6 +38,7 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
         HgvsVariant::Protein(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
         HgvsVariant::RnaFusion(_)
         | HgvsVariant::Allele(_)
         | HgvsVariant::NullAllele

--- a/tests/gene_selector_roundtrip.rs
+++ b/tests/gene_selector_roundtrip.rs
@@ -44,6 +44,7 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
         HgvsVariant::Protein(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
         // RnaFusion, Allele: selectors live on sub-variants/breakpoints.
         HgvsVariant::RnaFusion(_)
         | HgvsVariant::Allele(_)

--- a/tests/genome_ring_join.rs
+++ b/tests/genome_ring_join.rs
@@ -1,0 +1,86 @@
+//! Same-chromosome ring `::` deletion-join (#546). HGVS DNA/complex.md:127 —
+//! the surviving ISCN2020 meaning of `::` (ring-chromosome break junction).
+//! A ring requires at least two segments (DNA/complex.md:130); a single segment
+//! or trailing empty segment is rejected by the grammar.
+use ferro_hgvs::hgvs::variant::AlleleVariant;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+#[test]
+fn ring_deletion_join_round_trips() {
+    let s = "NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+}
+
+#[test]
+fn cross_chromosome_double_colon_is_rejected() {
+    // Cross-chromosome `::` (inner accession) is ISCN2016, removed in ISCN2020
+    // and spec-invalid — must NOT parse as a ring.
+    assert!(parse_hgvs("NC_000002.12:g.pter_8247756::NC_000011.10:g.15825273_cen_qter").is_err());
+}
+
+#[test]
+fn three_segment_ring_round_trips() {
+    // exercises the join loop past the first separator
+    let s = "NC_000022.11:g.pter_1000del::2000_3000del::4000_qterdel";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+fn trailing_empty_segment_is_rejected() {
+    assert!(parse_hgvs("NC_000022.11:g.pter_1000del::").is_err());
+}
+
+#[test]
+fn plain_genome_variant_without_double_colon_is_unaffected() {
+    let s = "NC_000022.11:g.1000_2000del";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+fn genome_ring_variant_type_is_g_ring() {
+    // GenomeRing must report "g::g" (not "g") so it is distinct from a plain
+    // GenomeVariant and excluded from the compact-allele path.
+    let s = "NC_000022.11:g.pter_1000del::2000_qterdel";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(
+        v.variant_type(),
+        "g::g",
+        "GenomeRing must report variant_type \"g::g\""
+    );
+}
+
+#[test]
+fn cis_allele_of_genome_rings_uses_expanded_form() {
+    // Two GenomeRing sub-variants that share accession must NOT collapse into
+    // compact allele form `ACC:g.[seg1;seg2]` — the segments already contain
+    // `::` separators, so compact form would produce a malformed string.
+    // The expanded form `[ACC:g.seg1::seg2;ACC:g.seg3::seg4]` must be used.
+    let r1 = parse_hgvs("NC_000022.11:g.pter_1000del::2000_qterdel")
+        .unwrap_or_else(|e| panic!("must parse ring 1: {e}"));
+    let r2 = parse_hgvs("NC_000022.11:g.pter_3000del::4000_qterdel")
+        .unwrap_or_else(|e| panic!("must parse ring 2: {e}"));
+
+    // Confirm sub-variant types
+    assert_eq!(r1.variant_type(), "g::g");
+    assert_eq!(r2.variant_type(), "g::g");
+
+    // Build a programmatic cis allele and confirm it uses the expanded form.
+    let allele = HgvsVariant::Allele(AlleleVariant::cis(vec![r1, r2]));
+    let rendered = format!("{allele}");
+
+    // The expanded form emits each sub-variant with its full `ACC:g.` prefix
+    // inside the outer brackets.  A compact rendering would have only one
+    // prefix before the `[` — check that both accessions appear.
+    assert!(
+        rendered.starts_with('['),
+        "cis allele of rings must use expanded form (starts with `[`); got: {rendered}"
+    );
+    assert_eq!(
+        rendered.matches("NC_000022.11:g.").count(),
+        2,
+        "expanded form must repeat the accession prefix for each sub-variant; got: {rendered}"
+    );
+}

--- a/tests/mutalyzer_grammar_tests.rs
+++ b/tests/mutalyzer_grammar_tests.rs
@@ -78,6 +78,7 @@ fn test_mutalyzer_grammar_patterns() {
                         HgvsVariant::Mt(_) => "mitochondrial",
                         HgvsVariant::Circular(_) => "genomic",
                         HgvsVariant::RnaFusion(_) => "rna",
+                        HgvsVariant::GenomeRing(_) => "genomic",
                         HgvsVariant::Allele(_) => "allele",
                         HgvsVariant::NullAllele => "null",
                         HgvsVariant::UnknownAllele => "unknown",

--- a/tests/mutalyzer_tests.rs
+++ b/tests/mutalyzer_tests.rs
@@ -60,6 +60,7 @@ fn test_mutalyzer_valid_variants() {
                         HgvsVariant::Mt(_) => "Mt",
                         HgvsVariant::Circular(_) => "Circular",
                         HgvsVariant::RnaFusion(_) => "RnaFusion",
+                        HgvsVariant::GenomeRing(_) => "GenomeRing",
                         HgvsVariant::Allele(_) => "Allele",
                         HgvsVariant::NullAllele => "NullAllele",
                         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -65,6 +65,7 @@ fn test_parsing_from_fixtures() {
                     ferro_hgvs::HgvsVariant::Mt(_) => "MtVariant",
                     ferro_hgvs::HgvsVariant::Circular(_) => "CircularVariant",
                     ferro_hgvs::HgvsVariant::RnaFusion(_) => "RnaFusionVariant",
+                    ferro_hgvs::HgvsVariant::GenomeRing(_) => "GenomeRing",
                     ferro_hgvs::HgvsVariant::Allele(_) => "AlleleVariant",
                     ferro_hgvs::HgvsVariant::NullAllele => "NullAllele",
                     ferro_hgvs::HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/variantvalidator_tests.rs
+++ b/tests/variantvalidator_tests.rs
@@ -55,6 +55,7 @@ fn test_variantvalidator_clinical_variants() {
                     HgvsVariant::Mt(_) => "Mt",
                     HgvsVariant::Circular(_) => "Circular",
                     HgvsVariant::RnaFusion(_) => "RnaFusion",
+                    HgvsVariant::GenomeRing(_) => "GenomeRing",
                     HgvsVariant::Allele(_) => "Allele",
                     HgvsVariant::NullAllele => "NullAllele",
                     HgvsVariant::UnknownAllele => "UnknownAllele",


### PR DESCRIPTION
## Summary

Closes part of #546 (structural-variant notation). Adds support for the HGVS **same-chromosome ring `::` deletion-join**:

```
NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel
```

This is the form in `DNA/complex.md:127/130` for a ring chromosome (`r(22)`): two deletions on one accession joined by `::`. Per ISCN2020 (complex.md:38-41), `::` now designates **break-point junctions creating a ring chromosome** — the cross-chromosome translocation meaning was removed and stays rejected (those forms are `<code class="invalid">` / use the `delins` format, which ferro already parses).

## Changes

- New `HgvsVariant::GenomeRing { accession, gene_symbol, segments }` — holds the shared accession and the segment loc-edits. `Display` joins segments with `::` and round-trips byte-identically. `GenomeRing::new` enforces the `>= 2` segment invariant so an invalid ring can't be constructed outside the parser.
- Parser: the genome path detects a top-level `::` (bracket/paren-depth aware), parses each segment with the existing per-segment genome parser, requires full consumption, and rejects any segment that names another accession (cross-chromosome) via `looks_like_accession_start`.
- `parse_genome_boundary` now accepts bare `pter`/`qter`/`cen` boundary markers — required for the ring example's `pter_(a_b)` / `(a_b)_qter` locations (location boundary only; inserted-range pter/qter is a separate PR).
- DRY: the per-loc-edit genome formatter is extracted into a shared `fmt_genome_loc_edit` used by both `GenomeVariant` and `GenomeRing`.
- All exhaustive `HgvsVariant` match sites gain a `GenomeRing` arm mirroring `RnaFusion` (genome-axis accessors; normalize passthrough; convert/SPDI/VCF return the unsupported-variant error).

## Spec-fixture impact

`NC_000022.11:g.pter_(12200001_14700000)del::(37600001_410000000)_qterdel` and the structurally-identical `chr22:g.pter_10000000del::40000000_qterdel` flip `parse-error → preserved`. No new `false-acceptance` rows (baseline 75 → 75). The `[…]sup` and `…add` ring rows remain `parse-error` (deferred to the `sup` PR and a fixture-hygiene PR).

## Testing

- `tests/genome_ring_join.rs`: round-trip, 3-segment ring, cross-chromosome rejection, trailing-empty rejection, plain-genome-unaffected.
- `cargo fmt --check` + `cargo clippy --features dev --all-targets` clean.
- Full suite: only the 9 pre-existing corpus-parity environment failures.
- Reviewed in two stages (spec-compliance + code-quality).
