### PR TITLE
feat(perf-table): render README performance tables from a results JSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date
         run: cargo run --features dev --example generate_tool_support_tables -- --check
+      - name: Perf tables up to date
+        run: cargo run --features dev --example generate_perf_tables -- --check
       - name: Install dev dependencies
         run: uv sync --group dev --locked --no-install-project
       - name: Run Python tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,10 @@ anyhow = "1"
 name = "generate_tool_support_tables"
 required-features = ["dev"]
 
+[[example]]
+name = "generate_perf_tables"
+required-features = ["dev"]
+
 [[bin]]
 name = "ferro"
 path = "src/bin/ferro.rs"

--- a/README.md
+++ b/README.md
@@ -222,12 +222,45 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 
 ### Performance Comparison
 
-| Tool | Speed (local) | Speed (network) | ferro Speedup |
-|------|---------------|-----------------|---------------|
-| **ferro-hgvs** | ~4M patterns/sec | N/A (offline) | — |
-| mutalyzer | ~20 patterns/sec | ~1 pattern/sec | **200,000x** |
-| biocommons/hgvs | ~20 patterns/sec | ~0.2 patterns/sec | **200,000x** |
-| hgvs-rs | ~2 patterns/sec | ~0.2 patterns/sec | **2,000,000x** |
+<!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
+
+_Throughput on a stratified ClinVar sample, local/offline, same sample across tools; per-process startup excluded. See `docs/BENCHMARK_GUIDE.md` for methodology._
+
+**Parse**
+
+<!-- BEGIN perf:parse -->
+> ⚠️ **Placeholder data — not yet measured.** These figures are illustrative pending a real benchmark run; do not cite them.
+
+| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
+|------|----------------------:|-----------------------:|-------------------:|
+| ferro | 1.2M/s | 8.0M/s | — |
+| mutalyzer | 21/s | 150/s | 53,000× |
+| biocommons | 20/s | 140/s | 57,000× |
+| hgvs-rs | 2/s | 14/s | 570,000× |
+<!-- END perf:parse -->
+
+**Normalize**
+
+<!-- BEGIN perf:normalize -->
+> ⚠️ **Placeholder data — not yet measured.** These figures are illustrative pending a real benchmark run; do not cite them.
+
+| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
+|------|----------------------:|-----------------------:|-------------------:|
+| ferro | 250.0k/s | 1.8M/s | — |
+| mutalyzer | 19/s | 140/s | 13,000× |
+| biocommons | — | — | — |
+| hgvs-rs | — | — | — |
+<!-- END perf:normalize -->
+
+**ferro thread scaling**
+
+<!-- BEGIN perf:ferro_scaling -->
+> ⚠️ **Placeholder data — not yet measured.** These figures are illustrative pending a real benchmark run; do not cite them.
+
+| Threads | 1 | 2 | 4 | 8 |
+|---------|--:|--:|--:|--:|
+| ferro parse | 1.2M/s | 2.3M/s | 4.4M/s | 8.0M/s |
+<!-- END perf:ferro_scaling -->
 
 **Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.
 

