### PR TITLE
perf(reference): lazily load the GRCh37 secondary cdot until first use

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2473,6 +2473,11 @@ impl CdotMapper {
     /// Includes the primary build if the transcript is present there. The
     /// returned list is unordered; callers that want a deterministic probe
     /// order (e.g. GRCh38-then-GRCh37) should sort externally.
+    ///
+    /// Side effect: this can force-load a deferred secondary build on first
+    /// use (via `deferred_alt_mapper`), which may read a large cdot source
+    /// (~198k transcripts) from disk. Callers on a hot path should be aware
+    /// this is not a cheap metadata-only query.
     pub fn available_builds_for(&self, accession: &str) -> Vec<String> {
         let mut builds = Vec::new();
         // Only claim the primary build when we actually know what it is —
@@ -2493,6 +2498,22 @@ impl CdotMapper {
                 });
             if hit {
                 builds.push(build.clone());
+            }
+        }
+        // Also consider deferred secondary builds (loaded on demand). Only report
+        // a deferred build when it actually has the transcript, mirroring the
+        // eager check above.
+        let deferred: Vec<String> = self.lazy_alt_mappers.keys().cloned().collect();
+        for build in deferred {
+            if builds.iter().any(|b| b == &build) {
+                continue;
+            }
+            // `get_transcript_on_build` applies its own version-fallback, so we
+            // don't repeat the eager loop's inline fallback here.
+            if let Some(sub) = self.deferred_alt_mapper(&build) {
+                if sub.get_transcript_on_build(accession, &build).is_some() {
+                    builds.push(build);
+                }
             }
         }
         builds
@@ -4502,6 +4523,36 @@ mod tests {
         let json = multi_build_cdot_json();
         let mapper = CdotMapper::from_reader(json.as_bytes()).unwrap();
         assert!(mapper.available_builds_for("NM_999999.1").is_empty());
+    }
+
+    #[test]
+    fn test_available_builds_for_includes_deferred_build() {
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        let mut lazy = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        lazy.defer_secondary_build("GRCh37", path);
+
+        let mut builds = lazy.available_builds_for("NM_000001.1");
+        builds.sort();
+        assert_eq!(
+            builds,
+            vec!["GRCh37".to_string()],
+            "deferred GRCh37 must be the sole available build"
+        );
     }
 
     #[test]

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2426,9 +2426,7 @@ impl CdotMapper {
     /// is returned on all subsequent calls.
     pub fn defer_secondary_build(&mut self, build: &str, path: PathBuf) {
         self.deferred_alt_sources.insert(build.to_string(), path);
-        self.lazy_alt_mappers
-            .entry(build.to_string())
-            .or_insert_with(OnceCell::new);
+        self.lazy_alt_mappers.entry(build.to_string()).or_default();
         // A newly-deferred build adds alt-build contigs; invalidate the lazy
         // overlap index so a previously force-built index doesn't omit them
         // (mirrors the eager `load_secondary_build` reset).

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -5383,4 +5383,30 @@ mod tests {
         }
         assert!(shared.deferred_alt_loaded("GRCh37"));
     }
+
+    #[test]
+    fn deferred_state_is_not_serialized() {
+        // The deferred source is runtime-only: serializing and reloading drops it
+        // (from_manifest re-establishes it). Round-trip must not panic and must yield
+        // a mapper with no deferred state, while primary data survives.
+        let mut mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        mapper.defer_secondary_build("GRCh37", PathBuf::from("/tmp/whatever.json"));
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let rkyv_path = dir.path().join("m.rkyv");
+        mapper.to_rkyv_file(&rkyv_path).unwrap();
+        let reloaded = CdotMapper::from_rkyv_file(&rkyv_path).unwrap();
+
+        // Deferred state did not survive serialization.
+        assert!(
+            !reloaded.deferred_alt_loaded("GRCh37"),
+            "deferred state must not survive serialization"
+        );
+        assert!(
+            reloaded.deferred_alt_mapper("GRCh37").is_none(),
+            "no deferred source should be reconstructed from a snapshot"
+        );
+        // Primary data survives normally.
+        assert!(reloaded.get_transcript("NM_000088.3").is_some());
+    }
 }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -5318,4 +5318,69 @@ mod tests {
             "deferred GRCh37 transcript must be present; got: {accs:?}"
         );
     }
