### PR TITLE
fix(benchmark): time normalize tools by subprocess-internal timer (#609)

### DIFF
--- a/src/benchmark/biocommons.rs
+++ b/src/benchmark/biocommons.rs
@@ -2180,8 +2180,6 @@ pub fn run_biocommons_normalizer_parallel(
         return Ok(());
     }
 
-    let start = std::time::Instant::now();
-
     // Shard patterns across workers
     let chunk_size = patterns.len().div_ceil(num_workers);
     let chunks: Vec<Vec<String>> = patterns.chunks(chunk_size).map(|c| c.to_vec()).collect();
@@ -2192,8 +2190,9 @@ pub fn run_biocommons_normalizer_parallel(
         patterns.len()
     );
 
-    // Run subprocesses in parallel
-    let results: Vec<Result<Vec<ParseResult>, FerroError>> = chunks
+    // Run subprocesses in parallel. Each shard returns its parsed results
+    // plus the subprocess's own internal (startup-excluded) compute time.
+    let results: Vec<Result<(Vec<ParseResult>, f64), FerroError>> = chunks
         .par_iter()
         .map(|chunk| {
             // Create temp files for this shard
@@ -2265,17 +2264,26 @@ pub fn run_biocommons_normalizer_parallel(
                 .collect();
             let parsed_results = parsed_results?;
 
-            Ok(parsed_results)
+            // The Python subprocess records its own startup-excluded timer.
+            let shard_secs = output_data["elapsed_seconds"].as_f64().unwrap_or(0.0);
+
+            Ok((parsed_results, shard_secs))
         })
         .collect();
 
-    let elapsed = start.elapsed();
-
-    // Merge all results
+    // Merge all results and collect each shard's internal compute time.
     let mut all_results: Vec<ParseResult> = Vec::new();
+    let mut shard_secs: Vec<f64> = Vec::new();
     for result in results {
-        all_results.extend(result?);
+        let (parsed_results, secs) = result?;
+        all_results.extend(parsed_results);
+        shard_secs.push(secs);
     }
+
+    // Time the tool by the subprocess's own internal timer (startup-excluded),
+    // using the critical path across concurrent shards rather than Rust wall
+    // time, which would fold in interpreter startup + import (#609).
+    let internal_secs = super::compare::critical_path_secs(&shard_secs);
 
     let successful = all_results.iter().filter(|r| r.success).count();
     let failed = all_results.len() - successful;
@@ -2295,8 +2303,12 @@ pub fn run_biocommons_normalizer_parallel(
         "total_patterns": all_results.len(),
         "successful": successful,
         "failed": failed,
-        "elapsed_seconds": elapsed.as_secs_f64(),
-        "patterns_per_second": all_results.len() as f64 / elapsed.as_secs_f64(),
+        "elapsed_seconds": internal_secs,
+        "patterns_per_second": if internal_secs > 0.0 {
+            all_results.len() as f64 / internal_secs
+        } else {
+            0.0
+        },
         "error_counts": error_counts,
         "results": all_results,
     });

--- a/src/benchmark/compare.rs
+++ b/src/benchmark/compare.rs
@@ -1009,12 +1009,13 @@ pub fn compare_normalize<P: AsRef<Path>>(
                     "\n[2/2] Running mutalyzer normalize ({} workers)...",
                     config.workers
                 );
-                let (results, elapsed, error_counts) = run_mutalyzer_normalize_parallel(
-                    &mutalyzer_patterns,
-                    config.workers,
-                    config.mutalyzer_settings.as_deref(),
-                    config.allow_mutalyzer_network,
-                )?;
+                let (results, elapsed, _internal_elapsed, error_counts) =
+                    run_mutalyzer_normalize_parallel(
+                        &mutalyzer_patterns,
+                        config.workers,
+                        config.mutalyzer_settings.as_deref(),
+                        config.allow_mutalyzer_network,
+                    )?;
                 eprintln!(
                     "      {} patterns in {:.2}s ({:.0} p/s)",
                     sampled.len(),
@@ -1588,6 +1589,24 @@ fn run_ferro_parse(
     (results, elapsed)
 }
 
+/// Aggregate per-shard subprocess-internal compute times into a single
+/// startup-excluded wall-time estimate.
+///
+/// Each shard's value is the Python subprocess's own `time.perf_counter()`
+/// timer (the `elapsed_seconds` it writes to its output), so it already
+/// excludes interpreter startup and import. Shards run concurrently — one
+/// subprocess per worker — so the startup-excluded wall time is the slowest
+/// shard (the critical path), never the sum of per-shard compute times. For a
+/// single shard (the cross-tool W=1 perf-matrix point) this is exactly that
+/// shard's internal time, mirroring how the parse path records timing.
+///
+/// Note: under the work-stealing pre-sharded path a worker may process several
+/// shards in sequence, so this is a lower bound on the true per-worker critical
+/// path there; it still removes the dominant per-process startup term.
+pub(crate) fn critical_path_secs(shard_secs: &[f64]) -> f64 {
+    shard_secs.iter().copied().fold(0.0, f64::max)
+}
+
 /// Run mutalyzer normalization in parallel using sharded subprocesses.
 ///
 /// Supports two modes:
@@ -1596,6 +1615,10 @@ fn run_ferro_parse(
 ///    Each worker processes one or more shards sequentially.
 /// 2. Runtime partitioning (fallback): Patterns are distributed round-robin to
 ///    workers, and each worker gets symlinks to only the sequences it needs.
+///
+/// Returns the parsed results, the Rust wall time, the subprocess-internal
+/// critical-path time (startup-excluded; see [`critical_path_secs`]), and the
+/// aggregated error counts.
 #[allow(clippy::type_complexity)]
 pub fn run_mutalyzer_normalize_parallel(
     patterns: &[String],
@@ -1605,6 +1628,7 @@ pub fn run_mutalyzer_normalize_parallel(
 ) -> Result<
     (
         Vec<ParseResult>,
+        std::time::Duration,
         std::time::Duration,
         HashMap<String, usize>,
     ),
@@ -1751,6 +1775,7 @@ pub fn run_mutalyzer_normalize_parallel(
     // Collect results and aggregate error counts
     let mut all_results = Vec::new();
     let mut aggregated_error_counts: HashMap<String, usize> = HashMap::new();
+    let mut shard_secs: Vec<f64> = Vec::new();
     for (_, output_path) in &shard_paths {
         let file = File::open(output_path).map_err(|e| FerroError::Io {
             msg: format!("Failed to open shard output: {}", e),
@@ -1760,6 +1785,7 @@ pub fn run_mutalyzer_normalize_parallel(
             serde_json::from_reader(reader).map_err(|e| FerroError::Json {
                 msg: format!("Failed to parse shard output: {}", e),
             })?;
+        shard_secs.push(output.elapsed_seconds);
         all_results.extend(output.results);
 
         // Aggregate error counts from each shard
@@ -1768,7 +1794,17 @@ pub fn run_mutalyzer_normalize_parallel(
         }
     }
 
-    Ok((all_results, elapsed, aggregated_error_counts))
+    // The Python subprocess records its own startup-excluded compute time per
+    // shard; use the critical path across concurrent shards rather than the
+    // Rust wall time (which folds in interpreter startup + import).
+    let internal_elapsed = std::time::Duration::from_secs_f64(critical_path_secs(&shard_secs));
+
+    Ok((
+        all_results,
+        elapsed,
+        internal_elapsed,
+        aggregated_error_counts,
+    ))
 }
 
 /// Run mutalyzer normalization using pre-sharded cache with work-stealing.
@@ -1789,6 +1825,7 @@ fn run_mutalyzer_normalize_presharded(
 ) -> Result<
     (
         Vec<ParseResult>,
+        std::time::Duration,
         std::time::Duration,
         HashMap<String, usize>,
     ),
@@ -1935,6 +1972,7 @@ fn run_mutalyzer_normalize_presharded(
     // Collect results from all completed shards
     let mut all_results = Vec::new();
     let mut aggregated_error_counts: HashMap<String, usize> = HashMap::new();
+    let mut shard_secs: Vec<f64> = Vec::new();
 
     for output_path in &completed_outputs {
         let file = File::open(output_path).map_err(|e| FerroError::Io {
@@ -1945,6 +1983,7 @@ fn run_mutalyzer_normalize_presharded(
             serde_json::from_reader(reader).map_err(|e| FerroError::Json {
                 msg: format!("Failed to parse output: {}", e),
             })?;
+        shard_secs.push(output.elapsed_seconds);
         all_results.extend(output.results);
 
         for (category, count) in output.error_counts {
@@ -1952,7 +1991,17 @@ fn run_mutalyzer_normalize_presharded(
         }
     }
 
-    Ok((all_results, elapsed, aggregated_error_counts))
+    // The Python subprocess records its own startup-excluded compute time per
+    // shard; use the critical path across concurrent shards rather than the
+    // Rust wall time (which folds in interpreter startup + import).
+    let internal_elapsed = std::time::Duration::from_secs_f64(critical_path_secs(&shard_secs));
+
+    Ok((
+        all_results,
+        elapsed,
+        internal_elapsed,
+        aggregated_error_counts,
+    ))
 }
 
 /// Kill and wait on a single child process, logging any errors.
@@ -4591,6 +4640,33 @@ fn save_detailed_results<P: AsRef<Path>>(
     eprintln!("Detailed results saved to: {}", path.display());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod critical_path_tests {
+    use super::*;
+
+    #[test]
+    fn no_shards_is_zero() {
+        // No subprocess ran, so there is no startup-excluded compute time.
+        assert_eq!(critical_path_secs(&[]), 0.0);
+    }
+
+    #[test]
+    fn single_shard_returns_its_own_internal_time() {
+        // The cross-tool W=1 matrix point: one subprocess, so the
+        // startup-excluded time is exactly that shard's internal timer —
+        // mirroring how the parse path reads `elapsed_seconds`.
+        assert_eq!(critical_path_secs(&[1.5]), 1.5);
+    }
+
+    #[test]
+    fn concurrent_shards_take_the_slowest_not_the_sum() {
+        // Shards run concurrently (one subprocess per worker), so the
+        // startup-excluded wall time is the critical path (the slowest shard),
+        // never the sum of per-shard compute times.
+        assert_eq!(critical_path_secs(&[0.4, 1.2, 0.9]), 1.2);
+    }
 }
 
 #[cfg(test)]

--- a/src/benchmark/perf_matrix.rs
+++ b/src/benchmark/perf_matrix.rs
@@ -257,10 +257,12 @@ pub fn run_operation(
 /// so Python startup is NOT included in parse throughput numbers. ferro and
 /// hgvs-rs parse throughput is also measured after any one-time setup.
 pub const TIMED_REGION_NOTE: &str =
-    "normalize throughput for mutalyzer/biocommons includes Python subprocess \
-     startup in the timed region (ferro/hgvs-rs exclude it; <2% at this sample \
-     size); parse throughput excludes Python startup (measured by the \
-     subprocess's internal timer). See issue tracker.";
+    "All tools exclude process/interpreter startup from the timed region: the \
+     mutalyzer/biocommons subprocesses are timed by their own internal \
+     (startup-excluded) timer for both parse and normalize, matching ferro/hgvs-rs \
+     (#609). For mutalyzer normalize at >1 worker under the pre-sharded cache, the \
+     internal time is the slowest shard's critical path — a lower bound that still \
+     excludes the dominant per-process startup term.";
 
 // ---------------------------------------------------------------------------
 // Real HarnessMeasure implementation
@@ -414,7 +416,10 @@ impl HarnessMeasure {
             .as_ref()
             .and_then(|p| p.to_str().map(str::to_owned));
 
-        let (results, elapsed, _errs) = run_mutalyzer_normalize_parallel(
+        // Time mutalyzer by its Python subprocess's own internal timer
+        // (startup-excluded, position 3), matching the parse path and the other
+        // tools — not the Rust wall time, which folds in interpreter startup (#609).
+        let (results, _wall, elapsed, _errs) = run_mutalyzer_normalize_parallel(
             sample,
             workers,
             settings.as_deref(),
@@ -511,7 +516,6 @@ with open(sys.argv[2],'w') as f:
             has_biocommons_normalizer, run_biocommons_normalizer_parallel,
             run_biocommons_normalizer_subprocess,
         };
-        use std::time::Instant;
 
         if !has_biocommons_normalizer() {
             return None;
@@ -520,7 +524,6 @@ with open(sys.argv[2],'w') as f:
         let tmp = Self::write_sample_to_tempfile(sample).ok()?;
         let results_tmp = tempfile::NamedTempFile::new().ok()?;
 
-        let start = Instant::now();
         if workers > 1 {
             run_biocommons_normalizer_parallel(
                 tmp.path().to_str()?,
@@ -541,17 +544,20 @@ with open(sys.argv[2],'w') as f:
             )
             .ok()?;
         }
-        let elapsed = start.elapsed();
 
+        // Time biocommons by the startup-excluded `elapsed_seconds` the Python
+        // subprocess records in its results JSON (the internal critical-path
+        // time), not the Rust wall time — matching the parse path and #609.
         let content = std::fs::read_to_string(results_tmp.path()).ok()?;
         let v: serde_json::Value = serde_json::from_str(&content).ok()?;
         let total = v["total_patterns"].as_u64().unwrap_or(0) as usize;
         let successful = v["successful"].as_u64().unwrap_or(0) as usize;
-        if total == 0 || successful == 0 || elapsed.as_secs_f64() <= 0.0 {
+        let elapsed = v["elapsed_seconds"].as_f64().unwrap_or(0.0);
+        if total == 0 || successful == 0 || elapsed <= 0.0 {
             return None;
         }
         Some(RepRate {
-            pps: total as f64 / elapsed.as_secs_f64(),
+            pps: total as f64 / elapsed,
             success_rate: successful as f64 / total as f64,
         })
     }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -841,16 +841,12 @@ fn run_normalize_biocommons(
     lrg_mapping_file: Option<&str>,
     workers: usize,
 ) -> Result<(), ferro_hgvs::FerroError> {
-    use std::time::Instant;
-
     // Check if biocommons is available
     if !has_biocommons_normalizer() {
         eprintln!("biocommons/hgvs is NOT available");
         eprintln!("Install with: pip install hgvs");
         std::process::exit(1);
     }
-
-    let start = Instant::now();
 
     // Run normalization (parallel or sequential based on workers)
     if workers > 1 {
@@ -872,8 +868,6 @@ fn run_normalize_biocommons(
         )?;
     }
 
-    let elapsed = start.elapsed();
-
     // Read results to get counts
     let results_content =
         std::fs::read_to_string(results_path).map_err(|e| ferro_hgvs::FerroError::Io {
@@ -887,6 +881,13 @@ fn run_normalize_biocommons(
     let total = results_data["total_patterns"].as_u64().unwrap_or(0) as usize;
     let successful = results_data["successful"].as_u64().unwrap_or(0) as usize;
 
+    // Time the tool by the subprocess's own internal timer (startup-excluded),
+    // which both the single-process and parallel paths record in the results
+    // JSON — not Rust wall time, which folds in interpreter startup + import
+    // (#609, matching the parse path and the other tools).
+    let elapsed =
+        std::time::Duration::from_secs_f64(results_data["elapsed_seconds"].as_f64().unwrap_or(0.0));
+
     // Write timing info
     let timing_info = TimingInfo::new("biocommons-hgvs", total, successful, elapsed);
     let timing_json =
@@ -897,11 +898,11 @@ fn run_normalize_biocommons(
         msg: format!("Failed to write timing file: {}", e),
     })?;
 
+    let secs = elapsed.as_secs_f64();
+    let throughput = if secs > 0.0 { total as f64 / secs } else { 0.0 };
     println!(
         "Normalized {} patterns in {:.2}s ({:.0} patterns/s)",
-        total,
-        elapsed.as_secs_f64(),
-        total as f64 / elapsed.as_secs_f64()
+        total, secs, throughput
     );
     println!(
         "Successful: {} ({:.1}%)",
@@ -2766,13 +2767,17 @@ fn run_normalize_tool(
                 effective_workers
             );
 
-            // Use parallel normalization
-            let (results, elapsed, _error_counts) = run_mutalyzer_normalize_parallel(
-                &patterns_to_normalize,
-                effective_workers,
-                Some(settings.to_str().unwrap()),
-                allow_network,
-            )?;
+            // Use parallel normalization. Time the tool by the Python
+            // subprocess's own internal timer (startup-excluded), matching the
+            // parse path and the other tools — not the Rust wall time, which
+            // would fold in interpreter startup + import (#609).
+            let (results, _wall_elapsed, elapsed, _error_counts) =
+                run_mutalyzer_normalize_parallel(
+                    &patterns_to_normalize,
+                    effective_workers,
+                    Some(settings.to_str().unwrap()),
+                    allow_network,
+                )?;
 
             let total = patterns.len();
             let successful = results.iter().filter(|r| r.success).count();


### PR DESCRIPTION
Closes #609.

## Problem

The cross-tool perf matrix timed **mutalyzer/biocommons normalize** by Rust wall time wrapping the subprocess spawn, which folds Python interpreter startup + import into the timed region. The parse path and the `ferro`/`hgvs-rs` tools already exclude setup, so the normalize numbers were biased against the Python tools (disclosed as <2% at the confident sample size in the `perf_results.json` provenance notes and the README footnote).

## Fix

Each Python subprocess already records its own `time.perf_counter()` timer and writes it to its results JSON as `elapsed_seconds`. The normalize path now records *that* (startup-excluded) value into `timing.json` instead of the Rust wall time — exactly mirroring what the parse path already does.

- **mutalyzer** (`run_mutalyzer_normalize_parallel` + the pre-sharded variant): collect each shard's internal `elapsed_seconds` and return it alongside the wall time; `run_normalize_tool` uses the internal value.
- **biocommons** (`run_biocommons_normalizer_parallel`): write the internal critical-path time as the merged JSON `elapsed_seconds`; `run_normalize_biocommons` reads `elapsed_seconds` from the results JSON (both the single-process and parallel paths now populate it with startup-excluded time).

### Aggregating concurrent shards

A new pure helper `critical_path_secs` aggregates per-shard internal times. Shards run concurrently (one subprocess per worker), so the startup-excluded wall time is the **slowest shard** (the critical path), never the sum. For a single shard — the cross-tool **W=1** matrix point — this is exactly that subprocess's internal time.

Under the work-stealing pre-sharded path a worker may process several shards in sequence, so the max is a lower bound on the true per-worker critical path there; it still removes the dominant per-process startup term. I'm happy to switch the W>1 aggregation if you'd prefer different semantics.

The `compare` command is left on wall time (it's a separate correctness/throughput diagnostic, not the published matrix); only the matrix path that feeds `perf_results.json` changes.

## Tests

- TDD unit tests for `critical_path_secs` (empty → 0, single shard → its own time, concurrent shards → slowest not sum).
- `cargo clippy --features benchmark --all-targets -- -D warnings` clean; full benchmark module unit suite passes.

End-to-end timing requires the mutalyzer/biocommons Python tools installed, so it isn't exercised in CI.