### PR TITLE
fix(normalize): reconcile MultiRepeat needs_normalization with the shuffle dispatch

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -6340,6 +6340,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     }
                 }
             }
+            // MultiRepeat (compound tandem repeat, e.g. `GT[2]GC[2]…`) is
+            // deliberately NOT 3'-shifted: unlike a single-unit `Repeat`, a
+            // multi-unit tract has no canonical shuffle target — the spec
+            // describes it as reported, and the rules-layer shuffler
+            // (`normalize_repeat`) only handles one repeat unit + count. It is
+            // still routed here (via `needs_normalization` → `true`) for the
+            // reference-tract validation (`validate_multirepeat_tract`, run at the
+            // top of this function) — that validation, not shuffling, is why the
+            // flag stays `true`. Return the (validated) edit unchanged. Giving it
+            // an explicit arm — rather than letting it fall to the generic `_`
+            // below — makes this pass-through intentional and documented, not a
+            // silent contradiction of the `needs_normalization` flag (#953).
+            NaEdit::MultiRepeat { .. } => return Ok((start, end, edit.clone(), warnings.clone())),
             _ => return Ok((start, end, edit.clone(), warnings.clone())), // Other edits don't need shuffling
         };
 

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -25,6 +25,16 @@ use crate::hgvs::edit::{InsertedPart, InsertedSequence, NaEdit, Sequence};
 use crate::reference::ReferenceProvider;
 
 /// Check if an edit type needs normalization
