### PR TITLE
fix(project): re-normalize projected genomic variants in their own frame

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -754,7 +754,23 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         match self.project_to_genomic_nc(variant)? {
             HgvsVariant::Genome(gv) => {
-                self.reanchor_genome_output(gv, self.build_hint_for_variant(variant))
+                let reanchored =
+                    self.reanchor_genome_output(gv, self.build_hint_for_variant(variant))?;
+                // #737: re-normalize the genomic output in its own frame — the
+                // transcript-space normalization is genome-5' on a minus-strand
+                // transcript, so a shiftable variant must be re-shuffled to its
+                // genomic-3' position here. Falls back to the un-normalized form
+                // if normalization fails (e.g. no reference bases); the dropped
+                // error is `trace!`-logged so a regression is observable rather
+                // than silently masked (the fallback swallows *any* normalize
+                // error, not only missing bases).
+                Ok(self.normalizer.normalize(&reanchored).unwrap_or_else(|e| {
+                    log::trace!(
+                        "genomic-frame renormalization failed for {reanchored}; \
+                             emitting un-normalized re-anchored form: {e}"
+                    );
+                    reanchored
+                }))
             }
             other => Ok(other),
         }
@@ -2717,7 +2733,28 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             _ => match projected_genome {
                 HgvsVariant::Genome(gv) => self
                     .reanchor_genome_output(gv, self.build_hint_for_variant(normalized))
-                    .ok(),
+                    .ok()
+                    // #737: re-normalize the genomic *output* in its own
+                    // (parent/`NC_`) frame. The pivot was 3'-normalized in
+                    // transcript space; for a minus-strand transcript that is the
+                    // genome's 5' end, so without a genomic-frame renormalization
+                    // a shiftable del/dup/ins lands at the wrong (5') end on the
+                    // genome. Normalizing the re-anchored variant against the
+                    // output accession's own sequence yields the spec-canonical
+                    // genomic-3' form. Falls back to the un-normalized re-anchored
+                    // form if normalization fails (e.g. no reference bases); the
+                    // dropped error is `trace!`-logged so a regression is
+                    // observable rather than silently masked (the fallback
+                    // swallows *any* normalize error, not only missing bases).
+                    .map(|reanchored| {
+                        self.normalizer.normalize(&reanchored).unwrap_or_else(|e| {
+                            log::trace!(
+                                "genomic-frame renormalization failed for {reanchored}; \
+                                 emitting un-normalized re-anchored form: {e}"
+                            );
+                            reanchored
+                        })
+                    }),
                 other => Some(other),
             },
         };
