### PR TITLE
fix(normalize): spec-compliant repeat normalization — 3' rotation + flank absorption

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5073,11 +5073,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 // Get the repeat unit as bytes
                 let repeat_unit: Vec<u8> = seq.bases().iter().map(|b| b.to_u8()).collect();
                 let pos_idx = hgvs_pos_to_index(start); // Convert 1-based to 0-based
+                let end_idx = hgvs_pos_to_index(end); // 0-based inclusive end of input range
 
                 // Normalize the repeat
                 match rules::normalize_repeat(
                     ref_seq,
                     pos_idx,
+                    end_idx,
                     &repeat_unit,
                     *specified_count,
                     is_coding,

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1307,7 +1307,11 @@ pub enum RepeatNormResult {
 ///
 /// Arguments:
 /// - ref_seq: The reference sequence (0-indexed)
-/// - pos: The position (0-indexed) where the repeat is specified
+/// - pos: The 0-indexed start of the input repeat range
+/// - end_pos: The 0-indexed inclusive end of the input repeat range. For a
+///   single-position anchor (`c.4CAT[1]`, where only the repeat start is named)
+///   this equals `pos`; for an explicit range (`g.3_4GT[5]`, `c.*16_*18T[8]`) it
+///   is the range's last base. See the flank-absorption note below.
 /// - repeat_unit: The repeated sequence (e.g., b"CAT")
 /// - specified_count: The count specified in the variant
 ///
@@ -1315,6 +1319,7 @@ pub enum RepeatNormResult {
 pub fn normalize_repeat(
     ref_seq: &[u8],
     pos: usize,
+    end_pos: usize,
     repeat_unit: &[u8],
     specified_count: u64,
     is_coding: bool,
@@ -1334,7 +1339,7 @@ pub fn normalize_repeat(
     // (2 ATs removed).
     let canonical_unit = smallest_repeat_unit(repeat_unit);
     let copies_per_input_unit = (repeat_unit.len() / canonical_unit.len()) as u64;
-    let specified_count = specified_count * copies_per_input_unit;
+    let mut specified_count = specified_count * copies_per_input_unit;
 
     // Count how many times the canonical unit appears in the reference
     let Some((ref_count, mut ref_start, mut ref_end)) =
@@ -1342,6 +1347,26 @@ pub fn normalize_repeat(
     else {
         return RepeatNormResult::Unchanged;
     };
+
+    // Flank absorption for an under-specified explicit range. `[N]` counts the
+    // alt copies of the *stated* reference units; reference repeat copies inside
+    // the maximal tract but outside the stated range are untouched by the edit
+    // and remain in the variant, so they must be added to the canonical count
+    // (which re-anchors to the full tract `count_tandem_repeats` found). This is
+    // mutalyzer-verified real-world behavior: `LRG_303:g.3_4GT[5]` ->
+    // `g.1_4GT[6]` (the 5' copy g.1_2 absorbs, 5+1=6); `c.*16_*18T[8]` ->
+    // `c.*16_*19T[9]` (the 3' copy *19 absorbs). A single-position anchor
+    // (`end_pos == pos`, e.g. `c.4CAT[1]`) names only the repeat start and means
+    // "the whole repeat -> N copies", so it absorbs nothing. A well-formed
+    // explicit range (stated span == true tract) also absorbs nothing (the
+    // flanks below are zero).
+    if end_pos > pos {
+        let unit_len = canonical_unit.len();
+        let three_prime_bases = ref_end.saturating_sub(end_pos + 1);
+        let five_prime_bases = pos.saturating_sub(ref_start);
+        let absorbed = ((three_prime_bases + five_prime_bases) / unit_len) as u64;
+        specified_count += absorbed;
+    }
 
     // 3'-rule unit rotation (repeated.md L44: "applying the 3'rule, the repeat
     // has to be described as an AGC repeat"). A repeat unit shifts 3' exactly
@@ -2719,7 +2744,7 @@ mod tests {
         // Specifying CAT[1]: ref_count=4, specified=1, k=3 >= 2, post=1 >= 1 → B2 → Repeat
         let ref_seq = b"GGGCATCATCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 1, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 1, false);
         match result {
             RepeatNormResult::Repeat {
                 sequence, count, ..
@@ -2737,7 +2762,7 @@ mod tests {
         // Specifying CAT[3] (ref is 2, so 2+1=3) should become duplication
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 3, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 3, false);
         match result {
             RepeatNormResult::Duplication {
                 start,
@@ -2757,7 +2782,7 @@ mod tests {
         // Specifying CAT[5] (ref is 2, 5 > 2+1) should stay as repeat
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 5, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 5, false);
         match result {
             RepeatNormResult::Repeat {
                 count, sequence, ..
@@ -2775,7 +2800,7 @@ mod tests {
         // Specifying CAT[2] (same as ref) should be unchanged
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, b"CAT", 2, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 2, false);
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -2789,7 +2814,7 @@ mod tests {
         // canonical_unit.len()` unless we guard up front. This test pins the
         // pre-refactor contract.
         let ref_seq = b"GGGCATCATGGG";
-        let result = normalize_repeat(ref_seq, 3, b"", 1, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"", 1, false);
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -2801,7 +2826,7 @@ mod tests {
         // this would fall to a 1-unit (ATAT) reduction → deletion (k<2).
         let ref_seq = b"GGGATATATATGGG"; // AT-tract at indices 3..11 (4 AT)
 
-        let result = normalize_repeat(ref_seq, 3, b"ATAT", 1, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"ATAT", 1, false);
         match result {
             RepeatNormResult::Repeat {
                 start,
@@ -3283,7 +3308,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_routes_contraction_to_deletion() {
         // 5-A tract, specified A[3] in coding → must NOT emit Repeat; emits Deletion.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, b"A", 3, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 3, true);
         match result {
             RepeatNormResult::Deletion { .. } => {}
             other => panic!("expected Deletion under gate, got {:?}", other),
@@ -3294,7 +3319,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_routes_expansion_to_insertion() {
         // 5-A tract, specified A[8] in coding → must NOT emit Repeat; emits Insertion.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, b"A", 8, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 8, true);
         match result {
             RepeatNormResult::Insertion { sequence, .. } => {
                 assert_eq!(sequence, b"AAA", "3 extra A's");
@@ -3307,7 +3332,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_passes_through_dup_branch() {
         // 5-A tract, specified A[6] in coding → +1 copy = dup, gate doesn't change this.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, b"A", 6, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 6, true);
         match result {
             RepeatNormResult::Duplication { .. } => {}
             other => panic!("expected Duplication, got {:?}", other),

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1337,10 +1337,32 @@ pub fn normalize_repeat(
     let specified_count = specified_count * copies_per_input_unit;
 
     // Count how many times the canonical unit appears in the reference
-    let Some((ref_count, ref_start, ref_end)) = count_tandem_repeats(ref_seq, pos, canonical_unit)
+    let Some((ref_count, mut ref_start, mut ref_end)) =
+        count_tandem_repeats(ref_seq, pos, canonical_unit)
     else {
         return RepeatNormResult::Unchanged;
     };
+
+    // 3'-rule unit rotation (repeated.md L44: "applying the 3'rule, the repeat
+    // has to be described as an AGC repeat"). A repeat unit shifts 3' exactly
+    // like a homopolymer: while the base immediately after the tract equals the
+    // unit's first base, the tract can slide one base 3' with the unit rotated
+    // left by one (e.g. CAA tract abutting a trailing C -> AAC tract one base
+    // over). This picks the 3'-most phase. Each step drops one base at
+    // `ref_start` and adds one matching base at `ref_end`, so on a periodic
+    // tract it is a pure re-phasing: the width (`ref_end - ref_start =
+    // ref_count * unit_len`) is unchanged and the new window is still
+    // `ref_count` copies of the rotated unit — hence `ref_count` is preserved
+    // and only the phase and anchor move. The loop terminates because `ref_end`
+    // strictly increases and is bounded by `ref_seq.len()`. A clean tract
+    // bounded by a non-matching base (the common case) does not rotate.
+    let mut rotated_unit = canonical_unit.to_vec();
+    while ref_end < ref_seq.len() && ref_seq[ref_end] == rotated_unit[0] {
+        rotated_unit.rotate_left(1);
+        ref_start += 1;
+        ref_end += 1;
+    }
+    let canonical_unit: &[u8] = &rotated_unit;
 
     let unit_len = canonical_unit.len() as u64;
     // HGVS spec (repeated.md): in c. context, repeat notation requires

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -884,6 +884,64 @@ mod mutalyzer_verified {
         );
     }
 
+    /// Real-world (mutalyzer-verified) evidence that an under-specified repeat
+    /// range absorbs flanking reference copies. The sequence is the actual
+    /// LRG_303 genomic prefix (g.1-110, extracted from the LRG record): a `GT`
+    /// tract at g.1-4 (`GTGT`, 2 copies) bounded by `C` at g.5.
+    ///
+    /// Mutalyzer corpus: `LRG_303:g.3_4GT[5]` -> `LRG_303:g.1_4GT[6]`. The input
+    /// states only the 3' copy (g.3_4); the 5' reference copy (g.1_2) is not
+    /// touched by the edit, so the canonical count over the re-anchored full
+    /// tract is 5 + 1 = 6. (`[N]` is the count for the stated units; reference
+    /// repeat copies flanking the stated range are absorbed on re-anchoring.)
+    #[test]
+    fn test_repeat_underspecified_range_absorbs_flank_real_lrg303() {
+        let seq = "GTGTCTGCCAAGGGTGCCAGCACAGCCGCCCCACTCCAGGGGAAGAGGAGTGCCAGCCC\
+                   TTACCCACCTGAGTGGGCACAGTGTAGCATTTATTCATTAGCCCCCACACT";
+        let mut provider = MockProvider::with_test_data();
+        provider.add_genomic_sequence("LRG_303", seq);
+        let normalizer = Normalizer::new(provider);
+        let v = parse_hgvs("LRG_303:g.3_4GT[5]").expect("parse");
+        let out = format!("{}", normalizer.normalize(&v).expect("normalize"));
+        assert_eq!(
+            out, "LRG_303:g.1_4GT[6]",
+            "under-specified range must absorb the 5' reference copy (5+1=6), got '{out}'"
+        );
+    }
+
+    /// Counterpart to `..._absorbs_flank_real_lrg303`, which exercises the 5'
+    /// (`five_prime_bases`) absorption path. This pins the 3'
+    /// (`three_prime_bases`) branch of the flank-absorption arithmetic in
+    /// `normalize_repeat` (src/normalize/rules.rs): when the stated range begins
+    /// at the true 5' edge of the tract but stops short of its 3' end, the
+    /// trailing (3') reference repeat copies are not touched by the edit and so
+    /// are absorbed on re-anchoring to the full tract.
+    ///
+    /// This is the shape of the doc-cited mutalyzer case `c.*16_*18T[8]` ->
+    /// `c.*16_*19T[9]` (one trailing reference copy absorbed). Here a `GT` tract
+    /// at g.2-7 (`GTGTGT`, 3 copies) is bounded by `C` on both sides; the input
+    /// states only the 5'-most copy (g.2_3) and expands it to 5, so the two
+    /// untouched trailing reference copies (g.4-7) are absorbed: 5 + 2 = 7.
+    #[test]
+    fn test_repeat_underspecified_range_absorbs_3prime_flank() {
+        // Reuses the LRG_303 setup of the 5' test (same provider/accession path),
+        // but with a constructed sequence whose `GT` tract sits at g.1-6
+        // (`GTGTGT`, 3 copies) bounded by `C` at g.7. The input states only the
+        // 5'-most copy (g.1_2) and expands it to 5; the two untouched trailing
+        // (3') reference copies (g.3-6) are absorbed on re-anchoring: 5 + 2 = 7.
+        let seq = "GTGTGTCAAGGGTGCCAGCACAGCCGCCCCACTCCAGGGGAAGAGGAGTGCCAGCCC\
+                   TTACCCACCTGAGTGGGCACAGTGTAGCATTTATTCATTAGCCCCCACACT";
+        let mut provider = MockProvider::with_test_data();
+        provider.add_genomic_sequence("LRG_303", seq);
+        let normalizer = Normalizer::new(provider);
+        let v = parse_hgvs("LRG_303:g.1_2GT[5]").expect("parse");
+        let out = format!("{}", normalizer.normalize(&v).expect("normalize"));
+        assert_eq!(
+            out, "LRG_303:g.1_6GT[7]",
+            "under-specified range must absorb the trailing 3' reference copies (5+2=7), got '{out}'"
+        );
+    }
+
     #[test]
     fn test_repeat_stays_repeat() {
         // When repeat count > reference count + 1, should stay as repeat
@@ -2334,7 +2392,7 @@ mod benchmark_comparison_tests {
 
     #[test]
     fn test_repeat_expansion_vs_duplication() {
-        // Pattern: c.351_352AG[2]
+        // Pattern: c.351_356AG[2]
         // ferro: c.355_356del (if ref has 3 copies)
         // mutalyzer: c.355_356dup (different interpretation)
         //
@@ -2346,7 +2404,7 @@ mod benchmark_comparison_tests {
 
         let provider = provider_with_utr_transcript("NM_TEST.1", &seq, 1, seq.len() as u64);
 
-        let result = normalize_to_string(provider, "NM_TEST.1:c.351_352AG[2]");
+        let result = normalize_to_string(provider, "NM_TEST.1:c.351_356AG[2]");
 
         // With 3 copies, AG[2] should be a deletion
         assert!(
@@ -2721,7 +2779,7 @@ mod repeat_position_tests {
         );
 
         // Test normalize_repeat - should return Unchanged
-        let result = normalize_repeat(ref_seq, 6, b"CA", 1, false);
+        let result = normalize_repeat(ref_seq, 6, 6, b"CA", 1, false);
         assert!(
             matches!(result, RepeatNormResult::Unchanged),
             "Should return Unchanged when repeat unit not found at position. Got {:?}",
@@ -2745,7 +2803,7 @@ mod repeat_position_tests {
         );
 
         // normalize_repeat with count=1 should produce deletion
-        let result = normalize_repeat(ref_seq, 0, b"CA", 1, false);
+        let result = normalize_repeat(ref_seq, 0, 0, b"CA", 1, false);
         match result {
             RepeatNormResult::Deletion { start, end } => {
                 // Should delete one copy (2 bases) from the 3' end
@@ -3529,7 +3587,7 @@ mod comprehensive_normalization_tests {
             // CAG[2] when ref has 3 = delete one CAG
             let seq = "NNCAGCAGCAGNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_5CAG[2]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_11CAG[2]");
             // Should become deletion (removing 3 bases)
             assert!(
                 result.contains("del"),
@@ -3555,7 +3613,7 @@ mod comprehensive_normalization_tests {
             // forbids CT[N], routes to plain del.
             let seq = "AACTCTCTAA"; // 3 CTs at positions 3-8
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_4CT[1]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_8CT[1]");
             assert_eq!(result, "NM_TEST.1:c.5_8del");
         }
 
@@ -3565,7 +3623,7 @@ mod comprehensive_normalization_tests {
             // CAG[3] = reference, should be unchanged or become identity
             let seq = "NNCAGCAGCAGNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_5CAG[3]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_11CAG[3]");
             // Should be identity (c.=) or unchanged
             assert!(
                 result.contains("=") || result.contains("CAG[3]"),
@@ -3590,7 +3648,7 @@ mod comprehensive_normalization_tests {
             // CAG[4] = one more than ref = dup
             let seq = "NNCAGCAGCAGNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_5CAG[4]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_11CAG[4]");
             assert!(
                 result.contains("dup"),
                 "CAG[4] with 3 copies should become dup, got: {}",
@@ -3619,7 +3677,7 @@ mod comprehensive_normalization_tests {
             // GT[3] = one more than ref = dup one GT
             let seq = "NNGTGTNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_4GT[3]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_6GT[3]");
             assert!(
                 result.contains("dup"),
                 "GT[3] with 2 copies should become dup, got: {}",
@@ -3643,7 +3701,7 @@ mod comprehensive_normalization_tests {
             // CAG[10] = large expansion, stays as repeat
             let seq = "NNCAGCAGCAGNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_5CAG[10]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_11CAG[10]");
             assert!(
                 result.contains("CAG[10]"),
                 "Large expansion should stay as repeat, got: {}",
@@ -3673,7 +3731,7 @@ mod comprehensive_normalization_tests {
             // CAG[6] = 3 more than ref, stays as repeat
             let seq = "NNCAGCAGCAGNN";
             let provider = provider_with_transcript("NM_TEST.1", seq);
-            let result = normalize_to_string(provider, "NM_TEST.1:c.3_5CAG[6]");
+            let result = normalize_to_string(provider, "NM_TEST.1:c.3_11CAG[6]");
             assert!(
                 result.contains("CAG[6]"),
                 "Moderate expansion should stay as repeat, got: {}",

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -850,6 +850,40 @@ mod mutalyzer_verified {
         );
     }
 
+    /// 3'-rule unit rotation for repeats (HGVS DNA/repeated.md L44: "applying
+    /// the 3'rule, the repeat has to be described as an AGC repeat"). The
+    /// reference `CAACAACAAC` tract (c.3-12, CDS context, unit length 3 so the
+    /// coding codon exception does not apply) can be tiled as `CAA[3]` at
+    /// c.3-11 or, shifted one base 3', as `AAC[3]` at c.4-12. The 3' rule
+    /// mandates the 3'-most placement, so an expansion must be reported in the
+    /// rotated `AAC` phase, not the input's `CAA` phase.
+    #[test]
+    fn test_repeat_rotates_to_3prime_canonical_unit() {
+        let seq = "GGCAACAACAACGG";
+        let provider = provider_with_transcript("NM_TEST.1", seq, 1, seq.len() as u64);
+        let out = normalize_to_string(provider, "NM_TEST.1:c.3CAA[6]");
+        assert_eq!(
+            out, "NM_TEST.1:c.4_12AAC[6]",
+            "expansion must adopt the 3'-most repeat unit phase (AAC), got '{out}'"
+        );
+    }
+
+    /// Counterpart to the rotation test: a tract bounded by a non-matching base
+    /// must NOT rotate. The `CAT` tract (c.3-11) is flanked by `G` on both
+    /// sides, so the base after the tract (`G`) never equals the unit's first
+    /// base (`C`) — the 3'-shift loop does not fire and the input `CAT` phase is
+    /// preserved. Pins the common no-rotation path against future edits.
+    #[test]
+    fn test_repeat_does_not_rotate_when_tract_is_boundary_blocked() {
+        let seq = "GGCATCATCATGG";
+        let provider = provider_with_transcript("NM_TEST.1", seq, 1, seq.len() as u64);
+        let out = normalize_to_string(provider, "NM_TEST.1:c.3CAT[6]");
+        assert_eq!(
+            out, "NM_TEST.1:c.3_11CAT[6]",
+            "boundary-blocked tract must keep its input unit phase (CAT), got '{out}'"
+        );
+    }
+
     #[test]
     fn test_repeat_stays_repeat() {
         // When repeat count > reference count + 1, should stay as repeat


### PR DESCRIPTION
**Stacked on #640** (base `fix/issue-487-tandem-repeat`) — review/merge that first.

Two related HGVS-spec-compliance fixes to `normalize_repeat` (`src/normalize/rules.rs`), validated by real, mutalyzer-verified data points (per the spec; mutalyzer is non-compliant for coding non-codon repeats, so the spec is the authority there).

## 1. 3′-rule unit rotation

`DNA/repeated.md` L44 mandates the 3′ rule for repeats — including rotating the repeat **unit** to its 3′-most phase. ferro normalized in the input unit's phase and never rotated.

```
NM_TEST.1:c.3CAA[6]   before: c.3_11CAG-phase CAA[6]   after: c.4_12AAC[6]
```

A repeat unit 3′-shifts like a homopolymer: while the base after the tract equals the unit's first base, slide one base 3′ and rotate the unit left. Tracts bounded by a non-matching base (common case) don't rotate. Tests: `test_repeat_rotates_to_3prime_canonical_unit`, `test_repeat_does_not_rotate_when_tract_is_boundary_blocked`.

## 2. Flank absorption for under-specified ranges

When a repeat description's stated range is shorter than the true reference tract, the reference copies outside that range are untouched by the edit and remain in the variant — so they must be added to the canonical count, which re-anchors to the entire tract.

Spec basis (`DNA/repeated.md`):
- Canonical form indicates the **entire range** of the repeat (Community Consultation note: `g.123_191CAG[23]`, not `g.123CAG[23]`).
- `[N]` is the variant's **total** copy count (`c.171_239GCA[34]` = 34 copies, reference has 23) — normalization is sequence-preserving over the full tract.

`normalize_repeat` now takes the input range end and adds the flank copies. A single-position anchor (`c.4CAT[1]`) absorbs nothing; a well-formed entire-range input absorbs nothing.

**Real-evidence TDD** (mutalyzer-verified, against the actual reference):
- new hermetic test on **real LRG_303 bytes**: `g.3_4GT[5]` → `g.1_4GT[6]` (5′ copy absorbed).
- conformance corpus now passes `c.*16_*18T[8]` → `c.*16_*19T[9]` and `c.33_35CAA[5]` → `c.34_39AAC[6]` (absorb composed with rotation).

## Test maintenance

The pre-existing synthetic repeat tests used **partial-range** inputs as shorthand (implicitly assuming no absorption) — the form the spec's Community-Consultation note discourages. Converted them to the spec-preferred **entire-range** inputs, which preserves their original intent and expected values (no absorption fires when the stated range equals the tract). Coding non-codon-unit cases remain spec-gated to dup/ins/del.

## Verification

Full unit suite green; the only remaining failures are pre-existing reference-gated conformance axes (manifest drift, skip on PR CI). Conformance effect on the `normalized` axis: +2 real rows fixed, zero regressions.

Refs #487.