### PR TITLE
test(conformance): cite ferro's spec-correct inserted-inversion resolution (#854)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -859,6 +859,18 @@ pub enum SpecSection {
     /// `r.[(…)]` is the spec-correct value (#693).
     #[serde(rename = "HGVS §RNA alleles (predicted bracket placement)")]
     RnaAlleleBracketPlacement,
+    /// HGVS inserted inversion — an `<range>inv` segment in an `ins`/`delins`
+    /// payload inserts the **reverse complement** (inverted copy) of that range's
+    /// reference bases (`docs/recommendations/DNA/insertion.md` L52-62, e.g.
+    /// `c.940_941ins[903_940inv;851_885inv]` = "an inverted copy of nucleotides";
+    /// `docs/recommendations/DNA/inversion.md` L5, L48-49, L53-62 define an
+    /// inversion as the reverse complement, explicitly *not* the plain reverse or
+    /// plain complement). ferro reverse-complements the `inv` segment and then
+    /// normalizes the resulting delins (common-prefix trim); mutalyzer leaves the
+    /// segment forward (inversion not applied) and so also skips the trim, which
+    /// is invalid HGVS. ferro's output is the spec-correct value (#854).
+    #[serde(rename = "HGVS §Inserted inversion (reverse complement)")]
+    InsertedInversion,
 }
 
 impl SpecSection {
@@ -883,6 +895,7 @@ impl SpecSection {
             SpecSection::RnaAlleleBracketPlacement => {
                 "HGVS §RNA alleles (predicted bracket placement)"
             }
+            SpecSection::InsertedInversion => "HGVS §Inserted inversion (reverse complement)",
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/baseline-failures/genomic.txt
+++ b/tests/fixtures/mutalyzer-normalize/baseline-failures/genomic.txt
@@ -2,7 +2,6 @@ LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]
 LRG_24t1:c.pter_qterdelinspter_qter
 NG_008835.1:g.320802_320803del
-NG_008939.1:g.5207_5212delins[4300_4309inv;4310_4320]
 NG_009299.1(NM_017668.3):c.[41>CA;250del]
 NG_009299.1(NM_017668.3):c.[41A>C;250del]
 NG_009299.1(NM_017668.3):c.33_35CAA[5]

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -76,6 +76,12 @@
       "title": "n. projection onto an overlapping transcript outside its exonic span",
       "spec_section": "background/numbering.md#DNAn (3' downstream offset)",
       "note": "The n. corpus rows expect a projection onto the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), where the variant lies 3' downstream of its single exon and mutalyzer addresses it as n.616+offset. ferro's transcript fan-out enumerates only transcripts the variant overlaps, so it emits valid n. forms on the overlapping NM_ isoforms but declines NR_024274.1 ('variant does not overlap transcript'). Spec tension: numbering.md L43-44 bars describing variants beyond a bare transcript's boundaries, so a bare NR_024274.1:n.616+offset would be invalid; but mutalyzer (and the corpus) frame it under its NG_007485.1 genomic parent (NG_007485.1(NR_024274.1):n.616+offset), the same genomic-context construction numbering.md L65 endorses (e.g. NG_012232.1(NM_004006.2):r.186+1_186+4), where the parent supplies the flanking sequence. Under that framing the form is valid and ferro should produce it -> known_bug, not accepted_divergence. Cross-isoform enumeration scope tracked by #646 (core landed in #647); ferro should extend enumeration/addressing to the downstream-of-last-exon case when the genomic parent is present. XPASS-guarded: if #646 lands and ferro starts matching, the annotation fails loudly and the row demotes."
+    },
+    {
+      "id": "inserted-inversion-854",
+      "title": "Inserted inversion (reverse complement) not applied by mutalyzer",
+      "spec_section": "HGVS §Inserted inversion (reverse complement)",
+      "note": "An `<range>inv` segment in an ins/delins payload inserts the reverse complement (inverted copy) of the range's bases (DNA/insertion.md L52-62; DNA/inversion.md L5, L48-49, L53-62). ferro applies the inversion and normalizes the delins; mutalyzer leaves the segment forward (inversion not applied). ferro's output is the spec-correct value. #854."
     }
   ],
   "cases": [
@@ -1252,7 +1258,13 @@
           "NG_008939.1(NP_000523.2):p.(Arg53_Arg54delinsAlaGlnAspHisTyrLeuAla)"
         ]
       ],
