### PR TITLE
feat(cli,project): ferro project --axis {g,c,n,p,r} multi-axis projection surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ pre-commit run --all-files           # Run manually
 
 ### CLI Binaries (`src/bin/`)
 
-- `ferro.rs` - Main CLI (`ferro parse`, `ferro normalize`, `ferro prepare`, etc.)
+- `ferro.rs` - Main CLI (`ferro parse`, `ferro normalize`, `ferro project`, `ferro prepare`, etc.)
 - `benchmark.rs` - Tool comparison benchmark (requires `--features benchmark`)
 - `ferro-web.rs` - Web service (requires `--features web-service`)
 

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -264,6 +264,36 @@ enum Commands {
         workers: usize,
     },
 
+    /// Project an HGVS variant onto a chosen output axis (g/c/n/p/r)
+    Project {
+        /// HGVS variant to project
+        variant: Option<String>,
+
+        /// Output axis: g (genomic), c (coding), n (non-coding), p (protein), r (RNA)
+        #[arg(long, required = true, value_parser = ["g", "c", "n", "p", "r"])]
+        axis: String,
+
+        /// Transcript accession to project onto (required for a bare g. input)
+        #[arg(long)]
+        transcript: Option<String>,
+
+        /// Input file (one variant per line)
+        #[arg(short, long)]
+        input: Option<PathBuf>,
+
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+
+        /// Output format
+        #[arg(short = 'f', long, default_value = "text", value_parser = ["text", "json"])]
+        format: String,
+
+        /// Reference directory (with manifest.json from 'ferro prepare')
+        #[arg(long, required = true)]
+        reference: PathBuf,
+    },
+
     /// Parse HGVS variants (validation only)
     Parse {
         /// HGVS variant to parse
@@ -704,6 +734,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 &config,
             )
         }
+        Commands::Project {
+            variant,
+            axis,
+            transcript,
+            input,
+            output,
+            format,
+            reference,
+        } => run_project(
+            variant.as_deref(),
+            &axis,
+            transcript.as_deref(),
+            input.as_ref(),
+            output.as_ref(),
+            &format,
+            &reference,
+        ),
         Commands::Parse {
             variant,
             input,
@@ -1528,6 +1575,123 @@ fn run_normalize(
 
     if error_count > 0 {
         Err(format!("{} variant(s) failed to normalize", error_count).into())
+    } else {
+        Ok(())
+    }
+}
+
+fn run_project(
+    variant: Option<&str>,
+    axis: &str,
+    transcript: Option<&str>,
+    input: Option<&PathBuf>,
+    output: Option<&PathBuf>,
+    format: &str,
+    reference: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use ferro_hgvs::cli::format::{output_project_error, output_projection};
+    use ferro_hgvs::cli::{project_axis, Axis, OutputFormat};
+    use ferro_hgvs::data::cdot::CdotMapper;
+    use ferro_hgvs::data::projection::Projector;
+    use ferro_hgvs::project::VariantProjector;
+    use ferro_hgvs::reference::multi_fasta::MultiFastaProvider;
+    use std::sync::Arc;
+
+    let axis = Axis::parse(axis).expect("clap value_parser guarantees a valid axis");
+    // OutputFormat: FromStr (Infallible) — use the inherent str::parse so no
+    // `use std::str::FromStr` is needed; Default = Text covers the never-taken err arm.
+    let out_format: OutputFormat = format.parse().unwrap_or_default();
+
+    // Build the projector. The Box<dyn ReferenceProvider> from
+    // create_reference_provider is not Clone, and VariantProjector requires
+    // P: Clone. MultiFastaProvider is itself NOT Clone, but `Arc<T>` has a
+    // blanket `impl ReferenceProvider` (reference/provider.rs) and is Clone, so
+    // build the concrete provider, extract the owned cdot, then project through
+    // an Arc.
+    let manifest_path = reference.join("manifest.json");
+    let provider = MultiFastaProvider::from_manifest(&manifest_path)?;
+    // Extract owned cdot BEFORE moving the provider into the Arc.
+    let cdot = provider
+        .cdot_mapper()
+        .cloned()
+        .unwrap_or_else(CdotMapper::new);
+    let provider = Arc::new(provider);
+    let projector = VariantProjector::new(Projector::new(cdot), provider);
+
+    let mut writer: Box<dyn Write> = match output {
+        Some(path) => Box::new(BufWriter::new(File::create(path)?)),
+        None => Box::new(io::stdout()),
+    };
+    let mut error_count = 0usize;
+
+    let process = |v: &str, writer: &mut dyn Write, line: Option<usize>| -> bool {
+        let parsed = match parse_hgvs(v) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = cli_output_error_with_context(&mut io::stderr(), v, &e, out_format, line);
+                return false;
+            }
+        };
+        match project_axis(&projector, &parsed, axis, transcript) {
+            Ok(outcome) => {
+                // A failed write to the result stream (e.g. a full or unwritable
+                // --output file) must not be reported as success; count it so the
+                // exit code reflects the truncated output. (A broken pipe from a
+                // downstream `| head` lands here too and exits nonzero, which is
+                // acceptable — the output was genuinely truncated.)
+                if let Err(e) = output_projection(writer, v, axis, &outcome, out_format, line) {
+                    let _ = writeln!(
+                        io::stderr(),
+                        "ERROR: failed writing output for {}: {}",
+                        v,
+                        e
+                    );
+                    return false;
+                }
+                true
+            }
+            Err(e) => {
+                // Format-aware so `--format json` stays parseable (parity with the
+                // parse-error path above, which uses cli_output_error_with_context).
+                let _ = output_project_error(&mut io::stderr(), v, &e.0, out_format, line);
+                false
+            }
+        }
+    };
+
+    if let Some(v) = variant {
+        if !process(v, &mut writer, None) {
+            error_count += 1;
+        }
+    } else if let Some(input_path) = input {
+        let file = std::fs::File::open(input_path)?;
+        let reader = io::BufReader::new(file);
+        for (line_num, line) in reader.lines().enumerate() {
+            let line = line?;
+            if let Some(vs) = process_input_line(&line, line_num == 0) {
+                if !process(vs, &mut writer, Some(line_num + 1)) {
+                    error_count += 1;
+                }
+            }
+        }
+    } else {
+        let stdin = io::stdin();
+        for (line_num, line) in stdin.lock().lines().enumerate() {
+            let line = line?;
+            if let Some(vs) = process_input_line(&line, line_num == 0) {
+                if !process(vs, &mut writer, Some(line_num + 1)) {
+                    error_count += 1;
+                }
+            }
+        }
+    }
+
+    // Flush the BufWriter explicitly so a write error surfaces here rather than
+    // being silently swallowed by the drop-time flush (parity with run_parse).
+    writer.flush()?;
+
+    if error_count > 0 {
+        Err(format!("{} variant(s) failed to project", error_count).into())
     } else {
         Ok(())
     }

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -85,6 +85,120 @@ pub fn output_result<W: Write>(
     }
 }
 
