### PR TITLE
fix(project): surface the genomic axis for LRG inputs and pter/qter termini on project_variant (#886, #887)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1364,10 +1364,13 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// `Cds` input, an endpoint that is not a `pter`/`qter` marker (numeric,
     /// `?`, `cen`, or a mixed marker/numeric range), or a reversed `qter_pter` —
     /// so the caller falls through to the normal transcript-mapped projection
-    /// (which declines or numbers as appropriate). Returns `Some(Err(..))` when
-    /// the parent reference is unresolvable or its length is unknown to the
-    /// provider (e.g. the pinned parent version is absent — a reference-coverage
-    /// gap, #645/#672 — not a projection bug).
+    /// (which declines or numbers as appropriate). Returns `Some(Err(..))` only
+    /// for a *supported* terminus whose parent reference is unresolvable or whose
+    /// length is unknown to the provider (e.g. the pinned parent version is
+    /// absent — a reference-coverage gap, #645/#672 — not a projection bug); the
+    /// marker-pair classification runs *before* the parent-length lookup, so an
+    /// unsupported pair always declines with `None` regardless of whether the
+    /// parent length could be resolved.
     fn project_cds_terminus_to_parent(
         &self,
         variant: &HgvsVariant,
@@ -1386,6 +1389,24 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let end = resolve_uncertain_boundary(&v.loc_edit.location.end, "c.", "end").ok()?;
         let (Some(start_marker), Some(end_marker)) = (start.special, end.special) else {
             return None;
+        };
+
+        // Classify the whole-arm terminus BEFORE resolving the parent length, so
+        // an unsupported marker pair (`cen`, a reversed `qter_pter`, a mixed
+        // `pter_cen`, …) declines here and falls through to the normal rejection
+        // path — rather than surfacing an incidental parent-length-lookup error,
+        // which is only meaningful for a supported terminus. `pter` → 5'-most
+        // (g.1), `qter` → 3'-most (g.<length>), `pter_qter` → the whole reference.
+        enum ArmTerminus {
+            Pter,
+            Qter,
+            Whole,
+        }
+        let terminus = match (start_marker, end_marker) {
+            (SpecialPosition::Pter, SpecialPosition::Pter) => ArmTerminus::Pter,
+            (SpecialPosition::Qter, SpecialPosition::Qter) => ArmTerminus::Qter,
+            (SpecialPosition::Pter, SpecialPosition::Qter) => ArmTerminus::Whole,
+            _ => return None,
         };
 
         // Resolve the parent genomic reference: an explicit `genomic_context`
@@ -1409,14 +1430,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             return None;
         }
 
-        // pter → 5'-most (g.1); qter → 3'-most (g.<length>); pter_qter → the
-        // whole reference. `cen` and a reversed `qter_pter` are out of scope and
-        // left to the normal path (which declines).
-        let (g_start, g_end) = match (start_marker, end_marker) {
-            (SpecialPosition::Pter, SpecialPosition::Pter) => (1, 1),
-            (SpecialPosition::Qter, SpecialPosition::Qter) => (length, length),
-            (SpecialPosition::Pter, SpecialPosition::Qter) => (1, length),
-            _ => return None,
+        let (g_start, g_end) = match terminus {
+            ArmTerminus::Pter => (1, 1),
+            ArmTerminus::Qter => (length, length),
+            ArmTerminus::Whole => (1, length),
         };
 
         let interval = GenomeInterval::new(GenomePos::new(g_start), GenomePos::new(g_end));
@@ -3535,6 +3552,63 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         normalized: &HgvsVariant,
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
+        // #887: resolve a whole-arm terminus (pter/qter) to the parent genome
+        // frame via the same handler the raw project_to_genomic pivot uses
+        // (1310), BEFORE the direct-path gate and the nc pivot — both reject the
+        // sentinel. Fires only for a CDS special-terminus with a derivable
+        // parent; otherwise falls through to the existing (correct) rejection.
+        // Enforce the transcript_id match first (mirrors the pivot arm at
+        // 3572-3584) so a mismatched target still errors.
+        if let HgvsVariant::Cds(c) = normalized {
+            // `.is_special()` lives on `CdsPos`, not on `UncertainBoundary<CdsPos>`,
+            // so reach through `.inner()` — the exact idiom normalize uses
+            // (normalize/mod.rs:1993).
+            let start_special = c
+                .loc_edit
+                .location
+                .start
+                .inner()
+                .is_some_and(|p| p.is_special());
+            let end_special = c
+                .loc_edit
+                .location
+                .end
+                .inner()
+                .is_some_and(|p| p.is_special());
+            if start_special || end_special {
+                if let Some(acc) = normalized.accession() {
+                    let input_tx = acc.transcript_accession();
+                    if input_tx != transcript_id {
+                        return Err(FerroError::UnsupportedProjection {
+                            reason: format!(
+                                "transcript_id mismatch: input is on {} but projection \
+                                 requested against {}; transcript-coordinate inputs must \
+                                 be projected against their own transcript",
+                                input_tx, transcript_id,
+                            ),
+                        });
+                    }
+                }
+                if let Some(result) = self.project_cds_terminus_to_parent(normalized) {
+                    // `result?` propagates a genuine terminus-resolution error
+                    // (parent known but its length lookup failed). Normalize the
+                    // resolved terminus to match the raw pivot + harness normalize;
+                    // on a normalize failure fall back to the un-normalized parent
+                    // terminus (still a valid coordinate) rather than aborting the
+                    // whole projection — the genomic axis degrades gracefully,
+                    // mirroring reanchor_and_normalize_genomic.
+                    let raw = result?;
+                    let genomic = self.normalizer.normalize(&raw).unwrap_or(raw);
+                    return Ok(self.terminus_multiaxis_projection(
+                        normalized,
+                        transcript_id,
+                        genomic,
+                    ));
+                }
+                // No derivable parent (bare NM_/NR_) or cen/?/reversed -> fall
+                // through; the direct-path gate / nc pivot rejects it as today.
+            }
+        }
         // Direct c.→p. path: a bare coding input (no genomic_context parent)
         // has no genome alignment to roundtrip through, but protein can be
         // predicted straight from the CDS (#498).
@@ -4016,6 +4090,42 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             is_utr: true,
             affects_init: false,
         })
