### PR TITLE
refactor(reference): derive accession→assembly from NCBI assembly_report (#716)

### DIFF
--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -182,6 +182,24 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    // A missing assembly report silently disables the data-driven build map
+    // at load (#716), so surface it like the other optional inputs above.
+    if let Some(ref report) = manifest.assembly_report {
+        if !report.exists() {
+            result
+                .warnings
+                .push(format!("Assembly report not found: {}", report.display()));
+        }
+    }
+    if let Some(ref report) = manifest.assembly_report_grch37 {
+        if !report.exists() {
+            result.warnings.push(format!(
+                "GRCh37 assembly report not found: {}",
+                report.display()
+            ));
+        }
+    }
+
     // A missing derived-placements JSON silently disables version-gap NG_/LRG_
     // projection at load, so surface it like the other optional inputs above.
     if let Some(ref placements) = manifest.derived_refseqgene_placements {
@@ -335,6 +353,8 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
@@ -387,6 +407,8 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: Some(missing_alignments.clone()),
             refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
@@ -441,6 +463,8 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: Some(missing_alignments.clone()),
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
@@ -476,6 +500,118 @@ mod tests {
     }
 
     #[test]
+    fn test_check_warns_on_missing_assembly_report() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point assembly_report at a file that does not exist.
+        let missing_report = dir.path().join("missing_assembly_report.txt");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
+            assembly_report: Some(missing_report.clone()),
+            assembly_report_grch37: None,
+            derived_refseqgene_placements: None,
+            refseqgene_summary: None,
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("Assembly report not found")),
+            "Expected a warning for the missing assembly report file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_check_warns_on_missing_assembly_report_grch37() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point assembly_report_grch37 at a file that does not exist.
+        let missing_report = dir.path().join("missing_assembly_report_grch37.txt");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: Some(missing_report.clone()),
+            derived_refseqgene_placements: None,
+            refseqgene_summary: None,
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("GRCh37 assembly report not found")),
+            "Expected a warning for the missing GRCh37 assembly report file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
     fn test_check_warns_on_missing_refseqgene_summary() {
         let dir = TempDir::new().unwrap();
 
@@ -495,6 +631,8 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: Some(missing_summary.clone()),
             lrg_fastas: Vec::new(),
@@ -549,6 +687,8 @@ mod tests {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: Some(missing_placements.clone()),
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),

--- a/src/conformance/reference_window.rs
+++ b/src/conformance/reference_window.rs
@@ -280,7 +280,11 @@ impl ReferenceProvider for WindowProvider {
         // resolved build (or GRCh38-preferred with no hint), declining rather
         // than mis-anchoring onto another build's placement.
         let list = self.placements.get(&parent.full())?;
-        select_placement_for_build(list, build)
+        select_placement_for_build(
+            list,
+            build,
+            crate::liftover::aliases::infer_genome_build_from_accession,
+        )
     }
 
     fn get_sequence_length(&self, id: &str) -> Result<u64, FerroError> {

--- a/src/liftover/aliases.rs
+++ b/src/liftover/aliases.rs
@@ -341,6 +341,31 @@ pub fn infer_genome_build_from_accession_with(
     None
 }
 
+/// Infer the genome build for an accession, consulting a data-driven
+/// [`ContigAliases`] (from the prepared reference's own assembly report, #716)
+/// before falling back to the bundled hardcoded table.
+///
+/// `table` is `None` when the prepared reference carries no assembly report
+/// (old manifest, bare library use), in which case this is exactly
+/// [`infer_genome_build_from_accession`]. When `Some`, the data-driven table is
+/// authoritative for any accession it describes; accessions it omits still
+/// classify via the hardcoded fallback. Returns the first build found, so the
+/// data-driven layer wins on disagreement — safe because the two only overlap
+/// on accessions identical across builds (e.g. mtDNA), which the GRCh38-first
+/// check order in [`infer_genome_build_from_accession_with`] resolves the same
+/// way either source would.
+pub fn infer_genome_build_layered(
+    table: Option<&ContigAliases>,
+    accession: &crate::hgvs::variant::Accession,
+) -> Option<&'static str> {
+    if let Some(table) = table {
+        if let Some(build) = infer_genome_build_from_accession_with(table, accession) {
+            return Some(build);
+        }
+    }
+    infer_genome_build_from_accession(accession)
+}
+
 /// Normalize a user-supplied assembly name to ferro's canonical build string
 /// (`"GRCh37"` / `"GRCh38"`), or `None` if unrecognized (#715).
 ///
@@ -581,6 +606,54 @@ mod tests {
         assert_eq!(
             infer_genome_build_from_accession(&Accession::new("NG", "012337", Some(1))),
             None
+        );
+    }
+
+    /// A GRCh38-only report whose chr17 row carries a version (`.99`) the
+    /// hardcoded table does not know — proves the data-driven layer adds reach.
+    const GRCH38_FUTURE_SAMPLE: &str = "\
+# Assembly name:  GRCh38.future
+# Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\tGenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name
+17\tassembled-molecule\t17\tChromosome\tCM000679.9\t=\tNC_000017.99\tPrimary Assembly\t83257441\tchr17
+";
+
+    #[test]
+    fn layered_classifies_report_only_version() {
+        use crate::hgvs::variant::Accession;
+        let report = parse_assembly_report(GRCH38_FUTURE_SAMPLE);
+        let table = ContigAliases::from_assembly_reports(&[(GenomeBuild::GRCh38, &report)]);
+
+        let future = Accession::new("NC", "000017", Some(99));
+        // Hardcoded table has never seen .99 → None.
+        assert_eq!(infer_genome_build_from_accession(&future), None);
+        // Data-driven layer classifies it from the report.
+        assert_eq!(
+            infer_genome_build_layered(Some(&table), &future),
+            Some("GRCh38")
+        );
+    }
+
+    #[test]
+    fn layered_falls_back_to_hardcoded_when_absent_from_report() {
+        use crate::hgvs::variant::Accession;
+        let report = parse_assembly_report(GRCH38_FUTURE_SAMPLE);
+        let table = ContigAliases::from_assembly_reports(&[(GenomeBuild::GRCh38, &report)]);
+
+        // GRCh37 chr1 (.10) is not in this GRCh38-only report → hardcoded fallback.
+        let grch37_chr1 = Accession::new("NC", "000001", Some(10));
+        assert_eq!(
+            infer_genome_build_layered(Some(&table), &grch37_chr1),
+            Some("GRCh37")
+        );
+    }
+
+    #[test]
+    fn layered_with_no_table_matches_hardcoded() {
+        use crate::hgvs::variant::Accession;
+        let grch38_chr17 = Accession::new("NC", "000017", Some(11));
+        assert_eq!(
+            infer_genome_build_layered(None, &grch38_chr17),
+            infer_genome_build_from_accession(&grch38_chr17)
         );
     }
 }

--- a/src/liftover/aliases.rs
+++ b/src/liftover/aliases.rs
@@ -219,6 +219,11 @@ impl ContigAliases {
         }
     }
 
