### PR TITLE
fix(normalize): normalize r. edits carrying the RNA base `u` (#736)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -51,7 +51,7 @@ use boundary::Boundaries;
 pub use config::{NormalizeConfig, ShuffleDirection};
 use rules::{
     canonicalize_conversion_to_delins, canonicalize_edit, canonicalize_insertion_expand,
-    needs_normalization, should_canonicalize, DelinsSubedit, InsCoordKind,
+    needs_normalization, rna_uracil_to_thymine, should_canonicalize, DelinsSubedit, InsCoordKind,
 };
 use shuffle::shuffle;
 
@@ -3883,6 +3883,25 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(e) => e,
             None => return Ok((HV::Rna(variant.clone()), vec![])),
         };
+
+        // #736: re-express any RNA base `u` in the edit as `T` before
+        // normalization. The transcript reference is stored as DNA, and the
+        // parser keeps `u` as a distinct `Base::U` (separate from `Base::T`), so
+        // a literal `u` in an insertion / delins would never match the reference
+        // and the edit would silently fail to canonicalize or 3'-shift. Re-run
+        // on the DNA-rewritten variant; `RnaVariant`'s Display renders `T`→`u`
+        // again on output, so this is display-neutral.
+        if let Some(dna_edit) = rna_uracil_to_thymine(edit) {
+            let new_variant = RnaVariant {
+                accession: variant.accession.clone(),
+                gene_symbol: variant.gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    variant.loc_edit.location.clone(),
+                    variant.loc_edit.edit.map_ref(|_| dna_edit.clone()),
+                ),
+            };
+            return self.normalize_rna(&new_variant);
+        }
 
         // SVD-WG009: rewrite `con` to `delins`. Re-run on the rewritten
         // variant so downstream passes (3' shift, ins→dup, canonical

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1658,6 +1658,146 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
     })
 }
 
