### PR TITLE
fix(project): de-anchor bare NG_/LRG_ genomic input on the single-transcript projection paths (#879)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -830,6 +830,54 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         self.project_variant(&variant, transcript_id)
     }
 
+    /// #879: project a bare `NG_`/`LRG_` genomic input onto a single requested
+    /// transcript by de-anchoring it into the `NC_` chromosome frame — so the
+    /// overlap guard and cdot see matching coordinates — then re-framing the
+    /// result under the parent. This mirrors the fan-out parent path
+    /// (`project_variant_all:946-989`), which the single-transcript entry points
+    /// otherwise skip; without it a parent-frame `g.` coordinate is compared
+    /// against `NC_`-frame cdot exon spans and the projection wrongly declines
+    /// with `TranscriptNotOverlapping`.
+    ///
+    /// Returns `None` for any input that is not a placement-backed bare-genomic
+    /// parent input, so the caller falls back to its normal path (which handles
+    /// the genuine non-overlap decline unchanged).
+    fn project_bare_genomic_parent(
+        &self,
+        variant: &HgvsVariant,
+        transcript_id: &str,
+    ) -> Option<Result<VariantProjection, FerroError>> {
+        // Gate on a bare genomic input (review M1). A transcript-coordinate
+        // (c./n./r.) input carrying an `NG_`/`LRG_` `genomic_context` also has a
+        // `deanchor_genomic_parent_input` parent branch, but it must keep its
+        // existing pivot path here — so restrict this to `Genome` inputs.
+        if !matches!(variant, HgvsVariant::Genome(_)) {
+            return None;
+        }
+        // Capture the build the input carries BEFORE de-anchor shadows it: the
+        // de-anchored form is on an `NC_` accession whose build would be circular
+        // to read back, and the parent placement must be selected by the input's
+        // build, matching what `deanchor` itself used (#653/#713).
+        let input_build = self.build_hint_for_variant(variant);
+        let (deanchored, parent) = self.deanchor_genomic_parent_input(variant);
+        // No placement-backed parent → not our case; let the caller's normal path
+        // run (it emits the genuine non-overlap decline where appropriate).
+        let parent = parent?;
+        Some((|| {
+            // Re-normalize in the `NC_` frame: `deanchor` is a frame/strand
+            // transform that leaves the variant non-canonical, and even the
+            // `project_normalized` caller cannot pre-normalize it in the `NC_`
+            // frame because it does not know the placement (review M2).
+            let normalized = self.normalizer.normalize(&deanchored)?;
+            let target = Self::reconcile_self_projection_target(&normalized, transcript_id);
+            let result = self.project_variant_inner(&normalized, &target)?;
+            let placement = self
+                .provider
+                .genomic_placement_on_build(&parent, input_build);
+            Ok(self.frame_projection_owned(result, &parent, placement.as_ref()))
+        })())
+    }
+
     /// Normalize and project an already-parsed g. variant onto a transcript.
     ///
     /// The variant is normalized first; for pre-normalized variants use
@@ -840,6 +888,14 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
         self.warn_assembly_conflict(variant);
+        // 0. A bare `NG_`/`LRG_` genomic input carries parent-relative coordinates
+        //    that the overlap guard (NC_-frame) cannot compare against; de-anchor,
+        //    re-normalize, project, and re-frame under the parent (#879). Only a
+        //    placement-backed bare-genomic parent input takes this branch; every
+        //    other input falls through to the normal path below.
+        if let Some(r) = self.project_bare_genomic_parent(variant, transcript_id) {
+            return r;
+        }
         // 1. Normalize the genomic variant. The normalizer is built once at
         // construction time so we don't clone the (potentially heavy) provider
         // on every call.
