### PR TITLE
ci: drop duplicate Python tests from the Test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,10 +217,6 @@ jobs:
         with:
           toolchain: stable
       - uses: taiki-e/install-action@8e83571c9a797c9e42a58141f098806bfec453a0  # nextest
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
-        with:
-          python-version: "3.12"
-          enable-cache: true
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
@@ -261,10 +257,12 @@ jobs:
         run: cargo run --features dev --example generate_tool_support_tables -- --check
       - name: Perf tables up to date
         run: cargo run --features dev --example generate_perf_tables -- --check
-      - name: Install dev dependencies
-        run: uv sync --group dev --locked --no-install-project
-      - name: Run Python tests
-        run: uv run poe check-tests
+      # Python tests run in the parallel `python-wheel-test` job, which
+      # exercises the same `tests/python/` suite against a from-scratch
+      # release wheel. Running them here too forced a serial
+      # `--features python` rebuild of the extension (~80s; the job's cache
+      # is warm only for `--features dev`) for a 0.3s pytest run, so the
+      # duplicate has been dropped from this job's critical path.
 
   # Builds the release wheel with maturin and exercises it from a clean venv,
   # outside the source tree. This catches packaging issues (missing data files,


### PR DESCRIPTION
## Summary

Speeds up the `Test` job in CI by removing a redundant Python test run that was dominated by a duplicate native build.

Profiling the `Test` job (run [27527440603](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/27527440603/job/81357630047)) showed its "Run Python tests" step took **83s, of which pytest itself was 0.33s** (`175 passed in 0.33s`). The other ~82s was `uv run poe check-tests` compiling the native extension with `--features python` before pytest ever started. The job's cargo cache is warm only for `--features dev` (used by `cargo nextest` and the `generate_*` examples earlier in the same job), so the `python`-feature build can't be reused — the `ferro` crate and its pyo3-dependent dependency chain recompile from scratch, on the job's serial critical path.

## What changed

- Remove the `Install dev dependencies` and `Run Python tests` steps from the `Test` job.
- Remove the now-orphaned `astral-sh/setup-uv` step from the `Test` job — those two steps were its only consumers.

The identical `tests/python/` suite (the same 175 tests) already runs in the parallel `python-wheel-test` job, which builds a from-scratch **release wheel** and runs pytest against it from a clean venv. That is the stronger of the two checks: it catches packaging / `sys.path` / data-file issues that the editable `maturin develop` install hides (as the job's own comment notes). So the `Test` job's copy was a strict duplicate of work already covered in parallel.

## Impact

- `Test` job critical path: **5m50s → ~4m25s** (~84s removed), with no change to which Python tests run in CI.

## Coverage note (deliberate, minor)

This is not *literally* zero-coverage: the deleted `maturin develop` step built a **debug** extension (with `debug_assert!` enabled), whereas `python-wheel-test` builds a `--release` wheel where `[profile.release]` leaves debug assertions off. After this change, the Python suite no longer exercises those `debug_assert!`s through the PyO3 layer.

I judged this acceptable rather than papering over it:

- The same `debug_assert!` sites (e.g. in `normalize/merge.rs`, `normalize/rules.rs`) are still exercised with far more inputs by the debug-profile `cargo nextest` suite in this very job — the assertions remain armed in CI; only the thin PyO3 marshalling path no longer re-checks them.
- The alternatives each have a worse trade: enabling `debug-assertions` on `[profile.release]` would change the semantics of the *shipped* wheel (out of scope for a CI speedup), and giving the Python tests a dedicated debug-mode job re-introduces the ~80s `--features python` build this PR is removing.

Happy to take either alternative if reviewers prefer keeping debug-assert coverage through PyO3.
