### PR TITLE
fix(normalize): resolve legacy GENE_v001 selector against the NG_ parent's hosted transcript (#792)

### DIFF
--- a/examples/derive_ng_placements.rs
+++ b/examples/derive_ng_placements.rs
@@ -109,20 +109,20 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
          Source manifest: {}.",
         cli.manifest.display()
     );
-    let (artifact, declined) =
-        derive_placements_for_accessions(&provider, &accessions, &builds, description)
-            .map_err(|e| anyhow::anyhow!("derive: {e}"))?;
+    let out = derive_placements_for_accessions(&provider, &accessions, &builds, description)
+        .map_err(|e| anyhow::anyhow!("derive: {e}"))?;
 
-    let json = artifact
+    let json = out
+        .artifact
         .to_json()
         .map_err(|e| anyhow::anyhow!("serialize: {e}"))?;
     std::fs::write(&cli.out, &json)
         .map_err(|e| anyhow::anyhow!("write {}: {e}", cli.out.display()))?;
     println!(
         "Derived {} placement(s) for {} accession(s), {} declined. Wrote {}.",
-        artifact.placements.len(),
+        out.artifact.placements.len(),
         accessions.len(),
-        declined,
+        out.declined_count,
         cli.out.display()
     );
     Ok(())

--- a/examples/extract_mutalyzer_genomic_windows.rs
+++ b/examples/extract_mutalyzer_genomic_windows.rs
@@ -187,8 +187,12 @@ impl ReferenceProvider for RecordingProvider {
         Some(p)
     }
 
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        self.inner.resolve_legacy_gene_selector(selector)
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.inner.resolve_legacy_gene_selector(selector, ng_parent)
     }
 
     fn has_transcript(&self, id: &str) -> bool {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -223,6 +223,19 @@ pub fn check_reference(reference_dir: &Path) -> CheckResult {
         }
     }
 
+    // A missing NG_ hosted-transcripts map silently drops parent-relative legacy
+    // selector resolution at load (#792) — every NG_-parent legacy selector then
+    // falls back to the global reference-standard map — so surface it like the
+    // other optional inputs above.
+    if let Some(ref ng_hosted) = manifest.ng_hosted_transcripts {
+        if !ng_hosted.exists() {
+            result.warnings.push(format!(
+                "NG_ hosted-transcripts map not found: {}",
+                ng_hosted.display()
+            ));
+        }
+    }
+
     result
 }
 
@@ -356,6 +369,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -410,6 +424,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -466,6 +481,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -522,6 +538,7 @@ mod tests {
             assembly_report: Some(missing_report.clone()),
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -578,6 +595,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: Some(missing_report.clone()),
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -634,6 +652,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: Some(missing_summary.clone()),
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -690,6 +709,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: Some(missing_placements.clone()),
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -719,6 +739,63 @@ mod tests {
                 .iter()
                 .any(|w| w.contains("Derived RefSeqGene placements not found")),
             "Expected a warning for the missing derived placements file, got {:?}",
+            result.warnings
+        );
+    }
+
+    #[test]
+    fn test_check_warns_on_missing_ng_hosted_transcripts() {
+        let dir = TempDir::new().unwrap();
+
+        // A real transcript FASTA so the manifest is otherwise valid.
+        let transcript_fasta = dir.path().join("example.fna");
+        File::create(&transcript_fasta).unwrap();
+
+        // Point ng_hosted_transcripts at a file that does not exist.
+        let missing_ng_hosted = dir.path().join("missing_ng_hosted_transcripts.json");
+
+        let mut manifest = ReferenceManifest {
+            prepared_at: "2024-01-01T00:00:00Z".to_string(),
+            transcript_fastas: vec![transcript_fasta],
+            protein_fastas: Vec::new(),
+            genome_fasta: None,
+            genome_grch37_fasta: None,
+            refseqgene_fastas: Vec::new(),
+            refseqgene_alignments: None,
+            refseqgene_alignments_grch37: None,
+            assembly_report: None,
+            assembly_report_grch37: None,
+            derived_refseqgene_placements: None,
+            ng_hosted_transcripts: Some(missing_ng_hosted.clone()),
+            refseqgene_summary: None,
+            lrg_fastas: Vec::new(),
+            lrg_xmls: Vec::new(),
+            lrg_refseq_mapping: None,
+            cdot_json: None,
+            cdot_grch37_json: None,
+            ensembl_cdot_json: None,
+            ensembl_cdot_grch37_json: None,
+            ensembl_transcript_fastas: Vec::new(),
+            supplemental_fasta: None,
+            legacy_transcripts_fasta: None,
+            legacy_transcripts_metadata: None,
+            legacy_genbank_fasta: None,
+            legacy_genbank_metadata: None,
+            canonical_overrides: None,
+            transcript_count: 1,
+            available_prefixes: vec!["NM".to_string()],
+            reference_dir: dir.path().to_path_buf(),
+        };
+
+        manifest.save().unwrap();
+
+        let result = check_reference(dir.path());
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.contains("NG_ hosted-transcripts map not found")),
+            "Expected a warning for the missing NG_ hosted-transcripts map, got {:?}",
             result.warnings
         );
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3267,9 +3267,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Rewrite a legacy LOVD gene-model selector on a genomic reference —
     /// `NG_/NC_/LRG(GENE[_v001]):c.…` — to the spec-preferred transcript-accession
     /// form `NG_/NC_/LRG(NM_):c.…`, when the provider resolves the gene's
-    /// reference-standard transcript (#500/#637). `_v001` and the bare gene name
-    /// both resolve to that transcript; the `c.` coordinates are unchanged (the
-    /// gene-model selector *is* that transcript).
+    /// transcript (#500/#637). `_v001` and the bare gene name resolve identically;
+    /// the `c.` coordinates are unchanged (the gene-model selector *is* that
+    /// transcript).
+    ///
+    /// Resolution is parent-relative-first (#792): the `NG_` parent accession is
+    /// passed through (`Some(accession)` below), so when that exact `NG_` version
+    /// uniquely hosts the gene, its hosted transcript wins; only otherwise does
+    /// resolution fall back to the global reference-standard map.
     ///
     /// Returns `None` (preserve the input selector unchanged) when there is no
     /// gene-symbol selector, the reference is not genomic (`NM_(GENE)` keeps the
@@ -3298,7 +3303,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if !is_genomic_ref || accession.genomic_context.is_some() {
             return None;
         }
