### PR TITLE
perf(annotate-vcf): parallelize file-input record annotation behind -j/--workers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ lru = "0.12.5"
 [features]
 default = []
 dhat-heap = ["dep:dhat"]
-# rayon is now an unconditional dependency (the `ferro normalize -j` batch
-# driver uses it); this feature is retained as a no-op alias and to gate the
-# library `parallel` module's public API.
+# rayon is now an unconditional dependency (the CLI `-j` batch drivers use it);
+# this feature is retained as a no-op alias and to gate the library `parallel`
+# module's public API.
 parallel = []
 validation = ["dep:ahash"]
 # The Python batch API parallelizes across a rayon pool, so the `parallel`

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -77,6 +77,11 @@ enum Commands {
         /// Include all transcripts (default: true)
         #[arg(long, default_value = "true")]
         all_transcripts: bool,
+
+        /// Number of parallel workers for record annotation (default: 1).
+        /// Only applies to file input; stdin is always processed serially.
+        #[arg(short = 'j', long, default_value = "1")]
+        workers: usize,
     },
 
     /// Liftover genomic coordinates between genome builds
@@ -590,6 +595,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             build,
             ann_format,
             all_transcripts,
+            workers,
         } => run_annotate_vcf(
             &input,
             output.as_ref(),
@@ -597,6 +603,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &build,
             ann_format,
             all_transcripts,
+            workers,
         ),
         Commands::Liftover {
             position,
@@ -853,6 +860,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_annotate_vcf(
     input: &PathBuf,
     output: Option<&PathBuf>,
@@ -860,6 +868,7 @@ fn run_annotate_vcf(
     build: &str,
     ann_format: bool,
     all_transcripts: bool,
+    workers: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Parse genome build
     let genome_build = parse_genome_build(build);
@@ -937,11 +946,45 @@ fn run_annotate_vcf(
         }
         writeln!(writer, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO")?;
 
-        // Process records
-        for record in reader.records() {
-            let record = record?;
-            let annotated = annotator.annotate(&record)?;
-            writeln!(writer, "{}", annotated)?;
+        // Process records. Annotation is independent per record, so with
+        // `workers > 1` we annotate fixed-size chunks across a rayon pool and
+        // write the results in input order — output is byte-identical to the
+        // serial path. The first per-record annotation error is propagated
+        // (matching the serial `?`).
+        if workers > 1 {
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(workers)
+                .build()?;
+            const ANNOTATE_CHUNK: usize = 4096;
+            let mut records = reader.records();
+            let mut chunk: Vec<VcfRecord> = Vec::with_capacity(ANNOTATE_CHUNK);
+            loop {
+                chunk.clear();
+                for record in records.by_ref() {
+                    chunk.push(record?);
+                    if chunk.len() >= ANNOTATE_CHUNK {
+                        break;
+                    }
+                }
+                if chunk.is_empty() {
+                    break;
+                }
+                let annotated: Vec<Result<String, FerroError>> = pool.install(|| {
+                    chunk
+                        .par_iter()
+                        .map(|r| annotator.annotate(r).map(|a| a.to_string()))
+                        .collect()
+                });
+                for line in annotated {
+                    writeln!(writer, "{}", line?)?;
+                }
+            }
+        } else {
+            for record in reader.records() {
+                let record = record?;
+                let annotated = annotator.annotate(&record)?;
+                writeln!(writer, "{}", annotated)?;
+            }
         }
     }
 

--- a/tests/cli_parallel_annotate.rs
+++ b/tests/cli_parallel_annotate.rs
@@ -1,0 +1,95 @@
+//! Integration test for parallel batch `ferro annotate-vcf` (`-j/--workers`).
+//!
+//! Invariance property: the annotated output for any worker count must be
+//! byte-identical to the serial (`-j1`) output, including record ordering across
+//! chunk boundaries. Uses the committed micro chr21 GFF fixture (one transcript,
+//! `NR_027228.1`, two exons) so the test needs no external data.
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+// Exon ranges of NR_027228.1 in the micro GFF.
+const EXONS: &[(u64, u64)] = &[(5_016_902, 5_017_178), (5_011_799, 5_012_256)];
+const BASES: [&str; 4] = ["A", "C", "G", "T"];
+
+/// Write a VCF with `n` distinct records placed inside the transcript's exons
+/// (so every record annotates). `n` exceeds the driver's 4096-record chunk size
+/// so ordering is exercised across multiple chunks. Each record has a unique ID
+/// so any reordering changes the output byte stream.
+fn write_vcf(n: usize) -> (NamedTempFile, std::path::PathBuf) {
+    let mut tf = tempfile::Builder::new().suffix(".vcf").tempfile().unwrap();
+    writeln!(tf, "##fileformat=VCFv4.2").unwrap();
+    writeln!(tf, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO").unwrap();
+    // Walk positions across both exons, cycling as needed to reach `n`, but give
+    // every record a unique ID so duplicate positions stay distinguishable.
+    let mut written = 0usize;
+    let mut id = 0usize;
+    while written < n {
+        for &(start, end) in EXONS {
+            for pos in start..=end {
+                if written >= n {
+                    break;
+                }
+                let r = BASES[(pos % 4) as usize];
+                let a = BASES[((pos + 1) % 4) as usize];
+                writeln!(tf, "NC_000021.9\t{pos}\tv{id}\t{r}\t{a}\t.\tPASS\t.").unwrap();
+                written += 1;
+                id += 1;
+            }
+        }
+    }
+    tf.flush().unwrap();
+    let path = tf.path().to_path_buf();
+    (tf, path)
+}
+
+fn annotate(vcf: &std::path::Path, workers: usize) -> Vec<u8> {
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args([
+            "annotate-vcf",
+            "-i",
+            vcf.to_str().unwrap(),
+            "--gff",
+            "tests/fixtures/annotation/refseq_chr21_micro.gff3",
+            "--build",
+            "GRCh38",
+            "-j",
+            &workers.to_string(),
+            "-o",
+            "-",
+        ])
+        .output()
+        .expect("run ferro annotate-vcf");
+    assert!(
+        out.status.success(),
+        "annotate-vcf -j{workers} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out.stdout
+}
+
+#[test]
+fn parallel_annotate_output_is_byte_identical_to_serial() {
+    let (_keep, vcf) = write_vcf(10_000); // > 2 chunks
+    let serial = annotate(&vcf, 1);
+    // Sanity: the output actually contains annotations, not just pass-through.
+    assert!(
+        String::from_utf8_lossy(&serial).contains("HGVS_C="),
+        "expected annotated records"
+    );
+    for workers in [2usize, 4, 8] {
+        assert_eq!(
+            serial,
+            annotate(&vcf, workers),
+            "annotate-vcf -j{workers} output differs from serial (-j1)"
+        );
+    }
+}
+
+#[test]
+fn parallel_annotate_is_deterministic() {
+    let (_keep, vcf) = write_vcf(8_000);
+    assert_eq!(annotate(&vcf, 8), annotate(&vcf, 8));
+}


### PR DESCRIPTION
Adds a `-j/--workers` flag to `ferro annotate-vcf` and parallelizes the per-record annotation for file input. Each record is annotated independently, so this is the natural follow-up to the output-buffering fix.

> **Stacked on #695** (the buffering fix) — base branch is `perf/annotate-vcf-buffered`. Review/merge that first; this rebases onto `main` afterward. The diff here is the `-j` flag + parallel loop only.

## What changed

- The file-input path annotates fixed-size (4096) chunks across a rayon pool when `--workers > 1`, writing results **in input order** — byte-identical to serial. The first per-record annotation error is propagated as before.
- `workers` defaults to **1** (serial, unchanged). Parallelism applies to **file input only**; stdin (with its raw-line pass-through and header-state semantics) stays serial.
- `rayon` becomes an unconditional dependency so `-j` works in the default binary (same change as the `normalize`/`parse` parallelism PRs; trivially de-dups if those merge first).

## Why this, and why after buffering

Profiling drove the order. The first annotate profile (1M records, real RefSeq GRCh38 GFF → 199,979 transcripts) was **35% kernel** from unbuffered writes — fixed in #695 (→20%). *After* buffering, the workload is CPU/allocation-bound (ferro ~44%, malloc+memcpy ~36%), which is what makes record-level parallelism worthwhile.

## Correctness & scaling

- `tests/cli_parallel_annotate.rs` (committed micro chr21 GFF, input spanning >2 chunks) asserts `-j{2,4,8}` output equals `-j1` and is deterministic. Verified byte-identical on a 250k-record real-GFF annotation; all existing VCF-annotate tests pass; clippy `-D warnings` + fmt clean.
- 1M-record VCF, real GFF, total wall **including the fixed ~one-time GFF load**:

  | workers | wall | vs -j1 |
  |---|---|---|
  | 1 | 46.7s | 1.0x |
  | 2 | 26.4s | 1.8x |
  | 4 | 14.7s | 3.2x |
  | 8 | 20.4s | 2.3x* |

  *the -j8 dip is oversubscription on a heavily-loaded dev box (load avg ~26-41); the annotation work itself scales further. Numbers are directional — a quiet-host re-measure is worth doing before quoting precise multipliers.