### PR TITLE
test(conformance): re-home stale-tracker annotations to live issues (#912)

### DIFF
--- a/tests/fixtures/hgvs-rs-projection/cases.json
+++ b/tests/fixtures/hgvs-rs-projection/cases.json
@@ -9863,9 +9863,8 @@
       "to_test": true,
       "input": "NM_000051.3:c.9170_9171delGA",
       "protein_description": "NP_000042.3:p.Ter3057Pheext*4",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "stop-loss extension: with #615 fixed (PR #621 routes stop-disrupting indels to a C-terminal extension), ferro emits the spec-preferred three-letter parenthesized extension form p.(...extTer...) rather than the corpus legacy single-character NP_000042.3:p.Ter3057Pheext*4. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). Previously known_bug #615 (an Xaa placeholder) until the fix landed; XPASS-guarded."
@@ -9894,9 +9893,8 @@
       "to_test": true,
       "input": "NM_000249.3:c.2266_2269dupTGTT",
       "protein_description": "NP_000240.1:p.Ter757Leuext*34",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "ferro emits the spec-preferred three-letter extension glyph NP_000240.1:p.(Ter757LeuextTer34); the corpus carries the legacy single-character form NP_000240.1:p.Ter757Leuext*34. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). XPASS-guarded."
@@ -9910,9 +9908,8 @@
       "to_test": true,
       "input": "NM_000249.3:c.2269dupT",
       "protein_description": "NP_000240.1:p.Ter757Leuext*33",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "ferro emits the spec-preferred three-letter extension glyph NP_000240.1:p.(Ter757LeuextTer33); the corpus carries the legacy single-character form NP_000240.1:p.Ter757Leuext*33. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). XPASS-guarded."
@@ -9926,9 +9923,8 @@
       "to_test": true,
       "input": "NM_000425.3:c.3772dupT",
       "protein_description": "NP_000416.1:p.Ter1258Leuext*96",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "stop-loss extension: with #615 fixed (PR #621 routes stop-disrupting indels to a C-terminal extension), ferro emits the spec-preferred three-letter parenthesized extension form p.(...extTer...) rather than the corpus legacy single-character NP_000416.1:p.Ter1258Leuext*96. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). Previously known_bug #615 (an Xaa placeholder) until the fix landed; XPASS-guarded."
@@ -9942,9 +9938,8 @@
       "to_test": true,
       "input": "NM_000488.3:c.1391dupA",
       "protein_description": "NP_000479.1:p.Ter465Valext*18",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "stop-loss extension: with #615 fixed (PR #621 routes stop-disrupting indels to a C-terminal extension), ferro emits the spec-preferred three-letter parenthesized extension form p.(...extTer...) rather than the corpus legacy single-character NP_000479.1:p.Ter465Valext*18. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). Previously known_bug #615 (an Xaa placeholder) until the fix landed; XPASS-guarded."
@@ -9958,9 +9953,8 @@
       "to_test": true,
       "input": "NM_152263.2:c.855delA",
       "protein_description": "NP_689476.2:p.Ter286Asnext*73",
-      "improvement": {
+      "spec_citation": {
         "axis": "protein_description",
-        "tracking_issue": 224,
         "section": "HGVS §Standards (three-letter ext Ter preferred over ext*)",
         "cluster": "extter-vs-legacy-glyph",
         "note": "stop-loss extension: with #615 fixed (PR #621 routes stop-disrupting indels to a C-terminal extension), ferro emits the spec-preferred three-letter parenthesized extension form p.(...extTer...) rather than the corpus legacy single-character NP_689476.2:p.Ter286Asnext*73. Three-letter codes (incl. Ter) are preferred per standards.md; ferro canonicalizes ext* to extTer (#224). Previously known_bug #615 (an Xaa placeholder) until the fix landed; XPASS-guarded."

--- a/tests/fixtures/hgvs-rs-projection/failure-patterns.md
+++ b/tests/fixtures/hgvs-rs-projection/failure-patterns.md
@@ -38,12 +38,12 @@ For a C-terminal stop-loss extension, ferro canonicalizes to the three-letter fo
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
-| `NM_000051.3:c.9170_9171delGA` | protein_description | improvement | — | #224 |
-| `NM_000249.3:c.2266_2269dupTGTT` | protein_description | improvement | — | #224 |
-| `NM_000249.3:c.2269dupT` | protein_description | improvement | — | #224 |
-| `NM_000425.3:c.3772dupT` | protein_description | improvement | — | #224 |
-| `NM_000488.3:c.1391dupA` | protein_description | improvement | — | #224 |
-| `NM_152263.2:c.855delA` | protein_description | improvement | — | #224 |
+| `NM_000051.3:c.9170_9171delGA` | protein_description | spec_citation | — | — |
+| `NM_000249.3:c.2266_2269dupTGTT` | protein_description | spec_citation | — | — |
+| `NM_000249.3:c.2269dupT` | protein_description | spec_citation | — | — |
+| `NM_000425.3:c.3772dupT` | protein_description | spec_citation | — | — |
+| `NM_000488.3:c.1391dupA` | protein_description | spec_citation | — | — |
+| `NM_152263.2:c.855delA` | protein_description | spec_citation | — | — |
 
 ### whole-CDS-deletion protein form: corpus p.0? vs ferro p.(Met1?)
 
@@ -59,4 +59,4 @@ For a deletion spanning the entire coding sequence (including the initiation cod
 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
-| protein_description | 1 | 0 | 6 | 0 | 0 |
+| protein_description | 1 | 0 | 0 | 0 | 6 |

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -151,8 +151,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       },
       "accepted_divergence": {
@@ -197,8 +197,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       }
     },
@@ -229,8 +229,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       },
       "accepted_divergence": {
@@ -273,8 +273,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       }
     },
