### PR TITLE
feat(reference,project): bundle GRCh37 RefSeqGene alignment + thread build through projection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ variant = ferro_hgvs.parse("NM_000088.3:c.459A>G")
 The `ferro prepare` command downloads RefSeq transcripts, genome FASTAs, and cdot metadata needed for normalization. Data goes to a reference directory checked with `ferro check --reference <dir>`.
 
 It also downloads genomic-parent placement data used to project transcript-coordinate variants into a genomic parent's own frame (#480):
-- **RefSeqGene→genome alignments** (`GCF_*_refseqgene_alignments.gff3`, from NCBI's archived `alignments/ARCHIVE/all/` — the feed stopped updating in 2024; latest GRCh38 is the RS-109/p13 snapshot, valid for p14 since primary `NC_` accessions are unchanged) → manifest `refseqgene_alignments`; parsed by `MultiFastaProvider` into per-`NG_` `GenomicPlacement`.
+- **RefSeqGene→genome alignments** (`GCF_*_refseqgene_alignments.gff3`, from NCBI's archived `alignments/ARCHIVE/all/` — the feed stopped updating in 2024; latest GRCh38 is the RS-109/p13 snapshot, valid for p14 since primary `NC_` accessions are unchanged) → manifest `refseqgene_alignments`; parsed by `MultiFastaProvider` into per-`NG_` `GenomicPlacement`. The corresponding GRCh37 snapshot (`GCF_000001405.25_105.*`) → manifest `refseqgene_alignments_grch37`, merged with the GRCh38 file so an `NG_` resolves to its build-appropriate placement (#653/#713).
 - **LRG XML** genomic mapping → per-`LRG_` `GenomicPlacement` (parsed on demand).
 
 `ReferenceProvider::genomic_placement` exposes these; `VariantProjector::project_to_genomic` composes the `NM_`→`NC_` (cdot) step with the `NC_`→`NG_`/`LRG_` affine transform to re-express coordinates in the parent frame. With no placement it declines rather than emit chromosome coordinates under the parent accession.

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -173,6 +173,14 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
             ));
         }
     }
+    if let Some(ref alignments) = manifest.refseqgene_alignments_grch37 {
+        if !alignments.exists() {
+            result.warnings.push(format!(
+                "GRCh37 RefSeqGene alignments GFF3 not found: {}",
+                alignments.display()
+            ));
+        }
+    }
 
     result
 }
