### PR TITLE
fix(reference): resolve cdot version-exact in normalize, never substitute a sibling version

### DIFF
--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -2503,6 +2503,71 @@ impl CdotMapper {
         None
     }
 
+    /// Version-**exact** transcript lookup: like [`get_transcript`](Self::get_transcript)
+    /// but **without** the version-fallback that substitutes a sibling version
+    /// (`NM_000088.2 → NM_000088.3`).
+    ///
+    /// Use this where the caller has already committed to a specific version's
+    /// *sequence* and must not pair it with a *different* version's CDS/exon
+    /// frame. Per HGVS, a `c.`/`r.` description is defined only against its
+    /// named `accession.version` — `c.1` is the `A` of that version's start
+    /// codon (`background/numbering.md`), and a versioned identifier is required
+    /// precisely because versions differ in length/CDS offset
+    /// (`background/refseq.md`). Substituting a sibling version's frame onto
+    /// another version's sequence yields a spec-invalid description whose stated
+    /// reference and coordinate frame disagree (#714).
+    ///
+    /// The LRG → RefSeq mapping is honored exactly (it is an alias to a specific
+    /// `accession.version`, not a version fuzz).
+    pub fn get_transcript_exact(&self, accession: &str) -> Option<&CdotTranscript> {
+        if let Some(tx) = self.transcripts.get(accession) {
+            return Some(tx);
+        }
+        if accession.starts_with("LRG_") {
+            if let Some(refseq) = self.lrg_to_refseq.get(accession) {
+                return self.transcripts.get(refseq);
+            }
+        }
+        None
+    }
+
+    /// Build-aware version-**exact** lookup: the
+    /// [`get_transcript_on_build`](Self::get_transcript_on_build) analogue of
+    /// [`get_transcript_exact`](Self::get_transcript_exact). Consults the
+    /// primary build, eagerly-captured alt views, and any deferred secondary
+    /// build, but **never** falls back to a different version of the same base
+    /// accession (#714).
+    pub fn get_transcript_on_build_exact(
+        &self,
+        accession: &str,
+        build: &str,
+    ) -> Option<&CdotTranscript> {
+        let primary_matches = match self.primary_build.as_deref() {
+            Some(pb) => pb == build,
+            None => true,
+        };
+        if primary_matches {
+            return self.get_transcript_exact(accession);
+        }
+        let resolved: &str = if accession.starts_with("LRG_") {
+            self.lrg_to_refseq
+                .get(accession)
+                .map(String::as_str)
+                .unwrap_or(accession)
+        } else {
+            accession
+        };
+        if let Some(alt) = self.alt_build_transcripts.get(build) {
+            if let Some(tx) = alt.get(resolved) {
+                return Some(tx);
+            }
+            // NO version fallback here (exact only) — unlike
+            // `get_transcript_on_build`.
+        }
+        self.deferred_alt_mapper(build)?
+            .get_transcript_on_build_exact(accession, build)
+    }
+
     /// Get a transcript by accession, restricted to a specific genome build.
     ///
     /// When `build` matches the mapper's primary load build, delegates to
