### PR TITLE
fix(project): build-scope the predicted-r. allele transcript fetch (#843)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -139,6 +139,121 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .map(|gc| gc.to_string())
     }
 
+    /// The build-bearing genomic accession to stamp as `genomic_context` when
+    /// fetching a transcript for [`crate::project::rna::predict_rna`], so the
+    /// fetch partitions by genome build the same way the single genome-pivot
+    /// path does via its parallel `cache_variant` (#843).
+    ///
+    /// `predict_rna` reads the transcript *sequence* (e.g. to 3'-shift a
+    /// deletion or resolve a range insert), so the served bases must come from
+    /// the build the `input` is addressed on — a `g.` allele on `NC_*.10`
+    /// (GRCh37) must read the GRCh37 transcript, not the GRCh38 primary. The
+    /// raw `cached_get_transcript_for_variant(input, …)` keys on
+    /// [`Self::parent_key_for`], which is `None` for a bare `g.` input (its
+    /// build-bearing `NC_*` accession lives in `accession`, not
+    /// `genomic_context`), collapsing both builds onto the primary transcript.
+    ///
+    /// Resolution order, mirroring the genome-pivot path's build selection:
+    /// 1. If `input`'s accession already carries a `genomic_context` (an
+    ///    NG/NC-parented c./n./r. input), reuse it — that context already
+    ///    drives the correct build probe, so the cache identity is unchanged
+    ///    (a no-op for the existing NG-parented corpus cases).
+    /// 2. Else, if `input`'s own accession is a build-bearing genomic
+    ///    accession (a `g.` on `NC_*.10`/`.11`), use the accession itself as
+    ///    the context — the new build-scoping for bare `g.` inputs.
+    /// 3. Else (truly build-agnostic — bare `NM_`/`NG_`/`LRG_`), `None`: the
+    ///    primary-build fetch is the only defined answer and no divergence is
+    ///    possible, so behavior is unchanged.
+    ///
+    /// The [`Self::assembly_override`] (`--assembly`) is deliberately *not*
+    /// consulted here. It only `fills in` a build for a build-agnostic
+    /// `NG_`/`LRG_` parent, and such a parent's transcript bases are
+    /// build-independent: RefSeqGene/`LRG_` transcripts are served from the
+    /// build-agnostic transcript FASTA, so `predict_rna` (which reads the
+    /// transcript *sequence*) produces identical output under either build. The
+    /// override changes only the genomic *placement* (the `.genomic` re-anchor),
+    /// which the genome-pivot path handles separately via its build-resolved
+    /// `cache_variant`. Folding the override in here would stamp a build the
+    /// fetch cannot observably honor (no per-build NG transcript bases exist) —
+    /// a no-op that no test could exercise — so it is intentionally omitted.
+    fn rna_build_context(&self, input: &HgvsVariant) -> Option<Accession> {
+        let accession = input.accession()?;
+        if let Some(parent) = accession.genomic_context.as_deref() {
+            return Some(parent.clone());
+        }
+        // Reached only when `accession.genomic_context` is None (step 1 returned
+        // early otherwise), so the accession is already bare — a build-bearing
+        // genomic accession (a `g.` on `NC_*.10`/`.11`) is used directly as the
+        // context to stamp.
+        if self.provider.infer_genome_build(accession).is_some() {
+            return Some(accession.clone());
+        }
+        None
+    }
+
+    /// Fetch the transcript for a `predict_rna` call, build-scoped by `input`
+    /// (#843). Builds a minimal `cache_variant` that stamps the build-bearing
+    /// genomic accession from [`Self::rna_build_context`] as `genomic_context`
+    /// on `transcript_id`, then resolves through the parent-aware
+    /// [`Self::cached_get_transcript_for_variant`] so the transcript/ref caches
+    /// partition by build — exactly the mechanism the single genome-pivot path
+    /// uses (`cache_variant` at the `predict_rna` site). When no build-bearing
+    /// context is derivable the cache_variant is bare and the fetch is the
+    /// (unchanged) primary-build lookup.
+    ///
+    /// `predict_rna` walks the transcript *bases*, so unlike the coding/protein
+    /// axes (which read build-identical CDS coordinates) it must not run against
+    /// another build's sequence. The build-stamped fetch above resolves the
+    /// correct build when the provider has it, but the parent-aware cache it
+    /// shares with the g.→c./n. fetch can hold a build-agnostic *primary*
+    /// transcript that the provider degraded to on a build-keyed miss (the
+    /// `ReferenceNotFound` fallback in `cached_get_transcript_for_variant`).
+    /// Serving that for a non-primary input would emit a wrong-build `r.` (#843),
+    /// so when the input encodes a build, require the resolved transcript's build
+    /// to match it; a *definite* mismatch (a known, different build) declines
+    /// rather than predicting against the wrong bases. A build-agnostic
+    /// transcript (`GenomeBuild::Unknown`, e.g. FASTA-served bases that are
+    /// build-independent) is accepted — there is no divergence to get wrong.
+    fn predict_rna_transcript(
+        &self,
+        input: &HgvsVariant,
+        transcript_id: &str,
+    ) -> Result<Arc<Transcript>, FerroError> {
+        let mut accession = parse_accession(transcript_id);
+        if let Some(context) = self.rna_build_context(input) {
+            accession = accession.with_genomic_context(context);
+        }
+        // A minimal Cds carrier: `cached_get_transcript_for_variant` only reads
+        // `accession()` (for the parent key and the build-aware provider probe),
+        // so the location/edit are immaterial.
+        let cache_variant = HgvsVariant::Cds(CdsVariant {
+            accession,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                CdsInterval::point(CdsPos::new(1)),
+                NaEdit::Substitution {
+                    reference: crate::hgvs::edit::Base::A,
+                    alternative: crate::hgvs::edit::Base::G,
+                },
+            ),
+        });
+        let tx = self.cached_get_transcript_for_variant(&cache_variant, transcript_id)?;
+        if let Some(input_build) = self.infer_input_build(input) {
+            let tx_build = tx.genome_build;
+            if tx_build != crate::reference::transcript::GenomeBuild::Unknown
+                && tx_build.to_string() != input_build
+            {
+                return Err(FerroError::ReferenceNotFound {
+                    id: format!(
+                        "{transcript_id} on build {input_build}: resolved transcript is \
+                         build {tx_build} (refusing to predict r. against wrong-build bases)"
+                    ),
+                });
+            }
+        }
+        Ok(tx)
+    }
+
     /// Reject parentless c./n./r. fan-out inputs up front.
     ///
     /// `project_normalized_all` seeds a stab query against the contig