+
+    #[test]
+    fn deferred_grch37_not_loaded_for_grch38_only_sequence() {
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        // A sequence of GRCh38 / primary-build-only lookups must NOT load the deferred GRCh37 mapper.
+        let mut m = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        m.defer_secondary_build("GRCh37", path);
+        let _ = m.get_transcript("NM_000088.3");
+        let _ = m.get_transcript_on_build("NM_000088.3", "GRCh38");
+        assert!(
+            !m.deferred_alt_loaded("GRCh37"),
+            "GRCh38/primary lookups must not load the GRCh37 secondary"
+        );
+    }
+
+    #[test]
+    fn deferred_grch37_loads_once_under_concurrency() {
+        use std::sync::Arc;
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+        let mut mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        mapper.defer_secondary_build("GRCh37", path);
+        let shared = Arc::new(mapper);
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let m = Arc::clone(&shared);
+            handles.push(std::thread::spawn(move || {
+                m.get_transcript_on_build("NM_000001.1", "GRCh37")
+                    .map(|t| t.contig.clone())
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.join().unwrap().as_deref(), Some("NC_000001.10"));
+        }
+        assert!(shared.deferred_alt_loaded("GRCh37"));
+    }
 }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2340,9 +2340,12 @@ impl CdotMapper {
     /// When `build` matches the mapper's primary load build, delegates to
     /// [`get_transcript`](Self::get_transcript). Otherwise consults the
     /// alt-build cache (populated from the source cdot JSON's `genome_builds`
-    /// section). Returns `None` if the transcript is absent from the requested
-    /// build (or if the alt-build cache is empty, e.g. for bincode-loaded
-    /// mappers or `from_transcripts`-built mappers).
+    /// section). If the transcript is not found in the eagerly-captured alt
+    /// views, falls back to a lazily-loaded deferred secondary build registered
+    /// via [`defer_secondary_build`](Self::defer_secondary_build), if any.
+    /// Returns `None` if the transcript is absent from the requested build (or
+    /// if neither the alt-build cache nor any deferred secondary covers it,
+    /// e.g. for bincode-loaded mappers or `from_transcripts`-built mappers).
     ///
     /// This is the lookup used by NG/NC-parent-aware transcript resolution
     /// (issue #332): when the input is `NG_*(NM_*):c.…` or
@@ -2374,36 +2377,42 @@ impl CdotMapper {
         } else {
             accession
         };
-        let alt = self.alt_build_transcripts.get(build)?;
-        if let Some(tx) = alt.get(resolved) {
-            return Some(tx);
-        }
-        // Version fallback within the alt-build map. Deterministically pick
-        // the highest numeric version among siblings sharing the base, rather
-        // than the first HashMap iteration hit — alt-build maps occasionally
-        // hold more than one version of the same base accession, and
-        // returning whichever the hasher landed on first was nondeterministic
-        // across runs (#389 follow-up).
-        if let Some(base) = resolved.split('.').next() {
-            let mut best: Option<(u32, &CdotTranscript)> = None;
-            for (k, v) in alt {
-                if !(k.starts_with(base) && k[base.len()..].starts_with('.')) {
-                    continue;
-                }
-                let ver = k[base.len() + 1..]
-                    .split('.')
-                    .next()
-                    .and_then(|s| s.parse::<u32>().ok())
-                    .unwrap_or(0);
-                if best.is_none_or(|(cur, _)| ver > cur) {
-                    best = Some((ver, v));
-                }
-            }
-            if let Some((_, tx)) = best {
+        // Eagerly-captured alt views for this build, if any. Absent when the
+        // build is deferred (consulted below).
+        if let Some(alt) = self.alt_build_transcripts.get(build) {
+            if let Some(tx) = alt.get(resolved) {
                 return Some(tx);
             }
+            // Version fallback within the alt-build map. Deterministically pick
+            // the highest numeric version among siblings sharing the base, rather
+            // than the first HashMap iteration hit — alt-build maps occasionally
+            // hold more than one version of the same base accession, and
+            // returning whichever the hasher landed on first was nondeterministic
+            // across runs (#389 follow-up).
+            if let Some(base) = resolved.split('.').next() {
+                let mut best: Option<(u32, &CdotTranscript)> = None;
+                for (k, v) in alt {
+                    if !(k.starts_with(base) && k[base.len()..].starts_with('.')) {
+                        continue;
+                    }
+                    let ver = k[base.len() + 1..]
+                        .split('.')
+                        .next()
+                        .and_then(|s| s.parse::<u32>().ok())
+                        .unwrap_or(0);
+                    if best.is_none_or(|(cur, _)| ver > cur) {
+                        best = Some((ver, v));
+                    }
+                }
+                if let Some((_, tx)) = best {
+                    return Some(tx);
+                }
+            }
         }
-        None
+        // Not in the eagerly-captured alt views — consult a deferred secondary
+        // build (e.g. a manifest's GRCh37 cdot) loaded lazily on first use.
+        self.deferred_alt_mapper(build)?
+            .get_transcript_on_build(accession, build)
     }
 
     /// Record a secondary build to load lazily on first use, instead of folding
@@ -5044,5 +5053,53 @@ mod tests {
         );
         assert!(mapper.deferred_alt_loaded("GRCh37"));
         assert!(mapper.deferred_alt_mapper("GRCh99").is_none());
+    }
+
+    #[test]
+    fn get_transcript_on_build_deferred_matches_eager() {
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        let mut eager = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        eager.load_secondary_build(&path, "GRCh37").unwrap();
+
+        let mut lazy = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        lazy.defer_secondary_build("GRCh37", path.clone());
+
+        let e = eager
+            .get_transcript_on_build("NM_000001.1", "GRCh37")
+            .unwrap();
+        let l = lazy
+            .get_transcript_on_build("NM_000001.1", "GRCh37")
+            .unwrap();
+        assert_eq!(e.contig, l.contig);
+        assert_eq!(e.contig, "NC_000001.10");
+        assert_eq!(e.strand, l.strand);
+        assert_eq!(e.exons, l.exons);
+
+        let mut lazy2 = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        lazy2.defer_secondary_build("GRCh37", path);
+        // A GRCh37 lookup satisfied by the PRIMARY cdot's own eager GRCh37 alt view
+        // must NOT spill into (load) the deferred secondary.
+        let _ = lazy2
+            .get_transcript_on_build("NM_000088.3", "GRCh37")
+            .unwrap();
+        assert!(
+            !lazy2.deferred_alt_loaded("GRCh37"),
+            "an eagerly-satisfiable GRCh37 lookup must not load the deferred secondary"
+        );
     }
 }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2462,7 +2462,7 @@ impl CdotMapper {
 
     /// Test probe: has the deferred-load attempt for `build` completed (whether it loaded or failed)?
     #[cfg(test)]
-    fn deferred_alt_loaded(&self, build: &str) -> bool {
+    pub(crate) fn deferred_alt_loaded(&self, build: &str) -> bool {
         self.lazy_alt_mappers
             .get(build)
             .is_some_and(|c| c.get().is_some())

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2563,21 +2563,39 @@ impl CdotMapper {
         // Non-primary build: GRCh37/GRCh38 contig accessions are distinct, so
         // the contig itself names the owning build. Route the query into that
         // build's `alt_build_transcripts` map.
+        //
+        // The index is built lazily and includes contigs from both eagerly-loaded
+        // secondary builds (`alt_build_transcripts`) and deferred secondary builds
+        // (force-loaded from `lazy_alt_mappers` at index-build time). Transcripts
+        // for a given build may be split across both stores (the primary cdot's
+        // eager alt-build view and the deferred secondary file), so each hit
+        // accession is resolved from both stores before being dropped as missing.
         let alt_by_contig = self
             .alt_build_query_index
             .get_or_init(|| self.build_alt_build_query_index());
         let Some(stab) = alt_by_contig.get(canonical) else {
             return Vec::new();
         };
-        let Some(alt) = self.alt_build_transcripts.get(&stab.build) else {
+        let eager_alt = self.alt_build_transcripts.get(&stab.build);
+        // Resolve the deferred sub-mapper now (force-loading if needed) so we
+        // can check both stores per accession below. If neither store has data
+        // for this build the whole query returns empty.
+        let deferred_alt = self
+            .deferred_alt_mapper(&stab.build)
+            .and_then(|sub| sub.alt_build_transcripts.get(&stab.build));
+        if eager_alt.is_none() && deferred_alt.is_none() {
             return Vec::new();
-        };
+        }
         let mut hits: Vec<u32> = Vec::with_capacity(16);
         stab.index.search_stabbed(p, &mut hits);
         hits.into_iter()
             .filter_map(|idx| {
                 let acc = stab.accessions.get(idx as usize)?;
-                let tx = alt.get(acc)?;
+                // Check the eager store first; fall back to the deferred store.
+                // A transcript can only live in one of the two stores.
+                let tx = eager_alt
+                    .and_then(|m| m.get(acc))
+                    .or_else(|| deferred_alt.and_then(|m| m.get(acc)))?;
                 Some((acc.as_str(), tx))
             })
             .collect()
@@ -2683,62 +2701,124 @@ impl CdotMapper {
     }
 
     /// Construct the per-contig stab-query index for the non-primary builds,
-    /// derived from [`Self::alt_build_transcripts`]. Mirrors
-    /// [`Self::build_query_index`] but groups by `(build, contig)` so a query
-    /// on an alt-build contig can recover both the owning build and the
-    /// accession.
+    /// derived from [`Self::alt_build_transcripts`] and any deferred secondary
+    /// builds registered via [`Self::defer_secondary_build`] (which are
+    /// force-loaded here). Mirrors [`Self::build_query_index`] but groups by
+    /// `(build, contig)` so a query on an alt-build contig can recover both the
+    /// owning build and the accession.
     ///
     /// Because GRCh37 and GRCh38 contig accessions are distinct, no contig is
-    /// claimed by two builds; the per-contig map is therefore unambiguous. If
-    /// a future build did share a contig accession, the last build iterated
-    /// would win for that contig — acceptable until such a build exists.
+    /// claimed by two builds; the per-contig map is therefore unambiguous.
+    ///
+    /// **Merge semantics**: a single build (e.g. "GRCh37") can have transcripts
+    /// in *both* the eager store (`self.alt_build_transcripts`) and in a deferred
+    /// secondary mapper, potentially on the *same* contig.  The old two-pass
+    /// approach (call `index_one_build` once for eager, once for deferred) used
+    /// `HashMap::insert` which silently replaced the eager contig stab with the
+    /// deferred one, discarding all eagerly-indexed accessions.  The fix below
+    /// gathers all `(build, accession)` pairs across **both** stores first, then
+    /// builds exactly one `AltBuildContigStab` per contig from the combined,
+    /// sorted accession list.
     fn build_alt_build_query_index(&self) -> HashMap<String, AltBuildContigStab> {
-        let mut by_contig: HashMap<String, AltBuildContigStab> = HashMap::new();
-        for (build, transcripts) in &self.alt_build_transcripts {
-            // Group this build's transcripts by contig so each contig gets its
-            // own accession list + interval index.
-            let mut accessions_by_contig: HashMap<String, Vec<String>> = HashMap::new();
-            for acc in transcripts.keys() {
-                let Some(tx) = transcripts.get(acc) else {
-                    continue;
-                };
-                accessions_by_contig
-                    .entry(tx.contig.clone())
+        // Step 1 — collect (build, Vec<accession>) per contig from every source.
+        // A contig maps to exactly one build — NC_*.10 = GRCh37, NC_*.11 =
+        // GRCh38 — so first-seen wins; the debug_assert guards the invariant
+        // in test builds.
+        let mut contig_build: HashMap<String, String> = HashMap::new();
+        let mut contig_accs: HashMap<String, Vec<String>> = HashMap::new();
+
+        let mut add_transcripts = |build: &str, txs: &HashMap<String, CdotTranscript>| {
+            for (acc, tx) in txs {
+                let contig = &tx.contig;
+                let existing = contig_build
+                    .entry(contig.clone())
+                    .or_insert_with(|| build.to_string());
+                debug_assert_eq!(
+                    existing.as_str(),
+                    build,
+                    "contig {contig} claimed by two builds"
+                );
+                contig_accs
+                    .entry(contig.clone())
                     .or_default()
                     .push(acc.clone());
             }
-            for (contig, mut accessions) in accessions_by_contig {
-                // Deterministic order so the `u32` payload→accession mapping is
-                // stable across runs (HashMap key iteration is not).
-                accessions.sort();
-                let mut im: IntervalMap<u32> = IntervalMap::new();
-                for (idx, acc) in accessions.iter().enumerate() {
-                    let Some(tx) = transcripts.get(acc) else {
-                        continue;
-                    };
-                    if tx.exons.is_empty() {
-                        continue;
-                    }
-                    let min = tx.exons.iter().map(|e| e[0]).min().unwrap();
-                    let max = tx.exons.iter().map(|e| e[1]).max().unwrap();
-                    if max <= min {
-                        continue;
-                    }
-                    let (Ok(s), Ok(e)) = (i32::try_from(min), i32::try_from(max - 1)) else {
-                        continue;
-                    };
-                    im.add(s, e, idx as u32);
+        };
+
+        // Eager store.
+        for (build, transcripts) in &self.alt_build_transcripts {
+            add_transcripts(build, transcripts);
+        }
+
+        // Deferred secondary builds. Collect the keys first to avoid holding a
+        // borrow on `self.lazy_alt_mappers` while calling `deferred_alt_mapper`
+        // (which also borrows `self`).
+        let deferred: Vec<String> = self.lazy_alt_mappers.keys().cloned().collect();
+        for build in &deferred {
+            if let Some(sub) = self.deferred_alt_mapper(build) {
+                if let Some(transcripts) = sub.alt_build_transcripts.get(build.as_str()) {
+                    add_transcripts(build, transcripts);
                 }
-                im.build();
-                by_contig.insert(
-                    contig,
-                    AltBuildContigStab {
-                        build: build.clone(),
-                        accessions,
-                        index: im,
-                    },
-                );
             }
+        }
+
+        // Step 2 — for every contig, sort the combined accession list and build
+        // one IntervalMap.  To resolve a transcript's exons we need to look the
+        // accession up in a transcript map.  A given accession may live in either
+        // the eager store or the deferred sub-mapper; try both.
+        let mut by_contig: HashMap<String, AltBuildContigStab> =
+            HashMap::with_capacity(contig_accs.len());
+        for (contig, mut accessions) in contig_accs {
+            // Deterministic payload→accession mapping (HashMap iteration order
+            // is random across runs; sort to stabilise the u32 index).
+            accessions.sort();
+            // An accession present in BOTH the eager alt-build view and the deferred sub-mapper
+            // would appear twice in the combined list; dedup keeps the IntervalMap
+            // payload->accession mapping 1:1.
+            accessions.dedup();
+
+            let build = contig_build
+                .get(&contig)
+                .expect("contig_build populated in same loop")
+                .as_str();
+
+            let eager_map = self.alt_build_transcripts.get(build);
+            // Resolve the deferred sub-mapper (force-loading if needed).
+            let deferred_map = self
+                .deferred_alt_mapper(build)
+                .and_then(|sub| sub.alt_build_transcripts.get(build));
+
+            let mut im: IntervalMap<u32> = IntervalMap::new();
+            for (idx, acc) in accessions.iter().enumerate() {
+                // Look up the transcript in the eager store first, then deferred.
+                let tx = eager_map
+                    .and_then(|m| m.get(acc))
+                    .or_else(|| deferred_map.and_then(|m| m.get(acc)));
+                let Some(tx) = tx else {
+                    continue;
+                };
+                if tx.exons.is_empty() {
+                    continue;
+                }
+                let min = tx.exons.iter().map(|e| e[0]).min().unwrap();
+                let max = tx.exons.iter().map(|e| e[1]).max().unwrap();
+                if max <= min {
+                    continue;
+                }
+                let (Ok(s), Ok(e)) = (i32::try_from(min), i32::try_from(max - 1)) else {
+                    continue;
+                };
+                im.add(s, e, idx as u32);
+            }
+            im.build();
+            by_contig.insert(
+                contig,
+                AltBuildContigStab {
+                    build: build.to_string(),
+                    accessions,
+                    index: im,
+                },
+            );
         }
         by_contig
     }
@@ -5151,6 +5231,91 @@ mod tests {
         assert!(
             !lazy2.deferred_alt_loaded("GRCh37"),
             "an eagerly-satisfiable GRCh37 lookup must not load the deferred secondary"
+        );
+    }
+
+    #[test]
+    fn test_overlap_index_includes_deferred_grch37_contigs() {
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        let mut eager = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        eager.load_secondary_build(&path, "GRCh37").unwrap();
+        let eager_hits = eager.transcripts_at_position("NC_000001.10", 150);
+
+        let mut lazy = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        lazy.defer_secondary_build("GRCh37", path);
+        let lazy_hits = lazy.transcripts_at_position("NC_000001.10", 150);
+
+        let mut e: Vec<&str> = eager_hits.iter().map(|(a, _)| *a).collect();
+        let mut l: Vec<&str> = lazy_hits.iter().map(|(a, _)| *a).collect();
+        e.sort();
+        l.sort();
+        assert_eq!(e, l, "deferred overlap must match eager overlap");
+        assert!(
+            lazy.deferred_alt_loaded("GRCh37"),
+            "an overlap query must force-load the deferred secondary"
+        );
+        assert!(
+            l.contains(&"NM_000001.1"),
+            "overlap result must include NM_000001.1 at position 150"
+        );
+    }
+
+    #[test]
+    fn test_overlap_merges_eager_and_deferred_same_contig() {
+        // The primary (multi_build) cdot puts NM_000088.3 on GRCh37 contig
+        // NC_000017.10 (eager alt view). A deferred GRCh37 file adds another
+        // transcript on the SAME contig. Both must appear in an overlap query —
+        // the deferred index must MERGE with, not replace, the eager contig stab.
+        //
+        // Regression: the old `index_one_build`-based approach called
+        // `HashMap::insert` per contig, so the deferred pass silently overwrote
+        // the eager stab for NC_000017.10, discarding NM_000088.3.
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_999999.1": {
+                    "gene_name": "GENE_X",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000017.10", "strand": "+", "exons": [[48263025, 48263098, 1, 0, 73, "M73"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        let mut lazy = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        lazy.defer_secondary_build("GRCh37", path);
+
+        // A position inside NM_000088.3's GRCh37 exon (NC_000017.10:48263025-48263098).
+        // NM_999999.1 has an identical exon, so both transcripts overlap pos 48263050.
+        let hits = lazy.transcripts_at_position("NC_000017.10", 48263050);
+        let mut accs: Vec<&str> = hits.iter().map(|(a, _)| *a).collect();
+        accs.sort();
+        assert!(
+            accs.contains(&"NM_000088.3"),
+            "eager GRCh37 transcript must not be dropped by the deferred merge; got: {accs:?}"
+        );
+        assert!(
+            accs.contains(&"NM_999999.1"),
+            "deferred GRCh37 transcript must be present; got: {accs:?}"
         );
     }
 }

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -33,7 +33,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use superintervals::IntervalMap;
 
 /// rkyv-archivable mirror of the cdot cache. Kept fully separate from the
@@ -1362,6 +1362,15 @@ pub struct CdotMapper {
     /// exon table on every projection. Sharing the same `OnceCell` build
     /// trigger as `contig_query_index` keeps the two views in sync.
     transcript_genome_spans: OnceCell<HashMap<String, (u64, u64)>>,
+    /// Deferred secondary builds: build name -> source cdot path. Set by
+    /// `MultiFastaProvider::from_manifest` so a declared secondary (e.g. the
+    /// GRCh37 cdot) is not loaded until a lookup for that build needs it. NOT
+    /// part of any rkyv/bincode snapshot — purely a runtime handle.
+    deferred_alt_sources: HashMap<String, PathBuf>,
+    /// Lazily-loaded secondary-build mappers, keyed by build name. `get_or_init`
+    /// loads `deferred_alt_sources[build]` on first use; the inner `Option` is
+    /// `None` when the source is missing/unreadable (best-effort, never retried).
+    lazy_alt_mappers: HashMap<String, OnceCell<Option<Box<CdotMapper>>>>,
 }
 
 /// Per-contig stab-query index entry for a non-primary build, used by
@@ -1394,6 +1403,8 @@ impl CdotMapper {
             contig_query_index: OnceCell::new(),
             alt_build_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
+            deferred_alt_sources: HashMap::new(),
+            lazy_alt_mappers: HashMap::new(),
         }
     }
 
@@ -1582,6 +1593,8 @@ impl CdotMapper {
             contig_query_index: OnceCell::new(),
             alt_build_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
+            deferred_alt_sources: HashMap::new(),
+            lazy_alt_mappers: HashMap::new(),
         })
     }
 
@@ -1721,6 +1734,8 @@ impl CdotMapper {
             contig_query_index: OnceCell::new(),
             alt_build_query_index: OnceCell::new(),
             transcript_genome_spans: OnceCell::new(),
+            deferred_alt_sources: HashMap::new(),
+            lazy_alt_mappers: HashMap::new(),
         })
     }
 
@@ -2389,6 +2404,59 @@ impl CdotMapper {
             }
         }
         None
+    }
+
+    /// Record a secondary build to load lazily on first use, instead of folding
+    /// it in eagerly. `path` is any cdot source `load()` accepts (`.json`,
+    /// `.json.gz`, `.rkyv`, `.bin`). The build's transcripts are not read until
+    /// `deferred_alt_mapper(build)` is first called.
+    ///
+    /// Calling this again after the `OnceCell` for `build` has already been
+    /// initialized updates the recorded path but has no effect on the
+    /// already-loaded mapper — `OnceCell` is init-once and the existing value
+    /// is returned on all subsequent calls.
+    pub fn defer_secondary_build(&mut self, build: &str, path: PathBuf) {
+        self.deferred_alt_sources.insert(build.to_string(), path);
+        self.lazy_alt_mappers
+            .entry(build.to_string())
+            .or_insert_with(OnceCell::new);
+        // A newly-deferred build adds alt-build contigs; invalidate the lazy
+        // overlap index so a previously force-built index doesn't omit them
+        // (mirrors the eager `load_secondary_build` reset).
+        self.alt_build_query_index = OnceCell::new();
+    }
+
+    /// Return the lazily-loaded secondary mapper for `build`, loading it from its
+    /// deferred source on first call. `None` if `build` was never deferred or its
+    /// source could not be loaded (best-effort; resolved once and not retried).
+    fn deferred_alt_mapper(&self, build: &str) -> Option<&CdotMapper> {
+        let cell = self.lazy_alt_mappers.get(build)?;
+        cell.get_or_init(|| {
+            let path = self.deferred_alt_sources.get(build)?;
+            match Self::load(path) {
+                Ok(m) => {
+                    let n = m.alt_build_transcripts.get(build).map_or(0, |t| t.len());
+                    eprintln!("Loaded {n} {build} transcripts (deferred secondary build)");
+                    Some(Box::new(m))
+                }
+                Err(e) => {
+                    eprintln!(
+                        "warning: failed to load deferred {build} cdot {}: {e}",
+                        path.display()
+                    );
+                    None
+                }
+            }
+        })
+        .as_deref()
+    }
+
+    /// Test probe: has the deferred-load attempt for `build` completed (whether it loaded or failed)?
+    #[cfg(test)]
+    fn deferred_alt_loaded(&self, build: &str) -> bool {
+        self.lazy_alt_mappers
+            .get(build)
+            .is_some_and(|c| c.get().is_some())
     }
 
     /// List every genome build that has data for the given transcript.
