### PR TITLE
refactor(project): untangle project_to_genomic_nc — extract the coordinate map and #785 gate (#868)

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1772,6 +1772,203 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Some(g)
     }
 
+    /// #785 silent-version-substitution gate for the c./n./r. → g. pivot: decline
+    /// (`TranscriptVersionNotExact`) when the input names an explicit transcript
+    /// version the reference does not carry exactly but a *sibling* version
+    /// resolves — projecting onto the sibling's exon/CDS frame would silently
+    /// disagree with the stated reference. `version_present` is the caller's
+    /// `accession.version.is_some() && is_transcript_accession(id)` guard; an LRG
+    /// transcript (no version) and a genuinely-absent transcript are both left
+    /// untouched (the latter falls through to the `ReferenceNotFound` miss).
+    /// Extracted from `project_to_genomic_nc`'s step 4 (#868); pure predicate over
+    /// the provider + cdot.
+    fn enforce_exact_transcript_version(
+        &self,
+        transcript_id: &str,
+        version_present: bool,
+        build_hint: Option<&'static str>,
+    ) -> Result<(), FerroError> {
+        let cdot_mapper = self.projector.mapper();
+        // Silent version-substitution gate (#785), c.→g. direction. Unlike
+        // `project_variant`/`project_variant_all`, this path does not normalize
+        // the original transcript-coordinate input first, so it would not inherit
+        // the gate the normalizer applies in `normalize_core`. Apply the same
+        // guarantee here: when the input names an EXPLICIT transcript version the
+        // reference does not carry exactly, the lenient `get_transcript[_on_build]`
+        // pivot below would silently fall back to a *sibling* version and project
+        // onto the genome using that sibling's exon/CDS frame — a spec-invalid
+        // result whose stated reference and coordinate frame disagree, with no
+        // error. Decline with `TranscriptVersionNotExact` instead of fuzzing the
+        // version. The predicate permits exact-version cdot-genome synthesis and
+        // rejects only cross-version substitution; an LRG transcript carries no
+        // version (`accession.version == None`), so its exact RefSeq alias path is
+        // untouched. A transcript that is simply absent with no sibling to
+        // substitute is left to the `ReferenceNotFound` miss below, unchanged.
+        if version_present && is_transcript_accession(transcript_id) {
+            let exact = self.provider.has_transcript_version_exact(transcript_id);
+            let resolves = match build_hint {
+                Some(b) => cdot_mapper
+                    .cdot()
+                    .get_transcript_on_build(transcript_id, b)
+                    .is_some(),
+                None => cdot_mapper.cdot().get_transcript(transcript_id).is_some(),
+            };
+            if !exact && resolves {
+                return Err(FerroError::TranscriptVersionNotExact {
+                    requested: transcript_id.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Map a single c./n./r. position (as `CdsPos`) onto a genome coordinate on
+    /// the transcript's chromosome. Encapsulates: the n./r. → CDS-frame
+    /// conversion (`to_cds_frame`, #693), the coding (`cds_to_genome_on_build`)
+    /// vs non-coding (`tx_to_genome`) primitive split, the #797 poly-A `c.*`
+    /// fallback (coding, cds input only), and the #644 sequence-aware exon-indel
+    /// correction. This is the reusable "coordinate math" #868 wanted separable
+    /// from the outer pivot (step 5). Lifts the former `map_pos`/`to_cds_frame`
+    /// closures verbatim.
+    #[allow(clippy::too_many_arguments)]
+    fn map_cnr_position_to_genome(
+        &self,
+        cdot_tx: &crate::data::cdot::CdotTranscript,
+        transcript_id: &str,
+        p: crate::hgvs::location::CdsPos,
+        is_coding: bool,
+        is_cds_input: bool,
+        input_is_transcript_coord: bool,
+        build_hint: Option<&'static str>,
+    ) -> Result<u64, FerroError> {
+        use crate::hgvs::location::CdsPos;
+        let cdot_mapper = self.projector.mapper();
+        // For an `n.`/`r.` input on a coding transcript, the carried `base` is a
+        // 1-based *transcript* position, not a CDS coordinate; convert it to the
+        // CDS frame before the CDS-aware genome mapping (#693). An exonic
+        // position converts directly; an intronic-offset position converts its
+        // exon-anchor `base` and keeps the offset/utr3 flags. A transcript
+        // position that cannot be expressed in the CDS frame (`base < 1`, or a
+        // `None` conversion for a position past the last exon) is rejected here:
+        // leaving it unconverted would let the CDS-aware mapping interpret an
+        // `n.`/`r.` coordinate as a `c.` coordinate and emit the wrong g.
+        // position (#693).
+        let to_cds_frame = |p: CdsPos| -> Result<CdsPos, FerroError> {
+            // A position already flagged 3'UTR/downstream (`r.*N`, `n.*N`) carries
+            // its `*N` distance in `base`, not an absolute 1-based transcript
+            // position — feeding it to `cds_pos_from_tx_pos` would renumber it as a
+            // transcript base. Leave such positions untouched so the downstream
+            // CDS-aware mapping interprets the `*N` directly.
+            if !(input_is_transcript_coord && is_coding) || p.utr3 {
+                return Ok(p);
+            }
+            if p.base < 1 {
+                return Err(FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "transcript position {} is outside coding transcript {} and cannot be \
+                         mapped as a CDS coordinate",
+                        p.base, transcript_id
+                    ),
+                });
+            }
+            match cdot_tx.cds_pos_from_tx_pos((p.base - 1) as u64) {
+                Some(cds) => Ok(CdsPos {
+                    base: cds.base,
+                    offset: p.offset,
+                    // Keep the resolved 3'UTR flag even for intronic anchors
+                    // (`c.*N±M`); dropping it when an offset is present would
+                    // collapse a 3'UTR intron into a plain `c.N±M`.
+                    utr3: cds.utr3,
+                    special: p.special,
+                }),
+                None => Err(FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "transcript position {} is outside coding transcript {} and cannot be \
+                         mapped as a CDS coordinate",
+                        p.base, transcript_id
+                    ),
+                }),
+            }
+        };
+        let p = to_cds_frame(p)?;
+        if is_coding {
+            let result = match cdot_mapper.cds_to_genome_on_build(transcript_id, &p, build_hint) {
+                Ok(r) => r,
+                Err(e) => {
+                    // Poly-A-region 3'UTR fallback (#797). A `c.*` position
+                    // can land in the transcript's post-transcriptional
+                    // poly-A tail, which the (e.g. #790-derived) exon→genome
+                    // map strips — so `cds_to_genome` declines. mutalyzer
+                    // maps such positions by a contiguous coordinate walk into
+                    // downstream genome from the transcript's own 3'-terminal
+                    // exon. `try_extend_polya_to_genome` self-gates (a `c.*`
+                    // position whose base lands in the poly-A region, an
+                    // optional positive downstream offset, and an effective
+                    // tx position within the transcript's TRUE length, i.e.
+                    // inside the real poly-A tail) and returns None to
+                    // propagate the original decline otherwise — so beyond
+                    // the tail we never walk into non-transcript genome.
+                    if is_cds_input {
+                        if let Some(g) = self.try_extend_polya_to_genome(cdot_tx, transcript_id, &p)
+                        {
+                            return Ok(g);
+                        }
+                    }
+                    return Err(e);
+                }
+            };
+            // Sequence-aware correction (#644), mirroring the g.→c. path.
+            // Only simple exonic positions are corrected; intronic / special
+            // positions are derived by boundary arithmetic the realignment
+            // doesn't model, so leave them to the naive result.
+            if p.offset.is_some() || p.special.is_some() || p.utr3 {
+                return Ok(result.variant.base);
+            }
+            let tx_pos = match cdot_tx.cds_to_tx(p.base) {
+                Some(t) => t,
+                None => return Ok(result.variant.base),
+            };
+            self.correct_genome_for_exon_indel(cdot_tx, transcript_id, tx_pos, result.variant.base)
+        } else {
+            if p.offset.is_some() {
+                // Intronic n. offsets require coding-style exon-boundary
+                // arithmetic; we don't currently expose that primitive
+                // for non-coding transcripts. Surface a clear error.
+                return Err(FerroError::UnsupportedProjection {
+                    reason: format!(
+                        "project_to_genomic does not yet support intronic offsets on \
+                         non-coding transcripts ({}); see #332",
+                        transcript_id
+                    ),
+                });
+            }
+            // `base` is 1-based on TxPos / RnaPos; cdot's tx coords are
+            // 0-based, so subtract 1.
+            if p.base <= 0 {
+                return Err(FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "non-coding transcript {} position must be positive, got {}",
+                        transcript_id, p.base
+                    ),
+                });
+            }
+            let tx_pos_0based = (p.base - 1) as u64;
+            let naive = cdot_tx.tx_to_genome(tx_pos_0based).ok_or_else(|| {
+                FerroError::InvalidCoordinates {
+                    msg: format!(
+                        "tx position {} not in any exon of {}",
+                        p.base, transcript_id
+                    ),
+                }
+            })?;
+            // Sequence-aware correction (#644): the inbound g.→n. path runs
+            // `correct_cds_for_exon_indel` regardless of coding status, so a
+            // non-coding `n.`/`r.` coordinate is corrected on the way in.
+            // Apply the matching outbound correction here so it round-trips.
+            self.correct_genome_for_exon_indel(cdot_tx, transcript_id, tx_pos_0based, naive)
+        }
+    }
+
     fn project_to_genomic_nc(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
         use crate::hgvs::edit::NaEdit;
         use crate::hgvs::interval::GenomeInterval;
@@ -1969,36 +2166,14 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             })
             .or_else(|| self.provider.infer_genome_build(&parent));
         let cdot_mapper = self.projector.mapper();
