### PR TITLE
fix(reference): report the true secondary-build transcript count

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1963,6 +1963,13 @@ impl CdotMapper {
     /// in (so a multi-build secondary file still contributes its nested views).
     /// Clears the lazy overlap indexes so they rebuild with the new contigs.
     fn absorb_secondary_build(&mut self, other: Self, build_name: &str) -> usize {
+        // Snapshot the build's transcript count so we can report how many this
+        // secondary file *newly* contributes (the primary cdot may already have
+        // populated some `build_name` views from its own `genome_builds`).
+        let before = self
+            .alt_build_transcripts
+            .get(build_name)
+            .map_or(0, |m| m.len());
         let CdotMapper {
             transcripts: other_transcripts,
             alt_build_transcripts: other_alt,
@@ -1971,14 +1978,20 @@ impl CdotMapper {
             ..
         } = other;
 
-        let target = self
-            .alt_build_transcripts
-            .entry(build_name.to_string())
-            .or_default();
-        let mut loaded = 0usize;
-        for (acc, tx) in other_transcripts {
-            target.insert(acc, tx);
-            loaded += 1;
+        // The requested build's transcripts can arrive two ways: as `other`'s
+        // primary view (when the secondary file's primary build *is*
+        // `build_name`), or nested under `other.alt_build_transcripts[build_name]`
+        // (when the file nests its data under `genome_builds`, which the real
+        // RefSeq cdot files do — there the primary view selected by the default
+        // load build is empty). Absorb both into our `build_name` slot.
+        {
+            let target = self
+                .alt_build_transcripts
+                .entry(build_name.to_string())
+                .or_default();
+            for (acc, tx) in other_transcripts {
+                target.insert(acc, tx);
+            }
         }
         // Fold in any builds the secondary file nested under `genome_builds`,
         // EXCEPT the primary build of this mapper (that data is authoritative
@@ -2008,7 +2021,15 @@ impl CdotMapper {
 
         // The new alt-build contigs invalidate the lazy overlap indexes.
         self.alt_build_query_index = OnceCell::new();
-        loaded
+        // Report how many transcripts this secondary file newly contributed to
+        // `build_name` (the net new entries). For real (`genome_builds`-nested)
+        // cdot files the default-build primary view is empty, so the old count —
+        // which only tallied `other.transcripts` — logged a misleading "0" even
+        // though the build's transcripts were absorbed via the fold above.
+        self.alt_build_transcripts
+            .get(build_name)
+            .map_or(0, |m| m.len())
+            .saturating_sub(before)
     }
 
     /// Create from a raw CdotFile, converting to internal format.
@@ -4314,6 +4335,63 @@ mod tests {
             .get_transcript_on_build("NM_000088.3", "GRCh37")
             .expect("GRCh37 view must be retained even when GRCh38 is primary");
         assert_eq!(tx37.contig, "NC_000017.10");
+    }
+
+    #[test]
+    fn load_secondary_build_counts_genome_builds_nested_transcripts() {
+        // Regression for the misleading "Loaded 0 GRCh37 transcripts" log. Real
+        // cdot files nest their alignments under `genome_builds`, and the
+        // path-based `load_secondary_build` loads via `load()` using the default
+        // build — so a GRCh37-nested file's *primary* (default-build) view is
+        // empty and the transcripts arrive through the alt-build fold. The
+        // reported count must reflect what is actually queryable for the build,
+        // not the empty primary view (which previously logged "0").
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000001.10",
+                            "strand": "+",
+                            "exons": [[100, 200, 1, 0, 100, "M100"]]
+                        }
+                    }
+                },
+                "NM_000002.1": {
+                    "gene_name": "GENE_B",
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000001.10",
+                            "strand": "+",
+                            "exons": [[300, 400, 1, 0, 100, "M100"]]
+                        }
+                    }
+                }
+            }
+        }
+        "#;
+        // Primary mapper on GRCh38; write the GRCh37 secondary to a temp file
+        // (no sibling cache) so `load_secondary_build` parses the JSON via the
+        // default-build `load()` path that exhibited the miscount.
+        let mut mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let path = temp_dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        let count = mapper.load_secondary_build(&path, "GRCh37").unwrap();
+        assert_eq!(
+            count, 2,
+            "secondary load must count the GRCh37-nested transcripts, not the empty primary view"
+        );
+        // And the data is genuinely queryable on GRCh37 (not just counted).
+        assert!(
+            mapper
+                .get_transcript_on_build("NM_000002.1", "GRCh37")
+                .is_some(),
+            "GRCh37-nested transcript must be resolvable after secondary load"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On a real GRCh38-primary manifest with a `cdot_grch37_json` secondary, startup logs:

```
Loading GRCh37 cdot transcript metadata from .../cdot-0.2.32.refseq.GRCh37.json...
Loaded 0 GRCh37 transcripts (secondary build)
```

The "0" is wrong — **197,846** GRCh37 transcripts are in fact loaded and queryable. This fixes the count.

## Root cause

`absorb_secondary_build` tallied only `other.transcripts` — the loaded file's *default-build primary view*. Real RefSeq cdot files nest their alignments under `genome_builds`, and the path-based `load_secondary_build` reads via `load()` using the default build (GRCh38). So a GRCh37 file's default-build (GRCh38) primary view is empty, and its transcripts are absorbed through the **alt-build fold** instead — which the count never tallied. The data was always present (GRCh37 projection works); only the log was misleading. (This is the same "silent/misleading signal" failure mode as the cdot-cache regression earlier this cycle.)

## Fix

Report how many transcripts this secondary file *newly contributes* to the build — the net increase in the build's `alt_build_transcripts` slot. This fixes the count and naturally dedups against any `build_name` views the primary cdot already populated from its own `genome_builds`.

After: `Loaded 197846 GRCh37 transcripts (secondary build)`.

## Tests

Adds a regression test exercising the `genome_builds`-nested, **path-based** load that the previous unit test (a flat, non-nested fixture loaded via the reader path) did not cover. Full `cargo nextest run --features dev` green except the pre-existing reference-gated `axis_*` conformance failures; `clippy --features dev --all-targets` and `fmt` clean.

## Follow-up (not in this PR)

The GRCh37 secondary load is **eager** and costs ~0.20s of startup (loading ~198k transcripts), but `alt_build_transcripts["GRCh37"]` is only consulted for variants carrying an explicit GRCh37 NC_/NG_ genomic context. Deferring it (lazy load behind the first GRCh37-context resolution) would reclaim that startup time for the common case — but it must route all ~8 alt-build consultation sites through a load guard, so it deserves a dedicated, carefully-designed change rather than being bundled here.
