### PR TITLE
fix(project): cis-sort minus-strand compound-allele members on the project_variant genomic axis (#894)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -2639,10 +2639,19 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // into `.genomic` (#508 review).
         let all_have_genomic = inner_projections.iter().all(|p| p.genomic.is_some());
         let genomic = if all_have_genomic {
-            let genomic_variants: Vec<HgvsVariant> = inner_projections
+            let mut genomic_variants: Vec<HgvsVariant> = inner_projections
                 .iter()
                 .filter_map(|p| p.genomic.clone())
                 .collect();
+            // #894: re-canonicalize cis members into ascending genomic order, so the
+            // user-facing `project_variant().genomic` matches the raw `project_to_genomic`
+            // pivot (which sorts at :1365). A minus-strand transcript projects members in
+            // descending genomic order; cis alleles must be listed genomic-ascending
+            // (alleles.md:118). Trans alleles encode haplotype assignment by member order
+            // and must NOT reorder — same cis-only guard as the raw path.
+            if allele.phase == AllelePhase::Cis {
+                sort_genomic_allele_members(&mut genomic_variants);
+            }
             Some(HgvsVariant::Allele(AlleleVariant::new(
                 genomic_variants,
                 allele.phase,

--- a/tests/it/issue_851_compound_utr_projection.rs
+++ b/tests/it/issue_851_compound_utr_projection.rs
@@ -242,6 +242,54 @@ fn trans_allele_members_not_reordered() {
     );
 }
 
+/// Extract the `.genomic` axis allele's member start positions from a
+/// `project_variant` projection (the user-facing path, #894).
+fn genomic_member_starts(vp: &VariantProjector<MockProvider>, input: &str, tx: &str) -> Vec<u64> {
+    let v = parse_hgvs(input).expect("parse");
+    let g = vp
+        .project_variant(&v, tx)
+        .expect("should project")
+        .genomic
+        .expect("genomic axis present");
+    member_starts(&g)
+}
+
+#[test]
+fn minus_strand_cis_allele_via_project_variant_sorted_genomic_order() {
+    // #894: the user-facing `project_variant().genomic` path (what `ferro project
+    // --axis g` uses) must match the raw `project_to_genomic` pivot — a cis allele
+    // on a minus-strand transcript must render members ascending by genomic start,
+    // not in transcript (descending) order. Same fixture/input as the raw-path
+    // test above; only the entry point differs.
+    let vp = minus_fixture();
+    let starts = genomic_member_starts(&vp, "NG_M.1(NM_M.1):c.[1A>C;5A>C;9A>C]", "NM_M.1");
+    assert!(
+        starts.windows(2).all(|w| w[0] < w[1]),
+        "project_variant members must be ascending by genomic start, got {starts:?}"
+    );
+    assert_eq!(starts, vec![2009, 2013, 2017]);
+}
+
+#[test]
+fn trans_allele_via_project_variant_not_reordered() {
+    // #894: the cis-only guard must hold on the project_variant path too — a trans
+    // allele encodes haplotype assignment by member order, so it must NOT reorder.
+    let vp = minus_fixture();
+    let starts = genomic_member_starts(&vp, "NG_M.1(NM_M.1):c.[1A>C];[9A>C]", "NM_M.1");
+    assert_eq!(starts, vec![2017, 2009], "trans order must be preserved");
+}
+
+#[test]
+fn plus_strand_cis_allele_via_project_variant_stays_ascending() {
+    // #894 sibling symmetry: a plus-strand cis allele already projects members in
+    // ascending genomic order, so the cis sort is a stable no-op — but assert it on
+    // the project_variant path too, documenting plus/minus parity. c.1→g.1002,
+    // c.4→g.1005 (identity placement, no reverse-complement).
+    let vp = plus_fixture();
+    let starts = genomic_member_starts(&vp, "NG_P.1(NM_P.1):c.[1A>T;4C>A]", "NM_P.1");
+    assert_eq!(starts, vec![1002, 1005]);
+}
+
 #[test]
 fn minus_strand_5utr_within_modeled_utr_unchanged() {
     // cds_start=2 ⇒ c.-1→tx1→g.2018, c.-2→tx0→g.2019 (last in-UTR). These route


### PR DESCRIPTION
Closes #894.

## Bug

`VariantProjector::project_variant(...).genomic` — the user-facing path, e.g. `ferro project --axis g` — built a compound **cis** allele's genomic axis in **transcript order**. For a **minus-strand** transcript that is descending genomic order, not the HGVS-canonical ascending order (alleles.md:118, "variants should be listed in genomic order").

The raw `project_to_genomic` pivot already sorts (the #851 fix), so the two paths diverged. PR #881 added the sort to the raw path only; `project_allele_inner`'s genomic build was never wired up.

## Reproducer (blessed reference)

`NG_012337.1(NM_012459.2):c.[10del;23_25del;36_37insAAT]` (minus strand):
- raw `project_to_genomic` → `NG_012337.1:g.[4886_4887insATT;4898_4900del;4913del]` (ascending, correct — this is what the conformance corpus is blessed to, because `axis_genomic` runs the raw path).
- `project_variant().genomic` (before) → `g.[4913del;4898_4900del;4886_4887insATT]` (descending).
- `project_variant().genomic` (after) → `g.[4886_4887insATT;4898_4900del;4913del]` ✓

## Fix

Apply the existing `sort_genomic_allele_members` helper in `project_allele_inner`'s genomic-axis build (`src/project/projector.rs`), cis-guarded, mirroring the raw path's call at `:1365`. One added call + `mut`.

- **Cis only.** Trans alleles (`[m1];[m2]`) encode haplotype assignment by member order and must not reorder — same guard as the raw path.
- **Plus-strand unaffected.** Members already project ascending, so the stable sort is a no-op.
- **Coding/noncoding/protein axes unchanged** — those are correctly listed in transcript order for their frames; only the genomic axis sorts.

Unblocks routing conformance allele rows through `project_variant` (#870, currently kept on the raw pivot to avoid this regression).

## Tests

The existing #851 tests only exercised the raw `project_to_genomic` pivot. Added three tests to `tests/it/issue_851_compound_utr_projection.rs` that drive the `project_variant` path directly (MockProvider, non-identity minus-strand fixture): minus-strand cis → ascending, trans → order preserved, plus-strand cis → ascending (stable-sort no-op, sibling symmetry).

## Verification

- `cargo nextest run --features dev` → **7680 passed** (2 net-new), 0 failed. `cargo clippy --features dev --all-targets -- -D warnings` + `cargo fmt --all --check` clean.
- Manifest reproducer confirmed (`ferro project … --axis g` now emits ascending).

Single-behavior change in `src/project/projector.rs`; no public API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genomic allele member ordering so cis alleles are now consistently presented in ascending genomic order.
  * Preserved the original member order for trans alleles, avoiding unintended reordering.
  * Added coverage for projection behavior to confirm ordering remains correct across strand and phase combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->