### PR TITLE
fix(equivalence/service): make unsupported variant classes explicit

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -211,10 +211,17 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
         str1: &str,
         str2: &str,
     ) -> Option<EquivalenceResult> {
-        // Get accessions (handle allele and null/unknown cases gracefully)
+        // This helper only detects whether two variants are the *same change on
+        // different accession versions*. `None` here means "not an accession-version
+        // difference" — it is not an "unsupported" signal. For compound/null/unknown
+        // alleles there is no single accession version to compare (an allele's
+        // `accession()` reports only its first member, which would be misleading), so
+        // we decline. The caller (`check`) then falls through to the normalizer, which
+        // handles alleles directly, so allele equivalence is fully determined — just
+        // not via this version-comparison path.
         let acc1 = match v1 {
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => return None,
-            HgvsVariant::Allele(_) => return None, // Complex case, skip for now
+            HgvsVariant::Allele(_) => return None,
             _ => v1.accession()?,
         };
         let acc2 = match v2 {
@@ -371,6 +378,47 @@ mod tests {
         let result = checker.check(&v1, &v2).unwrap();
         assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
         assert!(!result.is_equivalent());
+    }
+
+    #[test]
+    fn test_identical_compound_alleles_are_equivalent() {
+        // Regression: `check_accession_version_difference` declines (returns None) for
+        // alleles, and `check()` must fall through to the normalizer, which handles
+        // alleles. Two identical compound alleles must compare as Identical, proving
+        // there is no silent "unsupported" gap for alleles.
+        let checker = checker();
+        let v1 = parse_hgvs("NM_000088.3:c.[10A>G;20C>T]").unwrap();
+        let v2 = parse_hgvs("NM_000088.3:c.[10A>G;20C>T]").unwrap();
+        assert!(matches!(v1, HgvsVariant::Allele(_)));
+
+        let result = checker.check(&v1, &v2).unwrap();
+        assert_eq!(result.level, EquivalenceLevel::Identical);
+        assert!(result.is_equivalent());
+    }
+
+    #[test]
+    fn test_differing_alleles_do_not_error() {
+        // A pair of non-identical alleles must still flow through `check()` without
+        // erroring. The version-difference helper declines for alleles (returns None,
+        // not an error), so these resolve via normalization rather than being reported
+        // as an accession-version match — confirming the helper's None is
+        // "not-applicable", never a silent unsupported failure.
+        //
+        // Both alleles use `NM_000088.3` (present in the MockProvider fixture) so the
+        // test exercises real normalization and its correctness does not hinge on how
+        // the normalizer treats an unknown accession. The members differ in
+        // coordinates, so the alleles are not identical.
+        let checker = checker();
+        let v1 = parse_hgvs("NM_000088.3:c.[10A>G;20C>T]").unwrap();
+        let v2 = parse_hgvs("NM_000088.3:c.[11A>G;21C>T]").unwrap();
+        assert!(matches!(v1, HgvsVariant::Allele(_)));
+        assert!(matches!(v2, HgvsVariant::Allele(_)));
+
+        // The contract under test: `check()` returns Ok for every allele pair.
+        let result = checker.check(&v1, &v2).unwrap();
+        // The differing member coordinates do not normalize equal, so they compare as
+        // NotEquivalent — the point is the Ok, not the level.
+        assert_eq!(result.level, EquivalenceLevel::NotEquivalent);
     }
 
     #[test]

--- a/src/service/handlers/validate.rs
+++ b/src/service/handlers/validate.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use crate::hgvs::interval::interval_is_wraparound;
 use crate::service::{
     server::AppState,
-    types::{ErrorResponse, ParsedVariantDetails, PositionDetails, ServiceError, ValidateResponse},
+    types::{extract_variant_details, ErrorResponse, ServiceError, ValidateResponse},
     validation::validate_hgvs as security_validate_hgvs,
 };
 
@@ -136,364 +136,46 @@ pub fn validate_hgvs(hgvs: &str) -> ValidateResponse {
     }
 }
 
-/// Extract parsed variant details from an HgvsVariant
-fn extract_variant_details(
-    variant: &crate::hgvs::variant::HgvsVariant,
-) -> Option<ParsedVariantDetails> {
-    use crate::hgvs::variant::HgvsVariant;
-
-    match variant {
-        HgvsVariant::Cds(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "c".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0,
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Genome(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "g".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0,
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Tx(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "n".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0,
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Protein(v) => Some(ParsedVariantDetails {
-            reference: v.accession.to_string(),
-            coordinate_system: "p".to_string(),
-            variant_type: "protein_change".to_string(),
-            position: PositionDetails {
-                start: 0,
-                end: None,
-                offset: None,
-                display: v.loc_edit.location.to_string(),
-            },
-            deleted: None,
-            inserted: None,
-            was_shifted: None,
-            original_position: None,
-        }),
-        HgvsVariant::Mt(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "m".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0,
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Circular(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "o".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0,
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        _ => None,
-    }
-}
-
-/// Extract edit type and sequences from NaEdit
-fn extract_na_edit_info(
-    edit: &crate::hgvs::edit::NaEdit,
-) -> (String, Option<String>, Option<String>) {
-    use crate::hgvs::edit::NaEdit;
-
-    match edit {
-        NaEdit::Substitution {
-            reference,
-            alternative,
-        } => (
-            "substitution".to_string(),
-            Some(reference.to_string()),
-            Some(alternative.to_string()),
-        ),
-        NaEdit::SubstitutionNoRef { alternative } => (
-            "substitution".to_string(),
-            None,
-            Some(alternative.to_string()),
-        ),
-        NaEdit::Deletion { sequence, length } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("deletion".to_string(), deleted, None)
-        }
-        NaEdit::Insertion { sequence } => {
-            ("insertion".to_string(), None, Some(sequence.to_string()))
-        }
-        NaEdit::Delins {
-            sequence,
-            deleted,
-            deleted_length,
-        } => {
-            let deleted = deleted
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| deleted_length.map(|l| format!("{} bp", l)));
-            ("delins".to_string(), deleted, Some(sequence.to_string()))
-        }
-        NaEdit::Duplication {
-            sequence, length, ..
-        } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("duplication".to_string(), deleted, None)
-        }
-        NaEdit::Inversion { sequence, length } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("inversion".to_string(), deleted, None)
-        }
-        NaEdit::Repeat {
-            sequence, count, ..
-        } => {
-            let seq = sequence.as_ref().map(|s| s.to_string());
-            ("repeat".to_string(), seq, Some(format!("{}", count)))
-        }
-        NaEdit::Identity { .. } => ("identity".to_string(), None, None),
-        NaEdit::Unknown { .. } => ("unknown".to_string(), None, None),
-        _ => ("other".to_string(), None, None),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // Per-arm coverage of the shared `extract_variant_details` /
+    // `extract_na_edit_info` helpers lives in `crate::service::types`. Here we
+    // cover the validate handler's own surface: that `validate_hgvs` wires the
+    // shared component breakdown into the response and that `variant_wraps_origin`
+    // is axis-aware.
+
     #[test]
-    fn test_extract_variant_details_cds() {
+    fn test_validate_hgvs_populates_components() {
+        let response = validate_hgvs("NM_000249.4:c.350C>T");
+        assert!(response.valid);
+        let components = response.components.expect("components populated");
+        assert_eq!(components.coordinate_system, "c");
+        assert_eq!(components.variant_type, "substitution");
+        assert_eq!(components.reference, "NM_000249.4");
+    }
+
+    #[test]
+    fn test_validate_hgvs_allele_has_no_components() {
+        // Compound alleles have no single coordinate/position to flatten, so the
+        // shared extractor returns None and the response carries no breakdown.
+        let response = validate_hgvs("NM_000088.3:c.[10A>G;20C>T]");
+        assert!(response.valid);
+        assert!(response.components.is_none());
+    }
+
+    #[test]
+    fn test_validate_hgvs_invalid_input() {
+        let response = validate_hgvs("not a variant");
+        assert!(!response.valid);
+        assert!(response.components.is_none());
+        assert!(!response.wraps_origin);
+    }
+
+    #[test]
+    fn test_variant_wraps_origin_linear_axis_is_false() {
         let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350C>T").unwrap();
-        let details = extract_variant_details(&result.result);
-
-        assert!(details.is_some());
-        let d = details.unwrap();
-        assert_eq!(d.coordinate_system, "c");
-        assert_eq!(d.variant_type, "substitution");
-        assert_eq!(d.reference, "NM_000249.4");
-    }
-
-    #[test]
-    fn test_extract_variant_details_genomic() {
-        let result =
-            crate::hgvs::parser::parse_hgvs_lenient("NC_000007.14:g.117559593G>A").unwrap();
-        let details = extract_variant_details(&result.result);
-
-        assert!(details.is_some());
-        let d = details.unwrap();
-        assert_eq!(d.coordinate_system, "g");
-        assert_eq!(d.variant_type, "substitution");
-    }
-
-    #[test]
-    fn test_extract_variant_details_protein() {
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NP_000240.1:p.Val600Glu").unwrap();
-        let details = extract_variant_details(&result.result);
-
-        assert!(details.is_some());
-        let d = details.unwrap();
-        assert_eq!(d.coordinate_system, "p");
-        assert_eq!(d.variant_type, "protein_change");
-    }
-
-    #[test]
-    fn test_extract_variant_details_mitochondrial() {
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NC_012920.1:m.8993T>G").unwrap();
-        let details = extract_variant_details(&result.result);
-
-        assert!(details.is_some());
-        let d = details.unwrap();
-        assert_eq!(d.coordinate_system, "m");
-    }
-
-    #[test]
-    fn test_extract_variant_details_noncoding() {
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NR_000001.1:n.100A>G").unwrap();
-        let details = extract_variant_details(&result.result);
-
-        assert!(details.is_some());
-        let d = details.unwrap();
-        assert_eq!(d.coordinate_system, "n");
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_substitution() {
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350C>T").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "substitution");
-                assert_eq!(deleted, Some("C".to_string()));
-                assert_eq!(inserted, Some("T".to_string()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_deletion() {
-        // W3025 (DelExplicitSeq) strips the explicit sequence in lenient mode,
-        // so the parsed NaEdit::Deletion has sequence=None after preprocessing.
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350delC").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "deletion");
-                assert_eq!(deleted, None);
-                assert!(inserted.is_none());
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_insertion() {
-        let result =
-            crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_351insATG").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "insertion");
-                assert!(deleted.is_none());
-                assert_eq!(inserted, Some("ATG".to_string()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_delins() {
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350delinsATG").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "delins");
-                assert_eq!(deleted, None, "short form has no explicit deleted");
-                assert_eq!(inserted, Some("ATG".to_string()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_delins_with_explicit_deleted_seq() {
-        let result =
-            crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_352delATGinsTTCC").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "delins");
-                assert_eq!(deleted, Some("ATG".to_string()));
-                assert_eq!(inserted, Some("TTCC".to_string()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_delins_with_explicit_deleted_length() {
-        let result =
-            crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350_352del3insTA").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "delins");
-                assert_eq!(deleted, Some("3 bp".to_string()));
-                assert_eq!(inserted, Some("TA".to_string()));
-            }
-        }
-    }
-
-    #[test]
-    fn test_extract_na_edit_info_duplication() {
-        // W3024 (DupExplicitSeq) strips the explicit sequence in lenient mode,
-        // so the parsed NaEdit::Duplication has sequence=None after preprocessing.
-        let result = crate::hgvs::parser::parse_hgvs_lenient("NM_000249.4:c.350dupC").unwrap();
-        if let crate::hgvs::variant::HgvsVariant::Cds(v) = &result.result {
-            if let Some(edit) = v.loc_edit.edit.inner() {
-                let (vtype, deleted, _inserted) = extract_na_edit_info(edit);
-                assert_eq!(vtype, "duplication");
-                assert_eq!(deleted, None);
-            }
-        }
+        assert!(!variant_wraps_origin(&result.result));
     }
 }

--- a/src/service/tools/ferro.rs
+++ b/src/service/tools/ferro.rs
@@ -2,170 +2,15 @@
 
 use std::sync::Arc;
 
-use crate::benchmark::types::{ParseResult, ParsedVariantDetails, PositionDetails};
+use crate::benchmark::types::ParseResult;
 use crate::error_handling::{ErrorConfig, ErrorMode};
-use crate::hgvs::edit::NaEdit;
-use crate::hgvs::variant::HgvsVariant;
 use crate::normalize::{NormalizeConfig, Normalizer, ShuffleDirection};
 use crate::reference::MultiFastaProvider;
 use crate::service::{
     config::FerroConfig,
     tools::HgvsToolService,
-    types::{health_check::HealthCheckResult, ServiceError, ToolName},
+    types::{extract_variant_details, health_check::HealthCheckResult, ServiceError, ToolName},
 };
-
-/// Extract parsed variant details from an HgvsVariant
-fn extract_variant_details(variant: &HgvsVariant) -> Option<ParsedVariantDetails> {
-    match variant {
-        HgvsVariant::Cds(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "c".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0, // Position encoded in display string
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Genome(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "g".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0, // Position encoded in display string
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Tx(v) => {
-            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
-                extract_na_edit_info(edit)
-            } else {
-                ("unknown".to_string(), None, None)
-            };
-            Some(ParsedVariantDetails {
-                reference: v.accession.to_string(),
-                coordinate_system: "n".to_string(),
-                variant_type,
-                position: PositionDetails {
-                    start: 0, // Position encoded in display string
-                    end: None,
-                    offset: None,
-                    display: v.loc_edit.location.to_string(),
-                },
-                deleted,
-                inserted,
-                was_shifted: None,
-                original_position: None,
-            })
-        }
-        HgvsVariant::Protein(v) => Some(ParsedVariantDetails {
-            reference: v.accession.to_string(),
-            coordinate_system: "p".to_string(),
-            variant_type: "protein_change".to_string(),
-            position: PositionDetails {
-                start: 0,
-                end: None,
-                offset: None,
-                display: v.loc_edit.location.to_string(),
-            },
-            deleted: None,
-            inserted: None,
-            was_shifted: None,
-            original_position: None,
-        }),
-        _ => None, // For alleles, RNA fusions, etc. - skip for now
-    }
-}
-
-/// Extract edit type and sequences from NaEdit
-fn extract_na_edit_info(edit: &NaEdit) -> (String, Option<String>, Option<String>) {
-    match edit {
-        NaEdit::Substitution {
-            reference,
-            alternative,
-        } => (
-            "substitution".to_string(),
-            Some(reference.to_string()),
-            Some(alternative.to_string()),
-        ),
-        NaEdit::SubstitutionNoRef { alternative } => (
-            "substitution".to_string(),
-            None,
-            Some(alternative.to_string()),
-        ),
-        NaEdit::Deletion { sequence, length } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("deletion".to_string(), deleted, None)
-        }
-        NaEdit::Insertion { sequence } => {
-            ("insertion".to_string(), None, Some(sequence.to_string()))
-        }
-        NaEdit::Delins {
-            sequence,
-            deleted,
-            deleted_length,
-        } => {
-            let deleted = deleted
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| deleted_length.map(|l| format!("{} bp", l)));
-            ("delins".to_string(), deleted, Some(sequence.to_string()))
-        }
-        NaEdit::Duplication {
-            sequence, length, ..
-        } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("duplication".to_string(), deleted, None)
-        }
-        NaEdit::Inversion { sequence, length } => {
-            let deleted = sequence
-                .as_ref()
-                .map(|s| s.to_string())
-                .or_else(|| length.map(|l| format!("{} bp", l)));
-            ("inversion".to_string(), deleted, None)
-        }
-        NaEdit::Repeat {
-            sequence, count, ..
-        } => {
-            let seq = sequence.as_ref().map(|s| s.to_string());
-            ("repeat".to_string(), seq, Some(format!("{}", count)))
-        }
-        NaEdit::Identity { .. } => ("identity".to_string(), None, None),
-        NaEdit::Unknown { .. } => ("unknown".to_string(), None, None),
-        _ => ("other".to_string(), None, None),
-    }
-}
 
 /// Ferro tool service
 pub struct FerroService {
@@ -442,6 +287,11 @@ mod tests {
             assert!(matches!(e, ServiceError::ConfigError(_)));
         }
     }
+
+    // Per-arm coverage of the shared `extract_variant_details` helper (including
+    // the RNA/Mt/Circular arms and the `Allele -> None` path) lives alongside the
+    // function in `crate::service::types`. The service exercises it end-to-end via
+    // `parse`/`normalize`, which populate `ParseResult::details`.
 
     #[test]
     fn test_invalid_config() {

--- a/src/service/types.rs
+++ b/src/service/types.rs
@@ -6,6 +6,268 @@ use std::collections::HashMap;
 // Re-export parsed variant types from benchmark module
 pub use crate::benchmark::types::{ParsedVariantDetails, PositionDetails};
 
+use crate::hgvs::edit::NaEdit;
+use crate::hgvs::variant::HgvsVariant;
+
+/// Extract parsed variant details from an [`HgvsVariant`].
+///
+/// Returns `Some` with a flattened [`ParsedVariantDetails`] for the seven
+/// variant classes that map onto a single coordinate/position (`c`/`g`/`n`/`p`/
+/// `r`/`m`/`o`). Returns `None` for the complex classes (allele lists, fusions,
+/// genome rings, supernumerary contigs, null/unknown alleles) which have no
+/// single coordinate/position to flatten into the [`ParsedVariantDetails`]
+/// shape; this `None` is a "no structured breakdown" signal, not an error.
+///
+/// The complex classes are listed explicitly (no `_` arm) so that adding a new
+/// [`HgvsVariant`] arm fails to compile here rather than being silently dropped.
+///
+/// This is the single shared implementation used by both the validate HTTP
+/// handler and the ferro MCP tool so the two surfaces stay in lockstep.
+pub(crate) fn extract_variant_details(variant: &HgvsVariant) -> Option<ParsedVariantDetails> {
+    match variant {
+        HgvsVariant::Cds(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "c".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        HgvsVariant::Genome(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "g".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        HgvsVariant::Tx(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "n".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        HgvsVariant::Protein(v) => Some(ParsedVariantDetails {
+            reference: v.accession.to_string(),
+            coordinate_system: "p".to_string(),
+            variant_type: "protein_change".to_string(),
+            position: PositionDetails {
+                start: 0,
+                end: None,
+                offset: None,
+                display: v.loc_edit.location.to_string(),
+            },
+            deleted: None,
+            inserted: None,
+            was_shifted: None,
+            original_position: None,
+        }),
+        HgvsVariant::Rna(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "r".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        HgvsVariant::Mt(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "m".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        HgvsVariant::Circular(v) => {
+            let (variant_type, deleted, inserted) = if let Some(edit) = v.loc_edit.edit.inner() {
+                extract_na_edit_info(edit)
+            } else {
+                ("unknown".to_string(), None, None)
+            };
+            Some(ParsedVariantDetails {
+                reference: v.accession.to_string(),
+                coordinate_system: "o".to_string(),
+                variant_type,
+                position: PositionDetails {
+                    start: 0, // Position encoded in display string
+                    end: None,
+                    offset: None,
+                    display: v.loc_edit.location.to_string(),
+                },
+                deleted,
+                inserted,
+                was_shifted: None,
+                original_position: None,
+            })
+        }
+        // These classes have no single coordinate/position to flatten into the
+        // ParsedVariantDetails shape, so they intentionally have no structured
+        // breakdown. Listed explicitly (no `_`) so a future HgvsVariant arm fails to
+        // compile here rather than being silently dropped.
+        HgvsVariant::RnaFusion(_)
+        | HgvsVariant::GenomeRing(_)
+        | HgvsVariant::Supernumerary(_)
+        | HgvsVariant::Allele(_)
+        | HgvsVariant::NullAllele
+        | HgvsVariant::UnknownAllele => None,
+    }
+}
+
+/// Extract the edit type label and the deleted/inserted sequences from a
+/// [`NaEdit`], returning `(variant_type, deleted, inserted)`.
+pub(crate) fn extract_na_edit_info(edit: &NaEdit) -> (String, Option<String>, Option<String>) {
+    match edit {
+        NaEdit::Substitution {
+            reference,
+            alternative,
+        } => (
+            "substitution".to_string(),
+            Some(reference.to_string()),
+            Some(alternative.to_string()),
+        ),
+        NaEdit::SubstitutionNoRef { alternative } => (
+            "substitution".to_string(),
+            None,
+            Some(alternative.to_string()),
+        ),
+        NaEdit::Deletion { sequence, length } => {
+            let deleted = sequence
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| length.map(|l| format!("{} bp", l)));
+            ("deletion".to_string(), deleted, None)
+        }
+        NaEdit::Insertion { sequence } => {
+            ("insertion".to_string(), None, Some(sequence.to_string()))
+        }
+        NaEdit::Delins {
+            sequence,
+            deleted,
+            deleted_length,
+        } => {
+            let deleted = deleted
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| deleted_length.map(|l| format!("{} bp", l)));
+            ("delins".to_string(), deleted, Some(sequence.to_string()))
+        }
+        NaEdit::Duplication {
+            sequence, length, ..
+        } => {
+            let deleted = sequence
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| length.map(|l| format!("{} bp", l)));
+            ("duplication".to_string(), deleted, None)
+        }
+        NaEdit::Inversion { sequence, length } => {
+            let deleted = sequence
+                .as_ref()
+                .map(|s| s.to_string())
+                .or_else(|| length.map(|l| format!("{} bp", l)));
+            ("inversion".to_string(), deleted, None)
+        }
+        NaEdit::Repeat {
+            sequence, count, ..
+        } => {
+            let seq = sequence.as_ref().map(|s| s.to_string());
+            ("repeat".to_string(), seq, Some(format!("{}", count)))
+        }
+        NaEdit::Identity { .. } => ("identity".to_string(), None, None),
+        NaEdit::Unknown { .. } => ("unknown".to_string(), None, None),
+        // The remaining edit classes either carry no flat sequence to surface or
+        // are non-standard/structural forms without a single deleted/inserted
+        // pair. They are listed explicitly (no `_`) so a future `NaEdit` arm
+        // fails to compile here rather than being silently mapped to "other".
+        NaEdit::NPaddedDeletion { count } => {
+            ("deletion".to_string(), Some(format!("N[{}]", count)), None)
+        }
+        NaEdit::BreakpointInsertion { sequence } => {
+            ("insertion".to_string(), None, Some(sequence.to_string()))
+        }
+        NaEdit::DupIns { sequence } => ("dupins".to_string(), None, Some(sequence.to_string())),
+        NaEdit::MultiRepeat { .. } => ("repeat".to_string(), None, None),
+        NaEdit::Conversion { .. } => ("conversion".to_string(), None, None),
+        NaEdit::Methylation { .. } => ("methylation".to_string(), None, None),
+        NaEdit::CopyNumber { .. } => ("copy_number".to_string(), None, None),
+        NaEdit::Splice { .. } => ("splice".to_string(), None, None),
+        NaEdit::NoProduct => ("no_product".to_string(), None, None),
+        NaEdit::PositionOnly => ("position_only".to_string(), None, None),
+    }
+}
+
 /// Strongly-typed tool names to prevent injection attacks
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ToolName {
@@ -1041,5 +1303,142 @@ pub mod health_check {
                 ],
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(hgvs: &str) -> Option<ParsedVariantDetails> {
+        let result = crate::hgvs::parser::parse_hgvs_lenient(hgvs).unwrap();
+        extract_variant_details(&result.result)
+    }
+
+    #[test]
+    fn test_extract_variant_details_cds() {
+        let d = extract("NM_000249.4:c.350C>T").expect("cds details");
+        assert_eq!(d.coordinate_system, "c");
+        assert_eq!(d.variant_type, "substitution");
+        assert_eq!(d.reference, "NM_000249.4");
+    }
+
+    #[test]
+    fn test_extract_variant_details_genomic() {
+        let d = extract("NC_000007.14:g.117559593G>A").expect("genomic details");
+        assert_eq!(d.coordinate_system, "g");
+        assert_eq!(d.variant_type, "substitution");
+    }
+
+    #[test]
+    fn test_extract_variant_details_noncoding() {
+        let d = extract("NR_000001.1:n.100A>G").expect("noncoding details");
+        assert_eq!(d.coordinate_system, "n");
+    }
+
+    #[test]
+    fn test_extract_variant_details_protein() {
+        let d = extract("NP_000240.1:p.Val600Glu").expect("protein details");
+        assert_eq!(d.coordinate_system, "p");
+        assert_eq!(d.variant_type, "protein_change");
+    }
+
+    #[test]
+    fn test_extract_variant_details_rna() {
+        let d = extract("NR_000001.1:r.100a>g").expect("rna details should be populated");
+        assert_eq!(d.coordinate_system, "r");
+    }
+
+    #[test]
+    fn test_extract_variant_details_mitochondrial() {
+        let d =
+            extract("NC_012920.1:m.8993T>G").expect("mitochondrial details should be populated");
+        assert_eq!(d.coordinate_system, "m");
+    }
+
+    #[test]
+    fn test_extract_variant_details_circular() {
+        let d = extract("J01749.1:o.100A>G").expect("circular details should be populated");
+        assert_eq!(d.coordinate_system, "o");
+    }
+
+    #[test]
+    fn test_extract_variant_details_allele_returns_none() {
+        // Compound alleles have no single coordinate/position to flatten into the
+        // ParsedVariantDetails shape, so they intentionally return None.
+        let result =
+            crate::hgvs::parser::parse_hgvs_lenient("NM_000088.3:c.[10A>G;20C>T]").unwrap();
+        assert!(matches!(result.result, HgvsVariant::Allele(_)));
+        assert!(extract_variant_details(&result.result).is_none());
+    }
+
+    fn edit_info(hgvs: &str) -> (String, Option<String>, Option<String>) {
+        let result = crate::hgvs::parser::parse_hgvs_lenient(hgvs).unwrap();
+        match &result.result {
+            HgvsVariant::Cds(v) => {
+                let edit = v.loc_edit.edit.inner().expect("inner edit");
+                extract_na_edit_info(edit)
+            }
+            other => panic!("expected a CDS variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_substitution() {
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350C>T");
+        assert_eq!(vtype, "substitution");
+        assert_eq!(deleted, Some("C".to_string()));
+        assert_eq!(inserted, Some("T".to_string()));
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_deletion() {
+        // W3025 (DelExplicitSeq) strips the explicit sequence in lenient mode,
+        // so the parsed NaEdit::Deletion has sequence=None after preprocessing.
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350delC");
+        assert_eq!(vtype, "deletion");
+        assert_eq!(deleted, None);
+        assert!(inserted.is_none());
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_insertion() {
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350_351insATG");
+        assert_eq!(vtype, "insertion");
+        assert!(deleted.is_none());
+        assert_eq!(inserted, Some("ATG".to_string()));
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_delins() {
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350delinsATG");
+        assert_eq!(vtype, "delins");
+        assert_eq!(deleted, None, "short form has no explicit deleted");
+        assert_eq!(inserted, Some("ATG".to_string()));
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_delins_with_explicit_deleted_seq() {
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350_352delATGinsTTCC");
+        assert_eq!(vtype, "delins");
+        assert_eq!(deleted, Some("ATG".to_string()));
+        assert_eq!(inserted, Some("TTCC".to_string()));
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_delins_with_explicit_deleted_length() {
+        let (vtype, deleted, inserted) = edit_info("NM_000249.4:c.350_352del3insTA");
+        assert_eq!(vtype, "delins");
+        assert_eq!(deleted, Some("3 bp".to_string()));
+        assert_eq!(inserted, Some("TA".to_string()));
+    }
+
+    #[test]
+    fn test_extract_na_edit_info_duplication() {
+        // W3024 (DupExplicitSeq) strips the explicit sequence in lenient mode,
+        // so the parsed NaEdit::Duplication has sequence=None after preprocessing.
+        let (vtype, deleted, _inserted) = edit_info("NM_000249.4:c.350dupC");
+        assert_eq!(vtype, "duplication");
+        assert_eq!(deleted, None);
     }
 }


### PR DESCRIPTION
Closes #810

Two spots silently returned `None` for variant classes they did not handle, so unsupported inputs looked like a clean "no result" rather than carrying an explicit signal. This addresses #810 at each named site according to what its `None` actually means, rather than mechanically converting every `None` to an error (which would regress correct behavior).

## `equivalence/checker.rs` — the `Allele` arm was already correct; the comment lied

`check_accession_version_difference` is a private predicate that answers exactly one question: are these two variants the same change on two different *accession versions*? An allele has no single accession version to compare (`accession()` reports only its first member, which would be misleading), so the helper declines with `None`. That `None` is "not-applicable", not "unsupported": `check()` falls through to the normalizer, which handles alleles directly (`normalize_allele`), so allele equivalence is fully determined — just not via the version-comparison path.

Converting this helper to error on alleles would make `check()` *error* on allele pairs that currently compare correctly — a real regression and exactly the "indeterminate ≠ unsupported" trap. So the only defect here was the misleading `// Complex case, skip for now` comment. Replaced it with an accurate rationale and added regression tests proving allele pairs flow through `check()` without erroring:

- two identical compound alleles → `Ok(Identical)`
- two differing compound alleles → `Ok(NotEquivalent)` (no error)

## `service/tools/ferro.rs` and `service/handlers/validate.rs` — eliminate accidental silence

`extract_variant_details` (two diverged copies of the same function) was dropping supported axes to `None`:

- `ferro.rs` dropped `Rna`, `Mt`, and `Circular` — all carry a `loc_edit` and can produce real, correct details.
- `validate.rs` dropped `Rna` (`Mt`/`Circular` arms already existed there).

Added the missing arms so these axes are populated (`r`/`m`/`o`), mirroring the existing `Cds`/`Genome`/`Tx`/`Protein` arms. Then replaced the catch-all `_ => None` with **explicit named arms** for the classes that genuinely have no single coordinate/position to flatten — `RnaFusion | GenomeRing | Supernumerary | Allele | NullAllele | UnknownAllele => None`. With no wildcard, a future `HgvsVariant` variant fails to compile here instead of being silently swallowed (registration-completeness guarantee).

The `validate.rs` sibling is the same function by copy and shares the latent silent-drop pattern, so the matching fix is applied there too — a sibling-pattern fix, not scope creep.

## Why not change the return types

Neither site changes its `Option`/`Result` contract. At the checker, returning an error would regress allele checks (above). At the service sites, switching to `Result` would ripple into `ParseResult`/`ValidateResponse`, the JSON/HTTP contract, and the web UI — disproportionate, and `None` = "no structured breakdown" is a legitimate value. `FerroError::UnsupportedVariant` exists but is not the right tool at either site.

## Tests

Added unit tests for the new arms (`r`/`m`/`o` populated; `Allele` returns `None`) and the checker regression tests above. Full suite (`cargo nextest run --features dev`, 7479 tests) green; `cargo clippy --all-features --all-targets -- -D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added regression tests for compound allele equivalence checking to ensure consistent variant comparison behavior.

* **Refactor**
  * Consolidated shared HGVS component extraction logic across validation and parsing modules for improved code maintainability and consistency. No changes to validation behavior or output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->