### PR TITLE
test(normalize): cross-check ins→repeat paths; document tract-finder contracts

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -189,6 +189,13 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// output is invariant under `ShuffleDirection`. A direction-parameter
 /// audit was performed in #357 and locked in by
 /// `insertion_to_repeat_output_is_direction_invariant_on_n_axis`.
+///
+/// Shares the 3'-phase step (`three_prime_align_tract`) with
+/// [`normalize_repeat`]; the two are kept in lockstep by the cross-check test
+/// `insertion_to_repeat_agrees_with_normalize_repeat_phase`. They keep separate
+/// tract-finders (`find_tandem_extent` here, [`count_tandem_repeats`] there)
+/// because their anchoring contracts genuinely differ — see #866 and the note on
+/// [`count_tandem_repeats`].
 pub fn insertion_to_repeat(
     ref_seq: &[u8],
     pos: u64,
@@ -1241,6 +1248,20 @@ pub fn duplication_to_repeat(
 /// - count is the number of repeats found
 /// - start is the 0-indexed start of the repeat region
 /// - end is the 0-indexed exclusive end
+///
+/// # Anchoring contract (do NOT replace with `extend_tandem_tract`)
+///
+/// This finder scans **backward** from `pos` in unit-length steps, so it accepts
+/// a tract that merely *ends at or before* `pos` — `pos` itself need not match
+/// `unit`. `extend_tandem_tract` (used by `find_tandem_extent`) instead
+/// *requires* the anchor span `ref_seq[pos..pos+unit_len]` to equal `unit`. The
+/// two are therefore **not interchangeable** (#866): e.g.
+/// `count_tandem_repeats(b"ATATXX", 4, b"AT") == Some((2, 0, 4))` (the `AT`
+/// tract ends at index 4) while `extend_tandem_tract(b"ATATXX", 4..6, b"AT")
+/// == None` (`ref[4..6] == "XX"`). `normalize_repeat` relies on this
+/// boundary-anchor behavior, so delegating here would silently drop valid
+/// tracts. The genuinely shared piece across the ins→repeat / repeat paths is
+/// the 3'-phase step `three_prime_align_tract` (#852), not the tract finder.
 pub fn count_tandem_repeats(
     ref_seq: &[u8],
     pos: usize,
@@ -1367,6 +1388,14 @@ fn three_prime_align_tract(
 /// - specified_count: The count specified in the variant
 ///
 /// Returns the normalized representation
+///
+/// Shares the 3'-phase step (`three_prime_align_tract`) with
+/// [`insertion_to_repeat`]; kept in lockstep by the cross-check test
+/// `insertion_to_repeat_agrees_with_normalize_repeat_phase`. Uses
+/// [`count_tandem_repeats`] (+ an off-phase rotation/offset search) as its
+/// tract-finder rather than `find_tandem_extent` because it anchors at an
+/// existing position (possibly mid- or end-of-tract), not an insertion point —
+/// see #866 and the note on [`count_tandem_repeats`].
 pub fn normalize_repeat(
     ref_seq: &[u8],
     pos: usize,
@@ -2715,21 +2744,67 @@ mod tests {
 
     #[test]
     fn insertion_to_repeat_agrees_with_normalize_repeat_phase() {
-        // Idempotency invariant: the window insertion_to_repeat reports must equal
-        // the window normalize_repeat produces for the same tract/unit/count.
-        let r = b"CTGTGTT";
-        let (_b, _c, ins_start, ins_end, ins_unit) =
-            insertion_to_repeat(r, 4, b"TGTGTG", false).expect("repeat");
-        match normalize_repeat(r, 1, 5, b"TG", 5, false) {
-            RepeatNormResult::Repeat {
-                start,
-                end,
-                sequence,
-                ..
-            } => {
-                assert_eq!((ins_start, ins_end, ins_unit), (start, end, sequence));
+        // #866 cross-check. The two ins→repeat entry points reach the canonical
+        // repeat window by DIFFERENT tract-finders (`find_tandem_extent` anchored
+        // at an insertion point vs `count_tandem_repeats` + off-phase rotation
+        // search anchored at an existing position) but MUST agree on the final
+        // 3'-aligned window `(start, end, rotated_unit)` for the same reference
+        // tract — both share `three_prime_align_tract` (#852). That agreement is
+        // what prevents the #852 non-idempotency from recurring; the count
+        // differs by construction (insertion adds copies) and is not compared.
+        //
+        // Covers both off-phase di-repeat shapes #852 fixed: a mid-tract phase
+        // rotation (`CTGTGTT`, unit reported as `GT` not `TG`) and a tract-end
+        // boundary anchor (`TGCGCA`, anchor at the last base).
+        struct Case {
+            ref_seq: &'static [u8],
+            ins_pos: u64,
+            ins_seq: &'static [u8],
+            nr_pos: usize,
+            nr_end: usize,
+            nr_unit: &'static [u8],
+            nr_count: u64,
+        }
+        let cases = [
+            Case {
+                ref_seq: b"CTGTGTT",
+                ins_pos: 4,
+                ins_seq: b"TGTGTG",
+                nr_pos: 1,
+                nr_end: 5,
+                nr_unit: b"TG",
+                nr_count: 5,
+            },
+            Case {
+                ref_seq: b"TGCGCA",
+                ins_pos: 1,
+                ins_seq: b"GCGC",
+                nr_pos: 4,
+                nr_end: 4,
+                nr_unit: b"GC",
+                nr_count: 5,
+            },
+        ];
+        for c in cases {
+            let (_b, _c, ins_start, ins_end, ins_unit) =
+                insertion_to_repeat(c.ref_seq, c.ins_pos, c.ins_seq, false)
+                    .unwrap_or_else(|| panic!("insertion_to_repeat None for {:?}", c.ref_seq));
+            match normalize_repeat(c.ref_seq, c.nr_pos, c.nr_end, c.nr_unit, c.nr_count, false) {
+                RepeatNormResult::Repeat {
+                    start,
+                    end,
+                    sequence,
+                    ..
+                } => {
+                    assert_eq!(
+                        (ins_start, ins_end, ins_unit),
+                        (start, end, sequence),
+                        "ins→repeat phase disagreement on {:?}",
+                        std::str::from_utf8(c.ref_seq).unwrap()
+                    );
+                }
+                other => panic!("expected Repeat for {:?}, got {other:?}", c.ref_seq),
             }
-            other => panic!("expected Repeat, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Stacked on #864 (which stacks on #869).

Resolves #866. #852 already unified the substantive part — both ins→repeat entry points share `three_prime_align_tract` (the 3'-phase logic that was the actual divergence/bug source). Investigation (scoped under the no-perf-regression constraint) found the remaining two tract-finders are **not** safe to merge: they encode different, load-bearing anchoring contracts.

`count_tandem_repeats` scans **backward** from `pos` and accepts a tract ending at/before `pos` (the anchor need not match the unit); `extend_tandem_tract`/`find_tandem_extent` **require** the anchor span to equal the unit. They are not interchangeable:

```
count_tandem_repeats(b"ATATXX", 4, b"AT") == Some((2, 0, 4))
extend_tandem_tract (b"ATATXX", 4..6, b"AT") == None
```

Delegating one to the other would silently drop valid tracts — a hot-path regression. So instead of a risky merge:

- **Broaden** `insertion_to_repeat_agrees_with_normalize_repeat_phase` to both off-phase di-repeat shapes #852 fixed (mid-tract phase rotation `CTGTGTT`→`GT`, and tract-end boundary anchor `TGCGCA`→`GC`), asserting the two finders agree on the 3'-aligned window.
- **Document** the distinct anchoring contracts + the shared 3'-phase step on `count_tandem_repeats`, `insertion_to_repeat`, and `normalize_repeat`, with an explicit "do NOT replace with `extend_tandem_tract`" note so the divergence the cross-check guards against is not reintroduced.

Test + docs only — no behavior change. Full suite (7592), clippy, fmt, and both generator `--check`s pass.

Closes #866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repeat-normalization guidance for key entry points, including how phase alignment is shared and how anchoring behavior should be interpreted.
  * Added clearer notes about expected repeat-window handling at boundary cases.

* **Tests**
  * Expanded repeat-normalization test coverage with a table-driven approach.
  * Added scenarios for off-phase and tract-end boundary anchoring to verify consistent repeat-phase agreement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->