### PR TITLE
feat(prepare): version-aware transcript backfill (#842)

### DIFF
--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1515,6 +1515,7 @@ fn run_prepare_tool(
                 patterns_file: None,
                 validate_canonical_accessions: None,
                 derive_ng_placements: None,
+                backfill_transcripts: None,
                 genome: match genome {
                     GenomeOption::None => "none".to_string(),
                     GenomeOption::Grch37 => "grch37".to_string(),

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -542,6 +542,19 @@ enum Commands {
         #[arg(long)]
         derive_ng_placements: Option<PathBuf>,
 
+        /// Newline-delimited file of exact `accession.version`s (e.g.
+        /// `NM_002001.2`) to backfill at prepare time (#842): for each that is
+        /// present in cdot but absent from the bulk RefSeq RNA FASTA, fetch its
+        /// deposited sequence and append it to `backfill/backfill_transcripts.fna`,
+        /// wiring the manifest field so the primary path serves it instead of
+        /// synthesizing lossy bases from the genome. Requires cdot (downloaded
+        /// in this run or already in the reference). Networked (NCBI EFetch per
+        /// accession); per-accession failures warn and continue.
+        ///
+        /// Example: `ferro prepare --backfill-transcripts targets.txt`
+        #[arg(long)]
+        backfill_transcripts: Option<PathBuf>,
+
         /// Dry run - show what would be downloaded without downloading
         #[arg(long)]
         dry_run: bool,
@@ -871,6 +884,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             validate_canonical,
             ensembl,
             derive_ng_placements,
+            backfill_transcripts,
             dry_run,
         } => run_prepare(
             &output_dir,
@@ -886,6 +900,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             validate_canonical.as_deref(),
             ensembl,
             derive_ng_placements,
+            backfill_transcripts,
             dry_run,
         ),
         Commands::Check {
@@ -3238,6 +3253,7 @@ fn run_prepare(
     validate_canonical: Option<&Path>,
     ensembl: bool,
     derive_ng_placements: Option<PathBuf>,
+    backfill_transcripts: Option<PathBuf>,
     dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::prepare::{prepare_references, PrepareConfig};
@@ -3258,6 +3274,7 @@ fn run_prepare(
         patterns_file: patterns.map(|p| p.to_path_buf()),
         validate_canonical_accessions: validate_canonical.map(|p| p.to_path_buf()),
         derive_ng_placements,
+        backfill_transcripts,
         genome: genome.to_string(),
         dry_run,
     };

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -317,6 +317,10 @@ pub fn print_check_summary(result: &CheckResult, reference_dir: &Path) {
         eprintln!("  Supplemental transcripts: {}", supp.display());
     }
 
+    if let Some(ref backfill) = manifest.backfill_transcripts_fasta {
+        eprintln!("  Backfilled transcripts: {}", backfill.display());
+    }
+
     if let Some(ref legacy) = manifest.legacy_transcripts_fasta {
         eprintln!("  Legacy transcripts: {}", legacy.display());
     }
@@ -386,6 +390,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -442,6 +447,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -500,6 +506,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -558,6 +565,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -616,6 +624,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -674,6 +683,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -732,6 +742,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),
@@ -790,6 +801,7 @@ mod tests {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: dir.path().to_path_buf(),

--- a/src/prepare/backfill.rs
+++ b/src/prepare/backfill.rs
@@ -1,0 +1,381 @@
+//! Version-aware transcript backfill for `ferro prepare` (issue #842).
+//!
+//! `ferro prepare` populates the transcript FASTA from NCBI's **bulk** RefSeq
+//! RNA release, a current-snapshot product that carries roughly one version per
+//! accession. cdot, downloaded separately, carries exon alignments for many
+//! **historical** versions. When a query names a superseded version whose bases
+//! are absent from the prepared FASTA but whose alignment is in cdot, the
+//! provider falls back to reconstructing bases from the genome via the cdot exon
+//! CIGAR — a lossy path that cannot see deposited-transcript substitutions
+//! (#807/#471/#400).
+//!
+//! This module closes that reference-coverage gap at prepare time: it diffs the
+//! `accession.version` keys present in cdot against those present in the
+//! transcript FASTA(s), then fetches the deposited sequence for the missing ones
+//! and appends them to a backfill FASTA so the primary FASTA path serves them
+//! and synthesis is never invoked for those accessions.
+//!
+//! The network fetch is injected (see [`execute_backfill`]), so the diff +
+//! append logic is unit-testable with a mocked fetcher and CI stays offline. The
+//! design mirrors [`crate::reference::authoritative::build_canonical_overrides`].
+
+use crate::FerroError;
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+/// The result of diffing a requested accession set against cdot and the
+/// transcript FASTA(s).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BackfillPlan {
+    /// Requested accessions that are in cdot but absent from the FASTA — these
+    /// are the genuine gap to fetch. Sorted and deduplicated.
+    pub to_fetch: Vec<String>,
+    /// Requested accessions already present in the transcript FASTA(s) (which
+    /// includes any prior backfill output) — skipped as an incremental-cache
+    /// hit. Sorted and deduplicated.
+    pub already_present: Vec<String>,
+    /// Requested accessions absent from cdot — fetched bases would still serve
+    /// the primary path, but with no exon alignment they fall outside the
+    /// cdot-vs-FASTA gap this feature targets, so they are reported and skipped.
+    /// Sorted and deduplicated.
+    pub not_in_cdot: Vec<String>,
+}
+
+/// Diff `requested` against the `accession.version` keys present in cdot and in
+/// the transcript FASTA(s), classifying each requested accession.
+///
+/// Classification is order-independent and deterministic: an accession already
+/// present in the FASTA is always `already_present` (so a re-run never re-fetches
+/// it); otherwise an accession in cdot is `to_fetch` and one absent from cdot is
+/// `not_in_cdot`. Each output list is sorted and deduplicated.
+pub fn plan_backfill(
+    requested: &[String],
+    cdot_versions: &HashSet<String>,
+    present_versions: &HashSet<String>,
+) -> BackfillPlan {
+    let mut to_fetch = Vec::new();
+    let mut already_present = Vec::new();
+    let mut not_in_cdot = Vec::new();
+
+    for acc in requested {
+        if present_versions.contains(acc) {
+            already_present.push(acc.clone());
+        } else if cdot_versions.contains(acc) {
+            to_fetch.push(acc.clone());
+        } else {
+            not_in_cdot.push(acc.clone());
+        }
+    }
+
+    for v in [&mut to_fetch, &mut already_present, &mut not_in_cdot] {
+        v.sort();
+        v.dedup();
+    }
+
+    BackfillPlan {
+        to_fetch,
+        already_present,
+        not_in_cdot,
+    }
+}
+
+/// The outcome of fetching and appending the planned accessions.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BackfillOutcome {
+    /// Accessions whose deposited sequence was fetched and appended.
+    pub fetched: Vec<String>,
+    /// Accessions whose fetch or parse failed (warned, but not fatal).
+    pub failed: Vec<String>,
+}
+
+/// Extract the concatenated, upper-cased sequence from a single FASTA record,
+/// validating that the record's header accession equals `expected`.
+///
+/// The header token compared is the first whitespace-delimited field after the
+/// leading `>` (e.g. `>NM_000088.3 Homo sapiens ...` → `NM_000088.3`). A header
+/// whose accession differs from `expected` is rejected (returns `None`): NCBI
+/// efetch resolves a bare accession to its current version, so this guard keeps
+/// us from writing a *different* version's bases under the requested key (the
+/// same requested-vs-fetched check `build_canonical_overrides` applies). An empty
+/// sequence also returns `None`.
+pub fn parse_fasta_record(text: &str, expected: &str) -> Option<String> {
+    let mut lines = text.lines();
+    let header = lines.next()?;
+    let accession = header.strip_prefix('>')?.split_whitespace().next()?;
+    if accession != expected {
+        return None;
+    }
+    // Keep only the first record's bases: stop at the next record header so a
+    // multi-record efetch response (or trailing text) can't be folded in.
+    let sequence: String = lines
+        .take_while(|line| !line.starts_with('>'))
+        .flat_map(str::chars)
+        .filter(|c| c.is_ascii_alphabetic())
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+    if sequence.is_empty() {
+        None
+    } else {
+        Some(sequence)
+    }
+}
+
+/// Fetch each accession in `to_fetch` via the injected `fetch` and append its
+/// sequence to `backfill_fasta`, returning which accessions were written vs
+/// failed.
+///
+/// `fetch` is the FASTA-text source: given an exact versioned accession it
+/// returns the efetch FASTA record text, or `None` on a fetch failure. Injecting
+/// it keeps this orchestration network-free and testable.
+///
+/// The output is opened in **append** mode, and only **lazily on the first
+/// successful record**, so an incremental re-run adds only the newly planned
+/// records and a run where every fetch fails (or `to_fetch` is empty) leaves no
+/// orphan 0-byte file behind — mirroring the no-orphan-empty-file rule in
+/// `fetch_canonical_overrides`. The caller reindexes the whole file afterward.
+/// Records are written `>{accession}\n` followed by the sequence wrapped at 70
+/// columns, so the resulting `.fai` key is exactly the requested
+/// `accession.version`.
+///
+/// A per-accession fetch, parse, or version-mismatch failure is collected into
+/// `BackfillOutcome::failed` and does not abort; only an I/O error on the output
+/// file returns `Err`.
+pub fn execute_backfill<F>(
+    to_fetch: &[String],
+    backfill_fasta: &Path,
+    mut fetch: F,
+) -> Result<BackfillOutcome, FerroError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut outcome = BackfillOutcome::default();
+    // Created lazily on the first record actually written, so a fully-failed or
+    // empty run never orphans a 0-byte FASTA.
+    let mut writer: Option<BufWriter<std::fs::File>> = None;
+
+    for acc in to_fetch {
+        let Some(sequence) = fetch(acc)
+            .as_deref()
+            .and_then(|t| parse_fasta_record(t, acc))
+        else {
+            outcome.failed.push(acc.clone());
+            continue;
+        };
+
+        if writer.is_none() {
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(backfill_fasta)
+                .map_err(|e| FerroError::Io {
+                    msg: format!(
+                        "Failed to open backfill FASTA {}: {}",
+                        backfill_fasta.display(),
+                        e
+                    ),
+                })?;
+            writer = Some(BufWriter::new(file));
+        }
+        let w = writer.as_mut().expect("writer initialized above");
+
+        writeln!(w, ">{}", acc).map_err(|e| FerroError::Io {
+            msg: format!("Failed to write backfill record {}: {}", acc, e),
+        })?;
+        for chunk in sequence.as_bytes().chunks(70) {
+            writeln!(w, "{}", std::str::from_utf8(chunk).unwrap_or("")).map_err(|e| {
+                FerroError::Io {
+                    msg: format!("Failed to write backfill sequence {}: {}", acc, e),
+                }
+            })?;
+        }
+        outcome.fetched.push(acc.clone());
+    }
+
+    if let Some(mut w) = writer {
+        w.flush().map_err(|e| FerroError::Io {
+            msg: format!("Failed to flush backfill FASTA: {}", e),
+        })?;
+    }
+
+    Ok(outcome)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::fs;
+
+    fn set(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn vec_of(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ---- plan_backfill ----
+
+    #[test]
+    fn plan_identifies_exactly_the_missing() {
+        let plan = plan_backfill(
+            &vec_of(&["NM_A.1", "NM_B.2", "NM_C.3"]),
+            &set(&["NM_A.1", "NM_B.2", "NM_C.3", "NM_D.4"]),
+            &set(&["NM_A.1"]),
+        );
+        assert_eq!(plan.to_fetch, vec_of(&["NM_B.2", "NM_C.3"]));
+        assert_eq!(plan.already_present, vec_of(&["NM_A.1"]));
+        assert!(plan.not_in_cdot.is_empty());
+    }
+
+    #[test]
+    fn plan_routes_not_in_cdot_never_to_fetch() {
+        let plan = plan_backfill(&vec_of(&["NM_GHOST.9"]), &set(&["NM_A.1"]), &set(&[]));
+        assert!(plan.to_fetch.is_empty());
+        assert_eq!(plan.not_in_cdot, vec_of(&["NM_GHOST.9"]));
+    }
+
+    #[test]
+    fn plan_present_wins_for_incremental_rerun() {
+        // An accession already written by a prior backfill (so in present_versions)
+        // must be skipped even though it is also in cdot.
+        let plan = plan_backfill(&vec_of(&["NM_B.2"]), &set(&["NM_B.2"]), &set(&["NM_B.2"]));
+        assert!(plan.to_fetch.is_empty());
+        assert_eq!(plan.already_present, vec_of(&["NM_B.2"]));
+    }
+
+    #[test]
+    fn plan_sorts_and_deduplicates() {
+        let plan = plan_backfill(
+            &vec_of(&["NM_C.3", "NM_B.2", "NM_B.2", "NM_A.1"]),
+            &set(&["NM_A.1", "NM_B.2", "NM_C.3"]),
+            &set(&[]),
+        );
+        assert_eq!(plan.to_fetch, vec_of(&["NM_A.1", "NM_B.2", "NM_C.3"]));
+    }
+
+    #[test]
+    fn plan_empty_requested_is_empty() {
+        let plan = plan_backfill(&[], &set(&["NM_A.1"]), &set(&[]));
+        assert_eq!(plan, BackfillPlan::default());
+    }
+
+    // ---- parse_fasta_record ----
+
+    #[test]
+    fn parse_extracts_sequence_uppercased() {
+        let text = ">NM_000088.3 Homo sapiens\nacgt\nACGT\n";
+        assert_eq!(
+            parse_fasta_record(text, "NM_000088.3"),
+            Some("ACGTACGT".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_rejects_header_accession_mismatch() {
+        // efetch resolved the bare accession to a newer version: reject it.
+        let text = ">NM_000088.4 newer version\nACGT\n";
+        assert_eq!(parse_fasta_record(text, "NM_000088.3"), None);
+    }
+
+    #[test]
+    fn parse_keeps_only_first_record_bases() {
+        // A multi-record response must not fold the second record's bases in.
+        let text = ">NM_A.1 first\nACGT\n>NM_B.2 second\nTTTT\n";
+        assert_eq!(parse_fasta_record(text, "NM_A.1"), Some("ACGT".to_string()));
+    }
+
+    #[test]
+    fn parse_rejects_empty_sequence() {
+        let text = ">NM_000088.3 header only\n";
+        assert_eq!(parse_fasta_record(text, "NM_000088.3"), None);
+    }
+
+    // ---- execute_backfill ----
+
+    #[test]
+    fn execute_appends_fetched_records_with_accession_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        let outcome = execute_backfill(&vec_of(&["NM_A.1", "NM_B.2"]), &fasta, |acc| {
+            Some(format!(">{} desc\nACGTACGT\n", acc))
+        })
+        .unwrap();
+        assert_eq!(outcome.fetched, vec_of(&["NM_A.1", "NM_B.2"]));
+        assert!(outcome.failed.is_empty());
+
+        let body = fs::read_to_string(&fasta).unwrap();
+        assert!(body.contains(">NM_A.1\n"));
+        assert!(body.contains(">NM_B.2\n"));
+        assert_eq!(body.matches('>').count(), 2);
+    }
+
+    #[test]
+    fn execute_continues_on_fetch_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        let outcome = execute_backfill(&vec_of(&["NM_OK.1", "NM_BAD.2"]), &fasta, |acc| {
+            (acc == "NM_OK.1").then(|| format!(">{} desc\nACGT\n", acc))
+        })
+        .unwrap();
+        assert_eq!(outcome.fetched, vec_of(&["NM_OK.1"]));
+        assert_eq!(outcome.failed, vec_of(&["NM_BAD.2"]));
+    }
+
+    #[test]
+    fn execute_rejects_version_mismatch_as_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        let outcome = execute_backfill(&vec_of(&["NM_X.1"]), &fasta, |_acc| {
+            // efetch returns the *current* version, not the requested .1.
+            Some(">NM_X.2 newer\nACGT\n".to_string())
+        })
+        .unwrap();
+        assert!(outcome.fetched.is_empty());
+        assert_eq!(outcome.failed, vec_of(&["NM_X.1"]));
+        // Nothing written for the mismatched record.
+        let body = fs::read_to_string(&fasta).unwrap_or_default();
+        assert!(!body.contains('>'));
+    }
+
+    #[test]
+    fn execute_appends_incrementally_without_clobbering() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        execute_backfill(&vec_of(&["NM_A.1"]), &fasta, |acc| {
+            Some(format!(">{} desc\nACGT\n", acc))
+        })
+        .unwrap();
+        execute_backfill(&vec_of(&["NM_B.2"]), &fasta, |acc| {
+            Some(format!(">{} desc\nGGGG\n", acc))
+        })
+        .unwrap();
+        let body = fs::read_to_string(&fasta).unwrap();
+        assert!(body.contains(">NM_A.1\n"), "first record preserved");
+        assert!(body.contains(">NM_B.2\n"), "second record appended");
+    }
+
+    #[test]
+    fn execute_leaves_no_orphan_file_when_all_fetches_fail() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        let outcome = execute_backfill(&vec_of(&["NM_A.1", "NM_B.2"]), &fasta, |_| None).unwrap();
+        assert!(outcome.fetched.is_empty());
+        assert_eq!(outcome.failed, vec_of(&["NM_A.1", "NM_B.2"]));
+        assert!(
+            !fasta.exists(),
+            "a fully-failed run must not orphan a 0-byte FASTA"
+        );
+    }
+
+    #[test]
+    fn execute_empty_plan_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let fasta = dir.path().join("backfill.fna");
+        let outcome = execute_backfill(&[], &fasta, |_| panic!("must not fetch")).unwrap();
+        assert_eq!(outcome, BackfillOutcome::default());
+        assert!(!fasta.exists(), "no file created for an empty plan");
+    }
+}

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -97,6 +97,14 @@ pub struct ReferenceManifest {
     /// Supplemental FASTA file (missing ClinVar transcripts fetched from NCBI)
     #[serde(default)]
     pub supplemental_fasta: Option<PathBuf>,
+    /// Version-aware backfill FASTA (#842): deposited sequences for
+    /// `accession.version`s that are present in cdot but absent from the bulk
+    /// RefSeq RNA feed, fetched by `ferro prepare --backfill-transcripts`. The
+    /// provider ingests it as a transcript FASTA so the primary path serves
+    /// those versions directly instead of synthesizing lossy bases from the
+    /// genome via the cdot exon CIGAR.
+    #[serde(default)]
+    pub backfill_transcripts_fasta: Option<PathBuf>,
     /// Legacy transcript versions FASTA (older versions not in current RefSeq)
     #[serde(default)]
     pub legacy_transcripts_fasta: Option<PathBuf>,
@@ -156,6 +164,7 @@ impl Default for ReferenceManifest {
             legacy_genbank_fasta: None,
             legacy_genbank_metadata: None,
             canonical_overrides: None,
+            backfill_transcripts_fasta: None,
             transcript_count: 0,
             available_prefixes: Vec::new(),
             reference_dir: PathBuf::new(),
@@ -303,6 +312,7 @@ impl ReferenceManifest {
             &self.legacy_genbank_fasta,
             &self.legacy_genbank_metadata,
             &self.canonical_overrides,
+            &self.backfill_transcripts_fasta,
         ]
         .into_iter()
         .flatten()
@@ -347,6 +357,7 @@ impl ReferenceManifest {
             &mut self.legacy_genbank_fasta,
             &mut self.legacy_genbank_metadata,
             &mut self.canonical_overrides,
+            &mut self.backfill_transcripts_fasta,
         ] {
             if let Some(p) = o.as_mut() {
                 f(p);
@@ -583,6 +594,7 @@ mod tests {
             legacy_genbank_fasta: Some(ref_dir.join("genbank.fa")),
             legacy_genbank_metadata: Some(ref_dir.join("genbank.json")),
             canonical_overrides: None,
+            backfill_transcripts_fasta: Some(ref_dir.join("backfill/backfill_transcripts.fna")),
             transcript_count: 100,
             available_prefixes: vec!["NM".to_string()],
             reference_dir: ref_dir.to_path_buf(),
@@ -843,6 +855,42 @@ mod tests {
             loaded.ng_hosted_transcripts,
             Some(ref_dir.join("ng_hosted_transcripts.json"))
         );
+    }
+
+    #[test]
+    fn backfill_transcripts_fasta_path_roundtrips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path().to_path_buf();
+        let mut m = ReferenceManifest {
+            reference_dir: ref_dir.clone(),
+            backfill_transcripts_fasta: Some(ref_dir.join("backfill/backfill_transcripts.fna")),
+            ..Default::default()
+        };
+        m.save().unwrap();
+        // On-disk JSON stores the path relative to reference_dir.
+        let raw = std::fs::read_to_string(ref_dir.join("manifest.json")).unwrap();
+        assert!(raw.contains("backfill/backfill_transcripts.fna"));
+        assert!(!raw.contains(ref_dir.to_str().unwrap()));
+        // Reloading absolutizes it back under reference_dir.
+        let loaded = ReferenceManifest::load_or_default(&ref_dir).unwrap();
+        assert_eq!(
+            loaded.backfill_transcripts_fasta,
+            Some(ref_dir.join("backfill/backfill_transcripts.fna"))
+        );
+    }
+
+    #[test]
+    fn pre_842_manifest_without_backfill_field_loads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path();
+        // A manifest JSON with NO backfill_transcripts_fasta key (pre-#842).
+        std::fs::write(
+            ref_dir.join("manifest.json"),
+            r#"{"prepared_at":"","transcript_fastas":[],"genome_fasta":null,"cdot_json":null,"transcript_count":0,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+        let m = ReferenceManifest::load_or_default(ref_dir).unwrap();
+        assert_eq!(m.backfill_transcripts_fasta, None);
     }
 
     #[test]

--- a/src/prepare/mod.rs
+++ b/src/prepare/mod.rs
@@ -11,6 +11,7 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+pub mod backfill;
 pub mod manifest;
 pub use manifest::{check_references, ReferenceManifest};
 
@@ -65,6 +66,13 @@ pub struct PrepareConfig {
     /// Optional newline-delimited NG_ accession file; when set, prepare derives
     /// `derived_refseqgene_placements.json` and wires the manifest field.
     pub derive_ng_placements: Option<PathBuf>,
+    /// Optional newline-delimited `accession.version` file (#842); when set,
+    /// prepare backfills each listed transcript that is present in cdot but
+    /// absent from the bulk RefSeq RNA FASTA — fetching its deposited sequence
+    /// from NCBI and appending it to `backfill/backfill_transcripts.fna`, then
+    /// wiring the manifest field. Requires cdot in the same prepare run.
+    /// Networked; per-accession failures warn and continue.
+    pub backfill_transcripts: Option<PathBuf>,
     /// Genome build selection string ("grch38", "grch37", "all", "none").
     /// Stored so `builds_for_genome` can map it to build names at derivation time.
     pub genome: String,
@@ -90,6 +98,7 @@ impl Default for PrepareConfig {
             patterns_file: None,
             validate_canonical_accessions: None,
             derive_ng_placements: None,
+            backfill_transcripts: None,
             genome: "grch38".to_string(),
             dry_run: false,
         }
@@ -249,6 +258,26 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
 
     // Load existing manifest if present, else default
     let mut manifest = ReferenceManifest::load_or_default(&config.output_dir)?;
+
+    // Pre-flight: the version-aware backfill (#842) targets the cdot-vs-FASTA
+    // gap, so it needs cdot to know which versions are worth fetching — either
+    // downloaded in this run, or already on disk from a prior prepare (so a
+    // user can backfill a few accessions against an existing reference without
+    // re-downloading cdot). Reject a truly cdot-less selection up front.
+    if config.backfill_transcripts.is_some()
+        && !(config.download_cdot
+            || config.download_cdot_grch37
+            || manifest.cdot_json.is_some()
+            || manifest.cdot_grch37_json.is_some())
+    {
+        return Err(FerroError::Io {
+            msg: "--backfill-transcripts requires cdot, either downloaded in this run or \
+                  already present in the reference; the current selection (e.g. \
+                  --genome none or --no-cdot against a reference with no cdot) has none, \
+                  so the cdot-vs-FASTA version gap cannot be computed"
+                .to_string(),
+        });
+    }
 
     // Download transcripts
     if config.download_transcripts {
@@ -794,6 +823,15 @@ pub fn prepare_references(config: &PrepareConfig) -> Result<ReferenceManifest, F
         }
     }
 
+    // Version-aware transcript backfill (#842): fetch deposited sequences for
+    // requested accession.versions that are present in cdot but absent from the
+    // bulk transcript FASTA, append them to the backfill FASTA, and wire the
+    // manifest field so the provider serves them from the primary index path
+    // (synthesis is never invoked for those accessions). Networked; opt-in.
+    if let Some(acc_file) = config.backfill_transcripts.clone() {
+        backfill_transcripts_step(config, &mut manifest, &acc_file)?;
+    }
+
     manifest.save()?;
 
     // Derive version-independent NG_ placements (#728/#740) when requested.
@@ -902,6 +940,192 @@ fn write_ng_hosted_transcripts(
         msg: format!("write {}: {e}", out.display()),
     })?;
     Ok(out.to_path_buf())
+}
+
+/// Load the union of `accession.version` keys present in the manifest's cdot
+/// JSON file(s) (GRCh38 primary + GRCh37 secondary, whichever are present).
+///
+/// Used by the version-aware backfill (#842) to know which requested versions
+/// cdot actually carries an alignment for. A load failure for one file warns and
+/// is skipped (the other file's keys still count).
+fn load_cdot_versions(manifest: &ReferenceManifest) -> HashSet<String> {
+    let mut versions = HashSet::new();
+    for path in [&manifest.cdot_json, &manifest.cdot_grch37_json]
+        .into_iter()
+        .flatten()
+    {
+        // Use `load` (not `from_json_file`) so the rkyv cache built by
+        // `download_cdot` is reused instead of re-parsing the ~200MB JSON.
+        match crate::data::cdot::CdotMapper::load(path) {
+            Ok(mapper) => versions.extend(mapper.transcript_ids().map(str::to_string)),
+            Err(e) => eprintln!(
+                "  Warning: failed to load cdot {} for backfill diff: {}",
+                path.display(),
+                e
+            ),
+        }
+    }
+    versions
+}
+
+/// Version-aware transcript backfill (#842).
+///
+/// Reads the requested `accession.version` list, diffs it against the cdot keys
+/// and the transcript-FASTA keys, fetches the genuine gap (in cdot, absent from
+/// the FASTA) from NCBI, appends it to `backfill/backfill_transcripts.fna`,
+/// reindexes, and wires the manifest field. Per-accession fetch failures warn and
+/// continue; the prepare run is never aborted by them.
+fn backfill_transcripts_step(
+    config: &PrepareConfig,
+    manifest: &mut ReferenceManifest,
+    acc_file: &Path,
+) -> Result<(), FerroError> {
+    use backfill::{execute_backfill, plan_backfill};
+
+    eprintln!("\n=== Version-aware transcript backfill (#842) ===");
+    let requested = read_accession_list(acc_file)?;
+    eprintln!("  {} requested accession.version(s)", requested.len());
+
+    let backfill_dir = config.output_dir.join("backfill");
+    let backfill_fasta = backfill_dir.join("backfill_transcripts.fna");
+
+    if config.dry_run {
+        eprintln!(
+            "  [dry-run] would diff {} requested accessions against cdot + the \
+             transcript FASTA and backfill the gap into {}",
+            requested.len(),
+            backfill_fasta.display()
+        );
+        return Ok(());
+    }
+
+    // cdot keys (the alignment-bearing universe worth backfilling).
+    let cdot_versions = load_cdot_versions(manifest);
+    if cdot_versions.is_empty() {
+        return Err(FerroError::Io {
+            msg: "no cdot transcripts could be loaded for --backfill-transcripts; \
+                  refresh or re-download cdot in this reference before retrying"
+                .to_string(),
+        });
+    }
+
+    // `--force` (skip_existing == false): discard any prior backfill output so
+    // every requested accession is re-fetched, and so the append path never
+    // produces a duplicate `>accession` record (which would make `.fai` keys
+    // collide). In the default incremental mode the prior output is kept and
+    // folded into the present set below as the cache.
+    let force = !config.skip_existing;
+    if force {
+        let fai = PathBuf::from(format!("{}.fai", backfill_fasta.display()));
+        let _ = fs::remove_file(&backfill_fasta);
+        let _ = fs::remove_file(&fai);
+    }
+
+    // Present keys: bulk transcript FASTA + supplemental + (incremental only)
+    // any prior backfill output, so a re-run skips already-fetched accessions —
+    // the incremental cache. The backfill present set is read from the FASTA
+    // headers themselves (the file `execute_backfill` appends to), not its
+    // derived `.fai`: a prior run interrupted after the append but before
+    // reindex — or a deleted `.fai` — would otherwise look empty and re-fetch
+    // and re-append the same accession, duplicating its `>accession` record
+    // (and colliding `.fai` keys on the subsequent reindex).
+    let transcripts_dir = config.output_dir.join("transcripts");
+    let supplemental_dir = config.output_dir.join("supplemental");
+    let mut present = load_available_versions(&transcripts_dir, Some(&supplemental_dir));
+    if !force {
+        present.extend(load_fasta_header_accessions(&backfill_fasta));
+    }
+
+    let plan = plan_backfill(&requested, &cdot_versions, &present);
+    eprintln!(
+        "  {} to fetch, {} already present, {} not in cdot",
+        plan.to_fetch.len(),
+        plan.already_present.len(),
+        plan.not_in_cdot.len()
+    );
+    if !plan.not_in_cdot.is_empty() {
+        eprintln!(
+            "  Warning: {} requested accession(s) are absent from cdot and will not be \
+             backfilled (no exon alignment): {}",
+            plan.not_in_cdot.len(),
+            plan.not_in_cdot.join(", ")
+        );
+    }
+
+    if !plan.to_fetch.is_empty() {
+        fs::create_dir_all(&backfill_dir).map_err(|e| FerroError::Io {
+            msg: format!("Failed to create backfill directory: {}", e),
+        })?;
+        eprintln!(
+            "  Fetching {} deposited transcript sequence(s) from NCBI...",
+            plan.to_fetch.len()
+        );
+        let outcome = execute_backfill(&plan.to_fetch, &backfill_fasta, fetch_transcript_fasta)?;
+        eprintln!(
+            "  Backfilled {} sequence(s), {} failed",
+            outcome.fetched.len(),
+            outcome.failed.len()
+        );
+        if !outcome.failed.is_empty() {
+            eprintln!(
+                "  Warning: {} accession(s) could not be backfilled (fetch/parse/version \
+                 mismatch): {}",
+                outcome.failed.len(),
+                outcome.failed.join(", ")
+            );
+        }
+    }
+
+    // Wire the manifest field iff a non-empty backfill FASTA exists (newly
+    // written this run, or carried over from a prior incremental run); otherwise
+    // clear it so a deleted/empty file never leaves a dangling manifest
+    // reference. Mirrors the no-orphan rule in fetch_canonical_overrides.
+    let has_content = backfill_fasta
+        .metadata()
+        .map(|m| m.len() > 0)
+        .unwrap_or(false);
+    if has_content {
+        eprintln!("  Indexing backfill FASTA...");
+        index_fasta(&backfill_fasta)?;
+        manifest.backfill_transcripts_fasta = Some(backfill_fasta);
+    } else {
+        manifest.backfill_transcripts_fasta = None;
+    }
+
+    Ok(())
+}
+
+/// Fetch a transcript's deposited sequence from NCBI EFetch as FASTA text.
+///
+/// Returns the raw FASTA record (`>{accession.version} desc\n<bases>`) on success,
+/// or `None` on a fetch failure. `rettype=fasta` (not `gb`): the version-exact CDS
+/// frame comes from cdot, so only the bases are needed here. Same 100 ms NCBI
+/// rate-limit as the other efetch callers. The injected boundary for
+/// [`backfill::execute_backfill`]; tests supply fixtures instead.
+fn fetch_transcript_fasta(accession: &str) -> Option<String> {
+    let url = format!(
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=fasta&retmode=text",
+        accession
+    );
+    // `--fail` turns an HTTP 4xx/5xx into a non-zero exit (treated as a failed
+    // fetch below); the timeouts bound a single slow/stalled request so one
+    // accession cannot hang the whole prepare run.
+    let result = Command::new("curl")
+        .args([
+            "-sS",
+            "-L",
+            "--fail",
+            "--connect-timeout",
+            "10",
+            "--max-time",
+            "60",
+            &url,
+        ])
+        .output();
+    std::thread::sleep(std::time::Duration::from_millis(100)); // NCBI rate limit
+    let out = result.ok()?;
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+    (out.status.success() && text.starts_with('>')).then_some(text)
 }
 
 /// Fetch supplemental data from ClinVar/patterns (benchmark feature only)
@@ -1441,6 +1665,31 @@ fn load_available_versions(
     versions
 }
 
+/// Read the set of record accessions directly from a FASTA file's headers
+/// (`>{accession} description` → `accession`, the first whitespace-delimited
+/// token after `>`).
+///
+/// Unlike [`load_available_versions`], which scans the derived `.fai`, this
+/// reads the `.fna` itself — the source of truth for the incremental backfill
+/// cache, since [`backfill::execute_backfill`] appends to the `.fna`. A prior
+/// run interrupted after the append but before reindex, or a deleted `.fai`,
+/// would leave the index empty (or stale) and cause the same accession to be
+/// re-fetched and appended a second time. Returns an empty set if the file is
+/// absent or unreadable.
+fn load_fasta_header_accessions(fasta: &Path) -> HashSet<String> {
+    let mut versions = HashSet::new();
+    if let Ok(file) = File::open(fasta) {
+        for line in BufReader::new(file).lines().map_while(Result::ok) {
+            if let Some(rest) = line.strip_prefix('>') {
+                if let Some(acc) = rest.split_whitespace().next() {
+                    versions.insert(acc.to_string());
+                }
+            }
+        }
+    }
+    versions
+}
+
 /// Extract versioned accessions from patterns file.
 ///
 /// Filters to only transcript accessions (NM_, NR_, XM_, XR_) with version numbers.
@@ -1912,6 +2161,69 @@ mod tests {
     }
 
     #[test]
+    fn test_backfill_transcripts_step_errors_when_no_cdot_loaded() {
+        // #842: an explicit `--backfill-transcripts` run against a reference
+        // whose cdot cannot be loaded (empty version universe) must fail loudly
+        // rather than succeed as a warning-only no-op — otherwise a stale or
+        // corrupt manifest silently produces no backfill output.
+        let temp_dir = TempDir::new().unwrap();
+        let acc_file = temp_dir.path().join("accessions.txt");
+        std::fs::write(&acc_file, "NM_000088.3\n").unwrap();
+
+        let config = PrepareConfig {
+            output_dir: temp_dir.path().to_path_buf(),
+            dry_run: false,
+            ..PrepareConfig::default()
+        };
+        // Default manifest carries no cdot paths, so `load_cdot_versions`
+        // returns an empty set.
+        let mut manifest = ReferenceManifest::default();
+
+        let err = backfill_transcripts_step(&config, &mut manifest, &acc_file)
+            .expect_err("empty cdot must abort the backfill step");
+        match err {
+            FerroError::Io { msg } => {
+                assert!(
+                    msg.contains("no cdot transcripts could be loaded"),
+                    "unexpected error message: {msg}"
+                );
+            }
+            other => panic!("expected FerroError::Io, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_load_fasta_header_accessions_reads_unindexed_fna() {
+        // #842 regression: the incremental backfill cache must reflect what is
+        // actually in backfill_transcripts.fna even when its `.fai` is missing
+        // (e.g. a prior run was interrupted after the append but before reindex,
+        // or the index was deleted). Reading only the `.fai` would treat the
+        // file as empty and re-append the same accession, duplicating the
+        // `>accession` record.
+        let dir = TempDir::new().unwrap();
+        let fasta = dir.path().join("backfill_transcripts.fna");
+        let mut f = File::create(&fasta).unwrap();
+        writeln!(f, ">NM_000088.3 Homo sapiens collagen").unwrap();
+        writeln!(f, "ACGTACGT").unwrap();
+        writeln!(f, ">NM_000001.1 some description").unwrap();
+        writeln!(f, "GGGGCCCC").unwrap();
+        drop(f);
+        // Deliberately no `.fai` written alongside the `.fna`.
+
+        let present = load_fasta_header_accessions(&fasta);
+        assert_eq!(present.len(), 2);
+        assert!(present.contains("NM_000088.3"));
+        assert!(present.contains("NM_000001.1"));
+    }
+
+    #[test]
+    fn test_load_fasta_header_accessions_absent_file_is_empty() {
+        let dir = TempDir::new().unwrap();
+        let present = load_fasta_header_accessions(&dir.path().join("missing.fna"));
+        assert!(present.is_empty());
+    }
+
+    #[test]
     fn test_detect_patterns_from_ferro_reference_with_patterns() {
         let temp_dir = TempDir::new().unwrap();
         let ferro_ref = temp_dir.path();
@@ -2051,6 +2363,35 @@ mod tests {
     fn prepare_config_default_has_no_derive_ng() {
         let cfg = PrepareConfig::default();
         assert!(cfg.derive_ng_placements.is_none());
+    }
+
+    #[test]
+    fn prepare_config_default_has_no_backfill() {
+        let cfg = PrepareConfig::default();
+        assert!(cfg.backfill_transcripts.is_none());
+    }
+
+    #[test]
+    fn backfill_requires_cdot_in_same_run() {
+        // A cdot-less selection (no GRCh38/GRCh37 cdot) must be rejected up front,
+        // before any downloads, mirroring the --derive-ng-placements guard.
+        let tmp = tempfile::tempdir().unwrap();
+        let acc_file = tmp.path().join("targets.txt");
+        std::fs::write(&acc_file, "NM_002001.2\n").unwrap();
+        let config = PrepareConfig {
+            output_dir: tmp.path().join("ref"),
+            download_transcripts: false,
+            download_genome: false,
+            download_cdot: false,
+            download_cdot_grch37: false,
+            backfill_transcripts: Some(acc_file),
+            ..Default::default()
+        };
+        let err = prepare_references(&config).expect_err("cdot-less backfill must be rejected");
+        assert!(
+            format!("{err}").contains("--backfill-transcripts requires cdot"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -3180,7 +3180,8 @@ impl PyPrepareConfig {
         skip_existing=true,
         dry_run=false,
         download_cdot_grch37=false,
-        download_ensembl=false
+        download_ensembl=false,
+        backfill_transcripts=None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -3195,6 +3196,7 @@ impl PyPrepareConfig {
         dry_run: bool,
         download_cdot_grch37: bool,
         download_ensembl: bool,
+        backfill_transcripts: Option<&str>,
     ) -> Self {
         Self {
             inner: PrepareConfig {
@@ -3213,6 +3215,7 @@ impl PyPrepareConfig {
                 patterns_file: None,
                 validate_canonical_accessions: None,
                 derive_ng_placements: None,
+                backfill_transcripts: backfill_transcripts.map(std::path::PathBuf::from),
                 genome: "grch38".to_string(),
                 dry_run,
             },
@@ -3247,6 +3250,14 @@ impl PyPrepareConfig {
     #[getter]
     fn download_ensembl(&self) -> bool {
         self.inner.download_ensembl
+    }
+
+    #[getter]
+    fn backfill_transcripts(&self) -> Option<String> {
+        self.inner
+            .backfill_transcripts
+            .as_ref()
+            .map(|p| p.display().to_string())
     }
 }
 

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -802,6 +802,29 @@ impl MultiFastaProvider {
             }
         }
 
+        // Version-aware backfill FASTA (#842): deposited sequences for
+        // accession.versions present in cdot but absent from the bulk RNA feed.
+        // Scanning its directory ensures the backfilled `accession.version` is
+        // served by the primary index path (version-exact cdot metadata), so the
+        // lossy genome+CIGAR synthesis fallback is never reached for it.
+        if let Some(backfill) = manifest
+            .get("backfill_transcripts_fasta")
+            .and_then(|v| v.as_str())
+        {
+            let path = resolve_path(backfill);
+            let fai = PathBuf::from(format!("{}.fai", path.display()));
+            if !path.exists() || !fai.exists() {
+                warn!(
+                    "Backfill transcript FASTA or its .fai is missing: {}; skipping backfill index",
+                    path.display()
+                );
+            } else if let Some(backfill_dir) = path.parent() {
+                if !dirs.contains(&backfill_dir.to_path_buf()) {
+                    dirs.push(backfill_dir.to_path_buf());
+                }
+            }
+        }
+
         if dirs.is_empty() {
             return Err(FerroError::Io {
                 msg: "No FASTA directories found in manifest".to_string(),
@@ -3958,6 +3981,100 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
         assert!(
             cdot.get_transcript("NM_000088.3").is_some(),
             "RefSeq transcript still resolves in cdot"
+        );
+    }
+
+    #[test]
+    fn from_manifest_serves_backfilled_transcript_from_index() {
+        // #842: a backfill FASTA named in the manifest (in its own subdir, NOT
+        // the bulk transcript dir) must be ingested so the accession.version is
+        // served from the primary index path rather than synthesized.
+        use crate::reference::ReferenceProvider;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // Bulk transcript FASTA that does NOT contain the superseded version.
+        fs::write(d.join("tx.fna"), ">NM_000088.4\nAAAA\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000088.4\t4\t13\t4\t5\n").unwrap();
+
+        // Backfill FASTA in its own dedicated `backfill/` subdir, carrying the
+        // superseded version's deposited bases.
+        let backfill_dir = d.join("backfill");
+        fs::create_dir_all(&backfill_dir).unwrap();
+        fs::write(
+            backfill_dir.join("backfill_transcripts.fna"),
+            ">NM_000088.3\nACGTACGT\n",
+        )
+        .unwrap();
+        fs::write(
+            backfill_dir.join("backfill_transcripts.fna.fai"),
+            "NM_000088.3\t8\t13\t8\t9\n",
+        )
+        .unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "backfill_transcripts_fasta": "backfill/backfill_transcripts.fna",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json")).unwrap();
+        let tx = provider
+            .get_transcript("NM_000088.3")
+            .expect("backfilled NM_000088.3 is served from the index");
+        assert_eq!(
+            tx.sequence.as_deref(),
+            Some("ACGTACGT"),
+            "the deposited backfill bases are served, not synthesized"
+        );
+    }
+
+    #[test]
+    fn from_manifest_skips_missing_backfill_fasta() {
+        // #842: a stale `backfill_transcripts_fasta` (named in the manifest but
+        // the file/.fai absent on disk) must not brick provider load. Backfill
+        // is optional, so the entry is warned and skipped while the rest of the
+        // provider loads normally.
+        use crate::reference::ReferenceProvider;
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // Bulk transcript FASTA the provider must still serve.
+        fs::write(d.join("tx.fna"), ">NM_000088.4\nAAAA\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000088.4\t4\t13\t4\t5\n").unwrap();
+
+        // Manifest names a backfill FASTA whose directory exists but whose
+        // FASTA/.fai were never written (stale path). Create the dir so the
+        // failure mode being guarded — pushing a FASTA-less dir into
+        // from_directory — would otherwise trigger.
+        fs::create_dir_all(d.join("backfill")).unwrap();
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "backfill_transcripts_fasta": "backfill/backfill_transcripts.fna",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let provider = MultiFastaProvider::from_manifest(d.join("manifest.json"))
+            .expect("provider loads despite the stale backfill path");
+        assert!(
+            provider.get_transcript("NM_000088.4").is_ok(),
+            "the bulk transcript still resolves after the backfill entry is skipped"
         );
     }
 


### PR DESCRIPTION
## Summary

`ferro prepare` populates the transcript FASTA from NCBI's **bulk** RefSeq RNA release (`human.N.rna.fna.gz`), a current-snapshot product carrying ~one version per accession, while cdot (downloaded separately) carries exon alignments for **many historical versions**. When a query names a superseded version (e.g. `NM_000088.3`) whose bases are absent from the prepared FASTA but whose alignment is in cdot, `MultiFastaProvider` falls back to `synthesize_transcript_from_cdot`, reconstructing bases from the genome via the cdot exon CIGAR. That path is lossy: insertions decline (#807), deletions apply, and **substitutions are undetectable** (genome + CIGAR cannot see a deposited-transcript substitution). The root cause is a reference-coverage gap — the authoritative `accession.version` sequence exists at NCBI, it just isn't in the prepared reference.

This PR adds an opt-in, prepare-time **version-aware backfill** that closes the gap:

```
ferro prepare --backfill-transcripts targets.txt
```

reads a newline-delimited `accession.version` list, diffs it against the cdot keys (`CdotMapper::transcript_ids`) and the transcript-FASTA `.fai` keys (`load_available_versions`), fetches the genuine gap (present in cdot, absent from the FASTA) from NCBI EFetch, appends it to `backfill/backfill_transcripts.fna`, reindexes, and wires a new manifest field (`backfill_transcripts_fasta`) that the provider ingests. The backfilled `accession.version` is then served by the **primary index path** with version-exact cdot CDS — the lossy genome+CIGAR synthesis is never invoked for it. Synthesis remains the last-resort fallback for accessions unavailable anywhere, and query time stays fully offline.

## Design

- **Injectable fetcher boundary** (mirrors `authoritative::build_canonical_overrides`): `backfill::execute_backfill` takes `F: FnMut(&str) -> Option<String>`, so the diff/append/manifest logic is unit-tested with a mocked fetcher and **CI stays network-free**. The production fetcher (`fetch_transcript_fasta`) curls EFetch `rettype=fasta` with `--fail` + connect/total timeouts and a 100 ms NCBI rate-limit.
- **Two-phase**: pure `plan_backfill` (diff → `to_fetch` / `already_present` / `not_in_cdot`, sorted + deduped) then `execute_backfill` (lazy file creation so a fully-failed/empty run leaves no orphan 0-byte FASTA; appends `>accession\n`-headed records wrapped at 70 cols).
- **Dedicated `backfill/` directory**, not `supplemental/`, so the provider's whole-directory scan does not silently fold `legacy_genbank.fna` / benchmark-gated supplemental FASTAs into the primary index.
- **Incremental cache**: the present-set folds in the prior backfill `.fai`, so a re-run skips already-fetched accessions; `--force` discards the prior output and re-fetches without duplicate records.
- **Pre-flight guard** (mirrors `--derive-ng-placements`): requires cdot — downloaded this run *or* already present in the reference (enables cheap incremental backfill against a prepared reference).
- **Continue-on-failure**: a per-accession fetch/parse/version-mismatch failure warns and continues; only output-file I/O errors abort.

## Test coverage (all network-free, mocked fetcher)

- `plan_backfill`: exact-missing diff; `not_in_cdot` routing; incremental present-wins; sort/dedup determinism.
- `parse_fasta_record`: sequence extraction; header-accession **version-mismatch** rejection (efetch resolving bare→current); empty-sequence rejection; stop-at-next-record (no multi-record fold).
- `execute_backfill`: append with exact headers; continue-on-failure; version-mismatch → not written; incremental append without clobber; **no orphan file** when all fetches fail; empty plan no-ops.
- manifest: `backfill_transcripts_fasta` relative/absolute round-trip; pre-#842 manifest deserializes (`None`).
- provider: a manifest naming the backfill FASTA serves the accession from the index.
- prepare/CLI: config default `None`; pre-flight guard rejects a cdot-less selection.

`cargo build --features dev`/`--features benchmark`, `cargo nextest run --features dev` (7555 passed), `cargo clippy --features dev --all-targets -- -D warnings`, and `cargo fmt --all --check` are all clean. The generated spec fixture is untouched.

## Downstream

The mechanism is drivable for a specific target accession set, so **#802** (stacked on this PR) can provision `NM_002001.2` — a superseded version present in cdot but absent from the bulk feed — by passing a one-line targets file.

Closes #842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ferro prepare --backfill-transcripts <PATH>` to fetch missing exact `accession.version` transcript sequences and write a backfill FASTA.
  * Persisted the backfill FASTA path in the reference manifest and enabled downstream transcript lookup to index/serve it when present (including from Python).
* **Bug Fixes**
  * Transcript lookups now prefer backfilled exact-version FASTA records instead of falling back to less precise behavior.
  * Check summaries now report backfilled transcripts when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->