### PR TITLE
feat(reference): provision derived NG_ placements — load + produce (#728)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,6 +209,10 @@ name = "build_conformance_snapshot"
 required-features = ["dev"]
 
 [[example]]
+name = "derive_ng_placements"
+required-features = ["dev"]
+
+[[example]]
 name = "generate_tool_support_tables"
 required-features = ["dev"]
 

--- a/examples/derive_ng_placements.rs
+++ b/examples/derive_ng_placements.rs
@@ -1,0 +1,242 @@
+//! Produce the `derived_refseqgene_placements.json` artifact (#728): for each
+//! pinned `NG_` version in an input list, fetch its GenBank record + sequence
+//! from NCBI, derive its chromosomal placement from the record's exon
+//! annotation + cdot, validate by full-sequence comparison against the genome,
+//! and write the validated placements.
+//!
+//! This is the prepare-time **producer** for the runtime-consumption path
+//! (`conformance`/`reference::derived_placement` + the manifest's
+//! `derived_refseqgene_placements` field). It runs locally (it needs a prepared
+//! reference for cdot + genome, and network for EFetch); the committed/manifest
+//! artifact it writes is then consumed offline. Decline-rather-than-mis-anchor
+//! is enforced by [`derive_ng_placement`] — an accession that cannot be proven
+//! is simply omitted (reported), never guessed.
+//!
+//! Run:
+//!   cargo run --features dev --example derive_ng_placements -- \
+//!     --manifest <ref>/manifest.json --accessions ng_versions.txt \
+//!     --out <ref>/derived_refseqgene_placements.json [--builds GRCh38,GRCh37]
+
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+use clap::Parser;
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::hgvs::parser::accession::parse_accession;
+use ferro_hgvs::hgvs::variant::Accession;
+use ferro_hgvs::reference::derived_placement::{
+    derive_ng_placement, DerivedPlacement, DerivedPlacements, GenomeSlice, NcExonSource,
+};
+use ferro_hgvs::reference::multi_fasta::MultiFastaProvider;
+use ferro_hgvs::reference::{ReferenceProvider, Strand};
+
+#[derive(Parser, Debug)]
+#[command(about = "Derive version-independent NG_/LRG_ genomic placements (#728)")]
+struct Cli {
+    /// Prepared-reference manifest (for cdot + genome).
+    #[arg(long)]
+    manifest: PathBuf,
+    /// Newline-delimited file of exact `NG_` versions to derive (e.g.
+    /// `NG_012337.1`). Blank lines and `#` comments are ignored.
+    #[arg(long)]
+    accessions: PathBuf,
+    /// Output JSON path (`derived_refseqgene_placements.json`).
+    #[arg(long)]
+    out: PathBuf,
+    /// Comma-separated genome builds to derive for (default `GRCh38`).
+    #[arg(long, default_value = "GRCh38")]
+    builds: String,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match run(&cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// `NcExonSource` over a cdot mapper for a fixed build. The loaded
+/// `CdotTranscript.exons` entry `[genome_start, genome_end, ..]` is **0-based**
+/// half-open (e.g. SDHD exon 1 = `[112086872, 112086959]`), so the 1-based
+/// inclusive interval `derive_affine` expects is `(genome_start + 1, genome_end)`.
+struct CdotNcExons<'a> {
+    cdot: &'a CdotMapper,
+    build: &'a str,
+}
+
+impl NcExonSource for CdotNcExons<'_> {
+    fn nc_exons(&self, transcript_id: &str) -> Option<Vec<(u64, u64)>> {
+        let tx = self
+            .cdot
+            .get_transcript_on_build_exact(transcript_id, self.build)?;
+        Some(tx.exons.iter().map(|e| (e[0] + 1, e[1])).collect())
+    }
+    fn nc_contig(&self, transcript_id: &str) -> Option<Accession> {
+        let tx = self
+            .cdot
+            .get_transcript_on_build_exact(transcript_id, self.build)?;
+        match parse_accession(&tx.contig) {
+            Ok(("", acc)) => Some(acc),
+            _ => None,
+        }
+    }
+}
+
+/// `GenomeSlice` over a provider: 1-based inclusive `[start, end]` → the
+/// provider's 0-based half-open `get_sequence`.
+struct ProviderGenomeSlice<'a> {
+    provider: &'a MultiFastaProvider,
+}
+
+impl GenomeSlice for ProviderGenomeSlice<'_> {
+    fn slice(&self, nc: &Accession, start: u64, end: u64) -> Option<Vec<u8>> {
+        if start == 0 || end < start {
+            return None;
+        }
+        self.provider
+            .get_sequence(&nc.full(), start - 1, end)
+            .ok()
+            .map(String::into_bytes)
+    }
+}
+
+fn run(cli: &Cli) -> anyhow::Result<()> {
+    let provider = MultiFastaProvider::from_manifest(&cli.manifest)
+        .map_err(|e| anyhow::anyhow!("load manifest {}: {e}", cli.manifest.display()))?;
+    let cdot = provider
+        .cdot_mapper()
+        .ok_or_else(|| anyhow::anyhow!("manifest has no cdot; cannot derive placements"))?;
+
+    let accessions = read_accession_list(&cli.accessions)?;
+    let builds: Vec<&str> = cli.builds.split(',').map(str::trim).collect();
+
+    let mut placements = Vec::new();
+    let mut declined = Vec::new();
+    for ng in &accessions {
+        let genbank = match efetch(ng, "gb") {
+            Ok(t) => t,
+            Err(e) => {
+                declined.push(format!("{ng}: efetch gb failed: {e}"));
+                continue;
+            }
+        };
+        let ng_seq = match efetch(ng, "fasta") {
+            Ok(fa) => fasta_bases(&fa),
+            Err(e) => {
+                declined.push(format!("{ng}: efetch fasta failed: {e}"));
+                continue;
+            }
+        };
+        let mut any_build = false;
+        for build in &builds {
+            let nc_source = CdotNcExons { cdot, build };
+            let genome = ProviderGenomeSlice {
+                provider: &provider,
+            };
+            if let Some(p) = derive_ng_placement(&genbank, &ng_seq, &nc_source, &genome) {
+                placements.push(to_record(ng, &p));
+                any_build = true;
+            }
+        }
+        if !any_build {
+            declined.push(format!(
+                "{ng}: no validated placement on any requested build"
+            ));
+        }
+    }
+
+    let artifact = DerivedPlacements {
+        description: format!(
+            "GENERATED by `cargo run --features dev --example derive_ng_placements`. \
+             Version-independent NG_/LRG_ placements (#728) derived from each NG_'s \
+             GenBank exon annotation + cdot, validated by full-sequence comparison. \
+             Source manifest: {}.",
+            cli.manifest.display()
+        ),
+        placements,
+    };
+    let json = artifact
+        .to_json()
+        .map_err(|e| anyhow::anyhow!("serialize: {e}"))?;
+    std::fs::write(&cli.out, &json)
+        .map_err(|e| anyhow::anyhow!("write {}: {e}", cli.out.display()))?;
+
+    println!(
+        "Derived {} placement(s) for {} accession(s); {} declined. Wrote {}.",
+        artifact.placements.len(),
+        accessions.len(),
+        declined.len(),
+        cli.out.display()
+    );
+    for d in &declined {
+        println!("  declined: {d}");
+    }
+    Ok(())
+}
+
+/// Build a serializable record from a derived placement. (Provenance: the
+/// validation already passed, so the mismatch fraction is ~0; the producer does
+/// not currently surface the exact value, so record 0.0.)
+fn to_record(ng: &str, p: &ferro_hgvs::reference::GenomicPlacement) -> DerivedPlacement {
+    DerivedPlacement {
+        parent: ng.to_string(),
+        nc: p.nc.full(),
+        nc_start: p.nc_start,
+        nc_end: p.nc_end,
+        strand: match p.strand {
+            Strand::Plus => "+",
+            Strand::Minus => "-",
+            _ => "?", // Strand is #[non_exhaustive]; a derived placement is only
+                      // ever Plus/Minus (Unknown declines upstream).
+        }
+        .to_string(),
+        anchored_by: String::new(),
+        mismatch_fraction: 0.0,
+    }
+}
+
+/// Read exact accessions from a newline-delimited file (skipping blanks/`#`).
+fn read_accession_list(path: &std::path::Path) -> anyhow::Result<Vec<String>> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+    Ok(text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect())
+}
+
+/// EFetch one accession from NCBI nuccore in the given `rettype` (`gb`/`fasta`).
+fn efetch(accession: &str, rettype: &str) -> anyhow::Result<String> {
+    let url = format!(
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={accession}&rettype={rettype}&retmode=text"
+    );
+    let out = Command::new("curl")
+        .args(["-sS", "--fail", &url])
+        .output()
+        .map_err(|e| anyhow::anyhow!("spawn curl: {e}"))?;
+    if !out.status.success() {
+        anyhow::bail!("curl exit {:?}", out.status.code());
+    }
+    let body = String::from_utf8_lossy(&out.stdout).into_owned();
+    if body.trim().is_empty() {
+        anyhow::bail!("empty response");
+    }
+    Ok(body)
+}
+
+/// Extract uppercase bases from a FASTA string (strip headers + whitespace).
+fn fasta_bases(fasta: &str) -> Vec<u8> {
+    fasta
+        .lines()
+        .filter(|l| !l.starts_with('>'))
+        .flat_map(|l| l.trim().bytes())
+        .map(|b| b.to_ascii_uppercase())
+        .collect()
+}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -182,6 +182,17 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    // A missing derived-placements JSON silently disables version-gap NG_/LRG_
+    // projection at load, so surface it like the other optional inputs above.
+    if let Some(ref placements) = manifest.derived_refseqgene_placements {
+        if !placements.exists() {
+            result.warnings.push(format!(
+                "Derived RefSeqGene placements not found: {}",
+                placements.display()
+            ));
+        }
+    }
+
     // A missing RefSeqGene summary (LRG_RefSeqGene) silently disables legacy
     // gene-model selector resolution at load, so surface it like the other
     // optional inputs above.
