### PR TITLE
chore: remove machine-local paths from committed example and runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,16 @@ pre-commit install                   # Install hooks (one-time)
 pre-commit run --all-files           # Run manually
 ```
 
+## Repository Hygiene
+
+### No machine-local paths in committed files
+
+Never commit machine-specific absolute paths (e.g. `/Volumes/...`, `/Users/...`, `/home/...`) to source, tests, examples, docs, or fixtures. They break on every other machine and leak local/client directory layout into a public-org repo.
+
+- **Source / examples / tests:** take the location from a CLI argument, an environment variable (e.g. `FERRO_MANIFEST`), or a repo-relative default (e.g. `benchmark-output/manifest.json`) — never a hardcoded absolute path.
+- **Docs / runbooks:** use a placeholder (e.g. `/path/to/ferro-bench-data`) or a shell variable the reader sets, and say so explicitly.
+- The prepared-reference manifest itself lives outside the repo and is `.gitignore`d; reference manifest entries are stored as relative paths so the reference is portable across hosts.
+
 ## Architecture
 
 ### Core Modules (`src/`)

--- a/docs/BENCHMARK_RUNBOOK.md
+++ b/docs/BENCHMARK_RUNBOOK.md
@@ -32,19 +32,19 @@ Run this a few times a year when refreshing the published numbers, or when tooli
 
 ### Reference Stack
 
-The reference stack lives on a machine-specific scratch volume. The canonical location used by all commands in this runbook is:
+The reference stack lives on a machine-specific volume. All commands in this runbook refer to its root through the placeholder path:
 
 ```
-/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
+/path/to/ferro-bench-data
 ```
 
 Set it once and use throughout:
 
 ```bash
-export D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
+export D=/path/to/ferro-bench-data
 ```
 
-If you are on a different machine, adjust `$D` to wherever the stack lives. The variable is not persisted by any config file — export it in every shell session before running benchmark commands.
+Replace `/path/to/ferro-bench-data` with wherever the stack actually lives on your machine. The variable is not persisted by any config file — export it in every shell session before running benchmark commands. The `MUTALYZER_CACHE_DIR` / `HGVS_SEQREPO_DIR` settings written below use the same placeholder and must be edited to match.
 
 The stack contains:
 
@@ -154,7 +154,7 @@ mkdir -p /tmp/bench-settings
 
 ```bash
 cat > /tmp/bench-settings/mutalyzer_settings.conf << 'EOF'
-MUTALYZER_CACHE_DIR=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/mutalyzer
+MUTALYZER_CACHE_DIR=/path/to/ferro-bench-data/mutalyzer
 MUTALYZER_FILE_CACHE_ADD=False
 EOF
 ```
@@ -167,7 +167,7 @@ EOF
 # Replace <PORT> with the actual host port discovered above (e.g. 55432)
 cat > /tmp/bench-settings/biocommons_settings.conf << 'EOF'
 UTA_DB_URL = postgresql://anonymous:anonymous@localhost:<PORT>/uta/uta_20210129b
-HGVS_SEQREPO_DIR = /Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/seqrepo/2021-01-29
+HGVS_SEQREPO_DIR = /path/to/ferro-bench-data/seqrepo/2021-01-29
 EOF
 ```
 
@@ -178,7 +178,7 @@ The shipped biocommons settings use a relative SeqRepo path that only resolves c
 Confirm each tool is ready before running the matrix:
 
 ```bash
-D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
+D=/path/to/ferro-bench-data
 
 # ferro
 pixi run ./target/release/ferro-benchmark check ferro \
@@ -214,7 +214,7 @@ The `benchmark matrix` subcommand runs all four tools across parse and normalize
 Run a smoke pass before committing to the confident run. The smoke pass uses a small sample and a single repetition, and completes in a few minutes.
 
 ```bash
-D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
+D=/path/to/ferro-bench-data
 
 pixi run ./target/release/ferro-benchmark benchmark matrix \
   --population "$D/clinvar/clinvar_patterns.txt" \
