### PR TITLE
feat(project): resolve legacy GENE_vNNN selectors on NG_(...):c./n./r. projection

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -503,7 +503,40 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // construction time so we don't clone the (potentially heavy) provider
         // on every call.
         let normalized = self.normalizer.normalize(variant)?;
-        self.project_variant_inner(&normalized, transcript_id)
+        // 2. Reconcile the requested target against any selector resolution that
+        // normalization performed (#783). A legacy LOVD gene-model selector
+        // `NG_(GENE_v001):c.` keeps the genomic ref as its accession, so a
+        // self-projection caller (the CLI, the conformance harness) derives the
+        // target from `transcript_accession()` and gets the genomic ref, not a
+        // transcript. Normalization resolves the selector to `NG_(NM_):c.` (#637),
+        // so the requested target now names the variant's genomic-context wrapper
+        // rather than its transcript — re-point it at the resolved transcript.
+        let target = Self::reconcile_self_projection_target(&normalized, transcript_id);
+        self.project_variant_inner(&normalized, &target)
+    }
+
+    /// Reconcile a self-projection target with a selector/context that
+    /// normalization may have rewritten (#783).
+    ///
+    /// Returns the variant's own (resolved) transcript accession when the
+    /// requested target names this variant's genomic-context wrapper rather than
+    /// its transcript — i.e. the caller asked to project a transcript-coordinate
+    /// variant "against itself" but derived the target from an accession whose
+    /// transcript slot was a genomic ref (an unresolved legacy gene-model
+    /// selector, now resolved). Otherwise returns the requested target unchanged,
+    /// so a genuine transcript_id mismatch (an unrelated target) still errors.
+    fn reconcile_self_projection_target(normalized: &HgvsVariant, requested: &str) -> String {
+        if let Some(acc) = normalized.accession() {
+            let resolved_tx = acc.transcript_accession();
+            if resolved_tx != requested {
+                if let Some(ctx) = &acc.genomic_context {
+                    if ctx.full() == requested {
+                        return resolved_tx;
+                    }
+                }
+            }
+        }
+        requested.to_string()
     }
 
     /// Project an already-normalized g. variant onto a transcript, skipping the
@@ -520,7 +553,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
         self.warn_assembly_conflict(variant);
-        self.project_variant_inner(variant, transcript_id)
+        // Reconcile the requested target against any selector resolution carried
+        // by the (already-normalized) variant, mirroring `project_variant` (#783).
+        // A caller that pre-normalizes a legacy `NG_(GENE_v001):c.` once and then
+        // projects against the raw-derived `NG_900.1` target would otherwise name
+        // the genomic-context wrapper rather than the resolved transcript and trip
+        // the mismatch guard. Reconciliation is a no-op for a genuine transcript
+        // target, so this keeps the two public entry points behaving identically.
+        let target = Self::reconcile_self_projection_target(variant, transcript_id);
+        self.project_variant_inner(variant, &target)
     }
 
     /// Parse, normalize, and project an HGVS string onto the *curated* set of
