### PR TITLE
fix(vcf): classify coding indels by typed NaEdit and emit Frameshift

### DIFF
--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -386,6 +386,7 @@ fn compute_span(variant: &HgvsVariant) -> Option<i64> {
 /// - Insertion: +(inserted length), or None if length is unknowable
 /// - Delins: inserted_length - span, or None if inserted length is unknowable
 /// - Duplication: +(span)
+/// - DupIns: +(span + inserted_length), or None if inserted length is unknowable
 /// - Inversion: 0
 /// - Identity: 0
 ///
@@ -406,6 +407,13 @@ pub fn get_indel_length(variant: &HgvsVariant) -> Option<i64> {
         NaEdit::BreakpointInsertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
             Some(inserted_sequence_len(sequence)? - compute_span(variant)?)
+        }
+        // DupIns is a duplication of the interval span followed by an
+        // insertion: net = duplicated span + inserted length, when both are
+        // deterministic (the inserted length is unknown for non-literal
+        // payloads, so `inserted_sequence_len` returns None there).
+        NaEdit::DupIns { sequence } => {
+            Some(compute_span(variant)? + inserted_sequence_len(sequence)?)
         }
         _ => None,
     }
@@ -461,6 +469,12 @@ pub fn get_indel_length_with_provider<P: ReferenceProvider + ?Sized>(
         NaEdit::BreakpointInsertion { sequence } => inserted_sequence_len(sequence),
         NaEdit::Delins { sequence, .. } => {
             Some(inserted_sequence_len(sequence)? - compute_span_with_provider(variant, provider)?)
+        }
+        // DupIns is a duplication of the interval span followed by an
+        // insertion: net = duplicated span + inserted length, when both are
+        // deterministic.
+        NaEdit::DupIns { sequence } => {
+            Some(compute_span_with_provider(variant, provider)? + inserted_sequence_len(sequence)?)
         }
         _ => None,
     }
