### PR TITLE
fix(convert): map c.*N+offset 3'UTR positions past a transcript terminus

### DIFF
--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -647,6 +647,67 @@ impl<'a> CoordinateMapper<'a> {
             })
     }
 
+    /// Fold a UTR offset that has *no enclosing intron* into a plain
+    /// (non-intronic) CDS coordinate.
+    ///
+    /// A `+offset`/`-offset` is only meaningful when an intron spans the
+    /// boundary. In the UTRs that intron can be absent for two reasons:
+    /// - the boundary is the transcript terminus, so the offset points into the
+    ///   contiguous genome past the final/first exon (`c.*824+10` 3' of the last
+    ///   exon → `c.*834`); or
+    /// - the transcript model simply has no intron there (e.g. a single-exon
+    ///   supplemental transcript), so the offset is a spurious decoration.
+    ///
+    /// In both cases the offset is not intronic and folds linearly into the
+    /// base coordinate, matching the canonical interpretation and letting the
+    /// standard (non-intronic) machinery map and normalize the position instead
+    /// of the intron-window shuffle that has no intron to anchor on (#760).
+    ///
+    /// # Returns
+    /// The folded position, or `None` when it should keep its existing
+    /// handling: no offset, a position in the CDS proper (where a missing
+    /// intron means a genuinely invalid description, not an extended
+    /// coordinate), or a genuine enclosing intron.
+    pub fn fold_non_intronic_utr_offset(&self, pos: &CdsPos) -> Option<CdsPos> {
+        let offset = pos.offset?;
+        if offset == 0 {
+            return None;
+        }
+
+        // Only UTR offsets fold. A mid-CDS offset with no intron is invalid, not
+        // an extended coordinate, so it keeps erroring rather than folding.
+        let in_utr = pos.utr3 || pos.base < 0;
+        if !in_utr {
+            return None;
+        }
+
+        let tx = self.cds_to_tx(pos).ok()?;
+
+        // A negative tx base sits upstream of transcript base 1 (a deep 5'UTR
+        // offset, e.g. `c.-N` with N past the transcript start), so no interior
+        // intron can enclose it. Skip the intron probe — which is `u64`-indexed
+        // and cannot represent a pre-transcript base — and fold linearly below.
+        // A genuine enclosing intron only applies for a non-negative tx base.
+        if tx.base >= 0 {
+            let tx_base = tx.base as u64;
+            // A genuine intron encloses the offset → leave it to the intronic path.
+            if self
+                .transcript
+                .find_intron_at_tx_boundary(tx_base, offset)
+                .is_some()
+            {
+                return None;
+            }
+        }
+
+        // Transcript coordinates run 5'->3' regardless of strand, so a signed
+        // offset shifts the boundary directly; the (contiguous) sequence past
+        // the boundary maps back through the standard CDS conversion, which
+        // accepts coordinates beyond the transcript termini.
+        let folded_tx = tx.base.checked_add(offset)?;
+        self.tx_to_cds(&TxPos::new(folded_tx)).ok()
+    }
+
     /// Convert transcript position with intronic offset to genomic position
     pub fn tx_to_genomic_with_intron(&self, tx_pos: &TxPos) -> Result<u64, FerroError> {
         // If not intronic, use the standard method
@@ -797,6 +858,120 @@ mod tests {
         let result = mapper.tx_to_cds(&TxPos::new(37)).unwrap();
         assert_eq!(result.base, 2);
         assert!(result.utr3);
+    }
+
+    /// `c.*3+5` on a single-exon transcript whose 3'UTR ends at `*3` has no
+    /// enclosing intron — it is the extended 3'UTR coordinate `c.*8`. Folding
+    /// lets the standard (non-intronic) machinery map it. Regression for #760.
+    #[test]
+    fn fold_three_prime_utr_offset_at_terminus() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // cds_end=35, single exon ends at tx 38 → *3 is the final transcript base.
+        let pos = CdsPos {
+            base: 3,
+            offset: Some(5),
+            utr3: true,
+            special: None,
+        };
+        let folded = mapper
+            .fold_non_intronic_utr_offset(&pos)
+            .expect("should fold");
+        assert_eq!(folded.base, 8);
+        assert!(folded.utr3);
+        assert_eq!(folded.offset, None);
+    }
+
+    /// A 3'UTR offset *interior* to a single-exon transcript (no intron there at
+    /// all, the degenerate supplemental-transcript shape behind the #760 corpus
+    /// row) still folds: `c.*2+1` → `c.*3`.
+    #[test]
+    fn fold_three_prime_utr_offset_interior() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // *2 maps to tx 37, interior to the single exon (which ends at tx 38).
+        let pos = CdsPos {
+            base: 2,
+            offset: Some(1),
+            utr3: true,
+            special: None,
+        };
+        let folded = mapper
+            .fold_non_intronic_utr_offset(&pos)
+            .expect("should fold");
+        assert_eq!(folded.base, 3);
+        assert!(folded.utr3);
+        assert_eq!(folded.offset, None);
+    }
+
+    /// `c.-5-3` anchored at the first transcript base extends 5' past the
+    /// terminus to `c.-8`.
+    #[test]
+    fn fold_five_prime_utr_offset_at_terminus() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // cds_start=6 → c.-5 maps to tx 1, the first transcript base.
+        let pos = CdsPos {
+            base: -5,
+            offset: Some(-3),
+            utr3: false,
+            special: None,
+        };
+        let folded = mapper
+            .fold_non_intronic_utr_offset(&pos)
+            .expect("should fold");
+        assert_eq!(folded.base, -8);
+        assert!(!folded.utr3);
+        assert_eq!(folded.offset, None);
+    }
+
+    /// A deep 5'UTR offset whose anchor base already maps upstream of
+    /// transcript base 1 (a negative tx base) must still fold linearly rather
+    /// than short-circuit into the intronic path: `c.-7-2` (tx -1) → `c.-9`.
+    /// Regression for the negative-tx-base 5'UTR edge of #760.
+    #[test]
+    fn fold_five_prime_utr_offset_negative_tx_base() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // cds_start=6 → c.-7 maps to tx -1, upstream of transcript base 1.
+        let pos = CdsPos {
+            base: -7,
+            offset: Some(-2),
+            utr3: false,
+            special: None,
+        };
+        let folded = mapper
+            .fold_non_intronic_utr_offset(&pos)
+            .expect("should fold");
+        assert_eq!(folded.base, -9);
+        assert!(!folded.utr3);
+        assert_eq!(folded.offset, None);
+    }
+
+    /// A mid-CDS offset with no intron is a genuinely invalid description, not
+    /// an extended coordinate — it must not be folded.
+    #[test]
+    fn fold_offset_declines_cds_position() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // c.10+5 maps to tx 15, inside the CDS — not a UTR offset.
+        let pos = CdsPos {
+            base: 10,
+            offset: Some(5),
+            utr3: false,
+            special: None,
+        };
+        assert!(mapper.fold_non_intronic_utr_offset(&pos).is_none());
+    }
+
+    /// A non-intronic position (no offset) is never folded.
+    #[test]
+    fn fold_offset_declines_non_intronic_position() {
+        let tx = make_test_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        assert!(mapper
+            .fold_non_intronic_utr_offset(&CdsPos::utr3(2))
+            .is_none());
     }
 
     #[test]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2109,6 +2109,44 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HV::Cds(variant.clone()), vec![]));
         }
 
