### PR TITLE
feat(parser): parse the sup supernumerary marker (#546)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -243,8 +243,9 @@ class HgvsVariant:
     """A parsed HGVS variant.
 
     Attributes:
-        variant_type: The type of variant (genomic, coding, non_coding, protein, rna, mitochondrial,
-            circular, rna_fusion, genome_ring, allele, null_allele, unknown_allele)
+        variant_type: The type of variant (genomic, coding, non_coding, protein, rna,
+            mitochondrial, circular, rna_fusion, genome_ring, allele, null_allele,
+            unknown_allele, supernumerary)
         reference: The reference accession (e.g., "NM_000088.3")
         edit_type: The type of edit (substitution, deletion, duplication, insertion, delins, etc.)
     """

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -425,6 +425,7 @@ fn variant_type_name(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(_) => "Circular DNA (o.)",
         HgvsVariant::RnaFusion(_) => "RNA Fusion (::)",
         HgvsVariant::GenomeRing(_) => "Genome Ring (::)",
+        HgvsVariant::Supernumerary(_) => "Supernumerary (sup)",
         HgvsVariant::Allele(_) => "Allele/Compound",
         HgvsVariant::NullAllele => "Null Allele [0]",
         HgvsVariant::UnknownAllele => "Unknown Allele [?]",

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -18,9 +18,9 @@ use crate::hgvs::parser::position::{
 };
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
-    Accession, AllelePhase, AlleleVariant, CdsVariant, CircularVariant, GenomeRing, GenomeVariant,
-    HgvsVariant, LocEdit, MtVariant, ProteinVariant, RnaFusionBreakpoint, RnaFusionVariant,
-    RnaVariant, TxVariant,
+    make_supernumerary, Accession, AllelePhase, AlleleVariant, CdsVariant, CircularVariant,
+    GenomeRing, GenomeVariant, HgvsVariant, LocEdit, MtVariant, ProteinVariant,
+    RnaFusionBreakpoint, RnaFusionVariant, RnaVariant, TxVariant,
 };
 use std::collections::HashSet;
 
@@ -1144,6 +1144,64 @@ fn try_parse_genome_ring<'a>(
         parsed_segments,
     )?;
     Some(("", HgvsVariant::GenomeRing(ring)))
