### PR TITLE
fix(normalize): canonicalize degenerate bracketed inserted-repeat counts (#920)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -33,7 +33,7 @@ pub mod validate;
 
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
-use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, ProteinEdit, Sequence};
+use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, ProteinEdit, RepeatCount, Sequence};
 use crate::hgvs::interval::{Interval, ProtInterval};
 use crate::hgvs::location::{
     AminoAcid, CdsPos, GenomePos, ProtPos, RnaPos, SpecialPosition, TxPos,
@@ -5838,6 +5838,52 @@ impl<P: ReferenceProvider> Normalizer<P> {
         {
             if reference == alternative {
                 return Ok((start, end, NaEdit::position_identity(), warnings));
+            }
+        }
+
+        // A bracketed inserted repeat with an exact count — either a multi-base
+        // `ins<seq>[N]` (`SequenceRepeat`) or a single-base `ins<base>[N]`
+        // (`Repeat`) — is syntactic shorthand the plain-insertion path never
+        // canonicalizes: both `bases()` to `None`, so the alt-extraction below
+        // returns the edit verbatim. Rewrite the degenerate counts, matching
+        // mutalyzer:
+        //   [0] — zero copies inserted is a no-op → whole-entity identity (`g.=`).
+        //   [1] — a single inserted copy is equivalent to the plain
+        //         `ins<seq>`, which flows through insertion→duplication
+        //         detection below, so rewrite to `Literal` and recurse (a
+        //         single copy of the adjacent reference then becomes `dup`,
+        //         `duplication.md` L17).
+        // Counts >= 2 are a genuine multi-copy repeat, left for the
+        // repeat-tract machinery (out of scope). The rewrite is purely
+        // syntactic on the stated sequence, so it runs before shuffling. See #920.
+        if let NaEdit::Insertion { sequence } = edit {
+            let degenerate = match sequence {
+                InsertedSequence::SequenceRepeat {
+                    sequence,
+                    count: RepeatCount::Exact(n),
+                } => Some((*n, sequence.clone())),
+                InsertedSequence::Repeat {
+                    base,
+                    count: RepeatCount::Exact(n),
+                } => Some((*n, Sequence::new(vec![*base]))),
+                _ => None,
+            };
+            if let Some((count, unit)) = degenerate {
+                match count {
+                    0 => return Ok((start, end, NaEdit::whole_entity_identity(), warnings)),
+                    1 => {
+                        let literal = NaEdit::Insertion {
+                            sequence: InsertedSequence::Literal(unit),
+                        };
+                        let (new_start, new_end, new_edit, mut child_warnings) = self
+                            .normalize_na_edit(
+                                ref_seq, &literal, start, end, boundaries, is_coding,
+                            )?;
+                        warnings.append(&mut child_warnings);
+                        return Ok((new_start, new_end, new_edit, warnings));
+                    }
+                    _ => {}
+                }
             }
         }
 

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3014,12 +3014,7 @@
       ],
       "input": "LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[0]",
       "normalized": "LRG_303:g.=",
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ins[0] is a zero-copy (no-op) insertion; mutalyzer collapses to g.=. ferro should canonicalize the zero-copy insert to identity. Tracked in #487."
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -3027,12 +3022,7 @@
       ],
       "input": "LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[1]",
       "normalized": "LRG_303:g.6908_6932dup",
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "a single inserted copy of the adjacent 25-mer is a duplication; mutalyzer renders g.6908_6932dup. ferro keeps ins[1]. ins->dup canonicalization tracked in #487."
-      }
+      "to_test": true
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -245,8 +245,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `LRG_199t1:c.235_237delinsTAT` | normalized | known_bug | — | #487 |
 | `LRG_1t1:52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]` | errors | accepted_divergence | — | — |
 | `LRG_303:g.4_5insGT[5]` | normalized | known_bug | — | #487 |