--- a/data/benchmark/perf_results.json
+++ b/data/benchmark/perf_results.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "placeholder": true,
+  "provenance": {
+    "generated": "2026-06-12T00:00:00Z", "corpus_id": "clinvar_patterns",
+    "corpus_sha": "PLACEHOLDER", "machine": "Apple M2 Max (12 cores)", "os": "darwin-arm64",
+    "tool_versions": {"ferro":"0.6.0","mutalyzer":"3.1.1","biocommons":"fa02ca5","hgvs-rs":"0.20.2"}
+  },
+  "operations": {
+    "parse": {
+      "sample_size_slow": 1000, "ferro_full_population_n": 1000000, "ferro_full_population_pps": 4200000.0,
+      "by_workers": {
+        "1": {"tools": {
+          "ferro": {"median_pps": 1200000.0, "min_pps": 1150000.0, "max_pps": 1250000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 21.0, "min_pps": 20.0, "max_pps": 22.0, "reps": 5, "success_rate": 0.994},
+          "biocommons": {"median_pps": 20.0, "min_pps": 19.0, "max_pps": 21.0, "reps": 5, "success_rate": 0.994},
+          "hgvs-rs": {"median_pps": 2.0, "min_pps": 1.8, "max_pps": 2.2, "reps": 5, "success_rate": 0.994}
+        }},
+        "8": {"tools": {
+          "ferro": {"median_pps": 8000000.0, "min_pps": 7800000.0, "max_pps": 8200000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 150.0, "min_pps": 140.0, "max_pps": 160.0, "reps": 5, "success_rate": 0.994},
+          "biocommons": {"median_pps": 140.0, "min_pps": 130.0, "max_pps": 150.0, "reps": 5, "success_rate": 0.994},
+          "hgvs-rs": {"median_pps": 14.0, "min_pps": 13.0, "max_pps": 15.0, "reps": 5, "success_rate": 0.994}
+        }}
+      },
+      "ferro_scaling": {"1": 1200000.0, "2": 2300000.0, "4": 4400000.0, "8": 8000000.0}
+    },
+    "normalize": {
+      "sample_size_slow": 1000, "ferro_full_population_n": 1000000, "ferro_full_population_pps": 900000.0,
+      "by_workers": {
+        "1": {"tools": {
+          "ferro": {"median_pps": 250000.0, "min_pps": 240000.0, "max_pps": 260000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 19.0, "min_pps": 18.0, "max_pps": 20.0, "reps": 5, "success_rate": 0.99},
+          "biocommons": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"},
+          "hgvs-rs": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"}
+        }},
+        "8": {"tools": {
+          "ferro": {"median_pps": 1800000.0, "min_pps": 1750000.0, "max_pps": 1850000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 140.0, "min_pps": 130.0, "max_pps": 150.0, "reps": 5, "success_rate": 0.99},
+          "biocommons": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"},
+          "hgvs-rs": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"}
+        }}
+      },
+      "ferro_scaling": {"1": 250000.0, "2": 480000.0, "4": 920000.0, "8": 1800000.0}
+    }
+  }
+}