@@ -1031,6 +1045,45 @@ mod tests {
     fn test_indel_length_inversion() {
         let variant = parse_hgvs("NC_000001.11:g.12345_12350inv").unwrap();
         assert_eq!(get_indel_length(&variant), Some(0));
+    }
+
+    /// Build a coding variant whose interval spans `c.100_102` (span 3) carrying
+    /// the given `DupIns` inserted sequence. `dupins` cannot be parsed (the
+    /// parser rejects it via `validate_no_dupins`), and it is only ever
+    /// constructed internally as a normalization intermediate — so we parse a
+    /// real coding `dup` over the same interval and swap in the `DupIns` edit.
+    fn make_cds_dupins(inserted: &str) -> HgvsVariant {
+        use crate::hgvs::edit::Sequence;
+        use crate::hgvs::uncertainty::Mu;
+        use std::str::FromStr;
+
+        let mut variant = parse_hgvs("NM_000088.3:c.100_102dup").unwrap();
+        let edit = NaEdit::DupIns {
+            sequence: InsertedSequence::Literal(Sequence::from_str(inserted).unwrap()),
+        };
+        match &mut variant {
+            HgvsVariant::Cds(v) => v.loc_edit.edit = Mu::Certain(edit),
+            _ => panic!("expected a coding variant"),
+        }
+        variant
+    }
+
+    #[test]
+    fn test_indel_length_dupins_frameshift() {
+        // DupIns net length = duplicated interval span (3) + inserted length (2)
+        // = 5, which is not a multiple of 3 → frameshift.
+        let variant = make_cds_dupins("AT");
+        assert_eq!(get_indel_length(&variant), Some(5));
+        assert!(is_frameshift(&variant));
+    }
+
+    #[test]
+    fn test_indel_length_dupins_inframe() {
+        // DupIns net length = duplicated interval span (3) + inserted length (3)
+        // = 6, a multiple of 3 → in-frame (not a frameshift).
+        let variant = make_cds_dupins("ATG");
+        assert_eq!(get_indel_length(&variant), Some(6));
+        assert!(!is_frameshift(&variant));
     }
 
     #[test]

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -4,9 +4,9 @@
 //! following conventions similar to VEP and SnpEff.
 
 use crate::error::FerroError;
-use crate::hgvs::edit::ProteinEdit;
+use crate::hgvs::edit::{NaEdit, ProteinEdit};
 use crate::hgvs::location::AminoAcid;
-use crate::hgvs::variant::HgvsVariant;
+use crate::hgvs::variant::{is_frameshift, HgvsVariant};
 use crate::reference::loader::TranscriptDb;
 
 use super::annotator::MultiIsoformAnnotator;
@@ -196,25 +196,75 @@ pub fn determine_consequence(ann: &HgvsAnnotation) -> Consequence {
     // Look at the edit type from the variant
     match &ann.variant {
         HgvsVariant::Cds(v) => {
-            let edit_str = format!("{:?}", v.loc_edit.edit);
-
-            // Check for frameshift-causing edits (indels not divisible by 3)
-            if edit_str.contains("Deletion") || edit_str.contains("Insertion") {
-                // For a simple approximation, single base indels cause frameshifts
-                // A more complete implementation would analyze the exact length
-                if edit_str.contains("Insertion") {
-                    return Consequence::InframeInsertion;
+            // Classify the coding indel by matching the parsed `NaEdit` enum
+            // directly, then split each indel category into frameshift vs
+            // in-frame using the crate-wide `is_frameshift` rule (net indel
+            // length known, nonzero, and not divisible by 3). The prior
+            // implementation matched substrings on the `Debug` rendering of the
+            // edit, which never emitted `Frameshift` (length was never checked)
+            // and was order-dependent and brittle — the same anti-pattern that
+            // caused the protein-arm bug fixed in #228.
+            //
+            // `is_frameshift` delegates to `get_indel_length`, which returns
+            // `None` when the net length is non-deterministic (uncertain/ranged
+            // inserted length, named/reference insertion, N-padded deletion).
+            // In that case `is_frameshift` is `false`, so the variant stays in
+            // its in-frame category rather than being asserted a frameshift —
+            // the conservative choice, since we never claim a frameshift we
+            // cannot prove.
+            //
+            // The edit is wrapped in `Mu<NaEdit>` (predicted-vs-confirmed paren
+            // distinction); classification is identical for both, so we unwrap
+            // and dispatch on the inner edit. `Mu::Unknown` (a `c.?` shape) and
+            // non-indel edits (substitution, inversion, repeat, conversion,
+            // etc.) have no frame change we can classify here without protein
+            // prediction, so they fall through to `Unknown`.
+            match v.loc_edit.edit.inner() {
+                Some(NaEdit::Insertion { .. }) | Some(NaEdit::BreakpointInsertion { .. }) => {
+                    if is_frameshift(&ann.variant) {
+                        Consequence::Frameshift
+                    } else {
+                        Consequence::InframeInsertion
+                    }
                 }
-                return Consequence::InframeDeletion;
+                Some(NaEdit::Deletion { .. }) | Some(NaEdit::NPaddedDeletion { .. }) => {
+                    if is_frameshift(&ann.variant) {
+                        Consequence::Frameshift
+                    } else {
+                        Consequence::InframeDeletion
+                    }
+                }
+                // A delins is a replacement; its net length is
+                // `inserted_len - deleted_interval_span` (the span is read from
+                // the interval positions, not the edit's `deleted_length`
+                // field). In-frame net lengths (0 or a
+                // multiple of 3) keep the pre-existing delins→InframeDeletion
+                // convention (a delins is bucketed under deletion).
+                Some(NaEdit::Delins { .. }) => {
+                    if is_frameshift(&ann.variant) {
+                        Consequence::Frameshift
+                    } else {
+                        Consequence::InframeDeletion
+                    }
+                }
+                // A duplication is an insertion of the copied span; a
+                // non-standard dup-ins additionally inserts a sequence, so its
+                // net length is the duplicated span plus the inserted length.
+                // Both have deterministic net lengths in `get_indel_length`, so
+                // the frameshift branch is live for each (a non-3n net length
+                // yields `Frameshift`). Previously `dup` fell through to
+                // `Unknown`; classifying it here is a strict improvement.
+                Some(NaEdit::Duplication { .. }) | Some(NaEdit::DupIns { .. }) => {
+                    if is_frameshift(&ann.variant) {
+                        Consequence::Frameshift
+                    } else {
+                        Consequence::InframeInsertion
+                    }
+                }
+                // Substitution, inversion, identity, repeat, conversion, etc.:
+                // no classifiable frame change without protein prediction.
+                _ => Consequence::Unknown,
             }
-
-            if edit_str.contains("Delins") {
-                return Consequence::InframeDeletion;
-            }
-
-            // Substitution - could be synonymous, missense, or nonsense
-            // Without protein prediction, default to unknown for coding changes
-            Consequence::Unknown
         }
         HgvsVariant::Genome(_) => Consequence::Unknown,
         HgvsVariant::Tx(_) => Consequence::NonCoding,
@@ -961,5 +1011,181 @@ mod tests {
 
         let consequence = determine_consequence(&ann);
         assert_eq!(consequence, Consequence::StopLoss);
+    }
+
+    /// Build a coding (`c.`) annotation for a parsed HGVS string and return its
+    /// classified consequence. Centralizes the 9-field `HgvsAnnotation` literal
+    /// so the coding-indel frame tests below stay focused on input → verdict.
+    fn coding_consequence(hgvs: &str) -> Consequence {
+        use crate::hgvs::parser::parse_hgvs;
+
+        let variant = parse_hgvs(hgvs).unwrap();
+        let ann = HgvsAnnotation {
+            variant,
+            gene_symbol: Some("COL1A1".to_string()),
+            transcript_accession: Some("NM_000088.3".to_string()),
+            is_coding: true,
+            is_intronic: false,
+            mane_status: ManeStatus::None,
+            intron_number: None,
+            intron_position: None,
+            intronic_consequence: None,
+        };
+        determine_consequence(&ann)
+    }
+
+    #[test]
+    fn test_coding_insertion_frameshift() {
+        // Net inserted length not divisible by 3 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101insA"),
+            Consequence::Frameshift
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101insAC"),
+            Consequence::Frameshift
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101insACGT"),
+            Consequence::Frameshift
+        );
+    }
+
+    #[test]
+    fn test_coding_insertion_inframe() {
+        // Net inserted length divisible by 3 → in-frame insertion.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101insACG"),
+            Consequence::InframeInsertion
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101insACGGTA"),
+            Consequence::InframeInsertion
+        );
+    }
+
+    #[test]
+    fn test_coding_deletion_frameshift() {
+        // Deletion span not divisible by 3 → frameshift. The 1 bp case
+        // (`c.100del`) is the canonical pre-fix regression: the old
+        // Debug-string classifier returned `InframeDeletion` here.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100del"),
+            Consequence::Frameshift
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101del"),
+            Consequence::Frameshift
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_103del"),
+            Consequence::Frameshift
+        );
+    }
+
+    #[test]
+    fn test_coding_deletion_inframe() {
+        // Deletion span divisible by 3 → in-frame deletion.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_102del"),
+            Consequence::InframeDeletion
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_105del"),
+            Consequence::InframeDeletion
+        );
+    }
+
+    #[test]
+    fn test_coding_delins_net_frame() {
+        // delins net length = inserted_len - deleted_span; frameshift iff net % 3 != 0.
+        // del 3, ins 1, net -2 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_102delinsA"),
+            Consequence::Frameshift
+        );
+        // del 1, ins 3, net +2 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100delinsACG"),
+            Consequence::Frameshift
+        );
+        // del 1, ins 2, net +1 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100delinsAC"),
+            Consequence::Frameshift
+        );
+        // del 4, ins 3, net -1 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_103delinsACG"),
+            Consequence::Frameshift
+        );
+        // del 4, ins 6, net +2 → frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_103delinsACGTAC"),
+            Consequence::Frameshift
+        );
+        // del 3, ins 3, net 0 → in-frame (replacement, bucketed under deletion).
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_102delinsACG"),
+            Consequence::InframeDeletion
+        );
+        // del 6, ins 3, net -3 → in-frame.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_105delinsACG"),
+            Consequence::InframeDeletion
+        );
+    }
+
+    #[test]
+    fn test_coding_duplication() {
+        // A duplication is an insertion of the copied span; frameshift iff
+        // span % 3 != 0. Previously `dup` fell through to `Unknown`.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100dup"),
+            Consequence::Frameshift
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_102dup"),
+            Consequence::InframeInsertion
+        );
+    }
+
+    #[test]
+    fn test_coding_unknown_length_insertion_not_frameshift() {
+        // When the inserted length is unknowable (`ins(10_20)`), we cannot
+        // prove a frameshift, so the variant stays in its non-frameshift
+        // category rather than being asserted as a frameshift.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_101ins(10_20)"),
+            Consequence::InframeInsertion
+        );
+    }
+
+    #[test]
+    fn test_coding_npadded_deletion_inframe() {
+        // An N-padded deletion (`delN[k]`) reports only a count of unknown
+        // bases, so its net length is non-deterministic: `get_indel_length`
+        // returns `None` and `is_frameshift` is `false` regardless of the
+        // count. It therefore classifies as `InframeDeletion` (its in-frame
+        // category) rather than being asserted a frameshift, even when the
+        // count is not a multiple of 3.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.(100_102)delN[5]"),
+            Consequence::InframeDeletion
+        );
+    }
+
+    #[test]
+    fn test_coding_non_indel_unknown() {
+        // Substitutions and inversions carry no length change and have no
+        // protein prediction in this path → Unknown.
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100A>G"),
+            Consequence::Unknown
+        );
+        assert_eq!(
+            coding_consequence("NM_000088.3:c.100_105inv"),
+            Consequence::Unknown
+        );
     }
 }