@@ -5336,6 +5373,161 @@ mod tests {
                 s.contains("GAT"),
                 "expected revcomp(ATC) = GAT in g., got: {}",
                 s
+            );
+        }
+
+        // -- 3b: minus-strand deletion is re-normalized in genomic space (#737) -
+
+        /// A minus-strand transcript on `NC_000001.11` whose CDS reads
+        /// `GTAAAAAAA` (cdna 1..9), so the genome (its reverse complement) carries
+        /// a `T` homopolymer. cdot exon `[1000, 1009)` minus-strand maps c.N →
+        /// genome `1009 - N`, so the transcript's poly-A run (cdna 3..9) is the
+        /// genome poly-T run at g.1000..1006. A single-base deletion anywhere in
+        /// that run is the *same* variant; its spec-canonical genomic form is the
+        /// 3'-most (highest-coordinate) position, g.1006del.
+        ///
+        /// Keyed under `NC_000001.11` (not `chr1`) so `normalize` can fetch the
+        /// genomic bases back through the same accession the re-anchored output
+        /// carries — exercising the #737 genomic-frame renormalization end to end.
+        fn make_minus_homopolymer_provider_and_projector() -> (Projector, MockProvider) {
+            let mut cdot = CdotMapper::new();
+            cdot.add_transcript(
+                "NM_HOMO_MINUS.1".to_string(),
+                CdotTranscript {
+                    gene_name: Some("HOMOGENE".to_string()),
+                    contig: "NC_000001.11".to_string(),
+                    strand: ProvStrand::Minus,
+                    exons: vec![[1000, 1009, 0, 9]],
+                    cds_start: Some(0),
+                    cds_end: Some(9),
+                    gene_id: None,
+                    protein: Some("NP_HOMO_MINUS.1".to_string()),
+                    exon_cigars: Vec::new(),
+                },
+            );
+            let projector = Projector::new(cdot);
+
+            let mut provider = MockProvider::new();
+            provider.add_transcript(Transcript {
+                id: "NM_HOMO_MINUS.1".to_string(),
+                gene_symbol: Some("HOMOGENE".to_string()),
+                strand: TxStrand::Minus,
+                sequence: Some("GTAAAAAAA".to_string()),
+                cds_start: Some(1),
+                cds_end: Some(9),
+                exons: vec![Exon::new(1, 1, 9)],
+                chromosome: Some("NC_000001.11".to_string()),
+                genomic_start: Some(1000),
+                genomic_end: Some(1008),
+                genome_build: Default::default(),
+                mane_status: ManeStatus::default(),
+                refseq_match: None,
+                ensembl_match: None,
+                protein_id: None,
+                exon_cigars: Vec::new(),
+                cached_introns: OnceLock::new(),
+            });
+            // Genome forward: prefix + "TTTTTTTAC" (g.1000..1008) + suffix, so the
+            // poly-T run is g.1000..1006 (revcomp of the transcript poly-A run).
+            let prefix = "N".repeat(999);
+            let suffix = "N".repeat(100);
+            provider.add_genomic_sequence("NC_000001.11", format!("{}TTTTTTTAC{}", prefix, suffix));
+            (projector, provider)
+        }
+
+        #[test]
+        fn project_to_genomic_minus_strand_deletion_renormalizes_to_genomic_3prime() {
+            let (projector, provider) = make_minus_homopolymer_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+
+            // c.9del is the transcript-3'-most representation of the deletion in
+            // the poly-A run. On the minus strand that maps to g.1000 — the
+            // genome-5' end of the poly-T run. The spec-canonical genomic output
+            // is the genome-3'-most position, g.1006del. Before #737 the projector
+            // emitted the un-renormalized coordinate image (g.1000del); the
+            // re-anchored output is now normalized in its own frame.
+            let cds = CdsVariant {
+                accession: parse_accession("NM_HOMO_MINUS.1"),
+                gene_symbol: Some("HOMOGENE".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(9)),
+                    NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    },
+                ),
+            };
+            let cds = attach_genomic_context_cds(cds, nc_parent());
+            let input = HgvsVariant::Cds(cds);
+            let out = vp
+                .project_to_genomic(&input)
+                .expect("minus-strand c.9del should project to g.");
+            let g = match out {
+                HgvsVariant::Genome(ref g) => g,
+                _ => panic!("expected Genome variant, got: {}", out),
+            };
+            assert_eq!(g.accession.to_string(), "NC_000001.11");
+            let start = g
+                .loc_edit
+                .location
+                .start
+                .inner()
+                .expect("start should be concrete");
+            assert_eq!(
+                start.base, 1006,
+                "minus-strand c.9del must re-normalize to the genome-3' end of the \
+                 poly-T run (g.1006del), got g.{}del (#737)",
+                start.base
+            );
+        }
+
+        /// Companion to the g.-only test above, exercising the *other* #737
+        /// re-anchor site: the multi-axis `.genomic` field built in
+        /// `project_single_inner` (via `project_variant`). The two sites apply
+        /// the identical genomic-frame renormalization and could drift silently,
+        /// so assert the same minus-strand deletion lands at the genome-3' end of
+        /// the poly-T run (g.1006del) through a `VariantProjection.genomic`, not
+        /// just through the g.-only `project_to_genomic`.
+        #[test]
+        fn project_variant_minus_strand_deletion_renormalizes_genomic_axis_to_3prime() {
+            let (projector, provider) = make_minus_homopolymer_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+
+            // c.9del — the transcript-3'-most representation of the deletion in
+            // the poly-A run — maps to the genome-5' end of the poly-T run. The
+            // spec-canonical genomic output is the genome-3'-most position,
+            // g.1006del; #737 renormalizes the re-anchored `.genomic` axis here.
+            let cds = CdsVariant {
+                accession: parse_accession("NM_HOMO_MINUS.1"),
+                gene_symbol: Some("HOMOGENE".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(9)),
+                    NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    },
+                ),
+            };
+            let cds = attach_genomic_context_cds(cds, nc_parent());
+            let proj = vp
+                .project_variant(&HgvsVariant::Cds(cds), "NM_HOMO_MINUS.1")
+                .expect("minus-strand c.9del should project (multi-axis)");
+            let g = match proj.genomic {
+                Some(HgvsVariant::Genome(ref g)) => g,
+                other => panic!("expected a Genome `.genomic` axis, got: {:?}", other),
+            };
+            assert_eq!(g.accession.to_string(), "NC_000001.11");
+            let start = g
+                .loc_edit
+                .location
+                .start
+                .inner()
+                .expect("start should be concrete");
+            assert_eq!(
+                start.base, 1006,
+                "the multi-axis `.genomic` field must re-normalize to the genome-3' \
+                 end of the poly-T run (g.1006del), got g.{}del (#737)",
+                start.base
             );
         }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1134,6 +1134,78 @@ impl MultiFastaProvider {
         }
     }
 
