### PR TITLE
docs(tool-support): label the support matrix for the ferro 0.7.0 release

### DIFF
--- a/docs/tool_support_matrix.json
+++ b/docs/tool_support_matrix.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "_comment": "SOURCE OF TRUTH for tool-support tables. Edit cells here, then run: cargo run --features dev --example generate_tool_support_tables. Every cell is source-verified; each non-obvious value carries a 'note' citing the deciding behavior.",
   "tools": [
-    { "id": "ferro", "name": "ferro", "version": "0.6.0", "url": "https://github.com/fulcrumgenomics/ferro-hgvs" },
+    { "id": "ferro", "name": "ferro", "version": "0.7.0", "url": "https://github.com/fulcrumgenomics/ferro-hgvs" },
     { "id": "mutalyzer", "name": "mutalyzer", "version": "3.1.1", "url": "https://mutalyzer.nl/" },
     { "id": "biocommons", "name": "biocommons", "version": "fa02ca5ec0c9e28a1a6377b551e41ae77b450ce9", "url": "https://github.com/biocommons/hgvs" },
     { "id": "hgvs-rs", "name": "hgvs-rs", "version": "0.20.2", "url": "https://github.com/varfish-org/hgvs-rs" }

--- a/src/service/web/static/data/tool_support_matrix.json
+++ b/src/service/web/static/data/tool_support_matrix.json
@@ -573,7 +573,7 @@
       "id": "ferro",
       "name": "ferro",
       "url": "https://github.com/fulcrumgenomics/ferro-hgvs",
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     {
       "id": "mutalyzer",


### PR DESCRIPTION
## Summary

Updates the tool-support matrix (docs + webserver) for the **ferro 0.7.0** release: bumps ferro `0.6.0 → 0.7.0` in the source-of-truth `docs/tool_support_matrix.json` and regenerates the rendered `src/service/web/static/data/tool_support_matrix.json` (so the website shows 0.7.0).

## Why the support cells don't change

The matrix's axes are **parse/normalize per reference / coordinate / variant type** — coarse type-level support. ferro already supports all of these in 0.6.0 (21/22 `normalize=full`; the one caveat, ENST `c./n.` under the default RefSeq-only cdot, still holds in 0.7.0). The 0.7.0 release's improvements — protein-consequence rendering (#911, extension/stop handling), NG_/LRG_ genomic projection (#480/#646/#655), cross-isoform enumeration — are **within-category refinements** and a **projection surface this matrix does not model**, so no cell value changes.

Verified in sync via `cargo run --features dev --example generate_tool_support_tables -- --check`. The README / BENCHMARK_GUIDE tables are version-agnostic and are unchanged.

## Not included (see PR discussion / follow-ups)

- **Speed numbers** (README performance tables): refreshing these requires the manual, multi-hour `benchmark matrix` run (stand up the UTA Docker DB + pixi env with mutalyzer/biocommons/hgvs-rs; 5 reps over stratified ClinVar) per `docs/BENCHMARK_RUNBOOK.md` — deferred, not part of this docs PR.
- **Matrix expansion** to showcase ferro 0.7.0's new axes (genomic projection, protein-consequence prediction, cross-isoform enumeration) across all four tools would be a design change requiring per-tool verification — proposed separately, not done here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the tool support matrix to show the latest `ferro` version as **0.7.0**.
  * Kept all other tool details and matrix entries unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->