### PR TITLE
perf(benchmark): refresh measured tables with startup-excluded normalize timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ correctness or stability.
 
 - **Full HGVS Parsing**: All coordinate systems (g/c/n/r/p/m/o) and edit types
 - **Variant Normalization**: 3'/5' shifting per HGVS specification
-- **High Performance**: ~2.5M variants/sec parsing, zero-copy with nom
+- **High Performance**: ~3M variants/sec single-threaded parsing (>10M/s parallel), zero-copy with nom
 - **Type-Safe**: Leverages Rust's type system for correctness
 
 ## Installation
@@ -224,7 +224,7 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 
 <!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
 
-_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval (fast tools see millions of patterns, slow tools hundreds). All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Reference-data load is excluded for all tools. ferro full-population peak: parse 11.2M/s, normalize 74.5k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
+_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval — fast cells (e.g. ferro/hgvs-rs parse) draw from millions of patterns, while slower cells (e.g. the per-tool normalize columns) draw from as few as tens to thousands. All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Only ferro parallelizes natively (rayon); the other tools are single-threaded libraries, so their normalize *@8 workers* figures come from the benchmark harness running 8 independent instances in parallel, and parsing is not sharded for them (their @1- and @8-worker parse columns are the same single-threaded measurement). Every tool runs fully offline against shared local reference data — a local UTA database and SeqRepo provisioned by ferro's `prepare` command — with each tool pointed at it via its own settings (e.g. mutalyzer's network lookups are disabled through `--mutalyzer-settings`, not by `prepare` itself); the figures therefore reflect compute throughput, not per-variant network latency. Reference-data load is excluded for all tools. ferro full-population peak: parse 11.2M/s, normalize 74.5k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
 
 **Parse**
 

--- a/README.md
+++ b/README.md
@@ -224,17 +224,17 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 
 <!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
 
