### PR TITLE
perf(parse): parallelize the batch CLI loop behind -j/--workers

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -291,6 +291,10 @@ enum Commands {
         /// Output timing information to JSON file
         #[arg(short = 't', long)]
         timing: Option<PathBuf>,
+
+        /// Number of parallel workers (default: 1)
+        #[arg(short = 'j', long, default_value = "1")]
+        workers: usize,
     },
 
     /// Explain an error or warning code
@@ -702,6 +706,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ignore,
             reject,
             timing,
+            workers,
         } => {
             let config = build_error_config(&error_mode, &ignore, &reject);
             run_parse(
@@ -710,6 +715,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 output.as_ref(),
                 &format,
                 timing.as_ref(),
+                workers,
                 &config,
             )
         }
@@ -1484,12 +1490,14 @@ fn run_normalize(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_parse(
     variant: Option<&str>,
     input: Option<&PathBuf>,
     output: Option<&PathBuf>,
     format: &str,
     timing: Option<&PathBuf>,
+    workers: usize,
     error_config: &ErrorConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Instant;
@@ -1506,7 +1514,10 @@ fn run_parse(
     let mut total_count = 0usize;
     let start = Instant::now();
 
-    let process = |v: &str, writer: &mut dyn Write| -> Result<(), FerroError> {
+    // Per-line work, factored so it can run serially or in parallel: `out`
+    // receives the success output (the order-critical stdout/file stream) and
+    // `err` receives text-mode warnings. Mirrors `run_normalize`'s `process`.
+    let process = |v: &str, out: &mut dyn Write, err: &mut dyn Write| -> Result<(), FerroError> {
         // Preprocess input according to error mode
         let preprocess_result = preprocessor.preprocess(v);
         if !preprocess_result.success {
@@ -1540,7 +1551,7 @@ fn run_parse(
                     })
                     .collect();
                 writeln!(
-                    writer,
+                    out,
                     r#"{{"input": "{}", "parsed": "{}", "status": "ok", "corrections": [{}]}}"#,
                     v,
                     parsed,
@@ -1549,15 +1560,17 @@ fn run_parse(
                 .map_err(|e| FerroError::Io { msg: e.to_string() })?;
             }
             _ => {
-                // Print warnings to stderr if any
+                // Emit warnings to the stderr buffer if any
                 for warning in &preprocess_result.warnings {
-                    eprintln!(
+                    writeln!(
+                        err,
                         "warning[{}]: {}",
                         warning.error_type.code(),
                         warning.message
-                    );
+                    )
+                    .map_err(|e| FerroError::Io { msg: e.to_string() })?;
                 }
-                writeln!(writer, "{} -> {}", v, parsed)
+                writeln!(out, "{} -> {}", v, parsed)
                     .map_err(|e| FerroError::Io { msg: e.to_string() })?;
             }
         }
@@ -1565,44 +1578,63 @@ fn run_parse(
     };
 
     if let Some(v) = variant {
+        // Single-variant path: unchanged (no line context, errors via
+        // `output_error`). Warnings go straight to the live stderr.
         total_count += 1;
-        if let Err(e) = process(v, &mut writer) {
+        let mut stderr = io::stderr();
+        if let Err(e) = process(v, &mut writer, &mut stderr) {
             output_error(v, &e, format)?;
             error_count += 1;
         } else {
             success_count += 1;
         }
-    } else if let Some(input_path) = input {
-        let file = std::fs::File::open(input_path)?;
-        let reader = io::BufReader::new(file);
-        for (line_num, line) in reader.lines().enumerate() {
-            let line = line?;
-            let is_first = line_num == 0;
-            if let Some(variant_str) = process_input_line(&line, is_first) {
-                total_count += 1;
-                if let Err(e) = process(variant_str, &mut writer) {
-                    output_error_with_line(variant_str, &e, format, Some(line_num + 1))?;
-                    error_count += 1;
-                } else {
-                    success_count += 1;
-                }
-            }
-        }
     } else {
-        let stdin = io::stdin();
-        for (line_num, line) in stdin.lock().lines().enumerate() {
-            let line = line?;
+        // Batch path (file or stdin): same order-preserving, optionally parallel
+        // driver as `run_normalize`, producing byte-identical output to serial.
+        let format_owned: OutputFormat = format.parse().unwrap_or_default();
+        let item = |line_num: usize, line: &str| -> LineResult {
             let is_first = line_num == 0;
-            if let Some(variant_str) = process_input_line(&line, is_first) {
-                total_count += 1;
-                if let Err(e) = process(variant_str, &mut writer) {
-                    output_error_with_line(variant_str, &e, format, Some(line_num + 1))?;
-                    error_count += 1;
-                } else {
-                    success_count += 1;
+            let Some(variant_str) = process_input_line(line, is_first) else {
+                return LineResult::skipped();
+            };
+            let mut out = Vec::new();
+            let mut err = Vec::new();
+            let status = match process(variant_str, &mut out, &mut err) {
+                Ok(()) => LineStatus::Ok,
+                Err(e) => {
+                    let _ = cli_output_error_with_context(
+                        &mut err,
+                        variant_str,
+                        &e,
+                        format_owned,
+                        Some(line_num + 1),
+                    );
+                    LineStatus::Err
                 }
+            };
+            LineResult {
+                stdout: out,
+                stderr: err,
+                status,
             }
-        }
+        };
+
+        let (t, s, er) = if let Some(input_path) = input {
+            let file = std::fs::File::open(input_path)?;
+            run_batch(
+                io::BufReader::new(file).lines(),
+                &mut writer,
+                workers,
+                &item,
+            )?
+        } else {
+            let stdin = io::stdin();
+            let reader = stdin.lock();
+            run_batch(reader.lines(), &mut writer, workers, &item)?
+        };
+        total_count += t;
+        success_count += s;
+        error_count += er;
     }
 
     let elapsed = start.elapsed();
@@ -2959,23 +2991,6 @@ fn output_error(input: &str, error: &FerroError, format: &str) -> io::Result<()>
         input,
         error,
         format.parse().unwrap_or_default(),
-    )
-}
-
-fn output_error_with_line(
-    input: &str,
-    error: &FerroError,
-    format: &str,
-    line_number: Option<usize>,
-) -> io::Result<()> {
-    let stderr = io::stderr();
-    let mut handle = stderr.lock();
-    cli_output_error_with_context(
-        &mut handle,
-        input,
-        error,
-        format.parse().unwrap_or_default(),
-        line_number,
     )
 }
 

--- a/tests/cli_parallel_parse.rs
+++ b/tests/cli_parallel_parse.rs
@@ -1,0 +1,75 @@
+//! Integration tests for parallel batch `ferro parse` (`-j/--workers`).
+//!
+//! Like the parallel `normalize` tests, the core property is **invariance**:
+//! output must be byte-identical to the serial path regardless of worker count,
+//! including ordering across chunk boundaries. `parse` needs no reference data,
+//! so these tests are pure-CPU and fully self-contained.
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+/// Build an input with `n` distinct variants interleaved with comments and blank
+/// lines (which the driver must skip identically in serial and parallel). `n` is
+/// larger than the driver's chunk size so ordering spans multiple chunks.
+fn write_input(n: usize) -> (NamedTempFile, std::path::PathBuf) {
+    let mut tf = tempfile::Builder::new().suffix(".txt").tempfile().unwrap();
+    for i in 1..=n {
+        if i % 100 == 0 {
+            writeln!(tf, "# comment at {i}").unwrap();
+        }
+        if i % 50 == 0 {
+            writeln!(tf).unwrap();
+        }
+        writeln!(tf, "NM_000088.3:c.{i}A>G").unwrap();
+    }
+    tf.flush().unwrap();
+    let path = tf.path().to_path_buf();
+    (tf, path)
+}
+
+/// Run `ferro parse` over `input` with the given worker count, returning stdout.
+fn run_parse(input: &std::path::Path, workers: usize) -> Vec<u8> {
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args([
+            "parse",
+            "--error-mode",
+            "silent",
+            "-j",
+            &workers.to_string(),
+            "-i",
+            input.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run ferro parse");
+    assert!(
+        out.status.success(),
+        "ferro parse -j{workers} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out.stdout
+}
+
+#[test]
+fn parallel_parse_output_is_byte_identical_to_serial() {
+    let (_keep, path) = write_input(20_000);
+    let serial = run_parse(&path, 1);
+    assert!(!serial.is_empty(), "serial run produced no output");
+    for workers in [2usize, 4, 8] {
+        let parallel = run_parse(&path, workers);
+        assert_eq!(
+            serial, parallel,
+            "parse stdout for -j{workers} differs from serial (-j1)"
+        );
+    }
+}
+
+#[test]
+fn parallel_parse_is_deterministic() {
+    let (_keep, path) = write_input(12_000);
+    let a = run_parse(&path, 8);
+    let b = run_parse(&path, 8);
+    assert_eq!(a, b, "two -j8 parse runs differ (nondeterministic)");
+    assert!(!a.is_empty());
+}


### PR DESCRIPTION
Extends the order-preserving parallel batch driver (added for `ferro normalize` in #687) to `ferro parse`.

> **Stacked on #687** — base branch is `perf/parallel-cli-normalize`. Review/merge #687 first; this PR rebases onto `main` afterward. The diff here is parse-only.

## What changed

- `ferro parse` gains the same `-j/--workers` flag (default **1**, serial — unchanged behavior).
- Its file/stdin batch path now reuses `run_batch`: each line is parsed and formatted into per-line stdout/stderr buffers, written **in input order** — serially, or across a rayon pool when `--workers > 1`. Output is byte-identical to serial by construction.
- Single-variant path untouched.
- Removes the now-unused `output_error_with_line` helper (both batch paths format errors directly into per-line buffers via `cli_output_error_with_context`).

Parse is pure CPU (no reference data or I/O), so it parallelizes cleanly and should scale closer to core count than `normalize` (no shared FASTA/page-cache pressure).

## Correctness

CI integration test (`tests/cli_parallel_parse.rs`, input spanning >2 chunks) asserts `-j{2,4,8}` output equals `-j1` and is deterministic across runs. Verified locally byte-identical on 25k variants; clippy `-D warnings` and fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `ferro parse` command now supports a `--workers` flag for parallel execution
  * Parse error messages include line number context in output

* **Tests**
  * Added integration tests verifying parallel and serial parsing produce identical output with deterministic results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->