### PR TITLE
fix(normalize): collapse overlapping cis del+ins allele members on the transcript axis (#920)

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -3,7 +3,7 @@
 //! See `docs/superpowers/specs/2026-04-30-merge-consecutive-allele-edits-design.md`.
 
 use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, Sequence};
-use crate::hgvs::interval::{GenomeInterval, Interval, UncertainBoundary};
+use crate::hgvs::interval::{Interval, UncertainBoundary};
 use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 use crate::hgvs::uncertainty::Mu;
 use crate::hgvs::variant::{
@@ -238,39 +238,47 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     if phase != AllelePhase::Cis || variants.len() < 2 {
         return variants;
     }
-    // The genomic (`g.`) and mitochondrial (`m.`) axes share one single-axis
-    // coordinate system (`Region::Genome`), so both flow through this collapse.
-    // Track which kind the group is so we rebuild the correct variant at the
-    // end; a mixed Genome+Mt group is refused (mirrors the accession check).
+    // The single-axis genomic (`g.`) / mitochondrial (`m.`) systems share
+    // `Region::Genome`; the transcript axes (`c.`, `n.`, `r.`) each have a
+    // positive body region (`Cds` / `Tx` / `Rna`). Track which kind the group
+    // is so we rebuild the correct variant at the end and translate window
+    // coordinates correctly; a mixed-kind group is refused (mirrors the
+    // accession check). Transcript members are collapsed only within the
+    // positive body (issue #920) — see the `region != body` refusal below.
     let kind = match &variants[0] {
         HgvsVariant::Genome(_) => CisKind::Genome,
         HgvsVariant::Mt(_) => CisKind::Mt,
+        HgvsVariant::Cds(_) => CisKind::Cds,
+        HgvsVariant::Tx(_) => CisKind::Tx,
+        HgvsVariant::Rna(_) => CisKind::Rna,
         _ => return variants,
     };
-    // Borrow the head's `(accession, loc_edit)` as the template once; the
-    // helper rejects any variant whose kind doesn't match `kind`.
-    let Some((template_accession, _)) = cis_genome_axis_parts(&variants[0], kind) else {
+    // The positive body region every member must lie in for this axis.
+    let body = body_region(kind);
+    // Borrow the head's accession as the template once; the helper rejects any
+    // variant whose kind doesn't match `kind`.
+    let Some((template_accession, _, _, _, _)) = cis_axis_parts(&variants[0], kind) else {
         return variants;
     };
     let template_accession = template_accession.clone();
 
     let mut edits: Vec<GEdit> = Vec::with_capacity(variants.len());
     for v in &variants {
-        let Some((accession, loc_edit)) = cis_genome_axis_parts(v, kind) else {
+        let Some((accession, region, s, e, edit)) = cis_axis_parts(v, kind) else {
             return variants;
         };
         if *accession != template_accession {
             return variants;
         }
-        let Some((_region, s, e)) = simple_genome_range(&loc_edit.location) else {
-            return variants;
-        };
-        if !loc_edit.edit.is_certain() {
+        // CDS-body-only scope (issue #920): every member must lie in the
+        // positive body region for the axis — `Cds` for `c.`, `Tx` for `n.`,
+        // `Rna` for `r.`, `Genome` for `g.`/`m.`. Any 5'UTR (`c.-N`), 3'UTR
+        // (`c.*N`), intronic-offset, upstream/downstream, or mixed-region
+        // member refuses the whole group (all-or-nothing, mirroring the other
+        // conservative refusals). For `g.`/`m.` this is always satisfied.
+        if region != body {
             return variants;
         }
-        let Some(edit) = loc_edit.edit.inner() else {
-            return variants;
-        };
         match edit {
             NaEdit::Insertion { sequence } => {
                 let Some(bases) = sequence.bases() else {
@@ -368,10 +376,40 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
         return variants;
     }
 
-    // Fetch the reference window [w_lo, w_hi] (1-based inclusive -> 0-based
-    // half-open). Bail on any provider miss or short read.
+    // Fetch the reference window [w_lo, w_hi] (1-based inclusive on the axis)
+    // as a 0-based half-open slice of the underlying sequence. Bail on any
+    // provider miss or short read.
+    //
+    // The window is expressed in the axis's own coordinates; the underlying
+    // sequence offset differs per axis:
+    //   * `g.`/`m.` and `n.` (`Tx`): the axis IS the fetched sequence, so a
+    //     1-based position `N` is sequence offset `N` (delta = 0).
+    //   * `c.` (`Cds`) and `r.` (`Rna`): the axis is CDS-relative, so a
+    //     1-based position `N` maps to transcript position `cds_start + N - 1`
+    //     (delta = `cds_start - 1`) — the same mapping `lookup_codon_middle_ref`
+    //     uses. Both regions have been restricted to the positive body above.
     let accession = template_accession.transcript_accession();
-    let Ok(ref_seq) = provider.get_sequence(&accession, (w_lo - 1) as u64, w_hi as u64) else {
+    let delta: i64 = match kind {
+        CisKind::Genome | CisKind::Mt | CisKind::Tx => 0,
+        CisKind::Cds | CisKind::Rna => {
+            let Ok(tx) = provider.get_transcript(&accession) else {
+                return variants;
+            };
+            let Some(cds_start) = tx.cds_start else {
+                return variants;
+            };
+            let Ok(cds_start) = i64::try_from(cds_start) else {
+                return variants;
+            };
+            cds_start - 1
+        }
+    };
+    let start0 = w_lo + delta - 1;
+    let end0 = w_hi + delta;
+    if start0 < 0 {
+        return variants;
+    }
+    let Ok(ref_seq) = provider.get_sequence(&accession, start0 as u64, end0 as u64) else {
         return variants;
     };
     let ref_bytes = ref_seq.as_bytes();
@@ -450,47 +488,96 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
         (del_start, w_lo + hi_ref as i64 - 1)
     };
     let anchor = Anchor {
-        region: Region::Genome,
+        region: body,
         start: a_start,
         end: a_end,
         alt: alt_bases,
     };
-    // Rebuild the variant kind the group came in as. Both `g.` and `m.` use
-    // the same single-axis `Region::Genome` anchor; the head carries the
-    // accession / gene symbol to seed the merged variant. `kind` was derived
-    // from `variants[0]` and every member passed `cis_genome_axis_parts(_,
-    // kind)`, so the head necessarily matches `kind` here.
+    // Rebuild the variant kind the group came in as. `g.`/`m.` use the
+    // single-axis `Region::Genome` anchor; `c.`/`n.`/`r.` use the positive
+    // body region threaded into `anchor` so the builder reconstructs the
+    // right position shape. The head carries the accession / gene symbol to
+    // seed the merged variant. `kind` was derived from `variants[0]` and
+    // every member passed `cis_axis_parts(_, kind)`, so the head necessarily
+    // matches `kind` here.
     match (kind, &variants[0]) {
         (CisKind::Genome, HgvsVariant::Genome(g)) => {
             vec![HgvsVariant::Genome(build_genome_merged(g, anchor))]
         }
         (CisKind::Mt, HgvsVariant::Mt(m)) => vec![HgvsVariant::Mt(build_mt_merged(m, anchor))],
+        (CisKind::Cds, HgvsVariant::Cds(c)) => vec![HgvsVariant::Cds(build_cds_merged(c, anchor))],
+        (CisKind::Tx, HgvsVariant::Tx(t)) => vec![HgvsVariant::Tx(build_tx_merged(t, anchor))],
+        (CisKind::Rna, HgvsVariant::Rna(r)) => vec![HgvsVariant::Rna(build_rna_merged(r, anchor))],
         _ => variants,
     }
 }
 
-/// Which single-axis variant kind a cis-collapse group is. `g.` and `m.`
-/// share `Region::Genome` and the same `GenomeInterval`/`NaEdit` machinery,
-/// so the collapse handles both — but they must rebuild to distinct variant
-/// kinds, and a group mixing the two is refused.
+/// Which variant kind a cis-collapse group is. `g.` and `m.` share
+/// `Region::Genome` and the same `GenomeInterval`/`NaEdit` machinery; the
+/// transcript kinds (`c.`/`n.`/`r.`) each collapse within their positive body
+/// region (issue #920). Every kind rebuilds to a distinct variant kind, and a
+/// mixed-kind group is refused.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum CisKind {
     Genome,
     Mt,
+    Cds,
+    Tx,
+    Rna,
 }
 
-/// Borrow the `(accession, loc_edit)` of a `g.`/`m.` variant, but only when
-/// its kind matches `kind`. Returns `None` for any other variant kind (or a
-/// kind mismatch), which the caller treats as "decline to collapse".
-fn cis_genome_axis_parts(
+/// The positive body region a cis-collapse group of this kind must lie in.
+/// The collapse only ever operates within this single region — 5'UTR / 3'UTR
+/// / intronic-offset / upstream / downstream members are refused (issue #920).
+fn body_region(kind: CisKind) -> Region {
+    match kind {
+        CisKind::Genome | CisKind::Mt => Region::Genome,
+        CisKind::Cds => Region::Cds,
+        CisKind::Tx => Region::Tx,
+        CisKind::Rna => Region::Rna,
+    }
+}
+
+/// Extract the `(accession, region, start, end, edit)` of a variant for the
+/// cis-collapse pass, but only when its kind matches `kind` and the edit is
+/// certain. The `(region, start, end)` are the location's *raw* endpoints on
+/// the axis (unlike `simple_range_for_variant`, which swaps insertion
+/// endpoints into anchor form); the collapse reads insertion gaps from the
+/// raw endpoints. Returns `None` for any other variant kind, a kind mismatch,
+/// a disqualifying position (offset / special / mixed-region), or an
+/// uncertain / non-`NaEdit` edit — the caller treats that as "decline to
+/// collapse".
+fn cis_axis_parts(
     v: &HgvsVariant,
     kind: CisKind,
-) -> Option<(&Accession, &LocEdit<GenomeInterval, NaEdit>)> {
-    match (kind, v) {
-        (CisKind::Genome, HgvsVariant::Genome(g)) => Some((&g.accession, &g.loc_edit)),
-        (CisKind::Mt, HgvsVariant::Mt(m)) => Some((&m.accession, &m.loc_edit)),
-        _ => None,
+) -> Option<(&Accession, Region, i64, i64, &NaEdit)> {
+    let (accession, region, s, e, edit) = match (kind, v) {
+        (CisKind::Genome, HgvsVariant::Genome(g)) => {
+            let (r, s, e) = simple_genome_range(&g.loc_edit.location)?;
+            (&g.accession, r, s, e, &g.loc_edit.edit)
+        }
+        (CisKind::Mt, HgvsVariant::Mt(m)) => {
+            let (r, s, e) = simple_genome_range(&m.loc_edit.location)?;
+            (&m.accession, r, s, e, &m.loc_edit.edit)
+        }
+        (CisKind::Cds, HgvsVariant::Cds(c)) => {
+            let (r, s, e) = simple_cds_range(&c.loc_edit.location)?;
+            (&c.accession, r, s, e, &c.loc_edit.edit)
+        }
+        (CisKind::Tx, HgvsVariant::Tx(t)) => {
+            let (r, s, e) = simple_tx_range(&t.loc_edit.location)?;
+            (&t.accession, r, s, e, &t.loc_edit.edit)
+        }
+        (CisKind::Rna, HgvsVariant::Rna(rv)) => {
+            let (r, s, e) = simple_rna_range(&rv.loc_edit.location)?;
+            (&rv.accession, r, s, e, &rv.loc_edit.edit)
+        }
+        _ => return None,
+    };
+    if !edit.is_certain() {
+        return None;
     }
+    Some((accession, region, s, e, edit.inner()?))
 }
 
 /// Replace `output.last()` with a freshly-built variant from `anchor`.

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3872,18 +3872,7 @@
       "infos": [
         "ISORTEDVARIANTS"
       ],
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 487,
-        "note": "ferro keeps the two-member allele ([9del;7_8insC]); mutalyzer collapses the delete+insert into the equivalent substitution c.8A>C. Allele->substitution collapse tracked in #487."
-      },
-      "accepted_divergence": {
-        "axis": "infos",
-        "policy": "ferro-policy-499-shuffle-applied-compound-allele",
-        "note": "Compound-allele per-member 3'-shift; ferro emits SHUFFLE_APPLIED, mutalyzer emits only the allele-level ISORTEDVARIANTS internal code. Both spec-defensible (#499, precedent #481).",
-        "cluster": "shuffle-applied-compound-allele-499"
-      }
+      "to_test": true
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -119,7 +119,6 @@ ferro emits a per-member SHUFFLE_APPLIED for a genuine 3' shift in a compound al
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
 | `NG_009299.1(NM_002474.3):c.[310del;295G>A]` | infos | accepted_divergence | — | — |
-| `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` | infos | accepted_divergence | — | — |
 | `NG_012337.1:g.[104_105insA;105_106insC;105del]` | infos | accepted_divergence | — | — |
 | `NG_012337.1:g.[105_106insC;105del;104_105insA]` | infos | accepted_divergence | — | — |
 | `NG_012337.1:g.[105del;104_105insA;105_106insC]` | infos | accepted_divergence | — | — |
@@ -319,7 +318,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_012459.2):c.15_16insTGGAAGGTGGCGAGCCT` | coding_protein_descriptions | accepted_divergence | — | — |
 | `NG_012337.1(NM_012459.2):c.15_16insTGGAAGGTGGCGAGCCT` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_012459.2):c.15_17dup` | coding_protein_descriptions | accepted_divergence | — | — |
-| `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` | normalized | known_bug | — | #487 |
 | `NG_012337.1:274` | normalized | accepted_divergence | — | — |
 | `NG_012337.1:g.4delins7_31` | normalized | accepted_divergence | — | — |
 | `NG_012337.1:g.4delins7_50` | normalized | accepted_divergence | — | — |
@@ -347,8 +345,8 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | coding_protein_descriptions | 27 | 0 | 0 | 0 | 0 |
 | errors | 17 | 0 | 0 | 0 | 0 |
 | genomic | 22 | 4 | 0 | 0 | 1 |
-| infos | 9 | 0 | 0 | 0 | 1 |
+| infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 25 | 10 | 4 | 5 | 11 |
+| normalized | 25 | 9 | 4 | 5 | 11 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |

--- a/tests/it/issue_920_allele_sub_collapse.rs
+++ b/tests/it/issue_920_allele_sub_collapse.rs
@@ -1,0 +1,83 @@
+//! Issue #920: collapse an overlapping cis del+ins on the transcript axis
+//! into the equivalent substitution.
+//!
+//! `collapse_overlapping_cis_edits` already folds an overlapping del+ins cis
+//! group into a single `delins` on the genomic (`g.`/`m.`) axis, and a
+//! single-base `delins` reduces to a substitution downstream. Before #920 the
+//! pass bailed for any non-`Genome`/`Mt` variant, so a transcript-axis group
+//! like `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` was left as a two-member
+//! allele instead of collapsing to `c.8A>C`.
+//!
+//! #920 generalizes the collapse to the transcript axes (`c.`/`n.`/`r.`),
+//! scoped to the **positive body** only (`Cds` for `c.`, `Tx` for `n.`,
+//! `Rna` for `r.`). Members in the 5'UTR (`c.-N`), 3'UTR (`c.*N`), an
+//! intronic offset, upstream/downstream, or a mixed-region group refuse the
+//! whole collapse (all-or-nothing), leaving the allele unchanged.
+//!
+//! The collapse operates purely in transcript coordinates (it fetches the
+//! transcript sequence directly), so it is strand-agnostic; the minus-strand
+//! case below exercises that.
+
+use crate::common::synthetic::{normalize_to_string, SyntheticBuilder};
+use ferro_hgvs::reference::transcript::Strand;
+
+/// Plus-strand coding transcript with a non-trivial `cds_start` (= 4), so the
+/// collapse's CDS→transcript coordinate translation (delta = `cds_start - 1`)
+/// is genuinely exercised rather than an identity map.
+///
+/// Layout of `core = "TTTGGGGGGGACTTTTT"` (1-based transcript pos → base):
+///   pos 1..3   = 5'UTR (`c.-3`,`c.-2`,`c.-1`)
+///   pos 4..12  = CDS (`c.1`..`c.9`) = `GGGGGGGAC`, so `c.7 = G`, `c.8 = A`
+///   pos 13..17 = 3'UTR
+///
+/// `c.[8del;7_8insC]`: delete `c.8` (A) and insert `C` between `c.7`/`c.8`.
+/// Over the window `c.7..c.8` the variant is `G C` vs reference `G A`, so the
+/// net edit is `c.8delinsC`, which reduces to the substitution `c.8A>C`.
+#[test]
+fn cds_body_overlapping_del_ins_collapses_to_sub_plus_strand() {
+    let p = SyntheticBuilder::cds("TTTGGGGGGGACTTTTT", 4, 12, Strand::Plus).build();
+    let result = normalize_to_string(p, "NM_TEST.1:c.[8del;7_8insC]");
+    assert_eq!(result, "NM_TEST.1:c.8A>C");
+}
+
+/// Same collapse on a minus-strand transcript. The collapse works in
+/// transcript (CDS-relative) coordinates, so strand does not change the ref
+/// base read at `c.8`. `cds_start = 1` here (delta = 0).
+///
+/// `core = "GGGGGGGACGGGGGGG"`: `c.7 = G`, `c.8 = A`. `c.[8del;7_8insC]`
+/// collapses to `c.8A>C`.
+#[test]
+fn cds_body_overlapping_del_ins_collapses_to_sub_minus_strand() {
+    let p = SyntheticBuilder::cds("GGGGGGGACGGGGGGG", 1, 16, Strand::Minus).build();
+    let result = normalize_to_string(p, "NM_TEST.1:c.[8del;7_8insC]");
+    assert_eq!(result, "NM_TEST.1:c.8A>C");
+}
+
+/// The same collapse on the non-coding transcript (`n.`) axis, whose body is
+/// `Region::Tx` and whose coordinate is the transcript sequence directly
+/// (delta = 0). `core = "GGGGGGGACGGGGGGG"`: `n.7 = G`, `n.8 = A`.
+#[test]
+fn tx_body_overlapping_del_ins_collapses_to_sub() {
+    let p = SyntheticBuilder::noncoding("GGGGGGGACGGGGGGG", Strand::Plus).build();
+    let result = normalize_to_string(p, "NR_TEST.1:n.[8del;7_8insC]");
+    assert_eq!(result, "NR_TEST.1:n.8A>C");
+}
+
+/// Refusal: a group containing a 3'UTR (`c.*N`) member is outside the positive
+/// CDS body, so the whole collapse is refused (all-or-nothing) and the allele
+/// is left as its separate members rather than collapsing to a substitution.
+///
+/// `core = "GGGGGGGACGCC"`, `cds_start = 1`, `cds_end = 9`: `c.1..c.9` are the
+/// CDS body and `c.*1` is the first 3'UTR base. `c.[7_8insC;*1del]` mixes a
+/// CDS-body insertion with a 3'UTR deletion — no collapse.
+#[test]
+fn utr_member_refuses_collapse() {
+    let p = SyntheticBuilder::cds("GGGGGGGACGCC", 1, 9, Strand::Plus).build();
+    let result = normalize_to_string(p, "NM_TEST.1:c.[7_8insC;*1del]");
+    // The allele must be returned unchanged — the 3'UTR member forces the
+    // whole collapse to be refused (all-or-nothing), so both members survive
+    // verbatim rather than collapsing to a single substitution. Pin the exact
+    // string so a regression that reorders, drops, or partially collapses a
+    // member is caught (not just the presence of a `;`).
+    assert_eq!(result, "NM_TEST.1:c.[7_8insC;*1del]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -197,6 +197,7 @@ mod issue_867_project_to_genomic_normalized;
 mod issue_868_genomic_nc_units;
 mod issue_879_ng_g_to_c_overlap;
 mod issue_91_protein_three_prime_shift;
+mod issue_920_allele_sub_collapse;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;
 mod issue_97_utr_del_position;


### PR DESCRIPTION
Addresses the allele→substitution collapse row of #920. Part of #326.

`collapse_overlapping_cis_edits` already collapses an overlapping cis del+ins group into a delins (which reduces to a substitution downstream) — but only on the genomic/mitochondrial axis; it bailed on any `c.`/`n.`/`r.` variant. So `NG_012337.1(NM_012459.2):c.[8del;7_8insC]` stayed a two-member allele instead of collapsing to `c.8A>C`.

## Change

Generalize the collapse to the transcript axes (`Cds`/`Tx`/`Rna`), **scoped to the positive CDS/Tx/Rna body**:
- extend `CisKind` + the head-kind match to admit `Cds`/`Tx`/`Rna`;
- replace the `GenomeInterval`-typed `cis_genome_axis_parts` with an axis-generic `cis_axis_parts` that reuses the existing `simple_{cds,tx,rna}_range` for raw endpoints;
- translate the reference-window fetch from the CDS-relative axis to a transcript offset via `cds_start` (`delta = cds_start-1` for `c.`/`r.`; `0` for `g.`/`m.`/`n.` where the axis *is* the sequence);
- thread the real `Region` into the `Anchor`, and dispatch the rebuild to the existing `build_{cds,tx,rna}_merged`.

**All-or-nothing scope:** every member must lie in the positive body region; any 5'UTR (`c.-N`), 3'UTR (`c.*N`), intronic-offset, upstream/downstream, or mixed-region member refuses the whole group — mirroring the existing conservative refusals. The collapsed delins flows through the already-proven `delins`→substitution reduction, so there's no downstream change.

## Validation

- New MockProvider integration tests (`tests/it/issue_920_allele_sub_collapse.rs`): plus- and minus-strand CDS-body collapse → sub, `n.` Tx-body collapse → sub, and a 3'UTR-member refusal. Existing `issue_487_allele_collapse` + `merge` tests (73) still pass.
- fmt + clippy clean.
- Re-blessed against the prepared reference (`FERRO_MANIFEST`): **normalized 188 pass / 0 FAIL, no XPASS**; **genomic 0 FAIL**. Demotes the now-passing `c.[8del;7_8insC]` row (removes its normalized `known_bug` and its now-dormant `infos` policy-499 `accepted_divergence` — the collapsed single substitution no longer emits a per-member `SHUFFLE_APPLIED`, so it buckets via `INFO_NO_SPEC_EQUIVALENT`). The 2 pre-existing `infos` FAILs are the #908 rows (fixed by #919), unrelated.

## Notes
- ⚠️ Commit is **unsigned** (1Password unavailable this session) — flagged for re-signing (`git commit -S --amend --no-edit && git push --force-with-lease`).
- Touches `cases.json` + the generated `failure-patterns.md` — resolve any rebase conflict vs #919/#924/#926/#927/#928 by regenerating the summary.