+    /// Synthesize the parent-frame (`NG_`/`LRG_`) reference bases for a parent
+    /// that has a genomic placement but no FASTA record of its own — e.g. a
+    /// #728 *derived* `NG_` whose exact version is absent from the local
+    /// RefSeqGene FASTA. The parent sequence is, by construction of the
+    /// placement, exactly the placed chromosome (`NC_`) slice (reverse-
+    /// complemented for a minus-strand placement), so we serve it by mapping the
+    /// requested parent-frame window through the placement and fetching those
+    /// `NC_` bases.
+    ///
+    /// `start`/`end` are a 0-based half-open window in the parent's own frame,
+    /// matching [`ReferenceProvider::get_sequence`]. Returns an error when the
+    /// window falls outside the placed span.
+    fn synthesize_parent_sequence(
+        &self,
+        placement: &GenomicPlacement,
+        start: u64,
+        end: u64,
+    ) -> Result<String, FerroError> {
+        if end < start {
+            return Err(FerroError::InvalidCoordinates {
+                msg: format!("parent sequence window end {end} < start {start}"),
+            });
+        }
+        if start == end {
+            return Ok(String::new());
+        }
+        // The `[start, end)` window is 0-based into the parent *sequence*, so
+        // offset 0 is the parent's first base — parent coordinate
+        // `parent_start`. The mapping below assumes `parent_start == 1` (it maps
+        // the 0-based offset `start` to 1-based parent coordinate `start + 1`).
+        // The only reachable caller today is the FASTA-less #728 derived `NG_`,
+        // which always has `parent_start == 1` (`derived_placement.rs`); an
+        // LRG/RefSeqGene placement with `parent_start > 1` is never routed here.
+        // Guard the assumption in debug builds — a `parent_start > 1` placement
+        // would otherwise read the wrong window (or fail loud via `parent_to_nc`
+        // returning `None`) rather than corrupt bases.
+        debug_assert_eq!(
+            placement.parent_start, 1,
+            "synthesize_parent_sequence assumes parent_start == 1; offset the window \
+             by parent_start before mapping to support placement-only parents"
+        );
+        // 0-based half-open [start, end) → 1-based inclusive parent positions
+        // [start+1, end]. Map both endpoints onto the chromosome; on a minus-
+        // strand placement the parent runs antiparallel, so the low parent
+        // position maps to the *higher* `NC_` coordinate.
+        let (nc_a, nc_b) = match (
+            placement.parent_to_nc(start + 1),
+            placement.parent_to_nc(end),
+        ) {
+            (Some(a), Some(b)) => (a, b),
+            _ => {
+                return Err(FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "parent window [{start}, {end}) falls outside the placed span on {}",
+                        placement.nc.full()
+                    ),
+                });
+            }
+        };
+        let (nc_lo, nc_hi) = if nc_a <= nc_b {
+            (nc_a, nc_b)
+        } else {
+            (nc_b, nc_a)
+        };
+        // 1-based inclusive [nc_lo, nc_hi] → 0-based half-open for the fetch.
+        let bases = self.get_genomic_sequence(&placement.nc.full(), nc_lo - 1, nc_hi)?;
+        Ok(match placement.strand {
+            crate::reference::Strand::Minus => crate::sequence::reverse_complement(&bases),
+            _ => bases,
+        })
+    }
+
     /// Build a `Transcript` for `id` whose bases are synthesized from the genome
     /// FASTA by walking the cdot exon alignment. Used as a fallback when the
     /// transcript FASTA does not carry the requested versioned accession but
