### PR TITLE
fix: decline silent transcript version substitution in normalization and projection

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -494,6 +494,21 @@ pub enum RejectionReason {
     /// `spec_citation` rows and #537).
     #[serde(rename = "ferro-policy-758-transcript-flank-not-numberable-in-c")]
     TranscriptFlankNotNumberableInC758,
+    /// ferro rejects a c./n./r. input that names an explicit `accession.version`
+    /// the prepared manifest does not carry, where a lenient provider would
+    /// silently fall back to a *sibling* version and normalize against its
+    /// frame/sequence. A c./r. description is defined only against its named
+    /// version (versions differ in length/CDS offset, background/refseq.md), so
+    /// substituting a sibling's frame yields a result whose stated reference and
+    /// coordinate frame disagree. ferro declines with `TranscriptVersionNotExact`
+    /// rather than substitute; mutalyzer (which carries the pinned version)
+    /// normalizes it. ferro's decline is the spec-correct behaviour — a clean
+    /// reference-unavailable miss rather than a confidently-wrong substitution
+    /// (#785). Distinct from the `accession-version-absent` *no-op* disposition,
+    /// which covers an absent version with no sibling to substitute (ferro echoes
+    /// the input); here a sibling exists and the silent substitution is refused.
+    #[serde(rename = "ferro-policy-785-version-substitution-refused")]
+    VersionSubstitutionRefused785,
 }
 
 impl RejectionReason {
@@ -505,6 +520,9 @@ impl RejectionReason {
             }
             RejectionReason::TranscriptFlankNotNumberableInC758 => {
                 "ferro-policy-758-transcript-flank-not-numberable-in-c"
+            }
+            RejectionReason::VersionSubstitutionRefused785 => {
+                "ferro-policy-785-version-substitution-refused"
             }
         }
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1221,6 +1221,58 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Ok(NormalizeResult::with_diagnostics(result, warnings, infos))
     }
 
+    /// The requested transcript accession a transcript-coordinate variant would
+    /// be SILENTLY SUBSTITUTED for, if any — the #785 trigger.
+    ///
+    /// Returns `Some(requested_id)` only when ALL of the following hold:
+    /// - the variant is a transcript-coordinate axis (`c.`/`n.`/`r.`);
+    /// - the caller named an EXPLICIT version (bare references intentionally
+    ///   keep lenient "latest version" resolution and are not gated; LRG
+    ///   accessions never carry a version, so they are likewise unaffected);
+    /// - the named accession is a transcript ([`is_transcript_accession`], so a
+    ///   genomic/gene wrapper like an unrewritten `NG_(GENE):c.…` selector is
+    ///   not mistaken for a versioned transcript);
+    /// - the provider would NOT serve the bases of that exact version
+    ///   ([`ReferenceProvider::has_transcript_version_exact`] is false); and
+    /// - the provider nonetheless resolves the request — i.e. a sibling version
+    ///   is actually substituted.
+    ///
+    /// The version-exact predicate is the load-bearing signal: it answers "do
+    /// the bases the read path would serve correspond to the exact requested
+    /// version?" and so catches BOTH substitution paths — a FASTA version-strip
+    /// fallback (which serves the sibling's accession) AND a cdot-genome
+    /// reconstruction off a sibling record (which serves the *requested*
+    /// accession with the sibling's frame). A naive "served accession differs"
+    /// check would miss the latter. The `get_transcript(...).is_ok()` guard then
+    /// distinguishes a genuine substitution (a sibling is served) from a
+    /// transcript that is simply absent with no sibling to fall back to — the
+    /// latter is left to the existing missing-transcript handling (echoed
+    /// unchanged) rather than gated. The genomic-context wrapper is stripped, so
+    /// a compound `NC_…(NM_….3):c.…` is gated on its inner `NM_….3`.
+    fn silently_substituted_transcript(&self, variant: &HV) -> Option<String> {
+        let accession = match variant {
+            HV::Cds(v) => &v.accession,
+            HV::Tx(v) => &v.accession,
+            HV::Rna(v) => &v.accession,
+            _ => return None,
+        };
+        accession.version?; // explicit version only
+        let requested = accession.transcript_accession();
+        if !is_transcript_accession(&requested) {
+            return None;
+        }
+        if self.provider.has_transcript_version_exact(&requested) {
+            return None; // the exact version's bases are served — no substitution
+        }
+        // Not version-exact: a sibling would be served (substitution) — gate it —
+        // unless the transcript is simply absent with no sibling (Err), which is
+        // left to the existing missing-transcript path.
+        self.provider
+            .get_transcript(&requested)
+            .is_ok()
+            .then_some(requested)
+    }
+
     /// Core normalization: dispatch by variant kind and return the
     /// normalized variant plus warnings, WITHOUT computing the diagnostic
     /// `infos` axis. `normalize()` discards infos, so it calls this