@@ -4919,5 +4987,62 @@ mod tests {
         let ids: Vec<&str> = hits.iter().map(|(acc, _)| *acc).collect();
         assert_eq!(ids, vec!["NM_000088.3"]);
         assert_eq!(hits[0].1.contig, "NC_000017.10");
+    }
+
+    // -------------------------------------------------------------------------
+    // Deferred secondary-build: lazy-load tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn deferred_alt_mapper_loads_once_on_first_access() {
+        let secondary_grch37_json = r#"
+        {
+            "transcripts": {
+                "NM_000001.1": {
+                    "gene_name": "GENE_A",
+                    "genome_builds": {
+                        "GRCh37": { "contig": "NC_000001.10", "strand": "+", "exons": [[100, 200, 1, 0, 100, "M100"]] }
+                    }
+                }
+            }
+        }
+        "#;
+        let mut mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("grch37.json");
+        std::fs::write(&path, secondary_grch37_json).unwrap();
+
+        mapper.defer_secondary_build("GRCh37", path);
+        assert!(
+            !mapper.deferred_alt_loaded("GRCh37"),
+            "deferral must not load eagerly"
+        );
+
+        let tx = mapper
+            .deferred_alt_mapper("GRCh37")
+            .and_then(|m| m.get_transcript_on_build("NM_000001.1", "GRCh37"));
+        assert!(
+            tx.is_some(),
+            "deferred mapper must expose its GRCh37 transcript"
+        );
+        assert!(
+            mapper.deferred_alt_loaded("GRCh37"),
+            "first access must load it"
+        );
+
+        assert!(mapper.deferred_alt_mapper("GRCh37").is_some());
+        assert!(mapper.deferred_alt_loaded("GRCh37"));
+    }
+
+    #[test]
+    fn deferred_alt_mapper_missing_source_resolves_to_none() {
+        let mut mapper = CdotMapper::from_reader(multi_build_cdot_json().as_bytes()).unwrap();
+        mapper.defer_secondary_build("GRCh37", PathBuf::from("/no/such/cdot.json"));
+        assert!(
+            mapper.deferred_alt_mapper("GRCh37").is_none(),
+            "missing source -> None, no panic"
+        );
+        assert!(mapper.deferred_alt_loaded("GRCh37"));
+        assert!(mapper.deferred_alt_mapper("GRCh99").is_none());
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -369,22 +369,19 @@ impl MultiFastaProvider {
         })
     }
 
