### PR TITLE
ci: perf-regression gate (cdot load-source structural test + nightly startup budget)

### DIFF
--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -68,6 +68,9 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Cache prepared reference manifest
+        # SHARED cache key with .github/workflows/nightly-perf.yml — keep this
+        # key and MANIFEST_CACHE_VERSION identical across both files so the perf
+        # gate reuses the manifest this job prepares; bump them together.
         id: cache-manifest
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -1,0 +1,171 @@
+name: Nightly perf budget
+
+# Real-data startup-regression gate for `ferro normalize`.
+#
+# Why this exists: PR #585 fixed a silent perf regression where the cdot cache
+# fell back to re-parsing a 512 MB JSON on every run, inflating startup ~1s ->
+# ~4.8s for months with nothing failing. No CI job exercised real-data startup.
+# This workflow does, nightly, so that class of regression fails loudly.
+#
+# Two gates, both hard-failing (unlike nightly-mutalyzer.yml, which is
+# continue-on-error and only reports drift):
+#   1. Cache-path co-gate: `ferro check --build-cache` must report
+#      `cdot cache: archive`. A `json-fallback` after building the cache means
+#      the fast archive is genuinely unusable (the #585 class) — independent of
+#      runner speed.
+#   2. Startup budget: min-of-7 `ferro normalize` startup must stay under a
+#      fixed ceiling. Catches a gross real-data regression the structural unit
+#      tests can't see.
+#
+# Reference data: reuses the prepared-manifest cache populated by
+# nightly-mutalyzer.yml. The `Cache prepared reference manifest` step below
+# shares its cache key BYTE-FOR-BYTE (GitHub Actions cache is repo-scoped), so
+# no second multi-GB `ferro prepare` is needed on a warm cache.
+
+on:
+  schedule:
+    # 05:00 UTC — one hour after nightly-mutalyzer (04:00) so the shared
+    # manifest cache is warm. Clear of the Sunday 00:00 external-validation run.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-perf-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # SHARED with nightly-mutalyzer.yml — keep identical, bump together.
+  MANIFEST_CACHE_VERSION: v1
+  # Budget knobs (seconds). Today's startup floor is ~1.0s; the #585 bug was
+  # ~4.8s. 2.5s sits ~2.5x above healthy and ~2x below the bug — outside runner
+  # noise in both directions.
+  STARTUP_BUDGET_MAX: '2.5'   # hard-fail if min-of-N exceeds this
+  STARTUP_WARN_MEDIAN: '1.5'  # warn-only (summary) if median exceeds this
+  STARTUP_RUNS: '7'
+
+jobs:
+  startup-budget:
+    name: ferro normalize startup budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          submodules: true
+          lfs: true
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          toolchain: stable
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-nightly
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache prepared reference manifest
+        # SHARED cache key with nightly-mutalyzer.yml — DO NOT diverge. GitHub
+        # Actions cache is repo-scoped, so this restores the same benchmark-output/
+        # the mutalyzer nightly prepared. Keep the key and MANIFEST_CACHE_VERSION
+        # identical across both files; bump them together.
+        id: cache-manifest
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: benchmark-output/
+          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs') }}
+
+      - name: Build ferro (release)
+        run: cargo build --release --bin ferro
+
+      - name: Run `ferro prepare` (cache miss only)
+        if: steps.cache-manifest.outputs.cache-hit != 'true'
+        run: |
+          ./target/release/ferro prepare \
+            --output-dir benchmark-output \
+            --genome grch38
+
+      - name: Confirm manifest present
+        run: |
+          test -f benchmark-output/manifest.json || \
+            (echo "::error::manifest.json missing after prepare step"; exit 1)
+
+      - name: Warm cache + cache-path co-gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `--build-cache` builds/refreshes the on-disk rkyv cache, then prints
+          # the load source. After a successful build the source MUST be the
+          # archive; a `json-fallback` here means the freshly built archive is
+          # unusable (layout drift / unwritable) — the #585 failure mode.
+          # Tolerate a non-zero exit so we can emit a clear diagnostic below; an
+          # absent/`json-fallback` cache line then fails the gate explicitly.
+          out="$(./target/release/ferro check --reference benchmark-output --build-cache 2>&1 || true)"
+          echo "$out"
+          line="$(printf '%s\n' "$out" | grep 'cdot cache:' || true)"
+          if [[ "$line" != *"archive"* ]]; then
+            echo "::error::cdot cache did not load from archive after --build-cache (silent fallback / #585 class). Got: ${line:-<none>}"
+            exit 1
+          fi
+          echo "cache-path co-gate OK: ${line}"
+
+      - name: Startup wall-time budget
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '%s\n' \
+            'NM_000088.3:c.589G>T' \
+            'NM_000088.3:c.10A>G' \
+            'NC_000001.11:g.12345A>G' > /tmp/perf_in.txt
+
+          bin=./target/release/ferro
+          ref=benchmark-output
+          run() { "$bin" normalize --reference "$ref" --error-mode lenient -i /tmp/perf_in.txt >/dev/null 2>&1 || true; }
+
+          # Warmup (untimed) — prime OS page cache so we measure code, not disk.
+          run
+
+          : > /tmp/perf_times.txt
+          for _ in $(seq 1 "${STARTUP_RUNS}"); do
+            start=$(date +%s.%N)
+            run
+            end=$(date +%s.%N)
+            awk -v s="$start" -v e="$end" 'BEGIN { printf "%.3f\n", e - s }' >> /tmp/perf_times.txt
+          done
+
+          min=$(sort -n /tmp/perf_times.txt | head -1)
+          median=$(sort -n /tmp/perf_times.txt | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}')
+
+          {
+            echo "### ferro normalize startup"
+            echo ""
+            echo "| metric | seconds |"
+            echo "|--------|---------|"
+            echo "| min (gate) | ${min} |"
+            echo "| median | ${median} |"
+            echo "| budget max | ${STARTUP_BUDGET_MAX} |"
+            echo ""
+            echo "runs: $(paste -sd' ' /tmp/perf_times.txt)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if awk -v m="$min" -v b="${STARTUP_BUDGET_MAX}" 'BEGIN { exit !(m > b) }'; then
+            echo "::error::startup min ${min}s exceeds budget ${STARTUP_BUDGET_MAX}s (#585-class regression)"
+            exit 1
+          fi
+          if awk -v m="$median" -v w="${STARTUP_WARN_MEDIAN}" 'BEGIN { exit !(m > w) }'; then
+            echo "::warning::startup median ${median}s exceeds warn threshold ${STARTUP_WARN_MEDIAN}s"
+          fi
+          echo "startup OK: min=${min}s median=${median}s"

--- a/docs/CI_PERF_GATE_DESIGN.md
+++ b/docs/CI_PERF_GATE_DESIGN.md
@@ -1,0 +1,266 @@
+# CI perf-regression gate — design
+
+Date: 2026-06-10
+Author: nilshomer
+Status: design (pending implementation)
+
+## Motivation
+
+PR #585 fixed a perf regression that went unnoticed for months. The cdot
+transcript cache (`.bin`) silently fell back to re-parsing a 512 MB JSON on
+every `ferro` invocation, inflating `ferro normalize` startup from ~1.0 s to
+~4.8 s. It was silent because of three compounding failures:
+
+1. The cache layout drifted; the stale `.bin` failed to load.
+2. The fallback warning went through `log`, which the CLI never initializes —
+   so nothing was printed.
+3. `prepare` skipped regenerating a stale `.bin` when one already existed.
+
+No test and no CI job exercised real-data startup, so a ~5× regression shipped
+undetected. This gate exists so that this *class* of bug — a fast path silently
+degrading to a slow path — fails loudly, both per-PR (deterministically) and
+nightly (against real reference data).
+
+## Goals
+
+- Catch a silent fast-path → slow-path fallback in the cdot cache **per-PR,
+  deterministically**, with no reference data and no timing thresholds.
+- Catch a gross real-data startup regression (the #585 ~5× class) **nightly**,
+  against the real prepared manifest, with a fixed wall-time budget.
+- Reuse existing CI infrastructure (the `nightly-mutalyzer.yml` prepared-manifest
+  cache) rather than provisioning new multi-GB reference data.
+
+## Non-goals (v1)
+
+- No per-PR wall-time benchmarking (too noisy on shared GitHub runners).
+- No baseline database, trend storage, or criterion-in-CI.
+- No annotate-vcf / TranscriptDb (#593) budget or structural test (deferred to v2).
+- No parse-throughput / FASTA / convert budgets — not the regression class #585
+  represents.
+- Determinism regressions stay covered by the existing conformance gate and the
+  #583/#588/#594 fixes; out of scope here.
+
+## Prerequisite — sequencing (IMPORTANT)
+
+This gate protects behavior introduced by the **#585 → #591 → #593 cache stack**,
+which is **not yet merged to `main`** as of this writing. Specifically:
+
+- The structural test's *self-heal* assertion depends on #585 (current `main`
+  `load` does not regenerate a stale cache).
+- The `ferro check` cache-path co-gate depends on `ferro check --build-cache`,
+  added in #585.
+- The fast-path representation moves from **bincode** (current `main`) to **rkyv**
+  in #591. This spec writes "archive" to mean *whatever fast binary cache is in
+  `main` when the gate lands*, so it survives that swap.
+
+**Therefore: implement this gate on top of the merged stack.** The
+`ci/perf-regression-gate` branch must be rebased onto `origin/main` *after*
+#585/#591/#593 land, before the implementation (not this design doc) is written.
+The design doc itself has no code dependency and can be committed now.
+
+## Architecture — two layers
+
+| Layer | When | Mechanism | Catches | Reference data |
+|-------|------|-----------|---------|----------------|
+| A. Structural test | per-PR | deterministic Rust unit tests | silent fallback (the #585 root cause) | none |
+| B. Startup budget | nightly | wall-time ceiling + cache-path co-gate | gross real-data regression (the #585 symptom) | shared prepared manifest |
+
+Layer A is the primary guard: it makes the *root cause* (a silent fallback)
+impossible to merge. Layer B is the backstop: it catches real-data regressions
+A cannot see (e.g. an algorithmic slowdown at scale, or an eager init added
+elsewhere), and re-checks the cache path against real data.
+
+---
+
+## Layer A — per-PR deterministic structural test
+
+### Production change: make the load path observable
+
+The root API hole is that `CdotMapper::load` returns `Result<Self>` with **no
+signal of which path it took**. A caller cannot tell archive-load from
+JSON-fallback, which is exactly why #585 was silent. Close the hole:
+
+In `src/data/cdot.rs`:
+
+```rust
+/// Which path `load` actually took. Makes a silent JSON fallback
+/// impossible to ignore at the API level (root cause of #585).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdotLoadSource {
+    /// Loaded from the fast binary archive (bincode today, rkyv after #591).
+    Archive,
+    /// Fell back to parsing the source JSON.
+    JsonFallback,
+}
+
+impl CdotMapper {
+    /// Like `load`, but reports which path produced the mapper.
+    pub fn load_with_source<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<(Self, CdotLoadSource), FerroError> {
+        // current `load` body, returning the tagged source on each arm
+    }
+
+    /// Unchanged public behavior.
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        Self::load_with_source(path).map(|(mapper, _)| mapper)
+    }
+}
+```
+
+- The successful archive arm returns `CdotLoadSource::Archive`.
+- The fallback arm (currently the silent `log::warn!` at `cdot.rs:1109`) returns
+  `CdotLoadSource::JsonFallback` instead of being swallowed.
+- `load`'s signature and behavior are unchanged — this is purely additive.
+
+This change is independently useful: it is also what powers the `ferro check`
+co-gate in Layer B.
+
+### Tests
+
+Three `#[cfg(test)]` unit tests in `src/data/cdot.rs`, placed alongside the
+existing `test_bincode_roundtrip_*` block (same module already does temp-file
+archive round-trips, so they share helpers and idioms). All use the existing
+inline `multi_build_cdot_json()` fixture written into a `tempfile::tempdir()` —
+no committed data files (per project rule: generate test data programmatically).
+
+1. **Fast path is taken (round-trip).** Build a mapper from the inline cdot JSON,
+   write the sibling archive (`to_bincode_file` / the archive writer), then
+   `load_with_source(json_path)` → assert source `== Archive` **and** key data
+   round-trips (transcript count, a `base_to_versioned` entry, `primary_build`).
+   Catches "layout drifted but load still claims success."
+
+2. **Stale/corrupt cache surfaces, not silent (negative).** Write a valid
+   archive, truncate/corrupt it on disk, then `load_with_source(json_path)` →
+   assert it still returns `Ok` (graceful) **but** source `== JsonFallback`.
+   Encodes "a broken cache must be observable, not silently absorbed."
+
+3. **Self-heal regenerates (the `prepare`-skipped-stale mode; depends on #585).**
+   After the corrupt-fallback load, drive the regeneration path (whatever
+   `load`/`prepare` uses to rewrite a fresh archive), then `load_with_source`
+   again → assert source `== Archive`. Proves a stale cache heals rather than
+   re-parsing JSON forever.
+
+No timing, no thresholds, no reference data — fully deterministic, runs in the
+existing per-PR `Test` job (`cargo nextest run --features dev`).
+
+---
+
+## Layer B — nightly real-startup budget
+
+### Workflow file
+
+New file `.github/workflows/nightly-perf.yml` — **not** a job appended to
+`nightly-mutalyzer.yml`, because the two have different failure semantics: the
+mutalyzer nightly is `continue-on-error: true` (surfaces drift, never gates),
+whereas the perf gate **must fail** on a budget breach. Separate files keep
+ownership clean and allow independent `workflow_dispatch`.
+
+Conventions (match the rest of the repo):
+- `runs-on: ubuntu-latest`, `permissions: contents: read`, `timeout-minutes: 30`,
+  a `concurrency` group mirroring the mutalyzer file.
+- All actions pinned by commit SHA with a `# vX.Y.Z` comment — reuse the exact
+  pinned SHAs already in `nightly-mutalyzer.yml` (checkout, `dtolnay/rust-toolchain`,
+  `actions/cache`).
+- The timing/gate steps use `shell: bash` with `set -euo pipefail`.
+- **No `continue-on-error` on the gate steps.**
+
+### Shared prepared-manifest cache (the load-bearing detail)
+
+Copy the `Cache prepared reference manifest` step **byte-identically** from
+`nightly-mutalyzer.yml`:
+
+- `path: benchmark-output/`
+- key: `${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs') }}`
+- `env.MANIFEST_CACHE_VERSION: v1`
+
+GitHub Actions cache is repo-scoped, so an identical key restores the
+already-prepared `benchmark-output/` that the mutalyzer nightly populated — no
+second multi-GB `ferro prepare`. Keep the `if: steps.cache-manifest.outputs.cache-hit
+!= 'true'` guarded `ferro prepare --output-dir benchmark-output --genome grch38`
+fallback so the perf job self-heals if it ever runs on a cold cache.
+
+**Coordination:** add a cross-referencing comment in **both** nightly files —
+"manifest cache key is shared with the other nightly; keep this key and
+`MANIFEST_CACHE_VERSION` identical, bump them together."
+
+**Schedule:** mutalyzer runs `0 4 * * *`. Run perf at `0 5 * * *` (05:00 UTC) so
+the mutalyzer job populates the manifest cache first and perf gets a warm
+restore, avoiding two concurrent cold `prepare`s. (Also clear of the Sunday
+00:00 external-validation run.) Plus `workflow_dispatch`.
+
+### Measurement protocol
+
+- **Command measured:** `ferro normalize` with `FERRO_MANIFEST=$GITHUB_WORKSPACE/benchmark-output/manifest.json`,
+  fed a tiny fixed input written to `/tmp` from a heredoc (3–5 `c.`/`g.` variants).
+  Startup is ~90% of wall time, so input size is irrelevant — we are deliberately
+  measuring **startup**, which is where #585 lived.
+- **Protocol:** 1 untimed warmup run (primes OS page cache → measure code, not
+  disk), then **N = 7** timed runs. Capture wall time via `date +%s.%N` deltas
+  around the binary; write each run's seconds to a temp file, then compute min/median
+  (do not pipe a long-running command straight into a parser).
+- **Statistic + ceiling:** gate value = **min of 7** (startup is fixed-cost work;
+  min strips upward scheduler noise and exposes the floor a silent fallback shifts).
+  **Hard-fail if min > 2.5 s.** Today's floor ~1.0 s; the bug was 4.8 s. 2.5 s sits
+  ~2.5× above healthy and ~2× below the bug — comfortably outside runner noise.
+- **Soft warn (summary only):** also compute median; if median > 1.5 s, emit a
+  `::warning::` and a bold row in `$GITHUB_STEP_SUMMARY`, but **do not fail**.
+
+### Deterministic co-gate (the true #585 catch)
+
+A fast runner could squeak under 2.5 s while still silently re-parsing JSON, so
+timing alone is not a reliable #585 catch. Add a timing-free assertion:
+
+- Surface `CdotLoadSource` through `ferro check` (and `ferro check --build-cache`):
+  print `cache: archive` vs `cache: json-fallback`.
+- After the timed runs, the perf job runs `ferro check` against the prepared
+  manifest and **hard-fails if the output is not the archive path.**
+
+This catches the real #585 failure (silent fallback) independent of runner speed.
+It is the single most important part of Layer B.
+
+### Job summary
+
+Write a table to `$GITHUB_STEP_SUMMARY`: min / median / all 7 timings + the
+cache-path line. No artifact upload needed for v1 (the summary suffices).
+
+---
+
+## v1 scope summary
+
+- **Per-PR (deterministic, no reference data):** add `CdotLoadSource{Archive,
+  JsonFallback}` + `load_with_source` in `src/data/cdot.rs`; `load` wraps it.
+  Three unit tests beside `test_bincode_roundtrip_*`: (1) round-trip uses
+  `Archive`, (2) corrupt cache → `JsonFallback` not silent, (3) self-heal
+  restores `Archive`. Fixture = existing inline `multi_build_cdot_json()` +
+  `tempfile::tempdir()`.
+- **Nightly (`.github/workflows/nightly-perf.yml`, new, `0 5 * * *`):** restore
+  the shared `benchmark-output/` manifest via the byte-identical cache key +
+  `MANIFEST_CACHE_VERSION: v1`; `prepare` only on cache miss.
+- **Budget:** measure `ferro normalize` startup, 1 warmup + 7 timed runs;
+  hard-fail if min > 2.5 s; median > 1.5 s → warn-only in summary.
+- **Deterministic co-gate:** `ferro check` must report `cache: archive`;
+  hard-fail on `json-fallback` — the true #585 catch, independent of runner speed.
+- **Conventions:** actions pinned by SHA + version comment, `shell: bash` /
+  `set -euo pipefail`, `permissions: contents: read`, no `continue-on-error` on
+  the gate; keep the shared cache key in sync via cross-referencing comments.
+
+## Deferred to v2 (documented, not built)
+
+- annotate-vcf / TranscriptDb (#593) wall-time budget — add once #593 is in
+  `main` and a small GFF/VCF pair is cacheable; ceiling ~1.5 s (today ~0.6 s).
+- A TranscriptDb structural test — #593's binary cache is the same silent-fallback
+  class and deserves the identical `LoadSource` treatment as a fast-follow.
+
+## Risks / open questions
+
+- **Stack-merge sequencing** (see Prerequisite): if the gate is implemented before
+  #585/#591/#593 merge, test #3 and the `ferro check` co-gate will fail because
+  the self-heal / `--build-cache` behavior doesn't exist yet. Mitigation: build on
+  the rebased post-stack branch.
+- **rkyv archive-writer API (#591):** the exact "write the sibling archive" and
+  "regenerate" calls in tests #1/#3 must match whatever #591 lands; confirm the
+  symbol names when rebasing onto the stack.
+- **Runner-floor drift:** if `ubuntu-latest` hardware gets slower, the ~1.0 s
+  floor could rise. 2.5 s has wide headroom, but revisit the ceiling if the
+  warn-threshold (1.5 s median) starts firing routinely on healthy runs.

--- a/docs/CI_PERF_GATE_DESIGN.md
+++ b/docs/CI_PERF_GATE_DESIGN.md
@@ -191,7 +191,9 @@ restore, avoiding two concurrent cold `prepare`s. (Also clear of the Sunday
 
 ### Measurement protocol
 
-- **Command measured:** `ferro normalize` with `FERRO_MANIFEST=$GITHUB_WORKSPACE/benchmark-output/manifest.json`,
+- **Command measured:** `ferro normalize --reference benchmark-output` (the
+  `ferro` binary takes a reference *directory* via `--reference`; it does not
+  read the `FERRO_MANIFEST` env var, which is a test-harness-only convention),
   fed a tiny fixed input written to `/tmp` from a heredoc (3–5 `c.`/`g.` variants).
   Startup is ~90% of wall time, so input size is irrelevant — we are deliberately
   measuring **startup**, which is where #585 lived.

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -2847,6 +2847,22 @@ fn run_check(reference: &Path, build_cache: bool) -> Result<(), Box<dyn std::err
         eprintln!("Reference cache ready in {:.1?}.", started.elapsed());
     }
 
+    // Report which path the cdot cache loads from, so a silent fast-path →
+    // JSON-fallback regression (the #585 class) is visible rather than only
+    // showing up as a slow startup. The nightly perf gate parses this line as a
+    // timing-free co-assertion that the prepared cache is on the fast path.
+    // Printed after `--build-cache` so it reflects the freshly built cache.
+    match ferro_hgvs::commands::cdot_cache_load_source(reference) {
+        Ok(Some(ferro_hgvs::data::CdotLoadSource::Archive)) => {
+            println!("cdot cache: archive");
+        }
+        Ok(Some(ferro_hgvs::data::CdotLoadSource::JsonFallback)) => {
+            println!("cdot cache: json-fallback");
+        }
+        Ok(None) => {} // No manifest or cdot entry — nothing to report.
+        Err(e) => eprintln!("warning: could not determine cdot cache source: {}", e),
+    }
+
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -134,6 +134,58 @@ pub fn create_reference_provider(
     }
 }
 
+/// Report which path the cdot cache loads from for a prepared reference dir.
+///
+/// Resolves the `cdot_json` entry of `<reference_dir>/manifest.json` (relative
+/// entries are resolved against the manifest's directory, mirroring
+/// [`MultiFastaProvider::from_manifest`]) and loads it via
+/// [`CdotMapper::load_with_source`], returning the [`CdotLoadSource`]. Returns
+/// `Ok(None)` when there is nothing to report — no manifest, no `cdot_json`
+/// entry, or the referenced cdot file is missing.
+///
+/// `ferro check` uses this to surface a silent fast-path → JSON-fallback
+/// regression (#585), and the nightly perf gate uses it as a timing-free
+/// co-assertion that the prepared cache is actually on the fast path.
+pub fn cdot_cache_load_source(
+    reference_dir: &Path,
+) -> Result<Option<crate::data::CdotLoadSource>, FerroError> {
+    let manifest_path = reference_dir.join("manifest.json");
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let base_dir = manifest_path.parent().unwrap_or(Path::new("."));
+    let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
+        msg: format!("Failed to open manifest {}: {}", manifest_path.display(), e),
+    })?;
+    let manifest: serde_json::Value =
+        serde_json::from_reader(file).map_err(|e| FerroError::Io {
+            msg: format!(
+                "Failed to parse manifest {}: {}",
+                manifest_path.display(),
+                e
+            ),
+        })?;
+
+    let Some(cdot_str) = manifest.get("cdot_json").and_then(|v| v.as_str()) else {
+        return Ok(None);
+    };
+    let cdot_path = {
+        let p = std::path::PathBuf::from(cdot_str);
+        if p.is_absolute() {
+            p
+        } else {
+            base_dir.join(p)
+        }
+    };
+    if !cdot_path.exists() {
+        return Ok(None);
+    }
+
+    let (_mapper, source) = crate::data::CdotMapper::load_with_source(&cdot_path)?;
+    Ok(Some(source))
+}
+
 /// Normalize variants from a file.
 ///
 /// # Arguments
@@ -469,5 +521,78 @@ mod tests {
         assert_eq!(timing.failed, 10);
         assert!((timing.elapsed_seconds - 2.0).abs() < 0.001);
         assert!((timing.variants_per_second - 50.0).abs() < 0.001);
+    }
+
+    const MINIMAL_CDOT_JSON: &str = r#"
+    {
+        "transcripts": {
+            "NM_000088.3": {
+                "gene_name": "COL1A1",
+                "contig": "NC_000017.11",
+                "strand": "+",
+                "exons": [[50184096, 50184169, 0, 73]],
+                "cds_start": 10,
+                "cds_end": 60
+            }
+        }
+    }
+    "#;
+
+    #[test]
+    fn cdot_cache_load_source_is_none_without_manifest() {
+        let dir = TempDir::new().unwrap();
+        assert!(cdot_cache_load_source(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn cdot_cache_load_source_is_none_without_cdot_entry() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            r#"{"genome_fasta": "x.fa"}"#,
+        )
+        .unwrap();
+        assert!(cdot_cache_load_source(dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn cdot_cache_load_source_reports_archive_for_fresh_cache() {
+        use crate::data::CdotLoadSource;
+        let dir = TempDir::new().unwrap();
+        let cdot_json = dir.path().join("cdot.json");
+        std::fs::write(&cdot_json, MINIMAL_CDOT_JSON).unwrap();
+        // Prime the cache: the first load self-heals a fresh sibling .rkyv.
+        crate::data::CdotMapper::load(&cdot_json).unwrap();
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            r#"{"cdot_json": "cdot.json"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            cdot_cache_load_source(dir.path()).unwrap(),
+            Some(CdotLoadSource::Archive),
+            "a prepared cdot with a fresh sibling archive must report archive"
+        );
+    }
+
+    #[test]
+    fn cdot_cache_load_source_reports_json_fallback_without_archive() {
+        use crate::data::CdotLoadSource;
+        let dir = TempDir::new().unwrap();
+        let cdot_json = dir.path().join("cdot.json");
+        std::fs::write(&cdot_json, MINIMAL_CDOT_JSON).unwrap();
+        // No sibling .rkyv exists yet → the load must fall back to JSON.
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            r#"{"cdot_json": "cdot.json"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            cdot_cache_load_source(dir.path()).unwrap(),
+            Some(CdotLoadSource::JsonFallback),
+            "a cdot with no usable archive must report json-fallback, not archive"
+        );
     }
 }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1116,6 +1116,21 @@ impl From<CdotTranscriptSnapshot> for CdotTranscript {
     }
 }
 
+/// Which path [`CdotMapper::load_with_source`] took to produce the mapper.
+///
+/// Makes a silent fast-path → slow-path fallback impossible to ignore at the
+/// API level (the root cause of the #585 regression, where a broken binary
+/// cache silently re-parsed 512 MB of JSON on every run). A binary cache
+/// (`.rkyv` or legacy `.bin`) is the fast `Archive` path; an actual JSON parse
+/// is `JsonFallback`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdotLoadSource {
+    /// Loaded from a fast binary archive (`.rkyv`, or legacy `.bin`).
+    Archive,
+    /// Fell back to parsing the source JSON (slow path).
+    JsonFallback,
+}
+
 /// Coordinate mapper using cdot data.
 #[derive(Debug, Clone)]
 pub struct CdotMapper {
@@ -1583,15 +1598,31 @@ impl CdotMapper {
     /// usable, then writes a fresh `.rkyv` cache. Also accepts direct `.rkyv`
     /// or `.bin` paths.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        Self::load_with_source(path).map(|(mapper, _)| mapper)
+    }
+
+    /// Like [`load`](Self::load), but also reports which path produced the
+    /// mapper. This closes the API hole that let the #585 regression go silent:
+    /// before this, a caller could not tell a fast archive load from a slow
+    /// JSON re-parse, so a silently-broken cache (re-parsing 512 MB of JSON on
+    /// every run) was invisible. The returned [`CdotLoadSource`] makes that
+    /// distinction assertable in tests and observable via `ferro check`.
+    ///
+    /// A binary cache (`.rkyv` or legacy `.bin`) counts as
+    /// [`CdotLoadSource::Archive`] — the "fast path". Only an actual JSON parse
+    /// returns [`CdotLoadSource::JsonFallback`]. Note that the JSON-fallback arm
+    /// still self-heals the sibling `.rkyv` as a side effect, so a *subsequent*
+    /// `load_with_source` on the same path reports `Archive`.
+    pub fn load_with_source<P: AsRef<Path>>(path: P) -> Result<(Self, CdotLoadSource), FerroError> {
         let path = path.as_ref();
         let path_str = path.to_string_lossy();
 
         // Direct archive paths — no JSON fallback available.
         if path_str.ends_with(".rkyv") {
-            return Self::from_rkyv_file(path);
+            return Self::from_rkyv_file(path).map(|m| (m, CdotLoadSource::Archive));
         }
         if path_str.ends_with(".bin") {
-            return Self::from_bincode_file(path);
+            return Self::from_bincode_file(path).map(|m| (m, CdotLoadSource::Archive));
         }
 
         // Sibling cache paths next to the JSON. Replace the *single* trailing
@@ -1625,7 +1656,7 @@ impl CdotMapper {
         // 1. Prefer the rkyv archive (fastest, validated).
         if rkyv_path.exists() && cache_is_fresh(&rkyv_path) {
             match Self::from_rkyv_file(&rkyv_path) {
-                Ok(mapper) => return Ok(mapper),
+                Ok(mapper) => return Ok((mapper, CdotLoadSource::Archive)),
                 Err(e) => eprintln!(
                     "warning: cdot rkyv cache {} is unusable ({}); trying other formats",
                     rkyv_path.display(),
@@ -1647,7 +1678,7 @@ impl CdotMapper {
                             e
                         );
                     }
-                    return Ok(mapper);
+                    return Ok((mapper, CdotLoadSource::Archive));
                 }
                 Err(e) => eprintln!(
                     "warning: cdot bincode cache {} is unusable ({}); \
@@ -1676,7 +1707,7 @@ impl CdotMapper {
             );
         }
 
-        Ok(mapper)
+        Ok((mapper, CdotLoadSource::JsonFallback))
     }
 
     /// Load from any reader, defaulting to GRCh38 genome build.
@@ -3314,6 +3345,112 @@ mod tests {
                 .as_deref(),
             Some("COL1A1"),
             "load() should refresh the stale rkyv after reparsing the JSON"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Load-source observability (the #585 perf-regression gate). These assert
+    // the `CdotLoadSource` tag, not just the data — so a silent fast-path →
+    // JSON-fallback regression fails the build deterministically, with no
+    // reference data and no timing thresholds.
+    // -------------------------------------------------------------------------
+
+    /// A fresh sibling archive is taken AND reported as `Archive`, and the data
+    /// round-trips through it. Guards "layout drifted but load still claims the
+    /// fast path" (#585): a load that quietly fell back to JSON would report
+    /// `JsonFallback` and fail this.
+    #[test]
+    fn load_with_source_reports_archive_for_fresh_rkyv() {
+        let json = multi_build_cdot_json();
+        let expected = CdotMapper::from_reader(json.as_bytes()).unwrap();
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+        let rkyv_path = temp_dir.path().join("cdot.rkyv");
+
+        // Write the JSON first, then the sibling archive — so the archive is at
+        // least as new as the source and `load` prefers it.
+        std::fs::write(&json_path, json).unwrap();
+        expected.to_rkyv_file(&rkyv_path).unwrap();
+
+        let (loaded, source) = CdotMapper::load_with_source(&json_path).unwrap();
+        assert_eq!(
+            source,
+            CdotLoadSource::Archive,
+            "a fresh sibling .rkyv must load via the fast archive path"
+        );
+        // Data round-trips through the archive.
+        assert_eq!(loaded.transcript_count(), expected.transcript_count());
+        assert_eq!(loaded.primary_build, expected.primary_build);
+    }
+
+    /// A stale archive is observably *not* served: the load falls back to JSON
+    /// and reports `JsonFallback` (rather than silently re-parsing forever as in
+    /// #585), and the side-effecting self-heal makes the *next* load report
+    /// `Archive`.
+    #[test]
+    fn load_with_source_reports_json_fallback_then_self_heals() {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let original = CdotMapper::from_reader(json.as_bytes()).unwrap();
+
+        // A stale rkyv carrying a sentinel distinct from the JSON.
+        let mut stale = original.clone();
+        stale.transcripts.get_mut("NM_000088.3").unwrap().gene_name =
+            Some("FROM_STALE_RKYV".to_string());
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let json_path = temp_dir.path().join("cdot.json");
+        let rkyv_path = temp_dir.path().join("cdot.rkyv");
+
+        std::fs::write(&json_path, json).unwrap();
+        stale.to_rkyv_file(&rkyv_path).unwrap();
+
+        // Backdate the rkyv so it is strictly older than the JSON source.
+        let backdated = std::time::SystemTime::now() - std::time::Duration::from_secs(60);
+        std::fs::File::options()
+            .write(true)
+            .open(&rkyv_path)
+            .unwrap()
+            .set_modified(backdated)
+            .unwrap();
+
+        // First load: stale archive skipped → slow JSON path, observably tagged.
+        let (first, first_source) = CdotMapper::load_with_source(&json_path).unwrap();
+        assert_eq!(
+            first_source,
+            CdotLoadSource::JsonFallback,
+            "a stale archive must surface as a JSON fallback, not be silently served"
+        );
+        assert_eq!(
+            first
+                .get_transcript("NM_000088.3")
+                .unwrap()
+                .gene_name
+                .as_deref(),
+            Some("COL1A1"),
+            "the fallback must serve the real JSON data, not the stale sentinel"
+        );
+
+        // Second load: the self-heal refreshed the archive → fast path restored.
+        let (_second, second_source) = CdotMapper::load_with_source(&json_path).unwrap();
+        assert_eq!(
+            second_source,
+            CdotLoadSource::Archive,
+            "after self-heal the next load must take the fast archive path \
+             (not re-parse JSON forever, the #585 failure)"
         );
     }
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -29,8 +29,8 @@ pub mod mapping;
 pub mod projection;
 
 pub use cdot::{
-    cumulative_insertion_offset, parse_cigar, CdotFile, CdotMapper, CdotTranscript, CdsPosition,
-    CigarOp, Exon,
+    cumulative_insertion_offset, parse_cigar, CdotFile, CdotLoadSource, CdotMapper, CdotTranscript,
+    CdsPosition, CigarOp, Exon,
 };
 pub use mapping::{CoordinateMapper, MappingInfo, MappingResult};
 pub use projection::{ManeStatus, ProjectionResult, Projector, TranscriptProjection};


### PR DESCRIPTION
## Summary

Adds a CI gate for the class of perf regression that #585 fixed — a silently-broken cdot cache that re-parsed ~512 MB of JSON on every run (≈1.0s → ≈4.8s startup) for months, with nothing failing because the fallback warning went through `log`, which the CLI never initializes.

The #585/#591/#593 stack fixed the *bug* (versioned/self-healing rkyv cache). This PR adds the *gate* so the failure mode can't silently return: `CdotMapper::load` still returns `Result<Self>` with no signal of which path it took, so neither a test nor an operator can tell a fast archive load from a slow JSON re-parse. This closes that hole.

Implements `docs/CI_PERF_GATE_DESIGN.md` (included).

## Two layers

**A. Per-PR deterministic structural test (no reference data, no timing).**
- New `CdotLoadSource { Archive, JsonFallback }` + `CdotMapper::load_with_source`; `load` delegates to it (behavior unchanged).
- Unit tests assert: a fresh sibling archive loads as `Archive`; a stale/corrupt archive surfaces as `JsonFallback` (not silently served) and then self-heals back to `Archive` on the next load.
- Uses the existing inline `multi_build_cdot_json()` fixture + `tempfile` — no committed test data.

**B. Nightly real-startup budget (`.github/workflows/nightly-perf.yml`).**
- Reuses the prepared-reference-manifest cache from `nightly-mutalyzer.yml` (byte-identical cache key — cross-referenced in both files), so no second multi-GB `ferro prepare` on a warm cache.
- Hard-fails on two gates: (1) `ferro check` must report the cdot cache loads from `archive` — a timing-free catch of the #585 silent-fallback independent of runner speed; (2) min-of-7 `ferro normalize` startup must stay under 2.5s (today ≈1.0s; the bug was ≈4.8s). Median > 1.5s warns in the job summary.
- `ferro check` now prints `cdot cache: archive | json-fallback` (via `commands::cdot_cache_load_source`), making the path observable to operators too.

## Scope (v1)

Deliberately cdot-`normalize`-only. annotate-vcf / TranscriptDb (#593) budget and its own structural test are explicitly deferred to v2 (documented in the design doc).

## Verification

`cargo nextest run --features dev` (6 gate tests pass), `cargo clippy --features dev --all-targets` and `--all-features --all-targets` clean, `cargo fmt --check` clean, `nightly-perf.yml` passes `actionlint`.