+    }
+
+    /// Genomic-only projection for a whole-arm terminus (pter/qter) `c.` input
+    /// whose parent genome frame IS resolvable (#887). Mirrors
+    /// `polya_multiaxis_projection`'s shape: echo the input's bare coding form,
+    /// no protein/noncoding/rna axis (a whole-arm marker does not round-trip
+    /// through cdot). `genomic` is the already-normalized parent-frame
+    /// (NG_/LRG_) coordinate.
+    fn terminus_multiaxis_projection(
+        &self,
+        normalized: &HgvsVariant,
+        transcript_id: &str,
+        genomic: HgvsVariant,
+    ) -> VariantProjection {
+        let coding = match normalized {
+            HgvsVariant::Cds(c) => {
+                let mut c = c.clone();
+                c.accession.genomic_context = None;
+                (Some(HgvsVariant::Cds(c.clone())), c.gene_symbol.clone())
+            }
+            _ => (None, None),
+        };
+        VariantProjection {
+            genomic: Some(genomic),
+            coding: coding.0,
+            noncoding: None,
+            protein: None,
+            rna: None,
+            transcript_id: transcript_id.to_string(),
+            gene_symbol: coding.1,
+            is_frameshift: false,
+            is_intronic: false,
+            // A whole-arm terminus is not a canonical UTR position.
+            is_utr: false,
+            affects_init: false,
+        }
     }
 }
 
