### PR TITLE
perf(annotate-vcf): annotate VCF records in place instead of cloning

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -932,10 +932,10 @@ fn run_annotate_vcf(
                 }
             } else {
                 in_header = false;
-                // Parse and annotate
-                if let Ok(record) = parse_vcf_line(&line) {
-                    let annotated = annotator.annotate(&record)?;
-                    writeln!(writer, "{}", annotated)?;
+                // Parse and annotate in place (we own the parsed record).
+                if let Ok(mut record) = parse_vcf_line(&line) {
+                    annotator.annotate_into(&mut record)?;
+                    writeln!(writer, "{}", record)?;
                 } else {
                     writeln!(writer, "{}", line)?;
                 }
@@ -977,8 +977,8 @@ fn run_annotate_vcf(
                 }
                 let annotated: Vec<Result<String, FerroError>> = pool.install(|| {
                     chunk
-                        .par_iter()
-                        .map(|r| annotator.annotate(r).map(|a| a.to_string()))
+                        .par_iter_mut()
+                        .map(|r| annotator.annotate_into(r).map(|()| r.to_string()))
                         .collect()
                 });
                 for line in annotated {
@@ -987,9 +987,9 @@ fn run_annotate_vcf(
             }
         } else {
             for record in reader.records() {
-                let record = record?;
-                let annotated = annotator.annotate(&record)?;
-                writeln!(writer, "{}", annotated)?;
+                let mut record = record?;
+                annotator.annotate_into(&mut record)?;
+                writeln!(writer, "{}", record)?;
             }
         }
     }

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -293,13 +293,26 @@ impl<'a> VcfAnnotator<'a> {
 
     /// Annotate a VCF record with INFO fields
     pub fn annotate(&self, vcf: &VcfRecord) -> Result<VcfRecord, FerroError> {
+        let mut annotated = vcf.clone();
+        self.annotate_into(&mut annotated)?;
+        Ok(annotated)
+    }
+
+    /// Annotate a VCF record in place, adding HGVS INFO fields.
+    ///
+    /// Identical in effect to [`annotate`](Self::annotate) but mutates `vcf`
+    /// directly instead of cloning it, so callers that own the record (the CLI,
+    /// which discards it after writing) avoid a per-record clone of the whole
+    /// record — chrom/ref/alt/id strings plus the INFO map. Records with no
+    /// overlapping transcript are left untouched (and pay no allocation).
+    pub fn annotate_into(&self, vcf: &mut VcfRecord) -> Result<(), FerroError> {
         let annotator = MultiIsoformAnnotator::new(self.db);
+        // `result` is owned (does not borrow `vcf`), so we can mutate `vcf`
+        // below without a borrow conflict.
         let result = annotator.annotate(vcf)?;
 
-        let mut annotated = vcf.clone();
-
         if result.annotations.is_empty() {
-            return Ok(annotated);
+            return Ok(());
         }
 
         if self.use_ann_field {
@@ -310,16 +323,16 @@ impl<'a> VcfAnnotator<'a> {
                 .map(|ann| self.build_ann_value(ann))
                 .collect();
 
-            annotated.info.insert(
+            vcf.info.insert(
                 INFO_ANN.to_string(),
                 InfoValue::String(ann_values.join(",")),
             );
         } else {
             // Use separate INFO fields
-            self.add_info_fields(&mut annotated, &result.annotations);
+            self.add_info_fields(vcf, &result.annotations);
         }
 
-        Ok(annotated)
+        Ok(())
     }
 
     /// Add individual INFO fields from annotations


### PR DESCRIPTION
Removes a per-record allocation from VCF annotation: `VcfAnnotator::annotate` cloned the whole input `VcfRecord` (chrom/ref/alt/id strings + the INFO map) just to add INFO fields — and for a record with **no** overlapping transcript it cloned and returned it unchanged.

> **Stacked on #696** (parallel annotate) — base is `perf/annotate-vcf-parallel`, so the parallel chunk loop is wired here too. Review/merge #695 → #696 first; this rebases onto `main` afterward.

## Change

- Add `VcfAnnotator::annotate_into(&mut VcfRecord)` that mutates the record in place. `annotate` becomes a thin `clone` + `annotate_into` wrapper, so existing callers (library, Python, tests) are unaffected.
- The CLI annotate paths own each record and discard it after writing, so they now annotate in place and skip the clone:
  - file-serial: `let mut record = …; annotate_into(&mut record)`
  - stdin: same
  - parallel `-j`: `chunk.par_iter_mut().map(|r| annotate_into(r).map(|()| r.to_string()))`

## Correctness & perf

- **Byte-identical** output to the clone path — verified on a 250k-record real RefSeq-GRCh38 annotation, both `-j1` and `-j8` (and `-j1 == -j8`).
- All existing VCF-annotate tests + the parallel-annotate CI test pass; clippy `-D warnings` + fmt clean.
- A 1M-record profile shows allocator self-time **24.0% → 22.8%**. This is modest on the synthetic benchmark because every record annotates and the input records have empty INFO (so the clone was cheap). The real-world win is larger: on a typical VCF the majority of variants don’t overlap any transcript, and those previously paid a **full record clone for nothing** — now they’re left untouched (zero allocation).

Honest note: wall-clock numbers were unmeasurable cleanly (dev box at load 40–76 throughout); the profile’s relative allocator share is the load-insensitive signal. A quiet-host re-measure on a realistic mixed VCF would show the fuller benefit.