### PR TITLE
test(vcf/mave): assert real outcomes in formerly-vacuous conversion tests

### DIFF
--- a/src/mave/parser.rs
+++ b/src/mave/parser.rs
@@ -350,16 +350,22 @@ mod tests {
     #[test]
     fn test_allele_variant() {
         let ctx = test_context();
-        // Alleles like c.[32T>C;39G>A] should work with context
-        let result = parse_mave_hgvs("c.[32T>C;39G>A]", &ctx);
-        // Note: this may fail depending on allele support, but we test the context injection
-        if let Err(e) = &result {
-            // Should not be a MissingAccession error
-            assert!(
-                !matches!(e, MaveParseError::MissingAccession { .. }),
-                "Should have injected accession"
-            );
-        }
+        // A short-form coding allele must parse with the context's coding
+        // accession (NM_000518.5) injected, yielding a full HGVS allele.
+        let variant = parse_mave_hgvs("c.[32T>C;39G>A]", &ctx)
+            .expect("short-form coding allele should parse");
+        // Assert the parsed structure directly (independent of Display): a
+        // two-member allele carrying the injected coding accession.
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 2);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NM_000518.5")
+        );
+        // And pin the exact deterministic compact-form round-trip.
+        assert_eq!(variant.to_string(), "NM_000518.5:c.[32T>C;39G>A]");
     }
 
     #[test]