@@ -2127,8 +2242,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // — `predict_rna` handles the `Allele` shape directly, emitting one
         // outer predicted wrapper `r.([a;b])` (recommendations/RNA/alleles.md).
         // Re-frame under the input's parent so it matches the input framing.
+        // Build-scope the transcript fetch by the input's NC/NG build (#843):
+        // for a bare `g.` allele the member NC accession is build-bearing but
+        // unparented, so a raw `cached_get_transcript_for_variant(original, …)`
+        // would read the primary (GRCh38) transcript even for a GRCh37 input,
+        // yielding a wrong-build `r.`. `predict_rna_transcript` stamps the
+        // build-bearing accession as `genomic_context` first, mirroring the
+        // single genome-pivot path's `cache_variant`.
         let rna = coding.as_ref().and_then(|coding_allele| {
-            self.cached_get_transcript_for_variant(original, transcript_id)
+            self.predict_rna_transcript(original, transcript_id)
                 .ok()
                 .and_then(|tx| crate::project::rna::predict_rna(coding_allele, &tx))
         });
@@ -2553,8 +2675,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             Err(_) => None,
         };
 
+        // Build-scope the `predict_rna` transcript fetch via the shared helper
+        // for consistency with the allele site and the genome-pivot path (#843).
+        // NOTE: this site is reached ONLY for a bare-`NM_` c. input
+        // (`genomic_context.is_none()` gates the dispatch above), which carries no
+        // genome build at all — so `rna_build_context` returns `None` and the
+        // fetch is byte-identical to the prior build-agnostic lookup. The change
+        // is therefore a deliberate latent no-op here: it makes every
+        // `predict_rna` fetch flow through one build-aware helper, so a future
+        // build-bearing input reaching this path would be scoped automatically
+        // rather than silently reading the primary build. (The reachable
+        // build-scoping fix is at the allele site.)
         let rna = self
-            .cached_get_transcript_for_variant(normalized, transcript_id)
+            .predict_rna_transcript(normalized, transcript_id)
             .ok()
             .and_then(|tx| crate::project::rna::predict_rna(normalized, &tx));
         let rna = Self::reframe_rna_from_input(rna, normalized);