-        let nm = self.provider.resolve_legacy_gene_selector(gene_symbol)?;
+        let nm = self
+            .provider
+            .resolve_legacy_gene_selector(gene_symbol, Some(accession))?;
         let (rest, nm_accession) = parse_accession(&nm).ok()?;
         // The resolver yields a reference-standard `NM_` coding transcript
         // (`parse_refseqgene_summary` keeps only `NM_` rows); reject anything else

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -54,6 +54,10 @@ pub struct ReferenceManifest {
     /// overridden); fills only genuine version gaps.
     #[serde(default)]
     pub derived_refseqgene_placements: Option<PathBuf>,
+    /// Per-`NG_`-version hosted-transcript map (`ng_hosted_transcripts.json`,
+    /// #792), for NG_-parent-aware legacy `GENE_v001` selector resolution.
+    #[serde(default)]
+    pub ng_hosted_transcripts: Option<PathBuf>,
     /// NCBI `LRG_RefSeqGene` association table, mapping each gene to its
     /// reference-standard transcript. Consumed to resolve legacy gene-model
     /// selectors (`NG_(GENE_v001):c.…`) to the transcript accession (#500/#637).
@@ -129,6 +133,7 @@ impl Default for ReferenceManifest {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: None,
             lrg_fastas: Vec::new(),
             lrg_xmls: Vec::new(),
@@ -277,6 +282,7 @@ impl ReferenceManifest {
             &self.assembly_report,
             &self.assembly_report_grch37,
             &self.derived_refseqgene_placements,
+            &self.ng_hosted_transcripts,
             &self.refseqgene_summary,
             &self.lrg_refseq_mapping,
             &self.cdot_json,
@@ -319,6 +325,7 @@ impl ReferenceManifest {
             &mut self.assembly_report,
             &mut self.assembly_report_grch37,
             &mut self.derived_refseqgene_placements,
+            &mut self.ng_hosted_transcripts,
             &mut self.refseqgene_summary,
             &mut self.lrg_refseq_mapping,
             &mut self.cdot_json,
@@ -550,6 +557,7 @@ mod tests {
             assembly_report: None,
             assembly_report_grch37: None,
             derived_refseqgene_placements: None,
+            ng_hosted_transcripts: None,
             refseqgene_summary: Some(ref_dir.join("LRG_RefSeqGene")),
             lrg_fastas: vec![ref_dir.join("lrg.fa")],
             lrg_xmls: vec![ref_dir.join("lrg.xml")],
@@ -780,6 +788,26 @@ mod tests {
         assert_eq!(
             loaded.assembly_report_grch37,
             Some(ref_dir.join("genome/GRCh37.assembly_report.txt"))
+        );
+    }
+
+    #[test]
+    fn ng_hosted_transcripts_path_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path().to_path_buf();
+        let mut m = ReferenceManifest {
+            reference_dir: ref_dir.clone(),
+            ng_hosted_transcripts: Some(ref_dir.join("ng_hosted_transcripts.json")),
+            ..Default::default()
+        };
+        m.save().unwrap();
+        let raw = std::fs::read_to_string(ref_dir.join("manifest.json")).unwrap();
+        assert!(raw.contains("ng_hosted_transcripts.json"));
+        assert!(!raw.contains(ref_dir.to_str().unwrap()));
+        let loaded = ReferenceManifest::load_or_default(&ref_dir).unwrap();
+        assert_eq!(
+            loaded.ng_hosted_transcripts,
+            Some(ref_dir.join("ng_hosted_transcripts.json"))
         );
     }
 

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -808,9 +808,21 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
             );
         } else {
             let out_path = config.output_dir.join("derived_refseqgene_placements.json");
+            let hosted_out_path = config.output_dir.join("ng_hosted_transcripts.json");
             if config.skip_existing && out_path.exists() {
+                // Caveat: if this is a pre-#792 reference (derived_refseqgene_placements.json
+                // exists but ng_hosted_transcripts.json does not), manifest.ng_hosted_transcripts
+                // will remain unset. Re-run with --force to regenerate both artifacts.
                 eprintln!("  Skipping NG_ placement derivation (exists)");
                 manifest.derived_refseqgene_placements = Some(out_path);
+                if hosted_out_path.exists() {
+                    manifest.ng_hosted_transcripts = Some(hosted_out_path);
+                } else {
+                    eprintln!(
+                        "  Note: ng_hosted_transcripts.json is absent (pre-#792 reference); \
+                         re-run with --force to derive it."
+                    );
+                }
                 manifest.save()?;
             } else {
                 eprintln!("  Deriving NG_ placements from {}...", acc_file.display());
@@ -825,22 +837,28 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
                      --derive-ng-placements {}`.",
                     acc_file.display()
                 );
-                let (artifact, declined) =
+                let derive_out =
                     crate::reference::ng_placement_builder::derive_placements_for_accessions(
                         &provider,
                         &accessions,
                         &builds,
                         description,
                     )?;
-                std::fs::write(&out_path, artifact.to_json()?).map_err(|e| FerroError::Io {
-                    msg: format!("write {}: {e}", out_path.display()),
+                std::fs::write(&out_path, derive_out.artifact.to_json()?).map_err(|e| {
+                    FerroError::Io {
+                        msg: format!("write {}: {e}", out_path.display()),
+                    }
                 })?;
                 eprintln!(
                     "  Derived {} placement(s), {} declined.",
-                    artifact.placements.len(),
-                    declined
+                    derive_out.artifact.placements.len(),
+                    derive_out.declined_count
                 );
                 manifest.derived_refseqgene_placements = Some(out_path);
+                // Co-emit ng_hosted_transcripts.json from the same GenBank fetch (#792).
+                let hosted_path =
+                    write_ng_hosted_transcripts(&derive_out.hosted, &hosted_out_path)?;
+                manifest.ng_hosted_transcripts = Some(hosted_path);
                 manifest.save()?;
             }
         }
@@ -866,6 +884,24 @@ fn builds_for_genome(genome: &str) -> Vec<String> {
         // a selection; returning empty keeps this consistent if reached otherwise.
         _ => Vec::new(),
     }
+}
+
+/// Build [`NgHostedTranscripts`](crate::reference::ng_hosted_transcripts::NgHostedTranscripts)
+/// from `(NG_acc.version, [(gene, transcript_id)])` records and write it as
+/// JSON to `out`, returning the written path (#792).
+fn write_ng_hosted_transcripts(
+    records: &[(String, Vec<(String, String)>)],
+    out: &Path,
+) -> Result<PathBuf, FerroError> {
+    use crate::reference::ng_hosted_transcripts::NgHostedTranscripts;
+    let nh = NgHostedTranscripts::from_records(records.iter().cloned());
+    let json = nh.to_json().map_err(|e| FerroError::Io {
+        msg: format!("serialize ng_hosted_transcripts: {e}"),
+    })?;
+    std::fs::write(out, json).map_err(|e| FerroError::Io {
+        msg: format!("write {}: {e}", out.display()),
+    })?;
+    Ok(out.to_path_buf())
 }
 
 /// Fetch supplemental data from ClinVar/patterns (benchmark feature only)
@@ -2057,5 +2093,25 @@ mod tests {
         .unwrap();
 
         assert_eq!(manifest, Some(report));
+    }
+
+    #[test]
+    fn build_and_write_ng_hosted_writes_artifact_and_returns_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = tmp.path().join("ng_hosted_transcripts.json");
+        let recs = vec![(
+            "NG_012337.1".to_string(),
+            vec![("TIMM8B".to_string(), "NM_012459.2".to_string())],
+        )];
+        let p = write_ng_hosted_transcripts(&recs, &out).unwrap();
+        assert_eq!(p, out);
+        let loaded = crate::reference::ng_hosted_transcripts::NgHostedTranscripts::from_json(
+            &std::fs::read_to_string(&out).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            loaded.hosted_unique("NG_012337.1", "TIMM8B"),
+            Some("NM_012459.2")
+        );
     }
 }

--- a/src/reference/derived_placement.rs
+++ b/src/reference/derived_placement.rs
@@ -67,6 +67,33 @@ pub struct AffineCandidate {
     pub strand: Strand,
 }
 
+/// Parse the `mRNA` features of an `NG_` GenBank record into ordered
+/// `(gene_upper, transcript_id)` pairs for the hosting map (#792).
+///
+/// Unlike [`parse_ng_hosted_transcripts`] (which skips partial `<`/`>` features
+/// because their exon coordinates can't anchor an affine), this **includes**
+/// partial features: a partial mRNA still authoritatively states "this `NG_`
+/// hosts this transcript for this gene." Only features carrying BOTH a `/gene`
+/// and a `/transcript_id` are kept. Order is the GenBank feature order.
+pub fn parse_ng_gene_transcripts(genbank: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let bytes = genbank.as_bytes();
+    let mut search_from = 0;
+    while let Some(rel) = genbank[search_from..].find("     mRNA ") {
+        let feat_start = search_from + rel;
+        let block_end = next_feature_offset(bytes, feat_start + 1);
+        let block = &genbank[feat_start..block_end];
+        search_from = block_end;
+        if let (Some(gene), Some(tx)) = (
+            extract_qualifier(block, "gene"),
+            extract_qualifier(block, "transcript_id"),
+        ) {
+            out.push((gene.to_ascii_uppercase(), tx));
+        }
+    }
+    out
+}
+
 /// Parse the `mRNA` features of an `NG_` GenBank record into hosted transcripts.
 ///
 /// Each `mRNA` feature carries an exon join in `NG_` coordinates and a
@@ -489,6 +516,32 @@ impl DerivedPlacements {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- parse_ng_gene_transcripts ----
+
+    const NG_GENE_SAMPLE: &str = concat!(
+        "     mRNA            join(1..100,200..300)\n",
+        "                     /gene=\"TIMM8B\"\n",
+        "                     /transcript_id=\"NM_012459.2\"\n",
+        "     mRNA            join(<136..200,400..500)\n",
+        "                     /gene=\"C11orf57\"\n",
+        "                     /transcript_id=\"NM_001321072.1\"\n",
+        "     CDS             join(50..100,200..280)\n",
+        "                     /gene=\"TIMM8B\"\n",
+    );
+
+    #[test]
+    fn parse_ng_gene_transcripts_captures_gene_and_includes_partials() {
+        let got = parse_ng_gene_transcripts(NG_GENE_SAMPLE);
+        assert_eq!(
+            got,
+            vec![
+                ("TIMM8B".to_string(), "NM_012459.2".to_string()),
+                // partial (`<136`) feature is INCLUDED for hosting membership:
+                ("C11ORF57".to_string(), "NM_001321072.1".to_string()),
+            ]
+        );
+    }
 
     // ---- GenBank mRNA parsing ----
 

--- a/src/reference/legacy_selector.rs
+++ b/src/reference/legacy_selector.rs
@@ -7,23 +7,19 @@
 //! gene-model selector — `NG_012337.1(TIMM8B_v001):c.…` — should resolve to the
 //! gene's transcript.
 //!
-//! The `_v00N` numbering is positional on the RefSeqGene record. NCBI's
-//! `LRG_RefSeqGene` association table flags each gene's *reference standard*
-//! transcript (`Category == "reference standard"`); for the ~96% of genes with
-//! a single reference-standard `NM_`, that transcript is the LOVD `_v001`, so a
-//! gene-symbol → reference-standard `NM_` map resolves `_v001`/bare selectors
-//! authoritatively.
+//! The `_v00N` numbering is a LOVD-internal gene-model registry; there is no
+//! authoritative rule mapping it to the `NG_` GenBank mRNA feature order (the
+//! spec submodule and NCBI docs define none, and e.g. `SDHD_v002` has only one
+//! SDHD mRNA on NG_012337). So ferro does NOT resolve `_vNNN` positionally.
 //!
-//! It does **not** resolve everything: ~4.3% of genes (e.g. APC, ABL1, BCL2)
-//! carry *multiple* reference-standard transcripts on one record, and the table
-//! does not encode the LOVD `_v` ordering (its row order is neither the `_v`
-//! order nor accession-numeric). So a gene with more than one reference-standard
-//! `NM_` is **excluded from the map** — it declines (preserves the input)
-//! rather than guess a transcript that could shift the `c.` numbering. Higher
-//! locus versions (`_v002`…), which name the 2nd/3rd transcript on exactly those
-//! multi-transcript records, are likewise declined. Reliable `_vNNN` resolution
-//! for multi-transcript genes needs the `NG_` GenBank feature order (the
-//! definitional `_v` source) — a future enhancement.
+//! Resolution is parent-relative and unambiguous-only: a bare / `_v001`
+//! selector on an `NG_` parent resolves to the transcript that exact parent
+//! version uniquely hosts ([`resolve_legacy_selector_with_parent`], #792);
+//! failing that, to the gene's single reference-standard `NM_` from the
+//! `LRG_RefSeqGene` table. `_v002+`, genes with multiple
+//! hosted/reference-standard transcripts, and genes absent from both sources
+//! decline (preserve the input) rather than guess a transcript that could shift
+//! the `c.` numbering.
 
 use rustc_hash::FxHashMap;
 

--- a/src/reference/legacy_selector.rs
+++ b/src/reference/legacy_selector.rs
@@ -106,6 +106,34 @@ where
     lookup(&gene.to_ascii_uppercase())
 }
 
+/// Parent-aware legacy selector resolution (#792). For a bare/`_v001` selector
+/// on an `NG_` parent, prefer the transcript that exact parent uniquely hosts;
+/// otherwise (no parent, gene not uniquely hosted there, or `_v002+`) fall back
+/// to the global reference-standard `lookup`. `_v002+` still declines via the
+/// existing rule.
+pub fn resolve_legacy_selector_with_parent<H, G>(
+    selector: &str,
+    ng_parent: Option<&str>,
+    hosted_unique: H,
+    lookup: G,
+) -> Option<String>
+where
+    H: Fn(&str, &str) -> Option<String>,
+    G: Fn(&str) -> Option<String>,
+{
+    let (gene, version) = split_legacy_gene_selector(selector);
+    if version.is_some_and(|n| n != 1) {
+        return None;
+    }
+    let gene_upper = gene.to_ascii_uppercase();
+    if let Some(ng) = ng_parent {
+        if let Some(tx) = hosted_unique(ng, &gene_upper) {
+            return Some(tx);
+        }
+    }
+    lookup(&gene_upper)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,5 +217,37 @@ mod tests {
         assert_eq!(resolve_legacy_selector_in("SDHD_v002", lookup), None);
         // Unknown gene → decline.
         assert_eq!(resolve_legacy_selector_in("NOTAGENE_v001", lookup), None);
+    }
+
+    #[test]
+    fn ng_parent_hosted_wins_over_global_for_v001() {
+        // hosted: NG_012337.1 hosts TIMM8B → NM_012459.2 (the parent-relative answer)
+        let hosted = |ng: &str, g: &str| -> Option<String> {
+            (ng == "NG_012337.1" && g == "TIMM8B").then(|| "NM_012459.2".to_string())
+        };
+        // global reference-standard map would say NM_012459.4 (the bug)
+        let global =
+            |g: &str| -> Option<String> { (g == "TIMM8B").then(|| "NM_012459.4".to_string()) };
+        // _v001 on the NG parent → hosted wins
+        assert_eq!(
+            resolve_legacy_selector_with_parent("TIMM8B_v001", Some("NG_012337.1"), hosted, global),
+            Some("NM_012459.2".to_string())
+        );
+        // _v002 → still declines (no positional)
+        assert_eq!(
+            resolve_legacy_selector_with_parent("TIMM8B_v002", Some("NG_012337.1"), hosted, global),
+            None
+        );
+        // no NG parent → falls back to global
+        assert_eq!(
+            resolve_legacy_selector_with_parent("TIMM8B", None, hosted, global),
+            Some("NM_012459.4".to_string())
+        );
+        // NG parent present but gene not hosted there → falls back to global
+        let nohost = |_: &str, _: &str| None;
+        assert_eq!(
+            resolve_legacy_selector_with_parent("TIMM8B", Some("NG_999999.9"), nohost, global),
+            Some("NM_012459.4".to_string())
+        );
     }
 }

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -414,7 +414,11 @@ impl ReferenceProvider for MockProvider {
         )
     }
 
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        _ng_parent: Option<&crate::hgvs::variant::Accession>,
+    ) -> Option<String> {
         crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
             self.legacy_gene_models.get(g).cloned()
         })

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -10,6 +10,7 @@ pub mod legacy_selector;
 pub mod loader;
 pub mod mock;
 pub mod multi_fasta;
+pub mod ng_hosted_transcripts;
 pub mod ng_placement_builder;
 pub mod protein;
 pub mod provider;

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -242,6 +242,9 @@ pub struct MultiFastaProvider {
     /// assembly report(s) (#716). `None` when the manifest names no report, in
     /// which case build inference uses only the hardcoded fallback.
     contig_aliases: Option<crate::liftover::aliases::ContigAliases>,
+    /// Per-`NG_`-version hosted-transcript map (#792); `None` when the manifest
+    /// names no artifact (resolution falls back to the global reference map).
+    ng_hosted: Option<crate::reference::ng_hosted_transcripts::NgHostedTranscripts>,
 }
 
 /// Resolution inputs that uniquely identify a resolved transcript: the requested
@@ -343,6 +346,7 @@ impl MultiFastaProvider {
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
             contig_aliases: None,
+            ng_hosted: None,
         })
     }
 
@@ -382,6 +386,7 @@ impl MultiFastaProvider {
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
             contig_aliases: None,
+            ng_hosted: None,
         })
     }
 
@@ -770,6 +775,46 @@ impl MultiFastaProvider {
         provider.legacy_gene_models = legacy_gene_models;
         provider.contig_aliases = contig_aliases;
 
+        // Load NG_-hosted transcript map (#792). A read/parse failure is warned
+        // (not silently swallowed); an absent field or empty artifact is fine
+        // (NG_-parent selector resolution falls back to the global reference map).
+        let ng_hosted = match manifest
+            .get("ng_hosted_transcripts")
+            .and_then(|v| v.as_str())
+        {
+            None => None,
+            Some(rel) => {
+                let path = resolve_path(rel);
+                match std::fs::read_to_string(&path) {
+                    Ok(s) => {
+                        match crate::reference::ng_hosted_transcripts::NgHostedTranscripts::from_json(&s) {
+                            Ok(nh) if !nh.is_empty() => Some(nh),
+                            Ok(_) => None,
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse ng_hosted_transcripts {}: {}; \
+                                     NG_-parent selector resolution falls back to the global map",
+                                    path.display(),
+                                    e
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to read ng_hosted_transcripts {}: {}; \
+                             falling back to the global map",
+                            path.display(),
+                            e
+                        );
+                        None
+                    }
+                }
+            }
+        };
+        provider.ng_hosted = ng_hosted;
+
         // Load cdot transcript metadata if available
         if let Some(cdot_path_str) = manifest.get("cdot_json").and_then(|v| v.as_str()) {
             let cdot_path = resolve_path(cdot_path_str);
@@ -995,6 +1040,7 @@ impl MultiFastaProvider {
             refseqgene_placements: FxHashMap::default(),
             legacy_gene_models: FxHashMap::default(),
             contig_aliases: None,
+            ng_hosted: None,
         })
     }
 
@@ -1177,6 +1223,19 @@ impl MultiFastaProvider {
     /// Get the cdot mapper if one was loaded with this provider.
     pub fn cdot_mapper(&self) -> Option<&CdotMapper> {
         self.cdot_mapper.as_ref()
+    }
+
+    /// Return the single transcript `ng` hosts for `gene` from the loaded
+    /// `ng_hosted_transcripts` artifact (#792), or `None` when the artifact is
+    /// absent, the `(ng, gene)` pair is unknown, or the gene is hosted by more
+    /// than one transcript (ambiguous).
+    // T6 will call this from the resolver; allow until then.
+    #[allow(dead_code)]
+    pub(crate) fn ng_hosted_unique(&self, ng: &str, gene: &str) -> Option<String> {
+        self.ng_hosted
+            .as_ref()?
+            .hosted_unique(ng, gene)
+            .map(str::to_string)
     }
 
     /// Get CDS info from supplemental metadata for old/superseded transcripts.
@@ -5498,6 +5557,30 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         assert_eq!(
             provider.infer_genome_build(&grch38_chr17),
             crate::liftover::aliases::infer_genome_build_from_accession(&grch38_chr17)
+        );
+    }
+
+    #[test]
+    fn from_manifest_loads_ng_hosted_transcripts() {
+        use std::fs;
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+        fs::write(
+            d.join("ngh.json"),
+            r#"{"schema_version":1,"records":{"NG_012337.1":{"TIMM8B":["NM_012459.2"]}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            d.join("manifest.json"),
+            r#"{"prepared_at":"t","transcript_fastas":["tx.fna"],"ng_hosted_transcripts":"ngh.json","transcript_count":1,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+        let p = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+        assert_eq!(
+            p.ng_hosted_unique("NG_012337.1", "TIMM8B"),
+            Some("NM_012459.2".to_string())
         );
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1229,8 +1229,6 @@ impl MultiFastaProvider {
     /// `ng_hosted_transcripts` artifact (#792), or `None` when the artifact is
     /// absent, the `(ng, gene)` pair is unknown, or the gene is hosted by more
     /// than one transcript (ambiguous).
-    // T6 will call this from the resolver; allow until then.
-    #[allow(dead_code)]
     pub(crate) fn ng_hosted_unique(&self, ng: &str, gene: &str) -> Option<String> {
         self.ng_hosted
             .as_ref()?
@@ -2399,10 +2397,18 @@ impl ReferenceProvider for MultiFastaProvider {
         placement
     }
 
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
-            self.legacy_gene_models.get(g).cloned()
-        })
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&crate::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        let ng = ng_parent.map(|a| a.full());
+        crate::reference::legacy_selector::resolve_legacy_selector_with_parent(
+            selector,
+            ng.as_deref(),
+            |ng, g| self.ng_hosted_unique(ng, g),
+            |g| self.legacy_gene_models.get(g).cloned(),
+        )
     }
 
     fn infer_genome_build(

--- a/src/reference/ng_hosted_transcripts.rs
+++ b/src/reference/ng_hosted_transcripts.rs
@@ -1,0 +1,130 @@
+//! Per-`NG_`-version hosted-transcript map for NG_-parent-aware legacy
+//! `GENE_v001` selector resolution (#792). Built from the `NG_` GenBank mRNA
+//! features (gene + transcript_id); a selector resolves only when the exact
+//! parent version hosts exactly one transcript for the gene.
+
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NgHostedTranscripts {
+    schema_version: u32,
+    /// NG_ accession.version → gene (upper) → hosted transcript ids (feature order, deduped).
+    records: FxHashMap<String, FxHashMap<String, Vec<String>>>,
+}
+
+impl NgHostedTranscripts {
+    pub fn from_records(
+        records: impl IntoIterator<Item = (String, Vec<(String, String)>)>,
+    ) -> Self {
+        let mut out: FxHashMap<String, FxHashMap<String, Vec<String>>> = FxHashMap::default();
+        for (ng, pairs) in records {
+            let per_gene = out.entry(ng).or_default();
+            for (gene, tx) in pairs {
+                let list = per_gene.entry(gene).or_default();
+                if !list.contains(&tx) {
+                    list.push(tx);
+                }
+            }
+        }
+        Self {
+            schema_version: 1,
+            records: out,
+        }
+    }
+
+    /// The single transcript `ng_acc_version` hosts for `gene_upper`, or `None`
+    /// when absent or ambiguous (≥2 hosted).
+    pub fn hosted_unique(&self, ng_acc_version: &str, gene_upper: &str) -> Option<&str> {
+        let list = self.records.get(ng_acc_version)?.get(gene_upper)?;
+        match list.as_slice() {
+            [one] => Some(one.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    pub fn from_json(s: &str) -> serde_json::Result<Self> {
+        let v: Self = serde_json::from_str(s)?;
+        if v.schema_version != 1 {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported ng_hosted_transcripts schema_version {}",
+                v.schema_version
+            )));
+        }
+        Ok(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hosted_unique_resolves_single_and_declines_multi_and_missing() {
+        let nh = NgHostedTranscripts::from_records([
+            (
+                "NG_012337.1".to_string(),
+                vec![("TIMM8B".to_string(), "NM_012459.2".to_string())],
+            ),
+            (
+                "NG_000000.1".to_string(),
+                vec![
+                    ("MULTI".to_string(), "NM_1.1".to_string()),
+                    ("MULTI".to_string(), "NM_2.1".to_string()),
+                ],
+            ),
+        ]);
+        // exact version + single hosted → resolves
+        assert_eq!(
+            nh.hosted_unique("NG_012337.1", "TIMM8B"),
+            Some("NM_012459.2")
+        );
+        // multi-hosted → declines
+        assert_eq!(nh.hosted_unique("NG_000000.1", "MULTI"), None);
+        // wrong version / unknown gene → declines
+        assert_eq!(nh.hosted_unique("NG_012337.3", "TIMM8B"), None);
+        assert_eq!(nh.hosted_unique("NG_012337.1", "SDHD"), None);
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let nh = NgHostedTranscripts::from_records([(
+            "NG_012337.1".to_string(),
+            vec![("TIMM8B".to_string(), "NM_012459.2".to_string())],
+        )]);
+        let back = NgHostedTranscripts::from_json(&nh.to_json().unwrap()).unwrap();
+        assert_eq!(
+            back.hosted_unique("NG_012337.1", "TIMM8B"),
+            Some("NM_012459.2")
+        );
+    }
+
+    #[test]
+    fn from_json_rejects_unknown_schema_version() {
+        let json = r#"{"schema_version":2,"records":{}}"#;
+        let err = NgHostedTranscripts::from_json(json).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported ng_hosted_transcripts schema_version 2"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn from_json_accepts_schema_version_1() {
+        let json = r#"{"schema_version":1,"records":{"NG_012337.1":{"TIMM8B":["NM_012459.2"]}}}"#;
+        let nh = NgHostedTranscripts::from_json(json).unwrap();
+        assert_eq!(
+            nh.hosted_unique("NG_012337.1", "TIMM8B"),
+            Some("NM_012459.2")
+        );
+    }
+}

--- a/src/reference/ng_placement_builder.rs
+++ b/src/reference/ng_placement_builder.rs
@@ -11,24 +11,40 @@ use crate::data::cdot::CdotMapper;
 use crate::hgvs::parser::accession::parse_accession;
 use crate::hgvs::variant::Accession;
 use crate::reference::derived_placement::{
-    derive_ng_placement, DerivedPlacement, DerivedPlacements, GenomeSlice, NcExonSource,
+    derive_ng_placement, parse_ng_gene_transcripts, DerivedPlacement, DerivedPlacements,
+    GenomeSlice, NcExonSource,
 };
 use crate::reference::multi_fasta::MultiFastaProvider;
 use crate::reference::{GenomicPlacement, ReferenceProvider, Strand};
 use crate::FerroError;
 
+/// Output of [`build_placements`]: the validated placement records, the
+/// hosting map entries for `ng_hosted_transcripts.json` (#792), and a list of
+/// human-readable decline messages.
+pub struct BuildOutput {
+    /// Validated `DerivedPlacement` records, one per validated (NG_, build) pair.
+    pub placements: Vec<DerivedPlacement>,
+    /// Per-NG_ hosting records: `(ng_acc_version, [(gene_upper, transcript_id)])`.
+    /// Collected from the same GenBank fetch as the placements — no second fetch.
+    pub hosted: Vec<(String, Vec<(String, String)>)>,
+    /// Human-readable decline messages (fetch failures, no-build declines).
+    pub declined: Vec<String>,
+}
+
 /// Derive placements for `accessions` over `builds`, fetching record/sequence
 /// via `fetch(accession, rettype)` (`rettype` is `"gb"` or `"fasta"`) and
-/// deriving via `derive(genbank, seq, build)`. Returns the validated records
-/// and a list of human-readable decline messages. Never panics on a single
-/// accession's failure.
+/// deriving via `derive(genbank, seq, build)`. Returns a [`BuildOutput`]
+/// containing the validated records, per-NG_ hosting entries (#792), and
+/// human-readable decline messages. Never panics on a single accession's
+/// failure.
 pub fn build_placements(
     accessions: &[String],
     builds: &[String],
     fetch: impl Fn(&str, &str) -> Result<String, FerroError>,
     derive: impl Fn(&str, &[u8], &str) -> Option<GenomicPlacement>,
-) -> (Vec<DerivedPlacement>, Vec<String>) {
-    let mut records = Vec::new();
+) -> BuildOutput {
+    let mut placements = Vec::new();
+    let mut hosted = Vec::new();
     let mut declined = Vec::new();
     for ng in accessions {
         let genbank = match fetch(ng, "gb") {
@@ -38,6 +54,11 @@ pub fn build_placements(
                 continue;
             }
         };
+        // Collect hosted-transcript entries from this GenBank fetch (#792).
+        let gene_txs = parse_ng_gene_transcripts(&genbank);
+        if !gene_txs.is_empty() {
+            hosted.push((ng.clone(), gene_txs));
+        }
         let seq = match fetch(ng, "fasta") {
             Ok(fa) => fasta_bases(&fa),
             Err(e) => {
@@ -48,7 +69,7 @@ pub fn build_placements(
         let mut any_build = false;
         for build in builds {
             if let Some(p) = derive(&genbank, &seq, build) {
-                records.push(placement_to_record(ng, &p));
+                placements.push(placement_to_record(ng, &p));
                 any_build = true;
             }
         }
@@ -58,7 +79,11 @@ pub fn build_placements(
             ));
         }
     }
-    (records, declined)
+    BuildOutput {
+        placements,
+        hosted,
+        declined,
+    }
 }
 
 /// Serializable record from a derived placement. Validation already passed, so
@@ -178,18 +203,30 @@ impl GenomeSlice for ProviderGenomeSlice<'_> {
     }
 }
 
+/// Output of [`derive_placements_for_accessions`]: the validated placement
+/// artifact, the per-NG_ hosting records (#792), and the number of accessions
+/// that declined on every requested build.
+pub struct DeriveOutput {
+    /// Validated `DerivedPlacements` artifact ready to write to disk.
+    pub artifact: DerivedPlacements,
+    /// Per-NG_ hosting records: `(ng_acc_version, [(gene_upper, transcript_id)])`.
+    /// Collected from the same GenBank fetch as the placements — no second fetch.
+    pub hosted: Vec<(String, Vec<(String, String)>)>,
+    /// Number of accessions that declined on every requested build.
+    pub declined_count: usize,
+}
+
 /// Derive validated placements for `accessions` over `builds` using `provider`
 /// (cdot + genome) and live NCBI EFetch. Declines are logged via `warn!`.
-/// Derives NG_/LRG_ placements for `accessions` over `builds`, returning the
-/// validated artifact and the number of accessions that declined on every
-/// requested build (so callers can surface an all-declined run rather than
-/// reporting a bare success).
+/// Returns a [`DeriveOutput`] containing the validated artifact, per-NG_
+/// hosting records (#792), and the number of declined accessions — so callers
+/// can surface an all-declined run rather than reporting a bare success.
 pub fn derive_placements_for_accessions(
     provider: &MultiFastaProvider,
     accessions: &[String],
     builds: &[String],
     description: String,
-) -> Result<(DerivedPlacements, usize), FerroError> {
+) -> Result<DeriveOutput, FerroError> {
     let cdot = provider.cdot_mapper().ok_or_else(|| FerroError::Io {
         msg: "manifest has no cdot; cannot derive NG_ placements".to_string(),
     })?;
@@ -198,18 +235,19 @@ pub fn derive_placements_for_accessions(
         let nc_source = CdotNcExons { cdot, build };
         derive_ng_placement(genbank, seq, &nc_source, &genome)
     };
-    let (placements, declined) = build_placements(accessions, builds, efetch_text, derive);
-    for d in &declined {
+    let out = build_placements(accessions, builds, efetch_text, derive);
+    for d in &out.declined {
         log::warn!("derive NG_ placement declined: {d}");
     }
-    let declined_count = declined.len();
-    Ok((
-        DerivedPlacements {
+    let declined_count = out.declined.len();
+    Ok(DeriveOutput {
+        artifact: DerivedPlacements {
             description,
-            placements,
+            placements: out.placements,
         },
+        hosted: out.hosted,
         declined_count,
-    ))
+    })
 }
 
 #[cfg(test)]
@@ -257,19 +295,19 @@ mod tests {
             }
         };
 
-        let (records, declined) = build_placements(&accessions, &builds, fetch, derive);
+        let out = build_placements(&accessions, &builds, fetch, derive);
 
         assert_eq!(
-            records.len(),
+            out.placements.len(),
             1,
             "one validated placement (NG_aaa on GRCh38)"
         );
-        assert_eq!(records[0].parent, "NG_aaa.1");
-        assert_eq!(records[0].nc_start, 100);
-        assert_eq!(records[0].strand, "+");
+        assert_eq!(out.placements[0].parent, "NG_aaa.1");
+        assert_eq!(out.placements[0].nc_start, 100);
+        assert_eq!(out.placements[0].strand, "+");
         // NG_bad declined (fetch failure); NG_aaa not fully declined (had a build).
-        assert_eq!(declined.len(), 1);
-        assert!(declined[0].contains("NG_bad.1"));
+        assert_eq!(out.declined.len(), 1);
+        assert!(out.declined[0].contains("NG_bad.1"));
     }
 
     #[test]
@@ -284,10 +322,11 @@ mod tests {
             })
         };
         let derive = |_gb: &str, _seq: &[u8], _b: &str| -> Option<GenomicPlacement> { None };
-        let (records, declined) = build_placements(&accessions, &builds, fetch, derive);
-        assert!(records.is_empty());
-        assert_eq!(declined.len(), 1);
-        assert!(declined[0].contains("no validated placement"));
+        let out = build_placements(&accessions, &builds, fetch, derive);
+        assert!(out.placements.is_empty());
+        assert_eq!(out.declined.len(), 1);
+        assert!(out.declined[0].contains("no validated placement"));
+        assert!(out.hosted.is_empty());
     }
 
     #[test]
@@ -316,10 +355,9 @@ mod tests {
             .expect("load manifest");
         let accs = vec!["NG_012337.3".to_string()];
         let builds = vec!["GRCh38".to_string()];
-        let (artifact, _declined) =
-            super::derive_placements_for_accessions(&provider, &accs, &builds, "test".into())
-                .expect("derive");
+        let out = super::derive_placements_for_accessions(&provider, &accs, &builds, "test".into())
+            .expect("derive");
         // Either a validated placement or a principled decline (no panic, valid artifact).
-        assert!(artifact.placements.len() <= 1);
+        assert!(out.artifact.placements.len() <= 1);
     }
 }

--- a/src/reference/provider.rs
+++ b/src/reference/provider.rs
@@ -218,12 +218,21 @@ pub trait ReferenceProvider {
     /// genomic reference to a transcript accession (#500/#637).
     ///
     /// `selector` is the gene-symbol selector verbatim (e.g. `"TIMM8B_v001"`).
-    /// Returns the gene's reference-standard transcript accession (e.g.
-    /// `"NM_012459.4"`) for a bare gene or `_v001`, or `None` to decline (an
-    /// unknown gene, a higher locus version `_v002…`, or a provider with no
-    /// gene-model summary ingested). Declining preserves the input selector
-    /// rather than emitting a guessed transcript.
-    fn resolve_legacy_gene_selector(&self, _selector: &str) -> Option<String> {
+    /// `ng_parent` is the versioned `NG_` accession the selector sits on, when
+    /// known. When `ng_parent` is `Some` and that exact `NG_` version uniquely
+    /// hosts the gene, the hosted transcript takes precedence over the global
+    /// reference-standard map (#792); otherwise resolution falls back to that
+    /// global map.
+    /// Returns the resolved transcript accession (e.g. `"NM_012459.4"`) for a
+    /// bare gene or `_v001`, or `None` to decline (an unknown gene, a higher
+    /// locus version `_v002…`, or a provider with no gene-model summary
+    /// ingested). Declining preserves the input selector rather than emitting a
+    /// guessed transcript.
+    fn resolve_legacy_gene_selector(
+        &self,
+        _selector: &str,
+        _ng_parent: Option<&Accession>,
+    ) -> Option<String> {
         None
     }
 
@@ -472,10 +481,14 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for std::sync::Arc<T> {
         (**self).genomic_placement_on_build(parent, build)
     }
 
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&Accession>,
+    ) -> Option<String> {
         // Forward so legacy gene-model resolution survives an Arc wrapper; the
         // default declines (`None`) and would bypass the wrapped provider.
-        (**self).resolve_legacy_gene_selector(selector)
+        (**self).resolve_legacy_gene_selector(selector, ng_parent)
     }
 
     fn get_protein_sequence(
@@ -571,10 +584,14 @@ impl<T: ReferenceProvider + ?Sized> ReferenceProvider for Box<T> {
         (**self).genomic_placement_on_build(parent, build)
     }
 
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&Accession>,
+    ) -> Option<String> {
         // Forward so legacy gene-model resolution survives a Box wrapper; the
         // default declines (`None`) and would bypass the wrapped provider.
-        (**self).resolve_legacy_gene_selector(selector)
+        (**self).resolve_legacy_gene_selector(selector, ng_parent)
     }
 
     fn get_protein_sequence(
@@ -779,7 +796,11 @@ mod wrapper_forwarding_tests {
             })
         }
 
-        fn resolve_legacy_gene_selector(&self, _selector: &str) -> Option<String> {
+        fn resolve_legacy_gene_selector(
+            &self,
+            _selector: &str,
+            _ng_parent: Option<&Accession>,
+        ) -> Option<String> {
             Some("NM_999999.9".to_string())
         }
 
@@ -812,7 +833,7 @@ mod wrapper_forwarding_tests {
         );
         // Without the forward, this drops to the trait default (`None`).
         assert_eq!(
-            arc.resolve_legacy_gene_selector("GENE"),
+            arc.resolve_legacy_gene_selector("GENE", None),
             Some("NM_999999.9".to_string())
         );
         // Use a bogus NC_ accession the hardcoded table doesn't know → None; the
@@ -839,7 +860,7 @@ mod wrapper_forwarding_tests {
             "override-marker"
         );
         assert_eq!(
-            boxed.resolve_legacy_gene_selector("GENE"),
+            boxed.resolve_legacy_gene_selector("GENE", None),
             Some("NM_999999.9".to_string())
         );
         // Same forwarding check for Box.

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -610,14 +610,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5AspfsTer21)",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -676,14 +669,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5AspfsTer21)",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's gene-symbol selector on an NG_ reference; HGVS refseq.md:38-42 says gene symbols should not be used as the transcript specification (mutalyzer emits the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500. The NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -744,14 +730,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insTTTGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCAAAG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5PhefsTer22)",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's gene-symbol selector on an NG_ reference; HGVS refseq.md:38-42 says gene symbols should not be used as the transcript specification (mutalyzer emits the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500. The NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2014,14 +1993,7 @@
       ],
       "input": "NG_012337.1(TIMM8B):c.12delC",
       "normalized": "NG_012337.1(NM_012459.2):c.12del",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2030,14 +2002,7 @@
       ],
       "input": "NG_012337.1(TIMM8B):c.12_15delCAGC",
       "normalized": "NG_012337.1(NM_012459.2):c.12_15del",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2046,14 +2011,7 @@
       ],
       "input": "NG_012337.1(TIMM8B):c.12delCinsAT",
       "normalized": "NG_012337.1(NM_012459.2):c.12delinsAT",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's gene-symbol selector on an NG_ reference; HGVS refseq.md:38-42 says gene symbols should not be used as the transcript specification (mutalyzer emits the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500. The NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2062,14 +2020,7 @@
       ],
       "input": "NG_012337.1(TIMM8B):c.12_15delCAGCinsTTT",
       "normalized": "NG_012337.1(NM_012459.2):c.12_15delinsTTT",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's gene-symbol selector on an NG_ reference; HGVS refseq.md:38-42 says gene symbols should not be used as the transcript specification (mutalyzer emits the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500. The NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2095,13 +2046,6 @@
       ],
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5GlnfsTer20)",
       "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      },
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -2133,13 +2077,6 @@
       ],
       "protein_description": "NG_012337.1(NP_036591.2):p.(Cys6GlnfsTer20)",
       "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      },
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -2672,12 +2609,7 @@
       "input": "NG_009497.1(USH2A_v001):c.8682-19dup",
       "normalized": "NG_009497.1(NM_206933.2):c.8682-19dup",
       "genomic": "NG_009497.1:g.561208dup",
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "note": "ferro resolves the legacy selector USH2A_v001 to the current reference-standard NM_206933.4; the corpus pins NM_206933.2. The variant body is identical (c.8682-19dup); only the resolved transcript version differs. Selector version-selection tracked in #500."
-      }
+      "to_test": true
     },
     {
       "keywords": [],
@@ -2860,14 +2792,7 @@
       "input": "NG_012337.1(SDHD_v001):c.274G>T",
       "normalized": "NG_012337.1(NM_003002.2):c.274G>T",
       "genomic": "NG_012337.1:g.7125G>T",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -2876,14 +2801,7 @@
       "input": "NG_012337.1(SDHD):c.274G>T",
       "normalized": "NG_012337.1(NM_003002.2):c.274G>T",
       "genomic": "NG_012337.1:g.7125G>T",
-      "to_test": true,
-      "improvement": {
-        "axis": "normalized",
-        "tracking_issue": 500,
-        "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
-        "cluster": "refseqgene-selector"
-      }
+      "to_test": true
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -18,17 +18,6 @@ On an `NG_/NC_/LRG_` reference ferro preserves the input's gene-symbol selector;
 | `NG_008939.1:c.155_157delAAC` | normalized | improvement | — | #500 |
 | `NG_008939.1:c.274_275inv` | normalized | improvement | — | #500 |
 | `NG_012337.1(10683):c.274G>T` | normalized | improvement | — | #500 |
-| `NG_012337.1(SDHD):c.274G>T` | normalized | improvement | — | #500 |
-| `NG_012337.1(SDHD_v001):c.274G>T` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12_15delCAGC` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12_15delCAGCinsTTT` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12_15dupCAGC` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12delC` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12delCinsAT` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B):c.12dupC` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B_v001):c.12_13insGATC` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B_v001):c.12_13ins[GATC]` | normalized | improvement | — | #500 |
-| `NG_012337.1(TIMM8B_v001):c.12_13ins[TTT;GATC]` | normalized | improvement | — | #500 |
 
 ### Bare NP_ protein reference
 
@@ -203,7 +192,6 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | `NG_009299.1(NM_017668.3):c.[250del;41A>C]` | normalized | known_bug | — | #487 |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | normalized | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | normalized | known_bug | — | #487 |
-| `NG_009497.1(USH2A_v001):c.8682-19dup` | normalized | known_bug | — | #500 |
 | `NG_009930.1(NM_001099625.2):c.1010` | errors | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):n.110del` | errors | accepted_divergence | — | — |
 | `NG_012337.1(DUMMYACCNO_9999.9):c.12_13insGATC` | errors | accepted_divergence | — | — |
@@ -241,5 +229,5 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 | errors | 16 | 0 | 0 | 0 | 0 |
 | genomic | 2 | 0 | 0 | 0 | 0 |
 | infos | 4 | 0 | 0 | 0 | 0 |
-| normalized | 24 | 21 | 15 | 5 | 9 |
+| normalized | 24 | 20 | 4 | 5 | 9 |
 | protein_description | 0 | 0 | 0 | 0 | 31 |

--- a/tests/it/biocommons_normalize_tests.rs
+++ b/tests/it/biocommons_normalize_tests.rs
@@ -186,8 +186,12 @@ impl ReferenceProvider for ArcProvider {
     ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
         self.0.genomic_placement_on_build(parent, build)
     }
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        self.0.resolve_legacy_gene_selector(selector)
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
     }
     fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
         self.0.get_protein_length(accession)

--- a/tests/it/hgvs_rs_projection_tests.rs
+++ b/tests/it/hgvs_rs_projection_tests.rs
@@ -197,8 +197,12 @@ impl ReferenceProvider for ArcProvider {
     ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
         self.0.genomic_placement_on_build(parent, build)
     }
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        self.0.resolve_legacy_gene_selector(selector)
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
     }
     fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
         self.0.get_protein_length(accession)