### PR DESCRIPTION
## Problem

`determine_consequence` in `src/vcf/annotate.rs` classified coding (`HgvsVariant::Cds`) indels by rendering the edit to its `Debug` string and substring-matching. This had two defects, both verified against current code:

1. **`Consequence::Frameshift` was never emitted for coding indels.** The net indel length mod 3 was never checked, so every coding insertion became `InframeInsertion` and every coding deletion `InframeDeletion` — even a 1 bp or 2 bp frameshift was mislabeled in-frame.
2. **Classification matched on the `Edit` `Debug` rendering** — the same fragile, order-dependent anti-pattern that caused the prior protein-arm bug fixed in #228 (`p.Ter…ext…` misclassified via a `.contains("Ter")` substring heuristic).

## Fix

Rewrite only the `HgvsVariant::Cds(v)` arm to match the parsed `NaEdit` enum directly (via `v.loc_edit.edit.inner()`, the same pattern the protein arm uses post-#228), and split each indel category into frameshift vs in-frame using the crate-wide `crate::hgvs::variant::is_frameshift` rule (net indel length known, nonzero, and not divisible by 3).

- **Insertion / BreakpointInsertion** → `Frameshift` if `is_frameshift`, else `InframeInsertion`.
- **Deletion / NPaddedDeletion** → `Frameshift` if `is_frameshift`, else `InframeDeletion`.
- **Delins** → net length is `inserted_len - deleted_span`; `Frameshift` if `is_frameshift`, else `InframeDeletion` (a delins is a replacement, bucketed under deletion per the pre-existing convention).
- **Duplication / DupIns** → treated as an insertion of the copied span; `Frameshift` if `is_frameshift`, else `InframeInsertion`. (Previously `dup` fell through to `Unknown` — a strict improvement.)
- **Everything else** (substitution, inversion, identity, repeat, conversion, etc.) → `Unknown`, unchanged (no protein prediction available in this path).

This reuses the canonical, already-tested net-length logic (`get_indel_length`: deletion `-span`, insertion `+ins_len`, delins `ins_len - span`, duplication `+span`) so the VCF path and the rest of the crate share one definition of "frameshift". When the net length is non-deterministic — uncertain/ranged inserted length (`ins(10_20)`), named/reference insertion, N-padded deletion — `is_frameshift` is `false`, so the variant stays in its in-frame category rather than being asserted a frameshift. This is the conservative choice: we never claim a frameshift we cannot prove.

No `format!("{:?}", …).contains(…)` classification remains in the VCF consequence path.

## Tests

Added coding-indel tests (TDD; the 1 bp `c.100del` case fails against the old code, returning `InframeDeletion`):

- Insertions: 1/2/4 bp → `Frameshift`; 3/6 bp → `InframeInsertion`.
- Deletions: 1/2/4 bp → `Frameshift`; 3/6 bp → `InframeDeletion`.
- delins net-frame: `delinsA` over a 3 bp del (net −2), `delinsACG` over a 1 bp del (net +2), `delinsAC` (net +1), `c.100_103delinsACG` (net −1), `c.100_103delinsACGTAC` (net +2) → `Frameshift`; net 0 and net −3 → `InframeDeletion`.
- Duplication: `c.100dup` (1 bp) → `Frameshift`; `c.100_102dup` (3 bp) → `InframeInsertion`.
- Unknown-length insertion `ins(10_20)` → `InframeInsertion` (never `Frameshift`).
- Non-indel coding (`c.100A>G`, `c.100_105inv`) → `Unknown`.

All existing protein/UTR/intronic tests stay green.

## Verification

- `cargo nextest run --features dev` — 7478 passed.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.

## Follow-up (out of scope here)

`python_helpers::edit_type_from_debug` is a sibling `format!("{:?}", …).contains(…)` classifier with the same #228/#803 anti-pattern (and a latent ordering issue). It is `pub` but only exercised by its own tests — no production call site — and is not on the VCF consequence path, so it is left for a separate cleanup that replaces it with the typed `na_edit_type_str`.

Closes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved frameshift variant detection for duplicate insertions.
  * Enhanced consequence classification accuracy for coding indels.

* **Tests**
  * Extended test coverage for variant frameshift and in-frame behavior classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->