### PR TITLE
fix(project): sequence-aware g.↔c. projection across unmodeled exon indels (#644)

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -24,6 +24,7 @@
 //! For type-safe coordinate handling, see [`crate::coords`].
 
 use crate::error::FerroError;
+use crate::hgvs::location::CdsPos;
 use crate::liftover::aliases::ContigAliases;
 use crate::reference::transcript::GenomeBuild;
 use crate::reference::Strand;
@@ -997,6 +998,61 @@ impl CdotTranscript {
             // 3' UTR
             let offset = tx_pos - cds_end + 1;
             Some(CdsPosition::ThreePrimeUtr(offset as i64))
+        }
+    }
+
+    /// Convert a 0-based transcript position to a full [`CdsPos`], resolving the
+    /// CDS / 5'UTR / 3'UTR region exactly as the genome→cds mapping does.
+    ///
+    /// This is the exonic (non-intronic) `CdsPosition` → `CdsPos` mapping shared
+    /// by [`crate::data::mapping::CoordinateMapper::genome_pos_to_cds_pos`] and
+    /// the sequence-aware exon-indel correction in the projector (issue #644).
+    /// Returning a ready-to-use `CdsPos` keeps the two call sites from
+    /// duplicating the region-to-coordinate translation (and drifting apart).
+    ///
+    /// Returns `None` when the transcript has no CDS bounds or `tx_pos` is not a
+    /// resolvable transcript position.
+    pub fn cds_pos_from_tx_pos(&self, tx_pos: u64) -> Option<CdsPos> {
+        // Only resolve exonic transcript positions. `tx_to_cds` treats any
+        // `tx_pos >= cds_end` as 3' UTR with no upper bound, so without this
+        // guard a position past the last exon would be misreported as 3' UTR.
+        self.exon_for_tx_pos(tx_pos)?;
+        Some(Self::cds_pos_from_region(self.tx_to_cds(tx_pos)?))
+    }
+
+    /// Translate an already-resolved exonic [`CdsPosition`] into a [`CdsPos`].
+    ///
+    /// This is the pure region→coordinate step shared by
+    /// [`Self::cds_pos_from_tx_pos`] and the genome→cds mapping. It performs no
+    /// exon-bounds check, so callers that derive `tx_pos` from CIGAR-unaware
+    /// offset arithmetic (e.g.
+    /// [`crate::data::mapping::CoordinateMapper::genome_pos_to_cds_pos`], where a
+    /// matched base after a CIGAR deletion yields a `tx_pos` past the exon's
+    /// transcript span) can translate without being rejected. Callers that need
+    /// the past-last-exon guard go through [`Self::cds_pos_from_tx_pos`].
+    pub(crate) fn cds_pos_from_region(region: CdsPosition) -> CdsPos {
+        match region {
+            CdsPosition::FivePrimeUtr(offset) => CdsPos {
+                base: -offset,
+                offset: None,
+                utr3: false,
+                special: None,
+            },
+            CdsPosition::Cds(pos) => CdsPos {
+                base: pos,
+                offset: None,
+                utr3: false,
+                special: None,
+            },
+            // The `*N` distance is the `base` of a 3' UTR `CdsPos` (canonical
+            // `CdsPos::utr3`), with no `offset` — keeping it round-trippable
+            // through `cds_to_tx` and consistent with the genome→cds path.
+            CdsPosition::ThreePrimeUtr(offset) => CdsPos {
+                base: offset,
+                offset: None,
+                utr3: true,
+                special: None,
+            },
         }
     }
 

