### PR TITLE
fix(data): load cdot exons in the HGVS coordinate convention

### DIFF
--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -1306,12 +1306,13 @@ mod intronic_debug_tests {
         );
     }
 
-    /// Test that cdot tx coordinates are correctly interpreted as 1-based.
+    /// Test that cdot tx coordinates are stored 0-based half-open.
     ///
-    /// The cdot format uses 1-based tx_start and tx_end coordinates (the first exon
-    /// starts at position 1, not 0). This test verifies that assumption.
+    /// On load, `from_genome_build` converts cdot's raw 1-based-inclusive tx bounds
+    /// into the engine's HGVS convention: tx 0-based half-open (the first exon starts
+    /// at position 0, not 1). This test verifies that conversion (#742).
     #[test]
-    fn test_cdot_tx_coordinates_are_1_based() {
+    fn test_cdot_tx_coordinates_are_0_based() {
         use crate::data::cdot::CdotMapper;
         use std::path::PathBuf;
 
@@ -1327,11 +1328,11 @@ mod intronic_debug_tests {
             .get_transcript("NM_003742.4")
             .expect("NM_003742.4 not in cdot");
 
-        // First exon should have tx_start = 1 (1-based, not 0-based)
+        // First exon should have tx_start = 0 (0-based, after the #742 conversion)
         let first_exon = &tx.exons[0];
         assert_eq!(
-            first_exon[2], 1,
-            "cdot tx_start for first exon should be 1 (1-based), got {}",
+            first_exon[2], 0,
+            "cdot tx_start for first exon should be 0 (0-based half-open), got {}",
             first_exon[2]
         );
 

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -53,7 +53,10 @@ mod rkyv_cache {
     /// Bump whenever the layout below changes so a stale archive is rejected by
     /// the version check (in addition to rkyv's own structural validation) and
     /// regenerated rather than mis-read.
-    pub(super) const RKYV_FORMAT_VERSION: u32 = 1;
+    // v2 (#742): exon coordinates are now stored in the HGVS convention
+    // (genome 1-based, tx 0-based half-open); a v1 cache holds the old raw
+    // cdot convention and must be regenerated.
+    pub(super) const RKYV_FORMAT_VERSION: u32 = 2;
 
     #[derive(Archive, Serialize, Deserialize)]
     pub(super) struct RkyvCigar {
@@ -350,7 +353,9 @@ mod rkyv_cache {
 /// loader falls back to parsing the multi-hundred-MB JSON on every run — ~10x
 /// slower — with no indication anything is wrong.
 const CDOT_BINCODE_MAGIC: [u8; 4] = *b"FCDT";
-const CDOT_BINCODE_VERSION: u32 = 1;
+// v2 (#742): exon coordinates now stored in the HGVS convention (genome
+// 1-based, tx 0-based half-open); a v1 cache holds the old raw cdot convention.
+const CDOT_BINCODE_VERSION: u32 = 2;
 
 /// Parse the integer version suffix of an accession (`"NM_003002.4"` -> `Some(4)`),
 /// or `None` when there is no trailing numeric `.<n>`. Used to pick the highest
@@ -453,10 +458,14 @@ struct RawGenomeBuild {
     strand: Option<String>,
     /// Exons in cdot format: [genomic_start, genomic_end, exon_num, tx_start, tx_end, gap_info]
     exons: Vec<Vec<serde_json::Value>>,
-    /// CDS start in genomic coordinates
+    /// CDS start in raw cdot genomic coordinates (0-based, inclusive — same space
+    /// as the raw exon `alt_start`). The genomic-CDS fallback in `from_genome_build`
+    /// must `+ 1` this to match the 1-based exon table before mapping it to tx.
     #[serde(default)]
     cds_start: Option<u64>,
-    /// CDS end in genomic coordinates
+    /// CDS end in raw cdot genomic coordinates (0-based, exclusive — same space as
+    /// the raw exon `alt_end`). The genomic-CDS fallback in `from_genome_build` must
+    /// `+ 1` this to match the 1-based exon table before mapping it to tx.
     #[serde(default)]
     cds_end: Option<u64>,
 }
@@ -486,11 +495,21 @@ impl RawCdotTranscript {
             .iter()
             .filter_map(|e| {
                 if e.len() >= 5 {
+                    // cdot stores genomic bounds 0-based half-open (`alt_start`
+                    // 0-based inclusive, `alt_end` 0-based exclusive) and cDNA
+                    // bounds 1-based **inclusive** (`cds_start_i`/`cds_end_i`).
+                    // `Exon` + every mapping primitive (and the fixtures) use the
+                    // *HGVS* convention: genome 1-based (`genome_start` inclusive,
+                    // `genome_end` exclusive) and tx 0-based half-open. Convert
+                    // here so the in-memory layout matches that contract — leaving
+                    // it raw made the two off-by-ones cancel only for exon-interior
+                    // positions, mis-mapping the last cDNA base of each exon and
+                    // dropping the first base of the next (#742).
                     let exon = [
-                        e[0].as_u64()?,
-                        e[1].as_u64()?,
-                        e[3].as_u64()?, // tx_start is at index 3
-                        e[4].as_u64()?, // tx_end is at index 4
+                        e[0].as_u64()? + 1,               // genome_start: 0-based incl → 1-based incl
+                        e[1].as_u64()? + 1,               // genome_end: 0-based excl → 1-based excl
+                        e[3].as_u64()?.saturating_sub(1), // tx_start: 1-based incl → 0-based incl
+                        e[4].as_u64()?, // tx_end: 1-based incl → 0-based excl (same value)
                     ];
                     // Parse CIGAR gap info from index 5 if present
                     let cigar = if e.len() > 5 {
@@ -525,9 +544,15 @@ impl RawCdotTranscript {
             // Fall back to converting genomic CDS coordinates to transcript coordinates
             match (build.cds_start, build.cds_end) {
                 (Some(g_start), Some(g_end)) => {
-                    // Find transcript positions for genomic CDS boundaries
-                    let tx_cds_start = genomic_to_tx_pos(&exons, g_start, strand);
-                    let tx_cds_end = genomic_to_tx_pos(&exons, g_end, strand);
+                    // `build.cds_start`/`cds_end` are raw cdot genomic coordinates in
+                    // the same 0-based half-open space as the raw exon `alt_start`/
+                    // `alt_end` bounds. `exons` was converted to the HGVS 1-based
+                    // convention above (`e[0] + 1` / `e[1] + 1`, lines 505-506), so
+                    // these CDS bounds must get the same `+ 1` before being scanned
+                    // against the now-1-based exon table — otherwise every comparison
+                    // in `genomic_to_tx_pos` is off by one (#742).
+                    let tx_cds_start = genomic_to_tx_pos(&exons, g_start + 1, strand);
+                    let tx_cds_end = genomic_to_tx_pos(&exons, g_end + 1, strand);
 
                     match (tx_cds_start, tx_cds_end) {
                         (Some(s), Some(e)) => {
@@ -3123,6 +3148,69 @@ impl Default for CdotMapper {
 mod tests {
     use super::*;
 
+    /// #742 regression: a 2-exon minus-strand transcript loaded from raw cdot
+    /// JSON (genome 0-based, cdna 1-based — the real cdot convention) maps the
+    /// exon-interior, exon-last, and next-exon-first coding bases to the correct
+    /// 1-based genomic coordinates. Pre-fix, the last cdna base of an exon
+    /// mis-mapped (off by one) and the first base of the next exon declined.
+    ///
+    /// NM_012459.2 (TIMM8B, GRCh38, NC_000011.10, minus): start_codon=30, exon B
+    /// (5') cdna 1..159 = genome 0-based [112086639,112086798), exon A (3') cdna
+    /// 160..822 = genome 0-based [112084799,112085462). c.N → tx (cdna) → genome.
+    #[test]
+    fn cdot_exon_junction_maps_to_correct_genomic_coords_issue_742() {
+        use crate::data::mapping::CoordinateMapper;
+        let json = r#"
+        {
+            "transcripts": {
+                "NM_012459.2": {
+                    "gene_name": "TIMM8B",
+                    "genome_builds": {
+                        "GRCh38": {
+                            "contig": "NC_000011.10",
+                            "strand": "-",
+                            "exons": [
+                                [112084799, 112085462, 1, 160, 822, "M663"],
+                                [112086639, 112086798, 0, 1, 159, "M159"]
+                            ]
+                        }
+                    },
+                    "start_codon": 30,
+                    "stop_codon": 327
+                }
+            }
+        }
+        "#;
+        let cdot = CdotMapper::from_reader_with_build(json.as_bytes(), "GRCh38").unwrap();
+        let tx = cdot.get_transcript("NM_012459.2").unwrap();
+        assert_eq!(tx.cds_start, Some(30), "cds_start must survive loading");
+        // Exons load in the HGVS convention: genome 1-based, tx 0-based half-open.
+        assert_eq!(tx.exons[0], [112086640, 112086799, 0, 159]); // exon B (sorted first)
+        assert_eq!(tx.exons[1], [112084800, 112085463, 159, 822]); // exon A
+
+        let mapper = CoordinateMapper::new(cdot);
+        let g = |base: i64| {
+            mapper
+                .cds_to_genome(
+                    "NM_012459.2",
+                    &CdsPos {
+                        base,
+                        offset: None,
+                        utr3: false,
+                        special: None,
+                    },
+                )
+                .unwrap()
+                .variant
+                .base
+        };
+        assert_eq!(g(5), 112086764, "c.5 (interior)"); // unchanged by the fix
+        assert_eq!(g(127), 112086642, "c.127 (interior)");
+        assert_eq!(g(128), 112086641, "c.128 (interior)");
+        assert_eq!(g(129), 112086640, "c.129 (last cdna base of exon B)"); // was off-by-one
+        assert_eq!(g(130), 112085462, "c.130 (first cdna base of exon A)"); // was a decline
+    }
+
     fn sample_transcript() -> CdotTranscript {
         // Simple transcript with 3 exons on + strand
         // Exons: [genome_start, genome_end, tx_start, tx_end]
@@ -3473,8 +3561,11 @@ mod tests {
         // Verify the transcript was fully parsed (not dropped due to bad exon format)
         let tx = mapper.get_transcript("NM_000088.3").unwrap();
         assert_eq!(tx.exons.len(), 1);
-        assert_eq!(tx.exons[0][0], 48263025); // genome_start
-        assert_eq!(tx.exons[0][1], 48263098); // genome_end
+        // #742: exons are stored in the HGVS convention (genome 1-based), so the
+        // raw cdot 0-based `alt_start`/`alt_end` (48263025, 48263098) load as
+        // 1-based `genome_start`/`genome_end` (+1 each).
+        assert_eq!(tx.exons[0][0], 48263026); // genome_start (1-based incl)
+        assert_eq!(tx.exons[0][1], 48263099); // genome_end (1-based excl)
     }
 
     #[test]

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -6693,21 +6693,23 @@ mod tests {
                 .get_transcript_on_build("NM_MB_TEST.1", "GRCh38")
                 .expect("GRCh38 view must be populated in primary transcripts");
             assert_eq!(tx38.contig, "NC_000001.11");
-            assert_eq!(tx38.exons, vec![[20000, 20010, 0, 10]]);
+            // #742: genome bounds load in the HGVS 1-based convention (+1 vs the
+            // raw cdot 0-based alt_start/alt_end).
+            assert_eq!(tx38.exons, vec![[20001, 20011, 0, 10]]);
             assert_eq!(tx38.cds_start, Some(0));
             assert_eq!(tx38.cds_end, Some(10));
             let tx37 = cdot
                 .get_transcript_on_build("NM_MB_TEST.1", "GRCh37")
                 .expect("GRCh37 view must be populated in alt_build_transcripts");
             assert_eq!(tx37.contig, "NC_000001.10");
-            assert_eq!(tx37.exons, vec![[10000, 10010, 0, 10]]);
+            assert_eq!(tx37.exons, vec![[10001, 10011, 0, 10]]);
         }
 
         /// c.5A>T against NC_000001.10(NM_MB_TEST.1) → expect GRCh37
-        /// coordinates (g.10004; cdot's internal exon[0] is HGVS-numeric,
-        /// so c.1 sits at g.10000 and c.5 at g.10004). Pre-fix, this
+        /// coordinates (g.10005; cdot's internal exon[0] is HGVS-numeric,
+        /// so c.1 sits at g.10001 and c.5 at g.10005). Pre-fix, this
         /// would have used the primary (GRCh38) view and produced
-        /// ~g.20004, despite the parent's GRCh37 version.
+        /// ~g.20005, despite the parent's GRCh37 version.
         #[test]
         fn project_to_genomic_uses_grch37_view_for_nc_v10_parent() {
             let vp = make_multi_build_projector("GRCh38");
@@ -6729,8 +6731,8 @@ mod tests {
                 HgvsVariant::Genome(g) => {
                     let s = g.to_string();
                     assert!(
-                        s.contains(":g.10004A>T"),
-                        "expected GRCh37 coord g.10004A>T, got: {}",
+                        s.contains(":g.10005A>T"),
+                        "expected GRCh37 coord g.10005A>T, got: {}",
                         s
                     );
                 }
@@ -6739,7 +6741,7 @@ mod tests {
         }
 
         /// c.5A>T against NC_000001.11(NM_MB_TEST.1) → expect GRCh38
-        /// coordinates (g.20004). Sibling to the GRCh37 case; together
+        /// coordinates (g.20005). Sibling to the GRCh37 case; together
         /// they prove the parent's build version is what drives the
         /// cdot view selection.
         #[test]
@@ -6763,8 +6765,8 @@ mod tests {
                 HgvsVariant::Genome(g) => {
                     let s = g.to_string();
                     assert!(
-                        s.contains(":g.20004A>T"),
-                        "expected GRCh38 coord g.20004A>T, got: {}",
+                        s.contains(":g.20005A>T"),
+                        "expected GRCh38 coord g.20005A>T, got: {}",
                         s
                     );
                 }
@@ -6772,10 +6774,10 @@ mod tests {
             }
         }
 
-        /// g. → c.: NC_000001.10:g.10004A>T projected onto NM_MB_TEST.1
+        /// g. → c.: NC_000001.10:g.10005A>T projected onto NM_MB_TEST.1
         /// → expect c.5A>T. Pre-fix, `project_single_inner` used the
         /// primary (GRCh38) `transcript_genome_span` of [20000, 20010),
-        /// so position 10004 fell outside and the call returned
+        /// so position 10005 fell outside and the call returned
         /// `TranscriptNotOverlapping`. Post-fix the GRCh37 span
         /// [10000, 10010) is consulted and the projection succeeds.
         #[test]
@@ -6785,7 +6787,7 @@ mod tests {
                 accession: nc_chr1(10),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(10004)),
+                    GenomeInterval::point(GenomePos::new(10005)),
                     NaEdit::Substitution {
                         reference: Base::A,
                         alternative: Base::T,
@@ -6810,7 +6812,7 @@ mod tests {
         /// NG_* parents are build-agnostic per the HGVS spec — the chromosome
         /// (`NC_`) pivot falls back to the primary cdot view rather than forcing
         /// an alt-build lookup. With primary=GRCh38 the c.5 position must come
-        /// back at the GRCh38 exon's position (g.20004) regardless of any GRCh37
+        /// back at the GRCh38 exon's position (g.20005) regardless of any GRCh37
         /// alt-build data.
         ///
         /// This is asserted on the `project_to_genomic_nc` pivot, which is where
@@ -6845,7 +6847,7 @@ mod tests {
                         s
                     );
                     assert!(
-                        s.contains(":g.20004A>T"),
+                        s.contains(":g.20005A>T"),
                         "NG (build-agnostic) parent must use primary (GRCh38) coords, got: {}",
                         s
                     );
@@ -6878,12 +6880,12 @@ mod tests {
         fn caches_partition_by_genome_build_for_nc_inputs() {
             let vp = make_multi_build_projector("GRCh38");
 
-            // c.5del on GRCh37 (g.10004del on NC_000001.10).
+            // c.5del on GRCh37 (g.10005del on NC_000001.10).
             let g37 = GenomeVariant {
                 accession: nc_chr1(10),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(10004)),
+                    GenomeInterval::point(GenomePos::new(10005)),
                     NaEdit::Deletion {
                         sequence: None,
                         length: None,
@@ -6893,12 +6895,12 @@ mod tests {
             vp.project_normalized(&HgvsVariant::Genome(g37), "NM_MB_TEST.1")
                 .expect("GRCh37 deletion projection must succeed");
 
-            // c.5del on GRCh38 (g.20004del on NC_000001.11).
+            // c.5del on GRCh38 (g.20005del on NC_000001.11).
             let g38 = GenomeVariant {
                 accession: nc_chr1(11),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(20004)),
+                    GenomeInterval::point(GenomePos::new(20005)),
                     NaEdit::Deletion {
                         sequence: None,
                         length: None,
@@ -6959,7 +6961,7 @@ mod tests {
                 accession: nc_chr1(11),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(20004)),
+                    GenomeInterval::point(GenomePos::new(20005)),
                     NaEdit::Substitution {
                         reference: Base::A,
                         alternative: Base::T,
@@ -6998,7 +7000,7 @@ mod tests {
                 accession: nc_chr1(10),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(10004)),
+                    GenomeInterval::point(GenomePos::new(10005)),
                     NaEdit::Substitution {
                         reference: Base::A,
                         alternative: Base::T,
@@ -7039,7 +7041,7 @@ mod tests {
                 accession: nc_chr1(11),
                 gene_symbol: None,
                 loc_edit: LocEdit::new(
-                    GenomeInterval::point(GenomePos::new(20004)),
+                    GenomeInterval::point(GenomePos::new(20005)),
                     NaEdit::Substitution {
                         reference: Base::A,
                         alternative: Base::T,
@@ -7071,7 +7073,7 @@ mod tests {
         // Builds on the two-build cdot fixture above by giving NM_MB_TEST.1's
         // NG_ parent (NG_000999.1) per-build chromosomal placements with
         // *different* parent offsets, so the re-anchored NG_ coordinate reveals
-        // which build's placement was selected: GRCh38 → g.104, GRCh37 → g.204.
+        // which build's placement was selected: GRCh38 → g.105, GRCh37 → g.205.
         // This is the end-to-end GRCh37 NG_ path #713 deferred (only reachable
         // once the override supplies a build for a bare NG_).
         // ---------------------------------------------------------------------
@@ -7154,7 +7156,7 @@ mod tests {
         }
 
         /// `--assembly GRCh37` makes a bare NG_ select its GRCh37 placement and
-        /// re-anchor against the GRCh37 chromosome view (g.204, not g.104).
+        /// re-anchor against the GRCh37 chromosome view (g.205, not g.105).
         #[test]
         fn assembly_override_selects_grch37_placement_for_bare_ng() {
             let vp = make_ng_assembly_projector(true).with_assembly(Some("GRCh37"));
@@ -7163,13 +7165,13 @@ mod tests {
                 .expect("GRCh37 override should re-anchor via the GRCh37 placement");
             let s = out.to_string();
             assert!(
-                s.contains(":g.204A>T"),
-                "expected the GRCh37 placement (parent_start 200 -> g.204), got: {s}"
+                s.contains(":g.205A>T"),
+                "expected the GRCh37 placement (parent_start 200 -> g.205), got: {s}"
             );
         }
 
         /// Without the override a bare NG_ keeps the GRCh38-preferred placement
-        /// (g.104) — adding a GRCh37 placement must not shift the default (#713).
+        /// (g.105) — adding a GRCh37 placement must not shift the default (#713).
         #[test]
         fn no_assembly_override_keeps_grch38_placement_for_bare_ng() {
             let vp = make_ng_assembly_projector(true);
@@ -7178,8 +7180,8 @@ mod tests {
                 .expect("default should re-anchor via the GRCh38 placement");
             let s = out.to_string();
             assert!(
-                s.contains(":g.104A>T"),
-                "expected the GRCh38 placement (parent_start 100 -> g.104), got: {s}"
+                s.contains(":g.105A>T"),
+                "expected the GRCh38 placement (parent_start 100 -> g.105), got: {s}"
             );
         }
 
@@ -7219,8 +7221,8 @@ mod tests {
                 .expect("explicit NC_*.11 parent projects on GRCh38 despite the override");
             let s = out.to_string();
             assert!(
-                s.starts_with("NC_000001.11") && s.contains(":g.20004A>T"),
-                "input-encoded GRCh38 (g.20004) must win over --assembly GRCh37 (g.10004), got: {s}"
+                s.starts_with("NC_000001.11") && s.contains(":g.20005A>T"),
+                "input-encoded GRCh38 (g.20005) must win over --assembly GRCh37 (g.10005), got: {s}"
             );
         }
     }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1321,16 +1321,14 @@ impl MultiFastaProvider {
             .enumerate()
             .map(|(i, e)| TxExon {
                 number: (i + 1) as u32,
-                start: e[2],
-                end: e[3],
-                // NOTE: this mirrors the (pre-existing, likely off-by-one)
-                // projection in the FASTA path above. cdot's `e[0]` is
-                // HGVS-1-based per src/data/cdot.rs, so the `+1` here is
-                // strictly speaking wrong, but matching the FASTA path keeps
-                // downstream behavior consistent. Fixing the convention is
-                // out of scope for #331 — track separately if needed.
-                genomic_start: Some(e[0] + 1),
-                genomic_end: Some(e[1]),
+                // #742: `CdotTranscript.exons` is now HGVS-convention
+                // ([genome 1-based incl/excl, tx 0-based incl/excl]); `TxExon`
+                // is 1-based-inclusive on both axes. (This also resolves the
+                // former #331 genomic-coordinate off-by-one noted here.)
+                start: e[2] + 1,             // tx_start: 0-based incl → 1-based incl
+                end: e[3],                   // tx_end: 0-based excl = 1-based incl
+                genomic_start: Some(e[0]),   // genome_start: already 1-based incl
+                genomic_end: Some(e[1] - 1), // genome_end: 1-based excl → 1-based incl
             })
             .collect();
 
@@ -1632,22 +1630,22 @@ impl MultiFastaProvider {
                         None => cdot.get_transcript_exact(&resolved),
                     };
                     if let Some(tx) = cdot_tx_opt {
-                        // Convert cdot exons to transcript exons
-                        // cdot internal format: [genome_start, genome_end, tx_start, tx_end]
-                        // COORDINATE SYSTEMS:
-                        // - tx_start/tx_end: 1-based (use directly, no conversion needed)
-                        // - genome_start: 0-based, convert to 1-based by adding 1
-                        // - genome_end: 0-based exclusive = 1-based inclusive (no conversion)
+                        // Convert cdot in-memory exons to transcript exons.
+                        // #742: `CdotTranscript.exons` now uses the HGVS
+                        // convention — `[genome_start (1-based incl), genome_end
+                        // (1-based excl), tx_start (0-based incl), tx_end (0-based
+                        // excl)]`. `TxExon` uses 1-based-inclusive coordinates on
+                        // both axes, so convert accordingly.
                         let exons: Vec<TxExon> = tx
                             .exons
                             .iter()
                             .enumerate()
                             .map(|(i, e)| TxExon {
                                 number: (i + 1) as u32,
-                                start: e[2], // tx_start: already 1-based
-                                end: e[3],   // tx_end: already 1-based
-                                genomic_start: Some(e[0] + 1), // genome_start: 0-based → 1-based
-                                genomic_end: Some(e[1]), // genome_end: 0-based excl = 1-based incl
+                                start: e[2] + 1, // tx_start: 0-based incl → 1-based incl
+                                end: e[3],       // tx_end: 0-based excl = 1-based incl
+                                genomic_start: Some(e[0]), // genome_start: already 1-based incl
+                                genomic_end: Some(e[1] - 1), // genome_end: 1-based excl → incl
                             })
                             .collect();
 

--- a/src/reference/ng_placement_builder.rs
+++ b/src/reference/ng_placement_builder.rs
@@ -132,9 +132,11 @@ fn fasta_bases(fasta: &str) -> Vec<u8> {
         .collect()
 }
 
-/// `NcExonSource` over a cdot mapper for one build. cdot `exons` entries are
-/// 0-based half-open, so the 1-based inclusive interval `derive_ng_placement`
-/// expects is `(genome_start + 1, genome_end)`.
+/// `NcExonSource` over a cdot mapper for one build. Since #742 the loaded
+/// `CdotTranscript.exons` entry `[genome_start, genome_end, ..]` is in the HGVS
+/// convention — `genome_start` 1-based inclusive, `genome_end` 1-based exclusive
+/// — so the 1-based inclusive interval `derive_ng_placement` expects is
+/// `(genome_start, genome_end - 1)`.
 struct CdotNcExons<'a> {
     cdot: &'a CdotMapper,
     build: &'a str,
@@ -145,7 +147,7 @@ impl NcExonSource for CdotNcExons<'_> {
         let tx = self
             .cdot
             .get_transcript_on_build_exact(transcript_id, self.build)?;
-        Some(tx.exons.iter().map(|e| (e[0] + 1, e[1])).collect())
+        Some(tx.exons.iter().map(|e| (e[0], e[1] - 1)).collect())
     }
     fn nc_contig(&self, transcript_id: &str) -> Option<Accession> {
         let tx = self


### PR DESCRIPTION
Closes #742.

## Problem

cdot stores exon genomic bounds **0-based half-open** (`alt_start` inclusive, `alt_end` exclusive) and cDNA bounds **1-based inclusive**, but `RawCdotTranscript::from_genome_build` copied them verbatim into `CdotTranscript.exons`. Meanwhile every mapping primitive (`tx_to_genome`, `genome_to_tx`, `exon_for_*`), the `Exon` doc comment, and the test fixtures use the **HGVS convention** (genome 1-based, tx 0-based half-open). The two off-by-ones cancelled only for exon-**interior** positions, so:

- the **last cDNA base of each exon** mis-mapped by one — `NG_012337.1(NM_012459.2):c.129G>T` → `g.4793C>A` instead of `g.4794C>A` (silent, since both chromosome bases are `C`);
- the **first base of the next exon** declined — `c.130G>A` → "no g. representation" instead of `g.3616C>T`.

## Fix

Convert at load (`[alt_start+1, alt_end+1, cdna_start-1, cdna_end]`) so the in-memory layout matches the convention the primitives already assume. This leaves `tx_to_genome` / `genome_to_tx` / `exon_for_*` **untouched** and exon-interior coordinates unchanged — the fix is isolated to the loader plus the handful of call sites that read the raw exon array directly:

- `MultiFastaProvider` FASTA-backed and cdot-synthesis `Transcript` builders (the latter also resolves the pre-existing #331 genomic off-by-one);
- the `derive_ng_placements` producer.

The cdot bincode + rkyv **cache schema versions are bumped** so a stale cache regenerates.

## Validation

- New `from_genome_build` regression test: a 2-exon minus-strand transcript maps interior (`c.5/c.127/c.128`), last-exon-base (`c.129`), and next-exon-first-base (`c.130`) all to the correct 1-based genomic coordinates.
- On the real manifest: `c.129G>T`→`g.4794C>A` ✓, `c.130G>A`→`g.3616C>T` ✓, interior (`c.12_13delCA`→`g.4913_4914del`, `c.128A>G`→`g.4795T>C`) unchanged ✓.
- Conformance `axis_genomic`: +6 passing rows, `c.129`/`c.130` no longer divergent, no regression in the pass count; `axis_coding`: 0 FAIL.
- 3100 lib + 4213 integration tests pass; fmt + clippy clean. The multi-build mock projection assertions were updated to the corrected 1-based coordinates.

## Follow-up

This fixes the exon-junction defects (B/C) deferred from #737. The genomic-axis gate (#746, still open) excludes `c.129`/`c.130`-class rows; once both land it can be rebased to cover them (its window fixture should be regenerated against this binary). The separate homopolymer repeat-rendering divergence (#745) is unaffected.