--- a/examples/generate_perf_tables.rs
+++ b/examples/generate_perf_tables.rs
@@ -1,0 +1,113 @@
+//! Generator for the README performance tables.
+//!
+//! Reads `data/benchmark/perf_results.json` and renders the parse + normalize
+//! cross-tool tables and the ferro thread-scaling table into README.md between
+//! `perf:<id>` markers.
+//!
+//! Run:   cargo run --features dev --example generate_perf_tables
+//! Check: cargo run --features dev --example generate_perf_tables -- --check
+//!
+//! See: docs/superpowers/specs/2026-06-12-benchmark-perf-tables-design.md
+
+use std::process::ExitCode;
+
+use clap::Parser;
+use ferro_hgvs::perf_table::PerfResults;
+
+#[derive(Parser, Debug)]
+#[command(about = "Generate the README performance tables")]
+struct Cli {
+    /// Re-render in memory and fail if README.md differs.
+    #[arg(long)]
+    check: bool,
+    /// Path to the results JSON.
+    #[arg(long, default_value = "data/benchmark/perf_results.json")]
+    results: String,
+}
+
+const README: &str = "README.md";
+
+/// Replace the text between `<!-- BEGIN perf:<id> -->` and `<!-- END perf:<id> -->`.
+fn splice(content: &str, id: &str, body: &str) -> Result<String, String> {
+    let begin = format!("<!-- BEGIN perf:{id} -->");
+    let end = format!("<!-- END perf:{id} -->");
+    let b = content
+        .find(&begin)
+        .ok_or_else(|| format!("missing {begin}"))?;
+    let after = b + begin.len();
+    let e = content[after..]
+        .find(&end)
+        .ok_or_else(|| format!("missing {end} after {begin}"))?
+        + after;
+    let mut out = String::new();
+    out.push_str(&content[..after]);
+    out.push('\n');
+    out.push_str(body.trim_end());
+    out.push('\n');
+    out.push_str(&content[e..]);
+    Ok(out)
+}
+
+fn render_all(r: &PerfResults, current: &str) -> Result<String, String> {
+    let banner = r.placeholder_banner();
+    let with_banner = |table: String| match banner {
+        Some(b) => format!("{b}\n\n{table}"),
+        None => table,
+    };
+    let mut out = current.to_string();
+    out = splice(&out, "parse", &with_banner(r.render_cross_tool("parse")?))?;
+    out = splice(
+        &out,
+        "normalize",
+        &with_banner(r.render_cross_tool("normalize")?),
+    )?;
+    out = splice(
+        &out,
+        "ferro_scaling",
+        &with_banner(r.render_ferro_scaling("parse")?),
+    )?;
+    Ok(out)
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let r = match PerfResults::load(&cli.results) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let current = match std::fs::read_to_string(README) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: read {README}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let rendered = match render_all(&r, &current) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if cli.check {
+        if rendered != current {
+            eprintln!(
+                "README perf tables are out of date; rerun: \
+                 cargo run --features dev --example generate_perf_tables \
+                 (edit data/benchmark/perf_results.json, not README.md)"
+            );
+            return ExitCode::FAILURE;
+        }
+    } else if rendered != current {
+        if let Err(e) = std::fs::write(README, &rendered) {
+            eprintln!("error: write {README}: {e}");
+            return ExitCode::FAILURE;
+        }
+        println!("updated {README}");
+    }
+    ExitCode::SUCCESS
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@ pub mod mave;
 pub mod normalize;
 #[cfg(feature = "parallel")]
 pub mod parallel;
+/// Performance-comparison table types + rendering (used by the
+/// `generate_perf_tables` example and its tests).
+#[cfg(feature = "dev")]
+pub mod perf_table;
 pub mod prepare;
 pub mod project;
 #[cfg(feature = "python")]

--- a/src/perf_table/mod.rs
+++ b/src/perf_table/mod.rs
@@ -1,0 +1,356 @@
+//! Performance-comparison tables: types + rendering.
+//!
+//! Loads `data/benchmark/perf_results.json` (produced by the benchmark
+//! measurement engine) and renders the README perf tables. See
+//! `docs/superpowers/specs/2026-06-12-benchmark-perf-tables-design.md`.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical column order for every table.
+pub const TOOL_ORDER: [&str; 4] = ["ferro", "mutalyzer", "biocommons", "hgvs-rs"];
+
+/// Provenance for one benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Provenance {
+    pub generated: String,
+    pub corpus_id: String,
+    pub corpus_sha: String,
+    pub machine: String,
+    pub os: String,
+    pub tool_versions: BTreeMap<String, String>,
+}
+
+/// One tool's measured throughput at a given worker count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolMeasure {
+    pub median_pps: f64,
+    pub min_pps: f64,
+    pub max_pps: f64,
+    pub reps: u32,
+    pub success_rate: f64,
+    /// Set when the tool's stack could not run (e.g. UTA unavailable).
+    #[serde(default)]
+    pub not_run: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// All tools' measurements at a single worker count.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerPoint {
+    pub tools: BTreeMap<String, ToolMeasure>,
+}
+
+/// One operation (parse or normalize): cross-tool points + ferro scaling.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Operation {
+    pub sample_size_slow: u64,
+    pub ferro_full_population_n: u64,
+    pub ferro_full_population_pps: f64,
+    /// Keyed by worker count as a decimal-integer string ("1", "8"). BTreeMap
+    /// iteration is lexicographic; renderers use explicit key lists, so this is fine.
+    pub by_workers: BTreeMap<String, WorkerPoint>,
+    /// ferro-only thread scaling: thread count ("1","2","4","8") -> patterns/sec.
+    /// Keys are decimal-integer strings; renderers iterate explicit `["1","2","4","8"]`,
+    /// so lexicographic BTreeMap order does not affect output.
+    #[serde(default)]
+    pub ferro_scaling: BTreeMap<String, f64>,
+}
+
+/// The whole results document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerfResults {
+    pub schema_version: u32,
+    /// When `true`, the data has not yet been measured and the README tables
+    /// should display a "not measured" warning. Omitting the field defaults to
+    /// `false` (real data, no banner).
+    #[serde(default)]
+    pub placeholder: bool,
+    pub provenance: Provenance,
+    /// Keyed by operation name ("parse", "normalize").
+    pub operations: BTreeMap<String, Operation>,
+}
+
+impl PerfResults {
+    /// A markdown warning to render above the tables when the data has not yet
+    /// been measured (`placeholder == true`). `None` once real measurements
+    /// replace the placeholder, so the warning auto-disappears.
+    pub fn placeholder_banner(&self) -> Option<&'static str> {
+        if self.placeholder {
+            Some("> ⚠️ **Placeholder data — not yet measured.** These figures are illustrative pending a real benchmark run; do not cite them.")
+        } else {
+            None
+        }
+    }
+
+    /// Parse from a JSON string.
+    pub fn from_json_str(s: &str) -> Result<Self, String> {
+        serde_json::from_str(s).map_err(|e| format!("parse perf_results: {e}"))
+    }
+
+    /// Load from a file path.
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+        let p = path.as_ref();
+        let s = std::fs::read_to_string(p).map_err(|e| format!("read {}: {e}", p.display()))?;
+        Self::from_json_str(&s)
+    }
+
+    /// Render the cross-tool throughput table for an operation ("parse" or
+    /// "normalize"): one row per tool present in the JSON (in `TOOL_ORDER`),
+    /// columns for W=1 and W=8 throughput and ferro's speedup at W=8.
+    pub fn render_cross_tool(&self, op: &str) -> Result<String, String> {
+        let operation = self
+            .operations
+            .get(op)
+            .ok_or_else(|| format!("no operation {op}"))?;
+        let w1 = operation
+            .by_workers
+            .get("1")
+            .ok_or_else(|| format!("op {op} missing worker point 1"))?;
+        let w8 = operation
+            .by_workers
+            .get("8")
+            .ok_or_else(|| format!("op {op} missing worker point 8"))?;
+
+        let cell = |wp: &WorkerPoint, tool: &str| -> String {
+            match wp.tools.get(tool) {
+                None => "—".to_string(),
+                Some(m) if m.not_run => "—".to_string(),
+                Some(m) => fmt_pps(m.median_pps),
+            }
+        };
+
+        let ferro8 = w8.tools.get("ferro").filter(|m| !m.not_run);
+
+        let mut out = String::new();
+        out.push_str(
+            "| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |\n",
+        );
+        out.push_str(
+            "|------|----------------------:|-----------------------:|-------------------:|\n",
+        );
+        for tool in TOOL_ORDER {
+            // Skip tools absent from BOTH worker points entirely.
+            if !w1.tools.contains_key(tool) && !w8.tools.contains_key(tool) {
+                continue;
+            }
+            let speedup = if tool == "ferro" {
+                "—".to_string()
+            } else {
+                match (ferro8, w8.tools.get(tool).filter(|m| !m.not_run)) {
+                    (Some(f), Some(m)) => fmt_speedup(f.median_pps, m.median_pps),
+                    _ => "—".to_string(),
+                }
+            };
+            out.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                tool,
+                cell(w1, tool),
+                cell(w8, tool),
+                speedup
+            ));
+        }
+        Ok(out)
+    }
+
+    /// Render ferro's thread-scaling row (1/2/4/8 threads) for an operation.
+    /// Returns `Err` if the operation has no `ferro_scaling` data.
+    pub fn render_ferro_scaling(&self, op: &str) -> Result<String, String> {
+        let operation = self
+            .operations
+            .get(op)
+            .ok_or_else(|| format!("no operation {op}"))?;
+        if operation.ferro_scaling.is_empty() {
+            return Err(format!("op {op} has no ferro_scaling data"));
+        }
+        let mut out = String::new();
+        out.push_str("| Threads | 1 | 2 | 4 | 8 |\n");
+        out.push_str("|---------|--:|--:|--:|--:|\n");
+        out.push_str(&format!("| ferro {op} |"));
+        for t in ["1", "2", "4", "8"] {
+            let v = operation
+                .ferro_scaling
+                .get(t)
+                .copied()
+                .map(fmt_pps)
+                .unwrap_or_else(|| "—".to_string());
+            out.push_str(&format!(" {v} |"));
+        }
+        out.push('\n');
+        Ok(out)
+    }
+}
+
+/// Human-readable throughput: `>=1e6` as `X.YM/s`, `>=1e3` as `X.Yk/s`,
+/// `>=1` as integer `/s`, else one decimal `/s`.
+pub fn fmt_pps(pps: f64) -> String {
+    if pps >= 1_000_000.0 {
+        format!("{:.1}M/s", pps / 1_000_000.0)
+    } else if pps >= 1_000.0 {
+        format!("{:.1}k/s", pps / 1_000.0)
+    } else if pps >= 1.0 {
+        format!("{:.0}/s", pps)
+    } else {
+        format!("{:.1}/s", pps)
+    }
+}
+
+/// Speedup `ferro/tool`, rounded to two significant figures and grouped with
+/// thousands separators, suffixed `×`. Returns `1×` for equal rates.
+pub fn fmt_speedup(ferro_pps: f64, tool_pps: f64) -> String {
+    if tool_pps <= f64::EPSILON {
+        return "—".to_string();
+    }
+    let ratio = ferro_pps / tool_pps;
+    if !ratio.is_finite() || ratio <= 0.0 {
+        return "—".to_string();
+    }
+    let rounded = round_2sig(ratio);
+    format!("{}×", group_thousands(rounded))
+}
+
+/// Round to 2 significant figures. Returns 0 for non-finite or non-positive input.
+fn round_2sig(x: f64) -> u64 {
+    if x <= 0.0 || !x.is_finite() {
+        return 0;
+    }
+    let mag = x.log10().floor();
+    let scale = 10f64.powf(mag - 1.0);
+    let rounded = ((x / scale).round() * scale).round();
+    rounded.min(u64::MAX as f64) as u64
+}
+
+/// Group an integer with `,` thousands separators.
+fn group_thousands(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::new();
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+      "schema_version": 1,
+      "provenance": {
+        "generated": "2026-06-12T00:00:00Z", "corpus_id": "clinvar_patterns",
+        "corpus_sha": "abc123", "machine": "Apple M2 Max (12 cores)", "os": "darwin-arm64",
+        "tool_versions": {"ferro":"0.6.0","mutalyzer":"3.1.1","biocommons":"fa02ca5","hgvs-rs":"0.20.2"}
+      },
+      "operations": {
+        "parse": {
+          "sample_size_slow": 1000, "ferro_full_population_n": 1000000,
+          "ferro_full_population_pps": 4200000.0,
+          "by_workers": {
+            "1": {"tools": {
+              "ferro": {"median_pps": 1200000.0, "min_pps": 1150000.0, "max_pps": 1250000.0, "reps": 10, "success_rate": 1.0},
+              "mutalyzer": {"median_pps": 21.0, "min_pps": 20.0, "max_pps": 22.0, "reps": 5, "success_rate": 0.994}
+            }},
+            "8": {"tools": {
+              "ferro": {"median_pps": 8000000.0, "min_pps": 7800000.0, "max_pps": 8200000.0, "reps": 10, "success_rate": 1.0},
+              "mutalyzer": {"median_pps": 150.0, "min_pps": 140.0, "max_pps": 160.0, "reps": 5, "success_rate": 0.994}
+            }}
+          },
+          "ferro_scaling": {"1": 1200000.0, "2": 2300000.0, "4": 4400000.0, "8": 8000000.0}
+        }
+      }
+    }"#;
+
+    #[test]
+    fn loads_results() {
+        let r = PerfResults::from_json_str(SAMPLE).expect("parse");
+        assert_eq!(r.schema_version, 1);
+        let parse = &r.operations["parse"];
+        assert_eq!(parse.by_workers["8"].tools["ferro"].median_pps, 8000000.0);
+        assert_eq!(parse.ferro_scaling["4"], 4400000.0);
+    }
+
+    #[test]
+    fn formats_throughput() {
+        assert_eq!(fmt_pps(4_200_000.0), "4.2M/s");
+        assert_eq!(fmt_pps(8_000_000.0), "8.0M/s");
+        assert_eq!(fmt_pps(1_200_000.0), "1.2M/s");
+        assert_eq!(fmt_pps(150.0), "150/s");
+        assert_eq!(fmt_pps(21.0), "21/s");
+        assert_eq!(fmt_pps(0.2), "0.2/s");
+    }
+
+    #[test]
+    fn formats_speedup() {
+        assert_eq!(fmt_speedup(8_000_000.0, 150.0), "53,000×");
+        assert_eq!(fmt_speedup(1_200_000.0, 21.0), "57,000×");
+        assert_eq!(fmt_speedup(100.0, 100.0), "1×");
+    }
+
+    #[test]
+    fn renders_cross_tool_table() {
+        let r = PerfResults::from_json_str(SAMPLE).unwrap();
+        let out = r.render_cross_tool("parse").unwrap();
+        assert!(out.contains(
+            "| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |"
+        ));
+        // ferro is the baseline row (no speedup vs itself).
+        assert!(out.contains("| ferro | 1.2M/s | 8.0M/s | — |"));
+        // mutalyzer: 8000000/150 -> ~53,000x.
+        assert!(out.contains("| mutalyzer | 21/s | 150/s | 53,000× |"));
+        // Tools absent from the JSON are omitted (only ferro+mutalyzer in SAMPLE).
+        assert!(!out.contains("biocommons"));
+    }
+
+    #[test]
+    fn renders_not_run_tool() {
+        let json = SAMPLE.replace(
+            r#""mutalyzer": {"median_pps": 150.0, "min_pps": 140.0, "max_pps": 160.0, "reps": 5, "success_rate": 0.994}"#,
+            r#""mutalyzer": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"}"#,
+        );
+        let r = PerfResults::from_json_str(&json).unwrap();
+        let out = r.render_cross_tool("parse").unwrap();
+        assert!(out.contains("| mutalyzer | 21/s | — | — |")); // W=1 ran, W=8 not_run
+    }
+
+    #[test]
+    fn renders_ferro_scaling() {
+        let r = PerfResults::from_json_str(SAMPLE).unwrap();
+        let out = r.render_ferro_scaling("parse").unwrap();
+        assert!(out.contains("| Threads | 1 | 2 | 4 | 8 |"));
+        assert!(out.contains("| ferro parse | 1.2M/s | 2.3M/s | 4.4M/s | 8.0M/s |"));
+    }
+
+    #[test]
+    fn speedup_edge_cases() {
+        // Sub-1 ratio (ferro slower): round_2sig(0.5) -> 1 (Rust rounds half away from zero).
+        assert_eq!(fmt_speedup(50.0, 100.0), "1×");
+        // Zero / non-finite guards render the em-dash.
+        assert_eq!(fmt_speedup(100.0, 0.0), "—");
+        assert_eq!(fmt_speedup(f64::INFINITY, 1.0), "—");
+        assert_eq!(fmt_speedup(f64::NAN, 1.0), "—");
+    }
+
+    #[test]
+    fn ferro_scaling_missing_thread_renders_dash() {
+        // Drop the "2" key -> that column renders "—".
+        let json = SAMPLE.replace(r#""2": 2300000.0, "#, "");
+        let r = PerfResults::from_json_str(&json).unwrap();
+        let out = r.render_ferro_scaling("parse").unwrap();
+        assert!(out.contains("| ferro parse | 1.2M/s | — | 4.4M/s | 8.0M/s |"));
+    }
+
+    #[test]
+    fn placeholder_banner_toggles() {
+        let mut r = PerfResults::from_json_str(SAMPLE).unwrap();
+        assert!(r.placeholder_banner().is_none()); // SAMPLE has no placeholder field -> default false
+        r.placeholder = true;
+        assert!(r.placeholder_banner().unwrap().contains("Placeholder data"));
+    }
+}

