### PR TITLE
test(conformance): bless genomic-axis rejections via multi-axis accepted_rejection (#870 follow-up)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -43,9 +43,6 @@ impl Fixture {
                 case.reference_unavailable
                     .as_ref()
                     .and_then(|d| d.cluster.as_deref()),
-                case.accepted_rejection
-                    .as_ref()
-                    .and_then(|d| d.cluster.as_deref()),
             ]
             .into_iter()
             .flatten()
@@ -53,13 +50,18 @@ impl Fixture {
                 refs.push((input, cluster));
             }
             // A `Case` may carry multiple per-axis accepted divergences (#870),
-            // known bugs (#870), and spec citations (#827); collect the cluster
-            // ref of each.
+            // known bugs (#870), accepted rejections (#870), and spec citations
+            // (#827); collect the cluster ref of each.
             for cluster in case
                 .accepted_divergences
                 .iter()
                 .filter_map(|d| d.cluster.as_deref())
                 .chain(case.known_bugs.iter().filter_map(|d| d.cluster.as_deref()))
+                .chain(
+                    case.accepted_rejections
+                        .iter()
+                        .filter_map(|d| d.cluster.as_deref()),
+                )
                 .chain(
                     case.spec_citations
                         .iter()
@@ -85,7 +87,7 @@ impl Fixture {
     }
 
     /// Reject any `Case` whose multi-axis annotations (`spec_citations`,
-    /// `accepted_divergences`, `known_bugs`) name the same axis more than once
+    /// `accepted_divergences`, `known_bugs`, `accepted_rejections`) name the same axis more than once
     /// within a single annotation kind — the matcher `find`s the first match per
     /// axis, so a duplicate-axis entry would be silently ignored. Surfacing it
     /// here turns an authoring mistake into a hard error at fixture-validation
@@ -125,6 +127,11 @@ impl Fixture {
                 &case.input,
                 "known_bug",
                 case.known_bugs.iter().map(|d| d.axis),
+            )?;
+            check_unique(
+                &case.input,
+                "accepted_rejection",
+                case.accepted_rejections.iter().map(|d| d.axis),
             )?;
         }
         Ok(())