@@ -7937,6 +8047,101 @@ mod tests {
                 s.starts_with("NC_000001.11") && s.contains(":g.1003C>A"),
                 "expected NC_000001.11:g.1003C>A unchanged, got: {s}"
             );
+        }
+
+        // -- 8b: #887 — NG-parented pter/qter termini resolve on project_variant ---
+
+        /// A projector whose provider knows only the NG parent's sequence, so a
+        /// whole-arm terminus resolves against it. The reference's first and last
+        /// bases are deliberately NOT part of a homopolymer run (`C…G`) so that
+        /// `normalize(g.1del)` stays `g.1del` and `normalize(g.<len>del)` stays
+        /// `g.<len>del` (an all-`A` ref would 3'-shift both to the same
+        /// coordinate). Returns the projector and the transcript id to project
+        /// against (`NM_TEST.1`, the input's own transcript).
+        fn ng_parent_projector_with_seq(seq: &str) -> (VariantProjector<MockProvider>, String) {
+            let projector = Projector::new(CdotMapper::new());
+            let mut provider = MockProvider::new();
+            provider.add_genomic_sequence("NG_TEST.1", seq.to_string());
+            (
+                VariantProjector::new(projector, provider),
+                "NM_TEST.1".to_string(),
+            )
+        }
+
+        #[test]
+        fn project_variant_ng_parent_pter_resolves_genomic_887() {
+            // len = 50, first base `C` (not shiftable), last base `G`.
+            let (projector, tx_id) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
+            let v = crate::parse_hgvs("NG_TEST.1(NM_TEST.1):c.pterdel").unwrap();
+            let proj = projector
+                .project_variant(&v, &tx_id)
+                .expect("pter must resolve, not error");
+            assert_eq!(
+                proj.genomic.as_ref().map(|g| g.to_string()),
+                Some("NG_TEST.1:g.1del".to_string())
+            );
+            assert!(proj.protein.is_none());
+            assert!(proj.coding.is_some(), "coding echoes the bare input form");
+        }
+
+        #[test]
+        fn project_variant_ng_parent_qter_resolves_genomic_887() {
+            let (projector, tx_id) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
+            let v = crate::parse_hgvs("NG_TEST.1(NM_TEST.1):c.qterdel").unwrap();
+            let proj = projector
+                .project_variant(&v, &tx_id)
+                .expect("qter must resolve");
+            assert_eq!(
+                proj.genomic.as_ref().map(|g| g.to_string()),
+                Some("NG_TEST.1:g.50del".to_string())
+            );
+        }
+
+        #[test]
+        fn project_variant_ng_parent_pter_qter_range_resolves_887() {
+            let (projector, tx_id) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
+            let v = crate::parse_hgvs("NG_TEST.1(NM_TEST.1):c.pter_qterdel").unwrap();
+            let proj = projector
+                .project_variant(&v, &tx_id)
+                .expect("pter_qter range must resolve");
+            assert_eq!(
+                proj.genomic.as_ref().map(|g| g.to_string()),
+                Some("NG_TEST.1:g.1_50del".to_string())
+            );
+        }
+
+        /// An unsupported terminus marker pair (`cen`) must decline with `None`
+        /// — falling through to the normal rejection path — **even when the
+        /// parent-length lookup would itself fail**. The marker-pair
+        /// classification runs *before* the parent-length lookup, so an
+        /// unsupported pair never leaks an incidental length-lookup `Some(Err)`
+        /// (which is meaningful only for a supported `pter`/`qter` terminus) and
+        /// so aborts the whole projection instead of the intended fall-through.
+        #[test]
+        fn unsupported_cen_terminus_declines_before_parent_length_lookup_887() {
+            let (projector, _tx) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
+            // Parent `NG_MISSING.1` is unknown to the provider, so a length
+            // lookup against it errors — the exact condition that previously
+            // leaked a `Some(Err(..))` for the unsupported `cen` pair.
+            let HgvsVariant::Cds(cds) = crate::parse_hgvs("NM_TEST.1:c.cendel").unwrap() else {
+                panic!("c.cendel must parse as a Cds variant");
+            };
+            let cds = attach_genomic_context_cds(cds, ng_parent("MISSING", 1));
+            let variant = HgvsVariant::Cds(cds);
+            assert!(
+                projector.project_cds_terminus_to_parent(&variant).is_none(),
+                "unsupported cen terminus must decline with None, not surface a \
+                 parent-length-lookup error",
+            );
+        }
+
+        #[test]
+        fn project_variant_pter_transcript_id_mismatch_still_errors_887() {
+            // The early terminus guard must sit AFTER a transcript_id match check,
+            // so a mismatched target still errors instead of silently resolving.
+            let (projector, _tx) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
+            let v = crate::parse_hgvs("NG_TEST.1(NM_TEST.1):c.pterdel").unwrap();
+            assert!(projector.project_variant(&v, "NM_OTHER.9").is_err());
         }
 
         // -- 9: protein input → unsupported ------------------------------------

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -2962,8 +2962,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// `genomic_context` parent). The c.→g.→CDS roundtrip cannot run without a
     /// genome alignment, but protein prediction only needs the transcript's
     /// CDS sequence and the 1-based CDS position — which an exonic c. variant
