### PR TITLE
feat(normalize,project): resolve legacy gene-model selectors on genomic references

### DIFF
--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -182,11 +182,14 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
-    if let Some(ref alignments) = manifest.refseqgene_alignments_grch37 {
-        if !alignments.exists() {
+    // A missing RefSeqGene summary (LRG_RefSeqGene) silently disables legacy
+    // gene-model selector resolution at load, so surface it like the other
+    // optional inputs above.
+    if let Some(ref summary) = manifest.refseqgene_summary {
+        if !summary.exists() {
             result.warnings.push(format!(
-                "RefSeqGene GRCh37 alignments GFF3 not found: {}",
-                alignments.display()
+                "RefSeqGene summary (LRG_RefSeqGene) not found: {}",
+                summary.display()
             ));
         }
     }
@@ -321,6 +324,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -371,6 +375,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: Some(missing_alignments.clone()),
             refseqgene_alignments_grch37: None,
+            refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -423,6 +428,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: Some(missing_alignments.clone()),
+            refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -451,6 +457,59 @@ mod tests {
                 .iter()
                 .any(|w| w.contains("GRCh37 RefSeqGene alignments GFF3 not found")),
             "Expected a warning for the missing GRCh37 alignments file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_check_warns_on_missing_refseqgene_summary() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point refseqgene_summary at a file that does not exist.
+        let missing_summary = dir.path().join("missing_LRG_RefSeqGene");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
+            refseqgene_summary: Some(missing_summary.clone()),
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("RefSeqGene summary (LRG_RefSeqGene) not found")),
+            "Expected a warning for the missing summary file, got {:?}",
             result.warnings
         );
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1231,6 +1231,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self,
         variant: &HgvsVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // Rewrite a legacy gene-model selector (`NG_(GENE_v001):c.…`) to the
+        // spec-preferred transcript form (`NG_(NM_):c.…`) up front, so the rest
+        // of normalization — and projection, which normalizes first (#637) —
+        // operates on the resolved transcript. Unresolvable selectors are left
+        // unchanged (#500).
+        let rewritten = self.rewrite_legacy_gene_selector(variant);
+        let variant = rewritten.as_ref().unwrap_or(variant);
+
         // EINTRONIC (#486): an intronic offset on a bare transcript reference
         // (NM_ c. / NR_ n., no NG_(…)/NC_(…) context) is a spec-invalid
         // description form. Detect it up front — before any per-axis
@@ -3081,6 +3089,57 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return None;
         }
         Some(protein_accession.with_genomic_context((**context).clone()))
