### PR TITLE
feat(normalize): expand r. (RNA) cross-reference insert/delins payloads

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -2011,11 +2011,12 @@ struct CrossReferenceParse {
     start: u64,
     /// One-based end position (equal to `start` for a single-position payload).
     end: u64,
-    /// Whether the positions index the transcript (`c.`/`n.`) rather than a
+    /// Whether the positions index the transcript (`c.`/`n.`/`r.`) rather than a
     /// genomic / absolute frame (`g./m./o.`). When set, a genomic-context
     /// compound accession (`NG_(NM_)`) must be reduced to its transcript before
     /// lookup. `n.` shares the `Direct` *fetch* path with `g./m./o.` (it needs
-    /// no `cds_start` translation), so `kind` alone cannot distinguish it — this
+    /// no `cds_start` translation), and `r.` resolves to `Direct` for a
+    /// non-coding transcript, so `kind` alone cannot distinguish either — this
     /// flag carries that bit.
     transcript_relative: bool,
 }

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1869,6 +1869,13 @@ pub enum InsCoordKind {
     /// translates to transcript coordinates via `cds_start` looked up
     /// from the provider.
     Cds,
+    /// RNA (`r.`): position numbering follows the associated DNA reference —
+    /// CDS-relative (== `c.`) for a coding transcript, transcript-relative
+    /// (== `n.`) for a non-coding one. The coding/non-coding split needs the
+    /// provider, so this is resolved to `Cds`/`Direct` at fetch time in
+    /// `fetch_position_range_bases` via `Transcript::is_coding()`. Produced only
+    /// by `parse_cross_reference` for an `r.` cross-reference payload. #773.
+    Rna,
 }
 
 /// Fetch a 1-based inclusive byte range `[start_1based..=end_1based]`
@@ -1897,6 +1904,26 @@ fn fetch_position_range_bases<P: ReferenceProvider>(
             ),
         });
     }
+
+    // Resolve an `r.` axis to its effective DNA-numbering frame. r. follows the
+    // associated DNA numbering: CDS-relative (== `c.`) for a coding transcript,
+    // transcript-relative (== `n.`) for a non-coding one. Deciding this needs
+    // the provider, so it happens here rather than in `parse_cross_reference`.
+    // We reuse the existing `Cds`/`Direct` arithmetic below so the cross-ref
+    // path cannot drift from `normalize_rna`. No `U->T` step is applied: the
+    // provider stores transcript bases as DNA (T), so fetched bases are already
+    // DNA — translating them would be a no-op (the `g./c./n.` paths splice
+    // provider output directly for the same reason). #773.
+    let kind = match kind {
+        InsCoordKind::Rna => {
+            if provider.get_transcript(accession)?.is_coding() {
+                InsCoordKind::Cds
+            } else {
+                InsCoordKind::Direct
+            }
+        }
+        other => other,
+    };
 
     // Translate CDS → transcript coordinates if needed. The helper only
     // accepts positive CDS positions; UTR-3 (`*N`) and 5' UTR (`-N`) are
@@ -1956,6 +1983,9 @@ fn fetch_position_range_bases<P: ReferenceProvider>(
             })?;
             (tx_start, tx_end)
         }
+        // `Rna` is always resolved to `Cds` or `Direct` by the block above
+        // before this match is reached — this arm is unreachable in practice.
+        InsCoordKind::Rna => unreachable!("Rna kind must be resolved before this match"),
     };
 
     // `provider.get_sequence(id, s, e)` follows the convention used
