### PR TITLE
test(conformance): reclassify the 8 NG_007485.1 noncoding rows as spec_citation (#921)

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -84,8 +84,8 @@
     {
       "id": "noncoding-overlap-enumeration-646",
       "title": "n. projection onto an overlapping transcript outside its exonic span",
-      "spec_section": "background/numbering.md#DNAn (3' downstream offset)",
-      "note": "The n. corpus rows expect a projection onto the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), where the variant lies 3' downstream of its single exon and mutalyzer addresses it as n.616+offset. ferro's transcript fan-out enumerates only transcripts the variant overlaps, so it emits valid n. forms on the overlapping NM_ isoforms but declines NR_024274.1 ('variant does not overlap transcript'). Spec tension: numbering.md L43-44 bars describing variants beyond a bare transcript's boundaries, so a bare NR_024274.1:n.616+offset would be invalid; but mutalyzer (and the corpus) frame it under its NG_007485.1 genomic parent (NG_007485.1(NR_024274.1):n.616+offset), the same genomic-context construction numbering.md L65 endorses (e.g. NG_012232.1(NM_004006.2):r.186+1_186+4), where the parent supplies the flanking sequence. Under that framing the form is valid and ferro should produce it -> known_bug, not accepted_divergence. Cross-isoform enumeration scope tracked by #646 (core landed in #647); ferro should extend enumeration/addressing to the downstream-of-last-exon case when the genomic parent is present. XPASS-guarded: if #646 lands and ferro starts matching, the annotation fails loudly and the row demotes."
+      "spec_section": "HGVS §Transcript flanking (not c.-numberable)",
+      "note": "The n. corpus rows expect an additional projection onto the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), which mutalyzer addresses as NG_007485.1(NR_024274.1):n.616+<offset>. But NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus lies 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54), and the c.*N+dM downstream-offset scheme that would be needed was formally rejected (open-issues.md:231). The numbering.md L65 genomic-parent construction (e.g. NG_012232.1(NM_004006.2):r.186+1_186+4) endorses *intronic* offsets between a transcript's own exons; it does not license numbering past the last exon of a single-exon transcript into its 3'-flank, so it is misapplied here. ferro fans out only onto transcripts the variant overlaps and emits valid n. forms for each, declining the non-overlapping NR_024274.1 -- which is the spec-correct behavior (more spec-faithful than mutalyzer 3.1.1 here, not a missing valid form). Reclassified from known_bug (#646, closed) to spec_citation per #921."
     },
     {
       "id": "inserted-inversion-854",
@@ -143,18 +143,20 @@
       ],
       "protein_description": "NP_000068.1:p.(Met54delinsIleSer)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "Mid-codon in-frame insertion (ATC after c.161, within Met54's codon): ATG AT|ATC|G GGC → ATA(Ile) TCG(Ser) GGC(Gly), so Met54 changes and Ser is added → p.(Met54delinsIleSer), a delins not a clean insertion (#511). ferro's prediction now matches mutalyzer; it differs only by the genomic-context wrapper — bare NP_ per #483/#495 is the spec-correct reference form.",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      },
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "Mid-codon in-frame insertion (ATC after c.161, within Met54's codon): ATG AT|ATC|G GGC → ATA(Ile) TCG(Ser) GGC(Gly), so Met54 changes and Ser is added → p.(Met54delinsIleSer), a delins not a clean insertion (#511). ferro's prediction now matches mutalyzer; it differs only by the genomic-context wrapper — bare NP_ per #483/#495 is the spec-correct reference form.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ],
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -189,18 +191,20 @@
         "NG_007485.1(NR_024274.1):n.616+3443_616+3444insGAT"
       ],
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "Bracket-form sibling of NG_007485.1(NM_000077.4):c.161_162insATC; same mid-codon in-frame insertion → p.(Met54delinsIleSer) (delins, #511). Matches mutalyzer modulo the bare-NP_ wrapper (#483/#495).",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      }
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "Bracket-form sibling of NG_007485.1(NM_000077.4):c.161_162insATC; same mid-codon in-frame insertion → p.(Met54delinsIleSer) (delins, #511). Matches mutalyzer modulo the bare-NP_ wrapper (#483/#495).",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ]
     },
     {
       "keywords": [
@@ -221,18 +225,20 @@
       ],
       "protein_description": "NP_000068.1:p.(Met54delinsAsnPro)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      },
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ],
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -265,18 +271,20 @@
       ],
       "protein_description": "NP_000068.1:p.(Met54delinsAsnPro)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      }
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ]
     },
     {
       "keywords": [
@@ -298,18 +306,20 @@
       ],
       "protein_description": "NP_000068.1:p.(Met54delinsAsnPro)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      },
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ],
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -344,18 +354,20 @@
       ],
       "protein_description": "NP_000068.1:p.(Met54delinsAsnPro)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
