### PR TITLE
fix(project): decline protein prediction when the CDS frame is inconsistent (#625)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -14,8 +14,8 @@ use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
 use crate::project::protein::{
-    affects_initiation_codon, build_initiator_unknown, predict_indel_protein,
-    predict_substitution_protein, RefProteinBundle,
+    affects_initiation_codon, build_initiator_unknown, cds_has_valid_start, predict_indel_protein,
+    predict_substitution_protein, read_cds_start_codon, RefProteinBundle,
 };
 use crate::project::result::VariantProjection;
 use crate::reference::transcript::Transcript;
@@ -1079,6 +1079,45 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         if !self.provider.has_transcript_version_exact(transcript_id) {
             return Ok(None);
         }
+        // Issue #625: CDS-start sanity. Every protein prediction below trusts
+        // that `Transcript.cds_start` points at the first base of the
+        // initiation codon and translates the CDS bases directly from there.
+        // When the cdot CDS annotation is inconsistent with the transcript
+        // FASTA — cds_start lands mid-frame, not on an `ATG` (e.g.
+        // NM_000425.3 cds_start→"AGG", NM_152263.2 cds_start→"GAT") — that
+        // assumption is false: translation reads the wrong frame and would
+        // fabricate a garbage consequence (premature internal stop, Xaa,
+        // wrong anchor). Decline to predict rather than emit a bogus protein.
+        //
+        // The discriminator is the START codon only. Selenoproteins (e.g.
+        // SELENON / NM_020451.2) legitimately carry an in-frame internal `TGA`
+        // recoded as selenocysteine yet begin with `ATG`; keying on internal
+        // stops would wrongly decline them, so we never inspect them here.
+        //
+        // This is a deliberate over-approximation: a few RefSeq transcripts use
+        // experimentally-supported non-AUG initiation (CUG/GUG with a
+        // `transl_except`), whose CDS is consistent yet non-`ATG`; we decline
+        // those too rather than risk wrong-frame translation of the common
+        // inconsistent-annotation case.
+        //
+        // A failure to read the CDS (missing sequence, degenerate coords) is
+        // left to the per-edit paths below, which already treat
+        // `ProteinSequenceUnavailable` as a non-fatal "no protein" — so we
+        // only act on a CDS we could read whose start is not `ATG`. Read just
+        // the start codon (not the whole 1–10 kbp CDS) since that is all the
+        // guard inspects.
+        let tx_for_cds_check =
+            self.cached_get_transcript_for_variant(cache_variant, transcript_id)?;
+        if let Ok(start_codon) = read_cds_start_codon(&tx_for_cds_check) {
+            if !cds_has_valid_start(&start_codon) {
+                log::trace!(
+                    "declining protein prediction for {transcript_id}: reference CDS does \
+                     not begin with an ATG start codon (cds_start is inconsistent with the \
+                     transcript FASTA); first codon = {start_codon:?}",
+                );
+                return Ok(None);
+            }
+        }
         // An initiation-codon-affecting edit short-circuits to `p.(Met1?)`
         // here, before edit-type dispatch, so boundary-spanning edits whose
         // 5' end is in the 5'UTR (which the per-edit paths reject via their
@@ -2097,6 +2136,152 @@ mod tests {
         assert!(!result.is_frameshift);
         assert!(!result.is_intronic);
         assert!(!result.is_utr);
+    }
+
+    // -------------------------------------------------------------------------
+    // CDS-start sanity (issue #625)
+    //
+    // When a transcript's cdot CDS coordinates are inconsistent with its FASTA
+    // (cds_start does not land on an ATG start codon), the reference CDS reads
+    // the wrong frame. ferro must DECLINE protein prediction (Ok(None)) rather
+    // than emit a fabricated consequence translated from the wrong frame.
+    // -------------------------------------------------------------------------
+
+    /// Build a single-transcript projector whose CDS sequence and length are
+    /// chosen by the caller. The whole transcript is one plus-strand exon at
+    /// genome `[1000, 1000+len)`, with `cds_start = 1` and `cds_end = len`
+    /// (1-based, full-length CDS, no UTR). The genomic sequence mirrors the
+    /// transcript so a `g.(1000+k)` SNV maps to `c.(k+1)`.
+    ///
+    /// `seq` is the transcript/CDS sequence; its first codon is what the
+    /// CDS-start sanity guard inspects.
+    #[cfg(test)]
+    fn make_custom_cds_provider_and_projector(seq: &str) -> (Projector, MockProvider) {
+        let len_u = seq.len() as u64;
+        let genome_end_excl_u = 1000_u64 + len_u; // 0-based exclusive
+
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_CUSTOM.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("CUSTOMGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                // [genome_start(0-based), genome_end(0-based excl), tx_start, tx_end]
+                exons: vec![[1000, genome_end_excl_u, 0, len_u]],
+                cds_start: Some(0),   // 0-based: CDS starts at tx_pos 0 (no 5'UTR)
+                cds_end: Some(len_u), // 0-based exclusive
+                gene_id: None,
+                protein: Some("NP_CUSTOM.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_CUSTOM.1".to_string(),
+            gene_symbol: Some("CUSTOMGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some(seq.to_string()),
+            cds_start: Some(1), // 1-based inclusive per Transcript convention
+            cds_end: Some(len_u),
+            exons: vec![Exon::new(1, 1, len_u)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(genome_end_excl_u - 1),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let prefix = "N".repeat(1000);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{prefix}{seq}{suffix}"));
+        (projector, provider)
+    }
+
+    /// (a) RED-FIRST: a transcript whose `cds_start` lands on a non-ATG codon
+    /// ("AGG", not a start) is FASTA/CDS-inconsistent. A coding SNV must
+    /// DECLINE protein prediction (no fabricated consequence from the wrong
+    /// frame), even though c. and n. axes are still emitted.
+    #[test]
+    fn project_non_atg_start_declines_protein() {
+        // CDS "AGGGGCGCTAA": first codon AGG (Arg) is NOT a start codon.
+        // g.1003 → c.4 (4th base 'G'), a plainly coding position.
+        let (projector, provider) = make_custom_cds_provider_and_projector("AGGGGCGCTAA");
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003G>A", "NM_CUSTOM.1")
+            .expect("projection should still succeed at the c./n. level");
+
+        // c. axis must still be present (the inconsistency is CDS-only).
+        assert!(
+            result.coding.is_some(),
+            "c. axis should still be emitted for a coding SNV"
+        );
+        // Protein must be DECLINED: the CDS does not start with ATG, so any
+        // translation would be from the wrong frame.
+        assert!(
+            result.protein.is_none(),
+            "expected NO protein for a non-ATG-start (inconsistent) CDS, got: {:?}",
+            result.protein
+        );
+    }
+
+    /// (b) CONTROL: a normal ATG-start CDS predicts protein as before. This
+    /// must stay green after the guard is added.
+    #[test]
+    fn project_atg_start_predicts_protein_control() {
+        // CDS "ATGCGCTAA": Met-Arg-Ter, a valid ATG start.
+        let (projector, provider) = make_custom_cds_provider_and_projector("ATGCGCTAA");
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "NM_CUSTOM.1")
+            .expect("projection should succeed");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present for a valid ATG-start CDS")
+            .to_string();
+        assert_eq!(p, "NP_CUSTOM.1:p.(Arg2Ser)");
+    }
+
+    /// (c) SELENOPROTEIN CONTROL: a valid ATG-start CDS that contains an
+    /// in-frame internal TGA (recoded as selenocysteine in real selenoproteins
+    /// such as SELENON / NM_020451.2) before the true stop. The guard MUST key
+    /// on the START codon only — an internal stop is legitimate, so protein
+    /// prediction must still succeed (NOT be declined).
+    #[test]
+    fn project_selenoprotein_internal_tga_predicts_protein() {
+        // CDS "ATGAAATGAAAATAA":
+        //   codon0 ATG (Met, start)  codon1 AAA (Lys)  codon2 TGA (internal,
+        //   Sec in vivo / Ter for the naive translator)  codon3 AAA (Lys)
+        //   codon4 TAA (true Ter).
+        // A naive translator stops at the internal TGA, but the START is a
+        // valid ATG, so the CDS-start guard must NOT decline.
+        let (projector, provider) = make_custom_cds_provider_and_projector("ATGAAATGAAAATAA");
+        let vp = VariantProjector::new(projector, provider);
+        // g.1004 → c.5: 2nd base of codon1 (AAA, Lys) — squarely coding and
+        // upstream of the internal TGA so prediction is well-defined.
+        let result = vp
+            .project("chr1:g.1004A>G", "NM_CUSTOM.1")
+            .expect("projection should succeed");
+        // Assert the concrete consequence, not just presence: codon1 AAA (Lys2)
+        // → AGA (Arg2). A regression that declined selenoproteins — or emitted a
+        // wrong-but-present protein — would slip past a bare is_some() check.
+        let p = result
+            .protein
+            .as_ref()
+            .expect(
+                "selenoprotein-style internal TGA must NOT decline protein \
+                 (guard keys on START codon, not internal stops)",
+            )
+            .to_string();
+        assert_eq!(p, "NP_CUSTOM.1:p.(Lys2Arg)");
     }
 
     #[test]

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -52,6 +52,37 @@ pub(crate) fn build_initiator_unknown(
     })
 }
 
+/// Does the reference CDS begin with a canonical `ATG` start codon?
+///
+/// The protein-consequence path translates a transcript's CDS bases directly,
+/// trusting that `Transcript.cds_start` points at the first base of the
+/// initiation codon. When the cdot CDS annotation is inconsistent with the
+/// transcript FASTA (cds_start lands mid-frame, not on an `ATG`), translation
+/// reads the wrong frame and fabricates a garbage protein (issue #625). A
+/// non-`ATG` first codon is the dominant signal of that inconsistency, so
+/// callers decline protein prediction when this returns `false`.
+///
+/// This is a deliberate over-approximation: RefSeq does annotate a small number
+/// of transcripts with experimentally-supported non-AUG initiation (CUG/GUG
+/// starts carried with a `transl_except` exception), whose `cds_start` *is*
+/// consistent with the FASTA. Keying on `ATG` declines protein on those too. We
+/// accept that rare false-decline rather than translate the common
+/// inconsistent-annotation case from the wrong frame.
+///
+/// The check keys on the **start codon only**. It deliberately does *not*
+/// inspect internal codons: selenoproteins (e.g. SELENON / NM_020451.2)
+/// legitimately carry an in-frame internal `TGA` recoded as selenocysteine,
+/// and they begin with `ATG` — rejecting internal stops would wrongly decline
+/// every selenoprotein.
+///
+/// `ref_cds` is expected uppercase (the form [`read_full_cds`] /
+/// [`read_cds_start_codon`] return); the comparison is therefore a plain byte
+/// compare of the first three bases. A CDS shorter than three bases returns
+/// `false` (no start codon is possible), so callers correctly decline on it.
+pub(crate) fn cds_has_valid_start(ref_cds: &str) -> bool {
+    ref_cds.as_bytes().get(..3) == Some(b"ATG")
+}
+
 // ── CDS sequence readers ──────────────────────────────────────────────────────
 
 /// Read the full CDS as an uppercase `String` from a transcript.
@@ -84,6 +115,43 @@ pub(crate) fn read_full_cds(transcript: &Transcript) -> Result<String, FerroErro
     // Transcript.cds_start is 1-based → 0-based index = cds_start - 1.
     // Transcript.cds_end is 1-based inclusive → exclusive index = cds_end.
     Ok(seq[cds_start - 1..cds_end].to_uppercase())
+}
+
+/// Read **only** the three start-codon bases of the CDS, uppercase.
+///
+/// Same coordinate validation as [`read_full_cds`] (returns
+/// [`FerroError::ProteinSequenceUnavailable`] on a missing sequence or
+/// degenerate coords, including a CDS shorter than three bases), but slices and
+/// uppercases just the first codon instead of the whole 1–10 kbp CDS. Used by
+/// the issue-#625 CDS-start sanity guard, which needs nothing more than the
+/// first codon to decide whether the annotation begins with an `ATG`.
+pub(crate) fn read_cds_start_codon(transcript: &Transcript) -> Result<String, FerroError> {
+    let cds_start = transcript
+        .cds_start
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS start", transcript.id),
+        })? as usize;
+    let cds_end = transcript
+        .cds_end
+        .ok_or_else(|| FerroError::ConversionError {
+            msg: format!("transcript {} has no CDS end", transcript.id),
+        })? as usize;
+    let seq =
+        transcript
+            .sequence
+            .as_deref()
+            .ok_or_else(|| FerroError::ProteinSequenceUnavailable {
+                accession: transcript.id.clone(),
+            })?;
+    // Reject the same degenerate coords as `read_full_cds`, plus require at
+    // least three CDS bases so the start codon exists.
+    if cds_start < 1 || cds_end > seq.len() || cds_start > cds_end + 1 || cds_end < cds_start + 2 {
+        return Err(FerroError::ProteinSequenceUnavailable {
+            accession: transcript.id.clone(),
+        });
+    }
+    // Transcript.cds_start is 1-based → 0-based index = cds_start - 1.
+    Ok(seq[cds_start - 1..cds_start + 2].to_uppercase())
 }
 
 /// Build the mutated CDS sequence by applying `edit` at a given CDS coordinate.

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -15,6 +15,9 @@ mod indel;
 mod substitution;
 
 // Re-export the public API used by `projector.rs`.
