### PR TITLE
fix(parser): correct self-cancelling-allele guard docs and fixture classification

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7098,7 +7098,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     };
 
     // Spec-mandated post-parse semantic check: reject self-cancelling alleles
-    // (HGVS recommendations/general.md line 47, tracked under issue #115).
+    // (HGVS recommendations/general.md line 58, tracked under issue #115).
     validate_no_self_cancelling(&variant, input)?;
 
     // Spec-mandated post-parse semantic check: reject `dupins` mash-up
@@ -7439,7 +7439,7 @@ fn reject_protein_bracketed_aa_insertion(input: &str) -> Result<(), FerroError> 
 }
 
 /// Walk the variant tree and reject any `AlleleVariant` that contains an
-/// overlapping `del` + `dup` pair (HGVS `recommendations/general.md` line 47:
+/// overlapping `del` + `dup` pair (HGVS `recommendations/general.md` line 58:
 /// "descriptions removing part of a reference sequence replacing it with
 /// part of the same sequence are not allowed").
 ///

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -619,10 +619,21 @@ impl AlleleVariant {
         Self::new(variants, AllelePhase::Unknown)
     }
 
-    /// Detect whether the allele contains a self-cancelling (`del` + `dup`)
-    /// pair that the HGVS spec disallows ("descriptions removing part of a
-    /// reference sequence replacing it with part of the same sequence are
-    /// not allowed", `recommendations/general.md` line 47).
+    /// Detect whether the allele contains a `del` + `dup` pair over
+    /// **overlapping** reference positions, which the HGVS spec disallows:
+    /// "descriptions removing part of a reference sequence and replacing it
+    /// with part of the same sequence are not allowed" — with the spec's own
+    /// example being exactly `NM_004006.2:c.[762_768del;767_774dup]`
+    /// (`recommendations/general.md` line 58).
+    ///
+    /// The trigger is positional **overlap**, not exact cancellation — and
+    /// that is deliberate, matching the spec. The spec's example overlaps only
+    /// at 767–768 (a 7-base `del` vs an 8-base `dup`) and does *not* exactly
+    /// cancel, yet it is disallowed: a `del` combined with a `dup` of
+    /// overlapping bases describes removing-then-restoring part of the same
+    /// sequence and must be rewritten as a single `delins`. So the check is
+    /// intentionally broader than "equal/inverse edits over the same span".
+    /// Non-overlapping `del` + `dup` members on the same allele are accepted.
     ///
     /// Returns `Some((idx_del, idx_dup))` for the first offending pair found
     /// (deterministic by ascending pair index), or `None` otherwise.
