### PR TITLE
docs(normalize): correct misleading circular o. normalization comments

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1406,7 +1406,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
             HV::Rna(v) => self.normalize_rna(v)?,
             HV::Mt(v) => self.normalize_mt(v)?,
             HV::Allele(a) => self.normalize_allele(a)?,
-            // Circular variants normalize like genomic variants
+            // Circular (`o.`, SVD-WG006) variants are returned unchanged: no
+            // 3'-shift runs and no warning is emitted. A genuine circular
+            // normalizer would 3'-shift with origin-wraparound semantics (cf.
+            // the mitochondrial wraparound handling in `normalize_mt`), which is
+            // not yet implemented. Tracked by #951. (The earlier "normalize like
+            // genomic variants" note overstated this pass-through clone.)
             HV::Circular(v) => (
                 HV::Circular(crate::hgvs::variant::CircularVariant {
                     accession: v.accession.clone(),
@@ -7250,8 +7255,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
 ///
 /// `Circular` (o.) is included even though its current normalizer is a
 /// pass-through clone (positions cannot change); the surface is
-/// forward-safe for when #129 wires real circular shuffling and costs
-/// nothing today (the post-hoc equality check trivially returns no info).
+/// forward-safe for when circular shuffling is implemented (tracked by
+/// #951 — the prior reference to the now-closed #129 was to its MT-scoped
+/// deferral) and costs nothing today (the post-hoc equality check trivially
+/// returns no info).
 fn position_text_if_shuffleable(variant: &HgvsVariant) -> Option<String> {
     match variant {
         HV::Genome(v) => Some(format!("{}", v.loc_edit.location)),

--- a/tests/it/issue_951_circular_normalize_passthrough.rs
+++ b/tests/it/issue_951_circular_normalize_passthrough.rs
@@ -1,0 +1,47 @@
+//! Issue #951 — `o.` (circular, SVD-WG006) normalization is a deliberate
+//! pass-through: the variant is returned unchanged, with no 3'-shift and no
+//! warning. A genuine circular normalizer would 3'-shift with origin-wraparound
+//! semantics, which is not yet implemented (tracked by the open #951; the prior
+//! in-code reference to the now-closed, MT-scoped #129 was misleading).
+//!
+//! These tests pin the current documented behavior so a future implementer of
+//! circular shuffling knows exactly what contract they are changing.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// A `del` is a classic 3'-shift candidate on the linear axes, yet the `o.`
+/// normalizer returns it verbatim with no shuffle applied and no warning.
+#[test]
+fn circular_deletion_is_returned_unchanged_without_warnings() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let input = "NC_001416.1:o.5del";
+    let variant = parse_hgvs(input).expect("parse o. deletion");
+    let outcome = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize o. deletion");
+    assert_eq!(
+        format!("{}", outcome.result),
+        input,
+        "circular o. normalization must be a pass-through (no 3'-shift) — #951",
+    );
+    assert!(
+        outcome.warnings.is_empty(),
+        "circular o. pass-through must emit no warnings; got {:?}",
+        outcome.warnings,
+    );
+}
+
+/// Idempotence follows trivially from the pass-through, but pin it too so a
+/// future shuffling implementation cannot silently make the second pass differ.
+#[test]
+fn circular_normalization_is_idempotent() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant = parse_hgvs("NC_001416.1:o.100_105del").expect("parse");
+    let once = normalizer.normalize(&variant).expect("first normalize");
+    let twice = normalizer.normalize(&once).expect("second normalize");
+    assert_eq!(
+        format!("{once}"),
+        format!("{twice}"),
+        "o. normalize idempotent"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -201,6 +201,7 @@ mod issue_920_allele_sub_collapse;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;
 mod issue_952_protein_consequence_decline;
+mod issue_951_circular_normalize_passthrough;
 mod issue_953_multirepeat_normalization;
 mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;


### PR DESCRIPTION
## Summary

`o.` (circular, SVD-WG006) normalization is a **silent no-op**: `Normalizer::normalize` clones the variant and returns it with no 3'-shift and no warning, while the inline comment claimed it *"normalize[s] like genomic variants"* — overstating the pass-through clone. The forward-looking deferral note pointed at **#129, which is closed** (it was scoped to mitochondrial handling), so circular-`o.` shuffling had no open tracker.

Per the issue's "at minimum" ask, this corrects the comments and keeps **#951 as the open tracker** for real circular normalization (3'-shift with origin-wraparound semantics) — it does **not** implement wraparound shuffling.

## Changes

- **`HV::Circular` dispatch arm** (`src/normalize/mod.rs`): replace *"normalize like genomic variants"* with an honest description of the pass-through, noting the missing 3'-shift/wraparound semantics and pointing at #951 (with a `cf.` to the mitochondrial wraparound handling in `normalize_mt`).
- **`position_text_if_shuffleable` note**: retarget the "forward-safe for when #129 wires real circular shuffling" line from the closed, MT-scoped #129 to the open #951.
- **Test** (`tests/it/issue_951_circular_normalize_passthrough.rs`): pin the documented contract — an `o.` deletion (a 3'-shift candidate on linear axes) normalizes to itself with no warnings, and normalization is idempotent — so a future implementer knows exactly what contract they are changing.

## Out of scope (deliberately)

The MT-specific `#129` references inside `normalize_mt` (and the `mito_*_audit` tests) are left as-is: they belong to a **distinct** mitochondrial-circular deferral, not the `o.` tracker, and mostly describe #129's completed Path 1 work accurately. Retargeting them to #951 would be mis-scoped.

Behavior is unchanged (comment + test only). Full suite green (7714 passed, 147 manifest-gated skips); `fmt`/`clippy` clean.

Part of #951