### PR TITLE
chore: remove committed machine-specific manifest path from benchmark tests

### DIFF
--- a/tests/biocommons_normalize_tests.rs
+++ b/tests/biocommons_normalize_tests.rs
@@ -84,14 +84,9 @@ fn manifest_path() -> Option<PathBuf> {
         let p = PathBuf::from(path);
         return if p.exists() { Some(p) } else { None };
     }
-    for candidate in [
-        "/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/ferro/manifest.json",
-        "benchmark-output/manifest.json",
-    ] {
-        let p = Path::new(candidate);
-        if p.exists() {
-            return Some(p.to_path_buf());
-        }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
     }
     None
 }
@@ -195,8 +190,8 @@ fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("biocommons-normalize: using manifest {}", p.display()),
         None => println!(
-            "biocommons-normalize: skipping — no manifest at FERRO_MANIFEST, \
-             /Volumes/scratch-00001/.../manifest.json, or benchmark-output/manifest.json"
+            "biocommons-normalize: skipping — no manifest at FERRO_MANIFEST \
+             or benchmark-output/manifest.json"
         ),
     }
 }

--- a/tests/hgvs_rs_projection_tests.rs
+++ b/tests/hgvs_rs_projection_tests.rs
@@ -98,14 +98,9 @@ fn manifest_path() -> Option<PathBuf> {
         let p = PathBuf::from(path);
         return if p.exists() { Some(p) } else { None };
     }
-    for candidate in [
-        "/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/ferro/manifest.json",
-        "benchmark-output/manifest.json",
-    ] {
-        let p = Path::new(candidate);
-        if p.exists() {
-            return Some(p.to_path_buf());
-        }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
     }
     None
 }
@@ -724,8 +719,8 @@ fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("hgvs-rs-projection: using manifest {}", p.display()),
         None => println!(
-            "hgvs-rs-projection: skipping — no manifest at FERRO_MANIFEST, \
-             /Volumes/scratch-00001/.../manifest.json, or benchmark-output/manifest.json"
+            "hgvs-rs-projection: skipping — no manifest at FERRO_MANIFEST \
+             or benchmark-output/manifest.json"
         ),
     }
 }

--- a/tests/mutalyzer_normalize_tests.rs
+++ b/tests/mutalyzer_normalize_tests.rs
@@ -106,14 +106,9 @@ fn manifest_path() -> Option<PathBuf> {
         let p = PathBuf::from(path);
         return if p.exists() { Some(p) } else { None };
     }
-    for candidate in [
-        "/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/ferro/manifest.json",
-        "benchmark-output/manifest.json",
-    ] {
-        let p = Path::new(candidate);
-        if p.exists() {
-            return Some(p.to_path_buf());
-        }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
     }
     None
 }
@@ -520,8 +515,8 @@ fn manifest_or_skip() {
     match manifest_path() {
         Some(p) => println!("mutalyzer-normalize: using manifest {}", p.display()),
         None => println!(
-            "mutalyzer-normalize: skipping — no manifest at FERRO_MANIFEST, \
-             /Volumes/scratch-00001/.../manifest.json, or benchmark-output/manifest.json"
+            "mutalyzer-normalize: skipping — no manifest at FERRO_MANIFEST \
+             or benchmark-output/manifest.json"
         ),
     }
 }


### PR DESCRIPTION
Closes #624.

The `manifest_path()` fallback in the three manifest-backed conformance tests (`tests/biocommons_normalize_tests.rs`, `tests/hgvs_rs_projection_tests.rs`, `tests/mutalyzer_normalize_tests.rs`) hardcoded a developer-machine absolute path (`/Volumes/scratch-00001/...`) as a fallback candidate, and the skip messages echoed it. This removes that path so no machine-specific location is committed.

The resolution order is unchanged in spirit:

- `FERRO_MANIFEST` env var — authoritative, used by CI when manifest-backed tests run.
- `benchmark-output/manifest.json` — repo-relative fallback.

These are Layer-2 conformance tests that skip cleanly when no manifest is available, so behavior is unchanged for anyone setting `FERRO_MANIFEST`.

## Verification

- `cargo build --features benchmark` — ok
- `cargo clippy --features benchmark --all-targets -- -D warnings` — clean
- `cargo nextest run --features benchmark -E 'test(manifest_or_skip)'` (no `FERRO_MANIFEST`) — 3 passed, skip messages no longer reference any machine path

## Audit note

Repo-wide check confirmed these three test files were the only **tracked code/config** carrying a machine-specific path. `docs/BENCHMARK_RUNBOOK.md` references the same path only as a documented `$D` example with an "adjust to your machine" note, which is left as-is.