-    /// already provides. The resulting projection has `genomic = None` (no
-    /// genomic representation is available for a bare-NM_ input) (#498).
+    /// already provides. The genomic axis is `None` for a bare `NM_`/`NR_`
+    /// input (no genome alignment), but is filled with the reanchored
+    /// `LRG_<n>:g.…` form when the input is a bare LRG transcript whose
+    /// structural parent resolves (`lrg_genomic_parent`, #886) (#498).
     fn project_coding_direct(
         &self,
         cds: &CdsVariant,
@@ -3093,8 +3095,20 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .and_then(|tx| crate::project::rna::predict_rna(normalized, &tx));
         let rna = Self::reframe_rna_from_input(rna, normalized);
 
+        // #886: a bare LRG transcript has a structurally derivable genomic
+        // parent, so its genomic axis IS resolvable (via the raw pivot, which
+        // fills the LRG parent and reanchors into the LRG frame). A bare
+        // NM_/NR_ has no genome alignment -> stays None. project_to_genomic
+        // already normalizes; `.ok()` degrades to None if the LRG placement is
+        // genuinely unavailable.
+        let genomic = if Self::lrg_genomic_parent(&cds.accession).is_some() {
+            self.project_to_genomic(normalized).ok()
+        } else {
+            None
+        };
+
         Ok(VariantProjection {
-            genomic: None,
+            genomic,
             coding: Some(normalized.clone()),
             noncoding,
             protein,
@@ -3114,9 +3128,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// 1-based transcript position: convert it to a CDS position via the
     /// transcript's `cds_start` (the exon/CIGAR-aware
     /// [`CoordinateMapper::tx_to_cds`]), then run the same protein-consequence
-    /// prediction the coding path uses. The resulting projection has
-    /// `genomic = None` (no genomic representation is available for a bare-NM_
-    /// input) (#506).
+    /// prediction the coding path uses. The genomic axis is `None` for a bare
+    /// `NM_`/`NR_` input (no genome alignment), but is filled with the
+    /// reanchored `LRG_<n>:g.…` form when the input is a bare LRG transcript
+    /// whose structural parent resolves (`lrg_genomic_parent`, #886) (#506).
     ///
     /// `normalized` must be an [`HgvsVariant::Tx`] or [`HgvsVariant::Rna`].
     fn project_noncoding_direct(
@@ -3257,12 +3272,22 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // U→T mapping. This is a no-op for n. (DNA) inputs.
         let c_edit = transform_edit_for_strand(&edit, RefStrand::Plus);
 
+        // #886: a bare LRG transcript has a structurally derivable genomic
+        // parent, so its genomic axis IS resolvable; a bare NM_/NR_ has no
+        // genome alignment -> stays None. Computed once here because the two
+        // return sites below sit in different branches (the `!is_coding` early
+        // return and the tail), so there is no shared tail to set it in.
+        let genomic = normalized
+            .accession()
+            .filter(|acc| Self::lrg_genomic_parent(acc).is_some())
+            .and_then(|_| self.project_to_genomic(normalized).ok());
+
         // Non-coding transcript: there is no CDS to convert into, so there is
         // no protein consequence and no c. form. The n. form is the input
         // itself; report it on the non-coding axis and stop.
         if !is_coding {
             return Ok(VariantProjection {
-                genomic: None,
+                genomic,
                 coding: None,
                 noncoding: Some(normalized.clone()),
                 protein: None,
@@ -3323,7 +3348,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // renders bare (or under the input's parent for an `NG_(NM_)` input).
         let rna = Self::reframe_rna_from_input(rna, normalized);
         Ok(VariantProjection {
-            genomic: None,
+            genomic,
             coding: Some(coding),
             // The non-coding axis is the input itself.
             noncoding: Some(normalized.clone()),
@@ -8142,6 +8167,17 @@ mod tests {
             let (projector, _tx) = ng_parent_projector_with_seq(&format!("C{}G", "A".repeat(48)));
             let v = crate::parse_hgvs("NG_TEST.1(NM_TEST.1):c.pterdel").unwrap();
             assert!(projector.project_variant(&v, "NM_OTHER.9").is_err());
+        }
+
+        #[test]
+        fn bare_nm_coding_input_genomic_stays_none_886() {
+            // A bare NM_ (no LRG parent, no genomic_context) must keep the genomic
+            // axis None — the #886 fill is gated on a derivable LRG parent.
+            let (projector, provider) = make_test_provider_and_projector();
+            let vp = VariantProjector::new(projector, provider);
+            let v = crate::parse_hgvs("NM_TEST.1:c.4C>A").unwrap();
+            let proj = vp.project_variant(&v, "NM_TEST.1").unwrap();
+            assert!(proj.genomic.is_none());
         }
 
         // -- 9: protein input → unsupported ------------------------------------

--- a/tests/it/issue_860_lrg_namespace.rs
+++ b/tests/it/issue_860_lrg_namespace.rs
@@ -121,3 +121,31 @@ fn lrg_transcript_input_emits_lrg_protein_accession() {
         coding
     );
 }
+
+/// #886: a bare `LRG_<n>t<k>:c.` input has a structurally derivable genomic
+/// parent, so its genomic axis must resolve (namespaced to `LRG_1`), not stay
+/// `None`. Namespace preservation on the coding/protein axes is unchanged.
+#[test]
+fn lrg_transcript_input_populates_genomic_axis_886() {
+    let (projector, provider) = lrg_fixture();
+    let vp = VariantProjector::new(projector, provider);
+    let variant = parse_hgvs("LRG_1t1:c.4C>A").expect("parse");
+    let proj = vp.project_variant(&variant, "LRG_1t1").expect("projects");
+    assert_eq!(
+        proj.genomic.as_ref().map(|g| g.to_string()),
+        Some("LRG_1:g.4C>A".to_string())
+    );
+    // Namespace preservation unchanged:
+    assert!(proj
+        .coding
+        .as_ref()
+        .unwrap()
+        .to_string()
+        .starts_with("LRG_1t1"));
+    assert!(proj
+        .protein
+        .as_ref()
+        .unwrap()
+        .to_string()
+        .starts_with("LRG_1p1"));
+}


### PR DESCRIPTION
Closes #886. Closes #887.

## Problem

The user-facing `VariantProjector::project_variant` computed its `.genomic` axis via a narrower internal path than the raw `project_to_genomic` pivot, so it produced a worse result for two input classes:

| bug | input | `project_variant().genomic` before | after (matches raw pivot / mutalyzer) |
|---|---|---|---|
| #886 | `LRG_1t1:c.266G>T` | `None` | `LRG_1:g.6855G>T` |
| #887 | `NG_012337.1(NM_003002.2):c.pterdel` | **Err** (sentinel) | `NG_012337.1:g.3del` |
| #887 | `NG_012337.1(NM_003002.2):c.qterdel` | **Err** (sentinel) | `NG_012337.1:g.15948del` |

All three verified against live mutalyzer / the raw pivot on the real reference. These jointly unblock #870 (route the conformance `axis_genomic` through `project_variant`), which is a separate follow-up PR.

## Fix (both confined to the `project_single_inner` subtree; no shared-helper changes)

**#887 — early terminus guard.** At the top of `project_single_inner`, before the direct-path gate and the nc pivot (both of which reject `pter`/`qter`/`cen`), resolve a whole-arm terminus via the same `project_cds_terminus_to_parent` handler the raw pivot uses (1306), then normalize. It fires only for a CDS special-terminus, enforces the transcript_id match first (so a mismatched target still errors), and returns a genomic-only projection (`terminus_multiaxis_projection`, modeled on `polya_multiaxis_projection`). A parentless bare-`NM_` terminus, `cen`, and `?` return `None` from the handler and fall through to the existing (correct) rejection.

**#886 — genomic-axis fill.** In `project_coding_direct`/`project_noncoding_direct`, fill the previously-`None` genomic axis with the reanchored `LRG_<n>:g.…` form when the input is a bare LRG transcript whose structural parent resolves (`lrg_genomic_parent`), keeping bare LRG on the direct path so its LRG_t/LRG_p namespace on the coding/protein axes is preserved (#860/#874). Bare `NM_`/`NR_` (no genome alignment) stays `None`.

## Scope / non-goals

- **#887 covers NG-parented termini** (the reproducer). The projector's lenient front-normalize keeps the sentinel marker verbatim for a genomic-context input, so the guard sees it.
- **Out of scope:** bare-LRG termini via `project_variant` (`LRG_<n>t<k>:c.pterdel`) — on a real reference, normalize resolves the marker to a concrete CDS position before the guard runs, so it diverges from the raw pivot; fixing needs pre-normalize handling (follow-up). True `HgvsVariant::Allele` LRG inputs (different dispatch) likewise unchanged.

## Tests

- #887: NG-parented `pter`/`qter`/`pter_qter` resolve via `project_variant().genomic` (fixture uses a non-homopolymer-flanked reference `C…G` so `pter`→`g.1del` and `qter`→`g.50del` stay distinct after normalization); transcript_id mismatch still errors; bare-`NM_` `pter`/`qter` and `cen`/`?` stay unsupported (regression guards).
- #886: bare LRG resolves `.genomic` while coding/protein namespace stays LRG_t/LRG_p; bare `NM_` stays `None`.
- Regression guards green: the NG/NC-parent reanchor tests, `issue_480_*`, `issue_537_*`, `issue_860_*`, and the bare-NM rejection tests.

## Verification

`cargo nextest run --features dev` → all pass (0 failed); `cargo clippy --features dev --all-targets -- -D warnings` clean. Real-reference reproducers confirmed via the scratch manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genomic coordinate resolution for bare transcript (LRG t) coding inputs by mapping them to the corresponding genomic (LRG g) form when derivable.
  * Added whole-arm terminus handling (pter/qter combinations) so projections can populate genomic coordinates when only the genomic context is available.
  * Ensured unsupported terminus pairings decline cleanly, and preserved transcript-ID mismatch errors for these terminus cases.
  * Kept `genomic` unset for inputs that should not resolve (e.g., bare NM_/NR_ coding).
* **Tests**
  * Added conformance coverage for these projection behaviors and mismatch rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->