### PR TITLE
refactor(reference): NCBI assembly_report parser + data-driven build inference (#716)

### DIFF
--- a/src/liftover/aliases.rs
+++ b/src/liftover/aliases.rs
@@ -5,6 +5,7 @@
 //! - RefSeq: NC_000001.10 (GRCh37), NC_000001.11 (GRCh38)
 //! - Ensembl: 1, 2, ..., X, Y, MT
 
+use crate::liftover::assembly_report::AssemblyReport;
 use crate::reference::transcript::GenomeBuild;
 use std::collections::HashMap;
 
@@ -115,6 +116,48 @@ impl ContigAliases {
             .refseq_to_ensembl
             .insert("NC_012920.1".to_string(), "MT".to_string());
 
+        aliases
+    }
+
+    /// Build a contig-alias table from parsed NCBI assembly reports, one per
+    /// genome build.
+    ///
+    /// Data-driven counterpart to [`default_human`](Self::default_human): the
+    /// `(name, build) → RefSeq` and reverse maps are derived from the report's
+    /// own `assembled-molecule` rows rather than a hardcoded per-chromosome
+    /// version table (#716). For each such row the RefSeq accession is
+    /// registered as a self-alias (so [`infer_genome_build_from_accession_with`]
+    /// can classify it), alongside its UCSC-style name (column 9) and Ensembl
+    /// name (the Assigned-Molecule, column 2). Rows whose UCSC name is the `na`
+    /// placeholder contribute no UCSC alias.
+    ///
+    /// Multiple reports are merged, so passing both the GRCh37 and GRCh38
+    /// reports yields one table covering both builds — an accession present in
+    /// only one build resolves under that build alone, which is exactly the
+    /// signal build inference needs.
+    pub fn from_assembly_reports(reports: &[(GenomeBuild, &AssemblyReport)]) -> Self {
+        let mut aliases = Self::new();
+        for (build, report) in reports {
+            for entry in report.assembled_molecules_with_refseq() {
+                let refseq = entry.refseq_accession.as_str();
+                let ensembl = entry.assigned_molecule.as_str();
+                let ucsc = entry.ucsc_name.as_str();
+
+                aliases.add_alias(refseq, *build, refseq);
+                if !ensembl.is_empty() && ensembl != "na" {
+                    aliases.add_alias(ensembl, *build, refseq);
+                    aliases
+                        .refseq_to_ensembl
+                        .insert(refseq.to_string(), ensembl.to_string());
+                }
+                if !ucsc.is_empty() && ucsc != "na" {
+                    aliases.add_alias(ucsc, *build, refseq);
+                    aliases
+                        .refseq_to_ucsc
+                        .insert(refseq.to_string(), ucsc.to_string());
+                }
+            }
+        }
         aliases
     }
 
@@ -249,6 +292,25 @@ fn default_human_aliases() -> &'static ContigAliases {
 pub fn infer_genome_build_from_accession(
     accession: &crate::hgvs::variant::Accession,
 ) -> Option<&'static str> {
+    infer_genome_build_from_accession_with(default_human_aliases(), accession)
+}
+
+/// Like [`infer_genome_build_from_accession`] but consulting an explicitly
+/// supplied [`ContigAliases`] table rather than the bundled
+/// [`default_human`](ContigAliases::default_human) heuristic.
+///
+/// This is the data-driven entry point (#716): pass a table built from the
+/// prepared reference's own `assembly_report.txt`
+/// ([`ContigAliases::from_assembly_reports`]) and build inference becomes
+/// authoritative — it classifies any `NC_` accession the report describes,
+/// including versions absent from the hardcoded table. The `accession.assembly`
+/// explicit-build field and the `NC_`-prefix gate are honored identically to
+/// the bundled path, so the only behavioral difference is the source of the
+/// accession→build mapping.
+pub fn infer_genome_build_from_accession_with(
+    aliases: &ContigAliases,
+    accession: &crate::hgvs::variant::Accession,
+) -> Option<&'static str> {
     // Assembly-style references (`GRCh37(chr1)`, `GRCh38(chrX)`) carry the
     // build name explicitly; honor it before the prefix check.
     if let Some(asm) = accession.assembly.as_deref() {
@@ -261,8 +323,9 @@ pub fn infer_genome_build_from_accession(
     if &*accession.prefix != "NC" {
         return None;
     }
-    let aliases = default_human_aliases();
     let acc_str = accession.full();
+    // GRCh38 is checked first so an accession present under both builds (e.g.
+    // mtDNA `NC_012920.1`) resolves to GRCh38, ferro's default-when-ambiguous.
     if aliases
         .resolve_to_refseq(&acc_str, GenomeBuild::GRCh38)
         .is_some()
@@ -397,5 +460,127 @@ mod tests {
             "NC_000001.10"
         );
         assert_eq!(aliases.normalize("unknown", GenomeBuild::GRCh37), "unknown");
+    }
+
+    // ----- #716: data-driven build inference from assembly reports -----
+
+    use crate::hgvs::variant::Accession;
+    use crate::liftover::assembly_report::parse_assembly_report;
+
+    /// A minimal but format-faithful assembly_report for one or more
+    /// chromosomes: `(ucsc, ensembl, refseq)` rows under the given name.
+    fn synthetic_report(name: &str, rows: &[(&str, &str, &str)]) -> String {
+        let mut s = format!("# Assembly name:  {name}\n");
+        for (ucsc, ensembl, refseq) in rows {
+            // cols: name role assigned type genbank rel refseq unit length ucsc
+            s.push_str(&format!(
+                "{ensembl}\tassembled-molecule\t{ensembl}\tChromosome\tCM000000.1\t=\t{refseq}\tPrimary Assembly\t1000\t{ucsc}\n"
+            ));
+        }
+        s
+    }
+
+    #[test]
+    fn from_assembly_reports_builds_resolvable_aliases() {
+        let report = parse_assembly_report(&synthetic_report(
+            "GRCh38.p14",
+            &[("chr1", "1", "NC_000001.11"), ("chrX", "X", "NC_000023.11")],
+        ));
+        let aliases = ContigAliases::from_assembly_reports(&[(GenomeBuild::GRCh38, &report)]);
+
+        assert_eq!(
+            aliases.resolve_to_refseq("chr1", GenomeBuild::GRCh38),
+            Some("NC_000001.11")
+        );
+        assert_eq!(
+            aliases.resolve_to_refseq("1", GenomeBuild::GRCh38),
+            Some("NC_000001.11")
+        );
+        // Self-alias powers build inference.
+        assert_eq!(
+            aliases.resolve_to_refseq("NC_000023.11", GenomeBuild::GRCh38),
+            Some("NC_000023.11")
+        );
+        assert_eq!(aliases.refseq_to_ucsc("NC_000001.11"), Some("chr1"));
+        assert_eq!(aliases.refseq_to_ensembl("NC_000023.11"), Some("X"));
+    }
+
+    #[test]
+    fn infer_with_classifies_from_merged_reports() {
+        let g38 = parse_assembly_report(&synthetic_report(
+            "GRCh38.p14",
+            &[("chr1", "1", "NC_000001.11")],
+        ));
+        let g37 = parse_assembly_report(&synthetic_report(
+            "GRCh37.p13",
+            &[("chr1", "1", "NC_000001.10")],
+        ));
+        let aliases = ContigAliases::from_assembly_reports(&[
+            (GenomeBuild::GRCh38, &g38),
+            (GenomeBuild::GRCh37, &g37),
+        ]);
+
+        assert_eq!(
+            infer_genome_build_from_accession_with(
+                &aliases,
+                &Accession::new("NC", "000001", Some(11))
+            ),
+            Some("GRCh38")
+        );
+        assert_eq!(
+            infer_genome_build_from_accession_with(
+                &aliases,
+                &Accession::new("NC", "000001", Some(10))
+            ),
+            Some("GRCh37")
+        );
+    }
+
+    #[test]
+    fn infer_with_hardens_beyond_the_hardcoded_table() {
+        // A version the bundled table does not know (`NC_000001.12` is a
+        // hypothetical future GRCh38 chr1 build). The hardcoded default
+        // declines; a report-built table classifies it authoritatively.
+        let unknown_to_default = Accession::new("NC", "000001", Some(12));
+        assert_eq!(
+            infer_genome_build_from_accession(&unknown_to_default),
+            None,
+            "the bundled version table must not know NC_000001.12"
+        );
+
+        let report = parse_assembly_report(&synthetic_report(
+            "GRCh38.p15",
+            &[("chr1", "1", "NC_000001.12")],
+        ));
+        let aliases = ContigAliases::from_assembly_reports(&[(GenomeBuild::GRCh38, &report)]);
+        assert_eq!(
+            infer_genome_build_from_accession_with(&aliases, &unknown_to_default),
+            Some("GRCh38"),
+            "report-derived aliases must classify accessions absent from the bundled table"
+        );
+    }
+
+    #[test]
+    fn infer_default_path_is_unchanged() {
+        // The public no-arg entry point delegates to the bundled table; its
+        // behavior must be identical to before the #716 refactor.
+        assert_eq!(
+            infer_genome_build_from_accession(&Accession::new("NC", "000017", Some(11))),
+            Some("GRCh38")
+        );
+        assert_eq!(
+            infer_genome_build_from_accession(&Accession::new("NC", "000017", Some(10))),
+            Some("GRCh37")
+        );
+        // mtDNA is shared across builds and resolves to the GRCh38 default.
+        assert_eq!(
+            infer_genome_build_from_accession(&Accession::new("NC", "012920", Some(1))),
+            Some("GRCh38")
+        );
+        // Non-NC prefixes still decline.
+        assert_eq!(
+            infer_genome_build_from_accession(&Accession::new("NG", "012337", Some(1))),
+            None
+        );
     }
 }

