### PR TITLE
chore(conformance): reclassify #745 homopolymer repeat-contraction as accepted divergence

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -277,6 +277,16 @@ pub enum Policy {
     /// bug. (`p.0?` is arguably preferable as a future refinement.)
     #[serde(rename = "ferro-policy-whole-cds-del-met1")]
     WholeCdsDeletionMet1,
+    /// ferro renders a deletion inside a genomic homopolymer (mononucleotide
+    /// tandem tract) as the spec-valid repeat contraction `N[k]` (e.g.
+    /// `g.320802_320804T[1]`) — `deletion_to_repeat` makes the repeat nature
+    /// explicit; DNA `repeated.md` L5 allows a repeat unit of "one or more"
+    /// nucleotides. mutalyzer keeps a plain `del` for a contraction (while both
+    /// use repeat notation for an expansion). Both spec-defensible; ferro's
+    /// repeat form is deliberate (`test_deletion_to_repeat_homopolymer_two_removed`).
+    /// Accepted divergence per #745.
+    #[serde(rename = "ferro-policy-745-homopolymer-repeat-contraction")]
+    HomopolymerRepeatContraction745,
 }
 
 impl Policy {
@@ -289,6 +299,9 @@ impl Policy {
                 "ferro-policy-499-shuffle-applied-compound-allele"
             }
             Policy::WholeCdsDeletionMet1 => "ferro-policy-whole-cds-del-met1",
+            Policy::HomopolymerRepeatContraction745 => {
+                "ferro-policy-745-homopolymer-repeat-contraction"
+            }
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -2423,10 +2423,10 @@
       "input": "NG_008835.1(NM_022124.6):c.3304_3305del",
       "normalized": "NG_008835.1(NM_022124.6):c.3305_3306del",
       "genomic": "NG_008835.1:g.320803_320804del",
-      "known_bug": {
+      "accepted_divergence": {
         "axis": "genomic",
-        "tracking_issue": 745,
-        "note": "ferro re-expresses this deletion inside a genomic homopolymer run as a repeat contraction (g.320802_320804T[1]) instead of del; convergence to mutalyzer's del tracked in #745."
+        "policy": "ferro-policy-745-homopolymer-repeat-contraction",
+        "note": "ferro renders this deletion inside a genomic homopolymer run as the spec-valid repeat contraction (g.320802_320804T[1]); mutalyzer emits a plain del. DNA repeated.md L5 allows a unit of one or more nucleotides, and ferro's repeat rendering is deliberate, so both forms are spec-defensible (#745, working as intended)."
       },
       "to_test": true
     },
@@ -2456,10 +2456,10 @@
       "input": "NG_008835.1(NM_001168390.2):c.*3186_*3187del",
       "normalized": "NG_008835.1(NM_001168390.2):c.*3187_*3188del",
       "genomic": "NG_008835.1:g.320803_320804del",
-      "known_bug": {
+      "accepted_divergence": {
         "axis": "genomic",
-        "tracking_issue": 745,
-        "note": "ferro re-expresses this deletion inside a genomic homopolymer run as a repeat contraction (g.320802_320804T[1]) instead of del; convergence to mutalyzer's del tracked in #745."
+        "policy": "ferro-policy-745-homopolymer-repeat-contraction",
+        "note": "ferro renders this deletion inside a genomic homopolymer run as the spec-valid repeat contraction (g.320802_320804T[1]); mutalyzer emits a plain del. DNA repeated.md L5 allows a unit of one or more nucleotides, and ferro's repeat rendering is deliberate, so both forms are spec-defensible (#745, working as intended)."
       },
       "to_test": true
     },

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -141,8 +141,8 @@ ferro shuffles genomic-context c./n. variants in spliced transcript space (cross
 | `ENST00000375549.8:c.100del` | normalized | reference_unavailable | — | #671 |
 | `ENST00000375549:c.100del` | normalized | reference_unavailable | — | #671 |
 | `ENST00000452863.10:c.9del` | normalized | reference_unavailable | — | #671 |
-| `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | genomic | known_bug | — | #745 |
-| `NG_008835.1(NM_022124.6):c.3304_3305del` | genomic | known_bug | — | #745 |
+| `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | genomic | accepted_divergence | — | — |
+| `NG_008835.1(NM_022124.6):c.3304_3305del` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.pterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.qterdel` | normalized | spec_citation | — | — |
 
@@ -150,7 +150,7 @@ ferro shuffles genomic-context c./n. variants in spliced transcript space (cross
 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
-| genomic | 0 | 2 | 0 | 0 | 0 |
+| genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | normalized | 0 | 4 | 24 | 5 | 6 |
 | protein_description | 0 | 0 | 0 | 0 | 19 |

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -1595,9 +1595,10 @@ fn genomic_coverable(input: &str) -> bool {
     // NG_008835.1 is a large (>400 KB) RefSeqGene with homopolymer runs where the
     // genomic 3' shift / repeat detection needs more flanking sequence than the
     // committed padded windows carry; serving it via windows truncates the shift
-    // (and a deletion that the full sequence renders as a repeat contraction —
-    // a tracked known_bug #745 — collapses to del). Those rows stay on the
-    // manifest-backed axis_genomic rather than being faithfully gateable here.
+    // (and a deletion that the full sequence renders as the spec-valid repeat
+    // contraction — an accepted divergence from mutalyzer's del, #745 — collapses
+    // to del). Those rows stay on the manifest-backed axis_genomic rather than
+    // being faithfully gateable here.
     if parent.starts_with("NG_008835.") {
         return false;
     }


### PR DESCRIPTION
Closes #745.

Investigation found ferro's `g.…T[1]` rendering of a deletion inside a genomic homopolymer is **deliberate and spec-valid**, not a bug:

- DNA `repeated.md` L5 defines a repeat unit as "**one or more** nucleotides", so a mononucleotide-run repeat contraction (`T[1]`) is valid HGVS.
- It is intentional ferro behavior — `deletion_to_repeat` + `test_deletion_to_repeat_homopolymer_two_removed`.
- mutalyzer emits a plain `del` for a contraction (both tools use repeat notation for an *expansion*), so the two forms are spec-defensible stylistic choices — the same pattern as the existing `ferro-policy-499-shuffle-applied-compound-allele` accepted divergence.

So the two `NG_008835.1` corpus rows are reclassified from `known_bug` (which asserts ferro is wrong) to `accepted_divergence` under a new `Policy::HomopolymerRepeatContraction745`. `failure-patterns.md` is regenerated and the genomic-gate carve-out comment updated. **No normalize behavior change.**

Follow-up to the genomic-axis gate (#746): those rows were already excluded from `gate_genomic_snapshot` for a separate window-fidelity reason, so the gate is unaffected.