@@ -4978,6 +5043,87 @@ mod tests {
             Some(20),
             "primary-build base->version fallback must deterministically pick \
              the highest version (.4 over .3)"
+        );
+    }
+
+    /// JSON with only `NM_000088.3` and `.4` present (no `.2`), used to contrast
+    /// fuzzy vs. exact resolution.
+    fn version_skew_mapper() -> CdotMapper {
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_000088.3": {
+                    "gene_name": "COL1A1",
+                    "genome_builds": { "GRCh38": {
+                        "contig": "NC_000017.11", "strand": "+",
+                        "exons": [[50184096, 50184169, 1, 0, 73, "M73"]]
+                    }},
+                    "start_codon": 10, "stop_codon": 60
+                },
+                "NM_000088.4": {
+                    "gene_name": "COL1A1",
+                    "genome_builds": { "GRCh38": {
+                        "contig": "NC_000017.11", "strand": "+",
+                        "exons": [[50184096, 50184269, 1, 0, 173, "M173"]]
+                    }},
+                    "start_codon": 20, "stop_codon": 160
+                }
+            }
+        }
+        "#;
+        CdotMapper::from_reader(json.as_bytes()).unwrap()
+    }
+
+    // #714: `get_transcript_exact` must NOT substitute a sibling version. An
+    // absent exact version returns `None`, where the fuzzy `get_transcript`
+    // returns a different version — pairing that frame with the requested
+    // version's sequence is what silently mis-normalizes `c.` variants.
+    #[test]
+    fn test_get_transcript_exact_does_not_version_fuzz() {
+        let mapper = version_skew_mapper();
+        // Absent exact version: fuzzy finds a sibling, exact returns None.
+        assert!(
+            mapper.get_transcript("NM_000088.2").is_some(),
+            "fuzzy get_transcript still resolves an absent version to a sibling"
+        );
+        assert!(
+            mapper.get_transcript_exact("NM_000088.2").is_none(),
+            "exact lookup must NOT substitute a sibling version (#714)"
+        );
+        // Present exact versions resolve to their OWN frame.
+        assert_eq!(
+            mapper
+                .get_transcript_exact("NM_000088.3")
+                .map(|t| t.cds_start),
+            Some(Some(10)),
+            "exact .3 must return .3's own CDS frame"
+        );
+        assert_eq!(
+            mapper
+                .get_transcript_exact("NM_000088.4")
+                .map(|t| t.cds_start),
+            Some(Some(20)),
+            "exact .4 must return .4's own CDS frame"
+        );
+    }
+
+    // #714: the build-aware exact lookup is also version-exact on the primary
+    // build (the path the normalize transcript resolution uses with no hint).
+    #[test]
+    fn test_get_transcript_on_build_exact_no_version_fuzz_primary() {
+        let mapper = version_skew_mapper();
+        assert!(
+            mapper
+                .get_transcript_on_build_exact("NM_000088.2", "GRCh38")
+                .is_none(),
+            "build-exact lookup must not substitute a sibling on the primary build (#714)"
+        );
+        assert_eq!(
+            mapper
+                .get_transcript_on_build_exact("NM_000088.4", "GRCh38")
+                .map(|t| t.cds_start),
+            Some(Some(20)),
+            "build-exact lookup resolves the exact version when present"
         );
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1479,9 +1479,20 @@ impl MultiFastaProvider {
 
                 // Try to get metadata from cdot
                 let meta = if let Some(ref cdot) = self.cdot_mapper {
+                    // Version-EXACT cdot lookup (#714): `resolved` is the
+                    // concrete accession.version whose *sequence* we just read
+                    // from the index. cdot's fuzzy version-fallback would pair
+                    // that sequence with a *sibling* version's CDS/exon frame
+                    // (e.g. NM_003002.2's bases with .3's CDS, start_codon 84 vs
+                    // 61), producing a spec-invalid `c.` description: HGVS numbers
+                    // `c.1` from the named version's start codon and requires the
+                    // exact version precisely because versions differ in
+                    // length/CDS offset (background/numbering.md, refseq.md). On
+                    // an exact miss, fall through to the supplemental-CDS path
+                    // below rather than adopt a foreign frame.
                     let cdot_tx_opt = match build_hint {
-                        Some(b) => cdot.get_transcript_on_build(&resolved, b),
-                        None => cdot.get_transcript(&resolved),
+                        Some(b) => cdot.get_transcript_on_build_exact(&resolved, b),
+                        None => cdot.get_transcript_exact(&resolved),
                     };
                     if let Some(tx) = cdot_tx_opt {
                         // Convert cdot exons to transcript exons


### PR DESCRIPTION
Closes #714.

## Problem

`cdot::get_transcript` does version-fuzzy fallback (`NM_X.2` absent → `NM_X.3`). The normalize transcript-resolution path (`MultiFastaProvider::get_transcript_on_build_inner`) called it on `resolved` — the concrete `accession.version` whose **sequence** it just read from the FASTA index. So an older version present only as a supplemental sequence (absent from the active cdot) was paired with a **sibling version's CDS/exon frame**. The frames disagree, silently mis-normalizing `c.` variants.

**Quantified on `NM_003002.2`** (sequence present; GRCh38 cdot has only `.3`/`.4`): of 480 single-base CDS deletions, **202 normalized wrong** — **110 to a confidently wrong, well-formed coordinate** (e.g. `c.6del` → `c.8del`, truth `c.7del`) and 92 to a wrong no-op — because cdot returned `.3`'s frame (`start_codon` 84 vs `.2`'s 61).

## Why it's a spec violation (not just an inconsistency)

Per HGVS, `c.` is numbered from **the named version's** start codon (`background/numbering.md` §20–21), and the exact `accession.version` is **required** precisely because versions differ in length/CDS offset (`background/refseq.md` §23–26, §232–240). A description naming `.2` whose coordinate was deduced from `.3`'s frame is self-contradictory by the spec's own definitions. (Full citation in #714.)

## Fix

- Add version-**exact** lookups `CdotMapper::get_transcript_exact` and `get_transcript_on_build_exact` — no sibling-version fallback; the `LRG_→RefSeq` alias is still honored exactly.
- Point `MultiFastaProvider`'s normalize resolution at the exact variants. The fuzzy `get_transcript`/`get_transcript_on_build` and their tests (`cdot.rs` version-fallback tests) are **preserved** for callers without a sequence-version constraint.

A version whose exact cdot annotation is absent now falls through to the supplemental-CDS path (an honest no-op when CDS is unknown) instead of adopting a foreign frame.

## Validation

- New cdot unit tests: exact lookup returns `None` for an absent version where fuzzy returns a sibling; returns each present version's **own** CDS frame (primary + build-aware).
- Existing version-fallback tests unchanged and green (fuzzy semantics preserved).
- Empirical (against a prepared reference carrying `NM_003002.2`):
  - **Safety:** `NM_003002.2:c.6del → c.6del` (honest no-op; the fabricated `c.8del` is gone). Sweep `wrong_nonecho` 110 → 0. `NM_003002.4` control unaffected.
  - **Correctness:** with the version's own CDS available, the same path normalizes correctly — `c.273del → c.274del`, `c.6del → c.7del`.
- Full suite: **7180/7180 pass**, 0 regressions. `clippy --all-targets -D warnings` clean; `fmt` clean.

## Scope / follow-up

This is the **safety layer** (stop the silent corruption). The **correctness layer** — rows resolving correctly even on a vanilla manifest — follows from provisioning each pinned version's own CDS (the supplemental path now consumes it correctly with no further normalize change) or a cross-build exact GRCh37-cdot fallback. Tracked with the conformance reference-snapshot work.

Refs #672.