### PR TITLE
feat(project): emit the g. axis for NG/LRG/NC-parent c.pter/c.qter inputs (#537)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -752,12 +752,100 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             return Ok(variant.clone());
         }
 
+        // #537: a `c.pter`/`c.qter` telomere-flank input resolves to the parent
+        // reference's own genomic terminus, not a transcript-mapped coordinate.
+        // Handle it before the cdot pivot below, which cannot (and per #534
+        // must not) number a transcript-flank marker.
+        if let Some(result) = self.project_cds_terminus_to_parent(variant) {
+            return result;
+        }
+
         match self.project_to_genomic_nc(variant)? {
             HgvsVariant::Genome(gv) => {
                 self.reanchor_genome_output(gv, self.build_hint_for_variant(variant))
             }
             other => Ok(other),
         }
+    }
+
+    /// Project a `c.pter`/`c.qter` (telomere-flank marker) coding input onto its
+    /// parent reference's own genomic frame (#537).
+    ///
+    /// `pter` denotes the 5'-most position of the parent reference (`g.1`) and
+    /// `qter` the 3'-most (`g.<length>`); a `pter_qter` range spans the whole
+    /// reference. Unlike a numeric `c.` coordinate these markers do not number a
+    /// transcript position — PR #534 correctly refuses to do so on the `c.`
+    /// axis — so they map straight to the parent reference's termini with no
+    /// cdot transcript mapping. The emitted `g.1` / `g.<length>` is normalized
+    /// downstream (e.g. the 3' rule rolls `g.1del` through a leading homopolymer
+    /// run, matching mutalyzer's `g.3del`).
+    ///
+    /// Returns `None` when `variant` is not a handled terminus case — not a
+    /// `Cds` input, an endpoint that is not a `pter`/`qter` marker (numeric,
+    /// `?`, `cen`, or a mixed marker/numeric range), or a reversed `qter_pter` —
+    /// so the caller falls through to the normal transcript-mapped projection
+    /// (which declines or numbers as appropriate). Returns `Some(Err(..))` when
+    /// the parent reference is unresolvable or its length is unknown to the
+    /// provider (e.g. the pinned parent version is absent — a reference-coverage
+    /// gap, #645/#672 — not a projection bug).
+    fn project_cds_terminus_to_parent(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Option<Result<HgvsVariant, FerroError>> {
+        use crate::hgvs::interval::GenomeInterval;
+        use crate::hgvs::location::{GenomePos, SpecialPosition};
+        use crate::hgvs::variant::{GenomeVariant, LocEdit};
+
+        let HgvsVariant::Cds(v) = variant else {
+            return None;
+        };
+        // Both endpoints must be telomere markers. A numeric or `?` endpoint, or
+        // a mixed marker/numeric range (e.g. `c.pter_-51`), needs the transcript
+        // mapping and is left to the normal path.
+        let start = resolve_uncertain_boundary(&v.loc_edit.location.start, "c.", "start").ok()?;
+        let end = resolve_uncertain_boundary(&v.loc_edit.location.end, "c.", "end").ok()?;
+        let (Some(start_marker), Some(end_marker)) = (start.special, end.special) else {
+            return None;
+        };
+
+        // Resolve the parent genomic reference: an explicit `genomic_context`
+        // parent, or the structural `LRG_<n>` parent of a bare LRG transcript
+        // (#480). No parent → leave it to the normal path, which raises the
+        // canonical "no parent reference" error.
+        let parent = match v.accession.genomic_context.as_deref().cloned() {
+            Some(p) => p,
+            None => Self::lrg_genomic_parent(&v.accession)?,
+        };
+        let length = match self.provider.get_sequence_length(&parent.full()) {
+            Ok(n) => n,
+            Err(e) => return Some(Err(e)),
+        };
+        // A zero-length parent is unreachable for any real NG/LRG/NC contig, but
+        // guard the endpoint math against it (#526): `qter` would build an
+        // invalid 1-based `g.0` and `pter_qter` a reversed `g.1_0`. Decline so
+        // the normal path raises the canonical refusal rather than emitting a
+        // malformed interval.
+        if length == 0 {
+            return None;
+        }
+
+        // pter → 5'-most (g.1); qter → 3'-most (g.<length>); pter_qter → the
+        // whole reference. `cen` and a reversed `qter_pter` are out of scope and
+        // left to the normal path (which declines).
+        let (g_start, g_end) = match (start_marker, end_marker) {
+            (SpecialPosition::Pter, SpecialPosition::Pter) => (1, 1),
+            (SpecialPosition::Qter, SpecialPosition::Qter) => (length, length),
+            (SpecialPosition::Pter, SpecialPosition::Qter) => (1, length),
+            _ => return None,
+        };
+
+        let interval = GenomeInterval::new(GenomePos::new(g_start), GenomePos::new(g_end));
+        let gv = GenomeVariant {
+            accession: parent,
+            gene_symbol: None,
+            loc_edit: LocEdit::with_uncertainty(interval, v.loc_edit.edit.clone()),
+        };
+        Some(Ok(HgvsVariant::Genome(gv)))
     }
 
     /// Re-anchor a chromosome-frame genomic projection into its parent's own
@@ -6193,12 +6281,16 @@ mod tests {
 
         // -- special positions (pter/qter/cen) in project_to_genomic ----------
 
-        /// A `pter` CDS position is special (base==0, special.is_some()): it must
-        /// not slip past the `is_unknown()` guard and then fail with "Invalid CDS
-        /// position: 0". The extended guard must catch it as `UnsupportedProjection`.
+        /// #537: a `pter` CDS marker projects to the parent reference's 5'-most
+        /// genomic coordinate (`g.1`), not the old special-sentinel rejection.
+        /// (PR #534 keeps the *c.-axis* refusal; this covers the g. axis.) The
+        /// raw projection is `g.1del`; the normalizer's 3' rule rolls it
+        /// downstream.
         #[test]
-        fn project_to_genomic_special_pter_returns_unsupported() {
-            let (projector, provider) = make_test_provider_and_projector();
+        fn project_to_genomic_special_pter_projects_to_parent_terminus() {
+            let (projector, mut provider) = make_test_provider_and_projector();
+            // pter/qter resolve against the parent reference's length.
+            provider.add_genomic_sequence("NG_TEST.1", "A".repeat(40));
             let vp = VariantProjector::new(projector, provider);
 
             let cds = CdsVariant {
@@ -6213,17 +6305,17 @@ mod tests {
                 ),
             };
             let input = HgvsVariant::Cds(cds);
-            let err = vp
+            let g = vp
                 .project_to_genomic(&input)
-                .expect_err("pter position must not project to genomic");
-            assert!(
-                matches!(err, FerroError::UnsupportedProjection { .. }),
-                "expected UnsupportedProjection for pter position, got: {:?}",
-                err
-            );
+                .expect("pter must project to the parent's 5' terminus");
+            assert_eq!(g.to_string(), "NG_TEST.1:g.1del");
         }
 
-        /// A `qter` endpoint must be rejected with the same error.
+        /// A *mixed* numeric/`qter` range (`c.1_qter`) is out of #537 scope —
+        /// the numeric endpoint still needs a transcript mapping — so it remains
+        /// `UnsupportedProjection`. (A pure `c.qter` resolves to the parent
+        /// terminus; that is covered by the `tests/it/issue_537_*` integration
+        /// tests, which have a parent length to resolve against.)
         #[test]
         fn project_to_genomic_special_qter_returns_unsupported() {
             let (projector, provider) = make_test_provider_and_projector();

--- a/tests/it/issue_537_pter_qter_genomic.rs
+++ b/tests/it/issue_537_pter_qter_genomic.rs
@@ -1,0 +1,145 @@
+//! Issue #537 — emit the genomic (g.) axis for `c.pter`/`c.qter` inputs on an
+//! NG/LRG/NC-parent reference.
+//!
+//! PR #534 made ferro spec-correctly *refuse* to number a transcript-flank
+//! `c.pter`/`c.qter` marker on the `c.` axis. The genomic axis, however, has a
+//! concrete spec-valid answer: the marker denotes the parent reference's own
+//! terminus, so `pter` → the 5'-most genomic coordinate (`g.1`) and `qter` →
+//! the 3'-most (`g.<length>`); a `pter_qter` range spans the whole reference.
+//! These map straight to the parent reference's termini with no transcript
+//! mapping — `project_to_genomic` previously rejected them as unresolvable
+//! special sentinels.
+//!
+//! The emitted `g.1`/`g.<length>` is the pre-normalization projection; the
+//! normalizer's 3' rule rolls it further (e.g. `g.1del` through a leading
+//! homopolymer run, which is how mutalyzer's `NG_012337.1:g.3del` arises). That
+//! normalization step is exercised by the conformance harness, not here.
+//!
+//! Source: <https://github.com/fulcrumgenomics/ferro-hgvs/issues/537>.
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, FerroError, VariantProjector};
+
+/// A projector whose provider knows only the NG parent's *length* — pter/qter
+/// resolution needs nothing else (no cdot transcript, no chromosomal
+/// placement). The parent reference is `len` bases long.
+fn ng_parent_projector(len: usize) -> VariantProjector<MockProvider> {
+    let projector = Projector::new(CdotMapper::new());
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NG_TEST.1", "A".repeat(len));
+    VariantProjector::new(projector, provider)
+}
+
+/// A projector whose provider knows only the genomic LRG parent's *length*.
+/// A bare `LRG_<n>t<m>` transcript has no `genomic_context`, so the terminus
+/// path derives its parent structurally (`LRG_<n>`, #480); the parent reference
+/// is `len` bases long.
+fn lrg_parent_projector(len: usize) -> VariantProjector<MockProvider> {
+    let projector = Projector::new(CdotMapper::new());
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("LRG_24", "A".repeat(len));
+    VariantProjector::new(projector, provider)
+}
+
+#[test]
+fn pter_resolves_to_parent_five_prime_terminus() {
+    let vp = ng_parent_projector(50);
+    let v = parse_hgvs("NG_TEST.1(NM_TEST.1):c.pterdel").expect("parse");
+    let g = vp
+        .project_to_genomic(&v)
+        .expect("pter must project to the parent terminus");
+    assert_eq!(g.to_string(), "NG_TEST.1:g.1del");
+}
+
+#[test]
+fn qter_resolves_to_parent_three_prime_terminus() {
+    let vp = ng_parent_projector(50);
+    let v = parse_hgvs("NG_TEST.1(NM_TEST.1):c.qterdel").expect("parse");
+    let g = vp
+        .project_to_genomic(&v)
+        .expect("qter must project to the parent terminus");
+    // qter → the parent reference's last base (g.<length>).
+    assert_eq!(g.to_string(), "NG_TEST.1:g.50del");
+}
+
+#[test]
+fn pter_qter_range_spans_the_whole_parent_reference() {
+    let vp = ng_parent_projector(50);
+    let v = parse_hgvs("NG_TEST.1(NM_TEST.1):c.pter_qterdel").expect("parse");
+    let g = vp
+        .project_to_genomic(&v)
+        .expect("pter_qter must span the whole parent reference");
+    assert_eq!(g.to_string(), "NG_TEST.1:g.1_50del");
+}
+
+#[test]
+fn qter_uses_the_actual_parent_length() {
+    // A different reference length must change the qter coordinate — confirming
+    // it is read from the provider, not a constant.
+    let vp = ng_parent_projector(12345);
+    let v = parse_hgvs("NG_TEST.1(NM_TEST.1):c.qterdel").expect("parse");
+    let g = vp.project_to_genomic(&v).expect("qter projects");
+    assert_eq!(g.to_string(), "NG_TEST.1:g.12345del");
+}
+
+#[test]
+fn lrg_bare_transcript_pter_resolves_to_its_structural_lrg_parent() {
+    // A bare `LRG_<n>t<m>` transcript carries no `genomic_context`, so the
+    // terminus path derives the genomic parent structurally (`LRG_24`, #480)
+    // and resolves `pter` to its 5'-most genomic coordinate (g.1) — exercising
+    // the `lrg_genomic_parent` arm, not the `genomic_context` arm.
+    let vp = lrg_parent_projector(50);
+    let v = parse_hgvs("LRG_24t1:c.pterdel").expect("parse");
+    let g = vp
+        .project_to_genomic(&v)
+        .expect("LRG pter must project to the structural LRG parent terminus");
+    assert_eq!(g.to_string(), "LRG_24:g.1del");
+}
+
+#[test]
+fn lrg_bare_transcript_qter_resolves_to_its_structural_lrg_parent() {
+    // The qter mirror of the pter case: the 3'-most genomic coordinate is the
+    // structural LRG parent's last base (g.<length>).
+    let vp = lrg_parent_projector(50);
+    let v = parse_hgvs("LRG_24t1:c.qterdel").expect("parse");
+    let g = vp
+        .project_to_genomic(&v)
+        .expect("LRG qter must project to the structural LRG parent terminus");
+    assert_eq!(g.to_string(), "LRG_24:g.50del");
+}
+
+#[test]
+fn unknown_parent_length_is_an_honest_error() {
+    // The provider does not know the parent's length (the pinned parent version
+    // is absent — a reference-coverage gap, #645/#672, not a projection bug).
+    // `project_to_genomic` surfaces the provider error rather than fabricating a
+    // coordinate.
+    let projector = Projector::new(CdotMapper::new());
+    let vp = VariantProjector::new(projector, MockProvider::new());
+    let v = parse_hgvs("NG_TEST.1(NM_TEST.1):c.pterdel").expect("parse");
+    let err = vp
+        .project_to_genomic(&v)
+        .expect_err("absent parent reference must error, not fabricate a coordinate");
+    assert!(
+        matches!(err, FerroError::ReferenceNotFound { .. }),
+        "expected ReferenceNotFound for the absent parent, got: {err:?}"
+    );
+}
+
+#[test]
+fn bare_transcript_pter_falls_through_to_the_no_parent_path() {
+    // No `genomic_context` parent and not an LRG transcript: the terminus path
+    // declines (returns to the normal projection), which raises the canonical
+    // "no parent reference" error rather than the terminus path inventing one.
+    let vp = ng_parent_projector(50);
+    let v = parse_hgvs("NM_TEST.1:c.pterdel").expect("parse");
+    let err = vp
+        .project_to_genomic(&v)
+        .expect_err("a bare-transcript pter has no parent reference to anchor on");
+    assert!(
+        matches!(err, FerroError::UnsupportedProjection { .. }),
+        "expected UnsupportedProjection (no parent), got: {err:?}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -183,6 +183,7 @@ mod issue_486_position_out_of_bounds;
 mod issue_487_allele_collapse;
 mod issue_487_mito_g_to_m;
 mod issue_502_np_protein_selector;
+mod issue_537_pter_qter_genomic;
 mod issue_573_intronic_shuffle_window;
 mod issue_736_rna_uracil_normalize;
 mod issue_91_protein_three_prime_shift;


### PR DESCRIPTION
## Summary

PR #534 made ferro spec-correctly *refuse* to number a transcript-flank `c.pter`/`c.qter` marker on the **c.** axis, but it left the **genomic** axis returning an error: `project_to_genomic` rejected the special `CdsPos` terminus markers as unresolvable sentinels. The genomic axis, however, has a concrete spec-valid answer — the marker denotes the parent reference's own terminus.

This resolves `c.pter` to the parent reference's 5'-most genomic coordinate (`g.1`) and `c.qter` to the 3'-most (`g.<length>`); a `pter_qter` range spans the whole reference. These map straight to the parent's termini with no cdot transcript mapping, so they no longer need — and per #534 must not use — a transcript coordinate. The emitted `g.1` / `g.<length>` is the pre-normalization projection; the normalizer's 3' rule then rolls it (e.g. `g.1del` through a leading homopolymer run, which is how mutalyzer's `NG_012337.1:g.3del` arises).

## Implementation

An additive early branch in the public `project_to_genomic` — `project_cds_terminus_to_parent` — intercepts `pter`/`qter` `Cds` inputs and returns `None` for everything else, so the normal transcript-mapped projection path is untouched. `cen` and mixed marker/numeric ranges (e.g. `c.pter_-51`) remain out of scope and fall through to the existing decline. The handler reads the parent's length from `ReferenceProvider::get_sequence_length`; an absent parent surfaces the provider error rather than fabricating a coordinate.

## Scope / blocked demotion

The two mutalyzer-corpus rows (`NG_012337.1(NM_003002.2):c.pterdel`/`c.qterdel`) **cannot be demoted from `baseline-failures/genomic.txt` yet**: their pinned parent version `NG_012337.1` is absent from the prepared manifest (a reference-coverage gap, #645/#672), so they surface `ReferenceNotFound` rather than the genomic form. Hence **Refs #537**, not "Closes" — the demotion lands when the pinned versions are provisioned.

## Testing

- New `tests/it/issue_537_pter_qter_genomic.rs` (MockProvider, deterministic): `pter`→`g.1del`, `qter`→`g.<length>del`, `pter_qter`→`g.1_<length>del`, length read from the provider, unknown-parent → `ReferenceNotFound`, bare-transcript `pter` → no-parent decline.
- Updated the projector unit test that pinned the old reject-pter behavior.
- Full suite: 7248 passed / 54 skipped. `clippy --all-targets` + `fmt` clean.
- Manifest-backed `axis_genomic`: **0 new failures** vs. the committed baseline (current fail set is a strict subset; the pter/qter rows stay failing only because `NG_012337.1` is absent). Mechanism confirmed on the present `NG_012337.3`: `g.1del` normalizes to `g.3del`, `qter` resolves to the reference length.

Refs #537, #534, #480, #326.