### PR TITLE
feat(python): normalize project_to_genomic output by default; raw via normalize=False

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1720,6 +1720,47 @@ class VariantProjector:
         """
         ...
 
+    def project_to_genomic(self, variant: HgvsVariant, normalize: bool = True) -> HgvsVariant:
+        """Project a transcript-coordinate variant (c./n./r.) onto its parent
+        genomic reference and return a Genome-kind HgvsVariant.
+
+        The output g. variant carries the parent NG/NC accession from the input's
+        ``Accession.genomic_context``.
+
+        By default (``normalize=True``) the result is the projector-normalized
+        genomic form — what most callers want; a Genome input is canonicalized
+        too. The normalizer follows this projector's configured shuffle
+        direction (``VariantProjector(direction=...)``): with the default
+        ``direction="3prime"`` that is the spec-canonical, 3'-shifted form (e.g.
+        a non-3'-most ``g.1003del`` in a poly-A run → ``g.1007del``); a
+        ``direction="5prime"`` projector instead returns the 5'-anchored form.
+        Pass ``normalize=False`` for the raw pivot, which intentionally does not
+        normalize its input (#785): a non-canonical input then yields a
+        non-canonical genomic output, and a Genome input passes through
+        unchanged (idempotent).
+
+        Limitations:
+            - ``Allele`` inputs are rejected pending #328.
+            - Plus-strand ``Base::U`` in r. inputs is forwarded verbatim into the
+              g. output; callers should pre-translate U→T.
+            - Intronic offsets on non-coding transcripts are rejected pending
+              #332.
+
+        Args:
+            variant: A c./n./r./g. HgvsVariant. Transcript-coordinate variants
+                must carry a genomic_context (NG/NC parent) on their Accession.
+            normalize: When True (default), return the normalized genomic form;
+                when False, return the raw un-normalized pivot.
+
+        Returns:
+            The Genome-kind HgvsVariant for the requested projection.
+
+        Raises:
+            RuntimeError: If the input lacks a parent reference, carries an
+                unknown (`?`) position, or is otherwise unsupported.
+        """
+        ...
+
     def project_normalized_many(self, variants: list[HgvsVariant]) -> list[list[VariantProjection]]:
         """Batched ``project_normalized_all`` over a list of already-normalized
         g. variants.

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1333,6 +1333,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// resolved position (uncertain/compound boundary) (#655). See
     /// [`Self::project_to_genomic_nc`] for the rest of the error contract
     /// (`UnsupportedProjection` / `InvalidCoordinates` / `ReferenceNotFound`).
+    ///
+    /// Most callers should prefer [`Self::project_to_genomic_normalized`], which
+    /// returns the spec-canonical 3'-shifted form; this raw pivot intentionally
+    /// does **not** normalize its input (#785).
     pub fn project_to_genomic(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
         self.warn_assembly_conflict(variant);
         // A `Genome` input is already in its parent frame: an `NC_` chromosome
@@ -1378,11 +1382,36 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
 
         match self.project_to_genomic_nc(variant)? {
+            // Raw pivot: re-anchor into the parent frame but do NOT normalize
+            // (#785/#867). The pivot was 3'-normalized in *transcript* space,
+            // which is the genome's 5' end on a minus-strand transcript, so the
+            // genomic image can still be non-3'-most; `project_to_genomic_normalized`
+            // owns the genomic-frame 3'-shift. Normalizing here would make the
+            // raw (`normalize=False`) contract indistinguishable from the
+            // normalized one for c./n./r. inputs.
             HgvsVariant::Genome(gv) => {
-                self.reanchor_and_normalize_genomic(gv, self.build_hint_for_variant(variant))
+                self.reanchor_genome_output(gv, self.build_hint_for_variant(variant))
             }
             other => Ok(other),
         }
+    }
+
+    /// Normalize `v` in its own frame, falling back to the un-normalized form on a
+    /// normalize error (the dropped error is `warn!`-logged so a regression is
+    /// discoverable without enabling `trace` logs — this now backs the default
+    /// `normalize=True` surface, so a silent non-canonical fallback would
+    /// otherwise be invisible in production). Shared by
+    /// [`Self::reanchor_and_normalize_genomic`] and
+    /// [`Self::project_to_genomic_normalized`] so the fallback/log semantics stay
+    /// identical between the two call sites.
+    fn normalize_or_fallback(&self, v: HgvsVariant) -> HgvsVariant {
+        self.normalizer.normalize(&v).unwrap_or_else(|e| {
+            log::warn!(
+                "genomic-frame renormalization failed for {v}; \
+                 emitting un-normalized form: {e}"
+            );
+            v
+        })
     }
 
     /// Re-anchor an NC-frame pivot into its parent frame, then re-normalize in the
@@ -1405,13 +1434,35 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         build: Option<&str>,
     ) -> Result<HgvsVariant, FerroError> {
         let reanchored = self.reanchor_genome_output(gv, build)?;
-        Ok(self.normalizer.normalize(&reanchored).unwrap_or_else(|e| {
-            log::trace!(
-                "genomic-frame renormalization failed for {reanchored}; \
-                 emitting un-normalized re-anchored form: {e}"
-            );
-            reanchored
-        }))
+        Ok(self.normalize_or_fallback(reanchored))
+    }
+
+    /// Project a transcript-coordinate (`c.`/`n.`/`r.`) variant onto its genomic
+    /// parent, or canonicalize an already-genomic (`g.`) variant, and return the
+    /// **spec-canonical, normalized** genomic form.
+    ///
+    /// [`Self::project_to_genomic`] is the raw pivot: it intentionally does not
+    /// normalize (#785), so a non-3'-most input yields a non-3'-most genomic
+    /// output. This wrapper applies the projector's normalizer to the pivot
+    /// output, so callers get the 3'-shifted / `ins`→`dup` canonical form they
+    /// usually want (#867). Reach for the raw [`Self::project_to_genomic`] only
+    /// when you explicitly need the un-normalized coordinate image.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`Self::project_to_genomic`]'s error contract. A normalization
+    /// failure on the projected genomic variant is NOT propagated — it is logged at
+    /// `warn` and the un-normalized projection is returned instead (the graceful
+    /// fallback shared with [`Self::reanchor_and_normalize_genomic`] via
+    /// [`Self::normalize_or_fallback`]), so the default (`normalize=True`) path never
+    /// regresses a result that the pre-#867 `project_to_genomic` would have returned
+    /// into a hard error.
+    pub fn project_to_genomic_normalized(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<HgvsVariant, FerroError> {
+        let projected = self.project_to_genomic(variant)?;
+        Ok(self.normalize_or_fallback(projected))
     }
 
     /// Project a `c.pter`/`c.qter` (telomere-flank marker) coding input onto its
@@ -3162,13 +3213,14 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let rna = Self::reframe_rna_from_input(rna, normalized);
 
         // #886: a bare LRG transcript has a structurally derivable genomic
-        // parent, so its genomic axis IS resolvable (via the raw pivot, which
-        // fills the LRG parent and reanchors into the LRG frame). A bare
-        // NM_/NR_ has no genome alignment -> stays None. project_to_genomic
-        // already normalizes; `.ok()` degrades to None if the LRG placement is
-        // genuinely unavailable.
+        // parent, so its genomic axis IS resolvable (the normalized wrapper
+        // fills the LRG parent, reanchors into the LRG frame, and 3'-shifts). A
+        // bare NM_/NR_ has no genome alignment -> stays None. Use
+        // `project_to_genomic_normalized` (not the raw pivot) so the reported
+        // genomic axis is spec-canonical (#867); `.ok()` degrades to None if the
+        // LRG placement is genuinely unavailable.
         let genomic = if Self::lrg_genomic_parent(&cds.accession).is_some() {
-            self.project_to_genomic(normalized).ok()
+            self.project_to_genomic_normalized(normalized).ok()
         } else {
             None
         };
@@ -3340,13 +3392,15 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
         // #886: a bare LRG transcript has a structurally derivable genomic
         // parent, so its genomic axis IS resolvable; a bare NM_/NR_ has no
-        // genome alignment -> stays None. Computed once here because the two
-        // return sites below sit in different branches (the `!is_coding` early
-        // return and the tail), so there is no shared tail to set it in.
+        // genome alignment -> stays None. Use `project_to_genomic_normalized`
+        // (not the raw pivot) so the reported genomic axis is spec-canonical
+        // (#867). Computed once here because the two return sites below sit in
+        // different branches (the `!is_coding` early return and the tail), so
+        // there is no shared tail to set it in.
         let genomic = normalized
             .accession()
             .filter(|acc| Self::lrg_genomic_parent(acc).is_some())
-            .and_then(|_| self.project_to_genomic(normalized).ok());
+            .and_then(|_| self.project_to_genomic_normalized(normalized).ok());
 
         // Non-coding transcript: there is no CDS to convert into, so there is
         // no protein consequence and no c. form. The n. form is the input
@@ -3687,9 +3741,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     // on a normalize failure fall back to the un-normalized parent
                     // terminus (still a valid coordinate) rather than aborting the
                     // whole projection — the genomic axis degrades gracefully,
-                    // mirroring reanchor_and_normalize_genomic.
+                    // via the same `normalize_or_fallback` helper (warn-logs the
+                    // dropped error) that `reanchor_and_normalize_genomic` uses.
                     let raw = result?;
-                    let genomic = self.normalizer.normalize(&raw).unwrap_or(raw);
+                    let genomic = self.normalize_or_fallback(raw);
                     return Ok(self.terminus_multiaxis_projection(
                         normalized,
                         transcript_id,
@@ -7391,16 +7446,19 @@ mod tests {
         }
 
         #[test]
-        fn project_to_genomic_minus_strand_deletion_renormalizes_to_genomic_3prime() {
+        fn project_to_genomic_minus_strand_deletion_raw_vs_normalized() {
             let (projector, provider) = make_minus_homopolymer_provider_and_projector();
             let vp = VariantProjector::new(projector, provider);
 
             // c.9del is the transcript-3'-most representation of the deletion in
             // the poly-A run. On the minus strand that maps to g.1000 — the
-            // genome-5' end of the poly-T run. The spec-canonical genomic output
-            // is the genome-3'-most position, g.1006del. Before #737 the projector
-            // emitted the un-renormalized coordinate image (g.1000del); the
-            // re-anchored output is now normalized in its own frame.
+            // genome-5' end of the poly-T run. The raw pivot intentionally does
+            // NOT renormalize in the genomic frame (#785/#867), so
+            // `project_to_genomic` returns the 5'-anchored g.1000del;
+            // `project_to_genomic_normalized` 3'-shifts it to the spec-canonical
+            // genome-3'-most position, g.1006del (#737). A minus-strand transcript
+            // input is the case that actually exercises the split: tx-3' is
+            // genome-5', so the raw and normalized genomic images genuinely differ.
             let cds = CdsVariant {
                 accession: parse_accession("NM_HOMO_MINUS.1"),
                 gene_symbol: Some("HOMOGENE".to_string()),
@@ -7414,25 +7472,48 @@ mod tests {
             };
             let cds = attach_genomic_context_cds(cds, nc_parent());
             let input = HgvsVariant::Cds(cds);
-            let out = vp
+
+            let raw = vp
                 .project_to_genomic(&input)
                 .expect("minus-strand c.9del should project to g.");
-            let g = match out {
-                HgvsVariant::Genome(ref g) => g,
-                _ => panic!("expected Genome variant, got: {}", out),
+            let raw_start = match raw {
+                HgvsVariant::Genome(ref g) => {
+                    assert_eq!(g.accession.to_string(), "NC_000001.11");
+                    g.loc_edit
+                        .location
+                        .start
+                        .inner()
+                        .expect("start should be concrete")
+                        .base
+                }
+                _ => panic!("expected Genome variant, got: {}", raw),
             };
-            assert_eq!(g.accession.to_string(), "NC_000001.11");
-            let start = g
-                .loc_edit
-                .location
-                .start
-                .inner()
-                .expect("start should be concrete");
             assert_eq!(
-                start.base, 1006,
-                "minus-strand c.9del must re-normalize to the genome-3' end of the \
-                 poly-T run (g.1006del), got g.{}del (#737)",
-                start.base
+                raw_start, 1000,
+                "raw project_to_genomic must NOT renormalize: the minus-strand c.9del \
+                 pivot is the genome-5' end of the poly-T run (g.1000del), got g.{}del",
+                raw_start
+            );
+
+            let norm = vp
+                .project_to_genomic_normalized(&input)
+                .expect("minus-strand c.9del should project (normalized)");
+            let norm_start = match norm {
+                HgvsVariant::Genome(ref g) => {
+                    g.loc_edit
+                        .location
+                        .start
+                        .inner()
+                        .expect("start should be concrete")
+                        .base
+                }
+                _ => panic!("expected Genome variant, got: {}", norm),
+            };
+            assert_eq!(
+                norm_start, 1006,
+                "project_to_genomic_normalized must re-normalize to the genome-3' end \
+                 of the poly-T run (g.1006del), got g.{}del (#737)",
+                norm_start
             );
         }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -982,7 +982,18 @@ impl PyVariantProjector {
     /// The output `g.` variant carries the parent NG/NC `Accession` stored in
     /// the input's `Accession.genomic_context` (e.g.
     /// `NG_007485.1(NM_000077.4):c.161_162insATC` projects onto
-    /// `NG_007485.1:g.28294_28295insATC`). Idempotent on `Genome` input.
+    /// `NG_007485.1:g.28294_28295insATC`).
+    ///
+    /// By default (`normalize=True`) the result is the projector-normalized
+    /// genomic form — what most callers want; a `Genome` input is canonicalized
+    /// too. The normalizer follows this projector's configured shuffle direction
+    /// (`VariantProjector(direction=...)`): with the default `direction="3prime"`
+    /// that is the spec-canonical, 3'-shifted form (e.g. a non-3'-most `g.1003del`
+    /// in a poly-A run → `g.1007del`); a `direction="5prime"` projector instead
+    /// returns the 5'-anchored form. Pass `normalize=False` to get the raw pivot,
+    /// which intentionally does not normalize its input (#785): a non-canonical
+    /// input then yields a non-canonical genomic output, and a `Genome` input
+    /// passes through unchanged (idempotent). (#867)
     ///
     /// Limitations:
     ///   - `Allele` inputs are rejected pending #328.
@@ -995,6 +1006,10 @@ impl PyVariantProjector {
     ///     variant: A c./n./r./g. HgvsVariant. Transcript-coord variants must
     ///         have a `genomic_context` (NG/NC parent reference) on their
     ///         `Accession`.
+    ///     normalize: When True (default), return the projector-normalized
+    ///         genomic form (spec-canonical 3'-shifted for the default
+    ///         `direction="3prime"`); when False, return the raw un-normalized
+    ///         pivot.
     ///
     /// Returns:
     ///     The Genome-kind HgvsVariant for the requested projection.
@@ -1003,9 +1018,24 @@ impl PyVariantProjector {
     ///     RuntimeError: If the input lacks a parent reference, carries an
     ///         unknown (`?`) position, or is otherwise unsupported (`p.`/`m.`/
     ///         `o.`/Allele/fusion/null/unknown-allele).
-    fn project_to_genomic(&self, variant: &PyHgvsVariant) -> PyResult<PyHgvsVariant> {
-        self.inner
-            .project_to_genomic(&variant.inner)
+    #[pyo3(signature = (variant, normalize=true))]
+    fn project_to_genomic(
+        &self,
+        py: Python<'_>,
+        variant: &PyHgvsVariant,
+        normalize: bool,
+    ) -> PyResult<PyHgvsVariant> {
+        // Release the GIL for the Rust projection work so it doesn't block other
+        // Python threads (mirrors `project_normalized_all`/`project_many`).
+        let inner_variant = variant.inner.clone();
+        let result = py.detach(|| {
+            if normalize {
+                self.inner.project_to_genomic_normalized(&inner_variant)
+            } else {
+                self.inner.project_to_genomic(&inner_variant)
+            }
+        });
+        result
             .map(|inner| PyHgvsVariant { inner })
             .map_err(|e| PyRuntimeError::new_err(format!("Projection error: {}", e)))
     }

--- a/tests/it/issue_867_project_to_genomic_normalized.rs
+++ b/tests/it/issue_867_project_to_genomic_normalized.rs
@@ -1,0 +1,116 @@
+//! #867: `VariantProjector::project_to_genomic_normalized` returns the
+//! spec-canonical 3'-shifted genomic form, vs the raw (un-normalized) pivot
+//! `project_to_genomic`. Hermetic MockProvider, no manifest.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::VariantProjector;
+
+/// Plus-strand single-exon transcript NM_POLY.1 on NC_000001.11 with a poly-A
+/// run in the CDS, so a 5'-anchored deletion is non-3'-canonical.
+/// CDS = "ATGAAAAACGCTAA" (14 nt): poly-A run c.4..c.8.
+fn poly_a_fixture() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_POLY.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("POLYGENE".to_string()),
+            contig: "NC_000001.11".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1014, 0, 14]],
+            cds_start: Some(0),
+            cds_end: Some(14),
+            gene_id: None,
+            protein: Some("NP_POLY.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_POLY.1".to_string(),
+        Some("POLYGENE".to_string()),
+        TxStrand::Plus,
+        "ATGAAAAACGCTAA".to_string(),
+        Some(1),
+        Some(14),
+        vec![Exon::new(1, 1, 14)],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(1013),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence(
+        "NC_000001.11",
+        format!("{}ATGAAAAACGCTAA{}", prefix, suffix),
+    );
+
+    VariantProjector::new(projector, provider)
+}
+
+#[test]
+fn project_to_genomic_normalized_3prime_shifts_noncanonical_genome_input() {
+    let vp = poly_a_fixture();
+    // A non-3'-most g. deletion inside the poly-A run g.1003..1007. The raw pivot
+    // is idempotent on Genome input (#785) — it passes the input through
+    // un-normalized — whereas the normalized form 3'-shifts to the spec-canonical
+    // position (HGVS 3'rule). This is the case #867 is about.
+    let v = parse_hgvs("NC_000001.11:g.1003del").unwrap();
+
+    let raw = format!("{}", vp.project_to_genomic(&v).expect("raw pivot"));
+    assert_eq!(
+        raw, "NC_000001.11:g.1003del",
+        "raw project_to_genomic must NOT normalize a Genome input"
+    );
+
+    let norm = format!(
+        "{}",
+        vp.project_to_genomic_normalized(&v).expect("normalized")
+    );
+    assert_eq!(
+        norm, "NC_000001.11:g.1007del",
+        "project_to_genomic_normalized must return the 3'-most canonical form"
+    );
+}
+
+#[test]
+fn project_to_genomic_splits_raw_vs_normalized_for_transcript_input() {
+    let vp = poly_a_fixture();
+    // The transcript-side contract split (the case #867 advertises). The pivot
+    // (`project_to_genomic_nc`) does NOT 3'-shift, so a non-3'-most c. deletion in
+    // the poly-A run projects to a non-canonical genomic image: c.4del deletes the
+    // first A of the run (c.4..c.8 → g.1003..1007) and the raw pivot yields the
+    // 5'-anchored g.1003del. `project_to_genomic_normalized` 3'-shifts it to the
+    // spec-canonical g.1007del. If `project_to_genomic` re-normalized internally,
+    // the raw form would wrongly equal g.1007del — so this catches the contract
+    // break that a plus-strand-only "raw == normalized" assertion misses.
+    let v = parse_hgvs("NC_000001.11(NM_POLY.1):c.4del").unwrap();
+    let raw = format!("{}", vp.project_to_genomic(&v).expect("raw"));
+    let norm = format!(
+        "{}",
+        vp.project_to_genomic_normalized(&v).expect("normalized")
+    );
+    assert_eq!(
+        raw, "NC_000001.11:g.1003del",
+        "raw project_to_genomic must NOT 3'-shift the transcript-coordinate projection"
+    );
+    assert_eq!(
+        norm, "NC_000001.11:g.1007del",
+        "project_to_genomic_normalized must return the 3'-most canonical form"
+    );
+    assert_ne!(
+        raw, norm,
+        "raw and normalized must differ for a non-3'-most transcript input"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -193,6 +193,7 @@ mod issue_843_allele_rna_build_scoping;
 mod issue_851_compound_utr_projection;
 mod issue_857_cterminal_extension;
 mod issue_860_lrg_namespace;
+mod issue_867_project_to_genomic_normalized;
 mod issue_879_ng_g_to_c_overlap;
 mod issue_91_protein_three_prime_shift;
 mod issue_92_protein_delins_to_dup;

--- a/tests/python/test_variant_projection.py
+++ b/tests/python/test_variant_projection.py
@@ -651,3 +651,109 @@ class TestAssemblyOverride:
     def test_default_assembly_is_none(self) -> None:
         # Omitting the kwarg is unchanged behavior (no override).
         ferro_hgvs.VariantProjector()
+
+
+def _write_poly_reference(tmp_path: Path) -> str:
+    """Write the shared poly-A reference JSON and return its path.
+
+    Plus-strand NM_POLY.1 on chr1 with a poly-A run in the CDS, so a deletion in
+    the run is directional: the 5'-anchored form is g.1003del and the 3'-most is
+    g.1007del (g.1003..1007 = AAAAA). CDS "ATGAAAAACGCTAA" (14 nt). Mirrors the
+    issue_867 Rust fixture.
+    """
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_POLY.1",
+                "gene_symbol": "POLYGENE",
+                "strand": "+",
+                "sequence": "ATGAAAAACGCTAA",
+                "cds_start": 1,
+                "cds_end": 14,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 14,
+                        "genomic_start": 1000,
+                        "genomic_end": 1013,
+                    }
+                ],
+                "chromosome": "NC_000001.11",
+                "genomic_start": 1000,
+                "genomic_end": 1013,
+            }
+        ],
+        "genomic_sequences": {
+            "NC_000001.11": "N" * 999 + "ATGAAAAACGCTAA" + "N" * 100,
+        },
+    }
+    path = tmp_path / "poly.json"
+    path.write_text(json.dumps(fixture))
+    return str(path)
+
+
+@pytest.fixture
+def poly_projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """Default (3'-shifting) projector over the shared poly-A reference."""
+    return ferro_hgvs.VariantProjector(reference_json=_write_poly_reference(tmp_path))
+
+
+@pytest.fixture
+def poly_projector_5prime(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """5'-shifting projector over the shared poly-A reference (#867 direction)."""
+    return ferro_hgvs.VariantProjector(
+        reference_json=_write_poly_reference(tmp_path), direction="5prime"
+    )
+
+
+class TestProjectToGenomicNormalize:
+    """#867: project_to_genomic(normalize=...) — default normalizes, False=raw."""
+
+    def test_default_returns_3prime_canonical(
+        self, poly_projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # g.1003del is a non-3'-most deletion in the poly-A run g.1003..1007.
+        v = ferro_hgvs.parse("NC_000001.11:g.1003del")
+        # Default (normalize=True) → spec-canonical 3'-most.
+        assert str(poly_projector.project_to_genomic(v)) == "NC_000001.11:g.1007del"
+        assert str(poly_projector.project_to_genomic(v, normalize=True)) == "NC_000001.11:g.1007del"
+
+    def test_normalize_false_returns_raw_pivot(
+        self, poly_projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # Raw pivot is idempotent on Genome input → passes through un-normalized.
+        v = ferro_hgvs.parse("NC_000001.11:g.1003del")
+        assert (
+            str(poly_projector.project_to_genomic(v, normalize=False)) == "NC_000001.11:g.1003del"
+        )
+
+    def test_transcript_input_split_raw_vs_normalized(
+        self, poly_projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # Exercise the transcript-coordinate (c.) projection path, not just the
+        # Genome passthrough. The pivot does NOT 3'-shift, so c.4del (the first A of
+        # the poly-A run c.4..c.8 → g.1003..1007) projects to the 5'-anchored
+        # g.1003del raw; the default (normalize=True) 3'-shifts it to the
+        # spec-canonical g.1007del. This is the transcript-side contract split #867
+        # advertises — a c. input is NOT pre-canonicalized in tx-space.
+        v = ferro_hgvs.parse("NC_000001.11(NM_POLY.1):c.4del")
+        assert str(poly_projector.project_to_genomic(v)) == "NC_000001.11:g.1007del"
+        assert (
+            str(poly_projector.project_to_genomic(v, normalize=False)) == "NC_000001.11:g.1003del"
+        )
+
+    def test_normalize_follows_projector_direction(
+        self, poly_projector_5prime: ferro_hgvs.VariantProjector
+    ) -> None:
+        # normalize=True must honor the projector's configured shuffle direction,
+        # not hard-code 3'. c.8del is the last A of the poly-A run (c.4..c.8 →
+        # g.1003..1007), so its raw pivot is the 3'-anchored g.1007del; a
+        # 5'-shifting projector re-shuffles that to the 5'-anchored g.1003del.
+        # (The default 3'-shifting projector would leave it at g.1007del.)
+        v = ferro_hgvs.parse("NC_000001.11(NM_POLY.1):c.8del")
+        assert str(poly_projector_5prime.project_to_genomic(v)) == "NC_000001.11:g.1003del"
+        assert (
+            str(poly_projector_5prime.project_to_genomic(v, normalize=False))
+            == "NC_000001.11:g.1007del"
+        )


### PR DESCRIPTION
The Python `project_to_genomic` binding exposed the raw NC-frame pivot, which intentionally does not normalize its input (#785) — so a non-3'-most input yielded a non-3'-most genomic output, not the spec-canonical form users expect.

## Change

- **Rust:** add `VariantProjector::project_to_genomic_normalized`, composing the raw pivot with the projector's normalizer to return the 3'-shifted canonical form.
- **Python:** `project_to_genomic(variant, normalize=True)` — the default now returns the normalized form; `normalize=False` returns the raw pivot. The raw pivot is kept one flag away because it handles cases the user/normalized path does not (LRG genomic projection, pter/qter sentinels — filed as #886/#887).
- **Stub:** add the missing `project_to_genomic` entry to `__init__.pyi` with the new param; document the raw-vs-normalized contract on both the Rust and Python surfaces.

## Tests

- Hermetic MockProvider Rust integration test (`tests/it/issue_867_*`): a non-3'-most `g.` deletion in a poly-A run passes through unchanged via the raw pivot (`g.1003del`) and 3'-shifts to canonical via the normalized path (`g.1007del`); a transcript-coordinate input agrees both ways.
- Python tests for `normalize=True`/`False` (`TestProjectToGenomicNormalize`).

No behavior change to the other `project_*` methods. Full Rust suite + clippy + fmt + Python pytest/ruff/mypy + both generator `--check`s pass.

Closes #867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `normalize` option to `project_to_genomic` to choose between raw genomic pivots and spec-canonical, 3’-shifted output.
  * Added `project_to_genomic_normalized` for always returning spec-canonical results.
  * Extended the Python API to `project_to_genomic(variant, normalize=true)` with matching semantics.
* **Bug Fixes**
  * Corrected poly-A run deletion projections so normalized output yields the correct 3’-most canonical genomic coordinates.
* **Tests**
  * Added integration and Python end-to-end coverage for raw vs normalized behavior and projector shuffle-direction effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->