### PR TITLE
fix(project): force initiator Met at residue 1 for non-AUG ref-protein translation

### DIFF
--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -363,6 +363,20 @@ fn extract_literal_sequence(
 
 // ── Translation helpers ───────────────────────────────────────────────────────
 
+/// Force residue 1 of a translated protein to the initiator `Met`, in place.
+///
+/// A no-op on an empty protein. Callers must only invoke this when the start
+/// codon is a recognized initiator (see [`cds_has_recognized_start`]); on a
+/// canonical `ATG` start residue 1 is already `Met` so this is a no-op, and on a
+/// non-recognized (drift) start it must NOT be called or a wrong `cds_start`
+/// would be masked. Mirrors the `replace_range(0..1, "M")` normalization in
+/// [`crate::reference::validate::validate_translation_against_protein`] (#801).
+pub(crate) fn force_initiator_met(protein: &mut [AminoAcid]) {
+    if let Some(first) = protein.first_mut() {
+        *first = AminoAcid::Met;
+    }
+}
+
 /// Translate a CDS sequence to a protein, stopping before the first stop codon.
 ///
 /// Incomplete codons at the end are silently dropped.
@@ -393,10 +407,26 @@ pub(crate) struct RefProteinBundle {
 
 impl RefProteinBundle {
     /// Build a bundle by reading and translating the CDS of `transcript`.
+    ///
+    /// When the CDS begins with a **recognized** initiator (`ATG` or the
+    /// near-cognates `CTG`/`GTG`/`TTG`, per [`cds_has_recognized_start`]),
+    /// residue 1 of the reference protein is forced to the initiator `Met`:
+    /// translation initiation installs Met regardless of the start codon, so the
+    /// authoritative `NP_` always begins with `M`, but `translate_full_cds`
+    /// renders the codon's own amino acid (e.g. Leu for `CTG`). This mirrors the
+    /// `replace_range(0..1, "M")` normalization in
+    /// [`crate::reference::validate::validate_translation_against_protein`] so the
+    /// bundle and that validator agree (#801, a #780 follow-up). The `ATG` case
+    /// is a no-op (already `Met`); a non-recognized start (genuine `cds_start`
+    /// drift) is left untouched so a wrong annotation is not masked (#625).
     pub(crate) fn from_transcript(transcript: &Transcript) -> Result<Self, FerroError> {
         let ref_cds = read_full_cds(transcript)?;
-        let ref_protein = translate_full_cds(&ref_cds);
-        let ref_protein_with_stop = translate_full_cds_with_stop(&ref_cds);
+        let mut ref_protein = translate_full_cds(&ref_cds);
+        let mut ref_protein_with_stop = translate_full_cds_with_stop(&ref_cds);
+        if cds_has_recognized_start(&ref_cds) {
+            force_initiator_met(&mut ref_protein);
+            force_initiator_met(&mut ref_protein_with_stop);
+        }
         Ok(Self {
             ref_cds,
             ref_protein,
@@ -1118,6 +1148,75 @@ mod tests {
         // The stricter ATG-only predicate is unchanged: it accepts only ATG.
         assert!(cds_has_valid_start("ATGAAA"));
         assert!(!cds_has_valid_start("CTGAAA"));
+    }
+
+    // ── RefProteinBundle::from_transcript Met1 normalization (#801) ───────────
+
+    #[test]
+    fn bundle_forces_met1_on_non_aug_recognized_start() {
+        // CTG start (Leu) followed by Arg + stop. Translation initiation installs
+        // Met regardless of the start codon, so residue 1 of the reference
+        // protein must be Met, not Leu (#801). The authoritative NP_ begins with M.
+        let t = tx("CTGCGCTAA", 1, 9);
+        let bundle = RefProteinBundle::from_transcript(&t).unwrap();
+        assert_eq!(
+            bundle.ref_protein,
+            vec![AminoAcid::Met, AminoAcid::Arg],
+            "CTG start: residue 1 forced to Met"
+        );
+        assert_eq!(
+            bundle.ref_protein_with_stop,
+            vec![AminoAcid::Met, AminoAcid::Arg, AminoAcid::Ter],
+            "the with-stop vector must agree at residue 1"
+        );
+    }
+
+    #[test]
+    fn bundle_forces_met1_for_gtg_and_ttg_starts() {
+        for start in ["GTG", "TTG"] {
+            let seq = format!("{start}CGCTAA");
+            let t = tx(&seq, 1, 9);
+            let bundle = RefProteinBundle::from_transcript(&t).unwrap();
+            assert_eq!(
+                bundle.ref_protein.first(),
+                Some(&AminoAcid::Met),
+                "{start} start: residue 1 forced to Met"
+            );
+            assert_eq!(
+                bundle.ref_protein_with_stop.first(),
+                Some(&AminoAcid::Met),
+                "{start} start: with-stop residue 1 forced to Met"
+            );
+        }
+    }
+
+    #[test]
+    fn bundle_atg_start_unchanged_no_op() {
+        // ATG start already begins with Met; forcing is a no-op and the rest of
+        // the protein is untouched.
+        let t = tx("ATGCGCTAA", 1, 9);
+        let bundle = RefProteinBundle::from_transcript(&t).unwrap();
+        assert_eq!(bundle.ref_protein, vec![AminoAcid::Met, AminoAcid::Arg]);
+        assert_eq!(
+            bundle.ref_protein_with_stop,
+            vec![AminoAcid::Met, AminoAcid::Arg, AminoAcid::Ter]
+        );
+    }
+
+    #[test]
+    fn bundle_drift_start_not_forced_to_met() {
+        // AGT is genuine off-the-start drift (not a recognized initiator). We must
+        // NOT force Met1 — masking a wrong cds_start would emit a confidently
+        // wrong residue 1 (#625 protection). Residue 1 stays the translated AA.
+        // AGT → Ser.
+        let t = tx("AGTCGCTAA", 1, 9);
+        let bundle = RefProteinBundle::from_transcript(&t).unwrap();
+        assert_eq!(
+            bundle.ref_protein.first(),
+            Some(&AminoAcid::Ser),
+            "drift start: residue 1 left as translated (Ser), not forced to Met"
+        );
+        assert_eq!(bundle.ref_protein_with_stop.first(), Some(&AminoAcid::Ser));
     }
 
     #[test]

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -11,9 +11,9 @@ use crate::reference::transcript::Transcript;
 
 use super::helpers::{
     affects_initiation_codon, build_cterminal_extension, build_initiator_unknown,
-    build_mutated_cds_with_ref, first_diff_position, mut_cds_with_3utr, net_length_change,
-    translate_full_cds_with_stop, translate_mutated_cds, translate_mutated_cds_inframe,
-    RefProteinBundle,
+    build_mutated_cds_with_ref, cds_has_recognized_start, first_diff_position, force_initiator_met,
+    mut_cds_with_3utr, net_length_change, translate_full_cds_with_stop, translate_mutated_cds,
+    translate_mutated_cds_inframe, RefProteinBundle,
 };
 
 // ── Main entry point ──────────────────────────────────────────────────────────
@@ -721,7 +721,15 @@ fn is_stop_loss_readthrough(
     }
 
     let scan_seq = mut_cds_with_3utr(mut_cds, transcript)?;
-    let readthrough = translate_full_cds_with_stop(&scan_seq);
+    let mut readthrough = translate_full_cds_with_stop(&scan_seq);
+    // `ref_protein` had residue 1 forced to the initiator `Met` for a recognized
+    // initiator (`RefProteinBundle::from_transcript`, #801); apply the same
+    // normalization to the freshly re-translated read-through so the sense-prefix
+    // comparison below stays consistent. `scan_seq` shares the CDS start codon
+    // (a downstream stop-loss edit never touches codon 0), so the gate matches.
+    if cds_has_recognized_start(&scan_seq) {
+        force_initiator_met(&mut readthrough);
+    }
     let stop_idx = ref_protein.len();
     // The former-stop slot must hold a non-terminator residue (the stop was
     // read through) and every sense residue before it must be unchanged.
@@ -1082,6 +1090,37 @@ mod tests {
         assert!(s.contains("Ter3"), "expected Ter3 in '{}'", s);
         assert!(s.contains("Trp"), "expected Trp in '{}'", s);
         assert!(s.contains("ext"), "expected ext in '{}'", s);
+    }
+
+    #[test]
+    fn stop_readthrough_extension_on_non_aug_start() {
+        // #801 regression: stop-loss readthrough on a non-AUG-initiation
+        // transcript must still route to the C-terminal extension path. The
+        // RefProteinBundle now forces residue 1 to Met for a recognized
+        // initiator (CTG here), so `is_stop_loss_readthrough` must apply the
+        // same Met1 normalization to the re-translated read-through sequence
+        // before comparing — otherwise readthrough[0] (Leu, from the literal
+        // CTG) would not equal ref_protein[0] (Met) and the variant would
+        // misroute out of the extension path.
+        //
+        // CDS "CTGCGCTAA": Met(forced)-Arg-Ter; stop "TAA" at c.7_9.
+        // delins c.7_9 TGG converts the stop to Trp → readthrough, no further
+        // stop in CDS → p.(Ter3Trpext*?).
+        let t = tx("CTGCGCTAA", 1, 9);
+        let seq: crate::hgvs::edit::Sequence = "TGG".parse().unwrap();
+        let edit = NaEdit::Delins {
+            sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
+            deleted: None,
+            deleted_length: None,
+        };
+        let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
+        let s = prot_str(&result);
+        assert!(
+            s.contains("Ter3") && s.contains("Trp") && s.contains("ext"),
+            "expected a C-terminal extension (Ter3...ext) on a CTG-start \
+             transcript, got '{}'",
+            s
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A #780 follow-up. After #780, downstream variants on non-AUG-initiation transcripts (CTG/GTG/TTG starts) translate via `predict_indel_protein`, but `RefProteinBundle::from_transcript` translated the CDS as-is, so **residue 1 of the reference protein was the start codon's amino acid** (e.g. Leu for CTG) rather than the installed initiator `Met`. The authoritative `NP_`/GenBank `/translation` always begins with `M`, so any downstream indel whose consequence references residue 1 (a frameshift/extension reaching the N-terminus, or a whole-protein comparison) would carry the wrong residue 1.

This is a latent gap: no corpus row hits it today (the only non-AUG corpus row is a substitution, and substitutions don't use the bundle).

## Change

- `RefProteinBundle::from_transcript` now forces residue 1 to `Met` when the start codon is a **recognized initiator** — `cds_has_recognized_start`: `ATG` plus the near-cognates `CTG`/`GTG`/`TTG`, the same classification the data-side CDS-start validator (`is_alternative_start_codon`) uses. This mirrors `validate_translation_against_protein`'s `replace_range(0..1, "M")`.
- Both `ref_protein` and `ref_protein_with_stop` are normalized so they agree at residue 1.
- A non-recognized (genuine `cds_start` drift) start is left untouched so a wrong annotation is not masked (#625). The `ATG` case is a no-op.
- `is_stop_loss_readthrough` re-translates the read-through sequence from byte 0, so it applies the same Met1 normalization before its sense-prefix comparison; otherwise a stop-loss readthrough on a non-AUG-initiation transcript would misroute out of the extension path.

## Unregressed paths

- **Substitution** is independent of the bundle (`predict_substitution_protein` reads codons directly).
- **Start-loss `p.Met1?`**: an init-codon-affecting edit short-circuits to `build_initiator_unknown` before any protein comparison.
- **Downstream alt side**: `translate_mutated_cds`/`_inframe` lift the unchanged prefix (incl. codon 0) from `ref_protein`, so forcing `ref_protein[0] = Met` forces `alt_protein[0]` to Met too — ref and alt stay consistent at residue 1.

## Tests

New unit tests (synthetic transcripts): CTG/GTG/TTG starts force Met1 on both vectors; ATG unchanged (no-op); genuine drift (`AGT`) left untouched; stop-loss readthrough on a CTG-start transcript still routes to the C-terminal extension. Full suite green (7525 passed), clippy clean.

Closes #801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed protein normalization for recognized non-ATG initiator codons (CTG, GTG, TTG).
  * Resolved stop-loss readthrough extension handling for non-AUG initiation transcripts.

* **Tests**
  * Added test coverage for initiator codon normalization across various start codons.
  * Added regression test for stop-codon-disrupting variants on non-AUG starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->