### PR TITLE
fix(project): make c.→p. consequence decline observable, not silent

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -3139,7 +3139,27 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     Err(other) => return Err(other),
                 }
             }
-            _ => {}
+            // No c.→p. consequence predictor exists yet for the remaining edit
+            // kinds — Repeat / MultiRepeat (STR expansion/contraction), DupIns,
+            // Conversion, NPaddedDeletion, SubstitutionNoRef, BreakpointInsertion,
+            // and Identity — nor for the whole-entity / non-coding-DNA kinds
+            // (Unknown, Methylation, CopyNumber, Splice, NoProduct, PositionOnly).
+            // A concrete Deletion / Insertion / Duplication / Delins / Inversion
+            // whose CDS position failed the coding-span guards above (e.g. a `*N`
+            // 3'UTR endpoint, or an intronic offset not caught by the whole-exon
+            // or boundary arms) also lands here. We decline by leaving
+            // `protein = None`, but log the edit kind so the gap is *observable*
+            // rather than a silent empty result callers cannot distinguish from a
+            // deliberate "no consequence". Implementing these consequences (e.g.
+            // a repeat-expansion `p.` form) is future work tracked by #952.
+            other => {
+                log::trace!(
+                    "no c.→p. protein consequence predicted for {transcript_id}: edit \
+                     {other:?} has no protein predictor (or a concrete indel here failed \
+                     the coding-span guards); declining (protein=None) rather than emitting \
+                     a silent empty result (#952)",
+                );
+            }
         }
         Ok(protein)
     }

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -735,6 +735,13 @@ pub(crate) fn net_length_change(edit: &NaEdit, del_len: usize) -> Option<i64> {
         NaEdit::Delins { sequence, .. } => sequence.len().map(|n| n as i64 - del_len as i64),
         NaEdit::Inversion { .. } => Some(0),
         NaEdit::Substitution { .. } => Some(0),
+        // Repeat / MultiRepeat / DupIns / Conversion / NPaddedDeletion /
+        // SubstitutionNoRef / BreakpointInsertion / Identity (and the
+        // whole-entity kinds) have no c.→p. predictor yet, so their net length
+        // change is intentionally left undetermined here; the caller declines
+        // the protein consequence for them (#952). This `None` is deliberate,
+        // not a silent gap — it mirrors the documented per-edit decline in
+        // `predict_protein_consequence`.
         _ => None,
     }
 }

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -253,6 +253,16 @@ fn build_inframe_variant(
             // Always use the generic delins pathway for delins and inversion.
             delins(cds_pos_start)
         }
