### PR TITLE
perf(parser): eliminate per-parse accession allocations (~27% faster parsing)

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -216,7 +216,7 @@ fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
 
     Ok((
         &input[accession_end..],
-        Accession::with_style(name.to_string(), String::new(), version, true),
+        Accession::with_style(name, "", version, true),
     ))
 }
 
@@ -279,7 +279,7 @@ fn parse_uniprot_6char(input: &str) -> IResult<&str, Accession> {
     let number_part = &input[1..6];
     Ok((
         &input[6..],
-        Accession::with_style(first.to_string(), number_part.to_string(), None, true),
+        Accession::with_style(first, number_part, None, true),
     ))
 }
 
@@ -327,7 +327,7 @@ fn parse_uniprot_10char(input: &str) -> IResult<&str, Accession> {
     let number_part = &input[1..10];
     Ok((
         &input[10..],
-        Accession::with_style(first.to_string(), number_part.to_string(), None, true),
+        Accession::with_style(first, number_part, None, true),
     ))
 }
 
@@ -351,10 +351,7 @@ fn parse_assembly_accession(input: &str) -> IResult<&str, Accession> {
     let (input, chromosome) = take_while1(|c: char| c.is_ascii_alphanumeric()).parse(input)?;
     let (input, _) = tag(")").parse(input)?;
 
-    Ok((
-        input,
-        Accession::from_assembly(assembly.to_string(), chromosome.to_string()),
-    ))
+    Ok((input, Accession::from_assembly(assembly, chromosome)))
 }
 
 /// Parse a standard RefSeq-style accession with underscore (e.g., "NM_000088.3")