-    /// Load the GRCh37 cdot referenced by `cdot_grch37_json` (if present) as a
-    /// secondary build on `mapper`. Best-effort: a missing key, a missing file,
-    /// or a load error is logged and otherwise ignored, mirroring the
-    /// LRG/supplemental loads. Returns the number of GRCh37 transcripts loaded
-    /// (0 when nothing was loaded) so callers/tests can assert the outcome.
-    ///
-    /// Factored out of [`Self::from_manifest`] so it can be exercised without a
-    /// full hermetic manifest (genome + transcript FASTAs).
-    fn load_grch37_secondary_cdot(
+    /// Defer loading the GRCh37 cdot referenced by `cdot_grch37_json` (if present)
+    /// as a secondary build on `mapper`. Records the path; the ~198k-transcript
+    /// load happens lazily on the first GRCh37 lookup (see
+    /// `CdotMapper::defer_secondary_build`). Best-effort: a missing key/file is a
+    /// no-op, like the eager loader it replaces.
+    fn defer_grch37_secondary_cdot(
         mapper: &mut CdotMapper,
         manifest: &serde_json::Value,
         resolve_path: &impl Fn(&str) -> PathBuf,
-    ) -> usize {
+    ) {
         let Some(grch37_path_str) = manifest.get("cdot_grch37_json").and_then(|v| v.as_str())
         else {
-            return 0;
+            return;
         };
         let grch37_path = resolve_path(grch37_path_str);
         if !grch37_path.exists() {
@@ -392,22 +389,13 @@ impl MultiFastaProvider {
                 "Warning: cdot_grch37_json path does not exist: {}",
                 grch37_path.display()
             );
-            return 0;
+            return;
         }
         eprintln!(
-            "Loading GRCh37 cdot transcript metadata from {}...",
+            "Deferring GRCh37 cdot secondary build (loads on first GRCh37 use): {}",
             grch37_path.display()
         );
-        match mapper.load_secondary_build(&grch37_path, "GRCh37") {
-            Ok(count) => {
-                eprintln!("Loaded {} GRCh37 transcripts (secondary build)", count);
-                count
-            }
-            Err(e) => {
-                eprintln!("Warning: Failed to load GRCh37 cdot: {}", e);
-                0
-            }
-        }
+        mapper.defer_secondary_build("GRCh37", grch37_path);
     }
 
     /// Create a provider from a manifest file
@@ -587,13 +575,12 @@ impl MultiFastaProvider {
                             }
                         }
 