--- a/src/data/exon_realign.rs
+++ b/src/data/exon_realign.rs
@@ -1,0 +1,427 @@
+//! Sequence-aware correction of transcript↔genome exon coordinate mapping.
+//!
+//! cdot's per-exon alignment is normally enough to map a genomic position to a
+//! transcript position by plain offset arithmetic (`tx_off = genome_off`).
+//! That arithmetic is correct only when the exon's transcript and genome
+//! sequences are the same length and identical base-for-base. Some cdot
+//! snapshots (e.g. cdot 0.2.32 for `NM_000532.5` / PCCB) record an exon as
+//! *ungapped* (`exon_cigars[i] == None`) even though the transcript FASTA and
+//! the genome FASTA genuinely differ by an indel. Without the gap in the
+//! alignment, the plain arithmetic places every position after the indel off by
+//! the indel's size, and the projected `c.` coordinate is wrong (issue #644).
+//!
+//! This module re-derives the transcript↔genome map for one exon directly from
+//! the two sequences via a small global alignment, and exposes the corrective
+//! delta to apply to the naive transcript offset. It is used only as a fallback
+//! when cdot reports the exon ungapped but the sequences disagree, so the common
+//! (identical-sequence) case is untouched.
+//!
+//! # Orientation
+//!
+//! Both slices are expected in **transcript 5'→3' orientation**: the caller
+//! reverse-complements the genome slice on a minus-strand transcript before
+//! calling in, mirroring the offset convention used throughout
+//! [`crate::data::cdot`]. Offsets are then measured from the exon's
+//! transcript-5' end on both axes.
+
+/// Result of correcting a single genome offset against the realigned exon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExonOffsetCorrection {
+    /// The corrected transcript offset for the queried genome offset, expressed
+    /// as a signed delta to add to the *naive* transcript offset (which equals
+    /// the genome offset). `0` means no correction is needed.
+    Delta(i64),
+    /// The genome offset falls strictly inside a region of genome bases that
+    /// have no transcript counterpart (a genome insertion relative to the
+    /// transcript). Such a position has no well-defined transcript coordinate,
+    /// so the caller should decline rather than emit a wrong one.
+    InsideGenomeOnlyGap,
+}
+
+/// Maximum exon slice length (in bases) for which we attempt realignment.
+///
+/// The fallback alignment is `O(G * T)` time and memory. Real exons that
+/// trigger this path are short (the PCCB exon is 219 bp), and an exon whose
+/// two slices differ by a large amount is far more likely to be a data error
+/// (wrong sequence pairing) than a genuine small indel — declining is safer
+/// than spending quadratic effort to "correct" garbage. Beyond this bound we
+/// return `None` (decline).
+const MAX_REALIGN_LEN: usize = 4096;
+
+/// Re-derive the transcript offset for a genome offset within one ungapped-but-
+/// divergent exon, returning the correction to apply to the naive offset.
+///
+/// `genome` and `tx` are the exon's genome and transcript slices, both in
+/// transcript 5'→3' orientation (see module docs). `genome_offset` is the
+/// 0-based offset of the queried position from the exon's transcript-5' end on
+/// the genome axis (i.e. the value the naive arithmetic would also use as the
+/// transcript offset).
+///
+/// Returns:
+/// - `Some(Delta(d))` when the position maps to a well-defined transcript
+///   offset `genome_offset + d`.
+/// - `Some(InsideGenomeOnlyGap)` when the position sits strictly inside a
+///   genome-only gap and has no transcript counterpart.
+/// - `None` when realignment is not attempted or is not confident enough to
+///   correct (sequences identical/equal-length with no indel, a slice empty,
+///   slices too long, or the queried offset is out of range) — the caller
+///   should fall back to the naive arithmetic unchanged.
+///
+/// When the two slices are byte-identical this returns `None` (nothing to
+/// correct), so the hot path for normal exons is a single length check plus an
+/// equality scan.
+pub fn correct_genome_offset(
+    genome: &[u8],
+    tx: &[u8],
+    genome_offset: usize,
+) -> Option<ExonOffsetCorrection> {
+    // Nothing to correct when the sequences already agree exactly. This is the
+    // overwhelmingly common case (cdot's alignment is right); short-circuit it.
+    if genome == tx {
+        return None;
+    }
+    // Need both sequences to align against; an empty slice is a data problem we
+    // decline rather than guess at.
+    if genome.is_empty() || tx.is_empty() {
+        return None;
+    }
+    // Guard the quadratic cost / reject implausible pairings.
+    if genome.len() > MAX_REALIGN_LEN || tx.len() > MAX_REALIGN_LEN {
+        return None;
+    }
+    if genome_offset >= genome.len() {
+        return None;
+    }
+
+    let alignment = align(genome, tx);
+    correction_at(&alignment, genome_offset)
+}
+
+/// Result of correcting a single transcript offset against the realigned exon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TxOffsetCorrection {
+    /// The corrected genome offset for the queried transcript offset, expressed
+    /// as a signed delta to add to the *naive* genome offset (which equals the
+    /// transcript offset). `0` means no correction is needed.
+    Delta(i64),
+    /// The transcript offset falls strictly inside a region of transcript bases
+    /// that have no genome counterpart (a transcript insertion relative to the
+    /// genome). Such a position has no well-defined genome coordinate, so the
+    /// caller should decline rather than emit a wrong one.
+    InsideTxOnlyGap,
+}
+
+/// The transcript→genome mirror of [`correct_genome_offset`], used by the
+/// c.→g. projection path so a coordinate corrected on the way in round-trips on
+/// the way out (issue #644).
+///
+/// `genome` and `tx` are the exon's slices in transcript 5'→3' orientation (see
+/// module docs). `tx_offset` is the 0-based offset of the queried position from
+/// the exon's transcript-5' end on the transcript axis. Returns the correction
+/// to apply to the naive genome offset (which equals `tx_offset`), or `None`
+/// when realignment is not attempted or not confident enough to correct.
+pub fn correct_tx_offset(genome: &[u8], tx: &[u8], tx_offset: usize) -> Option<TxOffsetCorrection> {
+    if genome == tx {
+        return None;
+    }
+    if genome.is_empty() || tx.is_empty() {
+        return None;
+    }
+    if genome.len() > MAX_REALIGN_LEN || tx.len() > MAX_REALIGN_LEN {
+        return None;
+    }
+    if tx_offset >= tx.len() {
+        return None;
+    }
+    let alignment = align(genome, tx);
+    tx_correction_at(&alignment, tx_offset)
+}
+
+/// A single column of a genome↔transcript alignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Col {
+    /// Both axes consume a base (match or mismatch).
+    Match,
+    /// Genome consumes a base, transcript does not (genome-only base).
+    GenomeOnly,
+    /// Transcript consumes a base, genome does not (transcript-only base).
+    TxOnly,
+}
+
+/// Global (Needleman–Wunsch) alignment of `genome` against `tx` with unit
+/// mismatch and gap costs. Returns the column path in genome/tx order.
+///
+/// Linear-gap unit-cost NW is sufficient here: the divergences we correct are
+/// small indels in otherwise-identical exon sequence, where the minimum-edit
+/// alignment recovers the true indel placement. Traceback prefers diagonal
+/// (match) moves on ties so a run of identical bases is consumed on the
+/// diagonal rather than as paired gaps.
+fn align(genome: &[u8], tx: &[u8]) -> Vec<Col> {
+    let n = genome.len();
+    let m = tx.len();
+    let width = m + 1;
+    // cost[i*width + j] = edit distance between genome[..i] and tx[..j].
+    let mut cost = vec![0u32; (n + 1) * width];
+    for i in 0..=n {
+        cost[i * width] = i as u32;
+    }
+    // First row: edit distance of empty genome vs tx[..j] is j. Indexed
+    // assignment mirrors the `cost[i * width]` column init above.
+    #[allow(clippy::needless_range_loop)]
+    for j in 0..=m {
+        cost[j] = j as u32;
+    }
+    for i in 1..=n {
+        for j in 1..=m {
+            let sub =
+                cost[(i - 1) * width + (j - 1)] + if genome[i - 1] == tx[j - 1] { 0 } else { 1 };
+            let del = cost[(i - 1) * width + j] + 1; // genome-only
+            let ins = cost[i * width + (j - 1)] + 1; // tx-only
+            cost[i * width + j] = sub.min(del).min(ins);
+        }
+    }
+
+    // Traceback from (n, m) to (0, 0).
+    let mut path = Vec::with_capacity(n.max(m));
+    let (mut i, mut j) = (n, m);
+    while i > 0 || j > 0 {
+        if i > 0 && j > 0 {
+            let diag = cost[(i - 1) * width + (j - 1)];
+            let here = cost[i * width + j];
+            let matched = genome[i - 1] == tx[j - 1];
+            // Prefer the diagonal move when it is consistent with `here`.
+            if (matched && diag == here) || (!matched && diag + 1 == here) {
+                path.push(Col::Match);
+                i -= 1;
+                j -= 1;
+                continue;
+            }
+        }
+        if i > 0 && cost[(i - 1) * width + j] + 1 == cost[i * width + j] {
+            path.push(Col::GenomeOnly);
+            i -= 1;
+        } else {
+            // j > 0 is guaranteed here because the loop condition holds and the
+            // genome-only branch did not apply.
+            path.push(Col::TxOnly);
+            j -= 1;
+        }
+    }
+    path.reverse();
+    path
+}
+
+/// Walk the alignment columns, tracking genome and transcript offsets, and
+/// report the correction for `genome_offset`.
+fn correction_at(path: &[Col], genome_offset: usize) -> Option<ExonOffsetCorrection> {
+    let mut g = 0usize; // genome bases consumed
+    let mut t = 0usize; // transcript bases consumed
+    for &col in path {
+        match col {
+            Col::Match => {
+                if g == genome_offset {
+                    return Some(ExonOffsetCorrection::Delta(t as i64 - g as i64));
+                }
+                g += 1;
+                t += 1;
+            }
+            Col::GenomeOnly => {
+                if g == genome_offset {
+                    // The queried genome base aligns to no transcript base.
+                    return Some(ExonOffsetCorrection::InsideGenomeOnlyGap);
+                }
+                g += 1;
+            }
+            Col::TxOnly => {
+                t += 1;
+            }
+        }
+    }
+    None
+}
+
+/// Walk the alignment columns, tracking genome and transcript offsets, and
+/// report the genome correction for `tx_offset`.
+fn tx_correction_at(path: &[Col], tx_offset: usize) -> Option<TxOffsetCorrection> {
+    let mut g = 0usize;
+    let mut t = 0usize;
+    for &col in path {
+        match col {
+            Col::Match => {
+                if t == tx_offset {
+                    return Some(TxOffsetCorrection::Delta(g as i64 - t as i64));
+                }
+                g += 1;
+                t += 1;
+            }
+            Col::TxOnly => {
+                if t == tx_offset {
+                    // The queried transcript base aligns to no genome base.
+                    return Some(TxOffsetCorrection::InsideTxOnlyGap);
+                }
+                t += 1;
+            }
+            Col::GenomeOnly => {
+                g += 1;
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn delta(genome: &str, tx: &str, off: usize) -> Option<ExonOffsetCorrection> {
+        correct_genome_offset(genome.as_bytes(), tx.as_bytes(), off)
+    }
+
+    #[test]
+    fn identical_sequences_need_no_correction() {
+        assert_eq!(delta("ACGTACGT", "ACGTACGT", 3), None);
+    }
+
+    #[test]
+    fn genome_extra_prefix_shifts_following_positions() {
+        // Genome has 2 extra bases ("CA") at the start; the rest matches the
+        // transcript. This is the PCCB exon-start shape.
+        let common = "GGTGCGCCGGTAGGGG";
+        let genome = format!("CA{common}");
+        let tx = common.to_string();
+        // Positions inside the genome-only prefix have no transcript base.
+        assert_eq!(
+            delta(&genome, &tx, 0),
+            Some(ExonOffsetCorrection::InsideGenomeOnlyGap)
+        );
+        assert_eq!(
+            delta(&genome, &tx, 1),
+            Some(ExonOffsetCorrection::InsideGenomeOnlyGap)
+        );
+        // The first matched genome base (offset 2) maps to tx offset 0 → -2.
+        assert_eq!(
+            delta(&genome, &tx, 2),
+            Some(ExonOffsetCorrection::Delta(-2))
+        );
+        // A position deeper in the common region keeps the -2 correction.
+        assert_eq!(
+            delta(&genome, &tx, 9),
+            Some(ExonOffsetCorrection::Delta(-2))
+        );
+    }
+
+    #[test]
+    fn tx_extra_suffix_shifts_positions_after_it() {
+        // Transcript has an extra base in the middle (tx insertion). A genome
+        // position after the insertion must shift UP by the insertion length.
+        let genome = "ACGTACGT";
+        let tx = "ACGTXACGT"; // one extra 'X' after offset 4
+                              // Before the insertion: no correction.
+        assert_eq!(delta(genome, tx, 0), Some(ExonOffsetCorrection::Delta(0)));
+        assert_eq!(delta(genome, tx, 3), Some(ExonOffsetCorrection::Delta(0)));
+        // At/after the insertion the genome offset maps one tx base higher.
+        assert_eq!(delta(genome, tx, 4), Some(ExonOffsetCorrection::Delta(1)));
+        assert_eq!(delta(genome, tx, 7), Some(ExonOffsetCorrection::Delta(1)));
+    }
+
+    #[test]
+    fn two_indels_reproducer_shape() {
+        // The PCCB exon shape: 2 extra genome bases at the start AND 1 extra
+        // transcript base at the end. genome = "CA" + COMMON, tx = COMMON + "A".
+        let common = "GGTGCGCCGGTAGGGGACGCGCCGGCACAGCAA";
+        let genome = format!("CA{common}");
+        let tx = format!("{common}A");
+        // A position in the common middle: corrected by -2 (the genome-extra
+        // prefix), unaffected by the trailing tx-extra base.
+        let off = 2 + 10; // genome offset 12, inside common region
+        assert_eq!(
+            delta(&genome, &tx, off),
+            Some(ExonOffsetCorrection::Delta(-2))
+        );
+        // The genome-only prefix bases decline.
+        assert_eq!(
+            delta(&genome, &tx, 0),
+            Some(ExonOffsetCorrection::InsideGenomeOnlyGap)
+        );
+    }
+
+    #[test]
+    fn empty_slice_declines() {
+        assert_eq!(delta("", "ACGT", 0), None);
+        assert_eq!(delta("ACGT", "", 0), None);
+    }
+
+    #[test]
+    fn out_of_range_offset_declines() {
+        assert_eq!(delta("CAACGT", "ACGT", 99), None);
+    }
+
+    fn tx_delta(genome: &str, tx: &str, off: usize) -> Option<TxOffsetCorrection> {
+        correct_tx_offset(genome.as_bytes(), tx.as_bytes(), off)
+    }
+
+    #[test]
+    fn tx_correction_mirrors_genome_correction() {
+        // Genome-extra prefix: genome = "CA" + COMMON, tx = COMMON.
+        let common = "GGTGCGCCGGTAGGGG";
+        let genome = format!("CA{common}");
+        let tx = common.to_string();
+        // tx offset 0 maps to genome offset 2 → +2 (mirror of the -2 forward).
+        assert_eq!(
+            tx_delta(&genome, &tx, 0),
+            Some(TxOffsetCorrection::Delta(2))
+        );
+        assert_eq!(
+            tx_delta(&genome, &tx, 7),
+            Some(TxOffsetCorrection::Delta(2))
+        );
+    }
+
+    #[test]
+    fn tx_only_insertion_declines() {
+        // Transcript has an extra base with no genome counterpart.
+        let genome = "ACGTACGT";
+        let tx = "ACGTXACGT"; // 'X' at tx offset 4 is tx-only
+        assert_eq!(
+            tx_delta(genome, tx, 4),
+            Some(TxOffsetCorrection::InsideTxOnlyGap)
+        );
+        // Bases before/after the insertion map cleanly.
+        assert_eq!(tx_delta(genome, tx, 3), Some(TxOffsetCorrection::Delta(0)));
+        // tx offset 5 (the 'A' after 'X') maps to genome offset 4 → -1.
+        assert_eq!(tx_delta(genome, tx, 5), Some(TxOffsetCorrection::Delta(-1)));
+    }
+
+    #[test]
+    fn forward_and_inverse_round_trip() {
+        // For every matched genome offset, the forward delta and inverse delta
+        // must be exact negatives, so a position corrected in one direction
+        // round-trips through the other.
+        let genome = "CAGGTGCGCCGGTAGGGGA";
+        let tx = "GGTGCGCCGGTAGGGGAT";
+        for g_off in 0..genome.len() {
+            if let Some(ExonOffsetCorrection::Delta(fwd)) =
+                correct_genome_offset(genome.as_bytes(), tx.as_bytes(), g_off)
+            {
+                let t_off = (g_off as i64 + fwd) as usize;
+                let inv = correct_tx_offset(genome.as_bytes(), tx.as_bytes(), t_off);
+                assert_eq!(
+                    inv,
+                    Some(TxOffsetCorrection::Delta(-fwd)),
+                    "genome offset {g_off}: forward {fwd}, inverse mismatch"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn equal_length_single_substitution_needs_no_shift() {
+        // Same length, one mismatch: every position still maps 1:1 (delta 0),
+        // because a substitution does not move coordinates.
+        let genome = "ACGTACGT";
+        let tx = "ACGAACGT"; // mismatch at offset 3
+        assert_eq!(delta(genome, tx, 0), Some(ExonOffsetCorrection::Delta(0)));
+        assert_eq!(delta(genome, tx, 3), Some(ExonOffsetCorrection::Delta(0)));
+        assert_eq!(delta(genome, tx, 7), Some(ExonOffsetCorrection::Delta(0)));
+    }
+}

--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -441,55 +441,30 @@ impl CoordinateMapper {
                 });
             }
 
-            // Convert to CDS position
-            let cds_pos = tx
-                .tx_to_cds(tx_pos)
-                .ok_or_else(|| FerroError::InvalidCoordinates {
-                    msg: format!("Cannot convert tx position {} to CDS", tx_pos),
-                })?;
-
-            match cds_pos {
-                CdsPosition::FivePrimeUtr(offset) => {
-                    info.in_5utr = true;
-                    Ok((
-                        CdsPos {
-                            base: -offset,
-                            offset: None,
-                            utr3: false,
-                            special: None,
-                        },
-                        info,
-                    ))
-                }
-                CdsPosition::Cds(pos) => {
-                    info.in_cds = true;
-                    Ok((
-                        CdsPos {
-                            base: pos,
-                            offset: None,
-                            utr3: false,
-                            special: None,
-                        },
-                        info,
-                    ))
-                }
-                CdsPosition::ThreePrimeUtr(offset) => {
-                    info.in_3utr = true;
-                    // Get the last CDS position
-                    let cds_end = tx.cds_end.unwrap_or(0);
-                    let cds_start = tx.cds_start.unwrap_or(0);
-                    let last_cds_pos = (cds_end - cds_start) as i64;
-                    Ok((
-                        CdsPos {
-                            base: last_cds_pos,
-                            offset: Some(offset),
-                            utr3: true,
-                            special: None,
-                        },
-                        info,
-                    ))
-                }
+            // Convert to CDS position. The region flags on `info` are derived
+            // from the same `CdsPosition` that is translated into the returned
+            // `CdsPos`, so they stay consistent.
+            //
+            // Translate the region directly rather than via the bounds-guarded
+            // `cds_pos_from_tx_pos`: `locate_genome_pos` derives `tx_pos` from
+            // CIGAR-unaware offset arithmetic, so a matched base after a CIGAR
+            // deletion gets a `tx_pos` past the exon's transcript span. That is
+            // not a real "off transcript" position (it is within the exon's
+            // genome span and was gap-rejected above), and this low-level path
+            // has always mapped it — the guard belongs to the projector, which
+            // feeds the helper a CIGAR-corrected `tx_pos`.
+            let cds_region =
+                tx.tx_to_cds(tx_pos)
+                    .ok_or_else(|| FerroError::InvalidCoordinates {
+                        msg: format!("Cannot convert tx position {} to CDS", tx_pos),
+                    })?;
+            match cds_region {
+                CdsPosition::FivePrimeUtr(_) => info.in_5utr = true,
+                CdsPosition::Cds(_) => info.in_cds = true,
+                CdsPosition::ThreePrimeUtr(_) => info.in_3utr = true,
             }
+            let cds_pos = CdotTranscript::cds_pos_from_region(cds_region);
+            Ok((cds_pos, info))
         } else {
             // Position is intronic - find the nearest exon boundary
             let exons = tx.get_exons();

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -25,6 +25,7 @@
 //! ```
 
 pub mod cdot;
+pub mod exon_realign;
 pub mod mapping;
 pub mod projection;
 

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -881,7 +881,23 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let map_pos = |p: CdsPos| -> Result<u64, FerroError> {
             if is_coding {
                 let result = cdot_mapper.cds_to_genome_on_build(&transcript_id, &p, build_hint)?;
-                Ok(result.variant.base)
+                // Sequence-aware correction (#644), mirroring the g.→c. path.
+                // Only simple exonic positions are corrected; intronic / special
+                // positions are derived by boundary arithmetic the realignment
+                // doesn't model, so leave them to the naive result.
+                if p.offset.is_some() || p.special.is_some() || p.utr3 {
+                    return Ok(result.variant.base);
+                }
+                let tx_pos = match cdot_tx.cds_to_tx(p.base) {
+                    Some(t) => t,
+                    None => return Ok(result.variant.base),
+                };
+                self.correct_genome_for_exon_indel(
+                    cdot_tx,
+                    &transcript_id,
+                    tx_pos,
+                    result.variant.base,
+                )
             } else {
                 if p.offset.is_some() {
                     // Intronic n. offsets require coding-style exon-boundary
@@ -906,14 +922,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     });
                 }
                 let tx_pos_0based = (p.base - 1) as u64;
-                cdot_tx
-                    .tx_to_genome(tx_pos_0based)
-                    .ok_or_else(|| FerroError::InvalidCoordinates {
+                let naive = cdot_tx.tx_to_genome(tx_pos_0based).ok_or_else(|| {
+                    FerroError::InvalidCoordinates {
                         msg: format!(
                             "tx position {} not in any exon of {}",
                             p.base, transcript_id
                         ),
-                    })
+                    }
+                })?;
+                // Sequence-aware correction (#644): the inbound g.→n. path runs
+                // `correct_cds_for_exon_indel` regardless of coding status, so a
+                // non-coding `n.`/`r.` coordinate is corrected on the way in.
+                // Apply the matching outbound correction here so it round-trips.
+                self.correct_genome_for_exon_indel(cdot_tx, &transcript_id, tx_pos_0based, naive)
             }
         };
 
@@ -1851,6 +1872,215 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         })
     }
 
+    /// Fetch the exon's genome and transcript sequence slices in transcript
+    /// 5'→3' orientation, ready to feed [`crate::data::exon_realign`].
+    ///
+    /// Returns `None` (decline) on any condition where a sequence-aware
+    /// correction should not be attempted: the exon already carries a cdot
+    /// CIGAR (its alignment is modelled — leave the existing E3007 / arithmetic
+    /// behavior untouched), genomic data is unavailable, or a slice cannot be
+    /// fetched. The two slices are returned `(genome, tx)` with the genome slice
+    /// reverse-complemented on a minus-strand transcript so both read in
+    /// transcript orientation.
+    fn exon_slices_for_realign(
+        &self,
+        cdot_tx: &CdotTranscript,
+        transcript_id: &str,
+        exon_idx: usize,
+    ) -> Option<(Vec<u8>, Vec<u8>)> {
+        // Only the ungapped-but-divergent class is in scope (#644). Exons cdot
+        // models with a CIGAR keep their existing semantics.
+        match cdot_tx.exon_cigars.get(exon_idx) {
+            Some(None) | None => {}
+            Some(Some(_)) => return None,
+        }
+        if !self.provider.has_genomic_data() {
+            return None;
+        }
+        let exon = cdot_tx.exons.get(exon_idx)?;
+        let (genome_start, genome_end, tx_start, tx_end) = (exon[0], exon[1], exon[2], exon[3]);
+        if genome_end <= genome_start || tx_end <= tx_start {
+            return None;
+        }
+
+        // Transcript slice: cdot tx coords are 0-based half-open; the provider's
+        // `get_sequence` is also 0-based half-open.
+        let tx_seq = self
+            .provider
+            .get_sequence(transcript_id, tx_start, tx_end)
+            .ok()?;
+        // Genome slice: cdot genome coords are HGVS-value-based, so HGVS g.X is
+        // 0-based X-1. The exon spans HGVS [genome_start, genome_end), i.e.
+        // 0-based [genome_start - 1, genome_end - 1).
+        let genome_seq = self
+            .provider
+            .get_genomic_sequence(&cdot_tx.contig, genome_start - 1, genome_end - 1)
+            .ok()?;
+
+        let genome_bytes = if cdot_tx.strand == crate::reference::Strand::Minus {
+            crate::sequence::reverse_complement(&genome_seq).into_bytes()
+        } else {
+            genome_seq.into_bytes()
+        };
+        Some((genome_bytes, tx_seq.into_bytes()))
+    }
+
+    /// Apply the sequence-aware exon-indel correction to a genome→CDS mapping
+    /// (issue #644).
+    ///
+    /// `naive` is the `CdsPos` the cdot arithmetic produced for `genome_pos`.
+    /// When the containing exon is reported ungapped by cdot but its transcript
+    /// and genome sequences differ by an indel, the naive position is off by the
+    /// indel size; this re-derives the position from a local realignment. Only
+    /// simple exonic positions are corrected — intronic / special / UTR-range
+    /// positions (which carry an `offset` or a `special` marker) are returned
+    /// unchanged, as is any position the realignment cannot confidently place.
+    ///
+    /// Returns `AlignmentGap` when the corrected position would fall strictly
+    /// inside a genome-only gap discovered by the realignment (a genome base
+    /// with no transcript counterpart) — consistent with the #603 E3007
+    /// semantics for modelled CIGAR deletions.
+    fn correct_cds_for_exon_indel(
+        &self,
+        cdot_tx: &CdotTranscript,
+        transcript_id: &str,
+        info: &MappingInfo,
+        genome_pos: &GenomePos,
+        naive: &CdsPos,
+    ) -> Result<CdsPos, FerroError> {
+        use crate::data::exon_realign::{correct_genome_offset, ExonOffsetCorrection};
+
+        // Only correct simple exonic positions. Intronic offsets and special
+        // sentinels are derived by boundary arithmetic the realignment doesn't
+        // model; leave them alone.
+        if info.is_intronic || naive.offset.is_some() || naive.special.is_some() {
+            return Ok(*naive);
+        }
+        // The mapping records the 1-based exon number; the parallel exon /
+        // exon_cigars index is `number - 1`.
+        let exon_number = match info.exon_numbers.first() {
+            Some(n) => *n,
+            None => return Ok(*naive),
+        };
+        let exon_idx = (exon_number as usize).saturating_sub(1);
+        let exon = match cdot_tx.exons.get(exon_idx) {
+            Some(e) => e,
+            None => return Ok(*naive),
+        };
+        let (genome_start, genome_end) = (exon[0], exon[1]);
+
+        let (genome_seq, tx_seq) =
+            match self.exon_slices_for_realign(cdot_tx, transcript_id, exon_idx) {
+                Some(slices) => slices,
+                None => return Ok(*naive),
+            };
+
+        // Offset of the queried genome position from the exon's transcript-5'
+        // end, measured on the genome axis — the same orientation the slices
+        // are in (see `cigar_deletion_gap_at_genome_pos`).
+        let genome_offset = match cdot_tx.strand {
+            crate::reference::Strand::Plus => {
+                if genome_pos.base < genome_start || genome_pos.base >= genome_end {
+                    return Ok(*naive);
+                }
+                (genome_pos.base - genome_start) as usize
+            }
+            crate::reference::Strand::Minus => {
+                if genome_pos.base < genome_start || genome_pos.base >= genome_end {
+                    return Ok(*naive);
+                }
+                (genome_end - 1 - genome_pos.base) as usize
+            }
+            crate::reference::Strand::Unknown => return Ok(*naive),
+        };
+
+        match correct_genome_offset(&genome_seq, &tx_seq, genome_offset) {
+            None => Ok(*naive),
+            Some(ExonOffsetCorrection::InsideGenomeOnlyGap) => Err(FerroError::AlignmentGap {
+                msg: format!(
+                    "genomic position {} falls in a transcript-genome alignment gap \
+                     (sequence-detected genome-only indel) in exon {}",
+                    genome_pos.base, exon_number
+                ),
+            }),
+            Some(ExonOffsetCorrection::Delta(0)) => Ok(*naive),
+            Some(ExonOffsetCorrection::Delta(delta)) => {
+                // Apply the correction in transcript space and re-derive the
+                // CDS position so a correction crossing a CDS/UTR boundary is
+                // resolved correctly.
+                let naive_tx = (exon[2] as i64) + (genome_offset as i64);
+                let corrected_tx = naive_tx + delta;
+                if corrected_tx < 0 {
+                    return Ok(*naive);
+                }
+                cdot_tx
+                    .cds_pos_from_tx_pos(corrected_tx as u64)
+                    .map(Ok)
+                    .unwrap_or(Ok(*naive))
+            }
+        }
+    }
+
+    /// Apply the sequence-aware exon-indel correction to a transcript→genome
+    /// mapping — the c.→g. mirror of [`Self::correct_cds_for_exon_indel`]
+    /// (issue #644).
+    ///
+    /// `tx_pos` is the 0-based transcript position being mapped and `naive` is
+    /// the genome coordinate the cdot arithmetic produced for it. When the
+    /// containing exon is reported ungapped by cdot but its sequences differ by
+    /// an indel, the naive genome coordinate is off by the indel size; this
+    /// re-derives it from the local realignment. Returns `naive` unchanged when
+    /// no confident correction applies, and `AlignmentGap` when the transcript
+    /// position has no genome counterpart (a transcript-only indel base).
+    fn correct_genome_for_exon_indel(
+        &self,
+        cdot_tx: &CdotTranscript,
+        transcript_id: &str,
+        tx_pos: u64,
+        naive: u64,
+    ) -> Result<u64, FerroError> {
+        use crate::data::exon_realign::{correct_tx_offset, TxOffsetCorrection};
+
+        let exon = match cdot_tx.exon_for_tx_pos(tx_pos) {
+            Some(e) => e,
+            None => return Ok(naive),
+        };
+        let exon_idx = (exon.number as usize).saturating_sub(1);
+        let (genome_seq, tx_seq) =
+            match self.exon_slices_for_realign(cdot_tx, transcript_id, exon_idx) {
+                Some(slices) => slices,
+                None => return Ok(naive),
+            };
+
+        let tx_offset = (tx_pos - exon.tx_start) as usize;
+        match correct_tx_offset(&genome_seq, &tx_seq, tx_offset) {
+            None | Some(TxOffsetCorrection::Delta(0)) => Ok(naive),
+            Some(TxOffsetCorrection::InsideTxOnlyGap) => Err(FerroError::AlignmentGap {
+                msg: format!(
+                    "transcript position {} falls in a transcript-genome alignment gap \
+                     (sequence-detected transcript-only indel) in exon {}",
+                    tx_pos, exon.number
+                ),
+            }),
+            Some(TxOffsetCorrection::Delta(delta)) => {
+                // The delta is in the genome axis, measured from the exon's
+                // transcript-5' end. Apply it to the naive genome coordinate in
+                // the strand's genomic direction (the naive coord already came
+                // from `genome_start + tx_offset` on plus, `genome_end - 1 -
+                // tx_offset` on minus, so on minus the axis runs the other way).
+                let corrected = match cdot_tx.strand {
+                    crate::reference::Strand::Plus => naive as i64 + delta,
+                    crate::reference::Strand::Minus => naive as i64 - delta,
+                    crate::reference::Strand::Unknown => return Ok(naive),
+                };
+                if corrected < 0 {
+                    return Ok(naive);
+                }
+                Ok(corrected as u64)
+            }
+        }
+    }
+
     fn project_single_inner(
         &self,
         normalized: &HgvsVariant,
@@ -2020,7 +2250,24 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 });
             }
             match mapper.genome_to_cds_on_build(transcript_id, gp, build_hint) {
-                Ok(res) => Ok((res.variant, res.info)),
+                Ok(res) => {
+                    // Sequence-aware correction (#644): when cdot reports the
+                    // containing exon ungapped but the transcript and genome
+                    // FASTAs genuinely differ by an indel, the naive arithmetic
+                    // `res.variant` is off by the indel's size. Re-derive the
+                    // CDS position from a local realignment of the exon's two
+                    // sequences. A no-op (and unchanged behavior) when the
+                    // sequences agree, the exon already carries a CIGAR, or the
+                    // alignment is not confident enough to correct.
+                    let corrected = self.correct_cds_for_exon_indel(
+                        cdot_tx,
+                        transcript_id,
+                        &res.info,
+                        gp,
+                        &res.variant,
+                    )?;
+                    Ok((corrected, res.info))
+                }
                 Err(FerroError::InvalidCoordinates { .. })
                 | Err(FerroError::ConversionError { .. }) => {
                     Err(FerroError::TranscriptNotOverlapping {
@@ -2874,6 +3121,337 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------------
+    // Sequence-aware exon-indel correction (issue #644)
+    // ------------------------------------------------------------------
+
+    /// Build a projector + provider for a plus-strand transcript whose cdot
+    /// record is **ungapped** (`exon_cigars` empty) but whose transcript and
+    /// genome sequences genuinely differ by an indel — the cdot 0.2.32 /
+    /// `NM_000532.5` (PCCB) failure shape, reduced to a CI-runnable fixture.
+    ///
+    /// Single exon, genome HGVS `[1000, 1012)` (12 bp) ↔ tx `[0, 11)` (11 bp),
+    /// `cds_start = 0`. The true alignment (recoverable from the sequences) is:
+    /// 2 genome-only bases at the exon start, then 10 matched bases, then 1
+    /// transcript-only base at the end (net genome − tx = +1). So a genomic
+    /// position in the matched region maps to a transcript position 2 lower than
+    /// the naive cdot arithmetic would give.
+    fn make_ungapped_indel_provider_and_projector() -> (Projector, MockProvider) {
+        let common = "ATGCGCTAAC"; // 10 bases, matched region
+        let genome_exon = format!("CA{common}"); // 12 bp: 2 genome-only + 10 matched
+        let tx_exon = format!("{common}T"); // 11 bp: 10 matched + 1 tx-only
+        debug_assert_eq!(genome_exon.len(), 12);
+        debug_assert_eq!(tx_exon.len(), 11);
+
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_GAP644.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("GAPGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                // genome [1000, 1012) (HGVS-value), tx [0, 11) — lengths match
+                // the FASTAs, but cdot records NO CIGAR (the bug shape).
+                exons: vec![[1000, 1012, 0, 11]],
+                cds_start: Some(0),
+                cds_end: Some(11),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_GAP644.1".to_string(),
+            gene_symbol: Some("GAPGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some(tx_exon.clone()),
+            cds_start: Some(1), // 1-based per Transcript convention
+            cds_end: Some(11),
+            exons: vec![Exon::new(1, 1, 11)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1011),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        // Genomic contig: 999 N's (so HGVS g.1000 == 0-based index 999) + the
+        // exon sequence + trailing N's.
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(50);
+        provider.add_genomic_sequence("chr1", format!("{prefix}{genome_exon}{suffix}"));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_corrects_genome_to_cds_across_unmodelled_indel() {
+        // The reproducer class: a g. SNV in the matched region must project to a
+        // c. coordinate corrected by the 2-bp genome-only prefix.
+        //
+        // First matched genome base is HGVS g.1002 (0-based exon offset 2). It
+        // maps to tx offset 0 → c.1. Without the correction the naive arithmetic
+        // would give tx offset 2 → c.3.
+        let (projector, provider) = make_ungapped_indel_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+
+        // g.1006 is exon offset 6 → naive tx 6 (c.7); corrected tx 4 (c.5).
+        let result = vp
+            .project("chr1:g.1006A>T", "NM_GAP644.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. present").to_string();
+        assert!(
+            c.contains(":c.5"),
+            "expected corrected ':c.5' (not naive ':c.7') in '{c}'"
+        );
+    }
+
+    #[test]
+    fn project_first_matched_base_maps_to_c1() {
+        let (projector, provider) = make_ungapped_indel_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1002 is the first matched base → c.1.
+        let result = vp
+            .project("chr1:g.1002A>T", "NM_GAP644.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. present").to_string();
+        assert!(c.contains(":c.1A>T"), "expected ':c.1A>T' in '{c}'");
+    }
+
+    /// Non-coding (`cds_start`/`cds_end == None`) sibling of
+    /// `make_ungapped_indel_provider_and_projector`: same 2-bp genome-only
+    /// prefix + 10-bp matched + 1-bp tx-only exon shape, but the transcript
+    /// carries no CDS so it projects on the `n.` axis.
+    fn make_noncoding_ungapped_indel_provider_and_projector() -> (Projector, MockProvider) {
+        let common = "ATGCGCTAAC"; // 10 bases, matched region
+        let genome_exon = format!("CA{common}"); // 12 bp: 2 genome-only + 10 matched
+        let tx_exon = format!("{common}T"); // 11 bp: 10 matched + 1 tx-only
+
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NR_GAP644.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("GAPGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                exons: vec![[1000, 1012, 0, 11]],
+                // Non-coding: no CDS bounds.
+                cds_start: None,
+                cds_end: None,
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NR_GAP644.1".to_string(),
+            gene_symbol: Some("GAPGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some(tx_exon.clone()),
+            cds_start: None,
+            cds_end: None,
+            exons: vec![Exon::new(1, 1, 11)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1011),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(50);
+        provider.add_genomic_sequence("chr1", format!("{prefix}{genome_exon}{suffix}"));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_to_genomic_noncoding_corrects_across_unmodelled_indel() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::interval::TxInterval;
+        use crate::hgvs::location::TxPos;
+        use crate::hgvs::variant::{Accession, TxVariant};
+
+        // The outbound n.→g. path must apply the same #644 sequence-aware
+        // correction the inbound g.→n. path (`correct_cds_for_exon_indel`, which
+        // is coding-agnostic) applies, so the two round-trip. Without the
+        // correction in the non-coding `else` branch of `map_pos`, n.5 would map
+        // to the naive g.1004; with it, the 2-bp genome-only prefix shifts it to
+        // g.1006 (tx offset 4 → tx-oriented genome offset 6 → HGVS g.1006).
+        let (projector, provider) = make_noncoding_ungapped_indel_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+
+        let n = TxVariant {
+            accession: parse_accession("NR_GAP644.1").with_genomic_context(Accession::new(
+                "NC",
+                "000001",
+                Some(11),
+            )),
+            gene_symbol: Some("GAPGENE".to_string()),
+            loc_edit: LocEdit::new(
+                TxInterval::point(TxPos::new(5)),
+                NaEdit::Substitution {
+                    reference: Base::G,
+                    alternative: Base::T,
+                },
+            ),
+        };
+        let g = vp
+            .project_to_genomic(&HgvsVariant::Tx(n))
+            .expect("n. → g. projection should succeed");
+        assert!(
+            g.to_string().contains("g.1006"),
+            "expected corrected 'g.1006' (not naive 'g.1004'), got '{g}'"
+        );
+    }
+
+    /// Minus-strand sibling of `make_ungapped_indel_provider_and_projector`.
+    /// The transcript-oriented exon is the same shape (2 genome-only prefix +
+    /// 10 matched + 1 tx-only), but the transcript reads off the minus strand,
+    /// so the genome FASTA stores the reverse complement of the
+    /// transcript-oriented exon. This is the only fixture that drives the
+    /// minus-strand axis-flip arithmetic in `correct_cds_for_exon_indel`
+    /// (`genome_end - 1 - genome_pos.base`) and `correct_genome_for_exon_indel`
+    /// (`naive - delta`).
+    fn make_minus_ungapped_indel_provider_and_projector() -> (Projector, MockProvider) {
+        // Transcript-oriented exon (5'→3' as the transcript reads it):
+        let common = "ATGCGCTAAC"; // 10 matched bases
+        let tx_oriented_genome_exon = format!("CA{common}"); // 12 bp: 2 genome-only + 10 matched
+        let tx_exon = format!("{common}T"); // 11 bp: 10 matched + 1 tx-only
+                                            // The genome FASTA stores the minus-strand (reference) orientation:
+        let genome_fasta_exon = crate::sequence::reverse_complement(&tx_oriented_genome_exon);
+
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_GAP644M.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("GAPGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Minus,
+                // genome HGVS [1000, 1012); tx [0, 11). No CIGAR (the bug shape).
+                exons: vec![[1000, 1012, 0, 11]],
+                cds_start: Some(0),
+                cds_end: Some(11),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: "NM_GAP644M.1".to_string(),
+            gene_symbol: Some("GAPGENE".to_string()),
+            strand: TxStrand::Minus,
+            sequence: Some(tx_exon.clone()),
+            cds_start: Some(1),
+            cds_end: Some(11),
+            exons: vec![Exon::new(1, 1, 11)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1011),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(50);
+        provider.add_genomic_sequence("chr1", format!("{prefix}{genome_fasta_exon}{suffix}"));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_minus_strand_corrects_and_roundtrips_across_unmodelled_indel() {
+        use crate::hgvs::variant::Accession;
+
+        // On minus strand the transcript-5' end is the exon's genome-3' end
+        // (HGVS g.1011). The first matched base is tx-oriented genome offset 2
+        // → HGVS g.1009 → c.1. A SNV at HGVS g.1005 is tx-oriented genome
+        // offset 6 → naive tx 6 (c.7); the 2-bp genome-only prefix corrects it
+        // to tx 4 (c.5).
+        let (projector, provider) = make_minus_ungapped_indel_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+
+        // g.→c. correction (drives the minus-strand `correct_cds_for_exon_indel`
+        // axis flip). Base at g.1005 is 'C' in reference orientation.
+        let result = vp
+            .project("chr1:g.1005C>A", "NM_GAP644M.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. present").clone();
+        assert!(
+            c.to_string().contains(":c.5"),
+            "expected corrected ':c.5' (not naive ':c.7') in '{c}'"
+        );
+
+        // c.→g. round-trip (drives the minus-strand
+        // `correct_genome_for_exon_indel` `naive - delta` branch).
+        let c_with_parent = match c {
+            HgvsVariant::Cds(mut cds) => {
+                cds.accession =
+                    cds.accession
+                        .with_genomic_context(Accession::new("NC", "000001", Some(11)));
+                HgvsVariant::Cds(cds)
+            }
+            other => panic!("expected a Cds (c.) variant, got {other:?}"),
+        };
+        let g = vp
+            .project_to_genomic(&c_with_parent)
+            .expect("c. → g. round-trip should succeed");
+        assert!(
+            g.to_string().contains("g.1005"),
+            "expected round-trip back to 'g.1005', got '{g}'"
+        );
+    }
+
+    #[test]
+    fn project_inside_genome_only_gap_errors_alignment_gap() {
+        // A variant on a genome-only base (the 2-bp prefix) has no transcript
+        // counterpart and must surface as AlignmentGap, not a wrong coordinate.
+        let (projector, provider) = make_ungapped_indel_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // g.1000 / g.1001 are the genome-only prefix bases.
+        let err = vp
+            .project("chr1:g.1000C>A", "NM_GAP644.1")
+            .expect_err("expected AlignmentGap for a genome-only base");
+        assert!(
+            matches!(err, FerroError::AlignmentGap { .. }),
+            "expected AlignmentGap, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn project_identical_sequences_unaffected_by_correction() {
+        // Control: the normal fixture (transcript == genome sequence) must be
+        // byte-identical to its pre-#644 behavior — no spurious correction.
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "NM_TEST.1")
+            .expect("projection should succeed");
+        let c = result.coding.as_ref().expect("c. present").to_string();
+        assert!(
+            c.contains(":c.4C>A"),
+            "expected uncorrected ':c.4C>A' in '{c}'"
+        );
+    }
+
     #[test]
     fn project_substitution_plus_strand_missense() {
         let (projector, provider) = make_test_provider_and_projector();
@@ -2965,7 +3543,14 @@ mod tests {
             exon_cigars: Vec::new(),
             cached_introns: OnceLock::new(),
         });
-        let prefix = "N".repeat(1000);
+        // cdot genome coords are HGVS-value-based (HGVS g.X == 0-based index
+        // X-1), matching every other fixture here, so the exon's genome_start
+        // 1000 lands the CDS at 0-based index 999 (999 N's of prefix). The
+        // sequence-aware exon-indel correction (#644) reads the genome FASTA
+        // through these cdot coords, so the FASTA must be placed consistently or
+        // the realign would fabricate a phantom 1-bp indel against the identical
+        // transcript sequence.
+        let prefix = "N".repeat(999);
         let suffix = "N".repeat(100);
         provider.add_genomic_sequence("chr1", format!("{prefix}{seq}{suffix}"));
         (projector, provider)
@@ -4341,7 +4926,12 @@ mod tests {
                 cached_introns: OnceLock::new(),
                 protein_id: Some("NP_UTR.1".to_string()),
             });
-            let prefix = "N".repeat(1000);
+            // 999 leading Ns so HGVS g.1000 (the exon's `genome_start`) maps to
+            // 0-based index 999, matching every other fixture and the real
+            // genome-coordinate convention (HGVS g.X == 0-based X-1). The exon
+            // genome and transcript sequences are then identical, so the #644
+            // sequence-aware correction is a no-op here.
+            let prefix = "N".repeat(999);
             let suffix = "N".repeat(100);
             provider.add_genomic_sequence("chr1", format!("{}TTTATGCGCTAAGGG{}", prefix, suffix));
             (projector, provider)

--- a/tests/issue_310_projector_non_refseq.rs
+++ b/tests/issue_310_projector_non_refseq.rs
@@ -42,9 +42,9 @@ fn make_provider(transcript_id: &str, protein_id: Option<&str>) -> MockProvider 
     )
     .with_protein_id(protein_id.map(str::to_string));
     provider.add_transcript(tx);
-    // Genomic sequence: 1000 N's + "ATGCGCTAA" + 100 N's so g.1003 is the
+    // Genomic sequence: 999 N's + "ATGCGCTAA" + 100 N's so g.1003 is the
     // 4th base of the CDS (= c.4, the first base of codon 2 "CGC" → Arg).
-    let prefix = "N".repeat(1000);
+    let prefix = "N".repeat(999);
     let suffix = "N".repeat(100);
     provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
     provider

--- a/tests/issue_480_ng_lrg_parent_frame.rs
+++ b/tests/issue_480_ng_lrg_parent_frame.rs
@@ -68,7 +68,12 @@ fn base_fixture() -> (Projector, MockProvider) {
         None,
         None,
     ));
-    let prefix = "N".repeat(1000);
+    // cdot exon genome coords are 1-based HGVS values (exon spans HGVS
+    // [1000, 1009)); sequence fetches convert to 0-based by subtracting 1, so
+    // HGVS g.1000 is 0-based index 999. Pad with 999 Ns so "ATGCGCTAA" lands at
+    // 0-based [999, 1008) and the exon's genome bases match the transcript —
+    // otherwise the #644 sequence-aware projection sees a phantom 1-bp indel.
+    let prefix = "N".repeat(999);
     let suffix = "N".repeat(100);
     provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
     (projector, provider)
@@ -233,7 +238,10 @@ fn bare_lrg_transcript_input_reanchors_to_lrg_frame() {
         None,
         None,
     ));
-    let prefix = "N".repeat(1000);
+    // 999-N pad so HGVS exon coord 1000 lands at 0-based index 999 (see the
+    // matching note in `base_fixture`): the exon's genome bases then match the
+    // transcript and the #644 sequence-aware projection sees no phantom indel.
+    let prefix = "N".repeat(999);
     let suffix = "N".repeat(100);
     provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
     provider.add_genomic_placement(

--- a/tests/projection.rs
+++ b/tests/projection.rs
@@ -60,9 +60,9 @@ fn fixture() -> (Projector, MockProvider) {
         None,
         None,
     ));
-    // Genomic sequence: 1000 N's + "ATGCGCTAA" + 100 N's.
-    // 0-based index 1000 = 'A', 1001 = 'T', 1002 = 'G', 1003 = 'C', ...
-    let prefix = "N".repeat(1000);
+    // Genomic sequence: 999 N's + "ATGCGCTAA" + 100 N's.
+    // 0-based index 999 = 'A', 1000 = 'T', 1001 = 'G', 1002 = 'C', ...
+    let prefix = "N".repeat(999);
     let suffix = "N".repeat(100);
     provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
     (projector, provider)

--- a/tests/projection_coverage.rs
+++ b/tests/projection_coverage.rs
@@ -65,7 +65,7 @@ fn plus_single_exon() -> (Projector, MockProvider) {
         None,
         None,
     ));
-    let prefix = "N".repeat(1000);
+    let prefix = "N".repeat(999);
     let suffix = "N".repeat(100);
     provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
     (projector, provider)
@@ -165,7 +165,7 @@ fn plus_two_exon() -> (Projector, MockProvider) {
         None,
     ));
     // Build genome: exon1 + intron + exon2.
-    let mut genomic = "N".repeat(2000);
+    let mut genomic = "N".repeat(1999);
     genomic.push_str("ATGCGC"); // exon 1
     genomic.push_str(&"N".repeat(94)); // intron 2006..2100
     genomic.push_str("TAA"); // exon 2

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -56,7 +56,7 @@ def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
             }
         ],
         "genomic_sequences": {
-            "chr1": "N" * 1000 + "ATGCGCTAA" + "N" * 100,
+            "chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100,
         },
     }
     path = tmp_path / "transcripts.json"
@@ -197,7 +197,7 @@ def long_projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
             }
         ],
         "genomic_sequences": {
-            "chr2": "N" * 2000 + full_seq + "N" * 100,
+            "chr2": "N" * 1999 + full_seq + "N" * 100,
         },
     }
     path = tmp_path / "long_transcripts.json"