-| `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[0]` | normalized | known_bug | — | #487 |
-| `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[1]` | normalized | known_bug | — | #487 |
 | `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]` | normalized | known_bug | — | #487 |
 | `NG_007485.1(1787):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
@@ -352,6 +350,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 9 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 25 | 13 | 4 | 5 | 11 |
+| normalized | 25 | 11 | 4 | 5 | 11 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |

--- a/tests/it/ins_repeat_b1_matrix.rs
+++ b/tests/it/ins_repeat_b1_matrix.rs
@@ -74,6 +74,36 @@ mod genomic {
         let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAC", &[4, 5]));
         assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}dup", &[5, 6]));
     }
+
+    // --- #920: degenerate bracketed inserted-repeat counts ------------------
+    // `ins<seq>[N]` with an exact count previously bypassed normalization (its
+    // `bases()` is `None`), so `[0]`/`[1]` were left verbatim. `[1]` is a single
+    // copy ≡ the plain `ins<seq>` (→ `dup` when it matches the adjacent
+    // reference, `duplication.md` L17); `[0]` inserts nothing (→ `g.=`).
+
+    #[rstest]
+    fn single_copy_bracketed_ins_repeat_emits_dup() {
+        // insAC[1] at 4_5 must canonicalize identically to the plain insAC above.
+        let p = provider("ACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAC[1]", &[4, 5]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}dup", &[5, 6]));
+    }
+
+    #[rstest]
+    fn single_base_bracketed_ins_repeat_emits_dup() {
+        // Single-base insA[1] in an A-tract → dup, matching the plain insA.
+        let p = provider("ACAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA[1]", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}dup", &[6]));
+    }
+
+    #[rstest]
+    fn zero_copy_bracketed_ins_repeat_is_identity() {
+        // insAC[0] inserts zero copies — a no-op → whole-entity identity g.=.
+        let p = provider("ACGTACGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAC[0]", &[4, 5]));
+        assert_eq!(result, "NC_TEST.1:g.=");
+    }
 }
 
 mod cds_plus {


### PR DESCRIPTION
Addresses the degenerate-count rows of #920. Part of #326.

A bracketed inserted repeat with an exact count — multi-base `ins<seq>[N]` (`InsertedSequence::SequenceRepeat`) or single-base `ins<base>[N]` (`InsertedSequence::Repeat`) — bypassed normalization entirely: both `InsertedSequence::bases()` return `None`, so `normalize_na_edit`'s alt-sequence extraction returned the edit verbatim, never reaching insertion→duplication detection. mutalyzer canonicalizes the degenerate counts; ferro left them as-is.

## Fix

Intercept the two degenerate counts in the `NaEdit::Insertion` arm of `normalize_na_edit`, before the alt-sequence extraction (mirroring the `Substitution` ref==alt → identity rewrite just above it):

- **`[0]`** — zero copies inserted is a no-op → whole-entity identity `g.=`.
- **`[1]`** — a single copy is equivalent to the plain `ins<seq>`; rewrite to a `Literal` and recurse, so the existing insertion→duplication detection fires (a single copy of the adjacent reference becomes `dup`, `duplication.md` L17). The plain form already did this; only the bracketed `[1]` shorthand bypassed it.

Counts ≥ 2 are a genuine multi-copy repeat and are left for the repeat-tract machinery (out of scope).

## Validation

- Demotes the two now-passing conformance rows: `LRG_303:g.6932_6933insAGC…CT[0]` → `g.=` and `…[1]` → `g.6908_6932dup`.
- Adds MockProvider unit tests (`ins_repeat_b1_matrix`) covering the multi-base `[1]`→dup, single-base `[1]`→dup, and `[0]`→`g.=` cases.
- Re-blessed against the prepared reference (`FERRO_MANIFEST`): `normalized` **189 pass / 0 FAIL, no XPASS** (the 2 rows move `known_bug`→pass, 17→15); no ripple to `genomic` or any other axis. Idempotency + spec-fixture + 1881 no-manifest tests green; the generated spec fixture regenerates with no drift.

## Scope — what this does NOT include (and why)

#920 lists 10 rows; this PR fixes the 2 degenerate-count rows. The rest remain:

- **Redundant identity-member (`=`) drop** (`c.[274=;275del]`→`c.275del`) — **intentionally excluded**. It's contested: the same rows carry a `genomic`-axis `accepted_divergence` (policy-654 / #851) arguing ferro's *retention* of a cis `=` member is spec-faithful (`alleles.md` governs *trans* cross-spelling, not a single cis bracket; `substitution.md:19` provides the `=` form). Dropping the member would contradict that policy and XPASS-break the genomic disposition. This is a classification decision (#912 action 4 — reconcile the normalized `known_bug` vs genomic `accepted_divergence`), not a bug fix.
- **`ins…[2]`→repeat, block-delins interior trim, tandem-repeat merge, repeat 3'-shift, allele→substitution collapse, bare-position allele identity** — remain `known_bug` under #920.

## Merge interlock (harmless)

This branch is off current `main` (post-#913), where the two rows still carry `known_bug{#487}`; this PR removes those annotations. The open **#924** (stale-tracker sweep) re-points those same rows to #920. They touch the same two case entries, so whichever merges second needs a trivial rebase (here the rows are deleted; there they are re-pointed — the deletion wins). Both also regenerate `failure-patterns.md` — resolve any conflict by regenerating (`generate_conformance_summary`).