@@ -3552,6 +3593,52 @@ mod tests {
         let proj = vp
             .project("NG_900.1(GENE1_v001):c.4C>A", "NM_TX2.1")
             .expect("legacy gene-model selector must resolve and project, not error on NG_");
+        let coding = proj
+            .coding
+            .as_ref()
+            .expect("coding axis present")
+            .to_string();
+        assert!(
+            coding.contains("NM_TX2.1"),
+            "the GENE1_v001 selector must resolve to the transcript: {coding}"
+        );
+    }
+
+    #[test]
+    fn legacy_gene_model_selector_projects_against_self_derived_target() {
+        // Realistic CLI / conformance-harness path (#783): the projection target
+        // is derived from the *raw* input accession via `transcript_accession()`.
+        // For an `NG_(GENE_v001)` legacy selector the transcript slot is the
+        // genomic ref itself (`NG_900.1`), not a transcript — unlike `NG_(NM_)`,
+        // whose `transcript_accession()` already returns the inner `NM_`.
+        // Normalization resolves the selector to `NM_TX2.1` (#637); without
+        // reconciling the target against the resolved transcript, this
+        // self-projection tripped the transcript_id-mismatch guard.
+        let (projector, mut provider) = make_nc_two_transcript_setup();
+        provider.add_genomic_placement(
+            "NG_900.1",
+            crate::reference::GenomicPlacement {
+                nc: Accession::new("NC", "000001", Some(11)),
+                parent_start: 1,
+                nc_start: 1000,
+                nc_end: 1008,
+                strand: crate::reference::Strand::Plus,
+            },
+        );
+        provider.add_legacy_gene_model("GENE1", "NM_TX2.1");
+        let vp = VariantProjector::new(projector, provider);
+
+        let variant = crate::parse_hgvs("NG_900.1(GENE1_v001):c.4C>A").unwrap();
+        // Derive the target exactly as the CLI and conformance harness do.
+        let target = variant.accession().unwrap().transcript_accession();
+        assert_eq!(
+            target, "NG_900.1",
+            "the raw LOVD selector form's transcript slot is the genomic ref"
+        );
+
+        let proj = vp
+            .project_variant(&variant, &target)
+            .expect("self-projection of a legacy selector must resolve, not mismatch");
         let coding = proj
             .coding
             .as_ref()
@@ -8463,6 +8550,26 @@ mod tests {
         let err = vp
             .project_normalized(&variant, "NM_OTHER.1")
             .expect_err("transcript_id mismatch must be rejected");
+        assert!(
+            matches!(err, FerroError::UnsupportedProjection { .. }),
+            "transcript_id mismatch should be UnsupportedProjection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn project_variant_unrelated_transcript_id_mismatch_is_rejected() {
+        let (projector, provider) = make_test_provider_and_projector();
+        let vp = VariantProjector::new(projector, provider);
+        // A bare `c.` input on NM_TEST.1 projected against an unrelated transcript
+        // must still error, exercising `reconcile_self_projection_target`'s
+        // fallthrough on the `project_variant` path: the variant carries no
+        // genomic_context, so reconciliation returns the requested target
+        // unchanged and the `project_coding_direct` guard rejects the genuine
+        // mismatch (#783).
+        let variant = make_coding_variant("NM_TEST.1", None);
+        let err = vp
+            .project_variant(&variant, "NM_NOATG.1")
+            .expect_err("unrelated transcript_id mismatch must be rejected");
         assert!(
             matches!(err, FerroError::UnsupportedProjection { .. }),
             "transcript_id mismatch should be UnsupportedProjection, got {err:?}"

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -455,7 +455,13 @@
       "input": "NG_012772.1(BRCA2_v001):c.632_681del",
       "normalized": "NG_012772.1(NM_000059.3):c.632_681del",
       "protein_description": "NG_012772.1(NP_000050.2):p.(Val211GlufsTer10)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -486,7 +492,13 @@
       "normalized": "NG_012772.1(NM_000059.3):c.622_674del",
       "genomic": "NG_012772.1:g.16125_19006del",
       "protein_description": "NG_012772.1(NP_000050.2):p.(Val208TyrfsTer3)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -507,7 +519,13 @@
       "normalized": "NG_012772.1(NM_000059.3):c.622_672del",
       "genomic": "NG_012772.1:g.16125_19004del",
       "protein_description": "NG_012772.1(NP_000050.2):p.(Val208_Asp224del)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -840,7 +858,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_157insGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5208insGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Gln52_Arg53insValLeuCysSerLeuSerGly)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -852,7 +876,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_157insGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5208insGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Gln52_Arg53insValLeuCysSerLeuSerGly)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -863,7 +893,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_157insGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5208insGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Gln52_Arg53insValLeuCysSerLeuSerGly)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -1155,7 +1191,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_161delinsGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53_Arg54delinsSerCysAlaHisTyrLeuAla)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -1167,7 +1209,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_161delinsGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53_Arg54delinsSerCysAlaHisTyrLeuAla)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [
@@ -1178,7 +1226,13 @@
       "normalized": "NG_008939.1(NM_000532.5):c.156_161delinsGTCCTGTGCTCATTATCTGGC",
       "genomic": "NG_008939.1:g.5207_5212delinsGTCCTGTGCTCATTATCTGGC",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53_Arg54delinsSerCysAlaHisTyrLeuAla)",
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "protein_description",
+        "section": "HGVS protein reference (bare NP)",
+        "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
+        "cluster": "bare-np-protein"
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -47,6 +47,15 @@ A p. description references the protein accession alone (NP_); mutalyzer's genom
 | `NG_007485.1(NM_000077.4):c.161_163del` | protein_description | spec_citation | — | — |
 | `NG_007485.1(NM_058195.3):c.141_142del` | protein_description | spec_citation | — | — |
 | `NG_008835.1(NM_022153.2):c.568del` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_157insGTCCTGTGCTCATTATCTGGC` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_157ins[GTCCTGTGCTC;ATTATCTGGC]` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_157ins[GTCCTGTGCTCATTATCTGGC]` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delinsGTCCTGTGCTCATTATCTGGC` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[GTCCTGTGCT;CATTATCTGGC]` | protein_description | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[GTCCTGTGCTCATTATCTGGC]` | protein_description | spec_citation | — | — |
+| `NG_012772.1(BRCA2_v001):c.622_672del` | protein_description | spec_citation | — | — |
+| `NG_012772.1(BRCA2_v001):c.622_674del` | protein_description | spec_citation | — | — |
+| `NG_012772.1(BRCA2_v001):c.632_681del` | protein_description | spec_citation | — | — |
 | `NM_000143.3:c.1531T>G` | protein_description | spec_citation | — | — |
 | `NM_000193.2:c.108_109del2insG` | protein_description | spec_citation | — | — |
 | `NM_001199.3:c.2188dup` | protein_description | spec_citation | — | — |
@@ -232,4 +241,4 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | normalized | 23 | 21 | 15 | 5 | 9 |
-| protein_description | 0 | 0 | 0 | 0 | 22 |
+| protein_description | 0 | 0 | 0 | 0 | 31 |


### PR DESCRIPTION
## Summary

A coding-coordinate variant whose transcript is a legacy LOVD gene-model selector inside a genomic context — `NG_012772.1(BRCA2_v001):c.632_681del` — failed to project on **every** axis with a `transcript_id mismatch` error, even though ferro resolves the selector to the correct RefSeq transcript. #637 fixed this for genomic-*coordinate* inputs; this is the sibling fix for `c.`/`n.`/`r.` coordinate inputs.

```
# before
ferro project --axis p ... 'NG_012772.1(BRCA2_v001):c.632_681del'
#  -> unavailable: transcript_id mismatch: input is on NM_000059.3 but projection requested against NG_012772.1
# after
#  -> NP_000050.2:p.(Val211GlufsTer10)        # the corpus oracle's consequence
```

## Root cause & fix

Normalization rewrites `NG_(GENE_v001):c.` → `NG_(NM_):c.` (#637/#500), but a self-projection caller (the CLI, the conformance harness) derives the projection target from the *un-resolved* input accession via `transcript_accession()` — which for the selector form is the genomic ref itself (`NG_`), not a transcript (unlike `NG_(NM_)`, whose `transcript_accession()` already returns the inner `NM_`). The post-normalization input (`NM_`) then mismatched that target.

`project_variant` now reconciles the target after normalization: when the requested target names the variant's genomic-context wrapper rather than its transcript, it projects against the variant's own resolved transcript — the caller's self-projection intent. A genuinely unrelated target still errors (the mismatch guard and its test are unchanged).

## Validation

- New unit test `legacy_gene_model_selector_projects_against_self_derived_target` exercises the realistic path (target derived from the raw accession, as the CLI/harness do); the pre-existing `projector_rejects_transcript_id_mismatch_for_cds_input` guard test still passes.
- Conformance (manifest): **9 protein_description FAILs → spec_overridden** (50 → 41 FAIL). BRCA2_v001 (×3) and PCCB_v001 (×6) now produce the exact oracle consequence; the only delta is the bare-NP vs `NM_x(NP_y)` rendering, dispositioned under the existing `bare-np-protein` cluster.
- The remaining LOVD rows stay FAIL on **independent, now-visible** divergences my change surfaces (TIMM8B_v001 protein-version drift #505; PCCB range-reference insertions; BRCA2 uncertain-endpoint declines) — out of scope here.
- `cargo clippy --features dev --all-targets` clean; full manifest-less suite (7408 tests) green.

Closes #783