### PR TITLE
test(conformance): reclassify NM_017668.3 cross-junction rows as spec_citation (#918)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -1100,6 +1100,18 @@ pub enum SpecSection {
     /// the spec-preferred predicted-consequence value (#861).
     #[serde(rename = "HGVS §Synonymous (residue-level p.(Xaa=))")]
     SynonymousResidueLevel,
+    /// HGVS 3'-rule exon/exon-junction exception (`general.md` 3'-rule
+    /// exception; `background/numbering.md#DNAc`): the 3' rule is NOT applied
+    /// when a deletion/duplication around an exon/exon junction would shift the
+    /// variant into the next exon (projecting back to `g.` would then land in
+    /// the wrong exon). ferro correctly keeps the within-exon most-3' form and
+    /// does not shift across the junction. Here mutalyzer's cross-junction
+    /// `c.*<M>` form (`NM_017668.3:c.250del` → `c.*189del` spans ~947 bases
+    /// across 8 exon junctions) both violates that exception and is an artifact
+    /// of the truncated reverse-strand `NG_009299.1` partial embedding — ferro's
+    /// within-exon value is the spec-correct one (#918).
+    #[serde(rename = "HGVS §3'-rule (exon/exon-junction exception)")]
+    ThreePrimeRuleExonJunction,
 }
 
 impl SpecSection {
@@ -1126,6 +1138,9 @@ impl SpecSection {
             }
             SpecSection::InsertedInversion => "HGVS §Inserted inversion (reverse complement)",
             SpecSection::SynonymousResidueLevel => "HGVS §Synonymous (residue-level p.(Xaa=))",
+            SpecSection::ThreePrimeRuleExonJunction => {
+                "HGVS §3'-rule (exon/exon-junction exception)"
+            }
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3421,7 +3421,7 @@
       "known_bug": {
         "axis": "normalized",
         "tracking_issue": 918,
-        "note": "ferro echoes the input c.-1_*1del; mutalyzer 3'-shifts the deletion across the CDS boundary to c.1_*2del. 3' shift tracked in #918."
+        "note": "ferro echoes c.-1_*1del; the most-3' form is c.1_*2del (verified: seq[c.-1]==seq[c.*2]==C on NM_012459.2, so the whole-CDS-spanning deletion shifts right by one). ferro currently BAILS via CrossAxisVariantNotShuffled because both endpoints sit in the UTR spanning the entire CDS -- a cross-axis whole-CDS deletion. The #918 (a) fix relaxes the clamp only for both-endpoints-CDS del/dup; this cross-axis case needs the broader CrossAxisVariantNotShuffled relaxation (follow-up). Genuine ferro bug (not an artifact)."
       },
       "accepted_divergence": {
         "axis": "protein_description",
@@ -3452,22 +3452,24 @@
       ],
       "protein_description": "NG_009299.1(NP_060138.1):p.?",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 918,
-        "note": "ferro keeps c.250del; mutalyzer 3'-shifts it to c.*189del. Compound-allele 3' shift tracked in #918."
-      },
       "accepted_rejection": {
         "axis": "genomic",
         "reason": "ferro-policy-853-ng-partial-transcript-coverage-declined",
         "note": "NG_009299.1 annotates NM_017668.3 only partially, so the c.41 endpoint falls outside the placed genomic span; the user-facing genomic axis (#870) declines to re-anchor (#480/#655) rather than emit chromosome coordinates under the NG_ accession. mutalyzer resolves the full genomic form."
       },
-      "spec_citation": {
-        "axis": "protein_description",
-        "section": "HGVS protein reference (bare NP)",
-        "note": "An in-cis allele mixing a sense change with a downstream frameshift has no combined spec form, so its protein consequence collapses to p.? ('an effect is expected but cannot be reliably predicted', uncertain.md) — the spec-correct body (#855), matching mutalyzer's p.?. The remaining divergence is framing only: ferro emits the bare NP_ reference, mutalyzer wraps it as NG_x(NP_y):p. — ferro's bare-NP form is the spec-correct value (#483/#495).",
-        "cluster": "bare-np-protein"
-      },
+      "spec_citation": [
+        {
+          "axis": "protein_description",
+          "section": "HGVS protein reference (bare NP)",
+          "note": "An in-cis allele mixing a sense change with a downstream frameshift has no combined spec form, so its protein consequence collapses to p.? ('an effect is expected but cannot be reliably predicted', uncertain.md) — the spec-correct body (#855), matching mutalyzer's p.?. The remaining divergence is framing only: ferro emits the bare NP_ reference, mutalyzer wraps it as NG_x(NP_y):p. — ferro's bare-NP form is the spec-correct value (#483/#495).",
+          "cluster": "bare-np-protein"
+        },
+        {
+          "axis": "normalized",
+          "section": "HGVS §3'-rule (exon/exon-junction exception)",
+          "note": "ferro keeps the within-exon most-3' form (c.250del is already most-3' in a GG dinucleotide); mutalyzer's c.*189del spans ~947 bases across 8 exon junctions, which the HGVS 3'-rule exon/exon-junction exception forbids (general.md 3'-rule exception; numbering.md#DNAc), and additionally arises from the truncated reverse-strand NG_009299.1 partial embedding. ferro's value is spec-correct (#918)."
+        }
+      ],
       "accepted_divergence": {
         "axis": "coding_protein_descriptions",
         "policy": "ferro-policy-763-transcript-set-enumeration",
@@ -3486,10 +3488,10 @@
         "ISORTEDVARIANTS"
       ],
       "to_test": true,
