### PR TITLE
test(spdi): run SPDI roundtrip + rsID tests offline via synthetic fixture

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ Utility scripts for generating and updating test fixtures used by ferro-hgvs.
 |--------|-------------|----------------|
 | `extract_hgvs_spec_examples.py` | Scrapes HGVS examples from [hgvs-nomenclature.org](https://hgvs-nomenclature.org) | `tests/fixtures/grammar/hgvs_spec_examples.json` |
 | `extract_mutalyzer_github.py` | Extracts test patterns from the [mutalyzer-hgvs-parser](https://github.com/mutalyzer/mutalyzer-hgvs-parser) repo | `tests/fixtures/grammar/mutalyzer_github.json` |
-| `fetch_ncbi_variation.py` | Fetches HGVS/SPDI conversions from the [NCBI Variation Services API](https://api.ncbi.nlm.nih.gov/variation/v0/) | `tests/fixtures/validation/ncbi_variation.json` |
+| `fetch_ncbi_variation.py` | Ad-hoc live fetch of HGVS/SPDI conversions from the [NCBI Variation Services API](https://api.ncbi.nlm.nih.gov/variation/v0/). **Does not regenerate the committed fixture** (see note below). | `tests/fixtures/validation/ncbi_variation.live.json` (live; not committed) |
 | `fetch_variantvalidator.py` | Fetches validated HGVS variants from the [VariantValidator API](https://rest.variantvalidator.org) | `tests/fixtures/validation/variantvalidator_api.json` |
 | `benchmark_python.py` | Benchmarks ferro-hgvs Python bindings against biocommons/hgvs | N/A (prints results) |
 
@@ -38,8 +38,14 @@ python scripts/extract_hgvs_spec_examples.py
 git clone https://github.com/mutalyzer/mutalyzer-hgvs-parser external-repos/mutalyzer-hgvs-parser
 python scripts/extract_mutalyzer_github.py
 
-# Regenerate NCBI fixture (rate-limited, takes several minutes)
-python scripts/fetch_ncbi_variation.py
+# Ad-hoc live NCBI fetch (rate-limited, takes several minutes).
+# NOTE: tests/fixtures/validation/ncbi_variation.json is a curated, hand-authored
+# offline fixture that tests/it/spdi_tests.rs parses and asserts semantic invariants
+# against (not a byte-level file comparison). This script
+# does NOT regenerate it — by default it writes the live response to
+# tests/fixtures/validation/ncbi_variation.live.json instead. To inspect live data,
+# point --output at a scratch path; do not overwrite the curated fixture.
+python scripts/fetch_ncbi_variation.py --output /tmp/ncbi_variation.live.json
 
 # Regenerate VariantValidator fixture (rate-limited, takes several minutes)
 python scripts/fetch_variantvalidator.py

--- a/scripts/fetch_ncbi_variation.py
+++ b/scripts/fetch_ncbi_variation.py
@@ -14,6 +14,15 @@ Key endpoints:
 
 Rate Limit: 3 requests/second
 
+This script performs live network fetches and is provided for ad-hoc exploration
+only. It does NOT regenerate the committed test fixture: by default it writes to
+`tests/fixtures/validation/ncbi_variation.live.json`, NOT the curated, hand-authored
+`tests/fixtures/validation/ncbi_variation.json` that `tests/it/spdi_tests.rs` parses
+and asserts semantic invariants against (exact SPDI/variant equality on the parsed
+JSON, not a byte-level file comparison). Overwriting the curated fixture with live
+data would re-introduce network variability and break those assertions. Point
+`--output` somewhere else (e.g. a scratch path) if you want the raw live response.
+
 Usage:
     python scripts/fetch_ncbi_variation.py [--output OUTPUT_PATH]
 """
@@ -334,8 +343,15 @@ def main() -> None:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("tests/fixtures/validation/ncbi_variation.json"),
-        help="Output fixture path",
+        # NOT the committed fixture: tests/fixtures/validation/ncbi_variation.json is a
+        # curated, hand-authored offline oracle whose parsed contents the SPDI tests
+        # assert semantic invariants against (not a byte-level file comparison).
+        # Default to a distinct, non-asserted live path so a stray run cannot clobber it.
+        default=Path("tests/fixtures/validation/ncbi_variation.live.json"),
+        help=(
+            "Output path for the live NCBI response. Defaults to a non-asserted "
+            "'.live.json' path; does NOT overwrite the committed, curated fixture."
+        ),
     )
     parser.add_argument(
         "--limit",

--- a/tests/fixtures/validation/ncbi_variation.json
+++ b/tests/fixtures/validation/ncbi_variation.json
@@ -1,0 +1,130 @@
+{
+  "source": "synthetic (hand-authored offline fixture; NOT a live NCBI fetch)",
+  "api_base": "https://api.ncbi.nlm.nih.gov/variation/v0",
+  "generated": "2026-06-21 00:00:00 UTC",
+  "hgvs_conversions": {
+    "total": 6,
+    "successful": 4,
+    "variants": [
+      {
+        "input_hgvs": "NC_000017.11:g.7674220C>T",
+        "spdi_result": {
+          "data": {
+            "spdis": [
+              {
+                "seq_id": "NC_000017.11",
+                "position": 7674219,
+                "deleted_sequence": "C",
+                "inserted_sequence": "T"
+              }
+            ]
+          }
+        },
+        "roundtrip_hgvs": {
+          "data": {
+            "hgvs_list": ["NC_000017.11:g.7674220C>T"]
+          }
+        },
+        "vcf": null
+      },
+      {
+        "input_hgvs": "NC_000017.11:g.7673802G>A",
+        "spdi_result": {
+          "data": {
+            "spdis": [
+              {
+                "seq_id": "NC_000017.11",
+                "position": 7673801,
+                "deleted_sequence": "G",
+                "inserted_sequence": "A"
+              }
+            ]
+          }
+        },
+        "roundtrip_hgvs": {
+          "data": {
+            "hgvs_list": ["NC_000017.11:g.7673802G>A"]
+          }
+        },
+        "vcf": null
+      },
+      {
+        "input_hgvs": "NC_000007.14:g.140753336A>T",
+        "spdi_result": {
+          "data": {
+            "spdis": [
+              {
+                "seq_id": "NC_000007.14",
+                "position": 140753335,
+                "deleted_sequence": "A",
+                "inserted_sequence": "T"
+              }
+            ]
+          }
+        },
+        "roundtrip_hgvs": {
+          "data": {
+            "hgvs_list": ["NC_000007.14:g.140753336A>T"]
+          }
+        },
+        "vcf": null
+      },
+      {
+        "input_hgvs": "NC_000013.11:g.32316461C>T",
+        "spdi_result": {
+          "data": {
+            "spdis": [
+              {
+                "seq_id": "NC_000013.11",
+                "position": 32316460,
+                "deleted_sequence": "C",
+                "inserted_sequence": "T"
+              }
+            ]
+          }
+        },
+        "roundtrip_hgvs": {
+          "data": {
+            "hgvs_list": ["NC_000013.11:g.32316461C>T"]
+          }
+        },
+        "vcf": null
+      },
+      {
+        "input_hgvs": "NM_000546.6:c.215C>G",
+        "spdi_result": null,
+        "roundtrip_hgvs": null,
+        "vcf": null
+      },
+      {
+        "input_hgvs": "NM_000492.4:c.1521_1523del",
+        "spdi_result": null,
+        "roundtrip_hgvs": null,
+        "vcf": null
+      }
+    ]
+  },
+  "rsid_lookups": {
+    "total": 2,
+    "successful": 2,
+    "variants": [
+      {
+        "rsid": "rs121913529",
+        "info": null,
+        "hgvs_expressions": [
+          "NC_000007.14:g.140753336A>T",
+          "NM_004333.4:c.1799T>A"
+        ],
+        "spdi": null
+      },
+      {
+        "rsid": "rs113993960",
+        "info": null,
+        "hgvs_expressions": [
+          "NM_000492.4:c.1521_1523del"
+        ],
+        "spdi": null
+      }
+    ]
+  }
+}

--- a/tests/it/spdi_tests.rs
+++ b/tests/it/spdi_tests.rs
@@ -1,14 +1,18 @@
 //! SPDI Roundtrip Tests
 //!
-//! These tests validate HGVS ↔ SPDI consistency using data from NCBI Variation Services.
-//! SPDI (Sequence Position Deletion Insertion) is NCBI's canonical representation
-//! for sequence variants.
+//! These tests validate HGVS ↔ SPDI consistency using an offline, hand-authored
+//! synthetic fixture (`tests/fixtures/validation/ncbi_variation.json`) rather than
+//! a live NCBI Variation Services fetch — the fixture is committed and curated, so
+//! the tests run deterministically without network access. SPDI (Sequence Position
+//! Deletion Insertion) is NCBI's canonical representation for sequence variants.
 //!
 //! Tests verify that:
 //! 1. HGVS expressions parse correctly
-//! 2. When NCBI returns SPDI, we can parse the corresponding HGVS
+//! 2. When the fixture records an SPDI, we can parse the corresponding HGVS
 //! 3. Roundtrip conversions maintain semantic equivalence
 
+use ferro_hgvs::spdi::convert::{hgvs_to_spdi_simple, spdi_to_hgvs};
+use ferro_hgvs::spdi::SpdiVariant;
 use ferro_hgvs::{parse_hgvs, HgvsVariant};
 use serde::Deserialize;
 use std::fs;
@@ -115,16 +119,18 @@ struct SpdiTestReport {
     hgvs_with_spdi: usize,
     roundtrip_available: usize,
     roundtrip_parsed: usize,
+    roundtrip_verified: usize,
     parse_failures: Vec<String>,
 }
 
 impl SpdiTestReport {
     fn summary(&self) -> String {
         format!(
-            "HGVS total: {}, parsed: {}, with SPDI: {}, roundtrip available: {}, roundtrip parsed: {}",
+            "HGVS total: {}, parsed: {}, with SPDI: {}, SPDI roundtrips verified: {}, roundtrip available: {}, roundtrip parsed: {}",
             self.total_hgvs,
             self.hgvs_parsed,
             self.hgvs_with_spdi,
+            self.roundtrip_verified,
             self.roundtrip_available,
             self.roundtrip_parsed
         )
@@ -136,18 +142,32 @@ impl SpdiTestReport {
 // ============================================================================
 
 #[test]
-#[ignore = "Requires ncbi_variation.json fixture - run scripts/fetch_ncbi_variation.py first"]
 fn test_hgvs_to_spdi_parsing() {
-    let fixture_path = Path::new("tests/fixtures/validation/ncbi_variation.json");
+    let fixture = load_fixture();
 
-    if !fixture_path.exists() {
-        eprintln!("NCBI fixture not found. Run: python scripts/fetch_ncbi_variation.py");
-        return;
-    }
+    assert!(
+        !fixture.hgvs_conversions.variants.is_empty(),
+        "fixture must contain HGVS conversions; otherwise this test passes vacuously"
+    );
 
-    let content = fs::read_to_string(fixture_path).expect("Failed to read ncbi_variation.json");
-    let fixture: NcbiVariationFixture =
-        serde_json::from_str(&content).expect("Failed to parse ncbi_variation.json");
+    // The fixture's aggregate header counts must agree with the actual data so
+    // they cannot silently drift: `total` is the number of recorded conversions,
+    // and `successful` is the number that carry an SPDI result.
+    assert_eq!(
+        fixture.hgvs_conversions.total,
+        fixture.hgvs_conversions.variants.len(),
+        "hgvs_conversions.total must equal the number of recorded conversions"
+    );
+    let hgvs_with_spdi_result = fixture
+        .hgvs_conversions
+        .variants
+        .iter()
+        .filter(|conversion| conversion.spdi_result.is_some())
+        .count();
+    assert_eq!(
+        fixture.hgvs_conversions.successful, hgvs_with_spdi_result,
+        "hgvs_conversions.successful must equal the number of conversions with an SPDI result"
+    );
 
     let mut report = SpdiTestReport {
         total_hgvs: fixture.hgvs_conversions.variants.len(),
@@ -155,63 +175,213 @@ fn test_hgvs_to_spdi_parsing() {
     };
 
     for conversion in &fixture.hgvs_conversions.variants {
-        // Parse the input HGVS
+        // Every input HGVS in the fixture must parse.
         let parse_result = parse_hgvs(&conversion.input_hgvs);
-
-        if parse_result.is_ok() {
-            report.hgvs_parsed += 1;
-        } else {
-            report.parse_failures.push(conversion.input_hgvs.clone());
+        match parse_result {
+            Ok(_) => report.hgvs_parsed += 1,
+            Err(_) => report.parse_failures.push(conversion.input_hgvs.clone()),
         }
 
-        // Check if NCBI returned SPDI
+        // When the fixture carries an SPDI for this variant, verify the full
+        // HGVS -> SPDI -> HGVS roundtrip is exact. We only assert SPDI equality
+        // for variants whose HGVS -> SPDI conversion is computable offline (i.e.
+        // without a reference provider): genomic substitutions. Such variants
+        // need no reference bases, so `hgvs_to_spdi_simple` resolves them fully.
+        // The asserted SPDI values therefore come from ferro's own converter,
+        // never a hand-guessed relationship.
         if let Some(ref spdi_result) = conversion.spdi_result {
             if let Some(ref data) = spdi_result.data {
-                if !data.spdis.is_empty() {
+                if let Some(expected) = data.spdis.first() {
                     report.hgvs_with_spdi += 1;
+                    verify_spdi_roundtrip(&conversion.input_hgvs, expected, &mut report);
                 }
             }
         }
 
-        // Check roundtrip HGVS
+        // Any roundtrip HGVS strings the fixture records must parse AND be
+        // semantically equal to the input variant — not merely syntactically
+        // valid. For these genomic substitutions NCBI's SPDI->HGVS roundtrip
+        // reproduces the input exactly, so we assert full variant equality
+        // (catches silent position/allele drift, which an is_ok() check would
+        // miss).
         if let Some(ref roundtrip) = conversion.roundtrip_hgvs {
             if let Some(ref data) = roundtrip.data {
                 if !data.hgvs_list.is_empty() {
                     report.roundtrip_available += 1;
-
-                    // Try to parse each roundtrip HGVS
-                    let mut any_parsed = false;
+                    let input_variant = parse_hgvs(&conversion.input_hgvs).unwrap_or_else(|e| {
+                        panic!("input HGVS should parse: {}: {e:?}", conversion.input_hgvs)
+                    });
                     for hgvs in &data.hgvs_list {
-                        if parse_hgvs(hgvs).is_ok() {
-                            any_parsed = true;
-                            break;
-                        }
+                        let round = parse_hgvs(hgvs).unwrap_or_else(|e| {
+                            panic!("roundtrip HGVS should parse: {hgvs}: {e:?}")
+                        });
+                        assert_eq!(
+                            round, input_variant,
+                            "roundtrip HGVS {hgvs} should be semantically equal to input {}",
+                            conversion.input_hgvs
+                        );
                     }
-                    if any_parsed {
-                        report.roundtrip_parsed += 1;
-                    }
+                    report.roundtrip_parsed += 1;
                 }
             }
         }
     }
 
-    // Print report
     println!("\n=== SPDI Roundtrip Test Report ===");
     println!("{}", report.summary());
 
-    if !report.parse_failures.is_empty() {
-        println!("\nParse failures: {}", report.parse_failures.len());
-        for input in report.parse_failures.iter().take(10) {
-            println!("  - {}", input);
-        }
-    }
+    // All input HGVS in the synthetic fixture are valid and must parse.
+    assert!(
+        report.parse_failures.is_empty(),
+        "all input HGVS should parse; failures: {:?}",
+        report.parse_failures
+    );
+    assert_eq!(report.hgvs_parsed, report.total_hgvs);
 
-    // Calculate success rate
-    let parse_rate = (report.hgvs_parsed as f64 / report.total_hgvs as f64) * 100.0;
-    println!("\nParse success rate: {:.1}%", parse_rate);
+    // The fixture carries genomic-substitution SPDIs; each must roundtrip
+    // exactly. Guard against the assertions becoming a no-op.
+    assert!(
+        report.hgvs_with_spdi >= 4,
+        "expected at least 4 variants with verifiable SPDI, found {}",
+        report.hgvs_with_spdi
+    );
+    assert_eq!(
+        report.roundtrip_verified, report.hgvs_with_spdi,
+        "every variant with an SPDI should pass the exact HGVS<->SPDI roundtrip"
+    );
+}
 
-    // Should parse most HGVS expressions
-    assert!(parse_rate > 80.0, "Parse rate should be above 80%");
+/// Verify that an input genomic-substitution HGVS converts to exactly the
+/// SPDI recorded in the fixture, and that converting that SPDI back yields an
+/// HGVS expression that parses and re-expresses the original variant.
+///
+/// This proves the asserted HGVS<->SPDI relationship genuinely holds rather
+/// than trusting a hand-authored value. Only genomic substitutions are
+/// asserted here because their HGVS->SPDI conversion needs no reference
+/// provider (`hgvs_to_spdi_simple`); transcript/`c.` variants are exercised
+/// on the parse path only (their conversion requires CDS metadata / reference
+/// bases that a unit fixture cannot supply offline).
+fn verify_spdi_roundtrip(input_hgvs: &str, expected: &Spdi, report: &mut SpdiTestReport) {
+    let variant = parse_hgvs(input_hgvs)
+        .unwrap_or_else(|e| panic!("input HGVS should parse: {input_hgvs}: {e:?}"));
+
+    let expected_pos = u64::try_from(expected.position)
+        .unwrap_or_else(|_| panic!("SPDI position must be non-negative: {}", expected.position));
+
+    // Independent oracle (not ferro): the fixture's SPDI must satisfy the SPDI
+    // spec's own arithmetic, derived directly from the input HGVS string by a
+    // standalone parse. For a genomic substitution `<acc>:g.<pos><ref>><alt>`
+    // the canonical SPDI is `<acc>:<pos-1>:<ref>:<alt>` (0-based interbase
+    // coordinate, deleted = ref base, inserted = alt base). This check does not
+    // call any ferro converter, so passing it is not circular with the forward
+    // conversion asserted below.
+    let oracle = expected_spdi_from_genomic_substitution(input_hgvs);
+    assert_eq!(
+        (
+            expected.seq_id.as_str(),
+            expected_pos,
+            expected.deleted_sequence.as_str(),
+            expected.inserted_sequence.as_str(),
+        ),
+        (
+            oracle.sequence.as_str(),
+            oracle.position,
+            oracle.deletion.as_str(),
+            oracle.insertion.as_str(),
+        ),
+        "fixture SPDI for {input_hgvs} must match the independently derived SPDI"
+    );
+
+    // Forward: ferro's HGVS -> SPDI must equal the (independently validated)
+    // fixture SPDI.
+    let computed = hgvs_to_spdi_simple(&variant)
+        .unwrap_or_else(|e| panic!("genomic HGVS should convert to SPDI: {input_hgvs}: {e:?}"));
+    assert_eq!(
+        computed.sequence, expected.seq_id,
+        "SPDI seq_id for {input_hgvs}"
+    );
+    assert_eq!(
+        computed.position, expected_pos,
+        "SPDI position for {input_hgvs}"
+    );
+    assert_eq!(
+        computed.deletion, expected.deleted_sequence,
+        "SPDI del for {input_hgvs}"
+    );
+    assert_eq!(
+        computed.insertion, expected.inserted_sequence,
+        "SPDI ins for {input_hgvs}"
+    );
+
+    // Backward: rebuild the SPDI from the fixture fields, convert to HGVS, and
+    // assert the result is semantically equal to the original variant (full
+    // variant equality, not just a string/parse check).
+    let spdi = SpdiVariant::new(
+        &expected.seq_id,
+        expected_pos,
+        &expected.deleted_sequence,
+        &expected.inserted_sequence,
+    );
+    let back = spdi_to_hgvs(&spdi)
+        .unwrap_or_else(|e| panic!("SPDI should convert back to HGVS: {spdi}: {e:?}"));
+    assert_eq!(
+        back, variant,
+        "SPDI {spdi} should round-trip to the original variant {input_hgvs}"
+    );
+
+    report.roundtrip_verified += 1;
+}
+
+/// Independently derive the canonical SPDI for a genomic-substitution HGVS
+/// string of the form `<accession>:g.<pos><ref>><alt>`, using only the SPDI
+/// specification's coordinate arithmetic (0-based interbase position =
+/// 1-based HGVS position − 1; deleted = ref base; inserted = alt base).
+///
+/// This deliberately does not call any ferro conversion routine so it can
+/// serve as an external oracle for the fixture's recorded SPDI values, rather
+/// than re-deriving them from the same code under test.
+fn expected_spdi_from_genomic_substitution(input_hgvs: &str) -> SpdiVariant {
+    let (accession, rest) = input_hgvs
+        .split_once(":g.")
+        .unwrap_or_else(|| panic!("expected a genomic (g.) substitution: {input_hgvs}"));
+
+    // rest looks like "<pos><ref>><alt>", e.g. "7674220C>T".
+    let (lhs, alt) = rest
+        .split_once('>')
+        .unwrap_or_else(|| panic!("expected a substitution (`>`): {input_hgvs}"));
+    let ref_base = lhs
+        .chars()
+        .next_back()
+        .unwrap_or_else(|| panic!("missing reference base: {input_hgvs}"));
+    let pos_str = &lhs[..lhs.len() - ref_base.len_utf8()];
+    let one_based: u64 = pos_str
+        .parse()
+        .unwrap_or_else(|_| panic!("invalid position {pos_str:?} in {input_hgvs}"));
+    assert!(
+        one_based >= 1,
+        "1-based position must be >= 1: {input_hgvs}"
+    );
+
+    SpdiVariant::substitution(
+        accession,
+        one_based - 1,
+        ref_base.to_string(),
+        alt.to_string(),
+    )
+}
+
+/// Load the synthetic, committed NCBI variation fixture. The fixture is a
+/// checked-in test asset (not a network fetch), so its absence is a real test
+/// failure rather than a reason to skip.
+fn load_fixture() -> NcbiVariationFixture {
+    let fixture_path = Path::new("tests/fixtures/validation/ncbi_variation.json");
+    let content = fs::read_to_string(fixture_path).unwrap_or_else(|e| {
+        panic!(
+            "failed to read committed fixture {}: {e}",
+            fixture_path.display()
+        )
+    });
+    serde_json::from_str(&content).expect("failed to parse ncbi_variation.json")
 }
 
 // ============================================================================
@@ -219,20 +389,34 @@ fn test_hgvs_to_spdi_parsing() {
 // ============================================================================
 
 #[test]
-#[ignore = "Requires ncbi_variation.json fixture"]
 fn test_rsid_hgvs_parsing() {
-    let fixture_path = Path::new("tests/fixtures/validation/ncbi_variation.json");
+    let fixture = load_fixture();
 
-    if !fixture_path.exists() {
-        return;
-    }
+    assert!(
+        !fixture.rsid_lookups.variants.is_empty(),
+        "fixture must contain rsID lookups; otherwise this test passes vacuously"
+    );
 
-    let content = fs::read_to_string(fixture_path).expect("Failed to read fixture");
-    let fixture: NcbiVariationFixture =
-        serde_json::from_str(&content).expect("Failed to parse fixture");
+    // The fixture's aggregate header counts must agree with the actual data so
+    // they cannot silently drift: `total` is the number of recorded lookups, and
+    // `successful` is the number that resolved to at least one HGVS expression.
+    assert_eq!(
+        fixture.rsid_lookups.total,
+        fixture.rsid_lookups.variants.len(),
+        "rsid_lookups.total must equal the number of recorded lookups"
+    );
+    let rsids_resolved = fixture
+        .rsid_lookups
+        .variants
+        .iter()
+        .filter(|lookup| !lookup.hgvs_expressions.is_empty())
+        .count();
+    assert_eq!(
+        fixture.rsid_lookups.successful, rsids_resolved,
+        "rsid_lookups.successful must equal the number of lookups with HGVS expressions"
+    );
 
     let mut total_hgvs = 0;
-    let mut parsed_hgvs = 0;
     let mut rsids_with_hgvs = 0;
 
     for lookup in &fixture.rsid_lookups.variants {
@@ -241,9 +425,49 @@ fn test_rsid_hgvs_parsing() {
 
             for hgvs in &lookup.hgvs_expressions {
                 total_hgvs += 1;
-                if parse_hgvs(hgvs).is_ok() {
-                    parsed_hgvs += 1;
-                }
+                // Every HGVS expression associated with an rsID must parse, and
+                // re-parsing the variant's own rendering must yield an equal
+                // variant (display/parse idempotency). This verifies semantic
+                // stability, not merely that the string is syntactically valid.
+                let variant = parse_hgvs(hgvs).unwrap_or_else(|e| {
+                    panic!("HGVS for {} should parse: {hgvs}: {e:?}", lookup.rsid)
+                });
+                // Independent oracle (a different internal path than the
+                // render->reparse idempotency check below): the parser must store
+                // the accession exactly as written. The accession is the literal
+                // substring before the first ':'; comparing it against the parsed
+                // variant's own `accession()` field exercises field extraction, not
+                // the Display+parse cycle, so the two assertions cannot mask a
+                // shared parser/renderer defect.
+                let expected_accession = hgvs
+                    .split_once(':')
+                    .map(|(accession, _)| accession)
+                    .unwrap_or_else(|| panic!("HGVS for {} must contain ':': {hgvs}", lookup.rsid));
+                let parsed_accession = variant
+                    .accession()
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "variant for {} should carry an accession: {hgvs}",
+                            lookup.rsid
+                        )
+                    })
+                    .to_string();
+                assert_eq!(
+                    parsed_accession, expected_accession,
+                    "parsed accession for {} should match the input literal: {hgvs}",
+                    lookup.rsid
+                );
+                let reparsed = parse_hgvs(&variant.to_string()).unwrap_or_else(|e| {
+                    panic!(
+                        "rendered HGVS for {} should re-parse: {variant}: {e:?}",
+                        lookup.rsid
+                    )
+                });
+                assert_eq!(
+                    reparsed, variant,
+                    "HGVS for {} should be display/parse idempotent: {hgvs}",
+                    lookup.rsid
+                );
             }
         }
     }
@@ -254,13 +478,17 @@ fn test_rsid_hgvs_parsing() {
         rsids_with_hgvs,
         fixture.rsid_lookups.variants.len()
     );
-    println!("Total HGVS expressions: {}", total_hgvs);
-    println!("Parsed successfully: {}", parsed_hgvs);
+    println!("Total HGVS expressions: {total_hgvs}");
 
-    if total_hgvs > 0 {
-        let rate = (parsed_hgvs as f64 / total_hgvs as f64) * 100.0;
-        println!("Parse rate: {:.1}%", rate);
-    }
+    // Guard against the per-expression assertions never running.
+    assert!(
+        rsids_with_hgvs >= 1,
+        "at least one rsID should carry HGVS expressions"
+    );
+    assert!(
+        total_hgvs > 0,
+        "expected at least one HGVS expression to verify"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Two tests in `tests/it/spdi_tests.rs` were `#[ignore]`d because they required `tests/fixtures/validation/ncbi_variation.json`, a file produced only by a live NCBI Variation Services fetch (`scripts/fetch_ncbi_variation.py`) that is never generated in CI. As a result the HGVS↔SPDI roundtrip and rsID→HGVS parse paths were never exercised.

This PR commits a tiny, hand-authored **synthetic** `ncbi_variation.json` (matching the fetch script's schema exactly), un-ignores both tests, and strengthens them so they assert meaningful, verifiable outcomes offline — no network, no large committed dump.

## What changed

- **`tests/fixtures/validation/ncbi_variation.json`** (new, ~140 lines): 6 HGVS conversion records (4 genomic substitutions on `NC_000017.11`/`NC_000007.14`/`NC_000013.11` with real, verified SPDI values; 2 transcript `c.` variants with `spdi_result: null`) and 2 rsID-lookup records (`rs121913529`, `rs113993960`) carrying parseable HGVS expressions. Clearly labeled synthetic in its `source` field.
- **`tests/it/spdi_tests.rs`**: removed both `#[ignore]` attributes and the early-return-on-missing-file branches (the fixture is now a committed asset, so its absence is a real failure).
  - `test_hgvs_to_spdi_parsing` now asserts every input HGVS parses and, for each genomic-substitution record, verifies the full **HGVS → SPDI → HGVS roundtrip is exact**: the forward conversion (`hgvs_to_spdi_simple`) equals the fixture SPDI, and the back conversion (`spdi_to_hgvs`) re-expresses the original HGVS. The asserted SPDI values are produced by ferro's own converters, never hand-guessed.
  - `test_rsid_hgvs_parsing` now asserts every rsID-associated HGVS expression parses.
  - Both tests assert non-empty record lists and concrete counts so neither can pass vacuously.

## Correctness of the synthetic relationships

Only genomic substitutions are asserted for full HGVS↔SPDI equality, because their conversion needs no reference provider. The four asserted pairs (e.g. `NC_000017.11:g.7674220C>T` ⇄ `NC_000017.11:7674219:C:T`) were generated by running ferro's `hgvs_to_spdi_simple`/`spdi_to_hgvs` and confirmed to roundtrip bidirectionally. Transcript/`c.` variants are exercised on the parse path only — their HGVS→SPDI conversion requires CDS metadata / reference bases a unit fixture can't supply offline (documented in the test).

## Testing

- `cargo nextest run --features dev` — all pass; both formerly-ignored tests now execute (not skipped).
- `cargo clippy --features dev --all-targets -- -D warnings` — clean.

Closes #812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified NCBI variation fetch script behavior: performs live network requests and defaults to writing to a non-curated fixture file rather than the committed one.

* **Tests**
  * Migrated HGVS↔SPDI validation to deterministic, offline fixture-based tests with enhanced verification logic and strictness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->