@@ -382,96 +388,94 @@ mod tests {
     fn test_allele_simple_coding() {
         let ctx = test_context();
         // Simple two-variant allele
-        let result = parse_mave_hgvs("c.[20A>T;30G>C]", &ctx);
-        assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
-        let variant = result.unwrap();
-        let output = variant.to_string();
-        assert!(
-            output.contains("NM_000518.5"),
-            "Output should contain accession: {}",
-            output
+        let variant =
+            parse_mave_hgvs("c.[20A>T;30G>C]", &ctx).expect("two-variant allele should parse");
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 2);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NM_000518.5")
         );
-        assert!(
-            output.contains("c.[") || output.contains("c.20"),
-            "Output should contain allele notation: {}",
-            output
-        );
+        assert_eq!(variant.to_string(), "NM_000518.5:c.[20A>T;30G>C]");
     }
 
     #[test]
     fn test_allele_multiple_variants() {
         let ctx = test_context();
         // MaveDB style: c.[32T>C;39G>A;42A>G;81C>T]
-        let result = parse_mave_hgvs("c.[32T>C;39G>A;42A>G]", &ctx);
-        assert!(result.is_ok(), "Failed to parse multi-variant allele");
+        let variant = parse_mave_hgvs("c.[32T>C;39G>A;42A>G]", &ctx)
+            .expect("multi-variant allele should parse");
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 3);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NM_000518.5")
+        );
+        assert_eq!(variant.to_string(), "NM_000518.5:c.[32T>C;39G>A;42A>G]");
     }
 
     #[test]
     fn test_allele_protein() {
         let ctx = test_context();
-        // Protein allele
-        let result = parse_mave_hgvs("p.[Glu6Val;Lys17Arg]", &ctx);
-        if let Ok(variant) = result {
-            let output = variant.to_string();
-            assert!(
-                output.contains("NP_000509.1"),
-                "Output should contain protein accession: {}",
-                output
-            );
-        }
-        // Note: Some allele formats may not be fully supported
+        // A short-form protein allele must parse with the context's protein
+        // accession (NP_000509.1) injected.
+        let variant = parse_mave_hgvs("p.[Glu6Val;Lys17Arg]", &ctx)
+            .expect("short-form protein allele should parse");
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 2);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NP_000509.1")
+        );
+        assert_eq!(variant.to_string(), "NP_000509.1:p.[Glu6Val;Lys17Arg]");
     }
 
     #[test]
     fn test_allele_genomic() {
         let ctx = test_context();
-        // Genomic allele
-        let result = parse_mave_hgvs("g.[12345A>G;12350C>T]", &ctx);
-        // Genomic alleles may not be fully supported, check accession injection
-        if let Err(e) = &result {
-            // Should not be a MissingAccession error - accession should be injected
-            assert!(
-                !matches!(e, MaveParseError::MissingAccession { .. }),
-                "Accession should be injected: {:?}",
-                e
-            );
-        } else {
-            let variant = result.unwrap();
-            let output = variant.to_string();
-            assert!(
-                output.contains("NC_000011.10"),
-                "Output should contain genomic accession: {}",
-                output
-            );
-        }
+        // A short-form genomic allele must parse with the context's genomic
+        // accession (NC_000011.10) injected.
+        let variant = parse_mave_hgvs("g.[12345A>G;12350C>T]", &ctx)
+            .expect("short-form genomic allele should parse");
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 2);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NC_000011.10")
+        );
+        assert_eq!(variant.to_string(), "NC_000011.10:g.[12345A>G;12350C>T]");
     }
 
     #[test]
     fn test_allele_roundtrip_structure() {
         let ctx = test_context();
 
-        // Test that parsing produces a variant we can re-serialize
+        // Parsing produces a full HGVS allele that survives a serialize → reparse
+        // round-trip unchanged.
         let input = "c.[20A>T;30G>C]";
-        let result = parse_mave_hgvs(input, &ctx);
-        if let Ok(variant) = result {
-            let output = variant.to_string();
-            // The accession should be included in the output
-            // Note: Allele output format may include accession on each part:
-            // "[NM_000518.5:c.20A>T;NM_000518.5:c.30G>C]"
-            // Or may keep the structure: "NM_000518.5:c.[20A>T;30G>C]"
-            assert!(
-                output.contains("NM_000518.5"),
-                "Should contain accession: {}",
-                output
-            );
-            // Should still be parseable (even if format differs)
-            let reparsed = crate::hgvs::parser::parse_hgvs(&output);
-            assert!(
-                reparsed.is_ok(),
-                "Reparsed variant should be valid HGVS: {}",
-                output
-            );
-        }
+        let variant = parse_mave_hgvs(input, &ctx).expect("short-form allele should parse");
+        let HgvsVariant::Allele(allele) = &variant else {
+            panic!("expected an allele variant, got: {variant:?}");
+        };
+        assert_eq!(allele.variants.len(), 2);
+        assert_eq!(
+            variant.accession().map(|a| a.to_string()).as_deref(),
+            Some("NM_000518.5")
+        );
+        let output = variant.to_string();
+        assert_eq!(output, "NM_000518.5:c.[20A>T;30G>C]");
+        // Reparsing the serialized form yields a structurally identical variant.
+        let reparsed = crate::hgvs::parser::parse_hgvs(&output)
+            .expect("serialized allele should reparse as valid HGVS");
+        assert_eq!(reparsed, variant);
     }
 
     #[test]

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -2120,11 +2120,15 @@ mod tests {
         assert_eq!(result.record.chrom, "chr1");
     }
 
+    /// `c.1_3delinsTTT`: CDS 1..3 → genomic 1049..1051. The deleted span and the
+    /// replacement are both 3 bases, so no anchor base is added — REF is the
+    /// deleted genomic bases, ALT is the literal replacement, POS is the start.
     #[test]
     fn test_build_vcf_record_delins_same_length() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2139,15 +2143,22 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        // genomic 1049..1051 = indices 1048..1050 of "ACGT".repeat → "ACG".
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "ACG");
+        assert_eq!(record.alternate, vec!["TTT"]);
     }
 
+    /// `c.1_3dup` of "ATG": a duplication is an insertion of the duplicated
+    /// sequence anchored on the base at the end of the duplicated region (CDS 3
+    /// → genomic 1051). REF is that anchor base, ALT is anchor + duplicated unit.
     #[test]
     fn test_build_vcf_record_duplication() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2162,15 +2173,23 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        // anchor = genomic 1051 = index 1050 of "ACGT".repeat → 'G'.