+    /// `true` when no `(name, build)` mappings are registered.
+    pub fn is_empty(&self) -> bool {
+        self.to_refseq.is_empty()
+    }
+
     /// Add an alias mapping.
     pub fn add_alias(&mut self, name: &str, build: GenomeBuild, refseq: &str) {
         self.to_refseq

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -37,6 +37,15 @@ pub struct ReferenceManifest {
     /// the same way `genome_grch37_fasta`/`cdot_grch37_json` pair their GRCh38 fields.
     #[serde(default)]
     pub refseqgene_alignments_grch37: Option<PathBuf>,
+    /// Path to the GRCh38 NCBI `*_assembly_report.txt` (#716). Authoritative
+    /// RefSeq-accession → assembly map for build inference; absent on manifests
+    /// prepared before #716 (build inference then uses the hardcoded fallback).
+    #[serde(default)]
+    pub assembly_report: Option<PathBuf>,
+    /// Path to the GRCh37 NCBI `*_assembly_report.txt` (#716). Present only when
+    /// the GRCh37 genome was downloaded (`download_genome_grch37`).
+    #[serde(default)]
+    pub assembly_report_grch37: Option<PathBuf>,
     /// Derived `NG_`/`LRG_` placements (`derived_placement::DerivedPlacements`
     /// JSON) for versions absent from the alignment snapshots above — built at
     /// prepare time from each NG_'s GenBank record + cdot and validated by full
@@ -117,6 +126,8 @@ impl Default for ReferenceManifest {
             refseqgene_fastas: Vec::new(),
             refseqgene_alignments: None,
             refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
@@ -263,6 +274,8 @@ impl ReferenceManifest {
             &self.genome_grch37_fasta,
             &self.refseqgene_alignments,
             &self.refseqgene_alignments_grch37,
+            &self.assembly_report,
+            &self.assembly_report_grch37,
             &self.derived_refseqgene_placements,
             &self.refseqgene_summary,
             &self.lrg_refseq_mapping,
@@ -303,6 +316,8 @@ impl ReferenceManifest {
             &mut self.genome_grch37_fasta,
             &mut self.refseqgene_alignments,
             &mut self.refseqgene_alignments_grch37,
+            &mut self.assembly_report,
+            &mut self.assembly_report_grch37,
             &mut self.derived_refseqgene_placements,
             &mut self.refseqgene_summary,
             &mut self.lrg_refseq_mapping,
@@ -532,6 +547,8 @@ mod tests {
             refseqgene_fastas: vec![ref_dir.join("ng.fa")],
             refseqgene_alignments: Some(ref_dir.join("refseqgene_alignments.gff3")),
             refseqgene_alignments_grch37: Some(ref_dir.join("refseqgene_alignments_grch37.gff3")),
+            assembly_report: None,
+            assembly_report_grch37: None,
             derived_refseqgene_placements: None,
             refseqgene_summary: Some(ref_dir.join("LRG_RefSeqGene")),
             lrg_fastas: vec![ref_dir.join("lrg.fa")],
@@ -734,6 +751,51 @@ mod tests {
             )),
             "derived_refseqgene_placements must be preserved across load_or_default/save"
         );
+    }
+
+    #[test]
+    fn assembly_report_paths_roundtrip_and_relativize() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path().to_path_buf();
+
+        let mut manifest = ReferenceManifest {
+            reference_dir: ref_dir.clone(),
+            assembly_report: Some(ref_dir.join("genome/GRCh38.assembly_report.txt")),
+            assembly_report_grch37: Some(ref_dir.join("genome/GRCh37.assembly_report.txt")),
+            ..Default::default()
+        };
+        manifest.save().unwrap();
+
+        // On-disk JSON must store the report paths relative to reference_dir.
+        let raw = std::fs::read_to_string(ref_dir.join("manifest.json")).unwrap();
+        assert!(raw.contains("genome/GRCh38.assembly_report.txt"));
+        assert!(!raw.contains(ref_dir.to_str().unwrap()));
+
+        // Reloading absolutizes them back under reference_dir.
+        let loaded = ReferenceManifest::load_or_default(&ref_dir).unwrap();
+        assert_eq!(
+            loaded.assembly_report,
+            Some(ref_dir.join("genome/GRCh38.assembly_report.txt"))
+        );
+        assert_eq!(
+            loaded.assembly_report_grch37,
+            Some(ref_dir.join("genome/GRCh37.assembly_report.txt"))
+        );
+    }
+
+    #[test]
+    fn pre_716_manifest_without_report_fields_loads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path();
+        // A manifest JSON with NO assembly_report keys (pre-#716).
+        std::fs::write(
+            ref_dir.join("manifest.json"),
+            r#"{"prepared_at":"","transcript_fastas":[],"genome_fasta":null,"cdot_json":null,"transcript_count":0,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+        let m = ReferenceManifest::load_or_default(ref_dir).unwrap();
+        assert_eq!(m.assembly_report, None);
+        assert_eq!(m.assembly_report_grch37, None);
     }
 
     #[test]

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -110,6 +110,11 @@ pub mod urls {
     /// GRCh37 reference genome (with RefSeq accessions NC_000001.10, etc.)
     pub const GRCH37_GENOME: &str = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_genomic.fna.gz";
 
+    /// GRCh38 assembly report (RefSeq-accession → assembly map, #716).
+    pub const GRCH38_ASSEMBLY_REPORT: &str = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14/GCF_000001405.40_GRCh38.p14_assembly_report.txt";
+    /// GRCh37 assembly report (#716).
+    pub const GRCH37_ASSEMBLY_REPORT: &str = "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.25_GRCh37.p13/GCF_000001405.25_GRCh37.p13_assembly_report.txt";
+
     /// RefSeqGene sequences (NG_* accessions) - 9 files
     pub const REFSEQGENE_BASE: &str = "https://ftp.ncbi.nlm.nih.gov/refseq/H_sapiens/RefSeqGene/";
     pub const REFSEQGENE_COUNT: usize = 9;
@@ -397,6 +402,17 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             index_fasta(&fasta_path)?;
         }
 
+        // Only overwrite the recorded path when a new one is produced: a
+        // transient download soft-fail returns `None`, and assigning that would
+        // erase a previously valid path and persist a degraded manifest.
+        if let Some(path) = record_assembly_report(
+            &genome_dir,
+            "GRCh38.assembly_report.txt",
+            urls::GRCH38_ASSEMBLY_REPORT,
+            config.skip_existing,
+        )? {
+            manifest.assembly_report = Some(path);
+        }
         manifest.genome_fasta = Some(fasta_path);
     }
 
@@ -429,6 +445,16 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             eprintln!("  Done.");
         }
 
+        // Preserve a previously valid path on a transient soft-fail (`None`);
+        // see the GRCh38 call above.
+        if let Some(path) = record_assembly_report(
+            &genome_dir,
+            "GRCh37.assembly_report.txt",
+            urls::GRCH37_ASSEMBLY_REPORT,
+            config.skip_existing,
+        )? {
+            manifest.assembly_report_grch37 = Some(path);
+        }
         manifest.genome_grch37_fasta = Some(fasta_path);
     }
 
@@ -1023,6 +1049,33 @@ fn download_cdot(url: &str, cdot_dir: &Path, skip_existing: bool) -> Result<Path
 
 // Helper functions
 // ============================================================================
+
+/// Download an NCBI assembly report into `genome_dir/<filename>` (unless it
+/// already exists and `skip_existing`), returning the path to record in the
+/// manifest. A download failure is a soft warning that yields `Ok(None)` — the
+/// report is strictly additive (build inference falls back to the hardcoded
+/// table), so it must never abort the genome download (#716).
+fn record_assembly_report(
+    genome_dir: &Path,
+    filename: &str,
+    url: &str,
+    skip_existing: bool,
+) -> Result<Option<PathBuf>, FerroError> {
+    let dest = genome_dir.join(filename);
+    if skip_existing && dest.exists() {
+        return Ok(Some(dest));
+    }
+    match download_file(url, &dest) {
+        Ok(()) => Ok(Some(dest)),
+        Err(e) => {
+            eprintln!(
+                "  Warning: failed to download assembly report {url}: {e}; \
+                 build inference will use the hardcoded fallback"
+            );
+            Ok(None)
+        }
+    }
+}
 
 /// Download a file from a URL.
 fn download_file(url: &str, output: &Path) -> Result<(), FerroError> {
@@ -1976,5 +2029,33 @@ mod tests {
         // placements for (the up-front guard rejects --derive-ng-placements
         // with this selection).
         assert!(builds_for_genome("none").is_empty());
+    }
+
+    #[test]
+    fn skip_existing_still_records_assembly_report() {
+        let tmp = tempfile::tempdir().unwrap();
+        let genome_dir = tmp.path().join("genome");
+        std::fs::create_dir_all(&genome_dir).unwrap();
+        // Pre-place a genome FASTA + its .fai and the assembly report so the
+        // skip_existing branch is taken (no network).
+        let fasta = genome_dir.join("GRCh38.fna");
+        std::fs::write(&fasta, ">NC_000001.11\nACGT\n").unwrap();
+        std::fs::write(
+            format!("{}.fai", fasta.display()),
+            "NC_000001.11\t4\t13\t4\t5\n",
+        )
+        .unwrap();
+        let report = genome_dir.join("GRCh38.assembly_report.txt");
+        std::fs::write(&report, "# Assembly name:  GRCh38.p14\n").unwrap();
+
+        let manifest = record_assembly_report(
+            genome_dir.as_path(),
+            "GRCh38.assembly_report.txt",
+            urls::GRCH38_ASSEMBLY_REPORT,
+            /* skip_existing */ true,
+        )
+        .unwrap();
+
+        assert_eq!(manifest, Some(report));
     }
 }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -179,14 +179,13 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// consulted. Anything else returns `None` (e.g. a bare `NG_`/`LRG_`,
     /// which carries no build), so the caller falls back to the
     /// build-agnostic primary-cdot path (issue #389).
-    fn infer_input_build(variant: &HgvsVariant) -> Option<&'static str> {
-        use crate::liftover::aliases::infer_genome_build_from_accession;
+    fn infer_input_build(&self, variant: &HgvsVariant) -> Option<&'static str> {
         let acc = variant.accession()?;
-        if let Some(b) = infer_genome_build_from_accession(acc) {
+        if let Some(b) = self.provider.infer_genome_build(acc) {
             return Some(b);
         }
         if let Some(parent) = acc.genomic_context.as_deref() {
-            return infer_genome_build_from_accession(parent);
+            return self.provider.infer_genome_build(parent);
         }
         None
     }
@@ -201,7 +200,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// `NC_*.10`/`.11` accession, which would emit wrong coordinates under a
     /// right-looking accession (the #655/#702 failure class).
     fn build_hint_for_variant(&self, variant: &HgvsVariant) -> Option<&'static str> {