@@ -303,6 +311,7 @@ mod tests {
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -352,6 +361,7 @@ mod tests {
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: Some(missing_alignments.clone()),
+            refseqgene_alignments_grch37: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -380,6 +390,58 @@ mod tests {
                 .iter()
                 .any(|w| w.contains("RefSeqGene alignments GFF3 not found")),
             "Expected a warning for the missing alignments file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_check_warns_on_missing_refseqgene_alignments_grch37() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point refseqgene_alignments_grch37 at a file that does not exist.
+        let missing_alignments = dir.path().join("missing_refseqgene_alignments_grch37.gff3");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: Some(missing_alignments.clone()),
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("GRCh37 RefSeqGene alignments GFF3 not found")),
+            "Expected a warning for the missing GRCh37 alignments file, got {:?}",
             result.warnings
         );
     }

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -27,10 +27,16 @@ pub struct ReferenceManifest {
     #[serde(default)]
     pub refseqgene_fastas: Vec<PathBuf>,
     /// RefSeqGene→genome alignment GFF3 (NCBI `GCF_*_refseqgene_alignments.gff3`),
-    /// giving each NG_ record's chromosomal placement. Consumed to re-express
-    /// transcript coordinates in an NG_ parent's own frame (#480).
+    /// giving each NG_ record's **GRCh38** chromosomal placement. Consumed to
+    /// re-express transcript coordinates in an NG_ parent's own frame (#480).
     #[serde(default)]
     pub refseqgene_alignments: Option<PathBuf>,
+    /// GRCh37 RefSeqGene→genome alignment GFF3 (the archived `GCF_000001405.25_105.*`
+    /// snapshot). Merged with `refseqgene_alignments` so an NG_ resolves to its
+    /// build-appropriate placement (#653/#713). Paired with `refseqgene_alignments`
+    /// the same way `genome_grch37_fasta`/`cdot_grch37_json` pair their GRCh38 fields.
+    #[serde(default)]
+    pub refseqgene_alignments_grch37: Option<PathBuf>,
     /// LRG FASTA files (LRG_* accessions)
     #[serde(default)]
     pub lrg_fastas: Vec<PathBuf>,
@@ -97,6 +103,7 @@ impl Default for ReferenceManifest {
             genome_grch37_fasta: None,
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
             lrg_refseq_mapping: None,
@@ -240,6 +247,7 @@ impl ReferenceManifest {
             &self.genome_fasta,
             &self.genome_grch37_fasta,
             &self.refseqgene_alignments,
+            &self.refseqgene_alignments_grch37,
             &self.lrg_refseq_mapping,
             &self.cdot_json,
             &self.cdot_grch37_json,
@@ -277,6 +285,7 @@ impl ReferenceManifest {
             &mut self.genome_fasta,
             &mut self.genome_grch37_fasta,
             &mut self.refseqgene_alignments,
+            &mut self.refseqgene_alignments_grch37,
             &mut self.lrg_refseq_mapping,
             &mut self.cdot_json,
             &mut self.cdot_grch37_json,
@@ -395,6 +404,32 @@ mod tests {
         );
     }
 
+    /// A manifest written before #713 (no `refseqgene_alignments_grch37` key)
+    /// must still deserialize, with the new field defaulting to `None`
+    /// (`#[serde(default)]`) — backward compatibility for prepared references.
+    #[test]
+    fn test_legacy_manifest_without_grch37_alignments_deserializes() {
+        let json = r#"{
+            "prepared_at": "2024-01-01T00:00:00Z",
+            "transcript_fastas": ["transcripts.fa"],
+            "genome_fasta": "genome.fa",
+            "refseqgene_alignments": "refseqgene/aln.gff3",
+            "transcript_count": 0,
+            "available_prefixes": []
+        }"#;
+        let manifest: ReferenceManifest =
+            serde_json::from_str(json).expect("legacy manifest must deserialize");
+        assert_eq!(
+            manifest.refseqgene_alignments,
+            Some(PathBuf::from("refseqgene/aln.gff3")),
+            "the GRCh38 alignment field is preserved"
+        );
+        assert_eq!(
+            manifest.refseqgene_alignments_grch37, None,
+            "absent GRCh37 alignment field defaults to None"
+        );
+    }
+
     #[test]
     fn test_make_paths_absolute() {
         use tempfile::TempDir;
@@ -477,6 +512,7 @@ mod tests {
             genome_grch37_fasta: Some(ref_dir.join("genome37.fa")),
             refseqgene_fastas: vec![ref_dir.join("ng.fa")],
             refseqgene_alignments: Some(ref_dir.join("refseqgene_alignments.gff3")),
+            refseqgene_alignments_grch37: Some(ref_dir.join("refseqgene_alignments_grch37.gff3")),
             lrg_fastas: vec![ref_dir.join("lrg.fa")],
             lrg_xmls: vec![ref_dir.join("lrg.xml")],
             lrg_refseq_mapping: Some(ref_dir.join("lrg_mapping.txt")),

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -122,6 +122,19 @@ pub mod urls {
     pub const REFSEQGENE_ALIGNMENTS_URL: &str =
         "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/alignments/ARCHIVE/all/GCF_000001405.39_109.20211119_refseqgene_alignments.gff3";
 
+    /// GRCh37 RefSeqGene→genome alignment GFF3 (#653/#713).
+    ///
+    /// The final **GRCh37** RefSeqGene alignment is the archived RefSeq
+    /// annotation-release-105 snapshot (assembly `GCF_000001405.25` = GRCh37.p13,
+    /// dated 2020-10-22) under `alignments/ARCHIVE/all/`. NCBI froze the GRCh37
+    /// feed, so this is the latest; `NG_` records curated later are simply absent
+    /// (they decline — never a wrong coordinate). Merged with the GRCh38 file
+    /// (above) so an `NG_` resolves to its build-appropriate placement.
+    pub const REFSEQGENE_ALIGNMENTS_GRCH37_FILE: &str =
+        "GCF_000001405.25_105.20201022_refseqgene_alignments.gff3";
+    pub const REFSEQGENE_ALIGNMENTS_GRCH37_URL: &str =
+        "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/alignments/ARCHIVE/all/GCF_000001405.25_105.20201022_refseqgene_alignments.gff3";
+
     /// cdot transcript database (contains CDS metadata, exon coordinates, etc.)
     /// From https://github.com/SACGF/cdot/releases
     pub const CDOT_REFSEQ_GRCH38: &str = "https://github.com/SACGF/cdot/releases/download/data_v0.2.32/cdot-0.2.32.refseq.GRCh38.json.gz";
@@ -427,19 +440,42 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             manifest.refseqgene_fastas.len()
         );
 
-        // RefSeqGene→genome alignment GFF3 — each NG_ record's chromosomal
+        // RefSeqGene→genome alignment GFF3s — each NG_ record's chromosomal
         // placement, used to project transcript coordinates into an NG_ parent's
-        // own frame (#480). Plain (un-gzipped) GFF3.
-        let aln_name = urls::REFSEQGENE_ALIGNMENTS_FILE;
-        let aln_path = refseqgene_dir.join(aln_name);
-        if config.skip_existing && aln_path.exists() {
-            eprintln!("  Skipping {} (exists)", aln_name);
-            manifest.refseqgene_alignments = Some(aln_path);
-        } else {
-            eprintln!("  Downloading {}...", aln_name);
-            match download_file(urls::REFSEQGENE_ALIGNMENTS_URL, &aln_path) {
-                Ok(_) => manifest.refseqgene_alignments = Some(aln_path),
-                Err(e) => eprintln!("  Warning: Failed to download {}: {}", aln_name, e),
+        // own frame (#480). Plain (un-gzipped) GFF3. Two single-build snapshots
+        // are fetched and merged downstream so an NG_ resolves to its
+        // build-appropriate placement: GRCh38 (release 109) and GRCh37 (release
+        // 105, #653/#713). A failed/absent file is non-fatal — that build's
+        // placements are simply unavailable (NG_ inputs on it decline).
+        for (name, url, is_grch37) in [
+            (
+                urls::REFSEQGENE_ALIGNMENTS_FILE,
+                urls::REFSEQGENE_ALIGNMENTS_URL,
+                false,
+            ),
+            (
+                urls::REFSEQGENE_ALIGNMENTS_GRCH37_FILE,
+                urls::REFSEQGENE_ALIGNMENTS_GRCH37_URL,
+                true,
+            ),
+        ] {
+            let aln_path = refseqgene_dir.join(name);
+            let record = |manifest: &mut ReferenceManifest, path: PathBuf| {
+                if is_grch37 {
+                    manifest.refseqgene_alignments_grch37 = Some(path);
+                } else {
+                    manifest.refseqgene_alignments = Some(path);
+                }
+            };
+            if config.skip_existing && aln_path.exists() {
+                eprintln!("  Skipping {} (exists)", name);
+                record(&mut manifest, aln_path);
+            } else {
+                eprintln!("  Downloading {}...", name);
+                match download_file(url, &aln_path) {
+                    Ok(_) => record(&mut manifest, aln_path),
+                    Err(e) => eprintln!("  Warning: Failed to download {}: {}", name, e),
+                }
             }
         }
     }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -488,7 +488,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // 0. An NG_/LRG_ genomic *input* carries parent-relative coordinates that
         //    cdot cannot map; rewrite it into the chromosome (NC_) frame so the
         //    fan-out below can enumerate and project onto the overlapping
-        //    transcripts (#480 inverse).
+        //    transcripts (#480 inverse). Capture the build the *original* input
+        //    carries before `deanchor` shadows `variant` — the de-anchored form is
+        //    on an `NC_` accession whose build would be circular to read back
+        //    (#653/#713); the parent placement must be selected by the input's
+        //    build, matching what `deanchor` itself used.
+        let input_build = Self::build_hint_for_variant(variant);
         let (variant, parent) = self.deanchor_genomic_parent_input(variant);
         // 1. Normalize once in the genome frame, then fan out across the
         //    overlapping transcripts.
@@ -503,7 +508,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    two bases off from the HGVS-correct, transcript-frame-normalized
         //    position. Re-project each transcript from its own coding form (which
         //    normalizes in the transcript frame), then re-frame under the parent.
-        let placement = self.provider.genomic_placement(&parent);
+        let placement = self
+            .provider
+            .genomic_placement_on_build(&parent, input_build);
         let mut framed = Vec::with_capacity(results.len());
         for r in results {
             let r = match r.coding.as_ref() {
@@ -679,7 +686,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
 
         match self.project_to_genomic_nc(variant)? {
-            HgvsVariant::Genome(gv) => self.reanchor_genome_output(gv),
+            HgvsVariant::Genome(gv) => {
+                self.reanchor_genome_output(gv, Self::build_hint_for_variant(variant))
+            }
             other => Ok(other),
         }
     }
@@ -692,7 +701,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// [`Self::project_to_genomic_nc`]). An `NC_` chromosome parent is already in
     /// the genome frame and is returned unchanged; an `NG_`/`LRG_` parent is
     /// re-anchored into its own frame via
-    /// [`ReferenceProvider::genomic_placement`].
+    /// [`ReferenceProvider::genomic_placement_on_build`].
+    ///
+    /// `build` is the genome build the *original input* carries (from
+    /// [`Self::build_hint_for_variant`]); it selects the parent's build-appropriate
+    /// placement (#653/#713). `None` (a bare `NG_` with no build signal) keeps the
+    /// GRCh38-preferred behavior.
     ///
     /// Shared by the public [`Self::project_to_genomic`] (which propagates the
     /// decline as an error) and the multi-axis single-transcript path in
@@ -709,8 +723,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     fn reanchor_genome_output(
         &self,
         gv: crate::hgvs::variant::GenomeVariant,
+        build: Option<&str>,
     ) -> Result<HgvsVariant, FerroError> {
-        let reanchored = match self.provider.genomic_placement(&gv.accession) {
+        let reanchored = match self
+            .provider
+            .genomic_placement_on_build(&gv.accession, build)
+        {
             Some(placement) => Self::reanchor_genome_to_parent(gv, &placement)?,
             // No placement: an `NC_` chromosome parent is already in the genome
             // frame and passes through unchanged, but an `NG_`/`LRG_` parent
@@ -932,10 +950,20 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // placement — and the downstream re-anchor / de-anchor steps that stamp
         // `placement.nc` — assume (#646). Fall back to the parent's own build tag
         // (e.g. an explicit `NC_*` parent) when there is no placement.
-        let build_hint = self
-            .provider
-            .genomic_placement(&parent)
-            .and_then(|p| crate::liftover::aliases::infer_genome_build_from_accession(&p.nc))
+        // Prefer the build the *input variant* carries (an explicit `NC_*.10`/`.11`
+        // accession or `genomic_context`, or a `GRCh37(...)` assembly tag) — the
+        // authoritative signal of intended build (#653/#713). Only when the input
+        // is build-agnostic (e.g. a bare `NG_` parent) fall back to the build
+        // implied by the GRCh38-preferred placement, then to the parent's own
+        // version. Deriving the build from the variant first (rather than from the
+        // chosen placement) lets the placement *selection* below honor it, instead
+        // of being circularly fixed to GRCh38.
+        let build_hint = Self::build_hint_for_variant(variant)
+            .or_else(|| {
+                self.provider.genomic_placement(&parent).and_then(|p| {
+                    crate::liftover::aliases::infer_genome_build_from_accession(&p.nc)
+                })
+            })
             .or_else(|| crate::liftover::aliases::infer_genome_build_from_accession(&parent));
         let cdot_mapper = self.projector.mapper();
         let cdot_tx = match build_hint {
@@ -1151,6 +1179,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         use crate::hgvs::interval::GenomeInterval;
         use crate::hgvs::variant::GenomeVariant;
 
+        // The parent placement is selected by the build the input variant carries
+        // (an explicit `NC_*.10`/`.11` or `GRCh37(...)` tag; `None` for a bare
+        // `NG_`, which defaults to GRCh38). `None` keeps the prior GRCh38-preferred
+        // behavior, so this is inert until an explicit build is present (#653/#713).
+        let build = Self::build_hint_for_variant(variant);
+
         // Transcript-coordinate inputs (c./n./r.) carrying an NG_/LRG_
         // genomic_context are taken into the chromosome (NC_) frame here too, so
         // the fan-out below enumerates the OTHER overlapping transcripts
@@ -1165,7 +1199,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         if let Some(acc) = cnr_accession {
             if let Some(ctx) = acc.genomic_context.as_deref() {
                 if let Some(placement) = (ctx.prefix.as_ref() == "NG" || ctx.is_lrg())
-                    .then(|| self.provider.genomic_placement(ctx))
+                    .then(|| self.provider.genomic_placement_on_build(ctx, build))
                     .flatten()
                 {
                     if let Ok(HgvsVariant::Genome(nc_gv)) = self.project_to_genomic_nc(variant) {
@@ -1192,7 +1226,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let HgvsVariant::Genome(gv) = variant else {
             return (variant.clone(), None);
         };
-        let Some(placement) = self.provider.genomic_placement(&gv.accession) else {
+        let Some(placement) = self
+            .provider
+            .genomic_placement_on_build(&gv.accession, build)
+        else {
             return (variant.clone(), None);
         };
         let bounds = match (
@@ -2573,7 +2610,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let genomic = match normalized {
             HgvsVariant::Genome(_) => Some(projected_genome),
             _ => match projected_genome {
-                HgvsVariant::Genome(gv) => self.reanchor_genome_output(gv).ok(),
+                HgvsVariant::Genome(gv) => self
+                    .reanchor_genome_output(gv, Self::build_hint_for_variant(normalized))
+                    .ok(),
                 other => Some(other),
             },
         };

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -569,41 +569,42 @@ impl MultiFastaProvider {
             .and_then(|p| p.parent().map(Path::to_path_buf));
 
         // Parse NG_ RefSeqGene→chromosome placements from the NCBI alignment
-        // GFF3, if the manifest names one (#480). Read/parse failures are warned
+        // GFF3(s) the manifest names (#480). Two single-build snapshots are
+        // merged so an NG_ resolves to its build-appropriate placement: the
+        // GRCh38 file (`refseqgene_alignments`) and the GRCh37 file
+        // (`refseqgene_alignments_grch37`, #713). Read/parse failures are warned
         // (not silently swallowed): a named-but-unreadable file would otherwise
-        // disable NG_ re-anchoring invisibly. An absent field is fine (NG_
-        // parents keep prior behavior).
-        let refseqgene_placements = match manifest
-            .get("refseqgene_alignments")
-            .and_then(|v| v.as_str())
-        {
-            None => FxHashMap::default(),
-            Some(rel) => {
-                let path = resolve_path(rel);
-                match std::fs::read_to_string(&path) {
-                    Ok(gff3) => {
-                        let placements = parse_refseqgene_alignments(&gff3);
-                        if placements.is_empty() {
-                            warn!(
-                                "RefSeqGene alignments {} parsed to 0 placements; \
-                                 NG_ projection disabled",
-                                path.display()
-                            );
-                        }
-                        placements
-                    }
-                    Err(e) => {
+        // disable NG_ re-anchoring invisibly. An absent field is fine (that build
+        // simply has no placements).
+        let mut refseqgene_placements: FxHashMap<String, Vec<GenomicPlacement>> =
+            FxHashMap::default();
+        for field in ["refseqgene_alignments", "refseqgene_alignments_grch37"] {
+            let Some(rel) = manifest.get(field).and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let path = resolve_path(rel);
+            match std::fs::read_to_string(&path) {
+                Ok(gff3) => {
+                    let placements = parse_refseqgene_alignments(&gff3);
+                    if placements.is_empty() {
                         warn!(
-                            "Failed to read RefSeqGene alignments {}: {}; \
-                             NG_ projection disabled",
-                            path.display(),
-                            e
+                            "RefSeqGene alignments {} parsed to 0 placements \
+                             (this source contributes none)",
+                            path.display()
                         );
-                        FxHashMap::default()
                     }
+                    merge_refseqgene_placements(&mut refseqgene_placements, placements);
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to read RefSeqGene alignments {}: {}; \
+                         NG_ projection disabled for this source",
+                        path.display(),
+                        e
+                    );
                 }
             }
-        };
+        }
 
         // Get supplemental directory (missing ClinVar transcripts)
         if let Some(supplemental) = manifest.get("supplemental_fasta").and_then(|v| v.as_str()) {
@@ -1917,11 +1918,14 @@ fn gff_attr<'a>(attrs: &'a str, key: &str) -> Option<&'a str> {
 /// (The GFF `match` strand in col 7 is always `+`; the real orientation is the
 /// Target strand.)
 ///
-/// Only **ungapped** (`gap_count=0`) alignments to a **GRCh38 primary
-/// chromosome** are kept — matching cdot's primary build, against which the
-/// `NM_`→`NC_` step is computed. GRCh37 placements, alt-loci/patches, and gapped
-/// alignments (which a single affine span cannot represent) are skipped, so the
-/// projector keeps prior behavior rather than emit a wrong `NG_` coordinate.
+/// Only **ungapped** (`gap_count=0`) alignments to a **GRCh37 or GRCh38 primary
+/// chromosome** are kept (the build is derivable from the `NC_` version), stored
+/// per build so the input's resolved build selects the right placement at lookup
+/// (#653). Alt-loci/patch contigs and gapped alignments — which a single affine
+/// span cannot represent — are skipped, so the projector declines rather than
+/// emit a wrong `NG_` coordinate. At most one placement is kept per (NG version,
+/// build); see [`merge_refseqgene_placements`] for combining multiple alignment
+/// files (e.g. the separate GRCh38 and GRCh37 RefSeqGene snapshots, #713).
 fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlacement>> {
     let mut out: FxHashMap<String, Vec<GenomicPlacement>> = FxHashMap::default();
     for line in gff3.lines() {
@@ -1996,6 +2000,37 @@ fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlace
         }
     }
     out
+}
+
+/// Merge the per-`NG_` placement lists parsed from an additional RefSeqGene
+/// alignment file into an accumulator, keeping **at most one placement per
+/// (NG version, genome build)** — first source wins (#713).
+///
+/// `ferro prepare` downloads two RefSeqGene→genome alignment snapshots: the
+/// GRCh38 release-109 file and the GRCh37 release-105 file. Each is single-build
+/// (GRCh38 rows are on `NC_*.11`, GRCh37 on `NC_*.10`-era accessions), so merging
+/// them gives each `NG_` both builds, and [`select_placement_for_build`] picks
+/// the one matching the input's resolved build. The build is read back from each
+/// placement's `NC_` accession, mirroring `parse_refseqgene_alignments`'
+/// per-build de-duplication so a build already present from an earlier file is
+/// never overwritten.
+fn merge_refseqgene_placements(
+    acc: &mut FxHashMap<String, Vec<GenomicPlacement>>,
+    addition: FxHashMap<String, Vec<GenomicPlacement>>,
+) {
+    use crate::liftover::aliases::infer_genome_build_from_accession;
+    for (ng, placements) in addition {
+        let entry = acc.entry(ng).or_default();
+        for placement in placements {
+            let build = infer_genome_build_from_accession(&placement.nc);
+            let has_build = entry
+                .iter()
+                .any(|p| infer_genome_build_from_accession(&p.nc) == build);
+            if !has_build {
+                entry.push(placement);
+            }
+        }
+    }
 }
 
 impl ReferenceProvider for MultiFastaProvider {
@@ -2592,6 +2627,63 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
             crate::liftover::aliases::infer_genome_build_from_accession(&grch37.nc),
             Some("GRCh37")
         );
+    }
+
+    /// `ferro prepare` writes two single-build RefSeqGene alignment files; the
+    /// provider merges them so each NG_ carries both builds and
+    /// `genomic_placement_on_build` selects the right one (#713). The GRCh38
+    /// snapshot lists `NC_*.11` placements; the GRCh37 snapshot `NC_*.10`.
+    #[test]
+    fn merges_grch38_and_grch37_alignment_files_per_ng() {
+        const GRCH38_FILE: &str = "\
+##gff-version 3
+NC_000001.11\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\tID=a0;Target=NG_007000.1 1 100 +;gap_count=0\n";
+        const GRCH37_FILE: &str = "\
+##gff-version 3
+NC_000001.10\tRefSeq\tmatch\t5000\t5099\t100\t+\t.\tID=a1;Target=NG_007000.1 1 100 +;gap_count=0\n";
+
+        // Merge in prepare's order: GRCh38 first, then GRCh37.
+        let mut merged = parse_refseqgene_alignments(GRCH38_FILE);
+        merge_refseqgene_placements(&mut merged, parse_refseqgene_alignments(GRCH37_FILE));
+
+        let list = merged.get("NG_007000.1").expect("NG_ present after merge");
+        assert_eq!(list.len(), 2, "both builds retained: {list:?}");
+
+        let g38 = crate::reference::provider::select_placement_for_build(list, Some("GRCh38"))
+            .expect("GRCh38 placement selectable");
+        let g37 = crate::reference::provider::select_placement_for_build(list, Some("GRCh37"))
+            .expect("GRCh37 placement selectable");
+        assert_eq!(g38.nc.to_string(), "NC_000001.11");
+        assert_eq!(g38.nc_start, 1000);
+        assert_eq!(g37.nc.to_string(), "NC_000001.10");
+        assert_eq!(g37.nc_start, 5000);
+
+        // Regression: adding the GRCh37 placement must NOT shift the
+        // build-agnostic default away from GRCh38 (cdot primary / mutalyzer).
+        let default = crate::reference::provider::select_placement_for_build(list, None)
+            .expect("default placement selectable");
+        assert_eq!(default.nc.to_string(), "NC_000001.11");
+    }
+
+    /// `merge_refseqgene_placements` keeps the first source's placement for a
+    /// build that is already present (first-source-wins), mirroring the
+    /// per-build de-duplication inside `parse_refseqgene_alignments`.
+    #[test]
+    fn merge_keeps_first_source_per_build() {
+        const FIRST: &str = "\
+##gff-version 3
+NC_000001.11\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\tID=a0;Target=NG_008000.1 1 100 +;gap_count=0\n";
+        // A second GRCh38 placement for the same NG_ at a different span.
+        const SECOND: &str = "\
+##gff-version 3
+NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 100 +;gap_count=0\n";
+
+        let mut merged = parse_refseqgene_alignments(FIRST);
+        merge_refseqgene_placements(&mut merged, parse_refseqgene_alignments(SECOND));
+
+        let list = &merged["NG_008000.1"];
+        assert_eq!(list.len(), 1, "only one placement per build is kept");
+        assert_eq!(list[0].nc_start, 1000, "first source wins");
     }
 
     /// An unknown-orientation placement has no defined parent frame, so


### PR DESCRIPTION
Closes #713. Follow-up to the build-aware placement foundation in #711 (#653). **Stacked on #711** — base is `feat/issue-653-645-placement-data`; review #711 first, and this PR's base retargets to `main` once #711 merges.

#711 added the *machinery* for per-build NG_/LRG_ placement (per-build storage, `genomic_placement_on_build` + `select_placement_for_build` with the build-match guard, `genomic_placement` kept GRCh38-preferred). This PR fills in the two pieces that make a build-resolved NG_/LRG_ input actually use its build-appropriate placement end to end.

## Part 1 — bundle a GRCh37 RefSeqGene alignment and merge per-build placements

- `ferro prepare` now also downloads the archived **GRCh37** RefSeqGene→genome alignment (`GCF_000001405.25_105.20201022_refseqgene_alignments.gff3`, the final GRCh37/release-105 snapshot under `alignments/ARCHIVE/all/`), non-fatal on failure like the other archived fetches.
- New manifest field `refseqgene_alignments_grch37` (`Option<PathBuf>`, `#[serde(default)]`), paired with `refseqgene_alignments` the same way `genome_grch37_fasta`/`cdot_grch37_json` pair their GRCh38 fields. Wired through `for_each_path`/`for_each_path_mut` so `ferro check` validates it and relativize/absolutize reach it. Old manifests without the key still deserialize (covered by a test).
- `MultiFastaProvider::from_manifest` reads both alignment files and merges them via the new `merge_refseqgene_placements` (union per-NG_, at most one placement per (NG version, build), first source wins). `select_placement_for_build` keys off `infer_genome_build_from_accession(p.nc)`, so each build is selectable from the merged list.
- Fixed the now-stale `parse_refseqgene_alignments` doc (GRCh37 has been kept since #653, not skipped).

## Part 2 — thread the input build into placement selection (behavior-preserving)

The build is derived from the **original input variant** (`build_hint_for_variant`) and passed to the NG_/LRG_ placement-**selection** sites via `genomic_placement_on_build`:

- `project_variant_all`: capture the build before `deanchor` shadows `variant`.
- `deanchor_genomic_parent_input`: derive once; select both the c./n./r. `genomic_context` and the bare-genomic placements with it.
- `reanchor_genome_output`: take a `build` parameter; the two callers pass the build of their original input.
- Invert the cds→genome cdot-build derivation to prefer the variant's own build over the (GRCh38-preferred) placement-derived build, so selection is no longer circularly fixed to GRCh38.

**This is behavior-preserving today.** A bare `NG_`/`LRG_` carries no build, so every current selection passes `build = None` and resolves exactly as before (`genomic_placement_on_build(parent, None) == genomic_placement(parent)`, GRCh38-preferred). The end-to-end GRCh37 NG_ projection only becomes *observable* once the `--assembly` override (#715) injects a build onto a bare `NG_`; that path and its e2e test land in #715, stacked on this PR.

## Tests

- `merges_grch38_and_grch37_alignment_files_per_ng`, `merge_keeps_first_source_per_build` — per-build merge + selection, including the regression that adding the GRCh37 placement must not shift the build-agnostic default off GRCh38.
- `test_legacy_manifest_without_grch37_alignments_deserializes` — manifest back-compat.
- Full suite green; build + clippy `-D warnings` + fmt clean.

Refs #653, #480, #642, #326.