+        assert_eq!(record.pos, 1051);
+        assert_eq!(record.reference, "G");
+        assert_eq!(record.alternate, vec!["GATG"]);
     }
 
+    /// `c.1_4inv`: CDS 1..4 → genomic 1049..1052. REF is the original genomic
+    /// span, ALT is its reverse complement. A non-palindromic seed is used so
+    /// REF != ALT (a palindrome would make the assertion vacuous).
     #[test]
     fn test_build_vcf_record_inversion() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        // "AACCGGTT" tiled: genomic 1049..1052 = indices 1048..1051 = "AACC".
+        let seq = "AACCGGTT".repeat(200);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2184,15 +2203,22 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "AACC");
+        // reverse_complement("AACC") == "GGTT".
+        assert_eq!(record.alternate, vec!["GGTT"]);
     }
 
+    /// `c.1 CAG[5]`: a repeat expansion is an insertion anchored on the base at
+    /// the start position (CDS 1 → genomic 1049). REF is the anchor base, ALT is
+    /// anchor + the unit repeated `count` times.
     #[test]
     fn test_build_vcf_record_repeat() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2208,15 +2234,21 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        // anchor = genomic 1049 = index 1048 of "ACGT".repeat → 'A'.
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        assert_eq!(record.alternate, vec![format!("A{}", "CAG".repeat(5))]);
     }
 
+    /// `c.1 CAG[5];[10]`: additional counts emit one ALT per count, sorted and
+    /// deduped. The x5 ALT is a string prefix of the x10 ALT, so it sorts first.
     #[test]
     fn test_build_vcf_record_repeat_with_additional_counts() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2232,8 +2264,16 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        assert_eq!(
+            record.alternate,
+            vec![
+                format!("A{}", "CAG".repeat(5)),
+                format!("A{}", "CAG".repeat(10)),
+            ]
+        );
     }
 
     #[test]
@@ -2284,11 +2324,15 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// `c.1=` (locus identity, not whole-entity): a no-op record whose REF and
+    /// ALT are both the reference base at the mapped position (CDS 1 → genomic
+    /// 1049). REF must equal ALT and equal the provider's base there.
     #[test]
     fn test_build_vcf_record_identity() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2302,8 +2346,11 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        // genomic 1049 = index 1048 of "ACGT".repeat → 'A'; identity REF == ALT.
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        assert_eq!(record.alternate, vec!["A"]);
     }
 
     #[test]
@@ -2369,11 +2416,19 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// `c.1_100` copy number 3: emitted as a symbolic `<CNV>` structural record.
+    /// POS/REF come from the start base (CDS 1 = tx 50 in exon1 → genomic 1049);
+    /// INFO carries SVTYPE=CNV, CN=count, END=genomic end. CDS 100 = tx 149,
+    /// which falls in exon2 (tx 101..200 → genomic 2000..2099), so it maps to
+    /// genomic 2000 + (149 - 101) = 2048 — the exon boundary is crossed.
     #[test]
     fn test_build_vcf_record_copy_number() {
+        use crate::vcf::record::InfoValue;
+
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2384,8 +2439,18 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        // genomic 1049 = index 1048 of "ACGT".repeat → 'A'.
+        assert_eq!(record.reference, "A");
+        assert_eq!(record.alternate, vec!["<CNV>"]);
+        assert_eq!(
+            record.info.get("SVTYPE"),
+            Some(&InfoValue::String("CNV".to_string()))
+        );
+        assert_eq!(record.info.get("CN"), Some(&InfoValue::Integer(3)));
+        // CDS 100 = tx 149 → exon2 → genomic 2048.
+        assert_eq!(record.info.get("END"), Some(&InfoValue::Integer(2048)));
     }
 
     #[test]
@@ -2413,11 +2478,14 @@ mod tests {
         assert!(vcf.warnings[0].contains("intronic"));
     }
 
+    /// `c.1 CAG[(5_10)]`: a bounded range collapses to its lower bound (5) for
+    /// VCF, so the ALT is anchor + unit repeated 5 times.
     #[test]
     fn test_repeat_count_range() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2433,15 +2501,21 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        // Range lower bound (5) drives the expansion.