--- a/tests/fixtures/perf/sample_perf_results.json
+++ b/tests/fixtures/perf/sample_perf_results.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "provenance": {
+    "generated": "2026-06-12T00:00:00Z", "corpus_id": "clinvar_patterns",
+    "corpus_sha": "PLACEHOLDER", "machine": "Apple M2 Max (12 cores)", "os": "darwin-arm64",
+    "tool_versions": {"ferro":"0.6.0","mutalyzer":"3.1.1","biocommons":"fa02ca5","hgvs-rs":"0.20.2"}
+  },
+  "operations": {
+    "parse": {
+      "sample_size_slow": 1000, "ferro_full_population_n": 1000000, "ferro_full_population_pps": 4200000.0,
+      "by_workers": {
+        "1": {"tools": {
+          "ferro": {"median_pps": 1200000.0, "min_pps": 1150000.0, "max_pps": 1250000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 21.0, "min_pps": 20.0, "max_pps": 22.0, "reps": 5, "success_rate": 0.994},
+          "biocommons": {"median_pps": 20.0, "min_pps": 19.0, "max_pps": 21.0, "reps": 5, "success_rate": 0.994},
+          "hgvs-rs": {"median_pps": 2.0, "min_pps": 1.8, "max_pps": 2.2, "reps": 5, "success_rate": 0.994}
+        }},
+        "8": {"tools": {
+          "ferro": {"median_pps": 8000000.0, "min_pps": 7800000.0, "max_pps": 8200000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 150.0, "min_pps": 140.0, "max_pps": 160.0, "reps": 5, "success_rate": 0.994},
+          "biocommons": {"median_pps": 140.0, "min_pps": 130.0, "max_pps": 150.0, "reps": 5, "success_rate": 0.994},
+          "hgvs-rs": {"median_pps": 14.0, "min_pps": 13.0, "max_pps": 15.0, "reps": 5, "success_rate": 0.994}
+        }}
+      },
+      "ferro_scaling": {"1": 1200000.0, "2": 2300000.0, "4": 4400000.0, "8": 8000000.0}
+    },
+    "normalize": {
+      "sample_size_slow": 1000, "ferro_full_population_n": 1000000, "ferro_full_population_pps": 900000.0,
+      "by_workers": {
+        "1": {"tools": {
+          "ferro": {"median_pps": 250000.0, "min_pps": 240000.0, "max_pps": 260000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 19.0, "min_pps": 18.0, "max_pps": 20.0, "reps": 5, "success_rate": 0.99},
+          "biocommons": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"},
+          "hgvs-rs": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"}
+        }},
+        "8": {"tools": {
+          "ferro": {"median_pps": 1800000.0, "min_pps": 1750000.0, "max_pps": 1850000.0, "reps": 10, "success_rate": 1.0},
+          "mutalyzer": {"median_pps": 140.0, "min_pps": 130.0, "max_pps": 150.0, "reps": 5, "success_rate": 0.99},
+          "biocommons": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"},
+          "hgvs-rs": {"median_pps": 0.0, "min_pps": 0.0, "max_pps": 0.0, "reps": 0, "success_rate": 0.0, "not_run": true, "reason": "UTA unavailable"}
+        }}
+      },
+      "ferro_scaling": {"1": 250000.0, "2": 480000.0, "4": 920000.0, "8": 1800000.0}
+    }
+  }
+}