+    }
+
+    /// Rewrite a legacy LOVD gene-model selector on a genomic reference —
+    /// `NG_/NC_/LRG(GENE[_v001]):c.…` — to the spec-preferred transcript-accession
+    /// form `NG_/NC_/LRG(NM_):c.…`, when the provider resolves the gene's
+    /// reference-standard transcript (#500/#637). `_v001` and the bare gene name
+    /// both resolve to that transcript; the `c.` coordinates are unchanged (the
+    /// gene-model selector *is* that transcript).
+    ///
+    /// Returns `None` (preserve the input selector unchanged) when there is no
+    /// gene-symbol selector, the reference is not genomic (`NM_(GENE)` keeps the
+    /// #121 behavior), the selector already names a transcript context, or the
+    /// gene is unresolvable (unknown, higher locus version, or no summary
+    /// ingested) — mirroring the #121 "preserve when present, don't synthesize"
+    /// policy. Never an error.
+    fn rewrite_legacy_gene_selector(
+        &self,
+        variant: &crate::hgvs::variant::HgvsVariant,
+    ) -> Option<crate::hgvs::variant::HgvsVariant> {
+        use crate::hgvs::parser::accession::parse_accession;
+        use crate::hgvs::variant::{CdsVariant, HgvsVariant};
+
+        // Only the coding axis carries the corpus's legacy selectors; the
+        // reference-standard map resolves to `NM_`, which suits `c.` coordinates.
+        let HgvsVariant::Cds(c) = variant else {
+            return None;
+        };
+        let gene_symbol = c.gene_symbol.as_deref()?;
+        let accession = &c.accession;
+        // Only a genomic-reference selector slot (`NG_`/`NC_`/`LRG_`) is in scope.
+        let is_genomic_ref = matches!(accession.prefix.as_ref(), "NG" | "NC") || accession.is_lrg();
+        // A selector that already names a transcript context is not a bare
+        // gene-model selector — leave it.
+        if !is_genomic_ref || accession.genomic_context.is_some() {
+            return None;
+        }
+        let nm = self.provider.resolve_legacy_gene_selector(gene_symbol)?;
+        let (rest, nm_accession) = parse_accession(&nm).ok()?;
+        // The resolver yields a reference-standard `NM_` coding transcript
+        // (`parse_refseqgene_summary` keeps only `NM_` rows); reject anything else
+        // rather than emit a malformed or non-coding selector for a `c.` variant.
+        if !rest.is_empty() || nm_accession.prefix.as_ref() != "NM" {
+            return None;
+        }
+        // The genomic reference becomes the context wrapper; the resolved
+        // transcript becomes the selector; the now-redundant gene symbol is dropped.
+        Some(HgvsVariant::Cds(CdsVariant {
+            accession: nm_accession.with_genomic_context(accession.clone()),
+            gene_symbol: None,
+            loc_edit: c.loc_edit.clone(),
+        }))
     }
 
     /// Apply the HGVS 3' rule to a protein deletion or duplication.

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -37,6 +37,11 @@ pub struct ReferenceManifest {
     /// the same way `genome_grch37_fasta`/`cdot_grch37_json` pair their GRCh38 fields.
     #[serde(default)]
     pub refseqgene_alignments_grch37: Option<PathBuf>,
+    /// NCBI `LRG_RefSeqGene` association table, mapping each gene to its
+    /// reference-standard transcript. Consumed to resolve legacy gene-model
+    /// selectors (`NG_(GENE_v001):c.…`) to the transcript accession (#500/#637).
+    #[serde(default)]
+    pub refseqgene_summary: Option<PathBuf>,
     /// LRG FASTA files (LRG_* accessions)
     #[serde(default)]
     pub lrg_fastas: Vec<PathBuf>,
@@ -104,6 +109,7 @@ impl Default for ReferenceManifest {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -248,6 +254,7 @@ impl ReferenceManifest {
             &self.genome_grch37_fasta,
             &self.refseqgene_alignments,
             &self.refseqgene_alignments_grch37,
+            &self.refseqgene_summary,
             &self.lrg_refseq_mapping,
             &self.cdot_json,
             &self.cdot_grch37_json,
@@ -286,6 +293,7 @@ impl ReferenceManifest {
             &mut self.genome_grch37_fasta,
             &mut self.refseqgene_alignments,
             &mut self.refseqgene_alignments_grch37,
+            &mut self.refseqgene_summary,
             &mut self.lrg_refseq_mapping,
             &mut self.cdot_json,
             &mut self.cdot_grch37_json,
@@ -513,6 +521,7 @@ mod tests {
             refseqgene_fastas: vec![ref_dir.join("ng.fa")],
             refseqgene_alignments: Some(ref_dir.join("refseqgene_alignments.gff3")),
             refseqgene_alignments_grch37: Some(ref_dir.join("refseqgene_alignments_grch37.gff3")),
+            refseqgene_summary: Some(ref_dir.join("LRG_RefSeqGene")),
             lrg_fastas: vec![ref_dir.join("lrg.fa")],
             lrg_xmls: vec![ref_dir.join("lrg.xml")],
             lrg_refseq_mapping: Some(ref_dir.join("lrg_mapping.txt")),

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -135,6 +135,14 @@ pub mod urls {
     pub const REFSEQGENE_ALIGNMENTS_GRCH37_URL: &str =
         "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/alignments/ARCHIVE/all/GCF_000001405.25_105.20201022_refseqgene_alignments.gff3";
 
+    /// NCBI `LRG_RefSeqGene` association table — maps each gene to its
+    /// reference-standard transcript, used to resolve legacy gene-model
+    /// selectors (`NG_(GENE_v001):c.…`) to the transcript accession (#500/#637).
+    /// A small plain (un-gzipped) TSV alongside the RefSeqGene FASTAs.
+    pub const REFSEQGENE_SUMMARY_FILE: &str = "LRG_RefSeqGene";
+    pub const REFSEQGENE_SUMMARY_URL: &str =
+        "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/LRG_RefSeqGene";
+
     /// cdot transcript database (contains CDS metadata, exon coordinates, etc.)
     /// From https://github.com/SACGF/cdot/releases
     pub const CDOT_REFSEQ_GRCH38: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.refseq.GRCh38.json.gz";
@@ -476,6 +484,21 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
                     Ok(_) => record(&mut manifest, aln_path),
                     Err(e) => eprintln!("  Warning: Failed to download {}: {}", name, e),
                 }
+            }
+        }
+
+        // `LRG_RefSeqGene` association table — gene → reference-standard
+        // transcript, used to resolve legacy gene-model selectors (#500/#637).
+        let summary_name = urls::REFSEQGENE_SUMMARY_FILE;
+        let summary_path = refseqgene_dir.join(summary_name);
+        if config.skip_existing && summary_path.exists() {
+            eprintln!("  Skipping {} (exists)", summary_name);
+            manifest.refseqgene_summary = Some(summary_path);
+        } else {
+            eprintln!("  Downloading {}...", summary_name);
+            match download_file(urls::REFSEQGENE_SUMMARY_URL, &summary_path) {
+                Ok(_) => manifest.refseqgene_summary = Some(summary_path),
+                Err(e) => eprintln!("  Warning: Failed to download {}: {}", summary_name, e),
             }
         }
     }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -3271,6 +3271,40 @@ mod tests {
         );
     }
 
+    /// #637: a legacy gene-model selector on a genomic reference
+    /// (`NG_900.1(GENE1_v001):c.…`) resolves to the gene's transcript via the
+    /// normalize-first step in projection, so it no longer fails with
+    /// "Reference not found: NG_900.1" — it projects onto the resolved `NM_`.
+    #[test]
+    fn legacy_gene_model_selector_projects_via_normalize_rewrite() {
+        let (projector, mut provider) = make_nc_two_transcript_setup();
+        provider.add_genomic_placement(
+            "NG_900.1",
+            crate::reference::GenomicPlacement {
+                nc: Accession::new("NC", "000001", Some(11)),
+                parent_start: 1,
+                nc_start: 1000,
+                nc_end: 1008,
+                strand: crate::reference::Strand::Plus,
+            },
+        );
+        provider.add_legacy_gene_model("GENE1", "NM_TX2.1");
+        let vp = VariantProjector::new(projector, provider);
+
+        let proj = vp
+            .project("NG_900.1(GENE1_v001):c.4C>A", "NM_TX2.1")
+            .expect("legacy gene-model selector must resolve and project, not error on NG_");
+        let coding = proj
+            .coding
+            .as_ref()
+            .expect("coding axis present")
+            .to_string();
+        assert!(
+            coding.contains("NM_TX2.1"),
+            "the GENE1_v001 selector must resolve to the transcript: {coding}"
+        );
+    }
+
     /// #652: a range-reference insertion (`ins<start>_<end>`) on an `NG_`
     /// genomic input must resolve to the literal parent bases — the range-ref
     /// endpoints are in the `NG_` parent frame and, if left unresolved through

--- a/src/reference/legacy_selector.rs
+++ b/src/reference/legacy_selector.rs
@@ -1,0 +1,193 @@
+//! Resolving legacy LOVD gene-model selectors (`GENE`, `GENE_v001`) on a
+//! genomic reference (`NG_`/`NC_`/`LRG_`) to a transcript accession (#500/#637).
+//!
+//! HGVS strongly prefers a transcript accession in the selector slot of a
+//! genomic-reference coding variant (`NG_012337.1(NM_003002.2):c.…`), not a
+//! gene symbol (`refseq.md:38-42`). Inputs that use the legacy LOVD
+//! gene-model selector — `NG_012337.1(TIMM8B_v001):c.…` — should resolve to the
+//! gene's transcript.
+//!
+//! The `_v00N` numbering is positional on the RefSeqGene record. NCBI's
+//! `LRG_RefSeqGene` association table flags each gene's *reference standard*
+//! transcript (`Category == "reference standard"`); for the ~96% of genes with
+//! a single reference-standard `NM_`, that transcript is the LOVD `_v001`, so a
+//! gene-symbol → reference-standard `NM_` map resolves `_v001`/bare selectors
+//! authoritatively.
+//!
+//! It does **not** resolve everything: ~4.3% of genes (e.g. APC, ABL1, BCL2)
+//! carry *multiple* reference-standard transcripts on one record, and the table
+//! does not encode the LOVD `_v` ordering (its row order is neither the `_v`
+//! order nor accession-numeric). So a gene with more than one reference-standard
+//! `NM_` is **excluded from the map** — it declines (preserves the input)
+//! rather than guess a transcript that could shift the `c.` numbering. Higher
+//! locus versions (`_v002`…), which name the 2nd/3rd transcript on exactly those
+//! multi-transcript records, are likewise declined. Reliable `_vNNN` resolution
+//! for multi-transcript genes needs the `NG_` GenBank feature order (the
+//! definitional `_v` source) — a future enhancement.
+
+use rustc_hash::FxHashMap;
+
+/// Parse NCBI's `LRG_RefSeqGene` association table into a
+/// `gene Symbol (upper-case) → reference-standard NM_ accession` map.
+///
+/// The tab-separated file's columns are
+/// `tax_id  GeneID  Symbol  RSG  LRG  RNA  t  Protein  p  Category`.
+/// Only rows whose `Category` marks the gene's reference standard and whose
+/// `RNA` is an `NM_` transcript are collected. A gene is kept **only when it has
+/// exactly one** such transcript: that is its unambiguous LOVD `_v001`. Genes
+/// with multiple reference-standard transcripts are dropped (the table does not
+/// encode which is `_v001`), so they decline rather than resolve to an
+/// arbitrary file-order pick.
+pub fn parse_refseqgene_summary(tsv: &str) -> FxHashMap<String, String> {
+    // Collect all distinct reference-standard NM_ transcripts per gene first;
+    // only genes with a single candidate are resolvable (see module docs).
+    let mut by_gene: FxHashMap<String, Vec<String>> = FxHashMap::default();
+    for line in tsv.lines() {
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        if cols.len() < 10 {
+            continue;
+        }
+        let symbol = cols[2];
+        let rna = cols[5];
+        let category = cols[9];
+        if !category.contains("reference standard") || !rna.starts_with("NM_") {
+            continue;
+        }
+        let entry = by_gene.entry(symbol.to_ascii_uppercase()).or_default();
+        if !entry.iter().any(|existing| existing == rna) {
+            entry.push(rna.to_string());
+        }
+    }
+    by_gene
+        .into_iter()
+        .filter_map(|(gene, mut nms)| (nms.len() == 1).then(|| (gene, nms.pop().unwrap())))
+        .collect()
+}
+
+/// Split a legacy gene-model selector into its gene symbol and optional locus
+/// version: `"TIMM8B_v001" → ("TIMM8B", Some(1))`, `"TIMM8B" → ("TIMM8B", None)`,
+/// `"SDHD_v002" → ("SDHD", Some(2))`. The `_v<n>` (transcript) and `_i<n>`
+/// (protein isoform) suffixes are recognized; anything else is treated as part
+/// of the gene symbol.
+pub fn split_legacy_gene_selector(selector: &str) -> (&str, Option<u32>) {
+    if let Some(idx) = selector.rfind('_') {
+        let suffix = &selector[idx + 1..];
+        let mut chars = suffix.chars();
+        if let Some(first) = chars.next() {
+            let digits = &suffix[1..];
+            if (first == 'v' || first == 'i')
+                && !digits.is_empty()
+                && digits.bytes().all(|b| b.is_ascii_digit())
+            {
+                return (&selector[..idx], digits.parse::<u32>().ok());
+            }
+        }
+    }
+    (selector, None)
+}
+
+/// Resolve a legacy gene-model selector to a transcript accession via `lookup`
+/// (a gene Symbol, upper-cased, → transcript accession map).
+///
+/// Returns the gene's reference-standard transcript for a bare gene or `_v001`;
+/// declines (`None`) for higher locus versions (`_v002`…), which the
+/// reference-standard map cannot disambiguate, and for an unknown gene.
+pub fn resolve_legacy_selector_in<F>(selector: &str, lookup: F) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let (gene, version) = split_legacy_gene_selector(selector);
+    if version.is_some_and(|n| n != 1) {
+        return None;
+    }
+    lookup(&gene.to_ascii_uppercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A representative slice of the real `LRG_RefSeqGene` table: a primary gene
+    // (SDHD on its own record), a secondary gene on a different record (TIMM8B),
+    // non-reference-standard rows, and a non-NM_ (NR_) reference row to skip.
+    const SAMPLE: &str = "\
+#tax_id\tGeneID\tSymbol\tRSG\tLRG\tRNA\tt\tProtein\tp\tCategory
+9606\t6392\tSDHD\tNG_012337.3\tLRG_9\tNR_077060.2\t\t\t\taligned: Selected
+9606\t6392\tSDHD\tNG_012337.3\tLRG_9\tNM_003002.4\tt1\tNP_002993.1\t\treference standard
+9606\t1788\tTIMM8B\tNG_033145.1\t\tNM_012459.4\t\tNP_036591.3\t\treference standard
+9606\t1788\tTIMM8B\tNG_033145.1\t\tNR_028383.2\t\t\t\taligned: Selected
+9606\t675\tBRCA2\tNG_012772.3\t\tNM_000059.3\tt1\tNP_000050.2\t\treference standard
+9606\t675\tBRCA2\tNG_012772.3\t\tNM_000059.4\t\tNP_000050.3\t\taligned: Selected";
+
+    #[test]
+    fn parses_reference_standard_nm_per_gene() {
+        let map = parse_refseqgene_summary(SAMPLE);
+        assert_eq!(map.get("SDHD").map(String::as_str), Some("NM_003002.4"));
+        assert_eq!(map.get("TIMM8B").map(String::as_str), Some("NM_012459.4"));
+        assert_eq!(map.get("BRCA2").map(String::as_str), Some("NM_000059.3"));
+        // The NR_ reference row and the "aligned: Selected" rows are not kept.
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn multi_reference_standard_gene_is_excluded() {
+        // APC carries three reference-standard transcripts on one record; the
+        // table doesn't encode which is `_v001`, so APC must be DROPPED (decline)
+        // rather than resolve to an arbitrary file-order pick.
+        let sample = "\
+#tax_id\tGeneID\tSymbol\tRSG\tLRG\tRNA\tt\tProtein\tp\tCategory
+9606\t324\tAPC\tNG_008481.4\tLRG_130\tNM_000038.6\t\tNP_000029.2\t\treference standard
+9606\t324\tAPC\tNG_008481.4\tLRG_130\tNM_001127510.3\t\tNP_001120982.2\t\treference standard
+9606\t324\tAPC\tNG_008481.4\tLRG_130\tNM_001127511.3\t\tNP_001120983.2\t\treference standard
+9606\t6392\tSDHD\tNG_012337.3\tLRG_9\tNM_003002.4\tt1\tNP_002993.1\t\treference standard";
+        let map = parse_refseqgene_summary(sample);
+        assert!(
+            !map.contains_key("APC"),
+            "ambiguous multi-transcript gene must be dropped"
+        );
+        assert_eq!(map.get("SDHD").map(String::as_str), Some("NM_003002.4"));
+        let lookup = |g: &str| map.get(g).cloned();
+        assert_eq!(resolve_legacy_selector_in("APC_v001", lookup), None);
+        assert_eq!(resolve_legacy_selector_in("APC", lookup), None);
+    }
+
+    #[test]
+    fn splits_locus_versions() {
+        assert_eq!(
+            split_legacy_gene_selector("TIMM8B_v001"),
+            ("TIMM8B", Some(1))
+        );
+        assert_eq!(split_legacy_gene_selector("SDHD_v002"), ("SDHD", Some(2)));
+        assert_eq!(split_legacy_gene_selector("BRCA2_i001"), ("BRCA2", Some(1)));
+        assert_eq!(split_legacy_gene_selector("TIMM8B"), ("TIMM8B", None));
+        // A trailing `_` group that isn't `_v<n>`/`_i<n>` stays part of the gene.
+        assert_eq!(split_legacy_gene_selector("C9orf72"), ("C9orf72", None));
+        assert_eq!(split_legacy_gene_selector("GENE_x1"), ("GENE_x1", None));
+    }
+
+    #[test]
+    fn resolves_v001_and_bare_declines_higher_and_unknown() {
+        let map = parse_refseqgene_summary(SAMPLE);
+        let lookup = |g: &str| map.get(g).cloned();
+        // _v001 and bare gene resolve to the reference standard (case-insensitive).
+        assert_eq!(
+            resolve_legacy_selector_in("TIMM8B_v001", lookup),
+            Some("NM_012459.4".to_string())
+        );
+        assert_eq!(
+            resolve_legacy_selector_in("timm8b", lookup),
+            Some("NM_012459.4".to_string())
+        );
+        assert_eq!(
+            resolve_legacy_selector_in("SDHD", lookup),
+            Some("NM_003002.4".to_string())
+        );
+        // _v002 is not expressible from the reference-standard map → decline.
+        assert_eq!(resolve_legacy_selector_in("SDHD_v002", lookup), None);
+        // Unknown gene → decline.
+        assert_eq!(resolve_legacy_selector_in("NOTAGENE_v001", lookup), None);
+    }
+}

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -28,6 +28,11 @@ pub struct MockProvider {
     /// One entry per genome build (the build is encoded in each placement's
     /// `nc` accession), so tests can exercise per-build selection (#653).
     genomic_placements: HashMap<String, Vec<GenomicPlacement>>,
+    /// Legacy gene-model selector resolution: gene Symbol (upper-case) →
+    /// reference-standard transcript accession (e.g. `"TIMM8B"` →
+    /// `"NM_012459.4"`). Lets tests exercise the #500/#637 selector rewrite
+    /// without ingesting NCBI's `LRG_RefSeqGene` table.
+    legacy_gene_models: HashMap<String, String>,
 }
 
 impl MockProvider {
@@ -39,7 +44,20 @@ impl MockProvider {
             genomic_sequences: HashMap::new(),
             non_version_exact: HashSet::new(),
             genomic_placements: HashMap::new(),
+            legacy_gene_models: HashMap::new(),
         }
+    }
+
+    /// Register a legacy gene-model → reference-standard transcript mapping
+    /// (e.g. `"TIMM8B"` → `"NM_012459.4"`), keyed case-insensitively by gene
+    /// Symbol, for the #500/#637 selector rewrite.
+    pub fn add_legacy_gene_model(
+        &mut self,
+        gene_symbol: impl AsRef<str>,
+        transcript: impl Into<String>,
+    ) {
+        self.legacy_gene_models
+            .insert(gene_symbol.as_ref().to_ascii_uppercase(), transcript.into());
     }
 
     /// Register the chromosomal placement of a genomic parent reference
@@ -119,6 +137,7 @@ impl MockProvider {
             genomic_sequences,
             non_version_exact: HashSet::new(),
             genomic_placements: HashMap::new(),
+            legacy_gene_models: HashMap::new(),
         })
     }
 