@@ -8990,6 +9123,297 @@ mod tests {
                 s.contains(":c.5A>T"),
                 "expected c.5A>T from the GRCh38-discovered projection, got: {}",
                 s
+            );
+        }
+
+        // ---------------------------------------------------------------------
+        // Predicted-RNA allele build-scoping (#843)
+        //
+        // The predicted `r.` allele in `project_allele_inner` fetches the
+        // transcript for `predict_rna` via the input. For a bare `g.` allele the
+        // member `NC_*` accession is build-bearing but carries no
+        // `genomic_context`, so before #843 the fetch resolved the primary-build
+        // transcript regardless of build — and `predict_rna`'s deletion 3'-shift
+        // (which walks the transcript *sequence*) then ran against the wrong
+        // build's bases, emitting a wrong-build `r.`. These tests model a
+        // transcript whose GRCh37 vs GRCh38 bases differ at a deletion-shift
+        // boundary (the real divergence a genome-reconstructed transcript shows;
+        // FASTA-backed transcripts serve build-identical bases) and assert the
+        // allele `r.` is now build-correct.
+        // ---------------------------------------------------------------------
+
+        /// A 30 nt single-exon coding fixture whose GRCh37 and GRCh38 transcript
+        /// *bases* differ only in the length of a poly-A run starting at c.5:
+        /// GRCh37 runs `A` over c.5..7 (blocked by `C` at c.8); GRCh38 runs `A`
+        /// over c.5..9 (blocked by `C` at c.10). A `c.5del` (deleting an `A`)
+        /// therefore 3'-shifts to `r.(7del)` on GRCh37 but `r.(9del)` on GRCh38
+        /// — a clean, build-dependent predicted-RNA output. The genome contigs
+        /// differ per build (`NC_000001.10` [10000,10030) GRCh37 /
+        /// `NC_000001.11` [20000,20030) GRCh38), so a `g.` input's build is
+        /// inferred from its `NC_*` version.
+        fn make_rna_divergence_projector() -> VariantProjector<MockProvider> {
+            make_rna_divergence_projector_inner(true)
+        }
+
+        /// Variant of [`make_rna_divergence_projector`] that omits the GRCh37
+        /// build-keyed transcript record, leaving only the GRCh38 build-keyed
+        /// record plus the build-agnostic primary. A GRCh37 `g.` input therefore
+        /// *misses* the build-keyed lookup (the mock surfaces `ReferenceNotFound`
+        /// for the partial setup), modeling a transcript whose sequence is present
+        /// only in the primary build's data.
+        fn make_rna_divergence_projector_grch38_keyed_only() -> VariantProjector<MockProvider> {
+            make_rna_divergence_projector_inner(false)
+        }
+
+        fn make_rna_divergence_projector_inner(
+            register_grch37_keyed: bool,
+        ) -> VariantProjector<MockProvider> {
+            use crate::reference::transcript::{
+                Exon, GenomeBuild as RefGenomeBuild, ManeStatus, Strand as TxStrand,
+                Transcript as RefTranscript,
+            };
+            use std::sync::OnceLock;
+
+            let cdot_json = r#"
+            {
+                "transcripts": {
+                    "NM_RNA_DIV.1": {
+                        "gene_name": "RNADIV",
+                        "genome_builds": {
+                            "GRCh37": {
+                                "contig": "NC_000001.10",
+                                "strand": "+",
+                                "exons": [[10000, 10030, 1, 0, 30, "M30"]]
+                            },
+                            "GRCh38": {
+                                "contig": "NC_000001.11",
+                                "strand": "+",
+                                "exons": [[20000, 20030, 1, 0, 30, "M30"]]
+                            }
+                        },
+                        "start_codon": 0,
+                        "stop_codon": 30
+                    }
+                }
+            }
+            "#;
+            // c.:  1 2 3 4 5 6 7 8 9 ...                      (1-based)
+            // 37:  G G C G A A A C T ...   poly-A c.5..7, C at c.8
+            // 38:  G G C G A A A A A C ... poly-A c.5..9, C at c.10
+            // The deletion projects to c.5 (a poly-A base on BOTH builds), so the
+            // g.→c. step is build-identical; only the run length downstream — and
+            // thus the predicted `r.` 3'-shift target — differs: GRCh37 shifts to
+            // c.7 (`r.(7del)`), GRCh38 to c.9 (`r.(9del)`).
+            let seq37 = "GGCGAAACTTTTTTTTTTTTTTTTTTTTTT"; // len 30
+            let seq38full = "GGCGAAAAACTTTTTTTTTTTTTTTTTTTTTT"; // len 32 -> trim to 30
+            let seq38 = &seq38full[..30];
+            assert_eq!(seq37.len(), 30, "seq37 must be 30 nt");
+            assert_eq!(seq38.len(), 30, "seq38 must be 30 nt");
+
+            let cdot = CdotMapper::from_reader_with_build(cdot_json.as_bytes(), "GRCh38")
+                .expect("rna-divergence cdot JSON should parse");
+            let projector = Projector::new(cdot);
+            let mut provider = MockProvider::new();
+            let mk = |build: RefGenomeBuild, seq: &str, chrom: &str, gstart: u64| RefTranscript {
+                id: "NM_RNA_DIV.1".to_string(),
+                gene_symbol: Some("RNADIV".to_string()),
+                strand: TxStrand::Plus,
+                sequence: Some(seq.to_string()),
+                cds_start: Some(1),
+                cds_end: Some(30),
+                exons: vec![Exon::new(1, 1, 30)],
+                chromosome: Some(chrom.to_string()),
+                genomic_start: Some(gstart),
+                genomic_end: Some(gstart + 29),
+                genome_build: build,
+                mane_status: ManeStatus::default(),
+                refseq_match: None,
+                ensembl_match: None,
+                protein_id: None,
+                exon_cigars: Vec::new(),
+                cached_introns: OnceLock::new(),
+            };
+            // Build-keyed transcripts (the #843 divergence vector). The GRCh37
+            // record is optional so a partial setup (GRCh38-keyed + primary only)
+            // can model a build-keyed miss for a GRCh37 input.
+            if register_grch37_keyed {
+                provider.add_transcript_on_build(
+                    "GRCh37",
+                    mk(RefGenomeBuild::GRCh37, seq37, "NC_000001.10", 10000),
+                );
+            }
+            provider.add_transcript_on_build(
+                "GRCh38",
+                mk(RefGenomeBuild::GRCh38, seq38, "NC_000001.11", 20000),
+            );
+            // Build-agnostic fallback = the primary (GRCh38) bases, matching how a
+            // real provider serves the primary transcript when no build is keyed.
+            // This is exactly what the pre-#843 build-agnostic fetch returned for
+            // BOTH builds, so a GRCh37 input wrongly read the GRCh38 run length.
+            provider.add_transcript(mk(RefGenomeBuild::GRCh38, seq38, "NC_000001.11", 20000));
+            VariantProjector::new(projector, provider)
+        }
+
+        /// Build a single-deletion `g.` allele at `g.<pos>del` on `NC_000001.<ver>`.
+        fn g_del_allele(version: u32, pos: u64) -> HgvsVariant {
+            let member = HgvsVariant::Genome(GenomeVariant {
+                accession: nc_chr1(version),
+                gene_symbol: None,
+                loc_edit: LocEdit::new(
+                    GenomeInterval::point(GenomePos::new(pos)),
+                    NaEdit::Deletion {
+                        sequence: None,
+                        length: None,
+                    },
+                ),
+            });
+            HgvsVariant::Allele(AlleleVariant::new(vec![member], AllelePhase::Cis))
+        }
+
+        /// The allele predicted `r.` must read the *input's build* transcript, so
+        /// a `g.` allele on GRCh37 (`NC_000001.10`) and one on GRCh38
+        /// (`NC_000001.11`) — same `c.6del` after projection — yield
+        /// build-distinct 3'-shifted `r.` outputs. Pre-#843 both read the primary
+        /// (GRCh38) transcript, so the GRCh37 allele emitted the GRCh38 shift
+        /// (`r.(10del)`): a wrong-build `r.`. Post-fix the GRCh37 allele emits its
+        /// own `r.(8del)`.
+        #[test]
+        fn allele_predicted_rna_is_build_scoped() {
+            let vp = make_rna_divergence_projector();
+
+            // g.10005del on NC_000001.10 (GRCh37) -> c.5del.
+            let g37 = g_del_allele(10, 10005);
+            let r37 = vp
+                .project_normalized(&g37, "NM_RNA_DIV.1")
+                .expect("GRCh37 g. allele must project")
+                .rna
+                .expect("GRCh37 allele must predict an r.")
+                .to_string();
+
+            // g.20005del on NC_000001.11 (GRCh38) -> c.6del.
+            let g38 = g_del_allele(11, 20005);
+            let r38 = vp
+                .project_normalized(&g38, "NM_RNA_DIV.1")
+                .expect("GRCh38 g. allele must project")
+                .rna
+                .expect("GRCh38 allele must predict an r.")
+                .to_string();
+
+            // The two builds 3'-shift the deletion to different positions because
+            // their poly-A run lengths differ. Pre-fix r37 == r38 (both GRCh38).
+            // Assert the FULL rendered string (exact, not a `contains` substring
+            // match that would also accept e.g. `17del`/`19del`).
+            assert_eq!(
+                r37, "NM_RNA_DIV.1:r.7del",
+                "GRCh37 allele r. must 3'-shift to its own run end (r.7del)"
+            );
+            assert_eq!(
+                r38, "NM_RNA_DIV.1:r.9del",
+                "GRCh38 allele r. must 3'-shift to its own run end (r.9del)"
+            );
+            assert_ne!(
+                r37, r38,
+                "GRCh37 and GRCh38 alleles must predict build-distinct r.; \
+                 equal output means predict_rna read the same (wrong-build) transcript"
+            );
+        }
+
+        /// The allele predicted-`r.` transcript fetch must partition the
+        /// transcript cache by build (mirrors
+        /// `caches_partition_by_genome_build_for_nc_inputs` for the single path).
+        /// Pre-#843 the bare `g.` allele fetched under `(id, None)` for both
+        /// builds (one colliding key); post-fix each build stamps its `NC_*`
+        /// accession, yielding two build-distinct keys.
+        #[test]
+        fn allele_predicted_rna_does_not_pollute_cache_with_parentless_key() {
+            // The build-distinct keys `(id, Some(NC_*.10))` / `(id, Some(NC_*.11))`
+            // are inserted by each member's genome-pivot projection regardless of
+            // the #843 bug, so their presence is NOT a fix signal. The bug's
+            // fingerprint is the PARENTLESS `(id, None)` key the buggy allele-site
+            // fetch (keyed on the unparented `g.` allele) inserted in ADDITION:
+            // post-fix `predict_rna_transcript` stamps the build-bearing accession
+            // first, so no `(id, None)` entry is ever created for the allele path.
+            let vp = make_rna_divergence_projector();
+            vp.project_normalized(&g_del_allele(10, 10005), "NM_RNA_DIV.1")
+                .expect("GRCh37 allele projection");
+            vp.project_normalized(&g_del_allele(11, 20005), "NM_RNA_DIV.1")
+                .expect("GRCh38 allele projection");
+
+            let tx_keys: std::collections::HashSet<_> = vp
+                .transcript_cache
+                .read()
+                .expect("transcript cache poisoned")
+                .keys()
+                .cloned()
+                .collect();
+            // Sanity: the build-scoped entries exist (from the member pivots).
+            assert!(
+                tx_keys.contains(&("NM_RNA_DIV.1".to_string(), Some("NC_000001.10".to_string())))
+                    && tx_keys
+                        .contains(&("NM_RNA_DIV.1".to_string(), Some("NC_000001.11".to_string()))),
+                "build-scoped member-pivot keys must be present, got: {tx_keys:?}"
+            );
+            // The actual fix signal: no parentless entry for the allele transcript.
+            assert!(
+                !tx_keys.contains(&("NM_RNA_DIV.1".to_string(), None)),
+                "predict_rna must not fetch the allele transcript build-agnostically;                  a parentless (id, None) key means it read the primary build, got: {tx_keys:?}"
+            );
+        }
+
+        /// A build-keyed miss under a stamped build context must NOT fall back to
+        /// the build-agnostic primary transcript (#843 / CodeRabbit). With only
+        /// the GRCh38 transcript build-keyed (plus the primary), a GRCh37 `g.`
+        /// allele's build-stamped fetch misses; `predict_rna_transcript` must
+        /// surface that miss instead of silently re-serving the GRCh38 primary —
+        /// which would emit the wrong-build `r.9del`. The c./g. forms stay
+        /// build-identical (they read cdot, not transcript bases), so the
+        /// projection still succeeds; only the predicted `r.` is withheld.
+        /// Pre-fix the `ReferenceNotFound` fallback masked the miss (rna = r.9del).
+        #[test]
+        fn allele_predicted_rna_does_not_fall_back_to_primary_on_build_miss() {
+            let vp = make_rna_divergence_projector_grch38_keyed_only();
+            let g37 = g_del_allele(10, 10005);
+            let proj = vp
+                .project_normalized(&g37, "NM_RNA_DIV.1")
+                .expect("GRCh37 g. allele must still project (c./g. are build-identical)");
+            // The coding form is build-identical, so it must be present — this
+            // confirms the projection reached the predicted-`r.` step rather than
+            // bailing earlier (which would make `rna.is_none()` vacuous).
+            assert!(
+                proj.coding.is_some(),
+                "the build-identical c. form must project even with the GRCh37 \
+                 transcript absent"
+            );
+            assert!(
+                proj.rna.is_none(),
+                "a build-keyed miss must not fall back to the primary transcript; \
+                 a predicted r. here ({:?}) means the wrong-build (GRCh38) bases \
+                 were served",
+                proj.rna.as_ref().map(|r| r.to_string())
+            );
+        }
+
+        /// The build-match guard must decline *only* on a wrong build, never
+        /// over-decline the matching one. On the same partial fixture (GRCh38
+        /// build-keyed + primary), a GRCh38 `g.` allele resolves its own
+        /// build-keyed transcript, so the guard passes and the predicted `r.` is
+        /// emitted as usual. This locks the guard's precision: a future "just
+        /// suppress the fallback" regression that broke the build-identical axes
+        /// (or dropped the matching-build `r.`) would fail here.
+        #[test]
+        fn grch38_predicted_rna_survives_build_guard_on_partial_fixture() {
+            let vp = make_rna_divergence_projector_grch38_keyed_only();
+            let g38 = g_del_allele(11, 20005);
+            let r38 = vp
+                .project_normalized(&g38, "NM_RNA_DIV.1")
+                .expect("GRCh38 g. allele must project")
+                .rna
+                .expect("GRCh38 allele must still predict an r. (build-keyed record present)")
+                .to_string();
+            assert_eq!(
+                r38, "NM_RNA_DIV.1:r.9del",
+                "GRCh38 allele must 3'-shift to its own run end (r.9del); the build guard \
+                 must not decline a matching-build transcript"
             );
         }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -41,6 +41,16 @@ pub struct MockProvider {
     /// otherwise refuses by design. Empty by default, so an unconfigured mock
     /// never substitutes a version.
     version_substitutions: HashMap<String, String>,
+    /// Build-keyed transcripts: `(transcript_id, build)` → the `Transcript` whose
+    /// bases/CDS the provider should serve for an input addressed on that genome
+    /// build. Lets a test model a transcript whose *sequence differs between
+    /// GRCh37 and GRCh38* — the real divergence a genome-reconstructed transcript
+    /// exhibits, which the single build-agnostic `transcripts` map cannot capture
+    /// (#843). Consulted by [`Self::get_transcript_for_accession`] when the input
+    /// accession carries a build-bearing `genomic_context` (an `NC_*.10`/`.11`
+    /// parent); falls back to the build-agnostic `transcripts` map otherwise.
+    /// Empty by default, so an unconfigured mock is build-agnostic as before.
+    build_transcripts: HashMap<(String, &'static str), Arc<Transcript>>,
 }
 
 impl MockProvider {
@@ -54,6 +64,7 @@ impl MockProvider {
             genomic_placements: HashMap::new(),
             legacy_gene_models: HashMap::new(),
             version_substitutions: HashMap::new(),
+            build_transcripts: HashMap::new(),
         }
     }
 
@@ -169,7 +180,19 @@ impl MockProvider {
             genomic_placements: HashMap::new(),
             legacy_gene_models: HashMap::new(),
             version_substitutions: HashMap::new(),
+            build_transcripts: HashMap::new(),
         })