@@ -1973,7 +2003,9 @@ struct CrossReferenceParse {
     /// `NG_012337.3(NM_012459.2)`), as written before the `:`.
     accession: String,
     /// How the positions are translated when fetching bases (`Cds` translates
-    /// via the foreign transcript's `cds_start`; `Direct` fetches directly).
+    /// via the foreign transcript's `cds_start`; `Direct` fetches directly;
+    /// `Rna` is resolved coding-aware to `Cds`/`Direct` in
+    /// `fetch_position_range_bases` via `Transcript::is_coding()`).
     kind: InsCoordKind,
     /// One-based start position.
     start: u64,
@@ -1995,7 +2027,7 @@ struct CrossReferenceParse {
 /// and the `transcript_relative` flag) on success.
 ///
 /// Two payload forms are accepted:
-///   - **Axis-qualified** (`<ACC>:<axis>.<range>`): supports g./m./o./c./n.
+///   - **Axis-qualified** (`<ACC>:<axis>.<range>`): supports g./m./o./c./n./r.
 ///     axes with simple positive-integer positions or ranges (no offsets,
 ///     no `*N`, no `?`, no `pter`/`qter` markers).
 ///   - **Axis-less native-frame** (`<ACC>:<range>`, #759): the bare positions
@@ -2020,12 +2052,16 @@ struct CrossReferenceParse {
 ///   - `n.`: non-coding transcript; positions are already transcript-
 ///     relative (`Direct`).
 ///
-/// **Deferred axes (`r.`, `p.`):** RNA needs U→T translation on the
-/// fetched bases (the existing `r.→g.` projection has the primitive
-/// but isn't wired here); protein is structurally invalid as a DNA-
-/// insertion payload. Both stay `UnsupportedVariant` for now. If
-/// `parse_reference_location` ever broadens to additional axes, keep
-/// the match arm below in sync.
+/// **`r.` (RNA):** supported — numbering follows the associated DNA frame
+/// (CDS-relative for coding transcripts, transcript-relative for non-coding),
+/// resolved coding-aware in `fetch_position_range_bases` via
+/// `Transcript::is_coding()`. No `U→T` step is needed: the provider stores
+/// transcript bases as DNA. #773.
+///
+/// **Deferred axis (`p.`):** protein is structurally invalid as a DNA-
+/// insertion payload, so it stays `UnsupportedVariant`. If
+/// `parse_reference_location` ever broadens to additional axes, keep the
+/// match arm below in sync.
 fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
     let (acc_part, after_colon) = reference.split_once(':')?;
     if acc_part.is_empty() || after_colon.is_empty() {
@@ -2038,20 +2074,23 @@ fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
     let (kind, transcript_relative, range_str) = if axis_qualified {
         // c. requires CDS translation via the foreign transcript's cds_start;
         // g./m./o./n. are direct position-range fetches on the inner accession.
-        // r. and p. are deferred — see the doc-comment above.
+        // r. is resolved coding-aware in fetch_position_range_bases; p. is
+        // deferred — see the doc-comment above. #773.
         let kind = match bytes[0] {
             b'g' | b'm' | b'o' | b'n' => InsCoordKind::Direct,
             b'c' => InsCoordKind::Cds,
+            b'r' => InsCoordKind::Rna,
             _ => return None,
         };
-        // `c.` and `n.` are transcript-relative (their positions index the
+        // `c.`, `n.`, and `r.` are transcript-relative (their positions index the
         // transcript), so a genomic-context compound payload accession
         // (`NG_(NM_)`) must be reduced to its transcript before lookup.
         // `g./m./o.` are genomic / absolute and fetch on the named accession
         // unchanged. (`n.` shares the `Direct` *fetch* path with `g./m./o.` — it
         // needs no cds_start translation — so the kind alone can't distinguish
-        // it; this flag carries that out.)
-        let transcript_relative = matches!(bytes[0], b'c' | b'n');
+        // it; this flag carries that out. `r.` likewise resolves to `Direct` for
+        // a non-coding transcript, so it relies on the flag too.)
+        let transcript_relative = matches!(bytes[0], b'c' | b'n' | b'r');
         (kind, transcript_relative, &after_colon[2..])
     } else {
         // Axis-less payload `<ACC>:<range>` (#759): the bare positions index the
@@ -2117,10 +2156,9 @@ fn cross_reference_shape_error(reference: &str) -> FerroError {
     FerroError::UnsupportedVariant {
         variant_type: format!(
             "ins[{}] cross-reference shape not yet supported. \
-             Expansion currently covers g./m./o./c./n. axes with simple \
-             positive-integer positions or ranges. Out-of-scope: r. (RNA — needs U->T \
-             translation; see follow-up), p. (protein — structurally \
-             invalid as DNA-insertion payload), offsets (+/-), UTR \
+             Expansion currently covers g./m./o./c./n./r. axes with simple \
+             positive-integer positions or ranges. Out-of-scope: p. (protein — \
+             structurally invalid as DNA-insertion payload), offsets (+/-), UTR \
              markers (*N), unknown markers (?), and pter/qter/cen \
              decorations",
             reference,
@@ -2139,7 +2177,7 @@ fn resolve_cross_reference_bases<P: ReferenceProvider>(
         end,
         transcript_relative,
     } = parse_cross_reference(reference).ok_or_else(|| cross_reference_shape_error(reference))?;
-    // A transcript-relative payload (`c.` or `n.`) indexes the transcript, so a
+    // A transcript-relative payload (`c.`, `n.`, or `r.`) indexes the transcript, so a
     // genomic-context compound accession (`NG_(NM_)`) must be reduced to its
     // transcript (`NM_`/`NR_`) before lookup — otherwise the fetch fails on the
     // compound string (`c.` at the cds_start lookup, `n.` at the sequence
@@ -2270,7 +2308,7 @@ fn append_part_bases<P: ReferenceProvider>(
 ///
 /// - intronic-offset CDS range (`CdsPositionRange`), and
 /// - an out-of-scope cross-reference (`ExternalRef` whose form
-///   `parse_cross_reference` cannot handle — r./p. axes, offsets, UTR
+///   `parse_cross_reference` cannot handle — p. axis, offsets, UTR
 ///   markers, `pter`/`qter`, etc.).
 ///
 /// Both are *shape* deferrals (provider-independent), unlike a resolvable
@@ -2358,11 +2396,11 @@ pub(crate) fn expand_complex_parts<P: ReferenceProvider>(
 ///   - **Intronic-offset / UTR-marker CDS range** (`CdsPositionRange`):
 ///     spec-undefined; error carries the grep tag `"CDS-offset range"`
 ///     and `"follow-up"`.
-///   - **Out-of-scope cross-reference** (r./p. axes, or `pter`/`qter`
+///   - **Out-of-scope cross-reference** (p. axis, or `pter`/`qter`
 ///     decoration, etc.): error carries `"cross-reference"` and
 ///     describes the supported axis set. Simple positive-integer
-///     ranges on g./m./o./c./n. are now expanded (#422) and no
-///     longer surface as errors.
+///     ranges on g./m./o./c./n. (#422) and r. (#773) are now
+///     expanded and no longer surface as errors.
 /// - `Err(FerroError::...)` — genuine provider lookup failure
 ///   (`ReferenceNotFound`, `InvalidCoordinates`, etc.).
 pub fn expand_inserted_sequence<P: ReferenceProvider>(
@@ -4063,6 +4101,59 @@ mod tests {
         let provider = crate::reference::mock::MockProvider::with_test_data();
         let bases = resolve_cross_reference_bases("NM_001234.1:2", &provider)
             .expect("axis-less single-position cross-reference should resolve");
+        assert_eq!(bases, "T");
+    }
+
+    #[test]
+    fn resolve_cross_reference_rna_coding_is_cds_relative() {
+        // r. numbering follows c. (CDS-relative) for a coding transcript, NOT
+        // the transcript/n. frame. NM_001234.1 has cds_start=5 over
+        // "AAAAATGCCCAAG…", so c.2 == transcript pos 6 == "T", while n.2 ==
+        // transcript pos 2 == "A". r.2 must equal c.2 ("T"), not n.2 ("A"). #773.
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let r = resolve_cross_reference_bases("NM_001234.1:r.2", &provider)
+            .expect("coding r. cross-reference should resolve");
+        let c = resolve_cross_reference_bases("NM_001234.1:c.2", &provider)
+            .expect("c.2 should resolve");
+        let n = resolve_cross_reference_bases("NM_001234.1:n.2", &provider)
+            .expect("n.2 should resolve");
+        assert_eq!(r, "T");
+        assert_eq!(r, c, "coding r.N must match c.N");
+        assert_ne!(r, n, "coding r.N must differ from n.N (off by 5'UTR)");
+    }
+
+    #[test]
+    fn resolve_cross_reference_rna_coding_range_is_cds_relative() {
+        // r.1_3 == c.1_3 == transcript pos 5..7 == "ATG" (cds_start=5), not
+        // n.1_3 == "AAA".
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let r = resolve_cross_reference_bases("NM_001234.1:r.1_3", &provider)
+            .expect("coding r. range should resolve");
+        assert_eq!(r, "ATG");
+    }
+
+    #[test]
+    fn resolve_cross_reference_rna_noncoding_is_transcript_relative() {
+        // A non-coding transcript has no CDS, so r. is transcript-relative
+        // (== n.). NR_000123.1 is "ACGTACGTACGT", so r.2 == n.2 == "C" and
+        // r.1_4 == "ACGT". #773.
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let single = resolve_cross_reference_bases("NR_000123.1:r.2", &provider)
+            .expect("non-coding r. cross-reference should resolve");
+        assert_eq!(single, "C");
+        let range = resolve_cross_reference_bases("NR_000123.1:r.1_4", &provider)
+            .expect("non-coding r. range should resolve");
+        assert_eq!(range, "ACGT");
+    }
+
+    #[test]
+    fn resolve_cross_reference_rna_reduces_genomic_context_compound() {
+        // A genomic-context compound payload addressed in r. must reduce to its
+        // transcript before lookup (r. is transcript/CDS-relative). The inner
+        // NM_001234.1 has cds_start=5, so r.2 == c.2 == "T". #773.
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let bases = resolve_cross_reference_bases("NG_999999.9(NM_001234.1):r.2", &provider)
+            .expect("genomic-context compound r. cross-reference should resolve");
         assert_eq!(bases, "T");
     }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -264,6 +264,29 @@ impl MockProvider {
             cached_introns: OnceLock::new(),
         });
 
+        // Add a non-coding transcript (NR_) for r.-axis cross-reference tests.
+        // With no CDS, r. numbering is transcript-relative (== n.); positions
+        // map directly to transcript bases (#773).
+        provider.add_transcript(Transcript {
+            id: "NR_000123.1".to_string(),
+            gene_symbol: Some("NONCODING".to_string()),
+            strand: Strand::Plus,
+            sequence: Some("ACGTACGTACGT".to_string()),
+            cds_start: None,
+            cds_end: None,
+            exons: vec![Exon::new(1, 1, 12)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::None,
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+
         // Add test protein sequences for validation testing
         // NP_000079.2 is used for BRAF V600E-style testing
         // We need Val at position 600, Arg at 97 for frameshift tests
@@ -624,6 +647,16 @@ mod tests {
         let provider = MockProvider::with_test_data();
         let result = provider.get_transcript("NM_NONEXISTENT.1");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn with_test_data_includes_a_noncoding_transcript() {
+        let provider = MockProvider::with_test_data();
+        let tx = provider
+            .get_transcript("NR_000123.1")
+            .expect("NR_000123.1 should be present in test data");
+        assert!(!tx.is_coding(), "NR_ transcript must be non-coding");
+        assert_eq!(tx.sequence.as_deref(), Some("ACGTACGTACGT"));
     }
 
     #[test]

--- a/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
@@ -210,7 +210,7 @@ NM_003002.2:c.pterdel	NM_003002.2:c.pterdel
 NM_003002.2:c.qterdel	NM_003002.2:c.qterdel
 LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.pter_-51'
 LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.*835_qter'
-LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n. axes with simple positive-integer positions or ranges. Out-of-scope: r. (RNA — needs U->T translation; see follow-up), p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations
+LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n./r. axes with simple positive-integer positions or ranges. Out-of-scope: p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations
 LRG_24t1:c.pter_qterdelinspter_qter	parse error: Parse error at position 26: Unexpected trailing characters: 'pter_qter'
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]	parse error: Parse error at position 23: Unexpected trailing characters: 'ins[pter_qter;NM_003002.2:c.*835_qter]'
 NG_012337.1(NM_003002.2):c.[274=;275del]	NG_012337.1(NM_003002.2):c.[274=;275del]

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -237,6 +237,38 @@ fn rna_cross_reference_expands_to_literal() {
     );
 }
 
+#[test]
+fn rna_cross_reference_coding_expands_cds_relative() {
+    let mut p = MockProvider::with_test_data();
+    p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
+    // NM_001234.1 is coding (cds_start=5 over "AAAAATGCCCAAG…"), so r. is
+    // CDS-relative: r.1_3 == c.1_3 == "ATG" (NOT n.1_3 == "AAA"). After
+    // expansion the normalizer suffix-trims the trailing "G" that matches the
+    // reference base at g.15, collapsing "ATG" → "AT" and the outer range from
+    // g.10_15 → g.10_14. If r. had been resolved transcript-relative the
+    // inserted bases would have been "AAA", which shares no suffix with the ref
+    // run "CGTACG" and would produce g.10_15delinsAAA — distinct from g.10_14.
+    // Asserting the g.10_14 outcome therefore proves CDS-relative r. numbering
+    // end to end. #773.
+    let out = normalize("NC_000022.10:g.10_15delins[NM_001234.1:r.1_3]", p)
+        .expect("coding r.-axis cross-reference must expand");
+    assert!(
+        !out.contains("[NM_"),
+        "r. cross-reference must be flattened; got {out}"
+    );
+    assert!(
+        !out.contains("AAA"),
+        "transcript-relative AAA must not appear in output; got {out}",
+    );
+    // The normalizer suffix-trims "ATG" to "AT" (trailing G matches ref).
+    // Presence of "g.10_14" in the output confirms CDS-relative expansion
+    // succeeded (transcript-relative "AAA" would produce "g.10_15").
+    assert!(
+        out.contains("g.10_14"),
+        "CDS-relative r.1_3 (ATG) must normalize to g.10_14 range; got {out}",
+    );
+}
+
 // =============================================================================
 // Out-of-scope axis: p. (protein) — structurally invalid as DNA payload
 // =============================================================================

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -219,26 +219,21 @@ fn mito_cross_reference_expands_to_literal() {
 }
 
 // =============================================================================
-// Out-of-scope axis: r. (RNA) — should defer with a clear message
+// r. (RNA) cross-reference now expands (coding-aware, transcript-relative for
+// non-coding). #773.
 // =============================================================================
 
 #[test]
-fn rna_cross_reference_continues_to_defer() {
-    let mut p = MockProvider::new();
+fn rna_cross_reference_expands_to_literal() {
+    let mut p = MockProvider::with_test_data();
     p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
-    // Inner is r. axis — needs U->T translation; deferred until that's
-    // wired through the cross-reference path.
-    let result = normalize("NC_000022.10:g.10_15delins[NR_001234.1:r.10_15]", p);
+    // NR_000123.1 is non-coding ("ACGTACGTACGT"), so r. is transcript-relative:
+    // r.1_4 == n.1_4 == "ACGT". The delins payload must flatten to that literal.
+    let out = normalize("NC_000022.10:g.10_15delins[NR_000123.1:r.1_4]", p)
+        .expect("r.-axis cross-reference must expand");
     assert!(
-        result.is_err(),
-        "r.-axis cross-reference must defer; got Ok({:?})",
-        result.ok(),
-    );
-    let err = result.unwrap_err();
-    let msg = format!("{}", err);
-    assert!(
-        msg.contains("cross-reference"),
-        "deferral message must mention 'cross-reference'; got {msg}",
+        !out.contains("[NR_"),
+        "r. cross-reference must be flattened; got {out}",
     );
 }
 
@@ -293,10 +288,10 @@ fn unsupported_cross_reference_after_repeat_part_still_defers() {
     let mut p = MockProvider::new();
     p.add_genomic_sequence("NC_000022.10", "ACGT".repeat(50));
     // `N[2800]` is a non-flattenable Repeat part; the trailing
-    // `NR_001234.1:r.10_15` is an out-of-scope r.-axis cross-reference.
-    // The r.-axis member must still surface an error regardless of its
-    // position after the Repeat.
-    let result = normalize("NC_000022.10:g.5_6ins[N[2800];NR_001234.1:r.10_15]", p);
+    // `NP_000079.2:p.10_15` is an out-of-scope p.-axis cross-reference
+    // (structurally invalid as a DNA payload). The p.-axis member must still
+    // surface an error regardless of its position after the Repeat.
+    let result = normalize("NC_000022.10:g.5_6ins[N[2800];NP_000079.2:p.10_15]", p);
     assert!(
         result.is_err(),
         "unsupported cross-reference after a Repeat part must defer; got Ok({:?})",


### PR DESCRIPTION
## Summary

Expands `r.` (RNA) cross-reference insert/delins payloads — `…ins<ACC>:r.<a>_<b>` / `…delins<ACC>:r.<a>_<b>` — into their literal DNA inserted sequence, the follow-up to the deferral noted for `…ins<ACC>:r.…` in `cross_reference_shape_error`. Expansion previously covered the `g./m./o./c./n.` axes (#692, #756, #759); `r.` was rejected as out-of-scope.

`r.` numbering is resolved **coding-aware**: CDS-relative (== `c.`) for coding transcripts, transcript-relative (== `n.`) for non-coding ones. A new `InsCoordKind::Rna` is produced only by `parse_cross_reference` and resolved to the existing `Cds`/`Direct` arithmetic at fetch time in `fetch_position_range_bases` via `Transcript::is_coding()` (requires both `cds_start` and `cds_end`). Because the cross-reference parser admits only simple positive integers, this reuses the existing coordinate math exactly, so the cross-reference path cannot drift from the rest of ferro's `r.` semantics (`rna_to_tx_pos` / `rna_pos_to_txpos`). Compound `NG_(NM_):r.N` payloads reduce to the transcript before lookup, like `c.`/`n.`.

## Two deliberate divergences from the issue text

The issue proposed treating `r.N` as a direct transcript-frame fetch plus a `U→T` translation. Both turned out to be wrong on closer analysis:

1. **`r.` is CDS-relative for coding transcripts, not transcript-relative.** HGVS numbers `r.` after the associated DNA reference — `c.` numbering for coding transcripts, `n.` only for non-coding. ferro's own model agrees: `RnaPos` is modeled identically to `CdsPos`, and `rna_to_tx_pos` maps positive `r.N` to `cds_start + N - 1`. So `NM_…:r.76` == `c.76`, not transcript base 76 — they differ by the 5'UTR length. Treating `r.` as the `n.` frame would have read the wrong bases for every coding transcript. This PR resolves coding-vs-non-coding at fetch time instead.

2. **No `U→T` step.** Providers store transcript bases as DNA (`T`), so a `U→T` map on fetched bases is a no-op; adding it only on the `r.` path would also falsely imply provider output differs by axis (the `g./c./n.` paths splice provider output directly). The real correctness fix is the coding-aware numbering above, not base translation. `rna_uracil_to_thymine` is retained for its actual job — rewriting user-typed literal `U` in parsed edits.

## Out of scope (unchanged)

`p.` (protein) stays unsupported (structurally invalid as a DNA-insertion payload). Offsets (`+/-`), `*N`, `?`, and `pter/qter` decorations on `r.` still defer via the cross-reference parser's existing digit-only guard.

## Tests

- Unit: coding `NM_001234.1:r.2` resolves identically to `c.2` ("T") and differs from `n.2` ("A") — the off-by-5'UTR check; plus a coding range, a non-coding `NR_000123.1` single/range (== `n.`), and a compound `NG_(NM_):r.N` reduction.
- End-to-end: a coding `delins NM_…:r.1_3` expands CDS-relative through the full normalizer (`g.10_14` discriminator after suffix-trimming, vs `g.10_15` for the transcript-relative interpretation).
- Added a non-coding `NR_` transcript to the mock provider (none existed); rewrote the prior "r. defers" integration test to a positive expansion test; repointed the order-independence test to a still-unsupported `p.` payload; re-blessed the mutalyzer-normalize mock-pin snapshot (only the out-of-scope message string changed).

All tests pass; clippy/fmt clean; the generated spec fixture is up to date.

Closes #773

Refs #759, #692, #654, #326