@@ -335,6 +354,12 @@ impl ReferenceProvider for MockProvider {
     ) -> Option<GenomicPlacement> {
         let list = self.genomic_placements.get(&parent.full())?;
         crate::reference::provider::select_placement_for_build(list, build)
+    }
+
+    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+        crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
+            self.legacy_gene_models.get(g).cloned()
+        })
     }
 
     fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -5,6 +5,7 @@
 pub mod annotation;
 pub mod authoritative;
 pub mod fasta;
+pub mod legacy_selector;
 pub mod loader;
 pub mod mock;
 pub mod multi_fasta;

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -233,6 +233,11 @@ pub struct MultiFastaProvider {
     /// the parsed RefSeqGene alignments cover (#653). Selection by the input's
     /// resolved build happens in `genomic_placement_on_build`.
     refseqgene_placements: FxHashMap<String, Vec<GenomicPlacement>>,
+    /// Legacy gene-model selector resolution: gene Symbol (upper-case) →
+    /// reference-standard transcript accession, parsed once from NCBI's
+    /// `LRG_RefSeqGene` table named by the manifest's `refseqgene_summary`
+    /// (#500/#637). Empty when the manifest carries no summary file.
+    legacy_gene_models: FxHashMap<String, String>,
 }
 
 /// Resolution inputs that uniquely identify a resolved transcript: the requested
