### PR TITLE
feat(prepare): add Ensembl reference support (ENST/ENSG/ENSP)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1238,6 +1238,7 @@ class PrepareConfig:
         skip_existing: bool = True,
         dry_run: bool = False,
         download_cdot_grch37: bool = False,
+        download_ensembl: bool = False,
     ) -> None: ...
     @property
     def output_dir(self) -> str: ...
@@ -1249,6 +1250,8 @@ class PrepareConfig:
     def download_cdot(self) -> bool: ...
     @property
     def download_cdot_grch37(self) -> bool: ...
+    @property
+    def download_ensembl(self) -> bool: ...
 
 class ReferenceManifest:
     """Manifest of prepared reference data."""

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1505,6 +1505,7 @@ fn run_prepare_tool(
                 download_lrg: !no_lrg,
                 download_cdot: matches!(genome, GenomeOption::Grch38 | GenomeOption::All),
                 download_cdot_grch37: matches!(genome, GenomeOption::Grch37 | GenomeOption::All),
+                download_ensembl: false,
                 skip_existing: !force,
                 clinvar_file: None,
                 patterns_file: None,

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -489,6 +489,11 @@ enum Commands {
         #[arg(long)]
         validate_canonical: Option<PathBuf>,
 
+        /// Also download Ensembl reference (cDNA sequences + cdot metadata) so
+        /// variants on Ensembl transcripts/genes (ENST/ENSG/ENSP) resolve
+        #[arg(long)]
+        ensembl: bool,
+
         /// Dry run - show what would be downloaded without downloading
         #[arg(long)]
         dry_run: bool,
@@ -795,6 +800,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             patterns,
             clinvar,
             validate_canonical,
+            ensembl,
             dry_run,
         } => run_prepare(
             &output_dir,
@@ -808,6 +814,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             patterns.as_deref(),
             clinvar.as_deref(),
             validate_canonical.as_deref(),
+            ensembl,
             dry_run,
         ),
         Commands::Check {
@@ -2839,6 +2846,7 @@ fn run_prepare(
     patterns: Option<&Path>,
     clinvar: Option<&Path>,
     validate_canonical: Option<&Path>,
+    ensembl: bool,
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::prepare::{prepare_references, PrepareConfig};
@@ -2853,6 +2861,7 @@ fn run_prepare(
         download_lrg: !no_lrg,
         download_cdot: !no_cdot && (genome == "grch38" || genome == "all"),
         download_cdot_grch37: !no_cdot && (genome == "grch37" || genome == "all"),
+        download_ensembl: ensembl,
         skip_existing: !force,
         clinvar_file: clinvar.map(|p| p.to_path_buf()),
         patterns_file: patterns.map(|p| p.to_path_buf()),

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -87,6 +87,30 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    // Validate Ensembl cDNA files exist.
+    //
+    // `ensembl_transcript_fastas` holds the downloaded Ensembl cDNA `.fa.gz`
+    // paths; `prepare_references` decompresses and `index_fasta`s the companion
+    // `.fa`, which is what `MultiFastaProvider` actually resolves from. Mirror
+    // the RefSeq loop above: map a trailing `.fa.gz`/`.fna.gz` to its
+    // decompressed sidecar and warn if that file is missing, so a missing or
+    // un-decompressed Ensembl FASTA surfaces here rather than as a silent
+    // runtime resolution miss. Any other extension is checked as-is.
+    for fasta in &manifest.ensembl_transcript_fastas {
+        let check_path = fasta
+            .file_name()
+            .and_then(|n| n.to_str())
+            .filter(|name| name.ends_with(".fa.gz") || name.ends_with(".fna.gz"))
+            .map(|name| fasta.with_file_name(&name[..name.len() - ".gz".len()]))
+            .unwrap_or_else(|| fasta.clone());
+        if !check_path.exists() {
+            result.warnings.push(format!(
+                "Ensembl cDNA FASTA not found: {}",
+                check_path.display()
+            ));
+        }
+    }
+
     // Validate genome file if specified
     if let Some(ref genome) = manifest.genome_fasta {
         if !genome.exists() {
@@ -110,6 +134,23 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
             result
                 .warnings
                 .push(format!("cdot GRCh37 JSON not found: {}", cdot.display()));
+        }
+    }
+
+    if let Some(ref cdot) = manifest.ensembl_cdot_json {
+        if !cdot.exists() {
+            result
+                .warnings
+                .push(format!("Ensembl cdot JSON not found: {}", cdot.display()));
+        }
+    }
+
+    if let Some(ref cdot) = manifest.ensembl_cdot_grch37_json {
+        if !cdot.exists() {
+            result.warnings.push(format!(
+                "Ensembl cdot GRCh37 JSON not found: {}",
+                cdot.display()
+            ));
         }
     }
 
@@ -174,6 +215,21 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
         eprintln!("  cdot metadata (GRCh37): {}", cdot.display());
     } else {
         eprintln!("  cdot metadata (GRCh37): not available");
+    }
+
+    if !manifest.ensembl_transcript_fastas.is_empty() {
+        eprintln!(
+            "  Ensembl cDNA files: {}",
+            manifest.ensembl_transcript_fastas.len()
+        );
+    }
+
+    if let Some(ref cdot) = manifest.ensembl_cdot_json {
+        eprintln!("  Ensembl cdot metadata (GRCh38): {}", cdot.display());
+    }
+
+    if let Some(ref cdot) = manifest.ensembl_cdot_grch37_json {
+        eprintln!("  Ensembl cdot metadata (GRCh37): {}", cdot.display());
     }
 
     if !manifest.protein_fastas.is_empty() {
@@ -241,6 +297,9 @@ mod tests {
             lrg_refseq_mapping: None,
             cdot_json: None,
             cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
             supplemental_fasta: None,
             legacy_transcripts_fasta: None,
             legacy_transcripts_metadata: None,

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2081,6 +2081,84 @@ impl CdotMapper {
             .saturating_sub(before)
     }
 
+    /// Merge the transcripts of an independently-loaded cdot file into this
+    /// mapper's **primary** build.
+    ///
+    /// Unlike [`Self::load_secondary_build`] — which layers the *same*
+    /// transcripts on a *different* genome build into `alt_build_transcripts` —
+    /// this absorbs *distinct* accessions that live on the *same* primary build
+    /// (e.g. Ensembl `ENST`/`ENSG`/`ENSP` records from `cdot-*.ensembl.*.json`,
+    /// alongside RefSeq `NM_`), so they resolve through the normal primary
+    /// lookup path. Returns the number of transcripts merged.
+    pub fn merge_primary_build<P: AsRef<Path>>(&mut self, path: P) -> Result<usize, FerroError> {
+        let other = Self::load(path.as_ref())?;
+        Ok(self.absorb_primary_build(other))
+    }
+
+    /// Reader-based variant of [`Self::merge_primary_build`] for tests and
+    /// in-memory callers. Parses a single-build cdot JSON from `reader` using
+    /// this mapper's primary build (defaulting to `GRCh38`).
+    pub fn merge_primary_build_from_reader<R: Read>(
+        &mut self,
+        reader: R,
+    ) -> Result<usize, FerroError> {
+        let build = self
+            .primary_build
+            .clone()
+            .unwrap_or_else(|| "GRCh38".to_string());
+        let other = Self::from_reader_with_build(reader, &build)?;
+        Ok(self.absorb_primary_build(other))
+    }
+
+    /// Absorb `other`'s primary-build transcripts into this mapper's primary
+    /// build via [`Self::add_transcript`] (which maintains `contig_index` and
+    /// the highest-version `base_to_versioned` fallback, and invalidates the
+    /// lazy query indexes). Non-primary builds `other` nests under
+    /// `genome_builds` are folded into the matching `alt_build_transcripts`
+    /// slot so e.g. Ensembl GRCh37 views remain available. Returns the count of
+    /// primary-build transcripts merged.
+    fn absorb_primary_build(&mut self, other: Self) -> usize {
+        let CdotMapper {
+            transcripts: other_transcripts,
+            alt_build_transcripts: other_alt,
+            lrg_to_refseq: other_lrg,
+            contig_alias_to_canonical: other_aliases,
+            ..
+        } = other;
+
+        let mut merged = 0usize;
+        for (accession, tx) in other_transcripts {
+            self.add_transcript(accession, tx);
+            merged += 1;
+        }
+        // Fold in any non-primary builds the merged file nested under
+        // `genome_builds` (e.g. GRCh37 ENST views), without overwriting the
+        // authoritative primary build.
+        for (nested_build, txs) in other_alt {
+            if Some(nested_build.as_str()) == self.primary_build.as_deref() {
+                continue;
+            }
+            let dest = self.alt_build_transcripts.entry(nested_build).or_default();
+            for (acc, tx) in txs {
+                dest.insert(acc, tx);
+            }
+        }
+        // Carry over contig aliases and LRG mappings without clobbering ours.
+        for (alias, canonical) in other_aliases {
+            self.contig_alias_to_canonical
+                .entry(alias)
+                .or_insert(canonical);
+        }
+        for (lrg, refseq) in other_lrg {
+            self.lrg_to_refseq.entry(lrg).or_insert(refseq);
+        }
+        // The alt-build fold above mutated `alt_build_transcripts` directly, so
+        // invalidate the lazy alt-build index (the primary index is already
+        // cleared per-transcript by `add_transcript`).
+        self.alt_build_query_index = OnceCell::new();
+        merged
+    }
+
     /// Create from a raw CdotFile, converting to internal format.
     ///
     /// Captures both the primary build's data (into [`Self::transcripts`])
@@ -3229,6 +3307,62 @@ mod tests {
         assert_eq!(tx.exons.len(), 1);
         assert_eq!(tx.exons[0][0], 48263025); // genome_start
         assert_eq!(tx.exons[0][1], 48263098); // genome_end
+    }
+
+    #[test]
+    fn test_merge_primary_build_adds_ensembl_alongside_refseq() {
+        // A RefSeq cdot mapper (NM_) ...
+        let refseq = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "contig": "NC_000017.11",
+                    "strand": "+",
+                    "exons": [[50184096, 50184169, 0, 73]],
+                    "cds_start": 10,
+                    "cds_end": 60
+                }
+            }
+        }
+        "#;
+        let mut mapper = CdotMapper::from_reader(refseq.as_bytes()).unwrap();
+        assert!(mapper.get_transcript("NM_000088.3").is_some());
+        assert!(mapper.get_transcript("ENST00000375549.8").is_none());
+
+        // ... merged with an Ensembl cdot file (ENST, distinct accession on the
+        // same primary build) resolves BOTH through the primary lookup path.
+        let ensembl = r#"
+        {
+            "transcripts": {
+                "ENST00000375549.8": {
+                    "gene_name": "EDN1",
+                    "contig": "NC_000006.12",
+                    "strand": "+",
+                    "exons": [[12290360, 12290460, 0, 100]],
+                    "cds_start": 5,
+                    "cds_end": 95
+                }
+            }
+        }
+        "#;
+        let merged = mapper
+            .merge_primary_build_from_reader(ensembl.as_bytes())
+            .unwrap();
+        assert_eq!(merged, 1, "one Ensembl transcript merged");
+
+        // RefSeq still resolves; Ensembl now resolves too.
+        assert!(mapper.get_transcript("NM_000088.3").is_some());
+        let enst = mapper
+            .get_transcript("ENST00000375549.8")
+            .expect("merged ENST resolves");
+        assert_eq!(enst.gene_name.as_deref(), Some("EDN1"));
+
+        // Version-fallback (base -> highest version) works for the merged ENST.
+        assert!(mapper.get_transcript("ENST00000375549").is_some());
+        // The Ensembl contig was indexed alongside the RefSeq one.
+        assert_eq!(mapper.transcripts_on_contig("NC_000006.12").len(), 1);
+        assert_eq!(mapper.transcripts_on_contig("NC_000017.11").len(), 1);
     }
 
     #[test]

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -45,6 +45,17 @@ pub struct ReferenceManifest {
     /// cdot transcript metadata JSON for GRCh37 (if downloaded)
     #[serde(default)]
     pub cdot_grch37_json: Option<PathBuf>,
+    /// Ensembl cdot transcript metadata JSON for GRCh38 (ENST/ENSG/ENSP), if
+    /// downloaded via `ferro prepare --ensembl`. Same schema as `cdot_json`.
+    #[serde(default)]
+    pub ensembl_cdot_json: Option<PathBuf>,
+    /// Ensembl cdot transcript metadata JSON for GRCh37, if downloaded.
+    #[serde(default)]
+    pub ensembl_cdot_grch37_json: Option<PathBuf>,
+    /// Ensembl cDNA FASTA files (ENST_* transcript sequences), if downloaded
+    /// via `ferro prepare --ensembl`.
+    #[serde(default)]
+    pub ensembl_transcript_fastas: Vec<PathBuf>,
     /// Supplemental FASTA file (missing ClinVar transcripts fetched from NCBI)
     #[serde(default)]
     pub supplemental_fasta: Option<PathBuf>,
@@ -91,6 +102,9 @@ impl Default for ReferenceManifest {
             lrg_refseq_mapping: None,
             cdot_json: None,
             cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
             supplemental_fasta: None,
             legacy_transcripts_fasta: None,
             legacy_transcripts_metadata: None,
@@ -218,6 +232,7 @@ impl ReferenceManifest {
             .chain(self.refseqgene_fastas.iter())
             .chain(self.lrg_fastas.iter())
             .chain(self.lrg_xmls.iter())
+            .chain(self.ensembl_transcript_fastas.iter())
         {
             f(p);
         }
@@ -228,6 +243,8 @@ impl ReferenceManifest {
             &self.lrg_refseq_mapping,
             &self.cdot_json,
             &self.cdot_grch37_json,
+            &self.ensembl_cdot_json,
+            &self.ensembl_cdot_grch37_json,
             &self.supplemental_fasta,
             &self.legacy_transcripts_fasta,
             &self.legacy_transcripts_metadata,
@@ -250,6 +267,7 @@ impl ReferenceManifest {
             &mut self.refseqgene_fastas,
             &mut self.lrg_fastas,
             &mut self.lrg_xmls,
+            &mut self.ensembl_transcript_fastas,
         ] {
             for p in v.iter_mut() {
                 f(p);
@@ -262,6 +280,8 @@ impl ReferenceManifest {
             &mut self.lrg_refseq_mapping,
             &mut self.cdot_json,
             &mut self.cdot_grch37_json,
+            &mut self.ensembl_cdot_json,
+            &mut self.ensembl_cdot_grch37_json,
             &mut self.supplemental_fasta,
             &mut self.legacy_transcripts_fasta,
             &mut self.legacy_transcripts_metadata,
@@ -312,6 +332,7 @@ impl ReferenceManifest {
             &mut self.refseqgene_fastas,
             &mut self.lrg_fastas,
             &mut self.lrg_xmls,
+            &mut self.ensembl_transcript_fastas,
         ] {
             v.sort();
             v.dedup();
@@ -461,6 +482,9 @@ mod tests {
             lrg_refseq_mapping: Some(ref_dir.join("lrg_mapping.txt")),
             cdot_json: Some(ref_dir.join("cdot.json")),
             cdot_grch37_json: Some(ref_dir.join("cdot37.json")),
+            ensembl_cdot_json: Some(ref_dir.join("ensembl_cdot.json")),
+            ensembl_cdot_grch37_json: Some(ref_dir.join("ensembl_cdot37.json")),
+            ensembl_transcript_fastas: vec![ref_dir.join("ensembl_cdna.fa")],
             supplemental_fasta: Some(ref_dir.join("supplemental.fa")),
             legacy_transcripts_fasta: Some(ref_dir.join("legacy.fa")),
             legacy_transcripts_metadata: Some(ref_dir.join("legacy.json")),
@@ -529,6 +553,31 @@ mod tests {
             loaded.cdot_json,
             Some(ref_dir.join("cdot.json")),
             "cdot_json should be absolute after load"
+        );
+
+        // Ensembl fields round-trip: relative on disk, absolute after load.
+        assert_eq!(
+            json["ensembl_cdot_json"], "ensembl_cdot.json",
+            "ensembl_cdot_json should be stored as relative path"
+        );
+        assert_eq!(
+            json["ensembl_transcript_fastas"][0], "ensembl_cdna.fa",
+            "ensembl_transcript_fastas should be stored as relative path"
+        );
+        assert_eq!(
+            loaded.ensembl_cdot_json,
+            Some(ref_dir.join("ensembl_cdot.json")),
+            "ensembl_cdot_json should be absolute after load"
+        );
+        assert_eq!(
+            loaded.ensembl_cdot_grch37_json,
+            Some(ref_dir.join("ensembl_cdot37.json")),
+            "ensembl_cdot_grch37_json should be absolute after load"
+        );
+        assert_eq!(
+            loaded.ensembl_transcript_fastas,
+            vec![ref_dir.join("ensembl_cdna.fa")],
+            "ensembl_transcript_fastas should be absolute after load"
         );
 
         // Verify all other fields are preserved

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -49,6 +49,9 @@ pub struct PrepareConfig {
     pub download_cdot: bool,
     /// Download GRCh37 cdot transcript metadata (CDS positions, exon coords, ~200MB)
     pub download_cdot_grch37: bool,
+    /// Download Ensembl cDNA transcript sequences (ENST_ accessions, ~75MB) and
+    /// the Ensembl cdot metadata. Off by default — opt in with `--ensembl`.
+    pub download_ensembl: bool,
     /// Skip download if files exist
     pub skip_existing: bool,
     /// ClinVar file to extract missing accessions from
@@ -75,6 +78,7 @@ impl Default for PrepareConfig {
             download_lrg: false,
             download_cdot: true,
             download_cdot_grch37: false,
+            download_ensembl: false,
             skip_existing: true,
             clinvar_file: None,
             patterns_file: None,
@@ -122,6 +126,22 @@ pub mod urls {
     /// From https://github.com/SACGF/cdot/releases
     pub const CDOT_REFSEQ_GRCH38: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.refseq.GRCh38.json.gz";
     pub const CDOT_REFSEQ_GRCH37: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.refseq.GRCh37.json.gz";
+
+    /// Ensembl cdot transcript database (ENST/ENSG/ENSP), same SACGF/cdot
+    /// release as the RefSeq files above and the identical JSON schema.
+    pub const CDOT_ENSEMBL_GRCH38: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.ensembl.GRCh38.json.gz";
+    pub const CDOT_ENSEMBL_GRCH37: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.ensembl.GRCh37.json.gz";
+
+    /// Ensembl cDNA (transcript) sequences (ENST_ accessions). Release 110 is
+    /// contemporaneous with cdot `data_v0.2.32`; both GRCh38 and GRCh37 mirrors
+    /// share the same file name under their respective release trees.
+    pub const ENSEMBL_CDNA_GRCH38: &str = "https://ftp.ensembl.org/pub/release-110/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh38.cdna.all.fa.gz";
+    /// GRCh37 cDNA mirror. Intentionally unused by the prepare flow: a
+    /// transcript's cDNA sequence is build-independent (only its genomic mapping
+    /// differs between GRCh37 and GRCh38), so the GRCh38 download above already
+    /// covers both builds. Kept here as the documented source URL should a
+    /// build-specific cDNA set ever be needed.
+    pub const ENSEMBL_CDNA_GRCH37: &str = "https://ftp.ensembl.org/pub/grch37/release-110/fasta/homo_sapiens/cdna/Homo_sapiens.GRCh37.cdna.all.fa.gz";
 
     /// LRG (Locus Reference Genomic) sequences from EBI
     /// ~1325 FASTA files
@@ -543,6 +563,62 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             &cdot_dir,
             config.skip_existing,
         )?);
+    }
+
+    // Download Ensembl reference (cDNA sequences + cdot metadata). Opt-in via
+    // `--ensembl`: lets variants on Ensembl transcripts/genes (ENST/ENSG/ENSP)
+    // resolve instead of no-op'ing.
+    if config.download_ensembl {
+        let ensembl_dir = config.output_dir.join("ensembl");
+        fs::create_dir_all(&ensembl_dir).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create directory: {}", e),
+        })?;
+        let cdot_dir = config.output_dir.join("cdot");
+
+        // 1. Ensembl cDNA FASTA (ENST_ sequences). Decompress + index so the
+        //    provider's directory scan picks it up like the RefSeq transcripts.
+        eprintln!("\n=== Downloading Ensembl cDNA transcripts (GRCh38, ~75MB) ===");
+        let gz_path = ensembl_dir.join("Homo_sapiens.GRCh38.cdna.all.fa.gz");
+        if config.skip_existing && gz_path.exists() {
+            eprintln!("  Skipping {} (exists)", gz_path.display());
+        } else {
+            download_file(urls::ENSEMBL_CDNA_GRCH38, &gz_path)?;
+            eprintln!("  Downloaded {}", gz_path.display());
+        }
+        // `with_extension("")` strips only the `.gz`, leaving the `.fa`.
+        let fasta_path = gz_path.with_extension("");
+        if config.skip_existing && fasta_path.exists() {
+            eprintln!("  Skipping decompress {} (exists)", fasta_path.display());
+        } else {
+            decompress_gzip(&gz_path, &fasta_path)?;
+            eprintln!("  Decompressed {}", fasta_path.display());
+        }
+        let fai_path = PathBuf::from(format!("{}.fai", fasta_path.display()));
+        if config.skip_existing && fai_path.exists() {
+            eprintln!("  Skipping index {} (exists)", fai_path.display());
+        } else {
+            index_fasta(&fasta_path)?;
+            eprintln!("  Indexed {}", fasta_path.display());
+        }
+        if !manifest.ensembl_transcript_fastas.contains(&gz_path) {
+            manifest.ensembl_transcript_fastas.push(gz_path);
+        }
+
+        // 2. Ensembl cdot metadata (GRCh38 primary; GRCh37 secondary if asked).
+        eprintln!("\n=== Downloading Ensembl cdot transcript metadata (GRCh38) ===");
+        manifest.ensembl_cdot_json = Some(download_cdot(
+            urls::CDOT_ENSEMBL_GRCH38,
+            &cdot_dir,
+            config.skip_existing,
+        )?);
+        if config.download_cdot_grch37 {
+            eprintln!("\n=== Downloading Ensembl cdot transcript metadata (GRCh37) ===");
+            manifest.ensembl_cdot_grch37_json = Some(download_cdot(
+                urls::CDOT_ENSEMBL_GRCH37,
+                &cdot_dir,
+                config.skip_existing,
+            )?);
+        }
     }
 
     // Fetch missing transcripts from ClinVar or pattern files (requires benchmark feature)

--- a/src/python.rs
+++ b/src/python.rs
@@ -3109,7 +3109,8 @@ impl PyPrepareConfig {
         download_cdot=true,
         skip_existing=true,
         dry_run=false,
-        download_cdot_grch37=false
+        download_cdot_grch37=false,
+        download_ensembl=false
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -3123,6 +3124,7 @@ impl PyPrepareConfig {
         skip_existing: bool,
         dry_run: bool,
         download_cdot_grch37: bool,
+        download_ensembl: bool,
     ) -> Self {
         Self {
             inner: PrepareConfig {
@@ -3135,6 +3137,7 @@ impl PyPrepareConfig {
                 download_lrg,
                 download_cdot,
                 download_cdot_grch37,
+                download_ensembl,
                 skip_existing,
                 clinvar_file: None,
                 patterns_file: None,
@@ -3167,6 +3170,11 @@ impl PyPrepareConfig {
     #[getter]
     fn download_cdot_grch37(&self) -> bool {
         self.inner.download_cdot_grch37
+    }
+
+    #[getter]
+    fn download_ensembl(&self) -> bool {
+        self.inner.download_ensembl
     }
 }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -398,6 +398,69 @@ impl MultiFastaProvider {
         mapper.defer_secondary_build("GRCh37", grch37_path);
     }
 
+    /// Merge Ensembl cdot metadata (GRCh38 primary, plus an optional GRCh37
+    /// secondary build) into an already-loaded RefSeq `mapper`. Ensembl
+    /// transcripts (`ENST`/`ENSG`/`ENSP`) are distinct accessions on the same
+    /// primary build, so they merge into the primary lookup path via
+    /// [`CdotMapper::merge_primary_build`] (not as an alt build). Best-effort:
+    /// warns but does not fail, like the LRG/GRCh37 loads. Returns the number of
+    /// Ensembl transcripts merged into the primary build.
+    fn load_ensembl_cdot(
+        mapper: &mut CdotMapper,
+        manifest: &serde_json::Value,
+        resolve_path: &impl Fn(&str) -> PathBuf,
+    ) -> usize {
+        let Some(ensembl_path_str) = manifest.get("ensembl_cdot_json").and_then(|v| v.as_str())
+        else {
+            return 0;
+        };
+        let ensembl_path = resolve_path(ensembl_path_str);
+        if !ensembl_path.exists() {
+            eprintln!(
+                "Warning: ensembl_cdot_json path does not exist: {}",
+                ensembl_path.display()
+            );
+            return 0;
+        }
+        eprintln!(
+            "Loading Ensembl cdot transcript metadata from {}...",
+            ensembl_path.display()
+        );
+        let merged = match mapper.merge_primary_build(&ensembl_path) {
+            Ok(count) => {
+                eprintln!("Merged {} Ensembl transcripts (primary build)", count);
+                count
+            }
+            Err(e) => {
+                eprintln!("Warning: Failed to load Ensembl cdot: {}", e);
+                0
+            }
+        };
+
+        // Layer the Ensembl GRCh37 cdot as a secondary build, if provided.
+        if let Some(grch37_str) = manifest
+            .get("ensembl_cdot_grch37_json")
+            .and_then(|v| v.as_str())
+        {
+            let grch37_path = resolve_path(grch37_str);
+            if grch37_path.exists() {
+                match mapper.load_secondary_build(&grch37_path, "GRCh37") {
+                    Ok(count) => {
+                        eprintln!(
+                            "Loaded {} Ensembl GRCh37 transcripts (secondary build)",
+                            count
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("Warning: Failed to load Ensembl GRCh37 cdot: {}", e);
+                    }
+                }
+            }
+        }
+
+        merged
+    }
+
     /// Create a provider from a manifest file
     pub fn from_manifest<P: AsRef<Path>>(manifest_path: P) -> Result<Self, FerroError> {
         let manifest_path = manifest_path.as_ref();
@@ -468,6 +531,24 @@ impl MultiFastaProvider {
                 if let Some(lrg_dir) = path.parent() {
                     if !dirs.contains(&lrg_dir.to_path_buf()) {
                         dirs.push(lrg_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+
+        // Get Ensembl cDNA directory (ENST_ accessions)
+        if let Some(fastas) = manifest
+            .get("ensembl_transcript_fastas")
+            .and_then(|v| v.as_array())
+        {
+            if let Some(first) = fastas.first().and_then(|v| v.as_str()) {
+                // Remove .gz extension if present (the indexed sidecar is the
+                // decompressed FASTA, as for RefSeq transcripts).
+                let path_str = first.strip_suffix(".gz").unwrap_or(first);
+                let path = resolve_path(path_str);
+                if let Some(ensembl_dir) = path.parent() {
+                    if !dirs.contains(&ensembl_dir.to_path_buf()) {
+                        dirs.push(ensembl_dir.to_path_buf());
                     }
                 }
             }
@@ -581,6 +662,12 @@ impl MultiFastaProvider {
                         // GRCh38/context-free workloads never pay for it.
                         // Best-effort: a missing key/file is a no-op.
                         Self::defer_grch37_secondary_cdot(&mut mapper, &manifest, &resolve_path);
+
+                        // Merge Ensembl cdot (ENST/ENSG/ENSP) into the primary
+                        // build alongside RefSeq, if the manifest provides it
+                        // (`ferro prepare --ensembl`). Best-effort, like the
+                        // LRG/GRCh37 loads above.
+                        Self::load_ensembl_cdot(&mut mapper, &manifest, &resolve_path);
 
                         provider.cdot_mapper = Some(mapper);
                     }
@@ -2658,6 +2745,160 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         let entry = index.get("NM_000001.1").unwrap();
         assert_eq!(entry.length, 10);
         assert_eq!(entry.offset, 13);
+    }
+
+    #[test]
+    fn test_from_manifest_resolves_ensembl_sequence_and_cdot() {
+        use crate::reference::ReferenceProvider;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // Ensembl cDNA FASTA (ENST_) + its .fai. Header ">ENST00000375549.8\n"
+        // is 19 bytes (1 + 17 + 1), so the sequence offset is 19.
+        fs::write(
+            d.join("ensembl_cdna.fna"),
+            ">ENST00000375549.8\nACGTACGTACGT\n",
+        )
+        .unwrap();
+        fs::write(
+            d.join("ensembl_cdna.fna.fai"),
+            "ENST00000375549.8\t12\t19\t12\t13\n",
+        )
+        .unwrap();
+
+        // Minimal RefSeq cdot (so the cdot-loading block fires) ...
+        fs::write(
+            d.join("refseq_cdot.json"),
+            r#"{"transcripts":{"NM_000088.3":{"gene_name":"COL1A1","contig":"NC_000017.11","strand":"+","exons":[[50184096,50184108,0,12]],"cds_start":0,"cds_end":12}}}"#,
+        )
+        .unwrap();
+        // ... and the Ensembl cdot it merges in.
+        fs::write(
+            d.join("ensembl_cdot.json"),
+            r#"{"transcripts":{"ENST00000375549.8":{"gene_name":"EDN1","contig":"NC_000006.12","strand":"+","exons":[[12290360,12290372,0,12]],"cds_start":0,"cds_end":12}}}"#,
+        )
+        .unwrap();
+
+        // Manifest references everything by relative path (resolved against its dir).
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": [],
+                "ensembl_transcript_fastas": ["ensembl_cdna.fna"],
+                "cdot_json": "refseq_cdot.json",
+                "ensembl_cdot_json": "ensembl_cdot.json",
+                "transcript_count": 2,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+
+        // Sequence resolution for the Ensembl transcript (versioned + length).
+        assert_eq!(
+            provider.get_sequence("ENST00000375549.8", 0, 4).unwrap(),
+            "ACGT"
+        );
+        assert_eq!(
+            provider.get_sequence_length("ENST00000375549.8").unwrap(),
+            12
+        );
+        // Version-less fallback resolves to the highest indexed version.
+        assert_eq!(
+            provider.get_sequence("ENST00000375549", 0, 4).unwrap(),
+            "ACGT"
+        );
+
+        // Coordinate mapping: the Ensembl cdot merged into the primary build
+        // alongside RefSeq, so both resolve through the same mapper.
+        let cdot = provider.cdot_mapper().expect("cdot mapper loaded");
+        assert!(
+            cdot.get_transcript("ENST00000375549.8").is_some(),
+            "Ensembl transcript resolves in cdot"
+        );
+        assert!(
+            cdot.get_transcript("NM_000088.3").is_some(),
+            "RefSeq transcript still resolves in cdot"
+        );
+    }
+
+    #[test]
+    fn test_from_manifest_layers_ensembl_grch37_secondary_build() {
+        // Covers the `ensembl_cdot_grch37_json` → `load_secondary_build(.., "GRCh37")`
+        // branch in `load_ensembl_cdot`: a GRCh37 Ensembl cdot named by the
+        // manifest must be absorbed as the GRCh37 alt build (distinct GRCh37
+        // contig accession), resolvable via `get_transcript_on_build`.
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // Ensembl cDNA FASTA so the provider has at least one FASTA directory.
+        fs::write(
+            d.join("ensembl_cdna.fna"),
+            ">ENST00000375549.8\nACGTACGTACGT\n",
+        )
+        .unwrap();
+        fs::write(
+            d.join("ensembl_cdna.fna.fai"),
+            "ENST00000375549.8\t12\t19\t12\t13\n",
+        )
+        .unwrap();
+
+        // Minimal RefSeq cdot so the cdot-loading block fires and creates the
+        // primary mapper that `load_ensembl_cdot` merges the Ensembl cdot into.
+        fs::write(
+            d.join("refseq_cdot.json"),
+            r#"{"transcripts":{"NM_000088.3":{"gene_name":"COL1A1","contig":"NC_000017.11","strand":"+","exons":[[50184096,50184108,0,12]],"cds_start":0,"cds_end":12}}}"#,
+        )
+        .unwrap();
+        // Primary (GRCh38) Ensembl cdot: contig is the GRCh38 accession.
+        fs::write(
+            d.join("ensembl_cdot.json"),
+            r#"{"transcripts":{"ENST00000375549.8":{"gene_name":"EDN1","contig":"NC_000006.12","strand":"+","exons":[[12290360,12290372,0,12]],"cds_start":0,"cds_end":12}}}"#,
+        )
+        .unwrap();
+        // Secondary (GRCh37) Ensembl cdot: same accession, GRCh37 contig.
+        fs::write(
+            d.join("ensembl_cdot_grch37.json"),
+            r#"{"transcripts":{"ENST00000375549.8":{"gene_name":"EDN1","contig":"NC_000006.11","strand":"+","exons":[[12290560,12290572,0,12]],"cds_start":0,"cds_end":12}}}"#,
+        )
+        .unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": [],
+                "ensembl_transcript_fastas": ["ensembl_cdna.fna"],
+                "cdot_json": "refseq_cdot.json",
+                "ensembl_cdot_json": "ensembl_cdot.json",
+                "ensembl_cdot_grch37_json": "ensembl_cdot_grch37.json",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+        let cdot = provider.cdot_mapper().expect("cdot mapper loaded");
+
+        // Primary build resolves to the GRCh38 contig.
+        let tx38 = cdot
+            .get_transcript_on_build("ENST00000375549.8", "GRCh38")
+            .expect("Ensembl transcript on GRCh38 (primary build)");
+        assert_eq!(tx38.contig, "NC_000006.12");
+
+        // The GRCh37 secondary build (the branch under test) resolves to the
+        // GRCh37 contig — proving the secondary cdot was layered, not dropped.
+        let tx37 = cdot
+            .get_transcript_on_build("ENST00000375549.8", "GRCh37")
+            .expect("Ensembl transcript on GRCh37 (secondary build)");
+        assert_eq!(tx37.contig, "NC_000006.11");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds Ensembl reference support to `ferro prepare` and the reference provider so variants on Ensembl transcripts/genes (`ENST…`, `ENSG…`, `ENSP…`) resolve instead of silently no-op'ing. The prepared manifest was RefSeq-only, so any Ensembl input echoed unchanged.

Closes #671.

## How it fits together

The parser already accepts ENST/ENSG/ENSP accessions; what was missing was reference data + resolution. cdot publishes an Ensembl transcript database in the **same release and identical JSON schema** as the RefSeq one we already use, so no cdot parser changes were needed — just a way to load it alongside RefSeq.

- **manifest** (`src/prepare/manifest.rs`): add `ensembl_cdot_json`, `ensembl_cdot_grch37_json`, `ensembl_transcript_fastas`, wired through every path-enumeration site (relative/absolute rebasing, dedup, root-invariant validation).
- **cdot** (`src/data/cdot.rs`): add `CdotMapper::merge_primary_build` (+ reader variant), which absorbs an independently-loaded cdot file's transcripts into the **primary** build. This differs from the existing `load_secondary_build`, which layers the *same* transcripts on a *different* genome build (`alt_build_transcripts`); Ensembl transcripts are *distinct* accessions on the *same* build, so they merge into the primary lookup path. Reuses `add_transcript`, so `contig_index` and the highest-version `base_to_versioned` fallback stay correct and the lazy query indexes invalidate.
- **provider** (`src/reference/multi_fasta.rs`): `from_manifest` now indexes the Ensembl cDNA FASTA directory and merges the Ensembl cdot (GRCh38 primary + optional GRCh37 secondary) into the RefSeq mapper. ENST resolves through the normal sequence + cdot path, both versioned (`ENST00000375549.8`) and version-less (`ENST00000375549`).
- **CLI / download** (`src/bin/ferro.rs`, `src/prepare/mod.rs`): `ferro prepare --ensembl` fetches the Ensembl cDNA FASTA and Ensembl cdot from the same `SACGF/cdot data_v0.2.32` release; `ferro check` reports them. **Off by default** — keeps the default manifest RefSeq-only and small.

## Tests (hermetic — no network)

- `manifest::tests::test_roundtrip_save_load_with_relative_paths` — extended to round-trip the new Ensembl fields (relative on disk, absolute after load).
- `cdot::tests::test_merge_primary_build_adds_ensembl_alongside_refseq` — both `NM_` and merged `ENST` resolve from one mapper, including version-fallback and contig indexing.
- `multi_fasta::tests::test_from_manifest_resolves_ensembl_sequence_and_cdot` — end-to-end from a synthetic manifest: ENST sequence (versioned + version-less) and length resolve, and the Ensembl cdot transcript resolves alongside RefSeq.

Verified: `cargo clippy --features dev --all-targets -D warnings` clean, `cargo fmt --check` clean, 549 cdot/multi_fasta/prepare/reference tests pass.

## Scope note

This makes the five `ENST`/`ENSG` conformance rows from #671 resolvable. Two of them (`ENST…:c.100del → c.102del`, `ENST…:c.9del → c.10del`) are also exon/intron-boundary 3′-shift cases, so they additionally depend on #670 to converge fully (annotated `known_bug` there). The actual download paths are network-dependent and follow the existing untested-download pattern; the resolution logic they feed is covered hermetically above.

Refs #487, #670