--- a/tests/perf_table.rs
+++ b/tests/perf_table.rs
@@ -1,0 +1,54 @@
+//! Golden tests for the perf-table renderer.
+#![cfg(feature = "dev")]
+
+use ferro_hgvs::perf_table::PerfResults;
+
+fn fixture() -> PerfResults {
+    PerfResults::load("tests/fixtures/perf/sample_perf_results.json").expect("load fixture")
+}
+
+#[test]
+fn fixture_loads_and_has_both_ops() {
+    let r = fixture();
+    assert!(r.operations.contains_key("parse"));
+    assert!(r.operations.contains_key("normalize"));
+}
+
+#[test]
+fn parse_cross_tool_renders_expected() {
+    let r = fixture();
+    let out = r.render_cross_tool("parse").unwrap();
+    let expected = "\
+| Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
+|------|----------------------:|-----------------------:|-------------------:|
+| ferro | 1.2M/s | 8.0M/s | — |
+| mutalyzer | 21/s | 150/s | 53,000× |
+| biocommons | 20/s | 140/s | 57,000× |
+| hgvs-rs | 2/s | 14/s | 570,000× |
+";
+    assert_eq!(out, expected);
+}
+
+#[test]
+fn normalize_marks_not_run() {
+    let r = fixture();
+    let out = r.render_cross_tool("normalize").unwrap();
+    // biocommons + hgvs-rs are not_run -> em-dash in both worker columns.
+    assert!(out.contains("| biocommons | — | — | — |"));
+    assert!(out.contains("| hgvs-rs | — | — | — |"));
+    assert!(out.contains("| mutalyzer | 19/s |"));
+}
+
+#[test]
+fn ferro_scaling_renders_expected() {
+    let r = fixture();
+    let out = r.render_ferro_scaling("parse").unwrap();
+    assert_eq!(
+        out,
+        "\
+| Threads | 1 | 2 | 4 | 8 |
+|---------|--:|--:|--:|--:|
+| ferro parse | 1.2M/s | 2.3M/s | 4.4M/s | 8.0M/s |
+"
+    );
+}