@@ -324,6 +335,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -375,6 +387,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: Some(missing_alignments.clone()),
             refseqgene_alignments_grch37: None,
+            derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -428,6 +441,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: Some(missing_alignments.clone()),
+            derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -481,6 +495,7 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            derived_refseqgene_placements: None,
             refseqgene_summary: Some(missing_summary.clone()),
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -510,6 +525,60 @@ mod tests {
                 .iter()
                 .any(|w| w.contains("RefSeqGene summary (LRG_RefSeqGene) not found")),
             "Expected a warning for the missing summary file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_check_warns_on_missing_derived_refseqgene_placements() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point derived_refseqgene_placements at a file that does not exist.
+        let missing_placements = dir.path().join("missing_derived_placements.json");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
+            derived_refseqgene_placements: Some(missing_placements.clone()),
+            refseqgene_summary: None,
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("Derived RefSeqGene placements not found")),
+            "Expected a warning for the missing derived placements file, got {:?}",
             result.warnings
         );
     }

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -37,6 +37,14 @@ pub struct ReferenceManifest {
     /// the same way `genome_grch37_fasta`/`cdot_grch37_json` pair their GRCh38 fields.
     #[serde(default)]
     pub refseqgene_alignments_grch37: Option<PathBuf>,
+    /// Derived `NG_`/`LRG_` placements (`derived_placement::DerivedPlacements`
+    /// JSON) for versions absent from the alignment snapshots above — built at
+    /// prepare time from each NG_'s GenBank record + cdot and validated by full
+    /// sequence comparison (#728). Merged into the placement map *after* the
+    /// authoritative GFF3 snapshots (first-source-wins, so a GFF3 entry is never
+    /// overridden); fills only genuine version gaps.
+    #[serde(default)]
+    pub derived_refseqgene_placements: Option<PathBuf>,
     /// NCBI `LRG_RefSeqGene` association table, mapping each gene to its
     /// reference-standard transcript. Consumed to resolve legacy gene-model
     /// selectors (`NG_(GENE_v001):c.…`) to the transcript accession (#500/#637).
@@ -109,6 +117,7 @@ impl Default for ReferenceManifest {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -254,6 +263,7 @@ impl ReferenceManifest {
             &self.genome_grch37_fasta,
             &self.refseqgene_alignments,
             &self.refseqgene_alignments_grch37,
+            &self.derived_refseqgene_placements,
             &self.refseqgene_summary,
             &self.lrg_refseq_mapping,
             &self.cdot_json,
@@ -293,6 +303,7 @@ impl ReferenceManifest {
             &mut self.genome_grch37_fasta,
             &mut self.refseqgene_alignments,
             &mut self.refseqgene_alignments_grch37,
+            &mut self.derived_refseqgene_placements,
             &mut self.refseqgene_summary,
             &mut self.lrg_refseq_mapping,
             &mut self.cdot_json,
@@ -521,6 +532,7 @@ mod tests {
             refseqgene_fastas: vec![ref_dir.join("ng.fa")],
             refseqgene_alignments: Some(ref_dir.join("refseqgene_alignments.gff3")),
             refseqgene_alignments_grch37: Some(ref_dir.join("refseqgene_alignments_grch37.gff3")),
+            derived_refseqgene_placements: None,
             refseqgene_summary: Some(ref_dir.join("LRG_RefSeqGene")),
             lrg_fastas: vec![ref_dir.join("lrg.fa")],
             lrg_xmls: vec![ref_dir.join("lrg.xml")],

--- a/src/reference/derived_placement.rs
+++ b/src/reference/derived_placement.rs
@@ -23,9 +23,15 @@
 //! All derivation runs at `ferro prepare` time; the derived placements are baked
 //! into the manifest and served by the unchanged version-exact runtime path.
 
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::hgvs::parser::accession::parse_accession;
 use crate::hgvs::variant::Accession;
 use crate::reference::provider::GenomicPlacement;
 use crate::reference::Strand;
+use crate::FerroError;
 
 /// Minimum exon count required to trust a derived affine. A single exon
 /// under-constrains it (one length match + one trivial offset is the weakest
@@ -386,6 +392,100 @@ pub fn derive_ng_placement(
     Some(placement_from_candidate(nc, &cand))
 }
 
+// ----------------------------------------------------------------------------
+// On-disk artifact (produced at prepare time, consumed at load)
+// ----------------------------------------------------------------------------
+
+/// The committed/manifest artifact of derived `NG_`/`LRG_` placements: the
+/// output of the prepare-time derivation, loaded by `MultiFastaProvider` and
+/// merged into its `refseqgene_placements` map. Self-describing (strand as
+/// `"+"`/`"-"`, per-entry provenance) so it is auditable independent of the
+/// runtime [`GenomicPlacement`] (which is not serializable).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DerivedPlacements {
+    /// Human-facing provenance note (generator command, source manifest).
+    #[serde(default)]
+    pub description: String,
+    /// One entry per derived placement.
+    pub placements: Vec<DerivedPlacement>,
+}
+
+/// One derived placement entry, keyed to its versioned parent accession.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DerivedPlacement {
+    /// Versioned `NG_`/`LRG_` accession this places (e.g. `"NG_012337.1"`).
+    pub parent: String,
+    /// Chromosome (`NC_`) accession (e.g. `"NC_000011.10"`).
+    pub nc: String,
+    /// Inclusive 1-based chromosome span.
+    pub nc_start: u64,
+    pub nc_end: u64,
+    /// Parent orientation relative to the chromosome: `"+"` or `"-"`.
+    pub strand: String,
+    /// The transcript whose exons anchored the affine (provenance). Optional:
+    /// empty when the producer does not surface it (the `dev` example producer
+    /// currently records `""`); not consumed at load.
+    pub anchored_by: String,
+    /// The full-sequence validation mismatch fraction (provenance; ~0 for a
+    /// clean placement). Optional: the `dev` example producer derives placements
+    /// only after validation passes and records `0.0` rather than the exact
+    /// fraction; not consumed at load.
+    pub mismatch_fraction: f64,
+}
+
+impl DerivedPlacements {
+    /// Load from a JSON file.
+    pub fn from_json_path<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        let content = std::fs::read_to_string(path.as_ref())?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    /// Serialize to pretty JSON with a trailing newline (stable for `--check`).
+    pub fn to_json(&self) -> Result<String, FerroError> {
+        let mut s = serde_json::to_string_pretty(self)?;
+        s.push('\n');
+        Ok(s)
+    }
+
+    /// Convert to `(parent_key, GenomicPlacement)` entries for merging into the
+    /// `refseqgene_placements` map. An entry with an unparseable `nc` accession
+    /// or a strand other than `"+"`/`"-"` is **skipped** (never silently
+    /// mis-placed). `parent_start` is always 1.
+    pub fn to_placements(&self) -> Vec<(String, GenomicPlacement)> {
+        self.placements
+            .iter()
+            .filter_map(|p| {
+                let strand = match p.strand.as_str() {
+                    "+" => Strand::Plus,
+                    "-" => Strand::Minus,
+                    _ => return None,
+                };
+                if p.nc_start > p.nc_end {
+                    return None;
+                }
+                // Decline on an unparseable / trailing-garbage NC accession
+                // rather than place against a malformed one.
+                let nc = match parse_accession(&p.nc) {
+                    Ok(("", acc)) => acc, // fully consumed — no trailing garbage
+                    _ => return None,
+                };
+                Some((
+                    p.parent.clone(),
+                    GenomicPlacement {
+                        nc,
+                        parent_start: 1,
+                        nc_start: p.nc_start,
+                        nc_end: p.nc_end,
+                        strand,
+                    },
+                ))
+            })
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -663,6 +763,39 @@ mod tests {
     }
 
     #[test]
+    fn derive_ng_placement_minus_success() {
+        // Minus-strand end-to-end: NG ascending exons align with NC *descending*
+        // exons, and the NG sequence is the reverse complement of the genome slice.
+        //
+        // NG exons (3,6) len 4 and (11,16) len 6 -> ng_lens [4, 6].
+        // NC exons (1001,1006) len 6 and (1011,1014) len 4 -> nc_asc_lens [6, 4];
+        // reversed nc_desc_lens [4, 6] == ng_lens, so only the minus orientation
+        // matches (the plus branch declines on the [4,6] != [6,4] length check).
+        // The minus affine then yields nc_end = nc1_e + (ng_s - 1) = 1006 + 10 = 1016
+        // and nc_start = nc_end - (ng_len - 1) = 1016 - 19 = 997.
+        let ng_seq = b"AAAACCCCGGGGTTTTACGT"; // len 20, not revcomp-palindromic
+        let gb = ng_record("NM_X.1", &[(3, 6), (11, 16)]);
+        let nc = acc("NC", "000001", 11);
+        let src = MockNc {
+            tid: "NM_X.1",
+            exons: vec![(1001, 1006), (1011, 1014)],
+            nc: nc.clone(),
+        };
+        // Genome slice [997, 1016] is the reverse complement of ng_seq.
+        let genome = MockGenome {
+            nc: nc.clone(),
+            start: 997,
+            bases: b"ACGTAAAACCCCGGGGTTTT".to_vec(),
+        };
+        let p = derive_ng_placement(gb.as_str(), ng_seq, &src, &genome).expect("derives");
+        assert_eq!(p.nc, nc);
+        assert_eq!(p.parent_start, 1);
+        assert_eq!(p.nc_start, 997);
+        assert_eq!(p.nc_end, 1016);
+        assert_eq!(p.strand, Strand::Minus);
+    }
+
+    #[test]
     fn derive_ng_placement_declines_on_sequence_mismatch() {
         // Genome slice is frame-shifted relative to the NG -> validation fails.
         let ng_seq = b"ACGTACGTACGTACGTACGT";
@@ -731,5 +864,80 @@ mod tests {
             bases: ng_seq.to_vec(),
         };
         assert!(derive_ng_placement(&gb, ng_seq, &TwoNc { nc }, &genome).is_none());
+    }
+
+    // ---- DerivedPlacements artifact ----
+
+    fn sample_entry() -> DerivedPlacement {
+        DerivedPlacement {
+            parent: "NG_012337.1".to_string(),
+            nc: "NC_000011.10".to_string(),
+            nc_start: 112081847,
+            nc_end: 112097794,
+            strand: "+".to_string(),
+            anchored_by: "NM_003002.2".to_string(),
+            mismatch_fraction: 0.0,
+        }
+    }
+
+    #[test]
+    fn derived_placements_json_round_trips() {
+        let dp = DerivedPlacements {
+            description: "test".to_string(),
+            placements: vec![sample_entry()],
+        };
+        let json = dp.to_json().expect("serializes");
+        assert!(json.ends_with('\n'));
+        let parsed: DerivedPlacements = serde_json::from_str(&json).expect("round-trips");
+        assert_eq!(parsed, dp);
+    }
+
+    #[test]
+    fn derived_placements_rejects_unknown_field() {
+        let json = r#"{"placements":[],"bogus":1}"#;
+        assert!(serde_json::from_str::<DerivedPlacements>(json).is_err());
+    }
+
+    #[test]
+    fn to_placements_builds_genomic_placement() {
+        let dp = DerivedPlacements {
+            description: String::new(),
+            placements: vec![sample_entry()],
+        };
+        let out = dp.to_placements();
+        assert_eq!(out.len(), 1);
+        let (key, p) = &out[0];
+        assert_eq!(key, "NG_012337.1");
+        assert_eq!(p.nc.full(), "NC_000011.10");
+        assert_eq!(p.parent_start, 1);
+        assert_eq!(p.nc_start, 112081847);
+        assert_eq!(p.nc_end, 112097794);
+        assert_eq!(p.strand, Strand::Plus);
+    }
+
+    #[test]
+    fn to_placements_minus_strand() {
+        let mut e = sample_entry();
+        e.strand = "-".to_string();
+        let dp = DerivedPlacements {
+            description: String::new(),
+            placements: vec![e],
+        };
+        assert_eq!(dp.to_placements()[0].1.strand, Strand::Minus);
+    }
+
+    #[test]
+    fn to_placements_skips_bad_strand_and_inverted_range() {
+        let mut bad_strand = sample_entry();
+        bad_strand.strand = "?".to_string();
+        let mut inverted = sample_entry();
+        inverted.nc_start = 200;
+        inverted.nc_end = 100;
+        let dp = DerivedPlacements {
+            description: String::new(),
+            placements: vec![bad_strand, inverted],
+        };
+        // Both invalid entries are skipped rather than mis-placed.
+        assert!(dp.to_placements().is_empty());
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -613,6 +613,35 @@ impl MultiFastaProvider {
             }
         }
 
+        // Derived NG_/LRG_ placements (#728): fill version gaps the authoritative
+        // GFF3 snapshots above do not cover (versions absent from NCBI's archived
+        // alignments). Merged AFTER the GFF3 sources with first-source-wins, so a
+        // GFF3 entry is never overridden — derived placements only add keys/builds
+        // the snapshots lack. A read/parse failure is warned, not fatal.
+        if let Some(rel) = manifest
+            .get("derived_refseqgene_placements")
+            .and_then(|v| v.as_str())
+        {
+            let path = resolve_path(rel);
+            match crate::reference::derived_placement::DerivedPlacements::from_json_path(&path) {
+                Ok(derived) => {
+                    let mut map: FxHashMap<String, Vec<GenomicPlacement>> = FxHashMap::default();
+                    for (key, placement) in derived.to_placements() {
+                        map.entry(key).or_default().push(placement);
+                    }
+                    merge_refseqgene_placements(&mut refseqgene_placements, map);
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to read derived NG_ placements {}: {}; \
+                         version-gap NG_ projection disabled",
+                        path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
         // Parse the NCBI `LRG_RefSeqGene` summary into a gene → reference-standard
         // transcript map for legacy gene-model selector resolution (#500/#637).
         // A read failure is warned (not silently swallowed); an absent field is
@@ -3071,6 +3100,51 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             cdot.get_transcript("NM_000088.3").is_some(),
             "RefSeq transcript still resolves in cdot"
         );
+    }
+
+    #[test]
+    fn test_from_manifest_loads_derived_ng_placement() {
+        use crate::hgvs::variant::Accession;
+        use crate::reference::Strand;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // A FASTA dir is required by from_manifest; a minimal transcript FASTA.
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+
+        // A derived-placements artifact (no GFF3 alignment present → this is the
+        // only source of the NG_ placement).
+        fs::write(
+            d.join("derived.json"),
+            r#"{"description":"test","placements":[{"parent":"NG_012337.1","nc":"NC_000011.10","nc_start":112081847,"nc_end":112097794,"strand":"+","anchored_by":"NM_003002.2","mismatch_fraction":0.0}]}"#,
+        )
+        .unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "derived_refseqgene_placements": "derived.json",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+        let ng = Accession::new("NG", "012337", Some(1));
+        let placement = provider
+            .genomic_placement(&ng)
+            .expect("derived NG_012337.1 placement is served from the manifest");
+        assert_eq!(placement.nc.full(), "NC_000011.10");
+        assert_eq!(placement.parent_start, 1);
+        assert_eq!(placement.nc_start, 112081847);
+        assert_eq!(placement.nc_end, 112097794);
+        assert_eq!(placement.strand, Strand::Plus);
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes #728 (stacked on the core PR #731): the runtime can now both **consume** derived `NG_`/`LRG_` placements from the manifest **and** **produce** them at prepare time. Together with #731 this lets `genomic_placement` resolve an `NG_` whose exact version is absent from NCBI's archived RefSeqGene alignment snapshot, instead of declining — derived from data obtainable by exact version (the `NG_` GenBank record + cdot), and validated by full-sequence comparison.

## Two halves

**Consume** (load-time):
- `DerivedPlacements` serde artifact (`reference::derived_placement`): per-entry `parent`/`nc`/span/`strand` + provenance; self-describing, auditable. `to_placements()` **declines** any malformed entry (unparseable `NC_`, non-`+`/`-` strand, inverted span).
- Manifest field `derived_refseqgene_placements`.
- `MultiFastaProvider` merges it into `refseqgene_placements` **after** the authoritative GFF3 snapshots with first-source-wins, so a GFF3 entry is **never overridden** — derived entries fill only version gaps. Runtime serving + the decline guard are otherwise untouched (additive).

**Produce** (prepare-time, `examples/derive_ng_placements`):
- Reads an input list of exact `NG_` versions, EFetches each `NG_`'s GenBank record + sequence, runs the #731 derivation core, and writes the artifact. A standalone example like the other provisioning generators (`build_conformance_snapshot`, `extract_biocommons_windows`) — needs a prepared reference + network, runs locally, output consumed offline.
- Adapters connect the trait-based core to real data: `CdotNcExons` over `CdotMapper` (the loaded `CdotTranscript.exons` is 0-based half-open ⇒ 1-based inclusive `(genome_start+1, genome_end)`), `ProviderGenomeSlice` over `MultiFastaProvider`.

## Validation

- **Consume:** unit tests (artifact round-trip, `to_placements` validity/decline) + an end-to-end `from_manifest` test serving a derived `NG_012337.1`.
- **Produce (end-to-end against GFF3 ground truth, both strands):** `NG_012337.3 → NC_000011.10:112081847-112121630(+)` and `NG_033963.1 → NC_000009.12:8312246-10617723(-)` reproduce the GFF3 **exactly**; the real absent target `NG_012337.1` derives + sequence-validates. The full-sequence guard correctly declined an off-by-one adapter bug during bring-up — the invariant working as designed.

fmt + clippy clean.

## Note

The producer is a standalone example (matching the snapshot-builder pattern); folding it into `ferro prepare` as a subcommand is an optional future nicety. This also unblocks the deferred conformance genomic snapshot (it can now provision the corpus `NG_`s).

Closes #728.