+        // #760: a UTR offset with no enclosing intron — past a transcript
+        // terminus (`c.*824+10`, 3' of the final exon → `c.*834`) or on a
+        // transcript whose model has no intron there at all — is not intronic.
+        // Fold it to a plain (non-intronic) position and recurse so the standard
+        // path maps it, instead of the intron-window shuffle that finds no
+        // intron to anchor on. The folded position carries no offset, so the
+        // recursion folds nothing and terminates.
+        {
+            use crate::hgvs::interval::UncertainBoundary;
+            let mapper = crate::convert::CoordinateMapper::new(&transcript);
+            let folded_start = mapper.fold_non_intronic_utr_offset(start_pos);
+            let folded_end = mapper.fold_non_intronic_utr_offset(end_pos);
+            if folded_start.is_some() || folded_end.is_some() {
+                // Replace each folded boundary while preserving its certainty.
+                let rebuild =
+                    |boundary: &UncertainBoundary<CdsPos>, folded: Option<CdsPos>| match folded {
+                        Some(p) => match boundary.as_single() {
+                            Some(mu) => UncertainBoundary::Single(mu.map_ref(|_| p)),
+                            None => UncertainBoundary::certain(p),
+                        },
+                        None => boundary.clone(),
+                    };
+                let new_location = Interval::with_complex_boundaries(
+                    rebuild(&variant.loc_edit.location.start, folded_start),
+                    rebuild(&variant.loc_edit.location.end, folded_end),
+                );
+                let new_variant = CdsVariant {
+                    accession: variant.accession.clone(),
+                    gene_symbol: variant.gene_symbol.clone(),
+                    loc_edit: LocEdit::with_uncertainty(
+                        new_location,
+                        variant.loc_edit.edit.clone(),
+                    ),
+                };
+                return self.normalize_cds(&new_variant);
+            }
+        }
+
         // Handle intronic variants specially
         if start_pos.is_intronic() || end_pos.is_intronic() {
             // Switch to the accession-aware lookup so an NG/NC-parented input

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -796,7 +796,14 @@ impl Transcript {
     /// # Returns
     /// The genomic position if the transcript has genomic coordinates
     pub fn intronic_to_genomic(&self, tx_boundary: u64, offset: i64) -> Option<u64> {
-        let intron = self.find_intron_at_tx_boundary(tx_boundary, offset)?;
+        let Some(intron) = self.find_intron_at_tx_boundary(tx_boundary, offset) else {
+            // No intron matches: the offset may point *past a transcript
+            // terminus* rather than into an interior intron (e.g. `c.*N+offset`
+            // 3' of the last exon, or `c.-N-offset` 5' of the first). There the
+            // genome continues contiguously past the terminal exon, so we extend
+            // the terminal exon's genomic coordinate linearly. #760.
+            return self.extend_past_terminus(tx_boundary, offset);
+        };
 
         // Get the genomic coordinates of the intron
         let (g_start, g_end) = (intron.genomic_start?, intron.genomic_end?);
@@ -826,6 +833,52 @@ impl Transcript {
                 }
             }
             Strand::Unknown => None,
+        }
+    }
+
+    /// Map an offset that points *past a transcript terminus* to a genomic
+    /// coordinate by extending the terminal exon's genomic position linearly.
+    ///
+    /// This handles intron-style offsets that have no enclosing intron because
+    /// they fall 3' of the last exon or 5' of the first exon — e.g.
+    /// `NG_012337.1(NM_003002.2):c.*824+10`, where `c.*824` is the final
+    /// transcript base and `+10` continues into the contiguous genome past the
+    /// 3' terminus (#760). The offset is only honored when `tx_boundary` is the
+    /// matching terminal exon edge and points *outward*:
+    /// - positive offset at the last transcript base → 3' of the transcript;
+    /// - negative offset at the first transcript base → 5' of the transcript.
+    ///
+    /// Any other (interior, non-terminal) boundary returns `None` so a genuinely
+    /// unmappable offset still fails rather than being silently extrapolated.
+    fn extend_past_terminus(&self, tx_boundary: u64, offset: i64) -> Option<u64> {
+        if offset == 0 || self.exons.is_empty() {
+            return None;
+        }
+        let first_exon = self.exons.iter().min_by_key(|e| e.start)?;
+        let last_exon = self.exons.iter().max_by_key(|e| e.end)?;
+
+        let (terminal_exon, beyond_three_prime) = if offset > 0 && tx_boundary == last_exon.end {
+            // 3' of the transcript terminus.
+            (last_exon, true)
+        } else if offset < 0 && tx_boundary == first_exon.start {
+            // 5' of the transcript terminus.
+            (first_exon, false)
+        } else {
+            return None;
+        };
+
+        let (g_start, g_end) = (terminal_exon.genomic_start?, terminal_exon.genomic_end?);
+        let distance = offset.unsigned_abs();
+
+        // The genomic anchor is the terminal exon edge nearest the terminus, and
+        // the direction we walk depends on strand. On the plus strand 3' is
+        // increasing genomic; on the minus strand 3' is decreasing genomic.
+        match (self.strand, beyond_three_prime) {
+            (Strand::Plus, true) => g_end.checked_add(distance),
+            (Strand::Plus, false) => g_start.checked_sub(distance),
+            (Strand::Minus, true) => g_start.checked_sub(distance),
+            (Strand::Minus, false) => g_end.checked_add(distance),
+            (Strand::Unknown, _) => None,
         }
     }
 
