### PR TITLE
test(conformance): quarantine hgvs-rs data-source divergences so red = real (burn-down PR 2)

### DIFF
--- a/tests/fixtures/CORPUS_LAYOUT.md
+++ b/tests/fixtures/CORPUS_LAYOUT.md
@@ -190,3 +190,12 @@ therefore uses the simpler `<input>\t<ferro_output_or_error>` shape.
 | hgvs-rs-projection | `tests/fixtures/hgvs-rs-projection/` | no (fixed config) | — |
 
 Add a row when importing a new corpus.
+
+The hgvs-rs-projection corpus additionally carries a data-source provenance
+doc, `tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md`. It
+backs the two `accepted_divergence` clusters (`alignment-source-skew`,
+`transcript-selection-vs-uta`): ferro projects on NCBI-canonical RefSeq-GFF
+alignments while the corpus expectations come from the 2021 biocommons UTA
+snapshot, and the doc records the per-transcript UTA splign CIGARs and the
+gate (ungapped → 0% divergence, gapped/boundary → 39–100%) that the structural
+quarantine in `tests/hgvs_rs_projection_tests.rs` keys off.

--- a/tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md
+++ b/tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md
@@ -75,6 +75,24 @@ auto-quarantined as `divergence_accepted` (cluster `alignment-source-skew`). A
 so an incomplete gate list surfaces for review instead of being silently
 accepted.
 
