### PR TITLE
feat(project): predict protein consequence for whole-exon deletions

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -15,7 +15,7 @@ use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
 use crate::project::protein::{
     affects_initiation_codon, build_initiator_unknown, cds_has_valid_start, predict_indel_protein,
-    predict_substitution_protein, read_cds_start_codon, RefProteinBundle,
+    predict_substitution_protein, read_cds_start_codon, whole_exon_deletion_span, RefProteinBundle,
 };
 use crate::project::result::VariantProjection;
 use crate::reference::transcript::Transcript;
@@ -1738,10 +1738,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// (`project_single_inner`) and the direct bare-NM_ path
     /// (`project_coding_direct`) so both compute protein identically.
     ///
-    /// Returns `Ok(None)` when no protein consequence applies — intronic, UTR,
-    /// a non-coding transcript, or an edit shape with no in-frame/frameshift
-    /// prediction. `Err` is reserved for genuine failures (unknown reference,
-    /// etc.), never for "no consequence" (mirrors the existing contract).
+    /// Returns `Ok(None)` when no protein consequence applies — most intronic
+    /// edits, UTR, a non-coding transcript, or an edit shape with no
+    /// in-frame/frameshift prediction. The intronic carve-out: a deletion whose
+    /// endpoints are both intronic and bracket one or more complete coding exons
+    /// (`whole_exon_deletion_span` returns `Some`) *is* predicted — it routes
+    /// through the indel predictor on its clamped exonic CDS span (#498) — so
+    /// only non-whole-exon intronic edits return `None`. `Err` is reserved for
+    /// genuine failures (unknown reference, etc.), never for "no consequence"
+    /// (mirrors the existing contract).
     ///
     /// `cds_start`/`cds_end` are 1-based CDS positions; `cache_variant` keys
     /// the per-(transcript, parent) sequence and ref-translation caches.
@@ -1770,7 +1775,13 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             && cds_start.offset.is_none()
             && cds_end.offset.is_none()
             && affects_initiation_codon(c_edit, cds_start.base, cds_end.base);
-        if is_intronic || !is_coding || (is_utr && !affects_init) {
+        // A deletion that removes one or more complete coding exons (both
+        // endpoints intronic, bracketing the exon) has a predictable protein
+        // consequence (HGVS protein/deletion.md "one or more exons"; #498).
+        // Clamp it to the exonic CDS bases removed; if that yields a span, let
+        // it through the intronic gate so the indel predictor runs on it below.
+        let whole_exon = whole_exon_deletion_span(c_edit, cds_start, cds_end);
+        if (is_intronic && whole_exon.is_none()) || !is_coding || (is_utr && !affects_init) {
             return Ok(None);
         }
         // Resolve the protein accession: explicit cdot/reference value, else
@@ -1875,13 +1886,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     &prot_acc,
                 )?);
             }
+            // Whole-exon deletion (both endpoints intronic): predict from the
+            // clamped exonic CDS span, reusing the indel predictor on a clean
+            // exonic deletion of that span (#498).
+            NaEdit::Deletion { .. } if whole_exon.is_some() => {
+                let (lo, hi) = whole_exon.expect("checked is_some");
+                let tx_for_codon =
+                    self.cached_get_transcript_for_variant(cache_variant, transcript_id)?;
+                let ref_bundle =
+                    self.cached_ref_translation(cache_variant, transcript_id, &tx_for_codon)?;
+                let exonic_del = NaEdit::Deletion { sequence: None, length: None };
+                match predict_indel_protein(
+                    &tx_for_codon,
+                    &ref_bundle,
+                    lo,
+                    hi,
+                    &exonic_del,
+                    &prot_acc,
+                ) {
+                    Ok(pv) => protein = Some(pv),
+                    Err(FerroError::UnsupportedProjection { .. })
+                    | Err(FerroError::ProteinSequenceUnavailable { .. }) => {}
+                    Err(other) => return Err(other),
+                }
+            }
             NaEdit::Deletion { .. }
             | NaEdit::Insertion { .. }
             | NaEdit::Duplication { .. }
             | NaEdit::Delins { .. }
             | NaEdit::Inversion { .. }
-                // Only predict for concrete exonic CDS positions (intronic
-                // offsets are already excluded by the is_intronic guard).
+                // Only predict for concrete exonic CDS positions. This arm's
+                // own `offset.is_none()` guards exclude intronic offsets — the
+                // loosened intronic gate above no longer does, since whole-exon
+                // deletions now pass it (they are handled by the arm above).
                 if cds_start.offset.is_none()
                     && cds_end.offset.is_none()
                     && cds_start.base > 0
