### PR TITLE
fix(normalize): keep out-of-phase insertions as ins, not spurious dup/repeat (#882)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -8060,6 +8060,50 @@ mod tests {
         );
     }
 
+    // Real #882 locus GACACACATAGGT padded with 120-base neutral flanks so the
+    // +/-100 normalize window stays in-contig. Motif G is at 1-based g.121, so
+    // the A|C cut of the ACACACA tract is between g.122 (A) and g.123 (C).
+    fn phase_gate_882_provider() -> MockProvider {
+        let flank = "ACGT".repeat(30); // 120 bases
+        let seq = format!("{flank}GACACACATAGGT{flank}"); // len 253
+        let mut provider = MockProvider::new();
+        provider.add_genomic_sequence("NC_000001.11", &seq);
+        provider
+    }
+
+    #[test]
+    fn normalize_out_of_phase_ins_stays_ins_882() {
+        // g.122_123insAC sits at the A|C cut, out of phase with the ACACACA
+        // tract, so it must NOT become a dup (that was the silent-corruption bug).
+        let normalizer = Normalizer::new(phase_gate_882_provider());
+        let variant = parse_hgvs("NC_000001.11:g.122_123insAC").unwrap();
+        let normalized = normalizer.normalize(&variant).unwrap();
+        let output = format!("{}", normalized);
+        assert!(
+            output.contains("ins") && !output.contains("dup"),
+            "out-of-phase insAC must stay an insertion, got: {output}"
+        );
+        // Re-normalizing the result must not flip the phase gate on a second pass.
+        let again = format!("{}", normalizer.normalize(&normalized).unwrap());
+        assert_eq!(output, again, "normalize must be idempotent, got: {again}");
+    }
+
+    #[test]
+    fn normalize_in_phase_ins_becomes_dup_882() {
+        // g.122_123insCA at the same cut IS a legitimate tandem dup.
+        let normalizer = Normalizer::new(phase_gate_882_provider());
+        let variant = parse_hgvs("NC_000001.11:g.122_123insCA").unwrap();
+        let normalized = normalizer.normalize(&variant).unwrap();
+        let output = format!("{}", normalized);
+        assert!(
+            output.contains("dup"),
+            "in-phase insCA should become a dup, got: {output}"
+        );
+        // The emitted dup must stay a dup when normalized again.
+        let again = format!("{}", normalizer.normalize(&normalized).unwrap());
+        assert_eq!(output, again, "normalize must be idempotent, got: {again}");
+    }
+
     #[test]
     fn test_normalize_duplication_shifts_3prime() {
         // NM_001234.1 has G repeat spanning positions c.9-33 (25 G's)

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -82,6 +82,73 @@ pub fn insertion_is_duplication(ref_seq: &[u8], pos: u64, inserted_seq: &[u8]) -
     false
 }
 