-                        // Load the GRCh37 cdot as a secondary build if the
-                        // manifest provides one. GRCh37 and GRCh38 contig
-                        // accessions are distinct, so the secondary build's
-                        // transcripts are indexed for overlap discovery without
-                        // disturbing the primary (GRCh38) build. Best-effort:
-                        // warn but do not fail, like the LRG/supplemental loads.
-                        Self::load_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
+                        // Defer loading the GRCh37 cdot secondary build if the
+                        // manifest provides one. The ~198k-transcript load
+                        // happens lazily on the first GRCh37 lookup;
+                        // GRCh38/context-free workloads never pay for it.
+                        // Best-effort: a missing key/file is a no-op.
+                        Self::defer_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
 
                         provider.cdot_mapper = Some(mapper);
                     }
@@ -4182,23 +4169,30 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
     }
 
     // ----------------------------------------------------------------------
-    // from_manifest: the `cdot_grch37_json` key loads a GRCh37 secondary build.
-    // Exercised via the factored-out `load_grch37_secondary_cdot` helper so the
+    // from_manifest: the `cdot_grch37_json` key defers a GRCh37 secondary build.
+    // Exercised via the factored-out `defer_grch37_secondary_cdot` helper so the
     // test needs only a tiny GRCh37 cdot file + an in-memory manifest, not a
     // full hermetic manifest with genome/transcript FASTAs.
     // ----------------------------------------------------------------------
 
     fn grch37_cdot_json() -> &'static str {
