### PR TITLE
fix(python): add missing ErrorType discriminants 41/42 to the type stub

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -973,6 +973,8 @@ class ErrorType(IntEnum):
     DupExplicitSeq = 38
     DelExplicitSeq = 39
     NonConformantBracketCardinality = 40
+    UnresolvableCentromere = 41
+    TranscriptFlankNotDescribable = 42
     IntronicOnBareTranscript = 43
 
 class ErrorOverride(IntEnum):

--- a/tests/python/test_error_handling.py
+++ b/tests/python/test_error_handling.py
@@ -1,6 +1,40 @@
 """Tests for error handling functionality."""
 
+import re
+from pathlib import Path
+
 import ferro_hgvs
+
+# Location of the committed type stub, relative to this test file
+# (<repo>/tests/python/test_error_handling.py -> <repo>/python/ferro_hgvs/__init__.pyi).
+_STUB_PATH = Path(__file__).resolve().parents[2] / "python" / "ferro_hgvs" / "__init__.pyi"
+
+
+def _stub_enum_members(class_name: str) -> dict[str, int]:
+    """Parse ``name = value`` members of an ``IntEnum`` class from the type stub.
+
+    Reads the block following ``class <class_name>(IntEnum):`` up to the next
+    top-level ``class`` declaration, returning the declared name->value mapping.
+    Comment and docstring lines are ignored, so retired discriminants documented
+    only in comments are not treated as members.
+    """
+    text = _STUB_PATH.read_text()
+    lines = text.splitlines()
+    header = re.compile(rf"^class {re.escape(class_name)}\(IntEnum\):")
+    member = re.compile(r"^    (\w+) = (\d+)$")
+    members: dict[str, int] = {}
+    in_block = False
+    for line in lines:
+        if header.match(line):
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith("class "):
+                break
+            match = member.match(line)
+            if match:
+                members[match.group(1)] = int(match.group(2))
+    return members
 
 
 class TestErrorConfig:
@@ -84,3 +118,28 @@ class TestErrorTypes:
         assert ferro_hgvs.ErrorOverride.WarnCorrect is not None
         assert ferro_hgvs.ErrorOverride.SilentCorrect is not None
         assert ferro_hgvs.ErrorOverride.Accept is not None
+
+    def test_error_type_stub_matches_runtime(self) -> None:
+        """The ``ErrorType`` type stub must list exactly the runtime members.
+
+        Guards against the stub drifting out of sync with the Rust
+        ``PyErrorType`` enum (issue #630: discriminants 41/42 were missing from
+        the stub while present at runtime). CI builds the native extension, so
+        the runtime enum is authoritative here.
+
+        ``ErrorType`` is a PyO3 enum, not a Python ``IntEnum``, so it is not
+        iterable; its variants are exposed as ``int``-valued class attributes.
+        """
+        error_type = ferro_hgvs.ErrorType
+        runtime = {
+            name: int(getattr(error_type, name))
+            for name in dir(error_type)
+            if not name.startswith("_") and isinstance(getattr(error_type, name), error_type)
+        }
+        stub = _stub_enum_members("ErrorType")
+        assert stub == runtime
+
+    def test_error_type_centromere_and_flank_members(self) -> None:
+        """Discriminants 41/42 are reachable as named members (issue #630)."""
+        assert int(ferro_hgvs.ErrorType.UnresolvableCentromere) == 41
+        assert int(ferro_hgvs.ErrorType.TranscriptFlankNotDescribable) == 42


### PR DESCRIPTION
Closes #630.

## Problem

The `ErrorType` type stub in `python/ferro_hgvs/__init__.pyi` skipped two discriminants that exist at runtime in the Rust `PyErrorType` enum (`src/python.rs`), jumping straight from `NonConformantBracketCardinality = 40` to `IntronicOnBareTranscript = 43`:

- `UnresolvableCentromere = 41` (W4005)
- `TranscriptFlankNotDescribable = 42` (W4006)

Both are valid `ErrorType` members at runtime, but IDEs and mypy did not recognize them. The gap predates the `IntronicOnBareTranscript = 43` addition — adding 43 only made the existing `40 → 43` hole visible. There is no CI check enforcing stub ↔ enum parity, so it went unnoticed.

## Fix

- Add `UnresolvableCentromere = 41` and `TranscriptFlankNotDescribable = 42` to the stub so the sequence reads 40, 41, 42, 43, matching the Rust enum (names taken verbatim from `PyErrorType`).
- Add a parity test (`test_error_type_stub_matches_runtime`) that parses the `ErrorType` members declared in the stub and asserts they match the runtime enum exactly — catching future drift in either direction. `ErrorType` is a PyO3 enum (not a Python `IntEnum`), so the test introspects its `int`-valued class attributes rather than iterating. A second test pins that discriminants 41/42 are reachable by name.

## Verification

- Built the extension (`maturin develop --features python`) and ran the `TestErrorTypes` suite against it — all pass, including the new parity test.
- Confirmed (build-free) that the stub `ErrorType` block now matches the `PyErrorType` enum discriminants in `src/python.rs` exactly (43 ↔ 43, no diffs).
- `ruff check` / `ruff format` clean; pre-commit (ruff, ruff-format, mypy) passed.