@@ -1238,6 +1290,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // unchanged (#500).
         let rewritten = self.rewrite_legacy_gene_selector(variant);
         let variant = rewritten.as_ref().unwrap_or(variant);
+
+        // Silent version-substitution gate (#785). A c./n./r. description is
+        // defined only against its named `accession.version`: per HGVS, `c.1` is
+        // the first base of *that* version's start codon and a versioned
+        // identifier is required precisely because versions differ in length/CDS
+        // offset (background/numbering.md, background/refseq.md). When the caller
+        // names an EXPLICIT transcript version the reference does not carry, a
+        // lenient provider silently falls back to a *sibling* version and serves
+        // its frame/sequence — yielding a spec-invalid result whose stated
+        // reference and coordinate frame disagree, with no error. Decline with
+        // `TranscriptVersionNotExact` (a clean reference-unavailable miss the
+        // conformance mapping and `ferro project` CLI already treat as soft)
+        // rather than substitute. Projection inherits this because it normalizes
+        // first (#637), and `normalize_allele` recurses through `normalize_core`
+        // so each allele member is checked.
+        if let Some(requested) = self.silently_substituted_transcript(variant) {
+            return Err(FerroError::TranscriptVersionNotExact { requested });
+        }
 
         // EINTRONIC (#486): an intronic offset on a bare transcript reference
         // (NM_ c. / NR_ n., no NG_(…)/NC_(…) context) is a spec-invalid
@@ -7706,6 +7776,22 @@ fn normalize_t_u(seq: &[u8]) -> Vec<u8> {
         .collect()
 }
 
