### PR TITLE
test(conformance): reclassify copy-range delins rows as spec_citation (#922)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -1126,6 +1126,19 @@ pub enum SpecSection {
     /// within-exon value is the spec-correct one (#918).
     #[serde(rename = "HGVS §3'-rule (exon/exon-junction exception)")]
     ThreePrimeRuleExonJunction,
+    /// Copy-range delins/insertion coding-frame reference (`delins.md` L61;
+    /// `insertion.md` L36/L53/L56; `background/numbering.md`): when the inserted
+    /// sequence is given as a range of the reference (`c.<start>_<end>`), that
+    /// range is read in the SAME coordinate frame as the variant — here `c.`
+    /// (coding DNA), which is spliced and excludes introns (intronic positions
+    /// require `+`/`-` offset notation). So `c.180_188` copies 9 contiguous
+    /// spliced coding bases; a genomic copy would be written with a `g.` prefix
+    /// (`insertion.md` L49). ferro copies the spliced coding range
+    /// (`c.156_161delinsGCGAGGAAA`); mutalyzer expands it through the genomic
+    /// NG_ reference, pulling in intronic bases (`183+69`) and decomposing the
+    /// allele. ferro's coding-frame expansion is the spec-correct one (#922).
+    #[serde(rename = "HGVS §Copy-range delins (coding-frame reference)")]
+    CopyRangeCodingFrame,
 }
 
 impl SpecSection {
@@ -1155,6 +1168,7 @@ impl SpecSection {
             SpecSection::ThreePrimeRuleExonJunction => {
                 "HGVS §3'-rule (exon/exon-junction exception)"
             }
+            SpecSection::CopyRangeCodingFrame => "HGVS §Copy-range delins (coding-frame reference)",
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -1432,16 +1432,16 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins180_183+69;156_161inv;161_162ins183+76_188]",
       "genomic": "NG_008939.1:g.[5206_5207ins5231_5303;5207_5212inv;5212_5213ins5310_10536]",
       "to_test": true,
-      "known_bug": [
+      "spec_citation": [
         {
           "axis": "normalized",
-          "tracking_issue": 922,
-          "note": "ferro expands the c.180_188 copy range as transcript-contiguous bases; mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele with intronic offsets. Genomic-context copy-range expansion tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "ferro copies the c.180_188 range as 9 contiguous spliced coding bases (c.156_161delinsGCGAGGAAA; inv = its reverse-complement), the faithful reading of a c.-prefixed copy-range: c. coordinates are spliced coding DNA and exclude introns (numbering.md; intronic positions require +/- offsets), and the copy-range shares the variant's frame (delins.md L61 'from the same reference sequence'; insertion.md L36/L53/L56). mutalyzer expands c.180_188 through the genomic NG_ reference, pulling in intronic bases (183+69) and decomposing the allele. ferro's coding-frame expansion is spec-correct (#922)."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 922,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the c.180_188 copy range as transcript-contiguous spliced bases (g.5207_5212delinsGCGAGGAAA); mutalyzer expands it through the genomic reference (whose introns split the range), yielding a decomposed allele. Genomic-context copy-range expansion tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "Same divergence on the user-facing project_variant().genomic path (#870): ferro projects the spliced coding-frame copy (g.5207_5212delinsGCGAGGAAA; inv = its reverse-complement); mutalyzer expands c.180_188 through the intron-containing genomic reference and decomposes the allele. A c.-prefixed copy-range denotes spliced coding bases (numbering.md; delins.md L61; insertion.md L36) — a genomic copy would carry a g. prefix (insertion.md L49). ferro is spec-correct (#922)."
         }
       ]
     },
@@ -1455,16 +1455,16 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins183+76_188inv;161_162ins180_183+69inv]",
       "genomic": "NG_008939.1:g.[5206_5207ins5310_10536inv;5212_5213ins5231_5303inv]",
       "to_test": true,
-      "known_bug": [
+      "spec_citation": [
         {
           "axis": "normalized",
-          "tracking_issue": 922,
-          "note": "inverted copy-range delins; ferro expands transcript-contiguous, mutalyzer through the genomic (intron-split) reference. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "ferro copies the c.180_188 range as 9 contiguous spliced coding bases (c.156_161delinsGCGAGGAAA; inv = its reverse-complement), the faithful reading of a c.-prefixed copy-range: c. coordinates are spliced coding DNA and exclude introns (numbering.md; intronic positions require +/- offsets), and the copy-range shares the variant's frame (delins.md L61 'from the same reference sequence'; insertion.md L36/L53/L56). mutalyzer expands c.180_188 through the genomic NG_ reference, pulling in intronic bases (183+69) and decomposing the allele. ferro's coding-frame expansion is spec-correct (#922)."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 922,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the inverted copy-range delins as transcript-contiguous bases (g.5207_5212delinsTTTCCTCGC); mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "Same divergence on the user-facing project_variant().genomic path (#870): ferro projects the spliced coding-frame copy (g.5207_5212delinsGCGAGGAAA; inv = its reverse-complement); mutalyzer expands c.180_188 through the intron-containing genomic reference and decomposes the allele. A c.-prefixed copy-range denotes spliced coding bases (numbering.md; delins.md L61; insertion.md L36) — a genomic copy would carry a g. prefix (insertion.md L49). ferro is spec-correct (#922)."
         }
       ]
     },
@@ -1479,16 +1479,16 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins180_183+69;156_161inv;161_162ins183+76_188]",
       "genomic": "NG_008939.1:g.[5206_5207ins5231_5303;5207_5212inv;5212_5213ins5310_10536]",
       "to_test": true,
-      "known_bug": [
+      "spec_citation": [
         {
           "axis": "normalized",
-          "tracking_issue": 922,
-          "note": "bracketed copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "ferro copies the c.180_188 range as 9 contiguous spliced coding bases (c.156_161delinsGCGAGGAAA; inv = its reverse-complement), the faithful reading of a c.-prefixed copy-range: c. coordinates are spliced coding DNA and exclude introns (numbering.md; intronic positions require +/- offsets), and the copy-range shares the variant's frame (delins.md L61 'from the same reference sequence'; insertion.md L36/L53/L56). mutalyzer expands c.180_188 through the genomic NG_ reference, pulling in intronic bases (183+69) and decomposing the allele. ferro's coding-frame expansion is spec-correct (#922)."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 922,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "Same divergence on the user-facing project_variant().genomic path (#870): ferro projects the spliced coding-frame copy (g.5207_5212delinsGCGAGGAAA; inv = its reverse-complement); mutalyzer expands c.180_188 through the intron-containing genomic reference and decomposes the allele. A c.-prefixed copy-range denotes spliced coding bases (numbering.md; delins.md L61; insertion.md L36) — a genomic copy would carry a g. prefix (insertion.md L49). ferro is spec-correct (#922)."
         }
       ]
     },
@@ -1503,16 +1503,16 @@
       "normalized": "NG_008939.1(NM_000532.5):c.[155_156ins183+76_188inv;161_162ins180_183+69inv]",
       "genomic": "NG_008939.1:g.[5206_5207ins5310_10536inv;5212_5213ins5231_5303inv]",
       "to_test": true,
-      "known_bug": [
+      "spec_citation": [
         {
           "axis": "normalized",
-          "tracking_issue": 922,
-          "note": "bracketed inverted copy-range delins; same transcript-vs-genomic expansion divergence. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "ferro copies the c.180_188 range as 9 contiguous spliced coding bases (c.156_161delinsGCGAGGAAA; inv = its reverse-complement), the faithful reading of a c.-prefixed copy-range: c. coordinates are spliced coding DNA and exclude introns (numbering.md; intronic positions require +/- offsets), and the copy-range shares the variant's frame (delins.md L61 'from the same reference sequence'; insertion.md L36/L53/L56). mutalyzer expands c.180_188 through the genomic NG_ reference, pulling in intronic bases (183+69) and decomposing the allele. ferro's coding-frame expansion is spec-correct (#922)."
         },
         {
           "axis": "genomic",
-          "tracking_issue": 922,
-          "note": "On the user-facing project_variant().genomic path (#870) ferro expands the bracketed inverted copy-range delins as transcript-contiguous bases; mutalyzer expands it through the genomic (intron-split) reference. Tracked in #922."
+          "section": "HGVS §Copy-range delins (coding-frame reference)",
+          "note": "Same divergence on the user-facing project_variant().genomic path (#870): ferro projects the spliced coding-frame copy (g.5207_5212delinsGCGAGGAAA; inv = its reverse-complement); mutalyzer expands c.180_188 through the intron-containing genomic reference and decomposes the allele. A c.-prefixed copy-range denotes spliced coding bases (numbering.md; delins.md L61; insertion.md L36) — a genomic copy would carry a g. prefix (insertion.md L49). ferro is spec-correct (#922)."
         }
       ]
     },

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -268,14 +268,14 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | genomic | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | normalized | accepted_divergence | — | — |
 | `NG_008939.1(PCCB_v001):c.156_157ins[180_188inv]` | protein_description | accepted_divergence | — | — |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | normalized | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | normalized | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | normalized | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | known_bug | — | #922 |
-| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | normalized | known_bug | — | #922 |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | genomic | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188` | normalized | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | genomic | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins180_188inv` | normalized | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | genomic | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188]` | normalized | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | genomic | spec_citation | — | — |
+| `NG_008939.1(PCCB_v001):c.156_161delins[180_188inv]` | normalized | spec_citation | — | — |
 | `NG_008939.1:c.155_157del3` | genomic | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157del3` | protein_description | accepted_divergence | — | — |
 | `NG_008939.1:c.155_157delAAC` | genomic | accepted_divergence | — | — |
@@ -344,9 +344,9 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 |---|---:|---:|---:|---:|---:|
 | coding_protein_descriptions | 27 | 0 | 0 | 0 | 0 |
 | errors | 17 | 0 | 0 | 0 | 0 |
-| genomic | 22 | 4 | 0 | 0 | 1 |
+| genomic | 22 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 8 | 0 | 0 | 0 |
-| normalized | 25 | 9 | 4 | 5 | 11 |
+| normalized | 25 | 5 | 4 | 5 | 15 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
The four `NG_008939.1(PCCB_v001):c.156_161delins180_188` copy-range delins rows (plus `inv` and bracketed variants — 8 rows across the normalized and genomic axes) were tracked `known_bug` on the premise that ferro's transcript-contiguous copy-range expansion was a defect. Research says it is **spec-correct**.

## The divergence

For `c.156_161delins180_188`:
- **ferro** → `c.156_161delinsGCGAGGAAA` (genomic: `g.5207_5212delinsGCGAGGAAA`) — copies `c.180_188` as 9 contiguous **spliced** coding bases. Internally consistent: the `inv` variant yields the exact reverse-complement `TTTCCTCGC`.
- **mutalyzer** → `c.[155_156ins180_183+69;156_161inv;161_162ins183+76_188]` — expands `c.180_188` through the **genomic** NG_ reference, pulling in intronic bases (`183+69`) and decomposing the allele.

## Why ferro is spec-correct

When the inserted sequence of a delins/insertion is given as a range of the reference (`c.<start>_<end>`), that range is read in the **same coordinate frame as the variant**:

1. **`numbering.md`** — `c.` positions are spliced coding DNA and exclude introns; intronic positions require `+`/`-` offset notation. A bare `180_188` (no offsets) therefore denotes 9 contiguous spliced bases with **no intron inside**, by definition.
2. **`delins.md:61`** — a conversion replaces `c.812`–`c.829` with `c.908`–`c.925` *"from the same reference sequence"*; **`insertion.md:36/53/56`** — "a copy of nucleotides `c.858` to `c.895`", inverted copies `c.850_900`. The copy-range shares the variant's `c.` frame.
3. **`insertion.md:49`** — a genuinely genomic copy is written with a `g.` prefix (Alu copy from `g.106370094_106370420`). mutalyzer treating a `c.`-prefixed copy-range as genomic contradicts the `c.` semantics.

## Change

- Reclassify all 8 rows (4 cases × normalized + genomic) `known_bug` → `spec_citation`.
- Add `SpecSection::CopyRangeCodingFrame` ("HGVS §Copy-range delins (coding-frame reference)").

## Verification

- normalized 0 FAIL / 0 XPASS (spec_overridden 7→11); genomic 0 FAIL / 0 XPASS (known_bug 4→0, spec_overridden 1→5).
- `generate_conformance_summary -- --check` passes; `cargo fmt` + `cargo clippy --features dev --all-targets` clean; signed.

Closes #922.
Part of #326.