-      "to_test": true
+      "to_test": true,
+      "spec_citation": {
+        "axis": "genomic",
+        "cluster": "inserted-inversion-854",
+        "note": "An inserted `<range>inv` segment in a delins/ins payload means the reverse-complement (inverted copy) of that range's bases (DNA/insertion.md L52-62; DNA/inversion.md L5, L48-49, L53-62). ferro reverse-complements g.4300_4309 (GTCCTGTGCT -> AGCACAGGAC), keeps g.4310_4320 forward (CATTATCTGGC), then normalizes -- the deleted span ACGCCG and the insert AGCAC... share a leading A, trimmed -- yielding g.5208_5212delinsGCACAGGACCATTATCTGGC. mutalyzer leaves the segment forward (GTCCTGTGCT; inversion not applied) and so also skips the prefix trim; its output is spec-incorrect. ferro's output is the spec-correct value (#854).",
+        "section": "HGVS §Inserted inversion (reverse complement)"
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -200,6 +200,16 @@ The n. corpus rows expect a projection onto the overlapping single-exon non-codi
 | `NG_007485.1(NM_058195.3):c.141_142del` | noncoding | known_bug | — | #646 |
 | `NG_007485.1:g.5479_5480insACT` | noncoding | known_bug | — | #646 |
 
+### Inserted inversion (reverse complement) not applied by mutalyzer
+
+Spec: `HGVS §Inserted inversion (reverse complement)`
+
+An `<range>inv` segment in an ins/delins payload inserts the reverse complement (inverted copy) of the range's bases (DNA/insertion.md L52-62; DNA/inversion.md L5, L48-49, L53-62). ferro applies the inversion and normalizes the delins; mutalyzer leaves the segment forward (inversion not applied). ferro's output is the spec-correct value. #854.
+
+| input | axis | disposition | ferro output | tracking |
+|---|---|---|---|---|
+| `NG_008939.1:g.5207_5212delins[4300_4309inv;4310_4320]` | genomic | spec_citation | — | — |
+
 ### Ungrouped
 
 | input | axis | disposition | ferro output | tracking |
@@ -309,7 +319,7 @@ The n. corpus rows expect a projection onto the overlapping single-exon non-codi
 |---|---:|---:|---:|---:|---:|
 | coding_protein_descriptions | 10 | 0 | 0 | 0 | 0 |
 | errors | 16 | 0 | 0 | 0 | 0 |
-| genomic | 36 | 0 | 0 | 0 | 0 |
+| genomic | 36 | 0 | 0 | 0 | 1 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
 | normalized | 24 | 18 | 4 | 5 | 9 |


### PR DESCRIPTION
## TL;DR

`NG_008939.1:g.5207_5212delins[4300_4309inv;4310_4320]` was filed as a ferro bug. Investigation (reference bases + the HGVS spec + an adversarial review) shows **ferro is spec-correct and mutalyzer is wrong** — it never applied the inversion. Dispositioned as `spec_citation`.

## Evidence

Ground-truth bases (NG_008939.1):
- `g.4300_4309` (forward) = `GTCCTGTGCT`; `revcomp` = `AGCACAGGAC`
- `g.4310_4320` (forward) = `CATTATCTGGC`
- deleted span `g.5207_5212` = `ACGCCG`

Spec: an inserted `<range>inv` segment = the **reverse complement** (inverted copy) of the range's bases — `DNA/insertion.md` L52-62 (`c.940_941ins[903_940inv;851_885inv]` = "an inverted copy of nucleotides"); `DNA/inversion.md` L5, L48-49, L53-62 (an inversion is the reverse complement, explicitly *not* plain reverse or complement).

- **ferro** reverse-complements the `inv` segment (`AGCACAGGAC`) ++ forward `CATTATCTGGC`, then normalizes — the del `ACGCCG` and the insert `AGCAC…` share a leading `A`, trimmed → **`g.5208_5212delinsGCACAGGACCATTATCTGGC`**. Correct `inv` handling *and* correct prefix-trim normalization (no residual bug).
- **mutalyzer** = `g.5207_5212delinsGTCCTGTGCTCATTATCTGGC` — uses the **forward** (un-inverted) `4300_4309` bases; the inversion was never applied (and the prefix trim consequently skipped). Spec-incorrect.

An adversarial Opus review tried to refute "ferro is spec-correct" against the spec and failed — no reading leaves an `inv` segment forward; no strand/self-reference subtlety applies; ferro's normalized form is exactly right.

## Change

New `SpecSection::InsertedInversion` + a `clusters` registry entry; `spec_citation` on the genomic axis; row removed from `baseline-failures/genomic.txt` (54 → 53). Verified against the prepared reference: the row buckets as `spec_overridden`, the ledger matches the regenerated snapshot, zero other drift, full suite 7577 pass; clippy/fmt/spec-fixture/summary `--check` clean.

Closes #854
Part of #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional HGVS spec citation for inserted inversions, improving normalization coverage and reporting.
  * Expanded test coverage for inversion-containing insertion/deletion cases, including a newly tracked scenario and matching reference data.

* **Bug Fixes**
  * Updated normalization expectations for a specific genomic case so the recorded failure set now matches current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->