@@ -306,8 +306,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       },
       "accepted_divergence": {
@@ -352,8 +352,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       }
     },
@@ -507,8 +507,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       },
       "accepted_rejection": {
@@ -1435,13 +1435,13 @@
       "known_bug": [
         {
           "axis": "normalized",
-          "tracking_issue": 480,
-          "note": "ferro expands the c.180_188 copy range as transcript-contiguous bases; mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele with intronic offsets. Genomic-context copy-range expansion tracked in #480."
+          "tracking_issue": 922,
+          "note": "ferro expands the c.180_188 copy range as transcript-contiguous bases; mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele with intronic offsets. Genomic-context copy-range expansion tracked in #922."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 480,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the c.180_188 copy range as transcript-contiguous spliced bases (g.5207_5212delinsGCGAGGAAA); mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele. Genomic-context copy-range expansion tracked in #480."
+          "tracking_issue": 922,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the c.180_188 copy range as transcript-contiguous spliced bases (g.5207_5212delinsGCGAGGAAA); mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele. Genomic-context copy-range expansion tracked in #922."
         }
       ]
     },
@@ -1458,13 +1458,13 @@
       "known_bug": [
         {
           "axis": "normalized",
-          "tracking_issue": 480,
-          "note": "inverted copy-range delins; ferro expands transcript-contiguous, mutalyzer through the genomic (intron-split) reference. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "inverted copy-range delins; ferro expands transcript-contiguous, mutalyzer through the genomic (intron-split) reference. Tracked in #922."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 480,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the inverted copy-range delins as transcript-contiguous bases (g.5207_5212delinsTTTCCTCGC); mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the inverted copy-range delins as transcript-contiguous bases (g.5207_5212delinsTTTCCTCGC); mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
         }
       ]
     },
@@ -1482,13 +1482,13 @@
       "known_bug": [
         {
           "axis": "normalized",
-          "tracking_issue": 480,
-          "note": "bracketed copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "bracketed copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #922."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 480,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
         }
       ]
     },
@@ -1506,13 +1506,13 @@
       "known_bug": [
         {
           "axis": "normalized",
-          "tracking_issue": 480,
-          "note": "bracketed inverted copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "bracketed inverted copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #922."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 480,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed inverted copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #480."
+          "tracking_issue": 922,
+          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed inverted copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
         }
       ]
     },