+/// Write one `ferro project` record.
+///
+/// - text: a rendered axis is the bare HGVS string (pipe-able); an unavailable
+///   axis is written as a `#`-prefixed comment line on the same stream so it
+///   never pollutes the HGVS output while remaining visible to humans.
+/// - json: one object per record carrying axis/transcript/output/status.
+///
+/// # Arguments
+///
+/// * `writer` - The output writer
+/// * `input` - The original input string
+/// * `axis` - The selected output axis
+/// * `outcome` - The axis selection outcome (rendered or unavailable)
+/// * `format` - The output format
+/// * `line_number` - Optional line number in the input file
+pub fn output_projection(
+    writer: &mut dyn Write,
+    input: &str,
+    axis: crate::cli::project::Axis,
+    outcome: &crate::cli::project::AxisOutcome,
+    format: OutputFormat,
+    line_number: Option<usize>,
+) -> io::Result<()> {
+    use crate::cli::project::AxisOutcome;
+    match (format, outcome) {
+        (
+            OutputFormat::Json,
+            AxisOutcome::Rendered {
+                transcript_id,
+                output,
+            },
+        ) => writeln!(
+            writer,
+            r#"{{"input": "{}", "axis": "{}", "transcript": "{}", "output": "{}", "status": "ok"}}"#,
+            escape_json(input),
+            axis.code(),
+            escape_json(transcript_id),
+            escape_json(output)
+        ),
+        (
+            OutputFormat::Json,
+            AxisOutcome::Unavailable {
+                transcript_id,
+                reason,
+            },
+        ) => writeln!(
+            writer,
+            r#"{{"input": "{}", "axis": "{}", "transcript": {}, "output": null, "status": "unavailable", "reason": "{}"}}"#,
+            escape_json(input),
+            axis.code(),
+            match transcript_id {
+                Some(t) => format!(r#""{}""#, escape_json(t)),
+                None => "null".to_string(),
+            },
+            escape_json(reason)
+        ),
+        (_, AxisOutcome::Rendered { output, .. }) => writeln!(writer, "{}", output),
+        (_, AxisOutcome::Unavailable { reason, .. }) => match line_number {
+            Some(n) => writeln!(
+                writer,
+                "# {} (line {}) [{}]: unavailable: {}",
+                input,
+                n,
+                axis.code(),
+                reason
+            ),
+            None => writeln!(
+                writer,
+                "# {} [{}]: unavailable: {}",
+                input,
+                axis.code(),
+                reason
+            ),
+        },
+    }
+}
+
+/// Write a `ferro project` hard-failure record (the exit-1 class: parse error,
+/// transcript not found, `--transcript` mismatch, ambiguous bare-g, IO) to
+/// `writer`, honoring the output format so `--format json` stays parseable.
+///
+/// Mirrors [`output_error_with_context`]'s JSON shape but takes a plain message
+/// string, because a `ferro project` hard failure is carried as a
+/// `ProjectCliError`, not a `FerroError`.
+pub fn output_project_error(
+    writer: &mut dyn Write,
+    input: &str,
+    message: &str,
+    format: OutputFormat,
+    line_number: Option<usize>,
+) -> io::Result<()> {
+    match format {
+        OutputFormat::Json => match line_number {
+            Some(n) => writeln!(
+                writer,
+                r#"{{"input": "{}", "error": "{}", "line": {}, "status": "error"}}"#,
+                escape_json(input),
+                escape_json(message),
+                n
+            ),
+            None => writeln!(
+                writer,
+                r#"{{"input": "{}", "error": "{}", "status": "error"}}"#,
+                escape_json(input),
+                escape_json(message)
+            ),
+        },
+        OutputFormat::Text | OutputFormat::Vcf => match line_number {
+            Some(n) => writeln!(writer, "ERROR (line {}): {} - {}", n, input, message),
+            None => writeln!(writer, "ERROR: {} - {}", input, message),
+        },
+    }
+}
+
 /// Write an error to the output
 ///
 /// # Arguments
@@ -548,6 +662,124 @@ mod tests {
         assert!(result.contains(r#""transcript": "NM_000088.3""#));
         assert!(result.contains(r#""gene": "BRCA1""#));
         assert!(result.contains(r#""hgvs": "c.100A>G""#));
+    }
+
+    // ===== output_projection Tests =====
+
+    #[test]
+    fn output_projection_text_rendered_is_bare_hgvs() {
+        use crate::cli::project::{Axis, AxisOutcome};
+        let mut buf = Cursor::new(Vec::new());
+        let outcome = AxisOutcome::Rendered {
+            transcript_id: "NM_000088.3".to_string(),
+            output: "NP_000079.2:p.(Gly197Cys)".to_string(),
+        };
+        output_projection(
+            &mut buf,
+            "NM_000088.3:c.589G>T",
+            Axis::Protein,
+            &outcome,
+            OutputFormat::Text,
+            None,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert_eq!(out, "NP_000079.2:p.(Gly197Cys)\n");
+    }
+
+    #[test]
+    fn output_projection_json_rendered_has_fields() {
+        use crate::cli::project::{Axis, AxisOutcome};
+        let mut buf = Cursor::new(Vec::new());
+        let outcome = AxisOutcome::Rendered {
+            transcript_id: "NM_000088.3".to_string(),
+            output: "NP_000079.2:p.(Gly197Cys)".to_string(),
+        };
+        output_projection(
+            &mut buf,
+            "NM_000088.3:c.589G>T",
+            Axis::Protein,
+            &outcome,
+            OutputFormat::Json,
+            None,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert!(out.contains(r#""axis": "p""#));
+        assert!(out.contains(r#""transcript": "NM_000088.3""#));
+        assert!(out.contains(r#""output": "NP_000079.2:p.(Gly197Cys)""#));
+        assert!(out.contains(r#""status": "ok""#));
+    }
+
+    #[test]
+    fn output_projection_json_unavailable_status() {
+        use crate::cli::project::{Axis, AxisOutcome};
+        let mut buf = Cursor::new(Vec::new());
+        let outcome = AxisOutcome::Unavailable {
+            transcript_id: Some("NM_000088.3".to_string()),
+            reason: "no p. representation for this variant".to_string(),
+        };
+        output_projection(
+            &mut buf,
+            "NM_000088.3:c.100-5A>G",
+            Axis::Protein,
+            &outcome,
+            OutputFormat::Json,
+            None,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert!(out.contains(r#""status": "unavailable""#));
+        assert!(out.contains(r#""reason""#));
+    }
+
+    #[test]
+    fn output_projection_text_unavailable_is_comment() {
+        use crate::cli::project::{Axis, AxisOutcome};
+        let mut buf = Cursor::new(Vec::new());
+        let outcome = AxisOutcome::Unavailable {
+            transcript_id: Some("NM_000088.3".to_string()),
+            reason: "no p. representation for this variant".to_string(),
+        };
+        output_projection(
+            &mut buf,
+            "NM_000088.3:c.100-5A>G",
+            Axis::Protein,
+            &outcome,
+            OutputFormat::Text,
+            None,
+        )
+        .unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert!(
+            out.starts_with("# NM_000088.3:c.100-5A>G [p]: unavailable:"),
+            "got {out}"
+        );
+    }
+
+    #[test]
+    fn output_project_error_json_is_parseable_object() {
+        let mut buf = Cursor::new(Vec::new());
+        output_project_error(
+            &mut buf,
+            "NC_000001.11:g.1003C>A",
+            "a genomic (g.) input requires --transcript",
+            OutputFormat::Json,
+            Some(3),
+        )
+        .unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert!(out.contains(r#""status": "error""#));
+        assert!(out.contains(r#""line": 3"#));
+        assert!(out.contains(r#""error": "a genomic (g.) input requires --transcript""#));
+    }
+
+    #[test]
+    fn output_project_error_text_is_plain() {
+        let mut buf = Cursor::new(Vec::new());
+        output_project_error(&mut buf, "x", "boom", OutputFormat::Text, None).unwrap();
+        let out = String::from_utf8(buf.into_inner()).unwrap();
+        assert_eq!(out, "ERROR: x - boom\n");
     }
 
     // ===== escape_json Tests =====

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,12 +6,17 @@
 
 pub mod format;
 pub mod parse;
+pub mod project;
 
 // Re-export commonly used items
-pub use format::{output_error, output_error_with_context, output_result, OutputFormat};
+pub use format::{
+    output_error, output_error_with_context, output_project_error, output_projection,
+    output_result, OutputFormat,
+};
 pub use parse::{
     parse_genome_build, parse_shuffle_direction, parse_vcf_line, parse_vcf_line_with_build,
 };
+pub use project::{project_axis, Axis, AxisOutcome, ProjectCliError};
 
 /// UTF-8 BOM (Byte Order Mark) constant
 const UTF8_BOM: &str = "\u{feff}";

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -1,0 +1,424 @@
+//! CLI-agnostic core for the `ferro project` subcommand: select one output
+//! axis from a [`VariantProjection`] and classify engine errors into
+//! "unavailable" (exit 0) vs "hard failure" (exit 1).
+
+use crate::error::FerroError;
+use crate::hgvs::variant::HgvsVariant;
+use crate::project::{VariantProjection, VariantProjector};
+use crate::reference::ReferenceProvider;
+
+/// The output axis selected by `--axis`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    Genomic,
+    Coding,
+    Noncoding,
+    Protein,
+    Rna,
+}
+
+impl Axis {
+    /// Parse the clap-validated `--axis` value (`g`/`c`/`n`/`p`/`r`).
+    pub fn parse(s: &str) -> Option<Axis> {
+        match s {
+            "g" => Some(Axis::Genomic),
+            "c" => Some(Axis::Coding),
+            "n" => Some(Axis::Noncoding),
+            "p" => Some(Axis::Protein),
+            "r" => Some(Axis::Rna),
+            _ => None,
+        }
+    }
+
+    /// The one-letter axis code.
+    pub fn code(self) -> &'static str {
+        match self {
+            Axis::Genomic => "g",
+            Axis::Coding => "c",
+            Axis::Noncoding => "n",
+            Axis::Protein => "p",
+            Axis::Rna => "r",
+        }
+    }
+}
+
+/// The result of selecting one axis from a projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AxisOutcome {
+    /// The axis rendered to an HGVS string.
+    Rendered {
+        transcript_id: String,
+        output: String,
+    },
+    /// The axis is legitimately not available (exit 0); carries a reason and,
+    /// when known, the transcript the projection was attempted on.
+    Unavailable {
+        transcript_id: Option<String>,
+        reason: String,
+    },
+}
+
+/// A hard failure for `ferro project` — maps to a nonzero exit (parse error,
+/// reference/transcript not found, `--transcript` mismatch, ambiguous bare-g,
+/// IO). Distinct from [`AxisOutcome::Unavailable`], which is exit 0.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectCliError(pub String);
+
+impl std::fmt::Display for ProjectCliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Whether an engine `FerroError` means "this representation is not available"
+/// (a clean decline → exit 0) rather than a hard failure. The #662 NG_/LRG_
+/// re-anchor decline and the p./m./o./allele / missing-`genomic_context` / `?`
+/// cases all surface as `UnsupportedProjection`.
+fn engine_error_is_unavailable(e: &FerroError) -> bool {
+    matches!(
+        e,
+        FerroError::UnsupportedProjection { .. }
+            | FerroError::GenomicReferenceNotAvailable { .. }
+            | FerroError::ProteinReferenceNotAvailable { .. }
+            | FerroError::ProteinSequenceUnavailable { .. }
+            | FerroError::IntronicVariant { .. }
+            | FerroError::TranscriptVersionNotExact { .. }
+    )
+}
+
+/// Read the chosen axis off a completed projection, rendering its HGVS string
+/// or reporting it unavailable.
+pub fn select_axis(projection: &VariantProjection, axis: Axis) -> AxisOutcome {
+    let field = match axis {
+        Axis::Genomic => &projection.genomic,
+        Axis::Coding => &projection.coding,
+        Axis::Noncoding => &projection.noncoding,
+        Axis::Protein => &projection.protein,
+        Axis::Rna => &projection.rna,
+    };
+    let tx = projection.transcript_id.clone();
+    match field {
+        Some(v) => AxisOutcome::Rendered {
+            transcript_id: tx,
+            output: v.to_string(),
+        },
+        None => AxisOutcome::Unavailable {
+            transcript_id: Some(tx),
+            reason: format!("no {}. representation for this variant", axis.code()),
+        },
+    }
+}
+
+/// The accession base (everything before the version dot), for version-flex
+/// matching of a user-supplied `--transcript` against enumerated results.
+fn accession_base(acc: &str) -> &str {
+    acc.split('.').next().unwrap_or(acc)
+}
+
+/// Project `variant` to the requested `axis`.
+///
+/// - Transcript-coordinate input (`c.`/`n.`/`r.`): the transcript is taken from
+///   the input accession; a supplied `--transcript` is cross-checked and a
+///   mismatch is a hard error.
+/// - Bare genomic input (`g.`): `--transcript` is required; the engine
+///   enumerates overlapping transcripts and the chosen one is selected.
+pub fn project_axis<P: ReferenceProvider + Clone>(
+    projector: &VariantProjector<P>,
+    variant: &HgvsVariant,
+    axis: Axis,
+    transcript: Option<&str>,
+) -> Result<AxisOutcome, ProjectCliError> {
+    if matches!(variant, HgvsVariant::Genome(_)) {
+        return project_axis_genomic(projector, variant, axis, transcript);
+    }
+
+    // Transcript-coordinate input: the transcript is named in the accession.
+    let input_tx = variant
+        .accession()
+        .map(|a| a.transcript_accession())
+        .ok_or_else(|| ProjectCliError(format!("input {variant} has no transcript to project")))?;
+
+    if let Some(requested) = transcript {
+        if accession_base(requested) != accession_base(&input_tx) {
+            return Err(ProjectCliError(format!(
+                "--transcript {requested} does not match the input's transcript {input_tx}"
+            )));
+        }
+    }
+
+    match projector.project_variant(variant, &input_tx) {
+        Ok(projection) => Ok(select_axis(&projection, axis)),
+        Err(e) if engine_error_is_unavailable(&e) => Ok(AxisOutcome::Unavailable {
+            transcript_id: Some(input_tx),
+            reason: e.to_string(),
+        }),
+        Err(e) => Err(ProjectCliError(e.to_string())),
+    }
+}
+
+/// Bare-genomic dispatch: enumerate overlapping transcripts and pick one.
+fn project_axis_genomic<P: ReferenceProvider + Clone>(
+    projector: &VariantProjector<P>,
+    variant: &HgvsVariant,
+    axis: Axis,
+    transcript: Option<&str>,
+) -> Result<AxisOutcome, ProjectCliError> {
+    let Some(requested) = transcript else {
+        // Ambiguous: list the overlapping transcripts so the user can choose.
+        let ids = enumerate_transcript_ids(projector, variant)?;
+        let listed = if ids.is_empty() {
+            "none overlap this position".to_string()
+        } else {
+            ids.join(", ")
+        };
+        return Err(ProjectCliError(format!(
+            "a genomic (g.) input requires --transcript; overlapping transcripts \
+             (longest-CDS, then alphabetical): {listed}"
+        )));
+    };
+
+    // Project directly onto the requested transcript rather than enumerating and
+    // filtering: `project_variant_all` silently drops per-transcript errors, so a
+    // transcript that overlaps but whose projection *declines* would otherwise be
+    // misreported as "does not overlap". Going direct surfaces a genuine decline
+    // as Unavailable (exit 0) and a non-overlap / hard error as a hard failure.
+    match projector.project_variant(variant, requested) {
+        Ok(projection) => Ok(select_axis(&projection, axis)),
+        Err(e) if engine_error_is_unavailable(&e) => Ok(AxisOutcome::Unavailable {
+            transcript_id: Some(requested.to_string()),
+            reason: e.to_string(),
+        }),
+        Err(e) => Err(ProjectCliError(e.to_string())),
+    }
+}
+
+/// Enumerate the transcript ids overlapping a genomic input (for the
+/// "needs --transcript" error message), in the engine's clinical-priority order
+/// (MANE/canonical sets are empty in CLI context, so this is longest-CDS then
+/// alphabetical).
+fn enumerate_transcript_ids<P: ReferenceProvider + Clone>(
+    projector: &VariantProjector<P>,
+    variant: &HgvsVariant,
+) -> Result<Vec<String>, ProjectCliError> {
+    match projector.project_variant_all(variant) {
+        Ok(ps) => Ok(ps.into_iter().map(|p| p.transcript_id).collect()),
+        Err(e) if engine_error_is_unavailable(&e) => Ok(Vec::new()),
+        Err(e) => Err(ProjectCliError(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::cdot::{CdotMapper, CdotTranscript};
+    use crate::data::projection::Projector;
+    use crate::project::VariantProjection;
+    use crate::reference::mock::MockProvider;
+    use crate::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+    use crate::reference::Strand;
+
+    #[test]
+    fn axis_parse_roundtrips_codes() {
+        for code in ["g", "c", "n", "p", "r"] {
+            assert_eq!(Axis::parse(code).unwrap().code(), code);
+        }
+        assert_eq!(Axis::parse("m"), None);
+        assert_eq!(Axis::parse(""), None);
+    }
+
+    #[test]
+    fn unsupported_projection_is_unavailable_not_hard() {
+        let e = FerroError::UnsupportedProjection {
+            reason: "no chromosomal placement is known for NG_TEST.1".to_string(),
+        };
+        assert!(engine_error_is_unavailable(&e));
+    }
+
+    #[test]
+    fn parse_and_not_found_are_hard() {
+        assert!(!engine_error_is_unavailable(
+            &FerroError::ReferenceNotFound {
+                id: "NM_X".to_string()
+            }
+        ));
+        assert!(!engine_error_is_unavailable(&FerroError::Parse {
+            msg: "bad".to_string(),
+            pos: 0,
+            diagnostic: None,
+        }));
+    }
+
+    fn projection_with(genomic: Option<&str>, protein: Option<&str>) -> VariantProjection {
+        VariantProjection {
+            genomic: genomic.map(|s| crate::parse_hgvs(s).unwrap()),
+            coding: None,
+            noncoding: None,
+            protein: protein.map(|s| crate::parse_hgvs(s).unwrap()),
+            rna: None,
+            transcript_id: "NM_000088.3".to_string(),
+            gene_symbol: None,
+            is_frameshift: false,
+            is_intronic: false,
+            is_utr: false,
+        }
+    }
+
+    #[test]
+    fn select_axis_renders_present_field() {
+        let proj = projection_with(Some("NC_000017.11:g.50198003C>A"), None);
+        let outcome = select_axis(&proj, Axis::Genomic);
+        assert_eq!(
+            outcome,
+            AxisOutcome::Rendered {
+                transcript_id: "NM_000088.3".to_string(),
+                output: "NC_000017.11:g.50198003C>A".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn select_axis_absent_field_is_unavailable() {
+        let proj = projection_with(None, None);
+        let outcome = select_axis(&proj, Axis::Protein);
+        match outcome {
+            AxisOutcome::Unavailable {
+                transcript_id,
+                reason,
+            } => {
+                assert_eq!(transcript_id.as_deref(), Some("NM_000088.3"));
+                assert!(reason.contains("protein") || reason.contains("p."));
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    /// A single plus-strand coding transcript NM_TEST.1 on NC_000001.11
+    /// [1000..1008], CDS = the whole 9-base exon "ATGCGCTAA". The contig is the
+    /// chromosome accession (NOT "chr1") because a bare `NC_000001.11:g.` input
+    /// resolves its contig from the accession, so the cdot/transcript must be
+    /// indexed under the same `NC_000001.11` name for overlap enumeration.
+    fn fixture() -> VariantProjector<MockProvider> {
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            "NM_TEST.1".to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "NC_000001.11".to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: Some("NP_TEST.1".to_string()),
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript::new(
+            "NM_TEST.1".to_string(),
+            Some("TESTGENE".to_string()),
+            TxStrand::Plus,
+            "ATGCGCTAA".to_string(),
+            Some(1),
+            Some(9),
+            vec![Exon::new(1, 1, 9)],
+            Some("NC_000001.11".to_string()),
+            Some(1000),
+            Some(1008),
+            Default::default(),
+            ManeStatus::default(),
+            None,
+            None,
+        ));
+        provider.add_genomic_sequence(
+            "NC_000001.11",
+            format!("{}ATGCGCTAA{}", "N".repeat(1000), "N".repeat(100)),
+        );
+
+        VariantProjector::new(projector, provider)
+    }
+
+    #[test]
+    fn project_axis_coding_input_renders_protein() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+        let outcome = project_axis(&vp, &variant, Axis::Protein, None).unwrap();
+        match outcome {
+            AxisOutcome::Rendered {
+                transcript_id,
+                output,
+            } => {
+                assert_eq!(transcript_id, "NM_TEST.1");
+                assert!(output.starts_with("NP_TEST.1:p."), "got {output}");
+            }
+            other => panic!("expected Rendered, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn project_axis_transcript_mismatch_is_hard_error() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+        let err = project_axis(&vp, &variant, Axis::Protein, Some("NM_OTHER.1")).unwrap_err();
+        assert!(
+            err.0.contains("NM_OTHER.1") && err.0.to_lowercase().contains("match"),
+            "got {}",
+            err.0
+        );
+    }
+
+    #[test]
+    fn project_axis_bare_nm_genomic_axis_unavailable() {
+        // A bare NM_ coding input has no genome alignment → g. is None.
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+        let outcome = project_axis(&vp, &variant, Axis::Genomic, None).unwrap();
+        assert!(
+            matches!(outcome, AxisOutcome::Unavailable { .. }),
+            "got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn project_axis_coding_input_n_axis_renders() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+        let outcome = project_axis(&vp, &variant, Axis::Noncoding, None).unwrap();
+        assert!(
+            matches!(outcome, AxisOutcome::Rendered { .. }),
+            "got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn project_axis_bare_genomic_without_transcript_is_hard_error_listing_overlaps() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NC_000001.11:g.1003C>A").unwrap();
+        let err = project_axis(&vp, &variant, Axis::Coding, None).unwrap_err();
+        assert!(err.0.contains("requires --transcript"), "got {}", err.0);
+        assert!(
+            err.0.contains("NM_TEST.1"),
+            "should list the overlapping transcript: {}",
+            err.0
+        );
+    }
+
+    #[test]
+    fn project_axis_bare_genomic_with_transcript_renders() {
+        let vp = fixture();
+        let variant = crate::parse_hgvs("NC_000001.11:g.1003C>A").unwrap();
+        let outcome = project_axis(&vp, &variant, Axis::Coding, Some("NM_TEST.1")).unwrap();
+        match outcome {
+            AxisOutcome::Rendered {
+                transcript_id,
+                output,
+            } => {
+                assert_eq!(transcript_id, "NM_TEST.1");
+                assert!(output.contains(":c."), "got {output}");
+            }
+            other => panic!("expected Rendered, got {other:?}"),
+        }
+    }
+}

--- a/tests/cli_project.rs
+++ b/tests/cli_project.rs
@@ -1,0 +1,150 @@
+//! CLI surface + axis-logic tests for `ferro project` (#626).
+//!
+//! Two kinds of test: spawned-binary surface tests (clap validation, exit
+//! codes — no reference data needed) and in-process axis/decline tests that
+//! call the library `project_axis` with a `MockProvider` fixture (so they need
+//! no on-disk manifest).
+
+use std::process::Command;
+
+use ferro_hgvs::cli::project::{project_axis, Axis, AxisOutcome};
+use ferro_hgvs::data::{CdotMapper, CdotTranscript, Projector};
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::project::VariantProjector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+// ===== spawned-binary surface tests =====
+
+#[test]
+fn project_rejects_invalid_axis() {
+    let out = ferro()
+        .args([
+            "project",
+            "NM_000088.3:c.589G>T",
+            "--axis",
+            "q",
+            "--reference",
+            "/tmp",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "invalid --axis must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("axis"), "stderr: {stderr}");
+}
+
+#[test]
+fn project_requires_axis_and_reference() {
+    // Missing --axis (required) -> clap error.
+    let out = ferro()
+        .args(["project", "NM_000088.3:c.589G>T", "--reference", "/tmp"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "missing --axis must fail");
+    // Missing --reference (required) -> clap error.
+    let out = ferro()
+        .args(["project", "NM_000088.3:c.589G>T", "--axis", "p"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "missing --reference must fail");
+}
+
+#[test]
+fn project_bad_manifest_exits_nonzero() {
+    // A nonexistent manifest dir surfaces a hard error (nonzero exit), not a panic.
+    let out = ferro()
+        .args([
+            "project",
+            "NM_000088.3:c.589G>T",
+            "--axis",
+            "g",
+            "--reference",
+            "/nonexistent-xyz-ferro",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+}
+
+// ===== in-process axis-logic tests (MockProvider fixture) =====
+
+/// A single plus-strand coding transcript NM_TEST.1 on NC_000001.11
+/// [1000..1008], CDS = the whole 9-base exon "ATGCGCTAA". The contig is the
+/// chromosome accession (NOT "chr1") because a bare `NC_000001.11:g.` input
+/// resolves its contig from the accession.
+fn fixture() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "NC_000001.11".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    provider.add_genomic_sequence(
+        "NC_000001.11",
+        format!("{}ATGCGCTAA{}", "N".repeat(1000), "N".repeat(100)),
+    );
+
+    VariantProjector::new(projector, provider)
+}
+
+#[test]
+fn coding_input_n_axis_renders() {
+    let vp = fixture();
+    let variant = parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+    let outcome = project_axis(&vp, &variant, Axis::Noncoding, None).unwrap();
+    assert!(
+        matches!(outcome, AxisOutcome::Rendered { .. }),
+        "got {outcome:?}"
+    );
+}
+
+#[test]
+fn bare_genomic_with_transcript_renders_coding() {
+    let vp = fixture();
+    let variant = parse_hgvs("NC_000001.11:g.1003C>A").unwrap();
+    let outcome = project_axis(&vp, &variant, Axis::Coding, Some("NM_TEST.1")).unwrap();
+    match outcome {
+        AxisOutcome::Rendered {
+            transcript_id,
+            output,
+        } => {
+            assert_eq!(transcript_id, "NM_TEST.1");
+            assert!(output.contains(":c."), "got {output}");
+        }
+        other => panic!("expected Rendered, got {other:?}"),
+    }
+}


### PR DESCRIPTION
The projection engine already computes a variant across axes (`VariantProjection { genomic, coding, noncoding, protein, rna }`), but none of it was reachable from the CLI — `ferro normalize` only ever emits the input's own axis. This adds the explicit, opt-in `ferro project` verb:

```
ferro project NG_007485.1(NM_000077.4):c.274G>T --axis g  -> NG_007485.1:g.28407G>T
ferro project NM_000088.3:c.589G>T              --axis p  -> NP_000079.2:p.(Gly197Cys)
ferro project NM_000088.3:c.589G>T              --axis n  -> NM_000088.3:n.659G>T
ferro project NG_012337.1(NM_003002.2):c.169T>A --axis r  -> NG_012337.1(NM_003002.2):r.(169u>a)
```

- `--axis {g,c,n,p,r}` (required) selects which `VariantProjection` field to render; all five axes are wired (r. via the merged #485/#701 RNA surface). `normalize()` stays axis-preserving by default — this is a dedicated projection verb, not a normalize contract change.
- Transcript resolution: a transcript-coordinate input uses its own named transcript; a bare `g.` input requires `--transcript` (else it errors, listing the overlapping transcripts) — never a silent auto-pick. A `--transcript` that disagrees with a transcript-coordinate input is a hard error.
- Decline semantics: an axis that is legitimately unavailable (intronic + `--axis p`, bare-`NM_` + `--axis g`, the #480/#655 NG_-without-placement decline) is reported as "unavailable" and exits 0; parse / not-found / mismatch / IO are hard failures (exit 1). The `#480` contract is honored — never emit chromosome coordinates stamped under an `NG_` accession.
- `--format text` (bare HGVS per line, pipe-able; unavailable rows as `#` comments) or `json` (one object per record with `axis`/`transcript`/`status`).

Python parity is already satisfied by the existing `VariantProjection` accessors (`g_name`/`c_name`/`n_name`/`p_name`/`r_name`); this PR adds the missing CLI surface only.

Closes #626
Closes #622