@@ -194,8 +201,9 @@ impl Fixture {
             // `accepted_rejection` (ferro correctly errors; mutalyzer lenient) is
             // an accepted, terminal divergence — aggregate it under the
             // `AcceptedDivergence` summary column. The distinct, reviewable
-            // disposition lives in `cases.json`.
-            if let Some(d) = &case.accepted_rejection {
+            // disposition lives in `cases.json`. One summary row per per-axis
+            // rejection (#870): a multi-axis row contributes one row per axis.
+            for d in &case.accepted_rejections {
                 rows.push(MemberRow {
                     cluster: d.cluster.clone(),
                     input: input.to_string(),
@@ -314,8 +322,22 @@ pub struct Case {
     /// an input mutalyzer leniently reinterprets (the only disposition that
     /// covers an `Err` on a projection axis). Tallied into
     /// `AxisTally::divergence_accepted`. See [`AcceptedRejection`].
-    #[serde(default)]
-    pub accepted_rejection: Option<AcceptedRejection>,
+    ///
+    /// Like [`accepted_divergences`](Self::accepted_divergences) and
+    /// [`known_bugs`](Self::known_bugs), a `Case` may carry MORE THAN ONE
+    /// rejection, each scoped to a different axis (#870): an input ferro rejects
+    /// at parse or projection time fails on *every* projected axis, so the same
+    /// rejection is dispositioned on both the `normalized` and `genomic` axes
+    /// once the genomic axis routes through the user-facing `project_variant`.
+    /// The wire (`cases.json`) key is `accepted_rejection` and accepts either a
+    /// single object or an array. Absent → empty vec. See
+    /// [`de_one_or_many`].
+    #[serde(
+        default,
+        rename = "accepted_rejection",
+        deserialize_with = "de_one_or_many"
+    )]
+    pub accepted_rejections: Vec<AcceptedRejection>,
 }
 
 /// Closed enum of corpus-runner axes. Replaces the previous free-form
@@ -1183,6 +1205,51 @@ mod tests {
     fn spec_citation_explicit_null_is_empty() {
         let fixture = parse("", r#"{"input":"N","spec_citation":null}"#);
         assert!(fixture.cases[0].spec_citations.is_empty());
+    }
+
+    #[test]
+    fn accepted_rejection_single_object_and_array_both_parse() {
+        // Single-object form (unchanged wire shape) -> one rejection.
+        let one = r#"{"input":"S","accepted_rejection":{"axis":"normalized",
+            "reason":"ferro-policy-654-malformed-input-rejected"}}"#;
+        let fixture = parse("", one);
+        assert_eq!(fixture.cases[0].accepted_rejections.len(), 1);
+        assert_eq!(
+            fixture.cases[0].accepted_rejections[0].axis,
+            Axis::Normalized
+        );
+
+        // Array form (#870) -> the same rejection dispositioned on two axes.
+        let many = r#"{"input":"M","accepted_rejection":[
+            {"axis":"normalized","reason":"ferro-policy-654-malformed-input-rejected"},
+            {"axis":"genomic","reason":"ferro-policy-654-malformed-input-rejected"}
+        ]}"#;
+        let case = &parse("", many).cases[0];
+        assert_eq!(case.accepted_rejections.len(), 2);
+        assert_eq!(case.accepted_rejections[0].axis, Axis::Normalized);
+        assert_eq!(case.accepted_rejections[1].axis, Axis::Genomic);
+
+        // Absent -> empty vec.
+        assert!(parse("", r#"{"input":"N"}"#).cases[0]
+            .accepted_rejections
+            .is_empty());
+    }
+
+    // #870: two rejections for the SAME axis on one case are rejected by
+    // `validate_clusters` — the matcher honors only one per axis, so a duplicate
+    // is an authoring mistake that must surface loudly (parity with
+    // `duplicate_spec_citation_axis_is_rejected`).
+    #[test]
+    fn duplicate_accepted_rejection_axis_is_rejected() {
+        let cases = r#"{"input":"D","accepted_rejection":[
+            {"axis":"genomic","reason":"ferro-policy-654-malformed-input-rejected"},
+            {"axis":"genomic","reason":"ferro-policy-758-transcript-flank-not-numberable-in-c"}
+        ]}"#;
+        let err = parse("", cases)
+            .validate_clusters()
+            .expect_err("two rejections on the same axis must be rejected");
+        assert!(err.contains("genomic"), "{err}");
+        assert!(err.contains("accepted_rejection"), "{err}");
     }
 
     // #827: two spec citations for the SAME axis on one case are rejected by

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -2725,11 +2725,18 @@
       "normalized": "NG_008835.1:g.320803_320804del",
       "genomic": "NG_008835.1:g.320803_320804del",
       "to_test": true,
-      "accepted_divergence": {
-        "axis": "normalized",
-        "policy": "ferro-policy-745-homopolymer-repeat-contraction",
-        "note": "ferro renders the deletion inside the genomic homopolymer as the spec-valid repeat contraction g.320802_320804T[1]; mutalyzer keeps del. Same class as #745/#750 on the genomic axis."
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-745-homopolymer-repeat-contraction",
+          "note": "ferro renders the deletion inside the genomic homopolymer as the spec-valid repeat contraction g.320802_320804T[1]; mutalyzer keeps del. Same class as #745/#750 on the genomic axis."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-745-homopolymer-repeat-contraction",
+          "note": "The genomic axis routes this pure g. input through the same normalizer (#870), so it emits the same spec-valid repeat contraction g.320802_320804T[1] while mutalyzer keeps del."
+        }
+      ]
     },
     {
       "keywords": [],
@@ -3285,6 +3292,11 @@
         "tracking_issue": 487,
         "note": "ferro keeps c.250del; mutalyzer 3'-shifts it to c.*189del. Compound-allele 3' shift tracked in #487."
       },
+      "accepted_rejection": {
+        "axis": "genomic",
+        "reason": "ferro-policy-853-ng-partial-transcript-coverage-declined",
+        "note": "NG_009299.1 annotates NM_017668.3 only partially, so the c.41 endpoint falls outside the placed genomic span; the user-facing genomic axis (#870) declines to re-anchor (#480/#655) rather than emit chromosome coordinates under the NG_ accession. mutalyzer resolves the full genomic form."
+      },
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS protein reference (bare NP)",
@@ -3321,11 +3333,18 @@
         "ICORRECTEDPOINT"
       ],
       "to_test": true,
