### PR TITLE
ci(nightly): derive ng_hosted_transcripts + NG_ placements in the nightly reference (#875)

### DIFF
--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -33,8 +33,10 @@ env:
   RUST_BACKTRACE: 1
   # Bump this tag whenever the manifest layout or `ferro prepare`
   # invocation changes meaningfully, so stale caches are invalidated
-  # without manual purging.
-  MANIFEST_CACHE_VERSION: v1
+  # without manual purging. (v2: added --derive-ng-placements so the
+  # prepared reference carries derived NG_ placements + ng_hosted_transcripts,
+  # matching the blessed reference; #875.) Keep in sync with nightly-perf.yml.
+  MANIFEST_CACHE_VERSION: v2
 
 jobs:
   reference-aware-tests:
@@ -81,12 +83,14 @@ jobs:
           # transcripts the manifest references.
           path: benchmark-output/
           # Invalidation surface: lock file (downstream-dep changes),
-          # the `prepare` crate (manifest-output shape), and the CLI
+          # the `prepare` crate (manifest-output shape), the CLI
           # wiring at `src/bin/ferro.rs` (the `prepare` subcommand
-          # binding). If a future PR adds a `src/reference/**` dep
-          # that changes `ferro prepare` behavior, bump
-          # MANIFEST_CACHE_VERSION manually.
-          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs') }}
+          # binding), and the NG accession fixture
+          # (`--derive-ng-placements` input — changing it changes the
+          # derived NG placements). If a future PR adds a
+          # `src/reference/**` dep that changes `ferro prepare`
+          # behavior, bump MANIFEST_CACHE_VERSION manually.
+          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs', 'tests/fixtures/mutalyzer-normalize/ng_accessions.txt') }}
 
       - name: Build ferro (for prepare)
         run: cargo build --release --bin ferro
@@ -96,7 +100,8 @@ jobs:
         run: |
           ./target/release/ferro prepare \
             --output-dir benchmark-output \
-            --genome grch38
+            --genome grch38 \
+            --derive-ng-placements tests/fixtures/mutalyzer-normalize/ng_accessions.txt
 
       - name: Confirm manifest present
         run: |

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -40,7 +40,8 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   # SHARED with nightly-mutalyzer.yml — keep identical, bump together.
-  MANIFEST_CACHE_VERSION: v1
+  # (v2: --derive-ng-placements added to the prepare step; #875.)
+  MANIFEST_CACHE_VERSION: v2
   # Budget knobs (seconds). Today's startup floor is ~1.0s; the #585 bug was
   # ~4.8s. 2.5s sits ~2.5x above healthy and ~2x below the bug — outside runner
   # noise in both directions.
@@ -86,7 +87,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: benchmark-output/
-          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs') }}
+          key: ${{ runner.os }}-ferro-manifest-${{ env.MANIFEST_CACHE_VERSION }}-${{ hashFiles('Cargo.lock', 'src/prepare/**', 'src/bin/ferro.rs', 'tests/fixtures/mutalyzer-normalize/ng_accessions.txt') }}
 
       - name: Build ferro (release)
         run: cargo build --release --bin ferro
@@ -96,7 +97,8 @@ jobs:
         run: |
           ./target/release/ferro prepare \
             --output-dir benchmark-output \
-            --genome grch38
+            --genome grch38 \
+            --derive-ng-placements tests/fixtures/mutalyzer-normalize/ng_accessions.txt
 
       - name: Confirm manifest present
         run: |

--- a/tests/fixtures/mutalyzer-normalize/ng_accessions.txt
+++ b/tests/fixtures/mutalyzer-normalize/ng_accessions.txt
@@ -1,0 +1,21 @@
+# Versioned NG_ RefSeqGene accessions referenced by the conformance corpus
+# (tests/fixtures/mutalyzer-normalize/cases.json). Fed to
+#   ferro prepare --derive-ng-placements <this file>
+# in the nightly workflows so the prepared reference carries derived NG_
+# placements + ng_hosted_transcripts (the #793 legacy-selector resolution).
+# Regenerate when the corpus's NG_ set changes:
+#   grep -oE 'NG_[0-9]+\.[0-9]+' tests/fixtures/mutalyzer-normalize/cases.json | sort -u
+NG_007107.2
+NG_007485.1
+NG_008835.1
+NG_008939.1
+NG_009113.2
+NG_009299.1
+NG_009497.1
+NG_009930.1
+NG_012232.1
+NG_012337.1
+NG_012337.3
+NG_012772.1
+NG_017013.2
+NG_029724.1


### PR DESCRIPTION
## Why

The nightly conformance/perf workflows ran `ferro prepare` **without** `--derive-ng-placements`, so their prepared reference carried neither the derived NG_ placements nor `ng_hosted_transcripts`. The #793 legacy-selector → NG_-hosted-version resolution was therefore dormant in nightly, and the #859 rows that PR #871 re-blessed (normalized 12 → 0) surface as **drift** in the nightly xfail report. More broadly the nightly reference was not a faithful reproduction of the blessed reference (no derived placements).

## What

- Add `tests/fixtures/mutalyzer-normalize/ng_accessions.txt` — the 14 versioned NG_ accessions referenced by the conformance corpus (with a header documenting the regeneration command).
- Pass `--derive-ng-placements <that list>` to the `ferro prepare` step in **both** `nightly-mutalyzer.yml` and `nightly-perf.yml` (they share the manifest cache, so both must match).
- Bump `MANIFEST_CACHE_VERSION` v1 → v2 in both (kept in sync per their comments) so the next nightly re-prepares with the new flag.

## Scope / caveats (called out for review)

- **Non-gating.** PR CI does not provision a manifest (the reference-aware axis tests skip), and the nightly is `continue-on-error`. This changes only the fidelity of the nightly drift report — it does not gate any PR.
- **Networked derive.** `--derive-ng-placements` does an NCBI EFetch per accession; per-accession failures warn and continue, and the manifest cache means it only runs on a cache miss. CI reliability of the fetch is unproven but tolerable given the non-gating nightly.
- **Accession-list drift.** The committed list can fall out of sync if the corpus's NG_ set changes; regenerate with the command in the file header. A future `--check` (mirroring `generate_conformance_summary --check`) could enforce coverage — deferred.
- This is the CI half of the #859/#871 reference wiring; the blessed local reference's `ng_hosted_transcripts` manifest field is wired separately (operator-owned).

Closes #875
Part of #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nightly workflow caching for prepared manifests by bumping the cache version to **v2**.
  * Enhanced nightly preparation to include **derived NG placements** using a dedicated accession fixture, keeping reference data aligned.
  * Updated cache keys so prepared reference manifests are invalidated when the accession fixture changes.
  * Added a new fixture file listing versioned **NG_ RefSeqGene accessions** for nightly derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->