### PR TITLE
test(conformance): make the whole-CDS-deletion p.0?/p.(Met1?) divergence terminal (#945)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -456,7 +456,8 @@ pub enum Policy {
     /// ("unknown effect on translation initiation") describe the same
     /// undetermined outcome. ferro reports the start-loss form it derives from
     /// the normalized variant; this is a terminal convention difference, not a
-    /// bug. (`p.0?` is arguably preferable as a future refinement.)
+    /// bug. Neither `p.0?` nor `p.(Met1?)` is uniquely spec-preferred, so this
+    /// is a settled accepted divergence rather than a pending refinement.
     #[serde(rename = "ferro-policy-whole-cds-del-met1")]
     WholeCdsDeletionMet1,
     /// ferro renders a deletion inside a genomic homopolymer (mononucleotide

--- a/tests/fixtures/hgvs-rs-projection/cases.json
+++ b/tests/fixtures/hgvs-rs-projection/cases.json
@@ -33,7 +33,7 @@
       "id": "wholeCDSdel-form",
       "title": "whole-CDS-deletion protein form: corpus p.0? vs ferro p.(Met1?)",
       "spec_section": "recommendations/protein/deletion.md",
-      "note": "For a deletion spanning the entire coding sequence (including the initiation codon), the corpus emits p.0? (no protein produced) while ferro emits p.(Met1?) (uncertain start-loss). Both are spec-allowed predicted forms for a variant removing the start codon; ferro reports the start-loss form it derives from the normalized variant. Terminal convention difference (accepted_divergence, policy ferro-policy-whole-cds-del-met1), not a bug; p.0? is arguably preferable as a future refinement."
+      "note": "For a deletion spanning the entire coding sequence (including the initiation codon), the corpus emits p.0? (no protein produced, deletion.md L62-65) while ferro emits p.(Met1?) (initiation-codon effect uncertain, substitution.md translation-initiation-codon section). Both are spec-accepted predicted forms for a variant removing the start codon, and neither is uniquely preferred by the spec; ferro reports the start-loss form it derives from the normalized variant. Terminal convention difference (accepted_divergence, policy ferro-policy-whole-cds-del-met1) — ferro's form is spec-valid, not a pending fix."
     }
   ],
   "cases": [
@@ -9882,7 +9882,7 @@
         "axis": "protein_description",
         "policy": "ferro-policy-whole-cds-del-met1",
         "cluster": "wholeCDSdel-form",
-        "note": "whole-CDS deletion (spans the initiation codon): the corpus emits NP_000240.1:p.0? (no protein), ferro emits NP_000240.1:p.(Met1?) (start-loss, uncertain). Both are spec-allowed predicted forms for a variant removing the start codon; p.0? is arguably preferable and is tracked as a possible future refinement."
+        "note": "whole-CDS deletion (spans the initiation codon): the corpus emits NP_000240.1:p.0? (no protein), ferro emits NP_000240.1:p.(Met1?) (start-loss, uncertain). Both are spec-accepted predicted forms for a variant removing the start codon (deletion.md L62-65; substitution.md translation-initiation-codon section); neither is uniquely preferred by the spec. Terminal accepted divergence — ferro's form is spec-valid."
       }
     },
     {

--- a/tests/fixtures/hgvs-rs-projection/failure-patterns.md
+++ b/tests/fixtures/hgvs-rs-projection/failure-patterns.md
@@ -49,7 +49,7 @@ For a C-terminal stop-loss extension, ferro canonicalizes to the three-letter fo
 
 Spec: `recommendations/protein/deletion.md`
 
-For a deletion spanning the entire coding sequence (including the initiation codon), the corpus emits p.0? (no protein produced) while ferro emits p.(Met1?) (uncertain start-loss). Both are spec-allowed predicted forms for a variant removing the start codon; ferro reports the start-loss form it derives from the normalized variant. Terminal convention difference (accepted_divergence, policy ferro-policy-whole-cds-del-met1), not a bug; p.0? is arguably preferable as a future refinement.
+For a deletion spanning the entire coding sequence (including the initiation codon), the corpus emits p.0? (no protein produced, deletion.md L62-65) while ferro emits p.(Met1?) (initiation-codon effect uncertain, substitution.md translation-initiation-codon section). Both are spec-accepted predicted forms for a variant removing the start codon, and neither is uniquely preferred by the spec; ferro reports the start-loss form it derives from the normalized variant. Terminal convention difference (accepted_divergence, policy ferro-policy-whole-cds-del-met1) — ferro's form is spec-valid, not a pending fix.
 
 | input | axis | disposition | ferro output | tracking |
 |---|---|---|---|---|

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3406,7 +3406,7 @@
       "accepted_divergence": {
         "axis": "protein_description",
         "policy": "ferro-policy-whole-cds-del-met1",
-        "note": "Whole-CDS deletion (c.-1_*1del removes the start codon and entire CDS). deletion.md L62-65 prescribes p.? / p.0? for a deletion removing the initiation codon (mutalyzer's p.?); ferro reports the start-loss p.(Met1?) by analogy to substitution.md L51 (a variant affecting the initiation codon). Both convey the undetermined initiation / no-protein outcome; terminal convention difference (p.0? arguably the future-preferred refinement). (Bare NP_ framing also differs.)"
+        "note": "Whole-CDS deletion (c.-1_*1del removes the start codon and entire CDS). Both p.0? (mutalyzer; 'no protein', deletion.md L62-65) and p.(Met1?) (ferro; initiation-codon effect uncertain, substitution.md translation-initiation-codon section) are spec-accepted predicted forms for a variant removing the initiation codon; neither is uniquely preferred by the spec. Terminal convention difference — ferro's start-loss form is spec-valid, not a pending fix. (Bare NP_ framing also differs.)"
       }
     },
     {


### PR DESCRIPTION
Closes #945.

The two `ferro-policy-whole-cds-del-met1` `accepted_divergence` rows described ferro's `p.(Met1?)` as a "future refinement" / "arguably preferable" to the comparator's `p.0?`, **with no tracking issue** — deferred work dressed as an accepted policy (audit finding).

Per the HGVS spec, both forms are accepted for a deletion that removes the initiation codon — `deletion.md` L62-65 offers `p.?`/`p.0?`, and `substitution.md`'s translation-initiation-codon section covers `p.(Met1?)` — and neither is uniquely preferred. So ferro's `p.(Met1?)` is **spec-valid, not a pending fix**.

## Change
Reword both notes (`NG_012337.1(NM_012459.2):c.-1_*1del` in mutalyzer; `NM_000249.3:c.-7_*46del` in hgvs-rs) to state the divergence is **terminal** and ferro's form is spec-valid, dropping the "future refinement" language. Disposition kind (`accepted_divergence` + `ferro-policy-whole-cds-del-met1`) is unchanged, so bucketing/behavior is unchanged; `generate_conformance_summary --check` clean.

(The mutalyzer row also carries a separate `known_bug` → closed `#487`; that's the stale-tracker sweep tracked by #912 and left for #924, not touched here.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified example notes about whole-CDS deletion cases to reflect that both protein notations are spec-accepted predicted forms.
  * Updated wording to remove preference language and better describe the difference as a notation convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->