@@ -7402,6 +7439,86 @@ mod tests {
             "intronic variant should not predict a protein consequence"
         );
         assert!(proj.is_intronic, "is_intronic flag should be set");
+    }
+
+    #[test]
+    fn project_whole_exon_deletion_predicts_inframe() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::variant::{CdsVariant, LocEdit};
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // c.4-1_6+1del: both endpoints intronic, brackets the exonic span c.4_6
+        // (codon 2, CGC = Arg). Clamp [4, 6] → in-frame single-residue deletion.
+        let variant = HgvsVariant::Cds(CdsVariant {
+            accession: parse_accession("NM_TEST.1"),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::new(CdsPos::with_offset(4, -1), CdsPos::with_offset(6, 1)),
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        });
+        let proj = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .expect("whole-exon deletion projection should succeed");
+        let protein = proj.protein.expect("protein should be predicted");
+        assert_eq!(format!("{protein}"), "NP_TEST.1:p.(Arg2del)");
+    }
+
+    #[test]
+    fn project_pure_intron_deletion_has_no_protein() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::variant::{CdsVariant, LocEdit};
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // c.4+1_4+9del: both offsets on base 4 → lo 5 > hi 4 → no exonic CDS → None.
+        let variant = HgvsVariant::Cds(CdsVariant {
+            accession: parse_accession("NM_TEST.1"),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::new(CdsPos::with_offset(4, 1), CdsPos::with_offset(4, 9)),
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        });
+        let proj = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .expect("pure-intron deletion projection should succeed (no protein)");
+        assert!(
+            proj.protein.is_none(),
+            "pure-intron deletion must not predict a protein"
+        );
+    }
+
+    #[test]
+    fn project_partial_exon_deletion_has_no_protein() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::variant::{CdsVariant, LocEdit};
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // c.4-1_5del: one exonic endpoint (c.5) → partial-exon / splice → None.
+        let variant = HgvsVariant::Cds(CdsVariant {
+            accession: parse_accession("NM_TEST.1"),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::new(CdsPos::with_offset(4, -1), CdsPos::new(5)),
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        });
+        let proj = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .expect("partial-exon deletion projection should succeed (no protein)");
+        assert!(
+            proj.protein.is_none(),
+            "partial-exon deletion must not predict a protein"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -6,7 +6,7 @@
 use crate::error::FerroError;
 use crate::hgvs::edit::{ExtDirection, InsertedSequence, NaEdit, ProteinEdit};
 use crate::hgvs::interval::ProtInterval;
-use crate::hgvs::location::{AminoAcid, ProtPos};
+use crate::hgvs::location::{AminoAcid, CdsPos, ProtPos};
 use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
 use crate::project::accession::parse_accession;
 use crate::reference::transcript::Transcript;
@@ -624,6 +624,69 @@ pub(crate) fn net_length_change(edit: &NaEdit, del_len: usize) -> Option<i64> {
     }
 }
 