@@ -257,7 +257,7 @@ Once the smoke pass is clean, run the confident pass. This is the run whose outp
 Instead, let the matrix **calibrate per-(tool, op) sample sizes**: it estimates each tool's rate, then picks N so each tool runs for about `--target-seconds` per rep, clamped to `[--min-sample, --max-sample]`. This is what produces the "fast tools see millions of patterns, slow tools hundreds" property described in the README footnote. The defaults (`--target-seconds 3 --min-sample 50 --max-sample 2000000`) are what the published numbers use; they give a total run time of a few tens of minutes at `--reps 5`, bounded by mutalyzer normalize.
 
 ```bash
-D=/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data
+D=/path/to/ferro-bench-data
 
 pixi run ./target/release/ferro-benchmark benchmark matrix \
   --population "$D/clinvar/clinvar_patterns.txt" \

--- a/examples/extract_biocommons_windows.rs
+++ b/examples/extract_biocommons_windows.rs
@@ -322,16 +322,10 @@ fn resolve_manifest(cli_manifest: Option<PathBuf>) -> Option<PathBuf> {
         let p = PathBuf::from(path);
         return p.exists().then_some(p);
     }
-    for candidate in [
-        "/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/ferro/manifest.json",
-        "benchmark-output/manifest.json",
-    ] {
-        let p = PathBuf::from(candidate);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    None
+    // Relative, machine-independent fallback only. Machine-specific locations
+    // belong in `--manifest` or `FERRO_MANIFEST`, never hardcoded here.
+    let fallback = PathBuf::from("benchmark-output/manifest.json");
+    fallback.exists().then_some(fallback)
 }
 
 fn main() -> ExitCode {
@@ -340,7 +334,7 @@ fn main() -> ExitCode {
     let Some(manifest_path) = resolve_manifest(cli.manifest) else {
         eprintln!(
             "extract_biocommons_windows: no manifest (pass --manifest, set FERRO_MANIFEST, or \
-             place it at a well-known path). This generator requires the full reference manifest."
+             place it at benchmark-output/manifest.json). This generator requires the full reference manifest."
         );
         return ExitCode::FAILURE;
     };


### PR DESCRIPTION
## What

Removes machine-specific absolute paths that were committed to the repo and replaces them with portable equivalents.

- `examples/extract_biocommons_windows.rs` — `resolve_manifest` hardcoded `/Volumes/scratch-00001/work/clients/fulcrum/ferro-hgvs/data/ferro/manifest.json` as a fallback candidate. Dropped it; resolution now uses `--manifest`, then `FERRO_MANIFEST`, then the repo-relative `benchmark-output/manifest.json`. The error message points at the relative path instead of "a well-known path."
- `docs/BENCHMARK_RUNBOOK.md` — the same absolute scratch path was embedded in seven places (the reference-stack section, two written config files, and three `D=` redefinitions). Replaced the literal base with a `/path/to/ferro-bench-data` placeholder throughout, and made the surrounding prose tell the reader to substitute their own location (including for the `MUTALYZER_CACHE_DIR` / `HGVS_SEQREPO_DIR` config writes).
- `CLAUDE.md` — added a short "Repository Hygiene" convention note so this does not recur: machine-local absolute paths never belong in committed source/tests/examples/docs/fixtures; use a CLI arg, an env var, a repo-relative default, or a documented placeholder.

## Why

These paths break on every other machine and leak local directory layout into a public-org repo. They predate this change (came in via earlier benchmark/conformance work); this is a standalone cleanup with no functional change to shipped library code.

## Verification

- `git grep` for `/Volumes/(scratch|backup)-N`, `/Users/<name>`, `/home/<name>` over the whole tree is now empty.
- `cargo clippy --features dev --example extract_biocommons_windows` is clean (the relative-only fallback is written without a single-element loop to satisfy `-D warnings`).