### PR TITLE
test(conformance): let accepted_rejection disposition an empty-projection Err (#903)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -654,9 +654,39 @@ pub enum RejectionReason {
     /// behaviour (#853, residual of #480/#655; subsumes #865).
     #[serde(rename = "ferro-policy-853-ng-partial-transcript-coverage-declined")]
     NgPartialTranscriptCoverageDeclined853,
+    /// ferro emits **no projection** on this axis for a variant its policy says
+    /// has no consequence there — e.g. a variant wholly outside the CDS
+    /// (pure-5'UTR / pure-3'UTR) produces no protein prediction (the #857 policy,
+    /// tested by `pure_3utr_deletion_has_no_protein_consequence`) — where the
+    /// comparator instead emits a value (e.g. mutalyzer `p.(=)`, "analysed, no
+    /// change"). The HGVS spec is ambiguous on no-projection vs the "analysed,
+    /// unchanged" value for a non-CDS variant, so ferro's decline is a spec-
+    /// defensible accepted rejection rather than a bug (#857/#891; #466 tracks the
+    /// upstream spec clarification). This is the **only** `RejectionReason` that
+    /// opts in to bucketing an empty-projection `Err` (see
+    /// [`RejectionReason::disposition_empty_projection`]): the harness represents
+    /// "ferro produced nothing" as an `EMPTY_PROJECTION_SENTINEL` `Err`, which is
+    /// otherwise a hard FAIL. The empty→output transition is handled honestly:
+    /// because `accepted_rejection` buckets only `Err`, if ferro later starts
+    /// emitting a value it is NOT masked — an `Ok` that *matches* XPASS-FAILs (the
+    /// stale annotation is caught), and an `Ok` that *mismatches* falls through to
+    /// a hard FAIL (ferro stopped declining, now produces a differing value). The
+    /// `#764` empty-projection count gate additionally catches any *rise* in the
+    /// empty count.
+    #[serde(rename = "ferro-policy-857-non-cds-no-projection")]
+    NonCdsNoProjection857,
 }
 
 impl RejectionReason {
+    /// Whether this reason opts in to dispositioning an **empty-projection**
+    /// `Err` (ferro produced no output on the axis) as an accepted rejection.
+    /// `accepted_rejection` normally excludes the `EMPTY_PROJECTION_SENTINEL`
+    /// (an empty projection is otherwise a hard FAIL, #651); a reason returning
+    /// `true` here relaxes that for its rows only. Closed match (`_ => false`) so
+    /// adding a reason is a deliberate, reviewed opt-in — never an ad-hoc flag.
+    pub fn disposition_empty_projection(self) -> bool {
+        matches!(self, RejectionReason::NonCdsNoProjection857)
+    }
     /// Stable identifier used in summary lines so reviewers can grep across runs.
     pub fn as_str(self) -> &'static str {
         match self {
@@ -675,6 +705,7 @@ impl RejectionReason {
             RejectionReason::NgPartialTranscriptCoverageDeclined853 => {
                 "ferro-policy-853-ng-partial-transcript-coverage-declined"
             }
+            RejectionReason::NonCdsNoProjection857 => "ferro-policy-857-non-cds-no-projection",
         }
     }
 }
