### PR TITLE
perf(cli): format the normalized variant once per output line

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1211,11 +1211,17 @@ fn run_normalize(
                         warning.message
                     );
                 }
-                if v == normalized.to_string() {
-                    writeln!(writer, "{}", normalized)
+                // Format the normalized variant once and reuse it for both the
+                // unchanged-vs-changed comparison and the written output. The
+                // previous code called `normalized.to_string()` for the compare
+                // and then formatted `normalized` again in `writeln!`, paying
+                // the `Display` cost twice per line (~8% of a batch run).
+                let normalized_str = normalized.to_string();
+                if v == normalized_str {
+                    writeln!(writer, "{}", normalized_str)
                         .map_err(|e| FerroError::Io { msg: e.to_string() })?;
                 } else {
-                    writeln!(writer, "{} -> {}", v, normalized)
+                    writeln!(writer, "{} -> {}", v, normalized_str)
                         .map_err(|e| FerroError::Io { msg: e.to_string() })?;
                 }
             }


### PR DESCRIPTION
## Summary

The text-output branch of `ferro normalize` formatted the normalized variant **twice** per line: once via `normalized.to_string()` to compare against the input (to decide between `X` and `X -> Y` output), then again inside the `writeln!`. This patch formats it once into a `String` and reuses it.

## Why

Profiling `ferro normalize` over a 333k-line ClinVar corpus (after the larger `has_genomic_data` hot-loop fix) attributed ~8% of inclusive samples to output formatting — `<HgvsVariant as Display>::fmt` plus `core::fmt::write`. Half of that is redundant: the `Display` impl runs once for the comparison and again for the write, each also allocating a `String`.

## Correctness

Output is **byte-identical** — verified by diffing a full 333k-variant run before/after (`diff -q` → identical). The change is strictly less work (one `Display` pass and one allocation per line instead of two).

## Note on measurement

The expected wall-time delta (~4%, halving an ~8% component) is below the run-to-run noise floor on the loaded machine I measured on (loadavg ~7–13), so I'm not quoting a headline number — but the change removes provably-redundant work and is output-identical. `cargo clippy --features dev` and `fmt` are clean.
