### PR TITLE
feat(python): forward the remaining MultiFasta-overridden methods to the Python provider

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -174,6 +174,61 @@ impl ReferenceProvider for PyProvider {
             PyProvider::MultiFasta(p) => p.sole_hosted_transcript(ng_parent),
         }
     }
+
+    fn get_sequence_length(&self, id: &str) -> Result<u64, crate::error::FerroError> {
+        // Forward to the inner provider so the real transcript/contig length
+        // reaches the Python path (#968). The trait default returns
+        // `Err(ReferenceNotFound)` unconditionally, so without this every
+        // length-dependent path on the Python side (mt/`qter` bounds checks,
+        // poly-A tail extension in projection) silently degrades even when the
+        // wrapped `MultiFasta` provider knows the length.
+        match self {
+            PyProvider::Mock(p) => p.get_sequence_length(id),
+            PyProvider::MultiFasta(p) => p.get_sequence_length(id),
+        }
+    }
+
+    fn infer_genome_build(
+        &self,
+        accession: &crate::hgvs::variant::Accession,
+    ) -> Option<&'static str> {
+        // Forward to the inner provider so its build inference reaches the Python
+        // path (#968). The trait default infers from the accession alone; the
+        // wrapped `MultiFasta` provider layers in assembly-report contig aliases,
+        // which the default would otherwise bypass for Python consumers.
+        match self {
+            PyProvider::Mock(p) => p.infer_genome_build(accession),
+            PyProvider::MultiFasta(p) => p.infer_genome_build(accession),
+        }
+    }
+
+    fn get_transcript_for_accession(
+        &self,
+        accession: &crate::hgvs::variant::Accession,
+    ) -> Result<Arc<crate::reference::transcript::Transcript>, crate::error::FerroError> {
+        // Forward to the inner provider so build-aware transcript resolution
+        // (#332) reaches the Python path (#968). The trait default self-dispatches
+        // to the build-*unaware* `get_transcript`, so without this a Python
+        // consumer resolving a transcript for an `NC_*.10/.11`- or `NG_`-contexted
+        // variant would bypass the wrapped `MultiFasta` provider's parent-build
+        // probe and get the primary-build (or wrong-build) transcript.
+        match self {
+            PyProvider::Mock(p) => p.get_transcript_for_accession(accession),
+            PyProvider::MultiFasta(p) => p.get_transcript_for_accession(accession),
+        }
+    }
+
+    fn get_transcript_for_variant(
+        &self,
+        variant: &crate::hgvs::variant::HgvsVariant,
+    ) -> Result<Arc<crate::reference::transcript::Transcript>, crate::error::FerroError> {
+        // Forward to the inner provider so the by-variant build-aware resolution
+        // (#332) reaches the Python path (#968), matching `get_transcript_for_accession`.
+        match self {
+            PyProvider::Mock(p) => p.get_transcript_for_variant(variant),
+            PyProvider::MultiFasta(p) => p.get_transcript_for_variant(variant),
+        }
+    }
 }
 
 impl PyProvider {
@@ -3933,5 +3988,155 @@ mod tests {
             assert_eq!(py.code, expected_code, "code mismatch for {expected_code}");
             assert_eq!(py.message, w.message(), "message round-trip mismatch");
         }
+    }
+
+    /// #968: `PyProvider` must forward `infer_genome_build` to its inner provider,
+    /// so the wrapped `MultiFasta` provider's assembly-report-derived build
+    /// inference reaches the Python path. Complements
+    /// `tests/python/test_issue_968_length_build_forwarders.py` (which covers the
+    /// sibling `get_sequence_length` forwarder through the Python surface).
+    ///
+    /// There is no Python-facing surface for `infer_genome_build` — it is consulted
+    /// only internally by projection — so the forwarding contract is verified here
+    /// at the Rust level (runs under `cargo test --features python`).
+    ///
+    /// The probe uses the report-only accession `NC_000017.99`: the hardcoded,
+    /// accession-only heuristic (the trait default) returns `None` for it, so a
+    /// `Some("GRCh38")` answer through the wrapper can only come from the
+    /// assembly-report `ContigAliases` the inner `MultiFasta` provider loads —
+    /// making the test non-vacuous (it fails if `PyProvider` falls through to the
+    /// trait default instead of forwarding).
+    #[test]
+    fn infer_genome_build_is_forwarded_to_inner_provider() {
+        use crate::hgvs::variant::Accession;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+        // A minimal transcript FASTA (required by `from_manifest`) + its `.fai`.
+        fs::write(d.join("tx.fna"), ">NM_000001.1\nACGT\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000001.1\t4\t13\t4\t5\n").unwrap();
+        // A minimal assembly report whose chr17 row uses `.99` — a version the
+        // hardcoded heuristic does not know, so only the report can classify it.
+        let report = "# Assembly name:  GRCh38.test\n\
+            # Sequence-Name\tSequence-Role\tAssigned-Molecule\tAssigned-Molecule-Location/Type\t\
+            GenBank-Accn\tRelationship\tRefSeq-Accn\tAssembly-Unit\tSequence-Length\tUCSC-style-name\n\
+            17\tassembled-molecule\t17\tChromosome\tCM000679.9\t=\tNC_000017.99\t\
+            Primary Assembly\t83257441\tchr17\n";
+        fs::write(d.join("assembly_report.txt"), report).unwrap();
+        fs::write(
+            d.join("manifest.json"),
+            r#"{"prepared_at":"test","transcript_fastas":["tx.fna"],"assembly_report":"assembly_report.txt","transcript_count":1,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+
+        // Build the inner provider directly and wrap it, mirroring how the Python
+        // constructors produce a `PyProvider::MultiFasta` (avoids the PyO3 GIL).
+        let inner = MultiFastaProvider::from_manifest(d.join("manifest.json"))
+            .expect("manifest with an assembly report loads");
+        let provider = PyProvider::MultiFasta(Arc::new(inner));
+
+        let future_chr17 = Accession::new("NC", "000017", Some(99));
+        // Premise: the accession-only default cannot classify `.99`.
+        assert_eq!(
+            crate::liftover::aliases::infer_genome_build_from_accession(&future_chr17),
+            None,
+            "hardcoded heuristic must not know NC_000017.99 (test premise)",
+        );
+        // Forwarded: the wrapper reaches the inner provider's report-derived table.
+        assert_eq!(
+            provider.infer_genome_build(&future_chr17),
+            Some("GRCh38"),
+            "PyProvider must forward infer_genome_build to the inner MultiFasta provider",
+        );
+    }
+
+    /// #968: `PyProvider` must forward the build-aware `get_transcript_for_accession`
+    /// / `get_transcript_for_variant` (#332) to its inner provider. The trait default
+    /// self-dispatches to the build-*unaware* `get_transcript`, so without the
+    /// forwarder a Python consumer resolving a transcript for a build-bearing
+    /// `genomic_context` parent would silently get the primary-build transcript
+    /// instead of the parent-build one.
+    ///
+    /// These methods have no Python-facing surface, so the contract is verified here
+    /// at the Rust level (runs under `cargo test --features python`), mirroring the
+    /// `infer_genome_build` test above.
+    ///
+    /// The fixture gives `NM_TEST.1` a GRCh38 primary cdot (contig `NC_000017.11`)
+    /// and a deferred GRCh37 secondary cdot (contig `NC_000017.10`). A bare
+    /// `get_transcript` resolves the primary build (`.11`); resolving *for* an
+    /// accession whose parent is the GRCh37 `NC_000017.10` must probe GRCh37 first
+    /// and return the `.10` transcript. The differing chromosome makes the test
+    /// non-vacuous — the trait default (bare `get_transcript`) would return `.11`.
+    #[test]
+    fn get_transcript_for_accession_build_aware_is_forwarded() {
+        use crate::hgvs::variant::Accession;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        // A 73-base transcript FASTA (matches the exon tx-span 0..73 below).
+        let seq = "A".repeat(73);
+        fs::write(d.join("tx.fna"), format!(">NM_TEST.1\n{seq}\n")).unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_TEST.1\t73\t11\t73\t74\n").unwrap();
+
+        // Primary GRCh38 cdot: NM_TEST.1 on NC_000017.11.
+        fs::write(
+            d.join("cdot.json"),
+            r#"{"transcripts":{"NM_TEST.1":{"gene_name":"COL1A1","contig":"NC_000017.11",
+                "strand":"+","exons":[[50184096,50184169,0,73,"M73"]],
+                "start_codon":10,"stop_codon":60}}}"#,
+        )
+        .unwrap();
+
+        // Deferred GRCh37 secondary cdot: same transcript on NC_000017.10, nested
+        // under genome_builds["GRCh37"] (the real GRCh37 cdot shape).
+        fs::write(
+            d.join("cdot-grch37.json"),
+            r#"{"transcripts":{"NM_TEST.1":{"gene_name":"COL1A1","genome_builds":{"GRCh37":{
+                "contig":"NC_000017.10","strand":"+","exons":[[48263025,48263098,0,73,"M73"]],
+                "cds_start":48263035,"cds_end":48263085}}}}}"#,
+        )
+        .unwrap();
+
+        fs::write(
+            d.join("manifest.json"),
+            r#"{"prepared_at":"test","transcript_fastas":["tx.fna"],"cdot_json":"cdot.json",
+                "cdot_grch37_json":"cdot-grch37.json","transcript_count":1,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+
+        let inner = MultiFastaProvider::from_manifest(d.join("manifest.json"))
+            .expect("manifest with primary + GRCh37 cdot loads");
+        let provider = PyProvider::MultiFasta(Arc::new(inner));
+
+        // Bare resolution → primary GRCh38 build (contig .11).
+        let bare = provider.get_transcript("NM_TEST.1").expect("bare resolves");
+        assert_eq!(bare.chromosome.as_deref(), Some("NC_000017.11"));
+
+        // Build-aware resolution for a GRCh37 (`NC_000017.10`) parent → probes GRCh37
+        // first and returns the .10 transcript. Only reachable if PyProvider forwards
+        // get_transcript_for_accession to the inner provider.
+        let context = Accession::new("NC", "000017", Some(10));
+        let accession = Accession::new("NM", "TEST", Some(1)).with_genomic_context(context);
+        let aware = provider
+            .get_transcript_for_accession(&accession)
+            .expect("build-aware resolution succeeds");
+        assert_eq!(
+            aware.chromosome.as_deref(),
+            Some("NC_000017.10"),
+            "PyProvider must forward the build-aware get_transcript_for_accession \
+             (GRCh37 parent → .10 transcript), not fall through to the primary-build default",
+        );
+
+        // The by-variant sibling delegates to the same build-aware path.
+        let variant = crate::parse_hgvs("NC_000017.10(NM_TEST.1):c.1A>G").expect("parse");
+        let via_variant = provider
+            .get_transcript_for_variant(&variant)
+            .expect("build-aware by-variant resolution succeeds");
+        assert_eq!(via_variant.chromosome.as_deref(), Some("NC_000017.10"));
     }
 }