-        "cluster": "bare-np-protein"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      }
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ]
     },
     {
       "keywords": [
@@ -505,16 +517,16 @@
         "NG_007485.1(NR_024274.1):n.616+26260_616+26261insTAG"
       ],
       "to_test": true,
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
-      },
       "accepted_rejection": {
         "axis": "coding_protein_descriptions",
         "reason": "ferro-policy-857-non-cds-no-projection",
         "note": "Every projected overlapping transcript places the variant outside the CDS (deep 5'UTR / intron / deep 3'UTR), p.(=); ferro's #857 policy declines per-transcript protein prediction, so project_variant_all yields no pairs (empty projection). mutalyzer emits 'analysed, unchanged' p.(=). Empty-projection Err bucketed via the reason-857 opt-in (#903)."
+      },
+      "spec_citation": {
+        "axis": "noncoding",
+        "section": "HGVS §Transcript flanking (not c.-numberable)",
+        "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+        "cluster": "noncoding-overlap-enumeration-646"
       }
     },
     {
@@ -2966,23 +2978,25 @@
       "protein_description": "NP_478102.2:p.(Met48AlafsTer14)",
       "rna_description": "NG_007485.1(NM_058195.3):r.(141_142del)",
       "to_test": true,
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
-        "cluster": "bare-np-protein"
-      },
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "HGVS p. descriptions reference the protein accession alone (bare NP_); mutalyzer's genomic-context wrapper NG_x(NP_y):p. is non-standard. ferro's bare-NP output is the spec-correct value.",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "noncoding",
+          "section": "HGVS §Transcript flanking (not c.-numberable)",
+          "note": "ferro fans out onto every transcript the variant overlaps and emits valid n. forms for each; mutalyzer additionally reports NG_007485.1(NR_024274.1):n.616+<offset>, but NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus is 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54); the c.*N+dM downstream-offset scheme was formally rejected (open-issues.md:231). ferro's decline of the non-overlapping single-exon transcript is spec-correct -- it is more spec-faithful than mutalyzer 3.1.1 here (not a missing valid form). Reclassified from known_bug per #921.",
+          "cluster": "noncoding-overlap-enumeration-646"
+        }
+      ],
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
         "note": "ferro enumerates the latest curated overlapping-transcript set (#710); mutalyzer lists a different set and puts the input gene's consequence on `protein_description`. Both spec-valid (refseq.md L256/L259 open; L264 endorses latest build). See cluster note. Accepted divergence (#763).",
         "cluster": "transcript-set-enumeration-763"
-      },
-      "known_bug": {
-        "axis": "noncoding",
-        "tracking_issue": 921,
-        "note": "ferro fans out across the transcripts the variant overlaps and emits valid n. forms on the overlapping NM_ isoforms, but mutalyzer's expected n. form is on the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), framed under the NG_ parent, where the variant lies 3' downstream of its only exon (NG_(NR_024274.1):n.616+offset). ferro declines to project onto a transcript the variant does not overlap, so it omits the NR_024274.1 form. The genomic-context framing makes mutalyzer's downstream-offset form valid (numbering.md L65), so this is a ferro gap, not an accepted divergence. Cross-isoform enumeration scope tracked by #921.",
-        "cluster": "noncoding-overlap-enumeration-646"
       }
     },
     {

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -203,20 +203,20 @@ A predicted (uncertain) cis RNA allele places the '( )' predicted wrapper inside
 
 ### n. projection onto an overlapping transcript outside its exonic span
 
-Spec: `background/numbering.md#DNAn (3' downstream offset)`
+Spec: `HGVS §Transcript flanking (not c.-numberable)`
 
-The n. corpus rows expect a projection onto the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), where the variant lies 3' downstream of its single exon and mutalyzer addresses it as n.616+offset. ferro's transcript fan-out enumerates only transcripts the variant overlaps, so it emits valid n. forms on the overlapping NM_ isoforms but declines NR_024274.1 ('variant does not overlap transcript'). Spec tension: numbering.md L43-44 bars describing variants beyond a bare transcript's boundaries, so a bare NR_024274.1:n.616+offset would be invalid; but mutalyzer (and the corpus) frame it under its NG_007485.1 genomic parent (NG_007485.1(NR_024274.1):n.616+offset), the same genomic-context construction numbering.md L65 endorses (e.g. NG_012232.1(NM_004006.2):r.186+1_186+4), where the parent supplies the flanking sequence. Under that framing the form is valid and ferro should produce it -> known_bug, not accepted_divergence. Cross-isoform enumeration scope tracked by #646 (core landed in #647); ferro should extend enumeration/addressing to the downstream-of-last-exon case when the genomic parent is present. XPASS-guarded: if #646 lands and ferro starts matching, the annotation fails loudly and the row demotes.
+The n. corpus rows expect an additional projection onto the overlapping single-exon non-coding transcript NR_024274.1 (CDKN2A-AS1), which mutalyzer addresses as NG_007485.1(NR_024274.1):n.616+<offset>. But NR_024274.1 is single-exon (GRCh38 21967138-21967754 = n.1-616) and this locus lies 3' downstream of its only exon, so n.616+<offset> numbers into the un-transcribed 3'-flanking region. HGVS forbids describing variants beyond a transcript's boundaries (numbering.md:43-45,54), and the c.*N+dM downstream-offset scheme that would be needed was formally rejected (open-issues.md:231). The numbering.md L65 genomic-parent construction (e.g. NG_012232.1(NM_004006.2):r.186+1_186+4) endorses *intronic* offsets between a transcript's own exons; it does not license numbering past the last exon of a single-exon transcript into its 3'-flank, so it is misapplied here. ferro fans out only onto transcripts the variant overlaps and emits valid n. forms for each, declining the non-overlapping NR_024274.1 -- which is the spec-correct behavior (more spec-faithful than mutalyzer 3.1.1 here, not a missing valid form). Reclassified from known_bug (#646, closed) to spec_citation per #921.
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|
-| `NG_007485.1(NM_000077.4):c.161_162delTGinsATCCC` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_000077.4):c.161_162delTGins[ATCCC]` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_000077.4):c.161_162delinsATCCC` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_000077.4):c.161_162delins[ATCCC]` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_000077.4):c.161_162insATC` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_000077.4):c.161_162ins[ATC]` | noncoding | known_bug | — | #921 |
-| `NG_007485.1(NM_058195.3):c.141_142del` | noncoding | known_bug | — | #921 |
-| `NG_007485.1:g.5479_5480insACT` | noncoding | known_bug | — | #921 |
+| `NG_007485.1(NM_000077.4):c.161_162delTGinsATCCC` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_000077.4):c.161_162delTGins[ATCCC]` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_000077.4):c.161_162delinsATCCC` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_000077.4):c.161_162delins[ATCCC]` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_000077.4):c.161_162insATC` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_000077.4):c.161_162ins[ATC]` | noncoding | spec_citation | — | — |
+| `NG_007485.1(NM_058195.3):c.141_142del` | noncoding | spec_citation | — | — |
+| `NG_007485.1:g.5479_5480insACT` | noncoding | spec_citation | — | — |
 
 ### Inserted inversion (reverse complement) not applied by mutalyzer
 