-        Self::infer_input_build(variant).or(self.assembly_override)
+        self.infer_input_build(variant).or(self.assembly_override)
     }
 
     /// Emit a warning when an explicit `--assembly` override contradicts the
@@ -209,7 +208,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// only flags the ignored override. Called once per public projection entry.
     fn warn_assembly_conflict(&self, variant: &HgvsVariant) {
         if let (Some(override_build), Some(input_build)) =
-            (self.assembly_override, Self::infer_input_build(variant))
+            (self.assembly_override, self.infer_input_build(variant))
         {
             if override_build != input_build {
                 log::warn!(
@@ -1175,11 +1174,11 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let build_hint = self
             .build_hint_for_variant(variant)
             .or_else(|| {
-                self.provider.genomic_placement(&parent).and_then(|p| {
-                    crate::liftover::aliases::infer_genome_build_from_accession(&p.nc)
-                })
+                self.provider
+                    .genomic_placement(&parent)
+                    .and_then(|p| self.provider.infer_genome_build(&p.nc))
             })
-            .or_else(|| crate::liftover::aliases::infer_genome_build_from_accession(&parent));
+            .or_else(|| self.provider.infer_genome_build(&parent));
         let cdot_mapper = self.projector.mapper();
         let cdot_tx = match build_hint {
             Some(b) => cdot_mapper
@@ -2712,13 +2711,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 reason: "g. variant has no concrete edit".to_string(),
             })?;
 
-        // Look up the transcript in the cdot mapper. When the projected
-        // g. accession is NC_*, infer the genome build from its version
-        // (NC_*.10 → GRCh37, NC_*.11 → GRCh38, etc.) so multi-build cdot
-        // loads return the alignment matching the input chromosome rather
-        // than silently using the primary build's view (issue #389).
-        let build_hint =
-            crate::liftover::aliases::infer_genome_build_from_accession(&genome_variant.accession);
+        // Look up the transcript in the cdot mapper. Prefer the build the
+        // *input* carries — an explicit `NC_*.10`/`.11`, a `genomic_context`
+        // parent, or the `--assembly` override that `project_to_genomic_nc`
+        // already used to pick the placement (#716). Re-deriving the build
+        // solely from the projected NC_ accession loses that signal when the
+        // pivot anchored onto a contig whose version the heuristic does not
+        // recognize (it would fall back to cdot's primary view and reject or
+        // misproject the NC-frame pivot). Fall back to inferring from the
+        // projected accession only when the input is build-agnostic (issue
+        // #389: NC_*.10 → GRCh37, NC_*.11 → GRCh38).
+        let build_hint = self
+            .build_hint_for_variant(normalized)
+            .or_else(|| self.provider.infer_genome_build(&genome_variant.accession));
         let cdot_tx = match build_hint {
             Some(b) => self
                 .projector
@@ -7446,6 +7451,140 @@ mod tests {
                 "input-encoded GRCh38 (g.20005) must win over --assembly GRCh37 (g.10005), got: {s}"
             );
         }
+
+        /// Regression (#716): the downstream cdot lookup in `project_single_inner`
+        /// must reuse the build that `project_to_genomic_nc` used for the pivot,
+        /// not re-derive it from the projected `NC_` accession.
+        ///
+        /// Fixture: a bare `NG_` parent whose GRCh37 placement re-anchors onto a
+        /// contig (`NC_000001.99`) whose version the hardcoded heuristic does NOT
+        /// recognize — exactly the case the data-driven inference targets, and the
+        /// case where re-deriving from the accession yields `None`. Under
+        /// `--assembly GRCh37` the pivot correctly selects the GRCh37 alignment,
+        /// but pre-fix the protein/cdot lookup re-inferred `None` from
+        /// `NC_000001.99`, fell back to cdot's primary (GRCh38) view, and the
+        /// GRCh37-frame genomic position fell outside the GRCh38 exon →
+        /// `TranscriptNotOverlapping`. With the build hint preserved, the full
+        /// projection succeeds on GRCh37.
+        #[test]
+        fn assembly_override_survives_downstream_cdot_lookup_for_unrecognized_contig() {
+            use crate::reference::transcript::{
+                Exon, GenomeBuild as RefGenomeBuild, ManeStatus, Strand as TxStrand,
+                Transcript as RefTranscript,
+            };
+            use std::sync::OnceLock;
+
+            // GRCh37 alignment lives on an accession the version heuristic cannot
+            // classify; GRCh38 on the canonical NC_000001.11.
+            const UR_PARENT: &str = "NG_000777.1";
+            let cdot_json = r#"
+            {
+                "transcripts": {
+                    "NM_UR_TEST.1": {
+                        "gene_name": "URTEST",
+                        "genome_builds": {
+                            "GRCh37": {
+                                "contig": "NC_000001.99",
+                                "strand": "+",
+                                "exons": [[10000, 10010, 1, 0, 10, "M10"]]
+                            },
+                            "GRCh38": {
+                                "contig": "NC_000001.11",
+                                "strand": "+",
+                                "exons": [[20000, 20010, 1, 0, 10, "M10"]]
+                            }
+                        },
+                        "start_codon": 0,
+                        "stop_codon": 10
+                    }
+                }
+            }
+            "#;
+
+            // Sanity-check the premise: the heuristic genuinely declines on the
+            // re-anchored GRCh37 contig, so a re-derive-from-accession path would
+            // lose the build and this test would distinguish the two.
+            assert_eq!(
+                crate::liftover::aliases::infer_genome_build_from_accession(&parse_accession(
+                    "NC_000001.99"
+                )),
+                None,
+                "premise: NC_000001.99 is unrecognized by the version heuristic",
+            );
+
+            let cdot = CdotMapper::from_reader_with_build(cdot_json.as_bytes(), "GRCh38")
+                .expect("multi-build cdot JSON should parse");
+            let projector = Projector::new(cdot);
+            let mut provider = MockProvider::new();
+            provider.add_transcript(RefTranscript {
+                id: "NM_UR_TEST.1".to_string(),
+                gene_symbol: Some("URTEST".to_string()),
+                strand: TxStrand::Plus,
+                sequence: Some("ATGCGCTAATC".to_string()),
+                cds_start: Some(1),
+                cds_end: Some(10),
+                exons: vec![Exon::new(1, 1, 10)],
+                chromosome: Some("NC_000001.11".to_string()),
+                genomic_start: Some(20000),
+                genomic_end: Some(20009),
+                genome_build: RefGenomeBuild::GRCh38,
+                mane_status: ManeStatus::default(),
+                refseq_match: None,
+                ensembl_match: None,
+                protein_id: None,
+                exon_cigars: Vec::new(),
+                cached_introns: OnceLock::new(),
+            });
+            provider.add_genomic_placement(
+                UR_PARENT,
+                crate::reference::provider::GenomicPlacement {
+                    nc: parse_accession("NC_000001.11"),
+                    parent_start: 100,
+                    nc_start: 20000,
+                    nc_end: 20010,
+                    strand: crate::reference::transcript::Strand::Plus,
+                },
+            );
+            provider.add_genomic_placement(
+                UR_PARENT,
+                crate::reference::provider::GenomicPlacement {
+                    nc: parse_accession("NC_000001.99"),
+                    parent_start: 200,
+                    nc_start: 10000,
+                    nc_end: 10010,
+                    strand: crate::reference::transcript::Strand::Plus,
+                },
+            );
+            let vp = VariantProjector::new(projector, provider).with_assembly(Some("GRCh37"));
+
+            // c.5A>T on NM_UR_TEST.1 with a *bare* NG_ parent (build-agnostic).
+            let input = HgvsVariant::Cds(CdsVariant {
+                accession: parse_accession("NM_UR_TEST.1")
+                    .with_genomic_context(parse_accession(UR_PARENT)),
+                gene_symbol: Some("URTEST".to_string()),
+                loc_edit: LocEdit::new(
+                    CdsInterval::point(CdsPos::new(5)),
+                    NaEdit::Substitution {
+                        reference: Base::A,
+                        alternative: Base::T,
+                    },
+                ),
+            });
+
+            let proj = vp.project_variant(&input, "NM_UR_TEST.1").expect(
+                "GRCh37 override must drive the downstream cdot lookup; pre-fix this errored \
+                 because the lookup re-inferred None from the unrecognized NC_000001.99 contig",
+            );
+            let coding = proj
+                .coding
+                .as_ref()
+                .expect("coding (c.) form must be present on the GRCh37 projection")
+                .to_string();
+            assert!(
+                coding.contains(":c.5A>T"),
+                "expected c.5A>T round-tripped via the GRCh37 alignment, got: {coding}",
+            );
+        }
     }
 
     #[test]
@@ -8574,5 +8713,73 @@ mod tests {
             matches!(err, FerroError::UnsupportedProjection { .. }),
             "transcript_id mismatch should be UnsupportedProjection, got {err:?}"
         );
+    }
+
+    /// Guard test: `MockProvider` (no assembly-report table) must return the same
+    /// build inference as the bare hardcoded free function for an NC_ accession —
+    /// i.e. routing through the provider is behavior-preserving (#716).
+    #[test]
+    fn infer_input_build_routes_through_provider() {
+        use crate::hgvs::variant::Accession;
+        let provider = crate::reference::mock::MockProvider::new();
+        let acc = Accession::new("NC", "000017", Some(11));
+        assert_eq!(
+            provider.infer_genome_build(&acc),
+            crate::liftover::aliases::infer_genome_build_from_accession(&acc)
+        );
+    }
+
+    /// A provider that delegates everything to an inner [`MockProvider`] but
+    /// reports a deliberately *different* build than the hardcoded heuristic for
+    /// one accession. Used to prove a projector path observes the provider's
+    /// `infer_genome_build` rather than the hardcoded free function (#716).
+    #[derive(Clone)]
+    struct BuildOverrideProvider {
+        inner: MockProvider,
+    }
+
+    impl ReferenceProvider for BuildOverrideProvider {
+        fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
+            self.inner.get_transcript(id)
+        }
+
+        fn get_sequence(&self, id: &str, start: u64, end: u64) -> Result<String, FerroError> {
+            self.inner.get_sequence(id, start, end)
+        }
+
+        fn infer_genome_build(&self, accession: &Accession) -> Option<&'static str> {
+            // NC_000017.11 is GRCh38 under the hardcoded heuristic; force GRCh37
+            // so a test can tell the provider's answer apart from the fallback.
+            if accession.full() == "NC_000017.11" {
+                Some("GRCh37")
+            } else {
+                self.inner.infer_genome_build(accession)
+            }
+        }
+    }
+
+    /// Override test: the projector must consult the provider's
+    /// `infer_genome_build`, not the hardcoded helper. With a provider that
+    /// deliberately classifies the `NC_000017.11` parent as GRCh37 (the heuristic
+    /// says GRCh38), `infer_input_build` must observe the provider's GRCh37 — if
+    /// it regressed to the hardcoded helper it would return GRCh38 and this would
+    /// fail (#716).
+    #[test]
+    fn infer_input_build_observes_provider_override() {
+        let parent = Accession::new("NC", "000017", Some(11));
+        // Sanity-check the premise: the hardcoded helper disagrees with the
+        // override, so the assertion below genuinely distinguishes the two paths.
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&parent),
+            Some("GRCh38"),
+        );
+        let provider = BuildOverrideProvider {
+            inner: MockProvider::new(),
+        };
+        let vp = VariantProjector::new(Projector::new(CdotMapper::new()), provider);
+        // A bare NM (no inherent build) whose genomic_context is the NC_ parent —
+        // `infer_input_build` falls through to consult the parent via the provider.
+        let variant = make_coding_variant("NM_TEST.1", Some(parent));
+        assert_eq!(vp.infer_input_build(&variant), Some("GRCh37"));
     }
 }

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -376,7 +376,11 @@ impl ReferenceProvider for MockProvider {
         build: Option<&str>,
     ) -> Option<GenomicPlacement> {
         let list = self.genomic_placements.get(&parent.full())?;
-        crate::reference::provider::select_placement_for_build(list, build)
+        crate::reference::provider::select_placement_for_build(
+            list,
+            build,
+            crate::liftover::aliases::infer_genome_build_from_accession,
+        )
     }
 
     fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1941,12 +1941,15 @@ impl MultiFastaProvider {
 
     /// Infer the genome build for an `NC_*` parent accession.
     ///
-    /// Thin wrapper around the shared
-    /// [`crate::liftover::aliases::infer_genome_build_from_accession`] —
-    /// kept on the impl so existing call sites and tests stay terse;
-    /// see the free function for the canonical contract.
-    fn infer_build_from_parent(parent: &crate::hgvs::variant::Accession) -> Option<&'static str> {
-        crate::liftover::aliases::infer_genome_build_from_accession(parent)
+    /// Thin `&self` wrapper around [`ReferenceProvider::infer_genome_build`], so the
+    /// cdot build-probe path consults this reference's assembly-report-derived table
+    /// (when present) before the hardcoded fallback (#716). See
+    /// [`crate::liftover::aliases::infer_genome_build_layered`] for the layering contract.
+    fn infer_build_from_parent(
+        &self,
+        parent: &crate::hgvs::variant::Accession,
+    ) -> Option<&'static str> {
+        self.infer_genome_build(parent)
     }
 
     /// Whether `id` names a transcript whose bases are directly available at
