### PR TITLE
ci: batch github-actions dependabot updates into one grouped PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all `github-actions` version bumps into a single weekly Dependabot PR instead of opening one PR per action.

Recently we got a separate PR for each action bump (#535, #536, #618, #619). Adding a `groups` block with `patterns: ["*"]` collapses them into one batched PR per weekly cycle.

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

This affects future runs only — the existing individual PRs (#535/#536/#618/#619) can be closed once the next grouped PR opens.