### PR TITLE
fix(normalize): 3'-align insertion→duplication; guarantee normalization idempotency

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -189,6 +189,13 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// output is invariant under `ShuffleDirection`. A direction-parameter
 /// audit was performed in #357 and locked in by
 /// `insertion_to_repeat_output_is_direction_invariant_on_n_axis`.
+///
+/// Shares the 3'-phase step (`three_prime_align_tract`) with
+/// [`normalize_repeat`]; the two are kept in lockstep by the cross-check test
+/// `insertion_to_repeat_agrees_with_normalize_repeat_phase`. They keep separate
+/// tract-finders (`find_tandem_extent` here, [`count_tandem_repeats`] there)
+/// because their anchoring contracts genuinely differ — see #866 and the note on
+/// [`count_tandem_repeats`].
 pub fn insertion_to_repeat(
     ref_seq: &[u8],
     pos: u64,
@@ -1241,6 +1248,20 @@ pub fn duplication_to_repeat(
 /// - count is the number of repeats found
 /// - start is the 0-indexed start of the repeat region
 /// - end is the 0-indexed exclusive end
+///
+/// # Anchoring contract (do NOT replace with `extend_tandem_tract`)
+///
+/// This finder scans **backward** from `pos` in unit-length steps, so it accepts
+/// a tract that merely *ends at or before* `pos` — `pos` itself need not match
+/// `unit`. `extend_tandem_tract` (used by `find_tandem_extent`) instead
+/// *requires* the anchor span `ref_seq[pos..pos+unit_len]` to equal `unit`. The
+/// two are therefore **not interchangeable** (#866): e.g.
+/// `count_tandem_repeats(b"ATATXX", 4, b"AT") == Some((2, 0, 4))` (the `AT`
+/// tract ends at index 4) while `extend_tandem_tract(b"ATATXX", 4..6, b"AT")
+/// == None` (`ref[4..6] == "XX"`). `normalize_repeat` relies on this
+/// boundary-anchor behavior, so delegating here would silently drop valid
+/// tracts. The genuinely shared piece across the ins→repeat / repeat paths is
+/// the 3'-phase step `three_prime_align_tract` (#852), not the tract finder.
 pub fn count_tandem_repeats(
     ref_seq: &[u8],
     pos: usize,
@@ -1367,6 +1388,14 @@ fn three_prime_align_tract(
 /// - specified_count: The count specified in the variant
 ///
 /// Returns the normalized representation
+///
+/// Shares the 3'-phase step (`three_prime_align_tract`) with
+/// [`insertion_to_repeat`]; kept in lockstep by the cross-check test
+/// `insertion_to_repeat_agrees_with_normalize_repeat_phase`. Uses
+/// [`count_tandem_repeats`] (+ an off-phase rotation/offset search) as its
+/// tract-finder rather than `find_tandem_extent` because it anchors at an
+/// existing position (possibly mid- or end-of-tract), not an insertion point —
+/// see #866 and the note on [`count_tandem_repeats`].
 pub fn normalize_repeat(
     ref_seq: &[u8],
     pos: usize,
@@ -2715,21 +2744,67 @@ mod tests {
 
     #[test]
     fn insertion_to_repeat_agrees_with_normalize_repeat_phase() {
-        // Idempotency invariant: the window insertion_to_repeat reports must equal
-        // the window normalize_repeat produces for the same tract/unit/count.
-        let r = b"CTGTGTT";
-        let (_b, _c, ins_start, ins_end, ins_unit) =
-            insertion_to_repeat(r, 4, b"TGTGTG", false).expect("repeat");
-        match normalize_repeat(r, 1, 5, b"TG", 5, false) {
-            RepeatNormResult::Repeat {
-                start,
-                end,
-                sequence,
-                ..
-            } => {
-                assert_eq!((ins_start, ins_end, ins_unit), (start, end, sequence));
+        // #866 cross-check. The two ins→repeat entry points reach the canonical
+        // repeat window by DIFFERENT tract-finders (`find_tandem_extent` anchored
+        // at an insertion point vs `count_tandem_repeats` + off-phase rotation
+        // search anchored at an existing position) but MUST agree on the final
+        // 3'-aligned window `(start, end, rotated_unit)` for the same reference
+        // tract — both share `three_prime_align_tract` (#852). That agreement is
+        // what prevents the #852 non-idempotency from recurring; the count
+        // differs by construction (insertion adds copies) and is not compared.
+        //
+        // Covers both off-phase di-repeat shapes #852 fixed: a mid-tract phase
+        // rotation (`CTGTGTT`, unit reported as `GT` not `TG`) and a tract-end
+        // boundary anchor (`TGCGCA`, anchor at the last base).
+        struct Case {
+            ref_seq: &'static [u8],
+            ins_pos: u64,
+            ins_seq: &'static [u8],
+            nr_pos: usize,
+            nr_end: usize,
+            nr_unit: &'static [u8],
+            nr_count: u64,
+        }
+        let cases = [
+            Case {
+                ref_seq: b"CTGTGTT",
+                ins_pos: 4,
+                ins_seq: b"TGTGTG",
+                nr_pos: 1,
+                nr_end: 5,
+                nr_unit: b"TG",
+                nr_count: 5,
+            },
+            Case {
+                ref_seq: b"TGCGCA",
+                ins_pos: 1,
+                ins_seq: b"GCGC",
+                nr_pos: 4,
+                nr_end: 4,
+                nr_unit: b"GC",
+                nr_count: 5,
+            },
+        ];
+        for c in cases {
+            let (_b, _c, ins_start, ins_end, ins_unit) =
+                insertion_to_repeat(c.ref_seq, c.ins_pos, c.ins_seq, false)
+                    .unwrap_or_else(|| panic!("insertion_to_repeat None for {:?}", c.ref_seq));
+            match normalize_repeat(c.ref_seq, c.nr_pos, c.nr_end, c.nr_unit, c.nr_count, false) {
+                RepeatNormResult::Repeat {
+                    start,
+                    end,
+                    sequence,
+                    ..
+                } => {
+                    assert_eq!(
+                        (ins_start, ins_end, ins_unit),
+                        (start, end, sequence),
+                        "ins→repeat phase disagreement on {:?}",
+                        std::str::from_utf8(c.ref_seq).unwrap()
+                    );
+                }
+                other => panic!("expected Repeat for {:?}, got {other:?}", c.ref_seq),
             }
-            other => panic!("expected Repeat, got {other:?}"),
         }
     }
 

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -371,14 +371,31 @@ pub(crate) fn insertion_to_duplication(
         }
     }
 
-    let (unit, ref_start, ref_count) = best?;
+    let (mut unit, ref_start, ref_count) = best?;
     let tract_end_idx = ref_start + (ref_count as usize) * unit.len();
     // `find_tandem_extent` returns `ref_start` aligned on a `unit`-length
     // anchor probe, so picking `ref_start` for the 5' end never lands the
     // dup slot mid-unit even when the inserted alt was a non-zero
     // rotation of the canonical reference unit.
     let dup_start_idx = match direction {
-        ShuffleDirection::ThreePrime => tract_end_idx - unit.len(),
+        ShuffleDirection::ThreePrime => {
+            // Push to the *true* 3'-most slot, crossing any off-phase tract
+            // extension. `tract_end_idx - unit.len()` only 3'-aligns within the
+            // abutting rotation's phase; when the run continues one base further
+            // in the opposite phase (e.g. inserting `TG` at the 5' edge of a
+            // `TGTGTGTGT` run — the abutting `TG`/`GT` tract ends one base short
+            // of the run's true 3' end), stopping there violates the 3'rule.
+            // `three_prime_align_tract` walks the remaining flank while
+            // `ref[end] == rotated[0]` — exactly the duplication slide rule
+            // `ref[s] == ref[s+L]` — rotating the unit to the run's 3' phase,
+            // mirroring the repeat path (#852). HGVS DNA duplication.md: "the
+            // most 3' position possible … is arbitrarily assigned to have been
+            // changed (3'rule)." Verified against mutalyzer (#864).
+            let (_, aligned_end, aligned_unit) =
+                three_prime_align_tract(ref_seq, ref_start, tract_end_idx, &unit);
+            unit = aligned_unit;
+            aligned_end - unit.len()
+        }
         ShuffleDirection::FivePrime => ref_start,
     };
     let dup_end_idx = dup_start_idx + unit.len() - 1;
@@ -4510,6 +4527,27 @@ mod tests {
         assert_eq!(r.unit, b"GT");
         assert_eq!(r.start, 7);
         assert_eq!(r.end, 8);
+    }
+
+    #[test]
+    fn test_insertion_to_duplication_offphase_slides_through_partial_flank() {
+        // #864: an ODD-length di-repeat run ("TGTGTGTGT", 9 bases) ends one base
+        // past the last full 2-copy window. The dup must still reach the run's
+        // true 3' end (3'rule), which lands on the GT phase — NOT stop at the
+        // abutting TG-phase boundary. ref "ACTGTGTGTGTAC": insert TG at pos=1
+        // (between C@1 and the run). `three_prime_align_tract` slides through the
+        // trailing base → dup unit "GT" at 1-based [10..11].
+        //
+        // Mirrors the real, mutalyzer-confirmed locus
+        // NC_000001.11:g.5010037_5010038insTG → g.5010045_5010046dup (same
+        // ACTGTGTGTGTAC context). Before #864 this stopped one base 5' (the
+        // under-shifted, mutalyzer-divergent form).
+        let ref_seq = b"ACTGTGTGTGTAC";
+        let r = insertion_to_duplication(ref_seq, 1, b"TG", ShuffleDirection::ThreePrime)
+            .expect("should fire");
+        assert_eq!(r.unit, b"GT");
+        assert_eq!(r.start, 10);
+        assert_eq!(r.end, 11);
     }
 
     #[test]

--- a/tests/it/idempotency_tests.rs
+++ b/tests/it/idempotency_tests.rs
@@ -565,3 +565,114 @@ fn test_clinvar_sample_parsing_idempotency() {
         );
     }
 }
+
+// =============================================================================
+// #864: CORPUS-WIDE + REGRESSION IDEMPOTENCY GUARANTEES
+// =============================================================================
+// `normalize` is single-pass; #852 (repeat path) and #864 (insertion→dup path)
+// each fixed a class where one pass produced a non-3'-most form that a second
+// pass would shift. These tests lock `normalize(normalize(x)) == normalize(x)`.
+
+/// Part 2 — corpus-wide, reference-free. With an empty provider, normalize the
+/// HGVS-spec + edge-case corpora twice and require idempotency on every input
+/// that normalizes without a reference (ref-stripping, delins canonicalization,
+/// repeat/dup collapse, identity stamping). Inputs needing a real transcript
+/// error on the first normalize and are skipped. CI-runnable (no manifest).
+#[test]
+fn test_normalization_idempotency_reference_free_corpus() {
+    let provider = MockProvider::new();
+    let mut inputs = load_spec_examples();
+    inputs.extend(load_edge_cases());
+
+    let mut tested = 0usize;
+    let mut transformed = 0usize;
+    let mut failures = Vec::new();
+
+    for input in &inputs {
+        let Ok(v) = parse_hgvs(input) else { continue };
+        let Ok(n1) = Normalizer::new(provider.clone()).normalize(&v) else {
+            continue;
+        };
+        let f1 = format!("{n1}");
+        if f1 != *input {
+            transformed += 1;
+        }
+        let Ok(v2) = parse_hgvs(&f1) else {
+            failures.push(format!("re-parse failed: {input} -> {f1}"));
+            continue;
+        };
+        let Ok(n2) = Normalizer::new(provider.clone()).normalize(&v2) else {
+            failures.push(format!("re-normalize failed: {input} -> {f1}"));
+            continue;
+        };
+        let f2 = format!("{n2}");
+        tested += 1;
+        if f1 != f2 {
+            failures.push(format!("not idempotent: {input} -> {f1} -> {f2}"));
+        }
+    }
+
+    eprintln!(
+        "reference-free idempotency: tested {tested}, transformed {transformed}, {} failures",
+        failures.len()
+    );
+    assert!(
+        tested > 100,
+        "corpus sweep exercised too few inputs ({tested})"
+    );
+    assert!(
+        failures.is_empty(),
+        "reference-free normalization not idempotent:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Part 3 — regression lock for the #852/#864 single-pass-non-3'-most classes,
+/// hermetic (MockProvider genomic sequence, no manifest). An off-phase di-repeat
+/// run "TGTGTGTGT" (odd length, 3'-flanked by a non-tract base) is the shape
+/// where the pre-#864 insertion→dup path stopped one base 5' of the run's true
+/// 3' end. The variant must (a) normalize to the most-3' dup in ONE pass
+/// (value-pin, mutalyzer-confirmed) and (b) be idempotent.
+#[test]
+fn test_insertion_to_dup_offphase_is_3prime_and_idempotent() {
+    use ferro_hgvs::reference::mock::MockProvider;
+    // 1-based: 1..=1000 = 'G' (avoid forming a T/A tract); 1001..=1013 =
+    // "ACTGTGTGTGTAC" (the mutalyzer-verified NC_000001.11:g.5010036.. context);
+    // rest 'G'. The TG run is g.1003..1011, 3'-flanked by A at g.1012.
+    let seq = format!(
+        "{}{}{}",
+        "G".repeat(1000),
+        "ACTGTGTGTGTAC",
+        "G".repeat(1000)
+    );
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_000001.11", seq);
+
+    // Insert TG at the 5' edge of the run (between C@1002 and T@1003).
+    let input = "NC_000001.11:g.1002_1003insTG";
+    let v = parse_hgvs(input).expect("parse");
+    let n1 = format!(
+        "{}",
+        Normalizer::new(provider.clone())
+            .normalize(&v)
+            .expect("normalize")
+    );
+
+    // Value-pin: most-3' dup is the GT phase at the run's 3' end (g.1010_1011),
+    // NOT the under-shifted TG-phase g.1009_1010. (3'rule; mutalyzer agrees.)
+    assert_eq!(
+        n1, "NC_000001.11:g.1010_1011dup",
+        "insertion into an off-phase di-repeat must land the dup at the most-3' \
+         position (3'rule); got {n1}"
+    );
+
+    // Idempotency: a second normalize must not shift it further.
+    let v2 = parse_hgvs(&n1).expect("re-parse");
+    let n2 = format!(
+        "{}",
+        Normalizer::new(provider)
+            .normalize(&v2)
+            .expect("re-normalize")
+    );
+    assert_eq!(n1, n2, "normalize is not idempotent: {n1} -> {n2}");
+}

--- a/tests/it/issue_132_cyclic_rotation_insertion.rs
+++ b/tests/it/issue_132_cyclic_rotation_insertion.rs
@@ -72,26 +72,30 @@ fn ins_agc_cag_tract_rotates_to_dup() {
     // HGVS 258_259 (just before tract's first C). alt "AGC" is the r=1
     // rotation of canonical "CAG".
     //
-    // Rotation iteration on `smallest_repeat_unit("AGC") = "AGC"` →
-    // "AGC" (r=0): no anchor matches the abutting window;
-    // "GCA" (r=1): no anchor matches;
-    // "CAG" (r=2): anchor at ins_point=258 matches; tract walks right
-    //   through CAGCAGCAG, ref_count=3.
-    // Only CAG-rotation matches. Most-3' CAG dup → tract end=267,
-    // dup_start_idx=264, dup_end_idx=266 → HGVS [265..267].
+    // CORE_CAG = "AACAGCAGCAGCAACAGAA": the CAG[3] tract is followed by a
+    // partial-match flank "CA" (from the trailing "CAA"). Per the HGVS 3'rule
+    // (DNA duplication.md: "the most 3' position possible … is arbitrarily
+    // assigned to have been changed"), the duplicated copy must shift as far 3'
+    // as the run allows — sliding one CAG copy right through the whole tandem
+    // run (valid while ref[s]==ref[s+3]) crosses the "CA" partial flank and
+    // lands on the GCA phase at HGVS [267..269]. The earlier `265_267dup`
+    // stopped at the pure-tandem boundary and was under-shifted (#864).
+    //
+    // Confirmed against mutalyzer on a real homologous locus:
+    // NC_000001.11:g.5010037_5010038insTG → g.5010045_5010046dup, and mutalyzer
+    // likewise re-normalizes the phase-aligned form to the most-3' slide.
     let p = SyntheticBuilder::genomic(CORE_CAG).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insAGC", SEQID));
-    assert_eq!(result, format!("{}:g.265_267dup", SEQID));
+    assert_eq!(result, format!("{}:g.267_269dup", SEQID));
 }
 
 #[test]
 fn ins_gca_cag_tract_rotates_to_dup() {
-    // Same layout as above, alt = GCA (r=2 of canonical "GCA"). Rotation
-    // iteration on `smallest_repeat_unit("GCA") = "GCA"`: only the "CAG"
-    // rotation finds an anchored tract abutting the ins point. Result is
-    // identical to the AGC case — both spec-equivalent rotations of the
-    // same tandem unit produce the same canonical dup.
+    // Same layout/flank as `ins_agc_cag_tract_rotates_to_dup`, alt = GCA (a
+    // different rotation of the same tandem unit). Both spec-equivalent
+    // rotations yield the same most-3' canonical dup — the #864 3'rule slide
+    // through the "CA" partial flank → HGVS [267..269].
     let p = SyntheticBuilder::genomic(CORE_CAG).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insGCA", SEQID));
-    assert_eq!(result, format!("{}:g.265_267dup", SEQID));
+    assert_eq!(result, format!("{}:g.267_269dup", SEQID));
 }

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -3848,3 +3848,107 @@ mod comparator_tests {
         );
     }
 }
+
+// ----------------------------------------------------------------------------
+// #864: corpus-wide normalization idempotency (manifest-gated)
+// ----------------------------------------------------------------------------
+// `normalize(normalize(x)) == normalize(x)` must hold for every corpus input on
+// both the normalized and genomic axes. This is a hard invariant, not a parity
+// tally — there is no baseline ledger; any non-idempotent case is a real bug to
+// fix (cf. #852 repeat path, #864 insertion→dup path). Skips without a manifest.
+
+/// Re-normalize `s`, returning the formatted output or an error string.
+fn renormalize_once(normalizer: &Normalizer<ArcProvider>, s: &str) -> Result<String, String> {
+    let v = parse_hgvs(s).map_err(|e| format!("parse: {e}"))?;
+    let n = normalizer
+        .normalize(&v)
+        .map_err(|e| format!("normalize: {e}"))?;
+    Ok(format!("{n}"))
+}
+
+#[test]
+fn axis_normalized_idempotent() {
+    let Some(normalizer) = normalizer() else {
+        eprintln!("axis_normalized_idempotent: skipping — no manifest");
+        return;
+    };
+    let mut tested = 0usize;
+    let mut failures = Vec::new();
+    for case in &fixture().cases {
+        if !case.to_test {
+            continue;
+        }
+        // Only inputs that normalize successfully participate; a normalize error
+        // is the concern of `axis_normalized`, not the idempotency invariant.
+        let Ok(n1) = renormalize_once(&normalizer, &case.input) else {
+            continue;
+        };
+        tested += 1;
+        match renormalize_once(&normalizer, &n1) {
+            Ok(n2) if n2 != n1 => failures.push(format!("{} : {n1} -> {n2}", case.input)),
+            Err(e) => failures.push(format!("{} : {n1} -> {e}", case.input)),
+            _ => {}
+        }
+    }
+    eprintln!(
+        "axis_normalized_idempotent: {tested} tested, {} non-idempotent",
+        failures.len()
+    );
+    assert!(tested > 0, "exercised no cases");
+    assert!(
+        failures.is_empty(),
+        "normalize is not idempotent on the normalized axis:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn axis_genomic_idempotent() {
+    let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
+        eprintln!("axis_genomic_idempotent: skipping — no manifest");
+        return;
+    };
+    let mut tested = 0usize;
+    let mut failures = Vec::new();
+    for case in &fixture().cases {
+        if !case.to_test {
+            continue;
+        }
+        // Project (c./n./r. → g.) then normalize, mirroring `axis_genomic`; only
+        // successfully-projected-and-normalized inputs participate.
+        let projected = (|| -> Result<String, String> {
+            let v = parse_hgvs(&case.input).map_err(|e| format!("parse: {e}"))?;
+            let g = if matches!(
+                v,
+                HgvsVariant::Cds(_) | HgvsVariant::Tx(_) | HgvsVariant::Rna(_)
+            ) {
+                projector
+                    .project_to_genomic(&v)
+                    .map_err(|e| format!("project: {e}"))?
+            } else {
+                v
+            };
+            let n = normalizer
+                .normalize(&g)
+                .map_err(|e| format!("normalize: {e}"))?;
+            Ok(format!("{n}"))
+        })();
+        let Ok(g1) = projected else { continue };
+        tested += 1;
+        match renormalize_once(&normalizer, &g1) {
+            Ok(g2) if g2 != g1 => failures.push(format!("{} : {g1} -> {g2}", case.input)),
+            Err(e) => failures.push(format!("{} : {g1} -> {e}", case.input)),
+            _ => {}
+        }
+    }
+    eprintln!(
+        "axis_genomic_idempotent: {tested} tested, {} non-idempotent",
+        failures.len()
+    );
+    assert!(tested > 0, "exercised no cases");
+    assert!(
+        failures.is_empty(),
+        "normalize is not idempotent on the genomic axis:\n{}",
+        failures.join("\n")
+    );
+}

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -2677,14 +2677,15 @@ mod insertion_rotation_tests {
         //
         // c.243 = position 38 + 242 = 280 (1-based), so index 279
         //
-        // Issue #132 update: the canonical dup is now phase-aligned with
-        // the GGC tract (most-3' GGC dup), not the rotated GCG-phase that
-        // shuffle's iterative walk happened to land on. The new helper
-        // `insertion_to_duplication` picks the tract-aligned phase (GGC at
-        // tract [279..300)), so the dup spans the most-3' GGC = c.261_263.
-        // Both the new and old positions describe the same edit; the new
-        // behavior is symmetric with the multi-copy `insertion_to_repeat`
-        // path's phase choice.
+        // #864: the canonical dup is the MOST-3' position (HGVS 3'rule,
+        // DNA duplication.md). The GGC[7] tract is followed by a partial-match
+        // flank "GC" (c.264=G, c.265=C); the 3'-shift slides one GGC copy right
+        // through the run while ref[s]==ref[s+3] — past c.261_263 (the last pure
+        // GGC) and one more base onto the GCG phase at c.262_264, stopping when
+        // ref[c.262]=G != ref[c.265]=C. The earlier `c.261_263dup` (tract-phase)
+        // stopped at the pure-tandem boundary and was under-shifted.
+        // Confirmed against mutalyzer on a real homologous locus (the strict
+        // 3'-slide; mutalyzer re-normalizes the phase-aligned form to it).
 
         let mut seq = String::new();
         seq.push_str(&"A".repeat(37)); // Positions 1-37 (5' UTR)
@@ -2702,11 +2703,10 @@ mod insertion_rotation_tests {
 
         let result = normalize_to_string(provider, "NM_TEST.1:c.242_243insGGC");
 
-        // GGC-phase tract: 7 GGC units at c.243..c.263 inclusive. Most-3'
-        // GGC dup → c.261_263.
+        // Most-3' dup, slid through the "GC" partial flank → c.262_264 (#864).
         assert_eq!(
-            result, "NM_TEST.1:c.261_263dup",
-            "Expected c.261_263dup (issue #132 GGC-phase canonical form), got: {}",
+            result, "NM_TEST.1:c.262_264dup",
+            "Expected c.262_264dup (#864 most-3' slide past the GGC[7]+GC flank), got: {}",
             result
         );
     }


### PR DESCRIPTION
Stacked on #869.

`normalize` is single-pass. #852 fixed one class where one pass produced a non-3'-most form a second pass would shift (the repeat path). This finds and fixes the **insertion→duplication** analogue, and adds property tests that lock `normalize(normalize(x)) == normalize(x)` corpus-wide.

## The bug

`insertion_to_duplication` 3'-aligned a single-copy tandem insertion only within the abutting rotation's phase. When an odd-length di/tri-repeat run continues one base further in the opposite phase (e.g. inserting `TG` at the 5' edge of a `TGTGTGTGT` run), the dup stopped one base 5' of the run's true 3' end — violating the HGVS 3'rule and producing a non-idempotent result. Pre-existing (reproduces before #852/#869); the CLI emits the non-canonical form.

## The fix

Apply `three_prime_align_tract` (the shared #852 helper) to the dup result for `ThreePrime`. Its loop `ref[end] == rotated[0]` is exactly the duplication slide rule `ref[s] == ref[s+L]`, so it slides the dup to the run's true 3'-most position and rotates the unit. `FivePrime` (#340) is unchanged.

Verified four ways that the most-3' form is correct: HGVS DNA `duplication.md` 3'rule; the slide-rule identity; **mutalyzer** on a real locus (`NC_000001.11:g.5010037_5010038insTG` → `g.5010045_5010046dup`, and mutalyzer re-normalizes the old phase-aligned form to it); and ferro+fix on the real reference. Red→green on that locus: pre-fix `g.5010044_5010045dup` → post-fix `g.5010045_5010046dup`.

## Idempotency guards (new)

- Manifest-gated conformance double-normalize sweep on both axes (`axis_normalized_idempotent`, `axis_genomic_idempotent`) — a hard invariant, no baseline ledger.
- CI-runnable reference-free corpus sweep over the HGVS-spec + edge-case inputs.
- CI-runnable regression lock for the off-phase insertion→dup class (value-pinned + idempotent), plus a `rules.rs` unit test.

## Impact

Updates 3 tests that had encoded the under-shifted (spec-violating) position. **Zero conformance-corpus change** (genomic ledger byte-identical; normalized axis 0 FAIL). Spawned #882 (a distinct, pre-existing out-of-phase false-dup bug found while cross-checking mutalyzer — not addressed here).

Closes #864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization to choose the true 3′-most duplication position for off-phase insertion scenarios, including partial-flank sliding behavior.
  * Corrected expected outputs for cyclic-rotation single-copy insertion cases so results now reflect the most-3′ aligned duplication.
  * Added regression coverage for a tricky di-repeat/off-phase repeat edge case to prevent early stopping.

* **Tests**
  * Expanded corpus idempotency coverage for normalization, including manifest-gated scenarios.
  * Added focused regression tests verifying stable repeated normalization for off-phase insertion→duplication cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->