+}
+
+/// Try to parse a supernumerary chromosome marker `sup` (#546; HGVS
+/// DNA/complex.md:33-34). Returns `Some(variant)` when `input` ends in `sup`
+/// and the leading description is a genome variant of one of the two
+/// spec-defined shapes:
+///
+/// - a bare supernumerary whole chromosome — `accession:g.<genome>sup` (e.g.
+///   `NC_000023.11:g.pter_qtersup`, DNA/duplication.md:117), where `<genome>`
+///   parses as an ordinary single genome variant; and
+/// - a supernumerary ring chromosome — `accession:g.[<ring>]sup` (e.g.
+///   DNA/complex.md:161), where the bracketed content parses as a
+///   [`GenomeRing`] (PR-B's `::`-join). Unlike a standalone ring the marker
+///   wraps the whole ring in `[...]`; the brackets are stripped here and
+///   re-added on `Display`.
+///
+/// Returns `None` (so the caller falls through to ordinary parsing) when the
+/// input does not end in `sup`, the inner description is not a genome variant,
+/// or the bracketed-ring content fails to parse as a ring.
+fn try_parse_supernumerary(input: &str) -> Option<HgvsVariant> {
+    let inner_str = input.strip_suffix("sup")?;
+
+    // Parse the `accession(gene)?:g.` prefix ONCE, the same way the rest of the
+    // file does (accession → optional gene-symbol → `:` → `g.` type prefix).
+    // Supernumerary is genome-only, so the type prefix must be `g.`.
+    let (remaining, accession) = parse_accession(inner_str).ok()?;
+    let (remaining, gene_symbol) = parse_gene_symbol(remaining).ok()?;
+    // Body is the post-`:` text; supernumerary is genome-only so it must start
+    // with the `g.` type prefix. `g_body` is the text after `g.`.
+    let after_colon = remaining.strip_prefix(':')?;
+    let g_body = after_colon.strip_prefix("g.")?;
+
+    let inner = if let Some(ring_body) = g_body.strip_prefix('[') {
+        // Supernumerary ring: `…g.[<ring>]sup`. Strip the closing `]` and
+        // parse the body as a `::`-joined ring on this accession.
+        let ring_body = ring_body.strip_suffix(']')?;
+        let (_, ring) = try_parse_genome_ring(ring_body, &accession, gene_symbol.as_deref())?;
+        ring
+    } else {
+        // Bare supernumerary whole chromosome: `…g.<genome>sup`. The leading
+        // text must parse as a single genome variant with nothing left over,
+        // and — per spec — the inner must be the editless / position-only
+        // whole-chromosome form (`pter_qter`). An editful inner
+        // (`pter_qterdel`, `12345A>G`, …) is not a supernumerary and must fall
+        // through to ordinary parsing (where it errors). `parse_genome_variant`
+        // re-consumes its own `g.` tag, so hand it the `g.`-prefixed body.
+        let (rest, variant) = parse_genome_variant(accession, gene_symbol)
+            .parse(after_colon)
+            .ok()?;
+        if !rest.is_empty() {
+            return None;
+        }
+        variant
+    };
+
+    // make_supernumerary enforces the inner invariant (editless whole-chromosome
+    // genome variant, or a GenomeRing); returns None for any other inner.
+    make_supernumerary(inner)
 }
 
 fn parse_genome_variant(
@@ -6496,8 +6554,22 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
         ));
     }
 
+    // Supernumerary chromosome marker `sup` (#546; HGVS DNA/complex.md:33-34).
+    // Checked before allele detection because the bracketed-ring form
+    // (`g.[<ring>]sup`) would otherwise be misrouted: the brackets here wrap a
+    // single ring expression, not a `;`-separated allele list.
+    // `try_parse_supernumerary` only engages when the input ends in `sup` and
+    // the inner is a genome description; otherwise we fall through unchanged.
+    // The result flows through the shared tail validators below.
+    let supernumerary = input
+        .ends_with("sup")
+        .then(|| try_parse_supernumerary(input))
+        .flatten();
+
     // Check for allele patterns and RNA fusion first
