### PR TITLE
feat(reference): build-aware NG_/LRG_ genomic placement (GRCh37 + GRCh38) foundation

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -132,6 +132,19 @@ impl ReferenceProvider for PyProvider {
             PyProvider::MultiFasta(p) => p.genomic_placement(parent),
         }
     }
+
+    fn genomic_placement_on_build(
+        &self,
+        parent: &crate::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<crate::reference::GenomicPlacement> {
+        // Forward the build hint to the inner provider so per-build placement
+        // selection survives the PyProvider wrapper, matching the Arc/Box impls.
+        match self {
+            PyProvider::Mock(p) => p.genomic_placement_on_build(parent, build),
+            PyProvider::MultiFasta(p) => p.genomic_placement_on_build(parent, build),
+        }
+    }
 }
 
 impl PyProvider {

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -25,7 +25,9 @@ pub struct MockProvider {
     /// keyed by the parent's full versioned accession (e.g. `"NG_007485.1"`).
     /// Lets tests exercise the #480 NC→parent-frame re-anchoring without a real
     /// RefSeqGene/LRG placement source.
-    genomic_placements: HashMap<String, GenomicPlacement>,
+    /// One entry per genome build (the build is encoded in each placement's
+    /// `nc` accession), so tests can exercise per-build selection (#653).
+    genomic_placements: HashMap<String, Vec<GenomicPlacement>>,
 }
 
 impl MockProvider {
@@ -41,14 +43,18 @@ impl MockProvider {
     }
 
     /// Register the chromosomal placement of a genomic parent reference
-    /// (`NG_`/`LRG_`), keyed by its full versioned accession (#480).
+    /// (`NG_`/`LRG_`), keyed by its full versioned accession (#480). May be
+    /// called more than once per accession to register a per-build placement
+    /// (e.g. a GRCh37 and a GRCh38 placement), for #653 build-selection tests.
     pub fn add_genomic_placement(
         &mut self,
         parent_accession: impl Into<String>,
         placement: GenomicPlacement,
     ) {
         self.genomic_placements
-            .insert(parent_accession.into(), placement);
+            .entry(parent_accession.into())
+            .or_default()
+            .push(placement);
     }
 
     /// Mark `id` as not available at its exact requested version, so
@@ -319,7 +325,16 @@ impl Default for MockProvider {
 
 impl ReferenceProvider for MockProvider {
     fn genomic_placement(&self, parent: &Accession) -> Option<GenomicPlacement> {
-        self.genomic_placements.get(&parent.full()).cloned()
+        self.genomic_placement_on_build(parent, None)
+    }
+
+    fn genomic_placement_on_build(
+        &self,
+        parent: &Accession,
+        build: Option<&str>,
+    ) -> Option<GenomicPlacement> {
+        let list = self.genomic_placements.get(&parent.full())?;
+        crate::reference::provider::select_placement_for_build(list, build)
     }
 
     fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
@@ -515,6 +530,61 @@ mod tests {
         let provider = MockProvider::with_test_data();
         assert!(!provider.is_empty());
         assert!(provider.len() >= 2);
+    }
+
+    /// #653: an NG_ parent with both a GRCh37 and a GRCh38 RefSeqGene placement
+    /// resolves per build — GRCh38 by default, GRCh37 on request — and an
+    /// explicit build with no matching placement declines (build-match guard).
+    #[test]
+    fn genomic_placement_selects_per_build() {
+        use crate::reference::provider::GenomicPlacement;
+        use crate::reference::transcript::Strand;
+        let mk = |chrom_version: u32| GenomicPlacement {
+            nc: Accession::new("NC", "000001", Some(chrom_version)),
+            parent_start: 1,
+            nc_start: 1000,
+            nc_end: 1008,
+            strand: Strand::Plus,
+        };
+        let mut provider = MockProvider::new();
+        provider.add_genomic_placement("NG_900.1", mk(11)); // GRCh38
+        provider.add_genomic_placement("NG_900.1", mk(10)); // GRCh37
+        let ng = Accession::new("NG", "900", Some(1));
+
+        // Default prefers GRCh38; explicit builds select their own placement.
+        assert_eq!(
+            provider.genomic_placement(&ng).unwrap().nc.to_string(),
+            "NC_000001.11"
+        );
+        assert_eq!(
+            provider
+                .genomic_placement_on_build(&ng, Some("GRCh37"))
+                .unwrap()
+                .nc
+                .to_string(),
+            "NC_000001.10"
+        );
+        assert_eq!(
+            provider
+                .genomic_placement_on_build(&ng, Some("GRCh38"))
+                .unwrap()
+                .nc
+                .to_string(),
+            "NC_000001.11"
+        );
+
+        // An NG_ with only a GRCh37 placement declines a GRCh38 request (guard).
+        let mut grch37_only = MockProvider::new();
+        grch37_only.add_genomic_placement("NG_901.1", mk(10));
+        let ng2 = Accession::new("NG", "901", Some(1));
+        assert!(grch37_only
+            .genomic_placement_on_build(&ng2, Some("GRCh38"))
+            .is_none());
+        // ...but resolves under GRCh37 and as the default-when-sole-coverage.
+        assert!(grch37_only
+            .genomic_placement_on_build(&ng2, Some("GRCh37"))
+            .is_some());
+        assert!(grch37_only.genomic_placement(&ng2).is_some());
     }
 
     #[test]

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -229,7 +229,10 @@ pub struct MultiFastaProvider {
     /// `GCF_*_refseqgene_alignments.gff3` named by the manifest's
     /// `refseqgene_alignments`, keyed by NG accession.version (#480). Empty when
     /// the manifest carries no alignments file.
-    refseqgene_placements: FxHashMap<String, GenomicPlacement>,
+    /// Per-NG-version placements, one entry per genome build (GRCh37/GRCh38)
+    /// the parsed RefSeqGene alignments cover (#653). Selection by the input's
+    /// resolved build happens in `genomic_placement_on_build`.
+    refseqgene_placements: FxHashMap<String, Vec<GenomicPlacement>>,
 }
 
 /// Resolution inputs that uniquely identify a resolved transcript: the requested
@@ -1919,8 +1922,8 @@ fn gff_attr<'a>(attrs: &'a str, key: &str) -> Option<&'a str> {
 /// `NM_`→`NC_` step is computed. GRCh37 placements, alt-loci/patches, and gapped
 /// alignments (which a single affine span cannot represent) are skipped, so the
 /// projector keeps prior behavior rather than emit a wrong `NG_` coordinate.
-fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, GenomicPlacement> {
-    let mut out = FxHashMap::default();
+fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlacement>> {
+    let mut out: FxHashMap<String, Vec<GenomicPlacement>> = FxHashMap::default();
     for line in gff3.lines() {
         if line.starts_with('#') || line.trim().is_empty() {
             continue;
@@ -1963,24 +1966,34 @@ fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, GenomicPlacement
         } else {
             crate::reference::transcript::Strand::Plus
         };
-        // Keep only GRCh38 primary-chromosome placements (cdot's build).
+        // Keep placements on a GRCh37 or GRCh38 PRIMARY chromosome (the build is
+        // derivable from the NC_ version). Alt-loci / fix-patch contigs return
+        // `None` and are skipped (a single affine span cannot anchor them).
+        // Both builds are retained and stored per-build; selection by the input's
+        // resolved build happens at lookup (#653).
         let Ok((_, nc)) = crate::hgvs::parser::accession::parse_accession(cols[0]) else {
             continue;
         };
-        if crate::liftover::aliases::infer_genome_build_from_accession(&nc) != Some("GRCh38") {
+        let Some(build) = crate::liftover::aliases::infer_genome_build_from_accession(&nc) else {
             continue;
-        }
+        };
         let (nc_start, nc_end) = if a <= b { (a, b) } else { (b, a) };
-        out.insert(
-            ng.to_string(),
-            GenomicPlacement {
-                nc,
-                parent_start,
-                nc_start,
-                nc_end,
-                strand,
-            },
-        );
+        let placement = GenomicPlacement {
+            nc,
+            parent_start,
+            nc_start,
+            nc_end,
+            strand,
+        };
+        // Keep at most one placement per (NG version, build): first wins if a
+        // release lists the same alignment twice.
+        let entry = out.entry(ng.to_string()).or_default();
+        let has_build = entry.iter().any(|p| {
+            crate::liftover::aliases::infer_genome_build_from_accession(&p.nc) == Some(build)
+        });
+        if !has_build {
+            entry.push(placement);
+        }
     }
     out
 }
@@ -1990,15 +2003,29 @@ impl ReferenceProvider for MultiFastaProvider {
         &self,
         parent: &crate::hgvs::variant::Accession,
     ) -> Option<GenomicPlacement> {
+        // Build-agnostic entry: prefer GRCh38 (cdot's primary / mutalyzer policy).
+        self.genomic_placement_on_build(parent, None)
+    }
+
+    fn genomic_placement_on_build(
+        &self,
+        parent: &crate::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<GenomicPlacement> {
         // NG_ RefSeqGene placement comes from the NCBI RefSeqGene→genome
         // alignments (`GCF_*_refseqgene_alignments.gff3`), parsed once at load
-        // and keyed by NG accession.version. Absent (no alignments file, or no
-        // GRCh38 primary placement) → None, and the projector keeps prior
-        // behavior rather than emit a wrong NG_ coordinate.
+        // and stored per genome build (#653). `select_placement_for_build`
+        // picks the entry matching the input's resolved build; with no build
+        // hint it prefers GRCh38, and with an explicit build it returns `None`
+        // (decline) rather than mis-anchor onto a different build's placement.
         if parent.prefix.as_ref() == "NG" {
-            return self.refseqgene_placements.get(&parent.full()).cloned();
+            let list = self.refseqgene_placements.get(&parent.full())?;
+            return crate::reference::provider::select_placement_for_build(list, build);
         }
-        // LRG placement comes from the on-hand LRG XMLs (parsed on demand).
+        // LRG placement comes from the on-hand LRG XMLs (parsed on demand). LRG
+        // carries a single main-assembly placement, so the build hint is not
+        // used here — a build mismatch is caught downstream by the re-anchor's
+        // endpoint-outside-span guard (#655).
         if !parent.is_lrg() {
             return None;
         }
@@ -2519,11 +2546,15 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
     fn parses_refseqgene_alignments_plus_and_minus() {
         let m = parse_refseqgene_alignments(RSG_GFF3_SAMPLE);
 
-        // GRCh37 placement and gapped alignment are excluded.
-        assert_eq!(m.len(), 2, "only GRCh38 ungapped placements kept: {m:?}");
+        // GRCh37 is now KEPT (#653); only the gapped and non-`match` rows drop.
+        assert_eq!(
+            m.len(),
+            3,
+            "GRCh37 + both GRCh38 ungapped placements kept: {m:?}"
+        );
         assert!(
-            !m.contains_key("NG_003000.1"),
-            "GRCh37 placement must be dropped"
+            m.contains_key("NG_003000.1"),
+            "GRCh37 placement must be kept (#653)"
         );
         assert!(
             !m.contains_key("NG_004000.1"),
@@ -2534,8 +2565,13 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
             "non-`match` record (cDNA_match) must be dropped even when it carries Target=NG_*"
         );
 
-        let plus = &m["NG_001000.1"];
+        // Each NG_ maps to a per-build list; these samples have one build each.
+        let plus = &m["NG_001000.1"][0];
         assert_eq!(plus.nc.to_string(), "NC_000001.11");
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&plus.nc),
+            Some("GRCh38")
+        );
         assert_eq!(plus.parent_start, 1);
         assert_eq!(plus.nc_start, 1000);
         assert_eq!(plus.nc_end, 1099);
@@ -2543,11 +2579,19 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         assert_eq!(plus.nc_to_parent(1000), Some(1));
         assert_eq!(plus.nc_to_parent(1099), Some(100));
 
-        let minus = &m["NG_002000.1"];
+        let minus = &m["NG_002000.1"][0];
         assert_eq!(minus.strand, crate::reference::transcript::Strand::Minus);
         // Minus: NG base 1 sits at the high chromosome coordinate.
         assert_eq!(minus.nc_to_parent(2099), Some(1));
         assert_eq!(minus.nc_to_parent(2000), Some(100));
+
+        // The GRCh37 placement is on the GRCh37 chromosome accession (NC_*.10).
+        let grch37 = &m["NG_003000.1"][0];
+        assert_eq!(grch37.nc.to_string(), "NC_000001.10");
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&grch37.nc),
+            Some("GRCh37")
+        );
     }
 
     /// An unknown-orientation placement has no defined parent frame, so

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -43,6 +43,29 @@ pub struct GenomicPlacement {
     pub strand: Strand,
 }
 
+/// Select the placement matching a resolved genome build from a parent's
+/// per-build placement list (#653).
+///
+/// - `Some(build)` → the placement whose `nc` is on that build, or `None`
+///   (decline) when absent — never substitute another build's placement.
+/// - `None` (no preference) → prefer the GRCh38 placement (cdot's primary build
+///   / mutalyzer policy), else the first available.
+pub(crate) fn select_placement_for_build(
+    placements: &[GenomicPlacement],
+    build: Option<&str>,
+) -> Option<GenomicPlacement> {
+    let build_of =
+        |p: &GenomicPlacement| crate::liftover::aliases::infer_genome_build_from_accession(&p.nc);
+    match build {
+        Some(b) => placements.iter().find(|p| build_of(p) == Some(b)).cloned(),
+        None => placements
+            .iter()
+            .find(|p| build_of(p) == Some("GRCh38"))
+            .or_else(|| placements.first())
+            .cloned(),
+    }
+}
+
 impl GenomicPlacement {
     /// Map a 1-based chromosome (`NC_`) coordinate into the parent's own frame.
     ///
@@ -159,6 +182,22 @@ pub trait ReferenceProvider {
     /// projector keeps the chromosome coordinates as-is.
     fn genomic_placement(&self, _parent: &Accession) -> Option<GenomicPlacement> {
         None
+    }
+
+    /// Return the chromosomal placement of a genomic *parent* reference for a
+    /// specific genome build (#653). `build` is `"GRCh37"`/`"GRCh38"` (or `None`
+    /// for "no preference", which prefers GRCh38). When an explicit build is
+    /// requested but no placement on that build exists, returns `None` (decline)
+    /// rather than mis-anchor onto a different build's placement.
+    ///
+    /// The default ignores the build hint and delegates to [`genomic_placement`]
+    /// (build-agnostic); providers that store per-build placements override this.
+    fn genomic_placement_on_build(
+        &self,
+        parent: &Accession,
+        _build: Option<&str>,
+    ) -> Option<GenomicPlacement> {
+        self.genomic_placement(parent)
     }
 
     /// Get a sequence region
@@ -385,6 +424,17 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for std::sync::Arc<T> {
         (**self).genomic_placement(parent)
     }
 
+    fn genomic_placement_on_build(
+        &self,
+        parent: &Accession,
+        build: Option<&str>,
+    ) -> Option<GenomicPlacement> {
+        // Forward the build hint to the wrapped provider so build-aware lookup
+        // survives an Arc/Box wrapper (the default would drop it to the
+        // build-agnostic path).
+        (**self).genomic_placement_on_build(parent, build)
+    }
+
     fn get_protein_sequence(
         &self,
         accession: &str,
@@ -460,6 +510,17 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for Box<T> {
         (**self).genomic_placement(parent)
     }
 
+    fn genomic_placement_on_build(
+        &self,
+        parent: &Accession,
+        build: Option<&str>,
+    ) -> Option<GenomicPlacement> {
+        // Forward the build hint to the wrapped provider so build-aware lookup
+        // survives an Arc/Box wrapper (the default would drop it to the
+        // build-agnostic path).
+        (**self).genomic_placement_on_build(parent, build)
+    }
+
     fn get_protein_sequence(
         &self,
         accession: &str,
@@ -514,6 +575,45 @@ mod placement_tests {
             nc_end: 1008,
             strand,
         }
+    }
+
+    fn placement_on(chrom_version: u32) -> GenomicPlacement {
+        GenomicPlacement {
+            nc: Accession::new("NC", "000001", Some(chrom_version)),
+            parent_start: 1,
+            nc_start: 1000,
+            nc_end: 1008,
+            strand: Strand::Plus,
+        }
+    }
+
+    #[test]
+    fn select_placement_for_build_picks_by_build_and_declines_mismatch() {
+        let grch38 = placement_on(11); // NC_000001.11 → GRCh38
+        let grch37 = placement_on(10); // NC_000001.10 → GRCh37
+        let both = vec![grch38.clone(), grch37.clone()];
+
+        // Explicit build selects that build's placement.
+        assert_eq!(
+            select_placement_for_build(&both, Some("GRCh38")),
+            Some(grch38.clone())
+        );
+        assert_eq!(
+            select_placement_for_build(&both, Some("GRCh37")),
+            Some(grch37.clone())
+        );
+        // No preference → GRCh38 even when listed second.
+        assert_eq!(
+            select_placement_for_build(&[grch37.clone(), grch38.clone()], None),
+            Some(grch38.clone())
+        );
+        // Build-match guard: an explicit build with no matching placement declines
+        // rather than substitute the other build (would mis-anchor).
+        let only37 = vec![grch37.clone()];
+        assert_eq!(select_placement_for_build(&only37, Some("GRCh38")), None);
+        // No preference with only GRCh37 present → return it (never empty if data exists).
+        assert_eq!(select_placement_for_build(&only37, None), Some(grch37));
+        assert_eq!(select_placement_for_build(&[], Some("GRCh38")), None);
     }
 
     #[test]


### PR DESCRIPTION
RefSeqGene placement parsing kept only GRCh38-primary alignments and `genomic_placement` was build-agnostic (one placement per NG_), so GRCh37 NG_/LRG_ projection was silently unavailable (#653).

This lays the build-aware foundation:
- `parse_refseqgene_alignments` keeps both GRCh37 and GRCh38 primary placements, storing a per-build list per NG_ version (alt/patch contigs dropped; one entry per build);
- `select_placement_for_build` picks the placement matching a resolved build, and declines (returns `None`) when an explicit build has no matching placement rather than substitute another build's placement (build-match guard — closes the latent mis-anchor where a wrong-build placement could be used silently);
- new `ReferenceProvider::genomic_placement_on_build` (default delegates to the build-agnostic `genomic_placement`; `MultiFastaProvider`/`MockProvider` override it and the `Arc`/`Box` blanket impls forward it). `genomic_placement` now delegates to `genomic_placement_on_build(parent, None)`, which prefers GRCh38 — preserving the existing GRCh38 behavior exactly (a single-placement NG_ resolves identically; full suite green).

Tests: parse keeps GRCh37; `select_placement_for_build` build pick + decline guard; `MockProvider` per-build selection.

This is the engine foundation. Bundling a GRCh37 RefSeqGene alignment file in `ferro prepare` and threading the resolved build through the projection path (so GRCh37 inputs project end-to-end) is the remaining follow-up, tracked separately.

Refs #653