### PR TITLE
ci: speed up the Test job (drop the disk-cleanup step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,24 +190,19 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      # The Test job builds and LINKS ~179 separate integration-test
+      # The Test job builds and LINKS ~230 separate integration-test
       # binaries (tests/*.rs). With full debuginfo (dev/test profile
       # default `debug = true`) the linked `target/` exhausts the stock
       # runner's ~14 GB free disk, and the linker dies with
       # `ld terminated with signal 7 (Bus error)` — a write past a full
       # disk. Stripping test-binary debuginfo in CI removes the bulk of
-      # each binary's size. CI-only (not in Cargo.toml), so local dev
+      # each binary's size and is now the sole guard against that crash
+      # (the old `rm -rf` preinstalled-toolchain step was dropped: it
+      # cost ~90s on the critical path for headroom the debuginfo strip
+      # already provides). CI-only (not in Cargo.toml), so local dev
       # keeps full debuginfo for backtraces.
       CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
-      - name: Free up runner disk space
-        # Reclaim large preinstalled toolchains ferro's build never uses
-        # (~25-30 GB), as a second guard against the disk-exhaustion link
-        # crash above. Inline removal avoids adding a third-party action.
-        run: |
-          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
-            /usr/local/lib/android /opt/hostedtoolcache/CodeQL
-          df -h /
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           lfs: true


### PR DESCRIPTION
## Summary

Drops the `Free up runner disk space` (`rm -rf /usr/share/dotnet …`) step from the `Test` job. That step cost **~74–94s** on the Test job's critical path (the longest job in the workflow, which gates the whole run's wall-clock) to reclaim disk headroom that `CARGO_PROFILE_TEST_DEBUG=0` — which strips test-binary debuginfo — already provides. Debuginfo-stripping remains in place as the sole guard against the `ld: Bus error` disk-exhaustion link crash the cleanup step originally backstopped.

Verified on CI: the Test job passes without the cleanup step, so the stripped `target/` fits the runner's free disk without it.

No sibling workflow used this step (only `ci.yml` had it).

## Note on linker / consolidation

An earlier revision of this PR also switched the Test job to the mold linker. That was dropped: measurement showed mold delivered no meaningful improvement, because the `Run Rust tests` step is dominated by rustc codegen (not linking), and the follow-up consolidation of the ~230 separate test binaries into one (#725) collapses the suite to a single link step — removing mold's reason to exist while adding an apt dependency and a RUSTFLAGS-driven cache bust. #725 is the structural win and also makes this cleanup removal safe by construction (one test binary writes a fraction of the `target/` bytes).