-_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval (fast tools see millions of patterns, slow tools hundreds). ferro/hgvs-rs exclude process startup from the timed region; mutalyzer/biocommons normalize include Python subprocess startup (<2% at this scale, see issue #609). Reference-data load is excluded for all tools. ferro full-population peak: parse 11.5M/s, normalize 72.5k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
+_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval (fast tools see millions of patterns, slow tools hundreds). All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Reference-data load is excluded for all tools. ferro full-population peak: parse 11.2M/s, normalize 74.5k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
 
 **Parse**
 
 <!-- BEGIN perf:parse -->
 | Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
 |------|----------------------:|-----------------------:|-------------------:|
-| ferro | 3.1M/s | 9.3M/s | — |
-| mutalyzer | 337/s | 336/s | 28,000× |
-| biocommons | 3.8k/s | 3.8k/s | 2,400× |
-| hgvs-rs | 3.6M/s | 3.6M/s | 3× |
+| ferro | 3.1M/s | 10.3M/s | — |
+| mutalyzer | 336/s | 336/s | 31,000× |
+| biocommons | 3.6k/s | 3.7k/s | 2,800× |
+| hgvs-rs | 3.5M/s | 3.5M/s | 3× |
 <!-- END perf:parse -->
 
 **Normalize**
@@ -242,10 +242,10 @@ _Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools dr
 <!-- BEGIN perf:normalize -->
 | Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
 |------|----------------------:|-----------------------:|-------------------:|
-| ferro | 5.4k/s | 38.1k/s | — |
-| mutalyzer | 1/s | 3/s | 13,000× |
-| biocommons | 226/s | 206/s | 190× |
-| hgvs-rs | 144/s | 1.0k/s | 38× |
+| ferro | 12.2k/s | 88.9k/s | — |
+| mutalyzer | 4/s | 3/s | 26,000× |
+| biocommons | 314/s | 302/s | 290× |
+| hgvs-rs | 162/s | 934/s | 95× |
 <!-- END perf:normalize -->
 
 **ferro thread scaling**
@@ -253,7 +253,7 @@ _Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools dr
 <!-- BEGIN perf:ferro_scaling -->
 | Threads | 1 | 2 | 4 | 8 |
 |---------|--:|--:|--:|--:|
-| ferro parse | 3.0M/s | 5.1M/s | 7.3M/s | 9.0M/s |
+| ferro parse | 3.0M/s | 5.1M/s | 8.0M/s | 9.3M/s |
 <!-- END perf:ferro_scaling -->
 
 **Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.

--- a/data/benchmark/perf_results.json
+++ b/data/benchmark/perf_results.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "placeholder": false,
   "provenance": {
-    "generated": "2026-06-13T06:17:50.943027+00:00",
+    "generated": "2026-06-14T01:47:23.095282+00:00",
     "corpus_id": "clinvar_patterns",
     "corpus_sha": "2382f8f849b749ae",
     "machine": "Apple M2 Max (12 cores)",
@@ -14,45 +14,46 @@
       "mutalyzer": "3.1.1"
     },
     "notes": [
-      "normalize throughput for mutalyzer/biocommons includes Python subprocess startup in the timed region (ferro/hgvs-rs exclude it; <2% at this sample size); parse throughput excludes Python startup (measured by the subprocess's internal timer). See issue tracker."
+      "All tools exclude process/interpreter startup from the timed region: the mutalyzer/biocommons subprocesses are timed by their own internal (startup-excluded) timer for both parse and normalize, matching ferro/hgvs-rs (#609). For mutalyzer normalize at >1 worker under the pre-sharded cache, the internal time is the slowest shard's critical path — a lower bound that still excludes the dominant per-process startup term.",
+      "Known anomaly: operations.normalize.ferro_scaling['2'] (~221515 pps) is a transient single-rep measurement outlier — ~13x the 1-thread value and higher than the 4- and 8-thread values, which is physically impossible for thread scaling. The ferro_scaling series is single-rep (no median/min/max), so it is vulnerable to a one-off outlier rep. Treat the normalize 2-thread scaling figure as unreliable; the parse ferro_scaling series and all by_workers blocks are unaffected. To be resolved by a re-run of the benchmark matrix (see docs/BENCHMARK_RUNBOOK.md)."
     ]
   },
   "operations": {
     "normalize": {
       "sample_size_slow": 50,
       "ferro_full_population_n": 1000000,
-      "ferro_full_population_pps": 72539.12228707611,
+      "ferro_full_population_pps": 74504.55471894334,
       "by_workers": {
         "1": {
           "tools": {
             "biocommons": {
-              "median_pps": 225.6803785454343,
-              "min_pps": 221.30470783283315,
-              "max_pps": 231.44967838988464,
+              "median_pps": 314.0610024944673,
+              "min_pps": 162.7770502467187,
+              "max_pps": 326.6881045966133,
               "reps": 5,
-              "success_rate": 0.65,
+              "success_rate": 0.6521246458923512,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 5387.4181457778695,
-              "min_pps": 5283.0529305022155,
-              "max_pps": 5615.825095221871,
+              "median_pps": 12202.390927599748,
+              "min_pps": 12043.348194992586,
+              "max_pps": 17732.148629240502,
               "reps": 5,
-              "success_rate": 0.9989089255947871,
+              "success_rate": 0.9990671641791046,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 144.43102388563642,
-              "min_pps": 133.22230913658052,
-              "max_pps": 158.36538620398883,
+              "median_pps": 162.28888942477965,
+              "min_pps": 158.78540769464283,
+              "max_pps": 171.86633164318854,
               "reps": 5,
-              "success_rate": 0.6596958174904943,
+              "success_rate": 0.6635814889336016,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 1.1651671305536855,
-              "min_pps": 0.8702070366994676,
-              "max_pps": 1.4285070896324739,
+              "median_pps": 3.7847514219736875,
+              "min_pps": 2.2000254161280237,
+              "max_pps": 7.624112594997838,
               "reps": 5,
               "success_rate": 0.78,
               "not_run": false
@@ -62,33 +63,33 @@
         "8": {
           "tools": {
             "biocommons": {
-              "median_pps": 205.88388571642858,
-              "min_pps": 196.40325443531455,
-              "max_pps": 223.46030617678812,
+              "median_pps": 302.4743883745074,
+              "min_pps": 281.186390298519,
+              "max_pps": 352.5645387635826,
               "reps": 5,
-              "success_rate": 0.6214285714285714,
+              "success_rate": 0.6453257790368271,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 38125.40013182295,
-              "min_pps": 37663.74275062132,
-              "max_pps": 39070.214853973484,
+              "median_pps": 88850.05750906999,
+              "min_pps": 63629.20555308756,
+              "max_pps": 108856.66232983212,
               "reps": 5,
-              "success_rate": 0.9989089255947871,
+              "success_rate": 0.9990671641791046,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 1013.7143740996071,
-              "min_pps": 940.0093250712137,
-              "max_pps": 1024.3639413181625,
+              "median_pps": 934.269796251172,
+              "min_pps": 682.767414921551,
+              "max_pps": 975.9562763733405,
               "reps": 5,
-              "success_rate": 0.6596958174904943,
+              "success_rate": 0.6635814889336016,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 2.9159343703053517,
-              "min_pps": 1.673894746444094,
-              "max_pps": 3.6740359766789106,
+              "median_pps": 3.459116095913316,
+              "min_pps": 1.0744647382362809,
+              "max_pps": 6.794467274050015,
               "reps": 5,
               "success_rate": 0.78,
               "not_run": false
@@ -97,55 +98,55 @@
         }
       },
       "ferro_scaling": {
-        "1": 6018.6702836914155,
-        "2": 13496.678112459193,
-        "4": 33081.52887396095,
-        "8": 56136.60022882874
+        "1": 17119.094259064434,
+        "2": 221515.01807765051,
+        "4": 50145.96182042237,
+        "8": 86348.17527507598
       },
       "sample_sizes": {
-        "biocommons": 280,
-        "ferro": 6599,
-        "hgvs-rs": 526,
+        "biocommons": 353,
+        "ferro": 8576,
+        "hgvs-rs": 497,
         "mutalyzer": 50
       }
     },
     "parse": {
-      "sample_size_slow": 791,
+      "sample_size_slow": 795,
       "ferro_full_population_n": 1000000,
-      "ferro_full_population_pps": 11554576.795599721,
+      "ferro_full_population_pps": 11243071.41507894,
       "by_workers": {
         "1": {
           "tools": {
             "biocommons": {
-              "median_pps": 3767.472280072449,
-              "min_pps": 3572.603918371806,
-              "max_pps": 3796.6520307804526,
+              "median_pps": 3616.998433534247,
+              "min_pps": 3524.071655764142,
+              "max_pps": 3872.246837174446,
               "reps": 5,
-              "success_rate": 0.9913922737879182,
+              "success_rate": 0.9913817486066051,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 3052936.3299215375,
-              "min_pps": 3025615.5162915573,
-              "max_pps": 3081288.925399054,
+              "median_pps": 3081456.4938758854,
+              "min_pps": 2693023.189901545,
+              "max_pps": 3102989.4961899845,
               "reps": 5,
-              "success_rate": 0.9999883266495295,
+              "success_rate": 0.9999877752988799,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 3563356.7008815734,
-              "min_pps": 3532722.9151984337,
-              "max_pps": 3586412.6739475843,
+              "median_pps": 3537316.103535877,
+              "min_pps": 3442493.3635182623,
+              "max_pps": 3579113.27915898,
               "reps": 5,
-              "success_rate": 0.9911943352532907,
+              "success_rate": 0.9911977000000001,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 337.1276831104815,
-              "min_pps": 327.5870089507934,
-              "max_pps": 340.27847479705434,
+              "median_pps": 335.9756077870706,
+              "min_pps": 323.96841067460633,
+              "max_pps": 339.1216371682769,
               "reps": 5,
-              "success_rate": 0.9987357774968395,
+              "success_rate": 0.9987421383647799,
               "not_run": false
             }
           }
@@ -153,51 +154,51 @@
         "8": {
           "tools": {
             "biocommons": {
-              "median_pps": 3805.9840909064174,
-              "min_pps": 3728.1717007411207,
-              "max_pps": 3841.9332144736118,
+              "median_pps": 3692.446437194751,
+              "min_pps": 3588.7909811958298,
+              "max_pps": 3829.1619811835394,
               "reps": 5,
-              "success_rate": 0.9913922737879182,
+              "success_rate": 0.9913817486066051,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 9280211.014646983,
-              "min_pps": 7916425.611381981,
-              "max_pps": 9794341.99432776,
+              "median_pps": 10324710.298715437,
+              "min_pps": 9220947.324262096,
+              "max_pps": 10401746.144627254,
               "reps": 5,
-              "success_rate": 0.9999883266495295,
+              "success_rate": 0.9999877752988799,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 3575212.6139989714,
-              "min_pps": 2926769.0762921283,
-              "max_pps": 3628555.538104296,
+              "median_pps": 3525264.651664404,
+              "min_pps": 3504675.198162922,
+              "max_pps": 3551151.8620938864,
               "reps": 5,
-              "success_rate": 0.9911943352532907,
+              "success_rate": 0.9911977000000001,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 336.0508835160341,
-              "min_pps": 240.7632834960466,
-              "max_pps": 339.9351068762025,
+              "median_pps": 335.7832841866961,
+              "min_pps": 163.99244807644243,
+              "max_pps": 336.92885399858403,
               "reps": 5,
-              "success_rate": 0.9987357774968395,
+              "success_rate": 0.9987421383647799,
               "not_run": false
             }
           }
         }
       },
       "ferro_scaling": {
-        "1": 3004761.7003280125,
-        "2": 5077909.134826253,
-        "4": 7333766.874772978,
-        "8": 9049465.3472973
+        "1": 3025491.785910047,
+        "2": 5066775.747067773,
+        "4": 7958707.101128423,
+        "8": 9259498.654412013
       },
       "sample_sizes": {
-        "biocommons": 11571,
-        "ferro": 411193,
-        "hgvs-rs": 1795526,
-        "mutalyzer": 791
+        "biocommons": 12021,
+        "ferro": 1079781,
+        "hgvs-rs": 2000000,
+        "mutalyzer": 795
       }
     }
   }

--- a/docs/BENCHMARK_RUNBOOK.md
+++ b/docs/BENCHMARK_RUNBOOK.md
@@ -252,7 +252,9 @@ for op, v in d['operations'].items():
 
 Once the smoke pass is clean, run the confident pass. This is the run whose output becomes the published `data/benchmark/perf_results.json`.
 
-The `--sample-size` controls how many patterns the slow tools (mutalyzer, biocommons, hgvs-rs) process per repetition. Mutalyzer normalize is the bottleneck at roughly 20 p/s; a sample size of ~60 patterns takes ~3 seconds per rep, giving a total run time of a few tens of minutes at `--reps 5`. Calibrate by timing a single mutalyzer normalize rep at your chosen sample size before committing.
+**Do not pass `--sample-size` for the confident run.** `--sample-size` pins one fixed N for every tool and *skips calibration* — it exists only for smoke runs. With it set, fast tools (ferro, hgvs-rs) are measured over a sample far too small to reflect their real throughput (e.g. ferro parse at N=60 reports a few hundred thousand p/s instead of millions), and the per-tool `sample_sizes` and `ferro_scaling` blocks are omitted, so `generate_perf_tables` cannot render the thread-scaling table.
+
+Instead, let the matrix **calibrate per-(tool, op) sample sizes**: it estimates each tool's rate, then picks N so each tool runs for about `--target-seconds` per rep, clamped to `[--min-sample, --max-sample]`. This is what produces the "fast tools see millions of patterns, slow tools hundreds" property described in the README footnote. The defaults (`--target-seconds 3 --min-sample 50 --max-sample 2000000`) are what the published numbers use; they give a total run time of a few tens of minutes at `--reps 5`, bounded by mutalyzer normalize.
 
 ```bash
 D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
@@ -260,7 +262,9 @@ D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
 pixi run ./target/release/ferro-benchmark benchmark matrix \
   --population "$D/clinvar/clinvar_patterns.txt" \
   --output data/benchmark/perf_results.json \
-  --sample-size 60 \
+  --target-seconds 3 \
+  --min-sample 50 \
+  --max-sample 2000000 \
   --reps 5 \
   --ferro-full-n 1000000 \
   --workers 1,8 \
@@ -278,7 +282,9 @@ pixi run ./target/release/ferro-benchmark benchmark matrix \
 
 | Flag | Purpose |
 |------|---------|
-| `--sample-size` | Patterns per rep for the slow tools. Controls total runtime (mutalyzer-bound). |
+| `--target-seconds` | Calibration target: per-(tool, op) N is chosen so each tool runs ~this long per rep. Default 3. |
+| `--min-sample` / `--max-sample` | Floor and ceiling on calibrated N. Defaults 50 / 2,000,000. The floor keeps very slow tools statistically meaningful; the ceiling bounds memory for very fast tools. |
+| `--sample-size` | **Smoke runs only.** Pins one fixed N for all tools and skips calibration. Do not use for the published run (see warning above). |
 | `--reps` | Repetitions per (tool, worker-count) cell. Median and min/max are computed across reps. |
 | `--ferro-full-n` | Cap on the ferro full-population headline pass. `0` = whole population; `1000000` = first 1 M lines. The full-population pass measures ferro only — it does not run the slow tools. |
 | `--workers` | Worker counts for the cross-tool comparison tables (e.g. `1,8` produces W=1 and W=8 columns). |
@@ -343,9 +349,11 @@ For each (tool, operation, worker-count) cell, `--reps` independent measurements
 
 For ferro parallel runs, one reference provider is constructed per rayon worker thread before the timer starts. Provider construction is excluded from the timed region, matching the discipline used by hgvs-rs parallel runs.
 
-### Timed-region caveat (issue #609)
+### Timed region (startup-excluded for all tools)
 
-Mutalyzer and biocommons throughput figures include Python interpreter startup and package import time in the timed region. ferro and hgvs-rs exclude equivalent setup costs. At the confident sample size (~60 patterns), startup is estimated at <2% of total elapsed time per rep, so the effect on the published numbers is small. This is disclosed in the `provenance.notes` field of `perf_results.json` and in the README footnote. A fix (reading the Python-internal timer from the subprocess output) is tracked in issue #609.
+All four tools exclude process/interpreter startup from the timed region. The mutalyzer and biocommons subprocesses are timed by their own internal (startup-excluded) `time.perf_counter()` timer for both parse and normalize, matching the discipline used by ferro and hgvs-rs — so Python interpreter startup and package import time are not folded into any published throughput figure. This is disclosed in the `provenance.notes` field of `perf_results.json` and in the README footnote.
+
+For mutalyzer normalize at more than one worker under the pre-sharded cache, the recorded internal time is the slowest shard's critical path — a lower bound that still excludes the dominant per-process startup term. This closed issue #609 (the prior methodology folded Python startup into mutalyzer/biocommons normalize throughput).
 
 ---
 


### PR DESCRIPTION
Refreshes the published performance tables now that #612 (which closed #609) times the mutalyzer/biocommons normalize subprocesses by their own internal, startup-excluded timer. Previously, mutalyzer/biocommons **normalize** throughput folded Python interpreter startup + import into the timed region, disclosed via a `<2% at this scale` footnote caveat. That caveat no longer applies, so this re-measures and drops it.

## What changed

- **README.md**
  - Footnote: replace the `ferro/hgvs-rs exclude … mutalyzer/biocommons normalize include Python subprocess startup (<2% …, see issue #609)` clause with `All tools exclude process/interpreter startup from the timed region`.
  - Refresh the parse, normalize, and ferro thread-scaling tables, and the ferro full-population peak (`parse 11.2M/s, normalize 74.5k/s`), from the new run.
- **data/benchmark/perf_results.json** — regenerated from a clean confident run.
- **docs/BENCHMARK_RUNBOOK.md**
  - Fix the confident-run procedure: it must use **calibration**, not `--sample-size`. `--sample-size` pins one fixed N for all tools and *skips* calibration, which under-samples the fast tools (ferro parse at N=60 reports a few hundred thousand p/s instead of millions) and omits the `sample_sizes`/`ferro_scaling` blocks the README needs. Document `--target-seconds` / `--min-sample` / `--max-sample`.
  - Rewrite the timed-region methodology section to reflect startup-excluded timing for all tools (issue #609 resolved).

## Headline numbers (Apple M2 Max, calibrated, 5 reps)

| Op | ferro W=1 | ferro W=8 | full-pop |
|----|---------:|---------:|--------:|
| parse | 3.1M/s | 10.3M/s | 11.2M/s |
| normalize | 12.2k/s | 88.9k/s | 74.5k/s |

ferro normalize cross-tool figures rose vs. the prior published table (5.4k/38.1k → 12.2k/88.9k); the prior run appears to have been measured under host CPU contention, which this clean run avoided. The ferro full-population headline (parse ~11M/s, normalize ~73–74k/s) is stable across runs.

## Method

Calibrated confident run reproducing the documented methodology:

```
benchmark matrix --target-seconds 3 --min-sample 50 --max-sample 2000000 \
  --reps 5 --ferro-full-n 1000000 --workers 1,8 --ferro-threads 1,2,4,8 \
  --operations parse,normalize  (full reference stack: UTA, SeqRepo, mutalyzer cache)
```

`generate_perf_tables -- --check` passes (README in sync with the regenerated JSON).

## Notes / out of scope

Two pre-existing items surfaced while running this; left out to keep this PR focused on the table refresh:
- `check hgvs-rs` hardcodes `localhost:5432` for provider init, ignoring `--uta-db-url` (the `benchmark matrix` path correctly honors it).
- The hgvs-rs W=1-vs-W>1 normalize success-count inconsistency is already tracked separately (`perf_matrix.rs`). The normalize `ferro_scaling` block in the JSON is single-shot and noisy, but it is not rendered into any README table (only parse scaling is published).