### PR TITLE
test(conformance): route genomic axis through the user-facing project_variant path (#870)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -39,10 +39,6 @@ impl Fixture {
         for case in &self.cases {
             let input = case.input.as_str();
             for cluster in [
-                case.accepted_divergence
-                    .as_ref()
-                    .and_then(|d| d.cluster.as_deref()),
-                case.known_bug.as_ref().and_then(|d| d.cluster.as_deref()),
                 case.improvement.as_ref().and_then(|d| d.cluster.as_deref()),
                 case.reference_unavailable
                     .as_ref()
@@ -56,12 +52,21 @@ impl Fixture {
             {
                 refs.push((input, cluster));
             }
-            // A `Case` may carry multiple per-axis spec citations (#827); collect
-            // the cluster ref of each.
-            for citation in &case.spec_citations {
-                if let Some(cluster) = citation.cluster.as_deref() {
-                    refs.push((input, cluster));
-                }
+            // A `Case` may carry multiple per-axis accepted divergences (#870),
+            // known bugs (#870), and spec citations (#827); collect the cluster
+            // ref of each.
+            for cluster in case
+                .accepted_divergences
+                .iter()
+                .filter_map(|d| d.cluster.as_deref())
+                .chain(case.known_bugs.iter().filter_map(|d| d.cluster.as_deref()))
+                .chain(
+                    case.spec_citations
+                        .iter()
+                        .filter_map(|d| d.cluster.as_deref()),
+                )
+            {
+                refs.push((input, cluster));
             }
         }
         refs
@@ -76,26 +81,51 @@ impl Fixture {
     /// fixture-validation time (#827).
     pub fn validate_clusters(&self) -> Result<(), String> {
         validate_cluster_refs(&self.clusters, self.cluster_refs())?;
-        self.validate_spec_citation_axes()
+        self.validate_multi_axis_annotation_uniqueness()
     }
 
-    /// Reject any `Case` whose `spec_citations` cite the same axis more than once
-    /// (the matcher would silently honor only the first). See
-    /// [`validate_clusters`](Self::validate_clusters).
-    fn validate_spec_citation_axes(&self) -> Result<(), String> {
-        for case in &self.cases {
+    /// Reject any `Case` whose multi-axis annotations (`spec_citations`,
+    /// `accepted_divergences`, `known_bugs`) name the same axis more than once
+    /// within a single annotation kind — the matcher `find`s the first match per
+    /// axis, so a duplicate-axis entry would be silently ignored. Surfacing it
+    /// here turns an authoring mistake into a hard error at fixture-validation
+    /// time (#827/#870). See [`validate_clusters`](Self::validate_clusters).
+    fn validate_multi_axis_annotation_uniqueness(&self) -> Result<(), String> {
+        fn check_unique(
+            input: &str,
+            kind: &str,
+            axes: impl IntoIterator<Item = Axis>,
+        ) -> Result<(), String> {
             let mut seen: Vec<Axis> = Vec::new();
-            for citation in &case.spec_citations {
-                if seen.contains(&citation.axis) {
+            for axis in axes {
+                if seen.contains(&axis) {
                     return Err(format!(
-                        "case {:?} has more than one spec_citation for axis {:?}; \
-                         the matcher honors only one citation per axis",
-                        case.input,
-                        citation.axis.as_str(),
+                        "case {input:?} has more than one {kind} for axis {:?}; \
+                         the matcher honors only one per axis",
+                        axis.as_str(),
                     ));
                 }
-                seen.push(citation.axis);
+                seen.push(axis);
             }
+            Ok(())
+        }
+
+        for case in &self.cases {
+            check_unique(
+                &case.input,
+                "spec_citation",
+                case.spec_citations.iter().map(|c| c.axis),
+            )?;
+            check_unique(
+                &case.input,
+                "accepted_divergence",
+                case.accepted_divergences.iter().map(|d| d.axis),
+            )?;
+            check_unique(
+                &case.input,
+                "known_bug",
+                case.known_bugs.iter().map(|d| d.axis),
+            )?;
         }
         Ok(())
     }
@@ -106,7 +136,9 @@ impl Fixture {
         let mut rows = Vec::new();
         for case in &self.cases {
             let input = case.input.as_str();
-            if let Some(d) = &case.accepted_divergence {
+            // One summary row per per-axis accepted divergence (#870): a
+            // multi-axis row contributes an `AcceptedDivergence` row per axis.
+            for d in &case.accepted_divergences {
                 rows.push(MemberRow {
                     cluster: d.cluster.clone(),
                     input: input.to_string(),
@@ -116,7 +148,8 @@ impl Fixture {
                     tracking_issue: None,
                 });
             }
-            if let Some(d) = &case.known_bug {
+            // One summary row per per-axis known bug (#870).
+            for d in &case.known_bugs {
                 rows.push(MemberRow {
                     cluster: d.cluster.clone(),
                     input: input.to_string(),
@@ -207,19 +240,42 @@ pub struct Case {
     pub noncoding: Option<Vec<String>>,
     #[serde(default = "default_true")]
     pub to_test: bool,
-    /// Marks a mismatch on a specific axis as an accepted (non-bug)
-    /// divergence — e.g. a ferro policy decision that intentionally
-    /// disagrees with mutalyzer while both outputs remain HGVS-spec-allowed.
-    /// Tallied into `AxisTally::divergence_accepted` instead of `fail`.
-    #[serde(default)]
-    pub accepted_divergence: Option<AcceptedDivergence>,
-    /// Marks a mismatch on a specific axis as a known ferro bug (xfail):
-    /// ferro is wrong and the divergence is tracked by an issue rather than
-    /// accepted as policy. Tallied into `AxisTally::known_bug` instead of
-    /// `fail`. If ferro starts matching mutalyzer (XPASS), the harness fails
-    /// so the annotation and now-fixed row are cleaned up.
-    #[serde(default)]
-    pub known_bug: Option<KnownBug>,
+    /// Per-axis accepted (non-bug) divergence annotations — e.g. a ferro policy
+    /// decision that intentionally disagrees with mutalyzer while both outputs
+    /// remain HGVS-spec-allowed. A mismatch on an axis that carries a divergence
+    /// for that axis is tallied into `AxisTally::divergence_accepted` instead of
+    /// `fail`.
+    ///
+    /// A `Case` may carry MORE THAN ONE divergence, each scoped to a different
+    /// axis (#870) — e.g. a `normalized`-axis divergence AND a `genomic`-axis
+    /// divergence on the same row (the copy-range literal-expansion policy
+    /// diverges on both axes once the genomic axis routes through the user-facing
+    /// `project_variant`). The matcher keys each divergence to its axis, so at
+    /// most one per axis takes effect.
+    ///
+    /// The wire (`cases.json`) key is `accepted_divergence` and accepts either a
+    /// single object (the common case, deserialized to a one-element vec) or an
+    /// array of objects (a multi-axis row). Absent → empty vec. See
+    /// [`de_one_or_many`].
+    #[serde(
+        default,
+        rename = "accepted_divergence",
+        deserialize_with = "de_one_or_many"
+    )]
+    pub accepted_divergences: Vec<AcceptedDivergence>,
+    /// Per-axis known-ferro-bug annotations (xfail): ferro is wrong and the
+    /// divergence is tracked by an issue rather than accepted as policy. A
+    /// mismatch on an axis that carries a known bug for that axis is tallied into
+    /// `AxisTally::known_bug` instead of `fail`. If ferro starts matching
+    /// mutalyzer (XPASS), the harness fails so the annotation and now-fixed row
+    /// are cleaned up.
+    ///
+    /// Like [`accepted_divergences`](Self::accepted_divergences), a `Case` may
+    /// carry MORE THAN ONE known bug, each scoped to a different axis (#870). The
+    /// wire key is `known_bug` and accepts a single object or an array. Absent →
+    /// empty vec. See [`de_one_or_many`].
+    #[serde(default, rename = "known_bug", deserialize_with = "de_one_or_many")]
+    pub known_bugs: Vec<KnownBug>,
     /// Marks a mismatch on a specific axis as a tracked *improvement* (not a
     /// bug): ferro's output is valid HGVS but not the spec-*preferred*
     /// canonical form, and `normalize()` should converge on the preferred form
@@ -251,12 +307,8 @@ pub struct Case {
     /// The wire (`cases.json`) key is `spec_citation` and accepts either a single
     /// citation object (the common case, deserialized to a one-element vec) or an
     /// array of citation objects (a multi-axis row). Absent → empty vec. See
-    /// [`de_spec_citations`].
-    #[serde(
-        default,
-        rename = "spec_citation",
-        deserialize_with = "de_spec_citations"
-    )]
+    /// [`de_one_or_many`].
+    #[serde(default, rename = "spec_citation", deserialize_with = "de_one_or_many")]
     pub spec_citations: Vec<SpecCitation>,
     /// Marks a non-panic `Err` on a specific axis as ferro *correctly rejecting*
     /// an input mutalyzer leniently reinterprets (the only disposition that
@@ -966,32 +1018,37 @@ fn default_true() -> bool {
     true
 }
 
-/// Deserialize the `cases.json` `spec_citation` field, accepting either a single
-/// citation object or an array of citation objects, normalizing both to a
-/// `Vec<SpecCitation>` (#827). The single-object form (the common case)
-/// deserializes to a one-element vec, so existing single-citation rows need no
-/// JSON change; a row that needs citations on more than one axis uses the array
-/// form. An explicit `null` (like an absent field, and like the prior
-/// `Option<SpecCitation>` shape this replaced) yields an empty vec. Each element
-/// is still validated against the closed [`Axis`]/[`SpecSection`] enums, so a
-/// typo in either form is a hard parse error.
-fn de_spec_citations<'de, D>(deserializer: D) -> Result<Vec<SpecCitation>, D::Error>
+/// Deserialize a per-axis annotation field, accepting either a single object or
+/// an array of objects and normalizing both to a `Vec<T>`. The single-object
+/// form (the common case) deserializes to a one-element vec, so existing
+/// single-annotation rows need no JSON change; a row that needs the annotation on
+/// more than one axis uses the array form. An explicit `null` (like an absent
+/// field, and like the prior `Option<T>` shapes this replaced) yields an empty
+/// vec. Each element is still validated against `T`'s closed enums, so a typo in
+/// either form is a hard parse error.
+///
+/// Shared by the `spec_citation` (#827), `accepted_divergence` (#870), and
+/// `known_bug` (#870) fields — the declared `Vec<T>` type of the annotated field
+/// drives the `T` inference, so one helper covers all three (and any future
+/// per-axis annotation field gets it for free).
+fn de_one_or_many<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
 {
     /// Untagged helper: serde tries `One` first, then `Many`, accepting whichever
     /// wire shape the field carries.
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum OneOrMany {
-        One(SpecCitation),
-        Many(Vec<SpecCitation>),
+    enum OneOrMany<T> {
+        One(T),
+        Many(Vec<T>),
     }
 
-    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+    Ok(match Option::<OneOrMany<T>>::deserialize(deserializer)? {
         None => Vec::new(),
-        Some(OneOrMany::One(citation)) => vec![citation],
-        Some(OneOrMany::Many(citations)) => citations,
+        Some(OneOrMany::One(item)) => vec![item],
+        Some(OneOrMany::Many(items)) => items,
     })
 }
 

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -513,12 +513,7 @@
       "input": "NG_012772.1(BRCA2_v001):c.632-5_670del",
       "normalized": "NG_012772.1(NM_000059.3):c.632-5_670del",
       "genomic": "NG_012772.1:g.18959_19002del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -528,12 +523,7 @@
       "input": "NG_012772.1(BRCA2_v001):c.632-5_681+7del",
       "normalized": "NG_012772.1(NM_000059.3):c.632-5_681+7del",
       "genomic": "NG_012772.1:g.18959_19020del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -559,12 +549,7 @@
       "input": "NG_012772.1(BRCA2_v001):c.68-7_316+7del",
       "normalized": "NG_012772.1(NM_000059.3):c.68-7_316+7del",
       "genomic": "NG_012772.1:g.8591_8853del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -574,12 +559,7 @@
       "input": "NG_012772.1(BRCA2_v001):c.632-5_793+7del",
       "normalized": "NG_012772.1(NM_000059.3):c.632-5_793+7del",
       "genomic": "NG_012772.1:g.18959_20558del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -596,11 +576,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -611,12 +586,7 @@
       "input": "NG_012772.1(BRCA2_v001):c.681+1_682-1del",
       "normalized": "NG_012772.1(NM_000059.3):c.681+1_682-1del",
       "genomic": "NG_012772.1:g.19014_20439del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -633,11 +603,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -723,12 +688,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5AspfsTer21)",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -787,12 +747,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5AspfsTer21)",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -853,12 +808,7 @@
       "normalized": "NG_012337.1(NM_012459.2):c.12_13insTTTGATC",
       "genomic": "NG_012337.1:g.4911_4912insATCAAAG",
       "protein_description": "NG_012337.1(NP_036591.2):p.(Ser5PhefsTer22)",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -971,11 +921,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -994,11 +939,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -1016,11 +956,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -1034,16 +969,18 @@
       "genomic": "NG_008939.1:g.5207_5208ins5231_10536",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53AlafsTer5)",
       "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-654-positional-insert-literal-expansion",
-        "note": "ferro expands the copy-range payload ins180_188 to the literal bases insGCGAGGAAA; mutalyzer keeps the positional notation. Same edit; literal inserted sequence is spec-valid."
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "ferro expands the copy-range payload ins180_188 to the literal bases insGCGAGGAAA; mutalyzer keeps the positional notation. Same edit; literal inserted sequence is spec-valid."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the copy-range payload ins180_188 to the literal spliced bases g.5207_5208insGCGAGGAAA (per insertion.md: an inserted sequence copied from a range is written as the literal bases). mutalyzer emits the positional intron-spanning range g.5207_5208ins5231_10536, which silently changes the inserted sequence. Same edit; ferro's literal form is spec-correct."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1056,16 +993,18 @@
       "genomic": "NG_008939.1:g.5207_5208ins5231_10536inv",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53PhefsTer11)",
       "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-654-positional-insert-literal-expansion",
-        "note": "ferro expands the inverted copy-range payload to literal bases (insTTTCCTCGC); mutalyzer keeps positional notation."
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "ferro expands the inverted copy-range payload to literal bases (insTTTCCTCGC); mutalyzer keeps positional notation."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the inverted copy-range payload to the literal spliced bases g.5207_5208insTTTCCTCGC; mutalyzer keeps the positional intron-spanning range. Same edit; ferro's literal form is spec-correct."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1079,16 +1018,18 @@
       "genomic": "NG_008939.1:g.5207_5208ins5231_10536",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53AlafsTer5)",
       "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-654-positional-insert-literal-expansion",
-        "note": "bracketed copy-range payload expanded to literal bases by ferro; mutalyzer keeps positional notation."
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "bracketed copy-range payload expanded to literal bases by ferro; mutalyzer keeps positional notation."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed copy-range payload to the literal spliced bases g.5207_5208insGCGAGGAAA; mutalyzer keeps the positional intron-spanning range. Same edit; ferro's literal form is spec-correct."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1102,16 +1043,18 @@
       "genomic": "NG_008939.1:g.5207_5208ins5231_10536inv",
       "protein_description": "NG_008939.1(NP_000523.2):p.(Arg53PhefsTer11)",
       "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-654-positional-insert-literal-expansion",
-        "note": "bracketed inverted copy-range payload expanded to literal bases by ferro; mutalyzer keeps positional notation."
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "bracketed inverted copy-range payload expanded to literal bases by ferro; mutalyzer keeps positional notation."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-positional-insert-literal-expansion",
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed inverted copy-range payload to the literal spliced bases g.5207_5208insTTTCCTCGC; mutalyzer keeps the positional intron-spanning range. Same edit; ferro's literal form is spec-correct."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1345,11 +1288,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -1368,11 +1306,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -1390,11 +1323,6 @@
         "section": "HGVS protein reference (bare NP)",
         "note": "ferro resolves the legacy LOVD gene-model selector (GENE_v001) on the NG_ genomic reference to its RefSeq transcript and projects the spec-correct protein consequence (#783, extending the #500/#637 selector resolution to the c./p. projection axes). The consequence is identical to the oracle; the only remaining delta is the protein reference form — HGVS p. descriptions reference the bare NP_ accession, while mutalyzer wraps it as NM_x(NP_y). ferro's bare-NP output is spec-correct.",
         "cluster": "bare-np-protein"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -1407,16 +1335,18 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins180_183+69;156_161inv;161_162ins183+76_188]",
       "genomic": "NG_008939.1:g.[5206_5207ins5231_5303;5207_5212inv;5212_5213ins5310_10536]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 480,
-        "note": "ferro expands the c.180_188 copy range as transcript-contiguous bases; mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele with intronic offsets. Genomic-context copy-range expansion tracked in #480. [review: ferro-vs-mutalyzer correctness]"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "known_bug": [
+        {
+          "axis": "normalized",
+          "tracking_issue": 480,
+          "note": "ferro expands the c.180_188 copy range as transcript-contiguous bases; mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele with intronic offsets. Genomic-context copy-range expansion tracked in #480."
+        },
+        {
+          "axis": "genomic",
+          "tracking_issue": 480,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the c.180_188 copy range as transcript-contiguous spliced bases (g.5207_5212delinsGCGAGGAAA); mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele. Genomic-context copy-range expansion tracked in #480."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1428,16 +1358,18 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins183+76_188inv;161_162ins180_183+69inv]",
       "genomic": "NG_008939.1:g.[5206_5207ins5310_10536inv;5212_5213ins5231_5303inv]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 480,
-        "note": "inverted copy-range delins; ferro expands transcript-contiguous, mutalyzer through the genomic (intron-split) reference. Tracked in #480. [review]"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "known_bug": [
+        {
+          "axis": "normalized",
+          "tracking_issue": 480,
+          "note": "inverted copy-range delins; ferro expands transcript-contiguous, mutalyzer through the genomic (intron-split) reference. Tracked in #480."
+        },
+        {
+          "axis": "genomic",
+          "tracking_issue": 480,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the inverted copy-range delins as transcript-contiguous bases (g.5207_5212delinsTTTCCTCGC); mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1450,16 +1382,18 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins180_183+69;156_161inv;161_162ins183+76_188]",
       "genomic": "NG_008939.1:g.[5206_5207ins5231_5303;5207_5212inv;5212_5213ins5310_10536]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 480,
-        "note": "bracketed copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480. [review]"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "known_bug": [
+        {
+          "axis": "normalized",
+          "tracking_issue": 480,
+          "note": "bracketed copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480."
+        },
+        {
+          "axis": "genomic",
+          "tracking_issue": 480,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+        }
+      ]
     },
     {
       "keywords": [
@@ -1472,16 +1406,18 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins183+76_188inv;161_162ins180_183+69inv]",
       "genomic": "NG_008939.1:g.[5206_5207ins5310_10536inv;5212_5213ins5231_5303inv]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 480,
-        "note": "bracketed inverted copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480. [review]"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "known_bug": [
+        {
+          "axis": "normalized",
+          "tracking_issue": 480,
+          "note": "bracketed inverted copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480."
+        },
+        {
+          "axis": "genomic",
+          "tracking_issue": 480,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed inverted copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+        }
+      ]
     },
     {
       "keywords": [
@@ -2288,11 +2224,6 @@
         "policy": "ferro-policy-763-transcript-set-enumeration",
         "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
         "cluster": "transcript-set-enumeration-763"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -2324,11 +2255,6 @@
         "policy": "ferro-policy-763-transcript-set-enumeration",
         "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
         "cluster": "transcript-set-enumeration-763"
-      },
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
       }
     },
     {
@@ -2810,12 +2736,7 @@
       "input": "NG_008835.1(CDH23_v001):c.1449+846delA",
       "normalized": "NG_008835.1(NM_022124.6):c.1449+858del",
       "genomic": "NG_008835.1:g.255529del",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [],
@@ -2857,12 +2778,7 @@
       "input": "NG_009497.1(USH2A_v001):c.8682-19dup",
       "normalized": "NG_009497.1(NM_206933.2):c.8682-19dup",
       "genomic": "NG_009497.1:g.561208dup",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [],
@@ -3062,12 +2978,7 @@
       "input": "NG_012337.1(SDHD_v001):c.274G>T",
       "normalized": "NG_012337.1(NM_003002.2):c.274G>T",
       "genomic": "NG_012337.1:g.7125G>T",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -3076,12 +2987,7 @@
       "input": "NG_012337.1(SDHD):c.274G>T",
       "normalized": "NG_012337.1(NM_003002.2):c.274G>T",
       "genomic": "NG_012337.1:g.7125G>T",
-      "to_test": true,
-      "accepted_rejection": {
-        "axis": "genomic",
-        "note": "On an NG_ genomic reference ferro declines to project a transcript-coordinate variant whose selector is a gene symbol / GENE_v001 / numeric gene-id (refseq.md L40-41: gene symbols are not valid HGVS specifications) or is absent (no transcript specification given on the genomic reference). mutalyzer leniently resolves these and projects anyway; ferro's refusal is spec-correct. Optional convergence with mutalyzer is tracked in #872.",
-        "reason": "ferro-policy-858-nonstandard-or-absent-selector-declined"
-      }
+      "to_test": true
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -235,7 +235,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A_v001):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(NM_058195.3):n.204_205insATC` | normalized | accepted_divergence | — | — |
-| `NG_008835.1(CDH23_v001):c.1449+846delA` | genomic | accepted_divergence | — | — |
 | `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | genomic | accepted_divergence | — | — |
 | `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | normalized | spec_citation | — | — |
 | `NG_008835.1(NM_022124.6):c.3304_3305del` | genomic | accepted_divergence | — | — |
@@ -244,24 +243,18 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1(PCCB_v001):c.156_157ins180_188` | normalized | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins180_188inv` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins180_188inv` | normalized | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_157insGTCCTGTGCTCATTATCTGGC` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188]` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188]` | normalized | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | normalized | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_157ins[GTCCTGTGCTC;ATTATCTGGC]` | genomic | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_157ins[GTCCTGTGCTCATTATCTGGC]` | genomic | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | accepted_divergence | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | known_bug | — | #480 |
 | `NG_008939.1(PCCB_v001):c.156_161delins180_188` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | accepted_divergence | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | known_bug | — | #480 |
 | `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delinsGTCCTGTGCTCATTATCTGGC` | genomic | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | accepted_divergence | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | known_bug | — | #480 |
 | `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | accepted_divergence | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | known_bug | — | #480 |
 | `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[GTCCTGTGCT;CATTATCTGGC]` | genomic | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_161delins[GTCCTGTGCTCATTATCTGGC]` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157del3` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157delAAC` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.274_275inv` | genomic | accepted_divergence | — | — |
@@ -273,7 +266,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_009299.1(NM_017668.3):c.[250del;41A>C]` | normalized | known_bug | — | #487 |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | normalized | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | normalized | known_bug | — | #487 |
-| `NG_009497.1(USH2A_v001):c.8682-19dup` | genomic | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):c.1010` | errors | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):n.110del` | errors | accepted_divergence | — | — |
 | `NG_012337.1(10683):c.274G>T` | genomic | accepted_divergence | — | — |
@@ -288,13 +280,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.qterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.-1_*1del` | normalized | known_bug | — | #487 |
 | `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` | normalized | known_bug | — | #487 |
-| `NG_012337.1(SDHD):c.274G>T` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(SDHD_v001):c.274G>T` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(TIMM8B):c.12_15dupCAGC` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(TIMM8B):c.12dupC` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(TIMM8B_v001):c.12_13insGATC` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(TIMM8B_v001):c.12_13ins[GATC]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(TIMM8B_v001):c.12_13ins[TTT;GATC]` | genomic | accepted_divergence | — | — |
 | `NG_012337.1:274` | normalized | accepted_divergence | — | — |
 | `NG_012337.1:g.4delins7_31` | normalized | accepted_divergence | — | — |
 | `NG_012337.1:g.4delins7_50` | normalized | accepted_divergence | — | — |
@@ -304,13 +289,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1:g.[4del;4_5insT;4insA;4_5insA]` | errors | accepted_divergence | — | — |
 | `NG_012337.3(NM_003002):274+400G>T` | errors | accepted_divergence | — | — |
 | `NG_012337.3(NM_003002.4):r.274+10G>T` | errors | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.622_672del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.622_674del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.632-5_670del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.632-5_681+7del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.632-5_793+7del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.68-7_316+7del` | genomic | accepted_divergence | — | — |
-| `NG_012772.1(BRCA2_v001):c.681+1_682-1del` | genomic | accepted_divergence | — | — |
 | `NG_017013.2:g.17496_17497insAGCTGCTCAGATAGCGA` | normalized | accepted_divergence | — | — |
 | `NG_029724.1(NM_004321.7):c.101del` | normalized | accepted_divergence | — | — |
 | `NM_002001.2:c.1_3delinsATG` | normalized | accepted_divergence | — | — |
@@ -324,7 +302,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 |---|---:|---:|---:|---:|---:|
 | coding_protein_descriptions | 10 | 0 | 0 | 0 | 0 |
 | errors | 16 | 0 | 0 | 0 | 0 |
-| genomic | 41 | 0 | 0 | 0 | 1 |
+| genomic | 15 | 4 | 0 | 0 | 1 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
 | normalized | 23 | 18 | 4 | 5 | 9 |

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -507,29 +507,29 @@ impl AxisTally {
             // annotation is stale — the divergence/bug the row documents is
             // gone. Fail loudly so the annotation (and, for known_bug, the
             // fixed row) is cleaned up rather than silently rotting.
-            if let Some(ad) = &case.accepted_divergence {
-                if ad.axis == self.axis {
-                    self.fail.push((
-                        case.input.clone(),
-                        format!(
-                            "XPASS: accepted_divergence (policy {}) now matches mutalyzer; the divergence is gone — remove the annotation",
-                            ad.policy
-                        ),
-                    ));
-                    return;
-                }
+            if let Some(ad) = case
+                .accepted_divergences
+                .iter()
+                .find(|ad| ad.axis == self.axis)
+            {
+                self.fail.push((
+                    case.input.clone(),
+                    format!(
+                        "XPASS: accepted_divergence (policy {}) now matches mutalyzer; the divergence is gone — remove the annotation",
+                        ad.policy
+                    ),
+                ));
+                return;
             }
-            if let Some(kb) = &case.known_bug {
-                if kb.axis == self.axis {
-                    self.fail.push((
-                        case.input.clone(),
-                        format!(
-                            "XPASS: known_bug #{} now matches mutalyzer; the fix appears to have landed — remove the annotation and demote the row",
-                            kb.tracking_issue
-                        ),
-                    ));
-                    return;
-                }
+            if let Some(kb) = case.known_bugs.iter().find(|kb| kb.axis == self.axis) {
+                self.fail.push((
+                    case.input.clone(),
+                    format!(
+                        "XPASS: known_bug #{} now matches mutalyzer; the fix appears to have landed — remove the annotation and demote the row",
+                        kb.tracking_issue
+                    ),
+                ));
+                return;
             }
             if let Some(imp) = &case.improvement {
                 if imp.axis == self.axis {
@@ -605,10 +605,12 @@ impl AxisTally {
         // A genuine panic / the empty-projection sentinel (#651) still hard-FAIL
         // below; a match XPASS-FAILs above.
         if self.axis == Axis::CodingProteinDescriptions {
-            if let Some(ad) = &case.accepted_divergence {
-                if ad.axis == self.axis
-                    && matches!(&actual, Err(e) if e.starts_with("missing pair"))
-                {
+            if let Some(ad) = case
+                .accepted_divergences
+                .iter()
+                .find(|ad| ad.axis == self.axis)
+            {
+                if matches!(&actual, Err(e) if e.starts_with("missing pair")) {
                     self.divergence_accepted
                         .push((case.input.clone(), ad.policy.to_string()));
                     return;
@@ -622,19 +624,19 @@ impl AxisTally {
         let errors_axis_divergence =
             self.axis == Axis::Errors && matches!(&actual, Err(e) if !e.starts_with("panic:"));
         if actual.is_ok() || errors_axis_divergence {
-            if let Some(ad) = &case.accepted_divergence {
-                if ad.axis == self.axis {
-                    self.divergence_accepted
-                        .push((case.input.clone(), ad.policy.to_string()));
-                    return;
-                }
+            if let Some(ad) = case
+                .accepted_divergences
+                .iter()
+                .find(|ad| ad.axis == self.axis)
+            {
+                self.divergence_accepted
+                    .push((case.input.clone(), ad.policy.to_string()));
+                return;
             }
-            if let Some(kb) = &case.known_bug {
-                if kb.axis == self.axis {
-                    self.known_bug
-                        .push((case.input.clone(), format!("#{}", kb.tracking_issue)));
-                    return;
-                }
+            if let Some(kb) = case.known_bugs.iter().find(|kb| kb.axis == self.axis) {
+                self.known_bug
+                    .push((case.input.clone(), format!("#{}", kb.tracking_issue)));
+                return;
             }
             if let Some(imp) = &case.improvement {
                 if imp.axis == self.axis {
@@ -1156,6 +1158,117 @@ fn axis_normalized() {
 // Axis: genomic
 // ----------------------------------------------------------------------------
 
+/// Compute the genomic-axis representation of a case input the way a user would
+/// (#870): single `c./n./r.` inputs go through the user-facing
+/// `project_variant().genomic`; `Allele` inputs stay on the raw
+/// `project_to_genomic` pivot (it cis-sorts minus-strand compound-allele members
+/// per #851, which `project_variant` does not yet — #894); pure `g./m.` inputs
+/// normalize only. Shared by `axis_genomic` and `axis_genomic_idempotent` so the
+/// two cannot drift.
+fn project_genomic_userfacing(
+    projector: &VariantProjector<ArcProvider>,
+    normalizer: &Normalizer<ArcProvider>,
+    v: &HgvsVariant,
+) -> Result<HgvsVariant, String> {
+    match v {
+        HgvsVariant::Cds(_) | HgvsVariant::Tx(_) | HgvsVariant::Rna(_) => {
+            let tx_id =
+                transcript_of(v).ok_or_else(|| "could not infer transcript_id".to_string())?;
+            projector
+                .project_variant(v, &tx_id)
+                .map_err(|e| format!("project: {e}"))?
+                .genomic
+                .ok_or_else(|| "project_variant produced no genomic axis".to_string())
+        }
+        HgvsVariant::Allele(_) => {
+            let g = projector
+                .project_to_genomic(v)
+                .map_err(|e| format!("project: {e}"))?;
+            normalizer
+                .normalize(&g)
+                .map_err(|e| format!("normalize: {e}"))
+        }
+        // Pure genomic axes (`g.`/`m.`) normalize in place. Anything else
+        // (e.g. a `p.` protein input) has no genomic-axis representation here, so
+        // reject it rather than let the permissive fall-through count a
+        // non-genomic normalization as a genomic-axis success.
+        HgvsVariant::Genome(_) | HgvsVariant::Mt(_) => normalizer
+            .normalize(v)
+            .map_err(|e| format!("normalize: {e}")),
+        other => Err(format!(
+            "unsupported genomic-axis input type {}",
+            other.variant_type()
+        )),
+    }
+}
+
+/// Direct contract test for [`project_genomic_userfacing`]'s routing (#870,
+/// #895 review). The rejection arm (`other => Err(...)`) — the subject of the
+/// original critical-issue review — must reject inputs with no genomic-axis
+/// representation (e.g. a `p.` protein), rather than let a permissive
+/// fall-through count a non-genomic normalization as a genomic-axis success.
+/// The remaining kinds (`c./n./r.` transcript, `g./m.` genomic, `Allele`
+/// compound) must dispatch into a real sub-path instead. Pinning this here
+/// keeps the contract independent of which corpus fixture rows happen to
+/// exercise each arm, so a fixture reshuffle cannot silently stop covering the
+/// rejection branch.
+#[test]
+fn project_genomic_userfacing_routing() {
+    let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
+        eprintln!("project_genomic_userfacing_routing: skipping — no manifest");
+        return;
+    };
+
+    const UNSUPPORTED: &str = "unsupported genomic-axis input type";
+
+    // A protein input has no genomic-axis representation here: the `other` arm
+    // must reject it up front, before touching the projector or normalizer.
+    let protein = parse_hgvs("NP_000079.2:p.Glu6Val").expect("parse protein input");
+    let err = project_genomic_userfacing(&projector, &normalizer, &protein)
+        .expect_err("protein input must be rejected");
+    assert!(
+        err.contains(UNSUPPORTED),
+        "protein input should hit the rejection arm, got: {err}"
+    );
+
+    // Every other kind must dispatch into a genomic sub-path, never the
+    // rejection arm. All inputs below use references present in the manifest, so
+    // whether the downstream projection/normalization returns `Ok` or a
+    // (non-`UNSUPPORTED`) `Err` is reference-dependent and measured by the axis
+    // tests — the invariant asserted here is only that these inputs are NOT
+    // rejected as an unsupported input type. A panic from `catch_unwind`, by
+    // contrast, is an unexpected crash rather than an expected reference miss, so
+    // it fails the test outright. The `c./r.` rows pin that the transcript arm
+    // dispatches for all of `c./n./r.`, not just the sampled `n.`.
+    for (input, arm) in [
+        ("NM_003002.2:c.273del", "coding-transcript-projection"),
+        ("NM_003002.4:n.206_210del", "transcript-projection"),
+        ("NM_003002.4:r.206_210del", "rna-transcript-projection"),
+        (
+            "NG_012337.1:g.4812_4813insTAC",
+            "genomic in-place normalize",
+        ),
+        ("NC_012920.1:m.3243A>G", "mitochondrial in-place normalize"),
+        (
+            "NG_012337.1(NM_003002.2):c.[274G>T;278A>G]",
+            "allele project-to-genomic",
+        ),
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            project_genomic_userfacing(&projector, &normalizer, &v)
+        }));
+        match outcome {
+            Ok(Ok(_)) => {}
+            Ok(Err(err)) => assert!(
+                !err.contains(UNSUPPORTED),
+                "{input} should dispatch into the {arm} arm, not the rejection arm; got: {err}"
+            ),
+            Err(_) => panic!("{input} panicked while dispatching into the {arm} arm"),
+        }
+    }
+}
+
 #[test]
 fn axis_genomic() {
     let (Some(projector), Some(normalizer)) = (variant_projector(), normalizer()) else {
@@ -1175,29 +1288,24 @@ fn axis_genomic() {
 
         let actual = catch_panics(|| -> Result<String, String> {
             let v = parse_hgvs(&case.input).map_err(|e| format!("parse: {e}"))?;
-            // Project transcript-coordinate (c./n./r.) inputs — and compound
-            // alleles, whose members are each projected and reassembled (cis
-            // members re-sorted into genomic order; #851) — onto their genomic
-            // reference frame; pass g. and other inputs through unchanged. Then
-            // normalize the genomic form so the output matches mutalyzer's
-            // normalized g. (3'-shift, ins→dup, …).
-            let g = if matches!(
-                v,
-                HgvsVariant::Cds(_)
-                    | HgvsVariant::Tx(_)
-                    | HgvsVariant::Rna(_)
-                    | HgvsVariant::Allele(_)
-            ) {
-                projector
-                    .project_to_genomic(&v)
-                    .map_err(|e| format!("project: {e}"))?
-            } else {
-                v
-            };
-            let n = normalizer
-                .normalize(&g)
-                .map_err(|e| format!("normalize: {e}"))?;
-            Ok(format!("{n}"))
+            // Route the genomic axis through the *user-facing* path (#870):
+            //   - c./n./r. single-variant rows → `project_variant().genomic`,
+            //     which normalizes-then-projects and reports the reanchored
+            //     genomic axis (the path users actually hit — this is what masked
+            //     the #852 single-pass bug when measured against the raw pivot).
+            //     A reanchor decline degrades to `.genomic == None` (not Err); map
+            //     that to Err so the `accepted_rejection` disposition still catches
+            //     it. Gene-symbol / `_v001` legacy selectors that normalization
+            //     resolves (#871) are accepted — ferro's resolved output is
+            //     spec-valid. `project_variant` already normalized internally, so
+            //     there is no redundant second normalize on this path.
+            //   - Compound alleles → keep the raw `project_to_genomic` pivot: it
+            //     cis-sorts members into genomic order (#851); `project_variant`
+            //     does not yet (#894), so rerouting them would regress minus-strand
+            //     multi-member cis rows. Project-then-normalize, as before.
+            //   - Pure g./m. rows → normalize only (today's pass-through).
+            let g = project_genomic_userfacing(&projector, &normalizer, &v)?;
+            Ok(format!("{g}"))
         });
 
         t.record(case, expected, actual);
@@ -1619,12 +1727,14 @@ fn axis_infos() {
                 .push((case.input.clone(), INFO_NO_SPEC_EQUIVALENT.to_string()));
         } else if let Err(ref e) = actual {
             if e.starts_with("ferro emitted extra info") {
-                if let Some(ad) = &case.accepted_divergence {
-                    if ad.axis == Axis::Infos {
-                        t.divergence_accepted
-                            .push((case.input.clone(), ad.policy.to_string()));
-                        continue;
-                    }
+                if let Some(ad) = case
+                    .accepted_divergences
+                    .iter()
+                    .find(|ad| ad.axis == Axis::Infos)
+                {
+                    t.divergence_accepted
+                        .push((case.input.clone(), ad.policy.to_string()));
+                    continue;
                 }
             }
             t.record(case, &expected_repr, actual);
@@ -2236,8 +2346,8 @@ mod comparator_tests {
             infos: None,
             noncoding: None,
             to_test: true,
-            accepted_divergence,
-            known_bug: None,
+            accepted_divergences: accepted_divergence.into_iter().collect(),
+            known_bugs: Vec::new(),
             improvement: None,
             reference_unavailable: None,
             spec_citations,
@@ -2256,7 +2366,7 @@ mod comparator_tests {
             r#"{"input": "NM_000088.3:c.459A>G", "normalized": "NM_000088.3:c.459A>G"}"#,
         );
         assert_eq!(case.input, "NM_000088.3:c.459A>G");
-        assert!(case.accepted_divergence.is_none());
+        assert!(case.accepted_divergences.is_empty());
         assert!(case.spec_citations.is_empty());
     }
 
@@ -2337,10 +2447,8 @@ mod comparator_tests {
                 }
             }"#,
         );
-        let ad = case
-            .accepted_divergence
-            .as_ref()
-            .expect("accepted_divergence present");
+        assert_eq!(case.accepted_divergences.len(), 1);
+        let ad = &case.accepted_divergences[0];
         assert_eq!(ad.axis, Axis::Normalized);
         assert_eq!(ad.policy, Policy::GeneSymbolSelector121);
         assert_eq!(ad.note.as_deref(), Some("ferro emits (COL1A1) per #121"));
@@ -3210,7 +3318,8 @@ mod comparator_tests {
                 }
             }"#,
         );
-        let kb = case.known_bug.as_ref().expect("known_bug present");
+        assert_eq!(case.known_bugs.len(), 1);
+        let kb = &case.known_bugs[0];
         assert_eq!(kb.axis, Axis::Normalized);
         assert_eq!(kb.tracking_issue, 325);
         assert_eq!(
@@ -3226,12 +3335,12 @@ mod comparator_tests {
     fn tally_known_bug_on_matching_axis() {
         let mut t = AxisTally::new(Axis::Normalized);
         let mut case = make_case("in", None, None);
-        case.known_bug = Some(KnownBug {
+        case.known_bugs = vec![KnownBug {
             axis: Axis::Normalized,
             tracking_issue: 325,
             note: None,
             cluster: None,
-        });
+        }];
         t.record(&case, "X", Ok("Y".to_string()));
         assert_eq!(t.pass, 0);
         assert_eq!(t.known_bug, vec![("in".to_string(), "#325".to_string())]);
@@ -3245,12 +3354,12 @@ mod comparator_tests {
     fn tally_known_bug_xpass_fails() {
         let mut t = AxisTally::new(Axis::Normalized);
         let mut case = make_case("in", None, None);
-        case.known_bug = Some(KnownBug {
+        case.known_bugs = vec![KnownBug {
             axis: Axis::Normalized,
             tracking_issue: 325,
             note: None,
             cluster: None,
-        });
+        }];
         t.record(&case, "X", Ok("X".to_string()));
         assert_eq!(t.pass, 0);
         assert!(t.known_bug.is_empty());
@@ -3290,12 +3399,12 @@ mod comparator_tests {
     fn tally_err_with_known_bug_still_fails() {
         let mut t = AxisTally::new(Axis::Normalized);
         let mut case = make_case("in", None, None);
-        case.known_bug = Some(KnownBug {
+        case.known_bugs = vec![KnownBug {
             axis: Axis::Normalized,
             tracking_issue: 325,
             note: None,
             cluster: None,
-        });
+        }];
         t.record(&case, "X", Err("normalize: panic boom".to_string()));
         assert_eq!(t.pass, 0);
         assert!(
@@ -3486,12 +3595,12 @@ mod comparator_tests {
     fn tally_empty_projection_on_annotated_row_still_surfaces() {
         let mut t = AxisTally::new(Axis::CodingProteinDescriptions);
         let mut case = make_case("in", None, None);
-        case.known_bug = Some(KnownBug {
+        case.known_bugs = vec![KnownBug {
             axis: Axis::CodingProteinDescriptions,
             tracking_issue: 326,
             note: None,
             cluster: None,
-        });
+        }];
         t.record(
             &case,
             "[(\"c\", \"p\")]",
@@ -3918,29 +4027,16 @@ fn axis_genomic_idempotent() {
         if !case.to_test {
             continue;
         }
-        // Project (c./n./r. → g.) then normalize, mirroring `axis_genomic`; only
-        // successfully-projected-and-normalized inputs participate. Include
-        // `Allele(_)` so compound alleles exercise the #851 cis-sort + genomic
-        // re-anchor path under the idempotency check, matching `axis_genomic`.
+        // Mirror `axis_genomic`'s user-facing routing exactly so the two axes
+        // never diverge: c./n./r. single rows through `project_variant().genomic`
+        // (#870), compound alleles kept on the raw `project_to_genomic` pivot
+        // (#851 cis-sort; #894), pure g./m. rows normalized only. Only
+        // successfully-projected-and-normalized inputs participate. The fixpoint
+        // still holds because `project_variant` normalizes internally.
         let projected = (|| -> Result<String, String> {
             let v = parse_hgvs(&case.input).map_err(|e| format!("parse: {e}"))?;
-            let g = if matches!(
-                v,
-                HgvsVariant::Cds(_)
-                    | HgvsVariant::Tx(_)
-                    | HgvsVariant::Rna(_)
-                    | HgvsVariant::Allele(_)
-            ) {
-                projector
-                    .project_to_genomic(&v)
-                    .map_err(|e| format!("project: {e}"))?
-            } else {
-                v
-            };
-            let n = normalizer
-                .normalize(&g)
-                .map_err(|e| format!("normalize: {e}"))?;
-            Ok(format!("{n}"))
+            let g = project_genomic_userfacing(&projector, &normalizer, &v)?;
+            Ok(format!("{g}"))
         })();
         let Ok(g1) = projected else { continue };
         tested += 1;


### PR DESCRIPTION
Closes #870.

**Stacked on #893** (`fix/issue-886-887-project-variant-genomic`) — this re-blesses against the fixed `project_variant().genomic`, so review/merge #893 first.

## What

The conformance genomic axis (`axis_genomic`, `axis_genomic_idempotent`) projected `c./n./r.` inputs through the raw `project_to_genomic` primitive + a second normalize — a path users don't hit (this masked the #852 single-pass bug). This routes the **single `Cds`/`Tx`/`Rna`** rows through the user-facing `project_variant().genomic`, so the ledger reflects what users actually get.

- **Alleles stay on the raw pivot** — `project_variant` doesn't yet cis-sort minus-strand compound-allele members the way the raw pivot does (#851); rerouting them would regress. Filed as **#894**.
- **`gate_genomic_snapshot` stays on the raw pivot** — deliberately, to keep hermetic conformance coverage of the public `project_to_genomic` primitive (it has a Python binding + ~40 unit tests). So both paths remain covered.

## Re-bless (full reference-backed run; 0 rows changed beyond the pre-adjudicated set)

Rerouting surfaces that `project_variant` (normalize-first) **resolves** legacy gene-symbol selectors (`NG_(GENE_v001):c.`) that the raw pivot declines. This is consistent with the already-blessed **#793/#871** normalized-axis behavior, and the resolved output is spec-valid (`NG_(NM_…):c.`). Disposition changes (30 rows, all previously `accepted_rejection{genomic}`):

- **22** selector-resolvable rows now **match mutalyzer** → `accepted_rejection{genomic}` removed (clean passes).
- **4** `PCCB_v001` positional-insertion rows (`ins180_188` family) → `accepted_divergence{genomic}`. Ferro expands the transcript-range payload to the literal spliced bases (`insGCGAGGAAA`), which is **spec-correct** per `insertion.md` + `refseq.md:44` (a transcript reference contains no introns, so `c.156_157ins180_188` means the spliced `c.180..c.188`); mutalyzer's genomic range (`ins5231_10536`) spans the intron and silently changes the inserted sequence.
- **4** `delins180_188`-family rows → `known_bug{genomic, #480}`.
- **4** truly-unresolvable rows (bare `NG_:c.` ×3 + numeric-gene-id `10683`) → **keep** `accepted_rejection{genomic}` (project_variant still declines).

Tally shift (manifest): pass 80→102, divergence_accepted 41→15, known_bug 0→4. `baseline-failures/genomic.txt` regenerates byte-identical.

## Schema change

`accepted_divergence`/`known_bug` become single-object-or-array (`Vec`), rename-preserving the JSON key, mirroring the #827 `spec_citations` pattern — because the 4 `ins180_188` rows need a `genomic`-axis annotation to coexist with their still-active `normalized`-axis one. Added per-`(kind, axis)` uniqueness validation.

## Not in scope / pre-existing

`axis_genomic` with a manifest has **7 pre-existing hard FAILs** (parse errors on malformed inputs, unsupported cross-reference-insertion shapes, an `NG_009299` re-anchor decline, and a repeat-vs-del divergence) — **byte-identical on the base branch**, unchanged by this PR, and documented in `baseline-failures/genomic.txt`. They are out of #870's reroute scope. `axis_genomic` is manifest-gated, so CI (no manifest) is unaffected.

## Verification

`cargo nextest run --features dev` (no manifest) → **7661 passed, 0 failed**; `gate_genomic_snapshot` green; clippy `-D warnings` + `cargo fmt --all --check` clean. Manifest run confirms the 30-row re-bless and the unchanged 7 pre-existing FAILs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-axis support for conformance annotations, allowing multiple accepted divergences and known bugs per case (data can now be provided as arrays for axis-specific entries).
  * Normalization and summaries now report per-axis entries consistently.

* **Bug Fixes**
  * Improved fixture validation to reject duplicate axis entries within the same annotation kind.
  * Updated conformance bucketing and reporting to align accepted divergences/known bugs with the correct axis.

* **Tests / Fixtures**
  * Refreshed fixtures and updated integration/unit test expectations to use the new plural per-axis forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->