+/// Map the RNA base `U`/`u` to thymine (`T`) throughout an `r.` edit's literal
+/// base sequences, so the edit can be compared against the DNA-stored reference
+/// during normalization (#736).
+///
+/// The parser keeps `u` as a distinct [`Base::U`] (`b'U'`), separate from
+/// [`Base::T`] (`b'T'`). `normalize_rna` compares the edit's inserted / delins
+/// bases against the transcript reference, which is stored as DNA (`T`), so a
+/// `Base::U` never matches and insertions / delins silently fail to canonicalize
+/// or 3'-shift. Re-expressing the edit in DNA before normalization fixes this;
+/// `RnaVariant`'s `Display` (`to_rna_string`) renders `T`→`u` again on output,
+/// so the rewrite is display-neutral.
+///
+/// Returns `Some` with the rewritten edit iff at least one `U` was present, and
+/// `None` for an already-DNA edit — mirroring
+/// [`canonicalize_conversion_to_delins`]'s `None`-means-no-op convention so
+/// callers can use it as an early-return probe. The walked shapes are a superset
+/// of the literal-base carriers checked by the parser's `validate_no_u_in_dna`
+/// (substitution, substitution-no-ref, deletion, duplication, insertion, delins,
+/// repeat, multi-repeat), additionally covering the inversion, breakpoint-insertion,
+/// and dupins shapes that `validate_no_u_in_dna` deliberately skips; every other
+/// shape carries no literal base alphabet and is returned unchanged.
+pub fn rna_uracil_to_thymine(edit: &NaEdit) -> Option<NaEdit> {
+    use crate::hgvs::edit::{Base, RepeatUnit};
+
+    fn map_base(b: Base) -> Base {
+        if matches!(b, Base::U) {
+            Base::T
+        } else {
+            b
+        }
+    }
+    fn map_seq(s: &Sequence) -> Sequence {
+        Sequence::new(s.bases().iter().copied().map(map_base).collect())
+    }
+    fn map_opt_seq(s: &Option<Sequence>) -> Option<Sequence> {
+        s.as_ref().map(map_seq)
+    }
+    fn map_part(p: &InsertedPart) -> InsertedPart {
+        match p {
+            InsertedPart::Literal(s) => InsertedPart::Literal(map_seq(s)),
+            InsertedPart::Repeat { base, count } => InsertedPart::Repeat {
+                base: map_base(*base),
+                count: count.clone(),
+            },
+            other => other.clone(),
+        }
+    }
+    fn map_ins(ins: &InsertedSequence) -> InsertedSequence {
+        match ins {
+            InsertedSequence::Literal(s) => InsertedSequence::Literal(map_seq(s)),
+            InsertedSequence::Repeat { base, count } => InsertedSequence::Repeat {
+                base: map_base(*base),
+                count: count.clone(),
+            },
+            InsertedSequence::SequenceRepeat { sequence, count } => {
+                InsertedSequence::SequenceRepeat {
+                    sequence: map_seq(sequence),
+                    count: count.clone(),
+                }
+            }
+            InsertedSequence::Complex(parts) => {
+                InsertedSequence::Complex(parts.iter().map(map_part).collect())
+            }
+            other => other.clone(),
+        }
+    }
+
+    let mapped = match edit {
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => NaEdit::Substitution {
+            reference: map_base(*reference),
+            alternative: map_base(*alternative),
+        },
+        NaEdit::SubstitutionNoRef { alternative } => NaEdit::SubstitutionNoRef {
+            alternative: map_base(*alternative),
+        },
+        NaEdit::Deletion { sequence, length } => NaEdit::Deletion {
+            sequence: map_opt_seq(sequence),
+            length: *length,
+        },
+        NaEdit::Duplication {
+            sequence,
+            length,
+            uncertain_extent,
+        } => NaEdit::Duplication {
+            sequence: map_opt_seq(sequence),
+            length: *length,
+            uncertain_extent: uncertain_extent.clone(),
+        },
+        NaEdit::Insertion { sequence } => NaEdit::Insertion {
+            sequence: map_ins(sequence),
+        },
+        NaEdit::BreakpointInsertion { sequence } => NaEdit::BreakpointInsertion {
+            sequence: map_ins(sequence),
+        },
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => NaEdit::Delins {
+            sequence: map_ins(sequence),
+            deleted: map_opt_seq(deleted),
+            deleted_length: *deleted_length,
+        },
+        NaEdit::DupIns { sequence } => NaEdit::DupIns {
+            sequence: map_ins(sequence),
+        },
+        NaEdit::Inversion { sequence, length } => NaEdit::Inversion {
+            sequence: map_opt_seq(sequence),
+            length: *length,
+        },
+        NaEdit::Repeat {
+            sequence,
+            count,
+            additional_counts,
+            trailing,
+        } => NaEdit::Repeat {
+            sequence: map_opt_seq(sequence),
+            count: count.clone(),
+            additional_counts: additional_counts.clone(),
+            trailing: map_opt_seq(trailing),
+        },
+        NaEdit::MultiRepeat { units } => NaEdit::MultiRepeat {
+            units: units
+                .iter()
+                .map(|u| RepeatUnit {
+                    sequence: map_seq(&u.sequence),
+                    count: u.count.clone(),
+                })
+                .collect(),
+        },
+        // Every other shape carries no literal base alphabet.
+        other => other.clone(),
+    };
+
+    (mapped != *edit).then_some(mapped)
+}
+
 /// If `s` is wrapped in a single matching outer `[...]` pair — i.e.
 /// the leading `[` at index 0 closes at the trailing `]` at
 /// `s.len() - 1` under standard bracket-depth bookkeeping — return the
@@ -3945,5 +4085,55 @@ mod tests {
             }
             other => panic!("expected NaEdit::Delins, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rna_uracil_to_thymine_rewrites_literal_u_in_insertion() {
+        use crate::hgvs::edit::InsertedSequence;
+        let edit = NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::from_str("UU").unwrap()),
+        };
+        let mapped = rna_uracil_to_thymine(&edit).expect("expected Some for a u-bearing edit");
+        assert_eq!(
+            mapped,
+            NaEdit::Insertion {
+                sequence: InsertedSequence::Literal(Sequence::from_str("TT").unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn rna_uracil_to_thymine_rewrites_delins_deleted_and_inserted() {
+        use crate::hgvs::edit::InsertedSequence;
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::from_str("AU").unwrap()),
+            deleted: Some(Sequence::from_str("UG").unwrap()),
+            deleted_length: None,
+        };
+        let mapped = rna_uracil_to_thymine(&edit).expect("expected Some");
+        assert_eq!(
+            mapped,
+            NaEdit::Delins {
+                sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
+                deleted: Some(Sequence::from_str("TG").unwrap()),
+                deleted_length: None,
+            }
+        );
+    }
+
+    #[test]
+    fn rna_uracil_to_thymine_is_noop_without_u() {
+        use crate::hgvs::edit::{Base, InsertedSequence};
+        // A DNA-only insertion (no U anywhere) must return None.
+        assert!(rna_uracil_to_thymine(&NaEdit::Insertion {
+            sequence: InsertedSequence::Literal(Sequence::from_str("ACGT").unwrap()),
+        })
+        .is_none());
+        // A non-literal-base shape returns None too.
+        assert!(rna_uracil_to_thymine(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        })
+        .is_none());
     }
 }