+    }
+
+    /// Register a build-specific transcript so the provider serves
+    /// build-divergent bases/CDS for the same `transcript_id` (#843). `build`
+    /// is `"GRCh37"` / `"GRCh38"`. Consulted by
+    /// [`ReferenceProvider::get_transcript_for_accession`] when the input
+    /// accession carries a build-bearing `genomic_context` whose inferred build
+    /// matches; the build-agnostic [`Self::add_transcript`] map is the fallback.
+    pub fn add_transcript_on_build(&mut self, build: &'static str, transcript: Transcript) {
+        self.build_transcripts
+            .insert((transcript.id.clone(), build), Arc::new(transcript));
     }
 
     /// Add a transcript to the provider
@@ -422,6 +445,71 @@ impl ReferenceProvider for MockProvider {
         crate::reference::legacy_selector::resolve_legacy_selector_in(selector, |g| {
             self.legacy_gene_models.get(g).cloned()
         })
+    }
+
+    /// Build-aware transcript resolution (#843). When the input accession
+    /// carries a build-bearing `genomic_context` (an `NC_*.10`/`.11` parent)
+    /// and a build-specific transcript was registered via
+    /// [`Self::add_transcript_on_build`], serve that build's record so a test
+    /// can model build-divergent transcript bases. Otherwise fall back to the
+    /// build-agnostic [`Self::get_transcript`] — preserving existing behavior
+    /// for every input that does not opt into build-keyed transcripts.
+    ///
+    /// To avoid silently masking an incomplete test setup, the fallback is
+    /// **refused for a partially build-keyed transcript**: if `tx_id` has a
+    /// build-keyed record for *some* build but not the requested one, return
+    /// [`FerroError::ReferenceNotFound`] rather than serving the build-agnostic
+    /// record (which would hide a wrong/missing `add_transcript_on_build` call).
+    /// A transcript with **no** build-keyed records keeps the build-agnostic
+    /// path, so cross-id fallback and the deliberate primary-build fixture
+    /// entry are unaffected.
+    fn get_transcript_for_accession(
+        &self,
+        accession: &Accession,
+    ) -> Result<Arc<Transcript>, FerroError> {
+        if !self.build_transcripts.is_empty() {
+            if let Some(parent) = accession.genomic_context.as_deref() {
+                if let Some(build) = self.infer_genome_build(parent) {
+                    let tx_id = accession.transcript_accession();
+                    // Apply the same unversioned → versioned base-accession rule
+                    // [`Self::get_transcript`] uses (`NM_123` resolves to a
+                    // stored `NM_123.1`): an exact-key lookup would miss a
+                    // build-keyed versioned record for a bare/unversioned input
+                    // accession and silently fall back to the build-agnostic
+                    // (wrong-build) bases — the very bug #843 fixes. Only an
+                    // unversioned query bridges to a versioned key; a versioned
+                    // miss never resolves a different version.
+                    let matches_tx_id = |keyed_id: &str| {
+                        keyed_id == tx_id.as_str()
+                            || (!tx_id.contains('.')
+                                && keyed_id.split('.').next().unwrap_or(keyed_id) == tx_id.as_str())
+                    };
+                    if let Some(tx) =
+                        self.build_transcripts
+                            .iter()
+                            .find_map(|((keyed_id, keyed_build), tx)| {
+                                (matches_tx_id(keyed_id) && *keyed_build == build)
+                                    .then(|| Arc::clone(tx))
+                            })
+                    {
+                        return Ok(tx);
+                    }
+                    // `tx_id` is build-keyed on a different build but not this
+                    // one: a partial setup. Surface it rather than silently
+                    // serving the build-agnostic record.
+                    let partially_keyed = self
+                        .build_transcripts
+                        .keys()
+                        .any(|(keyed_id, _)| matches_tx_id(keyed_id));
+                    if partially_keyed {
+                        return Err(FerroError::ReferenceNotFound {
+                            id: format!("{tx_id} (no build-keyed record for {build})"),
+                        });
+                    }
+                }
+            }
+        }
+        self.get_transcript(&accession.transcript_accession())
     }
 
     fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, FerroError> {
@@ -710,6 +798,69 @@ mod tests {
             .genomic_placement_on_build(&ng2, Some("GRCh37"))
             .is_some());
         assert!(grch37_only.genomic_placement(&ng2).is_some());
+    }
+
+    /// #843: the build-keyed transcript lookup must honor the same unversioned
+    /// → versioned base-accession rule that [`MockProvider::get_transcript`]
+    /// applies (`NM_123` resolves to a stored `NM_123.1`). Without it, a bare
+    /// `g.` allele whose transcript accession is unversioned would miss the
+    /// build-specific record and silently fall back to the build-agnostic
+    /// (primary) bases — exactly the wrong-build serving this fix exists to
+    /// prevent. Register a versioned record on GRCh37, query with the
+    /// unversioned accession carrying a GRCh37 `genomic_context`, and assert it
+    /// resolves to that build's record rather than the build-agnostic one.
+    #[test]
+    fn build_keyed_lookup_resolves_unversioned_accession() {
+        use crate::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand};
+
+        let mk = |build: GenomeBuild, seq: &str| Transcript {
+            id: "NM_555555.1".to_string(),
+            gene_symbol: Some("BUILDDIV".to_string()),
+            strand: Strand::Plus,
+            sequence: Some(seq.to_string()),
+            cds_start: Some(1),
+            cds_end: Some(seq.len() as u64),
+            exons: vec![Exon::new(1, 1, seq.len() as u64)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: build,
+            mane_status: ManeStatus::None,
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            exon_cigars: Vec::new(),
+            cached_introns: OnceLock::new(),
+        };
+
+        let mut provider = MockProvider::new();
+        // Build-keyed records (versioned ids) with build-divergent bases.
+        provider.add_transcript_on_build("GRCh37", mk(GenomeBuild::GRCh37, "AAAA"));
+        provider.add_transcript_on_build("GRCh38", mk(GenomeBuild::GRCh38, "CCCC"));
+        // Build-agnostic fallback = the primary (GRCh38) bases, mirroring how a
+        // real provider serves the primary record when no build is keyed.
+        provider.add_transcript(mk(GenomeBuild::GRCh38, "CCCC"));
+
+        // Unversioned transcript accession (`NM_555555`, version `None`) carrying
+        // a build-bearing GRCh37 `genomic_context` (`NC_000001.10`).
+        let unversioned = Accession::new("NM", "555555", None)
+            .with_genomic_context(Accession::new("NC", "000001", Some(10)));
+        let tx = provider
+            .get_transcript_for_accession(&unversioned)
+            .expect("unversioned accession must resolve to the GRCh37 build record");
+        assert_eq!(
+            tx.sequence.as_deref(),
+            Some("AAAA"),
+            "must serve the GRCh37 build-keyed bases, not the build-agnostic (GRCh38) fallback"
+        );
+
+        // GRCh38 context resolves to its own build's bases.
+        let unversioned_38 = Accession::new("NM", "555555", None)
+            .with_genomic_context(Accession::new("NC", "000001", Some(11)));
+        let tx38 = provider
+            .get_transcript_for_accession(&unversioned_38)
+            .expect("unversioned accession must resolve to the GRCh38 build record");
+        assert_eq!(tx38.sequence.as_deref(), Some("CCCC"));
     }
 
     #[test]