@@ -332,6 +337,7 @@ impl MultiFastaProvider {
             lrg_xml_dir: None,
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
+            legacy_gene_models: FxHashMap::default(),
         })
     }
 
@@ -369,6 +375,7 @@ impl MultiFastaProvider {
             lrg_xml_dir: None,
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
+            legacy_gene_models: FxHashMap::default(),
         })
     }
 
@@ -606,6 +613,29 @@ impl MultiFastaProvider {
             }
         }
 
+        // Parse the NCBI `LRG_RefSeqGene` summary into a gene → reference-standard
+        // transcript map for legacy gene-model selector resolution (#500/#637).
+        // A read failure is warned (not silently swallowed); an absent field is
+        // fine (legacy selectors stay un-resolved).
+        let legacy_gene_models = match manifest.get("refseqgene_summary").and_then(|v| v.as_str()) {
+            None => FxHashMap::default(),
+            Some(rel) => {
+                let path = resolve_path(rel);
+                match std::fs::read_to_string(&path) {
+                    Ok(tsv) => crate::reference::legacy_selector::parse_refseqgene_summary(&tsv),
+                    Err(e) => {
+                        warn!(
+                            "Failed to read RefSeqGene summary {}: {}; \
+                             legacy gene-model selector resolution disabled",
+                            path.display(),
+                            e
+                        );
+                        FxHashMap::default()
+                    }
+                }
+            }
+        };
+
         // Get supplemental directory (missing ClinVar transcripts)
         if let Some(supplemental) = manifest.get("supplemental_fasta").and_then(|v| v.as_str()) {
             let path = resolve_path(supplemental);
@@ -627,6 +657,7 @@ impl MultiFastaProvider {
         // be re-anchored (#480); `from_directories` cannot know about them.
         provider.lrg_xml_dir = lrg_xml_dir;
         provider.refseqgene_placements = refseqgene_placements;
+        provider.legacy_gene_models = legacy_gene_models;
 
         // Load cdot transcript metadata if available
         if let Some(cdot_path_str) = manifest.get("cdot_json").and_then(|v| v.as_str()) {
@@ -851,6 +882,7 @@ impl MultiFastaProvider {
             lrg_xml_dir: None,
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
+            legacy_gene_models: FxHashMap::default(),
         })
     }
 
@@ -2115,6 +2147,12 @@ impl ReferenceProvider for MultiFastaProvider {
             .expect("lrg placement cache poisoned")
             .insert(key, placement.clone());
         placement
+    }
+
+    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+        crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
+            self.legacy_gene_models.get(g).cloned()
+        })
     }
 
     fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -200,6 +200,19 @@ pub trait ReferenceProvider {
         self.genomic_placement(parent)
     }
 