--- a/tests/it/issue_498_whole_exon_deletion.rs
+++ b/tests/it/issue_498_whole_exon_deletion.rs
@@ -123,8 +123,12 @@ impl ReferenceProvider for ArcProvider {
     ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
         self.0.genomic_placement_on_build(parent, build)
     }
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        self.0.resolve_legacy_gene_selector(selector)
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
     }
     fn get_protein_length(&self, accession: &str) -> Result<u64, ferro_hgvs::FerroError> {
         self.0.get_protein_length(accession)

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -355,8 +355,12 @@ impl ReferenceProvider for ArcProvider {
     ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
         self.0.genomic_placement_on_build(parent, build)
     }
-    fn resolve_legacy_gene_selector(&self, selector: &str) -> Option<String> {
-        self.0.resolve_legacy_gene_selector(selector)
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
     }
     fn get_protein_length(&self, accession: &str) -> Result<u64, FerroError> {
         self.0.get_protein_length(accession)


### PR DESCRIPTION
Closes #792.

> Stacked on #787 (`fix/issue-785-version-exact-projection`) — this PR targets that branch; it will retarget to `main` automatically when #787 merges. The diff below is #792 only (8 commits).

## What

A legacy LOVD `GENE_v001`/bare selector on a **versioned** `NG_` parent resolved to the gene's **global reference-standard** transcript instead of the transcript the named parent actually hosts:

```
NG_012337.1(TIMM8B_v001):c.12_13insGATC
  before: NP_036591.3:p.(Gly5AspfsTer6)         (TIMM8B → global NM_012459.4, from NG_033145.1's row)
  after:  NG_012337.1(NP_036591.2):p.(Ser5AspfsTer21)   (NM_012459.2 — the transcript NG_012337.1 hosts)
```

The resolver was NG_-parent-blind: it consulted only a global `gene → reference-standard NM_` map (from `LRG_RefSeqGene`), whose TIMM8B row points at a *different* RefSeqGene (NG_033145.1) than the input names. LOVD `_v00N` is parent-relative (positional on a specific RefSeqGene record), so the global proxy is wrong whenever the input's parent is a different/older NG_.

## How

- **prepare** (`--derive-ng-placements`) now also emits `ng_hosted_transcripts.json` (`NG_acc.version → gene → [hosted transcript_ids]`) from the **same** NG_ GenBank records it already fetches for #728's placement derivation — no second efetch. The hosting parser includes partial (`<`/`>`) mRNA features (hosting membership, unlike the affine parser which skips them).
- **manifest** carries a new `ng_hosted_transcripts` path (serde-default; old manifests load).
- **`MultiFastaProvider`** loads the artifact (degrade-don't-abort on missing/garbled).
- **resolver**: the `ReferenceProvider::resolve_legacy_gene_selector` trait method gains an `ng_parent: Option<&Accession>` argument (forwarded through the `Arc`/`Box` blanket impls, mock, and test providers). A bare/`_v001` selector on an NG_ parent resolves to the transcript that **exact** NG_ version **uniquely hosts** (exactly one); otherwise it falls back to today's global reference-standard map. `normalize::rewrite_legacy_gene_selector` passes the in-scope NG_ parent.

Deliberately **not** positional `_vNNN`: there is no authoritative rule mapping GenBank mRNA feature order to LOVD `_v` numbering (the spec submodule defines none; `SDHD_v002` has only one SDHD mRNA on NG_012337). `_v002+` and genes with ≥2 hosted transcripts keep declining. The misleading `legacy_selector.rs` module doc that claimed feature-order is "the definitional `_v` source" is corrected.

## Effect

The fix is parent-relative and unambiguous-only, so it never guesses: it only overrides the global map when the exact NG_ parent hosts a single transcript for the gene. Verified against the real reference: the whole `NG_012337.1` TIMM8B/SDHD cluster (`_v001`, bare, and SDHD_v001) plus `NG_009497.1(USH2A_v001)` now reach the mutalyzer oracle; their now-stale `#500` normalized-axis annotations are removed. `BRCA2_v001`/`PCCB_v001` (#784) are unchanged — their NG_ parents host a single transcript matching the global map.

## Testing

- New hermetic unit tests: gene/partial-inclusion parser; `hosted_unique` (single-hosted resolves, multi-hosted/wrong-version/unknown decline; schema_version validation); manifest round-trip; prepare co-emit; provider load; resolver (`_v001` hosted wins, `_v002` declines, no-parent/not-hosted → global fallback).
- Full hermetic suite: 7435 passed / 54 skipped. `cargo clippy --features dev --all-targets -- -D warnings` + `cargo fmt --all --check` clean. Spec fixture `--check` passes.
- Manifest-gated conformance against the prepared reference (artifact provisioned from the corpus NG_ set): the TIMM8B/USH2A_v001 rows demote to passing; **no regression** — base-vs-HEAD per-axis divergence counts are identical (the remaining manifest-gated `axis_*` differences are pre-existing local-reference-vs-pinned-baseline mismatches, unchanged by this PR).

## Out of scope

Positional `_vNNN` (`_v002+`); LRG_ parent selectors; provisioning NCBI-purged old NG_ versions (a future corpus row naming a purged version falls back to the global map — documented).