+### Surfaced for review (not yet on the list)
+
+A manifest run surfaces a small number of low-count `CoordinateSkew` FAILs on
+transcripts **not** in the list above — each a ~2 bp shift consistent with an
+alignment indel, but not yet confirmed against a UTA CIGAR:
+
+| transcript | expected → ferro | shift |
+|---|---|---|
+| `NM_020451` (SELENON) | `c.943` → `c.945` | +2 |
+| `NM_007199` (IRAK3) | `c.1` → `c.3` | +2 |
+| `NM_002386` (MC1R) | `c.-11_19del` → `c.-9_21del` | +2 |
+
+These are **intentionally left red** — they are added to the list only after
+confirming the UTA `uta_20210129` splign CIGAR shows the corresponding indel
+(a follow-up; the gate list was seeded from the high-divergence transcripts and
+these low-count ones were below that threshold). If a confirmed CIGAR shows no
+indel, the case is instead a genuine ferro coordinate delta, not source skew.
+
 ## Category B — transcript selection/absence (cluster `transcript-selection-vs-uta`)
 
 ferro does **not** return the expected base transcript at all (a

--- a/tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md
+++ b/tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md
@@ -1,0 +1,124 @@
+# Alignment-source divergence in the hgvs-rs projection corpus
+
+This document is the re-runnable provenance for the two **data-source**
+divergence clusters in the hgvs-rs projection corpus
+(`tests/fixtures/hgvs-rs-projection/cases.json`):
+
+- `alignment-source-skew`
+- `transcript-selection-vs-uta`
+
+It records *why* a large fraction of the corpus diverges from ferro's output
+without being a ferro bug, and it backs the **structural** quarantine in
+`tests/hgvs_rs_projection_tests.rs` (the `classify_divergence` classifier plus
+the `SOURCE_SKEW_TRANSCRIPTS` gate list). The quarantine is auditable here, not
+spread across ~870 brittle per-case annotations.
+
+## Root cause: two different transcript→genome alignments
+
+ferro projects variants on **NCBI-canonical RefSeq-GFF alignments**
+(`cdot-0.2.32.refseq`). The hgvs-rs corpus expectations were generated against
+the **2021 biocommons UTA snapshot** (`uta_20210129`, which stores `splign`
+alignments). Where the two alignment sources disagree, ferro returns a result
+that is *correct for its alignment* but differs from the corpus oracle.
+
+RefSeq-GFF is the more principled **default** for a canonical / MANE-aligned
+engine: it is NCBI's own authoritative transcript-to-genome alignment, whereas
+UTA is a 2021-frozen derived snapshot. So these divergences are "ferro tracks
+NCBI-canonical; the corpus tracks a 2021 UTA snapshot," not ferro errors. We
+*document and classify* the divergence rather than regenerating the corpus
+against ferro's source (which would destroy the corpus's value as an
+independent, published oracle).
+
+## The gate: ungapped → 0% divergence, gapped/boundary → 39–100%
+
+A gate over the corpus split the per-transcript divergence rate by whether the
+two alignments agree:
+
+- **Ungapped transcripts** (RefSeq-GFF and UTA splign produce the same exon
+  structure with no indels): **0% divergence**. ferro and the corpus agree
+  exactly. These never appear in the quarantine.
+- **Gapped / boundary-skewed transcripts** (the alignments differ by a
+  within-exon `D`/`I` gap or an exon-boundary off-by-one): **39–100%
+  divergence**, concentrated entirely on the affected transcript.
+
+This is the evidence that the divergence is *alignment-source*, not algorithmic:
+it is perfectly predicted by whether the two sources' CIGARs differ, and it is
+zero everywhere they agree.
+
+## Category A — alignment-source skew (cluster `alignment-source-skew`)
+
+ferro returns the **expected base transcript** but at a **different coordinate**
+(the `c.`/`n.` position prefix differs). Each transcript below has a UTA
+`uta_20210129` splign CIGAR (transcript vs genome) that contains an indel or a
+boundary shift relative to ferro's RefSeq-GFF alignment, which is exactly the
+coordinate offset observed in the diverging cases.
+
+| Base accession | UTA `uta_20210129` splign CIGAR | Skew character |
+|---|---|---|
+| `NM_000682`      | `891=9D2375=`                          | 9 bp deletion gap → +9 coordinate shift downstream of the gap |
+| `NM_000804`      | `150=2D37=`                            | 2 bp deletion gap → +2 coordinate shift downstream |
+| `NM_001077527`   | `189=1X348=2D87=1X83=...`              | mismatch run + 2 bp deletion gap |
+| `NM_001080519`   | `177=1D`                               | terminal 1 bp deletion gap |
+| `NM_003777`      | `131=1I7=`                             | 1 bp insertion gap → −1 coordinate shift downstream |
+| `NM_006158`      | `238=1I82=`                            | 1 bp insertion gap → −1 coordinate shift downstream |
+| `NM_001277115`   | (ungapped per exon)                    | exon-**boundary** off-by-1 vs UTA: intronic offsets differ by 1 |
+
+`NM_001277115` is the boundary case: each exon is internally ungapped, but the
+exon boundaries are placed one base differently from UTA, so intronic
+`+N`/`-N` offsets differ by 1. It produces a coordinate skew without a
+within-exon indel.
+
+These seven accessions are the `SOURCE_SKEW_TRANSCRIPTS` gate list in
+`tests/hgvs_rs_projection_tests.rs`. A `CoordinateSkew` on one of them is
+auto-quarantined as `divergence_accepted` (cluster `alignment-source-skew`). A
+`CoordinateSkew` on **any other** transcript is deliberately **kept as a FAIL**
+so an incomplete gate list surfaces for review instead of being silently
+accepted.
+
+## Category B — transcript selection/absence (cluster `transcript-selection-vs-uta`)
+
+ferro does **not** return the expected base transcript at all (a
+selection-coverage miss): the expected accession is absent from, or not
+prioritized by, ferro's cdot set relative to the 2021 UTA snapshot. The clearest
+example is the noncoding (`NR_`) rows, where ferro returns an `NM_` transcript
+at the same locus rather than the corpus's expected `NR_`. The classifier routes
+these structurally — no returned consequence carries the expected base
+accession → `SelectionMiss` → `divergence_accepted`.
+
+## Safety invariant (what is NOT quarantined)
+
+A divergence where ferro returns the **expected base transcript** AND the
+**same coordinate position** but a **different edit form** (e.g. `dup` vs `ins`,
+`del` vs `delACCTT`, or the protein-prediction parenthesization `p.Arg268Trp`
+vs `p.(Arg268Trp)`) is **not** data-source skew — it is a genuine
+convention/algorithm delta and stays a **FAIL** (`FormOnly`). This preserves
+"red = real": the residual FAILs are the genuine signal, dispositioned
+individually in a later PR.
+
+## Regenerating the CIGARs (needs live UTA)
+
+The UTA splign CIGARs above come from the `tx_exon_aln_v` view of the 2021
+biocommons UTA Postgres dump (`uta_20210129`). To regenerate them you need a
+live UTA instance (the dump is large and access-gated), then per transcript:
+
+```sql
+-- uta_20210129 schema; one row per exon, ordered 5'→3'
+SELECT tx_ac, alt_ac, alt_aln_method, ord, cigar
+FROM   uta_20210129.tx_exon_aln_v
+WHERE  tx_ac = 'NM_000682.5'
+  AND  alt_aln_method = 'splign'
+ORDER  BY ord;
+```
+
+Concatenate the per-exon `cigar` values (5'→3') to get the transcript-level
+CIGAR shown above. ferro's RefSeq-GFF alignment for the same transcript comes
+from the cdot bundle in the reference manifest (`cdot-0.2.32.refseq`); the
+divergence is the difference between the two CIGARs.
+
+## See also
+
+- `tests/hgvs_rs_projection_tests.rs` — `classify_divergence`,
+  `SOURCE_SKEW_TRANSCRIPTS`, and the per-axis structural routing.
+- `tests/fixtures/hgvs-rs-projection/cases.json` — the `clusters` registry
+  entries `alignment-source-skew` and `transcript-selection-vs-uta`.
+- `tests/fixtures/CORPUS_LAYOUT.md` — corpus layout and consumer table.

