### PR TITLE
fix(normalize): keep W4007 on warn-only intronic-bare resolve-failure

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1251,7 +1251,44 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
-        let (result, mut warnings) = match variant {
+        // Dispatch normalization. On success, warn-only mode attaches W4007 to the
+        // fully normalized output below (3'-shift, W4004, repeat notation are all
+        // preserved). On failure, warn-only mode must NOT propagate the error for
+        // an intronic-on-bare-transcript form: the spec-invalidity of that form is
+        // independent of provider capability, so when the intronic position cannot
+        // resolve (e.g. an indel with no genomic sequence to anchor it) we recover
+        // by echoing the input with W4007 instead of dropping the warning and
+        // surfacing a capability IntronicVariant/ConversionError (#682). A
+        // substitution never reaches the resolution pass, so this only changes the
+        // resolve-failure path. Reject mode already short-circuited above; silent
+        // mode (no eintronic_warning) propagates the error unchanged.
+        let (result, mut warnings) = match self.normalize_dispatch(variant) {
+            Ok(resolved) => resolved,
+            Err(e) => match &eintronic_warning {
+                Some(w) => return Ok((variant.clone(), vec![w.clone()])),
+                None => return Err(e),
+            },
+        };
+
+        // Warn-only: attach the EINTRONIC warning to the resolved output. (Reject
+        // mode already short-circuited above; silent mode has no warning.)
+        if let Some(w) = eintronic_warning {
+            warnings.push(w);
+        }
+
+        Ok((result, warnings))
+    }
+
+    /// Dispatch normalization by variant kind, returning the normalized variant
+    /// plus warnings. Extracted from [`Self::normalize_core`] so the caller can
+    /// recover a warn-only EINTRONIC resolve-failure (#682) without the per-arm
+    /// `?` propagating the error and discarding the W4007 warning; this method
+    /// itself performs no EINTRONIC handling.
+    fn normalize_dispatch(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        Ok(match variant {
             // A `g.` variant on a mitochondrial reference (NC_012920 / NC_001807)
             // must be described with `m.` (#487). Coerce it to an `MtVariant`
             // — same accession/location/edit, only the coordinate system label
@@ -1290,16 +1327,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // Null and unknown allele markers pass through unchanged
             HV::NullAllele => (HV::NullAllele, vec![]),
             HV::UnknownAllele => (HV::UnknownAllele, vec![]),
-        };
-
-        // Lenient (warn-only): attach the EINTRONIC warning to the resolved
-        // output. (Reject mode already short-circuited above; if normalization
-        // errored, lenient surfaces that error as before.)
-        if let Some(w) = eintronic_warning {
-            warnings.push(w);
-        }
-
-        Ok((result, warnings))
+        })
     }
 
     /// Normalize an allele (compound) variant
@@ -8075,18 +8103,33 @@ mod tests {
     }
 
     #[test]
