### PR TITLE
feat(normalize): emit the NP_ protein-accession selector for p. on genomic references (#502)

### DIFF
--- a/src/error_handling/info_map.rs
+++ b/src/error_handling/info_map.rs
@@ -112,8 +112,11 @@ pub const NO_FERRO_INFO_EQUIV: &[&str] = &[
     // LRG-specific reference correction; ferro does not implement the LRG
     // reference system.
     "ICORRECTEDLRGREFERENCE",
-    // mutalyzer corrects a missing/wrong selector ID on the input; ferro
-    // requires explicit selectors and errors otherwise.
+    // mutalyzer corrects a missing/wrong selector ID on the input. ferro
+    // rewrites a coding-transcript selector to its protein accession for a
+    // `p.` coordinate on a genomic reference (NM_→NP_, #502) but emits no
+    // structured info for the rewrite; for other selector classes it requires
+    // explicit selectors. Either way there is no ferro info to map.
     "ICORRECTEDSELECTORID",
     // mutalyzer corrects the variant type (e.g. del→delins) when the
     // stated bases force the change. ferro canonicalizes via

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2912,7 +2912,76 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
+        // #502: a `p.` coordinate on a genomic reference whose parenthetical
+        // selector is a coding transcript (`NM_`/`XM_`) should carry the
+        // protein accession (`NP_`/`XP_`) — the spec-preferred selector for a
+        // protein-level statement (background/refseq.md L38-42). Rewrite the
+        // selector when the reference data resolves the paired protein;
+        // otherwise the input selector is preserved (#121).
+        let final_variant = match self.resolve_genomic_protein_selector(&final_variant.accession) {
+            Some(protein_accession) => ProteinVariant {
+                accession: protein_accession,
+                ..final_variant
+            },
+            None => final_variant,
+        };
+
         Ok((HV::Protein(final_variant), warnings))
+    }
+
+    /// Resolve the spec-preferred protein-accession (`NP_`/`XP_`) selector for a
+    /// `p.` variant on a genomic reference (#502).
+    ///
+    /// For an input like `NG_012337.3(NM_003002.4):p.(Asp92Tyr)` the
+    /// parenthetical selector is a coding *transcript* (`NM_`), but a `p.`
+    /// coordinate is a protein-level statement; per HGVS
+    /// (`background/refseq.md` L38-42) a protein accession (`NP_`) is an
+    /// accepted parenthetical specification for a protein coordinate (the
+    /// spec-preferred selector here). When the reference
+    /// data resolves the transcript's paired protein, this returns that
+    /// `NP_`/`XP_` accession with the genomic-context wrapper preserved, to
+    /// replace the `NM_`/`XM_` selector.
+    ///
+    /// Returns `None` (leave the selector unchanged) when there is no genomic
+    /// context, the selector is not a coding transcript, the provider has no
+    /// such transcript, or it carries no `protein_id`. This is never an error:
+    /// a genome-less or data-poor environment (e.g. `MockProvider`) simply
+    /// preserves the input `NM_` selector, mirroring the #121 "preserve when
+    /// present, don't synthesize" policy.
+    fn resolve_genomic_protein_selector(
+        &self,
+        accession: &crate::hgvs::variant::Accession,
+    ) -> Option<crate::hgvs::variant::Accession> {
+        use crate::hgvs::parser::accession::parse_accession;
+
+        // Only a genomic-reference compound accession (NG_/LRG_/NC_ wrapper) is
+        // in scope; a bare transcript selector is left untouched.
+        let context = accession.genomic_context.as_ref()?;
+        // Only a coding-transcript selector (NM_/XM_) has a paired NP_/XP_.
+        if !matches!(accession.prefix.as_ref(), "NM" | "XM") {
+            return None;
+        }
+        // Resolve the transcript's paired protein accession from reference data.
+        let transcript = self
+            .provider
+            .get_transcript(&accession.transcript_accession())
+            .ok()?;
+        let protein_id = transcript.protein_id.as_deref()?;
+        // Parse the protein accession and re-attach the genomic-context wrapper.
+        let (rest, protein_accession) = parse_accession(protein_id).ok()?;
+        if !rest.is_empty() {
+            // Malformed `protein_id`: preserve the input selector rather than
+            // emit a partially-parsed accession.
+            return None;
+        }
+        // The provider's `protein_id` must be an actual protein accession
+        // (`NP_`/`XP_`). A non-protein value (e.g. a transcript or gene
+        // accession) is semantically malformed for a protein selector, so
+        // preserve the input selector rather than emit it as a `p.` selector.
+        if !matches!(protein_accession.prefix.as_ref(), "NP" | "XP") {
+            return None;
+        }
+        Some(protein_accession.with_genomic_context((**context).clone()))
     }
 
     /// Apply the HGVS 3' rule to a protein deletion or duplication.

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -4063,13 +4063,7 @@
       "infos": [
         "ICORRECTEDSELECTORID"
       ],
-      "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-121-gene-symbol-selector",
-        "note": "ferro emits the gene-symbol selector per closed issue #121; mutalyzer emits a legacy accession selector (NM_* / NP_*). Both are HGVS-allowed.",
-        "cluster": "gene-symbol-selector-121"
-      }
+      "to_test": true
     }
   ]
 }

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -91,9 +91,7 @@ Spec: `background/refseq.md (NM_(GENE) form)`
 
 ferro's terminal #121 policy preserves the NM_(GENE) gene-symbol selector; both forms are spec-allowed (an accepted divergence, not a convergence target).
 
