### PR TITLE
fix(reference): skip hidden/AppleDouble files when scanning FASTA directories

### DIFF
--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -298,6 +298,20 @@ impl MultiFastaProvider {
             })?;
 
             let path = entry.path();
+
+            // Skip hidden files and macOS AppleDouble sidecars (names beginning with '.', e.g.
+            // `._LRG_430.fasta`). These are not real FASTAs — an accompanying `._*.fasta.fai` is a
+            // binary extended-attribute blob, and attempting to parse it as a FAI index would abort
+            // the entire reference load with a "stream did not contain valid UTF-8" error. Such files
+            // are commonly introduced when a reference directory is copied through macOS tooling.
+            let is_hidden = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'));
+            if is_hidden {
+                continue;
+            }
+
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
             // Look for .fna, .fa, or .fasta files
@@ -4296,6 +4310,39 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
 
         assert!(provider.has_sequence("NM_000001.1"));
         assert!(provider.has_sequence("NM_000001")); // Without version
+        assert_eq!(provider.sequence_length("NM_000001.1"), Some(10));
+    }
+
+    #[test]
+    fn test_from_directory_skips_macos_appledouble_sidecars() {
+        // A reference directory copied through macOS tooling can gain AppleDouble sidecar files
+        // (names beginning with `._`). Their `._*.fasta.fai` is a binary xattr blob; parsing it as
+        // a FAI index fails with "stream did not contain valid UTF-8". The scanner must skip these
+        // and still load the real FASTA rather than aborting the whole reference load.
+        let dir = tempdir().unwrap();
+
+        // Real, valid FASTA + index.
+        let mut fasta_file = File::create(dir.path().join("real.fna")).unwrap();
+        writeln!(fasta_file, ">NM_000001.1").unwrap();
+        writeln!(fasta_file, "ATGCATGCAT").unwrap();
+        let mut fai_file = File::create(dir.path().join("real.fna.fai")).unwrap();
+        writeln!(fai_file, "NM_000001.1\t10\t13\t10\t11").unwrap();
+
+        // AppleDouble sidecars with a `.fasta` extension and non-UTF-8 index content.
+        std::fs::write(
+            dir.path().join("._real.fasta"),
+            [0x00, 0x05, 0x16, 0x07, 0xff],
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("._real.fasta.fai"),
+            [0xff, 0xfe, 0x00, 0x80],
+        )
+        .unwrap();
+
+        // Must succeed (not abort on the sidecar) and expose the real sequence.
+        let provider = MultiFastaProvider::from_directory(dir.path()).unwrap();
+        assert!(provider.has_sequence("NM_000001.1"));
         assert_eq!(provider.sequence_length("NM_000001.1"), Some(10));
     }
 


### PR DESCRIPTION
## Problem

`MultiFastaProvider::from_directory` scans a reference subdirectory for `*.fna`/`*.fa`/`*.fasta` files and loads each one's `.fai` index. macOS AppleDouble sidecar files — e.g. `._LRG_430.fasta`, created whenever a reference directory is copied through macOS tooling (Finder, `tar`/`cp` carrying xattrs, some network shares) — match that extension filter. Their accompanying `._*.fasta.fai` is a binary extended-attribute blob, so `load_fai_index` fails with `stream did not contain valid UTF-8` and the **entire reference load aborts**.

The failure mode is subtle: parsing still works (it never reads the reference), so the provider looks healthy, but *every* normalization fails because no sequences can be resolved — with no indication that a stray `._*` file was the cause.

## Fix

Skip directory entries whose file name begins with `.` (hidden files and AppleDouble sidecars) before the extension check, so a reference directory contaminated with `._*` files loads cleanly.

## Test

Adds `test_from_directory_skips_macos_appledouble_sidecars`: a temp directory with a valid FASTA plus a `._real.fasta` / `._real.fasta.fai` pair carrying non-UTF-8 content; `from_directory` must load the real sequence and not abort on the sidecar.

## How this surfaced

Loading a reference stack that had been copied through macOS `tar` (which serializes xattrs into AppleDouble sidecars on extraction). ferro parse worked, but every normalize returned 0 successes with no surfaced error — tracing to `._LRG_*.fasta.fai` files under `lrg/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FASTA directory scanning to ignore hidden files, including macOS AppleDouble sidecar files and their index files, preventing reference loading failures.
- **Tests**
  - Added a regression test to confirm valid FASTA inputs still load correctly when hidden sidecar files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->