@@ -1462,5 +1515,75 @@ mod tests {
             "Should find intron when position is at upstream exon end with negative offset"
         );
         assert_eq!(result.unwrap().number, introns[0].number);
+    }
+
+    /// A minus-strand transcript whose terminal-exon boundaries we can extend
+    /// past for the beyond-terminus tests below.
+    ///
+    /// exon 1 (tx 1..5) sits at the higher genomic locus (the 5' end on the
+    /// minus strand); exon 2 (tx 6..10) sits at the lower genomic locus (the 3'
+    /// end). So tx 1 maps to g 204 and tx 10 maps to g 100.
+    fn make_minus_test_transcript() -> Transcript {
+        Transcript {
+            id: "NM_MINUS.1".to_string(),
+            strand: Strand::Minus,
+            cds_start: Some(2),
+            cds_end: Some(9),
+            exons: vec![
+                Exon::with_genomic(1, 1, 5, 200, 204),
+                Exon::with_genomic(2, 6, 10, 100, 104),
+            ],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(100),
+            genomic_end: Some(204),
+            ..Default::default()
+        }
+    }
+
+    /// A positive offset anchored at the last transcript base (3' terminal exon
+    /// end) has no downstream intron — it extends linearly past the transcript
+    /// 3' terminus into the contiguous genome. On the plus strand the genomic
+    /// coordinate increases. Regression for #760 (`c.*N+offset` past the 3' end).
+    #[test]
+    fn intronic_to_genomic_extends_past_three_prime_terminus_plus_strand() {
+        let tx = make_test_transcript_with_genomic();
+        // exon 3 (the 3' terminal exon) ends at tx 20 / g 50190505.
+        // tx 20 + 3 bases downstream = g 50190505 + 3.
+        assert_eq!(tx.intronic_to_genomic(20, 3), Some(50190508));
+    }
+
+    /// A negative offset anchored at the first transcript base (5' terminal exon
+    /// start) extends linearly past the transcript 5' terminus. On the plus
+    /// strand the genomic coordinate decreases.
+    #[test]
+    fn intronic_to_genomic_extends_before_five_prime_terminus_plus_strand() {
+        let tx = make_test_transcript_with_genomic();
+        // exon 1 (the 5' terminal exon) starts at tx 1 / g 50189542.
+        // tx 1 - 3 bases upstream = g 50189542 - 3.
+        assert_eq!(tx.intronic_to_genomic(1, -3), Some(50189539));
+    }
+
+    /// Beyond-terminus extension on the minus strand: 3' downstream of the last
+    /// transcript base walks to *lower* genomic coordinates; 5' upstream of the
+    /// first base walks to *higher* ones.
+    #[test]
+    fn intronic_to_genomic_extends_past_termini_minus_strand() {
+        let tx = make_minus_test_transcript();
+        // 3' terminus: tx 10 maps to g 100 (exon 2 genomic_start); +3 downstream
+        // on the minus strand decreases the genomic coordinate.
+        assert_eq!(tx.intronic_to_genomic(10, 3), Some(97));
+        // 5' terminus: tx 1 maps to g 204 (exon 1 genomic_end); -3 upstream on
+        // the minus strand increases the genomic coordinate.
+        assert_eq!(tx.intronic_to_genomic(1, -3), Some(207));
+    }
+
+    /// A boundary that is neither an intron edge nor a transcript terminus must
+    /// still decline — the beyond-terminus fallback must not paper over a
+    /// genuinely unmappable interior offset.
+    #[test]
+    fn intronic_to_genomic_declines_unanchored_interior_offset() {
+        let tx = make_test_transcript_with_genomic();
+        // tx 12 is interior to exon 2 (tx 8..14), not an exon boundary.
+        assert_eq!(tx.intronic_to_genomic(12, 3), None);
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
@@ -4,4 +4,3 @@ LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelinspter_qter
 NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]
