### PR TITLE
refactor(python_helpers): remove dead edit_type_from_debug {:?}-string matcher

### DIFF
--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -83,43 +83,6 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
     }
 }
 
-/// Get the edit type from debug string representation
-///
-/// This is a fallback function that determines the edit type by inspecting
-/// the Debug representation of an edit. Use `na_edit_type_str` when possible.
-pub fn edit_type_from_debug<T: std::fmt::Debug>(edit: &T) -> &'static str {
-    let debug = format!("{:?}", edit);
-    if debug.contains("Substitution") {
-        "substitution"
-    } else if debug.contains("Deletion") {
-        "deletion"
-    } else if debug.contains("DupIns") {
-        "dupins"
-    } else if debug.contains("Duplication") {
-        "duplication"
-    } else if debug.contains("BreakpointInsertion") {
-        "breakpoint_insertion"
-    } else if debug.contains("Insertion") {
-        "insertion"
-    } else if debug.contains("Delins") {
-        "delins"
-    } else if debug.contains("Inversion") {
-        "inversion"
-    } else if debug.contains("Repeat") {
-        "repeat"
-    } else if debug.contains("Identity") {
-        "identity"
-    } else if debug.contains("Conversion") {
-        "conversion"
-    } else if debug.contains("Methylation") {
-        "methylation"
-    } else if debug.contains("CopyNumber") {
-        "copy_number"
-    } else {
-        "unknown"
-    }
-}
-
 /// Parse a direction string into ShuffleDirection
 ///
 /// Accepts various common formats:
@@ -684,29 +647,6 @@ mod tests {
         // get_indel_length must return None (not Some(0) or any deterministic value).
         let variant = parse_hgvs("NM_000333.3:c.(4_246)delN[15]").expect("must parse delN[15]");
         assert_eq!(get_indel_length(&variant), None);
-    }
-
-    // ===== edit_type_from_debug Tests =====
-
-    #[test]
-    fn test_edit_type_from_debug_substitution() {
-        #[derive(Debug)]
-        struct TestSubstitution;
-        assert_eq!(edit_type_from_debug(&TestSubstitution), "substitution");
-    }
-
-    #[test]
-    fn test_edit_type_from_debug_deletion() {
-        #[derive(Debug)]
-        struct TestDeletion;
-        assert_eq!(edit_type_from_debug(&TestDeletion), "deletion");
-    }
-
-    #[test]
-    fn test_edit_type_from_debug_unknown() {
-        #[derive(Debug)]
-        struct TestOther;
-        assert_eq!(edit_type_from_debug(&TestOther), "unknown");
     }
 
     // ===== parse_direction Tests =====


### PR DESCRIPTION
## Summary

`src/python_helpers.rs` had `pub fn edit_type_from_debug<T: Debug>(edit: &T) -> &'static str` that classified an edit by matching on its `Debug` rendering (`format!("{:?}", edit).contains(...)`) — the same fragile `{:?}`-string anti-pattern behind #228 and removed from the VCF path by #803/#817. It also carried a latent substring/ordering hazard between similarly named variants (e.g. `Deletion` vs `Delins`, `Insertion` vs `BreakpointInsertion`, `Duplication` vs `DupIns`): one reorder of the `if`/`else` ladder would silently mis-classify.

This PR removes the function (and its three unit tests) as dead code rather than rewriting it, because the typed dispatcher it should have been already exists.

## Why remove instead of rewrite

A census across `src/`, `tests/`, and `python/` shows no production caller:

- `src/python.rs` imports a specific symbol list from `python_helpers` that does **not** include `edit_type_from_debug`.
- There is no glob re-export; `lib.rs` only has `pub mod python_helpers;`.
- The Python `edit_type` property routes through `get_variant_edit_type` -> `na_edit_type_str` — the typed `match` over the real `NaEdit` enum — never through the `Debug` fallback.
- The only references were its own three unit tests, which exercised hand-rolled fake structs (`TestSubstitution`/`TestDeletion`/`TestOther`) rather than any real edit type, so they carried no production coverage.

`na_edit_type_str` (already present and tested, immediately above the removed function) is an exhaustive typed `match` covering every `NaEdit` variant the `Debug`-matcher handled (substitution, deletion, duplication, dupins, insertion, breakpoint_insertion, delins, inversion, repeat, identity, conversion, methylation, copy_number) plus more. Rewriting `edit_type_from_debug` to typed dispatch would only duplicate it, so deletion is strictly cleaner and leaves no dead code behind.

## Verification

- `cargo nextest run --features dev` — 7517 passed, 54 skipped.
- `cargo clippy --features dev --all-targets -- -D warnings` — clean.
- `rg 'edit_type_from_debug'` across `src/ tests/ python/` — no matches.
- No `format!("{:?}", …).contains(...)` edit classification remains in `src/python_helpers.rs`.

Closes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed public helper function and associated unit tests, reducing codebase by 60 lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->