### PR TITLE
test(conformance): disposition pter/qter-in-c flank payloads; green the normalized axis

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -483,6 +483,17 @@ pub enum RejectionReason {
     /// ferro's rejection is the spec-correct behaviour (#654).
     #[serde(rename = "ferro-policy-654-malformed-input-rejected")]
     MalformedInputRejected654,
+    /// ferro rejects an input that numbers a transcript's 5'/3' flank in `c.`
+    /// (a `pter`/`qter` marker as a coordinate or inside a cross-reference /
+    /// delins payload). A coding/non-coding DNA reference does not contain the
+    /// gene's flanking sequences and "can not be used to describe variants"
+    /// there (HGVS background/refseq.md L45-46), so the flank is not
+    /// `c.`-numberable. mutalyzer leniently extrapolates `pter`/`qter` into the
+    /// genomic flank and resolves the bases; ferro declines, which is the
+    /// spec-correct behaviour (#758, consistent with the `c.pterdel`/`c.qterdel`
+    /// `spec_citation` rows and #537).
+    #[serde(rename = "ferro-policy-758-transcript-flank-not-numberable-in-c")]
+    TranscriptFlankNotNumberableInC758,
 }
 
 impl RejectionReason {
@@ -491,6 +502,9 @@ impl RejectionReason {
         match self {
             RejectionReason::MalformedInputRejected654 => {
                 "ferro-policy-654-malformed-input-rejected"
+            }
+            RejectionReason::TranscriptFlankNotNumberableInC758 => {
+                "ferro-policy-758-transcript-flank-not-numberable-in-c"
             }
         }
     }

--- a/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/baseline-failures/normalized.txt
@@ -1,5 +1,0 @@
-LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter
-LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51
-LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]
-LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]
-LRG_24t1:c.pter_qterdelinspter_qter

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -58,6 +58,12 @@
       "title": "coding_protein_descriptions transcript-set enumeration",
       "spec_section": "background/refseq.md L256, L259, L264",
       "note": "On `coding_protein_descriptions` (expected ⊆ got, version- and gene-suffix-insensitive) ferro enumerates the latest curated version of every transcript cdot reports overlapping the locus (#710: collapse superseded versions, prefer curated NM_/NR_ over predicted XM_/XR_). Mutalyzer instead lists the neighbouring overlapping transcripts and partitions the input gene's own consequence onto its separate `protein_description` field — an info-model choice, not spec-mandated. `background/refseq.md` L256/L259 pose 'which transcript / which reference sequence should one use' as open questions and L264 endorses the latest build, so ferro's complete-current-curated-set enumeration is spec-valid; both representations are correct. Accepted divergence, not a convergence target — tightening would regress the #710 curation and cannot fix the rows anyway (the matcher is version-insensitive). Reference-coverage gaps where cdot lacks a transcript base mutalyzer used are tracked separately in #645."