-NG_012337.1(NM_003002.2):c.*824+10del

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -2366,7 +2366,12 @@
       "input": "NG_012337.1(NM_003002.2):c.*824+10del",
       "normalized": "NG_012337.1(NM_003002.2):c.*834del",
       "genomic": "NG_012337.1:g.13958del",
-      "to_test": true
+      "to_test": true,
+      "known_bug": {
+        "axis": "normalized",
+        "tracking_issue": 672,
+        "note": "ferro folds the spurious `c.*824+10` UTR offset to `c.*834` (no enclosing intron exists for the offset in ferro's NM_003002.2 model), then 3'-shifts `*834del` to the transcript terminus `*841del`. The divergence from mutalyzer's `*834del` is a reference-version artifact: the prepared manifest carries only a degenerate single-exon supplemental NM_003002.2 (no genomic placement, a longer 3'UTR ending at *841), so the 3' shuffle runs to the end of that synthetic 3'UTR. ferro's shuffle is correct for the reference it resolves; provisioning the real NM_003002.2 (#672) will let it match. The underlying c.*N+offset->genomic conversion gap (which also hit the present NM_003002.4, now -> c.*834del) is fixed. [review: reference-version artifact]"
+      }
     },
     {
       "keywords": [],

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -164,6 +164,7 @@ _No seeded member rows yet (manifest-gated seeding, #325)._
 | `NG_009930.1(NM_001099625.2):c.1010` | errors | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):n.110del` | errors | accepted_divergence | — | — |
 | `NG_012337.1(DUMMYACCNO_9999.9):c.12_13insGATC` | errors | accepted_divergence | — | — |
+| `NG_012337.1(NM_003002.2):c.*824+10del` | normalized | known_bug | — | #672 |
 | `NG_012337.1(NM_003002.2):c.*824del` | normalized | known_bug | — | #487 |
 | `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #487 |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | known_bug | — | #487 |
@@ -195,5 +196,5 @@ _No seeded member rows yet (manifest-gated seeding, #325)._
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 18 | 20 | 15 | 5 | 8 |
+| normalized | 18 | 21 | 15 | 5 | 8 |
 | protein_description | 0 | 0 | 0 | 0 | 19 |


### PR DESCRIPTION
## Summary

A `c.*N+offset` whose anchor has **no enclosing intron** — 3' of the final exon, or on a single-exon transcript model — errored with `Could not convert intronic position N+offset to genomic`, hard-failing the mutalyzer-normalize normalized axis. Such an offset is not intronic: the genome continues contiguously past the terminal exon, so it is simply the extended UTR coordinate (`c.*824+10` ≡ `c.*834`).

| input | mutalyzer | ferro before | ferro after |
|---|---|---|---|
| `NG_012337.1(NM_003002.4):c.*824+10del` | `c.*834del` | `Could not convert intronic position 1339+10 to genomic` | `c.*834del` ✅ |
| `NG_012337.1(NM_003002.2):c.*824+10del` | `c.*834del` | `Could not find intron for normalization` | `c.*841del` (known_bug #672) |

## Changes

- `Transcript::intronic_to_genomic` extends a terminal exon's genomic coordinate linearly when an offset points past the 5'/3' terminus (strand-aware), instead of returning `None`.
- `CoordinateMapper::fold_non_intronic_utr_offset` folds a UTR offset that has no enclosing intron into a plain (non-intronic) coordinate. `normalize_cds` folds before the intronic routing and recurses, so the standard non-intronic path maps and normalizes the position rather than the intron-window shuffle that has no intron to anchor on.

## Verification

`NG_012337.1(NM_003002.4):c.*824+10del` now normalizes to `c.*834del`, matching mutalyzer. The corpus row uses `NM_003002.2`, which the prepared manifest carries only as a degenerate single-exon supplemental transcript (no genomic placement, 3'UTR ending at `*841`); ferro now produces a valid `c.*841del` (was a hard error). The residual `*841` vs `*834` shift is a reference-version artifact, dispositioned as `known_bug #672`. Normalized axis: **7 → 6** undispositioned failures, 0 XPASS. Full hermetic suite (7369 tests) green; `clippy -D warnings` and `fmt --check` clean.

## Notes

Stacked on #757 (base branch `fix/issue-654-genomic-clobber-and-rejections`). Will retarget to `main` and rebase once #756/#757 merge.

Closes #760
Refs #654, #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for folding non-intronic UTR offsets in variant coordinate notation.
  * Enhanced intronic-to-genomic conversion to handle offsets extending past transcript boundaries.

* **Tests**
  * Extended test coverage for UTR offset folding behavior and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->