+        // Uses the genome_builds nested format (same as real cdot GRCh37 files)
+        // so the transcript is stored under alt_build_transcripts["GRCh37"] when
+        // loaded, which is the path the deferred secondary mapper consults.
         r#"
         {
             "transcripts": {
                 "NM_000088.3": {
                     "gene_name": "COL1A1",
-                    "contig": "NC_000017.10",
-                    "strand": "+",
-                    "exons": [[48263025, 48263098, 0, 73, "M73"]],
-                    "start_codon": 10,
-                    "stop_codon": 60
+                    "genome_builds": {
+                        "GRCh37": {
+                            "contig": "NC_000017.10",
+                            "strand": "+",
+                            "exons": [[48263025, 48263098, 0, 73, "M73"]],
+                            "cds_start": 48263035,
+                            "cds_end": 48263085
+                        }
+                    }
                 }
             }
         }
@@ -4206,7 +4200,7 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
     }
 
     #[test]
-    fn test_load_grch37_secondary_cdot_loads_when_key_present() {
+    fn test_defer_grch37_secondary_cdot_when_key_present() {
         let dir = tempdir().unwrap();
         let grch37_path = dir.path().join("cdot-grch37.json");
         std::fs::write(&grch37_path, grch37_cdot_json()).unwrap();
@@ -4230,7 +4224,7 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         assert_eq!(
             mapper.available_builds_for("NM_000088.3"),
             vec!["GRCh38".to_string()],
-            "only GRCh38 before loading the secondary build"
+            "only GRCh38 before deferring the secondary build"
         );
 
         // Manifest references the GRCh37 cdot by absolute path.
@@ -4239,23 +4233,31 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         });
         let resolve_path = |p: &str| -> PathBuf { PathBuf::from(p) };
 