+/// Clamp a whole-exon deletion to the exonic CDS bases it removes, but only for
+/// the **well-formed canonical bracketing** form — the one configuration whose
+/// removed exonic span is unambiguous.
+///
+/// Returns `Some((start.base, end.base))` — the inclusive 1-based CDS span
+/// removed — when ALL of these hold:
+///   * `edit` is a plain `Deletion`;
+///   * both endpoints are intronic (`offset.is_some()`);
+///   * the interval is well-formed ascending: `start.base <= end.base`;
+///   * the 5' endpoint's offset is `< 0` (it lies in the intron *before*
+///     `start.base`, so `start.base` is the first exonic base removed);
+///   * the 3' endpoint's offset is `> 0` (it lies in the intron *after*
+///     `end.base`, so `end.base` is the last exonic base removed);
+///   * the span is entirely within the CDS (`start.base > 0`).
+///
+/// Returns `None` for everything else.
+///
+/// Why only the canonical form: an intronic-flanked deletion's removed exonic
+/// span is trustworthy only when the endpoints bracket the exon(s) from outside
+/// (5' offset `< 0`, 3' offset `> 0`) in a well-formed ascending interval. Other
+/// shapes — a descending/crossed-offset interval (e.g. ferro's reverse-strand
+/// mis-normalization `c.704-18_677+65del`, #762), a 5' offset `> 0`, an
+/// exonic endpoint, or a pure-/deep-intronic span — are ambiguous or known to
+/// come from unreliable normalization, so predicting from them risks a *wrong*
+/// protein. We decline rather than guess; cases blocked only by #762 begin
+/// predicting automatically once that normalization is corrected. See the
+/// design spec and HGVS `protein/deletion.md` "one or more exons".
+pub(crate) fn whole_exon_deletion_span(
+    edit: &NaEdit,
+    cds_start: &CdsPos,
+    cds_end: &CdsPos,
+) -> Option<(i64, i64)> {
+    if !matches!(edit, NaEdit::Deletion { .. }) {
+        return None;
+    }
+    // Both endpoints must be intronic.
+    let start_off = cds_start.offset?;
+    let end_off = cds_end.offset?;
+    // Reject any UTR endpoint. A 3'UTR position (`c.*N`) carries `utr3: true`
+    // with a *positive* `base`, so it would otherwise pass the `base > 0`
+    // check below and be mis-treated as a CDS coordinate — splicing 3'UTR
+    // offsets into the CDS and emitting a wrong protein. (5'UTR is `base <= 0`,
+    // already rejected below, but guard it here too for clarity.)
+    if cds_start.utr3 || cds_end.utr3 {
+        return None;
+    }
+    // Canonical bracketing only: well-formed ascending interval whose 5' end
+    // sits in the intron before its base and 3' end in the intron after its
+    // base. Anything else (incl. the reverse-strand crossed form) is declined.
+    if cds_start.base > cds_end.base || start_off >= 0 || end_off <= 0 {
+        return None;
+    }
+    let lo = cds_start.base;
+    let hi = cds_end.base;
+    // Span must sit inside the CDS, not the 5'UTR (`base <= 0`). The ascending
+    // `base` order (`lo <= hi`) is already guaranteed by the `cds_start.base >
+    // cds_end.base` rejection above.
+    if lo <= 0 {
+        return None;
+    }
+    Some((lo, hi))
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1001,5 +1064,148 @@ mod tests {
             length: None,
         };
         assert_eq!(net_length_change(&edit, 6), Some(0));
+    }
+
+    // ── whole_exon_deletion_span ──────────────────────────────────────────
+
+    #[test]
+    fn whole_exon_span_canonical_bracketing() {
+        // c.677-18_704+65del: 5' offset <0, 3' offset >0 → clamp [677, 704].
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(677, -18);
+        let end = CdsPos::with_offset(704, 65);
+        assert_eq!(
+            whole_exon_deletion_span(&edit, &start, &end),
+            Some((677, 704))
+        );
+    }
+
+    #[test]
+    fn whole_exon_span_inframe_codon_aligned() {
+        // DMD c.961-1_1149+3del → [961, 1149] (189 bases).
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(961, -1);
+        let end = CdsPos::with_offset(1149, 3);
+        assert_eq!(
+            whole_exon_deletion_span(&edit, &start, &end),
+            Some((961, 1149))
+        );
+    }
+
+    #[test]
+    fn whole_exon_span_noncanonical_offset_positive_start_declines() {
+        // c.960+1_1149+3del: 5' offset > 0 is non-canonical. We decline rather
+        // than guess (an offset>0 start can't be safely disambiguated from
+        // unreliable normalization). → None.
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(960, 1);
+        let end = CdsPos::with_offset(1149, 3);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_pure_intron_declines() {
+        // c.681+1_682-1del: lo = 682, hi = 681 → lo > hi → None.
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(681, 1);
+        let end = CdsPos::with_offset(682, -1);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_deep_intron_declines() {
+        // c.961-50_961-10del: both in the same intron, no exonic base → None.
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(961, -50);
+        let end = CdsPos::with_offset(961, -10);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_requires_both_intronic() {
+        // One exonic endpoint (partial-exon) → None.
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(632, -5);
+        let end = CdsPos::new(670); // exonic, offset None
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_only_plain_deletions() {
+        // A substitution with offsets is never a whole-exon deletion.
+        let edit = NaEdit::Substitution {
+            reference: crate::hgvs::edit::Base::A,
+            alternative: crate::hgvs::edit::Base::G,
+        };
+        let start = CdsPos::with_offset(677, -18);
+        let end = CdsPos::with_offset(704, 65);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_reverse_strand_crossed_form_declines() {
+        // The exact #762 reverse-strand mis-normalization for VSIR:
+        // cds_start = (704, -18), cds_end = (677, +65). Descending base order
+        // with crossed offsets — declining here is what prevents emitting a
+        // wrong protein (e.g. p.(Ala227GlnfsTer6) instead of the correct
+        // p.(Arg226ProfsTer102)). Predicts correctly once #762 is fixed and
+        // the endpoints arrive canonical as (677, -18)/(704, +65).
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(704, -18);
+        let end = CdsPos::with_offset(677, 65);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_utr_only_declines() {
+        // Exonic overlap entirely in the 5'UTR (CDS base <= 0) → None.
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos::with_offset(-5, -2);
+        let end = CdsPos::with_offset(-1, 2);
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
+    }
+
+    #[test]
+    fn whole_exon_span_utr3_intronic_declines() {
+        // 3'UTR positions (`c.*N`) carry utr3=true with a *positive* base, so
+        // they'd pass the `base > 0` check; the explicit utr3 guard must reject
+        // them rather than splice 3'UTR offsets into the CDS. (c.*100-5_*200+5del)
+        let edit = NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        };
+        let start = CdsPos {
+            utr3: true,
+            ..CdsPos::with_offset(100, -5)
+        };
+        let end = CdsPos {
+            utr3: true,
+            ..CdsPos::with_offset(200, 5)
+        };
+        assert_eq!(whole_exon_deletion_span(&edit, &start, &end), None);
     }
 }

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -17,7 +17,7 @@ mod substitution;
 // Re-export the public API used by `projector.rs`.
 pub(crate) use helpers::{
     affects_initiation_codon, build_initiator_unknown, cds_has_valid_start, read_cds_start_codon,
-    RefProteinBundle,
+    whole_exon_deletion_span, RefProteinBundle,
 };
 pub(crate) use indel::predict_indel_protein;
 pub(crate) use substitution::predict_substitution_protein;

--- a/tests/it/issue_498_whole_exon_deletion.rs
+++ b/tests/it/issue_498_whole_exon_deletion.rs
@@ -1,0 +1,238 @@
+//! Real-world whole-exon-deletion protein prediction (#498), gated on
+//! FERRO_MANIFEST (skips in manifest-less CI, like the other axis tests).
+//!
+//! Three cases:
+//! - DMD (NM_004006.2) exon 10: in-frame whole-exon deletion (c.961_1149,
+//!   189 nt = 63 codons) via the bare-`NM_` direct path. Oracle: HGVS spec
+//!   protein/deletion.md "one or more exons" `p.(His321_Glu383del)`.
+//! - DMD (NM_004006.2) exons 10–11: frameshift whole-exon deletion
+//!   (c.961_1331, 371 nt) via the direct path. Spec exons-10–11 case
+//!   (`p.(His321Leufs*3)` on NP_003997.2); ferro emits the version-`.1` value
+//!   with matching anchor + stop distance.
+//! - VSIR (NM_022153.2): a reverse-strand whole-exon deletion that currently
+//!   DECLINES, blocked by the reverse-strand normalization bug #762 — a
+//!   guard that ferro does not emit a *wrong* protein from mis-normalized
+//!   endpoints. Predicts the `cases.json` oracle once #762 lands.
+
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::{MultiFastaProvider, ReferenceProvider, VariantProjection, VariantProjector};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Manifest-gated provider — mirrors the construction in mutalyzer_normalize_tests.rs
+// ---------------------------------------------------------------------------
+
+fn manifest_path() -> Option<PathBuf> {
+    // FERRO_MANIFEST, when set, is authoritative — no fallback to well-known
+    // paths. This lets CI explicitly disable the runner via
+    // `FERRO_MANIFEST=/nonexistent` even on a host that happens to have one of
+    // the well-known paths mounted.
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+/// `Arc<MultiFastaProvider>` newtype that implements `ReferenceProvider + Clone`
+/// so it can be plugged into [`VariantProjector`], which requires `Clone`.
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(
+        &self,
+        id: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_sequence(id, start, end)
+    }
+    fn has_transcript(&self, id: &str) -> bool {
+        self.0.has_transcript(id)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_genomic_sequence(contig, start, end)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_protein_sequence(accession, start, end)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.0.has_protein_data()
+    }
+    fn genomic_placement(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement(parent)
+    }
+    fn get_transcript_for_variant(
+        &self,
+        variant: &ferro_hgvs::hgvs::variant::HgvsVariant,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_variant(variant)
+    }
+    fn get_transcript_for_accession(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_accession(accession)
+    }
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        self.0.has_transcript_version_exact(id)
+    }
+    fn genomic_placement_on_build(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement_on_build(parent, build)
+    }
+    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector)
+    }
+    fn get_protein_length(&self, accession: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_protein_length(accession)
+    }
+    fn get_sequence_length(&self, id: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_sequence_length(id)
+    }
+}
+
+fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
+    let p = provider()?;
+    let cdot = p.cdot_mapper()?.clone();
+    let projector = Projector::new(cdot);
+    Some(VariantProjector::new(projector, ArcProvider(p)))
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn protein_of(vp: &VariantProjector<ArcProvider>, input: &str, tx: &str) -> Option<String> {
+    let v = ferro_hgvs::parse_hgvs(input).expect("parse");
+    let proj: VariantProjection = vp.project_variant(&v, tx).expect("project");
+    proj.protein.map(|p| p.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// VSIR: internal whole-exon deletion on a reverse-strand gene — currently
+/// DECLINES, blocked by the reverse-strand coding-normalization bug (#762).
+///
+/// `NG_008835.1(NM_022153.2):c.677-21_704+62del` removes coding exon 7
+/// (c.677_704, 28 nt → frameshift); mutalyzer predicts `p.(Arg226ProfsTer102)`
+/// (the `cases.json` oracle). But ferro's reverse-strand normalization
+/// mis-renders the interval as the crossed form `c.704-18_677+65del`, so the
+/// protein gate is handed non-canonical endpoints and `whole_exon_deletion_span`
+/// declines — rather than predict a *wrong* protein from the bad positions
+/// (it would otherwise emit `p.(Ala227GlnfsTer6)`). This is the deliberate safe
+/// behavior; it stays `None` until #762 corrects the normalization, at which
+/// point the canonical endpoints `(677, -18)/(704, +65)` predict
+/// `p.(Arg226ProfsTer102)`. This test guards against silently emitting a wrong
+/// protein here.
+#[test]
+fn vsir_whole_exon_deletion_declines_pending_762() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("vsir_whole_exon_deletion_declines_pending_762: skipping — no manifest");
+        return;
+    };
+    let got = protein_of(
+        &vp,
+        "NG_008835.1(NM_022153.2):c.677-21_704+62del",
+        "NM_022153.2",
+    );
+    assert_eq!(
+        got, None,
+        "VSIR must decline (reverse-strand #762 mis-normalization) rather than \
+         emit a wrong protein; unblocks once #762 lands"
+    );
+}
+
+/// DMD exon 10 whole-exon in-frame deletion.
+///
+/// `NM_004006.2:c.961-1_1149+3del` removes exon 10 (c.961_1149, 189 nt =
+/// 63 codons) → in-frame protein deletion.
+///
+/// Expected protein: HGVS spec protein/deletion.md oracle
+/// `p.(His321_Glu383del)` on the DMD protein accession.
+#[test]
+fn dmd_exon10_whole_exon_deletion_inframe() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("dmd_exon10_whole_exon_deletion_inframe: skipping — no manifest");
+        return;
+    };
+    let got = protein_of(&vp, "NM_004006.2:c.961-1_1149+3del", "NM_004006.2");
+    // The exact NP_ accession and version are captured from ferro's live output.
+    // The consequence `p.(His321_Glu383del)` is pinned to the HGVS spec oracle.
+    assert_eq!(
+        got.as_deref(),
+        Some("NP_003997.1:p.(His321_Glu383del)"),
+        "DMD exon 10 whole-exon in-frame deletion must match spec oracle"
+    );
+}
+
+/// DMD exons 10–11 whole-exon deletion (forward-path frameshift).
+///
+/// `NM_004006.2:c.961-1_1331+1del` removes exons 10–11 (CDS c.961_1331, 371 nt,
+/// 371 mod 3 ≠ 0) via the clean bare-`NM_` direct path → a frameshift starting
+/// at codon 321. This is the spec's "deletion of exons 10 to 11" case
+/// (protein/deletion.md gives `p.(His321Leufs*3)` on `NP_003997.2`). ferro
+/// translates the version present in the manifest (`NP_003997.1`) and yields
+/// `p.(His321PhefsTer3)`: same anchor (His321) and same stop distance (`fsTer3`)
+/// as the spec; the substituted residue differs (Phe vs Leu) because the new
+/// codon 321 is read from the `.1` CDS rather than the spec's `.2`. The value is
+/// captured from ferro's live output; the anchor + frameshift structure match
+/// the spec oracle. Complements the in-frame case by exercising the frameshift
+/// branch of the predictor end-to-end on a real transcript.
+#[test]
+fn dmd_exons10_11_whole_exon_deletion_frameshift() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("dmd_exons10_11_whole_exon_deletion_frameshift: skipping — no manifest");
+        return;
+    };
+    let got = protein_of(&vp, "NM_004006.2:c.961-1_1331+1del", "NM_004006.2");
+    assert_eq!(
+        got.as_deref(),
+        Some("NP_003997.1:p.(His321PhefsTer3)"),
+        "DMD exons 10–11 whole-exon frameshift (His321 anchor, fsTer3) per spec"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -183,6 +183,7 @@ mod issue_486_overlap_insertion;
 mod issue_486_position_out_of_bounds;
 mod issue_487_allele_collapse;
 mod issue_487_mito_g_to_m;
+mod issue_498_whole_exon_deletion;
 mod issue_502_np_protein_selector;
 mod issue_537_pter_qter_genomic;
 mod issue_573_intronic_shuffle_window;


### PR DESCRIPTION
## Summary

A deletion that removes one or more complete coding exons now predicts its protein consequence (frameshift or in-frame deletion) instead of declining. This is spec-compliant — `protein/deletion.md` "one or more exons" gives confident predictions for whole-exon deletions — and addresses part of #498's protein-axis prediction gap. `Refs #498` (not `Closes`): the issue has other open threads.

## Approach

A new pure helper `whole_exon_deletion_span` (`src/project/protein/helpers.rs`) clamps a both-intronic deletion to the exonic CDS bases it removes. `predict_protein_consequence` is relaxed so a whole-exon deletion reaches a new guarded match arm that re-expresses the clamped span as a clean exonic deletion and runs it through the existing `predict_indel_protein` — reusing the verified frameshift/in-frame machinery. The change lives in the single gate shared by all three projection entry points (genome-pivot, bare-`NM_` direct, bare-`n.`/`r.` direct).

### Conservative by design — only the canonical form predicts

It predicts only the well-formed canonical bracketing: ascending interval, 5′ offset `< 0`, 3′ offset `> 0`, within the CDS. Every other shape declines, so the change never emits a wrong protein from ambiguous positions:

- **Reverse-strand crossed/descending intervals.** ferro's reverse-strand coding normalization (#762) hands the gate a mis-rendered interval — e.g. `c.704-18_677+65del` for VSIR, which literally describes removing the wrong exonic span. Predicting from it would emit a wrong protein (`p.(Ala227GlnfsTer6)` instead of `p.(Arg226ProfsTer102)`), so it declines. The case predicts correctly with no further change here once #762 normalizes the endpoints canonically.
- **3′UTR-intronic, exonic-endpoint (partial-exon / splice), and pure/deep-intronic spans** all decline (partial-exon matches mutalyzer's own `test_del_splice_site` rule).

## Validation

- **DMD exon 10 (in-frame):** `NM_004006.2:c.961-1_1149+3del` → `p.(His321_Glu383del)` — matches the HGVS spec example exactly.
- **DMD exons 10–11 (frameshift):** `NM_004006.2:c.961-1_1331+1del` → `p.(His321PhefsTer3)` — anchor (`His321`) and stop distance (`fsTer3`) match the spec's exons-10–11 example; the substituted residue differs (Phe vs Leu) because ferro translates `NP_003997.1` and the spec example is `.2`.
- **Reverse-strand VSIR:** declines safely, guarded by a manifest test, until #762.
- Helper unit tests cover every offset-sign / UTR / crossed-form case; projector integration tests cover predict-and-decline via `project_variant`. Manifest-gated real-world tests skip in manifest-less CI. Full suite: 7369 passing.

## Scope / not included

- VSIR corpus rows stay FAIL as a **safe decline** (not wrong output), gated on #762.
- The protein-axis empty-projection budget is **not** re-blessed (a separate reference-drift concern: the committed baseline of 19 does not reproduce against the current prepared reference).
- `coding_protein_descriptions` cluster-B (transcript-set/version selection) and the other #498 threads are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Protein consequence predictions now support whole-exon deletions with intronic endpoints.

* **Tests**
  * Added integration tests for whole-exon deletion prediction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->