-    fn test_boundary_no_genomic_data_returns_error() {
-        // Test that without genomic data, we still get the ExonIntronBoundary error
+    fn test_boundary_bare_intronic_no_genomic_data_warns_w4007() {
+        // #682: `c.11_11+3del` spans the exon/intron boundary on a bare `NM_`
+        // (no NG_(…)/NC_(…) context) — itself a spec-invalid intronic form. With
+        // no genomic data the intronic position cannot resolve. Default (warn)
+        // mode previously propagated that capability error; now the form-level
+        // invalidity (W4007) takes precedence: the input is echoed and the
+        // warning surfaced rather than hard-failing. (Strict mode still rejects
+        // it as EINTRONIC — see tests/issue_486_eintronic.rs.)
         let provider = MockProvider::with_test_data(); // No genomic data
         let normalizer = Normalizer::new(provider);
 
-        // NM_001234.1 doesn't have genomic coordinates
         let variant = parse_hgvs("NM_001234.1:c.11_11+3del").unwrap();
-        let result = normalizer.normalize(&variant);
-
+        // Warn-only must not propagate the capability error.
+        let out = normalizer
+            .normalize(&variant)
+            .expect("bare intronic form must warn, not error, in default mode (#682)");
+        assert_eq!(out.to_string(), "NM_001234.1:c.11_11+3del");
+        // W4007 is surfaced via diagnostics rather than silently dropped.
+        let diag = normalizer
+            .normalize_with_diagnostics(&variant)
+            .expect("diagnostics should succeed in warn-only mode");
         assert!(
-            result.is_err(),
-            "Boundary-spanning without genomic data should return error"
+            diag.warnings
+                .iter()
+                .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+            "expected INTRONIC_ON_BARE_TRANSCRIPT (W4007), got {:?}",
+            diag.warnings
         );
     }
 

--- a/tests/issue_486_eintronic.rs
+++ b/tests/issue_486_eintronic.rs
@@ -200,6 +200,42 @@ fn strict_rejects_cis_allele_with_intronic_member() {
 }
 
 #[test]
+fn lenient_warns_and_keeps_value_when_intronic_indel_cannot_resolve() {
+    // #682 regression: a substitution never reaches the genomic-sequence-dependent
+    // intronic resolution pass, so warn-only mode has always echoed it with W4007.
+    // An *indel* does reach that pass; with no genomic sequence to anchor it,
+    // `normalize_tx` errored and — because warn-only mode (unlike reject mode) did
+    // NOT short-circuit before normalization — that capability error propagated via
+    // `?`, dropping the W4007 warning entirely. The spec-invalidity of an intronic
+    // offset on a bare transcript is independent of provider capability, so warn-only
+    // mode must still surface W4007 and echo the input, not hard-fail.
+    //
+    // `provider_intronic_nr` has the transcript but no genomic sequence, so the
+    // intronic deletion cannot resolve.
+    let normalizer = Normalizer::with_config(provider_intronic_nr(), NormalizeConfig::lenient());
+    let variant = parse_hgvs("NR_INT.1:n.10+2_10+3del").expect("parse");
+
+    // Warn-only must NOT propagate the capability error.
+    let out = normalizer
+        .normalize(&variant)
+        .expect("warn-only must not fail when an intronic indel cannot resolve (#682)");
+    // The spec-invalid form is echoed unchanged (not normalized/shifted).
+    assert_eq!(out.to_string(), "NR_INT.1:n.10+2_10+3del");
+
+    // And W4007 is surfaced rather than silently dropped.
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("warn-only diagnostics");
+    assert!(
+        diag.warnings
+            .iter()
+            .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+        "expected INTRONIC_ON_BARE_TRANSCRIPT warning, got {:?}",
+        diag.warnings
+    );
+}
+
+#[test]
 fn silent_accepts_bare_nm_intronic_substitution_without_warning() {
     // Silent mode (`warn_accept()` → Accept): the intronic offset on a bare
     // NM_ is accepted without rejection and without emitting W4007.
@@ -221,4 +257,36 @@ fn silent_accepts_bare_nm_intronic_substitution_without_warning() {
         "silent mode must not emit INTRONIC_ON_BARE_TRANSCRIPT, got {:?}",
         diag.warnings
     );
+}
+
+#[test]
+fn silent_propagates_error_when_intronic_indel_cannot_resolve() {
+    // Silent-mode counterpart to `lenient_warns_and_keeps_value_when_intronic_indel_cannot_resolve`.
+    // Silent mode produces no EINTRONIC warning, so the `None => return Err(e)` arm in
+    // `normalize_core` must still propagate the capability error for an intronic *indel* that
+    // reaches the genomic-sequence-dependent resolution pass — no echo, no W4007 (#682).
+    //
+    // `provider_intronic_nr` has the transcript but no genomic sequence, so the intronic
+    // deletion cannot resolve.
+    let normalizer = Normalizer::with_config(provider_intronic_nr(), NormalizeConfig::silent());
+    let variant = parse_hgvs("NR_INT.1:n.10+2_10+3del").expect("parse");
+
+    // Silent mode has no EINTRONIC warning to recover with, so the capability error propagates.
+    assert!(
+        normalizer.normalize(&variant).is_err(),
+        "silent mode must propagate the resolve-failure error for an intronic indel (#682)"
+    );
+
+    // And it must not emit the INTRONIC_ON_BARE_TRANSCRIPT warning (no echo path taken).
+    let diag = normalizer.normalize_with_diagnostics(&variant);
+    if let Ok(diag) = diag {
+        assert!(
+            !diag
+                .warnings
+                .iter()
+                .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+            "silent mode must not emit INTRONIC_ON_BARE_TRANSCRIPT, got {:?}",
+            diag.warnings
+        );
+    }
 }

--- a/tests/issue_573_intronic_shuffle_window.rs
+++ b/tests/issue_573_intronic_shuffle_window.rs
@@ -12,6 +12,16 @@
 //! explicitly check that both intron edges lie within the resolved window and
 //! return a `ConversionError` when they do not.
 //!
+//! #682 interaction: the two `c.` fixtures here use a *bare* `NM_` transcript
+//! (no `NG_(…)`/`NC_(…)` context), which is itself a spec-invalid intronic form
+//! (W4007 / EINTRONIC). In warn-only (default) mode that form-level invalidity
+//! is the actionable signal, so `normalize()` now surfaces W4007 and echoes the
+//! input unchanged rather than propagating the internal shuffle-window
+//! `ConversionError`. The guard's *error* path is still exercised here by the
+//! `n.`-on-`NM_` case (not classified as intronic-on-bare-transcript), which
+//! continues to return the `ConversionError`; the guard also still fires for
+//! genomic-context forms, where preventing silent mis-normalization matters.
+//!
 //! Fixture geometry (minus strand, `c.`/`n.` notation):
 //!
 //! ```text
@@ -96,6 +106,34 @@ fn expect_conversion_error(provider: MockProvider, input: &str) -> FerroError {
     }
 }
 
