### PR TITLE
chore(conformance): accept coding_protein transcript-set enumeration divergences

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -372,6 +372,17 @@ pub enum Policy {
     /// positional `=` is spec-valid. Terminal rendering divergence (#654).
     #[serde(rename = "ferro-policy-654-explicit-identity-rendering")]
     ExplicitIdentityRendering654,
+    /// On `coding_protein_descriptions` ferro enumerates the latest curated
+    /// version of every transcript cdot reports overlapping the locus (#710:
+    /// collapse superseded versions, prefer curated NM_/NR_ over predicted
+    /// XM_/XR_), whereas mutalyzer lists a different overlapping-transcript set
+    /// and partitions the input gene's own consequence onto its separate
+    /// `protein_description` field. `background/refseq.md` L256/L259 leave "which
+    /// transcript / reference sequence should one use" open and L264 endorses
+    /// the latest build, so ferro's complete-current-curated-set enumeration is
+    /// spec-valid; both representations are correct. Accepted divergence (#763).
+    #[serde(rename = "ferro-policy-763-transcript-set-enumeration")]
+    TranscriptSetEnumeration763,
 }
 
 impl Policy {
@@ -383,6 +394,7 @@ impl Policy {
             Policy::ShuffleAppliedCompoundAllele499 => {
                 "ferro-policy-499-shuffle-applied-compound-allele"
             }
+            Policy::TranscriptSetEnumeration763 => "ferro-policy-763-transcript-set-enumeration",
             Policy::WholeCdsDeletionMet1 => "ferro-policy-whole-cds-del-met1",
             Policy::HomopolymerRepeatContraction745 => {
                 "ferro-policy-745-homopolymer-repeat-contraction"

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -52,6 +52,12 @@
       "title": "3' rule across exon/intron boundaries (#670)",
       "spec_section": "background/numbering.md#DNAc (exception 3' rule NOTE); recommendations/DNA/deletion.md L51-64",
       "note": "ferro shuffles genomic-context c./n. variants in spliced transcript space (cross_boundaries hardcoded false), which has no intronic bases, so it under-applies the 3' rule at exon/intron and intron/exon junctions. The spec applies the 3' rule across these junctions (suppressing it only at exon/exon junctions). The fix requires 3'-shifting in genomic coordinate space, which depends on the c↔g projection keystone (#642/#647/#616). Tracked in #670."
+    },
+    {
+      "id": "transcript-set-enumeration-763",
+      "title": "coding_protein_descriptions transcript-set enumeration",
+      "spec_section": "background/refseq.md L256, L259, L264",
+      "note": "On `coding_protein_descriptions` (expected ⊆ got, version- and gene-suffix-insensitive) ferro enumerates the latest curated version of every transcript cdot reports overlapping the locus (#710: collapse superseded versions, prefer curated NM_/NR_ over predicted XM_/XR_). Mutalyzer instead lists the neighbouring overlapping transcripts and partitions the input gene's own consequence onto its separate `protein_description` field — an info-model choice, not spec-mandated. `background/refseq.md` L256/L259 pose 'which transcript / which reference sequence should one use' as open questions and L264 endorses the latest build, so ferro's complete-current-curated-set enumeration is spec-valid; both representations are correct. Accepted divergence, not a convergence target — tightening would regress the #710 curation and cannot fix the rows anyway (the matcher is version-insensitive). Reference-coverage gaps where cdot lacks a transcript base mutalyzer used are tracked separately in #645."
     }
   ],
   "cases": [
@@ -352,7 +358,13 @@
           "NG_012337.1(NP_060665.3):p.(=)"
         ]
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
+      }
     },
     {
       "keywords": [
@@ -2011,6 +2023,12 @@
         "section": "HGVS §RefSeqGene transcript selection",
         "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
         "cluster": "refseqgene-selector"
+      },
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
       }
     },
     {
@@ -2043,6 +2061,12 @@
         "section": "HGVS §RefSeqGene transcript selection",
         "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
         "cluster": "refseqgene-selector"
+      },
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
       }
     },
     {
@@ -2599,6 +2623,12 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
         "cluster": "bare-np-protein"
+      },
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
       }
     },
     {
@@ -3752,6 +3782,12 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
         "cluster": "bare-np-protein"
+      },
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
       }
     },
     {
@@ -3839,7 +3875,13 @@
         ]
       ],
       "protein_description": "NG_012337.1(NP_036591.2):p.(Gln43His)",
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
+      }
     },
     {
       "keywords": [
@@ -3863,7 +3905,13 @@
         ]
       ],
       "protein_description": "NG_012337.1(NP_036591.2):p.(Val44Met)",
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-763-transcript-set-enumeration",
+        "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
+        "cluster": "transcript-set-enumeration-763"
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -118,6 +118,22 @@ ferro shuffles genomic-context c./n. variants in spliced transcript space (cross
 
 _No seeded member rows yet (manifest-gated seeding, #325)._
 
+### coding_protein_descriptions transcript-set enumeration
+
+Spec: `background/refseq.md L256, L259, L264`
+
+On `coding_protein_descriptions` (expected ⊆ got, version- and gene-suffix-insensitive) ferro enumerates the latest curated version of every transcript cdot reports overlapping the locus (#710: collapse superseded versions, prefer curated NM_/NR_ over predicted XM_/XR_). Mutalyzer instead lists the neighbouring overlapping transcripts and partitions the input gene's own consequence onto its separate `protein_description` field — an info-model choice, not spec-mandated. `background/refseq.md` L256/L259 pose 'which transcript / which reference sequence should one use' as open questions and L264 endorses the latest build, so ferro's complete-current-curated-set enumeration is spec-valid; both representations are correct. Accepted divergence, not a convergence target — tightening would regress the #710 curation and cannot fix the rows anyway (the matcher is version-insensitive). Reference-coverage gaps where cdot lacks a transcript base mutalyzer used are tracked separately in #645.
+
+| input | axis | disposition | ferro output | tracking |
+|---|---|---|---|---|
+| `NG_007485.1(NM_058195.3):c.141_142del` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_008835.1(NM_022153.2):c.568del` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_012337.1(NM_012459.2):c.129G>T` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_012337.1(NM_012459.2):c.130G>A` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_012337.1(TIMM8B):c.12_15dupCAGC` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_012337.1(TIMM8B):c.12dupC` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_012337.1:g.4812_4813insTAC` | coding_protein_descriptions | accepted_divergence | — | — |
+
 ### Ungrouped
 
 | input | axis | disposition | ferro output | tracking |
@@ -193,6 +209,7 @@ _No seeded member rows yet (manifest-gated seeding, #325)._
 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
+| coding_protein_descriptions | 7 | 0 | 0 | 0 | 0 |
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -454,6 +454,35 @@ impl AxisTally {
                 return;
             }
         }
+        // On the `coding_protein_descriptions` axis specifically, a "missing
+        // pair" `Err` is a transcript-SET divergence: ferro produced
+        // coding/protein pairs but not the exact set mutalyzer expected
+        // (`expected ⊆ got`). That is not a ferro failure — ferro enumerates the
+        // latest curated overlapping-transcript set while mutalyzer lists a
+        // different set (#763). So `accepted_divergence` buckets it here, like
+        // the errors-axis exception below buckets a divergent `Err`. The bucket
+        // is gated on the exact `missing pair` prefix the runner emits (see line
+        // ~1074); every other non-panic `Err` class on this axis — `parse:`
+        // (parse failure) and `project_all:` (projection error) — is a genuine
+        // ferro failure and must still hard-FAIL below, even with the
+        // annotation, so a regression on the 7 annotated #763 cases is never
+        // silently masked. This is scoped to this one axis on purpose: on every
+        // other axis an `Err` means ferro failed to produce a result and must
+        // still FAIL even when annotated (see
+        // `tally_infos_under_emission_err_with_accepted_divergence_still_fails`).
+        // A genuine panic / the empty-projection sentinel (#651) still hard-FAIL
+        // below; a match XPASS-FAILs above.
+        if self.axis == Axis::CodingProteinDescriptions {
+            if let Some(ad) = &case.accepted_divergence {
+                if ad.axis == self.axis
+                    && matches!(&actual, Err(e) if e.starts_with("missing pair"))
+                {
+                    self.divergence_accepted
+                        .push((case.input.clone(), ad.policy.to_string()));
+                    return;
+                }
+            }
+        }
         // On the errors axis a non-panic `Err` is the expected "ferro diverges"
         // outcome, so annotations bucket it the same way an `Ok` mismatch is
         // bucketed elsewhere; a genuine panic stays a hard FAIL. See the
@@ -2255,6 +2284,118 @@ mod comparator_tests {
             "stale errors-axis annotation must XPASS-FAIL"
         );
         assert!(t.fail[0].1.contains("XPASS"));
+    }
+
+    // (7g) coding_protein_descriptions axis: a non-panic "missing pair" `Err`
+    // (ferro produced a different transcript set) WITH an `accepted_divergence`
+    // buckets as divergence_accepted — the #763 transcript-set-enumeration
+    // exception, scoped to this one axis.
+    #[test]
+    fn tally_coding_protein_missing_pair_err_with_accepted_divergence_buckets() {
+        let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
+        let case = make_case(
+            "in",
+            Some(AcceptedDivergence {
+                axis: Axis::CodingProteinDescriptions,
+                policy: Policy::TranscriptSetEnumeration763,
+                note: None,
+                cluster: None,
+            }),
+            None,
+        );
+        t.record(
+            &case,
+            "[(\"NM_x.1:c.1A>T\", \"NP_x.1:p.(=)\")]",
+            Err("missing pair (\"NM_x.1:c.1A>T\", \"NP_x.1:p.(=)\"); got [...]".to_string()),
+        );
+        assert_eq!(t.pass, 0);
+        assert_eq!(t.fail.len(), 0, "transcript-set divergence must not FAIL");
+        assert_eq!(
+            t.divergence_accepted,
+            vec![(
+                "in".to_string(),
+                "ferro-policy-763-transcript-set-enumeration".to_string()
+            )]
+        );
+    }
+
+    // (7h) coding_protein_descriptions axis: a genuine PANIC still hard-FAILs
+    // even with the #763 annotation — real crashes are never masked.
+    #[test]
+    fn tally_coding_protein_panic_still_fails_despite_annotation() {
+        let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
+        let case = make_case(
+            "in",
+            Some(AcceptedDivergence {
+                axis: Axis::CodingProteinDescriptions,
+                policy: Policy::TranscriptSetEnumeration763,
+                note: None,
+                cluster: None,
+            }),
+            None,
+        );
+        t.record(&case, "exp", Err("panic: boom".to_string()));
+        assert_eq!(t.fail.len(), 1);
+        assert!(t.divergence_accepted.is_empty());
+    }
+
+    // (7i) coding_protein_descriptions axis: an empty-projection `Err` (#651)
+    // still hard-FAILs and is counted in `empty_got` even with the annotation —
+    // a populated→empty degradation must remain visible.
+    #[test]
+    fn tally_coding_protein_empty_projection_still_fails_despite_annotation() {
+        let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
+        let case = make_case(
+            "in",
+            Some(AcceptedDivergence {
+                axis: Axis::CodingProteinDescriptions,
+                policy: Policy::TranscriptSetEnumeration763,
+                note: None,
+                cluster: None,
+            }),
+            None,
+        );
+        t.record(
+            &case,
+            "exp",
+            Err(format!("{EMPTY_PROJECTION_SENTINEL}produced no pairs")),
+        );
+        assert_eq!(t.fail.len(), 1, "empty projection must still FAIL");
+        assert!(t.divergence_accepted.is_empty());
+        assert_eq!(t.empty_got, 1);
+    }
+
+    // (7j) coding_protein_descriptions axis: a `parse:` / `project_all:` `Err`
+    // (a genuine ferro parse or projection failure, NOT a transcript-set
+    // divergence) still hard-FAILs even with the #763 annotation present. The
+    // #763 exception is gated on the exact `missing pair` prefix, so these other
+    // non-panic `Err` classes are never silenced into divergence_accepted.
+    #[test]
+    fn tally_coding_protein_nondivergence_err_still_fails_despite_annotation() {
+        for err in ["parse: bad input", "project_all: projection failed"] {
+            let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
+            let case = make_case(
+                "in",
+                Some(AcceptedDivergence {
+                    axis: Axis::CodingProteinDescriptions,
+                    policy: Policy::TranscriptSetEnumeration763,
+                    note: None,
+                    cluster: None,
+                }),
+                None,
+            );
+            t.record(&case, "exp", Err(err.to_string()));
+            assert_eq!(t.pass, 0);
+            assert!(
+                t.divergence_accepted.is_empty(),
+                "a non-missing-pair Err ({err:?}) must not bucket into divergence_accepted"
+            );
+            assert_eq!(
+                t.fail.len(),
+                1,
+                "non-divergence Err ({err:?}) must still FAIL"
+            );
+        }
     }
 
     // (7) Mismatch with no annotation is FAIL.


### PR DESCRIPTION
## Summary

On the `coding_protein_descriptions` conformance axis (`expected ⊆ got`, version- and gene-suffix-insensitive), ~18 FAILs are transcript-**set** divergences: ferro enumerates the latest curated version of every transcript cdot reports overlapping the locus (#710 — collapse superseded versions, prefer curated `NM_`/`NR_` over predicted `XM_`/`XR_`), while mutalyzer lists a *different* overlapping-transcript set and partitions the input gene's own consequence onto its separate `protein_description` field.

Both representations are correct. `background/refseq.md` L256/L259 pose "which transcript / which reference sequence should one use" as open questions and L264 endorses the latest build, so ferro's complete-current-curated-set enumeration is spec-valid. This is an **accepted divergence, not a convergence target**: tightening would regress the #710 curation and cannot fix the rows anyway (the matcher is version-insensitive, so the divergence is pure set-membership). `Closes #763`.

## What changed

The harness previously could not record this: on projection axes a non-panic `Err` (here a "missing pair") is always a hard FAIL, and only the errors axis had an exception (#752's `accepted_rejection`). So:

- **Harness** (`AxisTally::record`): on the `coding_protein_descriptions` axis specifically, a non-panic, non-empty-projection `Err` carrying an `accepted_divergence` for that axis now buckets as `divergence_accepted` — mirroring the errors-axis exception. Scoped to this one axis on purpose: every other axis still hard-FAILs an `Err` even when annotated (a panic and the #651 empty-projection sentinel always hard-FAIL; an `Ok` match still XPASS-FAILs).
- **Policy**: new `ferro-policy-763-transcript-set-enumeration` + a `clusters` registry entry.
- **Annotations**: the 7 clean transcript-set rows (`NM_012459.2:c.129G>T`, `c.130G>A`, `NM_022153.2:c.568del`, `NM_058195.3:c.141_142del`, `g.4812_4813insTAC`, and the two `TIMM8B` gene-symbol-selector dups). `failure-patterns.md` regenerated.

Deliberately **not** annotated: the 5 empty-projection rows (a real output-quality concern, #651), the version-mismatch / delins-Ter / `c.41A>C` rows (other categories), and the gene-symbol-selector `TIMM8B` rows (#121). Reference-coverage gaps where cdot lacks a base mutalyzer used remain tracked in #645.

## Validation

- Manifest `axis_coding_protein_descriptions`: **27 → 20 FAIL** (7 → `divergence_accepted`); the rows confirmed gone from the FAIL set.
- Unit tests: bucket / panic-still-fails / empty-still-fails on the coding_protein axis; the existing infos-axis guard (`tally_infos_under_emission_err_with_accepted_divergence_still_fails`) confirms the scoping didn't broaden Err-bucketing elsewhere.
- Full manifest-less suite: 7363 passing; clippy/fmt clean.