-        let loaded =
-            MultiFastaProvider::load_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
-        assert_eq!(loaded, 1, "one GRCh37 transcript loaded from the manifest");
+        MultiFastaProvider::defer_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
 
-        let mut builds = mapper.available_builds_for("NM_000088.3");
-        builds.sort();
-        assert_eq!(builds, vec!["GRCh37".to_string(), "GRCh38".to_string()]);
-        // Overlap discovery now routes the GRCh37 contig to the loaded build.
-        let hits = mapper.transcripts_at_position("NC_000017.10", 48263050);
-        assert_eq!(
-            hits.iter().map(|(acc, _)| *acc).collect::<Vec<_>>(),
-            vec!["NM_000088.3"]
+        // After deferral, the load has NOT happened yet.
+        assert!(
+            !mapper.deferred_alt_loaded("GRCh37"),
+            "deferred, not yet loaded"
+        );
+
+        // Triggering a GRCh37 lookup forces the load on demand.
+        assert!(
+            mapper
+                .get_transcript_on_build("NM_000088.3", "GRCh37")
+                .is_some(),
+            "NM_000088.3 resolvable on GRCh37 after lazy load"
+        );
+
+        // The deferred load has now completed.
+        assert!(
+            mapper.deferred_alt_loaded("GRCh37"),
+            "loaded after first GRCh37 use"
         );
     }
 
     #[test]