### PR DESCRIPTION
**Plan 1 of 2** for the benchmark performance tables. This is the *rendering* half — the schema + generator + tables — with a placeholder data file. **Plan 2** (the measurement engine + actual benchmark runs that produce the real numbers) follows separately.

## What this adds

- **`src/perf_table/`** (dev-gated): serde types for `data/benchmark/perf_results.json` and pure renderers for:
  - the **parse** and **normalize** cross-tool throughput tables — each tool at **W=1 and W=8**, plus ferro's speedup at W=8 (tools whose stack can't run render `—` via a `not_run` flag);
  - the **ferro 1/2/4/8 thread-scaling** table.
  - Speedup rounding hardened against non-finite / overflow inputs.
- **`examples/generate_perf_tables.rs`**: rewrites `README.md` between `perf:*` markers, with a `--check` mode wired into CI (mirrors the tool-support matrix generator from #590).
- **Placeholder safety:** the committed `data/benchmark/perf_results.json` is flagged `"placeholder": true`, which renders a bold **"⚠️ Placeholder data — not yet measured"** banner above each table. The banner auto-disappears once Plan 2 replaces the file with measured numbers — so this PR never publishes unmarked fabricated benchmarks.
- Golden tests on the rendered tables; CI `--check` step.

## Why a placeholder

The numbers in the README right now are illustrative, not measured. Plan 2 builds the measurement engine (per-tool worker counts, repetitions with a shared seeded sample, timed-region discipline, parse-failure accounting) and runs it against the local reference stack to produce the real `perf_results.json`. Splitting the render half out first lets the rendering + CI machinery land and be reviewed independently of the heavier harness work.

## Test plan

- [ ] `cargo run --features dev --example generate_perf_tables -- --check` — exits 0
- [ ] `cargo clippy --features dev --all-targets -- -D warnings` and `--all-features` — clean
- [ ] `cargo nextest run --features dev` — perf_table unit + golden tests pass
- [ ] Confirm the README perf section shows the placeholder banner above each table