+/// Whether `id` is a versioned **transcript** accession subject to the
+/// base→latest version substitution the #785 gate guards against.
+///
+/// RefSeq (`NM_`/`NR_`/`XM_`/`XR_`) and Ensembl (`ENST`) transcripts qualify.
+/// Genomic references (`NG_`/`NC_`/`NW_`) and Ensembl *gene* identifiers
+/// (`ENSG`) do **not**: they are not transcript reading frames, and a `c.`/`n.`
+/// input that resolves to one of those (e.g. an unrewritten gene-model selector
+/// `NG_(GENE):c.…`) must not be gated as if it named a transcript version.
+fn is_transcript_accession(id: &str) -> bool {
+    id.starts_with("NM_")
+        || id.starts_with("NR_")
+        || id.starts_with("XM_")
+        || id.starts_with("XR_")
+        || id.starts_with("ENST")
+}
+
 /// If `variants` has 1 element return it directly; if >1 wrap in a cis Allele.
 fn wrap_allele_if_split(mut variants: Vec<HgvsVariant>) -> HgvsVariant {
     debug_assert!(!variants.is_empty(), "wrap_allele_if_split: empty input");
@@ -7760,6 +7846,146 @@ mod tests {
             format!("{}", variant),
             format!("{}", result.unwrap()),
             "Missing transcript should return variant unchanged"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_versioned_request_on_silent_substitution() {
+        // #785: a c./n./r. description is defined only against its named
+        // accession.version (background/numbering.md, refseq.md). When the
+        // request names an EXPLICIT version the reference lacks, a lenient
+        // provider silently falls back to a sibling version and normalizes
+        // against *its* frame/sequence — a confidently-wrong result attributed
+        // to the requested version. Decline with TranscriptVersionNotExact
+        // instead — the clean "reference unavailable" miss the conformance
+        // mapping already understands.
+        let mut provider = MockProvider::with_test_data();
+        // The reference carries only NM_000088.3; a request for .2 is silently
+        // served the .3 bases/frame.
+        provider.mark_version_substitution("NM_000088.2", "NM_000088.3");
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.2:c.10del").unwrap();
+        let err = normalizer.normalize(&variant).expect_err(
+            "an explicitly-versioned request the provider would silently \
+             substitute must be rejected, not normalized against the sibling",
+        );
+        match err {
+            FerroError::TranscriptVersionNotExact { requested } => {
+                assert_eq!(requested, "NM_000088.2");
+            }
+            other => panic!("expected TranscriptVersionNotExact, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_allows_bare_request_even_if_resolved_to_sibling() {
+        // #785: the gate applies ONLY to explicitly-versioned requests. A bare
+        // (unversioned) accession intentionally keeps lenient "latest version"
+        // resolution, so it must NOT be gated even though it resolves to a
+        // specific version under the hood.
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088:c.10A>G").unwrap();
+        let result = normalizer.normalize(&variant);
+        assert!(
+            result.is_ok(),
+            "a bare (unversioned) request must not be gated, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_allows_versioned_request_served_at_exact_version() {
+        // #785: a versioned request the reference serves at the EXACT version
+        // (no substitution) must pass the gate unchanged (no false positive).
+        let provider = MockProvider::with_test_data();
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
+        assert!(
+            normalizer.normalize(&variant).is_ok(),
+            "an exact-version request must not be gated"
+        );
+    }
+
+    #[test]
+    fn normalize_allows_versioned_request_absent_without_sibling() {
+        // #785: the gate fires only on a silent SUBSTITUTION (a sibling is
+        // actually served), never on a genuinely-absent transcript with no
+        // sibling to fall back to. Even when the provider reports the version as
+        // not exact, an absent transcript (`get_transcript` errors) falls through
+        // to the existing missing-transcript path (echoed unchanged), not a
+        // TranscriptVersionNotExact rejection — this guards against over-gating
+        // absent Ensembl/RefSeq references.
+        let mut provider = MockProvider::with_test_data();
+        // Not version-exact AND not registered → no sibling is served.
+        provider.mark_non_version_exact("NM_ABSENT.2");
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_ABSENT.2:c.100del").unwrap();
+        let result = normalizer.normalize(&variant);
+        assert!(
+            result.is_ok(),
+            "an absent versioned transcript with no sibling must not be gated, got {result:?}"
+        );
+        assert_eq!(
+            format!("{}", variant),
+            format!("{}", result.unwrap()),
+            "an absent transcript should be echoed unchanged"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_versioned_noncoding_request_on_silent_substitution() {
+        // #785 parity: the gate covers the non-coding (`n.`) axis, not just `c.`.
+        let mut provider = MockProvider::with_test_data();
+        provider.mark_version_substitution("NM_000088.2", "NM_000088.3");
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.2:n.10del").unwrap();
+        let err = normalizer
+            .normalize(&variant)
+            .expect_err("a versioned n. silent substitution must be rejected");
+        assert!(
+            matches!(err, FerroError::TranscriptVersionNotExact { ref requested } if requested == "NM_000088.2"),
+            "expected TranscriptVersionNotExact for NM_000088.2, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_versioned_rna_request_on_silent_substitution() {
+        // #785 parity: the gate covers the RNA (`r.`) axis too.
+        let mut provider = MockProvider::with_test_data();
+        provider.mark_version_substitution("NM_000088.2", "NM_000088.3");
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NM_000088.2:r.10del").unwrap();
+        let err = normalizer
+            .normalize(&variant)
+            .expect_err("a versioned r. silent substitution must be rejected");
+        assert!(
+            matches!(err, FerroError::TranscriptVersionNotExact { ref requested } if requested == "NM_000088.2"),
+            "expected TranscriptVersionNotExact for NM_000088.2, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_versioned_parented_request_on_silent_substitution() {
+        // #785: a genomic-context-wrapped request (`NC_…(NM_….v):c.…`) is gated on
+        // its inner transcript — `transcript_accession()` strips the wrapper, so
+        // the substituted inner NM is still caught.
+        let mut provider = MockProvider::with_test_data();
+        provider.mark_version_substitution("NM_000088.2", "NM_000088.3");
+        let normalizer = Normalizer::new(provider);
+
+        let variant = parse_hgvs("NC_000017.11(NM_000088.2):c.10del").unwrap();
+        let err = normalizer
+            .normalize(&variant)
+            .expect_err("a versioned parented silent substitution must be rejected");
+        assert!(
+            matches!(err, FerroError::TranscriptVersionNotExact { ref requested } if requested == "NM_000088.2"),
+            "expected TranscriptVersionNotExact for inner NM_000088.2, got {err:?}"
         );
     }
 

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1181,6 +1181,36 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             })
             .or_else(|| crate::liftover::aliases::infer_genome_build_from_accession(&parent));
         let cdot_mapper = self.projector.mapper();
+        // Silent version-substitution gate (#785), c.→g. direction. Unlike
+        // `project_variant`/`project_variant_all`, this path does not normalize
+        // the original transcript-coordinate input first, so it would not inherit
+        // the gate the normalizer applies in `normalize_core`. Apply the same
+        // guarantee here: when the input names an EXPLICIT transcript version the
+        // reference does not carry exactly, the lenient `get_transcript[_on_build]`
+        // pivot below would silently fall back to a *sibling* version and project
+        // onto the genome using that sibling's exon/CDS frame — a spec-invalid
+        // result whose stated reference and coordinate frame disagree, with no
+        // error. Decline with `TranscriptVersionNotExact` instead of fuzzing the
+        // version. The predicate permits exact-version cdot-genome synthesis and
+        // rejects only cross-version substitution; an LRG transcript carries no
+        // version (`accession.version == None`), so its exact RefSeq alias path is
+        // untouched. A transcript that is simply absent with no sibling to
+        // substitute is left to the `ReferenceNotFound` miss below, unchanged.
+        if accession.version.is_some() && is_transcript_accession(&transcript_id) {
+            let exact = self.provider.has_transcript_version_exact(&transcript_id);
+            let resolves = match build_hint {
+                Some(b) => cdot_mapper
+                    .cdot()
+                    .get_transcript_on_build(&transcript_id, b)
+                    .is_some(),
+                None => cdot_mapper.cdot().get_transcript(&transcript_id).is_some(),
+            };
+            if !exact && resolves {
+                return Err(FerroError::TranscriptVersionNotExact {
+                    requested: transcript_id.to_string(),
+                });
+            }
+        }
         let cdot_tx = match build_hint {
             Some(b) => cdot_mapper
                 .cdot()
@@ -3090,6 +3120,20 @@ fn split_accession_version(id: &str) -> (&str, Option<u32>) {
 /// opposed to a curated `NM_`/`NR_` transcript.
 fn is_predicted_model(id: &str) -> bool {
     id.starts_with("XM_") || id.starts_with("XR_")
+}
+
+/// Whether `id` names a transcript reading frame (RefSeq `NM_`/`NR_`/`XM_`/`XR_`
+/// or Ensembl `ENST`), gating the #785 silent version-substitution refusal to
+/// genuine transcript versions. Mirrors the normalizer's predicate of the same
+/// name: a genomic/gene reference (`NG_`/`NC_`/`NW_`, `ENSG`) is *not* a
+/// transcript version and must not be gated as one (e.g. an unrewritten
+/// `NG_(GENE):c.…` selector).
+fn is_transcript_accession(id: &str) -> bool {
+    id.starts_with("NM_")
+        || id.starts_with("NR_")
+        || id.starts_with("XM_")
+        || id.starts_with("XR_")
+        || id.starts_with("ENST")
 }
 
 /// Apply the `project_*_all` enumeration policy (#656) to a priority-ordered
@@ -5599,6 +5643,78 @@ mod tests {
             );
         }
 
+        // -- 1b: versioned silent-substitution refusal in the c.→g. direction --
+
+        #[test]
+        fn project_to_genomic_declines_silent_version_substitution() {
+            // Issue #785, c.→g. direction. `project_to_genomic` does not normalize
+            // the original transcript-coordinate input first, so without an
+            // explicit gate it would resolve a versioned request through the
+            // *lenient* cdot pivot and silently project onto the genome using a
+            // *sibling* version's exon/CDS frame. Here the reference carries only
+            // `NM_TEST.1`; a request for the absent `NM_TEST.2` must DECLINE with
+            // `TranscriptVersionNotExact` rather than silently use `.1`'s frame —
+            // the same guarantee `project_variant`/`project_variant_all` inherit
+            // by normalizing first.
+            let (projector, mut provider) = make_test_provider_and_projector();
+            // NM_TEST.2 is absent; a lenient lookup serves the .1 bases/frame.
+            provider.mark_version_substitution("NM_TEST.2", "NM_TEST.1");
+            let vp = VariantProjector::new(projector, provider);
+
+            // NC_000001.11(NM_TEST.2):c.4C>A — explicitly versioned, sibling-only.
+            let cds = CdsVariant {
+                accession: parse_accession("NM_TEST.2"),
+                gene_symbol: Some("TESTGENE".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(4)),
+                    NaEdit::Substitution {
+                        reference: Base::C,
+                        alternative: Base::A,
+                    },
+                ),
+            };
+            let cds = attach_genomic_context_cds(cds, nc_parent());
+            let input = HgvsVariant::Cds(cds);
+            let err = vp
+                .project_to_genomic(&input)
+                .expect_err("a versioned silent substitution must decline in c.→g.");
+            assert!(
+                matches!(err, FerroError::TranscriptVersionNotExact { ref requested } if requested == "NM_TEST.2"),
+                "expected TranscriptVersionNotExact for NM_TEST.2, got {err:?}"
+            );
+        }
+
+        // -- 1c: exact-version request still projects (no over-decline) ---------
+
+        #[test]
+        fn project_to_genomic_allows_exact_version() {
+            // Guard against over-declining: when the EXACT requested version is
+            // served, the #785 gate must NOT fire. `NM_TEST.1` is present, so
+            // `NC_000001.11(NM_TEST.1):c.4C>A` projects to g. unchanged.
+            let (projector, provider) = make_test_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+            let cds = CdsVariant {
+                accession: parse_accession("NM_TEST.1"),
+                gene_symbol: Some("TESTGENE".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(4)),
+                    NaEdit::Substitution {
+                        reference: Base::C,
+                        alternative: Base::A,
+                    },
+                ),
+            };
+            let cds = attach_genomic_context_cds(cds, nc_parent());
+            let input = HgvsVariant::Cds(cds);
+            let out = vp
+                .project_to_genomic(&input)
+                .expect("exact-version c.→g. projection must not be declined");
+            assert!(
+                out.to_string().contains(":g.1003C>A"),
+                "expected NC_000001.11...:g.1003C>A, got: {out}"
+            );
+        }
+
         // -- 2: minus-strand substitution --------------------------------------
 
         #[test]
@@ -7737,32 +7853,56 @@ mod tests {
     }
 
     #[test]
-    fn project_declines_protein_when_transcript_not_version_exact() {
-        // Issue #505: the protein path reads the transcript's CDS bases
-        // directly. When the reference only carries a *different* version of
-        // the requested transcript (a silent version-strip substitution),
-        // translating those bases would emit a wrong protein attributed to the
-        // requested version. The protein path must decline to predict rather
-        // than lie. The non-protein axes (coding) are unaffected.
+    fn project_rejects_versioned_request_on_silent_substitution() {
+        // Issue #785: projection normalizes first (#637), and normalization now
+        // declines an EXPLICITLY-versioned c./n./r. request whose exact version
+        // the reference does not serve but a sibling does (a silent
+        // substitution). Every downstream axis — coding coordinates included —
+        // would otherwise be computed against the sibling's frame, a mapping
+        // whose stated reference and frame disagree. So the whole projection
+        // declines with `TranscriptVersionNotExact` rather than emit a
+        // confidently-wrong coding form. This extends the protein-only gate of
+        // #505 to the coordinate axes for versioned requests.
         let (projector, mut provider) = make_test_provider_and_projector();
-        // Same input as `project_bare_nm_substitution_predicts_protein_without_genome`,
-        // but the provider now reports NM_TEST.1 as not available at the exact
-        // requested version (e.g. only a sibling version's bases are present).
-        provider.mark_non_version_exact("NM_TEST.1");
+        // NM_TEST.2 is absent; a request for it is silently served the .1 bases.
+        provider.mark_version_substitution("NM_TEST.2", "NM_TEST.1");
         let vp = VariantProjector::new(projector, provider);
-        let variant = make_coding_variant("NM_TEST.1", None);
+        let variant = make_coding_variant("NM_TEST.2", None);
+        let err = vp
+            .project_variant(&variant, "NM_TEST.2")
+            .expect_err("an explicitly-versioned silent substitution must decline wholesale");
+        assert!(
+            matches!(err, FerroError::TranscriptVersionNotExact { ref requested } if requested == "NM_TEST.2"),
+            "expected TranscriptVersionNotExact for NM_TEST.2, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn project_declines_protein_but_keeps_coding_for_bare_non_version_exact() {
+        // Issue #505 (still in force for BARE requests): a bare (unversioned)
+        // accession keeps lenient "latest version" resolution, so the #785
+        // version-substitution gate does NOT apply — coding still projects
+        // against the resolved transcript. But the protein path reads the CDS
+        // bases directly, so when the resolved bases are not version-exact it
+        // must still decline to predict a protein rather than attribute a
+        // possibly-wrong product to the request. Protein is declined; the coding
+        // axis is unaffected.
+        let (projector, mut provider) = make_test_provider_and_projector();
+        provider.mark_non_version_exact("NM_TEST");
+        let vp = VariantProjector::new(projector, provider);
+        // Bare NM_TEST (no .version) — not gated by #785.
+        let variant = make_coding_variant("NM_TEST", None);
         let proj = vp
-            .project_variant(&variant, "NM_TEST.1")
-            .expect("projection should still succeed; only protein prediction declines");
+            .project_variant(&variant, "NM_TEST")
+            .expect("a bare request must still project; only protein prediction declines");
         assert!(
             proj.protein.is_none(),
             "protein must be declined for a non-version-exact transcript, got {:?}",
             proj.protein
         );
-        // The protein-only gate must not suppress the coding axis.
         assert!(
             proj.coding.is_some(),
-            "coding form should still be present despite the protein gate"
+            "coding form should still be present for a bare request despite the protein gate"
         );
     }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -33,6 +33,14 @@ pub struct MockProvider {
     /// `"NM_012459.4"`). Lets tests exercise the #500/#637 selector rewrite
     /// without ingesting NCBI's `LRG_RefSeqGene` table.
     legacy_gene_models: HashMap<String, String>,
+    /// Silent version-substitution map: requested transcript accession (e.g.
+    /// `"NM_002001.2"`) → the *different*-version accession the provider should
+    /// actually serve for it (e.g. `"NM_002001.4"`). Lets tests model the #785
+    /// silent version-strip substitution that a real `MultiFastaProvider`
+    /// performs via `resolve_name`'s base→latest fallback, which `MockProvider`
+    /// otherwise refuses by design. Empty by default, so an unconfigured mock
+    /// never substitutes a version.
+    version_substitutions: HashMap<String, String>,
 }
 
 impl MockProvider {
@@ -45,6 +53,7 @@ impl MockProvider {
             non_version_exact: HashSet::new(),
             genomic_placements: HashMap::new(),
             legacy_gene_models: HashMap::new(),
+            version_substitutions: HashMap::new(),
         }
     }
 
@@ -80,6 +89,27 @@ impl MockProvider {
     /// it. Simulates a reference that only carries a sibling version's bases.
     pub fn mark_non_version_exact(&mut self, id: impl Into<String>) {
         self.non_version_exact.insert(id.into());
+    }
+
+    /// Model a silent version-strip substitution (#785): a lookup of `requested`
+    /// resolves to (and serves the bases of) the *different*-version `served`
+    /// accession, which must already be registered. Mirrors a real
+    /// `MultiFastaProvider` that, lacking the requested version, falls back to a
+    /// sibling. Used to exercise the normalization version-substitution gate.
+    ///
+    /// A substitution inherently means the exact requested version is not served,
+    /// so this also marks `requested` as not version-exact (as
+    /// [`Self::mark_non_version_exact`] would) — keeping
+    /// [`ReferenceProvider::has_transcript_version_exact`] and
+    /// [`ReferenceProvider::get_transcript`] mutually consistent for the gate.
+    pub fn mark_version_substitution(
+        &mut self,
+        requested: impl Into<String>,
+        served: impl Into<String>,
+    ) {
+        let requested = requested.into();
+        self.non_version_exact.insert(requested.clone());
+        self.version_substitutions.insert(requested, served.into());
     }
 
     /// Load reference data from a JSON file.
@@ -138,6 +168,7 @@ impl MockProvider {
             non_version_exact: HashSet::new(),
             genomic_placements: HashMap::new(),
             legacy_gene_models: HashMap::new(),
+            version_substitutions: HashMap::new(),
         })
     }
 
@@ -389,6 +420,16 @@ impl ReferenceProvider for MockProvider {
         // Handle versioned and unversioned lookups
         if let Some(tx) = self.transcripts.get(id) {
             return Ok(Arc::clone(tx));
+        }
+
+        // Modeled silent version substitution (#785): serve a configured
+        // sibling version's record (whose own `id` differs from `id`), mirroring
+        // a real `MultiFastaProvider`'s base→latest fallback. Only fires when a
+        // test explicitly opts in via `mark_version_substitution`.
+        if let Some(served) = self.version_substitutions.get(id) {
+            if let Some(tx) = self.transcripts.get(served) {
+                return Ok(Arc::clone(tx));
+            }
         }
 
         // Try without version: only match a stored key whose base id (the

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -1336,10 +1336,10 @@
       "input": "NM_002001.2:c.1_3delinsATG",
       "normalized": "NM_002001.2:c.=",
       "to_test": true,
-      "accepted_divergence": {
+      "accepted_rejection": {
         "axis": "normalized",
-        "policy": "ferro-policy-654-explicit-identity-rendering",
-        "note": "reference-identical delins (ATG==ref at c.1_3): ferro renders the positional identity c.1_3=; mutalyzer collapses to whole-reference c.=. Both denote no change."
+        "reason": "ferro-policy-785-version-substitution-refused",
+        "note": "NM_002001.2 is absent from this manifest (only the sibling .4 is carried); ferro refuses to normalize against .4's frame and declines with TranscriptVersionNotExact (#785). mutalyzer carries .2 and renders c.=. Previously ferro silently substituted .4 and rendered the positional identity c.1_3= (the #654 accepted_divergence this replaces)."
       }
     },
     {
@@ -3249,7 +3249,12 @@
         "IWHOLETRANSCRIPTEXON",
         "IMRNAGENOMICTIP"
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_rejection": {
+        "axis": "normalized",
+        "reason": "ferro-policy-785-version-substitution-refused",
+        "note": "NM_002001.2 is absent from this manifest (only the sibling .4 is carried); ferro refuses to normalize against .4's frame and declines with TranscriptVersionNotExact (#785). mutalyzer carries .2 and echoes c.=. Previously ferro silently substituted .4, which happened to echo c.= too."
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -228,6 +228,7 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | `NG_017013.2:g.17496_17497insAGCTGCTCAGATAGCGA` | normalized | accepted_divergence | — | — |
 | `NG_029724.1(NM_004321.7):c.101del` | normalized | accepted_divergence | — | — |
 | `NM_002001.2:c.1_3delinsATG` | normalized | accepted_divergence | — | — |
+| `NM_002001.2:c.=` | normalized | accepted_divergence | — | — |
 | `NM_003002.2:c.[100del;200_201insNM_003002.2:274+20]` | errors | accepted_divergence | — | — |
 | `NM_003002.4:c.206_210delins190_220inv` | normalized | accepted_divergence | — | — |
 | `NM_003002.4:n.206_210del` | normalized | accepted_divergence | — | — |
@@ -240,5 +241,5 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 23 | 21 | 15 | 5 | 9 |
+| normalized | 24 | 21 | 15 | 5 | 9 |
 | protein_description | 0 | 0 | 0 | 0 | 31 |


### PR DESCRIPTION
## Problem

When a versioned `c.`/`r.`/`n.` request named a transcript `accession.version` the loaded reference did not carry, a lenient provider silently fell back to a **sibling** version and normalized — and projected, since projection normalizes first (#637) — against *that* version's frame/sequence. The result was a spec-invalid coordinate mapping whose stated reference and coordinate frame disagree, emitted with **no error and no warning**. A user passing a legitimately historical accession version got a confidently-wrong result rather than a "reference unavailable" signal.

Per HGVS a `c.`/`r.` description is defined only against its named `accession.version` (`background/numbering.md`, `background/refseq.md`): versions differ in length/CDS offset, so a sibling-version frame produces wrong coordinates.

Closes #785.

## Fix

Gate normalization (the chokepoint projection routes through) on the silent-substitution case: when an explicitly-versioned transcript request is not version-exact yet the provider still resolves it (a sibling is served), decline with `TranscriptVersionNotExact` rather than substitute. `TranscriptVersionNotExact` already maps to a clean reference-unavailable miss in the CLI and conformance layers, so `ferro normalize`/`ferro project` now surface a clean miss instead of a confidently-wrong substitution.

The gate fires only when **all** hold: a transcript-coordinate axis (`c.`/`n.`/`r.`), an explicit version (bare requests keep lenient latest-version resolution; LRG never carries a version), a transcript accession (genomic/gene wrappers like an unrewritten `NG_(GENE):c.…` selector are excluded), the exact version is not served (`has_transcript_version_exact` is false), and the provider nonetheless resolves the request (a sibling is actually served — distinguishing substitution from a genuinely-absent transcript, which is left to the existing missing-transcript path).

The version-exact predicate is the load-bearing signal. It catches **both** substitution paths a `served.id != requested` comparison would not: the FASTA version-strip fallback (which serves the *sibling's* accession) and the cdot-genome reconstruction off a sibling record (which serves the *requested* accession with the sibling's frame). This extends the protein-only version-exact gate of #714/#505 to the coordinate axes for versioned requests.

## Scope

This builds on the deliberate strict/lenient split (#714/#505/#331): the lenient primitive stays lenient, and only versioned requests that would be *silently substituted* are gated — mirroring the existing protein-prediction gate rather than changing low-level lookup semantics. Bare requests, genomic-context wrappers, and the LRG→RefSeq alias path are untouched.

## Conformance

The two `NM_002001.2` mutalyzer-normalize rows previously passed only because ferro silently substituted the sibling `.4` and happened to render the same form. They now correctly decline. A `RejectionReason::VersionSubstitutionRefused785` disposition is added and the rows annotated `accepted_rejection`, so the harness buckets the correct decline (it already buckets a non-panic `Err` on the annotated axis); `failure-patterns.md` is regenerated accordingly.

## Testing

- New normalize unit tests: silent-substitution rejection across `c.`/`n.`/`r.` and a genomic-context-wrapped form; plus the negative cases (bare request, exact-version serve, and absent-without-sibling — all not gated).
- `MockProvider::mark_version_substitution` models the substitution a real `MultiFastaProvider` performs (which the mock otherwise refuses by design).
- Projector tests split into versioned-wholesale-decline and the bare protein-only #505 case.
- Full lib + integration suites pass; clippy `-D warnings` and `fmt --check` clean; spec fixture `--check` passes. Manifest-gated conformance has zero new failures vs. base (verified end-to-end with the prepared reference); only the two intended `NM_002001.2` rows change disposition.

## Reading order

1. `src/normalize/mod.rs` — `silently_substituted_transcript` + the `normalize_core` gate.
2. `src/reference/mock.rs` — substitution test-double support.
3. `src/conformance/mutalyzer.rs` + `tests/fixtures/mutalyzer-normalize/*` — conformance reclassification.
