### PR TITLE
test(conformance): disposition the 3 NG_008939 stop-insertion coding_protein rows (#911/#913 follow-up)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -566,6 +566,17 @@ pub enum Policy {
     /// *resolves* the input here rather than rejecting it. Accepted divergence.
     #[serde(rename = "ferro-policy-73-cross-ref-cds-resolved-no-enocds")]
     CrossRefCdsResolvedNoEnocds,
+    /// coding_protein_descriptions axis: for an in-frame insertion / delins that
+    /// encodes a premature stop, ferro renders the protein consequence as the
+    /// spec-mandated insertion / capped-delins form (`p.(…insXaaTer)` /
+    /// `p.(…delinsXaaTer)`, `protein/insertion.md` L37-41, `protein/delins.md`
+    /// L27-28), NOT the C-terminal-spanning `p.(Xaa_LastResiduedelins…)` that
+    /// those sections forbid. The mutalyzer-normalize corpus carries the
+    /// Mutalyzer2-era (`M2:`) spec-forbidden C-terminal delins (e.g.
+    /// `p.(Arg53_Leu539delinsAlaArg)`); ferro's form is spec-correct (#911,
+    /// fixed in #913). Accepted divergence from the stale corpus value.
+    #[serde(rename = "ferro-policy-911-stop-insertion-not-cterminal-delins")]
+    StopInsertionNotCterminalDelins911,
 }
 
 impl Policy {
@@ -608,6 +619,9 @@ impl Policy {
             }
             Policy::MutalyzerNoNormalizedForm654 => "ferro-policy-654-mutalyzer-no-normalized-form",
             Policy::ExplicitIdentityRendering654 => "ferro-policy-654-explicit-identity-rendering",
+            Policy::StopInsertionNotCterminalDelins911 => {
+                "ferro-policy-911-stop-insertion-not-cterminal-delins"
+            }
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -768,7 +768,12 @@
           "NG_008939.1(NP_000523.2):p.(Arg53_Leu539delinsAlaArg)"
         ]
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-911-stop-insertion-not-cterminal-delins",
+        "note": "ferro renders the premature-stop protein consequence as the spec insertion form p.(Gln52_Arg53insAlaArgTer) (insertion.md L37-41); the corpus carries the M2-era spec-forbidden C-terminal delins p.(Arg53_Leu539delinsAlaArg). Spec-correct per #911 (fixed in #913)."
+      }
     },
     {
       "keywords": [
@@ -837,7 +842,12 @@
           "NG_008939.1(NP_000523.2):p.(Arg53_Leu539delinsAlaArg)"
         ]
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-911-stop-insertion-not-cterminal-delins",
+        "note": "ferro renders the premature-stop protein consequence as the spec insertion form p.(Gln52_Arg53insAlaArgTer) (insertion.md L37-41); the corpus carries the M2-era spec-forbidden C-terminal delins p.(Arg53_Leu539delinsAlaArg). Spec-correct per #911 (fixed in #913)."
+      }
     },
     {
       "keywords": [
@@ -1321,7 +1331,12 @@
           "NG_008939.1(NP_000523.2):p.(Arg53_Leu539delinsSerCysAlaAlaArg)"
         ]
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "coding_protein_descriptions",
+        "policy": "ferro-policy-911-stop-insertion-not-cterminal-delins",
+        "note": "ferro renders the stop-encoding delins protein consequence capped at the change site p.(Arg53_Arg54delinsSerCysAlaAlaArgTer) (delins.md L27-28); the corpus carries the M2-era spec-forbidden C-terminal delins p.(Arg53_Leu539delinsSerCysAlaAlaArg). Spec-correct per #911 (fixed in #913)."
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -285,6 +285,9 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1:c.155_157delAAC` | protein_description | accepted_divergence | — | — |
 | `NG_008939.1:c.274_275inv` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.274_275inv` | protein_description | accepted_divergence | — | — |
+| `NG_008939.1:g.5207_5208ins4300_4320inv` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_008939.1:g.5207_5208ins[4300_4320inv]` | coding_protein_descriptions | accepted_divergence | — | — |
+| `NG_008939.1:g.5207_5212delins[GTCCTGTGCT;4310_4320inv]` | coding_protein_descriptions | accepted_divergence | — | — |
 | `NG_009299.1(NM_002474.3):c.[310del;295G>A]` | normalized | spec_citation | — | — |
 | `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | normalized | known_bug | — | #487 |
@@ -343,7 +346,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
-| coding_protein_descriptions | 24 | 0 | 0 | 0 | 0 |
+| coding_protein_descriptions | 27 | 0 | 0 | 0 | 0 |
 | errors | 17 | 0 | 0 | 0 | 0 |
 | genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 9 | 0 | 0 | 0 | 0 |


### PR DESCRIPTION
Follow-up to #911 / #913. Part of #326.

**#913 changed zero lines of `cases.json`** — it fixed the premature-stop protein consequence in `src/project/protein/indel.rs` but left the mutalyzer-normalize corpus expecting the old, spec-forbidden value. So under a manifest run the 3 `NG_008939` ins/delins-inv rows now FAIL the `coding_protein_descriptions` axis: ferro emits the spec-correct form, the corpus expects the Mutalyzer2-era (`M2:`) C-terminal-spanning delins.

| input | ferro (spec-correct, #913) | corpus (M2, spec-forbidden) |
|---|---|---|
| `g.5207_5208ins4300_4320inv` | `p.(Gln52_Arg53insAlaArgTer)` | `p.(Arg53_Leu539delinsAlaArg)` |
| `g.5207_5208ins[4300_4320inv]` | `p.(Gln52_Arg53insAlaArgTer)` | `p.(Arg53_Leu539delinsAlaArg)` |
| `g.5207_5212delins[GTCCTGTGCT;4310_4320inv]` | `p.(Arg53_Arg54delinsSerCysAlaAlaArgTer)` | `p.(Arg53_Leu539delinsSerCysAlaAlaArg)` |

The C-terminal-spanning delins is exactly what `protein/insertion.md` L37-41 and `protein/delins.md` L27-28 forbid; ferro's insertion / capped-delins form is spec-correct. Post-#913 the disposition flips from "known_bug (ferro wrong)" to **accepted_divergence (ferro spec-correct; corpus M2 value stale)**.

## Change

- New `Policy::StopInsertionNotCterminalDelins911` (`ferro-policy-911-stop-insertion-not-cterminal-delins`).
- `accepted_divergence{axis: coding_protein_descriptions}` on the 3 rows (the coding_protein "missing pair" Err only buckets `accepted_divergence`).
- Regenerated `failure-patterns.md`.

## Validation

Re-blessed against the prepared reference (`FERRO_MANIFEST`): mutalyzer `coding_protein_descriptions` **24 pass / 27 divergence_accepted / 0 FAIL** (was 3 FAIL), no XPASS. fmt + clippy + 209 no-manifest conformance tests green; `generate_conformance_summary --check` passes.

Note: touches `failure-patterns.md` (the generated conformance summary), which also changes in #919/#924/#926 — resolve any rebase conflict by regenerating.