+///
+/// "Needs normalization" gates entry into `normalize_na_edit`, which performs
+/// both reference-allele validation AND 3'-shifting. Most listed kinds need the
+/// shift; `MultiRepeat` is the exception — it is flagged `true` for the
+/// *validation* half (`validate_multirepeat_tract`), not the shift. A compound
+/// multi-unit tract has no canonical shuffle target, so `normalize_na_edit`'s
+/// `MultiRepeat` arm passes it through unchanged after validating (#953). If
+/// that arm ever gains a real canonicalization, this flag already routes it
+/// correctly; until then the two are reconciled and documented, not silently
+/// contradictory.
 pub fn needs_normalization(edit: &NaEdit) -> bool {
     if matches!(
         edit,

--- a/tests/it/issue_953_multirepeat_normalization.rs
+++ b/tests/it/issue_953_multirepeat_normalization.rs
@@ -1,0 +1,187 @@
+//! Issue #953 — `NaEdit::MultiRepeat` is flagged `needs_normalization == true`,
+//! but a compound multi-unit tandem repeat has no canonical 3'-shift target.
+//! The flag is `true` for the *validation* half (`validate_multirepeat_tract`),
+//! and the shuffle dispatch now has an explicit `MultiRepeat` arm that passes
+//! the (validated) edit through unchanged — reconciling the two so the
+//! pass-through is intentional and documented, not a silent contradiction.
+//!
+//! These tests pin that intended behavior: a MultiRepeat normalizes to itself
+//! and is idempotent. To make that assertion non-vacuous, each test registers
+//! **real reference bases** whose span exactly matches the declared tract, so
+//! the normalizer reaches the `MultiRepeat` arm and runs
+//! `validate_multirepeat_tract` (a validated pass-through) rather than bailing
+//! early on a missing-reference error the way a bare, empty `MockProvider`
+//! would. The `GT[2]GC[2]` tract occupies exactly 8 reference bases
+//! (`GTGTGCGC`), so the described span is 8 bp wide and the reference at that
+//! span literally spells `GTGTGCGC`; a coordinate/base mismatch would surface
+//! as a `RefSeqMismatch` (asserted absent here — see
+//! `issue_279_multirepeat_partial_validation` for the mismatch direction), so
+//! these tests genuinely exercise the validation path.
+//!
+//! (The parse assertion guards that the input really is a `MultiRepeat`, so the
+//! test keeps exercising the reconciled code path.)
+
+use ferro_hgvs::hgvs::edit::NaEdit;
+use ferro_hgvs::hgvs::variant::HgvsVariant;
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::reference::transcript::{Exon, GenomeBuild, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// 256 bp of `N` flanking the variant tract on each side, mirroring
+/// `issue_279_multirepeat_partial_validation`. `N` is inert against the
+/// byte-equality scans the normalizer / validator uses, so the boundaries
+/// never spuriously extend the apparent tract.
+const PAD: &str = "NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN\
+     NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN";
+
+fn padded(core: &str) -> String {
+    format!("{}{}{}", PAD, core, PAD)
+}
+
+/// HGVS position of the first base of `core` in `padded(core)`.
+/// `PAD` is 256 bp of `N`, so the first core base is the 257th overall
+/// (1-based HGVS coordinates).
+const CORE_START: u64 = PAD.len() as u64 + 1;
+
+/// Extract the concrete `NaEdit` from a genome/cds variant for a type assertion.
+fn edit_of(variant: &HgvsVariant) -> Option<&NaEdit> {
+    match variant {
+        HgvsVariant::Genome(v) => v.loc_edit.edit.inner(),
+        HgvsVariant::Cds(v) => v.loc_edit.edit.inner(),
+        _ => None,
+    }
+}
+
+fn has_refseq_mismatch(warnings: &[NormalizationWarning]) -> bool {
+    warnings
+        .iter()
+        .any(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. }))
+}
+
+/// A genomic provider whose contig `NC_000001.11` carries `core` (the exact
+/// reference tract) flanked by inert `N` padding, so a description anchored at
+/// `CORE_START` spanning `core.len()` bases finds `core` verbatim under it.
+fn g_provider(core: &str) -> MockProvider {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence("NC_000001.11", padded(core));
+    p
+}
+
+/// A provider carrying `NM_000088.3` with `cds_start == 1` (so `c.N` maps to
+/// transcript position `N`) and the reference tract `GTGTGCGC` at `c.100_107`
+/// (transcript bases 100..=107 → 0-based indices 99..107). The tract is
+/// surrounded by `A` padding within the CDS so the described 8 bp span lands
+/// exactly on `GTGTGCGC`.
+fn cds_gt2gc2_provider() -> MockProvider {
+    const LEN: usize = 120;
+    let mut bases = vec![b'A'; LEN];
+    // c.100 with cds_start == 1 is transcript position 100 == 0-based index 99.
+    for (i, b) in b"GTGTGCGC".iter().enumerate() {
+        bases[99 + i] = *b;
+    }
+    let seq = String::from_utf8(bases).expect("ASCII bases are valid UTF-8");
+    let tx = Transcript::new(
+        "NM_000088.3".to_string(),
+        Some("COL1A1".to_string()),
+        Strand::Plus,
+        seq,
+        Some(1),          // cds_start: c.1 == transcript position 1
+        Some(LEN as u64), // cds_end
+        vec![Exon::new(1, 1, LEN as u64)],
+        None,
+        None,
+        None,
+        GenomeBuild::GRCh38,
+        ManeStatus::Select,
+        None,
+        None,
+    );
+    let mut p = MockProvider::new();
+    p.add_transcript(tx);
+    p
+}
+
+#[test]
+fn genome_multirepeat_is_a_normalization_passthrough() {
+    // GT[2]GC[2] expands to GTGTGCGC (8 bp), so the described span is exactly
+    // 8 bp wide and the reference under it literally spells GTGTGCGC.
+    let end = CORE_START + 8 - 1;
+    let input = format!("NC_000001.11:g.{}_{}GT[2]GC[2]", CORE_START, end);
+    let normalizer = Normalizer::new(g_provider("GTGTGCGC"));
+    let variant = parse_hgvs(&input).expect("parse genome MultiRepeat");
+    assert!(
+        matches!(edit_of(&variant), Some(NaEdit::MultiRepeat { .. })),
+        "input must parse as a MultiRepeat so the test exercises the #953 arm",
+    );
+    let outcome = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize MultiRepeat");
+    assert_eq!(
+        format!("{}", outcome.result),
+        input,
+        "a compound MultiRepeat has no canonical 3'-shift; normalization must \
+         return it unchanged (#953)",
+    );
+    // The reference bases match the declared tract, so the validated
+    // pass-through must NOT emit a RefSeqMismatch. Absence here (over a real,
+    // matching reference) confirms the arm ran and validated rather than
+    // bailing early on a missing-reference error.
+    assert!(
+        !has_refseq_mismatch(&outcome.warnings),
+        "matching reference tract must validate cleanly, got {:?}",
+        outcome.warnings,
+    );
+}
+
+#[test]
+fn cds_multirepeat_is_a_normalization_passthrough() {
+    // c.100_107 is an 8 bp span matching GT[2]GC[2] = GTGTGCGC.
+    let input = "NM_000088.3:c.100_107GT[2]GC[2]";
+    let normalizer = Normalizer::new(cds_gt2gc2_provider());
+    let variant = parse_hgvs(input).expect("parse cds MultiRepeat");
+    assert!(
+        matches!(edit_of(&variant), Some(NaEdit::MultiRepeat { .. })),
+        "input must parse as a MultiRepeat",
+    );
+    let outcome = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize");
+    assert_eq!(
+        format!("{}", outcome.result),
+        input,
+        "cds MultiRepeat pass-through (#953)",
+    );
+    assert!(
+        !has_refseq_mismatch(&outcome.warnings),
+        "matching transcript tract must validate cleanly, got {:?}",
+        outcome.warnings,
+    );
+}
+
+#[test]
+fn multirepeat_normalization_is_idempotent() {
+    // AC[3]TG[2] expands to ACACACTGTG (10 bp); the span is 10 bp wide and the
+    // reference under it spells ACACACTGTG.
+    let end = CORE_START + 10 - 1;
+    let input = format!("NC_000001.11:g.{}_{}AC[3]TG[2]", CORE_START, end);
+    let normalizer = Normalizer::new(g_provider("ACACACTGTG"));
+    let variant = parse_hgvs(&input).expect("parse");
+    assert!(
+        matches!(edit_of(&variant), Some(NaEdit::MultiRepeat { .. })),
+        "input must parse as a MultiRepeat",
+    );
+    let once = normalizer.normalize(&variant).expect("first normalize");
+    let twice = normalizer.normalize(&once).expect("second normalize");
+    assert_eq!(
+        format!("{once}"),
+        input,
+        "a validated MultiRepeat over a matching reference must return unchanged",
+    );
+    assert_eq!(
+        format!("{once}"),
+        format!("{twice}"),
+        "MultiRepeat idempotent",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -200,6 +200,7 @@ mod issue_91_protein_three_prime_shift;
 mod issue_920_allele_sub_collapse;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;
+mod issue_953_multirepeat_normalization;
 mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;
 mod issue_l2_w4001_swapped_positions;


### PR DESCRIPTION
## Summary

`NaEdit::MultiRepeat` was flagged by `rules::needs_normalization` (`= true`) but had **no arm** in the shuffle dispatch (`normalize_na_edit`), so it fell to the generic catch-all `_ => … // Other edits don't need shuffling` and was returned verbatim — a silent pass-through that appeared to contradict the flag.

## The reconciliation

Investigating the two sides shows they are actually reconcilable, not contradictory:

- `needs_normalization` gates entry into `normalize_na_edit`, which does **two** things: reference-allele **validation** and **3'-shifting**.
- MultiRepeat needs the **validation** half — `validate_multirepeat_tract` (issues #214 / #279 / #395) does real reference-tract checking and can emit a `RefSeqMismatch` warning. That is the reason the flag must stay `true`.
- MultiRepeat does **not** need the shift: a compound multi-unit tract (`GT[2]GC[2]…`) has no canonical 3'-shift target, and the rules-layer shuffler (`normalize_repeat`) only handles a single repeat unit + count.

So the correct resolution is **keep the flag** and make the shuffle pass-through **explicit and documented** rather than removing the flag (which would also drop the needed validation).

## Changes

- **`src/normalize/mod.rs`**: add an explicit `NaEdit::MultiRepeat` arm to the shuffle dispatch that returns the validated edit unchanged, with a comment explaining the validation-vs-shift split. It no longer hides under the generic `_` catch-all.
- **`src/normalize/rules.rs`**: document on `needs_normalization` why MultiRepeat is flagged `true` (validation, not shift), and that the flag already routes correctly if a real canonicalization is added later.
- **`tests/it/issue_953_multirepeat_normalization.rs`**: pin the intended behavior — genome and cds MultiRepeat inputs (asserted to parse as `MultiRepeat`, so the test keeps exercising this arm) normalize to themselves and are idempotent.

**No behavior change** — the pass-through is now intentional and documented. Full suite green (7715 passed, 147 manifest-gated skips); `fmt`/`clippy` clean.

Closes #953