### PR TITLE
fix(project): let an init-codon p.? dominate a compound allele

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1654,9 +1654,36 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let noncoding = noncoding_variants
             .map(|variants| HgvsVariant::Allele(AlleleVariant::new(variants, allele.phase)));
 
+        // An initiation-codon-affecting member yields a whole-protein "unknown"
+        // (`p.?`) consequence (see `build_whole_protein_unknown`, #772/#771). When
+        // any member disrupts the start codon, that uncertainty dominates the whole
+        // allele: with the reading frame's start in question, the remaining members'
+        // individual consequences are moot. Report the single `p.?` for the compound
+        // — matching mutalyzer and the spec's "an effect is expected but cannot be
+        // reliably predicted" guidance (recommendations/uncertain.md). This must
+        // precede the all-or-nothing rule below: a downstream member on a non-AUG
+        // transcript declines protein (`None`) under the #625 guard and would
+        // otherwise sink the whole allele to `None`.
+        let whole_protein_unknown = inner_projections.iter().find_map(|p| match &p.protein {
+            Some(prot @ HgvsVariant::Protein(pv))
+                if matches!(
+                    pv.loc_edit.edit.inner(),
+                    Some(crate::hgvs::edit::ProteinEdit::Unknown {
+                        whole_protein: true,
+                        ..
+                    })
+                ) =>
+            {
+                Some(prot.clone())
+            }
+            _ => None,
+        });
+
         // Build the protein allele only if ALL inner projections have a protein.
         let all_have_protein = inner_projections.iter().all(|p| p.protein.is_some());
-        let protein = if all_have_protein {
+        let protein = if let Some(unknown) = whole_protein_unknown {
+            Some(unknown)
+        } else if all_have_protein {
             let protein_variants: Vec<HgvsVariant> = inner_projections
                 .iter()
                 .filter_map(|p| p.protein.clone())
@@ -7437,6 +7464,51 @@ mod tests {
             proj.protein.is_none(),
             "non-initiation variant on a non-ATG transcript must decline (#625)"
         );
+    }
+
+    #[test]
+    fn project_nonaug_compound_with_init_member_reports_unknown_protein() {
+        use crate::hgvs::edit::{Base, NaEdit};
+        use crate::hgvs::variant::{AlleleVariant, CdsVariant, LocEdit};
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // A cis compound on the non-AUG transcript NM_NOATG.1: the first member
+        // disrupts the initiation codon (c.1C>G → p.?), the second is a downstream
+        // substitution (c.4C>A) that individually declines under the #625 guard
+        // (no protein). The initiation-codon uncertainty must dominate: with the
+        // start in question, downstream consequences are moot, so the whole
+        // compound reports a single p.? rather than declining because one member
+        // has no protein.
+        let init = HgvsVariant::Cds(CdsVariant {
+            accession: parse_accession("NM_NOATG.1"),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(1)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::G,
+                },
+            ),
+        });
+        let downstream = HgvsVariant::Cds(CdsVariant {
+            accession: parse_accession("NM_NOATG.1"),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(4)),
+                NaEdit::Substitution {
+                    reference: Base::C,
+                    alternative: Base::A,
+                },
+            ),
+        });
+        let allele = HgvsVariant::Allele(AlleleVariant::cis(vec![init, downstream]));
+        let proj = vp
+            .project_variant(&allele, "NM_NOATG.1")
+            .expect("projection should succeed");
+        let protein = proj
+            .protein
+            .expect("an init-codon member must make the compound report p.?");
+        assert_eq!(format!("{protein}"), "NP_NOATG.1:p.?");
     }
 
     #[test]

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -1562,7 +1562,13 @@
       ],
       "input": "NM_024426.4:c.1_4delinsATGA",
       "protein_description": "NM_024426.4(NP_077744.3):p.?",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro reports this initiation-codon-disrupting compound — c.1_4delinsATGA, which normalizes to the cis pair c.[1C>A;4C>A] — on this non-AUG-initiation transcript as the spec-correct whole-protein unknown p.?: the init-codon member's uncertainty dominates the allele, so the whole compound is p.? rather than declining because the downstream member individually has no protein (#771). The only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -56,6 +56,7 @@ A p. description references the protein accession alone (NP_); mutalyzer's genom
 | `NM_003002.4:c.206_210delins190_220inv` | protein_description | spec_citation | — | — |
 | `NM_024426.4:c.1C>A` | protein_description | spec_citation | — | — |
 | `NM_024426.4:c.1C>G` | protein_description | spec_citation | — | — |
+| `NM_024426.4:c.1_4delinsATGA` | protein_description | spec_citation | — | — |
 
 ### Protein initiation codon → p.(Met1?)
 
@@ -231,4 +232,4 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | normalized | 23 | 21 | 15 | 5 | 9 |
-| protein_description | 0 | 0 | 0 | 0 | 21 |
+| protein_description | 0 | 0 | 0 | 0 | 22 |


### PR DESCRIPTION
## Summary

A compound (in-cis) allele declined its **protein** consequence when one member disrupts the initiation codon and another member individually has no protein. On a non-AUG-initiation transcript that combination is common, so a real variant like `NM_024426.4:c.1_4delinsATGA` (WT1, `CTG` start) reported no protein where the spec and mutalyzer give `p.?`.

`c.1_4delinsATGA` normalizes to the cis pair `c.[1C>A;4C>A]`: member `c.1C>A` disrupts the start codon → whole-protein `p.?` (#771), member `c.4C>A` is a downstream substitution that individually declines under the non-AUG `#625` guard. `project_allele_inner` built the compound protein only when **every** member had a protein, so the declining downstream member sank the whole allele to `None`.

## Fix

In `project_allele_inner`, when any member's protein is a whole-protein `Unknown` (`p.?`), report that single `p.?` for the compound — *before* the all-or-nothing rule. Once the start codon is in question the downstream members' individual consequences are moot, so the entire protein is unknown. This mirrors the single-substitution behavior (`c.1C>A` → `p.?`) and the spec's "effect expected but not reliably predictable" guidance (`recommendations/uncertain.md`).

## Validation

- New projector unit test `project_nonaug_compound_with_init_member_reports_unknown_protein` (cis `c.1C>G` + `c.4C>A` on the `NM_NOATG.1` non-AUG mock → `NP_NOATG.1:p.?`).
- CLI on the real reference: `NM_024426.4:c.1_4delinsATGA`, `c.[1C>A;4C>A]`, and the `NG_009299.1(NM_024426.4)` form all now yield `NP_077744.3:p.?`.
- Conformance (manifest): protein_description axis FAIL set 50 → 49, the case moves to **spec_overridden** (bare-NP cluster, matching its siblings); empty-projection count drops 6 → 5 (a quality improvement). Disposition added to `cases.json` and `failure-patterns.md` regenerated.
- `cargo clippy --features dev --all-targets` clean; manifest-less suite green.

Closes #781