-pub(crate) use helpers::{affects_initiation_codon, build_initiator_unknown, RefProteinBundle};
+pub(crate) use helpers::{
+    affects_initiation_codon, build_initiator_unknown, cds_has_valid_start, read_cds_start_codon,
+    RefProteinBundle,
+};
 pub(crate) use indel::predict_indel_protein;
 pub(crate) use substitution::predict_substitution_protein;


### PR DESCRIPTION
Fixes #625. When a transcript's cdot CDS coordinates are inconsistent with the transcript FASTA — `cds_start` doesn't land on an ATG — ferro silently translated the wrong frame and emitted a fabricated protein consequence (`Xaa…` / a wrong-anchor extension) from a reference protein that mistranslates to a premature internal stop.

**Fix:** a `cds_has_valid_start` guard (`ref_cds` first codon == `ATG`) in the shared `predict_protein_consequence` (covers both the genome-pivot and direct bare-`NM_` paths). When the reference CDS doesn't start with ATG, ferro declines protein prediction (`Ok(None)`) — its existing "cannot predict" convention — instead of emitting garbage.

**Selenoprotein-safe:** the guard keys on the *start codon only*, never on internal stops — selenoproteins (e.g. SELENON `NM_020451.2`) legitimately carry an in-frame internal `TGA` recoded as selenocysteine and must not be declined. A dedicated test (`project_selenoprotein_internal_tga_predicts_protein`) pins this.

**Effect (against a real manifest):** `NM_000425.3` and `NM_152263.2` (cds_start not at ATG) now decline instead of emitting a bogus consequence; valid ATG-start transcripts — including `NM_000051.3`/`NM_000488.3` fixed by #621 — are unchanged.

Discovered via a CDS-frame probe over ferro's own loaded reference data while triaging the hgvs-rs projection corpus. The underlying data issue is a cdot↔FASTA version/consistency mismatch in the prepared reference set; this PR makes ferro robust to it (decline rather than fabricate). TDD: 3 hermetic tests (non-ATG → declines; ATG control → predicts; selenoprotein control → predicts), red-first. Full suite 6899 passed, 0 failed; clippy/fmt clean. Scope: `src/project/` only.