@@ -2386,7 +2389,7 @@ impl ReferenceProvider for MultiFastaProvider {
         //   NG_*  : build-agnostic. Probe GRCh38 first (mutalyzer policy),
         //           then GRCh37.
         //   other : fall through to plain lookup (no extra information).
-        let probe_order: &[&str] = match Self::infer_build_from_parent(parent) {
+        let probe_order: &[&str] = match self.infer_build_from_parent(parent) {
             Some("GRCh38") => &["GRCh38", "GRCh37"],
             Some("GRCh37") => &["GRCh37", "GRCh38"],
             _ => {
@@ -3074,7 +3077,14 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     }
 
     // ----------------------------------------------------------------------
-    // infer_build_from_parent unit coverage (closes review gap on #332)
+    // Hardcoded-heuristic build inference (closes review gap on #332)
+    //
+    // These exercise the free function
+    // `crate::liftover::aliases::infer_genome_build_from_accession` directly —
+    // i.e. the version-aware hardcoded alias table, independent of any
+    // provider. The `&self` `infer_build_from_parent` method, which routes
+    // through the layered data-driven table, is covered separately by
+    // `infer_build_from_parent_uses_assembly_report_table` below.
     // ----------------------------------------------------------------------
 
     fn nc_accession(num: &str, version: u32) -> crate::hgvs::variant::Accession {
@@ -3089,7 +3099,9 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     fn infer_build_chr17_grch38() {
         // NC_000017.11 is chr17 on GRCh38.
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&nc_accession("000017", 11)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&nc_accession(
+                "000017", 11
+            )),
             Some("GRCh38")
         );
     }
@@ -3098,7 +3110,9 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     fn infer_build_chr17_grch37() {
         // NC_000017.10 is chr17 on GRCh37.
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&nc_accession("000017", 10)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&nc_accession(
+                "000017", 10
+            )),
             Some("GRCh37")
         );
     }
@@ -3108,11 +3122,11 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         // chr14 NC accessions are NC_000014.9 (GRCh38) / NC_000014.8 (GRCh37).
         // A naive ".11→GRCh38, .10→GRCh37" rule would mis-classify both.
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&nc_accession("000014", 9)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&nc_accession("000014", 9)),
             Some("GRCh38"),
         );
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&nc_accession("000014", 8)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&nc_accession("000014", 8)),
             Some("GRCh37"),
         );
     }
@@ -3121,7 +3135,9 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     fn infer_build_malformed_nc_returns_none() {
         // NC_000999.999 is not in the human alias table on any build.
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&nc_accession("000999", 999)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&nc_accession(
+                "000999", 999
+            )),
             None,
         );
     }
@@ -3130,7 +3146,7 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     fn infer_build_ng_parent_returns_none() {
         // NG accessions are build-agnostic; caller must probe builds.
         assert_eq!(
-            MultiFastaProvider::infer_build_from_parent(&ng_accession("012772", 1)),
+            crate::liftover::aliases::infer_genome_build_from_accession(&ng_accession("012772", 1)),
             None,
         );
     }
@@ -5352,6 +5368,64 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             provider.infer_genome_build(&future_chr17),
             Some("GRCh38"),
             "from_manifest must load the assembly report and wire it into infer_genome_build"
+        );
+    }
+
+    #[test]
+    fn infer_build_from_parent_uses_assembly_report_table() {
+        // Direct unit coverage of the `&self` `infer_build_from_parent` method
+        // (the probe-order caller at `get_transcript_for_accession`). It must
+        // route through the layered data-driven table, NOT the hardcoded
+        // heuristic. We again use NC_000017.99 — a version absent from the
+        // hardcoded table — so a `Some("GRCh38")` answer can only come from the
+        // assembly-report-derived ContigAliases.
+        use crate::hgvs::variant::Accession;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // A minimal transcript FASTA (required by from_manifest).
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+
+        // Assembly report with a chr17 row using .99 — unknown to the hardcoded table.
+        let report_text = "# Assembly name:  GRCh38.test\n\
+            # Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\t\
+            GenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name\n\
+            17\tassembled-molecule\t17\tChromosome\tCM000679.9\t=\tNC_000017.99\t\
+            Primary Assembly\t83257441\tchr17\n";
+        fs::write(d.join("assembly_report.txt"), report_text).unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "assembly_report": "assembly_report.txt",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+
+        let future_chr17 = Accession::new("NC", "000017", Some(99));
+
+        // Test premise: the hardcoded heuristic does not know .99, so a hit here
+        // must come from the data-driven table the method routes through.
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&future_chr17),
+            None,
+            "hardcoded table must not know NC_000017.99 (test premise)"
+        );
+
+        // The `&self` method resolves the accession via the layered table.
+        assert_eq!(
+            provider.infer_build_from_parent(&future_chr17),
+            Some("GRCh38"),
+            "infer_build_from_parent must route through the assembly-report-derived table"
         );
     }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -238,6 +238,10 @@ pub struct MultiFastaProvider {
     /// `LRG_RefSeqGene` table named by the manifest's `refseqgene_summary`
     /// (#500/#637). Empty when the manifest carries no summary file.
     legacy_gene_models: FxHashMap<String, String>,
+    /// Data-driven accession→build table from the prepared reference's own
+    /// assembly report(s) (#716). `None` when the manifest names no report, in
+    /// which case build inference uses only the hardcoded fallback.
+    contig_aliases: Option<crate::liftover::aliases::ContigAliases>,
 }
 
 /// Resolution inputs that uniquely identify a resolved transcript: the requested