-    let variant = if let Some(allele_type) = detect_allele_type(input) {
+    let variant = if let Some(variant) = supernumerary {
+        variant
+    } else if let Some(allele_type) = detect_allele_type(input) {
         match allele_type {
             "cis" => parse_cis_allele(input)?,
             "trans" => parse_trans_allele(input)?,

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1534,6 +1534,8 @@ impl fmt::Display for AlleleVariant {
 /// - m. (mitochondrial)
 /// - o. (circular DNA) - SVD-WG006
 /// - RNA fusion (::) - SVD-WG007
+/// - Ring chromosome (::) — HGVS DNA/complex.md:127
+/// - sup (supernumerary chromosome marker) — HGVS DNA/complex.md:33-34
 /// - Allele (compound variants)
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum HgvsVariant {
@@ -1556,6 +1558,20 @@ pub enum HgvsVariant {
     /// Ring chromosome: two or more genome edits on a single accession joined
     /// by `::` break junctions (HGVS DNA/complex.md:127/130).
     GenomeRing(GenomeRing),
+    /// Supernumerary chromosome marker `sup` (HGVS DNA/complex.md:33-34, the
+    /// ISCN named extension for a supernumerary chromosome). Wraps the inner
+    /// genome description and renders it with a trailing `sup`.
+    ///
+    /// Two inner shapes occur in the spec:
+    /// - a supernumerary whole chromosome (`pter_qtersup`,
+    ///   DNA/duplication.md:117), where the inner is a [`HgvsVariant::Genome`]
+    ///   with a `pter_qter` interval and no edit; and
+    /// - a supernumerary ring chromosome (`[<ring>]sup`,
+    ///   DNA/complex.md:161), where the inner is a [`HgvsVariant::GenomeRing`].
+    ///   Unlike a standalone ring (which renders without brackets), the
+    ///   supernumerary ring is bracketed (`g.[<ring>]sup`) so the marker
+    ///   applies to the whole ring; `Display` adds the brackets for this case.
+    Supernumerary(Box<HgvsVariant>),
     /// Allele/compound variant
     Allele(AlleleVariant),
     /// Null allele marker [0] - indicates no variant on this chromosome (hemizygous)
@@ -1581,6 +1597,7 @@ impl HgvsVariant {
             HgvsVariant::Circular(v) => Some(&v.accession),
             HgvsVariant::RnaFusion(v) => Some(&v.five_prime.accession),
             HgvsVariant::GenomeRing(g) => Some(&g.accession),
+            HgvsVariant::Supernumerary(inner) => inner.accession(),
             HgvsVariant::Allele(a) => a.variants.first().and_then(|v| v.accession()),
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => None,
         }
@@ -1604,6 +1621,7 @@ impl HgvsVariant {
             HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
             HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
             HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
+            HgvsVariant::Supernumerary(inner) => inner.gene_symbol(),
             HgvsVariant::RnaFusion(_)
             | HgvsVariant::Allele(_)
             | HgvsVariant::NullAllele
@@ -1623,6 +1641,7 @@ impl HgvsVariant {
             HgvsVariant::Circular(_) => "o",
             HgvsVariant::RnaFusion(_) => "r::r",
             HgvsVariant::GenomeRing(_) => "g::g",
+            HgvsVariant::Supernumerary(inner) => inner.variant_type(),
             HgvsVariant::Allele(_) => "allele",
             HgvsVariant::NullAllele => "null",
             HgvsVariant::UnknownAllele => "unknown",
@@ -1665,6 +1684,7 @@ impl HgvsVariant {
             // These types have no compact form — fall back to full Display.
             HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
             HgvsVariant::GenomeRing(g) => write!(f, "{}", g),
+            HgvsVariant::Supernumerary(_) => write!(f, "{}", self),
             HgvsVariant::Allele(a) => write!(f, "{}", a),
             HgvsVariant::NullAllele => write!(f, "0"),
             HgvsVariant::UnknownAllele => write!(f, "?"),
@@ -1692,6 +1712,7 @@ impl HgvsVariant {
             },
             HgvsVariant::RnaFusion(_)
             | HgvsVariant::GenomeRing(_)
+            | HgvsVariant::Supernumerary(_)
             | HgvsVariant::Allele(_)
             | HgvsVariant::NullAllele
             | HgvsVariant::UnknownAllele => false,
@@ -1733,6 +1754,38 @@ impl HgvsVariant {
     }
 }
 
+/// True if a nucleotide-edit `Mu` wrapper is a certain, position-only identity
+/// edit (`NaEdit::Identity { sequence: None, whole_entity: false }`) — the
+/// editless "position reference" form produced when a genome interval is given
+/// with no edit (e.g. `g.pter_qter`). Used by the supernumerary whole-chromosome
+/// Display to drop the trailing `=` so `pter_qtersup` round-trips.
+///
+/// Note: this is stricter than [`is_position_identity_lhs`], which accepts any
+/// position-bound identity (`whole_entity: false`) regardless of `sequence`.
+/// This predicate additionally requires `sequence: None` (no `<ref>` written),
+/// so `g.123A=` satisfies `is_position_identity_lhs` but not this — they are not
+/// redundant.
+fn is_position_only_identity(edit: &Mu<NaEdit>) -> bool {
+    matches!(
+        edit,
+        Mu::Certain(NaEdit::Identity {
+            sequence: None,
+            whole_entity: false,
+        })
+    )
+}
+
+/// Wrap a valid supernumerary inner (an editless whole-chromosome genome
+/// variant, or a [`GenomeRing`]) in [`HgvsVariant::Supernumerary`]. Returns
+/// `None` for any other inner — `sup` only applies to those two shapes
+/// (HGVS DNA/complex.md:33-34). This is the single constructor enforcing the
+/// supernumerary invariant, mirroring [`GenomeRing::new`].
+pub(crate) fn make_supernumerary(inner: HgvsVariant) -> Option<HgvsVariant> {
+    let ok = matches!(&inner, HgvsVariant::GenomeRing(_))
+        || matches!(&inner, HgvsVariant::Genome(g) if is_position_only_identity(&g.loc_edit.edit));
+    ok.then(|| HgvsVariant::Supernumerary(Box::new(inner)))
+}
+
 /// True if a nucleotide-edit `Mu` wrapper represents the per-variant unknown form
 /// (e.g. `c.?`, `r.?`).
 fn is_na_edit_unknown(edit: &Mu<NaEdit>) -> bool {
@@ -1754,6 +1807,27 @@ impl fmt::Display for HgvsVariant {
             HgvsVariant::Circular(v) => write!(f, "{}", v),
             HgvsVariant::RnaFusion(v) => write!(f, "{}", v),
             HgvsVariant::GenomeRing(g) => write!(f, "{}", g),
+            HgvsVariant::Supernumerary(inner) => {
+                // A supernumerary ring is bracketed (`g.[<ring>]sup`); a bare
+                // supernumerary whole chromosome is not (`g.pter_qtersup`).
+                match inner.as_ref() {
+                    HgvsVariant::GenomeRing(g) => g.fmt_bracketed(f)?,
+                    // A whole-chromosome supernumerary carries a position-only
+                    // (editless) interval such as `pter_qter`; the spec form is
+                    // `pter_qtersup`, with no trailing identity `=`. Render the
+                    // location alone so `sup` attaches directly to it.
+                    HgvsVariant::Genome(v) if is_position_only_identity(&v.loc_edit.edit) => {
+                        write_accession_with_optional_gene(
+                            f,
+                            &v.accession,
+                            v.gene_symbol.as_deref(),
+                        )?;
+                        write!(f, ":g.{}", v.loc_edit.location)?;
+                    }
+                    other => write!(f, "{}", other)?,
+                }
+                write!(f, "sup")
+            }
             HgvsVariant::Allele(a) => write!(f, "{}", a),
             HgvsVariant::NullAllele => write!(f, "0"),
             HgvsVariant::UnknownAllele => write!(f, "?"),
@@ -1813,12 +1887,11 @@ impl GenomeRing {
             segments,
         })
     }
-}
 
-impl fmt::Display for GenomeRing {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
-        write!(f, ":g.")?;
+    /// Format the `::`-joined ring segments (without the `accession:g.` prefix
+    /// or any surrounding brackets). Shared by [`Display`] and
+    /// [`GenomeRing::fmt_bracketed`] so the two renderings stay in lock-step.
+    fn fmt_segments(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (i, segment) in self.segments.iter().enumerate() {
             if i > 0 {
                 write!(f, "::")?;
@@ -1826,6 +1899,25 @@ impl fmt::Display for GenomeRing {
             fmt_genome_loc_edit(f, segment)?;
         }
         Ok(())
+    }
+
+    /// Format the ring with its `::`-joined segments wrapped in `[...]`, i.e.
+    /// `accession:g.[seg1::seg2…]`. This is the shape used when the ring is the
+    /// inner of a supernumerary ring chromosome (`g.[<ring>]sup`,
+    /// DNA/complex.md:161). The standalone ring [`Display`] is unbracketed.
+    fn fmt_bracketed(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":g.[")?;
+        self.fmt_segments(f)?;
+        write!(f, "]")
+    }
+}
+
+impl fmt::Display for GenomeRing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":g.")?;
+        self.fmt_segments(f)
     }
 }
 

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1125,6 +1125,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
             HV::RnaFusion(v) => (HV::RnaFusion(v.clone()), vec![]),
             // Genome rings pass through unchanged (not normalized; #546)
             HV::GenomeRing(g) => (HV::GenomeRing(g.clone()), vec![]),
+            // Supernumerary markers pass through unchanged (not normalized; #546)
+            HV::Supernumerary(inner) => (HV::Supernumerary(inner.clone()), vec![]),
             // Null and unknown allele markers pass through unchanged
             HV::NullAllele => (HV::NullAllele, vec![]),
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
@@ -5850,6 +5852,7 @@ fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
         | HV::Allele(_)
         | HV::RnaFusion(_)
         | HV::GenomeRing(_)
+        | HV::Supernumerary(_)
         | HV::NullAllele
         | HV::UnknownAllele => None,
     }
@@ -5872,6 +5875,7 @@ fn na_edit_if_shuffleable(variant: &HgvsVariant) -> Option<&NaEdit> {
         | HV::Allele(_)
         | HV::RnaFusion(_)
         | HV::GenomeRing(_)
+        | HV::Supernumerary(_)
         | HV::NullAllele
         | HV::UnknownAllele => return None,
     };

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -330,6 +330,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             HgvsVariant::GenomeRing(_) => Err(FerroError::UnsupportedProjection {
                 reason: "project_all does not accept genome ring inputs".to_string(),
             }),
+            HgvsVariant::Supernumerary(_) => Err(FerroError::UnsupportedProjection {
+                reason: "project_all does not accept supernumerary (sup) inputs".to_string(),
+            }),
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
                 Err(FerroError::UnsupportedProjection {
                     reason: "project_all does not accept null/unknown allele inputs".to_string(),
@@ -553,6 +556,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             HgvsVariant::GenomeRing(_) => {
                 return Err(FerroError::UnsupportedProjection {
                     reason: "project_to_genomic does not support genome ring inputs".to_string(),
+                })
+            }
+            HgvsVariant::Supernumerary(_) => {
+                return Err(FerroError::UnsupportedProjection {
+                    reason: "project_to_genomic does not support supernumerary (sup) inputs"
+                        .to_string(),
                 })
             }
             HgvsVariant::Allele(_) => {

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -38,6 +38,7 @@ pub fn variant_type_str(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
         HgvsVariant::GenomeRing(_) => "genome_ring",
+        HgvsVariant::Supernumerary(_) => "supernumerary",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",
@@ -162,6 +163,7 @@ pub fn get_variant_reference(variant: &HgvsVariant) -> Result<String, &'static s
         HgvsVariant::Circular(v) => Ok(v.accession.to_string()),
         HgvsVariant::RnaFusion(v) => Ok(v.five_prime.accession.to_string()),
         HgvsVariant::GenomeRing(g) => Ok(g.accession.to_string()),
+        HgvsVariant::Supernumerary(inner) => get_variant_reference(inner),
         HgvsVariant::Allele(a) => {
             if let Some(first) = a.variants.first() {
                 get_variant_reference(first)
@@ -199,6 +201,7 @@ pub fn get_variant_edit_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Protein(_) => "protein",
         HgvsVariant::RnaFusion(_) => "fusion",
         HgvsVariant::GenomeRing(_) => "ring",
+        HgvsVariant::Supernumerary(_) => "supernumerary",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null",
         HgvsVariant::UnknownAllele => "unknown",
@@ -273,6 +276,7 @@ pub fn get_variant_start(variant: &HgvsVariant) -> Option<i64> {
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
         | HgvsVariant::GenomeRing(_)
+        | HgvsVariant::Supernumerary(_)
         | HgvsVariant::NullAllele
         | HgvsVariant::UnknownAllele => None,
     }
@@ -299,6 +303,7 @@ pub fn get_variant_end(variant: &HgvsVariant) -> Option<i64> {
         HgvsVariant::Protein(_)
         | HgvsVariant::RnaFusion(_)
         | HgvsVariant::GenomeRing(_)
+        | HgvsVariant::Supernumerary(_)
         | HgvsVariant::NullAllele
         | HgvsVariant::UnknownAllele => None,
     }
@@ -520,6 +525,12 @@ mod tests {
     fn test_variant_type_str_circular() {
         let variant = parse_hgvs("NC_001416.1:o.100A>G").unwrap();
         assert_eq!(variant_type_str(&variant), "circular");
+    }
+
+    #[test]
+    fn test_variant_type_str_supernumerary() {
+        let variant = parse_hgvs("NC_000023.11:g.pter_qtersup").unwrap();
+        assert_eq!(variant_type_str(&variant), "supernumerary");
     }
 
     #[test]

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -253,6 +253,7 @@ pub fn determine_consequence(ann: &HgvsAnnotation) -> Consequence {
         HgvsVariant::Circular(_) => Consequence::Unknown,
         HgvsVariant::RnaFusion(_) => Consequence::Unknown, // Fusion transcripts - complex structural consequence
         HgvsVariant::GenomeRing(_) => Consequence::Unknown, // Ring chromosome - complex structural consequence
+        HgvsVariant::Supernumerary(_) => Consequence::Unknown, // Supernumerary chromosome - complex structural consequence
         HgvsVariant::Allele(_) => Consequence::Unknown,
         HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => Consequence::Unknown,
     }

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -154,6 +154,11 @@ impl<'a, P: ReferenceProvider> HgvsToVcfConverter<'a, P> {
                     "genome ring (::) conversion to VCF not supported (complex structural variant)"
                         .to_string(),
             }),
+            HgvsVariant::Supernumerary(_) => Err(FerroError::ConversionError {
+                msg: "supernumerary (sup) conversion to VCF not supported \
+                      (complex structural variant)"
+                    .to_string(),
+            }),
         }
     }
 

--- a/tests/api_comparison_tests.rs
+++ b/tests/api_comparison_tests.rs
@@ -134,6 +134,7 @@ fn get_variant_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
         HgvsVariant::GenomeRing(_) => "genome_ring",
+        HgvsVariant::Supernumerary(_) => "supernumerary",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",

--- a/tests/biocommons_tests.rs
+++ b/tests/biocommons_tests.rs
@@ -68,6 +68,7 @@ fn test_biocommons_valid_variants() {
                         HgvsVariant::Circular(_) => "Circular",
                         HgvsVariant::RnaFusion(_) => "RnaFusion",
                         HgvsVariant::GenomeRing(_) => "GenomeRing",
+                        HgvsVariant::Supernumerary(_) => "Supernumerary",
                         HgvsVariant::Allele(_) => "Allele",
                         HgvsVariant::NullAllele => "NullAllele",
                         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/clinvar_tests.rs
+++ b/tests/clinvar_tests.rs
@@ -555,6 +555,7 @@ fn get_variant_type(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(_) => "Circular",
         HgvsVariant::RnaFusion(_) => "RnaFusion",
         HgvsVariant::GenomeRing(_) => "GenomeRing",
+        HgvsVariant::Supernumerary(_) => "Supernumerary",
         HgvsVariant::Allele(_) => "Allele",
         HgvsVariant::NullAllele => "NullAllele",
         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/dbsnp_tests.rs
+++ b/tests/dbsnp_tests.rs
@@ -125,6 +125,7 @@ fn get_variant_type_name(variant: &HgvsVariant) -> &'static str {
         HgvsVariant::Circular(_) => "circular",
         HgvsVariant::RnaFusion(_) => "rna_fusion",
         HgvsVariant::GenomeRing(_) => "genome_ring",
+        HgvsVariant::Supernumerary(_) => "supernumerary",
         HgvsVariant::Allele(_) => "allele",
         HgvsVariant::NullAllele => "null_allele",
         HgvsVariant::UnknownAllele => "unknown_allele",

--- a/tests/gene_selector_display_preserve.rs
+++ b/tests/gene_selector_display_preserve.rs
@@ -39,6 +39,7 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
         HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
         HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
+        HgvsVariant::Supernumerary(inner) => inner.gene_symbol(),
         HgvsVariant::RnaFusion(_)
         | HgvsVariant::Allele(_)
         | HgvsVariant::NullAllele

--- a/tests/gene_selector_roundtrip.rs
+++ b/tests/gene_selector_roundtrip.rs
@@ -45,6 +45,7 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
         HgvsVariant::Mt(v) => v.gene_symbol.as_deref(),
         HgvsVariant::Circular(v) => v.gene_symbol.as_deref(),
         HgvsVariant::GenomeRing(g) => g.gene_symbol.as_deref(),
+        HgvsVariant::Supernumerary(inner) => inner.gene_symbol(),
         // RnaFusion, Allele: selectors live on sub-variants/breakpoints.
         HgvsVariant::RnaFusion(_)
         | HgvsVariant::Allele(_)

--- a/tests/mutalyzer_grammar_tests.rs
+++ b/tests/mutalyzer_grammar_tests.rs
@@ -79,6 +79,7 @@ fn test_mutalyzer_grammar_patterns() {
                         HgvsVariant::Circular(_) => "genomic",
                         HgvsVariant::RnaFusion(_) => "rna",
                         HgvsVariant::GenomeRing(_) => "genomic",
+                        HgvsVariant::Supernumerary(_) => "supernumerary",
                         HgvsVariant::Allele(_) => "allele",
                         HgvsVariant::NullAllele => "null",
                         HgvsVariant::UnknownAllele => "unknown",

--- a/tests/mutalyzer_tests.rs
+++ b/tests/mutalyzer_tests.rs
@@ -61,6 +61,7 @@ fn test_mutalyzer_valid_variants() {
                         HgvsVariant::Circular(_) => "Circular",
                         HgvsVariant::RnaFusion(_) => "RnaFusion",
                         HgvsVariant::GenomeRing(_) => "GenomeRing",
+                        HgvsVariant::Supernumerary(_) => "Supernumerary",
                         HgvsVariant::Allele(_) => "Allele",
                         HgvsVariant::NullAllele => "NullAllele",
                         HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -66,6 +66,7 @@ fn test_parsing_from_fixtures() {
                     ferro_hgvs::HgvsVariant::Circular(_) => "CircularVariant",
                     ferro_hgvs::HgvsVariant::RnaFusion(_) => "RnaFusionVariant",
                     ferro_hgvs::HgvsVariant::GenomeRing(_) => "GenomeRing",
+                    ferro_hgvs::HgvsVariant::Supernumerary(_) => "Supernumerary",
                     ferro_hgvs::HgvsVariant::Allele(_) => "AlleleVariant",
                     ferro_hgvs::HgvsVariant::NullAllele => "NullAllele",
                     ferro_hgvs::HgvsVariant::UnknownAllele => "UnknownAllele",

--- a/tests/supernumerary.rs
+++ b/tests/supernumerary.rs
@@ -1,0 +1,38 @@
+//! `sup` supernumerary marker (#546). HGVS duplication.md:117 (whole-chromosome
+//! supernumerary) and complex.md:161 (supernumerary ring chromosome).
+use ferro_hgvs::parse_hgvs;
+
+#[test]
+fn supernumerary_whole_chromosome_round_trips() {
+    let s = "NC_000023.11:g.pter_qtersup";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+fn supernumerary_ring_round_trips() {
+    let s = "NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+#[allow(clippy::single_element_loop)] // kept as a table for future sup forms
+fn supernumerary_with_gene_symbol_accession_round_trips() {
+    for s in ["NC_000023.11(SOMEGENE):g.pter_qtersup"] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s);
+    }
+}
+
+#[test]
+fn sup_on_an_editful_bare_variant_is_rejected() {
+    // `sup` applies only to the editless whole-chromosome form, not to an edit.
+    assert!(parse_hgvs("NC_000023.11:g.12345A>Gsup").is_err());
+    assert!(parse_hgvs("NC_000023.11:g.pter_qterdelsup").is_err());
+}
+
+#[test]
+fn sup_on_non_genome_variant_is_rejected() {
+    assert!(parse_hgvs("NM_000088.3:c.5A>Gsup").is_err());
+}

--- a/tests/variantvalidator_tests.rs
+++ b/tests/variantvalidator_tests.rs
@@ -56,6 +56,7 @@ fn test_variantvalidator_clinical_variants() {
                     HgvsVariant::Circular(_) => "Circular",
                     HgvsVariant::RnaFusion(_) => "RnaFusion",
                     HgvsVariant::GenomeRing(_) => "GenomeRing",
+                    HgvsVariant::Supernumerary(_) => "Supernumerary",
                     HgvsVariant::Allele(_) => "Allele",
                     HgvsVariant::NullAllele => "NullAllele",
                     HgvsVariant::UnknownAllele => "UnknownAllele",


### PR DESCRIPTION
## Summary

Closes part of #546. Adds the HGVS **`sup` supernumerary-chromosome marker** (DNA/complex.md:33-34) in its two recommended forms:

```
NC_000023.11:g.pter_qtersup                                                   # supernumerary whole chromosome (duplication.md:117)
NC_000022.11:g.[pter_(12200001_14700000)del::(37600001_410000000)_qterdel]sup # supernumerary ring (complex.md:161)
```

Both round-trip byte-identically.

> **Stacked on #595** (ring `::` join) — the supernumerary ring wraps a `GenomeRing`. Review/merge #595 first; this PR's base is `feat/issue-546-ring-join`.

## Changes

- New `HgvsVariant::Supernumerary(Box<HgvsVariant>)`. A `make_supernumerary` constructor enforces the invariant that the inner is either an **editless position-only** genome variant or a `GenomeRing` — so the AST cannot represent a meaningless `sup`-of-an-edit.
- `Display`: the bare whole-chromosome form renders without brackets; the ring form renders bracketed (`g.[...]sup`). Standalone `GenomeRing` Display is unchanged (a shared `fmt_segments` is used by both the plain and bracketed renderings).
- Parser: strips a trailing `sup`, parses accession + optional gene symbol + `g.` via the shared prefix primitives (no string-surgery), then branches on a leading `[` (ring) vs the editless bare interval. Checked before allele detection so `[...]sup` is not misrouted through the `;`-allele-list path. An editful bare variant (`g.…delsup`, `g.…A>Gsup`) and a non-genome inner are rejected.
- All exhaustive `HgvsVariant` match sites gain a `Supernumerary` arm delegating to the inner for accessors and treating it as unsupported for convert/SPDI/VCF, mirroring `GenomeRing`/`RnaFusion`.

## Spec-fixture impact

`NC_000023.11:g.pter_qtersup` and the `[…]sup` ring row flip `parse-error → preserved`. No new `false-acceptance` (baseline 75 → 75). `chr14:g.[pter_cen_qter]add` stays `parse-error` (deprecated `add` marker; handled by the later fixture-hygiene PR).

## Testing

- `tests/supernumerary.rs`: both round-trips, gene-symbol accession form, and rejection of editful-bare / non-genome `sup`.
- `cargo fmt --check` + `cargo clippy --features dev --all-targets` clean.
- Full suite: only the 9 pre-existing corpus-parity environment failures.
- Two-stage review (spec-compliance + code-quality), with the parser unified and the bare path restricted to the editless form per review.
