### PR TITLE
chore(pre-commit): bump ruff hook to v0.15.12 to match CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
   # Python linting with ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
The `ruff-pre-commit` hook in `.pre-commit-config.yaml` was pinned at `v0.4.4`, but CI's Python Lint lane runs ruff `0.15.12` (pinned in `uv.lock`). Those two versions format `assert` statements oppositely, so the local pre-commit hook reverts formatting that CI then requires — producing spurious Python-format churn (and silently undoing CI-correct formatting on `git commit`).

This bumps the hook to `v0.15.12` so local pre-commit and CI agree.

No file reformatting is needed — ruff 0.15.12 already reports the repo clean:

```
$ ruff check python/ tests/python/      → All checks passed!
$ ruff format --check python/ tests/python/  → 14 files already formatted
```