### PR TITLE
perf(python): parallelize the batch API and release the GIL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,9 @@ default = []
 dhat-heap = ["dep:dhat"]
 parallel = ["dep:rayon"]
 validation = ["dep:ahash"]
-python = ["dep:pyo3"]
+# The Python batch API parallelizes across a rayon pool, so the `parallel`
+# (rayon) feature is pulled in whenever the bindings are built.
+python = ["dep:pyo3", "parallel"]
 # memmap2 is now an unconditional dependency (used by the cdot rkyv loader);
 # this feature is retained as a no-op for compatibility with callers that
 # still pass `--features mmap`.

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -904,12 +904,28 @@ class BatchProcessor:
         """
         ...
 
-    def parse(self, variants: list[str]) -> BatchResult:
-        """Parse multiple HGVS strings."""
+    def parse(self, variants: list[str], workers: int = 0) -> BatchResult:
+        """Parse multiple HGVS strings in parallel (GIL released).
+
+        The returned BatchResult preserves the order of the input variants
+        regardless of the worker count used.
+
+        Args:
+            variants: HGVS strings to parse.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+        """
         ...
 
-    def parse_and_normalize(self, variants: list[str]) -> BatchResult:
-        """Parse and normalize multiple HGVS strings."""
+    def parse_and_normalize(self, variants: list[str], workers: int = 0) -> BatchResult:
+        """Parse and normalize multiple HGVS strings in parallel (GIL released).
+
+        The returned BatchResult preserves the order of the input variants
+        regardless of the worker count used.
+
+        Args:
+            variants: HGVS strings to parse and normalize.
+            workers: Worker threads. 0 (default) uses all cores; 1 is serial; N uses N threads.
+        """
         ...
 
     def parse_with_progress(

--- a/src/batch/processor.rs
+++ b/src/batch/processor.rs
@@ -450,6 +450,95 @@ impl<P: ReferenceProvider> BatchProcessor<P> {
     }
 }
 
+/// Parallel batch processing. Each input is independent, so the batch is mapped
+/// across a rayon pool; `rayon`'s ordered `collect` preserves input order, so
+/// results are identical to the serial methods (same order, same per-item
+/// success/error classification). Requires the provider to be `Sync`.
+///
+/// `num_threads` semantics: `0` uses rayon's global pool (all available cores),
+/// `1` runs serially (no pool, no fan-out overhead), and `N > 1` runs on a
+/// dedicated pool of `N` threads. These have no progress-callback variants —
+/// ordered progress under parallelism is ill-defined; use the serial
+/// `*_with_progress` methods when a callback is needed.
+#[cfg(feature = "parallel")]
+impl<P: ReferenceProvider + Sync> BatchProcessor<P> {
+    /// Parse multiple HGVS strings in parallel. Order-preserving; equivalent to
+    /// [`parse`](Self::parse) but spread across `num_threads` workers.
+    pub fn parse_parallel<S: AsRef<str> + Sync>(
+        &self,
+        variants: &[S],
+        num_threads: usize,
+    ) -> BatchResult<HgvsVariant> {
+        let start = Instant::now();
+        let map = |input: &S| match parse_hgvs(input.as_ref()) {
+            Ok(v) => ItemResult::Ok(v),
+            Err(error) => ItemResult::Err {
+                input: Some(input.as_ref().to_string()),
+                error,
+            },
+        };
+        let results = self.map_collect(variants, num_threads, map);
+        BatchResult::new(results, start.elapsed())
+    }
+
+    /// Parse and normalize multiple HGVS strings in parallel. Order-preserving;
+    /// equivalent to [`parse_and_normalize`](Self::parse_and_normalize) but
+    /// spread across `num_threads` workers.
+    pub fn parse_and_normalize_parallel<S: AsRef<str> + Sync>(
+        &self,
+        variants: &[S],
+        num_threads: usize,
+    ) -> BatchResult<HgvsVariant> {
+        let start = Instant::now();
+        let map = |input: &S| match parse_hgvs(input.as_ref())
+            .and_then(|v| self.normalizer.normalize(&v))
+        {
+            Ok(normalized) => ItemResult::Ok(normalized),
+            Err(error) => ItemResult::Err {
+                input: Some(input.as_ref().to_string()),
+                error,
+            },
+        };
+        let results = self.map_collect(variants, num_threads, map);
+        BatchResult::new(results, start.elapsed())
+    }
+
+    /// Map `f` over `variants`, preserving order. Serial for `num_threads == 1`,
+    /// the global rayon pool for `0`, or a dedicated `num_threads`-thread pool
+    /// otherwise (falling back to the global pool if one can't be built).
+    fn map_collect<S, F>(
+        &self,
+        variants: &[S],
+        num_threads: usize,
+        f: F,
+    ) -> Vec<ItemResult<HgvsVariant>>
+    where
+        S: AsRef<str> + Sync,
+        F: Fn(&S) -> ItemResult<HgvsVariant> + Sync + Send,
+    {
+        use rayon::prelude::*;
+        if num_threads == 1 {
+            return variants.iter().map(f).collect();
+        }
+        if num_threads == 0 {
+            return variants.par_iter().map(f).collect();
+        }
+        match rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .build()
+        {
+            Ok(pool) => pool.install(|| variants.par_iter().map(f).collect()),
+            Err(err) => {
+                log::warn!(
+                    "failed to build a dedicated {num_threads}-thread pool ({err}); \
+                     falling back to the global rayon pool"
+                );
+                variants.par_iter().map(f).collect()
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/python.rs
+++ b/src/python.rs
@@ -2175,30 +2175,50 @@ impl PyBatchProcessor {
         })
     }
 
-    /// Parse multiple HGVS strings
+    /// Parse multiple HGVS strings.
+    ///
+    /// The batch is processed across a thread pool with the GIL released, so it
+    /// scales across cores and does not block other Python threads. Results are
+    /// returned in input order.
     ///
     /// Args:
     ///     variants: List of HGVS strings to parse
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
     ///
     /// Returns:
     ///     BatchResult with parsed variants and errors
-    fn parse(&self, variants: Vec<String>) -> PyBatchResult {
-        PyBatchResult {
-            inner: self.processor.parse(&variants),
-        }
+    #[pyo3(signature = (variants, workers=0))]
+    fn parse(&self, py: Python<'_>, variants: Vec<String>, workers: usize) -> PyBatchResult {
+        let inner = py.detach(|| self.processor.parse_parallel(&variants, workers));
+        PyBatchResult { inner }
     }
 
-    /// Parse and normalize multiple HGVS strings
+    /// Parse and normalize multiple HGVS strings.
+    ///
+    /// The batch is processed across a thread pool with the GIL released, so it
+    /// scales across cores and does not block other Python threads. Results are
+    /// returned in input order.
     ///
     /// Args:
     ///     variants: List of HGVS strings to parse and normalize
+    ///     workers: Number of worker threads. 0 (default) uses all available
+    ///         cores; 1 runs serially; N uses N threads.
     ///
     /// Returns:
     ///     BatchResult with normalized variants and errors
-    fn parse_and_normalize(&self, variants: Vec<String>) -> PyBatchResult {
-        PyBatchResult {
-            inner: self.processor.parse_and_normalize(&variants),
-        }
+    #[pyo3(signature = (variants, workers=0))]
+    fn parse_and_normalize(
+        &self,
+        py: Python<'_>,
+        variants: Vec<String>,
+        workers: usize,
+    ) -> PyBatchResult {
+        let inner = py.detach(|| {
+            self.processor
+                .parse_and_normalize_parallel(&variants, workers)
+        });
+        PyBatchResult { inner }
     }
 
     /// Parse multiple HGVS strings with progress callback

--- a/tests/python/test_batch_parallel.py
+++ b/tests/python/test_batch_parallel.py
@@ -1,0 +1,71 @@
+"""Tests for the parallel batch API (``BatchProcessor.parse`` / ``parse_and_normalize``).
+
+The core property is invariance: parallel results must equal serial results
+(same order, same per-item success/error classification) for any worker count.
+These use the mock provider (``BatchProcessor()`` with no manifest), so they need
+no reference data.
+"""
+
+import ferro_hgvs
+
+
+def _variants(n: int) -> list[str]:
+    """`n` distinct variants with two deliberate parse errors at known positions."""
+    assert n >= 3, "need n >= 3 for two distinct, in-bounds error indices"
+    vs = [f"NM_000088.3:c.{i}A>G" for i in range(1, n + 1)]
+    vs[1] = "definitely not a variant"
+    vs[n - 1] = "also::not:valid"
+    return vs
+
+
+def _key(result) -> tuple:
+    """Order-sensitive fingerprint of a BatchResult."""
+    return (
+        result.total(),
+        result.success_count(),
+        result.error_count(),
+        [str(v) for v in result.successes()],
+    )
+
+
+def test_parse_parallel_matches_serial() -> None:
+    bp = ferro_hgvs.BatchProcessor()
+    variants = _variants(5000)
+
+    serial = _key(bp.parse(variants, workers=1))
+    assert serial[1] > 0, "expected some successful parses"
+    assert serial[2] == 2, "expected exactly the two injected errors"
+
+    for workers in (0, 2, 4, 8):
+        assert _key(bp.parse(variants, workers=workers)) == serial, (
+            f"parse(workers={workers}) differs from serial"
+        )
+
+
+def test_parse_and_normalize_parallel_matches_serial() -> None:
+    bp = ferro_hgvs.BatchProcessor()
+    variants = _variants(5000)
+
+    serial = _key(bp.parse_and_normalize(variants, workers=1))
+    assert serial[1] > 0, "expected some successful parses"
+    assert serial[2] == 2, "expected exactly the two injected errors"
+
+    for workers in (0, 2, 4, 8):
+        assert _key(bp.parse_and_normalize(variants, workers=workers)) == serial, (
+            f"parse_and_normalize(workers={workers}) differs from serial"
+        )
+
+
+def test_parallel_is_deterministic() -> None:
+    bp = ferro_hgvs.BatchProcessor()
+    variants = _variants(4000)
+    a = _key(bp.parse_and_normalize(variants, workers=8))
+    b = _key(bp.parse_and_normalize(variants, workers=8))
+    assert a == b
+
+
+def test_default_workers_is_parallel_and_correct() -> None:
+    # The default (workers=0, all cores) must produce the same result as serial.
+    bp = ferro_hgvs.BatchProcessor()
+    variants = _variants(2000)
+    assert _key(bp.parse(variants)) == _key(bp.parse(variants, workers=1))


### PR DESCRIPTION
The Python `BatchProcessor.parse` and `parse_and_normalize` processed each variant serially while holding the GIL. They now run across a rayon thread pool with the **GIL released** (`Python::detach`), so batch calls scale across cores and no longer block other Python threads. Independent of the CLI parallelism PRs (#687/#688) — this wires the existing `parallel`/rayon machinery into the Python batch surface.

## What changed

- Adds order-preserving `BatchProcessor::parse_parallel` / `parse_and_normalize_parallel` to the Rust batch processor (gated on the `parallel` feature, which the `python` feature now pulls in). rayon’s ordered `collect` preserves input order, so results — including per-item success/error classification — are **identical to the serial methods**.
- The Python methods gain a `workers` argument:
  - `0` (default) → all available cores
  - `1` → serial
  - `N` → N threads
- `parse_with_progress` stays serial (ordered progress callbacks are ill-defined under parallelism).
- Type stubs (`__init__.pyi`) updated; Python tests added.

## Default behavior note

Unlike the CLI (`-j` defaults to 1, opt-in), the Python batch methods default to `workers=0` (all cores). A batch API call is an explicit "process this whole list" request where parallelism is the expected behavior, and the GIL is released either way. Flagging this as a deliberate, reviewable choice — happy to switch the default to `1` if preferred.

## Correctness & perf

`tests/python/test_batch_parallel.py` asserts `workers ∈ {0,2,4,8}` produce results identical to `workers=1` (order-sensitive fingerprint over `successes()` + counts, with injected parse errors at known positions) and run-to-run determinism. Locally on a 50k batch, `parse_and_normalize` was ~2.4× faster with `workers=0` vs `workers=1` even on the fast mock provider (overhead-bound; real FASTA-backed providers scale further). clippy `-D warnings`, ruff, and mypy clean.