+        assert_eq!(record.alternate, vec![format!("A{}", "CAG".repeat(5))]);
     }
 
+    /// `c.1 CAG[(5_?)]`: a min-uncertain count uses its known lower bound (5),
+    /// so the ALT is anchor + unit repeated 5 times.
     #[test]
     fn test_repeat_count_min_uncertain() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2457,8 +2531,10 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        assert_eq!(record.alternate, vec![format!("A{}", "CAG".repeat(5))]);
     }
 
     #[test]
@@ -2485,11 +2561,14 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// `c.1 CAG[5]` with a trailing "T": the trailing bases are appended to the
+    /// repeat unit before expansion, so the unit is "CAGT" repeated 5 times.
     #[test]
     fn test_repeat_with_trailing() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2505,15 +2584,21 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        // unit = "CAG" + trailing "T" = "CAGT", repeated 5 times.
+        assert_eq!(record.alternate, vec![format!("A{}", "CAGT".repeat(5))]);
     }
 
+    /// `c.1` repeat with no primary sequence but a trailing "T": the trailing
+    /// bases alone form the repeat unit, so the unit is "T" repeated 5 times.
     #[test]
     fn test_repeat_trailing_only() {
         let transcript = create_test_transcript();
-        let provider = MockProvider::new();
-        let converter = HgvsToVcfConverter::new(&transcript, &provider);
+        let mut provider = MockProvider::new();
+        let seq = "ACGT".repeat(400);
+        let converter = converter_with_genomic_chr1(&transcript, &mut provider, &seq);
 
         let variant = HgvsVariant::Cds(CdsVariant {
             accession: Accession::new("NM", "000088", Some(3)),
@@ -2529,7 +2614,10 @@ mod tests {
             ),
         });
 
-        // Test exercises the conversion code path - may fail due to mock provider limitations
-        let _result = converter.convert(&variant);
+        let record = converter.convert(&variant).unwrap().record;
+        assert_eq!(record.pos, 1049);
+        assert_eq!(record.reference, "A");
+        // unit = trailing "T" only, repeated 5 times.
+        assert_eq!(record.alternate, vec![format!("A{}", "T".repeat(5))]);
     }
 }


### PR DESCRIPTION
## Summary

Several unit tests exercised the HGVS→VCF converter and MAVE allele parser but asserted nothing on the outcome — they bound `let _result = converter.convert(&variant);` (or used conditional `if let Ok`/`if let Err` guards) and passed regardless of whether conversion succeeded or returned the wrong thing, justified at the time by mock-provider limitations. With genomic anchor-base recovery and CDS/RNA→genomic coordinate mapping now in place (#821/#822), these paths actually work, so the tests can and must assert real outcomes.

## What changed

- **`src/vcf/from_hgvs.rs` (11 tests):** delins, duplication, inversion, repeat (+ additional counts, range, min-uncertain, trailing, trailing-only), identity, and copy-number tests now seed a capable `MockProvider` with genomic sequence under UCSC contig `chr1` (reusing the existing `converter_with_genomic_chr1` helper) so each conversion deterministically succeeds, then assert the exact `VcfConversionResult` fields — POS/REF/ALT, and SVTYPE/CN/END for the `<CNV>` symbolic record.
- **`src/mave/parser.rs` (3 tests):** the coding, protein, and genomic allele tests now assert real parse success with the injected context accession and bracket allele notation, instead of passing vacuously on parse failure.

No production code changes — this is purely a test-quality fix. The CDS→genomic expectations were verified empirically (e.g. the copy-number test's `c.1_100` end correctly maps through the second exon to genomic 2048, crossing the exon boundary, not a single-exon extrapolation).

Stacked on #822 (#805).

Closes #813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MAVE allele parser test assertions to validate variant structure, accession injection, and serialization round-trip behavior
  * Strengthened VCF converter tests with real genomic sequence data and comprehensive output validation for multiple variant types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->