### PR TITLE
fix(benchmark): surface the failure reason when ferro normalize yields zero successes

### DIFF
--- a/src/benchmark/perf_matrix.rs
+++ b/src/benchmark/perf_matrix.rs
@@ -7,6 +7,8 @@
 
 use std::collections::BTreeMap;
 
+use crate::benchmark::types::ParseResult;
+
 use serde::{Deserialize, Serialize};
 
 /// One tool's measured throughput at a given worker count.
@@ -151,6 +153,19 @@ fn mean(xs: &[f64]) -> f64 {
     } else {
         xs.iter().sum::<f64>() / xs.len() as f64
     }
+}
+
+/// The error message of the first unsuccessful result that captured one, if any.
+///
+/// Scans past failures with no captured error (`error: None` is allowed) so a later failure's real
+/// diagnostic is not masked. Used to surface *why* a tool produced zero successes. Without this the
+/// matrix records an unexplained `not_run`, which hides real setup problems (e.g. a reference that
+/// fails to load, so every normalization declines) behind a generic "did not run" message.
+fn first_failure_reason(results: &[ParseResult]) -> Option<&str> {
+    results
+        .iter()
+        .filter(|r| !r.success)
+        .find_map(|r| r.error.as_deref())
 }
 
 /// Run one operation across the worker × tool × rep matrix.
@@ -367,6 +382,16 @@ impl HarnessMeasure {
         // known path inconsistency tracked separately; both W=1 and W=8 will now
         // consistently return None when there are no successes.
         if total == 0 || successful == 0 {
+            match first_failure_reason(&shard.sample_results) {
+                Some(reason) => eprintln!(
+                    "[perf-matrix] ferro normalize: 0/{total} succeeded — recording not_run; \
+                     first failure: {reason}"
+                ),
+                None => eprintln!(
+                    "[perf-matrix] ferro normalize: 0/{total} succeeded — recording not_run \
+                     (no per-variant error captured)"
+                ),
+            }
             return None;
         }
         Some(RepRate {
@@ -951,6 +976,43 @@ pub fn run_matrix(args: &super::cli::MatrixArgs) -> Result<(), crate::FerroError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn first_failure_reason_reports_first_error() {
+        let pr = |success: bool, error: Option<&str>| ParseResult {
+            input: "x".to_string(),
+            success,
+            output: None,
+            error: error.map(str::to_string),
+            error_category: None,
+            ref_mismatch: None,
+            details: None,
+        };
+        // The first unsuccessful result's error is returned, skipping leading successes.
+        let results = vec![
+            pr(true, None),
+            pr(false, Some("stream did not contain valid UTF-8")),
+            pr(false, Some("later error")),
+        ];
+        assert_eq!(
+            first_failure_reason(&results),
+            Some("stream did not contain valid UTF-8")
+        );
+        // A failure with no captured error is skipped so a later failure's real error surfaces.
+        let with_empty_leading_failure = vec![pr(false, None), pr(false, Some("later error"))];
+        assert_eq!(
+            first_failure_reason(&with_empty_leading_failure),
+            Some("later error")
+        );
+        // Every failure lacking an error still reports no reason.
+        assert_eq!(
+            first_failure_reason(&[pr(false, None), pr(false, None)]),
+            None
+        );
+        // All-success and empty inputs report no reason.
+        assert_eq!(first_failure_reason(&[pr(true, None)]), None);
+        assert_eq!(first_failure_reason(&[]), None);
+    }
 
     #[test]
     fn aggregates_median_min_max() {


### PR DESCRIPTION
## Problem

When a tool produces **zero** successful results in the performance matrix, the harness records a generic `not_run` — `"{tool} {op} did not run (stack unavailable or tool error)"` — and the per-variant error (which `normalize_ferro` captured in `sample_results`) is discarded. A *total* failure is therefore invisible from the benchmark output.

This bit us concretely: a reference directory that failed to load made every ferro normalization decline, so ferro normalize reported `not_run` with no reason. Finding the actual cause required building a separate one-off `ferro normalize` reproduction outside the harness.

## Fix

At the zero-success `return None` in `measure_ferro_normalize`, log the first failing variant's error (or a clear "no per-variant error captured" fallback). This turns a silent `not_run` into an actionable line, e.g.:

```
[perf-matrix] ferro normalize: 0/50 succeeded — recording not_run; first failure: stream did not contain valid UTF-8
```

Adds a small pure helper `first_failure_reason(&[ParseResult]) -> Option<&str>` with a unit test (first-error, all-success, and empty cases). Behavior is otherwise unchanged — a zero-success cell is still recorded as `not_run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when normalization yields no successful results by reporting the first available failure message instead of a generic fallback.
  * Ensures normalize measurements are correctly recorded as “not run” when there’s no successful outcome, while preserving the underlying reason.

* **Tests**
  * Added unit tests to verify first-failure reason extraction across successes-first, failures-with/without captured errors, all-failure, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->