-| input | axis | disposition | ferro output | tracking |
-|---|---|---|---|---|
-| `NG_012337.3(NM_003002.4):p.(Asp92Tyr)` | normalized | accepted_divergence | — | — |
+_No seeded member rows yet (manifest-gated seeding, #325)._
 
 ### Compound-allele SHUFFLE_APPLIED (#499)
 
@@ -152,5 +150,5 @@ ferro shuffles genomic-context c./n. variants in spliced transcript space (cross
 | axis | accepted_divergence | known_bug | improvement | spec_citation |
 |---|---:|---:|---:|---:|
 | infos | 4 | 0 | 0 | 0 |
-| normalized | 1 | 10 | 24 | 6 |
+| normalized | 0 | 10 | 24 | 6 |
 | protein_description | 0 | 0 | 0 | 19 |

--- a/tests/issue_502_np_protein_selector.rs
+++ b/tests/issue_502_np_protein_selector.rs
@@ -1,0 +1,180 @@
+//! Issue #502: emit the `NP_` protein-accession selector for `p.` variants on
+//! a genomic reference.
+//!
+//! For `NG_/LRG_/NC_(NM_):p.` inputs the parenthetical selector is a coding
+//! transcript, but a `p.` coordinate is a protein-level statement — so the
+//! spec-preferred selector is the paired protein accession (`NP_`), per HGVS
+//! `background/refseq.md` L38-42. `normalize` resolves the transcript's
+//! `protein_id` and rewrites `NM_`→`NP_` (keeping the genomic-context wrapper),
+//! while leaving `c./n./r.` selectors and bare/already-`NP_` inputs untouched.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{ManeStatus, Strand};
+use ferro_hgvs::reference::Transcript;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// A `MockProvider` carrying the `NM_003002.4` transcript (SDHD) used by the
+/// #502 corpus row, optionally with its paired protein accession populated.
+/// The sequence is an all-`A` filler long enough to validate the `c.` coordinate
+/// used below; protein bases are intentionally absent so `has_protein_data()` is
+/// false and protein-reference validation is skipped (the selector rewrite is
+/// independent of it).
+fn provider_with(protein_id: Option<&str>) -> MockProvider {
+    let mut provider = MockProvider::new();
+    let tx = Transcript::new(
+        "NM_003002.4".to_string(),
+        Some("SDHD".to_string()),
+        Strand::Plus,
+        Some("A".repeat(300)),
+        Some(1),
+        Some(300),
+        Vec::new(),
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::Select,
+        None,
+        None,
+    )
+    .with_protein_id(protein_id.map(str::to_string));
+    provider.add_transcript(tx);
+    provider
+}
+
+fn normalize_str(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"));
+    format!("{normalized}")
+}
+
+#[test]
+fn ng_nm_protein_input_emits_np_selector() {
+    let out = provider_with(Some("NP_002993.1"));
+    assert_eq!(
+        normalize_str(out, "NG_012337.3(NM_003002.4):p.(Asp92Tyr)"),
+        "NG_012337.3(NP_002993.1):p.(Asp92Tyr)"
+    );
+}
+
+#[test]
+fn np_selector_rewrite_is_idempotent() {
+    // Normalizing the rewritten output again must be a no-op: the selector is
+    // already `NP_`, so there is nothing to resolve.
+    let once = normalize_str(
+        provider_with(Some("NP_002993.1")),
+        "NG_012337.3(NM_003002.4):p.(Asp92Tyr)",
+    );
+    let twice = normalize_str(provider_with(Some("NP_002993.1")), &once);
+    assert_eq!(once, twice);
+    assert_eq!(twice, "NG_012337.3(NP_002993.1):p.(Asp92Tyr)");
+}
+
+#[test]
+fn already_np_selector_is_preserved() {
+    // An input that already carries the `NP_` selector is left unchanged (the
+    // prefix is not a coding transcript, so no resolution is attempted).
+    assert_eq!(
+        normalize_str(
+            provider_with(Some("NP_002993.1")),
+            "NG_012337.3(NP_002993.1):p.(Asp92Tyr)"
+        ),
+        "NG_012337.3(NP_002993.1):p.(Asp92Tyr)"
+    );
+}
+
+#[test]
+fn bare_nm_protein_without_genomic_context_is_preserved() {
+    // No genomic-context wrapper → out of scope; the input selector is
+    // preserved verbatim (#121).
+    assert_eq!(
+        normalize_str(
+            provider_with(Some("NP_002993.1")),
+            "NM_003002.4:p.(Asp92Tyr)"
+        ),
+        "NM_003002.4:p.(Asp92Tyr)"
+    );
+}
+
+#[test]
+fn missing_protein_id_preserves_nm_selector() {
+    // The reference resolves the transcript but it carries no `protein_id`:
+    // fall back to preserving the input `NM_` selector rather than erroring.
+    assert_eq!(
+        normalize_str(provider_with(None), "NG_012337.3(NM_003002.4):p.(Asp92Tyr)"),
+        "NG_012337.3(NM_003002.4):p.(Asp92Tyr)"
+    );
+}
+
+#[test]
+fn unknown_transcript_preserves_nm_selector() {
+    // The provider has no such transcript (empty provider): preserve the input
+    // selector; never error on the missing-data path.
+    let out = normalize_str(MockProvider::new(), "NG_012337.3(NM_003002.4):p.(Asp92Tyr)");
+    assert_eq!(out, "NG_012337.3(NM_003002.4):p.(Asp92Tyr)");
+}
+
+#[test]
+fn non_protein_protein_id_preserves_nm_selector() {
+    // The provider carries a `protein_id` that parses but is not a protein
+    // accession (e.g. a transcript accession from malformed reference data).
+    // Emitting it as a `p.` selector would violate the NP_/XP_ contract, so the
+    // input `NM_` selector is preserved instead.
+    assert_eq!(
+        normalize_str(
+            provider_with(Some("NM_999999.9")),
+            "NG_012337.3(NM_003002.4):p.(Asp92Tyr)"
+        ),
+        "NG_012337.3(NM_003002.4):p.(Asp92Tyr)"
+    );
+}
+
+#[test]
+fn coding_selector_on_genomic_reference_is_not_rewritten() {
+    // The rewrite is `p.`-only: a `c.` coordinate on the same `NG_(NM_)`
+    // reference must keep its transcript selector (must NOT become `NP_`).
+    let out = normalize_str(
+        provider_with(Some("NP_002993.1")),
+        "NG_012337.3(NM_003002.4):c.92A>T",
+    );
+    assert!(
+        out.contains("(NM_003002.4)"),
+        "c. selector must stay NM_: {out}"
+    );
+    assert!(
+        !out.contains("NP_"),
+        "c. selector must not become NP_: {out}"
+    );
+}
+
+#[test]
+fn predicted_xm_transcript_selector_emits_xp() {
+    // The rewrite covers predicted models too: an `XM_` coding-transcript
+    // selector resolves to its `XP_` protein accession.
+    let mut provider = MockProvider::new();
+    let tx = Transcript::new(
+        "XM_011512873.2".to_string(),
+        Some("SDHD".to_string()),
+        Strand::Plus,
+        Some("A".repeat(300)),
+        Some(1),
+        Some(300),
+        Vec::new(),
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    )
+    .with_protein_id(Some("XP_011511175.1".to_string()));
+    provider.add_transcript(tx);
+    assert_eq!(
+        normalize_str(provider, "NG_012337.3(XM_011512873.2):p.(Asp92Tyr)"),
+        "NG_012337.3(XP_011511175.1):p.(Asp92Tyr)"
+    );
+}


### PR DESCRIPTION
## Summary

For a `p.` variant on a genomic reference whose parenthetical selector is a coding transcript — `NG_012337.3(NM_003002.4):p.(Asp92Tyr)` — the selector names a *transcript*, but a `p.` coordinate is a protein-level statement. Per HGVS (`background/refseq.md` L38-42) the spec-appropriate selector for a protein coordinate is the protein accession (`NP_`), which is what mutalyzer emits: `NG_012337.3(NP_002993.1):p.(Asp92Tyr)`.

`normalize_protein` now resolves the transcript's paired `protein_id` from the reference and rewrites the `NM_`/`XM_` selector to the corresponding `NP_`/`XP_` protein accession, preserving the genomic-context wrapper.

## Scope and safety

The rewrite is deliberately narrow and never fails:

- **`p.`-only, genomic-reference-only:** it fires only when a genomic-context wrapper (`NG_`/`LRG_`/`NC_`) is present and the selector is a coding transcript (`NM_`/`XM_`). `c./n./r.` selectors are a transcript-level coordinate and keep their transcript accession — there's a regression test asserting a `c.` variant on the same `NG_(NM_)` reference is **not** rewritten.
- **Graceful degradation (#121):** a bare selector, an already-`NP_` selector, an unknown transcript, or a transcript with no `protein_id` all preserve the input selector. Nothing errors. A genome-less / data-poor environment (e.g. `MockProvider`) is a no-op — which is why the CI-always mock regression pin is unchanged.
- **Idempotent:** the `NP_` output re-normalizes unchanged (the prefix is no longer a coding transcript).

## Corpus

Demotes the one corpus row from `accepted_divergence` (`gene-symbol-selector-121`) to a plain pass — ferro now converges on the spec-preferred `NP_` form, so the divergence annotation would XPASS-fail.

## No spec regression

The HGVS spec-normalization fixture is unchanged, and every mutalyzer conformance axis FAIL set is **byte-identical** to `origin/main` (verified with a clean same-worktree base-vs-branch diff across all eight axes). Normalize lib tests (270), gene-selector (71), protein, and idempotency suites all pass.

## Tests

`tests/issue_502_np_protein_selector.rs` covers: `NM_`→`NP_` conversion, `XM_`→`XP_` (predicted models), idempotency, already-`NP_` preserved, bare-`NM_` (no genomic context) preserved, missing-`protein_id` preserved, unknown-transcript preserved, and the `c.`-not-rewritten guard.

## Suggested reading order

1. `src/normalize/mod.rs` — `resolve_genomic_protein_selector` and its call site at the tail of `normalize_protein`.
2. `tests/issue_502_np_protein_selector.rs`.
3. `tests/fixtures/mutalyzer-normalize/cases.json` (annotation removal) + `src/error_handling/info_map.rs` (rationale refresh).

Closes #502