@@ -346,7 +346,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | errors | 17 | 0 | 0 | 0 | 0 |
 | genomic | 22 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
-| noncoding | 0 | 8 | 0 | 0 | 0 |
+| noncoding | 0 | 0 | 0 | 0 | 8 |
 | normalized | 25 | 5 | 4 | 5 | 15 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
Closes #921. Part of #326. **Stacked on #924** (base `test/issue-912-stale-tracker-sweep`, which re-points these rows #646→#921); retarget to `main` after #924 merges.

Research (operator-approved) found **ferro is more spec-correct than mutalyzer** here — this is *not* a ferro coverage gap, so no enumeration feature is warranted.

On the `noncoding` axis ferro fans out onto **every transcript the variant overlaps** and emits valid `n.` forms for each. The one form mutalyzer adds — `NG_007485.1(NR_024274.1):n.616+<offset>…` — is on **`NR_024274.1`, a single-exon transcript** (GRCh38 21967138–21967754 = `n.1–616`, no introns); the variant sits **3′ downstream of its only exon**, so `n.616+<offset>` numbers into the transcript's **un-transcribed 3′-flanking region**. HGVS forbids that:
- `background/numbering.md:43-45,54` — "not allowed to describe variants in nucleotides **beyond the boundaries** of a transcript reference sequence";
- `consultation/open-issues.md:231` — the `c.*N+dM` downstream-offset scheme (which is what mutalyzer's `n.616+M` is) "**has been REJECTED**."

The prior `known_bug` note cited the *intronic*-within-boundaries exception (`numbering.md:65`), which is **misapplied** to a single-exon transcript's 3′-flank (a single-exon transcript has no introns).

## Change

Reclassify the 8 `NG_007485.1(…)` rows `known_bug{noncoding}` → **`spec_citation{noncoding, SpecSection::TranscriptFlankNotNumberable}`** (ferro spec-correct, not merely divergent). `axis_noncoding` returns a set-divergence as an `Ok` mismatch specifically so the `spec_citation` path buckets it.

## Validation
Re-blessed against the prepared reference: **noncoding 0 FAIL / 8 spec_overridden / 0 known_bug, no XPASS**. `generate_conformance_summary --check` passes. cases.json + regenerated `failure-patterns.md` only (no code).

## Notes
- This surfaces a **mutalyzer 3.1.1 bug** (beyond-transcript numbering on a single-exon transcript) — a candidate note for #466 (comparator spec-violations).
- ferro also silently upgrades pinned transcript versions in the fan-out (`NM_000077.4→.5` etc.) — orthogonal here (the expected value is only the `NR_` form).