--- a/tests/it/issue_843_allele_rna_build_scoping.rs
+++ b/tests/it/issue_843_allele_rna_build_scoping.rs
@@ -1,0 +1,254 @@
+//! #843 — the predicted-`r.` allele transcript fetch must be build-scoped by the
+//! input's `NC_*` build, not resolved build-agnostically against the primary
+//! (GRCh38) transcript. Real-reference, end-to-end routing guard, gated on
+//! FERRO_MANIFEST (skips in manifest-less CI like the other manifest tests).
+//!
+//! The deterministic red→green for the bug lives in the hermetic unit tests
+//! `multi_build_projection_tests::allele_predicted_rna_is_build_scoped` /
+//! `…_does_not_pollute_cache_with_parentless_key` (they model a transcript whose
+//! GRCh37/GRCh38 bases differ at a deletion 3'-shift boundary — a divergence only
+//! genome-reconstructed transcripts exhibit, and only at a shift boundary, which
+//! is vanishingly rare on real data). This integration test instead pins the
+//! issue's literal acceptance — a GRCh37 `g.` allele → `r.` — end-to-end on the
+//! real dual-build reference: it confirms the allele path ROUTES GRCh37
+//! (resolves the GRCh37 transcript and emits a GRCh37-framed `r.`), and that the
+//! `g.`-allele prediction agrees with the equivalent `NC_(NM_)`-parented c.
+//! allele on the same build (the parented form was already build-scoped).
+//!
+//! Transcript: `XM_005254401.2` (on `NC_000015.9` GRCh37 / `NC_000015.10`
+//! GRCh38) — a genome-reconstructed transcript whose bases differ at a deletion
+//! 3'-shift boundary, so a real `g.`-allele `c.1191del` 3'-shifts to a
+//! **build-distinct** predicted `r.`: `r.1193del` on GRCh37, `r.1191del` on
+//! GRCh38. Pre-#843 the bare `g.` allele read the primary (GRCh38) transcript
+//! for `predict_rna`, so the GRCh37 allele did NOT emit its own `r.1193del`
+//! (it degraded to no/primary-build prediction) — a genuine, reproducible
+//! red→green on the real reference, not just a hermetic mock.
+
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::{
+    parse_hgvs, HgvsVariant, MultiFastaProvider, ReferenceProvider, VariantProjector,
+};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+fn manifest_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+/// `Arc<MultiFastaProvider>` newtype that forwards every build-aware method to
+/// the inner provider, so build routing (`get_transcript_for_accession`,
+/// `infer_genome_build`) reaches the real `MultiFastaProvider` logic.
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(&self, id: &str, s: u64, e: u64) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_sequence(id, s, e)
+    }
+    fn has_transcript(&self, id: &str) -> bool {
+        self.0.has_transcript(id)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        s: u64,
+        e: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_genomic_sequence(contig, s, e)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_variant(variant)
+    }
+    fn get_transcript_for_accession(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_accession(accession)
+    }
+    fn infer_genome_build(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<&'static str> {
+        self.0.infer_genome_build(accession)
+    }
+    fn genomic_placement(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement(parent)
+    }
+    fn genomic_placement_on_build(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement_on_build(parent, build)
+    }
+}
+
+fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
+    let p = provider()?;
+    let cdot = p.cdot_mapper()?.clone();
+    Some(VariantProjector::new(Projector::new(cdot), ArcProvider(p)))
+}
+
+const TX: &str = "XM_005254401.2";
+
+/// Project a single-deletion `g.` allele `NC_*(.ver):g.[<pos>del]` and return the
+/// predicted `r.` string (or `None` if no prediction).
+fn allele_rna(vp: &VariantProjector<ArcProvider>, nc: &str, pos: u64) -> Option<String> {
+    let input = format!("{nc}:g.[{pos}del]");
+    let v = parse_hgvs(&input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    vp.project_variant(&v, TX).ok()?.rna.map(|r| r.to_string())
+}
+
+/// The equivalent NC-parented c.-allele prediction on the same build. The
+/// parented form ALREADY carries the build via `genomic_context`, so it is the
+/// build-correct oracle the bare `g.` allele must match once #843 build-scopes
+/// the predict_rna fetch.
+fn parented_c_allele_rna(
+    vp: &VariantProjector<ArcProvider>,
+    nc: &str,
+    cpos: u64,
+) -> Option<String> {
+    let input = format!("{nc}({TX}):c.[{cpos}del]");
+    let v = parse_hgvs(&input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    vp.project_variant(&v, TX).ok()?.rna.map(|r| r.to_string())
+}
+
+/// Normalize a predicted-`r.` string to just its edit body (`(1193del)` /
+/// `1193del`), dropping the accession prefix and any predicted `( )` wrapper, so
+/// a bare `g.` allele's `r.<edit>` and a parented c. allele's `r.(<edit>)`
+/// compare on coordinate/edit alone (the build-sensitive part).
+fn rna_edit_body(rna: &str) -> String {
+    let after = rna.split(":r.").nth(1).unwrap_or(rna);
+    after
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .to_string()
+}
+
+/// The build-divergence oracle for `XM_005254401.2:c.1191del`: GRCh37 3'-shifts
+/// to `1193del`, GRCh38 stays `1191del`. Carries each build's genomic position
+/// for `c.1191` and its parented-c predicted-`r.` edit body; the helper returns
+/// `None` (skip) only if the manifest's placement drifted so the parented-c
+/// oracle no longer predicts.
+struct Oracle {
+    g37_pos: u64,
+    g38_pos: u64,
+    c37_body: String,
+    c38_body: String,
+}
+
+fn oracle(vp: &VariantProjector<ArcProvider>) -> Option<Oracle> {
+    // Genomic coordinates of c.1191 on each build (from the parented c. allele's
+    // `.genomic`), so the bare `g.` allele uses each build's own coordinate.
+    let g_of = |nc: &str| -> Option<u64> {
+        let v = parse_hgvs(&format!("{nc}({TX}):c.1191del")).ok()?;
+        let g = vp.project_variant(&v, TX).ok()?.genomic?;
+        format!("{g}")
+            .split(":g.")
+            .nth(1)?
+            .split(|c: char| !c.is_ascii_digit())
+            .next()?
+            .parse::<u64>()
+            .ok()
+    };
+    let c37_body = rna_edit_body(&parented_c_allele_rna(vp, "NC_000015.9", 1191)?);
+    let c38_body = rna_edit_body(&parented_c_allele_rna(vp, "NC_000015.10", 1191)?);
+    Some(Oracle {
+        g37_pos: g_of("NC_000015.9")?,
+        g38_pos: g_of("NC_000015.10")?,
+        c37_body,
+        c38_body,
+    })
+}
+
+/// A bare GRCh37 `g.` allele must predict the GRCh37-shifted `r.` — its own
+/// `r.1193del`, NOT the GRCh38 primary's `r.1191del`. Pre-#843 the allele's
+/// `predict_rna` read the primary (GRCh38) transcript, so the GRCh37 allele did
+/// not produce its build-correct `r.` (it degraded to none/primary). Post-fix it
+/// matches the build-scoped parented-c oracle. (The GRCh38 companion is checked
+/// in the same test to lock the builds apart.)
+#[test]
+fn g_allele_predict_rna_is_build_scoped_on_real_reference() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_843: skipping — no manifest");
+        return;
+    };
+    let Some(o) = oracle(&vp) else {
+        eprintln!("issue_843: skipping — parented-c oracle unavailable (data drift)");
+        return;
+    };
+
+    // Pin the divergence premise: the two builds' parented oracles must differ,
+    // else this transcript no longer exercises the bug (guards against silent
+    // data drift that would make the test a tautology).
+    assert_ne!(
+        o.c37_body, o.c38_body,
+        "test premise broken: XM_005254401.2 c.1191del no longer 3'-shifts \
+         differently across builds (37={}, 38={}); pick a new divergent locus",
+        o.c37_body, o.c38_body
+    );
+
+    // Bare g. alleles, each on its own build's genomic coordinate.
+    let g37 = allele_rna(&vp, "NC_000015.9", o.g37_pos)
+        .map(|r| rna_edit_body(&r))
+        .expect(
+            "GRCh37 bare g. allele MUST predict an r.; a missing prediction means \
+             predict_rna read the wrong (primary-build) transcript (#843 pre-fix)",
+        );
+    let g38 = allele_rna(&vp, "NC_000015.10", o.g38_pos)
+        .map(|r| rna_edit_body(&r))
+        .expect("GRCh38 bare g. allele MUST predict an r.");
+
+    // Each bare g. allele must equal its OWN build's oracle, not the primary's.
+    assert_eq!(
+        g37, o.c37_body,
+        "GRCh37 g. allele r. ({g37}) must match the GRCh37 oracle ({}); \
+         a mismatch (esp. equal to the GRCh38 value {}) means predict_rna read \
+         the primary (GRCh38) transcript",
+        o.c37_body, o.c38_body
+    );
+    assert_eq!(
+        g38, o.c38_body,
+        "GRCh38 g. allele r. ({g38}) must match the GRCh38 oracle ({})",
+        o.c38_body
+    );
+    // And the two builds must remain distinct end-to-end.
+    assert_ne!(
+        g37, g38,
+        "GRCh37 and GRCh38 g. alleles must predict build-distinct r."
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -188,6 +188,7 @@ mod issue_502_np_protein_selector;
 mod issue_537_pter_qter_genomic;
 mod issue_573_intronic_shuffle_window;
 mod issue_736_rna_uracil_normalize;
+mod issue_843_allele_rna_build_scoping;
 mod issue_91_protein_three_prime_shift;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;


### PR DESCRIPTION
Closes #843.

**Stacked on #838** (`fix/issue-693-rna-description-corpus`, which itself carries #693's `rna_description` wiring and #840's `#753` noncoding wiring) — base this PR on that branch, not `main`. The diff is only #843's change.

## The bug

`project_allele_inner` fetched the transcript for `predict_rna` via the raw allele input. For a bare `g.` allele the member `NC_*` accession is build-bearing (`NC_*.10` = GRCh37 / `.11` = GRCh38) but carries **no** `genomic_context`, so `parent_key_for` returned `None` and `cached_get_transcript_for_variant` resolved the **build-agnostic primary (GRCh38)** transcript regardless of the input's build. `predict_rna` then ran its deletion 3'-shift / range-insert resolution against the **wrong build's bases**, emitting a wrong-build `r.` for a GRCh37 `g.` allele.

This diverged from the rest of the pipeline: the single genome-pivot path (`project_single_inner`) already stamps the projected `NC_` accession as `genomic_context` on a parallel `cache_variant` precisely so the transcript/ref caches partition by build (see `caches_partition_by_genome_build_for_nc_inputs`). The inner allele members project against GRCh37 exons, but the allele's `predict_rna` read the GRCh38 transcript.

## The fix (two sites)

A new `predict_rna_transcript` helper builds a `cache_variant` that stamps the build-bearing accession (`rna_build_context`: the input's `genomic_context` parent if present, else its own build-bearing `NC_*` accession) before the fetch — mirroring the genome-pivot path's mechanism — so the fetch partitions by build.

- **Allele site** (`project_allele_inner`): the reachable fix. A bare `g.` allele on `NC_*.10` now reads the GRCh37 transcript.
- **`project_coding_direct` site**: applied for consistency, but a **latent no-op** — that path is reached only for a bare-`NM_` c. input (`genomic_context.is_none()` gates the dispatch), which carries no genome build, so `rna_build_context` returns `None` and the fetch is byte-identical to before. Routing every `predict_rna` fetch through one build-aware helper means a future build-bearing input reaching it would be scoped automatically.

### Why CodeRabbit's suggestion was insufficient

CodeRabbit suggested "reuse the parent-aware cache identity." That only helps an input that already carries a `genomic_context`. A bare `g.` allele has **none** — its build lives in the `accession` itself — so the parent-aware identity is `None` and nothing changes. The fix must stamp the build-bearing `NC_*` accession as the context, which is what the genome-pivot path does.

## Tests (TDD, true red→green)

- **MockProvider** gains `add_transcript_on_build` + a build-aware `get_transcript_for_accession` override (a no-op unless build-keyed transcripts are registered) so a hermetic fixture can model build-divergent transcript bases — the real divergence only genome-reconstructed transcripts exhibit (FASTA-backed transcripts serve build-identical bases).
- **Hermetic unit tests** (`allele_predicted_rna_is_build_scoped`, `allele_predicted_rna_does_not_pollute_cache_with_parentless_key`): a `g.` allele on GRCh37 vs GRCh38 over a transcript whose bases differ at a deletion 3'-shift boundary. Verified: pre-fix both emit the GRCh38 `r.(9del)` and a stray `(id, None)` cache key; post-fix GRCh37 → `r.(7del)`, GRCh38 → `r.(9del)`, no stray key. The cache assertion targets the `(id, None)`-absence signal specifically (the build-distinct keys are created by the member genome-pivots regardless of the bug, so their presence is not a fix signal).
- **Manifest-gated integration test** (`tests/it/issue_843_allele_rna_build_scoping.rs`) on the real dual-build reference: `XM_005254401.2:c.1191del` 3'-shifts to `r.1193del` on GRCh37 (`NC_000015.9`) but `r.1191del` on GRCh38 (`NC_000015.10`). Pre-fix the GRCh37 bare `g.` allele fails to predict an `r.` at all (wrong-build transcript); post-fix it matches the build-scoped parented-c oracle. Skips when `FERRO_MANIFEST` is unset.

## Non-regression

- The existing GRCh38-primary `NG_012337.1(NM_003002.2)` `rna_description` allele case is unchanged: the NG parent is reused as the context → byte-identical fetch. The `axis_rna_description` corpus test passes with the manifest.
- Full suite (`cargo nextest run --features dev --run-ignored all`, `FERRO_MANIFEST` set) vs the unmodified base: **identical 42-failure set, zero new failures** (the 42 are pre-existing env/oracle-dependent biocommons/UTA/gnomad/mutalyzer-axis cases).
- `cargo clippy --features dev --all-targets -- -D warnings`: clean. `cargo fmt --all --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed predicted-RNA allele projection to use the transcript sequence from the correct genome build when starting from build-scoped genomic variants.
  * Improved build-aware transcript resolution so predicted `r.` allele results match the originating build and avoid incorrect cross-build fallback.

* **Tests**
  * Added an integration test for issue `#843` validating build-scoped predicted-`r.` allele outputs for `g.` inputs on both GRCh37 and GRCh38, including expected transcript selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->