### PR TITLE
test(conformance): reconcile the redundant cis-= allele axis inconsistency (#912 action 4)

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -4124,16 +4124,18 @@
       "normalized": "NG_012337.1(NM_003002.2):c.275del",
       "genomic": "NG_012337.1:g.7126del",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the redundant c.274= identity member; mutalyzer drops it, collapsing the allele to c.275del. Allele identity-member collapse tracked in #487."
-      },
-      "accepted_divergence": {
-        "axis": "genomic",
-        "policy": "ferro-policy-654-explicit-identity-rendering",
-        "note": "ferro projects the cis allele faithfully, retaining the explicit identity member: g.[7125=;7126del]; mutalyzer drops the c.274= no-change member and de-brackets to g.7126del. The cited 'redundant =' prohibition (alleles.md:18-19,:49) governs trans cross-spelling, not a single cis bracket; the spec provides the = no-change form (substitution.md:19), so ferro's retention is at least as spec-faithful (#851)."
-      }
+      "accepted_divergence": [
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "ferro projects the cis allele faithfully, retaining the explicit identity member: g.[7125=;7126del]; mutalyzer drops the c.274= no-change member and de-brackets to g.7126del. The cited 'redundant =' prohibition (alleles.md:18-19,:49) governs trans cross-spelling, not a single cis bracket; the spec provides the = no-change form (substitution.md:19), so ferro's retention is at least as spec-faithful (#851)."
+        },
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "ferro retains the explicit cis identity member (c.[274=;275del]); mutalyzer drops the no-change member and collapses to c.275del. alleles.md:18-19,:49 governs trans cross-spelling, not a single cis bracket; substitution.md:19 provides the = no-change form, so ferro's retention is at least as spec-faithful (#851). Reconciled with the genomic-axis divergence per #912 action 4 (was known_bug)."
+        }
+      ]
     },
     {
       "keywords": [],
@@ -4141,16 +4143,18 @@
       "normalized": "NG_012337.1(NM_003002.2):c.274del",
       "genomic": "NG_012337.1:g.7125del",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the redundant c.275= identity member; mutalyzer collapses to c.274del. Allele identity-member collapse tracked in #487."
-      },
-      "accepted_divergence": {
-        "axis": "genomic",
-        "policy": "ferro-policy-654-explicit-identity-rendering",
-        "note": "ferro projects the cis allele faithfully, retaining the explicit identity member: g.[7125del;7126=]; mutalyzer drops the c.275= no-change member and de-brackets to g.7125del. The cited 'redundant =' prohibition (alleles.md:18-19,:49) governs trans cross-spelling, not a single cis bracket; the spec provides the = no-change form (substitution.md:19), so ferro's retention is at least as spec-faithful (#851)."
-      }
+      "accepted_divergence": [
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "ferro projects the cis allele faithfully, retaining the explicit identity member: g.[7125del;7126=]; mutalyzer drops the c.275= no-change member and de-brackets to g.7125del. The cited 'redundant =' prohibition (alleles.md:18-19,:49) governs trans cross-spelling, not a single cis bracket; the spec provides the = no-change form (substitution.md:19), so ferro's retention is at least as spec-faithful (#851)."
+        },
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "ferro retains the explicit cis identity member (c.[274del;275=]); mutalyzer drops the no-change member and collapses to c.274del. alleles.md:18-19,:49 governs trans cross-spelling, not a single cis bracket; substitution.md:19 provides the = no-change form, so ferro's retention is at least as spec-faithful (#851). Reconciled with the genomic-axis divergence per #912 action 4 (was known_bug)."
+        }
+      ]
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -308,9 +308,9 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.[274;600]` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #487 |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | known_bug | — | #487 |
+| `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274del;275=]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(NM_003002.2):c.[274del;275=]` | normalized | known_bug | — | #487 |
+| `NG_012337.1(NM_003002.2):c.[274del;275=]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.pterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.qterdel` | normalized | spec_citation | — | — |
 | `NG_012337.1(NM_012459.2):c.-1_*1del` | normalized | known_bug | — | #487 |
@@ -348,6 +348,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 9 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 23 | 17 | 4 | 5 | 9 |
+| normalized | 25 | 15 | 4 | 5 | 9 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
Resolves #912 action 4. Part of #326.

The two `NG_012337.1(NM_003002.2):c.[274=;275del]` / `c.[274del;275=]` rows carried **contradictory classifications** across axes:

- `normalized`: `known_bug` — "ferro should drop the redundant `=` identity member" (→ `c.275del` / `c.274del`).
- `genomic`: `accepted_divergence` (policy-654) — "ferro's *retention* of the cis `=` member is spec-faithful; `alleles.md:18-19,:49` governs *trans* cross-spelling, not a single cis bracket; `substitution.md:19` provides the `=` no-change form (#851)."

#912 action 4 flagged exactly this ("pick one classification"). This PR reconciles them in ferro's favor — reclassifying the `normalized`-axis `known_bug` to `accepted_divergence` under the same `ferro-policy-654-explicit-identity-rendering`, so both axes agree ferro is spec-correct to retain the member.

## Validation

Pure `cases.json` annotation change (no code). Re-blessed against the prepared reference (`FERRO_MANIFEST`): `normalized` **187 pass / 25 divergence_accepted / 15 known_bug / 0 FAIL** (known_bug 17→15), no XPASS; `genomic` unchanged. `generate_conformance_summary --check` passes; 92 no-manifest mutalyzer tests green.

## Interlock

- These 2 rows are therefore **not #920 bugs** (ferro is spec-correct). #926 (#920) already excluded them for this reason; #924 re-points their (now-removed) `known_bug` to #920 — whichever merges after this rebases (the reclassify wins; drop the stale re-point).
- Touches `failure-patterns.md` (generated), shared with #919/#924/#926/#927 — resolve rebase conflicts by regenerating.