-        // Silent version-substitution gate (#785), c.→g. direction. Unlike
-        // `project_variant`/`project_variant_all`, this path does not normalize
-        // the original transcript-coordinate input first, so it would not inherit
-        // the gate the normalizer applies in `normalize_core`. Apply the same
-        // guarantee here: when the input names an EXPLICIT transcript version the
-        // reference does not carry exactly, the lenient `get_transcript[_on_build]`
-        // pivot below would silently fall back to a *sibling* version and project
-        // onto the genome using that sibling's exon/CDS frame — a spec-invalid
-        // result whose stated reference and coordinate frame disagree, with no
-        // error. Decline with `TranscriptVersionNotExact` instead of fuzzing the
-        // version. The predicate permits exact-version cdot-genome synthesis and
-        // rejects only cross-version substitution; an LRG transcript carries no
-        // version (`accession.version == None`), so its exact RefSeq alias path is
-        // untouched. A transcript that is simply absent with no sibling to
-        // substitute is left to the `ReferenceNotFound` miss below, unchanged.
-        if accession.version.is_some() && is_transcript_accession(&transcript_id) {
-            let exact = self.provider.has_transcript_version_exact(&transcript_id);
-            let resolves = match build_hint {
-                Some(b) => cdot_mapper
-                    .cdot()
-                    .get_transcript_on_build(&transcript_id, b)
-                    .is_some(),
-                None => cdot_mapper.cdot().get_transcript(&transcript_id).is_some(),
-            };
-            if !exact && resolves {
-                return Err(FerroError::TranscriptVersionNotExact {
-                    requested: transcript_id.to_string(),
-                });
-            }
-        }
+        // Silent version-substitution gate (#785), c.→g. direction. Extracted to
+        // `enforce_exact_transcript_version` (#868); called here before the
+        // `get_transcript` pivot, with the same guard predicate as its argument.
+        self.enforce_exact_transcript_version(
+            &transcript_id,
+            accession.version.is_some() && is_transcript_accession(&transcript_id),
+            build_hint,
+        )?;
         let cdot_tx = match build_hint {
             Some(b) => cdot_mapper
                 .cdot()
@@ -2024,151 +2199,36 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    input `base` is the 1-based tx_pos directly; convert it to the
         //    0-based form cdot exposes and use `CdotTranscript::tx_to_genome`.
         let is_coding = cdot_tx.cds_start.is_some() && cdot_tx.cds_end.is_some();
-        // For an `n.`/`r.` input on a coding transcript, the carried `base` is a
-        // 1-based *transcript* position, not a CDS coordinate; convert it to the
-        // CDS frame before the CDS-aware genome mapping (#693). An exonic
-        // position converts directly; an intronic-offset position converts its
-        // exon-anchor `base` and keeps the offset/utr3 flags. A transcript
-        // position that cannot be expressed in the CDS frame (`base < 1`, or a
-        // `None` conversion for a position past the last exon) is rejected here:
-        // leaving it unconverted would let the CDS-aware mapping interpret an
-        // `n.`/`r.` coordinate as a `c.` coordinate and emit the wrong g.
-        // position (#693).
-        let to_cds_frame = |p: CdsPos| -> Result<CdsPos, FerroError> {
-            // A position already flagged 3'UTR/downstream (`r.*N`, `n.*N`) carries
-            // its `*N` distance in `base`, not an absolute 1-based transcript
-            // position — feeding it to `cds_pos_from_tx_pos` would renumber it as a
-            // transcript base. Leave such positions untouched so the downstream
-            // CDS-aware mapping interprets the `*N` directly.
-            if !(input_is_transcript_coord && is_coding) || p.utr3 {
-                return Ok(p);
-            }
-            if p.base < 1 {
-                return Err(FerroError::InvalidCoordinates {
-                    msg: format!(
-                        "transcript position {} is outside coding transcript {} and cannot be \
-                         mapped as a CDS coordinate",
-                        p.base, transcript_id
-                    ),
-                });
-            }
-            match cdot_tx.cds_pos_from_tx_pos((p.base - 1) as u64) {
-                Some(cds) => Ok(CdsPos {
-                    base: cds.base,
-                    offset: p.offset,
-                    // Keep the resolved 3'UTR flag even for intronic anchors
-                    // (`c.*N±M`); dropping it when an offset is present would
-                    // collapse a 3'UTR intron into a plain `c.N±M`.
-                    utr3: cds.utr3,
-                    special: p.special,
-                }),
-                None => Err(FerroError::InvalidCoordinates {
-                    msg: format!(
-                        "transcript position {} is outside coding transcript {} and cannot be \
-                         mapped as a CDS coordinate",
-                        p.base, transcript_id
-                    ),
-                }),
-            }
-        };
-        // The poly-A 3'UTR fallback below is a `c.*`-only refinement (#797): it
-        // reinterprets a `c.*` 3'UTR endpoint that lands in the transcript's
-        // post-transcriptional poly-A tail. `n.`/`r.` inputs are reshaped into
-        // `CdsPos` for this closure (with `utr3` carrying their own
-        // downstream/3'UTR flag), so without this gate an off-exon `n.*`/`r.*`
+        // The poly-A 3'UTR fallback inside `map_cnr_position_to_genome` is a
+        // `c.*`-only refinement (#797): it reinterprets a `c.*` 3'UTR endpoint
+        // that lands in the transcript's post-transcriptional poly-A tail.
+        // `n.`/`r.` inputs are reshaped into `CdsPos` (with `utr3` carrying their
+        // own downstream/3'UTR flag), so without this gate an off-exon `n.*`/`r.*`
         // endpoint would be reinterpreted as a `c.*` poly-A walk and emit a
         // genomic coordinate from a coordinate class that has no poly-A
         // semantics. Restrict the fallback to genuine `c.` (CDS) inputs.
         let is_cds_input = matches!(variant, HgvsVariant::Cds(_));
-        let map_pos = |p: CdsPos| -> Result<u64, FerroError> {
-            let p = to_cds_frame(p)?;
-            if is_coding {
-                let result =
-                    match cdot_mapper.cds_to_genome_on_build(&transcript_id, &p, build_hint) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            // Poly-A-region 3'UTR fallback (#797). A `c.*` position
-                            // can land in the transcript's post-transcriptional
-                            // poly-A tail, which the (e.g. #790-derived) exon→genome
-                            // map strips — so `cds_to_genome` declines. mutalyzer
-                            // maps such positions by a contiguous coordinate walk into
-                            // downstream genome from the transcript's own 3'-terminal
-                            // exon. `try_extend_polya_to_genome` self-gates (a `c.*`
-                            // position whose base lands in the poly-A region, an
-                            // optional positive downstream offset, and an effective
-                            // tx position within the transcript's TRUE length, i.e.
-                            // inside the real poly-A tail) and returns None to
-                            // propagate the original decline otherwise — so beyond
-                            // the tail we never walk into non-transcript genome.
-                            if is_cds_input {
-                                if let Some(g) =
-                                    self.try_extend_polya_to_genome(cdot_tx, &transcript_id, &p)
-                                {
-                                    return Ok(g);
-                                }
-                            }
-                            return Err(e);
-                        }
-                    };
-                // Sequence-aware correction (#644), mirroring the g.→c. path.
-                // Only simple exonic positions are corrected; intronic / special
-                // positions are derived by boundary arithmetic the realignment
-                // doesn't model, so leave them to the naive result.
-                if p.offset.is_some() || p.special.is_some() || p.utr3 {
-                    return Ok(result.variant.base);
-                }
-                let tx_pos = match cdot_tx.cds_to_tx(p.base) {
-                    Some(t) => t,
-                    None => return Ok(result.variant.base),
-                };
-                self.correct_genome_for_exon_indel(
-                    cdot_tx,
-                    &transcript_id,
-                    tx_pos,
-                    result.variant.base,
-                )
-            } else {
-                if p.offset.is_some() {
-                    // Intronic n. offsets require coding-style exon-boundary
-                    // arithmetic; we don't currently expose that primitive
-                    // for non-coding transcripts. Surface a clear error.
-                    return Err(FerroError::UnsupportedProjection {
-                        reason: format!(
-                            "project_to_genomic does not yet support intronic offsets on \
-                             non-coding transcripts ({}); see #332",
-                            transcript_id
-                        ),
-                    });
-                }
-                // `base` is 1-based on TxPos / RnaPos; cdot's tx coords are
-                // 0-based, so subtract 1.
-                if p.base <= 0 {
-                    return Err(FerroError::InvalidCoordinates {
-                        msg: format!(
-                            "non-coding transcript {} position must be positive, got {}",
-                            transcript_id, p.base
-                        ),
-                    });
-                }
-                let tx_pos_0based = (p.base - 1) as u64;
-                let naive = cdot_tx.tx_to_genome(tx_pos_0based).ok_or_else(|| {
-                    FerroError::InvalidCoordinates {
-                        msg: format!(
-                            "tx position {} not in any exon of {}",
-                            p.base, transcript_id
-                        ),
-                    }
-                })?;
-                // Sequence-aware correction (#644): the inbound g.→n. path runs
-                // `correct_cds_for_exon_indel` regardless of coding status, so a
-                // non-coding `n.`/`r.` coordinate is corrected on the way in.
-                // Apply the matching outbound correction here so it round-trips.
-                self.correct_genome_for_exon_indel(cdot_tx, &transcript_id, tx_pos_0based, naive)
-            }
-        };
-
-        let start_g = map_pos(start_cds)?;
-        let end_g = map_pos(end_cds)?;
+        // The coordinate map (n./r.→CDS frame #693, coding/non-coding split, #797
+        // poly-A fallback, #644 correction) is extracted to
+        // `map_cnr_position_to_genome` (#868).
+        let start_g = self.map_cnr_position_to_genome(
+            cdot_tx,
+            &transcript_id,
+            start_cds,
+            is_coding,
+            is_cds_input,
+            input_is_transcript_coord,
+            build_hint,
+        )?;
+        let end_g = self.map_cnr_position_to_genome(
+            cdot_tx,
+            &transcript_id,
+            end_cds,
+            is_coding,
+            is_cds_input,
+            input_is_transcript_coord,
+            build_hint,
+        )?;
 
         // 6. Build the genomic interval. On minus strand the c./n./r. interval
         //    runs anti-parallel to the genome, so the smaller genomic coord