--- a/tests/it/coverage_gap_tests.rs
+++ b/tests/it/coverage_gap_tests.rs
@@ -1023,4 +1023,38 @@ mod issue_704_r_intronic {
             Ok("NM_MUTR.1:n.24_26-3A[8]".to_string())
         );
     }
+
+    #[test]
+    fn r_intronic_edit_with_uracil_base() {
+        // Cross-cut of #704 (intronic `r.` routing) and #736 (the `u`->`T`
+        // normalization): an intronic `r.` delins whose inserted bases are
+        // written with the RNA base `u`. The genomic-space engine must see DNA,
+        // so without the #736 mapping the reverse-complement inversion would be
+        // missed and this would stay `delinsuu`. `r.30+1_30+2` is the intron-1
+        // `aa`; `uu` is its reverse complement, so the canonical form is `inv`,
+        // matching the `n.`-with-`T` analog.
+        assert_eq!(
+            normalize(
+                make_provider_with_plus_strand(),
+                "NM_PLUS.1:r.30+1_30+2delinsuu"
+            ),
+            "NM_PLUS.1:r.30+1_30+2inv",
+        );
+        assert_eq!(
+            normalize(
+                make_provider_with_plus_strand(),
+                "NM_PLUS.1:n.30+1_30+2delinsTT"
+            ),
+            "NM_PLUS.1:n.30+1_30+2inv",
+        );
+        // A plain intronic `r.` insertion carrying `u` must also normalize
+        // (not error) and match its `n.`-with-`T` analog.
+        assert_eq!(
+            try_normalize(
+                make_provider_with_plus_strand(),
+                "NM_PLUS.1:r.30+1_30+2insu"
+            ),
+            Ok("NM_PLUS.1:r.30+1_30+2insu".to_string()),
+        );
+    }
 }