+/// In-phase correctness gate for insertion->dup / insertion->repeat conversion
+/// (issue #882).
+///
+/// Returns `true` iff inserting `inserted_seq` at `ins_pos` (0-based index of
+/// the base immediately 5' of the insertion point; the insertion sits between
+/// `ins_pos` and `ins_pos + 1`) yields exactly the same full sequence as the
+/// tandem edit that replaces `ref_seq[region_start..region_end_excl]` with
+/// `unit` repeated `total_count` times.
+///
+/// `region_start`, `region_end_excl`, `unit`, and `total_count` are the
+/// POST-alignment values the caller is about to emit (the dup/repeat's own
+/// window and unit), so this validates the literal emitted edit — never the raw
+/// pre-selection tract. A conversion is spec-valid only when the tandem form
+/// decodes to the identical sequence as the input insertion.
+///
+/// Total: never panics; returns `false` on any out-of-range or degenerate
+/// argument.
+fn tandem_edit_preserves_insertion(
+    ref_seq: &[u8],
+    ins_pos: usize,
+    inserted_seq: &[u8],
+    region_start: usize,
+    region_end_excl: usize,
+    unit: &[u8],
+    total_count: u64,
+) -> bool {
+    // Bounds guards. `ref_seq[..=ins_pos]` is `ref_seq[..ins_pos + 1]`, which
+    // panics when `ins_pos == ref_seq.len()`, so guard `ins_pos >= len`.
+    if unit.is_empty()
+        || ins_pos >= ref_seq.len()
+        || region_start > region_end_excl
+        || region_end_excl > ref_seq.len()
+    {
+        return false;
+    }
+
+    // Sequence produced by applying the insertion.
+    let mut from_insertion = Vec::with_capacity(ref_seq.len() + inserted_seq.len());
+    from_insertion.extend_from_slice(&ref_seq[..=ins_pos]);
+    from_insertion.extend_from_slice(inserted_seq);
+    from_insertion.extend_from_slice(&ref_seq[ins_pos + 1..]);
+
+    // Sequence produced by the emitted tandem edit: replace the region with
+    // `unit` repeated `total_count` times. Compute the capacity with checked
+    // arithmetic so a degenerate `total_count` can't truncate (32-bit `usize`)
+    // or overflow into a panic; per the contract, bail out `false` if it would.
+    let Ok(total_count_usize) = usize::try_from(total_count) else {
+        return false;
+    };
+    let capacity = unit
+        .len()
+        .checked_mul(total_count_usize)
+        .and_then(|body| body.checked_add(region_start))
+        .and_then(|head| head.checked_add(ref_seq.len().saturating_sub(region_end_excl)));
+    let Some(capacity) = capacity else {
+        return false;
+    };
+    let mut from_tandem = Vec::with_capacity(capacity);
+    from_tandem.extend_from_slice(&ref_seq[..region_start]);
+    for _ in 0..total_count {
+        from_tandem.extend_from_slice(unit);
+    }
+    from_tandem.extend_from_slice(&ref_seq[region_end_excl..]);
+
+    from_insertion == from_tandem
+}
+
 /// Determine the canonical representation of an indel
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CanonicalForm {
@@ -172,7 +239,11 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// `is_coding` enables the spec's codon-frame exception (repeated.md): in
 /// c. context, repeat notation requires `unit_len % 3 == 0`. When the gate
 /// blocks the rewrite this returns `None` and the caller falls back to a
-/// literal `ins` description.
+/// literal `ins` description. A second gate, `tandem_edit_preserves_insertion`
+/// (#882), likewise returns `None` when the emitted repeat is out of phase —
+/// i.e. it would decode to a different sequence than the input insertion — so
+/// an out-of-phase insertion stays a literal `ins` rather than a spurious
+/// repeat.
 ///
 /// Returns `Some((first_byte, total_count, ref_start_1based,
 /// ref_end_1based, unit_bytes))` when repeat notation applies, `None`
@@ -245,6 +316,22 @@ pub fn insertion_to_repeat(
     let ref_end_excl = ref_start + ref_count as usize * unit.len();
     let (start, end_excl, rotated_unit) =
         three_prime_align_tract(ref_seq, ref_start, ref_end_excl, &unit);
+
+    // #882: only emit the repeat when it decodes to the same sequence as the
+    // input insertion. `start`/`end_excl`/`rotated_unit`/`total_count` are the
+    // post-alignment emitted window, unit, and count.
+    if !tandem_edit_preserves_insertion(
+        ref_seq,
+        pos as usize,
+        inserted_seq,
+        start,
+        end_excl,
+        &rotated_unit,
+        total_count,
+    ) {
+        return None;
+    }
+
     Some((
         rotated_unit[0],
         total_count,
@@ -317,7 +404,11 @@ pub(crate) struct InsToDupResult {
 ///    HGVS positions.
 ///
 /// Returns `None` when no rotation matches an adjacent tract (true
-/// non-tandem insertion — caller leaves it as plain `ins`).
+/// non-tandem insertion), **and also** when the best-matching rotation's
+/// emitted duplication is out of phase — i.e. it would decode to a different
+/// sequence than the input insertion, so it is not a tandem duplication per
+/// `duplication.md` (the `tandem_edit_preserves_insertion` gate, #882). In
+/// both cases the caller leaves it as a plain `ins`.
 pub(crate) fn insertion_to_duplication(
     ref_seq: &[u8],
     pos: u64,
@@ -406,6 +497,22 @@ pub(crate) fn insertion_to_duplication(
         ShuffleDirection::FivePrime => ref_start,
     };
     let dup_end_idx = dup_start_idx + unit.len() - 1;
+
+    // #882: only emit the dup when it decodes to the same sequence as the input
+    // insertion. `dup_start_idx`/`dup_end_idx`/`unit` are the post-alignment
+    // emitted values; a dup expands the emitted single unit to two copies.
+    if !tandem_edit_preserves_insertion(
+        ref_seq,
+        pos as usize,
+        inserted_seq,
+        dup_start_idx,
+        dup_end_idx + 1,
+        &unit,
+        2,
+    ) {
+        return None;
+    }
+
     Some(InsToDupResult {
         unit,
         start: index_to_hgvs_pos(dup_start_idx),
@@ -2775,10 +2882,12 @@ mod tests {
                 nr_unit: b"TG",
                 nr_count: 5,
             },
+            // Case 2: in-phase rotation `CGCG` (not the out-of-phase `GCGC`,
+            // which #882's gate now rejects). Same aligned window (2,5,"GC").
             Case {
                 ref_seq: b"TGCGCA",
                 ins_pos: 1,
-                ins_seq: b"GCGC",
+                ins_seq: b"CGCG",
                 nr_pos: 4,
                 nr_end: 4,
                 nr_unit: b"GC",
@@ -4626,6 +4735,92 @@ mod tests {
     }
 
     #[test]
+    fn tandem_edit_preserves_insertion_in_phase_dup_true() {
+        // GACACACATAGGT: insCA at the A|C cut (ins_pos=1) equals dup of the
+        // 3'-most CA (region [6,8), one unit -> total 2).
+        let r = b"GACACACATAGGT";
+        assert!(tandem_edit_preserves_insertion(r, 1, b"CA", 6, 8, b"CA", 2));
+    }
+
+    #[test]
+    fn tandem_edit_preserves_insertion_out_of_phase_dup_false() {
+        // Same tract, insAC at the same cut: out of phase -> reject.
+        let r = b"GACACACATAGGT";
+        assert!(!tandem_edit_preserves_insertion(
+            r, 1, b"AC", 6, 8, b"CA", 2
+        ));
+    }
+
+    #[test]
+    fn tandem_edit_preserves_insertion_in_phase_repeat_true() {
+        // TGCGCA: in-phase insCGCG at ins_pos=1 equals GC[4] over region [1,5).
+        let r = b"TGCGCA";
+        assert!(tandem_edit_preserves_insertion(
+            r, 1, b"CGCG", 1, 5, b"GC", 4
+        ));
+    }
+
+    #[test]
+    fn tandem_edit_preserves_insertion_out_of_phase_repeat_false() {
+        // TGCGCA: out-of-phase insGCGC at ins_pos=1 vs GC[4] over [1,5) -> reject.
+        let r = b"TGCGCA";
+        assert!(!tandem_edit_preserves_insertion(
+            r, 1, b"GCGC", 1, 5, b"GC", 4
+        ));
+    }
+
+    #[test]
+    fn tandem_edit_preserves_insertion_bounds_guards_no_panic() {
+        let r = b"ACGT";
+        // ins_pos == len (would panic on ref[..=ins_pos])
+        assert!(!tandem_edit_preserves_insertion(r, 4, b"A", 0, 1, b"A", 2));
+        // region_end_excl > len
+        assert!(!tandem_edit_preserves_insertion(r, 1, b"A", 0, 5, b"A", 2));
+        // empty unit
+        assert!(!tandem_edit_preserves_insertion(r, 1, b"A", 0, 1, b"", 2));
+        // region_start > region_end_excl
+        assert!(!tandem_edit_preserves_insertion(r, 1, b"A", 2, 1, b"A", 2));
+    }
+
+    #[test]
+    fn insertion_to_duplication_rejects_out_of_phase_882() {
+        // GACACACATAGGT, insAC at the A|C cut (pos=1) is out of phase with the
+        // AC-periodic tract; today it wrongly becomes a dup. Must be None now.
+        let r = b"GACACACATAGGT";
+        assert!(insertion_to_duplication(r, 1, b"AC", ShuffleDirection::ThreePrime).is_none());
+    }
+
+    #[test]
+    fn insertion_to_duplication_accepts_in_phase_882() {
+        // insCA at the same cut IS a legitimate tandem dup (3'-most CA).
+        let r = b"GACACACATAGGT";
+        let got = insertion_to_duplication(r, 1, b"CA", ShuffleDirection::ThreePrime)
+            .expect("in-phase insCA should still convert to dup");
+        assert_eq!(got.unit, b"CA");
+        assert_eq!(got.start, 7);
+        assert_eq!(got.end, 8);
+    }
+
+    #[test]
+    fn insertion_to_repeat_rejects_out_of_phase_882() {
+        // TGCGCA: insGCGC at the G|C cut (pos=1) is out of phase with the GC
+        // tract; today it wrongly becomes GC[4]. Must be None now.
+        let r = b"TGCGCA";
+        assert!(insertion_to_repeat(r, 1, b"GCGC", false).is_none());
+    }
+
+    #[test]
+    fn insertion_to_repeat_accepts_in_phase_882() {
+        // In-phase rotation insCGCG reaches the same GC[4] window and is preserved.
+        let r = b"TGCGCA";
+        let (_b, count, start, end, unit) =
+            insertion_to_repeat(r, 1, b"CGCG", false).expect("in-phase should convert");
+        assert_eq!(count, 4);
+        assert_eq!((start, end), (2, 5));
+        assert_eq!(unit, b"GC");
+    }
+
+    #[test]
     fn test_insertion_to_duplication_no_adjacent_tract() {
         // ref "ACGTACGT": no tandem of "X"; insert "X" at any pos returns None.
         let ref_seq = b"ACGTACGT";
@@ -4652,17 +4847,21 @@ mod tests {
     }
 
     #[test]
-    fn test_insertion_to_duplication_phase_matched_first_base() {
-        // Sanity: phase-matched alt (no rotation needed) returns the same
-        // most-3' dup position as the rotation case. Same reference layout
-        // as `test_insertion_to_duplication_cyclic_rotation_two_base`,
-        // but alt "GT" is r=0 (matched). Result is identical.
+    fn test_insertion_to_duplication_rejects_out_of_phase_alt_at_interior_cut() {
+        // #882: same reference layout as
+        // `test_insertion_to_duplication_cyclic_rotation_two_base`, but the alt
+        // is the OUT-OF-PHASE rotation "GT" (not the in-phase "TG"). At the
+        // interior G|T cut (pos=2, between idx2=G and idx3=T of the GTGTGT
+        // tract), inserting "TG" extends the tandem (-> ACGTGTGTGTAC, a real
+        // dup), but inserting "GT" yields ACGGTTGTGTAC — which is NOT a tandem
+        // expansion. Pre-#882 this was wrongly emitted as g.7_8dup (decoding to
+        // the different ACGTGTGTGTAC). The gate now rejects it; it stays `ins`,
+        // matching mutalyzer. (This test previously asserted the corrupt dup
+        // under the misnomer `phase_matched_first_base`.)
         let ref_seq = b"ACGTGTGTAC";
-        let r = insertion_to_duplication(ref_seq, 2, b"GT", ShuffleDirection::ThreePrime)
-            .expect("should fire");
-        assert_eq!(r.unit, b"GT");
-        assert_eq!(r.start, 7);
-        assert_eq!(r.end, 8);
+        assert!(
+            insertion_to_duplication(ref_seq, 2, b"GT", ShuffleDirection::ThreePrime).is_none()
+        );
     }
 
     #[test]

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -479,13 +479,13 @@
         "M2: Insertion on CDS start boundary should not be included in CDS."
       ],
       "input": "NM_000143.3:c.-1_1insCAT",
-      "normalized": "NM_000143.3:c.-1_2dup",
+      "normalized": "NM_000143.3:c.-1_1insCAT",
       "protein_description": "NP_000134.2:p.(Met1?)",
       "to_test": true,
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS protein initiation codon (Met1?)",
-        "note": "Both ferro and mutalyzer normalize this input to c.-1_2dup. That duplication's copy is inserted between c.2 and c.3, splitting the ATG initiation codon, so the consequence on translation initiation is unknown: p.(Met1?) (substitution.md:51). ferro derives the consequence from the canonical c.-1_2dup; mutalyzer computed p.(=) from the un-normalized 5'UTR-side input — inconsistent, since c.1_2insCAT shares the same normalized form yet mutalyzer reports p.? for it. ferro's p.(Met1?) (bare NP_ per #483/#495) is the spec-correct value (#504, #512).",
+        "note": "Normalized was corrected from the stale Mutalyzer2 value c.-1_2dup to the insertion form: an out-of-phase insertion is not a tandem duplication (duplication.md:19; #882), and live mutalyzer 3.1.1 agrees (both keep it as the insertion). protein_description p.(Met1?) is ferro's hermetic output (bare NP_ per #483/#495) and passes the gate_protein_snapshot check. Whether p.(Met1?) is the biologically-correct translation-initiation consequence for the insertion form — the value was originally derived from the now-superseded c.-1_2dup, whose duplicated copy split the ATG — is tracked for re-derivation in #891.",
         "cluster": "protein-init-codon"
       }
     },
@@ -495,13 +495,13 @@
         "M2: Insertion after CDS start boundary should be included in CDS."
       ],
       "input": "NM_000143.3:c.1_2insCAT",
-      "normalized": "NM_000143.3:c.-1_2dup",
+      "normalized": "NM_000143.3:c.1_2insCAT",
       "protein_description": "NP_000134.2:p.(Met1?)",
       "to_test": true,
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS protein initiation codon (Met1?)",
-        "note": "Both ferro and mutalyzer normalize this input to c.-1_2dup, whose copy splits the ATG initiation codon, so the translation-initiation consequence is unknown: p.(Met1?) (substitution.md:51). mutalyzer reports the coarser p.? here but p.(=) for c.-1_1insCAT, which shares the same normalized form — inconsistent, because it predicts from the un-normalized input. ferro predicts from the canonical c.-1_2dup; its p.(Met1?) (bare NP_ per #483/#495) is the spec-correct value (#504, #512).",
+        "note": "Normalized was corrected from the stale Mutalyzer2 value c.-1_2dup to the insertion form: an out-of-phase insertion is not a tandem duplication (duplication.md:19; #882), and live mutalyzer 3.1.1 agrees (both keep it as the insertion). protein_description p.(Met1?) is ferro's hermetic output (bare NP_ per #483/#495) and passes the gate_protein_snapshot check. Whether p.(Met1?) is the biologically-correct translation-initiation consequence for the insertion form — the value was originally derived from the now-superseded c.-1_2dup, whose duplicated copy split the ATG — is tracked for re-derivation in #891.",
         "cluster": "protein-init-codon"
       }
     },

--- a/tests/it/ins_shift_matrix.rs
+++ b/tests/it/ins_shift_matrix.rs
@@ -49,27 +49,24 @@ mod genomic {
     }
 
     #[rstest]
-    // Issue #132: single-copy ins where alt is a non-zero cyclic rotation
-    // of the reference repeat unit. `insertion_to_duplication` iterates
-    // rotations, picks the rotation matching an adjacent tract, and emits
-    // a dup at the most-3' unit-aligned position.
+    // Issue #132 / #882: single-copy ins where alt is a non-zero cyclic
+    // rotation of the reference repeat unit. Such a rotation is OUT OF PHASE
+    // with the tract at the insertion cut: decoding the candidate dup would
+    // yield a DIFFERENT sequence than the input insertion, so per HGVS
+    // duplication.md:19 ("no evidence the extra copy is in tandem … it should
+    // be described as an insertion") the #882 gate rejects the dup and the
+    // variant stays a plain `ins` at the input position. (Contrast the
+    // in-phase rotation in `multi_base_ins_in_tandem_one_unit`, which is a
+    // legitimate dup.)
     //
     // Case 1: GT tract (GTGTGT at core 3..9), insert TG at core 2_3.
-    //   alt "TG" is the r=1 rotation of canonical "GT". The flanking 'A'
-    //   on either side prevents leakage into padding. Most-3' GT in the
-    //   tract is at core 7_8 (with end of tract at core 8 and the trailing
-    //   T at core 9 breaking the tract for "GT" reading; 3 GT units span
-    //   core 3..9 — actually the tract is GTGTGT so 3 GT pairs at 3-4,5-6,7-8).
-    //   Most-3' GT dup → core 7_8.
-    #[case("ACGTGTGTAC", "g.{0}_{1}insTG", &[2u64, 3u64], "g.{0}_{1}dup", &[7u64, 8u64])]
+    //   alt "TG" is the r=1 (out-of-phase) rotation of canonical "GT"; the
+    //   candidate dup GT[core 7_8] would decode differently, so it stays ins.
+    #[case("ACGTGTGTAC", "g.{0}_{1}insTG", &[2u64, 3u64], "g.{0}_{1}insTG", &[2u64, 3u64])]
     // Case 2: GCA tract (GCAGCAGCA at core 3..11), insert CAG at core 2_3.
-    //   alt "CAG" is the r=1 rotation of canonical "GCA". Only the GCA
-    //   rotation finds an anchored tract abutting the insertion point;
-    //   the CAG and AGC rotations have no anchor in the abutting window
-    //   because padded[258]='G' (start of GCA tract) and the bases before
-    //   are 'TT' (padding boundary).
-    //   Most-3' GCA dup → core 9_11.
-    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAG", &[2u64, 3u64], "g.{0}_{1}dup", &[9u64, 11u64])]
+    //   alt "CAG" is the r=1 (out-of-phase) rotation of canonical "GCA"; the
+    //   candidate dup would decode differently, so it stays ins.
+    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAG", &[2u64, 3u64], "g.{0}_{1}insCAG", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -127,15 +124,15 @@ mod genomic {
     //   Insert ACAC at core 2_3 (between C and A). alt[0]=A, ref[3]=A → match → shifts.
     //   3+2=5 AC → AC[5]. Tract: core 3..8 (1-based, 6 bases = 3 units).
     #[case("GCACACACG", "g.{0}_{1}insACAC", &[2u64, 3u64], "g.{0}_{1}AC[5]", &[3u64, 8u64])]
-    // Case 5: alt is a cyclic rotation of the ref unit.
+    // Case 5: alt is an OUT-OF-PHASE cyclic rotation of the ref unit (#882).
     //   Core: TTGCAGCAGCATT. Ref tract (GCA)x3 at core 3..11; flanking T's
     //   at core 1-2 and 12-13 prevent the tract from extending into PAD.
     //   Insert CAGCAG at core 2_3 (between T and the start of the tract).
-    //   smallest_repeat_unit returns CAG, but the ref tract is GCA — the
-    //   algorithm must try all cyclic rotations of the unit to find the
-    //   reference-aligned tract.
-    //   Expected: GCA[5] at core 3..11.
-    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAGCAG", &[2u64, 3u64], "g.{0}_{1}GCA[5]", &[3u64, 11u64])]
+    //   The candidate repeat GCA[5] at core 3..11 would decode to a DIFFERENT
+    //   sequence than inserting CAGCAG at the cut (the rotation is out of
+    //   phase), so the #882 gate rejects it and the variant stays a plain
+    //   `ins` at the input position (duplication.md:19).
+    #[case("TTGCAGCAGCATT", "g.{0}_{1}insCAGCAG", &[2u64, 3u64], "g.{0}_{1}insCAGCAG", &[2u64, 3u64])]
     fn multi_base_ins_in_tandem_multiple_units(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -267,13 +264,16 @@ mod cds_plus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. Mirrors the genomic module case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). Mirrors the genomic module case shape.
     //
-    // Case 1: GT tract at c.3-8. Insert TG (r=1 of GT) at c.2_3 → dup at c.7_8.
-    #[case("ACGTGTGTACGTACGTACGT", "c.{0}_{1}insTG", &[2u64, 3u64], "c.{0}_{1}dup", &[7u64, 8u64])]
-    // Case 2: GCA tract at c.3-11. Insert CAG (r=1 of GCA) at c.2_3 → dup at c.9_11.
-    #[case("TTGCAGCAGCATTGACGTAC", "c.{0}_{1}insCAG", &[2u64, 3u64], "c.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: GT tract at c.3-8. Insert TG (out-of-phase r=1 of GT) at c.2_3 → stays ins.
+    #[case("ACGTGTGTACGTACGTACGT", "c.{0}_{1}insTG", &[2u64, 3u64], "c.{0}_{1}insTG", &[2u64, 3u64])]
+    // Case 2: GCA tract at c.3-11. Insert CAG (out-of-phase r=1 of GCA) at c.2_3 → stays ins.
+    #[case("TTGCAGCAGCATTGACGTAC", "c.{0}_{1}insCAG", &[2u64, 3u64], "c.{0}_{1}insCAG", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -418,13 +418,16 @@ mod cds_minus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. Mirrors the genomic module case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). Mirrors the genomic module case shape.
     //
-    // Case 1: GT tract at c.3-8. Insert TG (r=1 of GT) at c.2_3 → dup at c.7_8.
-    #[case("ACGTGTGTACGTACGTACGT", "c.{0}_{1}insTG", &[2u64, 3u64], "c.{0}_{1}dup", &[7u64, 8u64])]
-    // Case 2: GCA tract at c.3-11. Insert CAG (r=1 of GCA) at c.2_3 → dup at c.9_11.
-    #[case("TTGCAGCAGCATTGACGTAC", "c.{0}_{1}insCAG", &[2u64, 3u64], "c.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: GT tract at c.3-8. Insert TG (out-of-phase r=1 of GT) at c.2_3 → stays ins.
+    #[case("ACGTGTGTACGTACGTACGT", "c.{0}_{1}insTG", &[2u64, 3u64], "c.{0}_{1}insTG", &[2u64, 3u64])]
+    // Case 2: GCA tract at c.3-11. Insert CAG (out-of-phase r=1 of GCA) at c.2_3 → stays ins.
+    #[case("TTGCAGCAGCATTGACGTAC", "c.{0}_{1}insCAG", &[2u64, 3u64], "c.{0}_{1}insCAG", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -570,13 +573,16 @@ mod noncoding_plus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. Mirrors the genomic module case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). Mirrors the genomic module case shape.
     //
-    // Case 1: GT tract at n.3-8. Insert TG (r=1 of GT) at n.2_3 → dup at n.7_8.
-    #[case("ACGTGTGTACGTACGTACGT", "n.{0}_{1}insTG", &[2u64, 3u64], "n.{0}_{1}dup", &[7u64, 8u64])]
-    // Case 2: GCA tract at n.3-11. Insert CAG (r=1 of GCA) at n.2_3 → dup at n.9_11.
-    #[case("TTGCAGCAGCATTGACGTAC", "n.{0}_{1}insCAG", &[2u64, 3u64], "n.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: GT tract at n.3-8. Insert TG (out-of-phase r=1 of GT) at n.2_3 → stays ins.
+    #[case("ACGTGTGTACGTACGTACGT", "n.{0}_{1}insTG", &[2u64, 3u64], "n.{0}_{1}insTG", &[2u64, 3u64])]
+    // Case 2: GCA tract at n.3-11. Insert CAG (out-of-phase r=1 of GCA) at n.2_3 → stays ins.
+    #[case("TTGCAGCAGCATTGACGTAC", "n.{0}_{1}insCAG", &[2u64, 3u64], "n.{0}_{1}insCAG", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -721,13 +727,16 @@ mod noncoding_minus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. Mirrors the genomic module case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). Mirrors the genomic module case shape.
     //
-    // Case 1: GT tract at n.3-8. Insert TG (r=1 of GT) at n.2_3 → dup at n.7_8.
-    #[case("ACGTGTGTACGTACGTACGT", "n.{0}_{1}insTG", &[2u64, 3u64], "n.{0}_{1}dup", &[7u64, 8u64])]
-    // Case 2: GCA tract at n.3-11. Insert CAG (r=1 of GCA) at n.2_3 → dup at n.9_11.
-    #[case("TTGCAGCAGCATTGACGTAC", "n.{0}_{1}insCAG", &[2u64, 3u64], "n.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: GT tract at n.3-8. Insert TG (out-of-phase r=1 of GT) at n.2_3 → stays ins.
+    #[case("ACGTGTGTACGTACGTACGT", "n.{0}_{1}insTG", &[2u64, 3u64], "n.{0}_{1}insTG", &[2u64, 3u64])]
+    // Case 2: GCA tract at n.3-11. Insert CAG (out-of-phase r=1 of GCA) at n.2_3 → stays ins.
+    #[case("TTGCAGCAGCATTGACGTAC", "n.{0}_{1}insCAG", &[2u64, 3u64], "n.{0}_{1}insCAG", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -869,8 +878,11 @@ mod rna_plus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. RNA equivalent of the genomic case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). RNA equivalent of the genomic case shape.
     //
     // Note: avoid units containing 'u' — ferro stores RNA refs as DNA
     // (U→T). A `ug` rotation alt against a `gu` ref tract becomes byte
@@ -878,8 +890,8 @@ mod rna_plus {
     // uses only A/C/G, which are unambiguous between DNA and RNA byte
     // representations.
     //
-    // Case 1: gca tract at r.3-11. Insert cag (r=1 of gca) at r.2_3 → dup at r.9_11.
-    #[case("uugcagcagcauugacguac", "r.{0}_{1}inscag", &[2u64, 3u64], "r.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: gca tract at r.3-11. Insert cag (out-of-phase r=1 of gca) at r.2_3 → stays ins.
+    #[case("uugcagcagcauugacguac", "r.{0}_{1}inscag", &[2u64, 3u64], "r.{0}_{1}inscag", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,
@@ -1021,8 +1033,11 @@ mod rna_minus {
     }
 
     #[rstest]
-    // Issue #132: cyclic-rotation single-copy ins → dup at most-3'
-    // rotation-aligned position. RNA equivalent of the genomic case shape.
+    // Issue #132 / #882: single-copy ins where alt is an OUT-OF-PHASE cyclic
+    // rotation of the ref repeat unit. The candidate dup would decode to a
+    // different sequence than the input insertion, so the #882 gate rejects it
+    // and the variant stays a plain `ins` at the input position
+    // (duplication.md:19). RNA equivalent of the genomic case shape.
     //
     // Note: avoid units containing 'u' — ferro stores RNA refs as DNA
     // (U→T). A `ug` rotation alt against a `gu` ref tract becomes byte
@@ -1030,8 +1045,8 @@ mod rna_minus {
     // uses only A/C/G, which are unambiguous between DNA and RNA byte
     // representations.
     //
-    // Case 1: gca tract at r.3-11. Insert cag (r=1 of gca) at r.2_3 → dup at r.9_11.
-    #[case("uugcagcagcauugacguac", "r.{0}_{1}inscag", &[2u64, 3u64], "r.{0}_{1}dup", &[9u64, 11u64])]
+    // Case 1: gca tract at r.3-11. Insert cag (out-of-phase r=1 of gca) at r.2_3 → stays ins.
+    #[case("uugcagcagcauugacguac", "r.{0}_{1}inscag", &[2u64, 3u64], "r.{0}_{1}inscag", &[2u64, 3u64])]
     fn cyclic_rotation_ins_one_unit(
         #[case] core: &str,
         #[case] in_template: &str,

--- a/tests/it/issue_132_cyclic_rotation_insertion.rs
+++ b/tests/it/issue_132_cyclic_rotation_insertion.rs
@@ -1,10 +1,17 @@
-//! Issue #132: 3' rule misses cyclic-rotation single-copy insertions.
+//! Issue #132 / #882: cyclic-rotation single-copy insertions and the in-phase
+//! gate on dup/repeat conversion.
 //!
-//! When a literal `ins` payload is a non-zero cyclic rotation of an adjacent
-//! reference repeat unit, the 3' rule should shift the variant to the most-3'
-//! dup-aligned position. The 2+-copy path (`insertion_to_repeat`) already
-//! handles this; this file pins the single-copy fix and the round-trip
-//! equivalence between rotation-mismatched alts and the matched alt.
+//! Corrected understanding (#882): a cyclic rotation of the reference repeat
+//! unit only 3'-shifts to a `dup`/repeat when the rotation is IN PHASE with the
+//! tract at the insertion cut — i.e. when the emitted tandem edit decodes to
+//! exactly the same sequence as the input insertion. An IN-PHASE rotation
+//! (e.g. `ins_gt_matched_rotation_already_works`) becomes a dup. An OUT-OF-PHASE
+//! rotation would decode to a DIFFERENT sequence, so per HGVS duplication.md:19
+//! ("no evidence the extra copy is in tandem … it should be described as an
+//! insertion") the #882 phase gate rejects the conversion and the variant stays
+//! a plain `ins`. The synthetic cores below (`CORE_GT`, `CORE_CAG`) are phased
+//! so the tested rotations are OUT of phase, so they stay `ins` — matching live
+//! mutalyzer 3.1.1.
 
 use crate::common::synthetic::{normalize_to_string, SyntheticBuilder};
 
@@ -27,12 +34,16 @@ const CORE_CAG: &str = "AACAGCAGCAGCAACAGAA";
 const SEQID: &str = "NC_TEST.1";
 
 #[test]
-fn ins_tg_rotates_to_most_3prime_dup() {
-    // alt = TG, ref tract = GT (rotation r=1). Single copy added.
-    // Expected: 3'-shift through GT[3] then dup at most-3' GT.
+fn ins_tg_out_of_phase_stays_ins() {
+    // alt = TG, ref tract = GT (rotation r=1) — OUT OF PHASE at the 258_259
+    // cut. A candidate dup at the most-3' GT would decode to a different
+    // sequence than inserting "TG" here, so the #882 phase gate rejects it and
+    // the variant stays a plain `ins` (duplication.md:19). (Mutalyzer keeps
+    // out-of-phase insertions as ins; verified on real loci — this synthetic
+    // NC_TEST.1 accession isn't resolvable by mutalyzer.)
     let p = SyntheticBuilder::genomic(CORE_GT).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insTG", SEQID));
-    assert_eq!(result, format!("{}:g.263_264dup", SEQID));
+    assert_eq!(result, format!("{}:g.258_259insTG", SEQID));
 }
 
 #[test]
@@ -47,55 +58,48 @@ fn ins_gt_matched_rotation_already_works() {
 }
 
 #[test]
-fn ins_tgtg_two_copies_already_works() {
-    // alt = TGTG, ref tract = GT[3]. Multi-copy path
-    // (`insertion_to_repeat`) already handles this; lock the behavior.
+fn ins_tgtg_out_of_phase_stays_ins() {
+    // alt = TGTG, ref tract = GT[3] — OUT OF PHASE at the 258_259 cut. The
+    // candidate GT[5] repeat would decode to a different sequence than
+    // inserting "TGTG" here, so the #882 phase gate rejects it and the variant
+    // stays a plain `ins` (duplication.md:19).
     let p = SyntheticBuilder::genomic(CORE_GT).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insTGTG", SEQID));
-    assert_eq!(result, format!("{}:g.259_264GT[5]", SEQID));
+    assert_eq!(result, format!("{}:g.258_259insTGTG", SEQID));
 }
 
 #[test]
 fn ins_idempotent_post_fix() {
-    // Round-trip: normalize(normalize(insTG)) == normalize(insTG).
+    // Round-trip: normalize(normalize(insTG)) == normalize(insTG). The
+    // out-of-phase insTG stays a plain `ins` (#882) and is idempotent.
     let p = SyntheticBuilder::genomic(CORE_GT).build();
     let once = normalize_to_string(p, &format!("{}:g.258_259insTG", SEQID));
     let p2 = SyntheticBuilder::genomic(CORE_GT).build();
     let twice = normalize_to_string(p2, &once);
     assert_eq!(once, twice);
-    assert_eq!(once, format!("{}:g.263_264dup", SEQID));
+    assert_eq!(once, format!("{}:g.258_259insTG", SEQID));
 }
 
 #[test]
-fn ins_agc_cag_tract_rotates_to_dup() {
+fn ins_agc_out_of_phase_stays_ins() {
     // CAG[3] tract starting at HGVS 259 (core idx 2). Insert AGC at
     // HGVS 258_259 (just before tract's first C). alt "AGC" is the r=1
-    // rotation of canonical "CAG".
-    //
-    // CORE_CAG = "AACAGCAGCAGCAACAGAA": the CAG[3] tract is followed by a
-    // partial-match flank "CA" (from the trailing "CAA"). Per the HGVS 3'rule
-    // (DNA duplication.md: "the most 3' position possible … is arbitrarily
-    // assigned to have been changed"), the duplicated copy must shift as far 3'
-    // as the run allows — sliding one CAG copy right through the whole tandem
-    // run (valid while ref[s]==ref[s+3]) crosses the "CA" partial flank and
-    // lands on the GCA phase at HGVS [267..269]. The earlier `265_267dup`
-    // stopped at the pure-tandem boundary and was under-shifted (#864).
-    //
-    // Confirmed against mutalyzer on a real homologous locus:
-    // NC_000001.11:g.5010037_5010038insTG → g.5010045_5010046dup, and mutalyzer
-    // likewise re-normalizes the phase-aligned form to the most-3' slide.
+    // rotation of canonical "CAG" — OUT OF PHASE at this cut. A candidate dup
+    // anywhere in the tract would decode to a different sequence than inserting
+    // "AGC" here, so the #882 phase gate rejects the conversion and the variant
+    // stays a plain `ins` (duplication.md:19). (Mutalyzer keeps out-of-phase
+    // insertions as ins; verified on real loci — NC_TEST.1 is synthetic.)
     let p = SyntheticBuilder::genomic(CORE_CAG).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insAGC", SEQID));
-    assert_eq!(result, format!("{}:g.267_269dup", SEQID));
+    assert_eq!(result, format!("{}:g.258_259insAGC", SEQID));
 }
 
 #[test]
-fn ins_gca_cag_tract_rotates_to_dup() {
-    // Same layout/flank as `ins_agc_cag_tract_rotates_to_dup`, alt = GCA (a
-    // different rotation of the same tandem unit). Both spec-equivalent
-    // rotations yield the same most-3' canonical dup — the #864 3'rule slide
-    // through the "CA" partial flank → HGVS [267..269].
+fn ins_gca_out_of_phase_stays_ins() {
+    // Same layout/flank as `ins_agc_out_of_phase_stays_ins`, alt = GCA (a
+    // different out-of-phase rotation of the same tandem unit). It likewise
+    // stays a plain `ins` at the input position per the #882 phase gate.
     let p = SyntheticBuilder::genomic(CORE_CAG).build();
     let result = normalize_to_string(p, &format!("{}:g.258_259insGCA", SEQID));
-    assert_eq!(result, format!("{}:g.267_269dup", SEQID));
+    assert_eq!(result, format!("{}:g.258_259insGCA", SEQID));
 }

--- a/tests/it/issue_418_dup_after_branch.rs
+++ b/tests/it/issue_418_dup_after_branch.rs
@@ -109,26 +109,28 @@ fn ins_tc_three_prime_unaffected() {
 
 #[test]
 fn ins_tc_at_c35_five_prime_already_canonical() {
-    // Equivalence sanity: feeding the canonical biocommons output
-    // (`c.35_36dup` is dup notation for the same haplotype as
-    // `c.35_36insTC`) under 5'-direction lands at the same canonical
-    // dup position. Pins idempotency of the after-branch fix.
+    // #882: `c.35_36insTC` sits at the OUT-OF-PHASE cut relative to the
+    // adjacent tract — the candidate dup `c.35_36dup` would decode to a
+    // different sequence than inserting "TC" here, so the phase gate rejects
+    // the conversion and the variant stays a plain `ins` (duplication.md:19).
+    // (The in-phase sibling `c.36_37insTC` still becomes a dup — see
+    // `ins_tc_five_prime_emits_after_branch_dup`.)
     assert_eq!(
         normalize_with(ShuffleDirection::FivePrime, "NM_TEST418B.1:c.35_36insTC"),
-        "NM_TEST418B.1:c.35_36dup",
+        "NM_TEST418B.1:c.35_36insTC",
     );
 }
 
 #[test]
 fn ins_tc_at_c35_three_prime_already_canonical() {
-    // 3'-direction picks the most-3' equivalent dup anchor per the
-    // direction-aware tie-break in `insertion_to_duplication` (#408):
-    // both rotations "TC"@c.35..c.36 and "CT"@c.36..c.37 give
-    // `ref_count == 1`, and 3'-direction selects the larger `ref_start`.
-    // The result is haplotype-equivalent to `c.35_36dup`.
+    // #882: same out-of-phase input under 3'-direction. The candidate dup
+    // would decode to a different sequence than the input insertion, so the
+    // phase gate rejects it and the variant stays a plain `ins`
+    // (duplication.md:19). Contrast the in-phase `c.36_37insTC`, which still
+    // becomes `c.36_37dup` (see `ins_tc_three_prime_unaffected`).
     assert_eq!(
         normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418B.1:c.35_36insTC"),
-        "NM_TEST418B.1:c.36_37dup",
+        "NM_TEST418B.1:c.35_36insTC",
     );
 }
 

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -2534,14 +2534,13 @@ mod benchmark_comparison_tests {
     #[test]
     fn test_insertion_sequence_rotation() {
         // Pattern: c.247_248insAACA against ref where c.247_250 == "AACA".
-        // ferro post-issue-132: c.247_250dup (the inserted AACA matches the
-        //   following 4 ref bases verbatim → 1-copy AACA dup).
-        // mutalyzer: c.249_250insCAAA (a different rotation choice).
-        //
-        // The HGVS 3' rule prefers `dup` over `ins` when the inserted unit
-        // matches an adjacent reference unit (insertion_to_duplication's
-        // rotation iterator finds the AACA-phase tract with ref_count=1).
-        // The dup form is canonical regardless of input rotation.
+        // #882: the inserted "AACA" is OUT OF PHASE with the adjacent AACA
+        // tract at this cut — the candidate dup c.247_250dup would decode to a
+        // different sequence than inserting "AACA" here, so the phase gate
+        // rejects the conversion. The insertion still 3'-shifts (rotating the
+        // inserted unit) but stays a plain `ins`: c.248_249insACAA
+        // (duplication.md:19). (Mutalyzer keeps out-of-phase insertions as ins
+        // — verified on real loci; NM_TEST.1 is a synthetic accession here.)
         let mut seq = String::new();
         seq.push_str(&"G".repeat(246)); // Positions 1-246
         seq.push_str("AA"); // Positions 247-248
@@ -2552,11 +2551,10 @@ mod benchmark_comparison_tests {
 
         let result = normalize_to_string(provider, "NM_TEST.1:c.247_248insAACA");
 
-        // 1-copy AACA next to a single AACA in the ref → dup spanning
-        // the matched ref tract (c.247..c.250 inclusive).
+        // Out-of-phase insertion 3'-shifts but stays `ins` (not a dup) per #882.
         assert_eq!(
-            result, "NM_TEST.1:c.247_250dup",
-            "Expected c.247_250dup (issue #132 dup-over-ins canonicalization), got: {}",
+            result, "NM_TEST.1:c.248_249insACAA",
+            "Expected c.248_249insACAA (out-of-phase ins stays ins, #882), got: {}",
             result
         );
     }


### PR DESCRIPTION
Closes #882.

## Problem

`normalize` converted an **out-of-phase** insertion into a tandem duplication (or repeat) that decodes to a **different sequence** than the input — silent variant corruption. Reproducer on `NC_000001.11` (window `GACACACATAGGT`, an `ACACACA` tract):

| input | before | after (this PR) | mutalyzer 3.1.1 |
|---|---|---|---|
| `g.20004503_20004504insAC` | `g.20004508_20004509dup` ❌ | `…insAC` | `…insAC` |
| `g.20004503_20004504insCA` | `g.20004508_20004509dup` ✅ | `g.20004508_20004509dup` | `g.20004508_20004509dup` |

Both insert at the same `A|C` cut, but only `insCA` is in phase with the tract; `insAC` decodes to `GAACCACACATAGGT` while the emitted dup decodes to `GACACACACATAGGT` — a different variant.

Per HGVS `duplication.md`: *"when there is no evidence that the extra copy … is in tandem (directly 3'-flanking the original copy), the change can not be described as a duplication; it should be described as an insertion."* Confirmed against **live mutalyzer 3.1.1** for both cases (and the real chr1 in-phase `insTG` locus, which correctly stays a dup).

The sibling `insertion_to_repeat` (2+-copy path) had the identical latent bug; both are fixed.

## Fix

A single in-phase correctness gate `tandem_edit_preserves_insertion` in `src/normalize/rules.rs`: it builds the sequence produced by the input insertion and the sequence produced by the **exact emitted** dup/repeat (post-alignment window + unit), and returns `false` when they differ. `insertion_to_duplication` and `insertion_to_repeat` call it just before emitting and return `None` on failure, so the existing caller fallthrough leaves the variant as a plain (rotated) `ins`. No caller/behavioral changes outside these two functions; in-phase conversions are unaffected (they decode-equal by construction).

## Tests

- Unit tests for the gate (in-phase → accept, out-of-phase → reject, bounds guards → no panic) and for both `insertion_to_duplication`/`insertion_to_repeat` on the #882 reproducers.
- End-to-end `normalize` tests on the real locus (`insAC` stays `ins`, `insCA` becomes `dup`).
- **Re-blessed pre-existing over-conversions.** Several synthetic tests (`ins_shift_matrix` cyclic-rotation rows across all axes, `issue_132`, `issue_418`, a `normalize_tests` rotation case) asserted out-of-phase inputs converting to dup/repeat — spec-violating over-conversions the gate now correctly declines. Their expectations are updated to the spec-correct `ins` form, and `issue_132`'s doc comment is corrected (only **in-phase** rotations become dups; its in-phase `ins_gt_matched_rotation_already_works` still asserts a dup and passes). Two pre-existing unit tests whose inputs were themselves latent out-of-phase instances were repaired to in-phase equivalents.

## Corpus

The `mutalyzer-normalize` corpus rows `NM_000143.3:c.-1_1insCAT` / `c.1_2insCAT` expected `c.-1_2dup` — a stale **Mutalyzer2**-era value. Live mutalyzer 3.1.1 and fixed-ferro both keep these as the insertion; the `normalized` values and `spec_citation` notes are corrected. (A full sweep of all 246 mutalyzer-expected rows against mutalyzer 3.1.1 found the corpus otherwise 96% faithful — these two were the only genuine drift; see #890 for recording comparator provenance.)

**Follow-ups (filed, not in this PR):** #891 — the `protein_description` axis on those two rows (`p.(Met1?)`) is ferro's hermetically-verified output but was originally derived from the superseded `c.-1_2dup`; its biological correctness under the insertion form is tracked for re-derivation. #890 — bump the behind comparators (hgvs-rs, mutalyzer-hgvs-parser, biocommons hgvs) and record comparator versions in corpus provenance (the sweep that found these two rows also confirmed the corpus is otherwise 96% faithful to mutalyzer 3.1.1).

## Verification

`cargo nextest run --features dev` → all pass (0 failed); `cargo clippy --features dev --all-targets -- -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HGVS normalization for insertion variants in repeat regions and at CDS boundaries.
  * Out-of-phase insertions now stay as plain `ins` instead of incorrectly converting to duplications or repeat notation.
  * In-phase cases continue to normalize to the expected duplication form.
  * Updated regression coverage to ensure normalization remains stable and idempotent across genomic, CDS, RNA, and noncoding examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->