+        // Defensive, currently unreachable: the five indel kinds handled above
+        // are the only ones the caller routes here. Any other edit kind (Repeat
+        // / MultiRepeat / Conversion / …) would be a routing bug rather than an
+        // expected input, so we return an explicit typed `UnsupportedProjection`
+        // naming the edit rather than an ambiguous empty result (#952). Note the
+        // caller (`predict_protein_consequence`) currently swallows this `Err` to
+        // `None` without logging, so if this arm ever became reachable the
+        // decline would still be silent at the call site — the observability the
+        // enclosing decline path adds (`projector.rs`'s outer `match c_edit`
+        // trace) does not cover this inner defensive arm.
         _ => Err(FerroError::UnsupportedProjection {
             reason: format!(
                 "build_inframe_variant does not support edit type for protein prediction: {:?}",

--- a/tests/it/issue_952_protein_consequence_decline.rs
+++ b/tests/it/issue_952_protein_consequence_decline.rs
@@ -1,0 +1,107 @@
+//! Issue #952 — c.→p. consequence prediction must *decline observably* (never
+//! silently) for the edit kinds that have no protein predictor yet.
+//!
+//! `predict_protein_consequence` returns `Ok(None)` for Repeat / MultiRepeat /
+//! DupIns / Conversion / NPaddedDeletion / SubstitutionNoRef /
+//! BreakpointInsertion / Identity. Before #952 that decline was a bare
+//! `_ => {}` with no comment and no log, indistinguishable from a deliberate
+//! "no consequence". #952 keeps the `None` (implementing these consequences is
+//! future work) but makes the gap explicit + logged. These tests lock the
+//! contract: such a coding input projects *without error or panic* and simply
+//! carries no protein axis — the projection itself still succeeds.
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::VariantProjector;
+
+/// Mock reference with a clean `ATG`-start CDS: `ATG CGC GCG TAA`
+/// (Met-Arg-Ala-Stop), coding bases 1..12 on a single exon.
+fn make_provider() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let tx = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("MYGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCGCGTAA".to_string(),
+        Some(1),
+        Some(12),
+        vec![Exon::with_genomic(1, 1, 12, 1000, 1011)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1011),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    )
+    .with_protein_id(Some("NP_TEST.1".to_string()));
+    provider.add_transcript(tx);
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCGCGTAA{}", prefix, suffix));
+    provider
+}
+
+fn projector() -> VariantProjector<MockProvider> {
+    let provider = make_provider();
+    let cdot = CdotMapper::from_transcripts(provider.all_transcripts());
+    let proj = Projector::new(cdot);
+    VariantProjector::new(proj, provider)
+}
+
+/// Each of these coding inputs carries an edit kind with no c.→p. predictor
+/// (Repeat / MultiRepeat / NPaddedDeletion / SubstitutionNoRef / Identity), so
+/// `predict_protein_consequence` reaches the #952 decline arm. The projection
+/// must still succeed — no error, no panic — and simply carry no protein axis.
+///
+/// (`Conversion` is deliberately absent: it is rewritten to a `Delins` with the
+/// fetched source sequence *before* this dispatch, so it does get a protein
+/// consequence and never reaches the decline arm. `DupIns` is absent because the
+/// `dupins` notation is parse-rejected — DNA/duplication.md:92 — so no string can
+/// reach that arm.)
+#[test]
+fn unpredictable_edit_kinds_decline_gracefully_without_protein() {
+    let vp = projector();
+    for input in [
+        "NM_TEST.1:c.4_6[3]",        // Repeat
+        "NM_TEST.1:c.4CGC[2]GCG[2]", // MultiRepeat
+        "NM_TEST.1:c.4_6delN[3]",    // NPaddedDeletion
+        "NM_TEST.1:c.4>A",           // SubstitutionNoRef
+        "NM_TEST.1:c.4=",            // Identity (position-specific)
+    ] {
+        let variant =
+            ferro_hgvs::parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+        let projection = vp
+            .project_variant(&variant, "NM_TEST.1")
+            .unwrap_or_else(|e| panic!("project {input} must not error: {e}"));
+        assert!(
+            projection.protein.is_none(),
+            "{input}: no c.→p. predictor exists for this edit kind, so the projection must \
+             decline (protein=None), not fabricate a consequence — got {:?}",
+            projection.protein.as_ref().map(ToString::to_string),
+        );
+    }
+}
+
+/// Guardrail contrast: a plain substitution on the same transcript *does* get a
+/// protein consequence. This proves the decline above is specific to the
+/// unpredictable edit kinds and not a broken projector that drops every protein.
+#[test]
+fn substitution_still_predicts_protein() {
+    let vp = projector();
+    let variant = ferro_hgvs::parse_hgvs("NM_TEST.1:c.4C>A").expect("parse");
+    let projection = vp
+        .project_variant(&variant, "NM_TEST.1")
+        .expect("substitution projects");
+    assert_eq!(
+        projection
+            .protein
+            .as_ref()
+            .map(ToString::to_string)
+            .as_deref(),
+        Some("NP_TEST.1:p.(Arg2Ser)"),
+        "a plain substitution must still predict its protein consequence",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -200,6 +200,7 @@ mod issue_91_protein_three_prime_shift;
 mod issue_920_allele_sub_collapse;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;
+mod issue_952_protein_consequence_decline;
 mod issue_953_multirepeat_normalization;
 mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;


### PR DESCRIPTION
## Summary

c.→p. consequence prediction silently yielded **no protein** for several edit kinds. The dispatch in `predict_protein_consequence` (`src/project/projector.rs`) ended in a bare `_ => {}` arm with no explanatory comment, so a coding variant whose edit is **Repeat, MultiRepeat, DupIns, Conversion, NPaddedDeletion, SubstitutionNoRef, BreakpointInsertion, or Identity** produced no `p.` consequence at all — silently, with no error and no warning. Callers could not distinguish "not implemented" from a deliberate "no consequence".

This makes the gap **observable** without implementing the (hard) consequence logic, which remains future work:

- Replace the wildcard with a documented decline arm that `log::trace!`s the edit kind and explains why it declined, keeping `protein = None`.
- Document the two supporting fall-throughs the issue flagged:
  - `net_length_change`'s `_ => None` (`src/project/protein/helpers.rs`) — a deliberate "net length undetermined" for these kinds, mirroring the per-edit decline.
  - `build_inframe_variant`'s `_ =>` (`src/project/protein/indel.rs`) — already an explicit typed `UnsupportedProjection` naming the edit; annotated as a defensive routing-bug guard whose observable trace lives at the projector decline (the projector swallows this error to `None`).

## Test

New manifest-free `MockProvider` test (`tests/it/issue_952_protein_consequence_decline.rs`) locks the contract: `Repeat`, `MultiRepeat`, `NPaddedDeletion`, `SubstitutionNoRef`, and `Identity` coding inputs project **without error or panic** and carry no protein axis, while a plain substitution on the same transcript still predicts `p.(Arg2Ser)` (proving the decline is specific, not a broken projector).

Two edit kinds from the issue's list are intentionally not exercised by string inputs, with reasons documented in the test:
- `Conversion` is rewritten to a `Delins` (with the fetched source sequence) *before* this dispatch, so it does get a consequence and never reaches the decline arm.
- `DupIns` — the `dupins` notation is parse-rejected (`DNA/duplication.md:92`), so no string can reach that arm.

Full suite green (7714 passed, 147 manifest-gated skips); `fmt`/`clippy` clean.

Closes #952