--- a/tests/fixtures/hgvs-rs-projection/cases.json
+++ b/tests/fixtures/hgvs-rs-projection/cases.json
@@ -4,7 +4,20 @@
   "source_commit": "cf0e5a8d1b9a2ae3e883a58826f397aa6cb52e23",
   "license": "Apache-2.0",
   "refreshed_at": "2026-06-11",
-  "clusters": [],
+  "clusters": [
+    {
+      "id": "alignment-source-skew",
+      "title": "ferro RefSeq-GFF alignment vs 2021 UTA splign snapshot",
+      "spec_section": "recommendations/general/refseq.md",
+      "note": "ferro projects on NCBI-canonical RefSeq-GFF alignments (cdot-0.2.32.refseq); the corpus expectations come from the 2021 biocommons UTA snapshot (uta_20210129, splign). Where the two alignments disagree (within-exon D/I gaps or exon-boundary off-by-1) ferro returns the expected base transcript at a different coordinate. Auto-quarantined structurally for the gate-listed transcripts only; see tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md."
+    },
+    {
+      "id": "transcript-selection-vs-uta",
+      "title": "expected transcript absent/not-selected in ferro cdot-0.2.32.refseq vs UTA",
+      "spec_section": "recommendations/general/refseq.md",
+      "note": "ferro does not return the expected base transcript at all (selection-coverage miss): the expected accession is absent from, or not prioritized by, ferro cdot-0.2.32.refseq relative to the 2021 UTA snapshot. Auto-quarantined structurally when no returned consequence carries the expected base accession."
+    }
+  ],
   "cases": [
     {
       "keywords": [

--- a/tests/fixtures/hgvs-rs-projection/failure-patterns.md
+++ b/tests/fixtures/hgvs-rs-projection/failure-patterns.md
@@ -6,6 +6,22 @@ Generated from `cases.json` — do not edit by hand; regenerate with the example
 
 ## Root-cause clusters
 
+### ferro RefSeq-GFF alignment vs 2021 UTA splign snapshot
+
+Spec: `recommendations/general/refseq.md`
+
+ferro projects on NCBI-canonical RefSeq-GFF alignments (cdot-0.2.32.refseq); the corpus expectations come from the 2021 biocommons UTA snapshot (uta_20210129, splign). Where the two alignments disagree (within-exon D/I gaps or exon-boundary off-by-1) ferro returns the expected base transcript at a different coordinate. Auto-quarantined structurally for the gate-listed transcripts only; see tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md.
+
+_No seeded member rows yet (manifest-gated seeding, #325)._
+
+### expected transcript absent/not-selected in ferro cdot-0.2.32.refseq vs UTA
+
+Spec: `recommendations/general/refseq.md`
+
+ferro does not return the expected base transcript at all (selection-coverage miss): the expected accession is absent from, or not prioritized by, ferro cdot-0.2.32.refseq relative to the 2021 UTA snapshot. Auto-quarantined structurally when no returned consequence carries the expected base accession.
+
+_No seeded member rows yet (manifest-gated seeding, #325)._
+
 ## Disposition tallies
 
 | axis | accepted_divergence | known_bug | improvement | spec_citation |

--- a/tests/hgvs_rs_projection_tests.rs
+++ b/tests/hgvs_rs_projection_tests.rs
@@ -296,6 +296,113 @@ impl AxisTally {
         self.fail.push((case.input.clone(), diag));
     }
 
+    /// Record a discovery-axis case with structural data-source quarantine.
+    ///
+    /// `expected_repr`/`actual` are the same display/disposition pair the
+    /// [`AxisTally::record`] path uses (for PASS/XPASS and per-case annotation
+    /// routing). `expected_entries` are the individual expected rendered
+    /// strings (one for single-value axes, several for the pair/list axes) and
+    /// `returned` is the full set of rendered strings ferro produced for this
+    /// case.
+    ///
+    /// When the case is a genuine divergence (`actual` is `Ok` but did not
+    /// match, or `Err`), every *diverging* expected entry is classified via
+    /// [`classify_divergence`] and the case is routed **structurally** — never
+    /// by a per-case annotation:
+    ///
+    /// - All diverging entries are [`Divergence::SelectionMiss`] →
+    ///   `divergence_accepted` (cluster `transcript-selection-vs-uta`).
+    /// - All diverging entries are quarantinable and at least one is a
+    ///   [`Divergence::CoordinateSkew`] on a [`SOURCE_SKEW_TRANSCRIPTS`]
+    ///   transcript → `divergence_accepted` (cluster `alignment-source-skew`).
+    /// - Otherwise (a [`Divergence::FormOnly`], or a `CoordinateSkew` on a
+    ///   transcript NOT on the gate list, or an `Err` projection failure) →
+    ///   FAIL, so genuine convention/algorithm signal and gate-list gaps are
+    ///   surfaced rather than silently accepted.
+    ///
+    /// A clean match (or a stale per-case annotation XPASS) delegates to
+    /// [`AxisTally::record`] unchanged.
+    fn record_classified(
+        &mut self,
+        case: &Case,
+        expected_repr: &str,
+        actual: Result<String, String>,
+        expected_entries: &[String],
+        returned: &[String],
+    ) {
+        // The discovery-axis closures signal a clean match by returning
+        // `Ok(expected_repr)` and a divergence by returning `Err(...)` (a
+        // missing-entry diagnostic). A clean match (or a stale-annotation
+        // XPASS) is handled by the existing buckets; anything else is a
+        // candidate for structural quarantine.
+        let is_match = matches!(&actual, Ok(s) if s == expected_repr);
+        if is_match {
+            self.record(case, expected_repr, actual);
+            return;
+        }
+
+        // A hard projection failure (parse / project / panic) is always a real
+        // FAIL — it is not a data-source divergence. The discovery-axis closures
+        // signal a value divergence with a `missing …` diagnostic; any other
+        // `Err` is a hard failure that must surface via the normal path.
+        if let Err(e) = &actual {
+            if !e.starts_with("missing ") {
+                self.record(case, expected_repr, actual);
+                return;
+            }
+        }
+
+        // Classify each expected entry that did not match against ferro's set.
+        let diverging: Vec<Divergence> = expected_entries
+            .iter()
+            .map(|e| classify_divergence(e, returned))
+            .filter(|d| *d != Divergence::Match)
+            .collect();
+
+        // Defensive: if nothing classified as diverging (shouldn't happen given
+        // `is_divergence`), fall back to the standard path.
+        if diverging.is_empty() {
+            self.record(case, expected_repr, actual);
+            return;
+        }
+
+        let all_selection_miss = diverging.iter().all(|d| *d == Divergence::SelectionMiss);
+        // A coordinate skew is quarantinable only on a gate-listed transcript.
+        let listed_coordinate_skew = |entry: &str| -> bool {
+            base_accession(entry).is_some_and(|b| SOURCE_SKEW_TRANSCRIPTS.contains(&b.as_str()))
+        };
+        let all_quarantinable = expected_entries
+            .iter()
+            .map(|e| (e, classify_divergence(e, returned)))
+            .all(|(e, d)| match d {
+                Divergence::Match | Divergence::SelectionMiss => true,
+                Divergence::CoordinateSkew => listed_coordinate_skew(e),
+                Divergence::FormOnly => false,
+            });
+        let has_listed_skew = expected_entries.iter().any(|e| {
+            classify_divergence(e, returned) == Divergence::CoordinateSkew
+                && listed_coordinate_skew(e)
+        });
+
+        if all_selection_miss {
+            self.divergence_accepted
+                .push((case.input.clone(), CLUSTER_TRANSCRIPT_SELECTION.to_string()));
+        } else if all_quarantinable && has_listed_skew {
+            self.divergence_accepted.push((
+                case.input.clone(),
+                CLUSTER_ALIGNMENT_SOURCE_SKEW.to_string(),
+            ));
+        } else {
+            // FormOnly, or CoordinateSkew on a non-listed transcript (gate gap),
+            // or a mix that isn't cleanly one source-skew category: surface it.
+            let diag = match actual {
+                Ok(got) => format!("expected={expected_repr:?} got={got:?}"),
+                Err(e) => format!("expected={expected_repr:?} err={e}"),
+            };
+            self.fail.push((case.input.clone(), diag));
+        }
+    }
+
     /// Single-line, grep-friendly summary of the tally state.
     fn summary_line(&self, report_path: &Path) -> String {
         format!(
@@ -691,7 +798,21 @@ fn axis_coding_protein_descriptions() {
         {
             t.selection_hits += 1;
         }
-        t.record(case, &expected_repr, actual);
+        // Classify on the coding (c.) component against ferro's returned coding
+        // set — transcript selection and alignment-source skew manifest on the
+        // coding coordinate; the protein is derived downstream.
+        let expected_coding: Vec<String> = pairs
+            .iter()
+            .filter(|p| p.len() == 2)
+            .map(|p| p[0].clone())
+            .collect();
+        t.record_classified(
+            case,
+            &expected_repr,
+            actual,
+            &expected_coding,
+            &returned_coding,
+        );
     }
     t.finish();
 }
@@ -782,7 +903,7 @@ fn axis_coding() {
         if set_has_base(&returned, expected) {
             t.selection_hits += 1;
         }
-        t.record(case, expected, actual);
+        t.record_classified(case, expected, actual, &[expected.to_string()], &returned);
     }
     t.finish();
 }
@@ -837,7 +958,7 @@ fn axis_noncoding() {
         {
             t.selection_hits += 1;
         }
-        t.record(case, &expected, actual);
+        t.record_classified(case, &expected, actual, expected_list, &returned);
     }
     t.finish();
 }

--- a/tests/hgvs_rs_projection_tests.rs
+++ b/tests/hgvs_rs_projection_tests.rs
@@ -467,6 +467,111 @@ fn consequence_matches(expected: &str, actual: &str) -> bool {
     }
 }
 
+/// Why a case diverges from the corpus expectation, used to route structural
+/// data-source skew into `divergence_accepted` while keeping genuine
+/// algorithm/convention deltas as FAILs.
+///
+/// - [`Divergence::SelectionMiss`] — ferro never returned the expected base
+///   transcript accession (transcript selection/absence: ferro's cdot set vs
+///   the 2021 UTA snapshot).
+/// - [`Divergence::CoordinateSkew`] — ferro returned the expected base
+///   transcript but at a *different coordinate* (the `c.`/`n.` position prefix
+///   differs). This is the alignment-source skew (RefSeq-GFF vs UTA splign).
+/// - [`Divergence::FormOnly`] — ferro returned the expected base AND the same
+///   coordinate position, but a different *edit form* (e.g. `dup` vs `ins`).
+///   This is NOT data-source — it is a genuine convention/algorithm delta and
+///   stays a FAIL.
+/// - [`Divergence::Match`] — some actual consequence matched the expectation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Divergence {
+    SelectionMiss,
+    CoordinateSkew,
+    FormOnly,
+    Match,
+}
+
+/// Extract the *position prefix* of a `c.`/`n.` (or `p.`) consequence body: the
+/// leading coordinate token(s) before the edit operation. For a consequence
+/// body like `c.*1865G>T` this returns `*1865`; for `c.*1353+1856G>T` it
+/// returns `*1353+1856`; for an `c.10+830_10+831insG` range it returns
+/// `10+830_10+831`.
+///
+/// The position prefix is the maximal leading run of *coordinate* characters:
+/// digits, the UTR/offset sign markers `*`/`-`/`+`, and the range separator
+/// `_`. The first character that is none of those (an edit letter `A`–`Z`, a
+/// `>` substitution arrow, or an operation keyword like `del`/`ins`/`dup`)
+/// terminates the prefix. The leading datum-type letter and `.` (the `c.`/`n.`
+/// in `c.*1865`) are skipped first.
+fn position_prefix(consequence: &str) -> &str {
+    // Drop the `c.`/`n.`/`p.`/`r.`/`m.`/`g.` datum-type prefix (`<letter>.`).
+    let body = match consequence.split_once('.') {
+        Some((_datum, rest)) => rest,
+        None => consequence,
+    };
+    let end = body
+        .char_indices()
+        .find(|(_, c)| !(c.is_ascii_digit() || matches!(c, '*' | '-' | '+' | '_')))
+        .map(|(i, _)| i)
+        .unwrap_or(body.len());
+    &body[..end]
+}
+
+/// Classify why `expected` diverges from `actual_set` (the rendered strings
+/// ferro returned for this case), for structural quarantine routing.
+///
+/// See [`Divergence`] for the meaning of each variant. The ordering is
+/// significant: `Match` short-circuits; then a missing base accession is a
+/// `SelectionMiss`; then a position-prefix difference is `CoordinateSkew`;
+/// otherwise the base + position matched and only the edit form differs, which
+/// is `FormOnly`.
+fn classify_divergence(expected: &str, actual_set: &[String]) -> Divergence {
+    if actual_set.iter().any(|a| consequence_matches(expected, a)) {
+        return Divergence::Match;
+    }
+    if !set_has_base(actual_set, expected) {
+        return Divergence::SelectionMiss;
+    }
+    // Base accession is present. Compare the position prefix of the expected
+    // consequence against every actual that shares the expected base accession.
+    let Some(want_base) = base_accession(expected) else {
+        return Divergence::SelectionMiss;
+    };
+    let want_prefix = position_prefix(consequence_part(expected));
+    let same_position = actual_set.iter().any(|a| {
+        base_accession(a).as_deref() == Some(want_base.as_str())
+            && position_prefix(consequence_part(a)) == want_prefix
+    });
+    if same_position {
+        Divergence::FormOnly
+    } else {
+        Divergence::CoordinateSkew
+    }
+}
+
+/// Base accessions where ferro's RefSeq-GFF alignment is known (per the gate;
+/// see `tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md`) to
+/// disagree with the 2021 UTA splign snapshot the corpus expectations come
+/// from. A [`Divergence::CoordinateSkew`] on one of these is structural
+/// data-source skew and is auto-quarantined as `divergence_accepted`; a
+/// coordinate skew on any *other* transcript stays a FAIL (the gate list is
+/// incomplete — surface it, don't silently accept).
+const SOURCE_SKEW_TRANSCRIPTS: &[&str] = &[
+    "NM_001080519",
+    "NM_001077527",
+    "NM_000804",
+    "NM_000682",
+    "NM_003777",
+    "NM_006158",
+    "NM_001277115",
+];
+
+/// Cluster id for the alignment-source skew (coordinate differs, base matches,
+/// transcript is on the gate list).
+const CLUSTER_ALIGNMENT_SOURCE_SKEW: &str = "alignment-source-skew";
+
+/// Cluster id for transcript selection/absence (expected base never returned).
+const CLUSTER_TRANSCRIPT_SELECTION: &str = "transcript-selection-vs-uta";
+
 /// Version-insensitive set membership on base accession: does any rendered
 /// string in `rendered_set` share the same base accession (version digit and
 /// `(GENE)` suffix stripped) as `expected`? Used for the selection-coverage
@@ -1116,6 +1221,66 @@ mod comparator_tests {
         assert!(!set_has_base(&returned, "NR_111984.1:n.44G>A"));
         // Empty set → miss.
         assert!(!set_has_base(&[], "NM_000682.5:c.5A>T"));
+    }
+
+    // classify_divergence: a selection miss — the expected NR_ base accession
+    // is absent from ferro's set (ferro returned a different transcript).
+    #[test]
+    fn classify_selection_miss() {
+        assert!(matches!(
+            classify_divergence(
+                "NR_111984.1:n.44G>A",
+                &["NM_001103170.2(AADACL3):n.51G>A".into()]
+            ),
+            Divergence::SelectionMiss
+        ));
+    }
+
+    // classify_divergence: coordinate skew — same base accession, different
+    // position prefix (`*1865` vs `*1353+1856`).
+    #[test]
+    fn classify_coordinate_skew() {
+        assert!(matches!(
+            classify_divergence(
+                "NM_000682.5:c.*1865G>T",
+                &["NM_000682.7(ADRA2B):c.*1353+1856G>T".into()]
+            ),
+            Divergence::CoordinateSkew
+        ));
+    }
+
+    // classify_divergence: form-only — same base, same position prefix, the
+    // edit form differs (`insG` over a range vs `dup`). NOT data-source.
+    #[test]
+    fn classify_form_only() {
+        assert!(matches!(
+            classify_divergence(
+                "NM_X.1:c.10+830_10+831insG",
+                &["NM_X.2(G):c.10+830_10+831dup".into()]
+            ),
+            Divergence::FormOnly
+        ));
+    }
+
+    // classify_divergence: a match short-circuits to `Match`.
+    #[test]
+    fn classify_match() {
+        assert!(matches!(
+            classify_divergence("NM_X.1:c.5A>T", &["NM_X.2(G):c.5A>T".into()]),
+            Divergence::Match
+        ));
+    }
+
+    // position_prefix extracts the leading coordinate token before the edit,
+    // handling `*` UTR, `+`/`-` intronic offsets, and `_` ranges.
+    #[test]
+    fn position_prefix_handles_utr_offset_and_range() {
+        assert_eq!(position_prefix("c.*1865G>T"), "*1865");
+        assert_eq!(position_prefix("c.*1353+1856G>T"), "*1353+1856");
+        assert_eq!(position_prefix("c.10+830_10+831insG"), "10+830_10+831");
+        assert_eq!(position_prefix("n.51G>A"), "51");
+        assert_eq!(position_prefix("c.-12del"), "-12");
+        assert_eq!(position_prefix("c.5_7dup"), "5_7");
     }
 
     // The summary line carries the documented stable format including the new


### PR DESCRIPTION
Second burn-down step: turn the hgvs-rs projection dashboard from "≈all red" into "red = a genuine ferro algorithm/convention delta," by **structurally** quarantining the two *data-source* divergence categories — without per-case annotations and without masking genuine signal.

**Root cause (gated, see `tests/fixtures/hgvs-rs-projection/ALIGNMENT_SOURCE_DIVERGENCE.md`):** ferro projects on NCBI-canonical RefSeq-GFF alignments (cdot-0.2.32.refseq); the corpus expectations come from the 2021 biocommons UTA snapshot (uta_20210129, splign). The gate proved divergence concentrates where the two sources disagree: ungapped transcripts → 0%, gapped/boundary-skewed → 39–100%. RefSeq-GFF is the more principled default for a canonical/MANE-aligned engine, so these are "ferro tracks NCBI-canonical; corpus tracks a 2021 UTA snapshot," not ferro errors.

**Mechanism:** a `classify_divergence` helper labels each divergence `SelectionMiss` / `CoordinateSkew` / `FormOnly` / `Match` from the (version-insensitive) consequence + position-prefix. Routing: `SelectionMiss` → `accepted_divergence(transcript-selection-vs-uta)`; `CoordinateSkew` on a gate-listed source-skew transcript → `accepted_divergence(alignment-source-skew)`; everything else (`FormOnly`, or `CoordinateSkew` on a non-listed transcript) **stays a FAIL**. Quarantine is transcript-level + structural (a 7-transcript gate list + 2 cluster citations), not 870 brittle per-case `ferro_output` snapshots that would churn on cdot updates.

**Effect (against the real manifest):** total FAIL **879 → 63 residual**. The residual is genuine signal:
- **53** `p.(Arg268Trp)` (ferro's predicted-parenthesized form, HGVS-correct for a DNA-predicted consequence) vs the corpus's bare `p.Arg268Trp` — an `improvement` cluster for PR 3.
- the **7** protein-form rows (`extTer`/`Xaa`).
- **3** surfaced `CoordinateSkew`-on-non-listed transcripts (NM_020451/NM_007199/NM_002386, ~2 bp shifts) **intentionally left red** pending UTA-CIGAR confirmation — the design surfaces an incomplete gate list rather than silently accepting it.

Safety invariant: only structural criteria auto-quarantine; a same-coordinate different-form divergence stays red, so genuine signal is never masked. Preserves the corpus's independence as a published oracle (no regeneration/flip). Test/fixture-only; no `src/` changes. PR 3 dispositions the residual signal (the `p.()` improvement + protein rows + confirming the 3 surfaced transcripts).

Stacked on #607 (the version-insensitive comparator); the burn-down's PR 1.
