### PR TITLE
chore(benchmark): record comparator provenance in the mutalyzer-normalize corpus header (#890)

### DIFF
--- a/docs/BENCHMARK_GUIDE.md
+++ b/docs/BENCHMARK_GUIDE.md
@@ -44,7 +44,7 @@ Results in this guide were generated with:
 | mutalyzer-hgvs-parser | 0.3.9 |
 | mutalyzer-algebra | 1.5.2 |
 | biocommons hgvs | 1.5.6 |
-| hgvs-rs | 0.19.1 |
+| hgvs-rs | 0.20.2-1-gb6513b3 |
 | cdot | 0.2.32 (RefSeq GRCh38) |
 | SeqRepo | 2021-01-29 |
 | UTA | uta_20210129b |

--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -29,7 +29,47 @@ pub struct Fixture {
     /// field. Optional so a corpus with no taxonomy still parses.
     #[serde(default)]
     pub clusters: Vec<Cluster>,
+    /// Comparator runtime provenance (#890): the exact comparator versions the
+    /// corpus expected values are validated against, plus the ferro
+    /// `reference_identity()` hash (#764). Optional so a corpus without it still
+    /// parses; recorded so "which mutalyzer/biocommons/hgvs-rs" is unambiguous
+    /// (the root-cause provenance gap #890 identified).
+    #[serde(default)]
+    pub comparator_provenance: Option<ComparatorProvenance>,
     pub cases: Vec<Case>,
+}
+
+/// Comparator runtime versions the corpus expected values are validated against
+/// (#890). The `mutalyzer-normalize` corpus is *derived from* the mutalyzer
+/// normalizer, so `mutalyzer` / `mutalyzer_hgvs_parser` are its authoritative
+/// source; the biocommons/hgvs-rs versions are the benchmark suite's other
+/// comparators, recorded here for one canonical provenance record. Prefer
+/// **deriving** expected values from these pinned comparators (via
+/// `ferro-benchmark compare-normalize`) over copying an upstream test suite —
+/// the practice that prevents the Mutalyzer2-era drift #882 surfaced.
+#[derive(Debug, Deserialize, Default)]
+#[allow(dead_code)]
+pub struct ComparatorProvenance {
+    /// Free-text provenance note (validation scope, derivation practice).
+    pub note: String,
+    /// Date the versions below were confirmed against the corpus (ISO-8601).
+    pub validated_at: String,
+    /// ferro prepared-reference identity hash (#764) the corpus was blessed
+    /// against; must match `reference_identity_from_manifest`.
+    pub reference_identity: String,
+    /// mutalyzer normalizer version — the source of this corpus's values.
+    pub mutalyzer: String,
+    /// mutalyzer-hgvs-parser version (mutalyzer's HGVS parser dependency).
+    pub mutalyzer_hgvs_parser: String,
+    /// biocommons/hgvs version (cross-check comparator; empty if not recorded).
+    #[serde(default)]
+    pub biocommons_hgvs: String,
+    /// biocommons.seqrepo version (cross-check comparator).
+    #[serde(default)]
+    pub biocommons_seqrepo: String,
+    /// hgvs-rs version/tag (cross-check comparator; projection-fixture source).
+    #[serde(default)]
+    pub hgvs_rs: String,
 }
 
 impl Fixture {
@@ -1084,6 +1124,42 @@ mod tests {
     fn parse(clusters: &str, cases: &str) -> Fixture {
         let json = format!("{{{BASE},\"clusters\":[{clusters}],\"cases\":[{cases}]}}");
         serde_json::from_str(&json).expect("fixture should deserialize")
+    }
+
+    #[test]
+    fn comparator_provenance_absent_still_parses() {
+        // Backward-compat (#890): a corpus header with no `comparator_provenance`
+        // block (the pre-#890 shape, and every other corpus) parses with the
+        // field as `None`.
+        let f = parse("", "");
+        assert!(f.comparator_provenance.is_none());
+    }
+
+    #[test]
+    fn comparator_provenance_parses_and_exposes_versions() {
+        // #890: the recorded provenance deserializes into typed fields (not
+        // silently dropped as an unknown key), so a future test can assert the
+        // recorded reference_identity matches the pinned reference.
+        let json = format!(
+            "{{{BASE},{},\"clusters\":[],\"cases\":[]}}",
+            r#""comparator_provenance":{
+                "note":"n","validated_at":"2026-06-30",
+                "reference_identity":"28288ed4c39ee856",
+                "mutalyzer":"3.1.1","mutalyzer_hgvs_parser":"0.3.9",
+                "biocommons_hgvs":"1.5.6","biocommons_seqrepo":"0.6.11",
+                "hgvs_rs":"0.20.2-1-gb6513b3"
+            }"#
+        );
+        let f: Fixture = serde_json::from_str(&json).expect("provenance should deserialize");
+        let p = f
+            .comparator_provenance
+            .expect("comparator_provenance present");
+        assert_eq!(p.reference_identity, "28288ed4c39ee856");
+        assert_eq!(p.mutalyzer, "3.1.1");
+        assert_eq!(p.mutalyzer_hgvs_parser, "0.3.9");
+        assert_eq!(p.biocommons_hgvs, "1.5.6");
+        assert_eq!(p.biocommons_seqrepo, "0.6.11");
+        assert_eq!(p.hgvs_rs, "0.20.2-1-gb6513b3");
     }
 
     #[test]

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -4,6 +4,16 @@
   "source_commit": "00045d63feba04ccff18a4d95f4245ad5d8d3092",
   "license": "MIT",
   "refreshed_at": "2026-05-18",
+  "comparator_provenance": {
+    "note": "Comparator runtime versions the expected values are validated against. A full 246-row sweep of the corpus against live mutalyzer 3.1.1 (#882/#890) found it 96% faithful (236 match; the only genuine drift was 2 insCAT rows, fixed in #882). `source_commit` above is the mutalyzer test-suite import origin and is partly Mutalyzer2-era; these pinned versions supersede it as the authoritative provenance. Going forward, DERIVE expected values from the pinned comparator (`pixi run compare-mutalyzer` / `ferro-benchmark compare-normalize`) rather than copying an upstream test suite, to prevent recurrence of the M2 drift. biocommons/hgvs-rs are the benchmark suite's other comparators, recorded here for a single canonical provenance record.",
+    "validated_at": "2026-06-30",
+    "reference_identity": "28288ed4c39ee856",
+    "mutalyzer": "3.1.1",
+    "mutalyzer_hgvs_parser": "0.3.9",
+    "biocommons_hgvs": "1.5.6",
+    "biocommons_seqrepo": "0.6.11",
+    "hgvs_rs": "0.20.2-1-gb6513b3"
+  },
   "clusters": [
     {
       "id": "refseqgene-selector",

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -121,6 +121,29 @@ fn fixture() -> &'static Fixture {
     })
 }
 
+/// #890: the comparator provenance recorded in the corpus header must stay in
+/// sync with the reference it was validated against. Assert the recorded
+/// `reference_identity` (#764) equals the live prepared-reference identity — a
+/// mismatch means the provenance is stale and its 96%-faithful validation no
+/// longer applies to the checked-out reference. Manifest-gated (skips in CI,
+/// like every other reference-backed check here).
+#[test]
+fn comparator_provenance_reference_identity_matches_live() {
+    let Some(live) = reference_identity() else {
+        eprintln!("comparator_provenance_reference_identity_matches_live: skipping — no manifest");
+        return;
+    };
+    let recorded = &fixture()
+        .comparator_provenance
+        .as_ref()
+        .expect("corpus records comparator_provenance (#890)")
+        .reference_identity;
+    assert_eq!(
+        *recorded, live,
+        "corpus comparator_provenance.reference_identity is stale — re-record it (#890/#764)"
+    );
+}
+
 fn manifest_path() -> Option<PathBuf> {
     // `FERRO_MANIFEST`, when set, is authoritative — no fallback to the
     // well-known paths. This lets CI explicitly disable the runner via


### PR DESCRIPTION
Part of #890 (does not close it — see "Deferred" below).

## What

Addresses #890's identified **root cause**: the `mutalyzer-normalize` corpus expected values were imported from an upstream test suite (`source_commit 00045d63`, partly Mutalyzer2-era) and the comparator runtime versions were never recorded — so "which mutalyzer/biocommons/hgvs-rs" was ambiguous, which is how the M2-era `insCAT` drift (#882) slipped in.

Add a typed `comparator_provenance` block to the corpus header, parsed via a new `ComparatorProvenance` struct on `Fixture` (`#[serde(default)]`, so every other corpus and the pre-#890 shape still parse):

- **`mutalyzer` 3.1.1** + **`mutalyzer_hgvs_parser` 0.3.9** — this corpus's authoritative source (it's derived from the mutalyzer normalizer).
- **`biocommons_hgvs` 1.5.6**, **`biocommons_seqrepo` 0.6.11**, **`hgvs_rs` 0.20.2-1-gb6513b3** — the benchmark suite's other comparators, recorded here for one canonical provenance record.
- **`reference_identity` 28288ed4c39ee856** — the ferro prepared-reference hash (#764) the corpus was blessed against.
- A `note` recording the 96%-faithful validation (the #882 full-corpus sweep) and the **"derive expected values from the pinned comparator, don't copy an upstream suite"** practice (task 4) that prevents recurrence.

Also correct the stale `hgvs-rs 0.19.1` → `0.20.2-1-gb6513b3` in `BENCHMARK_GUIDE.md` (matching the `refresh-*-fixtures.py` SHA).

## Self-checking, not just documentation

Per review: the recorded `reference_identity` is **validated against the live reference** — a manifest-gated test (`comparator_provenance_reference_identity_matches_live`) asserts the recorded hash equals `reference_identity()`, so provenance drift fails fast rather than silently rotting. Plus hermetic unit tests for parse + backward-compat (absent block → `None`).

## Deferred (env/network-gated — #890 stays open)

- **Task 1/2 — comparator pin bumps** (`mutalyzer-hgvs-parser 0.4.0`, `hgvs-rs 0.22.0`, `biocommons 1.5.7`) + re-running the comparisons to verify no expected-value shift. Needs `pixi update` (PyPI), the biocommons **UTA database** connection, and a local `hgvs-rs` checkout for fixture regeneration — not verifiable in this change without those, and bumping a comparator without re-running would violate "verify the benchmark."
- **Task 5** — the 5 dormant `to_test:false` rows (needs live mutalyzer 3.1.1 re-derivation).
- **Task 6** — the optional nightly comparator-drift guard.

## Verification

- Real `cases.json` parses through the schema (summary generator + full suite **7680 passed**, 0 failed).
- Manifest self-check green: recorded `reference_identity` == live `28288ed4c39ee856`.
- `cargo clippy --features dev --all-targets -- -D warnings` + `cargo fmt --all --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the benchmark guide to reflect the latest recorded `hgvs-rs` version.

* **New Features**
  * Added support for recording comparator provenance in normalization fixtures, including version details and reference identity.
  * Fixture parsing now remains compatible with older data that doesn’t include the new provenance block.

* **Tests**
  * Added coverage for missing and populated provenance data.
  * Added a check to ensure recorded reference identity matches the live prepared-reference identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->