--- a/tests/python/test_issue_968_length_build_forwarders.py
+++ b/tests/python/test_issue_968_length_build_forwarders.py
@@ -1,0 +1,69 @@
+"""Issue #968: the Python provider must forward get_sequence_length (and
+infer_genome_build) to its inner provider.
+
+`PyProvider` delegated most `ReferenceProvider` methods to its inner
+`Mock`/`MultiFasta` provider but omitted `get_sequence_length`, so it fell
+through to the trait default — which returns `Err(ReferenceNotFound)`
+unconditionally. Every length-dependent path on the Python side therefore
+silently degraded even when the wrapped provider knew the length.
+
+This test exercises the mitochondrial position-past-end bounds check (#393,
+W4004 `POSITION_PAST_END`): in the default (lenient) mode, an `m.` position past
+the contig length emits a warning — but only if `get_sequence_length` returns the
+real contig length. Without the forwarder the length lookup errors and the
+warning is silently dropped, so the test fails, which makes it a non-vacuous
+guard on the forwarding.
+
+(`infer_genome_build` is forwarded in the same change; it is not covered here
+because it is only observable through a `MultiFastaProvider` manifest carrying an
+assembly-report contig-alias table plus a projection whose build inference
+depends on that alias — see the PR discussion.)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import ferro_hgvs
+
+MT_ACCESSION = "NC_012920.1"
+CONTIG_LENGTH = 100  # short synthetic mtDNA; the real 16569 bp is not needed.
+
+
+def _reference_json(tmp_path: Path) -> str:
+    """Write a MockProvider reference JSON with a short mt contig; return its path."""
+    payload = {
+        "transcripts": [],
+        "proteins": {},
+        "genomic_sequences": {MT_ACCESSION: "A" * CONTIG_LENGTH},
+    }
+    path = tmp_path / "ref.json"
+    path.write_text(json.dumps(payload))
+    return str(path)
+
+
+def test_get_sequence_length_forwarded_mt_past_end_warns(tmp_path: Path) -> None:
+    """An `m.` position past the contig end warns (W4004) — which requires the
+    forwarded `get_sequence_length`. Without the forwarder the length lookup
+    errors and the past-end check is silently skipped."""
+    norm = ferro_hgvs.Normalizer(reference_json=_reference_json(tmp_path))
+    # Position 150 > contig length 100 → past the mt contig 3' end.
+    result = norm.normalize_with_warnings(f"{MT_ACCESSION}:m.150A>G")
+    codes = [w.code for w in result.warnings]
+    assert "POSITION_PAST_END" in codes, (
+        f"expected a POSITION_PAST_END (W4004) warning once the contig length is "
+        f"available via the forwarded get_sequence_length; got {codes}"
+    )
+
+
+def test_in_bounds_mt_position_does_not_warn(tmp_path: Path) -> None:
+    """A control: an in-bounds `m.` position emits no past-end warning, so the
+    warning above is driven by the position exceeding the (forwarded) length, not
+    emitted unconditionally."""
+    norm = ferro_hgvs.Normalizer(reference_json=_reference_json(tmp_path))
+    result = norm.normalize_with_warnings(f"{MT_ACCESSION}:m.50A>G")
+    codes = [w.code for w in result.warnings]
+    assert "POSITION_PAST_END" not in codes, (
+        f"an in-bounds m. position must not emit POSITION_PAST_END; got {codes}"
+    )


### PR DESCRIPTION
`PyProvider` (the enum wrapping a Rust `ReferenceProvider` for the Python API) delegated most trait methods to its inner `Mock`/`MultiFasta` provider but omitted four that `MultiFastaProvider` overrides, so each fell through to the trait defaults on the Python path (the same bug class as #961):

- **`get_sequence_length`** — the trait default returns `Err(ReferenceNotFound)` unconditionally, so length-dependent paths (mt/`qter` bounds checks, poly-A tail extension in projection) silently degraded even when the wrapped provider knew the length.
- **`infer_genome_build`** — the trait default infers from the accession alone; the wrapped `MultiFasta` provider layers in assembly-report contig aliases, which the default bypassed.
- **`get_transcript_for_accession` / `get_transcript_for_variant`** — the trait default self-dispatches to the build-**unaware** `get_transcript`, so build-aware transcript resolution (#332 — probe the `genomic_context` parent's build first) was bypassed: a Python consumer resolving a transcript for an `NC_*.10/.11`- or `NG_`-contexted variant got the primary-build (or wrong-build) transcript.

## Change

Forward all four to the inner provider, like the other ~20 methods. After this, `PyProvider` forwards **every** method `MultiFastaProvider` overrides (the last two, `get_transcript_for_*`, were surfaced by a sibling audit while preparing this PR).

## Tests

- **`get_sequence_length`** — a Python test (`tests/python/test_issue_968_length_build_forwarders.py`) drives the mitochondrial position-past-end warning (W4004 `POSITION_PAST_END`), emitted in the default lenient mode only when the real contig length is available via the forwarded lookup. Verified it fails without the forwarder (non-vacuous), with an in-bounds control.
- **`infer_genome_build` and `get_transcript_for_accession`/`_for_variant`** have no Python-facing surface (consulted only internally by projection/normalization), so they are verified by Rust-level `PyProvider` tests under `cargo test --features python`:
  - `infer_genome_build` via a report-only accession (`NC_000017.99`) that only the assembly-report `ContigAliases` classifies (the accession-only default returns `None`).
  - the transcript resolvers via a GRCh38-primary + deferred-GRCh37 cdot fixture where the build-aware path returns the GRCh37 (`NC_000017.10`) transcript while the build-unaware default returns the primary (`NC_000017.11`).
  - Both are non-vacuous by construction. (These Rust tests compile in CI's all-features/wheel jobs and run locally with `--features python`; CI's `cargo nextest` runs `--features dev`, which excludes the PyO3 bindings.)

Closes #968