### PR TITLE
fix(normalize): correct 1-based↔0-based off-by-one in genomic-shuffle fetch

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4097,6 +4097,48 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
     }
 
+    /// Fetch a genomic window addressed by **1-based inclusive** coordinates.
+    ///
+    /// All genomic coordinates inside the normalizer's intronic / boundary-
+    /// spanning paths are 1-based: `Exon::genomic_start/end` are 1-based, and
+    /// every coordinate derived from them via `CoordinateMapper` (`cds_to_genomic`,
+    /// `cds_to_genomic_with_intron`, `genomic_to_cds_intronic`) is 1-based too.
+    /// `ReferenceProvider::get_genomic_sequence`, by contrast, is **0-based
+    /// half-open** (`seq[start..end]`). Calling it with a 1-based `start` reads
+    /// one base too far in the +forward direction, which silently corrupts the
+    /// homopolymer the shuffle inspects at an exon/intron junction (and only
+    /// there — non-shuffling variants round-trip correctly because
+    /// `new_g = seq_start + rel - 1` cancels the error, which is why this hid
+    /// until minus-strand junction cases like `NM_004992.3:c.378-17del`).
+    ///
+    /// Converting the 1-based inclusive `[start, end]` request to the 0-based
+    /// half-open `[start - 1, end)` the provider expects keeps the callers'
+    /// `rel = g - seq_start + 1` arithmetic correct: the base at 1-based
+    /// `start` lands at index 0 of the returned string.
+    fn get_genomic_sequence_1based(
+        &self,
+        chromosome: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        // Reject an invalid 1-based start. A `start` of 0 has no valid 0-based
+        // index (`start - 1` would saturate to 0 and fetch `[0, end)`), and
+        // because callers derive the relative variant position as
+        // `rel = g - seq_start + 1`, a `seq_start` of 0 would silently shift
+        // every relative coordinate by one. Callers clamp their window starts
+        // to >= 1; this guards the invariant rather than papering over it.
+        if start < 1 {
+            return Err(FerroError::ConversionError {
+                msg: format!(
+                    "invalid 1-based genomic window start {start} on {chromosome} \
+                     (must be >= 1)"
+                ),
+            });
+        }
+        self.provider
+            .get_genomic_sequence(chromosome, start - 1, end)
+    }
+
     /// Normalize an intronic CDS variant
     ///
     /// This converts the intronic position to genomic coordinates, normalizes
@@ -4196,10 +4238,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let (seq_start, seq_end) =
             intronic_window_bounds(g_start, g_end, intron_g_start, intron_g_end, window);
 
-        // Fetch genomic sequence
-        let genomic_seq = self
-            .provider
-            .get_genomic_sequence(chromosome, seq_start, seq_end)?;
+        // Fetch genomic sequence (1-based window; see `get_genomic_sequence_1based`)
+        let genomic_seq = self.get_genomic_sequence_1based(chromosome, seq_start, seq_end)?;
 
         // Calculate the variant position relative to the fetched sequence
         let rel_start = (g_start - seq_start) + 1; // 1-based
@@ -4395,10 +4435,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let (seq_start, seq_end) =
             intronic_window_bounds(g_start, g_end, intron_g_start, intron_g_end, window);
 
-        // Fetch genomic sequence
-        let genomic_seq = self
-            .provider
-            .get_genomic_sequence(chromosome, seq_start, seq_end)?;
+        // Fetch genomic sequence (1-based window; see `get_genomic_sequence_1based`)
+        let genomic_seq = self.get_genomic_sequence_1based(chromosome, seq_start, seq_end)?;
 
         // Calculate the variant position relative to the fetched sequence
         let rel_start = (g_start - seq_start) + 1; // 1-based
@@ -4542,12 +4580,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
         };
 
         // Fetch genomic sequence with window for normalization
+        // (1-based window; see `get_genomic_sequence_1based`).
+        // Clamp to the 1-based minimum: near a contig start `saturating_sub`
+        // can reach 0, which has no valid 1-based coordinate and would shift
+        // the `rel = g - seq_start + 1` arithmetic below.
         let window = self.config.window_size;
-        let seq_start = g_start.saturating_sub(window);
+        let seq_start = g_start.saturating_sub(window).max(1);
         let seq_end = g_end.saturating_add(window);
-        let genomic_seq = self
-            .provider
-            .get_genomic_sequence(chromosome, seq_start, seq_end)?;
+        let genomic_seq = self.get_genomic_sequence_1based(chromosome, seq_start, seq_end)?;
 
         // Calculate relative positions (1-based)
         let rel_start = (g_start - seq_start) + 1;
@@ -6263,10 +6303,15 @@ fn intronic_window_bounds(
     // the far intron edge `intron_g_end` only lands inside the 1-based window
     // when `seq_end > intron_g_end`. Extend one past it.
     let want_end = var_end.max(intron_g_end.saturating_add(1));
+    // Clamp the window start to the 1-based minimum. Near the start of a contig
+    // `saturating_sub(window)` can drive the start to 0, which has no valid
+    // 1-based coordinate and would break the caller's
+    // `rel = g - seq_start + 1` arithmetic (and is rejected by
+    // `get_genomic_sequence_1based`). Clamping to 1 keeps both correct.
     if want_end.saturating_sub(want_start) <= MAX_INTRONIC_SHUFFLE_WINDOW {
-        (want_start, want_end)
+        (want_start.max(1), want_end)
     } else {
-        (var_start, var_end)
+        (var_start.max(1), var_end)
     }
 }
 