@@ -894,6 +950,16 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         transcript_id: &str,
     ) -> Result<VariantProjection, FerroError> {
         self.warn_assembly_conflict(variant);
+        // A bare `NG_`/`LRG_` genomic input must still be de-anchored into the
+        // `NC_` frame before the overlap guard (#879). Its parent branch
+        // re-normalizes in the `NC_` frame — a documented exception to this
+        // method's skip-normalize contract, since a parent input is inherently
+        // non-canonical in the `NC_` frame and the caller cannot pre-normalize it
+        // there without knowing the placement (review M2). Non-parent inputs skip
+        // this and take the unchanged skip-normalize path below.
+        if let Some(r) = self.project_bare_genomic_parent(variant, transcript_id) {
+            return r;
+        }
         // Reconcile the requested target against any selector resolution carried
         // by the (already-normalized) variant, mirroring `project_variant` (#783).
         // A caller that pre-normalizes a legacy `NG_(GENE_v001):c.` once and then

--- a/tests/it/issue_879_ng_g_to_c_overlap.rs
+++ b/tests/it/issue_879_ng_g_to_c_overlap.rs
@@ -1,0 +1,289 @@
+//! #879 — a bare `NG_`/`LRG_` genomic input projected onto a *single* requested
+//! transcript must de-anchor into the `NC_` chromosome frame before the overlap
+//! guard runs, or it declines with `TranscriptNotOverlapping` (the parent-frame
+//! `g.` coordinate is compared against `NC_`-frame cdot exon spans).
+//!
+//! Split from #857. The fan-out (`project_variant_all`) already de-anchors +
+//! re-frames; this locks in that the single-transcript paths (`project_variant`,
+//! `project_normalized`) do too — while leaving `NG_(NM_):c.` transcript inputs
+//! on their existing pivot path (the Genome-gate, review M1).
+//!
+//! CI-runnable (MockProvider, no manifest). The `GenomicPlacement` is
+//! **non-identity** (`parent_start != nc_start`) so a frame bug cannot hide
+//! behind an identity transform (cf. the `issue_480_*` pattern), and the
+//! transcript has a terminal 3'UTR (`cds_end < exon_end`) so a boundary deletion
+//! spans `c.<n>_*1` and exercises the #857 C-terminal-extension protein shape.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::provider::GenomicPlacement;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, FerroError, VariantProjection, VariantProjector};
+
+/// CDS "ATGAAATAA" (Met-Lys-Ter, stop at c.7_9) followed by the 3'UTR "TCTAA",
+/// so the full transcript is "ATGAAATAATCTAA" (14 bp). The CDS ends at `c.9`
+/// (`cds_end = 9`) while the exon runs to tx position 14, so `c.9_*1` straddles
+/// the CDS→3'UTR boundary. Placed on chr1 plus strand at HGVS `[1000, 1014)`.
+const FULL_TX: &str = "ATGAAATAATCTAA";
+
+/// Build a projector + provider for `NM_TEST.1`/`NP_TEST.1` on chr1 (plus
+/// strand). Placements are added per-test so each can pick a strand/offset.
+fn base_fixture() -> (Projector, MockProvider) {
+    let len = FULL_TX.len() as u64;
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            // [g_start, g_end, tx_start, tx_end]; exon spans HGVS [1000, 1014).
+            exons: vec![[1000, 1000 + len, 0, len]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        FULL_TX.to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, len)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1000 + len - 1),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // 999-N pad so HGVS exon coord 1000 lands at 0-based index 999; the exon's
+    // genome bases then match the transcript and the #644 sequence-aware
+    // projection sees no phantom indel (see the note in issue_480's base_fixture).
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{prefix}{FULL_TX}{suffix}"));
+    (projector, provider)
+}
+
+fn parse_acc(s: &str) -> ferro_hgvs::hgvs::variant::Accession {
+    match parse_hgvs(&format!("{s}:g.1=")).expect("parse accession") {
+        ferro_hgvs::HgvsVariant::Genome(g) => g.accession,
+        other => panic!("expected genome variant, got {other:?}"),
+    }
+}
+
+/// Plus-strand, non-identity placement: `NG_TEST.1` base 5001 == chr 1000, so
+/// the CDS→3'UTR boundary deletion `c.9_*1del` (chr 1008_1009) is written in the
+/// parent frame as `NG_TEST.1:g.5009_5010del`.
+///
+/// The expected `c./p./g.` strings are a deliberate regression pin from the
+/// fixture's known placement + CDS layout, cross-validated against the real
+/// manifest reproducer in #879 (`NG_012337.1:g.13124_13125del` →
+/// `c.480_*1del` / `p.(Ter160CysextTer29)`), which exercises the same code path.
+#[test]
+fn bare_ng_genomic_projects_onto_single_transcript_plus_strand() {
+    let (projector, mut provider) = base_fixture();
+    provider.add_genomic_placement(
+        "NG_TEST.1",
+        GenomicPlacement {
+            nc: parse_acc("NC_000001.11"),
+            parent_start: 5001,
+            nc_start: 1000,
+            nc_end: 1013,
+            strand: Strand::Plus,
+        },
+    );
+    let vp = VariantProjector::new(projector, provider);
+
+    // Parent-frame input straddling the CDS→3'UTR boundary.
+    let variant = parse_hgvs("NG_TEST.1:g.5009_5010del").expect("parse");
+    let r = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("bare NG_ genomic input must de-anchor and project, not decline");
+
+    assert_eq!(
+        r.coding.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_TEST.1(NM_TEST.1):c.9_*1del"),
+        "coding must be framed under the NG_ parent"
+    );
+    // The protein axis (the #857 C-terminal-extension shape) must survive the
+    // re-frame and be relabeled under the NG_ parent (review N1).
+    assert_eq!(
+        r.protein.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_TEST.1(NP_TEST.1):p.(Ter3TyrextTer1)"),
+        "protein axis must survive + be reframed under the NG_ parent"
+    );
+    // The genomic axis is re-anchored back into the NG_ parent frame.
+    assert_eq!(
+        r.genomic.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_TEST.1:g.5009_5010del"),
+        "genomic axis must be re-anchored into the NG_ parent frame"
+    );
+}
+
+/// Minus-strand placement (revcomp de-anchor path): `NG_REV.1` runs antiparallel
+/// to the chromosome, so a parent-frame substitution reverse-complements into
+/// the `NC_` frame before projection, then re-frames back.
+#[test]
+fn bare_ng_genomic_projects_onto_single_transcript_minus_strand() {
+    let (projector, mut provider) = base_fixture();
+    provider.add_genomic_placement(
+        "NG_REV.1",
+        GenomicPlacement {
+            nc: parse_acc("NC_000001.11"),
+            parent_start: 1,
+            nc_start: 1000,
+            nc_end: 1013,
+            strand: Strand::Minus,
+        },
+    );
+    let vp = VariantProjector::new(projector, provider);
+
+    // chr 1003 (= c.4, base A) maps to parent frame 11 (1 + 1013 - 1003); the
+    // parent reads the complement (T), so `T>G` here revcomps to `A>C` on the
+    // chromosome → c.4A>C → Lys2Gln.
+    let variant = parse_hgvs("NG_REV.1:g.11T>G").expect("parse");
+    let r = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("minus-strand bare NG_ genomic input must de-anchor and project");
+
+    assert_eq!(
+        r.coding.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_REV.1(NM_TEST.1):c.4A>C"),
+        "coding must be framed under the NG_ parent (minus strand)"
+    );
+    assert_eq!(
+        r.protein.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_REV.1(NP_TEST.1):p.(Lys2Gln)"),
+        "protein axis must survive + be reframed under the NG_ parent (minus strand)"
+    );
+    assert_eq!(
+        r.genomic.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_REV.1:g.11T>G"),
+        "genomic axis must be re-anchored into the NG_ parent frame (minus strand)"
+    );
+}
+
+/// `project_normalized` on a (pre-normalized) bare-`NG_` genomic input must
+/// yield the same result as `project_variant` — the parent branch re-normalizes
+/// in the `NC_` frame (review M2), a documented exception to its skip-normalize
+/// contract, since the caller cannot pre-normalize in a frame it doesn't know.
+#[test]
+fn project_normalized_de_anchors_bare_ng_genomic() {
+    let (projector, mut provider) = base_fixture();
+    provider.add_genomic_placement(
+        "NG_TEST.1",
+        GenomicPlacement {
+            nc: parse_acc("NC_000001.11"),
+            parent_start: 5001,
+            nc_start: 1000,
+            nc_end: 1013,
+            strand: Strand::Plus,
+        },
+    );
+    let vp = VariantProjector::new(projector, provider);
+
+    let variant = parse_hgvs("NG_TEST.1:g.5009_5010del").expect("parse");
+    let via_normalized = vp
+        .project_normalized(&variant, "NM_TEST.1")
+        .expect("project_normalized must de-anchor a bare NG_ genomic input too");
+    // Cross-path check (not a duplicated string pin): `project_normalized` (whose
+    // parent branch re-normalizes) must agree with `project_variant` on every axis
+    // for the same bare-`NG_` genomic input — the two are distinct entry points.
+    let via_variant = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("project_variant must de-anchor a bare NG_ genomic input");
+    let axes = |r: &VariantProjection| {
+        (
+            r.coding.as_ref().map(ToString::to_string),
+            r.protein.as_ref().map(ToString::to_string),
+            r.genomic.as_ref().map(ToString::to_string),
+            r.noncoding.as_ref().map(ToString::to_string),
+            r.rna.as_ref().map(ToString::to_string),
+        )
+    };
+    assert_eq!(
+        axes(&via_normalized),
+        axes(&via_variant),
+        "project_normalized must match project_variant on a bare NG_ genomic input",
+    );
+    // Pin the shared value so a change to BOTH paths still surfaces.
+    assert_eq!(
+        via_normalized
+            .coding
+            .as_ref()
+            .map(ToString::to_string)
+            .as_deref(),
+        Some("NG_TEST.1(NM_TEST.1):c.9_*1del"),
+    );
+}
+
+/// Lock-in (review M1): a `c.` input carrying an `NG_` `genomic_context` must be
+/// **unchanged** by this PR — the Genome-gate keeps it on its existing pivot
+/// path (it must NOT be routed through the de-anchor helper, whose cnr branch
+/// would otherwise fire). Pin all three axes so a regression is caught.
+#[test]
+fn ng_context_coding_input_keeps_pivot_path_unchanged() {
+    let (projector, mut provider) = base_fixture();
+    provider.add_genomic_placement(
+        "NG_TEST.1",
+        GenomicPlacement {
+            nc: parse_acc("NC_000001.11"),
+            parent_start: 5001,
+            nc_start: 1000,
+            nc_end: 1013,
+            strand: Strand::Plus,
+        },
+    );
+    let vp = VariantProjector::new(projector, provider);
+
+    // c. input with NG_ context — NOT a bare Genome input.
+    let variant = parse_hgvs("NG_TEST.1(NM_TEST.1):c.4A>C").expect("parse");
+    let r = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("c. input with NG_ context projects via the pivot path");
+
+    // Today's pivot-path output, pinned verbatim: the single-transcript c. path
+    // renders the coding axis with its gene-symbol selector (not reframed under
+    // the NG_ parent), a bare protein, and an NG_-framed genomic axis. The
+    // Genome-gate must leave every one of these unchanged.
+    assert_eq!(
+        r.coding.as_ref().map(ToString::to_string).as_deref(),
+        Some("NM_TEST.1(TESTGENE):c.4A>C"),
+    );
+    assert_eq!(
+        r.protein.as_ref().map(ToString::to_string).as_deref(),
+        Some("NP_TEST.1:p.(Lys2Gln)"),
+    );
+    assert_eq!(
+        r.genomic.as_ref().map(ToString::to_string).as_deref(),
+        Some("NG_TEST.1:g.5004A>C"),
+    );
+}
+
+/// Regression: a genuinely-non-overlapping `NC_` genomic input still declines —
+/// de-anchoring happens BEFORE the overlap guard, it does not weaken the guard.
+#[test]
+fn genuine_non_overlap_still_declines() {
+    let (projector, provider) = base_fixture();
+    let vp = VariantProjector::new(projector, provider);
+    let variant = parse_hgvs("NC_000001.11:g.5000A>G").expect("parse");
+    let err = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect_err("a non-overlapping NC_ input must still decline");
+    assert!(
+        matches!(err, FerroError::TranscriptNotOverlapping { .. }),
+        "expected TranscriptNotOverlapping, got: {err:?}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -193,6 +193,7 @@ mod issue_843_allele_rna_build_scoping;
 mod issue_851_compound_utr_projection;
 mod issue_857_cterminal_extension;
 mod issue_860_lrg_namespace;
+mod issue_879_ng_g_to_c_overlap;
 mod issue_91_protein_three_prime_shift;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;


### PR DESCRIPTION
Closes #879.

## Problem

`project_variant(NG_012337.1:g.13124_13125del, "NM_003002.2")` (and the CLI `ferro project … --transcript NM_003002.2`) declined with `TranscriptNotOverlapping`, even though it should yield `NG_012337.1(NM_003002.2):c.480_*1del` (a deletion spanning the last CDS base `c.480` and the first 3'UTR base `c.*1`).

## Root cause — coordinate-frame mismatch

The single-transcript entry points `project_variant`/`project_normalized` never de-anchored a bare `NG_`/`LRG_` **genomic** input into the `NC_` chromosome frame, so a parent-frame coordinate (`g.13124`, in the `NG_012337.1` frame) was compared against the transcript's `NC_`-frame cdot exon span (≈ chr11:112 Mb) by the overlap guard — always "outside" → decline. The fan-out (`project_variant_all`) already de-anchors + re-frames; the single-transcript paths didn't.

## Fix

A private `project_bare_genomic_parent` helper, called first in both `project_variant` and `project_normalized`. For a **placement-backed bare-`Genome`** input it de-anchors into the `NC_` frame, re-normalizes, projects onto the requested transcript, and re-frames under the parent (`frame_projection_owned`) — reusing the fan-out's proven machinery. It returns `None` for everything else, so:
- a `c./n./r.` input (even with an `NG_`/`LRG_` `genomic_context`) keeps its existing pivot path (gated on `HgvsVariant::Genome`);
- a genuinely non-overlapping `NC_` input still declines (the guard is unchanged — de-anchoring happens *before* it, not weakening it);
- every other single-transcript caller is a no-op.

The parent branch **re-normalizes even on `project_normalized`** (a documented exception to its skip-normalize contract): a de-anchored variant is non-canonical in the `NC_` frame, and the caller cannot pre-normalize it there without knowing the placement.

## Scope

Fixes the single-transcript **API + CLI `--transcript`**. It does **not** touch the #326 conformance ledger — that routes bare-`NG_ g.` rows through the already-de-anchored fan-out (and its single-path axis skips bare-genomic inputs), so this PR can't and doesn't move it. The `.4`-vs-`.2` fan-out version divergence noted in the issue is a separate #763/#871/#875-family concern.

## Tests

New `tests/it/issue_879_ng_g_to_c_overlap.rs` (MockProvider, non-identity placement — an identity `parent_start == nc_start` masks the frame bug):
- plus- and minus-strand bare-`NG_` genomic → `c.<n>_*1del` with the `NG_(NM_)` context, protein axis reframed (`p.(Ter…extTer…)` — the #857 shape survives), genomic re-anchored;
- same via `project_normalized`;
- lock-in: an `NG_(NM_):c.` input is unchanged (pivot path);
- regression: genuine non-overlap still declines.

## Verification

`cargo nextest run --features dev` → all pass; clippy `-D warnings` + fmt clean. Manifest reproducer (`ferro project NG_012337.1:g.13124_13125del --transcript NM_003002.2`): `c` → `NG_012337.1(NM_003002.2):c.480_*1del`, `p` → `NG_012337.1(NP_002993.1):p.(Ter160CysextTer29)`, `g` → `NG_012337.1:g.13124_13125del` — matching the issue's expected values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variant projection for certain genomic inputs so overlapping transcript results are now handled correctly instead of incorrectly reporting no overlap.
  * Improved handling of genomic coordinates across both forward- and reverse-strand cases.

* **Tests**
  * Added coverage for the corrected projection behavior, including matching results across different output forms and ensuring non-overlapping cases still fail as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->