### PR TITLE
fix(normalize): treat LRG transcript references as bare for EINTRONIC (#834)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -600,14 +600,17 @@ fn boundary_has_intronic<T>(
 /// reference** (no `NG_(…)`/`NC_(…)` genomic context). Returns the warning
 /// to emit, or `None`.
 ///
-/// In scope: a bare coding transcript (`NM_`/`XM_`) used with `c.` and a bare
-/// non-coding transcript (`NR_`/`XR_`, via `is_noncoding_rna()`) used with
-/// `n.`, with `Accession.genomic_context == None`. The spec's "a (non-)coding
-/// DNA reference sequence does not contain introns" rule applies equally to
-/// curated (`NM_`/`NR_`) and predicted (`XM_`/`XR_`) transcripts, so both are
-/// covered on each axis. Out of scope: genomic-context forms
-/// (`genomic_context: Some`), `NG_`/`NC_` references (which never reach the
-/// c./n. transcript path), LRG, Ensembl `ENST`, and the r. axis. Both `Single`
+/// In scope: a bare coding transcript (`NM_`/`XM_` or LRG `LRG_<N>t<k>`) used
+/// with `c.` and a bare non-coding transcript (`NR_`/`XR_` via
+/// `is_noncoding_rna()`, or LRG) used with `n.`, with
+/// `Accession.genomic_context == None`. The spec's "a (non-)coding DNA
+/// reference sequence does not contain introns" rule applies equally to curated
+/// (`NM_`/`NR_`), predicted (`XM_`/`XR_`), and LRG transcript references — an
+/// LRG transcript is itself a bare reference with no `NG_`/`NC_` genomic
+/// context — so all are covered on each axis (#834). Out of scope:
+/// genomic-context forms (`genomic_context: Some`), `NG_`/`NC_` references
+/// (which never reach the c./n. transcript path), Ensembl `ENST`, and the r.
+/// axis. Both `Single`
 /// and `Range` (uncertain-breakpoint) position boundaries are inspected; an
 /// unknown (`?`) offset still counts as intronic (`CdsPos::is_intronic` treats
 /// the unknown-offset sentinel as intronic), which is correct — it is an
@@ -615,8 +618,15 @@ fn boundary_has_intronic<T>(
 fn intronic_on_bare_transcript_warning(variant: &HgvsVariant) -> Option<NormalizationWarning> {
     match variant {
         HV::Cds(v) => {
-            if !matches!(&*v.accession.prefix, "NM" | "XM") || v.accession.genomic_context.is_some()
-            {
+            // A bare coding-DNA reference does not contain introns, so an
+            // intronic offset on it is a spec-invalid form regardless of which
+            // transcript namespace addresses it. Curated/predicted RefSeq
+            // (`NM_`/`XM_`) and LRG transcript references (`LRG_<N>t<k>`, which
+            // carry no `NG_`/`NC_` genomic context — the LRG *is* the reference)
+            // are all bare coding transcripts; treat them uniformly (#834).
+            let is_bare_coding_transcript =
+                matches!(&*v.accession.prefix, "NM" | "XM") || v.accession.is_lrg();
+            if !is_bare_coding_transcript || v.accession.genomic_context.is_some() {
                 return None;
             }
             let intronic = boundary_has_intronic(&v.loc_edit.location.start, CdsPos::is_intronic)
@@ -627,7 +637,12 @@ fn intronic_on_bare_transcript_warning(variant: &HgvsVariant) -> Option<Normaliz
             })
         }
         HV::Tx(v) => {
-            if !v.accession.is_noncoding_rna() || v.accession.genomic_context.is_some() {
+            // Same rule on the non-coding axis: a bare `NR_`/`XR_` or LRG
+            // non-coding transcript reference used with `n.` has no introns
+            // (#834 extends the LRG coverage to match the `c.` arm).
+            let is_bare_noncoding_transcript =
+                v.accession.is_noncoding_rna() || v.accession.is_lrg();
+            if !is_bare_noncoding_transcript || v.accession.genomic_context.is_some() {
                 return None;
             }
             let intronic = boundary_has_intronic(&v.loc_edit.location.start, TxPos::is_intronic)
@@ -10898,6 +10913,56 @@ mod eintronic_helper_tests {
         // the spec-valid description — no warning.
         let v =
             parse_hgvs("NG_012337.1(NM_004006.2):c.(4185+1_4186-1)_(4357+1_4358-1)del").unwrap();
+        assert!(intronic_on_bare_transcript_warning(&v).is_none());
+    }
+
+    #[test]
+    fn bare_lrg_coding_intronic_yields_warning() {
+        // #834: an LRG transcript (`LRG_<N>t<k>`) is a bare coding reference
+        // with no NG_/NC_ genomic context — same "no introns on a coding
+        // reference" property as NM_, so a bare intronic c. form is spec-invalid
+        // and must warn, exactly like its NM-addressed equivalent.
+        let v = parse_hgvs("LRG_741t1:c.7007+30del").unwrap();
+        let w = intronic_on_bare_transcript_warning(&v).expect("bare LRG intronic must warn");
+        assert_eq!(w.code(), "INTRONIC_ON_BARE_TRANSCRIPT");
+    }
+
+    #[test]
+    fn bare_lrg_coding_minus_offset_intronic_yields_warning() {
+        // Offset-sign-agnostic, matching the NM behavior.
+        let v = parse_hgvs("LRG_763t1:c.53-6del").unwrap();
+        assert!(intronic_on_bare_transcript_warning(&v).is_some());
+    }
+
+    #[test]
+    fn bare_lrg_coding_exonic_no_warning() {
+        // A purely exonic LRG c. variant is a valid form — no warning.
+        let v = parse_hgvs("LRG_741t1:c.7007del").unwrap();
+        assert!(intronic_on_bare_transcript_warning(&v).is_none());
+    }
+
+    #[test]
+    fn bare_lrg_noncoding_intronic_yields_warning() {
+        // #834: the `HV::Tx` (`n.`) arm was widened to treat an LRG transcript
+        // as a bare non-coding reference, exactly like `NR_`/`XR_`. An LRG
+        // `n.<pos>+<offset>` intronic form has no introns on its bare reference,
+        // so it must warn just like the `NR_` form above.
+        let v = parse_hgvs("LRG_741t1:n.100+10del").unwrap();
+        let w = intronic_on_bare_transcript_warning(&v).expect("bare LRG n. intronic must warn");
+        assert_eq!(w.code(), "INTRONIC_ON_BARE_TRANSCRIPT");
+    }
+
+    #[test]
+    fn bare_lrg_noncoding_minus_offset_intronic_yields_warning() {
+        // Offset-sign-agnostic on the `n.` axis too, matching the `NR_` behavior.
+        let v = parse_hgvs("LRG_741t1:n.100-6del").unwrap();
+        assert!(intronic_on_bare_transcript_warning(&v).is_some());
+    }
+
+    #[test]
+    fn bare_lrg_noncoding_exonic_no_warning() {
+        // A purely exonic LRG n. variant is a valid form — no warning.
+        let v = parse_hgvs("LRG_741t1:n.100del").unwrap();
         assert!(intronic_on_bare_transcript_warning(&v).is_none());
     }
 }

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -11,7 +11,9 @@ use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleD
 /// Shared helpers for integration tests that require benchmark reference data.
 #[cfg(test)]
 mod integration_helpers {
-    use ferro_hgvs::{parse_hgvs, FerroError, MultiFastaProvider, Normalizer};
+    use ferro_hgvs::error_handling::ErrorMode;
+    use ferro_hgvs::normalize::NormalizationWarning;
+    use ferro_hgvs::{parse_hgvs, FerroError, MultiFastaProvider, NormalizeConfig, Normalizer};
     use std::path::Path;
 
     pub fn create_normalizer() -> Option<Normalizer<MultiFastaProvider>> {
@@ -21,6 +23,71 @@ mod integration_helpers {
         }
         let provider = MultiFastaProvider::from_manifest(ref_path).ok()?;
         Some(Normalizer::new(provider))
+    }
+
+    /// Build a `MultiFastaProvider`-backed normalizer in a given error mode,
+    /// panicking (rather than silently skipping) if the prepared reference is
+    /// absent — these helpers are only reached from `#[ignore]`d tests, so a
+    /// missing reference is a setup error, not an expected skip.
+    fn create_normalizer_with_mode(mode: ErrorMode) -> Normalizer<MultiFastaProvider> {
+        let ref_path = Path::new("benchmark-output/manifest.json");
+        let provider = MultiFastaProvider::from_manifest(ref_path).unwrap_or_else(|e| {
+            panic!(
+                "prepared reference required (symlink benchmark-output/ to a prepared ref); \
+                 these tests are #[ignore]d and must be run with --ignored + reference: {e:?}"
+            )
+        });
+        Normalizer::with_config(provider, NormalizeConfig::default().with_error_mode(mode))
+    }
+
+    /// Assert the full lenient-vs-strict W4007/EINTRONIC contract for a bare-LRG
+    /// intronic input whose genomic intronic conversion declines (Bucket C in
+    /// `#834`). Beyond `assert_normalizes_to`'s identity + idempotency check
+    /// (which alone cannot distinguish intended lenient recovery from an
+    /// accidental no-op success), this pins both axes of the contract:
+    ///
+    /// 1. **Lenient (default):** the input echoes verbatim *and* carries an
+    ///    `IntronicOnBareTranscript` (`INTRONIC_ON_BARE_TRANSCRIPT` / W4007)
+    ///    diagnostic — proving the echo is the deliberate lenient recovery, not
+    ///    a silent pass-through.
+    /// 2. **Strict:** the same input is rejected with `FerroError::IntronicVariant`
+    ///    (the EINTRONIC promotion of W4007), proving the form is genuinely
+    ///    spec-invalid rather than merely unshifted.
+    ///
+    /// This mirrors the contract the NM-addressed equivalents satisfy (`#834`).
+    pub fn assert_intronic_bare_transcript_echo(input: &str) {
+        let variant =
+            parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {input}: {e:?}"));
+
+        // 1. Lenient: echoes the input AND emits the W4007 diagnostic.
+        let lenient = create_normalizer_with_mode(ErrorMode::Lenient);
+        let outcome = lenient
+            .normalize_with_diagnostics(&variant)
+            .unwrap_or_else(|e| panic!("lenient normalize failed for {input}: {e:?}"));
+        assert_eq!(
+            format!("{}", outcome.result),
+            input,
+            "lenient recovery must echo the input verbatim for {input}"
+        );
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|w| matches!(w, NormalizationWarning::IntronicOnBareTranscript { .. })),
+            "lenient recovery for {input} must emit INTRONIC_ON_BARE_TRANSCRIPT (W4007); \
+             got warnings: {:?}",
+            outcome.warnings
+        );
+
+        // 2. Strict: the same form is rejected as EINTRONIC.
+        let strict = create_normalizer_with_mode(ErrorMode::Strict);
+        let err = strict.normalize(&variant).err().unwrap_or_else(|| {
+            panic!("strict mode must reject bare intronic transcript {input}, but it succeeded")
+        });
+        assert!(
+            matches!(err, FerroError::IntronicVariant { .. }),
+            "strict mode must reject {input} as IntronicVariant (EINTRONIC), got {err:?}"
+        );
     }
 
     pub fn try_normalize(input: &str) -> Option<String> {
@@ -82,21 +149,6 @@ mod integration_helpers {
             expected,
             "normalization is not idempotent for {input}: {normalized} re-normalizes to {renormalized}"
         );
-    }
-
-    /// Normalize `input` and return the `FerroError` it fails with (panicking if
-    /// it unexpectedly succeeds). Used by the Bucket C residual cases to pin the
-    /// exact current decline.
-    pub fn normalize_expect_err(input: &str) -> FerroError {
-        let normalizer = create_normalizer().unwrap_or_else(|| {
-            panic!("prepared reference required; run #[ignore]d tests with --ignored + reference")
-        });
-        let variant =
-            parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for {input}: {e:?}"));
-        match normalizer.normalize(&variant) {
-            Ok(n) => panic!("expected {input} to fail conversion, but it normalized to {n}"),
-            Err(e) => e,
-        }
     }
 }
 
@@ -4285,11 +4337,16 @@ mod comprehensive_normalization_tests {
 //     transcripts are served from the transcript FASTA, so cdot-synthesis (the
 //     only E2005 emitter) is never invoked. The apply/decline split is covered
 //     by the synthesis unit tests in `src/reference/multi_fasta.rs`.
-//   - Bucket C (7 cases): residual LRG-addressed-path failures (`ConversionFailed`)
-//     where the NM-addressed equivalent succeeds (LRG->genomic mapping gap), plus
-//     LRG_720t1 (no genomic alignment). #807 did not address this shape; these
-//     assert the exact current decline and are tracked in #811 (see
-//     `lrg_intronic_still_unsupported`).
+//   - Bucket C (0 cases, resolved by #834): the 7 LRG-addressed cases that
+//     formerly declined (`ConversionFailed`) where their NM-addressed
+//     equivalent appeared to succeed. The asymmetry was solely that the
+//     EINTRONIC / W4007 bare-transcript handling did not treat LRG transcripts
+//     as bare references. #834 fixed that, so all 7 now behave identically to
+//     their NM equivalents and have moved into `lrg_intronic_normalization`
+//     (asserting identity, mirroring the NM oracle). The two LRG_720t1 cases
+//     are included: their NM equivalent NM_000280.3 also lacks a genomic
+//     alignment and likewise echoes via the lenient W4007 recovery, so there is
+//     no LRG/NM distinction left to track.
 //
 // All of these need the prepared reference and so are `#[ignore]`d (not silently
 // skipped) — matching this file's `real_repeat_tests` / `ferro_mutalyzer_differences`
@@ -4495,19 +4552,35 @@ mod version_mismatch_normalization {
 
 #[cfg(test)]
 mod lrg_intronic_normalization {
-    use super::integration_helpers::assert_normalizes_to;
+    use super::integration_helpers::{assert_intronic_bare_transcript_echo, assert_normalizes_to};
     use rstest::rstest;
 
     // =========================================================================
-    // LRG transcripts (Bucket A subset): these LRG-addressed intronic variants
-    // resolve and normalize with #807. Each asserts the exact normalized
-    // string; a few renormalize to the canonical upstream span (e.g.
-    // `LRG_486t1:c.-234-1616_-234-235del1382` -> `c.-1850_-469del`).
+    // LRG-addressed intronic variants. An LRG transcript (`LRG_<N>t<k>`) is a
+    // bare transcript reference with no `NG_`/`NC_` genomic context, exactly
+    // like a bare `NM_`/`XM_`/`NR_`/`XR_` reference. #834 made the EINTRONIC /
+    // W4007 (`IntronicOnBareTranscript`) handling treat LRG transcripts
+    // uniformly with RefSeq, so an LRG-addressed intronic variant now behaves
+    // identically to its NM-addressed equivalent in every error mode:
+    //   - genuinely resolvable cases 3'-shift / re-anchor (e.g.
+    //     `LRG_311t1:c.80+1del` -> `c.79+1del`, mirroring
+    //     `NM_000314.4:c.80+1del` -> `c.79+1del`) — `test_lrg_intronic_normalizes_ok`;
+    //   - cases whose genomic intronic conversion declines instead echo the
+    //     input verbatim under the lenient W4007 recovery, again mirroring the
+    //     NM equivalent (the seven previously in `lrg_intronic_still_unsupported`)
+    //     — `test_lrg_intronic_bare_transcript_echo`, which pins the full
+    //     lenient-echo-with-W4007 / strict-EINTRONIC-rejection contract rather
+    //     than identity alone.
     //
-    // The 7 LRG cases that still fail are in `lrg_intronic_still_unsupported`.
+    // The genuinely-resolving cases assert the exact normalized string under the
+    // default (lenient) normalizer used by `assert_normalizes_to`, plus
+    // idempotency. The asserted value is the SAME string the NM-addressed
+    // equivalent produces — that NM output is the independent oracle for the
+    // expected LRG output (#834).
     // =========================================================================
 
     #[rstest]
+    // ---- Genuinely-resolving LRG intronic variants (3'-shift / re-anchor). ----
     // LRG_741t1 → NM_015120.4 (CIGAR-affected)
     #[case(
         "LRG_741t1:c.10078+1_10078+5delinsAAAAACCCTTGCAGAATGAAAA",
@@ -4525,60 +4598,34 @@ mod lrg_intronic_normalization {
     // LRG_311t1 → NM_000314.4
     #[case("LRG_311t1:c.-1032-222_-366del889", "LRG_311t1:c.-1254_-366del")]
     #[case("LRG_311t1:c.80+1del", "LRG_311t1:c.79+1del")]
-    #[ignore = "requires prepared reference (benchmark-output/) — run with --ignored; tracked in #811"]
+    #[ignore = "requires prepared reference (benchmark-output/) — run with --ignored; tracked in #834"]
     fn test_lrg_intronic_normalizes_ok(#[case] input: &str, #[case] expected: &str) {
         assert_normalizes_to(input, expected);
     }
-}
 
-#[cfg(test)]
-mod lrg_intronic_still_unsupported {
-    use super::integration_helpers::normalize_expect_err;
-    use ferro_hgvs::error::ErrorCode;
-    use ferro_hgvs::FerroError;
-    use rstest::rstest;
-
-    // =========================================================================
-    // Bucket C (issue #811, residual): LRG-addressed intronic variants that
-    // still fail with `ConversionFailed` even after #807. This is NOT a clean
-    // E2005 decline — for several of these the identical variant addressed via
-    // the NM_ accession succeeds (see the version_mismatch_normalization and
-    // cigar_aware_normalization modules), so the gap is in the LRG→genomic
-    // mapping path, not in resolving the intronic offset itself. The two
-    // LRG_720t1 cases are a distinct missing-genomic-alignment failure.
+    // ---- Previously declining (Bucket C); #834 makes them echo identity, ----
+    // ---- mirroring their NM-addressed equivalents (the oracle). Each NM ----
+    // ---- equivalent itself only echoes via the same lenient W4007 recovery, ----
+    // ---- because its intronic genomic conversion also declines — including ----
+    // ---- LRG_720t1 → NM_000280.3, whose NM equivalent likewise lacks a ----
+    // ---- genomic alignment (chromosome=None) and echoes via recovery. ----
     //
-    // These assert the EXACT current decline so the residual gap is tracked and
-    // a future fix that starts resolving them is forced to update this test
-    // (moving the case into the OK module) rather than silently passing.
-    //
-    // Residual shape — tracked follow-up: LRG-addressed intronic normalization
-    // fails (ConversionFailed) where the NM-addressed equivalent succeeds, plus
-    // LRG_720t1 lacking any genomic alignment.
-    // =========================================================================
-
+    // These cannot use `assert_normalizes_to`: identity + idempotency alone
+    // cannot tell intended lenient W4007 recovery from an accidental no-op
+    // success. `assert_intronic_bare_transcript_echo` pins both axes — lenient
+    // echo *with* the INTRONIC_ON_BARE_TRANSCRIPT diagnostic, and strict-mode
+    // EINTRONIC rejection (#834).
     #[rstest]
-    // NM-addressed equivalents succeed; only the LRG-addressed path fails.
-    #[case("LRG_741t1:c.7007+30del")] // cf. NM_015120.4:c.7007+30del (OK)
-    #[case("LRG_763t1:c.52+1del")] // cf. NM_002111.8:c.52+1del (OK)
-    #[case("LRG_763t1:c.53-6del")] // cf. NM_002111.8:c.53-6del (OK)
+    #[case("LRG_741t1:c.7007+30del")] // cf. NM_015120.4:c.7007+30del
+    #[case("LRG_763t1:c.52+1del")] // cf. NM_002111.8:c.52+1del
+    #[case("LRG_763t1:c.53-6del")] // cf. NM_002111.8:c.53-6del
     #[case("LRG_293t1:c.1-59_1-57del")] // BRCA2 5'-UTR intronic
-    #[case("LRG_486t1:c.1000+5del")]
-    // cf. NM_000368.4:c.1000+5del (OK)
-    // LRG_720t1 → NM_000280.3: no genomic alignment on any known build.
-    #[case("LRG_720t1:c.1183+4dup")]
-    #[case("LRG_720t1:c.1327+4del")]
-    #[ignore = "residual LRG-addressed intronic gap (Bucket C) — run with --ignored; tracked in #811"]
-    fn test_lrg_intronic_still_declines(#[case] input: &str) {
-        let err = normalize_expect_err(input);
-        assert!(
-            matches!(err, FerroError::ConversionError { .. }),
-            "expected a ConversionError (E5001) for residual LRG case {input}, got {err:?}"
-        );
-        assert_eq!(
-            err.code(),
-            Some(ErrorCode::ConversionFailed),
-            "expected E5001 (ConversionFailed) for residual LRG case {input}, got {err:?}"
-        );
+    #[case("LRG_486t1:c.1000+5del")] // cf. NM_000368.4:c.1000+5del
+    #[case("LRG_720t1:c.1183+4dup")] // cf. NM_000280.3:c.1183+4dup
+    #[case("LRG_720t1:c.1327+4del")] // cf. NM_000280.3:c.1327+4del
+    #[ignore = "requires prepared reference (benchmark-output/) — run with --ignored; tracked in #834"]
+    fn test_lrg_intronic_bare_transcript_echo(#[case] input: &str) {
+        assert_intronic_bare_transcript_echo(input);
     }
 }
 


### PR DESCRIPTION
Closes #834. Context: surfaced while resolving #811 (PR #833, merged); parent #811/#833 introduced the `lrg_intronic_still_unsupported` decline-bucket this PR resolves.

## Root cause

An LRG transcript reference (`LRG_<N>t<k>:c.…` / `:n.…`) is a **bare transcript** with no `NG_`/`NC_` genomic context — semantically identical to a bare `NM_`/`XM_` (`c.`) or `NR_`/`XR_` (`n.`) reference. The HGVS spec rule "a (non-)coding DNA reference sequence does not contain introns" applies to it equally. ferro models that rule as the EINTRONIC / W4007 (`IntronicOnBareTranscript`) path.

The classifier `intronic_on_bare_transcript_warning` (`src/normalize/mod.rs`) recognized only RefSeq prefixes (`NM`/`XM` on `c.`, `NR`/`XR` on `n.`) — its doc comment explicitly listed LRG as "out of scope." So an LRG-addressed intronic variant was denied the bare-transcript handling.

Why that produced the divergence: in the default **lenient** mode, `normalize_core` recovers a bare-transcript intronic variant whose genomic intronic conversion declines by **echoing the input** with W4007 attached. Because LRG was excluded, the underlying `ConversionError` (E5001) propagated for an LRG input while the **identical NM-addressed variant echoed its input** via the recovery. That asymmetry — not any genuine LRG→genomic mapping gap — is the entire bug. For the 7 reported cases, the genomic intronic conversion (`cds_to_genomic_with_intron` → `intronic_to_genomic`) declines for **both** the LRG and the NM accession; only the NM accession got the recovery.

## Fix

Extend the classifier to treat LRG transcript accessions as bare coding (`c.`) and non-coding (`n.`) references via `Accession::is_lrg()`, guarded by the same `genomic_context.is_none()` condition. LRG now behaves identically to its NM equivalent in every error mode:

- genuinely resolvable LRG intronic variants still 3'-shift / re-anchor (e.g. `LRG_311t1:c.80+1del` → `LRG_311t1:c.79+1del`, mirroring `NM_000314.4:c.80+1del` → `c.79+1del`) — the W4007 recovery only fires on a dispatch error, so these are untouched;
- LRG intronic variants whose genomic conversion declines echo the input under the lenient W4007 recovery, mirroring the NM equivalent;
- strict mode rejects an LRG bare intronic as EINTRONIC, symmetric with NM (this was already NM's strict-mode behavior).

## Scope: deviation from the issue's 5-fixed / 2-deferred split

The issue proposed fixing 5 cases (a "pure LRG→genomic mapping-path gap") and deferring 2 (`LRG_720t1`, said to "lack any genomic alignment", blocked on reference provisioning). **Careful verification against the prepared reference shows that split does not hold**, and the issue itself asked me to report rather than force it if so:

- The fix mechanism is the bare-transcript EINTRONIC recovery, **not** genomic-alignment resolution. Whether a case has a genomic alignment is irrelevant to whether the LRG path matches the NM path — the NM path of all 7 cases also fails genomic resolution and only "passes" via the same recovery.
- `LRG_720t1 → NM_000280.3`: the NM equivalent **also lacks a genomic alignment** (`chromosome=None`, synthetic single exon) and likewise "passes" only via the W4007 recovery. So the 2 `LRG_720t1` cases are indistinguishable from the other 5 under this fix.
- Forcing the 2 to remain declining would require **suppressing** the recovery for `LRG_720t1` while `NM_000280.3` keeps it — re-introducing the exact LRG-vs-NM asymmetry #834 exists to eliminate, with no spec basis.

Therefore the correct root-cause fix resolves **all 7 cases uniformly**. The scratch-SSD-offline provisioning blocker cited for the 2 is moot because the fix does not depend on genomic alignment. All 7 LRG cases move from `lrg_intronic_still_unsupported` into `lrg_intronic_normalization`, asserting identity (the NM-addressed output is the independent oracle) plus idempotency. The now-empty decline module and its unused `normalize_expect_err` helper are removed.

## Tests

- 3 new non-reference unit tests in `eintronic_helper_tests` pinning the LRG classifier on both axes (intronic → warn, minus-offset → warn, exonic → no-warn).
- 7 reference-gated cases flipped from decline to identity in `lrg_intronic_normalization::test_lrg_intronic_normalizes_ok` (16 cases total, all `#[ignore]`d; run with `--run-ignored all` + `FERRO_MANIFEST`).
- `cargo clippy --features dev --all-targets -- -D warnings`: clean.
- Targeted suites (eintronic / issue_486 / lrg / intronic / cigar / cdot_gap / version_mismatch) with the prepared reference: 532 passed.
- Full `cargo nextest run --features dev --run-ignored all`: the only failures are 37 pre-existing, environment-dependent external-oracle comparison tests (biocommons/UTA/docker, gnomad, mutalyzer/hgvs-rs) — identical on the unmodified base (verified). Zero new failures; no LRG cases appear in any baseline-failures ledger or corpus, so no ledger regeneration was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of intronic LRG transcript variants so valid `c.` and `n.` forms are now recognized consistently.
  * Expanded support for LRG coding and non-coding transcript references, including cases with `+`/`-` offsets and unknown positions.
  * Reduced false warnings for exon-only LRG variants, which now normalize without the intronic warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->