@@ -1641,9 +1641,9 @@
       "to_test": true,
       "improvement": {
         "axis": "normalized",
-        "tracking_issue": 500,
+        "tracking_issue": 923,
         "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500.",
+        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #923.",
         "cluster": "refseqgene-selector"
       },
       "accepted_rejection": [
@@ -1672,9 +1672,9 @@
       "to_test": true,
       "improvement": {
         "axis": "normalized",
-        "tracking_issue": 500,
+        "tracking_issue": 923,
         "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500.",
+        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #923.",
         "cluster": "refseqgene-selector"
       },
       "accepted_rejection": [
@@ -1703,9 +1703,9 @@
       "to_test": true,
       "improvement": {
         "axis": "normalized",
-        "tracking_issue": 500,
+        "tracking_issue": 923,
         "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #500.",
+        "note": "ferro emits no transcript selector on a bare NG_ c. input; HGVS refseq.md:138-139 says the transcript used should be indicated (mutalyzer synthesizes the NM_ accession). Valid HGVS but spec-non-preferred; convergence tracked in #923.",
         "cluster": "refseqgene-selector"
       },
       "accepted_rejection": [
@@ -2470,8 +2470,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the block delins c.235_237delinsTAT; mutalyzer trims the unchanged interior base and decomposes to per-position substitutions c.[235A>T;237G>T]. Canonical edit-form convergence tracked in #487."
+        "tracking_issue": 920,
+        "note": "ferro keeps the block delins c.235_237delinsTAT; mutalyzer trims the unchanged interior base and decomposes to per-position substitutions c.[235A>T;237G>T]. Canonical edit-form convergence tracked in #920."
       }
     },
     {
@@ -2980,8 +2980,8 @@
       },
       "known_bug": {
         "axis": "noncoding",
-        "tracking_issue": 646,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #646.",
+        "tracking_issue": 921,
+        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
         "cluster": "noncoding-overlap-enumeration-646"
       }
     },
