### PR TITLE
fix(parser): resolve ENSG(ENST) compound refs; require versions on Ensembl accessions (#933)

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -981,8 +981,10 @@ pub fn detect_missing_version(input: &str) -> Option<(usize, String)> {
         ("XM_", false),
         ("XP_", false),
         ("XR_", false),
-        ("ENST", true), // Ensembl doesn't always have versions
-        ("ENSP", true),
+        // Per HGVS refseq.md L24-25, Ensembl identifiers require a version too
+        // (unversioned is not a valid description) — same as RefSeq (#933).
+        ("ENST", false),
+        ("ENSP", false),
         ("LRG_", false),
     ];
 
@@ -1018,8 +1020,8 @@ pub fn detect_missing_version(input: &str) -> Option<(usize, String)> {
 ///
 /// Walks the input character-by-character, identifying contiguous
 /// `[A-Za-z_]+\d+` accession bodies, then classifying each by prefix.
-/// Accessions whose prefix is in the optional-version set (Ensembl
-/// ENST/ENSP/ENSG/ENSR) are skipped.
+/// Every recognised RefSeq/Ensembl/LRG family requires a version (#933), so an
+/// unversioned accession of any of them is flagged.
 pub fn detect_missing_versions(input: &str) -> Vec<DetectedCorrection> {
     let mut hits = Vec::new();
     let bytes = input.as_bytes();
@@ -1091,14 +1093,19 @@ pub fn detect_missing_versions(input: &str) -> Vec<DetectedCorrection> {
 /// Returns `(recognised, optional_version)`:
 /// - `recognised = true` when the prefix matches a known RefSeq/Ensembl/LRG
 ///   accession family.
-/// - `optional_version = true` when that family routinely appears in the
-///   wild without a version suffix (Ensembl).
+/// - `optional_version = true` when a version suffix is not required.
+///
+/// Per HGVS `background/refseq.md` (L24-25) "RefSeq **and Ensembl** reference
+/// sequence identifiers use version numbers … variant descriptions lacking a
+/// version number are **not** valid" — so Ensembl (`ENST`/`ENSP`/`ENSG`/`ENSR`)
+/// requires a version just like RefSeq (#933). No family is version-optional;
+/// the flag is retained for shape/future use.
 fn classify_accession_prefix(prefix: &str) -> (bool, bool) {
     match prefix {
         "NM_" | "NP_" | "NC_" | "NG_" | "NR_" | "NT_" | "NW_" | "XM_" | "XP_" | "XR_" | "LRG_" => {
             (true, false)
         }
-        "ENST" | "ENSP" | "ENSG" | "ENSR" => (true, true),
+        "ENST" | "ENSP" | "ENSG" | "ENSR" => (true, false),
         _ => (false, false),
     }
 }
@@ -4081,9 +4088,14 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_missing_versions_ensembl_optional() {
+    fn test_detect_missing_versions_ensembl_requires_version() {
+        // Ensembl identifiers require a version, same as RefSeq (HGVS
+        // refseq.md L24-25) — an unversioned ENST is flagged (#933).
         let hits = detect_missing_versions("ENST00000380152:c.100A>G");
-        assert!(hits.is_empty());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].original, "ENST00000380152");
+        // A versioned ENST is accepted.
+        assert!(detect_missing_versions("ENST00000380152.7:c.100A>G").is_empty());
     }
 
     #[test]
@@ -4186,9 +4198,13 @@ mod tests {
 
     #[test]
     fn test_detect_missing_version_ensembl() {
-        // Ensembl accessions don't require versions
+        // Ensembl identifiers require a version too, per HGVS refseq.md L24-25
+        // ("variant descriptions lacking a version number are not valid") — same
+        // rule as RefSeq (#933). An unversioned ENST is flagged MissingVersion.
         let result = detect_missing_version("ENST00000123456:c.100A>G");
-        assert!(result.is_none());
+        assert_eq!(result, Some((0, "ENST00000123456".to_string())));
+        // A versioned ENST is accepted.
+        assert!(detect_missing_version("ENST00000123456.7:c.100A>G").is_none());
     }
 
     #[test]

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -385,7 +385,7 @@ impl InputPreprocessor {
                                 .with_span(SourceSpan::new(first.start, first.end))
                                 .with_source(input)
                                 .with_hint(
-                                    "RefSeq accessions require a `.<version>` suffix (e.g. NM_000088.3, NC_000023.11)",
+                                    "RefSeq and Ensembl accessions require a `.<version>` suffix (e.g. NM_000088.3, NC_000023.11, ENST00000123456.7)",
                                 ),
                         ),
                     );

--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -449,13 +449,38 @@ fn parse_compound_inner(input: &str) -> IResult<&str, Accession> {
     )))
 }
 