@@ -2283,6 +2355,20 @@ impl ReferenceProvider for MultiFastaProvider {
     }
 
     fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+        // A parent (`NG_`/`LRG_`) that has a genomic placement but no FASTA
+        // record of its own — e.g. a #728 derived `NG_` — is served by
+        // synthesizing its bases from the chromosome via the placement. Checked
+        // before the version-fuzzy `resolve_name` fallback below so an absent
+        // *exact* version is reconstructed rather than silently served a sibling
+        // version's bases.
+        if !self.index.contains_key(id) {
+            if let Ok(("", acc)) = crate::hgvs::parser::accession::parse_accession(id) {
+                if let Some(placement) = self.genomic_placement(&acc) {
+                    return self.synthesize_parent_sequence(&placement, start, end);
+                }
+            }
+        }
+
         let resolved = self
             .resolve_name(id)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })?;
@@ -2331,6 +2417,16 @@ impl ReferenceProvider for MultiFastaProvider {
     }
 
     fn get_sequence_length(&self, id: &str) -> Result<u64, FerroError> {
+        // Mirror `get_sequence`: a placement-only parent (#728 derived `NG_`)
+        // has no FASTA record, so its length is the placed span on the
+        // chromosome. Checked before the version-fuzzy `sequence_length`.
+        if !self.index.contains_key(id) {
+            if let Ok(("", acc)) = crate::hgvs::parser::accession::parse_accession(id) {
+                if let Some(placement) = self.genomic_placement(&acc) {
+                    return Ok(placement.nc_end - placement.nc_start + 1);
+                }
+            }
+        }
         self.sequence_length(id)
             .ok_or_else(|| FerroError::ReferenceNotFound { id: id.to_string() })
     }
@@ -3145,6 +3241,85 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         assert_eq!(placement.nc_start, 112081847);
         assert_eq!(placement.nc_end, 112097794);
         assert_eq!(placement.strand, Strand::Plus);