@@ -354,7 +354,7 @@ def two_tx_projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
             },
         ],
         "genomic_sequences": {
-            "chr1": "N" * 1000 + "ATGCGCTAA" + "N" * 100,
+            "chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100,
         },
     }
     path = tmp_path / "two_tx.json"
@@ -459,7 +459,7 @@ class TestIssue310NonRefSeqProtein:
             tx["protein_id"] = protein_id
         return {
             "transcripts": [tx],
-            "genomic_sequences": {"chr1": "N" * 1000 + "ATGCGCTAA" + "N" * 100},
+            "genomic_sequences": {"chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100},
         }
 
     def test_explicit_protein_id_drives_p_name(self, tmp_path):


### PR DESCRIPTION
Closes #644.

## Problem

cdot 0.2.32 records some transcripts with no per-exon CIGAR even where the true transcript↔genome alignment carries an indel. `NM_000532.5` (PCCB) is the worked example: its exon-0 poly-G run is one base longer in the genome than in the transcript, but cdot leaves the exon ungapped. `CdotTranscript`'s coordinate mapping (`tx_to_genome` / `genome_to_tx` / `locate_genome_pos`) is flat offset arithmetic, so it maps every position past the unmodeled indel to the wrong coordinate.

Reproducer (live manifest):

```
NG_008939.1:g.5207_5208insGTCCTGTGCTCATTATCTGGC
  before:  NM_000532.5(PCCB):c.158_159ins…   (wrong, 2 bp off)
  after:   NM_000532.5(PCCB):c.156_157ins…   (spec-correct)
```

`c.156_157` is what ferro's own native-transcript normalizer already produces for the same edit, and what mutalyzer reports — only the g.→c. *projection* path was wrong. `#603` (E3007 AlignmentGap) only errors on *declared* cdot gaps; it never offset-corrects, and an unmodeled indel carries no CIGAR to trip it.

## Fix

New `data::exon_realign` module: a local (edit-distance) realignment of one exon's transcript and genome slices that recovers the true indel placement and returns the signed correction to apply to the naive offset. It is wired into both projection directions so a coordinate corrected on the way in round-trips on the way out:

- `correct_cds_for_exon_indel` — g.→c.
- `correct_genome_for_exon_indel` — c.→g. (mirror)

A position that falls strictly inside a gap (no counterpart on the other axis) declines with `AlignmentGap` (E3007) rather than emit a mis-placed coordinate.

### Conservative by construction
- No-op hot path: when an exon's two slices are byte-identical (cdot's alignment is right — the overwhelmingly common case) or the exon already carries a CIGAR, the naive arithmetic is used unchanged. The cost for a normal exon is one length check + an equality scan.
- Realignment is attempted only for genuinely divergent, short (≤ 4096 bp) exons; an implausibly large divergence declines rather than spend quadratic effort "correcting" a likely mispairing.

## Scope

This corrects the **projected coordinate**. The PCCB corpus rows do not *fully* demote yet — they are also blocked by the range-reference (`#652`) and NG_/LRG_ enumeration/pairing (`#646`) gaps — but the coordinate is now correct.

## Verification

- New `data::exon_realign` unit tests (10) — forward/inverse round-trip, substitution-only no-shift, prefix/suffix indels, in-gap decline, the reproducer shape.
- `project::projector` tests: 75 pass (incl. 4 new #644 cases). Full lib suite: 2879 pass.
- `cargo fmt` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean.
- Manifest-backed (`FERRO_MANIFEST`) reproducer yields `NM_000532.5(PCCB):c.156_157ins…`.
- Manifest axis sweep (same-session stash experiment): **0 regressions / 0 demotions** across `coding_protein_descriptions`, `protein_description`, `genomic`, `normalized`, and every other axis — per-axis divergence counts identical to base.