+    },
+    {
+      "id": "transcript-flank-not-numberable",
+      "title": "Transcript 5'/3' flank not c.-numberable (pter/qter)",
+      "spec_section": "background/refseq.md L45-46",
+      "note": "A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking sequences and can not be used to describe variants there (refseq.md L45-46). pter/qter denote those flanks, so they are not c.-numberable — as a coordinate or inside a cross-reference/delins payload. ferro declines; mutalyzer extrapolates the flank and resolves the bases. ferro's refusal is spec-correct (#758/#537)."
     }
   ],
   "cases": [
@@ -3583,7 +3589,13 @@
       "keywords": [],
       "input": "LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51",
       "normalized": "LRG_24:g.5525_5532delinsGTGGGAATTGT",
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+        "cluster": "transcript-flank-not-numberable",
+        "note": "delins payload `NM_003002.2:c.pter_-51` numbers the 5' transcript flank (pter) in c.; a c. reference can not describe flanking sequence (refseq.md L45-46). ferro rejects (parse error); mutalyzer extrapolates pter into the genomic 5' flank and resolves GTGGGAATTGT. ferro's refusal is spec-correct."
+      }
     },
     {
       "keywords": [],
@@ -3593,28 +3605,52 @@
         "LRG_24:5524:CGGGGCAC:AAAAAAA"
       ],
       "normalized": "LRG_24:g.5525_5532delinsAAAAAAA",
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+        "cluster": "transcript-flank-not-numberable",
+        "note": "delins payload `NM_003002.2:c.*835_qter` numbers the 3' transcript flank (qter) in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer extrapolates qter into the genomic 3' flank and resolves AAAAAAA. ferro's refusal is spec-correct."
+      }
     },
     {
       "keywords": [],
       "input": "LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]",
       "normalized": "LRG_24t1:c.126_133delinsGTGGGAATTGTAAAAAAA",
       "genomic": "LRG_24:g.5525_5532delinsGTGGGAATTGTAAAAAAA",
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+        "cluster": "transcript-flank-not-numberable",
+        "note": "bracketed delins payload references both the 5' (pter) and 3' (qter) transcript flanks in c. (refseq.md L45-46). ferro rejects (cross-reference shape error explicitly lists pter/qter decorations as out of scope); mutalyzer resolves the concatenated flank bases. ferro's refusal is spec-correct."
+      }
     },
     {
       "keywords": [],
       "input": "LRG_24t1:c.pter_qterdelinspter_qter",
       "normalized": "LRG_24t1:c.=",
       "genomic": "LRG_24:g.=",
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+        "cluster": "transcript-flank-not-numberable",
+        "note": "the variant coordinate `c.pter_qter` numbers both transcript flanks in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer treats pter_qter delins pter_qter as a whole-transcript identity (c.=). ferro's refusal is spec-correct."
+      }
     },
     {
       "keywords": [],
       "input": "LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]",
       "normalized": "LRG_24t1:c.*2327_*2328insAAAAAAA",
       "genomic": "LRG_24:g.11486_11487insAAAAAAA",
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+        "cluster": "transcript-flank-not-numberable",
+        "note": "the variant coordinate `c.pter_qter` and the bracketed payload both number transcript flanks (pter/qter) in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer resolves it to a 3'-flank insertion. ferro's refusal is spec-correct."
+      }
     },
     {
       "keywords": [],

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -135,6 +135,20 @@ On `coding_protein_descriptions` (expected ⊆ got, version- and gene-suffix-ins
 | `NG_012337.1(TIMM8B):c.12dupC` | coding_protein_descriptions | accepted_divergence | — | — |
 | `NG_012337.1:g.4812_4813insTAC` | coding_protein_descriptions | accepted_divergence | — | — |
 
+### Transcript 5'/3' flank not c.-numberable (pter/qter)
+
+Spec: `background/refseq.md L45-46`
+
+A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking sequences and can not be used to describe variants there (refseq.md L45-46). pter/qter denote those flanks, so they are not c.-numberable — as a coordinate or inside a cross-reference/delins payload. ferro declines; mutalyzer extrapolates the flank and resolves the bases. ferro's refusal is spec-correct (#758/#537).
+
+| input | axis | disposition | ferro output | tracking |
+|---|---|---|---|---|
+| `LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter` | normalized | accepted_divergence | — | — |
+| `LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.pter_qterdelinspter_qter` | normalized | accepted_divergence | — | — |
+
 ### Ungrouped
 
 | input | axis | disposition | ferro output | tracking |
@@ -214,5 +228,5 @@ On `coding_protein_descriptions` (expected ⊆ got, version- and gene-suffix-ins
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 18 | 21 | 15 | 5 | 9 |
+| normalized | 23 | 21 | 15 | 5 | 9 |
 | protein_description | 0 | 0 | 0 | 0 | 19 |


### PR DESCRIPTION
## Summary

The **last 5** mutalyzer-normalize normalized-axis failures all number a transcript's 5'/3' flank in `c.` — a `pter`/`qter` marker as the variant coordinate or inside a cross-reference / delins payload:

| input | mutalyzer | ferro |
|---|---|---|
| `LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51` | `…delinsGTGGGAATTGT` | declines |
| `LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter` | `…delinsAAAAAAA` | declines |
| `LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]` | `…delinsGTGGGAATTGTAAAAAAA` | declines |
| `LRG_24t1:c.pter_qterdelinspter_qter` | `c.=` | declines |
| `LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]` | `c.*2327_*2328insAAAAAAA` | declines |

## Decision: ferro is spec-correct to refuse

A coding/non-coding DNA reference does **not** contain the gene's 5'/3' flanking sequences and *"can not be used to describe variants"* there — HGVS `background/refseq.md` L45-46:

> 5' and 3' flanking sequences are considered to be **outside the boundaries** of a transcript reference sequence and **can not be used** to describe variants.

`pter`/`qter` denote exactly those flanks, so they are not `c.`-numberable. mutalyzer leniently extrapolates them into the genomic flank and resolves the bases; ferro declines. **Resolving them would make ferro emit non-spec output**, so no resolution code is added — this is consistent with the existing `c.pterdel`/`c.qterdel` `spec_citation` rows and #537 (which delivered the legitimate **g.-axis** path for these). The bracketed-payload row's error message already explicitly lists "pter/qter/cen decorations" as out of scope.

## Changes

- New `RejectionReason::TranscriptFlankNotNumberableInC758` (the `RejectionReason` enum is intentionally closed, so each "ferro-correctly-rejects" claim is a reviewed code change).
- A `transcript-flank-not-numberable` cluster grouping the five rows.
- The five rows dispositioned via the existing `accepted_rejection` disposition (the only one that buckets a non-panic `Err`), each with a spec-cited note.

## Result

**Normalized axis: 5 → 0 undispositioned failures — `axis_normalized` now passes.** This greens the full mutalyzer-normalize normalized axis (the #654 campaign goal). No behavior change (ferro already declined these); full hermetic suite (7374 tests) green, `clippy -D warnings` + `fmt --check` clean.

## Notes

Stacked on #759 (PR #769) → #760 (PR #765). Will retarget to `main` and rebase as the stack lands.

Closes #758
Refs #654, #326, #537