### PR TITLE
feat(normalize): expand axis-less cross-reference insert payloads

### DIFF
--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -595,19 +595,10 @@ fn is_crossref_accession(acc: &str) -> bool {
 /// Parse a reference location (e.g., NC_012920.1:m.12435_12527 or AF118569:g.14094_14382)
 /// Returns the full reference string if valid, None otherwise
 fn parse_reference_location(input: &str) -> Option<String> {
-    // Must contain a colon followed by coordinate type
+    // Must contain a colon separating the accession from the payload.
     let colon_pos = input.find(':')?;
-
-    // Check that we have at least "X:Y." pattern
     let after_colon = &input[colon_pos + 1..];
-    if after_colon.len() < 2 {
-        return None;
-    }
-
-    // Must have coordinate type (g., c., m., n., r., p., o.)
-    let coord_type = after_colon.as_bytes()[0];
-    let dot = after_colon.as_bytes()[1];
-    if dot != b'.' || !matches!(coord_type, b'g' | b'c' | b'm' | b'n' | b'r' | b'p' | b'o') {
+    if after_colon.is_empty() {
         return None;
     }
 
@@ -619,11 +610,24 @@ fn parse_reference_location(input: &str) -> Option<String> {
         return None;
     }
 
-    // Now find where the coordinates end
-    let mut end_pos = colon_pos + 3; // Skip past ":X."
-    let pos_part = &input[end_pos..];
+    // The payload is either axis-qualified — `<axis>.<positions>` with axis in
+    // g./c./m./n./r./p./o. — or axis-less — `<positions>` interpreted in the
+    // accession's native frame (#759). Locate where the positions start.
+    let bytes = after_colon.as_bytes();
+    let pos_start = if bytes.len() >= 2
+        && bytes[1] == b'.'
+        && matches!(bytes[0], b'g' | b'c' | b'm' | b'n' | b'r' | b'p' | b'o')
+    {
+        colon_pos + 3 // skip ":X."
+    } else if bytes[0].is_ascii_digit() {
+        colon_pos + 1 // skip ":" — axis-less native-frame payload
+    } else {
+        return None;
+    };
 
-    for c in pos_part.chars() {
+    // Find where the coordinates end.
+    let mut end_pos = pos_start;
+    for c in input[end_pos..].chars() {
         if c.is_ascii_digit() || c == '_' || c == '+' || c == '-' || c == '?' {
             end_pos += c.len_utf8();
         } else {
@@ -631,8 +635,8 @@ fn parse_reference_location(input: &str) -> Option<String> {
         }
     }
 
-    // Must have at least one position character
-    if end_pos <= colon_pos + 3 {
+    // Must have at least one position character.
+    if end_pos <= pos_start {
         return None;
     }
 
@@ -3145,6 +3149,47 @@ mod tests {
             parse_reference_location("NG_012337.1(NM_012459.2:c.200_203").is_none(),
             "unbalanced selector paren must not parse as a reference location"
         );
+    }
+
+    /// An axis-less cross-reference payload `<ACC>:<range>` (no `c.`/`g.`/…
+    /// prefix) must parse as a `Reference`, not fall through to reading the
+    /// accession letters as nucleotide bases (#759).
+    #[test]
+    fn test_parse_axisless_crossref_insertion() {
+        for ref_str in ["NM_003002.4:100_102", "NM_003002.4:100"] {
+            let ins_input = format!("ins{ref_str}");
+            let (remaining, edit) =
+                parse_na_edit(&ins_input).expect("axis-less cross-ref ins must parse");
+            assert_eq!(remaining, "", "input fully consumed for {ref_str}");
+            match edit {
+                NaEdit::Insertion {
+                    sequence: InsertedSequence::Reference(r),
+                } => assert_eq!(r, ref_str),
+                other => panic!("expected Reference insertion for {ref_str}, got {other:?}"),
+            }
+        }
+    }
+
+    /// `parse_reference_location` recognizes both the axis-qualified and the
+    /// axis-less forms, and still rejects payloads with neither an axis nor a
+    /// leading position digit.
+    #[test]
+    fn test_parse_reference_location_axisless() {
+        assert_eq!(
+            parse_reference_location("NM_003002.4:100_102").as_deref(),
+            Some("NM_003002.4:100_102")
+        );
+        assert_eq!(
+            parse_reference_location("NM_003002.4:100").as_deref(),
+            Some("NM_003002.4:100")
+        );
+        // Axis-qualified still works.
+        assert_eq!(
+            parse_reference_location("NC_012920.1:m.123_456").as_deref(),
+            Some("NC_012920.1:m.123_456")
+        );
+        // Neither axis nor a leading digit → not a reference location.
+        assert!(parse_reference_location("NM_003002.4:xyz").is_none());
     }
 
     #[test]

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1966,32 +1966,6 @@ fn fetch_position_range_bases<P: ReferenceProvider>(
     provider.get_sequence(accession, tx_start - 1, tx_end)
 }
 
-/// Parse a cross-reference string (e.g.
-/// `"NC_000022.10:g.42536337_42536382"`) into its components for
-/// provider lookup. Returns `(accession, coord_kind, start, end)` on
-/// success.
-///
-/// Supports g./m./o./c./n. axes with simple positive-integer positions or ranges
-/// (no offsets, no `*N`, no `?`, no `pter`/`qter` markers). Out-of-scope
-/// shapes return `None` so the caller can surface a focused
-/// `FerroError::UnsupportedVariant`. #422.
-///
-/// **Axis-set rationale:** the parser's `parse_reference_location`
-/// (`src/hgvs/parser/edit.rs`) accepts `g/c/m/n/r/p/o` axes for
-/// `Reference` strings. This helper accepts the subset that has a
-/// well-defined position-range fetch on the inner accession:
-///   - `g.`/`m.`/`o.`: genomic position-range fetch (`Direct`).
-///   - `c.`: CDS-relative; translated via the FOREIGN transcript's
-///     `cds_start` inside `fetch_position_range_bases`.
-///   - `n.`: non-coding transcript; positions are already transcript-
-///     relative (`Direct`).
-///
-/// **Deferred axes (`r.`, `p.`):** RNA needs U→T translation on the
-/// fetched bases (the existing `r.→g.` projection has the primitive
-/// but isn't wired here); protein is structurally invalid as a DNA-
-/// insertion payload. Both stay `UnsupportedVariant` for now. If
-/// `parse_reference_location` ever broadens to additional axes, keep
-/// the match arm below in sync.
 /// A parsed cross-reference payload: the inner accession, how its positions
 /// are interpreted, and the position range.
 struct CrossReferenceParse {
@@ -2014,29 +1988,84 @@ struct CrossReferenceParse {
     transcript_relative: bool,
 }
 
+/// Parse a cross-reference string (e.g.
+/// `"NC_000022.10:g.42536337_42536382"`) into its components for
+/// provider lookup. Returns a `CrossReferenceParse` (the inner accession,
+/// the `InsCoordKind` used to fetch its bases, the one-based `start`/`end`,
+/// and the `transcript_relative` flag) on success.
+///
+/// Two payload forms are accepted:
+///   - **Axis-qualified** (`<ACC>:<axis>.<range>`): supports g./m./o./c./n.
+///     axes with simple positive-integer positions or ranges (no offsets,
+///     no `*N`, no `?`, no `pter`/`qter` markers).
+///   - **Axis-less native-frame** (`<ACC>:<range>`, #759): the bare positions
+///     index the accession's *native frame* — the axis an explicit
+///     description would default to for that accession
+///     (`Accession::inferred_variant_type`, resolved via
+///     `axisless_native_frame`): `c.` for a coding transcript (`NM_`/`ENST`),
+///     `n.` for a non-coding one (`NR_`/`XR_`), `g.` for a genomic reference
+///     (`NC_`/`NG_`). So `NM_003002.4:100_102` == `NM_003002.4:c.100_102`.
+///     Protein / unknown native frames are out of scope.
+///
+/// Out-of-scope shapes return `None` so the caller can surface a focused
+/// `FerroError::UnsupportedVariant`. #422.
+///
+/// **Axis-set rationale:** the parser's `parse_reference_location`
+/// (`src/hgvs/parser/edit.rs`) accepts `g/c/m/n/r/p/o` axes for
+/// `Reference` strings. This helper accepts the subset that has a
+/// well-defined position-range fetch on the inner accession:
+///   - `g.`/`m.`/`o.`: genomic position-range fetch (`Direct`).
+///   - `c.`: CDS-relative; translated via the FOREIGN transcript's
+///     `cds_start` inside `fetch_position_range_bases`.
+///   - `n.`: non-coding transcript; positions are already transcript-
+///     relative (`Direct`).
+///
+/// **Deferred axes (`r.`, `p.`):** RNA needs U→T translation on the
+/// fetched bases (the existing `r.→g.` projection has the primitive
+/// but isn't wired here); protein is structurally invalid as a DNA-
+/// insertion payload. Both stay `UnsupportedVariant` for now. If
+/// `parse_reference_location` ever broadens to additional axes, keep
+/// the match arm below in sync.
 fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
     let (acc_part, after_colon) = reference.split_once(':')?;
-    // Minimum well-formed shape: a single position `g.A` = 3 chars (axis + dot
-    // + one position char). A range `g.A_B` is 5+.
-    if acc_part.is_empty() || after_colon.len() < 3 {
+    if acc_part.is_empty() || after_colon.is_empty() {
         return None;
     }
-    let coord_byte = *after_colon.as_bytes().first()?;
-    if after_colon.as_bytes().get(1) != Some(&b'.') {
-        return None;
-    }
-    // c. requires CDS translation via the foreign transcript's cds_start;
-    // g./m./o./n. are direct position-range fetches on the inner accession.
-    // r. and p. are deferred — see the doc-comment above.
-    let kind = match coord_byte {
-        b'g' | b'm' | b'o' | b'n' => InsCoordKind::Direct,
-        b'c' => InsCoordKind::Cds,
-        _ => return None,
+    let bytes = after_colon.as_bytes();
+    // An axis-qualified payload is `<axis>.<range>` (`g.`/`c.`/…); anything else
+    // is treated as an axis-less native-frame payload (`<ACC>:<range>`, #759).
+    let axis_qualified = bytes.len() >= 2 && bytes[1] == b'.';
+    let (kind, transcript_relative, range_str) = if axis_qualified {
+        // c. requires CDS translation via the foreign transcript's cds_start;
+        // g./m./o./n. are direct position-range fetches on the inner accession.
+        // r. and p. are deferred — see the doc-comment above.
+        let kind = match bytes[0] {
+            b'g' | b'm' | b'o' | b'n' => InsCoordKind::Direct,
+            b'c' => InsCoordKind::Cds,
+            _ => return None,
+        };
+        // `c.` and `n.` are transcript-relative (their positions index the
+        // transcript), so a genomic-context compound payload accession
+        // (`NG_(NM_)`) must be reduced to its transcript before lookup.
+        // `g./m./o.` are genomic / absolute and fetch on the named accession
+        // unchanged. (`n.` shares the `Direct` *fetch* path with `g./m./o.` — it
+        // needs no cds_start translation — so the kind alone can't distinguish
+        // it; this flag carries that out.)
+        let transcript_relative = matches!(bytes[0], b'c' | b'n');
+        (kind, transcript_relative, &after_colon[2..])
+    } else {
+        // Axis-less payload `<ACC>:<range>` (#759): the bare positions index the
+        // accession's *native frame*, i.e. the axis an explicit description would
+        // default to for that accession — `c.` for a coding transcript (`NM_`,
+        // `ENST`), `n.` for a non-coding one (`NR_`/`XR_`), `g.` for a genomic
+        // reference (`NC_`/`NG_`). So `NM_003002.4:100_102` == `NM_003002.4:c.100_102`.
+        // Protein / unknown native frames are out of scope (return None).
+        if !bytes[0].is_ascii_digit() {
+            return None;
+        }
+        let (kind, transcript_relative) = axisless_native_frame(acc_part)?;
+        (kind, transcript_relative, after_colon)
     };
-    // See `CrossReferenceParse::transcript_relative` for why `c.`/`n.` are set
-    // here while `g./m./o.` are not.
-    let transcript_relative = matches!(coord_byte, b'c' | b'n');
-    let range_str = &after_colon[2..];
     // A payload may name a range (`A_B`) or a single position (`A`, a one-base
     // copy with start == end).
     let (start_str, end_str) = match range_str.split_once('_') {
@@ -2122,6 +2151,32 @@ fn resolve_cross_reference_bases<P: ReferenceProvider>(
         accession
     };
     fetch_position_range_bases(&accession, start, end, kind, provider)
+}
+
+/// Resolve the `(InsCoordKind, transcript_relative)` an axis-less cross-reference
+/// payload should use, from the accession's *native frame* (#759).
+///
+/// An axis-less `<ACC>:<range>` is interpreted in the axis an explicit
+/// description would default to for that accession (`Accession::inferred_variant_type`):
+/// - `c.` (coding transcript `NM_`/`ENST`) → `Cds` (CDS-translated), transcript-relative;
+/// - `n.` (non-coding `NR_`/`XR_`) → `Direct` fetch, transcript-relative;
+/// - `g.`/`m.`/`o.` (genomic `NC_`/`NG_`/…) → `Direct` fetch, not transcript-relative.
+///
+/// `transcript_relative` lets a compound `NG_(NM_)` accession reduce to its inner
+/// transcript before lookup (the parsed accession of a compound is the inner one).
+/// Returns `None` when the accession does not parse or its native frame is out of
+/// scope (protein / unknown), so the cross-reference is rejected as unsupported.
+fn axisless_native_frame(accession: &str) -> Option<(InsCoordKind, bool)> {
+    let (rest, parsed) = crate::hgvs::parser::accession::parse_accession(accession).ok()?;
+    if !rest.is_empty() {
+        return None;
+    }
+    match parsed.inferred_variant_type() {
+        Some("c") => Some((InsCoordKind::Cds, true)),
+        Some("n") => Some((InsCoordKind::Direct, true)),
+        Some("g") | Some("m") | Some("o") => Some((InsCoordKind::Direct, false)),
+        _ => None,
+    }
 }
 
 /// Reduce an accession string to its transcript accession (`NM_`/`NR_`/`ENST`),
@@ -3948,6 +4003,66 @@ mod tests {
         let provider = crate::reference::mock::MockProvider::with_test_data();
         let bases = resolve_cross_reference_bases("NM_000088.3:n.2", &provider)
             .expect("single-position n. cross-reference should resolve");
+        assert_eq!(bases, "T");
+    }
+
+    #[test]
+    fn resolve_cross_reference_resolves_axisless_coding_payload_in_cds_frame() {
+        // An axis-less payload `<ACC>:<range>` (no `c.`/`n.`/`g.` prefix) is
+        // interpreted in the accession's native frame (#759). For a *coding*
+        // transcript that is `c.` (CDS), not `n.` — `NM_…:100` == `NM_…:c.100`.
+        // `NM_001234.1` is "AAAAATGCCC…" with cds_start=5, so the frames differ:
+        //   axis-less 1_3 == c.1_3 == "ATG"   (CDS-translated)
+        //   n.1_3 == "AAA"                     (sequence-native, NOT used here)
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let bases = resolve_cross_reference_bases("NM_001234.1:1_3", &provider)
+            .expect("axis-less coding cross-reference should resolve");
+        assert_eq!(bases, "ATG");
+        // Same as the explicit `c.` form, and distinct from the `n.` form.
+        assert_eq!(
+            resolve_cross_reference_bases("NM_001234.1:c.1_3", &provider).unwrap(),
+            "ATG"
+        );
+        assert_eq!(
+            resolve_cross_reference_bases("NM_001234.1:n.1_3", &provider).unwrap(),
+            "AAA"
+        );
+    }
+
+    #[test]
+    fn resolve_cross_reference_resolves_axisless_noncoding_payload_in_transcript_frame() {
+        // A non-coding accession's native frame is `n.` (sequence-native). The
+        // mock has no NR_; emulate by checking that the coding/non-coding split
+        // is driven by inferred_variant_type: NR_ would be Direct/transcript.
+        // Here we assert the helper classifies a coding NM_ as CDS-framed.
+        assert_eq!(
+            axisless_native_frame("NM_001234.1"),
+            Some((InsCoordKind::Cds, true))
+        );
+        assert_eq!(
+            axisless_native_frame("NR_000001.1"),
+            Some((InsCoordKind::Direct, true))
+        );
+        assert_eq!(
+            axisless_native_frame("NC_000001.11"),
+            Some((InsCoordKind::Direct, false))
+        );
+        // Compound NG_(NM_) parses to the inner transcript → CDS-framed.
+        assert_eq!(
+            axisless_native_frame("NG_012337.1(NM_003002.4)"),
+            Some((InsCoordKind::Cds, true))
+        );
+        // Protein / unparseable → out of scope.
+        assert_eq!(axisless_native_frame("NP_000079.2"), None);
+    }
+
+    #[test]
+    fn resolve_cross_reference_accepts_an_axisless_single_position() {
+        // A single axis-less position (no `_` range) — a one-base copy in the
+        // coding (c.) frame. `NM_001234.1` c.2 == transcript pos 6 == "T".
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let bases = resolve_cross_reference_bases("NM_001234.1:2", &provider)
+            .expect("axis-less single-position cross-reference should resolve");
         assert_eq!(bases, "T");
     }
 

--- a/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
@@ -3,4 +3,3 @@ LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51
 LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelinspter_qter
-NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3110,7 +3110,13 @@
         "ICORRECTEDCOORDINATESYSTEM",
         "ICORRECTEDPOINT"
       ],
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "normalized",
+        "section": "HGVS §Repeated (coding codon exception)",
+        "cluster": "coding-repeat-codon-exception",
+        "note": "Two independent divergences; ferro is spec-conforming on both. (1) The axis-less cross-reference insert payload now parses and expands (#759): `400_401insNM_003002.4:100_102` resolves in NM_003002.4's native coding frame (c.100_102 == TTT). mutalyzer renders the resulting +3-copy T expansion as `399_401T[6]`, but a length-1 repeat unit in coding c. is INVALID HGVS (DNA/repeated.md L21-24 marks `c.…A[10]`/`c.…TA[6]` class=\"invalid\"; repeat notation in c. is permitted only for units whose length is a multiple of 3). ferro emits the spec-mandated literal `401_402insTTT`, the spec-correct value. (2) Member 1 `c.274+20C>T`: mutalyzer corrects the point to `c.294C>T` using the real NM_003002.2 exon structure (the row's ICORRECTEDPOINT info), which ferro cannot reproduce because the prepared manifest carries only a degenerate single-exon supplemental NM_003002.2 (no intron there to resolve 274+20 against, and folding it would wrongly collapse genuine intronic positions like c.52+1 elsewhere). ferro echoes the valid-but-uncorrected `274+20C>T`; real-version provisioning is tracked by #672. Neither member emits invalid HGVS; the row simply cannot match mutalyzer (its member-2 expected value is itself invalid HGVS)."
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -105,6 +105,7 @@ On a coding DNA reference (c.), repeat notation unit[N] is permitted only for re
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
+| `NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.10CA[5]` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.3GC[5]` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.6C[4]` | normalized | spec_citation | — | — |
@@ -196,5 +197,5 @@ _No seeded member rows yet (manifest-gated seeding, #325)._
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 18 | 21 | 15 | 5 | 8 |
+| normalized | 18 | 21 | 15 | 5 | 9 |
 | protein_description | 0 | 0 | 0 | 0 | 19 |

--- a/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
@@ -183,7 +183,7 @@ NG_009299.1(NM_017668.3):c.[250del;41A>C]	NG_009299.1(NM_017668.3):c.[250del;41A
 NG_009299.1(NM_017668.3):c.[41>CA;250del]	parse error: Parse error at position 25: Failed to parse variant: Error(Error { input: ">CA", code: Tag })
 NG_009299.1(NM_017668.3):c.[250del;41>CA]	parse error: Parse error at position 25: Failed to parse variant: Error(Error { input: ">CA", code: Tag })
 NG_009299.1(NM_002474.3):c.[310del;295G>A]	NG_009299.1(NM_002474.3):c.[310del;295G>A]
-NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]	parse error: Parse error at position 25: Failed to parse variant: Error(Error { input: "_003002.4:100_102", code: Tag })
+NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]	normalize error: Reference not found: NM_003002.4
 NM_002001.2:c.=	NM_002001.2:c.=
 NG_012337.1(NM_003002.2):c.=	NG_012337.1(NM_003002.2):c.=
 ENST00000375549:c.100del	ENST00000375549:c.100del


### PR DESCRIPTION
## Summary

A cross-reference insert/delins payload may omit the axis prefix — `<ACC>:<a>_<b>` rather than `<ACC>:c.<a>_<b>`. The parser rejected it (`parse_reference_location` required a `g./c./m./n./r./p./o.` prefix), so `400_401insNM_003002.4:100_102` failed to parse.

| input | mutalyzer | ferro before | ferro after |
|---|---|---|---|
| `NG_012337.1(NM_003002.2):c.[274+20C>T;400_401insNM_003002.4:100_102]` | `c.[294C>T;399_401T[6]]` | parse error at `insNM_003002.4:100_102` | `c.[274+20C>T;401_402insTTT]` (spec_citation) |

## Changes

- **Parser** (`parse_reference_location`): also accepts an axis-less numeric payload `<ACC>:<digits>`, capturing it as a `Reference`.
- **Rules** (`parse_cross_reference`): interprets an axis-less payload in the accession's **native frame** (`Accession::inferred_variant_type`) — `c.` (CDS) for a coding transcript (`NM_`/`ENST`), `n.` for a non-coding one (`NR_`/`XR_`), `g.` for a genomic reference. So `NM_003002.4:100_102` ≡ `NM_003002.4:c.100_102` (= `TTT`), matching mutalyzer; an explicit `n.` would resolve the transcript-frame bases instead. Protein / unknown native frames are rejected as out of scope.

Unit-tested at both layers (parser: axis-less ins parses to `Reference`; rules: coding→CDS, non-coding→`n.`, genomic→`g.`, compound `NG_(NM_)`→inner transcript, protein→rejected).

## Disposition of the corpus row

The row now parses and expands (was a hard parse error), so it can finally be dispositioned. It is `spec_citation` (coding codon exception):

- **Member 2** (`insTTT` vs `399_401T[6]`): mutalyzer's `T[6]` is **invalid HGVS** — a length-1 repeat unit in coding `c.` is forbidden (DNA `repeated.md` L21-24 marks `c.…A[10]`/`c.…TA[6]` `class="invalid"`; repeat notation in c. requires unit length ÷ 3). ferro emits the spec-mandated literal `401_402insTTT` — the spec-correct value. (Same class as the existing `c.6C[4]`/`c.3GC[5]` rows.)
- **Member 1** (`274+20C>T` vs mutalyzer's reference-corrected `294C>T`): the prepared manifest carries only a degenerate single-exon supplemental `NM_003002.2`, so ferro cannot reproduce mutalyzer's `ICORRECTEDPOINT` correction (which uses the real exon structure). ferro emits valid, un-corrected HGVS. Reference-version provisioning is tracked by #672.

Neither member emits invalid HGVS; the row simply cannot match mutalyzer (its expected member-2 value is itself invalid HGVS). Normalized axis: **6 → 5** undispositioned failures, 0 XPASS. Full hermetic suite (7374 tests) green (mock-pin re-blessed: the row now parses instead of erroring); `clippy -D warnings` + `fmt --check` clean.

## Notes

Stacked on #760 (PR #765 → base branch `fix/issue-760-utr-intronic-genomic`). Will retarget to `main` and rebase once the stack lands.

Closes #759
Refs #654, #326, #692