-/// Parse an Ensembl-style accession without underscore (e.g., "ENST00000012345.1")
+/// Parse an Ensembl-style accession without underscore (e.g., "ENST00000012345.1").
+///
+/// Also handles the compound reference form `ENSG(ENST)` — an Ensembl gene
+/// wrapping the transcript that defines the coordinates, the Ensembl analogue of
+/// `NG_(NM_)` (`background/refseq.md`: the parenthetical specification names the
+/// annotated transcript). Mirrors the compound branch in
+/// [`parse_standard_accession`]: the inner transcript becomes the primary
+/// accession and the outer gene becomes its `genomic_context`, so
+/// `Accession::transcript_accession` resolves the inner `ENST` (not the gene).
 fn parse_ensembl_accession(input: &str) -> IResult<&str, Accession> {
     let (input, prefix) = parse_ensembl_prefix(input)?;
     let (input, number) = digit1.parse(input)?;
     let (input, version) = opt(preceded(tag("."), parse_version)).parse(input)?;
 
-    Ok((input, Accession::with_style(prefix, number, version, true)))
+    let outer = Accession::with_style(prefix, number, version, true);
+
+    // Compound reference syntax: outer(inner), e.g. `ENSG…(ENST…)`. Only attempt
+    // when the next char is '(' and the content looks like an accession start.
+    if let Some(rest) = input.strip_prefix('(') {
+        if looks_like_accession_start(rest) {
+            if let Ok((after_inner, inner)) = parse_compound_inner(rest) {
+                // Reject nested compound refs: inner must not already be compound.
+                if inner.genomic_context.is_none() {
+                    if let Some(after_close) = after_inner.strip_prefix(')') {
+                        return Ok((after_close, inner.with_genomic_context(outer)));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((input, outer))
 }
 
 /// Parse an Ensembl prefix of the shape `ENS<species_code><feature>`.
@@ -595,6 +620,49 @@ mod tests {
         assert_eq!(remaining, ":p");
         assert_eq!(&*acc.prefix, "ENSP");
         assert!(acc.ensembl_style);
+    }
+
+    #[test]
+    fn test_parse_ensembl_gene_transcript_compound() {
+        // #933: `ENSG(ENST)` is the Ensembl analogue of `NG_(NM_)` — the inner
+        // transcript defines the coordinates (refseq.md: the parenthetical names
+        // the annotated transcript). The inner ENST must become the PRIMARY
+        // accession (so `transcript_accession` resolves it), with the outer ENSG
+        // as its `genomic_context`.
+        let (remaining, acc) = parse_accession("ENSG00000204370.13(ENST00000375549.8):c").unwrap();
+        assert_eq!(remaining, ":c");
+        // Primary = inner transcript.
+        assert_eq!(&*acc.prefix, "ENST");
+        assert_eq!(&*acc.number, "00000375549");
+        assert_eq!(acc.version, Some(8));
+        assert_eq!(acc.transcript_accession(), "ENST00000375549.8");
+        // Context = outer gene.
+        let ctx = acc.genomic_context.as_ref().expect("has genomic context");
+        assert_eq!(&*ctx.prefix, "ENSG");
+        assert_eq!(ctx.version, Some(13));
+        // Round-trips to the compound display form.
+        assert_eq!(acc.full(), "ENSG00000204370.13(ENST00000375549.8)");
+    }
+
+    #[test]
+    fn test_parse_ensembl_compound_rejects_nested() {
+        // A bare Ensembl transcript (no parens) is unchanged — no context.
+        let (_rest, acc) = parse_accession("ENST00000375549.8:c").unwrap();
+        assert!(acc.genomic_context.is_none());
+
+        // A nested Ensembl compound `ENSG(ENSG(ENST))` must be rejected the same
+        // way the RefSeq `NC_(NG_(NM_))` nesting is: the outer accession parses
+        // as a bare `ENSG` (not a compound), because its inner is itself compound
+        // and the guard refuses an inner that already carries a genomic_context.
+        let (remaining, acc) =
+            parse_accession("ENSG00000204370.13(ENSG00000000001.1(ENST00000375549.8)):c").unwrap();
+        assert!(
+            acc.genomic_context.is_none(),
+            "nested Ensembl compound refs should be rejected, got: {}",
+            acc.full()
+        );
+        assert_eq!(&*acc.prefix, "ENSG");
+        assert!(remaining.starts_with('('));
     }
 
     #[test]


### PR DESCRIPTION
Two Ensembl reference-handling bugs surfaced while investigating the #933 conformance rows (`ENST`/`ENSG` normalize). Both are self-contained parser/validation fixes with no corpus/reference dependency.

## 1. `ENSG(ENST)` compound references didn't resolve

The compound form `reference(transcript)` — the Ensembl analogue of `NG_(NM_)`, where the parenthetical inner names the annotated transcript that defines the coordinates (`background/refseq.md:38–41`) — was implemented **only** in `parse_standard_accession` (the underscore/RefSeq path). So `ENSG00000204370.13(ENST00000375549.8):c.100del` parsed with the **ENSG gene** as the primary accession and swallowed `(ENST…)` as a gene-symbol selector. `transcript_accession()` then returned the *gene*, `get_transcript(ENSG…)` failed, and normalization **silently echoed** the input (projection errored).

**Fix:** add the same compound branch to `parse_ensembl_accession` — the inner `ENST` becomes the primary accession with the outer `ENSG` as its `genomic_context`. `ENSG(ENST):c.100del` now normalizes to `c.102del`, matching the bare-`ENST` and `NC_(ENST)` forms.

## 2. Ensembl accessions weren't version-required

`detect_missing_version(s)` treated `ENST`/`ENSP`/`ENSG`/`ENSR` as version-**optional**, so an unversioned Ensembl description was accepted (and echoed versionless), while the RefSeq equivalent is rejected in strict mode. The spec is explicit — **`background/refseq.md:24–25`**:

> "RefSeq **and Ensembl** reference sequence identifiers use version numbers … variant descriptions **lacking a version number are not valid**."

**Fix:** require a version for Ensembl too, matching RefSeq and ferro's existing **no-guess** policy (an unversioned identifier is *rejected*, not repaired to a guessed "latest"). `ENST00000375549:c.100del` now rejects with `MissingVersion` in strict mode, consistent with `NM_000088:…`.

## Tests
- Parser: `ENSG(ENST)` compound (primary/context split, round-trip).
- Version detection: `ENST` now flagged `MissingVersion` when unversioned, accepted when versioned (both the singular and plural detectors).
- Full suite: all unit tests pass; `cargo fmt` + `cargo clippy --features dev --all-targets` clean.

## Scope / what remains

This PR is the **code** half. The #933 **reference provisioning + conformance re-bless** of the 5 `ENST`/`ENSG` rows remains open there: provisioning Ensembl into the shared conformance reference has broader ripple (it makes the coding_protein overlapping-transcript enumeration include `ENST`/`ENSP`, and changes the reference identity), so that half is best done on the canonical (scratch) reference with a decision on the Ensembl-enumeration policy. Does **not** close #933.

Part of #326 / #933.