-      "known_bug": {
+      "spec_citation": {
         "axis": "normalized",
-        "tracking_issue": 918,
-        "note": "ferro keeps the c.250del member; mutalyzer 3'-shifts it across the allele to c.*189del (c.[41A>C;*189del]). Compound-allele 3' shift tracked in #918."
+        "section": "HGVS §3'-rule (exon/exon-junction exception)",
+        "note": "ferro keeps the within-exon most-3' form (c.250del is already most-3' in a GG dinucleotide); mutalyzer's c.*189del spans ~947 bases across 8 exon junctions, which the HGVS 3'-rule exon/exon-junction exception forbids (general.md 3'-rule exception; numbering.md#DNAc), and additionally arises from the truncated reverse-strand NG_009299.1 partial embedding. ferro's value is spec-correct (#918)."
       }
     },
     {

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -291,12 +291,12 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_009299.1(NM_017668.3):c.41A>C` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | infos | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | normalized | accepted_divergence | — | — |
-| `NG_009299.1(NM_017668.3):c.[250del;41A>C]` | normalized | known_bug | — | #918 |
+| `NG_009299.1(NM_017668.3):c.[250del;41A>C]` | normalized | spec_citation | — | — |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | infos | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41>CA;250del]` | normalized | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | genomic | accepted_divergence | — | — |
-| `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | normalized | known_bug | — | #918 |
+| `NG_009299.1(NM_017668.3):c.[41A>C;250del]` | normalized | spec_citation | — | — |
 | `NG_009930.1(NM_001099625.2):c.1010` | errors | accepted_divergence | — | — |
 | `NG_009930.1(NM_001099625.2):n.110del` | errors | accepted_divergence | — | — |
 | `NG_012337.1(10683):c.274G>T` | genomic | accepted_divergence | — | — |
@@ -348,6 +348,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 22 | 4 | 0 | 0 | 1 |
 | infos | 9 | 0 | 0 | 0 | 0 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 23 | 17 | 4 | 5 | 9 |
+| normalized | 23 | 15 | 4 | 5 | 11 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
Two conformance rows for the reverse-strand allele `NG_009299.1(NM_017668.3):c.[41A>C;250del]` (and its cis-swapped twin `c.[250del;41A>C]`) were annotated `known_bug{#918}` on the normalized axis, on the premise that ferro should 3'-shift `c.250del` to mutalyzer's `c.*189del`. That premise is wrong.

`c.*189del` sits ~947 bases downstream of `c.250`, spanning **8 exon/exon junctions**. The HGVS 3'-rule applies to the contiguous coding-DNA reference but explicitly does **not** shift a deletion/duplication across an exon/exon junction (general.md 3'-rule exception; `background/numbering.md#DNAc`) — shifting there would project back to the wrong exon in `g.`. On top of that, the `c.*189del` form is an artifact of the truncated reverse-strand `NG_009299.1` partial embedding of this transcript. `c.250del` is already most-3' within its exon (a `GG` dinucleotide), so ferro's value is the spec-correct one.

## Changes

- Add `SpecSection::ThreePrimeRuleExonJunction` (`"HGVS §3'-rule (exon/exon-junction exception)"`) citing the exception.
- Reclassify both rows' normalized-axis disposition `known_bug{#918}` → `spec_citation{ThreePrimeRuleExonJunction}`.
- Regenerate `failure-patterns.md` (normalized axis: `known_bug 17→15`, `spec_citation 9→11`).

## What this does *not* close

The genuine CDS↔UTR 3'-shift bug tracked by #918 — `NG_012337.1(NM_012459.2):c.-1_*1del` (ferro echoes the input; the most-3' form is `c.1_*2del`, verified `seq[c.-1]==seq[c.*2]==C` on `NM_012459.2`) — **remains** `known_bug{#918}`, so this PR intentionally does not `Closes #918`.

## Stacking

Stacked on #924 (`test/issue-912-stale-tracker-sweep`); retarget to `main` once #924 merges.

## Verification

- `axis_normalized` + `axis_normalized_idempotent`: 0 FAIL / 0 XPASS (against the prepared reference).
- `generate_conformance_summary -- --check` passes.
- `cargo fmt` + `cargo clippy --features dev --all-targets` clean.