### PR TITLE
feat(conformance): hermetic snapshot-backed normalized-axis PR gate (#719 I4)

### DIFF
--- a/src/conformance/reference_snapshot.rs
+++ b/src/conformance/reference_snapshot.rs
@@ -35,6 +35,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+use crate::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use crate::reference::MockProvider;
 use crate::FerroError;
 
 /// File name of the committed transcript FASTA within a snapshot directory.
@@ -165,6 +167,62 @@ pub fn load_sequences<P: AsRef<Path>>(dir: P) -> Result<BTreeMap<String, String>
     Ok(parse_fasta(&text))
 }
 
+impl TranscriptSnapshot {
+    /// Build an in-memory, **hermetic** [`MockProvider`] serving this snapshot's
+    /// transcripts with their real version-exact bases + CDS — the
+    /// reference oracle for the transcript-coordinate conformance axes with no
+    /// manifest or network.
+    ///
+    /// Each transcript is modeled as a **single-exon spliced** transcript: an
+    /// mRNA is already spliced, so its whole sequence is one exon spanning
+    /// `1..=length` — the same shape `MultiFastaProvider` uses for its
+    /// supplemental-CDS transcripts. Strand is `Plus`: a transcript's own
+    /// sequence is 5'→3' mRNA, so `c.`/`n.` normalization and CDS translation
+    /// are strand-independent here.
+    ///
+    /// `sequences` is the companion FASTA (see [`load_sequences`]); an entry
+    /// whose bases are absent from it is skipped (the metadata and FASTA are
+    /// expected to agree — the integrity test enforces that).
+    pub fn to_provider(&self, sequences: &BTreeMap<String, String>) -> MockProvider {
+        let mut provider = MockProvider::new();
+        for (accession, entry) in &self.transcripts {
+            let Some(bases) = sequences.get(accession) else {
+                continue;
+            };
+            let exons = vec![Exon::new(1, 1, entry.length)];
+            let transcript = Transcript::new(
+                accession.clone(),
+                entry.gene_symbol.clone(),
+                Strand::Plus,
+                Some(bases.clone()),
+                entry.cds_start,
+                entry.cds_end,
+                exons,
+                None,
+                None,
+                None,
+                GenomeBuild::default(),
+                ManeStatus::default(),
+                None,
+                None,
+            )
+            .with_protein_id(entry.protein.clone());
+            provider.add_transcript(transcript);
+        }
+        provider
+    }
+}
+
+/// Load the committed snapshot in `dir` (metadata + FASTA) and build a hermetic
+/// [`MockProvider`] from it — convenience over [`TranscriptSnapshot::from_json_path`]
+/// + [`load_sequences`] + [`TranscriptSnapshot::to_provider`].
+pub fn load_provider<P: AsRef<Path>>(dir: P) -> Result<MockProvider, FerroError> {
+    let dir = dir.as_ref();
+    let snapshot = TranscriptSnapshot::from_json_path(dir.join(TRANSCRIPTS_METADATA))?;
+    let sequences = load_sequences(dir)?;
+    Ok(snapshot.to_provider(&sequences))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,5 +297,42 @@ mod tests {
         // `deny_unknown_fields` guards against silent schema drift.
         let json = r#"{"description":"x","transcripts":{},"bogus":1}"#;
         assert!(serde_json::from_str::<TranscriptSnapshot>(json).is_err());
+    }
+
+    #[test]
+    fn to_provider_serves_bases_and_cds() {
+        use crate::reference::ReferenceProvider;
+
+        let bases = "ACGTACGTAC".to_string(); // length 10
+        let mut snapshot = TranscriptSnapshot::default();
+        snapshot.transcripts.insert(
+            "NM_000001.1".to_string(),
+            TranscriptEntry {
+                cds_start: Some(2),
+                cds_end: Some(7),
+                gene_symbol: Some("GENE".to_string()),
+                protein: Some("NP_000001.1".to_string()),
+                length: bases.len() as u64,
+                provenance: Provenance {
+                    source: "test".to_string(),
+                    sha256: "test".to_string(),
+                },
+            },
+        );
+        let mut sequences = BTreeMap::new();
+        sequences.insert("NM_000001.1".to_string(), bases.clone());
+
+        let provider = snapshot.to_provider(&sequences);
+        assert!(provider.has_transcript("NM_000001.1"));
+        // Real bases are served (a sliced read works), and CDS bounds survive.
+        assert_eq!(
+            provider.get_sequence("NM_000001.1", 0, 4).expect("bases"),
+            "ACGT"
+        );
+        let tx = provider.get_transcript("NM_000001.1").expect("transcript");
+        assert_eq!(tx.sequence.as_deref(), Some(bases.as_str()));
+        assert_eq!(tx.cds_start, Some(2));
+        assert_eq!(tx.cds_end, Some(7));
+        assert_eq!(tx.protein_id.as_deref(), Some("NP_000001.1"));
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -273,12 +273,6 @@
         "M2: Just a variant where we should roll."
       ],
       "input": "NM_003002.2:c.273del",
-      "reference_unavailable": {
-        "axis": "normalized",
-        "reason": "accession-version-absent",
-        "tracking_issue": 672,
-        "note": "Not a normalize bug — reference-version-absent: NM_003002.2 is not in the prepared manifest (only .4 present), so ferro no-ops. The .2 and .4 CDS are byte-identical and ferro rolls NM_003002.4:c.273del -> c.274del correctly (the GG at c.273-274). Resolves (XPASS) once the exact version is provisioned (#672)."
-      },
       "normalized": "NM_003002.2:c.274del",
       "protein_description": "NP_002993.1:p.(Asp92ThrfsTer43)",
       "infos": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -143,12 +143,11 @@ ferro shuffles genomic-context c./n. variants in spliced transcript space (cross
 | `ENST00000452863.10:c.9del` | normalized | reference_unavailable | — | #671 |
 | `NG_012337.1(NM_003002.2):c.pterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.qterdel` | normalized | spec_citation | — | — |
-| `NM_003002.2:c.273del` | normalized | reference_unavailable | — | #672 |
 
 ## Disposition tallies
 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 0 | 4 | 24 | 6 | 6 |
+| normalized | 0 | 4 | 24 | 5 | 6 |
 | protein_description | 0 | 0 | 0 | 0 | 19 |

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -1312,6 +1312,164 @@ fn regression_under_mock_normalized() {
 }
 
 // ----------------------------------------------------------------------------
+// Hermetic gate: snapshot-backed `normalized` axis (CI-always)
+// ----------------------------------------------------------------------------
+//
+// Unlike `regression_under_mock_normalized` (a `MockProvider` with NO bases, so
+// it pins ferro's no-op behavior), this gate serves the committed transcript
+// snapshot's REAL version-exact bases + CDS (issue #719, increment I4). It runs
+// every snapshot-covered `normalized` case against `cases.json` truth with NO
+// manifest, so the normalized axis becomes a real per-PR correctness gate, not
+// just a refactor pin.
+//
+// Coverage is the snapshot's transcript set. A row whose bare transcript the
+// snapshot does not carry — a genomic-anchored parent needing NG bases, or a
+// transcript absent from the local reference — is skipped here; it stays covered
+// by the manifest-backed `axis_normalized` (and, for genomic, the deferred
+// genomic snapshot). A skip is not a failure.
+//
+// Annotation-aware via the shared `AxisTally`: a snapshot-covered row carrying a
+// `known_bug`/`accepted_divergence`/`improvement`/`spec_citation`/
+// `reference_unavailable` annotation for the normalized axis is bucketed, not
+// failed — so this gate asserts only genuine, unannotated divergences on real
+// bases.
+
+const SNAPSHOT_DIR: &str = "tests/fixtures/mutalyzer-normalize/reference-snapshot";
+
+/// Whether a `normalized`-axis row is soundly coverable by the **transcript**
+/// snapshot, i.e. snapshot-normalize is equivalent to the manifest-backed
+/// `axis_normalized`. The snapshot models each transcript as a single-exon,
+/// transcript-space sequence + CDS with no cdot or genomic context, which
+/// supports bare `c.` exonic normalization but NOT:
+/// - a genomic / compound context `(...)` — needs the NG bases (deferred genomic
+///   snapshot);
+/// - intronic offset positions (`c.52+1`, `c.378-17`, `c.*824+10`) — need the
+///   multi-exon structure;
+/// - `n.` input on a coding transcript — mutalyzer's `n.→c.` conversion needs
+///   cdot; ferro keeps `n.` without it (so restrict to `c.` / [`HgvsVariant::Cds`]);
+/// - a `delins` against a *coordinate range* (`delinsN_M…`) — rendering the
+///   referenced/inverted segment needs reference context the snapshot lacks.
+///
+/// Excluded rows are not failures here; they stay covered by the manifest-backed
+/// `axis_normalized` (and, for genomic, the deferred genomic snapshot).
+fn snapshot_coverable_normalized(input: &str, v: &HgvsVariant) -> bool {
+    if !matches!(v, HgvsVariant::Cds(_)) {
+        return false;
+    }
+    if input.contains('(') {
+        return false;
+    }
+    let coord = match input.split_once(":c.") {
+        Some((_, c)) => c,
+        None => return false,
+    };
+    !has_intron_offset(coord) && !delins_coordinate_range(coord)
+}
+
+/// True if `coord` has an intron offset: a digit immediately followed by `+`/`-`
+/// then a digit (e.g. `52+1`, `378-17`, `*824+10`). The `+`/`-` in a UTR marker
+/// (`-1`, `*1`) is not between two digits, so those exonic positions are kept.
+fn has_intron_offset(coord: &str) -> bool {
+    let b = coord.as_bytes();
+    (1..b.len().saturating_sub(1)).any(|i| {
+        (b[i] == b'+' || b[i] == b'-') && b[i - 1].is_ascii_digit() && b[i + 1].is_ascii_digit()
+    })
+}
+
+/// True if `coord` is a `delins` against a coordinate range — `delins` directly
+/// followed by a digit (e.g. `delins190_220inv`), as opposed to literal bases
+/// (`delinsATC`).
+fn delins_coordinate_range(coord: &str) -> bool {
+    coord
+        .find("delins")
+        .and_then(|idx| coord.as_bytes().get(idx + "delins".len()))
+        .is_some_and(u8::is_ascii_digit)
+}
+
+#[test]
+fn gate_normalized_snapshot() {
+    use ferro_hgvs::conformance::reference_snapshot::{load_provider, TranscriptSnapshot};
+    use std::collections::HashSet;
+
+    let provider = load_provider(SNAPSHOT_DIR)
+        .unwrap_or_else(|e| panic!("load snapshot provider from {SNAPSHOT_DIR}: {e}"));
+    // Derive coverage from transcripts the provider actually serves, not raw
+    // metadata keys: `to_provider` skips any metadata entry whose bases are
+    // absent from the FASTA, so a metadata-only entry would otherwise count as
+    // covered yet no-op (a divergent FAIL) instead of being skipped. Filtering
+    // through `has_transcript` keeps `covered` and the served set in lockstep.
+    let covered: HashSet<String> = TranscriptSnapshot::from_json_path(
+        Path::new(SNAPSHOT_DIR).join("transcripts.metadata.json"),
+    )
+    .expect("snapshot metadata loads")
+    .transcripts
+    .keys()
+    .filter(|accession| provider.has_transcript(accession))
+    .cloned()
+    .collect();
+    let normalizer = Normalizer::new(provider);
+
+    let mut t = AxisTally::new(Axis::Normalized);
+    let mut covered_count = 0usize;
+    for case in &fixture().cases {
+        if !case.to_test {
+            continue;
+        }
+        let Some(expected) = case.normalized.as_deref() else {
+            continue;
+        };
+        // A parse error or non-transcript input is out of this gate's scope
+        // (still covered by the manifest-backed axis), not a failure here.
+        let Ok(v) = parse_hgvs(&case.input) else {
+            continue;
+        };
+        let Some(tx) = transcript_of(&v) else {
+            continue;
+        };
+        // Coverage: the snapshot must carry the transcript, and the row must be
+        // soundly coverable by a transcript-only (single-exon, no-cdot) model.
+        if !covered.contains(&tx) || !snapshot_coverable_normalized(&case.input, &v) {
+            continue;
+        }
+        covered_count += 1;
+
+        let actual = catch_panics(|| -> Result<String, String> {
+            let n = normalizer
+                .normalize(&v)
+                .map_err(|e| format!("normalize: {e}"))?;
+            Ok(format!("{n}"))
+        });
+        t.record(case, expected, actual);
+    }
+
+    assert!(
+        covered_count > 0,
+        "gate_normalized_snapshot: snapshot covered zero normalized rows — the \
+         coverage filter or the committed snapshot is broken"
+    );
+    assert!(
+        t.fail.is_empty(),
+        "gate_normalized_snapshot: {} hermetic divergence(s) from cases.json on \
+         {covered_count} snapshot-covered normalized row(s) (real version-exact \
+         bases, no manifest):\n{}",
+        t.fail.len(),
+        t.fail
+            .iter()
+            .take(20)
+            .map(|(i, d)| format!("  {i} | {d}"))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    println!(
+        "gate_normalized_snapshot: {covered_count} snapshot-covered normalized row(s) \
+         pass hermetically (no manifest); {} known_bug, {} improvement, {} reference_unavailable",
+        t.known_bug.len(),
+        t.improvement.len(),
+        t.reference_unavailable.len(),
+    );
+}
+
+// ----------------------------------------------------------------------------
 // Comparator unit tests
 // ----------------------------------------------------------------------------
 //


### PR DESCRIPTION
## What

Promotes the transcript-resolvable, exonic subset of the mutalyzer-normalize `normalized` axis from the nightly, manifest-backed, `continue-on-error` `axis_normalized` to a **real per-PR gate** that runs **hermetically** against the committed transcript snapshot's real version-exact bases — no manifest, no network. Increment **I4** of the pinned-snapshot arc (#719).

Stacked on #727 (I2). Review/merge that first; this PR's diff is only the I4 changes (base `feat/issue-719-snapshot-builder`).

## Why

The existing CI-always layer (`regression_under_mock_normalized`) runs under a base-less `MockProvider`, so it only pins ferro's *no-op* behavior — it can't catch a correctness regression because there are no reference bases to shift against. Correctness was asserted only by `axis_normalized`, which needs a multi-GB machine-specific manifest and so runs `continue-on-error` in the nightly (gating nothing). This PR closes that gap for the transcript axis: real bases, in CI, on every PR.

## How

- `conformance::reference_snapshot`: `TranscriptSnapshot::to_provider` / `load_provider` build an in-memory hermetic `ReferenceProvider` from the committed snapshot, serving each transcript's real bases + CDS as a single-exon spliced transcript (the same shape `MultiFastaProvider` uses for supplemental-CDS transcripts).
- `gate_normalized_snapshot` (CI-always): normalize every snapshot-covered `normalized` row against `cases.json` truth via the shared, annotation-aware `AxisTally`, and assert no divergence. This includes the flagship `NM_003002.2:c.273del -> c.274del` proven hermetically (26 rows covered today; 0 annotated).
- Coverage is the transcript-only model's *sound* subset — bare `c.` exonic rows whose transcript the snapshot carries. Intronic offsets (`c.52+1`), genomic/compound `NG_(NM_)` context, `n.->c.` conversion, and a delins against a coordinate range need cdot/genomic structure the transcript snapshot lacks; those stay covered by the nightly manifest-backed axis (and the deferred genomic snapshot, see below). A skip is not a failure — the filter is documented at `snapshot_coverable_normalized`.
- Drops the now-stale `reference_unavailable` (#672) annotation on `NM_003002.2:c.273del`. The snapshot provisions the exact version (and #720 resolves it cross-build on the manifest), satisfying the annotation's own stated XPASS condition (*"Resolves (XPASS) once the exact version is provisioned"*). `failure-patterns.md` regenerated; `reference_unavailable` tally 6 → 5, `pass` +1.

## Validation

- `gate_normalized_snapshot`: 26 snapshot-covered rows pass hermetically (no manifest).
- Manifest-backed `axis_normalized` re-checked with a real reference after the annotation removal: `NM_003002.2:c.273del` now PASSes (was bucketed `reference_unavailable`); the pre-existing scratch-manifest divergences are unchanged.
- fmt + clippy clean; all `mutalyzer_normalize_tests` + conformance + snapshot tests pass without a manifest.

## Scope notes

- This is the **normalized** axis only. The protein axis already works from I2's transcript+CDS (verified ferro predicts the correct `p.` with no protein data), but gating it hermetically needs a cdot-capable provider — a follow-up.
- Genomic axis is deferred: 115/129 genomic rows reference NG accessions whose exact pinned version is absent from the manifest (e.g. `NG_012337.1`), so it needs a one-time NG efetch + version-exact placement — its own increment.

Part of #719.