--- a/src/liftover/assembly_report.rs
+++ b/src/liftover/assembly_report.rs
@@ -1,0 +1,246 @@
+//! Parser for NCBI `*_assembly_report.txt` files.
+//!
+//! NCBI ships an `assembly_report.txt` alongside each genome assembly (in the
+//! same directory as the `*_genomic.fna.gz` that `ferro prepare` downloads).
+//! It is the authoritative description of every sequence in the assembly:
+//! which RefSeq accession maps to which molecule, and — from the header — the
+//! assembly's name (e.g. `GRCh38.p14`).
+//!
+//! This parser turns that file into a data-driven `accession → assembly` map,
+//! so build inference can consult the prepared reference's own report instead
+//! of a hardcoded per-chromosome version table (#716).
+//!
+//! # Format
+//!
+//! Header lines begin with `#`. The assembly name is carried on a
+//! `# Assembly name:  <name>` line. Data rows are tab-separated with the
+//! columns (NCBI's stable layout):
+//!
+//! | idx | column |
+//! |-----|--------|
+//! | 0 | Sequence-Name (`1`, `X`, `MT`) |
+//! | 1 | Sequence-Role (`assembled-molecule`, `alt-scaffold`, …) |
+//! | 2 | Assigned-Molecule (`1`, `X`, `MT`) |
+//! | 3 | Assigned-Molecule-Location/Type (`Chromosome`, `Mitochondrion`) |
+//! | 4 | GenBank-Accn (`CM000663.2`) |
+//! | 5 | Relationship (`=`) |
+//! | 6 | RefSeq-Accn (`NC_000001.11`) |
+//! | 7 | Assembly-Unit (`Primary Assembly`, `non-nuclear`) |
+//! | 8 | Sequence-Length |
+//! | 9 | UCSC-style-name (`chr1`, or `na`) |
+
+/// A single sequence row from an NCBI assembly report.
+///
+/// Only the columns relevant to contig/build inference are retained. A `na`
+/// in any source column is preserved verbatim (callers decide how to treat
+/// missing UCSC names, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssemblyReportEntry {
+    /// Sequence-Name (column 0), e.g. `1`, `X`, `MT`, `HSCHR1_CTG1_UNLOCALIZED`.
+    pub sequence_name: String,
+    /// Sequence-Role (column 1), e.g. `assembled-molecule`, `alt-scaffold`.
+    pub sequence_role: String,
+    /// Assigned-Molecule (column 2), e.g. `1`, `X`, `MT`, `na`.
+    pub assigned_molecule: String,
+    /// GenBank-Accn (column 4), e.g. `CM000663.2`.
+    pub genbank_accession: String,
+    /// RefSeq-Accn (column 6), e.g. `NC_000001.11` (may be `na`).
+    pub refseq_accession: String,
+    /// UCSC-style-name (column 9), e.g. `chr1` (may be `na`).
+    pub ucsc_name: String,
+}
+
+impl AssemblyReportEntry {
+    /// `true` for rows whose Sequence-Role is `assembled-molecule` — the
+    /// primary chromosomes (1–22, X, Y) plus the mitochondrion. These are the
+    /// rows that carry build-distinguishing `NC_` accessions; alt/patch/
+    /// unplaced scaffolds are excluded from build inference.
+    pub fn is_assembled_molecule(&self) -> bool {
+        self.sequence_role == "assembled-molecule"
+    }
+
+    /// `true` when the RefSeq accession column carries a real accession (not
+    /// the `na` placeholder NCBI uses for GenBank-only sequences).
+    pub fn has_refseq_accession(&self) -> bool {
+        !self.refseq_accession.is_empty() && self.refseq_accession != "na"
+    }
+}
+
+/// A parsed NCBI assembly report: the assembly name from the header plus every
+/// data row.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AssemblyReport {
+    /// Assembly name from the `# Assembly name:` header line, e.g.
+    /// `GRCh38.p14`. Empty if the header line was absent.
+    pub assembly_name: String,
+    /// All data (non-comment) rows that parsed into at least the columns
+    /// needed for inference.
+    pub entries: Vec<AssemblyReportEntry>,
+}
+
+impl AssemblyReport {
+    /// Iterator over the assembled-molecule entries that carry a RefSeq
+    /// accession — the `(NC_ accession, …)` rows build inference keys on.
+    pub fn assembled_molecules_with_refseq(&self) -> impl Iterator<Item = &AssemblyReportEntry> {
+        self.entries
+            .iter()
+            .filter(|e| e.is_assembled_molecule() && e.has_refseq_accession())
+    }
+}
+
+/// The `#` prefix that marks a header / comment line.
+const COMMENT_PREFIX: &str = "#";
+/// Header key carrying the assembly name.
+const ASSEMBLY_NAME_KEY: &str = "# Assembly name:";
+/// Number of tab-separated columns NCBI emits; rows with fewer are skipped.
+const MIN_COLUMNS: usize = 10;
+
+/// Parse the text of an NCBI `assembly_report.txt`.
+///
+/// Comment/header lines (`#`-prefixed) are scanned for the assembly name;
+/// everything else is parsed as a tab-separated data row. Rows with fewer than
+/// [`MIN_COLUMNS`] columns are skipped (defensive against truncated or
+/// reformatted files). The parse never fails — a malformed file simply yields
+/// fewer entries — because a missing/garbled report should degrade to the
+/// hardcoded fallback, not abort reference loading.
+pub fn parse_assembly_report(text: &str) -> AssemblyReport {
+    let mut assembly_name = String::new();
+    let mut entries = Vec::new();
+
+    for line in text.lines() {
+        if line.starts_with(COMMENT_PREFIX) {
+            // Header line. Capture the assembly name; ignore everything else
+            // (including the `##`-prefixed Assembly-Units block, which still
+            // starts with `#`).
+            if let Some(name) = line.strip_prefix(ASSEMBLY_NAME_KEY) {
+                let name = name.trim();
+                if !name.is_empty() {
+                    assembly_name = name.to_string();
+                }
+            }
+            continue;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        if cols.len() < MIN_COLUMNS {
+            continue;
+        }
+        entries.push(AssemblyReportEntry {
+            sequence_name: cols[0].to_string(),
+            sequence_role: cols[1].to_string(),
+            assigned_molecule: cols[2].to_string(),
+            genbank_accession: cols[4].to_string(),
+            refseq_accession: cols[6].to_string(),
+            ucsc_name: cols[9].to_string(),
+        });
+    }
+
+    AssemblyReport {
+        assembly_name,
+        entries,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A faithful slice of an NCBI GRCh38 assembly_report.txt: the header
+    /// block (including the `##` Assembly-Units sub-block), a few
+    /// assembled-molecule chromosomes, the mitochondrion, and one
+    /// alt-scaffold row that must be excluded from build inference.
+    const GRCH38_SAMPLE: &str = "\
+# Assembly name:  GRCh38.p14
+# Organism name:  Homo sapiens (human)
+# Assembly level: Chromosome
+# RefSeq assembly accession: GCF_000001405.40
+#
+## Assembly-Units:
+## GenBank Unit Accession\tRefSeq Unit Accession\tAssembly-Unit name
+## GCA_000001305.2\tGCF_000001305.15\tPrimary Assembly
+# Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\tGenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name
+1\tassembled-molecule\t1\tChromosome\tCM000663.2\t=\tNC_000001.11\tPrimary Assembly\t248956422\tchr1
+17\tassembled-molecule\t17\tChromosome\tCM000679.2\t=\tNC_000017.11\tPrimary Assembly\t83257441\tchr17
+X\tassembled-molecule\tX\tChromosome\tCM000685.2\t=\tNC_000023.11\tPrimary Assembly\t156040895\tchrX
+MT\tassembled-molecule\tMT\tMitochondrion\tJ01415.2\t=\tNC_012920.1\tnon-nuclear\t16569\tchrM
+HSCHR1_CTG1\talt-scaffold\t1\tChromosome\tKI270762.1\t=\tNT_187515.1\tALT_REF_LOCI_1\t354444\tchr1_KI270762v1_alt
+";
+
+    #[test]
+    fn parses_assembly_name_from_header() {
+        let report = parse_assembly_report(GRCH38_SAMPLE);
+        assert_eq!(report.assembly_name, "GRCh38.p14");
+    }
+
+    #[test]
+    fn parses_assembled_molecule_rows() {
+        let report = parse_assembly_report(GRCH38_SAMPLE);
+        // 5 data rows total (4 assembled-molecule + 1 alt-scaffold).
+        assert_eq!(report.entries.len(), 5);
+
+        let chr1 = &report.entries[0];
+        assert_eq!(chr1.sequence_name, "1");
+        assert_eq!(chr1.sequence_role, "assembled-molecule");
+        assert_eq!(chr1.refseq_accession, "NC_000001.11");
+        assert_eq!(chr1.genbank_accession, "CM000663.2");
+        assert_eq!(chr1.ucsc_name, "chr1");
+        assert!(chr1.is_assembled_molecule());
+        assert!(chr1.has_refseq_accession());
+    }
+
+    #[test]
+    fn assembled_molecules_with_refseq_excludes_alt_scaffolds() {
+        let report = parse_assembly_report(GRCH38_SAMPLE);
+        let refseqs: Vec<&str> = report
+            .assembled_molecules_with_refseq()
+            .map(|e| e.refseq_accession.as_str())
+            .collect();
+        assert_eq!(
+            refseqs,
+            vec![
+                "NC_000001.11",
+                "NC_000017.11",
+                "NC_000023.11",
+                "NC_012920.1"
+            ],
+            "alt-scaffold NT_187515.1 must be excluded from inference rows"
+        );
+    }
+
+    #[test]
+    fn skips_comment_and_short_rows() {
+        // A header without an Assembly-name line, a too-short row, and a blank
+        // line: the parser must tolerate all three and still find the one
+        // valid data row.
+        let text = "\
+# some banner
+1\tassembled-molecule\t1\tChromosome\tCM000663.2\t=\tNC_000001.11\tPrimary Assembly\t248956422\tchr1
+
+short\trow\twith\tfew\tcols
+";
+        let report = parse_assembly_report(text);
+        assert_eq!(report.assembly_name, "");
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].refseq_accession, "NC_000001.11");
+    }
+
+    #[test]
+    fn treats_na_refseq_as_absent() {
+        let text = "\
+# Assembly name:  GRCh38.p14
+HSCHR1_RANDOM\tunplaced-scaffold\tna\tna\tGL000008.2\t<>\tna\tPrimary Assembly\t209709\tchr1_GL000008v2_random
+";
+        let report = parse_assembly_report(text);
+        assert_eq!(report.entries.len(), 1);
+        assert!(!report.entries[0].has_refseq_accession());
+        assert_eq!(report.assembled_molecules_with_refseq().count(), 0);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_report() {
+        let report = parse_assembly_report("");
+        assert_eq!(report, AssemblyReport::default());
+    }
+}

--- a/src/liftover/mod.rs
+++ b/src/liftover/mod.rs
@@ -39,9 +39,11 @@
 //! - <https://hgdownload.cse.ucsc.edu/goldenpath/hg38/liftOver/hg38ToHg19.over.chain.gz>
 
 pub mod aliases;
+pub mod assembly_report;
 pub mod chain;
 pub mod lift;
 
 pub use aliases::ContigAliases;
+pub use assembly_report::{parse_assembly_report, AssemblyReport, AssemblyReportEntry};
 pub use chain::{Chain, ChainBlock, ChainFile};
 pub use lift::{IntervalLiftoverResult, Liftover, LiftoverResult, LiftoverStatus};


### PR DESCRIPTION
## Summary

Genome-build inference (GRCh37 vs GRCh38) currently decides from a hardcoded per-chromosome version table in `ContigAliases` (`grch37_version`/`grch38_version`). That is brittle — it only knows the accession versions baked into the table and encodes assembly identity as a version-number heuristic rather than reading it from an authoritative source.

NCBI ships an authoritative `assembly_report.txt` alongside each assembly (in the same directory as the `*_genomic.fna.gz` that `ferro prepare` already downloads) that maps every RefSeq accession to its molecule and assembly name. This PR lands the **data-driven foundation** for consulting it.

## What's here

- **`liftover::assembly_report`** (new module) — parses the assembly name (from the `# Assembly name:` header) and the assembled-molecule rows (RefSeq accession + UCSC/Ensembl names) from the tab-delimited NCBI format. Robust to comment/`##` blocks, short/truncated rows, and `na` placeholders; the parse never fails, so a missing or garbled report degrades to the hardcoded fallback rather than aborting reference loading.
- **`ContigAliases::from_assembly_reports`** — builds the contig-alias table from parsed reports, one per genome build, merging multiple builds into one table.
- **`infer_genome_build_from_accession_with`** — explicit-aliases inference entry point. The existing `infer_genome_build_from_accession` now delegates to it through the bundled default table, so its behavior is unchanged.

The hardcoded table is retained as the bundled fallback (the issue explicitly allows "instead of, or before falling back to" it).

## Scope / follow-up

This is increment 1 of #716. It deliberately stops short of recording the map in the prepared manifest and wiring `MultiFastaProvider::from_manifest` to consult it at runtime — that step is left to a follow-up to avoid colliding with in-flight manifest/provider work (#728). Hence **Refs #716**, not "Closes": the runtime hardening lands when the provider wiring does.

## Testing

- 10 new unit tests: parser format coverage (header, assembled-molecule rows, alt-scaffold exclusion, `na` handling, short/blank rows, empty input) and data-driven inference (report-built aliases classify accessions, including a version absent from the bundled table; the default path is pinned unchanged).
- Full suite: 7252 passed / 54 skipped (manifest-gated conformance). `clippy --all-targets` and `fmt` clean.

Refs #716.