+    }
+
+    #[test]
+    fn get_sequence_synthesizes_derived_ng_bases_from_placement() {
+        // #737: a parent (`NG_`) with a derived placement but no FASTA record of
+        // its own is served by synthesizing its bases from the chromosome via the
+        // placement — plus strand verbatim, minus strand reverse-complemented —
+        // and that *exact-version* synthesis takes precedence over the
+        // version-fuzzy `resolve_name` fallback to a sibling version's FASTA.
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // Chromosome FASTA. The placed span (1-based [5, 10]) is "AACGGT".
+        fs::write(d.join("genome.fna"), ">NC_000099.9\nNNNNAACGGTNNNN\n").unwrap();
+        fs::write(d.join("genome.fna.fai"), "NC_000099.9\t14\t13\t14\t15\n").unwrap();
+
+        // A *sibling* version of the plus-strand NG_ that IS present as a FASTA,
+        // with deliberately different bases. Version-fuzzy resolution would serve
+        // these for a request on NG_999999.1; exact-version synthesis must win.
+        fs::write(d.join("sibling.fna"), ">NG_999999.2\nTTTTTT\n").unwrap();
+        fs::write(d.join("sibling.fna.fai"), "NG_999999.2\t6\t13\t6\t7\n").unwrap();
+
+        // Derived placements: a plus- and a minus-strand NG_ over the same span.
+        fs::write(
+            d.join("derived.json"),
+            r#"{"description":"test","placements":[
+                {"parent":"NG_999999.1","nc":"NC_000099.9","nc_start":5,"nc_end":10,"strand":"+","anchored_by":"","mismatch_fraction":0.0},
+                {"parent":"NG_888888.1","nc":"NC_000099.9","nc_start":5,"nc_end":10,"strand":"-","anchored_by":"","mismatch_fraction":0.0}
+            ]}"#,
+        )
+        .unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["genome.fna", "sibling.fna"],
+                "derived_refseqgene_placements": "derived.json",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+
+        // Length is the placed span (no own FASTA record).
+        assert_eq!(provider.get_sequence_length("NG_999999.1").unwrap(), 6);
+        assert_eq!(provider.get_sequence_length("NG_888888.1").unwrap(), 6);
+
+        // Plus strand: verbatim chromosome slice.
+        assert_eq!(
+            provider.get_sequence("NG_999999.1", 0, 6).unwrap(),
+            "AACGGT"
+        );
+        // Sub-window (0-based half-open) maps through the placement.
+        assert_eq!(provider.get_sequence("NG_999999.1", 0, 3).unwrap(), "AAC");
+        assert_eq!(provider.get_sequence("NG_999999.1", 3, 6).unwrap(), "GGT");
+
+        // Minus strand: reverse complement of the same chromosome slice.
+        assert_eq!(
+            provider.get_sequence("NG_888888.1", 0, 6).unwrap(),
+            "ACCGTT"
+        );
+
+        // Exact-version synthesis wins over the sibling NG_999999.2 FASTA — a
+        // version-fuzzy result would (wrongly) return "TTTTTT".
+        assert_ne!(
+            provider.get_sequence("NG_999999.1", 0, 6).unwrap(),
+            "TTTTTT"
+        );
+
+        // The sibling version that DOES have a FASTA is still served from it.
+        assert_eq!(
+            provider.get_sequence("NG_999999.2", 0, 6).unwrap(),
+            "TTTTTT"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of #737 (defect A of the genomic-axis projection bugs).

## Problem

`project_to_genomic` emitted the direct coordinate image of the *transcript*-normalized variant without re-applying the HGVS 3′ rule in **genomic** space. On a minus-strand transcript the transcript-3′ position is the genome's 5′ end, so a shiftable deletion/duplication/insertion in a repeat came out anchored at the wrong (5′) end of the genome.

Example (NG_012337.1, plus-strand placement of a minus-strand transcript):

| input | before | after / expected |
|---|---|---|
| `NG_012337.1(NM_012459.2):c.12_13delCA` | `g.4910_4911del` | `g.4913_4914del` |
| `NG_012337.1(NM_012459.2):c.5_6dup` | `g.4917_4918dup` | `g.4919_4920dup` |
| `NG_012337.1(NM_012459.2):c.15_17dup` | `g.4906_4908dup` | `g.4907_4909dup` |

The deletion sits in a `TGTG` repeat (NG g.4911–4914), confirmed against the corpus’ own `c.10CA[5]` → `g.4911_4914GT[5]`; the spec-canonical genomic form is the 3′-most (highest-coordinate) position.

## Fix

- Re-normalize the re-anchored genomic output against the **output accession’s own** sequence at both `project_to_genomic` call sites (the standalone API and the multi-axis `.genomic` field), falling back to the un-normalized form when normalization cannot fetch reference bases.
- Serve a version-independent (derived, #728) `NG_`/`LRG_` parent’s bases by synthesizing the placed chromosome slice (reverse-complemented for a minus-strand placement) when the exact version has no FASTA record of its own. This exact-version synthesis is consulted **before** the version-fuzzy name fallback, so an absent exact version is reconstructed rather than silently served a sibling version’s bases — which is what lets the re-normalization fetch correct bases for derived `NG_` parents.

## Tests

- Hermetic minus-strand homopolymer test asserting the projected deletion re-normalizes to the genome-3′ end (verified non-vacuous: fails with `g.1000del` when the fix is disabled).
- Hermetic placement-synthesis test (plus/minus strand + exact-version-over-sibling precedence).
- 3085 lib + 4198 integration tests pass; `fmt` and `clippy --all-targets` clean.
- No regression: the manifest-backed axis tests are insensitive to this change because they already post-normalize the genomic form externally — this PR moves that normalization into the library so all callers (CLI/API/VCF) get the spec-canonical genomic form directly.

## Scope

Defect A only. The remaining #737 defects — the exon-junction coordinate bug (B/C, a core cdot coordinate-convention fix) and the gene-symbol/legacy-selector declines (D, a #500-class divergence) — follow in separate PRs.