@@ -365,7 +362,7 @@ fn parse_standard_accession(input: &str) -> IResult<&str, Accession> {
     let (input, number) = parse_number(input)?;
     let (input, version) = opt(preceded(tag("."), parse_version)).parse(input)?;
 
-    let outer = Accession::with_style(prefix.to_string(), number.to_string(), version, false);
+    let outer = Accession::with_style(prefix, number, version, false);
 
     // Check for compound reference syntax: outer(inner)
     // Only attempt if the next char is '(' and the content looks like an accession
@@ -458,10 +455,7 @@ fn parse_ensembl_accession(input: &str) -> IResult<&str, Accession> {
     let (input, number) = digit1.parse(input)?;
     let (input, version) = opt(preceded(tag("."), parse_version)).parse(input)?;
 
-    Ok((
-        input,
-        Accession::with_style(prefix.to_string(), number.to_string(), version, true),
-    ))
+    Ok((input, Accession::with_style(prefix, number, version, true)))
 }
 
 /// Parse an Ensembl prefix of the shape `ENS<species_code><feature>`.

--- a/src/hgvs/parser/fast_path.rs
+++ b/src/hgvs/parser/fast_path.rs
@@ -307,10 +307,7 @@ fn try_refseq_fast_path(input: &str, bytes: &[u8]) -> FastPathResult {
 
     let prefix = &input[0..prefix_end];
     let accession = Accession::with_style(
-        prefix.to_string(),
-        number_str.to_string(),
-        version,
-        false, // RefSeq uses underscore style
+        prefix, number_str, version, false, // RefSeq uses underscore style
     );
 
     // Dispatch based on type
@@ -373,10 +370,7 @@ fn try_ensembl_fast_path(input: &str, bytes: &[u8]) -> FastPathResult {
 
     let prefix = &input[0..4]; // ENST, ENSG, etc.
     let accession = Accession::with_style(
-        prefix.to_string(),
-        number_str.to_string(),
-        version,
-        true, // Ensembl style (no underscore)
+        prefix, number_str, version, true, // Ensembl style (no underscore)
     );
 
     let var_type_char = bytes[var_type_start];
@@ -437,8 +431,8 @@ fn try_lrg_fast_path(input: &str, bytes: &[u8]) -> FastPathResult {
     }
 
     let accession = Accession::with_style(
-        "LRG".to_string(),
-        full_number.to_string(),
+        "LRG",
+        full_number,
         None, // LRG doesn't use versions
         false,
     );
@@ -495,7 +489,7 @@ fn try_assembly_fast_path(input: &str, bytes: &[u8]) -> FastPathResult {
         return FastPathResult::Fallback;
     }
 
-    let accession = Accession::from_assembly(assembly.to_string(), chromosome.to_string());
+    let accession = Accession::from_assembly(assembly, chromosome);
 
     let type_char = bytes[type_start];
     let edit_start = type_start + 2;

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -106,14 +106,15 @@ pub struct Accession {
 impl Accession {
     /// Intern a prefix string, using a static Arc if available
     #[inline]
-    fn intern_prefix(prefix: impl Into<Arc<str>>) -> Arc<str> {
-        let prefix: Arc<str> = prefix.into();
-        // Try to use an interned version to avoid allocation
-        interned::get_prefix(&prefix).unwrap_or(prefix)
+    fn intern_prefix(prefix: impl AsRef<str> + Into<Arc<str>>) -> Arc<str> {
+        // Look up the interned static *before* allocating: for the common known
+        // prefixes (NC/NM/NP/ENST/…) this avoids allocating an `Arc<str>` on every
+        // parse just to discard it for the static. Only unknown prefixes allocate.
+        interned::get_prefix(prefix.as_ref()).unwrap_or_else(|| prefix.into())
     }
 
     pub fn new(
-        prefix: impl Into<Arc<str>>,
+        prefix: impl AsRef<str> + Into<Arc<str>>,
         number: impl Into<Arc<str>>,
         version: Option<u32>,
     ) -> Self {
@@ -139,7 +140,7 @@ impl Accession {
 
     /// Create with explicit Ensembl style setting
     pub fn with_style(
-        prefix: impl Into<Arc<str>>,
+        prefix: impl AsRef<str> + Into<Arc<str>>,
         number: impl Into<Arc<str>>,
         version: Option<u32>,
         ensembl_style: bool,

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -7,6 +7,7 @@ use super::edit::{NaEdit, ProteinEdit};
 use super::interval::{CdsInterval, GenomeInterval, ProtInterval, RnaInterval, TxInterval};
 use super::uncertainty::Mu;
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
 use std::fmt;
 use std::sync::Arc;
 
@@ -77,15 +78,21 @@ mod interned {
 
 /// Accession number with optional version
 ///
-/// Uses `Arc<str>` internally for cheap cloning - accession strings are frequently
-/// cloned during parsing and normalization, and `Arc<str>` reduces this to a
-/// simple reference count increment.
+/// The `prefix`, `assembly`, and `chromosome` fields use `Arc<str>` internally for
+/// cheap cloning - these strings are frequently cloned during parsing and
+/// normalization, and `Arc<str>` reduces this to a simple reference count increment.
+/// The `number` field is a `SmolStr`, which inlines short strings (no heap
+/// allocation) while still cloning cheaply (see its field doc below).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Accession {
     /// Accession prefix (e.g., "NC", "NM", "NP", "ENST")
     pub prefix: Arc<str>,
     /// Accession number
-    pub number: Arc<str>,
+    ///
+    /// `SmolStr` inlines strings up to 23 bytes (every real accession number
+    /// qualifies), so the number is stored without a heap allocation. It still
+    /// clones cheaply and serializes identically to a plain string.
+    pub number: SmolStr,
     /// Version number (e.g., .3 in NM_000088.3)
     pub version: Option<u32>,
     /// Whether this is an Ensembl-style accession (no underscore separator)
@@ -115,7 +122,7 @@ impl Accession {
 
     pub fn new(
         prefix: impl AsRef<str> + Into<Arc<str>>,
-        number: impl Into<Arc<str>>,
+        number: impl Into<SmolStr>,
         version: Option<u32>,
     ) -> Self {
         let prefix = Self::intern_prefix(prefix);
@@ -141,7 +148,7 @@ impl Accession {
     /// Create with explicit Ensembl style setting
     pub fn with_style(
         prefix: impl AsRef<str> + Into<Arc<str>>,
-        number: impl Into<Arc<str>>,
+        number: impl Into<SmolStr>,
         version: Option<u32>,
         ensembl_style: bool,
     ) -> Self {
@@ -167,7 +174,7 @@ impl Accession {
     pub fn from_assembly(assembly: impl Into<Arc<str>>, chromosome: impl Into<Arc<str>>) -> Self {
         Self {
             prefix: interned::empty(),
-            number: interned::empty(),
+            number: SmolStr::default(),
             version: None,
             ensembl_style: false,
             assembly: Some(assembly.into()),


### PR DESCRIPTION
## Summary

A fresh profile of the HGVS parser (samply over a 500k-variant ClinVar sample) showed ~35% of parse time going to allocation/copy in the allocator. The root cause was accession parsing, which heap-allocated 2–3 short strings on every parse. This PR removes those allocations.

## Changes

**1. Avoid intermediate `String`/`Arc` allocations in accession parsing** (`d629e5b`)

- The fast-path and generic accession parsers passed `&str` slices through `.to_string()` into `Accession::with_style`/`from_assembly`, which then built an `Arc<str>`. Because `Arc<str>` stores its refcount header inline it cannot reuse a `String` buffer, so this was String-alloc + Arc-alloc + memcpy + free per prefix and per number. Passing the `&str` slices directly drops the intermediate `String`.
- `Accession::intern_prefix` allocated an `Arc<str>` and *then* looked up the interned static, discarding the fresh allocation for known prefixes. Looking up the static from `&str` before allocating means the common prefixes (NC/NM/NP/ENST/…) allocate nothing.

**2. Store `Accession.number` as `SmolStr`** (`5ebd505`)

`Accession.number` was an `Arc<str>`, which heap-allocates on every parse. Accession numbers are short (≤15 chars), so `SmolStr` stores them inline with no allocation, clones by copy, and — with the already-enabled `serde` feature — serializes identically to a plain string. `SmolStr` derefs to `str`, so every read site is unchanged. `smol_str` is already a direct dependency; no new deps.

## Results

Measured on a 500k-variant ClinVar sample (interleaved min-of-N A/B, the load-robust metric):

| | parse/s | vs baseline |
|---|---|---|
| baseline | 3.71M | — |
| + commit 1 | 4.47M | +21% |
| + commit 2 | 4.71M | **+27%** |

Allocator self-time drops from ~21% to ~2% (re-profiled).

## Correctness

- Parse output is **byte-identical** over all 500k corpus variants (Debug + serde round-trip), verified before/after.
- 836 parser-focused tests pass; the full suite passes except the pre-existing 11 `axis_*` reference-projection baseline failures. Those are downstream of parsing, so identical parse output guarantees they are unaffected by this change.
- `cargo fmt`, `cargo clippy --features dev -- -D warnings` clean.

## Follow-up

The next-largest lever is nom combinator overhead (~23% inclusive): extending the fast path to cover del/dup/ins/delins (the corpus majority, currently routed through the generic nom parser). That is a larger change with a wider parity surface and will come as a separate PR built on this branch.
