### PR TITLE
perf(parser): skip Unicode trim when input has no surrounding whitespace

### DIFF
--- a/src/hgvs/parser/mod.rs
+++ b/src/hgvs/parser/mod.rs
@@ -52,12 +52,38 @@ use crate::hgvs::HgvsVariant;
 /// println!("Parsed: {}", variant);
 /// ```
 pub fn parse_hgvs(input: &str) -> Result<HgvsVariant, FerroError> {
-    let trimmed = input.trim();
+    let trimmed = trim_hgvs(input);
     match fast_path::try_fast_path(trimmed) {
         fast_path::FastPathResult::Success(variant) => Ok(variant),
         // Fall back on the original (untrimmed) input so the generic parser
         // sees exactly what it did before the fast path existed.
         fast_path::FastPathResult::Fallback => variant::parse_variant(input),
+    }
+}
+
+/// Trim surrounding whitespace, skipping the work when there is none.
+///
+/// `str::trim` is Unicode-aware, so even a string with no surrounding whitespace
+/// pays for boundary `char` decoding + the Unicode-whitespace test on every call.
+/// Virtually all HGVS strings begin and end with an ASCII non-whitespace byte
+/// (`NM…`, `…A>G`, `…del`, `…=`, `…)`), so when both boundary bytes are ASCII and
+/// non-whitespace the input cannot have surrounding whitespace (an ASCII byte is
+/// never part of a multi-byte UTF-8 whitespace char) and is returned untouched.
+/// Any ASCII-whitespace or non-ASCII (`>= 0x80`) boundary defers to `str::trim`,
+/// so Unicode-whitespace handling is byte-for-byte unchanged.
+#[inline]
+fn trim_hgvs(input: &str) -> &str {
+    let bytes = input.as_bytes();
+    match (bytes.first(), bytes.last()) {
+        (Some(&first), Some(&last))
+            if first < 0x80
+                && last < 0x80
+                && !first.is_ascii_whitespace()
+                && !last.is_ascii_whitespace() =>
+        {
+            input
+        }
+        _ => input.trim(),
     }
 }
 
@@ -349,6 +375,30 @@ mod tests {
     fn test_parse_simple_substitution() {
         let result = parse_hgvs("NC_000001.11:g.12345A>G");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_trim_hgvs_matches_str_trim() {
+        // `trim_hgvs` must be byte-for-byte identical to `str::trim` on every
+        // input, including ASCII and multi-byte Unicode whitespace at either end.
+        let cases = [
+            "NM_000088.3:c.459A>G",                 // no whitespace (the fast path)
+            "  NM_000088.3:c.459A>G  ",             // ASCII spaces
+            "\tNM_000088.3:c.459A>G\n",             // ASCII tab / newline
+            "\u{00A0}NM_000088.3:c.459A>G",         // leading non-breaking space (U+00A0)
+            "NM_000088.3:c.459A>G\u{3000}",         // trailing ideographic space (U+3000)
+            "\u{2028}NM_000088.3:c.459A>G\u{2029}", // line/paragraph separators
+            "  ",                                   // all whitespace
+            "",                                     // empty
+            "x",                                    // single non-ws byte
+        ];
+        for input in cases {
+            assert_eq!(
+                trim_hgvs(input),
+                input.trim(),
+                "trim mismatch for {input:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/fast_path_differential.rs
+++ b/tests/fast_path_differential.rs
@@ -132,9 +132,11 @@ const DIFFERENTIAL_CASES: &[&str] = &[
     "NM_000088.3:c.459_460insACGT",
     "NM_000088.3:c.459_460delinsAC",
     "NM_000088.3:c.459_460inv",
-    // --- whitespace / trimming edges ---
+    // --- whitespace / trimming edges (ASCII and Unicode) ---
     "  NC_000001.11:g.12345A>G  ",
     "\tNM_000088.3:c.459A>G\n",
+    "\u{00A0}NM_000088.3:c.459A>G\u{3000}", // non-breaking + ideographic space
+    "\u{2028}NC_000001.11:g.12345del\u{2029}",
     // --- invalid base `U` in DNA / non-canonical positions: fast must defer ---
     "NC_000001.11:g.100A>U",
     "NC_000001.11:g.100U>A",


### PR DESCRIPTION
## Summary

`parse_hgvs` called `str::trim` on every input. `str::trim` is Unicode-aware, so even a string with no surrounding whitespace pays for boundary `char` decoding and the Unicode-whitespace test on every parse. Virtually all HGVS strings begin and end with an ASCII non-whitespace byte (`NM…`, `…A>G`, `…del`, `…=`, `…)`).

**Stacked on #657 → #650 → #643 → #641 → #639.** Review last; this PR's own diff is just the trim helper (2 files, ~50 lines).

## How

`trim_hgvs` returns the input untouched when both boundary bytes are ASCII and non-whitespace — an ASCII byte can never be part of a multi-byte UTF-8 whitespace char, so such a string cannot have surrounding whitespace. Any ASCII-whitespace or non-ASCII (`>= 0x80`) boundary defers to `str::trim`, so Unicode-whitespace handling is byte-for-byte unchanged.

## Correctness

- `trim_hgvs == str::trim` unit test over ASCII and multi-byte Unicode whitespace (U+00A0 non-breaking space, U+3000 ideographic space, U+2028/U+2029 separators), all-whitespace, empty, and single-char inputs.
- `fast_path_differential` table gains Unicode-whitespace cases.
- Byte-identical parse output over a 500k-variant ClinVar sample.
- `cargo fmt` / `cargo clippy --features dev -- -D warnings` clean; full suite passes except the pre-existing 11 `axis_*` baseline.

## Results

~2% higher parse throughput on the mixed ClinVar corpus (interleaved best-of-N). Modest — the stdlib trim's ASCII boundary check was already partly cheap — but it applies to every parse and is risk-free.
