### PR TITLE
test(conformance): demote stale known_bug #487 for LRG_303t1 out-of-phase insertion

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3121,12 +3121,7 @@
         "ICORRECTEDLRGREFERENCE",
         "ILRGWARNING"
       ],
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro resolves the cross-reference payload then renders it as a duplication (c.10_11dup); mutalyzer keeps the literal insGA. ins->dup canonicalization (and the dup anchor position) tracked in #487."
-      }
+      "to_test": true
     },
     {
       "keywords": [],

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -233,7 +233,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[0]` | normalized | known_bug | — | #487 |
 | `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[1]` | normalized | known_bug | — | #487 |
 | `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]` | normalized | known_bug | — | #487 |
-| `LRG_303t1:c.10_11insLRG_1t1:c.100_101` | normalized | known_bug | — | #487 |
 | `NG_007485.1(1787):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A_v001):n.204_205insATC` | errors | accepted_divergence | — | — |
@@ -312,6 +311,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 4 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 23 | 18 | 4 | 5 | 9 |
+| normalized | 23 | 17 | 4 | 5 | 9 |
 | protein_description | 0 | 0 | 0 | 0 | 52 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
The mutalyzer-normalize conformance row `LRG_303t1:c.10_11insLRG_1t1:c.100_101` carried a `known_bug{normalized, #487}` annotation asserting ferro renders the resolved cross-reference payload as a duplication (`c.10_11dup`) instead of mutalyzer's literal `c.10_11insGA`.

The out-of-phase insertion fix (#882) makes ferro now emit `LRG_303t1:c.10_11insGA`, matching mutalyzer. The annotation is stale and `axis_normalized` XPASS-fails against the prepared reference:

```
FAIL  [normalized] LRG_303t1:c.10_11insLRG_1t1:c.100_101 | XPASS: known_bug #487 now matches mutalyzer; the fix appears to have landed — remove the annotation and demote the row
```

This PR drops the annotation so the row becomes a clean expected-match, and regenerates `failure-patterns.md` (normalized `known_bug` tally 18 → 17). Only this single row flipped — the other 13 `#487` normalized rows still legitimately diverge and keep their annotation.

Surfaced while rebasing #895 onto the advanced `main`; independent of #895's genomic-axis reroute.

### Validation
- `axis_normalized` (mutalyzer + biocommons) now **passes** against the prepared reference (was XPASS-failing).
- 169 conformance/regression tests pass (comparator, mock-regression, `failure_patterns_is_current`); `generate_conformance_summary --check` clean.

Closes #906