+    /// Resolve a legacy LOVD gene-model selector (`GENE`, `GENE_v001`) on a
+    /// genomic reference to a transcript accession (#500/#637).
+    ///
+    /// `selector` is the gene-symbol selector verbatim (e.g. `"TIMM8B_v001"`).
+    /// Returns the gene's reference-standard transcript accession (e.g.
+    /// `"NM_012459.4"`) for a bare gene or `_v001`, or `None` to decline (an
+    /// unknown gene, a higher locus version `_v002…`, or a provider with no
+    /// gene-model summary ingested). Declining preserves the input selector
+    /// rather than emitting a guessed transcript.
+    fn resolve_legacy_gene_selector(&self, _selector: &str) -> Option<String> {
+        None
+    }
+
     /// Get a sequence region
     ///
     /// # Arguments

--- a/tests/issue_500_legacy_gene_selector.rs
+++ b/tests/issue_500_legacy_gene_selector.rs
@@ -1,0 +1,143 @@
+//! Issue #500/#637: resolve a legacy LOVD gene-model selector on a genomic
+//! reference to the spec-preferred transcript accession.
+//!
+//! HGVS prefers a transcript accession in the selector slot of a
+//! genomic-reference coding variant (`NG_012337.1(NM_003002.2):c.…`), not a gene
+//! symbol (`refseq.md:38-42`). `normalize` rewrites a legacy gene-model selector
+//! — `NG_/NC_/LRG(GENE[_v001]):c.…` — to the gene's reference-standard
+//! transcript, resolved Symbol-keyed (so a secondary gene cited under another
+//! gene's RefSeqGene record resolves via its own reference standard), while
+//! leaving `NM_(GENE)` and unresolvable selectors untouched (#121).
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{ManeStatus, Strand};
+use ferro_hgvs::reference::Transcript;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// A `MockProvider` carrying the SDHD (`NM_003002.4`) and TIMM8B (`NM_012459.4`)
+/// transcripts and their legacy gene-model → reference-standard mappings. The
+/// sequences are all-`A` filler long enough to validate the `c.` coordinate
+/// used below.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    for (id, gene) in [("NM_003002.4", "SDHD"), ("NM_012459.4", "TIMM8B")] {
+        let tx = Transcript::new(
+            id.to_string(),
+            Some(gene.to_string()),
+            Strand::Plus,
+            Some("A".repeat(300)),
+            Some(1),
+            Some(300),
+            Vec::new(),
+            None,
+            None,
+            None,
+            Default::default(),
+            ManeStatus::Select,
+            None,
+            None,
+        );
+        provider.add_transcript(tx);
+        provider.add_legacy_gene_model(gene, id);
+    }
+    provider
+}
+
+fn normalize_str(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"));
+    format!("{normalized}")
+}
+
+#[test]
+fn ng_gene_v001_selector_rewritten_to_nm() {
+    assert_eq!(
+        normalize_str(provider(), "NG_012337.3(SDHD_v001):c.92A>T"),
+        "NG_012337.3(NM_003002.4):c.92A>T"
+    );
+}
+
+#[test]
+fn ng_bare_gene_selector_rewritten_to_nm() {
+    // A bare gene name (no `_vNNN`) resolves to the same reference-standard transcript.
+    assert_eq!(
+        normalize_str(provider(), "NG_012337.3(SDHD):c.92A>T"),
+        "NG_012337.3(NM_003002.4):c.92A>T"
+    );
+}
+
+#[test]
+fn nc_gene_selector_rewritten_to_nm() {
+    // `is_genomic_ref` also accepts an `NC_` genomic reference in the selector
+    // slot; the gene resolves via the same Symbol-keyed reference standard and
+    // the `NC_` wrapper is preserved as the genomic context.
+    assert_eq!(
+        normalize_str(provider(), "NC_000011.10(SDHD):c.92A>T"),
+        "NC_000011.10(NM_003002.4):c.92A>T"
+    );
+}
+
+#[test]
+fn lrg_gene_selector_rewritten_to_nm() {
+    // An `LRG_` genomic reference is likewise in scope; the gene resolves to the
+    // reference-standard transcript and the `LRG_` wrapper is preserved.
+    assert_eq!(
+        normalize_str(provider(), "LRG_9(SDHD):c.92A>T"),
+        "LRG_9(NM_003002.4):c.92A>T"
+    );
+}
+
+#[test]
+fn secondary_gene_resolves_via_its_own_reference_standard() {
+    // TIMM8B is a *secondary* gene annotated on the SDHD RefSeqGene record
+    // (NG_012337); the Symbol-keyed lookup resolves it via TIMM8B's own
+    // reference-standard transcript, not anything scoped to NG_012337.
+    assert_eq!(
+        normalize_str(provider(), "NG_012337.3(TIMM8B_v001):c.92A>T"),
+        "NG_012337.3(NM_012459.4):c.92A>T"
+    );
+}
+
+#[test]
+fn rewrite_is_idempotent() {
+    // Re-normalizing the rewritten output is a no-op: the selector already names
+    // a transcript (it carries a genomic context), so no resolution is attempted.
+    let once = normalize_str(provider(), "NG_012337.3(SDHD_v001):c.92A>T");
+    let twice = normalize_str(provider(), &once);
+    assert_eq!(once, twice);
+    assert_eq!(twice, "NG_012337.3(NM_003002.4):c.92A>T");
+}
+
+#[test]
+fn nm_gene_selector_is_preserved() {
+    // `NM_(GENE)` is out of scope (#121): the gene symbol stays on the already-named
+    // transcript; it is NOT treated as a legacy selector to resolve away.
+    let out = normalize_str(provider(), "NM_003002.4(SDHD):c.92A>T");
+    assert!(
+        out.contains("NM_003002.4"),
+        "transcript selector kept: {out}"
+    );
+    assert!(
+        out.contains("(SDHD)"),
+        "gene symbol preserved on NM_(GENE): {out}"
+    );
+}
+
+#[test]
+fn higher_locus_version_is_declined_and_preserved() {
+    // `_v002` is not expressible from the reference-standard map → no rewrite;
+    // the input selector is preserved (never an error on the unresolvable path).
+    let out = normalize_str(provider(), "NG_012337.3(SDHD_v002):c.92A>T");
+    assert_eq!(out, "NG_012337.3(SDHD_v002):c.92A>T");
+}
+
+#[test]
+fn unknown_gene_without_mapping_is_preserved() {
+    // An empty provider (no legacy gene-model summary) resolves nothing; the
+    // input selector is preserved verbatim, never an error.
+    let out = normalize_str(MockProvider::new(), "NG_012337.3(SDHD_v001):c.92A>T");
+    assert_eq!(out, "NG_012337.3(SDHD_v001):c.92A>T");
+}