+/// Assert warn-only (default) mode echoes a bare intronic form unchanged and
+/// surfaces W4007, rather than propagating the internal shuffle-window error
+/// (#682). The #573 guard still fires internally; for a bare (spec-invalid)
+/// form the actionable W4007 takes precedence and nothing is mis-normalized
+/// because the input is echoed.
+fn expect_w4007_warn_echo(provider: MockProvider, input: &str) {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse should succeed");
+    let out = normalizer.normalize(&variant).unwrap_or_else(|e| {
+        panic!("bare-NM intronic form must warn, not error (#682) for {input:?}, got {e:?}")
+    });
+    assert_eq!(
+        out.to_string(),
+        input,
+        "warn-only mode must echo the bare intronic form unchanged"
+    );
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("diagnostics should succeed in warn-only mode");
+    assert!(
+        diag.warnings
+            .iter()
+            .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+        "expected INTRONIC_ON_BARE_TRANSCRIPT (W4007) for {input:?}, got {:?}",
+        diag.warnings
+    );
+}
+
 /// **Regression — near 5'-donor (`c.20+3`): `intron_g_start` outside the cap
 /// fallback window.**
 ///
@@ -103,19 +141,15 @@ fn expect_conversion_error(provider: MockProvider, input: &str) -> FerroError {
 /// On minus strand, this is at genomic position 69981 - 3 = 69978.
 ///
 /// After the cap fires: `seq_start ≈ 69878`, `seq_end ≈ 70078`.
-/// `intron_g_start = 1021 < seq_start` → guard fires → `ConversionError`.
-///
-/// Before the fix: `saturating_sub(1021, 69878)` = 0, `intron_rel_start` = 1,
-/// the in-window guard in `flip_intronic_for_strand` silently passed,
-/// and minus-strand normalization proceeded with a wrong `boundaries.left`.
+/// `intron_g_start = 1021 < seq_start` → the #573 guard fires internally
+/// (`ConversionError`). Because this is a *bare* `NM_` intronic form, warn-only
+/// (default) mode surfaces W4007 and echoes the input rather than propagating
+/// that error (#682). Before #573 the guard did not exist and minus-strand
+/// normalization silently proceeded with a wrong `boundaries.left`.
 #[test]
-fn near_donor_huge_intron_cds_returns_error() {
+fn near_donor_huge_intron_cds_warns_w4007() {
     let provider = make_huge_intron_fixture();
-    let err = expect_conversion_error(provider, "NM_573TEST.1:c.20+3del");
-    assert!(
-        format!("{err}").contains("intronic shuffle window"),
-        "error should mention 'intronic shuffle window', got: {err}"
-    );
+    expect_w4007_warn_echo(provider, "NM_573TEST.1:c.20+3del");
 }
 
 /// **Regression — near 3'-acceptor (`c.21-3`): `intron_g_end + 1` outside the
@@ -127,25 +161,23 @@ fn near_donor_huge_intron_cds_returns_error() {
 /// After the cap fires: `seq_start ≈ 923`, `seq_end ≈ 1123`.
 /// `intron_g_end + 1 = 69981 > seq_end` → guard fires → `ConversionError`.
 ///
-/// Before the fix: `69980.saturating_sub(923)` = 69057, which produces a
+/// Before #573: `69980.saturating_sub(923)` = 69057, which produces a
 /// relative boundary far past the fetched window length, but the *left*
 /// boundary (`intron_g_start = 1021`) would also be clamped via `saturating_sub`
 /// only if `< seq_start` (here it isn't). The right boundary (69057) is >> seq_len,
 /// so `flip_intronic_for_strand` would have caught it — but the explicit guard
-/// makes the rejection happen earlier with a clearer diagnostic.
+/// makes the rejection happen earlier with a clearer diagnostic. As with the
+/// donor case, warn-only mode now surfaces W4007 + echo for this bare form
+/// instead of the internal `ConversionError` (#682).
 #[test]
-fn near_acceptor_huge_intron_cds_returns_error() {
+fn near_acceptor_huge_intron_cds_warns_w4007() {
     let provider = make_huge_intron_fixture();
-    let err = expect_conversion_error(provider, "NM_573TEST.1:c.21-3del");
-    assert!(
-        format!("{err}").contains("intronic shuffle window"),
-        "error should mention 'intronic shuffle window', got: {err}"
-    );
+    expect_w4007_warn_echo(provider, "NM_573TEST.1:c.21-3del");
 }
 
 /// **`n.` parity — near 5'-donor via `normalize_intronic_tx`.**
 ///
-/// Mirrors `near_donor_huge_intron_cds_returns_error` but uses `n.` notation,
+/// Mirrors `near_donor_huge_intron_cds_warns_w4007` but uses `n.` notation,
 /// which routes through `normalize_intronic_tx` instead of
 /// `normalize_intronic_cds`. Both callers now carry the same guard.
 #[test]


### PR DESCRIPTION
Closes #682.

## Problem

In warn-only (the default) mode, an intronic offset on a bare transcript reference (`NM_` c. / `NR_` n., no `NG_(…)`/`NC_(…)` context) whose normalization *fails to resolve* — e.g. an indel with no genomic sequence to anchor it — propagated a capability `IntronicVariant`/`ConversionError` via `?` and dropped the W4007 (`IntronicOnBareTranscript`) warning entirely. Only reject mode short-circuited before normalization; warn-only did not, so the spec-invalidity of the bare form was hidden behind an internal error. A substitution never reaches the resolution pass (it is echoed), so the gap only showed on the indel / resolve-failure path.

## Fix

Extract the per-kind dispatch into `normalize_dispatch` so `normalize_core` can recover a warn-only EINTRONIC resolve-failure:

- **Success path unchanged** — normalization (3′-shift, W4004, repeat notation) is performed and W4007 attached as an advisory.
- **Resolve-failure path** — for a bare intronic form, echo the input with W4007 instead of propagating the capability error. The spec-invalidity of the form is independent of provider capability (the reject path already short-circuits for this reason). Reject mode is unchanged; silent mode (no warning) propagates the error as before.

This is the HGVS-spec-faithful behavior: a bare intronic description is "not correct" per the spec, so W4007 ("use a genomic reference") is the actionable signal — not an internal "intronic shuffle window" diagnostic.

## Test changes for the behavior shift

The change flips a few tests that pinned the old error-on-resolve-failure behavior for bare intronic forms in warn mode. The #573 huge-intron shuffle-window guard still errors where it matters for correctness (genomic-context forms, and the `n.`-on-`NM_` case, which is not classified as intronic-on-bare-transcript); a bare form is echoed, so nothing is mis-normalized.

- `tests/issue_486_eintronic.rs` — new regression test (`lenient_warns_and_keeps_value_when_intronic_indel_cannot_resolve`).
- `tests/issue_573_intronic_shuffle_window.rs` — the two bare-`c.` cases now assert W4007 + echo; the `n.` case still asserts the `ConversionError` guard.
- `src/normalize/mod.rs` unit test — bare intronic + no genomic data now warns rather than erroring.

## Verification

- Hermetic suites green: `issue_486_eintronic` (9), `issue_573_intronic_shuffle_window` (3), the `normalize` unit test, plus the new regression — 13 tests.
- `cargo fmt` and `cargo clippy --features dev --all-targets` clean.
- Confirmed **no corpus impact**: the mutalyzer/biocommons/hgvs-rs axis divergence outputs are byte-identical between `origin/main` and this branch (the change is logically scoped to bare-transcript intronic resolve-failures). The axis tests that fail locally fail identically on `origin/main` (machine manifest state), unrelated to this change.