-      "accepted_rejection": {
-        "axis": "normalized",
-        "reason": "ferro-policy-654-malformed-input-rejected",
-        "note": "'41>CA' is a substitution lacking a reference base (malformed HGVS); ferro rejects it at parse time. mutalyzer leniently reinterprets the allele (-> c.[40dup;*189del])."
-      }
+      "accepted_rejection": [
+        {
+          "axis": "normalized",
+          "reason": "ferro-policy-654-malformed-input-rejected",
+          "note": "'41>CA' is a substitution lacking a reference base (malformed HGVS); ferro rejects it at parse time. mutalyzer leniently reinterprets the allele (-> c.[40dup;*189del])."
+        },
+        {
+          "axis": "genomic",
+          "reason": "ferro-policy-654-malformed-input-rejected",
+          "note": "The same malformed '41>CA' fails at parse time, so the user-facing genomic axis (#870) produces no output either, while mutalyzer leniently reinterprets."
+        }
+      ]
     },
     {
       "keywords": [
@@ -3848,12 +3867,20 @@
       "normalized": "LRG_24t1:c.126_133delinsGTGGGAATTGTAAAAAAA",
       "genomic": "LRG_24:g.5525_5532delinsGTGGGAATTGTAAAAAAA",
       "to_test": true,
-      "accepted_rejection": {
-        "axis": "normalized",
-        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
-        "cluster": "transcript-flank-not-numberable",
-        "note": "bracketed delins payload references both the 5' (pter) and 3' (qter) transcript flanks in c. (refseq.md L45-46). ferro rejects (cross-reference shape error explicitly lists pter/qter decorations as out of scope); mutalyzer resolves the concatenated flank bases. ferro's refusal is spec-correct."
-      }
+      "accepted_rejection": [
+        {
+          "axis": "normalized",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "bracketed delins payload references both the 5' (pter) and 3' (qter) transcript flanks in c. (refseq.md L45-46). ferro rejects (cross-reference shape error explicitly lists pter/qter decorations as out of scope); mutalyzer resolves the concatenated flank bases. ferro's refusal is spec-correct."
+        },
+        {
+          "axis": "genomic",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "Same unsupported cross-reference payload: ferro rejects rather than expand it, so the user-facing genomic axis (#870) produces no output either, while mutalyzer resolves the concatenated flank bases."
+        }
+      ]
     },
     {
       "keywords": [],
@@ -3861,12 +3888,20 @@
       "normalized": "LRG_24t1:c.=",
       "genomic": "LRG_24:g.=",
       "to_test": true,
-      "accepted_rejection": {
-        "axis": "normalized",
-        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
-        "cluster": "transcript-flank-not-numberable",
-        "note": "the variant coordinate `c.pter_qter` numbers both transcript flanks in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer treats pter_qter delins pter_qter as a whole-transcript identity (c.=). ferro's refusal is spec-correct."
-      }
+      "accepted_rejection": [
+        {
+          "axis": "normalized",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "the variant coordinate `c.pter_qter` numbers both transcript flanks in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer treats pter_qter delins pter_qter as a whole-transcript identity (c.=). ferro's refusal is spec-correct."
+        },
+        {
+          "axis": "genomic",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "The same `c.pter_qter` coordinate fails at parse time, so the user-facing genomic axis (#870) produces no output either, while mutalyzer resolves it to a whole-transcript identity (g.=)."
+        }
+      ]
     },
     {
       "keywords": [],
@@ -3874,12 +3909,20 @@
       "normalized": "LRG_24t1:c.*2327_*2328insAAAAAAA",
       "genomic": "LRG_24:g.11486_11487insAAAAAAA",
       "to_test": true,
-      "accepted_rejection": {
-        "axis": "normalized",
-        "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
-        "cluster": "transcript-flank-not-numberable",
-        "note": "the variant coordinate `c.pter_qter` and the bracketed payload both number transcript flanks (pter/qter) in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer resolves it to a 3'-flank insertion. ferro's refusal is spec-correct."
-      }
+      "accepted_rejection": [
+        {
+          "axis": "normalized",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "the variant coordinate `c.pter_qter` and the bracketed payload both number transcript flanks (pter/qter) in c. (refseq.md L45-46). ferro rejects (parse error); mutalyzer resolves it to a 3'-flank insertion. ferro's refusal is spec-correct."
+        },
+        {
+          "axis": "genomic",
+          "reason": "ferro-policy-758-transcript-flank-not-numberable-in-c",
+          "cluster": "transcript-flank-not-numberable",
+          "note": "The same `c.pter_qter` coordinate and bracketed flank payload fail at parse time, so the user-facing genomic axis (#870) produces no output either, while mutalyzer resolves it to a 3'-flank insertion."
+        }
+      ]
     },
     {
       "keywords": [],
@@ -4155,6 +4198,11 @@
       ],
       "protein_description": "NG_012337.1(NP_036591.2):p.(Cys6TrpfsTer13)",
       "to_test": true,
+      "accepted_divergence": {
+        "axis": "genomic",
+        "policy": "ferro-policy-654-positional-insert-literal-expansion",
+        "note": "ferro renders the projected insertion as its literal expanded sequence (g.4907_4908insAGGCTCGCCACCTTCCA, the reverse complement of the minus-strand c. payload); mutalyzer compresses the same bases into the positional copy-range form ins[4888_4903;A]. The inserted sequence is identical — both are spec-valid (#654)."
+      },
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS protein reference (bare NP)",

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -170,8 +170,11 @@ A coding/non-coding DNA reference does not contain the gene's 5'/3' flanking seq
 |---|---|---|---|---|
 | `LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter` | normalized | accepted_divergence | — | — |
 | `LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]` | genomic | accepted_divergence | — | — |
 | `LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]` | genomic | accepted_divergence | — | — |
 | `LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]` | normalized | accepted_divergence | — | — |
+| `LRG_24t1:c.pter_qterdelinspter_qter` | genomic | accepted_divergence | — | — |
 | `LRG_24t1:c.pter_qterdelinspter_qter` | normalized | accepted_divergence | — | — |
 
 ### RNA predicted allele bracket placement
@@ -238,6 +241,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | genomic | accepted_divergence | — | — |
 | `NG_008835.1(NM_001168390.2):c.*3186_*3187del` | normalized | spec_citation | — | — |
 | `NG_008835.1(NM_022124.6):c.3304_3305del` | genomic | accepted_divergence | — | — |
+| `NG_008835.1:g.320802_320803del` | genomic | accepted_divergence | — | — |
 | `NG_008835.1:g.320802_320803del` | normalized | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins180_188` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins180_188` | normalized | accepted_divergence | — | — |
@@ -264,7 +268,9 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_009299.1(NM_017668.3):c.41A>C` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | normalized | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41A>C]` | normalized | known_bug | — | #487 |
+| `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | normalized | accepted_divergence | — | — |
+| `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | normalized | known_bug | — | #487 |
 | `NG_009930.1(NM_001099625.2):c.1010` | errors | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):n.110del` | errors | accepted_divergence | — | — |
@@ -279,6 +285,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.pterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.qterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.-1_*1del` | normalized | known_bug | — | #487 |
+| `NG_012337.1(NM_012459.2):c.15_16insTGGAAGGTGGCGAGCCT` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` | normalized | known_bug | — | #487 |
 | `NG_012337.1:274` | normalized | accepted_divergence | — | — |
 | `NG_012337.1:g.4delins7_31` | normalized | accepted_divergence | — | — |
@@ -302,7 +309,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 |---|---:|---:|---:|---:|---:|
 | coding_protein_descriptions | 10 | 0 | 0 | 0 | 0 |
 | errors | 16 | 0 | 0 | 0 | 0 |
-| genomic | 15 | 4 | 0 | 0 | 1 |
+| genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
 | normalized | 23 | 18 | 4 | 5 | 9 |

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -555,17 +555,19 @@ impl AxisTally {
                     return;
                 }
             }
-            if let Some(ar) = &case.accepted_rejection {
-                if ar.axis == self.axis {
-                    self.fail.push((
-                        case.input.clone(),
-                        format!(
-                            "XPASS: accepted_rejection ({}) now matches mutalyzer; ferro no longer rejects this input — remove the annotation and demote the row",
-                            ar.reason
-                        ),
-                    ));
-                    return;
-                }
+            if let Some(ar) = case
+                .accepted_rejections
+                .iter()
+                .find(|ar| ar.axis == self.axis)
+            {
+                self.fail.push((
+                    case.input.clone(),
+                    format!(
+                        "XPASS: accepted_rejection ({}) now matches mutalyzer; ferro no longer rejects this input — remove the annotation and demote the row",
+                        ar.reason
+                    ),
+                ));
+                return;
             }
             self.pass += 1;
             return;
@@ -577,9 +579,12 @@ impl AxisTally {
         // sentinel (#651) still hard-FAIL below. Tallied alongside
         // `accepted_divergence`. (An `Ok` here — ferro stopped rejecting — falls
         // through: a match XPASS-FAILs above, a mismatch FAILs below.)
-        if let Some(ar) = &case.accepted_rejection {
-            if ar.axis == self.axis
-                && matches!(&actual, Err(e) if !e.starts_with("panic:") && !e.starts_with(EMPTY_PROJECTION_SENTINEL))
+        if let Some(ar) = case
+            .accepted_rejections
+            .iter()
+            .find(|ar| ar.axis == self.axis)
+        {
+            if matches!(&actual, Err(e) if !e.starts_with("panic:") && !e.starts_with(EMPTY_PROJECTION_SENTINEL))
             {
                 self.divergence_accepted
                     .push((case.input.clone(), ar.reason.to_string()));
@@ -2351,7 +2356,7 @@ mod comparator_tests {
             improvement: None,
             reference_unavailable: None,
             spec_citations,
-            accepted_rejection: None,
+            accepted_rejections: Vec::new(),
         }
     }
 
@@ -2848,12 +2853,12 @@ mod comparator_tests {
     fn tally_accepted_rejection_buckets_nonpanic_err() {
         let mut t = AxisTally::new(Axis::Normalized);
         let case = Case {
-            accepted_rejection: Some(AcceptedRejection {
+            accepted_rejections: vec![AcceptedRejection {
                 axis: Axis::Normalized,
                 reason: RejectionReason::MalformedInputRejected654,
                 note: None,
                 cluster: None,
-            }),
+            }],
             ..make_case("in", None, None)
         };
         t.record(&case, "X", Err("parse: malformed substitution".to_string()));
@@ -2877,12 +2882,12 @@ mod comparator_tests {
     fn tally_accepted_rejection_panic_still_fails() {
         let mut t = AxisTally::new(Axis::Normalized);
         let case = Case {
-            accepted_rejection: Some(AcceptedRejection {
+            accepted_rejections: vec![AcceptedRejection {
                 axis: Axis::Normalized,
                 reason: RejectionReason::MalformedInputRejected654,
                 note: None,
                 cluster: None,
-            }),
+            }],
             ..make_case("in", None, None)
         };
         t.record(&case, "X", Err("panic: boom".to_string()));
@@ -2897,12 +2902,12 @@ mod comparator_tests {
     fn tally_accepted_rejection_xpass_fails_when_ferro_no_longer_errors() {
         let mut t = AxisTally::new(Axis::Normalized);
         let case = Case {
-            accepted_rejection: Some(AcceptedRejection {
+            accepted_rejections: vec![AcceptedRejection {
                 axis: Axis::Normalized,
                 reason: RejectionReason::MalformedInputRejected654,
                 note: None,
                 cluster: None,
-            }),
+            }],
             ..make_case("in", None, None)
         };
         t.record(&case, "X", Ok("X".to_string()));
@@ -2910,6 +2915,45 @@ mod comparator_tests {
         assert!(t.divergence_accepted.is_empty());
         assert_eq!(t.fail.len(), 1, "ferro no longer rejecting must XPASS-FAIL");
         assert!(t.fail[0].1.contains("XPASS"));
+    }
+
+    // (7r-multiaxis) A `Case` may carry a rejection on MORE THAN ONE axis (#870):
+    // an input ferro rejects at parse/projection time fails on every projected
+    // axis, so the same rejection is dispositioned on both `normalized` and
+    // `genomic`. Each axis tally buckets its own rejection independently.
+    #[test]
+    fn tally_accepted_rejection_multi_axis_buckets_per_axis() {
+        let case = Case {
+            accepted_rejections: vec![
+                AcceptedRejection {
+                    axis: Axis::Normalized,
+                    reason: RejectionReason::MalformedInputRejected654,
+                    note: None,
+                    cluster: None,
+                },
+                AcceptedRejection {
+                    axis: Axis::Genomic,
+                    reason: RejectionReason::MalformedInputRejected654,
+                    note: None,
+                    cluster: None,
+                },
+            ],
+            ..make_case("in", None, None)
+        };
+        // The genomic-axis tally buckets the genomic rejection (not the
+        // normalized one), proving the matcher keys each rejection to its axis.
+        let mut g = AxisTally::new(Axis::Genomic);
+        g.record(&case, "X", Err("project: cannot re-anchor".to_string()));
+        assert!(
+            g.fail.is_empty(),
+            "genomic Err with a genomic rejection must bucket"
+        );
+        assert_eq!(g.divergence_accepted.len(), 1);
+        // And the normalized-axis tally independently buckets on the same case.
+        let mut n = AxisTally::new(Axis::Normalized);
+        n.record(&case, "X", Err("parse: malformed".to_string()));
+        assert!(n.fail.is_empty());
+        assert_eq!(n.divergence_accepted.len(), 1);
     }
 
     // (7c) `reference_unavailable` deserializes including its closed `reason`


### PR DESCRIPTION
Follow-up to #895. Stacked on its branch `test/issue-870-axis-genomic-via-project-variant` — retarget to `main` once #895 merges.

## Problem

The #870 reroute routes the genomic axis through the user-facing `project_variant().genomic`. As a result, an input ferro *rejects* (a parse error, or a projection decline) or renders divergently now surfaces on the **genomic** axis in addition to the normalized one.

`accepted_divergence` and `known_bug` were already migrated to multi-axis vecs in #870, but `accepted_rejection` was left singular. So a case that rejects an input could disposition only **one** axis — leaving the genomic axis unblessed. With a reference manifest, 7 corpus rows hard-FAIL `axis_genomic`:

- `NG_008835.1:g.320802_320803del` — genomic repeat-contraction rendering
- `NG_009299.1(NM_017668.3):c.[41A>C;250del]` — NG partial-coverage re-anchor decline
- `NG_009299.1(NM_017668.3):c.[41>CA;250del]` — malformed `41>CA` parse rejection
- `LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]` — cross-reference/pter payload
- `LRG_24t1:c.pter_qterdelinspter_qter` — `pter_qter` parse rejection
- `LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]` — same
- `NG_012337.1(NM_012459.2):c.15_16insTGGAAGGTGGCGAGCCT` — literal vs positional-range insert

(CI does not set a reference manifest, so these conformance axis tests skip in CI and this failure only appears locally.)

## Fix

- Finish the #870 multi-axis migration: `accepted_rejection` → `accepted_rejections: Vec`, with a single-or-array `de_accepted_rejections` deserializer mirroring `de_known_bugs`. The cluster-ref gather, per-axis uniqueness validation, summary-row emission, and the `AxisTally::record` matcher (XPASS guard + `Err` bucketing) all iterate per axis. A single-object wire entry still deserializes to a one-element vec, so every existing row is unchanged.
- Add genomic-axis dispositions to the 7 cases, **all reusing existing `Policy`/`RejectionReason` variants** — no new enum variants: repeat-contraction and literal-insert divergences as `accepted_divergence`; malformed-input, transcript-flank, and NG-partial-coverage rejections as `accepted_rejection`.
- Regenerate `failure-patterns.md` (genomic accepted rows 15 → 22).
- Add deserializer + duplicate-axis parity unit tests, and a multi-axis `record` bucketing test.

## Verification

- `axis_genomic` and `axis_genomic_idempotent` pass with a reference manifest — **0 FAIL** on the genomic axis.
- Full non-manifest suite green: 7663 passed, 0 failed.
- `cargo fmt` / `clippy --all-targets` clean.

Note: four other conformance axes (`coding_protein_descriptions`, `protein_description`, `infos`, `errors`) also fail locally, but they fail identically on the base branch — a pre-existing, reference/transcript-version drift issue unrelated to this change and out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accepted rejections can now be recorded for multiple axes within a single case, and both single-item and list-style inputs are supported.

- **Bug Fixes**
  - Conformance results now correctly track accepted rejections and divergences per axis.
  - Duplicate rejections for the same axis are now rejected during validation.

- **Tests**
  - Updated fixture coverage and test cases for multi-axis accepted rejections and axis-specific summary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->