@@ -690,10 +721,14 @@ impl std::fmt::Display for RejectionReason {
 /// divergence: ferro *correctly* declines an input that mutalyzer leniently
 /// reinterprets. Distinct from [`AcceptedDivergence`] (which covers a string
 /// *mismatch* from a successful run) — this is the only disposition that
-/// buckets an `Err` on a projection axis. A genuine panic and the
-/// empty-projection sentinel still hard-FAIL, and if ferro *starts* producing
-/// output (the rejection is gone) the harness FAILs loudly (XPASS). Tallied
-/// into `AxisTally::divergence_accepted` alongside `accepted_divergence`.
+/// buckets an `Err` on a projection axis. A genuine panic still hard-FAILs, and
+/// if ferro *starts* producing output (the rejection is gone) the harness FAILs
+/// loudly (XPASS). The empty-projection sentinel also hard-FAILs by default —
+/// **except** when `reason.disposition_empty_projection()` is `true` (#903), for
+/// a reason like [`RejectionReason::NonCdsNoProjection857`] where ferro's
+/// no-output is itself the spec-defensible decline; the `#764` empty-projection
+/// count gate remains the backstop against a genuinely-new empty. Tallied into
+/// `AxisTally::divergence_accepted` alongside `accepted_divergence`.
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct AcceptedRejection {
@@ -1077,6 +1112,36 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn non_cds_no_projection_857_opts_in_to_empty_projection() {
+        // #903: exactly one reason opts in to dispositioning an empty projection.
+        assert!(RejectionReason::NonCdsNoProjection857.disposition_empty_projection());
+        for r in [
+            RejectionReason::MalformedInputRejected654,
+            RejectionReason::TranscriptFlankNotNumberableInC758,
+            RejectionReason::VersionSubstitutionRefused785,
+            RejectionReason::NonstandardOrAbsentSelectorDeclined858,
+            RejectionReason::NgPartialTranscriptCoverageDeclined853,
+        ] {
+            assert!(
+                !r.disposition_empty_projection(),
+                "{} must NOT opt in to empty-projection bucketing",
+                r.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn accepted_rejection_857_reason_round_trips() {
+        // The new reason deserializes from its serde rename and stringifies back.
+        let ar: AcceptedRejection = serde_json::from_str(
+            r#"{"axis":"protein_description","reason":"ferro-policy-857-non-cds-no-projection"}"#,
+        )
+        .expect("accepted_rejection with the #903 reason should deserialize");
+        assert_eq!(ar.reason, RejectionReason::NonCdsNoProjection857);
+        assert_eq!(ar.reason.as_str(), "ferro-policy-857-non-cds-no-projection");
+    }
 
     const BASE: &str =
         r#""description":"t","source":"t","source_commit":"t","license":"t","refreshed_at":"t""#;

--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -463,13 +463,15 @@ impl AxisTally {
     /// 6. `spec_overridden` when the case carries a `spec_citation`
     ///    matching this tally's axis.
     /// 7. `divergence_accepted` when the case carries an `accepted_rejection`
-    ///    matching this tally's axis AND `actual` is a non-panic,
-    ///    non-empty-projection `Err` — ferro *correctly* rejecting an input
-    ///    mutalyzer leniently reinterprets. This is the only disposition that
-    ///    buckets an `Err` on a *projection* axis (XPASS-guarded: an `Ok` here
-    ///    means the rejection is gone, so a match XPASS-FAILs and a mismatch
-    ///    FAILs). A genuine `panic:` and the empty-projection sentinel still
-    ///    hard-FAIL.
+    ///    matching this tally's axis AND `actual` is a non-panic `Err` — ferro
+    ///    *correctly* rejecting an input mutalyzer leniently reinterprets. This
+    ///    is the only disposition that buckets an `Err` on a *projection* axis
+    ///    (XPASS-guarded: an `Ok` here means the rejection is gone, so a match
+    ///    XPASS-FAILs and a mismatch FAILs). A genuine `panic:` always hard-FAILs.
+    ///    The empty-projection sentinel (#651) also hard-FAILs **unless** the
+    ///    reason opts in via `disposition_empty_projection()` (#903) — for a
+    ///    reason like `NonCdsNoProjection857` where ferro's no-output IS the
+    ///    spec-defensible decline.
     /// 8. FAIL otherwise.
     ///
     /// The five *mismatch* dispositions — `accepted_divergence`, `known_bug`,
@@ -479,8 +481,9 @@ impl AxisTally {
     /// result (panic, parse error, normalize failure) — a real bug that must
     /// surface as FAIL even when an annotation is present. `accepted_rejection`
     /// (item 7) is the deliberate exception: it is the one disposition that
-    /// buckets a non-panic, non-empty-projection `Err` on a projection axis into
-    /// `divergence_accepted` rather than FAIL.
+    /// buckets a non-panic `Err` on a projection axis into `divergence_accepted`
+    /// rather than FAIL — a non-empty `Err`, plus the empty-projection sentinel
+    /// when the reason opts in via `disposition_empty_projection()` (#903).
     ///
     /// The **errors axis is the exception**: there a non-matching `Err` is the
     /// *expected* "ferro diverges" signal — ferro emitted no error, or a
@@ -572,19 +575,28 @@ impl AxisTally {
             self.pass += 1;
             return;
         }
-        // `accepted_rejection`: a non-panic, non-empty-projection `Err` on the
-        // annotated axis is ferro *correctly rejecting* an input mutalyzer
-        // leniently reinterprets. It is the only disposition that buckets an
-        // `Err` on a projection axis; a genuine panic and the empty-projection
-        // sentinel (#651) still hard-FAIL below. Tallied alongside
-        // `accepted_divergence`. (An `Ok` here — ferro stopped rejecting — falls
-        // through: a match XPASS-FAILs above, a mismatch FAILs below.)
+        // `accepted_rejection`: a non-panic `Err` on the annotated axis is ferro
+        // *correctly rejecting/declining* an input mutalyzer leniently
+        // reinterprets. It is the only disposition that buckets an `Err` on a
+        // projection axis. A genuine panic still hard-FAILs. The empty-projection
+        // sentinel (#651) also hard-FAILs below **unless** the reason opts in via
+        // `disposition_empty_projection()` (#903) — for a reason like
+        // `NonCdsNoProjection857` where ferro's no-output IS the spec-defensible
+        // decline (empty-`Err` and non-empty-`Err` share the same "ferro declines"
+        // meaning here). The `#764` empty-projection count gate in `finish` still
+        // catches any *rise* in the empty count, bucketed or not, so a genuinely-
+        // new empty cannot be masked. Tallied alongside `accepted_divergence`. (An
+        // `Ok` here — ferro stopped declining — falls through: a match XPASS-FAILs
+        // above, a mismatch FAILs below.) Each axis's rejection is matched
+        // independently (#870 multi-axis).
         if let Some(ar) = case
             .accepted_rejections
             .iter()
             .find(|ar| ar.axis == self.axis)
         {
-            if matches!(&actual, Err(e) if !e.starts_with("panic:") && !e.starts_with(EMPTY_PROJECTION_SENTINEL))
+            if matches!(&actual, Err(e) if !e.starts_with("panic:")
+                && (!e.starts_with(EMPTY_PROJECTION_SENTINEL)
+                    || ar.reason.disposition_empty_projection()))
             {
                 self.divergence_accepted
                     .push((case.input.clone(), ar.reason.to_string()));
@@ -2954,6 +2966,132 @@ mod comparator_tests {
         n.record(&case, "X", Err("parse: malformed".to_string()));
         assert!(n.fail.is_empty());
         assert_eq!(n.divergence_accepted.len(), 1);
+    }
+
+    // (#903) An empty-projection `Err` is dispositioned when the accepted_rejection
+    // reason opts in via `disposition_empty_projection()` — ferro's no-output IS
+    // the spec-defensible decline. The empty count STILL increments (the #764 gate
+    // backstop is unaffected by bucketing).
+    #[test]
+    fn tally_accepted_rejection_buckets_empty_projection_with_opt_in_reason() {
+        let mut t = AxisTally::new(Axis::ProteinDescription);
+        let case = Case {
+            accepted_rejections: vec![AcceptedRejection {
+                axis: Axis::ProteinDescription,
+                reason: RejectionReason::NonCdsNoProjection857,
+                note: None,
+                cluster: None,
+            }],
+            ..make_case("in", None, None)
+        };
+        t.record(
+            &case,
+            "NP_000134.2:p.(=)",
+            Err(format!("{EMPTY_PROJECTION_SENTINEL}no protein predicted")),
+        );
+        assert_eq!(t.pass, 0);
+        assert!(
+            t.fail.is_empty(),
+            "an empty projection with an opt-in reason must bucket, not FAIL"
+        );
+        assert_eq!(
+            t.divergence_accepted,
+            vec![(
+                "in".to_string(),
+                "ferro-policy-857-non-cds-no-projection".to_string()
+            )]
+        );
+        assert_eq!(
+            t.empty_got, 1,
+            "the empty count must still increment (the #764 count gate backstop)"
+        );
+    }
+
+    // (#903) An empty-projection `Err` with a NON-opt-in reason is STILL a hard
+    // FAIL — the opt-in is required, so a value-rejection reason cannot silently
+    // absorb an empty projection. (Disjointness: only opt-in reasons bucket the
+    // sentinel; every other reason keeps the pre-#903 hard-FAIL.)
+    #[test]
+    fn tally_accepted_rejection_empty_projection_without_opt_in_still_fails() {
+        let mut t = AxisTally::new(Axis::ProteinDescription);
+        let case = Case {
+            accepted_rejections: vec![AcceptedRejection {
+                axis: Axis::ProteinDescription,
+                reason: RejectionReason::MalformedInputRejected654, // does NOT opt in
+                note: None,
+                cluster: None,
+            }],
+            ..make_case("in", None, None)
+        };
+        t.record(
+            &case,
+            "NP_000134.2:p.(=)",
+            Err(format!("{EMPTY_PROJECTION_SENTINEL}no protein predicted")),
+        );
+        assert!(t.divergence_accepted.is_empty());
+        assert_eq!(
+            t.fail.len(),
+            1,
+            "an empty projection without an opt-in reason must still FAIL"
+        );
+        assert_eq!(t.empty_got, 1);
+    }
+
+    // (#903) An opt-in reason still buckets a normal NON-empty `Err` too — opting
+    // in to the empty sentinel doesn't narrow the reason to empty-only.
+    #[test]
+    fn tally_accepted_rejection_opt_in_reason_still_buckets_nonempty_err() {
+        let mut t = AxisTally::new(Axis::ProteinDescription);
+        let case = Case {
+            accepted_rejections: vec![AcceptedRejection {
+                axis: Axis::ProteinDescription,
+                reason: RejectionReason::NonCdsNoProjection857,
+                note: None,
+                cluster: None,
+            }],
+            ..make_case("in", None, None)
+        };
+        t.record(&case, "X", Err("project: some decline".to_string()));
+        assert!(t.fail.is_empty(), "a non-empty Err must still bucket");
+        assert_eq!(t.divergence_accepted.len(), 1);
+        assert_eq!(
+            t.empty_got, 0,
+            "a non-empty Err must not touch the empty count"
+        );
+    }
+
+    // (#903) The empty→output transition is NOT masked: if ferro starts emitting a
+    // non-empty value that MISMATCHES the expected, the opt-in reason (which
+    // buckets only `Err`) does not apply and the row hard-FAILs — surfacing that
+    // ferro stopped declining. (An `Ok` that *matches* XPASS-FAILs; covered by the
+    // shared XPASS test.)
+    #[test]
+    fn tally_accepted_rejection_opt_in_reason_ok_mismatch_still_fails() {
+        let mut t = AxisTally::new(Axis::ProteinDescription);
+        let case = Case {
+            accepted_rejections: vec![AcceptedRejection {
+                axis: Axis::ProteinDescription,
+                reason: RejectionReason::NonCdsNoProjection857,
+                note: None,
+                cluster: None,
+            }],
+            ..make_case("in", None, None)
+        };
+        t.record(
+            &case,
+            "NP_000134.2:p.(=)",
+            Ok("NP_000134.2:p.(Trp1*)".to_string()),
+        );
+        assert!(
+            t.divergence_accepted.is_empty(),
+            "an Ok mismatch must not bucket under an accepted_rejection"
+        );
+        assert_eq!(
+            t.fail.len(),
+            1,
+            "ferro emitting a differing value (no longer declining) must FAIL"
+        );
+        assert_eq!(t.empty_got, 0);
     }
 
     // (7c) `reference_unavailable` deserializes including its closed `reason`


### PR DESCRIPTION
Closes #903.

## Problem

`AxisTally::record` could give **no typed disposition** to an empty-projection `Err` (ferro produced no output on an axis): `accepted_divergence`/`known_bug`/`spec_citation` are gated behind `actual.is_ok()`, and `accepted_rejection` explicitly excluded the `EMPTY_PROJECTION_SENTINEL`. So a row where ferro **spec-correctly declines** but the comparator emits a value — e.g. #891's `NM_000143.3:c.-1_1insCAT` (ferro declines protein per the #857 non-CDS policy; mutalyzer emits `p.(=)`) — could only land in the raw `baseline-failures/<axis>.txt` ledger, never a typed bucket. This is why ~18 `protein_description` rows can't leave that ledger, blocking #326's "every ledger empty" close condition.

## Fix

An empty projection is a **decline**, and `accepted_rejection` is already the Err-on-projection-axis disposition — its *only* blocker was the sentinel exclusion. So (adversarial review picked this home over grafting a second Err-exception onto `accepted_divergence`):

- Add `RejectionReason::NonCdsNoProjection857` + a closed `RejectionReason::disposition_empty_projection()` predicate (`_ => false`, so opting in is a deliberate reviewed choice, never an ad-hoc flag).
- Relax the `record()` accepted_rejection condition to admit the sentinel **only** when the reason opts in.

## Safety — no masked regressions (verified)

- The `empty_got` increment is **unconditional at the top of `record()`**, above every disposition/`return`, so the `#764`-pinned empty-projection **count gate** in `finish` still catches any *rise* regardless of bucketing.
- **Disjoint by construction:** the opt-in block requires the sentinel; every non-opt-in reason keeps the pre-#903 hard-FAIL.
- **XPASS / Ok-transition honest:** `accepted_rejection` buckets only `Err`, so if ferro starts emitting a value it is not masked — an `Ok` that *matches* XPASS-FAILs (stale annotation caught), an `Ok` that *mismatches* hard-FAILs (ferro stopped declining).
- A genuine panic still hard-FAILs.

## Payoff

Gives the ~18 empty-projection `protein_description` rows a **typed, XPASS-guarded** disposition instead of raw ledger entries — advancing #326's close-path (option (b) in the #326 close-condition caveat) and unblocking their conversion in the #861 sweep.

## Scope

Mechanism + hermetic tests **only** — no `src/` production code (projector/normalizer), no corpus/ledger change. Converting the real rows (#891's row + the ~17 `NG_` init-codon rows) to this typed disposition is a follow-up re-bless (#861 / an amend to #900), kept out here so the mechanism lands conflict-free with the in-flight `cases.json` PRs.

## Verification

Full suite **7683 passed**; new hermetic tests cover: opt-in buckets an empty `Err` (+ count still increments), non-opt-in still FAILs, opt-in still buckets a non-empty `Err`, `Ok`-mismatch still FAILs, and the predicate/serde round-trip. `clippy -D warnings` + `fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new accepted-rejection reason that can treat empty-projection results as accepted in specific cases.

* **Bug Fixes**
  * Improved rejection handling so opted-in cases no longer hard-fail on empty-projection sentinel errors.
  * Preserved existing failure behavior for non-opted-in cases and for normal mismatches.
  * Updated matching behavior and coverage to confirm the new routing and serialization work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->