### PR TITLE
fix(data/cdot): drop frequently-wrong NM_→NP_ protein-accession inference

### DIFF
--- a/docs/transcripts_json_schema.md
+++ b/docs/transcripts_json_schema.md
@@ -59,7 +59,7 @@ Each transcript object has the following fields:
 | `mane_status` | string | MANE designation: `"MANE_Select"`, `"MANE_Plus_Clinical"`, or omitted if not MANE |
 | `refseq_match` | string | For Ensembl transcripts: matched RefSeq accession |
 | `ensembl_match` | string | For RefSeq transcripts: matched Ensembl accession |
-| `protein_id` | string | Protein accession (e.g. `"NP_000079.2"` or `"MYGENE-protein.1"`). Used as the `p.` accession for c. → p. projection. When omitted, the projector infers `NP_*` from `NM_*` and `XP_*` from `XM_*`; if neither applies, it falls back to using the transcript ID itself as the `p.` accession so protein prediction is never silently dropped. |
+| `protein_id` | string | Protein accession (e.g. `"NP_000079.2"` or `"MYGENE-protein.1"`). Used as the `p.` accession for c. → p. projection. When omitted, the projector falls back to using the transcript ID itself as the `p.` accession so protein prediction is never silently dropped. It does **not** fabricate an `NP_*`/`XP_*` accession from an `NM_*`/`XM_*` transcript by preserving the number — RefSeq does not guarantee the `NM_` and `NP_` numbers match (e.g. `NM_000077.4` ↔ `NP_000068.1`), so that inference was frequently wrong and was removed (#808). |
 
 ## Exon Object
 

--- a/src/benchmark/biocommons.rs
+++ b/src/benchmark/biocommons.rs
@@ -1512,15 +1512,24 @@ pub fn load_sequences_to_seqrepo(
                 if let Some(tx) = cdot.get_transcript(tx_id) {
                     let start = tx.cds_start.unwrap_or(0) as usize;
                     let end = tx.cds_end.unwrap_or(seq.len() as u64) as usize;
-                    let prot_id = tx
-                        .protein
-                        .clone()
-                        .unwrap_or_else(|| tx_id.replace("NM_", "NP_").replace("XM_", "XP_"));
+                    // Key the derived-protein FASTA by the authoritative cdot
+                    // protein accession if present, else the transcript id —
+                    // matching the projector's `p.` accession (#808). We do NOT
+                    // fabricate an NP_/XP_ by preserving the number: RefSeq does
+                    // not guarantee the NM and NP numbers match. The transcript-id
+                    // fallback is safe here because derived proteins are loaded
+                    // into a distinct `NCBI_protein` namespace (see below), so it
+                    // does not collide with the nucleotide transcript's `NCBI`
+                    // key.
+                    let prot_id = tx.protein.clone().unwrap_or_else(|| tx_id.clone());
                     (start, end, prot_id)
                 } else if let Some((start, end, _gene)) = supplemental_cds.get(tx_id) {
                     let start = start.map(|s| (s - 1) as usize).unwrap_or(0);
                     let end = end.map(|e| e as usize).unwrap_or(seq.len());
-                    let prot_id = tx_id.replace("NM_", "NP_").replace("XM_", "XP_");
+                    // No authoritative protein accession; key by the transcript
+                    // id rather than a fabricated NP_/XP_ (#808). Safe because
+                    // derived proteins load into the `NCBI_protein` namespace.
+                    let prot_id = tx_id.clone();
                     (start, end, prot_id)
                 } else {
                     continue;
@@ -1528,7 +1537,10 @@ pub fn load_sequences_to_seqrepo(
             } else if let Some((start, end, _gene)) = supplemental_cds.get(tx_id) {
                 let start = start.map(|s| (s - 1) as usize).unwrap_or(0);
                 let end = end.map(|e| e as usize).unwrap_or(seq.len());
-                let prot_id = tx_id.replace("NM_", "NP_").replace("XM_", "XP_");
+                // No authoritative protein accession; key by the transcript id
+                // rather than a fabricated NP_/XP_ (#808). Safe because derived
+                // proteins load into the distinct `NCBI_protein` namespace.
+                let prot_id = tx_id.clone();
                 (start, end, prot_id)
             } else {
                 continue;
@@ -1553,13 +1565,20 @@ pub fn load_sequences_to_seqrepo(
         }
     }
 
-    // Load derived proteins into SeqRepo
+    // Load derived proteins into SeqRepo under a distinct `NCBI_protein`
+    // namespace — NOT the `NCBI` namespace the nucleotide transcripts are loaded
+    // into above. A transcript that lacks an authoritative protein falls back to
+    // its transcript id for the protein FASTA header, so loading the derived
+    // protein into `NCBI` would create a duplicate `{tx_id}` key (the nucleotide
+    // transcript and its derived protein), yielding an ambiguous/rejected
+    // SeqRepo alias. Keeping proteins in their own namespace avoids the
+    // collision; consumers look up derived proteins via `NCBI_protein`.
     if proteins_derived > 0 {
         eprintln!(
             "  Loading {} derived protein sequences...",
             proteins_derived
         );
-        match load_fasta(std::slice::from_ref(&protein_fasta_path), "NCBI") {
+        match load_fasta(std::slice::from_ref(&protein_fasta_path), "NCBI_protein") {
             Ok(_) => {
                 eprintln!("  Loaded {} derived protein sequences", proteins_derived);
             }

--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -355,17 +355,31 @@ pub fn populate_mutalyzer_cache<P: AsRef<Path>>(
             // cdot CDS coordinates are 0-based, half-open
             let start = tx.cds_start.unwrap_or(0) as usize;
             let end = tx.cds_end.unwrap_or(seq.len() as u64) as usize;
+            // Key the derived-protein cache by the authoritative cdot protein
+            // accession if present, else a `protein:`-prefixed transcript id
+            // (see #808). We do NOT fabricate an `NP_`/`XP_` by preserving the
+            // number: RefSeq does not guarantee the NM and NP numbers match, so
+            // that key would be frequently wrong. The fallback MUST be prefixed
+            // so the derived protein lands in its own cache namespace — a bare
+            // `{tx_id}.sequence` would collide with (and be shadowed by) the
+            // transcript nucleotide cache entry created above, leaving the
+            // derived protein silently unwritten.
             let prot_id = tx
                 .protein
                 .clone()
-                .unwrap_or_else(|| tx_id.replace("NM_", "NP_").replace("XM_", "XP_"));
+                .unwrap_or_else(|| format!("protein:{}", tx_id));
             (start, end, prot_id)
         } else if let Some((start, end, _gene)) = supplemental_cds.get(tx_id) {
             // Supplemental metadata CDS coordinates are 1-based, inclusive
             // Convert to 0-based, half-open
             let start = start.map(|s| (s - 1) as usize).unwrap_or(0);
             let end = end.map(|e| e as usize).unwrap_or(seq.len());
-            let prot_id = tx_id.replace("NM_", "NP_").replace("XM_", "XP_");
+            // No authoritative protein accession available here; key by a
+            // `protein:`-prefixed transcript id rather than a fabricated
+            // NP_/XP_ (#808). The prefix keeps the derived protein out of the
+            // transcript cache namespace so it is not shadowed by the
+            // `{tx_id}.sequence` transcript entry.
+            let prot_id = format!("protein:{}", tx_id);
             (start, end, prot_id)
         } else {
             continue; // No CDS info available

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1139,15 +1139,19 @@ fn derive_proteins_for_ferro(ferro_dir: &Path) -> Result<(), ferro_hgvs::FerroEr
         let (cds_start, cds_end, protein_id) = if let Some(tx) = cdot.get_transcript(tx_id) {
             let start = tx.cds_start.unwrap_or(0) as usize;
             let end = tx.cds_end.unwrap_or(seq.len() as u64) as usize;
-            let prot_id = tx
-                .protein
-                .clone()
-                .unwrap_or_else(|| tx_id.replace("NM_", "NP_").replace("XM_", "XP_"));
+            // Key the derived-protein FASTA by the authoritative cdot protein
+            // accession if present, else the transcript id — matching the
+            // projector's `p.` accession (#808). We do NOT fabricate an NP_/XP_
+            // by preserving the number: RefSeq does not guarantee the NM and NP
+            // numbers match.
+            let prot_id = tx.protein.clone().unwrap_or_else(|| tx_id.clone());
             (start, end, prot_id)
         } else if let Some((start, end, _gene)) = supplemental_cds.get(tx_id) {
             let start = start.map(|s| (s - 1) as usize).unwrap_or(0);
             let end = end.map(|e| e as usize).unwrap_or(seq.len());
-            let prot_id = tx_id.replace("NM_", "NP_").replace("XM_", "XP_");
+            // No authoritative protein accession; key by the transcript id
+            // rather than a fabricated NP_/XP_ (#808).
+            let prot_id = tx_id.clone();
             (start, end, prot_id)
         } else {
             continue;

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -425,8 +425,10 @@ struct RawCdotTranscript {
     biotype: Option<Vec<String>>,
     /// Protein accession for the transcript's CDS (e.g. `NP_000068.1`). cdot
     /// records this per-transcript; plumbing it through lets the projector
-    /// emit the correct `p.` accession instead of falling back to the
-    /// (frequently wrong) `NM_*` → `NP_*` number-preserving inference.
+    /// emit the correct `p.` accession. When it is absent the projector falls
+    /// back to the transcript id itself, never the (frequently wrong) `NM_*` →
+    /// `NP_*` number-preserving inference, which was removed in #808 because
+    /// RefSeq does not guarantee the NM and NP numbers match.
     #[serde(default)]
     protein: Option<String>,
     #[serde(default)]
@@ -5333,9 +5335,10 @@ mod tests {
     fn test_protein_accession_parsed_from_cdot() {
         // cdot records the CDS protein accession per transcript. The loader
         // must surface it on `CdotTranscript.protein` so the projector emits
-        // the correct `p.` accession (here NP_000068.1) instead of falling
-        // back to the NM_* -> NP_* number-preserving inference (NP_000077.4),
-        // which is wrong whenever the NP number differs from the NM number.
+        // the correct `p.` accession (here NP_000068.1). Without it the
+        // projector falls back to the transcript id (#310); it never infers
+        // NP_000077.4 from NM_000077.4 by preserving the number, which is wrong
+        // whenever the NP number differs from the NM number (#808).
         let json = r#"
         {
             "transcripts": {

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1884,26 +1884,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         if (is_intronic && whole_exon.is_none()) || !is_coding || (is_utr && !affects_init) {
             return Ok(None);
         }
-        // Resolve the protein accession: explicit cdot/reference value, else
-        // RefSeq inference (NM_*→NP_*, XM_*→XP_*), else the transcript id
-        // itself (the HGVS p. grammar requires a sequence identifier; see
-        // #310). Substring stripping avoids mangling accessions whose suffix
-        // contains `NM_`.
-        let prot_acc: Option<String> = cdot_protein
-            .or_else(|| {
-                transcript_id
-                    .strip_prefix("NM_")
-                    .map(|rest| format!("NP_{rest}"))
-            })
-            .or_else(|| {
-                transcript_id
-                    .strip_prefix("XM_")
-                    .map(|rest| format!("XP_{rest}"))
-            })
-            .or_else(|| Some(transcript_id.to_string()));
-        let Some(prot_acc) = prot_acc else {
-            return Ok(None);
-        };
+        // Resolve the protein accession: the authoritative cdot/reference value
+        // if present, else the transcript id itself as the `p.` accession (the
+        // HGVS p. grammar requires a sequence identifier; see #310).
+        //
+        // We deliberately do NOT infer `NP_*`/`XP_*` from `NM_*`/`XM_*` by
+        // preserving the number: RefSeq does not guarantee the NM and NP
+        // numbers match (e.g. `NM_000077.4` ↔ `NP_000068.1`), so that inference
+        // is frequently wrong and would attach a real, translated prediction to
+        // a non-existent protein accession (#808). Falling back to the
+        // transcript id keeps the output honest — the identifier names the
+        // transcript whose CDS we actually translated — and still satisfies the
+        // grammar.
+        let prot_acc = cdot_protein.unwrap_or_else(|| transcript_id.to_string());
         // Issue #505: protein prediction below reads this transcript's CDS
         // bases directly and translates them. If the reference only carries a
         // *different* version of the transcript (a silent version-strip
@@ -4967,6 +4960,105 @@ mod tests {
             .expect("p. should be present via transcript-id fallback")
             .to_string();
         assert_eq!(p, "ENST00000000001.1:p.(Arg2Ser)");
+    }
+
+    /// Build a coding transcript on chr1 (plus strand, "ATGCGCTAA" = Met-Arg-Stop)
+    /// keyed by an arbitrary accession with **no** authoritative protein
+    /// accession (cdot `protein` and `Transcript.protein_id` both `None`), so
+    /// the projector's protein-accession resolution must fall through to the
+    /// transcript-id fallback rather than fabricate one. Mirrors
+    /// `make_test_provider_and_projector` otherwise.
+    #[cfg(test)]
+    fn make_protein_less_provider_and_projector(tx_id: &str) -> (Projector, MockProvider) {
+        let mut cdot = CdotMapper::new();
+        cdot.add_transcript(
+            tx_id.to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: "chr1".to_string(),
+                strand: ProvStrand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        let projector = Projector::new(cdot);
+
+        let mut provider = MockProvider::new();
+        provider.add_transcript(Transcript {
+            id: tx_id.to_string(),
+            gene_symbol: Some("TESTGENE".to_string()),
+            strand: TxStrand::Plus,
+            sequence: Some("ATGCGCTAA".to_string()),
+            cds_start: Some(1),
+            cds_end: Some(9),
+            exons: vec![Exon::new(1, 1, 9)],
+            chromosome: Some("chr1".to_string()),
+            genomic_start: Some(1000),
+            genomic_end: Some(1008),
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        });
+        let prefix = "N".repeat(999);
+        let suffix = "N".repeat(100);
+        provider.add_genomic_sequence("chr1", format!("{prefix}ATGCGCTAA{suffix}"));
+        (projector, provider)
+    }
+
+    #[test]
+    fn project_substitution_nm_without_protein_uses_transcript_id_not_inferred_np() {
+        // #808: a coding `NM_` transcript with no authoritative protein
+        // accession must NOT have one fabricated by number-preserving
+        // substitution (`NM_000077`→`NP_000077`), which is frequently wrong
+        // (RefSeq does not guarantee the NM and NP numbers match). Instead the
+        // projector falls back to the transcript id itself (#310) — honest, and
+        // still grammar-valid. The bug here would emit `NP_NOPROT.1:...`.
+        let (projector, provider) = make_protein_less_provider_and_projector("NM_NOPROT.1");
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "NM_NOPROT.1")
+            .expect("projection should succeed");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present via transcript-id fallback")
+            .to_string();
+        assert_eq!(
+            p, "NM_NOPROT.1:p.(Arg2Ser)",
+            "must use the transcript id, never a fabricated NP_"
+        );
+        assert!(
+            !p.starts_with("NP_"),
+            "must not fabricate a number-preserving NP_ accession: {p}"
+        );
+    }
+
+    #[test]
+    fn project_substitution_xm_without_protein_uses_transcript_id_not_inferred_xp() {
+        // #808, XM_/XP_ arm: same rule for predicted-model RefSeq transcripts.
+        let (projector, provider) = make_protein_less_provider_and_projector("XM_NOPROT.1");
+        let vp = VariantProjector::new(projector, provider);
+        let result = vp
+            .project("chr1:g.1003C>A", "XM_NOPROT.1")
+            .expect("projection should succeed");
+        let p = result
+            .protein
+            .as_ref()
+            .expect("p. should be present via transcript-id fallback")
+            .to_string();
+        assert_eq!(p, "XM_NOPROT.1:p.(Arg2Ser)");
+        assert!(
+            !p.starts_with("XP_"),
+            "must not fabricate a number-preserving XP_ accession: {p}"
+        );
     }
 
     // -------------------------------------------------------------------------

--- a/src/reference/annotation/builder.rs
+++ b/src/reference/annotation/builder.rs
@@ -1048,8 +1048,9 @@ mod tests {
     #[test]
     fn protein_id_absent_when_no_attribute() {
         // No `protein_id` attribute anywhere → `None`, and the projector's
-        // fallback chain (NM_ → NP_ inference, then transcript-id) takes
-        // over downstream. See #310.
+        // transcript-id fallback takes over downstream (the `NM_ → NP_`
+        // number-preserving inference was removed as frequently wrong, #808).
+        // See #310.
         let lines = &[
             "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1",
             "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1",

--- a/src/service/handlers/convert.rs
+++ b/src/service/handlers/convert.rs
@@ -208,7 +208,16 @@ fn perform_conversion(
                     // Calculate protein position: (cds_pos - 1) / 3 + 1
                     if cds_base > 0 {
                         let codon_num = ((cds_base - 1) / 3 + 1) as u64;
-                        let prot_acc = accession.replace("NM_", "NP_").replace("XM_", "XP_");
+                        // Protein accession: the authoritative cdot value if
+                        // present, else the transcript accession itself. We do
+                        // NOT infer `NP_*`/`XP_*` from `NM_*`/`XM_*` by
+                        // preserving the number — RefSeq does not guarantee the
+                        // NM and NP numbers match, so that is frequently wrong
+                        // (#808).
+                        let prot_acc = cdot_tx
+                            .protein
+                            .clone()
+                            .unwrap_or_else(|| accession.to_string());
                         let converted = format!("{}:p.{}", prot_acc, codon_num);
 
                         let all = if include_all {

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -734,11 +734,14 @@ fn predict_protein_consequence(
     // kept in the signature for symmetry with `ref_len`.
     let is_frameshift = is_frameshift && edit_type != "substitution";
 
-    // Get protein accession - prefer transcript's protein field if available
+    // Get the protein accession: the authoritative cdot value if present, else
+    // the transcript accession itself. We do NOT infer `NP_*`/`XP_*` from
+    // `NM_*`/`XM_*` by preserving the number — RefSeq does not guarantee the NM
+    // and NP numbers match, so that inference is frequently wrong (#808).
     let prot_acc = cdot_tx
         .protein
         .clone()
-        .unwrap_or_else(|| accession.replace("NM_", "NP_").replace("XM_", "XP_"));
+        .unwrap_or_else(|| accession.to_string());
 
     // Build HGVS protein notation
     // Without sequence data, we use position-based notation with uncertainty markers

--- a/src/service/handlers/vcf_convert.rs
+++ b/src/service/handlers/vcf_convert.rs
@@ -288,15 +288,27 @@ fn convert_to_transcript_notation(
         Some(CdsPosition::Cds(base)) if *base > 0 => {
             // Calculate protein position: (cds_pos - 1) / 3 + 1
             let prot_position = ((*base - 1) / 3 + 1) as u64;
-            let prot_acc = transcript_id.replace("NM_", "NP_").replace("XM_", "XP_");
-
-            if prot_acc.starts_with("NP_") || prot_acc.starts_with("XP_") {
-                Some(format!("{}:p.{}", prot_acc, prot_position))
-            } else {
-                None // Non-coding transcript
-            }
+            // Reaching this arm already proves the variant is in the CDS:
+            // `tx_to_cds` returns `Some(CdsPosition::Cds(_))` only for a
+            // transcript that has CDS bounds (`cds_start`/`cds_end` present) and
+            // a position inside them. A non-coding transcript (no `cds_start`)
+            // yields `None` and falls through to the `_ => None` arm below, so no
+            // prefix gate is needed to suppress its `p.`.
+            //
+            // Protein accession: the authoritative cdot value if present, else
+            // the transcript accession itself. We do NOT infer `NP_*`/`XP_*`
+            // from `NM_*`/`XM_*` by preserving the number — RefSeq does not
+            // guarantee the NM and NP numbers match, so that is frequently
+            // wrong (#808). Emitting unconditionally here also keeps the `p.`
+            // for coding `ENST_`/custom transcripts that have CDS bounds but no
+            // authoritative `cdot.protein`.
+            let prot_acc = cdot_tx
+                .protein
+                .clone()
+                .unwrap_or_else(|| transcript_id.to_string());
+            Some(format!("{}:p.{}", prot_acc, prot_position))
         }
-        _ => None, // UTR or intronic variant
+        _ => None, // UTR, intronic, or non-coding (no CDS) variant
     };
 
     (hgvs_c, hgvs_p, None)
@@ -867,5 +879,141 @@ mod tests {
         assert!(hgvs_p.is_none());
         assert!(error.is_some());
         assert!(error.unwrap().contains("cdot"));
+    }
+
+    /// Build a single-transcript cdot mapper on a `chr1`-style contig with the
+    /// canonical projector test layout: genome [1000, 1009) (0-based excl) /
+    /// tx [0, 9), CDS = whole transcript. `protein` is the authoritative
+    /// protein accession or `None`. With this layout genome position 1003
+    /// maps to CDS base 4 (protein codon 2).
+    #[cfg(test)]
+    fn coding_cdot(tx_id: &str, contig: &str, protein: Option<&str>) -> Arc<CdotMapper> {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::Strand;
+        let mut mapper = CdotMapper::new();
+        mapper.add_transcript(
+            tx_id.to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: contig.to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: Some(0),
+                cds_end: Some(9),
+                gene_id: None,
+                protein: protein.map(str::to_string),
+                exon_cigars: Vec::new(),
+            },
+        );
+        Arc::new(mapper)
+    }
+
+    /// Build a CdotMapper for a non-coding transcript: same exon span as
+    /// `coding_cdot` but with NO CDS bounds (`cds_start`/`cds_end` are `None`).
+    /// `tx_to_cds` returns `None` for such a transcript, so no `p.` is produced —
+    /// modeling "non-coding" by the absence of a CDS rather than by accession
+    /// prefix (#808).
+    fn noncoding_cdot(tx_id: &str, contig: &str) -> Arc<CdotMapper> {
+        use crate::data::cdot::CdotTranscript;
+        use crate::reference::Strand;
+        let mut mapper = CdotMapper::new();
+        mapper.add_transcript(
+            tx_id.to_string(),
+            CdotTranscript {
+                gene_name: Some("TESTGENE".to_string()),
+                contig: contig.to_string(),
+                strand: Strand::Plus,
+                exons: vec![[1000, 1009, 0, 9]],
+                cds_start: None,
+                cds_end: None,
+                gene_id: None,
+                protein: None,
+                exon_cigars: Vec::new(),
+            },
+        );
+        Arc::new(mapper)
+    }
+
+    #[test]
+    fn vcf_convert_p_prefers_authoritative_protein() {
+        // When cdot carries the authoritative protein accession, the p. uses
+        // it (here NP_000068.1, whose number differs from the NM_).
+        let cdot = coding_cdot("NM_000077.4", "chr1", Some("NP_000068.1"));
+        let (_c, p, err) = convert_to_transcript_notation(
+            1003,
+            "C",
+            "A",
+            "NM_000077.4",
+            Some(&cdot),
+            &VariantType::Substitution,
+        );
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(p.as_deref(), Some("NP_000068.1:p.2"));
+    }
+
+    #[test]
+    fn vcf_convert_p_coding_nm_without_protein_uses_transcript_id_not_inferred_np() {
+        // #808: a coding NM_ transcript with no authoritative protein must
+        // still emit a p. (it is coding), keyed off the transcript id — NOT a
+        // fabricated number-preserving NP_. The old prefix-proxy gate would
+        // have emitted NP_000077.4; the rework must not.
+        let cdot = coding_cdot("NM_000077.4", "chr1", None);
+        let (_c, p, err) = convert_to_transcript_notation(
+            1003,
+            "C",
+            "A",
+            "NM_000077.4",
+            Some(&cdot),
+            &VariantType::Substitution,
+        );
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(p.as_deref(), Some("NM_000077.4:p.2"));
+        assert!(
+            !p.as_deref().unwrap().starts_with("NP_"),
+            "must not fabricate an NP_: {p:?}"
+        );
+    }
+
+    #[test]
+    fn vcf_convert_p_noncoding_transcript_without_cds_drops_p() {
+        // A non-coding transcript — modeled by the ABSENCE of CDS bounds, not by
+        // an accession prefix — has no protein product. `tx_to_cds` returns
+        // `None`, so no `p.` is emitted. The NR_ accession here is incidental;
+        // the suppression is driven by the missing CDS, which is the correct
+        // signal (#808).
+        let cdot = noncoding_cdot("NR_000077.4", "chr1");
+        let (_c, p, err) = convert_to_transcript_notation(
+            1003,
+            "C",
+            "A",
+            "NR_000077.4",
+            Some(&cdot),
+            &VariantType::Substitution,
+        );
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert!(
+            p.is_none(),
+            "transcript without CDS bounds must not emit a p.: {p:?}"
+        );
+    }
+
+    #[test]
+    fn vcf_convert_p_coding_non_nm_transcript_without_protein_emits_p() {
+        // A coding transcript whose accession is NOT an NM_/XM_ RefSeq mRNA
+        // (e.g. an Ensembl ENST_ or a custom id) but which HAS CDS bounds and no
+        // authoritative `cdot.protein` must still emit a `p.`, keyed off the
+        // transcript id. The old NM_/XM_ prefix gate wrongly dropped this valid
+        // coding `p.` (#808); removing the gate restores it.
+        let cdot = coding_cdot("ENST00000367770.5", "chr1", None);
+        let (_c, p, err) = convert_to_transcript_notation(
+            1003,
+            "C",
+            "A",
+            "ENST00000367770.5",
+            Some(&cdot),
+            &VariantType::Substitution,
+        );
+        assert!(err.is_none(), "unexpected error: {err:?}");
+        assert_eq!(p.as_deref(), Some("ENST00000367770.5:p.2"));
     }
 }

--- a/tests/it/issue_310_projector_non_refseq.rs
+++ b/tests/it/issue_310_projector_non_refseq.rs
@@ -7,8 +7,12 @@
 //! 2. Without `protein_id`, the projector falls back to using the
 //!    transcript ID as the `p.` accession — never silently drops the
 //!    prediction just because of an ID format.
-//! 3. RefSeq `NM_*` transcripts still infer `NP_*` and now omit the
-//!    gene-symbol selector from Display.
+//! 3. RefSeq `NM_*`/`XM_*` transcripts WITHOUT an authoritative protein
+//!    accession fall back to the transcript ID for the `p.` accession and
+//!    omit the gene-symbol selector from Display. Per #808 they no longer
+//!    infer `NP_*`/`XP_*` by preserving the number — RefSeq does not
+//!    guarantee the NM/NP numbers match, so that inference was frequently
+//!    wrong (e.g. `NM_000077.4` ↔ `NP_000068.1`).
 //! 4. The parser still accepts the legacy `NP_*(GENE):p.` form and
 //!    preserves the selector text in `gene_symbol` for callers that
 //!    read it programmatically.
@@ -84,28 +88,41 @@ fn non_refseq_id_without_protein_id_falls_back_to_transcript_id() {
 }
 
 #[test]
-fn refseq_nm_prefix_still_infers_np_and_omits_gene_selector() {
+fn refseq_nm_prefix_without_protein_falls_back_to_transcript_id() {
+    // #808: an `NM_` transcript with no authoritative protein accession must
+    // NOT have one fabricated by number-preserving substitution
+    // (`NM_TEST.1`→`NP_TEST.1`), which is frequently wrong. It falls back to
+    // the transcript id itself (#310) — honest and still grammar-valid.
     let provider = make_provider("NM_TEST.1", None);
     let result = project(provider, "chr1:g.1003C>A", "NM_TEST.1");
     let p = result
         .protein
         .as_ref()
-        .expect("p. should be set via NM_ → NP_ inference")
+        .expect("p. should be set via transcript-id fallback")
         .to_string();
-    assert_eq!(p, "NP_TEST.1:p.(Arg2Ser)");
+    assert_eq!(p, "NM_TEST.1:p.(Arg2Ser)");
+    assert!(
+        !p.starts_with("NP_"),
+        "must not fabricate a number-preserving NP_ accession: {p}"
+    );
     assert!(!p.contains("(MYGENE)"), "no (GENE) selector on p.: {p}");
 }
 
 #[test]
-fn refseq_xm_prefix_still_infers_xp_and_omits_gene_selector() {
+fn refseq_xm_prefix_without_protein_falls_back_to_transcript_id() {
+    // #808, XM_/XP_ arm: same rule for predicted-model RefSeq transcripts.
     let provider = make_provider("XM_TEST.1", None);
     let result = project(provider, "chr1:g.1003C>A", "XM_TEST.1");
     let p = result
         .protein
         .as_ref()
-        .expect("p. should be set via XM_ → XP_ inference")
+        .expect("p. should be set via transcript-id fallback")
         .to_string();
-    assert_eq!(p, "XP_TEST.1:p.(Arg2Ser)");
+    assert_eq!(p, "XM_TEST.1:p.(Arg2Ser)");
+    assert!(
+        !p.starts_with("XP_"),
+        "must not fabricate a number-preserving XP_ accession: {p}"
+    );
     assert!(!p.contains("(MYGENE)"), "no (GENE) selector on p.: {p}");
 }
 

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -75,7 +75,11 @@ class TestVariantProjector:
         assert result.gene_symbol == "TESTGENE"
         assert result.c_name is not None
         assert ":c.4C>A" in result.c_name
-        assert result.p_name == "NP_TEST.1:p.(Arg2Ser)"
+        # The NM_TEST.1 fixture carries no authoritative protein accession, so
+        # the p. accession falls back to the transcript id (#310/#808) — never a
+        # fabricated number-preserving NP_ (RefSeq does not guarantee the NM and
+        # NP numbers match).
+        assert result.p_name == "NM_TEST.1:p.(Arg2Ser)"
         assert result.is_frameshift is False
         assert result.is_intronic is False
         assert result.is_utr is False
@@ -234,14 +238,16 @@ class TestIndelProteinNomenclature:
         result = long_projector.project("NC_000002.12:g.2006_2008del", transcript="NM_LONG.1")
         assert result.c_name is not None
         assert "del" in result.c_name
-        assert result.p_name == "NP_LONG.1:p.(Arg2del)"
+        # NM_LONG.1 carries no authoritative protein accession → transcript-id
+        # fallback, never a fabricated number-preserving NP_ (#310/#808).
+        assert result.p_name == "NM_LONG.1:p.(Arg2del)"
         assert result.is_frameshift is False
 
     def test_del_two_whole_codons(self, long_projector: ferro_hgvs.VariantProjector) -> None:
         # Delete Arg+Lys codons (c.4_9 = g.2006_2014del): p.(Arg2_Lys3del).
         result = long_projector.project("NC_000002.12:g.2006_2011del", transcript="NM_LONG.1")
         assert result.c_name is not None
-        assert result.p_name == "NP_LONG.1:p.(Arg2_Lys3del)"
+        assert result.p_name == "NM_LONG.1:p.(Arg2_Lys3del)"
         assert result.is_frameshift is False
 
     def test_del_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:
@@ -257,7 +263,7 @@ class TestIndelProteinNomenclature:
         result = long_projector.project("NC_000002.12:g.2006_2008dup", transcript="NM_LONG.1")
         assert result.c_name is not None
         assert "dup" in result.c_name
-        assert result.p_name == "NP_LONG.1:p.(Arg2dup)"
+        assert result.p_name == "NM_LONG.1:p.(Arg2dup)"
         assert result.is_frameshift is False
 
     def test_dup_single_base_frameshift(self, long_projector: ferro_hgvs.VariantProjector) -> None:


### PR DESCRIPTION
## Summary

`ferro` predicts a protein consequence (`p.`) by translating CDS bases, and that prediction needs a protein sequence identifier. When the transcript carried no authoritative protein accession, the fallback fabricated one by number-preserving substring substitution: `NM_000077` → `NP_000077`. RefSeq does **not** guarantee the NM and NP numbers match (e.g. `NM_000077.4` ↔ `NP_000068.1`), so — as the code comment itself flagged — this inference is "(frequently wrong)". It attached a real, translated prediction to a **non-existent** protein accession.

This PR removes the number-preserving `NM_*→NP_*` / `XM_*→XP_*` inference everywhere it was used as a user-facing fallback, declining to fabricate an accession while still satisfying the HGVS `p.` grammar (which requires a sequence identifier).

## What changed

- **`src/project/projector.rs`** (production `ferro project` / `ferro normalize` / Python bindings): collapse the protein-accession resolution chain to **authoritative cdot/reference value, else the transcript id itself**. The #310 grammar-required sequence-identifier fallback is preserved — only the wrong middle step is removed. A protein-less `NM_` transcript now emits `NM_…:p.(…)` rather than a fabricated `NP_…` — honest, because the identifier names the transcript whose CDS was actually translated.
- **`src/service/handlers/{effect,convert,vcf_convert}.rs`** (web-service handlers, position-based `p.`): prefer the authoritative `cdot_tx.protein`, else fall back to the transcript accession. In `vcf_convert`, the coding gate previously keyed off the *inferred* `NP_`/`XP_` prefix; it is reworked to key off the transcript's coding status (`NM_`/`XM_` or an authoritative protein present) so a coding transcript lacking an authoritative protein still emits a `p.` and a genuinely non-coding transcript still drops it.

## Out of scope (intentionally unchanged)

- **Benchmark comparison shims** (`benchmark.rs`, `benchmark/cache.rs`, `benchmark/biocommons.rs`) keep the substitution — they build like-for-like comparison keys against external tools that themselves infer `NP_`, and are not user-facing nomenclature.
- **`normalize/mod.rs::resolve_genomic_protein_selector`** (#502) already resolves only from the authoritative `Transcript.protein_id` and declines when absent — no number-preserving inference, so no change.

## Tests

- New projector regression tests: a protein-less `NM_`/`XM_` transcript emits the transcript id, never a fabricated `NP_`/`XP_`.
- New `vcf_convert` unit tests: authoritative protein preferred; coding `NM_` without protein emits transcript-id `p.`; non-coding transcript drops the `p.`.
- Updated the `#310` integration tests and Python projection tests that pinned the old inferred output to the transcript-id fallback (these assertions *were* the bug encoded as tests).
- `cargo nextest run --features dev`: 7475 passed. `cargo clippy --all-features --all-targets -- -D warnings`: clean. `pytest tests/python/`: 185 passed.

Closes #808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed protein accession inference: The system no longer fabricates protein identifiers by transforming transcript IDs. When no authoritative protein accession is available, the transcript ID itself is used as the protein accession in HGVS notation.

* **Documentation**
  * Updated schema and inline documentation to reflect the revised protein accession fallback behavior, clarifying that no automatic inference occurs.

* **Tests**
  * Updated test expectations to match the new protein accession handling; added coverage for transcript ID-based fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->