### PR TITLE
fix(tool-support): address CodeRabbit findings on the matrix generator

### DIFF
--- a/docs/tool_support_matrix.json
+++ b/docs/tool_support_matrix.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "_comment": "SOURCE OF TRUTH for tool-support tables. Edit cells here, then run: cargo run --features dev --example generate_tool_support_tables. Cells with a 'carried' note are inherited from the prior web table and not source-verified.",
+  "_comment": "SOURCE OF TRUTH for tool-support tables. Edit cells here, then run: cargo run --features dev --example generate_tool_support_tables. Every cell is source-verified; each non-obvious value carries a 'note' citing the deciding behavior.",
   "tools": [
     { "id": "ferro", "name": "ferro", "version": "0.6.0", "url": "https://github.com/fulcrumgenomics/ferro-hgvs" },
     { "id": "mutalyzer", "name": "mutalyzer", "version": "3.1.1", "url": "https://mutalyzer.nl/" },
-    { "id": "biocommons", "name": "biocommons", "version": "main @ fa02ca5 (post-1.5.3)", "url": "https://github.com/biocommons/hgvs" },
+    { "id": "biocommons", "name": "biocommons", "version": "fa02ca5ec0c9e28a1a6377b551e41ae77b450ce9", "url": "https://github.com/biocommons/hgvs" },
     { "id": "hgvs-rs", "name": "hgvs-rs", "version": "0.20.2", "url": "https://github.com/varfish-org/hgvs-rs" }
   ],
   "footnotes": {

--- a/examples/generate_tool_support_tables.rs
+++ b/examples/generate_tool_support_tables.rs
@@ -40,7 +40,7 @@ struct Cli {
     today: String,
     /// Staleness window in months.
     #[arg(long, default_value_t = 6)]
-    stale_months: i64,
+    stale_months: u64,
 }
 
 const VIEW: &str = "normalization_capabilities";
@@ -117,7 +117,7 @@ fn main() -> ExitCode {
     }
 
     // Staleness warnings (never fail).
-    for s in m.stale_cells(&cli.today, cli.stale_months) {
+    for s in m.stale_cells(&cli.today, cli.stale_months as i64) {
         eprintln!(
             "warning: stale tool-support cell {s} (>{} months)",
             cli.stale_months
@@ -134,7 +134,17 @@ fn main() -> ExitCode {
 
     let mut drift = false;
     for t in &targets {
-        let on_disk = std::fs::read_to_string(&t.path).unwrap_or_default();
+        // In --check mode a missing target is a distinct, actionable error
+        // (someone deleted a generated file) rather than silently "out of date".
+        let on_disk = match std::fs::read_to_string(&t.path) {
+            Ok(content) => content,
+            Err(e) if cli.check => {
+                drift = true;
+                eprintln!("error: {} is missing or unreadable: {e}", t.path);
+                continue;
+            }
+            Err(_) => String::new(), // non-check: the file is (re)created below
+        };
         if cli.check {
             if on_disk != t.content {
                 drift = true;

--- a/src/service/web/static/data/tool_support_matrix.json
+++ b/src/service/web/static/data/tool_support_matrix.json
@@ -585,7 +585,7 @@
       "id": "biocommons",
       "name": "biocommons",
       "url": "https://github.com/biocommons/hgvs",
-      "version": "main @ fa02ca5 (post-1.5.3)"
+      "version": "fa02ca5ec0c9e28a1a6377b551e41ae77b450ce9"
     },
     {
       "id": "hgvs-rs",


### PR DESCRIPTION
Follow-up to #590 — applies the four findings from a local CodeRabbit review (`coderabbit review --agent --base origin/main`) that landed after #590 had already merged.

## Changes

- **Generator (`examples/generate_tool_support_tables.rs`)**
  - `--stale-months` is now `u64`, so clap rejects negative windows at parse time.
  - In `--check` mode, a missing/unreadable generated target now produces a distinct error (`<path> is missing or unreadable: …`) instead of being reported as merely "out of date".
- **Matrix (`docs/tool_support_matrix.json`)**
  - The biocommons `version` is pinned to a full commit SHA (`fa02ca5ec0c9e28a1a6377b551e41ae77b450ce9`) rather than the short, non-durable `main @ fa02ca5 (post-1.5.3)`.
  - The `_comment` no longer references a "carried" note (every cell is source-verified now), so the guidance matches the data.
- The web JSON was regenerated to pick up the biocommons version change; `--check` is green.

No behavior change to the rendered tables beyond the biocommons version string.

## Test plan

- [ ] `cargo run --features dev --example generate_tool_support_tables -- --check` — exits 0
- [ ] `cargo clippy --features dev --all-targets -- -D warnings` — clean
- [ ] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [ ] `cargo nextest run --features dev` — tool-support tests pass