### PR DESCRIPTION
A legacy LOVD gene-model selector on a genomic reference — `NG_/NC_/LRG(GENE[_v001]):c.…` — names a gene, not the transcript whose frame the `c.` coordinate is in. HGVS prefers the transcript accession in that slot (`refseq.md:38-42`). `normalize` now rewrites the selector to the gene's reference-standard transcript (`NG_(NM_):c.…`); projection inherits this (it normalizes first), so `NG_(GENE_v001):c.…` inputs project instead of failing with "Reference not found: NG_" (#637).

Data source: NCBI's `LRG_RefSeqGene` association table, whose per-gene "reference standard" row is the LOVD `_v001` transcript. Resolution is correct-by-construction: a gene resolves only when it has exactly one reference-standard `NM_` (the unambiguous `_v001`). Genes with multiple reference-standard transcripts (~4.3%, e.g. APC/ABL1/BCL2 — the table does not encode the LOVD `_v` order), higher locus versions (`_v002…`), and unknown genes all decline and preserve the input selector unchanged. `NM_(GENE)` is untouched (#121). Reliable `_vNNN` resolution for multi-transcript genes would need the NG_ GenBank feature order — a future enhancement.

- `reference::legacy_selector`: parse `LRG_RefSeqGene` + selector split/resolve policy
- `ReferenceProvider::resolve_legacy_gene_selector` (MultiFastaProvider + MockProvider)
- manifest `refseqgene_summary` field; `ferro prepare` downloads `LRG_RefSeqGene`
- `Normalizer` rewrites the selector up front in `normalize_core`

Closes #500
Closes #637