@@ -338,6 +342,7 @@ impl MultiFastaProvider {
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
+            contig_aliases: None,
         })
     }
 
@@ -376,6 +381,7 @@ impl MultiFastaProvider {
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
+            contig_aliases: None,
         })
     }
 
@@ -575,6 +581,77 @@ impl MultiFastaProvider {
             .map(resolve_path)
             .and_then(|p| p.parent().map(Path::to_path_buf));
 
+        // Build the data-driven accession→build table from the assembly
+        // report(s) the manifest names (#716). Each report is paired with its
+        // build; a read/parse failure warns and is skipped (build inference
+        // then uses the hardcoded fallback). An empty table is treated as
+        // absent so it never shadows the fallback.
+        //
+        // This is built BEFORE placement ingestion so the same layered inferer
+        // drives both ingest and lookup: a report-only `NC_` accession (one the
+        // hardcoded heuristic cannot classify) is then retained and classified
+        // during parse/merge instead of being dropped before
+        // `select_placement_for_build` ever sees it.
+        use crate::reference::transcript::GenomeBuild;
+        let report_fields = [
+            ("assembly_report", GenomeBuild::GRCh38),
+            ("assembly_report_grch37", GenomeBuild::GRCh37),
+        ];
+        let mut parsed_reports: Vec<(
+            GenomeBuild,
+            crate::liftover::assembly_report::AssemblyReport,
+        )> = Vec::new();
+        for (field, build) in report_fields {
+            let Some(rel) = manifest.get(field).and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let path = resolve_path(rel);
+            match std::fs::read_to_string(&path) {
+                Ok(text) => {
+                    parsed_reports.push((
+                        build,
+                        crate::liftover::assembly_report::parse_assembly_report(&text),
+                    ));
+                }
+                Err(e) => warn!(
+                    "Failed to read assembly report {}: {}; \
+                     build inference uses the hardcoded fallback for this build",
+                    path.display(),
+                    e
+                ),
+            }
+        }
+        let contig_aliases = if parsed_reports.is_empty() {
+            None
+        } else {
+            let pairs: Vec<(
+                GenomeBuild,
+                &crate::liftover::assembly_report::AssemblyReport,
+            )> = parsed_reports.iter().map(|(b, r)| (*b, r)).collect();
+            let table = crate::liftover::aliases::ContigAliases::from_assembly_reports(&pairs);
+            // Empty parse (0 assembled-molecule rows) → treat as absent. Warn:
+            // a manifest named the report(s), so an empty table points at a
+            // corrupt/truncated report rather than an intentional absence.
+            if table.is_empty() {
+                warn!(
+                    "Assembly report(s) named by the manifest parsed to 0 assembled-molecule \
+                     rows; build inference falls back to the hardcoded version heuristic (the \
+                     report file may be corrupt or empty)"
+                );
+                None
+            } else {
+                Some(table)
+            }
+        };
+
+        // The layered inferer used everywhere below: the data-driven table first,
+        // the hardcoded heuristic as fallback (#716). Threading it into placement
+        // parse/merge keeps ingest consistent with lookup
+        // (`MultiFastaProvider::infer_genome_build`).
+        let infer_build = |acc: &crate::hgvs::variant::Accession| {
+            crate::liftover::aliases::infer_genome_build_layered(contig_aliases.as_ref(), acc)
+        };
+
         // Parse NG_ RefSeqGene→chromosome placements from the NCBI alignment
         // GFF3(s) the manifest names (#480). Two single-build snapshots are
         // merged so an NG_ resolves to its build-appropriate placement: the
@@ -592,7 +669,7 @@ impl MultiFastaProvider {
             let path = resolve_path(rel);
             match std::fs::read_to_string(&path) {
                 Ok(gff3) => {
-                    let placements = parse_refseqgene_alignments(&gff3);
+                    let placements = parse_refseqgene_alignments(&gff3, &infer_build);
                     if placements.is_empty() {
                         warn!(
                             "RefSeqGene alignments {} parsed to 0 placements \
@@ -600,7 +677,11 @@ impl MultiFastaProvider {
                             path.display()
                         );
                     }
-                    merge_refseqgene_placements(&mut refseqgene_placements, placements);
+                    merge_refseqgene_placements(
+                        &mut refseqgene_placements,
+                        placements,
+                        &infer_build,
+                    );
                 }
                 Err(e) => {
                     warn!(
@@ -629,7 +710,7 @@ impl MultiFastaProvider {
                     for (key, placement) in derived.to_placements() {
                         map.entry(key).or_default().push(placement);
                     }
-                    merge_refseqgene_placements(&mut refseqgene_placements, map);
+                    merge_refseqgene_placements(&mut refseqgene_placements, map, &infer_build);
                 }
                 Err(e) => {
                     warn!(
@@ -687,6 +768,7 @@ impl MultiFastaProvider {
         provider.lrg_xml_dir = lrg_xml_dir;
         provider.refseqgene_placements = refseqgene_placements;
         provider.legacy_gene_models = legacy_gene_models;
+        provider.contig_aliases = contig_aliases;
 
         // Load cdot transcript metadata if available
         if let Some(cdot_path_str) = manifest.get("cdot_json").and_then(|v| v.as_str()) {
@@ -912,6 +994,7 @@ impl MultiFastaProvider {
             lrg_placement_cache: Mutex::new(FxHashMap::default()),
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
+            contig_aliases: None,
         })
     }
 
@@ -2080,15 +2163,21 @@ fn gff_attr<'a>(attrs: &'a str, key: &str) -> Option<&'a str> {
 /// (The GFF `match` strand in col 7 is always `+`; the real orientation is the
 /// Target strand.)
 ///
-/// Only **ungapped** (`gap_count=0`) alignments to a **GRCh37 or GRCh38 primary
-/// chromosome** are kept (the build is derivable from the `NC_` version), stored
-/// per build so the input's resolved build selects the right placement at lookup
-/// (#653). Alt-loci/patch contigs and gapped alignments — which a single affine
+/// Only **ungapped** (`gap_count=0`) alignments to a chromosome `infer_build`
+/// can classify to a build are kept, stored per build so the input's resolved
+/// build selects the right placement at lookup (#653). `infer_build` is the
+/// caller's layered inferer (data-driven assembly-report table first, hardcoded
+/// `NC_`-version heuristic as fallback, #716), so a report-only accession the
+/// heuristic alone cannot place is still retained here rather than dropped before
+/// lookup. Alt-loci/patch contigs and gapped alignments — which a single affine
 /// span cannot represent — are skipped, so the projector declines rather than
 /// emit a wrong `NG_` coordinate. At most one placement is kept per (NG version,
 /// build); see [`merge_refseqgene_placements`] for combining multiple alignment
 /// files (e.g. the separate GRCh38 and GRCh37 RefSeqGene snapshots, #713).
-fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlacement>> {
+fn parse_refseqgene_alignments(
+    gff3: &str,
+    infer_build: &impl Fn(&crate::hgvs::variant::Accession) -> Option<&'static str>,
+) -> FxHashMap<String, Vec<GenomicPlacement>> {
     let mut out: FxHashMap<String, Vec<GenomicPlacement>> = FxHashMap::default();
     for line in gff3.lines() {
         if line.starts_with('#') || line.trim().is_empty() {
@@ -2132,15 +2221,16 @@ fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlace
         } else {
             crate::reference::transcript::Strand::Plus
         };
-        // Keep placements on a GRCh37 or GRCh38 PRIMARY chromosome (the build is
-        // derivable from the NC_ version). Alt-loci / fix-patch contigs return
-        // `None` and are skipped (a single affine span cannot anchor them).
-        // Both builds are retained and stored per-build; selection by the input's
-        // resolved build happens at lookup (#653).
+        // Keep placements whose build the layered inferer can classify (the
+        // data-driven assembly-report table first, the hardcoded NC_-version
+        // heuristic as fallback, #716). Alt-loci / fix-patch contigs the inferer
+        // cannot place return `None` and are skipped (a single affine span cannot
+        // anchor them). Both builds are retained and stored per-build; selection
+        // by the input's resolved build happens at lookup (#653).
         let Ok((_, nc)) = crate::hgvs::parser::accession::parse_accession(cols[0]) else {
             continue;
         };
-        let Some(build) = crate::liftover::aliases::infer_genome_build_from_accession(&nc) else {
+        let Some(build) = infer_build(&nc) else {
             continue;
         };
         let (nc_start, nc_end) = if a <= b { (a, b) } else { (b, a) };
@@ -2154,9 +2244,7 @@ fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlace
         // Keep at most one placement per (NG version, build): first wins if a
         // release lists the same alignment twice.
         let entry = out.entry(ng.to_string()).or_default();
-        let has_build = entry.iter().any(|p| {
-            crate::liftover::aliases::infer_genome_build_from_accession(&p.nc) == Some(build)
-        });
+        let has_build = entry.iter().any(|p| infer_build(&p.nc) == Some(build));
         if !has_build {
             entry.push(placement);
         }
@@ -2173,21 +2261,20 @@ fn parse_refseqgene_alignments(gff3: &str) -> FxHashMap<String, Vec<GenomicPlace
 /// (GRCh38 rows are on `NC_*.11`, GRCh37 on `NC_*.10`-era accessions), so merging
 /// them gives each `NG_` both builds, and [`select_placement_for_build`] picks
 /// the one matching the input's resolved build. The build is read back from each
-/// placement's `NC_` accession, mirroring `parse_refseqgene_alignments`'
-/// per-build de-duplication so a build already present from an earlier file is
-/// never overwritten.
+/// placement's `NC_` accession via the same injected `infer_build` (the layered
+/// inferer, #716), mirroring `parse_refseqgene_alignments`' per-build
+/// de-duplication so a build already present from an earlier file is never
+/// overwritten.
 fn merge_refseqgene_placements(
     acc: &mut FxHashMap<String, Vec<GenomicPlacement>>,
     addition: FxHashMap<String, Vec<GenomicPlacement>>,
+    infer_build: &impl Fn(&crate::hgvs::variant::Accession) -> Option<&'static str>,
 ) {
-    use crate::liftover::aliases::infer_genome_build_from_accession;
     for (ng, placements) in addition {
         let entry = acc.entry(ng).or_default();
         for placement in placements {
-            let build = infer_genome_build_from_accession(&placement.nc);
-            let has_build = entry
-                .iter()
-                .any(|p| infer_genome_build_from_accession(&p.nc) == build);
+            let build = infer_build(&placement.nc);
+            let has_build = entry.iter().any(|p| infer_build(&p.nc) == build);
             if !has_build {
                 entry.push(placement);
             }
@@ -2252,6 +2339,16 @@ impl ReferenceProvider for MultiFastaProvider {
         crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
             self.legacy_gene_models.get(g).cloned()
         })
+    }
+
+    fn infer_genome_build(
+        &self,
+        accession: &crate::hgvs::variant::Accession,
+    ) -> Option<&'static str> {
+        crate::liftover::aliases::infer_genome_build_layered(
+            self.contig_aliases.as_ref(),
+            accession,
+        )
     }
 
     fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
@@ -2623,6 +2720,13 @@ mod tests {
     use std::io::Write;
     use tempfile::tempdir;
 
+    /// The bundled hardcoded build inferer, matching what the placement parsers
+    /// used before the layered assembly-report table was threaded through (#716).
+    /// Tests pass it so their per-build expectations stay pinned to the heuristic.
+    fn heuristic_infer(acc: &crate::hgvs::variant::Accession) -> Option<&'static str> {
+        crate::liftover::aliases::infer_genome_build_from_accession(acc)
+    }
+
     // ----------------------------------------------------------------------
     // LRG placement parsing (#480)
     // ----------------------------------------------------------------------
@@ -2771,7 +2875,7 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
 
     #[test]
     fn parses_refseqgene_alignments_plus_and_minus() {
-        let m = parse_refseqgene_alignments(RSG_GFF3_SAMPLE);
+        let m = parse_refseqgene_alignments(RSG_GFF3_SAMPLE, &heuristic_infer);
 
         // GRCh37 is now KEPT (#653); only the gapped and non-`match` rows drop.
         assert_eq!(
@@ -2821,6 +2925,43 @@ NC_000001.11\tRefSeq\tcDNA_match\t4000\t4099\t100\t+\t.\tID=aln4;Target=NG_00500
         );
     }
 
+    /// Regression for #716: a "report-only" `NC_` accession — one whose version
+    /// the hardcoded heuristic cannot classify, but a data-driven assembly-report
+    /// table can — must be retained during alignment parsing, not dropped before
+    /// `select_placement_for_build` could ever see it. The placement parser honors
+    /// the injected layered inferer, so threading the table through ingest (not
+    /// just lookup) is what keeps the data-driven path reachable for these.
+    #[test]
+    fn parse_keeps_report_only_accession_via_injected_inferer() {
+        // `NC_000001.99` is an unknown version: the bundled heuristic declines it.
+        const REPORT_ONLY_GFF3: &str = "\
+##gff-version 3
+NC_000001.99\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\tID=aln0;Target=NG_009000.1 1 100 +;gap_count=0\n";
+
+        // Heuristic-only ingest drops the row (build is unclassifiable) — this is
+        // exactly the gap the layering closes.
+        let heuristic_only = parse_refseqgene_alignments(REPORT_ONLY_GFF3, &heuristic_infer);
+        assert!(
+            heuristic_only.is_empty(),
+            "the hardcoded heuristic cannot classify NC_000001.99, so it is dropped: {heuristic_only:?}"
+        );
+
+        // A data-driven inferer that classifies NC_000001.99 keeps the placement.
+        let layered = |acc: &crate::hgvs::variant::Accession| {
+            if acc.full() == "NC_000001.99" {
+                Some("GRCh38")
+            } else {
+                heuristic_infer(acc)
+            }
+        };
+        let kept = parse_refseqgene_alignments(REPORT_ONLY_GFF3, &layered);
+        let list = kept
+            .get("NG_009000.1")
+            .expect("report-only NC_ placement must be retained under the injected inferer");
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].nc.to_string(), "NC_000001.99");
+    }
+
     /// `ferro prepare` writes two single-build RefSeqGene alignment files; the
     /// provider merges them so each NG_ carries both builds and
     /// `genomic_placement_on_build` selects the right one (#713). The GRCh38
@@ -2835,8 +2976,12 @@ NC_000001.11\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\tID=a0;Target=NG_007000.1 1 1
 NC_000001.10\tRefSeq\tmatch\t5000\t5099\t100\t+\t.\tID=a1;Target=NG_007000.1 1 100 +;gap_count=0\n";
 
         // Merge in prepare's order: GRCh38 first, then GRCh37.
-        let mut merged = parse_refseqgene_alignments(GRCH38_FILE);
-        merge_refseqgene_placements(&mut merged, parse_refseqgene_alignments(GRCH37_FILE));
+        let mut merged = parse_refseqgene_alignments(GRCH38_FILE, &heuristic_infer);
+        merge_refseqgene_placements(
+            &mut merged,
+            parse_refseqgene_alignments(GRCH37_FILE, &heuristic_infer),
+            &heuristic_infer,
+        );
 
         let list = merged.get("NG_007000.1").expect("NG_ present after merge");
         assert_eq!(list.len(), 2, "both builds retained: {list:?}");
@@ -2870,8 +3015,12 @@ NC_000001.11\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\tID=a0;Target=NG_008000.1 1 1
 ##gff-version 3
 NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 100 +;gap_count=0\n";
 
-        let mut merged = parse_refseqgene_alignments(FIRST);
-        merge_refseqgene_placements(&mut merged, parse_refseqgene_alignments(SECOND));
+        let mut merged = parse_refseqgene_alignments(FIRST, &heuristic_infer);
+        merge_refseqgene_placements(
+            &mut merged,
+            parse_refseqgene_alignments(SECOND, &heuristic_infer),
+            &heuristic_infer,
+        );
 
         let list = &merged["NG_008000.1"];
         assert_eq!(list.len(), 1, "only one placement per build is kept");
@@ -2905,7 +3054,8 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
     #[test]
     fn provider_resolves_ng_placement_from_alignments() {
         let (mut provider, _dir) = build_provider_with_test_genome();
-        provider.refseqgene_placements = parse_refseqgene_alignments(RSG_GFF3_SAMPLE);
+        provider.refseqgene_placements =
+            parse_refseqgene_alignments(RSG_GFF3_SAMPLE, &heuristic_infer);
 
         let ng = crate::hgvs::variant::Accession::new("NG", "001000", Some(1));
         let p = provider
@@ -5139,6 +5289,136 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         assert_eq!(
             mapper.available_builds_for("NM_000088.3"),
             vec!["GRCh38".to_string()]
+        );
+    }
+
+    #[test]
+    fn from_manifest_loads_assembly_report_contig_aliases() {
+        // Prove that MultiFastaProvider::from_manifest ingests the assembly
+        // report and wires it into infer_genome_build via ContigAliases.
+        //
+        // We use NC_000017.99 — a version the hardcoded table does NOT know
+        // (the real table only knows .11 for chr17 GRCh38), so if this test
+        // passes it must come from the data-driven path, not the fallback.
+        use crate::hgvs::variant::Accession;
+        use crate::reference::ReferenceProvider;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // A minimal transcript FASTA (required by from_manifest).
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+
+        // Assembly report with a chr17 row using .99 — unknown to the hardcoded table.
+        // Format: 10 tab-separated columns matching NCBI's assembly_report layout.
+        let report_text = "# Assembly name:  GRCh38.test\n\
+            # Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\t\
+            GenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name\n\
+            17\tassembled-molecule\t17\tChromosome\tCM000679.9\t=\tNC_000017.99\t\
+            Primary Assembly\t83257441\tchr17\n";
+        fs::write(d.join("assembly_report.txt"), report_text).unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "assembly_report": "assembly_report.txt",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+
+        // Sanity: hardcoded heuristic does not know .99.
+        let future_chr17 = Accession::new("NC", "000017", Some(99));
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&future_chr17),
+            None,
+            "hardcoded table must not know NC_000017.99 (test premise)"
+        );
+
+        // Data-driven path: the loaded ContigAliases table classifies it.
+        assert_eq!(
+            provider.infer_genome_build(&future_chr17),
+            Some("GRCh38"),
+            "from_manifest must load the assembly report and wire it into infer_genome_build"
+        );
+    }
+
+    /// End-to-end regression for #716: an `NG_` alignment placed on a
+    /// report-only `NC_` accession (one the hardcoded heuristic cannot classify)
+    /// must survive ingestion and resolve at lookup. This proves the assembly
+    /// report is loaded BEFORE placement ingestion and the layered inferer is
+    /// threaded through parse/merge — if the report load were still ordered after
+    /// ingestion (or parse used the hardcoded fn), the placement would be dropped
+    /// and `genomic_placement` would return `None`.
+    #[test]
+    fn from_manifest_retains_ng_placement_on_report_only_accession() {
+        use crate::hgvs::variant::Accession;
+        use crate::reference::ReferenceProvider;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // A minimal transcript FASTA (required by from_manifest).
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+
+        // Assembly report mapping chr17 to NC_000017.99 — a version the hardcoded
+        // heuristic does NOT know, so any retained placement on it must come from
+        // the data-driven path threaded through parse.
+        let report_text = "# Assembly name:  GRCh38.test\n\
+            # Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\t\
+            GenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name\n\
+            17\tassembled-molecule\t17\tChromosome\tCM000679.9\t=\tNC_000017.99\t\
+            Primary Assembly\t83257441\tchr17\n";
+        fs::write(d.join("assembly_report.txt"), report_text).unwrap();
+
+        // A RefSeqGene alignment placing NG_009000.1 on the report-only NC_000017.99.
+        let alignments = "##gff-version 3\n\
+            NC_000017.99\tRefSeq\tmatch\t1000\t1099\t100\t+\t.\t\
+            ID=aln0;Target=NG_009000.1 1 100 +;gap_count=0\n";
+        fs::write(d.join("refseqgene_alignments.gff3"), alignments).unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "assembly_report": "assembly_report.txt",
+                "refseqgene_alignments": "refseqgene_alignments.gff3",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+
+        // The NG_ placement must resolve, anchored on the report-only accession —
+        // proof that ingestion retained it via the layered inferer.
+        let ng = Accession::new("NG", "009000", Some(1));
+        let placement = provider.genomic_placement(&ng).expect(
+            "NG_ placement on a report-only NC_ accession must be retained and resolve (#716)",
+        );
+        assert_eq!(placement.nc.to_string(), "NC_000017.99");
+    }
+
+    #[test]
+    fn trait_default_infer_genome_build_matches_hardcoded() {
+        use crate::hgvs::variant::Accession;
+        use crate::reference::provider::ReferenceProvider;
+        let provider = crate::reference::mock::MockProvider::new();
+        let grch38_chr17 = Accession::new("NC", "000017", Some(11));
+        assert_eq!(
+            provider.infer_genome_build(&grch38_chr17),
+            crate::liftover::aliases::infer_genome_build_from_accession(&grch38_chr17)
         );
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -2304,7 +2304,9 @@ impl ReferenceProvider for MultiFastaProvider {
         // (decline) rather than mis-anchor onto a different build's placement.
         if parent.prefix.as_ref() == "NG" {
             let list = self.refseqgene_placements.get(&parent.full())?;
-            return crate::reference::provider::select_placement_for_build(list, build);
+            return crate::reference::provider::select_placement_for_build(list, build, |a| {
+                self.infer_genome_build(a)
+            });
         }
         // LRG placement comes from the on-hand LRG XMLs (parsed on demand). LRG
         // carries a single main-assembly placement, so the build hint is not
@@ -2986,10 +2988,13 @@ NC_000001.10\tRefSeq\tmatch\t5000\t5099\t100\t+\t.\tID=a1;Target=NG_007000.1 1 1
         let list = merged.get("NG_007000.1").expect("NG_ present after merge");
         assert_eq!(list.len(), 2, "both builds retained: {list:?}");
 
-        let g38 = crate::reference::provider::select_placement_for_build(list, Some("GRCh38"))
-            .expect("GRCh38 placement selectable");
-        let g37 = crate::reference::provider::select_placement_for_build(list, Some("GRCh37"))
-            .expect("GRCh37 placement selectable");
+        let infer = crate::liftover::aliases::infer_genome_build_from_accession;
+        let g38 =
+            crate::reference::provider::select_placement_for_build(list, Some("GRCh38"), infer)
+                .expect("GRCh38 placement selectable");
+        let g37 =
+            crate::reference::provider::select_placement_for_build(list, Some("GRCh37"), infer)
+                .expect("GRCh37 placement selectable");
         assert_eq!(g38.nc.to_string(), "NC_000001.11");
         assert_eq!(g38.nc_start, 1000);
         assert_eq!(g37.nc.to_string(), "NC_000001.10");
@@ -2997,7 +3002,7 @@ NC_000001.10\tRefSeq\tmatch\t5000\t5099\t100\t+\t.\tID=a1;Target=NG_007000.1 1 1
 
         // Regression: adding the GRCh37 placement must NOT shift the
         // build-agnostic default away from GRCh38 (cdot primary / mutalyzer).
-        let default = crate::reference::provider::select_placement_for_build(list, None)
+        let default = crate::reference::provider::select_placement_for_build(list, None, infer)
             .expect("default placement selectable");
         assert_eq!(default.nc.to_string(), "NC_000001.11");
     }

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -206,6 +206,14 @@ pub trait ReferenceProvider {
         self.genomic_placement(parent)
     }
 
+    /// Infer the genome build (`"GRCh37"`/`"GRCh38"`) for a chromosome
+    /// accession. The default is the bundled hardcoded heuristic; providers
+    /// that carry an assembly-report-derived table override this to consult it
+    /// first (#716).
+    fn infer_genome_build(&self, accession: &Accession) -> Option<&'static str> {
+        crate::liftover::aliases::infer_genome_build_from_accession(accession)
+    }
+
     /// Resolve a legacy LOVD gene-model selector (`GENE`, `GENE_v001`) on a
     /// genomic reference to a transcript accession (#500/#637).
     ///
@@ -490,6 +498,13 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for std::sync::Arc<T> {
     fn get_sequence_length(&self, id: &str) -> Result<u64, FerroError> {
         (**self).get_sequence_length(id)
     }
+
+    fn infer_genome_build(&self, accession: &Accession) -> Option<&'static str> {
+        // Forward so the wrapped provider's data-driven table (e.g.
+        // MultiFastaProvider's ContigAliases) survives an Arc wrapper; the
+        // trait default calls the hardcoded heuristic and would bypass it.
+        (**self).infer_genome_build(accession)
+    }
 }
 
 /// Blanket implementation for boxed trait objects.
@@ -581,6 +596,13 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for Box<T> {
 
     fn get_sequence_length(&self, id: &str) -> Result<u64, FerroError> {
         (**self).get_sequence_length(id)
+    }
+
+    fn infer_genome_build(&self, accession: &Accession) -> Option<&'static str> {
+        // Forward so the wrapped provider's data-driven table (e.g.
+        // MultiFastaProvider's ContigAliases) survives a Box wrapper; the
+        // trait default calls the hardcoded heuristic and would bypass it.
+        (**self).infer_genome_build(accession)
     }
 }
 
@@ -729,6 +751,13 @@ mod wrapper_forwarding_tests {
         fn resolve_legacy_gene_selector(&self, _selector: &str) -> Option<String> {
             Some("NM_999999.9".to_string())
         }
+
+        fn infer_genome_build(&self, _accession: &Accession) -> Option<&'static str> {
+            // Return a sentinel that the hardcoded heuristic would NOT return for
+            // an unknown accession (which produces `None`), so a forwarding test
+            // can distinguish the override path from trait-default fall-through.
+            Some("GRCh38")
+        }
     }
 
     /// Extract the `ReferenceNotFound` id, which carries the sentinel marking
@@ -755,6 +784,19 @@ mod wrapper_forwarding_tests {
             arc.resolve_legacy_gene_selector("GENE"),
             Some("NM_999999.9".to_string())
         );
+        // Use a bogus NC_ accession the hardcoded table doesn't know → None; the
+        // override returns Some("GRCh38"), so forwarding is distinguishable.
+        let unknown_nc = Accession::new("NC", "000999", Some(999));
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&unknown_nc),
+            None,
+            "hardcoded heuristic must return None for the sentinel accession"
+        );
+        assert_eq!(
+            arc.infer_genome_build(&unknown_nc),
+            Some("GRCh38"),
+            "Arc must forward infer_genome_build to the wrapped provider"
+        );
     }
 
     #[test]
