### PR TITLE
feat(parser): accept pter/qter endpoints in inserted position-ranges (#546)

### DIFF
--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -2,7 +2,7 @@
 //!
 //! Edits describe the actual change (substitution, deletion, insertion, etc.)
 
-use super::location::AminoAcid;
+use super::location::{AminoAcid, GenomePos};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::str::FromStr;
@@ -218,6 +218,12 @@ pub enum InsertedSequence {
     /// This refers to positions in the same reference sequence
     PositionRange { start: u64, end: u64 },
     /// Position range with inversion (e.g., delins86116_86422inv)
+    ///
+    /// Note: this is the all-numeric inverted range. When an endpoint is a special
+    /// position (`pter`/`qter`/`cen`), inversion is instead folded into the
+    /// `inverted: bool` field of [`InsertedSequence::SpecialPositionRange`] rather
+    /// than a separate variant — a future author pattern-matching `PositionRangeInv`
+    /// should also consider `SpecialPositionRange`.
     PositionRangeInv { start: u64, end: u64 },
     /// Inserted copy of a single region with uncertain (parenthesized) start
     /// and end boundaries, inserted in inverted orientation
@@ -231,6 +237,19 @@ pub enum InsertedSequence {
         start: (u64, u64),
         /// Uncertain end position `(min, max)`.
         end: (u64, u64),
+    },
+    /// An inserted genome position-range where one or both endpoints are special
+    /// positions (`pter`/`qter`/`cen`), optionally inverted — e.g.
+    /// `delins102425452_qterinv`, `delinspter_26393001inv` (HGVS DNA/complex.md:94-95).
+    /// Genome-only (special positions don't apply to c./n./r.); all-numeric inserted
+    /// ranges stay on `PositionRange`/`PositionRangeInv`.
+    SpecialPositionRange {
+        /// Range start position (may be a special position).
+        start: GenomePos,
+        /// Range end position (may be a special position).
+        end: GenomePos,
+        /// Whether the inserted range is in inverted orientation.
+        inverted: bool,
     },
     /// Uncertain sequence (e.g., delins(?))
     Uncertain,
@@ -333,6 +352,17 @@ impl fmt::Display for InsertedSequence {
             InsertedSequence::UncertainRangeInv { start, end } => {
                 write!(f, "({}_{})_({}_{})inv", start.0, start.1, end.0, end.1)
             }
+            InsertedSequence::SpecialPositionRange {
+                start,
+                end,
+                inverted,
+            } => {
+                write!(f, "{}_{}", start, end)?;
+                if *inverted {
+                    write!(f, "inv")?;
+                }
+                Ok(())
+            }
             InsertedSequence::Uncertain => write!(f, "(?)"),
             InsertedSequence::Empty => Ok(()),
         }
@@ -403,6 +433,7 @@ impl InsertedSequence {
             InsertedSequence::PositionRange { start, end } => Some((end - start + 1) as usize),
             InsertedSequence::PositionRangeInv { start, end } => Some((end - start + 1) as usize),
             InsertedSequence::UncertainRangeInv { .. } => None, // Boundaries uncertain
+            InsertedSequence::SpecialPositionRange { .. } => None, // No fixed length (special pos)
             InsertedSequence::Uncertain => None,                // Unknown
             InsertedSequence::Empty => Some(0),
         }
@@ -444,6 +475,14 @@ impl InsertedSequence {
             InsertedSequence::PositionRangeInv { start, end } => format!("{}_{}inv", start, end),
             InsertedSequence::UncertainRangeInv { start, end } => {
                 format!("({}_{})_({}_{})inv", start.0, start.1, end.0, end.1)
+            }
+            InsertedSequence::SpecialPositionRange {
+                start,
+                end,
+                inverted,
+            } => {
+                let suffix = if *inverted { "inv" } else { "" };
+                format!("{}_{}{}", start, end, suffix)
             }
             InsertedSequence::Uncertain => String::from("(?)"),
             InsertedSequence::Empty => String::new(),

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -7,7 +7,9 @@ use crate::hgvs::edit::{
     MethylationStatus, NaEdit, ProteinEdit, RepeatCount, RepeatUnit, Sequence,
 };
 use crate::hgvs::location::AminoAcid;
-use crate::hgvs::parser::position::{parse_amino_acid, parse_amino_acid_one_letter};
+use crate::hgvs::parser::position::{
+    parse_amino_acid, parse_amino_acid_one_letter, parse_genome_pos, special_pos_marker_len,
+};
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
@@ -267,16 +269,26 @@ fn parse_deletion(input: &str) -> IResult<&str, NaEdit> {
 }
 
 /// Parse an insertion (e.g., insA, insATG, ins10, ins(10), ins(10_20), insA[10], ins[A[10];T])
-fn parse_insertion(input: &str) -> IResult<&str, NaEdit> {
+fn parse_insertion(input: &str, allow_special_positions: bool) -> IResult<&str, NaEdit> {
     let (input, _) = tag("ins").parse(input)?;
-    let (input, sequence) = parse_inserted_sequence(input)?;
+    let (input, sequence) = parse_inserted_sequence(input, allow_special_positions)?;
     Ok((input, NaEdit::Insertion { sequence }))
 }
 
 /// Parse an inserted sequence in any format
+///
+/// `allow_special_positions` gates the genome-only special-position inserted
+/// range (`pter`/`qter`/`cen` endpoints, e.g. `delins102425452_qterinv`). It is
+/// `true` only on the genome-family edit-parse path; for c./n./r./p. it is
+/// `false` so those coordinate systems reject special positions in an inserted
+/// range (they are genome-only per HGVS DNA/complex.md).
+///
 /// Optimized with byte-based dispatch to avoid trying multiple alternatives
 #[inline]
-fn parse_inserted_sequence(input: &str) -> IResult<&str, InsertedSequence> {
+fn parse_inserted_sequence(
+    input: &str,
+    allow_special_positions: bool,
+) -> IResult<&str, InsertedSequence> {
     let bytes = input.as_bytes();
 
     if bytes.is_empty() {
@@ -290,6 +302,19 @@ fn parse_inserted_sequence(input: &str) -> IResult<&str, InsertedSequence> {
     if let Some(reference) = parse_reference_location(input) {
         let ref_len = reference.len();
         return Ok((&input[ref_len..], InsertedSequence::Reference(reference)));
+    }
+
+    // Inserted genome position-range with a special-position endpoint
+    // (pter/qter/cen), e.g. `pter_26393001inv` or `102425452_qterinv`
+    // (HGVS DNA/complex.md:94-95). Genome-only: only attempted on the
+    // genome-family edit-parse path (`allow_special_positions`). This must be
+    // tried before the numeric and named-element dispatch below. It only
+    // succeeds when at least one endpoint is special, so all-numeric ranges
+    // fall through unchanged.
+    if allow_special_positions && (starts_with_special_pos(bytes) || bytes[0].is_ascii_digit()) {
+        if let Ok((remaining, seq)) = parse_special_position_range(input) {
+            return Ok((remaining, seq));
+        }
     }
 
     match bytes[0] {
@@ -864,10 +889,53 @@ fn parse_simple_count(input: &str) -> IResult<&str, InsertedSequence> {
     Ok((remaining, InsertedSequence::Count(start)))
 }
 
+/// Check whether the input starts with a special position marker (pter/qter/cen).
+#[inline]
+fn starts_with_special_pos(bytes: &[u8]) -> bool {
+    special_pos_marker_len(bytes).is_some()
+}
+
+/// Parse an inserted genome position-range where at least one endpoint is a
+/// special position (`pter`/`qter`/`cen`), with an optional trailing `inv` —
+/// e.g. `102425452_qterinv`, `pter_26393001inv` (HGVS DNA/complex.md:94-95).
+///
+/// Special positions are genome-only, so the all-numeric inserted ranges
+/// (`850_900`, `850_900inv`) are deliberately left to
+/// `PositionRange`/`PositionRangeInv`: this parser fails unless at least one
+/// endpoint is special, so it never disturbs the numeric path.
+fn parse_special_position_range(input: &str) -> IResult<&str, InsertedSequence> {
+    let (remaining, start) = parse_genome_pos(input)?;
+    let (remaining, _) = char('_').parse(remaining)?;
+    let (remaining, end) = parse_genome_pos(remaining)?;
+
+    // Genome-only construct: require at least one special endpoint so that
+    // all-numeric ranges keep their existing `PositionRange` representation.
+    if !start.is_special() && !end.is_special() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    let (remaining, inverted) = match tag::<_, _, nom::error::Error<&str>>("inv").parse(remaining) {
+        Ok((rest, _)) => (rest, true),
+        Err(_) => (remaining, false),
+    };
+
+    Ok((
+        remaining,
+        InsertedSequence::SpecialPositionRange {
+            start,
+            end,
+            inverted,
+        },
+    ))
+}
+
 /// Parse a delins (e.g., delinsA, delinsATG, delins10, delins(10_20), delinsA[10])
-fn parse_delins(input: &str) -> IResult<&str, NaEdit> {
+fn parse_delins(input: &str, allow_special_positions: bool) -> IResult<&str, NaEdit> {
     let (input, _) = tag("delins").parse(input)?;
-    let (input, sequence) = parse_inserted_sequence(input)?;
+    let (input, sequence) = parse_inserted_sequence(input, allow_special_positions)?;
     Ok((
         input,
         NaEdit::Delins {
@@ -885,11 +953,14 @@ fn parse_delins(input: &str) -> IResult<&str, NaEdit> {
 /// appears in databases. ferro preserves the explicit deleted sequence so
 /// `parse → Display` round-trips faithfully; `canonicalize_edit` strips it
 /// back to the short form when canonicalization is requested.
-fn parse_delins_with_deleted_seq(input: &str) -> IResult<&str, NaEdit> {
+fn parse_delins_with_deleted_seq(
+    input: &str,
+    allow_special_positions: bool,
+) -> IResult<&str, NaEdit> {
     let (input, _) = tag("del").parse(input)?;
     let (input, deleted_seq) = parse_sequence(input)?;
     let (input, _) = tag("ins").parse(input)?;
-    let (input, inserted_seq) = parse_inserted_sequence(input)?;
+    let (input, inserted_seq) = parse_inserted_sequence(input, allow_special_positions)?;
 
     Ok((
         input,
@@ -905,11 +976,14 @@ fn parse_delins_with_deleted_seq(input: &str) -> IResult<&str, NaEdit> {
 ///
 /// As with explicit deleted sequence, the spec prefers the short form but
 /// ferro preserves the count for round-trip fidelity.
-fn parse_delins_with_deleted_count(input: &str) -> IResult<&str, NaEdit> {
+fn parse_delins_with_deleted_count(
+    input: &str,
+    allow_special_positions: bool,
+) -> IResult<&str, NaEdit> {
     let (input, _) = tag("del").parse(input)?;
     let (input, deleted_count_str) = digit1.parse(input)?;
     let (input, _) = tag("ins").parse(input)?;
-    let (input, inserted_seq) = parse_inserted_sequence(input)?;
+    let (input, inserted_seq) = parse_inserted_sequence(input, allow_special_positions)?;
 
     let deleted_count: u64 = deleted_count_str.parse().unwrap_or(0);
 
@@ -926,9 +1000,9 @@ fn parse_delins_with_deleted_count(input: &str) -> IResult<&str, NaEdit> {
 /// Parse a dupins (duplication followed by insertion, e.g., dupinsCTCA)
 /// This is a non-standard but commonly used notation in databases like ClinVar
 #[inline]
-fn parse_dupins(input: &str) -> IResult<&str, NaEdit> {
+fn parse_dupins(input: &str, allow_special_positions: bool) -> IResult<&str, NaEdit> {
     let (input, _) = tag("dupins").parse(input)?;
-    let (input, sequence) = parse_inserted_sequence(input)?;
+    let (input, sequence) = parse_inserted_sequence(input, allow_special_positions)?;
     Ok((input, NaEdit::DupIns { sequence }))
 }
 
@@ -1515,16 +1589,39 @@ fn parse_reference_sequence(input: &str) -> IResult<&str, NaEdit> {
 
 /// Parse any nucleic acid edit
 pub fn parse_na_edit(input: &str) -> IResult<&str, NaEdit> {
+    // Non-genome coordinate systems (c./n./r.): special positions
+    // (pter/qter/cen) are not allowed in an inserted range.
+    parse_na_edit_inner(input, false)
+}
+
+/// Parse a nucleic-acid edit on the genome-family axis (g./m./o.).
+///
+/// Identical to [`parse_na_edit`] except that special-position inserted ranges
+/// (`pter`/`qter`/`cen` endpoints, e.g. `delins102425452_qterinv`) are allowed,
+/// since special positions are genome-only (HGVS DNA/complex.md).
+pub fn parse_genome_na_edit(input: &str) -> IResult<&str, NaEdit> {
+    parse_na_edit_inner(input, true)
+}
+
+/// Shared implementation of the nucleic-acid edit parser.
+///
+/// `allow_special_positions` is threaded into the inserted-sequence parser so
+/// that the genome-only special-position inserted range is accepted only on the
+/// genome-family axis (see [`parse_genome_na_edit`]).
+fn parse_na_edit_inner(input: &str, allow_special_positions: bool) -> IResult<&str, NaEdit> {
     alt((
         parse_substitution,
         parse_substitution_no_ref,    // Substitution without ref (e.g., >A)
         parse_multibase_substitution, // Must come after substitution (e.g., GG>G)
-        parse_delins_with_deleted_seq, // Must come before delins and deletion (e.g., delAinsT)
-        parse_delins_with_deleted_count, // Must come before delins and deletion (e.g., del35insTA)
-        parse_delins,                 // Must come before deletion
+        // Must come before delins and deletion (e.g., delAinsT)
+        |i| parse_delins_with_deleted_seq(i, allow_special_positions),
+        // Must come before delins and deletion (e.g., del35insTA)
+        |i| parse_delins_with_deleted_count(i, allow_special_positions),
+        |i| parse_delins(i, allow_special_positions), // Must come before deletion
         parse_deletion,
-        parse_insertion,
-        parse_dupins, // Must come before duplication (dupins starts with dup)
+        |i| parse_insertion(i, allow_special_positions),
+        // Must come before duplication (dupins starts with dup)
+        |i| parse_dupins(i, allow_special_positions),
         parse_duplication,
         parse_inversion,
         parse_conversion,  // Gene conversion

--- a/src/hgvs/parser/position.rs
+++ b/src/hgvs/parser/position.rs
@@ -10,6 +10,18 @@ use nom::{
     IResult, Parser,
 };
 
+/// Length of a leading `pter`/`qter`/`cen` special-position marker, if `bytes`
+/// starts with one. Single source of truth for the three special markers.
+pub(crate) fn special_pos_marker_len(bytes: &[u8]) -> Option<usize> {
+    if bytes.starts_with(b"pter") || bytes.starts_with(b"qter") {
+        Some(4)
+    } else if bytes.starts_with(b"cen") {
+        Some(3)
+    } else {
+        None
+    }
+}
+
 /// Parse a genomic position (unsigned integer >= 1, or special marker like pter/qter/cen)
 ///
 /// Also supports optional offsets for uncertain intronic-style notation (e.g., g.12345-? or g.67890+?).
@@ -30,16 +42,13 @@ use nom::{
 pub fn parse_genome_pos(input: &str) -> IResult<&str, GenomePos> {
     // Check for special position markers first
     let bytes = input.as_bytes();
-    if bytes.len() >= 4 {
-        if bytes[0..4] == *b"pter" {
-            return Ok((&input[4..], GenomePos::pter()));
-        }
-        if bytes[0..4] == *b"qter" {
-            return Ok((&input[4..], GenomePos::qter()));
-        }
-    }
-    if bytes.len() >= 3 && bytes[0..3] == *b"cen" {
-        return Ok((&input[3..], GenomePos::cen()));
+    if let Some(len) = special_pos_marker_len(bytes) {
+        let pos = match &bytes[..len] {
+            b"pter" => GenomePos::pter(),
+            b"qter" => GenomePos::qter(),
+            _ => GenomePos::cen(),
+        };
+        return Ok((&input[len..], pos));
     }
 
     // Regular numeric position
@@ -126,14 +135,13 @@ pub fn parse_cds_pos(input: &str) -> IResult<&str, CdsPos> {
     // Telomere/centromere markers (mirror parse_genome_pos): pter/qter (4 bytes),
     // cen (3 bytes).
     let bytes = input.as_bytes();
-    if bytes.len() >= 4 && bytes[0..4] == *b"pter" {
-        return Ok((&input[4..], CdsPos::pter()));
-    }
-    if bytes.len() >= 4 && bytes[0..4] == *b"qter" {
-        return Ok((&input[4..], CdsPos::qter()));
-    }
-    if bytes.len() >= 3 && bytes[0..3] == *b"cen" {
-        return Ok((&input[3..], CdsPos::cen()));
+    if let Some(len) = special_pos_marker_len(bytes) {
+        let pos = match &bytes[..len] {
+            b"pter" => CdsPos::pter(),
+            b"qter" => CdsPos::qter(),
+            _ => CdsPos::cen(),
+        };
+        return Ok((&input[len..], pos));
     }
 
     // ? or ?+5 or ?-232 (unknown position with optional offset)

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -12,7 +12,7 @@ use crate::hgvs::location::{AminoAcid, CdsPos, ProtPos};
 use crate::hgvs::parser::accession::{
     looks_like_accession_start, parse_accession, parse_gene_symbol,
 };
-use crate::hgvs::parser::edit::{parse_na_edit, parse_protein_edit};
+use crate::hgvs::parser::edit::{parse_genome_na_edit, parse_na_edit, parse_protein_edit};
 use crate::hgvs::parser::position::{
     parse_amino_acid, parse_cds_pos, parse_genome_pos, parse_prot_pos, parse_rna_pos, parse_tx_pos,
 };
@@ -1234,8 +1234,12 @@ fn parse_genome_variant(
 
         // Predicted variant: g.(positionEdit). #241.
         if input.starts_with('(') && !input.starts_with("(?") && !input.starts_with("(=)") {
-            if let Ok((remaining, (interval, edit))) =
-                delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(input)
+            if let Ok((remaining, (interval, edit))) = delimited(
+                char('('),
+                (parse_genome_interval, parse_genome_na_edit),
+                char(')'),
+            )
+            .parse(input)
             {
                 return Ok((
                     remaining,
@@ -1251,7 +1255,7 @@ fn parse_genome_variant(
         let (input, interval) = parse_genome_interval(input)?;
 
         // Try to parse an edit; if no edit found, use position-only identity
-        let (input, edit) = if let Ok((remaining, edit)) = parse_na_edit(input) {
+        let (input, edit) = if let Ok((remaining, edit)) = parse_genome_na_edit(input) {
             (remaining, edit)
         } else if input.is_empty() || input.starts_with(']') || input.starts_with(';') {
             // Position-only pattern (e.g., g.12345 or g.100_200)
@@ -1377,12 +1381,17 @@ fn parse_genome_bracket_member(
         let predicted = if is_circular {
             delimited(
                 char('('),
-                (parse_genome_interval_for_circular, parse_na_edit),
+                (parse_genome_interval_for_circular, parse_genome_na_edit),
                 char(')'),
             )
             .parse(part)
         } else {
-            delimited(char('('), (parse_genome_interval, parse_na_edit), char(')')).parse(part)
+            delimited(
+                char('('),
+                (parse_genome_interval, parse_genome_na_edit),
+                char(')'),
+            )
+            .parse(part)
         };
         if let Ok((remaining, (interval, edit))) = predicted {
             if is_circular {
@@ -1396,7 +1405,7 @@ fn parse_genome_bracket_member(
     } else {
         parse_genome_interval(part)?
     };
-    let (remaining, edit) = if let Ok((r, e)) = parse_na_edit(remaining) {
+    let (remaining, edit) = if let Ok((r, e)) = parse_genome_na_edit(remaining) {
         (r, e)
     } else {
         (
@@ -3117,7 +3126,7 @@ fn parse_mt_variant(
         if input.starts_with('(') && !input.starts_with("(?") && !input.starts_with("(=)") {
             if let Ok((remaining, (interval, edit))) = delimited(
                 char('('),
-                (parse_genome_interval_for_circular, parse_na_edit),
+                (parse_genome_interval_for_circular, parse_genome_na_edit),
                 char(')'),
             )
             .parse(input)
@@ -3137,7 +3146,7 @@ fn parse_mt_variant(
 
         let original_input = input;
         let (input, interval) = parse_genome_interval_for_circular(input)?;
-        let (input, edit) = parse_na_edit(input)?;
+        let (input, edit) = parse_genome_na_edit(input)?;
         // Reject spec-unauthorised reversed ranges (#129).
         check_circular_reversed_range(&interval, &edit, original_input)?;
 
@@ -4544,7 +4553,7 @@ fn parse_circular_variant(
         if input.starts_with('(') && !input.starts_with("(?") && !input.starts_with("(=)") {
             if let Ok((remaining, (interval, edit))) = delimited(
                 char('('),
-                (parse_genome_interval_for_circular, parse_na_edit),
+                (parse_genome_interval_for_circular, parse_genome_na_edit),
                 char(')'),
             )
             .parse(input)
@@ -4564,7 +4573,7 @@ fn parse_circular_variant(
 
         let original_input = input;
         let (input, interval) = parse_genome_interval_for_circular(input)?;
-        let (input, edit) = parse_na_edit(input)?;
+        let (input, edit) = parse_genome_na_edit(input)?;
         // Reject spec-unauthorised reversed ranges (#129).
         check_circular_reversed_range(&interval, &edit, original_input)?;
 
@@ -5166,7 +5175,7 @@ fn parse_compact_mosaic_rhs(
 ) -> Result<Option<HgvsVariant>, FerroError> {
     use crate::hgvs::edit::NaEdit;
     use crate::hgvs::interval::Interval;
-    use crate::hgvs::parser::edit::parse_na_edit;
+    use crate::hgvs::parser::edit::{parse_genome_na_edit, parse_na_edit};
 
     /// A single-base substitution targets one position, so the inherited
     /// compact-mosaic LHS identity must be a point (`c.85=`), not a range
@@ -5318,7 +5327,16 @@ fn parse_compact_mosaic_rhs(
     }
 
     // Parse the RHS as a bare NaEdit and require we consumed all of it.
-    let (remaining, edit) = match parse_na_edit(rhs) {
+    // Genome-family LHS (g./m./o.) routes through `parse_genome_na_edit` so the
+    // reconstructed RHS edit accepts the same genome-only special-position
+    // inserted ranges as the primary parse paths; c./n./r. keep `parse_na_edit`.
+    let parse_rhs_edit = match lhs {
+        HgvsVariant::Genome(_) | HgvsVariant::Mt(_) | HgvsVariant::Circular(_) => {
+            parse_genome_na_edit
+        }
+        _ => parse_na_edit,
+    };
+    let (remaining, edit) = match parse_rhs_edit(rhs) {
         Ok((rem, e)) => (rem, e),
         Err(_) => return Ok(None),
     };
@@ -5434,7 +5452,7 @@ fn parse_variant_with_inherited_accession(
             msg: format!("Failed to parse genome interval: {:?}", e),
             diagnostic: None,
         })?;
-        let (remaining, edit) = parse_na_edit(remaining).map_err(|e| FerroError::Parse {
+        let (remaining, edit) = parse_genome_na_edit(remaining).map_err(|e| FerroError::Parse {
             pos: input.len() - remaining.len(),
             msg: format!("Failed to parse edit: {:?}", e),
             diagnostic: None,
@@ -5583,7 +5601,7 @@ fn parse_variant_with_inherited_accession(
                 msg: format!("Failed to parse mitochondrial interval: {:?}", e),
                 diagnostic: None,
             })?;
-        let (remaining, edit) = parse_na_edit(remaining).map_err(|e| FerroError::Parse {
+        let (remaining, edit) = parse_genome_na_edit(remaining).map_err(|e| FerroError::Parse {
             pos: input.len() - remaining.len(),
             msg: format!("Failed to parse edit: {:?}", e),
             diagnostic: None,
@@ -5612,7 +5630,7 @@ fn parse_variant_with_inherited_accession(
                 msg: format!("Failed to parse circular interval: {:?}", e),
                 diagnostic: None,
             })?;
-        let (remaining, edit) = parse_na_edit(remaining).map_err(|e| FerroError::Parse {
+        let (remaining, edit) = parse_genome_na_edit(remaining).map_err(|e| FerroError::Parse {
             pos: input.len() - remaining.len(),
             msg: format!("Failed to parse edit: {:?}", e),
             diagnostic: None,

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -2118,7 +2118,9 @@ pub fn expand_inserted_sequence<P: ReferenceProvider>(
         // Already flat or out-of-scope for this canonicalization.
         // `UncertainRangeInv` has uncertain (parenthesized) breakpoints that
         // are not sequenced, so there are no exact bases to fetch — leave it
-        // as-is (DNA/complex.md).
+        // as-is (DNA/complex.md). `SpecialPositionRange` has pter/qter/cen
+        // endpoints that have no concrete coordinate, so it likewise cannot be
+        // expanded to literal bases.
         InsertedSequence::Literal(_)
         | InsertedSequence::Count(_)
         | InsertedSequence::Range(_, _)
@@ -2126,6 +2128,7 @@ pub fn expand_inserted_sequence<P: ReferenceProvider>(
         | InsertedSequence::SequenceRepeat { .. }
         | InsertedSequence::Named(_)
         | InsertedSequence::UncertainRangeInv { .. }
+        | InsertedSequence::SpecialPositionRange { .. }
         | InsertedSequence::Uncertain
         | InsertedSequence::Empty => Ok(None),
     }

--- a/tests/inserted_range_special_positions.rs
+++ b/tests/inserted_range_special_positions.rs
@@ -1,0 +1,127 @@
+//! pter/qter endpoints in an inserted position-range with `inv` (#546).
+//! HGVS DNA/complex.md:94-95 — homologous-chromosome translocation as delins.
+use ferro_hgvs::parse_hgvs;
+
+#[test]
+fn delins_inserted_range_with_special_endpoints_round_trips() {
+    for s in [
+        "NC_000009.12:g.pter_26393001delins102425452_qterinv",
+        "NC_000009.12:g.102425452_qterdelinspter_26393001inv",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+#[test]
+fn special_positions_in_inserted_range_are_rejected_outside_genome_axis() {
+    // pter/qter are genome-only; a c. inserted range must not accept them.
+    assert!(parse_hgvs("LRG_24t1:c.pter_qterdelinspter_qter").is_err());
+}
+
+#[test]
+fn all_numeric_inserted_range_is_unchanged() {
+    // Regression: numeric inserted ranges must keep their existing behavior.
+    let s = "NC_000009.12:g.100_200delins850_900inv";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+fn cen_endpoint_in_inserted_range_round_trips() {
+    // The parser claims `cen` (centromere) support as a special inserted endpoint;
+    // exercise both the inverted and the bare (`inverted: false`) Display branches.
+    for s in [
+        "NC_000009.12:g.cen_26393001delins102425452_qterinv",
+        "NC_000009.12:g.100_200delins26393001_cen",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+#[test]
+fn special_inserted_range_round_trips_on_mito_and_circular_axes() {
+    // The gate is the genome *family* (g./m./o.), not just `g.` — special-position
+    // inserted ranges must parse on the mitochondrial (m.) and circular (o.) axes too.
+    for s in [
+        "NC_012920.1:m.100_200delins102425452_qterinv",
+        "NC_012920.1:m.pter_200delins102425452_qter",
+        "NC_012920.1:o.100_200delins102425452_qterinv",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+#[test]
+fn special_positions_in_inserted_range_are_rejected_on_rna_axis() {
+    // Mirror the c. rejection: pter/qter inserted ranges are genome-only and must
+    // be refused on the r. (RNA) axis as well.
+    assert!(parse_hgvs("NM_004006.2:r.100_200delinspter_qter").is_err());
+    assert!(parse_hgvs("NM_004006.2:r.pter_200delins102425452_qter").is_err());
+}
+
+#[test]
+fn non_inverted_special_inserted_range_round_trips() {
+    // Exercise the `inverted: false` Display branch on the genome axis (no trailing `inv`).
+    let s = "NC_000009.12:g.102425452_qterdelinspter_26393001";
+    let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+    assert_eq!(format!("{v}"), s);
+}
+
+#[test]
+fn ins_inserted_range_with_special_endpoints_round_trips_on_genome_family() {
+    // `allow_special_positions` is threaded into `parse_insertion` as well as
+    // `parse_delins`, so the bare `ins<range>` form must accept special-position
+    // inserted ranges (inverted and non-inverted) on the whole genome family
+    // (g./m./o.), exactly like `delins`.
+    for s in [
+        "NC_000009.12:g.100_101inspter_qterinv",
+        "NC_000009.12:g.100_101inspter_qter",
+        "NC_000009.12:g.100_101ins102425452_qterinv",
+        "NC_012920.1:m.100_101inspter_qterinv",
+        "NC_012920.1:o.100_101inspter_qter",
+    ] {
+        let v = parse_hgvs(s).unwrap_or_else(|e| panic!("must parse `{s}`: {e}"));
+        assert_eq!(format!("{v}"), s, "round-trip for `{s}`");
+    }
+}
+
+#[test]
+fn ins_special_positions_in_inserted_range_are_rejected_outside_genome_axis() {
+    // Mirror the delins rejection: pter/qter inserted ranges are genome-only and
+    // must be refused for the `ins` form on c./r. axes too.
+    assert!(parse_hgvs("LRG_24t1:c.100_101inspter_qter").is_err());
+    assert!(parse_hgvs("NM_004006.2:r.100_101inspter_qter").is_err());
+}
+
+#[test]
+fn dupins_form_is_rejected_even_with_special_positions() {
+    // `parse_dupins` threads `allow_special_positions`, but the `dupins<seq>` form
+    // itself is not used in HGVS nomenclature (DNA/duplication.md:92) and is
+    // rejected regardless of the inserted payload — special positions must not
+    // provide a backdoor that lets `dupins` through.
+    assert!(parse_hgvs("NC_000009.12:g.100_200dupinspter_qterinv").is_err());
+    assert!(parse_hgvs("NC_000009.12:g.100_200dupins102425452_qter").is_err());
+}
+
+#[test]
+fn inherited_accession_slash_form_accepts_special_inserted_range_on_genome_family() {
+    // The slash mosaic form whose RHS omits the accession reconstructs the RHS as
+    // a genome-family variant; that fallback path must accept special-position
+    // inserted ranges (g./m./o.) consistently with the primary parse paths, and
+    // still reject them on c./r.
+    for s in [
+        "NC_000009.12:g.50A>T/g.100_101inspter_qter",
+        "NC_000009.12:g.50A>T/g.pter_26393001delins102425452_qterinv",
+        "NC_012920.1:m.50A>T/m.100_101inspter_qter",
+        "NC_012920.1:o.50A>T/o.100_101inspter_qter",
+    ] {
+        assert!(
+            parse_hgvs(s).is_ok(),
+            "genome-family inherited-accession must accept `{s}`"
+        );
+    }
+    assert!(parse_hgvs("NM_004006.2:c.50A>T/c.100_101inspter_qter").is_err());
+}


### PR DESCRIPTION
## Summary

Closes part of #546. Adds parse + byte-identical round-trip for **`pter`/`qter`/`cen` endpoints in a genome inserted position-range** (optional `inv`):

```
NC_000009.12:g.pter_26393001delins102425452_qterinv
NC_000009.12:g.102425452_qterdelinspter_26393001inv
```

These are the recommended HGVS delins renderings (DNA/complex.md:94-95) of a homologous-chromosome translocation — no `::`.

> **Stacked on #576** (inverted insertion of an uncertain-boundary range) — this generalizes the inserted-range support #576 introduced. Review/merge #576 first; this PR's base is `feat/issue-546-inverted-insertion`.

## Changes

- New `InsertedSequence::SpecialPositionRange { start: GenomePos, end: GenomePos, inverted: bool }` for genome inserted ranges with special-position endpoints. All-numeric inserted ranges keep `PositionRange`/`PositionRangeInv` unchanged (only used when at least one endpoint is special).
- **Genome-axis gate (important).** `pter`/`qter`/`cen` are genome-only, and the inserted-sequence parser is coordinate-agnostic, so accepting special positions unconditionally would wrongly accept `c.…inspter_qter`. `parse_na_edit` is split into a shared `parse_na_edit_inner(.., allow_special_positions)` with a `parse_genome_na_edit` entry point (flag set) used by the g./m./o. parse sites; c./n./r./p. keep `parse_na_edit` and reject special-position inserted ranges.
- De-duplicated the `pter`/`qter`/`cen` marker-length logic into one `special_pos_marker_len` helper shared by the genome and CDS position parsers.
- `expand_inserted_sequence` gets a no-op arm for the new variant (a special-position range has no concrete coordinates to expand), mirroring `UncertainRangeInv`.

## Spec-fixture impact

Both target rows flip `parse-error → preserved`. No new `false-acceptance` (75 → 75).

## Testing

- `tests/inserted_range_special_positions.rs`: the two `g.` round-trips, an all-numeric regression guard, `cen` endpoint, `m.`/`o.` (genome-family) acceptance, and `c.`/`r.` rejection (the gate).
- The mutalyzer mock-pin regression test guards the gate (`c.…inspter_qter` stays a parse-error — caught and fixed a coordinate-leak during review).
- `cargo fmt --check` + `cargo clippy --features dev --all-targets` clean; full suite only the 9 known env failures.
- Two-stage review (spec-compliance + code-quality) plus applied follow-ups.