--- a/tests/it/issue_868_genomic_nc_units.rs
+++ b/tests/it/issue_868_genomic_nc_units.rs
@@ -1,0 +1,268 @@
+//! Issue #868 — characterization tests for the two units extracted from
+//! `project_to_genomic_nc`:
+//!   1. the #785 silent-version-substitution gate
+//!      (`enforce_exact_transcript_version`), and
+//!   2. the step-5 coordinate map (`map_cnr_position_to_genome`), including the
+//!      #797 poly-A `c.*` fallback and the non-coding `n.` arm.
+//!
+//! These exercise the outbound `c./n./r. → g.` path via the public
+//! `VariantProjector::project_to_genomic` with a hermetic `MockProvider` + cdot
+//! fixture (no manifest). They pin today's behavior so the #868 extraction is
+//! provably byte-identical.
+//!
+//! Scope: these are **refactor-safety characterization tests**, not
+//! independent-oracle conformance checks — they assert ferro's own output for
+//! inputs that traverse the two extracted units, so they fail loudly if the
+//! extraction changes behavior. Independent-oracle conformance (vs mutalyzer)
+//! lives in the manifest-gated `mutalyzer_normalize_tests`.
+//! <https://github.com/fulcrumgenomics/ferro-hgvs/issues/868>
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, FerroError, VariantProjector};
+
+/// Build a deterministic sequence by repeating `pat` up to `len` bases (shared
+/// by the fixtures that need a long genomic flank).
+fn cycle(pat: &str, len: usize) -> String {
+    pat.chars().cycle().take(len).collect()
+}
+
+/// (a) #785 gate — the input names an explicit transcript version the reference
+/// does NOT carry exactly (`NM_000123.1`), but a *sibling* version resolves in
+/// cdot (`NM_000123.2`). The outbound `c. → g.` projection must decline with
+/// `TranscriptVersionNotExact` rather than silently projecting onto the
+/// sibling's frame.
+fn version_gate_fixture() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    // Only the SIBLING version (.2) lives in cdot; a request for .1 resolves to
+    // it via cdot's base-accession version fallback (`base_to_versioned`).
+    cdot.add_transcript(
+        "NM_000123.2".to_string(),
+        CdotTranscript {
+            gene_name: Some("GENE123".to_string()),
+            contig: "NC_000001.11".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1010, 0, 10]],
+            cds_start: Some(0),
+            cds_end: Some(10),
+            gene_id: None,
+            protein: Some("NP_000123.2".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    // The reference does not carry the exact requested version .1 — only a
+    // sibling's bases. This is the precondition the #785 gate keys off.
+    provider.mark_non_version_exact("NM_000123.1");
+    VariantProjector::new(projector, provider)
+}
+
+#[test]
+fn version_gate_declines_cross_version_substitution_outbound() {
+    let vp = version_gate_fixture();
+    // NG_ parent carries no build tag, so `build_hint` is None and the gate uses
+    // the build-agnostic cdot lookup — which resolves .1 → .2 (sibling present),
+    // firing the decline.
+    let v = parse_hgvs("NG_000123.1(NM_000123.1):c.1A>G").expect("parse");
+    let err = vp.project_to_genomic(&v).expect_err(
+        "an explicit non-exact transcript version with a resolving sibling must decline",
+    );
+    match err {
+        FerroError::TranscriptVersionNotExact { requested } => {
+            assert_eq!(
+                requested, "NM_000123.1",
+                "the requested version must be surfaced verbatim"
+            );
+        }
+        other => panic!("expected TranscriptVersionNotExact, got: {other:?}"),
+    }
+}
+
+#[test]
+fn version_gate_permits_exact_version_outbound() {
+    // Control: the SAME fixture, but requesting the exact sibling version .2
+    // (which the reference does carry exactly) must NOT trip the gate — it
+    // projects the c. position onto the genome. This proves the gate is a
+    // cross-version guard, not a blanket rejection. An NC_ parent is already in
+    // its own (chromosome) frame, so the pivot passes through without needing a
+    // placement to re-anchor.
+    let vp = version_gate_fixture();
+    let v = parse_hgvs("NC_000001.11(NM_000123.2):c.1A>G").expect("parse");
+    let out = vp
+        .project_to_genomic(&v)
+        .expect("an exact-version request must project, not decline");
+    // NC_ pivot returned in chromosome frame; c.1 (cds_start=0) → genome 1000.
+    let s = match out {
+        HgvsVariant::Genome(ref g) => g.to_string(),
+        other => panic!("expected Genome variant, got: {other:?}"),
+    };
+    assert!(
+        s.contains(":g.1000"),
+        "expected g.1000 for c.1 on the exact version, got: {s}"
+    );
+}
+
+/// (b) #797 poly-A `c.*` → g. — a coding transcript whose exon→genome map strips
+/// the post-transcriptional poly-A tail. A `c.*4` endpoint lands in the poly-A
+/// region, so the CDS-aware map (`cds_to_genome`) declines; the fallback
+/// (`try_extend_polya_to_genome`) resolves it to the contiguous downstream
+/// genome coordinate. Mirrors the in-module `make_polya_test_provider_and_projector`.
+fn polya_fixture() -> VariantProjector<MockProvider> {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_POLYA.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("POLYAGENE".to_string()),
+            contig: "NC_000001.11".to_string(),
+            strand: Strand::Plus,
+            // Exon covers only the genomic core (poly-A tail stripped): tx 0..12.
+            exons: vec![[1000, 1012, 0, 12]],
+            cds_start: Some(3),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_POLYA.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    // FASTA carries the full 15-base transcript incl. the 3-base poly-A tail;
+    // the exon map above only spans tx 0..12, so c.*4..c.*6 (tx 12..15) is the
+    // stripped poly-A region the fallback walks into.
+    provider.add_transcript(Transcript::new(
+        "NM_POLYA.1".to_string(),
+        Some("POLYAGENE".to_string()),
+        TxStrand::Plus,
+        "TTTATGCGCGTAAAA".to_string(), // 15 bases, trailing "AAA" tail
+        Some(4),                       // 1-based inclusive CDS start (tx index 3)
+        Some(9),
+        vec![Exon::with_genomic(1, 1, 12, 1000, 1011)],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(1011),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    // Genomic backbone: 999 non-repeating leading bases so HGVS g.1000 == 0-based
+    // index 999, then the 12-base exon core, then a non-repeating downstream tail
+    // (so a single-base del at the walked coordinate stays put under genomic-frame
+    // renormalization). Registered under the NC_ output accession too so the
+    // public projector's renormalization can fetch bases.
+    let genomic = format!(
+        "{}{}{}",
+        cycle("ACGT", 999),
+        "TTTATGCGCGTA",
+        cycle("CAGT", 100)
+    );
+    provider.add_genomic_sequence("NC_000001.11", genomic);
+    VariantProjector::new(projector, provider)
+}
+
+#[test]
+fn polya_core_3utr_projects_normally() {
+    // Control: a `c.*` in the genomic CORE of the 3'UTR (tx 9, still inside the
+    // exon) projects via the normal CDS-aware map, NOT the fallback. c.*1 → g.1009.
+    let vp = polya_fixture();
+    let v = parse_hgvs("NC_000001.11(NM_POLYA.1):c.*1del").expect("parse");
+    let out = vp
+        .project_to_genomic(&v)
+        .expect("genomic-core 3'UTR must project");
+    let s = match out {
+        HgvsVariant::Genome(ref g) => g.to_string(),
+        other => panic!("expected Genome variant, got: {other:?}"),
+    };
+    assert!(
+        s.contains(":g.1009del"),
+        "expected g.1009del for c.*1del, got: {s}"
+    );
+}
+
+#[test]
+fn polya_region_walks_into_downstream_genome() {
+    // c.*4 = tx 12 = the exon's genome_end (exclusive) → the first stripped
+    // poly-A base → genome 1012, resolved only by the #797 fallback walk.
+    let vp = polya_fixture();
+    let v = parse_hgvs("NC_000001.11(NM_POLYA.1):c.*4del").expect("parse");
+    let out = vp
+        .project_to_genomic(&v)
+        .expect("c.*4del in the poly-A region must project via the contiguous walk");
+    let s = match out {
+        HgvsVariant::Genome(ref g) => g.to_string(),
+        other => panic!("expected Genome variant, got: {other:?}"),
+    };
+    assert!(
+        s.contains(":g.1012del"),
+        "expected g.1012del for c.*4del (poly-A walk), got: {s}"
+    );
+}
+
+/// (c) non-coding `n.` → g. outbound — exercises the non-coding arm of the
+/// coordinate map (`tx_to_genome`), distinct from the coding CDS-aware path.
+#[test]
+fn noncoding_n_position_projects_via_tx_to_genome() {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NR_000200.1".to_string(),
+        CdotTranscript {
+            gene_name: Some("NCGENE".to_string()),
+            contig: "NC_000001.11".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1010, 0, 10]],
+            cds_start: None,
+            cds_end: None,
+            gene_id: None,
+            protein: None,
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NR_000200.1".to_string(),
+        Some("NCGENE".to_string()),
+        TxStrand::Plus,
+        "ACGTACGTAC".to_string(), // 10 bases
+        None,
+        None,
+        vec![Exon::with_genomic(1, 1, 10, 1000, 1009)],
+        Some("NC_000001.11".to_string()),
+        Some(1000),
+        Some(1009),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let genomic = format!(
+        "{}{}{}",
+        cycle("ACGT", 999),
+        "ACGTACGTAC",
+        cycle("CAGT", 100)
+    );
+    provider.add_genomic_sequence("NC_000001.11", genomic);
+    let vp = VariantProjector::new(projector, provider);
+
+    // n.5 (1-based tx 5 → 0-based tx 4) → genome 1000 + 4 = 1004 on the plus strand.
+    let v = parse_hgvs("NC_000001.11(NR_000200.1):n.5del").expect("parse");
+    let out = vp
+        .project_to_genomic(&v)
+        .expect("non-coding n. must project");
+    let s = match out {
+        HgvsVariant::Genome(ref g) => g.to_string(),
+        other => panic!("expected Genome variant, got: {other:?}"),
+    };
+    assert!(
+        s.contains(":g.1004del"),
+        "expected g.1004del for n.5del, got: {s}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -194,6 +194,7 @@ mod issue_851_compound_utr_projection;
 mod issue_857_cterminal_extension;
 mod issue_860_lrg_namespace;
 mod issue_867_project_to_genomic_normalized;
+mod issue_868_genomic_nc_units;
 mod issue_879_ng_g_to_c_overlap;
 mod issue_91_protein_three_prime_shift;
 mod issue_92_protein_delins_to_dup;


### PR DESCRIPTION
Closes #868.

## What

`project_to_genomic_nc` (the c./n./r.→NC coordinate pivot) was a ~440-line monolith tangling the pure coordinate map with orthogonal concerns. Extract two composable, documented units — **behavior-preserving, zero coordinate change**:

- **`enforce_exact_transcript_version`** — the #785 silent-version-substitution gate. This is a genuinely orthogonal, coordinate-independent version-validity predicate (decline when the input names an explicit transcript version the reference lacks but a sibling resolves), so it's lifted out. Called at the same site (after `build_hint`, before the `get_transcript` pivot), with the guard predicate passed as its argument.
- **`map_cnr_position_to_genome`** — the step-5 coordinate map: the n./r.→CDS-frame conversion (#693), the coding/non-coding primitive split, the #797 poly-A `c.*` fallback, and the #644 sequence-aware exon-indel correction. This is the reusable "coordinate math" #868 wanted separable from the outer pivot; step 5 collapses to two calls.

**Scope decision:** the #797 fallback (an `Err`-branch) and #644 correction (an `Ok`-refinement) stay *inside* the map — they refine the single coordinate result and can't be exercised independently of it; splitting them into wrapper passes would re-plumb the exact control flow being separated for no testability gain. Only the coordinate-independent #785 gate is lifted. (Adversarial review confirmed this is the correct cut.)

## Tests (a review requirement)

The #785 **outbound** gate and the #797 `c.*`→g. poly-A branch had **zero** non-manifest coverage — so the manifest parity gate alone wouldn't catch a faithfulness bug in exactly the two paths being cut. New hermetic file `tests/it/issue_868_genomic_nc_units.rs` (5 MockProvider tests) characterizes them (+ the non-coding `n.` arm and controls); each is confirmed to hit its target branch and passes both **before and after** the extraction.

## Verification (pure refactor)

- Hermetic suite **byte-identical** — 7683 passed, 0 failed, before and after.
- **Manifest parity:** `axis_genomic` / `axis_coding_protein_descriptions` / `axis_protein_description` (both the `mutalyzer_normalize` and `hgvs_rs_projection` copies) — the `/tmp/ferro-xfail/*` fail sets (inputs **and** input+diagnostic pairs) are **byte-identical** to `origin/main`. A pure extraction changes no coordinate; any diff would be a bug.
- `cargo clippy --features dev --all-targets -- -D warnings` + `cargo fmt --all --check` clean.

No public API change; `src/project/projector.rs` + the new hermetic test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genomic projection handling for transcript-based variants, including stricter transcript version matching and more reliable coordinate mapping for coding and noncoding inputs.
  * Fixed edge cases around poly-A region mapping and exon-indel behavior so results are more consistent and accurate.

* **Tests**
  * Added integration coverage for transcript version matching, poly-A fallback behavior, and noncoding transcript-to-genome mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->