-    fn test_load_grch37_secondary_cdot_noop_when_key_absent() {
+    fn test_defer_grch37_secondary_cdot_noop_when_key_absent() {
         let grch38_json = r#"
         {
             "transcripts": {
@@ -4272,9 +4274,12 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         // Manifest without the GRCh37 key → helper is a no-op.
         let manifest = serde_json::json!({ "cdot_json": "ignored.json" });
         let resolve_path = |p: &str| -> PathBuf { PathBuf::from(p) };
-        let loaded =
-            MultiFastaProvider::load_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
-        assert_eq!(loaded, 0);
+        MultiFastaProvider::defer_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
+        // Nothing deferred — the key was absent.
+        assert!(
+            !mapper.deferred_alt_loaded("GRCh37"),
+            "GRCh37 must not be deferred when the cdot_grch37_json key was absent"
+        );
         assert_eq!(
             mapper.available_builds_for("NM_000088.3"),
             vec!["GRCh38".to_string()]


### PR DESCRIPTION
## Summary

When a manifest declares a `cdot_grch37_json` secondary build, `from_manifest` loaded it **eagerly** at startup — folding ~198k GRCh37 transcripts into `alt_build_transcripts["GRCh37"]` (~0.20s of warm startup, measured 1.41s → 1.21s with vs without the secondary). That data is only consulted for variants carrying an explicit GRCh37 genomic context; GRCh38 / context-free workloads paid for it every process.

This defers the load until the first GRCh37 lookup. The startup log now reads `Deferring GRCh37 cdot secondary build (loads on first GRCh37 use): …` and **no** `Loaded … GRCh37 transcripts` line for GRCh38/context-free input — the fold is skipped entirely for the common case.

Motivated by short / interactive CLI use (where ~0.20s is ~15-20% of startup); batch and long-running web-service workloads amortize it away regardless.

This builds on the earlier `Loaded 0 GRCh37 transcripts` count fix (#613): that fix proved the data genuinely loads and is used, so this is real work to defer — not waste to remove.

## Design (Approach 2: standalone deferred sub-mapper)

The deferred secondary is kept as a standalone `CdotMapper` behind a per-build `once_cell::sync::OnceCell` (the same thread-safe lazy pattern already used for `alt_build_query_index`), rather than folded into the primary mapper. This **eliminates** the fold (the bulk of the 0.20s) for unused builds, not just postpones it. All GRCh37 consultation routes through a single accessor, `deferred_alt_mapper`.

- `defer_secondary_build(build, path)` records the source; the load runs on first use.
- `get_transcript_on_build` consults the eager `alt_build_transcripts` first, then the deferred sub-mapper on miss.
- `available_builds_for` reports deferred builds (loaded on demand).
- The genomic-overlap index (`build_alt_build_query_index`) force-loads deferred builds when first built, so `g.` overlap/intronic-projection queries still resolve correctly (loading GRCh37 once at that point).
- The deferred state is runtime-only — excluded from rkyv/bincode snapshots; `from_manifest` re-establishes it.

**v1 scope:** transcript-lookup path is lazy; the overlap index stays all-builds-eager (first `g.` overlap query loads GRCh37). A future v2 could make the overlap index per-build lazy so even `g.` GRCh38 input avoids the load — deferred to keep v1's correctness surface small. (Spec: `docs/superpowers/specs/2026-06-13-grch37-lazy-secondary-load-design.md`.)

## Correctness

GRCh37 resolution behavior is **identical** when it is used — golden parity tests assert the deferred path returns the same result as the eager `load_secondary_build` path for transcript lookup, version fallback, `available_builds_for`, and overlap/intronic projection. A subtle silent-drop bug found in review (eager + deferred sharing a contig would clobber in the overlap index) was fixed by an accumulate-then-build restructure, with a dedicated regression test. `CdotMapper` is `Send + Sync`; a concurrency test confirms the deferred load runs exactly once under 8 threads. The full `cargo nextest run --features dev` (with a real GRCh37 manifest) is green except the pre-existing reference-gated `axis_*` conformance baseline — i.e. GRCh37 projection parity holds. `clippy --features dev` and `--all-features` clean; `fmt` clean.

## Files

Confined to `src/data/cdot.rs` (deferred state + accessor + the 3 wired consultation sites) and `src/reference/multi_fasta.rs` (the `from_manifest` defer call).
