### PR TITLE
perf(normalize): skip reference teardown at process exit

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1270,6 +1270,16 @@ fn run_normalize(
         }
     }
 
+    // The reference provider (cdot maps + FASTA index, ~1.4 GB) is owned by
+    // `normalizer`. Running its destructor here only frees memory the OS
+    // reclaims at process exit anyway — on a batch run ~10% of wall time is
+    // spent walking the millions of map entries to drop them. `process`
+    // borrowed `normalizer`, but its last use is above, so that borrow has
+    // already ended; leak `normalizer` so the process can exit without the
+    // teardown. `writer` is independent (output is passed in, not captured)
+    // and still flushes on its own drop, so this does not affect output.
+    std::mem::forget(normalizer);
+
     let elapsed = start.elapsed();
 
     // Write timing info if requested


### PR DESCRIPTION
## Summary

A batch `ferro normalize` run spends ~10% of its wall time in destructors at process exit, walking the millions of entries in the cdot transcript maps + FASTA index (~1.4 GB) owned by the `Normalizer` — only to free memory the OS reclaims anyway when the process exits moments later. A samply profile of a 500k-variant run attributes ~10% to `drop_in_place` of the `Normalizer`/`MultiFastaProvider`/`CdotMapper`.

## Change

After the input loop finishes, drop the closure that borrows the normalizer and `std::mem::forget` it, so the process exits without running that teardown. The output `writer` is independent (passed into the per-variant closure, not captured) and still flushes on its own drop, so output is unaffected. This is a CLI one-shot path — the provider is created once per process and used only here.

## Results

- Output **byte-identical** over a 500k-variant ClinVar corpus (484,972 normalized lines + identical error set).
- **~9–10% lower wall time** (interleaved min-of-N: 4.20s → 3.82s).
- `cargo fmt` / `cargo clippy` clean.