@@ -768,6 +810,18 @@ mod wrapper_forwarding_tests {
         assert_eq!(
             boxed.resolve_legacy_gene_selector("GENE"),
             Some("NM_999999.9".to_string())
+        );
+        // Same forwarding check for Box.
+        let unknown_nc = Accession::new("NC", "000999", Some(999));
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&unknown_nc),
+            None,
+            "hardcoded heuristic must return None for the sentinel accession"
+        );
+        assert_eq!(
+            boxed.infer_genome_build(&unknown_nc),
+            Some("GRCh38"),
+            "Box must forward infer_genome_build to the wrapped provider"
         );
     }
 }

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -53,9 +53,9 @@ pub struct GenomicPlacement {
 pub(crate) fn select_placement_for_build(
     placements: &[GenomicPlacement],
     build: Option<&str>,
+    infer_build: impl Fn(&Accession) -> Option<&'static str>,
 ) -> Option<GenomicPlacement> {
-    let build_of =
-        |p: &GenomicPlacement| crate::liftover::aliases::infer_genome_build_from_accession(&p.nc);
+    let build_of = |p: &GenomicPlacement| infer_build(&p.nc);
     match build {
         Some(b) => placements.iter().find(|p| build_of(p) == Some(b)).cloned(),
         None => placements
@@ -655,28 +655,59 @@ mod placement_tests {
         let grch38 = placement_on(11); // NC_000001.11 → GRCh38
         let grch37 = placement_on(10); // NC_000001.10 → GRCh37
         let both = vec![grch38.clone(), grch37.clone()];
+        let infer = crate::liftover::aliases::infer_genome_build_from_accession;
 
         // Explicit build selects that build's placement.
         assert_eq!(
-            select_placement_for_build(&both, Some("GRCh38")),
+            select_placement_for_build(&both, Some("GRCh38"), infer),
             Some(grch38.clone())
         );
         assert_eq!(
-            select_placement_for_build(&both, Some("GRCh37")),
+            select_placement_for_build(&both, Some("GRCh37"), infer),
             Some(grch37.clone())
         );
         // No preference → GRCh38 even when listed second.
         assert_eq!(
-            select_placement_for_build(&[grch37.clone(), grch38.clone()], None),
+            select_placement_for_build(&[grch37.clone(), grch38.clone()], None, infer),
             Some(grch38.clone())
         );
         // Build-match guard: an explicit build with no matching placement declines
         // rather than substitute the other build (would mis-anchor).
         let only37 = vec![grch37.clone()];
-        assert_eq!(select_placement_for_build(&only37, Some("GRCh38")), None);
+        assert_eq!(
+            select_placement_for_build(&only37, Some("GRCh38"), infer),
+            None
+        );
         // No preference with only GRCh37 present → return it (never empty if data exists).
-        assert_eq!(select_placement_for_build(&only37, None), Some(grch37));
-        assert_eq!(select_placement_for_build(&[], Some("GRCh38")), None);
+        assert_eq!(
+            select_placement_for_build(&only37, None, infer),
+            Some(grch37)
+        );
+        assert_eq!(select_placement_for_build(&[], Some("GRCh38"), infer), None);
+    }
+
+    #[test]
+    fn select_placement_uses_injected_inference() {
+        let grch38 = placement_on(11); // NC_000001.11 → GRCh38 (per the hardcoded heuristic)
+        let grch37 = placement_on(10); // NC_000001.10 → GRCh37 (per the hardcoded heuristic)
+        let both = vec![grch37.clone(), grch38.clone()];
+        // Deliberately invert the heuristic: this closure calls NC_000001.10
+        // "GRCh38" and everything else `None`. If `select_placement_for_build`
+        // ignored the injected closure and reached for the hardcoded helper, it
+        // would return `grch38` (the .11 placement) and this assertion would
+        // fail — so the test now observes that the injected inferer truly drives
+        // selection.
+        let infer = |acc: &Accession| {
+            if acc.full() == "NC_000001.10" {
+                Some("GRCh38")
+            } else {
+                None
+            }
+        };
+        assert_eq!(
+            select_placement_for_build(&both, Some("GRCh38"), infer),
+            Some(grch37)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #716.

## What

Build inference (`infer_genome_build_from_accession`) decided GRCh37 vs GRCh38 from a hardcoded per-chromosome version table in `src/liftover/aliases.rs`. That is brittle: it only knows the chromosome `.version` accessions baked into the table, and it encodes assembly identity as a version-number heuristic rather than reading it from an authoritative source.

This wires up the data-driven path end-to-end so build inference consults the prepared reference's own NCBI `*_assembly_report.txt` first, falling back to the hardcoded table only when the report does not describe an accession (or no report is present). The parser (`assembly_report.rs`), `ContigAliases::from_assembly_reports`, and `infer_genome_build_from_accession_with` already existed and were unit-tested but unwired; this PR connects download → manifest → provider → inference.

## How

- **`ferro prepare`** downloads the `*_assembly_report.txt` alongside each genome it fetches (`record_assembly_report`) and records the path in the manifest. A report-download failure is a soft warning that degrades to the hardcoded fallback — it never aborts the genome download.
- **Manifest** carries two new `Option<PathBuf>` fields, `assembly_report` / `assembly_report_grch37`, with `#[serde(default)]` so pre-existing manifests still load. Both are wired into the `for_each_path` / `for_each_path_mut` relativize/absolutize/validate plumbing.
- **`MultiFastaProvider::from_manifest`** parses the recorded report(s) into a per-build `ContigAliases` table (stored as `None` when no report is named or it parses empty, so an empty table never shadows the fallback).
- **Inference** routes through a new `ReferenceProvider::infer_genome_build` trait method whose default is the hardcoded heuristic; `MultiFastaProvider` overrides it to layer the data-driven table over that fallback (`infer_genome_build_layered`). All provider-reachable call sites in `projector.rs` and `multi_fasta.rs` route through the provider, and `select_placement_for_build` takes the inference as an injected closure so the change reaches placement selection too. The `Arc<T>` / `Box<T>` blanket impls forward `infer_genome_build` so a wrapped provider keeps the data-driven behavior.
- **`ferro check`** warns when a named-but-missing assembly report is absent, matching the existing optional-input checks.

The hardcoded `default_human` table contents are unchanged — it remains the fallback. For any primary chromosome the two tables agree by construction (the hardcoded table was derived from these reports); the only cross-build accession, mtDNA `NC_012920.1`, resolves GRCh38 either way via the GRCh38-first check order. Net behavioral gain: `NC_` versions the report describes but the hardcoded table never knew now classify correctly.

## Out of scope

Disambiguating a bare `NG_` variant *input*'s intended build — a sidecar describes the *reference*, not the *query*; that ergonomic gap is the `--assembly` override (#715, already landed).

## Testing

- New unit tests: the layering helper (report-only version classifies, hardcoded fallback, no-table parity), manifest round-trip + pre-existing-manifest back-compat, the `skip_existing` prepare path, `Arc`/`Box` forwarding of `infer_genome_build`, a `from_manifest` integration test that classifies a report-only version via the loaded table, and `ferro check` missing-report warnings.
- Full suite: 7430 passed / 54 skipped. `cargo clippy --features dev --all-targets -- -D warnings` and `cargo fmt --all --check` clean. Spec fixture `--check` passes.
- Manifest-gated conformance against the prepared reference: zero regression (the prepared manifest carries no report yet, so this exercises the fallback path — the data-driven path is covered by the unit/integration tests above; re-running `ferro prepare` will provision the reports for end-to-end conformance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Genome preparation can now automatically download GRCh38/GRCh37 assembly reports and use them to improve genome build inference.
* **Bug Fixes**
  * Missing GRCh38/GRCh37 assembly report files now surface as warnings instead of failing silently.
* **Improvements**
  * Reference manifests now persist assembly report paths (when available), restoring them correctly on reload and including them in manifest path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->