### PR TITLE
perf(annotate-vcf): buffer the output writer

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -852,15 +852,18 @@ fn run_annotate_vcf(
         .use_ann_field(ann_format)
         .include_all_transcripts(all_transcripts);
 
-    // Set up output
+    // Set up output. Wrap in a `BufWriter` so the per-record `writeln!`s don't
+    // each cost a `write` syscall: annotating a 1M-record VCF previously spent
+    // ~35% of its time in the kernel doing one unbuffered write per output line
+    // (unlike `normalize`/`parse`, whose writers were already buffered).
     let mut writer: Box<dyn Write> = if let Some(out_path) = output {
         if out_path.to_string_lossy() == "-" {
-            Box::new(io::stdout())
+            Box::new(BufWriter::new(io::stdout()))
         } else {
-            Box::new(std::fs::File::create(out_path)?)
+            Box::new(BufWriter::new(std::fs::File::create(out_path)?))
         }
     } else {
-        Box::new(io::stdout())
+        Box::new(BufWriter::new(io::stdout()))
     };
 
     // Read VCF and annotate
@@ -911,6 +914,9 @@ fn run_annotate_vcf(
         }
     }
 
+    // Flush the BufWriter explicitly so a write error surfaces here rather than
+    // being silently swallowed by the drop-time flush.
+    writer.flush()?;
     Ok(())
 }
 


### PR DESCRIPTION
While profiling `ferro annotate-vcf` (to assess parallelism), the dominant cost turned out **not** to be annotation CPU — it was **unbuffered output**.

`run_annotate_vcf` wrote each annotated record through a raw `std::fs::File::create` (and a bare `io::stdout()`), so every per-record `writeln!` cost a `write` syscall. `normalize` and `parse` already wrap their writers in `BufWriter`; annotate did not.

## Evidence (samply, 1M-record VCF, real RefSeq GRCh38 GFF → 199,979 transcripts)

| Library | Unbuffered | Buffered |
|---|---|---|
| `libsystem_kernel` (syscalls) | **35.0%** | **20.4%** |
| `ferro` | 36.4% | 43.8% |
| `libsystem_malloc` | 17.0% | 22.6% |
| `libsystem_platform` (memcpy) | 11.6% | 13.2% |

Kernel/syscall time drops ~15 points; the remaining ~20% is the one-time read of the 1.5 GB GFF, not per-record writes. ferro’s own annotation logic was <2% of self-time throughout — this workload is I/O- and allocation-bound, not CPU-bound.

## Change

- Wrap the output writer in `BufWriter` for both the file and stdout cases.
- Add an explicit `writer.flush()?` before returning so write errors surface rather than being swallowed by the drop-time flush.

Output is **byte-identical** (verified on a 250k-record real-GFF annotation); all 46 existing VCF-annotate tests pass; clippy `-D warnings` and fmt clean.

Follow-up: after this, the remaining cost is allocation (malloc+memcpy ~36%) and per-record annotation CPU — a parallel `-j` path for the record loop is a sensible next step (separate PR).