@@ -3033,8 +3033,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "two inserted copies plus the existing copy form a 3-copy repeat; mutalyzer renders the repeat. ferro keeps ins[2]. Repeat canonicalization tracked in #487."
+        "tracking_issue": 920,
+        "note": "two inserted copies plus the existing copy form a 3-copy repeat; mutalyzer renders the repeat. ferro keeps ins[2]. Repeat canonicalization tracked in #920."
       }
     },
     {
@@ -3054,8 +3054,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the inserted repeat as ins GT[5]; mutalyzer merges it with the adjacent existing GT tract into g.1_4GT[7]. Tandem-repeat canonicalization tracked in #487."
+        "tracking_issue": 920,
+        "note": "ferro keeps the inserted repeat as ins GT[5]; mutalyzer merges it with the adjacent existing GT tract into g.1_4GT[7]. Tandem-repeat canonicalization tracked in #920."
       }
     },
     {
@@ -3112,8 +3112,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the input repeat anchor (c.33_35CAA[5]); mutalyzer 3'-shifts the repeat unit to c.34_39AAC[6]. Repeat 3' normalization tracked in #487."
+        "tracking_issue": 920,
+        "note": "ferro keeps the input repeat anchor (c.33_35CAA[5]); mutalyzer 3'-shifts the repeat unit to c.34_39AAC[6]. Repeat 3' normalization tracked in #920."
       },
       "accepted_rejection": {
         "axis": "genomic",
@@ -3158,9 +3158,9 @@
       "to_test": true,
       "improvement": {
         "axis": "normalized",
-        "tracking_issue": 500,
+        "tracking_issue": 923,
         "section": "HGVS §RefSeqGene transcript selection",
-        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #500. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
+        "note": "ferro preserves the input's non-transcript selector (gene symbol, gene-symbol-version, or numeric gene ID) on an NG_ reference; HGVS refseq.md:38-42 says the NG_ specification should be a transcript (NM_) accession, which mutalyzer resolves to. Valid HGVS but spec-non-preferred; convergence tracked in #923. Migrated from accepted_divergence (#121); the NM_(GENE) policy from #121 is unaffected.",
         "cluster": "refseqgene-selector"
       },
       "accepted_rejection": {
@@ -3379,8 +3379,8 @@
       "to_test": true,
       "known_bug": {
         "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro renders the bare-position allele members with explicit identity and an absolute past-CDS coordinate (c.[274=;600=]); mutalyzer uses the 3'UTR form and drops the identity (c.[274;*120]). Past-CDS coordinate rendering + allele identity tracked in #487."
+        "tracking_issue": 920,
+        "note": "ferro renders the bare-position allele members with explicit identity and an absolute past-CDS coordinate (c.[274=;600=]); mutalyzer uses the 3'UTR form and drops the identity (c.[274;*120]). Past-CDS coordinate rendering + allele identity tracked in #920."
       },
       "accepted_divergence": {
         "axis": "genomic",
@@ -3691,8 +3691,8 @@
       "reference_unavailable": {
         "axis": "normalized",
         "reason": "ensembl-absent-from-refseq-manifest",
-        "tracking_issue": 671,
-        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest, so the reference cannot be resolved and no shift is applied. Converges once Ensembl reference is added (#671)."
+        "tracking_issue": 933,
+        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest (ferro prepare --ensembl is opt-in), so the reference cannot be resolved and no shift is applied. The Ensembl-reference capability (#671) and exon/intron 3'-shift (#670) both shipped; converges once the conformance reference is provisioned with --ensembl and these rows are re-blessed (#933)."
       },
       "normalized": "ENST00000375549.8:c.102del",
       "to_test": true
@@ -3706,8 +3706,8 @@
       "reference_unavailable": {
         "axis": "normalized",
         "reason": "ensembl-absent-from-refseq-manifest",
-        "tracking_issue": 671,
-        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest, so the reference cannot be resolved and no shift is applied. Converges once Ensembl reference is added (#671)."
+        "tracking_issue": 933,
+        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest (ferro prepare --ensembl is opt-in), so the reference cannot be resolved and no shift is applied. The Ensembl-reference capability (#671) and exon/intron 3'-shift (#670) both shipped; converges once the conformance reference is provisioned with --ensembl and these rows are re-blessed (#933)."
       },
       "normalized": "ENST00000375549.8:c.102del",
       "to_test": true
@@ -3721,8 +3721,8 @@
       "reference_unavailable": {
         "axis": "normalized",
         "reason": "ensembl-absent-from-refseq-manifest",
-        "tracking_issue": 671,
-        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest, so the reference cannot be resolved and no shift is applied. Converges once Ensembl reference is added (#671)."
+        "tracking_issue": 933,
+        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest (ferro prepare --ensembl is opt-in), so the reference cannot be resolved and no shift is applied. The Ensembl-reference capability (#671) and exon/intron 3'-shift (#670) both shipped; converges once the conformance reference is provisioned with --ensembl and these rows are re-blessed (#933)."
       },
       "normalized": "ENSG00000204370.13(ENST00000375549.8):c.102del",
       "to_test": true
@@ -3751,8 +3751,8 @@
       "reference_unavailable": {
         "axis": "normalized",
         "reason": "ensembl-absent-from-refseq-manifest",
-        "tracking_issue": 671,
-        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest, so the reference cannot be resolved and no shift is applied. Converges once Ensembl reference is added (#671)."
+        "tracking_issue": 933,
+        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest (ferro prepare --ensembl is opt-in), so the reference cannot be resolved and no shift is applied. The Ensembl-reference capability (#671) and exon/intron 3'-shift (#670) both shipped; converges once the conformance reference is provisioned with --ensembl and these rows are re-blessed (#933)."
       },
       "normalized": "ENST00000452863.10:c.10del",
       "to_test": true
@@ -3766,8 +3766,8 @@
       "reference_unavailable": {
         "axis": "normalized",
         "reason": "ensembl-absent-from-refseq-manifest",
-        "tracking_issue": 671,
-        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest, so the reference cannot be resolved and no shift is applied. Converges once Ensembl reference is added (#671)."
+        "tracking_issue": 933,
+        "note": "ferro echoes the input: Ensembl transcripts (ENST/ENSG) are absent from the RefSeq-only prepared manifest (ferro prepare --ensembl is opt-in), so the reference cannot be resolved and no shift is applied. The Ensembl-reference capability (#671) and exon/intron 3'-shift (#670) both shipped; converges once the conformance reference is provisioned with --ensembl and these rows are re-blessed (#933)."
       },
       "normalized": "ENSG00000184937.16(ENST00000452863.10):c.10del",
       "to_test": true

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -14,10 +14,10 @@ On an `NG_/NC_/LRG_` reference ferro preserves the input's gene-symbol selector;
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
-| `NG_008939.1:c.155_157del3` | normalized | improvement | — | #500 |
-| `NG_008939.1:c.155_157delAAC` | normalized | improvement | — | #500 |
-| `NG_008939.1:c.274_275inv` | normalized | improvement | — | #500 |
-| `NG_012337.1(10683):c.274G>T` | normalized | improvement | — | #500 |
+| `NG_008939.1:c.155_157del3` | normalized | improvement | — | #923 |
+| `NG_008939.1:c.155_157delAAC` | normalized | improvement | — | #923 |
+| `NG_008939.1:c.274_275inv` | normalized | improvement | — | #923 |
+| `NG_012337.1(10683):c.274G>T` | normalized | improvement | — | #923 |
 
 ### Bare NP_ protein reference
 
@@ -209,14 +209,14 @@ The n. corpus rows expect a projection onto the overlapping single-exon non-codi
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
-| `NG_007485.1(NM_000077.4):c.161_162delTGinsATCCC` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_000077.4):c.161_162delTGins[ATCCC]` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_000077.4):c.161_162delinsATCCC` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_000077.4):c.161_162delins[ATCCC]` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_000077.4):c.161_162insATC` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_000077.4):c.161_162ins[ATC]` | noncoding | known_bug | — | #646 |
-| `NG_007485.1(NM_058195.3):c.141_142del` | noncoding | known_bug | — | #646 |
-| `NG_007485.1:g.5479_5480insACT` | noncoding | known_bug | — | #646 |
+| `NG_007485.1(NM_000077.4):c.161_162delTGinsATCCC` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162delTGins[ATCCC]` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162delinsATCCC` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162delins[ATCCC]` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162insATC` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162ins[ATC]` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_058195.3):c.141_142del` | noncoding | known_bug | — | #921 |
+| `NG_007485.1:g.5479_5480insACT` | noncoding | known_bug | — | #921 |
 
 ### Inserted inversion (reverse complement) not applied by mutalyzer
 
@@ -232,19 +232,19 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
-| `ENSG00000184937.16(ENST00000452863.10):c.9del` | normalized | reference_unavailable | — | #671 |
-| `ENSG00000204370.13(ENST00000375549.8):c.100del` | normalized | reference_unavailable | — | #671 |
+| `ENSG00000184937.16(ENST00000452863.10):c.9del` | normalized | reference_unavailable | — | #933 |
+| `ENSG00000204370.13(ENST00000375549.8):c.100del` | normalized | reference_unavailable | — | #933 |
 | `ENST00000375549.7:c.100del` | errors | accepted_divergence | — | — |
-| `ENST00000375549.8:c.100del` | normalized | reference_unavailable | — | #671 |
-| `ENST00000375549:c.100del` | normalized | reference_unavailable | — | #671 |
-| `ENST00000452863.10:c.9del` | normalized | reference_unavailable | — | #671 |
+| `ENST00000375549.8:c.100del` | normalized | reference_unavailable | — | #933 |
+| `ENST00000375549:c.100del` | normalized | reference_unavailable | — | #933 |
+| `ENST00000452863.10:c.9del` | normalized | reference_unavailable | — | #933 |
 | `LRG_199t1:c.11LRG_199t1:c.11` | errors | accepted_divergence | — | — |
 | `LRG_199t1:c.11LRG_199t1:c.11[10]` | normalized | accepted_divergence | — | — |
 | `LRG_199t1:c.11NG_012337.3(NM_003002.4):c.14[10]` | normalized | accepted_divergence | — | — |
-| `LRG_199t1:c.235_237delinsTAT` | normalized | known_bug | — | #487 |
+| `LRG_199t1:c.235_237delinsTAT` | normalized | known_bug | — | #920 |
 | `LRG_1t1:52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]` | errors | accepted_divergence | — | — |
-| `LRG_303:g.4_5insGT[5]` | normalized | known_bug | — | #487 |
-| `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]` | normalized | known_bug | — | #487 |
+| `LRG_303:g.4_5insGT[5]` | normalized | known_bug | — | #920 |
+| `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]` | normalized | known_bug | — | #920 |
 | `NG_007485.1(1787):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A_v001):n.204_205insATC` | errors | accepted_divergence | — | — |
@@ -268,14 +268,14 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | normalized | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | protein_description | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | normalized | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | known_bug | — | #480 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | normalized | known_bug | — | #480 |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | normalized | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | normalized | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | normalized | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | normalized | known_bug | — | #922 |
 | `NG_008939.1:c.155_157del3` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157del3` | protein_description | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157delAAC` | genomic | accepted_divergence | — | — |
@@ -287,7 +287,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1:g.5207_5212delins[GTCCTGTGCT;4310_4320inv]` | coding_protein_descriptions | accepted_divergence | — | — |
 | `NG_009299.1(NM_002474.3):c.[310del;295G>A]` | normalized | spec_citation | — | — |
 | `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | genomic | accepted_divergence | — | — |
-| `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | normalized | known_bug | — | #487 |
+| `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | normalized | known_bug | — | #920 |
 | `NG_009299.1(NM_017668.3):c.41A>C` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | infos | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | normalized | accepted_divergence | — | — |
@@ -307,7 +307,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.1_4delinsTTGA` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.276C>T` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.[274;600]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #487 |
+| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #920 |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274del;275=]` | genomic | accepted_divergence | — | — |


### PR DESCRIPTION
Closes #912. Part of #326.

Every `known_bug` / `improvement` annotation in the conformance corpora referenced a **CLOSED** tracking issue (#487, #646, #480, #500, #224 — and even #92, which #912's text assumed open). A closed issue behind a live divergence mis-tracks it: the divergence has no open home, and (for `known_bug`) the XPASS guard can no longer drive cleanup to the right issue. This sweep re-homes every stale reference to a **live** tracker, keeping the disposition bucket identical (a pure tracker re-point) except the one family where ferro is already spec-correct.

## `mutalyzer-normalize/cases.json` — 32 annotations re-pointed

**#487 (13 rows, overloaded) split by mechanism:**

- **CDS↔UTR 3'-shift** → **#918** (scope generalized from compound-only to also cover the single-deletion case): the single-del `NG_012337.1(NM_012459.2):c.-1_*1del` plus the compound-allele member `c.[41A>C;250del]`. Same #337 CDS↔UTR axis-clamp root cause.
- **Canonical edit-form + allele-member gaps** → **#920**: ins→dup MUST (`duplication.md` L17, DNA sibling of the closed #92), ins→repeat, tandem-repeat merge, repeat 3'-shift, zero-copy ins→identity, block-delins interior trim, allele→substitution collapse, redundant identity-member (`=`) drop, bare-position allele identity/coordinate.
- The 13th row, `c.[250del;41A>C]`, is re-pointed by **#908 / PR #919** (which also adds its `infos`-axis `known_bug`), so it is intentionally left untouched here to avoid a conflicting edit to the same case. Once both land, zero rows reference #487.

**#646** noncoding-overlap `n.` enumeration (8 rows) → **#921**.
**#480** copy-range delins transcript-vs-genomic expansion (8 rows, spec-unpinned) → **#922**.
**#500** bare-`NG_` transcript-selector synthesis `improvement` (4 rows) → **#923**.

## `hgvs-rs-projection/cases.json` — 6 rows reclassified

**#224** was a *backwards* `improvement`: ferro already emits the spec-preferred `extTerN` extension glyph while the corpus carries the legacy `ext*N` form. An `improvement` asserts ferro should converge on the comparator — but here ferro is the *more* correct one. Reclassify `improvement` → `spec_citation` (`SpecSection::ExtensionTerGlyph`, whose doc-comment already documents #224 as "both valid HGVS, ferro's `extTer` is spec-preferred"). No tracker needed — ferro is correct.

## Validation

- No Rust code changes — only the two `cases.json` and their regenerated `failure-patterns.md` summaries; `generate_conformance_summary --check` passes.
- The re-points keep the same disposition bucket, so no FAIL/count movement; #224 moves `improvement` → `spec_overridden`.
- Re-blessed against the prepared reference (`FERRO_MANIFEST`): no new FAIL and no XPASS on any re-pointed/reclassified row.

The two pre-existing `coding_protein_descriptions` FAILs on `main` (the #911 protein-`Ter` rows fixed by #913, and the untracked hgvs-rs burn-down these notes reference) are unrelated to this change. The remaining untracked hgvs-rs-projection FAIL residual (noted in #912's "Related" section) is deliberately left for a follow-up burn-down tracker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fixture notes and conformance summaries to reflect current issue references.
  * Clarified several case entries without changing expected outcomes.

* **Tests**
  * Refreshed test metadata across normalization and HGVS projection fixtures.
  * Adjusted disposition counts and tracking labels in failure-pattern tables to match the latest classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->