--- a/tests/it/issue_736_rna_uracil_normalize.rs
+++ b/tests/it/issue_736_rna_uracil_normalize.rs
@@ -1,0 +1,95 @@
+//! Regression test for issue #736: `normalize_rna` compares an `r.` edit's
+//! literal bases against the DNA-stored reference byte-for-byte, but the parser
+//! keeps the RNA base `u` as a distinct [`Base::U`] (`b'U'`), separate from
+//! [`Base::T`] (`b'T'`). So any `r.` edit carrying a literal `u` never matches
+//! the reference `T`, and insertions / delins fail to canonicalize or 3'-shift.
+//!
+//! The spec-correct `u` form produced a *wrong* result while the
+//! technically-invalid `T` form produced the right one — e.g. on a `TTT` run,
+//! `r.3_4insu` stayed `r.3_4insu` instead of collapsing to `r.5dup` (which is
+//! exactly what `r.3_4insT` already does).
+//!
+//! The fix maps the `r.` edit's literal `U` bases to `T` before the DNA-based
+//! normalization, then `RnaVariant`'s Display (`to_rna_string`) renders `T`→`u`
+//! on output. These tests pin the `u`-form results against the DNA-equivalent
+//! `n.`/`r.`-with-`T` outputs on the same transcript.
+
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Single-exon coding transcript `AATTTGCC` with a `TTT` run at tx 3-5 and
+/// `cds_start = 1` (so `r.N == c.N == n.N`). An insertion of one more thymine
+/// into the run canonicalizes to a duplication at the run's 3' end.
+fn provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_U.1".to_string(),
+        Some("UG".to_string()),
+        Strand::Plus,
+        "AATTTGCC".to_string(),
+        Some(1u64),
+        Some(8u64),
+        vec![Exon::new(1, 1, 8)],
+        None,
+        None,
+        None,
+        GenomeBuild::GRCh38,
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+fn normalize(input: &str) -> String {
+    let normalizer = Normalizer::new(provider());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input:?} failed: {e}"));
+    format!("{}", normalized)
+}
+
+#[test]
+fn rna_insertion_with_u_collapses_to_dup() {
+    // Inserting a single `u` into the `TTT` run must collapse to the 3'-most
+    // duplication, exactly as `r.3_4insT` / `n.3_4insT` -> `*.5dup`.
+    assert_eq!(normalize("NM_U.1:r.3_4insu"), "NM_U.1:r.5dup");
+}
+
+#[test]
+fn rna_two_base_u_insertion_canonicalizes_to_repeat() {
+    // `n.3_4insTT` -> `n.3_5T[5]`; the `r.` analog renders the repeat unit as `u`.
+    assert_eq!(normalize("NM_U.1:r.3_4insuu"), "NM_U.1:r.3_5u[5]");
+}
+
+#[test]
+fn rna_delins_with_u_simplifies() {
+    // `n.3_5delinsTT` -> `n.5del`; the `u` form must simplify identically.
+    assert_eq!(normalize("NM_U.1:r.3_5delinsuu"), "NM_U.1:r.5del");
+}
+
+#[test]
+fn rna_insertion_with_t_already_works() {
+    // Control: the technically-invalid `T` spelling already normalized
+    // correctly (the comparison matched the DNA reference); it must keep doing so.
+    assert_eq!(normalize("NM_U.1:r.3_4insT"), "NM_U.1:r.5dup");
+}
+
+#[test]
+fn rna_insertion_without_u_is_unaffected() {
+    // Control: a non-`u` insertion that does not touch the run must be untouched
+    // by the U->T mapping.
+    assert_eq!(normalize("NM_U.1:r.3_4insgg"), "NM_U.1:r.3_4insgg");
+}
+
+#[test]
+fn rna_delins_uracil_reverse_complement_recognized_as_inversion() {
+    // The same root cause also blocked RNA inversion recognition when the
+    // reverse complement contains `u`. `r.1_2` ref is `aa`, whose reverse
+    // complement is `uu`, so the canonical form is `inv`. Pre-#736 the inserted
+    // `uu` (`Base::U`) was compared against the DNA reverse complement `TT` and
+    // never matched, leaving a `delinsuu`; with the U->T normalization the RNA
+    // path now matches the DNA axes (`n.1_2delinsTT` -> `n.1_2inv`).
+    assert_eq!(normalize("NM_U.1:r.1_2delinsuu"), "NM_U.1:r.1_2inv");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -184,6 +184,7 @@ mod issue_487_allele_collapse;
 mod issue_487_mito_g_to_m;
 mod issue_502_np_protein_selector;
 mod issue_573_intronic_shuffle_window;
+mod issue_736_rna_uracil_normalize;
 mod issue_91_protein_three_prime_shift;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;

--- a/tests/it/merge_consecutive_edits_tests.rs
+++ b/tests/it/merge_consecutive_edits_tests.rs
@@ -810,25 +810,32 @@ fn test_merge_3utr_consecutive_subs_cds() {
 
 #[test]
 fn test_merge_5utr_consecutive_subs_rna() {
-    // r. mirrors c. for 5'UTR; lowercase nucleotides preserved in the
-    // merged delins per the existing case-handling rule.
+    // r. mirrors c. for 5'UTR. The merged edit deletes the 5'UTR reference
+    // `ac` and inserts `gu`, which is its reverse complement — so the
+    // canonical form is an inversion, exactly as the DNA-axis analog
+    // (`c.-2_-1delinsGT` -> `c.-2_-1inv`). Before #736 the RNA path kept this
+    // as `delinsgu` because the inserted `u` (`Base::U`) was compared against
+    // the DNA reference `T` and never matched the reverse complement; with the
+    // U->T normalization the inversion is now recognized on r. too.
     assert_eq!(
         normalize_with_provider(
             provider_with_utr_transcript(),
             "NM_TESTUTR.1:r.[-2a>g;-1c>u]",
         ),
-        "NM_TESTUTR.1:r.-2_-1delinsgu",
+        "NM_TESTUTR.1:r.-2_-1inv",
     );
 }
 
 #[test]
 fn test_merge_3utr_consecutive_subs_rna() {
+    // 3'UTR analog of the above: ref `ac` -> `gu` (its reverse complement) is
+    // canonicalized to `inv`, matching the DNA axes (#736).
     assert_eq!(
         normalize_with_provider(
             provider_with_utr_transcript(),
             "NM_TESTUTR.1:r.[*1a>g;*2c>u]",
         ),
-        "NM_TESTUTR.1:r.*1_*2delinsgu",
+        "NM_TESTUTR.1:r.*1_*2inv",
     );
 }
 


### PR DESCRIPTION
`normalize_rna` compared an `r.` edit's literal bases against the DNA-stored reference byte-for-byte, but the parser keeps the RNA base `u` as a distinct `Base::U` (`b'U'`), separate from `Base::T` (`b'T'`). Any `r.` edit carrying a literal `u` therefore never matched the reference, so insertions and delins silently failed to canonicalize / 3'-shift, and reverse-complement delins were not recognized as inversions. The spec-correct `u` form produced a **wrong** result while the technically-invalid `T` form produced the right one.

Closes #736

## Reproduction

Single-exon transcript `AATTTGCC` (a `TTT` run at tx 3–5), `cds_start=1`:

| input | before | after (correct) |
|-------|--------|-----------------|
| `r.3_4insu` | `r.3_4insu` | `r.5dup` |
| `r.3_4insuu` | `r.3_4insuu` | `r.3_5u[5]` |
| `r.3_5delinsuu` | `r.3_5delinsuu` | `r.5del` |
| `r.1_2delinsuu` | `r.1_2delinsuu` | `r.1_2inv` |
| `r.3_4insT` | `r.5dup` | `r.5dup` (unchanged) |

The `T`-spelled forms already worked; the spec-correct `u` forms did not.

## Root cause

In `normalize_rna`, the edit's inserted / delins bases are converted to bytes via `*b as u8` and compared against the DNA reference inside `normalize_na_edit` (validation, ins→dup recognition, the shuffle predicate, and reverse-complement inversion detection). `Base::U as u8 == b'U'` never equals `b'T'`, even under `eq_ignore_ascii_case`.

## Fix

Map the `r.` edit's literal `U` bases to `T` before the DNA-based normalization — new `rules::rna_uracil_to_thymine`, which walks exactly the literal-base-carrying `NaEdit` shapes enumerated by the parser's `validate_no_u_in_dna` (substitution, deletion, duplication, insertion, delins, repeat) and returns `None` for an already-DNA edit (so it can be used as an early-return probe, like `canonicalize_conversion_to_delins`). `normalize_rna` re-runs on the DNA-rewritten variant; `RnaVariant`'s Display (`to_rna_string`) renders `T`→`u` again on output, so the rewrite is display-neutral.

This also restores RNA **inversion recognition** for reverse-complement delins (e.g. `r.1_2delinsuu` where `uu` is the reverse complement of the `aa` reference), matching the `c.`/`n.` axes. Two `merge_consecutive_edits_tests` cases that merged consecutive `r.` substitutions into a reverse-complement delins are updated to expect the now-DNA-consistent `inv` form (previously they asserted the buggy `delinsgu`).

## Testing

- New `tests/it/issue_736_rna_uracil_normalize.rs`: insertion → dup, two-base insertion → repeat, delins simplification, `u`-reverse-complement → `inv`, plus `T`-form and no-`u` controls.
- New unit tests for `rna_uracil_to_thymine` (rewrites literal `U` in insertions and delins deleted/inserted sequences; `None` for DNA-only and non-literal shapes).
- The hook sits at the top of `normalize_rna`, before the intronic/boundary `r.` dispatch added in #704 — so intronic `r.` carrying a literal `u` works too. A cross-cutting test in `issue_704_r_intronic` covers an intronic `r.` reverse-complement delins (`r.30+1_30+2delinsuu` → `inv`, matching the `n.`-with-`T` analog).
- Full suite green (7302 passed); clippy `--all-features --all-targets -D warnings` clean; `cargo fmt` clean; generated spec fixture `--check` consistent.