@@ -687,7 +698,7 @@ impl AlleleVariant {
     /// Build a new allele after running the spec-mandated self-cancelling
     /// check. Returns `FerroError::Parse` with
     /// `ErrorCode::SelfCancellingAllele` if the allele violates HGVS
-    /// `recommendations/general.md` line 47.
+    /// `recommendations/general.md` line 58.
     ///
     /// `source_span` is the byte range of the offending allele in the
     /// caller's source string. Pass it through whenever it's known so that
@@ -725,7 +736,7 @@ pub(crate) fn build_self_cancelling_error(
         .with_hint(
             "HGVS does not allow describing both a deletion and a duplication \
              of overlapping reference positions in the same allele \
-             (recommendations/general.md line 47); drop one edit or rewrite \
+             (recommendations/general.md line 58); drop one edit or rewrite \
              as a single delins",
         );
     if let Some(span) = source_span {
@@ -3600,7 +3611,7 @@ mod tests {
 
     #[test]
     fn test_self_cancelling_cds_3utr_star_overlap() {
-        // 3'UTR (`c.*N`) range; HGVS general.md line 47 forbids overlapping
+        // 3'UTR (`c.*N`) range; HGVS general.md line 58 forbids overlapping
         // del+dup just as much in *-region as in the CDS proper.
         let del = parse_variant("NM_004006.2:c.*100_*150del").unwrap();
         let dup = parse_variant("NM_004006.2:c.*145_*160dup").unwrap();

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -10,7 +10,7 @@
     },
     "[spec_self_cancelling_allele]": {
       "category": "rejected_by_design",
-      "reason": "Overlapping del+dup in the same cis-allele that partially undo each other. HGVS recommendations/general.md line 47 forbids this; ferro emits E3006 SelfCancellingAllele.",
+      "reason": "Overlapping del+dup in the same cis-allele that partially undo each other. HGVS recommendations/general.md line 58 forbids this; ferro emits E3006 SelfCancellingAllele.",
       "tracking": "#115"
     },
     "[uncertain_range_to_3utr_end]": {

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -144,7 +144,7 @@
     {
       "code": "E3006",
       "description": "SelfCancellingAllele — overlapping del+dup pair within a single cis allele (e.g. 'c.[762_768del;767_774dup]').",
-      "spec_section": "recommendations/general.md line 47: 'descriptions removing part of a reference sequence replacing it with part of the same sequence are not allowed'",
+      "spec_section": "recommendations/general.md line 58: 'descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed'",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/general/",
       "status": "enforced"
     },

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -3,6 +3,10 @@
     "c.123C>C": {
       "spec_expected": "NM_004006.2:c.123="
     },
+    "NM_004006.2:c.[762_768del;767_774dup]": {
+      "spec_expected": null,
+      "note": "The spec's OWN canonical example of a *disallowed* description (general.md:58: \"descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed (e.g., NM_004006.2:c.[762_768del;767_774dup])\"). The del (762-768) and dup (767-774) overlap at 767-768; HGVS forbids a del+dup over overlapping reference positions (rewrite as a single delins). The generator harvested the string from that `e.g.` code span and seeded it as a valid example, so ferro's spec-correct E3006 rejection read as `parse-error`. Force spec-rejects so it reads as `correctly-rejected` (#954)."
+    },
     "NM_004006.2:c.6775_6777delGAGinsC": {
       "note": "Spec rejects the long-form `delGAGinsC` (`<code class=\"invalid\">`); ferro accepts but emits the spec-recommended canonical short form `delinsC` (DNA/delins.md). Status remains `false-acceptance` for the accepted-bad-input fact; `note` clarifies the canonical-on-output behavior. (#353)"
     },

--- a/tests/it/error_mode_tests.rs
+++ b/tests/it/error_mode_tests.rs
@@ -1861,6 +1861,27 @@ mod spec_mandated_rejections {
         );
     }
 
+    #[test]
+    fn e3006_fires_on_overlap_not_exact_cancellation() {
+        // #954: the guard keys on positional OVERLAP, not exact (equal/inverse)
+        // cancellation — matching the spec. This del (10–20, 11 bases) and dup
+        // (15–25, 11 bases) overlap only at 15–20 and do NOT exactly cancel,
+        // yet HGVS disallows any del+dup over overlapping reference positions
+        // (general.md:58; the spec's own example `c.[762_768del;767_774dup]`
+        // likewise overlaps without cancelling). A narrower "genuine
+        // cancellation" rule would wrongly accept these.
+        let err = parse_hgvs("NM_004006.2:c.[10_20del;15_25dup]")
+            .expect_err("overlapping-but-not-cancelling del+dup must still be rejected");
+        assert_eq!(err.code(), Some(ErrorCode::SelfCancellingAllele));
+
+        // The counterpart: shift the dup fully clear of the del (no shared
+        // positions) and the same pair is accepted — overlap is the trigger.
+        assert!(
+            parse_hgvs("NM_004006.2:c.[10_20del;25_35dup]").is_ok(),
+            "disjoint del+dup on the same allele must be accepted",
+        );
+    }
+
     // ----- Registry sanity -----
 
     #[test]


### PR DESCRIPTION
## Summary

The issue reported that the self-cancelling-allele guard (E3006) over-rejects `NM_004006.2:c.[762_768del;767_774dup]`, treating it as a `false-acceptance`/over-rejection in the spec-normalization fixture, and asked to tighten the guard to fire only on genuine cancellation.

**Investigation shows the guard is already spec-correct.** That exact string is the HGVS spec's **own canonical example of a *disallowed* description**:

> `general.md:58` — "descriptions removing part of a reference sequence and replacing it with part of the same sequence are not allowed (e.g., `NM_004006.2:c.[762_768del;767_774dup]`)."

The `del` (762–768) and `dup` (767–774) overlap at 767–768 but do **not** exactly cancel — yet the spec forbids them. So the guard keying on positional **overlap** (not exact/inverse cancellation) is correct, and narrowing it to "genuine cancellation" would wrongly *accept* the spec's own negative example.

This takes the issue's **second branch** (overlapping cis members are spec-disallowed → keep the guard, fix the docs and classification):

## Changes

- **Citation fix**: correct "general.md line 47" → "line 58" in all six references (`src/hgvs/variant.rs`, `src/hgvs/parser/variant.rs`). Line 47 is unrelated RNA-level text; the rule and its example are at line 58.
- **Docstring**: expand `detect_self_cancelling_pair` to explain that the trigger is positional overlap — not exact cancellation — and why that matches the spec (its example overlaps without cancelling).
- **Fixture classification**: add a spec-fixture override for the string. The generator had harvested it from the `e.g.` code span and seeded it as a valid example, so ferro's E3006 rejection read as `parse-error`; the override forces `spec_expected: null` so it reads as `correctly-rejected`. Regenerated + `--check` passes. (The generated fixture itself is gitignored; only the committed overrides JSON changes.)

## Test

Added `e3006_fires_on_overlap_not_exact_cancellation`: an overlapping-but-not-cancelling `del`+`dup` (distinct from the spec's exact example — `c.[10_20del;15_25dup]`, two 11-base edits overlapping only at 15–20) is still rejected, while the same pair shifted fully disjoint (`c.[10_20del;25_35dup]`) is accepted — proving overlap, not cancellation, is the trigger and that the rule generalizes. (The spec example's strict/lenient rejects and the non-overlap/trans-phase accepts were already covered in `error_mode_tests.rs`.)

Full suite green (7713 passed, 147 manifest-gated skips); `fmt`/`clippy` clean.

Closes #954