@@ -7688,30 +7733,23 @@ mod tests {
     /// - Strand: Plus
     /// - Chromosome: chr1
     ///
-    /// Genomic layout (chr1):
-    /// Position: 1000                   1020  1030                   1050  1060                   1080
-    ///           |-------- Exon 1 ------|      |-------- Exon 2 ------|      |-------- Exon 3 ------|
-    ///           ATGCCCAAAGGGTTTAGGCCC       AAAGGGTTTAGGCCCAAAAAA       GGGTTTAGGCCCAAATGA
-    ///                                 ^^^  ^^^                   ^^^  ^^^
-    ///                              intron 1                   intron 2
+    /// Genomic layout (chr1). Genomic coordinates are 1-based (matching real
+    /// cdot data); the gene region begins at g.1001 (after 1000 bp of padding):
     ///
     /// Transcript positions (tx):
-    /// - Exon 1: tx 1-20 = genomic 1000-1019
-    /// - Intron 1: genomic 1020-1029 (10 bp)
-    /// - Exon 2: tx 21-40 = genomic 1030-1049
-    /// - Intron 2: genomic 1050-1059 (10 bp)
-    /// - Exon 3: tx 41-58 = genomic 1060-1077
+    /// - Exon 1: tx 1-20 = genomic 1001-1020
+    /// - Intron 1: genomic 1021-1030 (10 bp)
+    /// - Exon 2: tx 21-40 = genomic 1031-1050
+    /// - Intron 2: genomic 1051-1060 (10 bp)
+    /// - Exon 3: tx 41-58 = genomic 1061-1078
     ///
     /// CDS: starts at tx 1 (no 5' UTR for simplicity)
     /// CDS positions: c.1 = tx 1, c.20 = tx 20 (last of exon 1), c.21 = tx 21 (first of exon 2)
     ///
-    /// Intron 1 sequence (g.1020-1029): "GTAAGCTAGG" (10 bp)
-    ///   - c.20+1 = g.1020 (G)
-    ///   - c.20+10 = g.1029 (G)
-    ///   - c.21-10 = g.1020 (G)
-    ///   - c.21-1 = g.1029 (G)
+    /// Intron 1 (g.1021-1030): "GTAAGCTAAA" (10 bp)
+    ///   - c.20+1 = g.1021, c.20+10 = c.21-1 = g.1030
     ///
-    /// Intron 2 sequence (g.1050-1059): "GTAAGTAAGG" (10 bp)
+    /// Intron 2 (g.1051-1060): "AAAGTAAGGG" (10 bp)
     fn make_boundary_test_provider() -> MockProvider {
         use crate::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
         use std::sync::OnceLock;
@@ -7730,29 +7768,32 @@ mod tests {
         // Gene region: exon1 + intron1 + exon2 + intron2 + exon3
         // = 20 + 10 + 20 + 10 + 18 = 78bp
         //
-        // Genomic: 900-999 (padding) + 1000-1019 (exon1) + 1020-1029 (intron1) +
-        //          1030-1049 (exon2) + 1050-1059 (intron2) + 1060-1077 (exon3) + 1078+ (padding)
+        // Genomic coordinates are 1-based (matching real cdot data). The 1000-byte
+        // padding occupies 1-based positions 1-1000 (0-based string indices 0-999),
+        // so the gene region begins at 1-based g.1001 (string index 1000):
+        //   exon1 g.1001-1020, intron1 g.1021-1030, exon2 g.1031-1050,
+        //   intron2 g.1051-1060, exon3 g.1061-1078, then trailing padding.
         let mut genomic_seq = String::new();
 
-        // Padding before (positions 0-999, 1000 bytes at 0-based)
+        // Padding before (1-based g.1-1000, 1000 bytes at 0-based indices 0-999)
         for _ in 0..1000 {
             genomic_seq.push('N');
         }
 
-        // Exon 1 (positions 1000-1019, 0-based 1000-1019)
+        // Exon 1 (g.1001-1020)
         genomic_seq.push_str("ATGCCCAAAGGGTTTAGGCC");
 
-        // Intron 1 (positions 1020-1029) - with splice consensus
-        // Note: The intron has AAA at the end (1027-1029) to test shifting
+        // Intron 1 (g.1021-1030) - with splice consensus
+        // Note: The intron has AAA at the end (g.1028-1030) to test shifting
         genomic_seq.push_str("GTAAGCTAAA");
 
-        // Exon 2 (positions 1030-1049)
+        // Exon 2 (g.1031-1050)
         genomic_seq.push_str("AAAGGGTTTAGGCCCAAAAA");
 
-        // Intron 2 (positions 1050-1059) - with AAA at start for testing
+        // Intron 2 (g.1051-1060) - with AAA at start for testing
         genomic_seq.push_str("AAAGTAAGGG");
 
-        // Exon 3 (positions 1060-1077)
+        // Exon 3 (g.1061-1078)
         genomic_seq.push_str("GGGTTTAGGCCCAAATGA");
 
         // Padding after (100 bytes)
@@ -7763,7 +7804,7 @@ mod tests {
         // Add genomic sequence to provider
         provider.add_genomic_sequence("chr1", genomic_seq);
 
-        // Create transcript with exons that have genomic coordinates
+        // Create transcript with exons that have genomic coordinates (1-based)
         provider.add_transcript(Transcript {
             id: "NM_BOUNDARY.1".to_string(),
             gene_symbol: Some("BOUNDARY".to_string()),
@@ -7772,13 +7813,13 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(58),
             exons: vec![
-                Exon::with_genomic(1, 1, 20, 1000, 1019),
-                Exon::with_genomic(2, 21, 40, 1030, 1049),
-                Exon::with_genomic(3, 41, 58, 1060, 1077),
+                Exon::with_genomic(1, 1, 20, 1001, 1020),
+                Exon::with_genomic(2, 21, 40, 1031, 1050),
+                Exon::with_genomic(3, 41, 58, 1061, 1078),
             ],
             chromosome: Some("chr1".to_string()),
-            genomic_start: Some(1000),
-            genomic_end: Some(1077),
+            genomic_start: Some(1001),
+            genomic_end: Some(1078),
             genome_build: Default::default(),
             mane_status: ManeStatus::None,
             refseq_match: None,
@@ -7798,7 +7839,8 @@ mod tests {
     /// content at the gene region is the reverse complement of each exon
     /// (so RC of the genomic plus strand recovers `tx_seq`), and the
     /// exon-to-genomic mapping is reversed: tx 1 maps to the high genomic
-    /// end (g.1077) and tx 58 to the low end (g.1000). Intron 2 is laid
+    /// end (g.1078) and tx 58 to the low end (g.1001). Genomic coordinates are
+    /// 1-based (the 1000-byte padding occupies g.1-1000). Intron 2 is laid
     /// out so that c.40+1..c.40+4 read as `A` in transcript view, putting
     /// the boundary-spanning dup inside the same 5-A tract that the plus
     /// fixture exercises.
@@ -7814,17 +7856,17 @@ mod tests {
         for _ in 0..1000 {
             genomic_seq.push('N');
         }
-        // Exon 3 region (g.1000-1017): RC of tx[41..58] ("GGGTTTAGGCCCAAATGA").
+        // Exon 3 region (g.1001-1018): RC of tx[41..58] ("GGGTTTAGGCCCAAATGA").
         genomic_seq.push_str("TCATTTGGGCCTAAACCC");
-        // Intron 2 (g.1018-1027): the last four bases (g.1024-1027) are 'T',
+        // Intron 2 (g.1019-1028): the last four bases (g.1025-1028) are 'T',
         // so c.40+1..c.40+4 read as 'A' in transcript view, extending the
         // exonic poly-A across the boundary.
         genomic_seq.push_str("AAAGTATTTT");
-        // Exon 2 region (g.1028-1047): RC of tx[21..40] ("AAAGGGTTTAGGCCCAAAAA").
+        // Exon 2 region (g.1029-1048): RC of tx[21..40] ("AAAGGGTTTAGGCCCAAAAA").
         genomic_seq.push_str("TTTTTGGGCCTAAACCCTTT");
-        // Intron 1 (g.1048-1057): mirrors the plus fixture's intron 1 content.
+        // Intron 1 (g.1049-1058): mirrors the plus fixture's intron 1 content.
         genomic_seq.push_str("GTAAGCTAAA");
-        // Exon 1 region (g.1058-1077): RC of tx[1..20] ("ATGCCCAAAGGGTTTAGGCC").
+        // Exon 1 region (g.1059-1078): RC of tx[1..20] ("ATGCCCAAAGGGTTTAGGCC").
         genomic_seq.push_str("GGCCTAAACCCTTTGGGCAT");
         for _ in 0..100 {
             genomic_seq.push('N');
@@ -7840,13 +7882,13 @@ mod tests {
             cds_start: Some(1),
             cds_end: Some(58),
             exons: vec![
-                Exon::with_genomic(1, 1, 20, 1058, 1077),
-                Exon::with_genomic(2, 21, 40, 1028, 1047),
-                Exon::with_genomic(3, 41, 58, 1000, 1017),
+                Exon::with_genomic(1, 1, 20, 1059, 1078),
+                Exon::with_genomic(2, 21, 40, 1029, 1048),
+                Exon::with_genomic(3, 41, 58, 1001, 1018),
             ],
             chromosome: Some("chr1".to_string()),
-            genomic_start: Some(1000),
-            genomic_end: Some(1077),
+            genomic_start: Some(1001),
+            genomic_end: Some(1078),
             genome_build: Default::default(),
             mane_status: ManeStatus::None,
             refseq_match: None,
@@ -7860,10 +7902,66 @@ mod tests {
     }
 
     #[test]
+    fn test_get_genomic_sequence_1based_addresses_one_based_inclusive() {
+        // Regression guard for the intronic/boundary-spanning off-by-one:
+        // `get_genomic_sequence_1based` must treat its `[start, end]` as 1-based
+        // inclusive, mapping the base at 1-based position `p` to 0-based index
+        // `p - 1` of the underlying 0-based-half-open provider. Dropping the
+        // `-1` conversion (the original bug) silently reads one base too far in
+        // the +forward direction, corrupting the homopolymer the shuffle
+        // inspects at an exon/intron junction (e.g. NM_004992.3:c.378-17del).
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("chrX", "ACGTACGTTT");
+        let normalizer = Normalizer::new(provider);
+
+        // 1-based position 1 is the first base.
+        assert_eq!(
+            normalizer
+                .get_genomic_sequence_1based("chrX", 1, 1)
+                .unwrap(),
+            "A"
+        );
+        // 1-based inclusive [1, 4] spans the first four bases.
+        assert_eq!(
+            normalizer
+                .get_genomic_sequence_1based("chrX", 1, 4)
+                .unwrap(),
+            "ACGT"
+        );
+        // An interior window: 1-based inclusive [5, 7].
+        assert_eq!(
+            normalizer
+                .get_genomic_sequence_1based("chrX", 5, 7)
+                .unwrap(),
+            "ACG"
+        );
+        // A single interior base: 1-based position 4 is 'T'.
+        assert_eq!(
+            normalizer
+                .get_genomic_sequence_1based("chrX", 4, 4)
+                .unwrap(),
+            "T"
+        );
+
+        // A 1-based start of 0 is invalid and must be rejected rather than
+        // silently fetching `[0, end)` from index 0. Near a contig start the
+        // window math can drive `seq_start` to 0; callers clamp to 1, and this
+        // guard ensures a stray 0 surfaces a clear error instead of shifting
+        // every `rel = g - seq_start + 1` coordinate by one.
+        assert!(
+            matches!(
+                normalizer.get_genomic_sequence_1based("chrX", 0, 4),
+                Err(FerroError::ConversionError { .. })
+            ),
+            "1-based start of 0 must be rejected"
+        );
+    }
+
+    #[test]
     fn test_boundary_spanning_exonic_to_intronic_del() {
         // Test: c.20_20+3del - deletion from last exon base into intron
-        // c.20 = last base of exon 1 (C at g.1019)
-        // c.20+3 = 3rd intronic base (A at g.1022)
+        // c.20 = last base of exon 1 (C at g.1020)
+        // c.20+3 = 3rd intronic base (A at g.1023)
         // Deletes: C (exonic) + GTA (intronic) = 4 bases
         //
         // This should normalize without error (using genomic space)
@@ -7890,11 +7988,11 @@ mod tests {
     #[test]
     fn test_boundary_spanning_intronic_to_exonic_del() {
         // Test: c.21-3_23del - deletion from intron into exon
-        // c.21-3 = 3rd base before exon 2 (A at g.1027)
-        // c.23 = 3rd base of exon 2 (A at g.1032)
+        // c.21-3 = 3rd base before exon 2 (A at g.1028)
+        // c.23 = 3rd base of exon 2 (A at g.1033)
         // Deletes: AAA (intronic) + AAA (exonic) = 6 bases
         //
-        // The intron ends with AAA (g.1027-1029) and exon starts with AAA (g.1030-1032)
+        // The intron ends with AAA (g.1028-1030) and exon starts with AAA (g.1031-1033)
         // This is a repeat, so normalization might shift
         let provider = make_boundary_test_provider();
         let normalizer = Normalizer::new(provider);
@@ -7953,8 +8051,8 @@ mod tests {
     #[test]
     fn test_boundary_splice_site_minus1() {
         // Test: c.21-1_22del - deletion of splice acceptor + first exon bases
-        // c.21-1 = last intronic base before exon 2 (A at g.1029)
-        // c.22 = 2nd base of exon 2 (A at g.1031)
+        // c.21-1 = last intronic base before exon 2 (A at g.1030)
+        // c.22 = 2nd base of exon 2 (A at g.1032)
         let provider = make_boundary_test_provider();
         let normalizer = Normalizer::new(provider);
 
@@ -8481,11 +8579,11 @@ mod tests {
 
         let mut provider = MockProvider::new();
 
-        // Create transcript: 2 exons with an intron in between
-        // Exon 1: tx 1-100, genomic 1000-1099
-        // Intron: genomic 1100-1199
-        // Exon 2: tx 101-200, genomic 1200-1299
-        // Sequence in the intron around position 1100+: AAAA... (for shifting test)
+        // Create transcript: 2 exons with an intron in between (1-based genomic)
+        // Exon 1: tx 1-100, genomic 1001-1100
+        // Intron: genomic 1101-1200
+        // Exon 2: tx 101-200, genomic 1201-1300
+        // Sequence in the intron around position 1101+: AAAA... (for shifting test)
         let tx_sequence = "A".repeat(200);
 
         provider.add_transcript(Transcript {
@@ -8496,12 +8594,12 @@ mod tests {
             cds_start: None,
             cds_end: None,
             exons: vec![
-                Exon::with_genomic(1, 1, 100, 1000, 1099),
-                Exon::with_genomic(2, 101, 200, 1200, 1299),
+                Exon::with_genomic(1, 1, 100, 1001, 1100),
+                Exon::with_genomic(2, 101, 200, 1201, 1300),
             ],
             chromosome: Some("chr1".to_string()),
-            genomic_start: Some(1000),
-            genomic_end: Some(1299),
+            genomic_start: Some(1001),
+            genomic_end: Some(1300),
             genome_build: GenomeBuild::GRCh38,
             mane_status: ManeStatus::None,
             refseq_match: None,
@@ -8511,8 +8609,8 @@ mod tests {
             cached_introns: std::sync::OnceLock::new(),
         });
 
-        // Add genomic sequence for chr1 around positions 1000-1299
-        // Make the intron region (1100-1199) be "AGCT" repeated to test shifting
+        // Add genomic sequence for chr1 around 1-based positions 1001-1300
+        // Make the intron region (g.1101-1200) be "AGCT" repeated to test shifting
         let mut genomic = String::new();
         for _ in 0..325 {
             genomic.push_str("AGCT");
@@ -8581,6 +8679,21 @@ mod tests {
         assert_eq!(
             intronic_window_bounds(1_000_000, 1_000_010, 1, 5_000_000, 100),
             (999_900, 1_000_110)
+        );
+
+        // Near the start of a contig the window start is clamped to the 1-based
+        // minimum: `g_start - window` (and the intron-extended `want_start`)
+        // would otherwise saturate to 0, which has no valid 1-based coordinate
+        // and breaks the caller's `rel = g - seq_start + 1` arithmetic.
+        // Variant near the contig start, intron entirely to the right.
+        let (s_near, _) = intronic_window_bounds(50, 60, 40, 200, 100);
+        assert_eq!(s_near, 1, "window start near contig start must clamp to 1");
+        // Cap-fallback path also clamps: a huge intron forces the variant-sized
+        // window, whose start (`g_start - window`) still underflows to 0 here.
+        let (s_cap, _) = intronic_window_bounds(50, 60, 1, 5_000_000, 100);
+        assert_eq!(
+            s_cap, 1,
+            "cap-fallback window start near contig start must clamp to 1"
         );
     }
 

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -49,13 +49,15 @@ const PAD_OFFSET: u64 = 256;
 
 /// Build a minus-strand, 3-exon transcript with genomic coordinates and introns.
 ///
-/// Transcript layout (in coding / transcript order):
+/// Genomic coordinates are 1-based (matching real cdot data): the core region's
+/// first base is at 1-based position `p = PAD_OFFSET + 1`. Transcript layout (in
+/// coding / transcript order):
 ///
-///   Exon 1: tx 1-30    genomic (PAD+80)–(PAD+109)
-///   Intron 1:           genomic (PAD+70)–(PAD+79)  GGGCCCTTTG
-///   Exon 2: tx 31-60   genomic (PAD+40)–(PAD+69)
-///   Intron 2:           genomic (PAD+30)–(PAD+39)  AAATTTAAAT
-///   Exon 3: tx 61-90   genomic (PAD+0)–(PAD+29)
+///   Exon 1: tx 1-30    genomic (p+80)–(p+109)
+///   Intron 1:           genomic (p+70)–(p+79)  GGGCCCTTTG
+///   Exon 2: tx 31-60   genomic (p+40)–(p+69)
+///   Intron 2:           genomic (p+30)–(p+39)  AAATTTAAAT
+///   Exon 3: tx 61-90   genomic (p+0)–(p+29)
 ///
 /// On minus strand, exon 1 (coding start) maps to rightmost genomic block.
 fn make_minus_strand_transcript() -> (Transcript, String) {
@@ -74,7 +76,7 @@ fn make_minus_strand_transcript() -> (Transcript, String) {
                    GCATGCATGCATGCATGCATGCATGCATGC\
                    TGCATGCATGCATGCATGCATGCATGCATG";
 
-    let p = PAD_OFFSET; // shorthand
+    let p = PAD_OFFSET + 1; // shorthand
     let transcript = Transcript::new(
         "NM_MINUS.1".to_string(),
         Some("MINUSGENE".to_string()),
@@ -101,12 +103,13 @@ fn make_minus_strand_transcript() -> (Transcript, String) {
 
 /// Build a plus-strand, 3-exon transcript with genomic mapping for comparison.
 ///
+/// Genomic coordinates are 1-based; the core's first base is at `p = PAD_OFFSET + 1`.
 /// Transcript layout:
-///   Exon 1: tx 1-30   genomic (PAD+0)–(PAD+29)
-///   Intron 1:          genomic (PAD+30)–(PAD+39)  AAACCCAAAT
-///   Exon 2: tx 31-60  genomic (PAD+40)–(PAD+69)
-///   Intron 2:          genomic (PAD+70)–(PAD+79)  GGGTTTTTTG
-///   Exon 3: tx 61-90  genomic (PAD+80)–(PAD+109)
+///   Exon 1: tx 1-30   genomic (p+0)–(p+29)
+///   Intron 1:          genomic (p+30)–(p+39)  AAACCCAAAT
+///   Exon 2: tx 31-60  genomic (p+40)–(p+69)
+///   Intron 2:          genomic (p+70)–(p+79)  GGGTTTTTTG
+///   Exon 3: tx 61-90  genomic (p+80)–(p+109)
 fn make_plus_strand_transcript() -> (Transcript, String) {
     let core = "ATGCATGCATGCATGCATGCATGCATGCAT\
                 AAACCCAAAT\
@@ -119,7 +122,7 @@ fn make_plus_strand_transcript() -> (Transcript, String) {
                    GCATGCATGCATGCATGCATGCATGCATGC\
                    CATGCATGCATGCATGCATGCATGCATGCA";
 
-    let p = PAD_OFFSET;
+    let p = PAD_OFFSET + 1;
     let transcript = Transcript::new(
         "NM_PLUS.1".to_string(),
         Some("PLUSGENE".to_string()),
@@ -146,12 +149,13 @@ fn make_plus_strand_transcript() -> (Transcript, String) {
 
 /// Build a minus-strand transcript with UTR regions and genomic mapping.
 ///
+/// Genomic coordinates are 1-based; the core's first base is at `p = PAD_OFFSET + 1`.
 /// Layout (minus strand, genomic left-to-right):
-///   Exon 3: genomic (PAD+0)–(PAD+19)    tx 51-70
-///   Intron 2: genomic (PAD+20)–(PAD+29)  GGGGGGGGGG
-///   Exon 2: genomic (PAD+30)–(PAD+54)   tx 26-50
-///   Intron 1: genomic (PAD+55)–(PAD+64)  TTTTTTTTTT
-///   Exon 1: genomic (PAD+65)–(PAD+89)   tx 1-25
+///   Exon 3: genomic (p+0)–(p+19)    tx 51-70
+///   Intron 2: genomic (p+20)–(p+29)  GGGGGGGGGG
+///   Exon 2: genomic (p+30)–(p+54)   tx 26-50
+///   Intron 1: genomic (p+55)–(p+64)  TTTTTTTTTT
+///   Exon 1: genomic (p+65)–(p+89)   tx 1-25
 ///   CDS: tx 6-65
 fn make_minus_strand_utr_transcript() -> (Transcript, String) {
     let core = "TTTTTGCATGCATGCATGCAT\
@@ -166,7 +170,7 @@ fn make_minus_strand_utr_transcript() -> (Transcript, String) {
                    GCATGCATGCATGCATGCATGCATGC\
                    ATGCATGCATGCATGCAAAAA";
 
-    let p = PAD_OFFSET;
+    let p = PAD_OFFSET + 1;
     let transcript = Transcript::new(
         "NM_MUTR.1".to_string(),
         Some("MUTRGENE".to_string()),

--- a/tests/issue_209_repeat_3prime_remaining.rs
+++ b/tests/issue_209_repeat_3prime_remaining.rs
@@ -107,11 +107,11 @@ fn rc(seq: &str) -> String {
 mod intronic_plus_strand {
     use super::*;
 
-    /// 2-exon plus-strand transcript layout (`p = PAD_OFFSET`; coordinates
-    /// follow ferro's 0-indexed genomic convention, i.e. `Exon::with_genomic`
-    /// takes the same numbering as the slice indices in
-    /// `MockProvider::get_genomic_sequence` — exon 1 spans bytes `[p, p+30)`
-    /// of the genomic sequence):
+    /// 2-exon plus-strand transcript layout (`p = PAD_OFFSET + 1`; genomic
+    /// coordinates are 1-based, matching real cdot data — `Exon::with_genomic`
+    /// genomic positions are 1-based HGVS positions, so the first core base
+    /// (0-based slice index `PAD_OFFSET`) is at 1-based genomic position
+    /// `p = PAD_OFFSET + 1`; exon 1 spans 1-based `[p, p+29]`):
     /// ```text
     ///   Exon 1: tx 1-30   genomic p    .. p+29
     ///   Intron 1 (30 bp): genomic p+30 .. p+59
@@ -129,7 +129,7 @@ mod intronic_plus_strand {
         let core = format!("{}{}{}", exon1, intron_content, exon2);
         let genomic = format!("{}{}{}", PAD, core, PAD);
 
-        let p = PAD_OFFSET;
+        let p = PAD_OFFSET + 1;
         let tx_seq = format!("{}{}", exon1, exon2);
         let transcript = Transcript::new(
             "NM_INTRON.1".to_string(),
@@ -286,7 +286,7 @@ mod intronic_minus_strand {
         let core = format!("{}{}{}", exon2_genomic, intron_genomic, exon1_genomic);
         let genomic = format!("{}{}{}", PAD, core, PAD);
 
-        let p = PAD_OFFSET;
+        let p = PAD_OFFSET + 1;
         let tx_seq = format!("{}{}", exon1_tx_view, exon2_tx_view);
         let transcript = Transcript::new(
             "NM_MINTRON.1".to_string(),
@@ -297,7 +297,7 @@ mod intronic_minus_strand {
             Some(60),
             vec![
                 // Exon 1 (coding start) maps to the rightmost genomic block.
-                // 0-indexed genomic ranges, following ferro's convention.
+                // 1-based genomic ranges (matching real cdot data).
                 Exon::with_genomic(1, 1, 30, p + 60, p + 89),
                 Exon::with_genomic(2, 31, 60, p, p + 29),
             ],
@@ -367,7 +367,7 @@ mod utr_5prime {
         let core = format!("{}{}", utr5, cds);
         let genomic = format!("{}{}{}", PAD, core, PAD);
 
-        let p = PAD_OFFSET;
+        let p = PAD_OFFSET + 1;
         let tx_seq = format!("{}{}", utr5, cds);
         let transcript = Transcript::new(
             "NM_UTR5.1".to_string(),
@@ -376,7 +376,7 @@ mod utr_5prime {
             tx_seq,
             Some(31), // CDS starts at tx 31 → c.1
             Some(60), // CDS ends at tx 60 → c.30
-            // 0-indexed genomic range: 60 bases at [p, p+60).
+            // 1-based genomic range: 60 bases at [p, p+60).
             vec![Exon::with_genomic(1, 1, 60, p, p + 59)],
             Some("chr_utr5".to_string()),
             Some(p),
@@ -430,7 +430,7 @@ mod utr_3prime {
         let core = format!("{}{}", cds, utr3);
         let genomic = format!("{}{}{}", PAD, core, PAD);
 
-        let p = PAD_OFFSET;
+        let p = PAD_OFFSET + 1;
         let tx_seq = format!("{}{}", cds, utr3);
         let transcript = Transcript::new(
             "NM_UTR3.1".to_string(),
@@ -439,7 +439,7 @@ mod utr_3prime {
             tx_seq,
             Some(1),
             Some(30),
-            // 0-indexed genomic range: 60 bases at [p, p+60).
+            // 1-based genomic range: 60 bases at [p, p+60).
             vec![Exon::with_genomic(1, 1, 60, p, p + 59)],
             Some("chr_utr3".to_string()),
             Some(p),
@@ -485,7 +485,7 @@ mod cds_proper_still_gates {
     fn make_provider() -> MockProvider {
         let tx = "GCCAAAAACCGGTACCGGTACCGGTACCGT"; // 30 bp; A[5] at tx 4..8
         let genomic = format!("{}{}{}", PAD, tx, PAD);
-        let p = PAD_OFFSET;
+        let p = PAD_OFFSET + 1;
         let transcript = Transcript::new(
             "NM_CDSP.1".to_string(),
             Some("CDSPGENE".to_string()),
@@ -493,7 +493,7 @@ mod cds_proper_still_gates {
             tx.to_string(),
             Some(1),
             Some(30),
-            // 0-indexed genomic range: 30 bases at [p, p+30).
+            // 1-based genomic range: 30 bases at [p, p+30).
             vec![Exon::with_genomic(1, 1, 30, p, p + 29)],
             Some("chr_cdsp".to_string()),
             Some(p),

--- a/tests/issue_214_repeat_unit_divides.rs
+++ b/tests/issue_214_repeat_unit_divides.rs
@@ -388,8 +388,9 @@ mod c_utr {
     ///   tx 31..=60  CDS proper
     ///   tx 61..=90  3' UTR
     ///
-    /// Genomic mapping: 1:1 onto the padded genomic sequence starting at
-    /// `PAD_OFFSET`. So tx pos 6 ↔ genomic pos (PAD_OFFSET + 5).
+    /// Genomic mapping: 1:1 onto the padded genomic sequence. Genomic coords are
+    /// 1-based, so tx pos 1 ↔ genomic `PAD_OFFSET + 1` and tx pos 6 ↔ genomic
+    /// `PAD_OFFSET + 6`.
     fn provider_with_utr_g6() -> MockProvider {
         let utr5 = "AAAAA".to_string() + "GGGGGG" + "AAAAAAAAAAAAAAAAAAA"; // 5+6+19 = 30
         let cds = "ATGAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(); // 30 bp, in-frame
@@ -407,10 +408,16 @@ mod c_utr {
             tx_seq,
             Some(31),
             Some(60),
-            vec![Exon::with_genomic(1, 1, 90, PAD_OFFSET, PAD_OFFSET + 89)],
+            vec![Exon::with_genomic(
+                1,
+                1,
+                90,
+                PAD_OFFSET + 1,
+                PAD_OFFSET + 90,
+            )],
             Some("chr_utr".to_string()),
-            Some(PAD_OFFSET),
-            Some(PAD_OFFSET + 89),
+            Some(PAD_OFFSET + 1),
+            Some(PAD_OFFSET + 90),
             GenomeBuild::GRCh38,
             ManeStatus::None,
             None,
@@ -459,10 +466,16 @@ mod c_utr {
             tx_seq,
             Some(31),
             Some(60),
-            vec![Exon::with_genomic(1, 1, 90, PAD_OFFSET, PAD_OFFSET + 89)],
+            vec![Exon::with_genomic(
+                1,
+                1,
+                90,
+                PAD_OFFSET + 1,
+                PAD_OFFSET + 90,
+            )],
             Some("chr_utr".to_string()),
-            Some(PAD_OFFSET),
-            Some(PAD_OFFSET + 89),
+            Some(PAD_OFFSET + 1),
+            Some(PAD_OFFSET + 90),
             GenomeBuild::GRCh38,
             ManeStatus::None,
             None,
@@ -499,11 +512,12 @@ mod c_intronic_plus_strand {
     /// `AT[4]`-shaped tract — `ATATATAT` at intronic positions
     /// c.30+1..=c.30+8.
     ///
-    /// Layout (plus strand, two exons + one intron):
-    ///   Exon 1: tx 1..=30  ↔ genomic (PAD..=PAD+29)
-    ///   Intron 1:           genomic (PAD+30..=PAD+39)   — 10 bp,
+    /// Layout (plus strand, two exons + one intron; genomic coords 1-based,
+    /// so `p = PAD_OFFSET + 1` is the first core base):
+    ///   Exon 1: tx 1..=30  ↔ genomic (p..=p+29)
+    ///   Intron 1:           genomic (p+30..=p+39)   — 10 bp,
     ///                       seeded with `ATATATATGG`
-    ///   Exon 2: tx 31..=60 ↔ genomic (PAD+40..=PAD+69)
+    ///   Exon 2: tx 31..=60 ↔ genomic (p+40..=p+69)
     fn provider_with_intronic_at4() -> MockProvider {
         let exon1 = "ATGCATGCATGCATGCATGCATGCATGCAT"; // 30 bp
         let intron = "ATATATATGG"; // 10 bp, `AT` tract followed by `GG`
@@ -514,7 +528,7 @@ mod c_intronic_plus_strand {
         let tx_seq = format!("{}{}", exon1, exon2);
         assert_eq!(tx_seq.len(), 60);
 
-        let p_off = PAD_OFFSET;
+        let p_off = PAD_OFFSET + 1;
         let transcript = Transcript::new(
             "NM_INTRON.1".to_string(),
             Some("INTRONGENE".to_string()),
@@ -599,7 +613,8 @@ mod c_intronic_plus_strand {
 mod c_intronic_minus_strand {
     use super::*;
 
-    /// Plus-strand intron contains `CCCCATATAT` at genomic (PAD+30..=PAD+39).
+    /// Plus-strand intron contains `CCCCATATAT` at genomic (p+30..=p+39),
+    /// where `p = PAD_OFFSET + 1` (genomic coords are 1-based).
     /// Reverse-complemented to transcript view, the intron looks like
     /// `ATATATGGGG` — so transcript-view AT[3] sits at intronic positions
     /// c.30+1..=c.30+6 (note: minus-strand intronic numbering puts +1 at
@@ -623,7 +638,7 @@ mod c_intronic_minus_strand {
         let tx_seq = format!("{}{}", tx_e1, tx_e2);
         assert_eq!(tx_seq.len(), 60);
 
-        let p_off = PAD_OFFSET;
+        let p_off = PAD_OFFSET + 1;
         let transcript = Transcript::new(
             "NM_MINTRON.1".to_string(),
             Some("MINTRONGENE".to_string()),
@@ -742,7 +757,7 @@ mod n_noncoding {
             .to_string();
         assert_eq!(tx_seq.len(), 60);
 
-        let p_off = PAD_OFFSET;
+        let p_off = PAD_OFFSET + 1;
         let padded_seq = padded(&tx_seq);
 
         let transcript = Transcript::new(

--- a/tests/issue_486_eintronic.rs
+++ b/tests/issue_486_eintronic.rs
@@ -23,7 +23,7 @@ fn provider_intronic_nm() -> MockProvider {
     let exon2 = "AAACAACATGGAAAAAAAAAAAAAAAAAAA"; // 30 bp
     let core = format!("{}{}{}", exon1, intron, exon2);
     let tx_seq = format!("{}{}", exon1, exon2);
-    let p_off = PAD_OFFSET;
+    let p_off = PAD_OFFSET + 1;
     let transcript = Transcript::new(
         "NM_INTRON.1".to_string(),
         Some("INTRONGENE".to_string()),

--- a/tests/issue_97_utr_del_position.rs
+++ b/tests/issue_97_utr_del_position.rs
@@ -29,7 +29,7 @@ fn make_minus_strand_utr_fixture() -> MockProvider {
 
     let tx_seq = "AAAAATGCATGCATGCATGCAAAAA";
 
-    let p = PAD_OFFSET;
+    let p = PAD_OFFSET + 1;
     let transcript = Transcript::new(
         "NM_MUTR.1".to_string(),
         Some("MUTRGENE".to_string()),

--- a/tests/issue_98_minus_strand_intronic_orientation.rs
+++ b/tests/issue_98_minus_strand_intronic_orientation.rs
@@ -31,7 +31,7 @@ fn make_minus_strand_fixture() -> MockProvider {
                    GCATGCATGCATGCATGCATGCATGCATGC\
                    TGCATGCATGCATGCATGCATGCATGCATG";
 
-    let p = PAD_OFFSET;
+    let p = PAD_OFFSET + 1;
     let transcript = Transcript::new(
         "NM_MINUS.1".to_string(),
         Some("MINUSGENE".to_string()),

--- a/tests/normalize_tests.rs
+++ b/tests/normalize_tests.rs
@@ -4973,13 +4973,15 @@ mod ng_prefix_normalization {
     fn boundary_spanning_del_with_ng_parent_succeeds() {
         let provider = mock_provider_with_intronic_transcript();
         let normalizer = Normalizer::new(provider);
-        // c.10_10+5del: last exonic base of exon 1 (an `A` from "ACGTACGTAC")
-        // + first 5 intronic bases (all `A` in the 50-A run). The deleted
-        // 6-base `A` stretch lives in a homopolymer that extends to the
-        // last intronic A (g.1060). 3'-shifted, the range becomes c.10_11-1
-        // and the edit canonicalizes to a repeat-notation `A[45]` (45 A's
-        // remain after the 6 are removed; the original `c.10` A merges with
-        // the 50 intronic A's into a 51-A stretch).
+        // c.10_10+5del: last exonic base of exon 1 (a `C`, the 10th base of
+        // "ACGTACGTAC" at g.1010) + the first 5 intronic bases (all `A` in the
+        // 50-A run, g.1011-1015). The deleted stretch is `C` followed by five
+        // `A`s. The exonic `C` is NOT part of the intronic A-homopolymer, and a
+        // deletion can 3'-shift only if its first base equals the base
+        // immediately following the deletion (`C` != the following `A`), so the
+        // canonical form does not shift: `c.10_10+5del`. (Before the 1-based
+        // genomic-fetch fix the engine misread g.1010 as the intron's first `A`,
+        // merging it into the run and emitting the spurious `c.10_11-1A[45]`.)
         let variant = parse_hgvs("NG_012772.1(NM_TEST.1):c.10_10+5del")
             .expect("NG-parented boundary-spanning input must parse");
         let normalized = normalizer
@@ -4987,8 +4989,8 @@ mod ng_prefix_normalization {
             .expect("boundary-spanning normalize with NG parent must succeed");
         let rendered = format!("{}", normalized);
         assert_eq!(
-            rendered, "NG_012772.1(NM_TEST.1):c.10_11-1A[45]",
-            "expected 3'-shifted boundary-spanning result c.10_11-1A[45]; got {}",
+            rendered, "NG_012772.1(NM_TEST.1):c.10_10+5del",
+            "expected boundary-spanning result c.10_10+5del (exonic C does not 3'-shift into the intronic A-run); got {}",
             rendered
         );
     }


### PR DESCRIPTION
Closes #689. Refs #487.

The intronic and boundary-spanning normalization paths address genomic sequence with 1-based coordinates (`Exon.genomic_start/end` and everything derived from them via `CoordinateMapper`), but `ReferenceProvider::get_genomic_sequence` is 0-based half-open. The three fetch sites passed the 1-based window straight through, so the shuffle read one base too far in the +forward direction. The error cancels for non-shuffling variants (the genomic round-trip `new_g = seq_start + rel - 1` restores the original position), so it only surfaced when the 3′ shuffle inspected the homopolymer at an exon/intron junction — most visibly on minus-strand intronic variants.

## Fix

Route all three fetch sites (`normalize_intronic_cds`, the `n.` intronic path, `normalize_boundary_spanning_cds`) through a `get_genomic_sequence_1based` helper that converts the 1-based inclusive window to the 0-based half-open range the provider expects. A contract test locks the convention (verified to fail under the old behavior).

## Test-fixture migration (the reason this wasn't caught before)

The `MockProvider` intronic/boundary fixtures encoded a **0-based** genomic convention that only ever matched the buggy fetch — so the unit suite never exercised the real 1-based convention. Every such fixture is migrated to 1-based (`p = PAD_OFFSET + 1` in the affected `tests/` files, plus the in-crate `make_boundary_test_provider{,_minus}` and `test_normalize_tx_intronic` fixtures), with layout/convention doc comments updated. Expected values are unchanged except `ng_prefix_normalization::boundary_spanning_del_with_ng_parent_succeeds`, whose prior expectation (`c.10_11-1A[45]`) reflected the bug — the engine misread the exonic `c.10` 'C' as an intronic 'A'; the correct result is `c.10_10+5del` (the exonic C does not 3′-shift into the intronic A-run).

## Impact

- mutalyzer `normalized` axis (reference-gated): 133→135 pass / 85→83 FAIL — fixes `NM_004992.3:c.378-17del` and `NM_206933.2:c.8682-19dup`; **0 regressions**, all other conformance axes unchanged.
- Full local non-conformance suite: green (the single `hgvs_rs_projection_tests::axis_protein_description` failure is pre-existing on `main` and manifest-gated). clippy + fmt clean.