### PR TITLE
fix(parser): validate compound-reference accession pairings (outer=gene/genomic)

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -13,10 +13,48 @@ use nom::{
     IResult, Parser,
 };
 
-/// Parse an accession (e.g., "NM_000088.3" or "ENST00000012345.1" or "GRCh37(chr23)" or "P54802")
-/// Optimized with byte-based dispatch to avoid trying all 5 alternatives
+/// Parse an accession (e.g., "NM_000088.3" or "ENST00000012345.1" or "GRCh37(chr23)" or "P54802").
+///
+/// For a compound reference `outer(inner)` (e.g. `NC_000013.11(NM_004119.3)`) the outer must be a
+/// genomic/gene reference; backwards pairings such as `NM_x(NG_y)`, `ENSP…(ENST…)`, or
+/// `ENST…(ENSG…)` are rejected here. See `is_valid_compound_outer` (#963).
 #[inline]
 pub fn parse_accession(input: &str) -> IResult<&str, Accession> {
+    let (rest, acc) = parse_accession_dispatch(input)?;
+    // A compound reference stores the inner as the primary accession and the outer in
+    // `genomic_context`. Validate the pairing: the outer must be a genomic/gene reference,
+    // otherwise the parenthetical form is backwards (transcript/protein outer) and rejected.
+    if let Some(outer) = acc.genomic_context.as_deref() {
+        if !is_valid_compound_outer(outer) {
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+    }
+    Ok((rest, acc))
+}
+
+/// Whether `outer` may serve as the outer reference of a compound `outer(inner)` reference —
+/// i.e. it is a genomic or gene reference. In a compound reference the parenthetical inner names
+/// the annotated transcript/feature whose coordinates are used, so the outer must be genomic or
+/// gene: RefSeq `NC_`/`NG_`/`NT_`/`NW_`, Ensembl `ENSG`, or a bare LRG record `LRG_<N>`. This is
+/// keyed off the accession's inferred coordinate class (`g`), so RefSeq, Ensembl, and LRG are
+/// treated consistently, and transcript/protein outers (`NM_`, `NR_`, `XM_`, `XR_`, `ENST`,
+/// `ENSP`, `NP_`, `LRG_<N>t<M>`, …) are rejected. The inner is intentionally not constrained:
+/// non-standard but real forms such as mutalyzer's `NG_x(NP_y)` protein wrapper must still parse.
+fn is_valid_compound_outer(outer: &Accession) -> bool {
+    // The shared coordinate-class oracle already classifies `NC_`/`NG_`/`NT_`/`NW_`/`ENSG`/
+    // bare `LRG_<N>` as genomic (`g`). Also accept the RefSeq genomic prefixes it does not
+    // classify — `AC_` (alternate-assembly) and `NZ_` (WGS) — so a valid genomic outer is
+    // never falsely rejected.
+    outer.inferred_variant_type() == Some("g") || matches!(&*outer.prefix, "AC" | "NZ")
+}
+
+/// Dispatch an accession parse on the first byte(s), avoiding trying all alternatives.
+/// Compound-reference pairing validation lives in [`parse_accession`].
+#[inline]
+fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
     let bytes = input.as_bytes();
     if bytes.is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -1070,6 +1108,58 @@ mod tests {
         );
         assert_eq!(&*acc.prefix, "NC");
         assert!(remaining.starts_with('('));
+    }
+
+    // =========================================================================
+    // Compound reference pairing validation (#963): outer must be genomic/gene.
+    // =========================================================================
+
+    #[test]
+    fn test_parse_compound_ref_rejects_transcript_outer() {
+        // NM_ (transcript) wrapping NG_ (gene) — the backwards RefSeq form.
+        assert!(parse_accession("NM_004119.3(NG_012232.1):c.100A>G").is_err());
+    }
+
+    #[test]
+    fn test_parse_compound_ref_rejects_noncoding_outer() {
+        // NR_ (non-coding RNA transcript) as outer.
+        assert!(parse_accession("NR_046018.2(NM_000088.3):n.100A>G").is_err());
+    }
+
+    #[test]
+    fn test_parse_compound_ref_rejects_protein_outer() {
+        // NP_ (protein) as outer.
+        assert!(parse_accession("NP_004110.2(NM_000088.3):p.Val600Glu").is_err());
+    }
+
+    #[test]
+    fn test_parse_ensembl_compound_rejects_transcript_outer() {
+        // ENST (transcript) wrapping ENSG (gene) — the backwards Ensembl form.
+        assert!(parse_accession("ENST00000375549.8(ENSG00000204370.13):c.100A>G").is_err());
+    }
+
+    #[test]
+    fn test_parse_ensembl_compound_rejects_protein_outer() {
+        // ENSP (protein) wrapping ENST (transcript).
+        assert!(parse_accession("ENSP00000012345.1(ENST00000375549.8):c.100A>G").is_err());
+    }
+
+    #[test]
+    fn test_parse_compound_ref_accepts_alt_assembly_genomic_outer() {
+        // AC_ (alternate-assembly genomic) and NZ_ (WGS) are valid genomic outers even
+        // though the shared coordinate-class oracle does not classify them — they must
+        // not be falsely rejected.
+        assert!(parse_accession("AC_000001.1(NM_000088.3):c.100A>G").is_ok());
+        assert!(parse_accession("NZ_CP000001.1(NM_000088.3):c.100A>G").is_ok());
+    }
+
+    #[test]
+    fn test_parse_compound_ref_keeps_lenient_inner() {
+        // The inner is intentionally not constrained: genomic/gene outers with a
+        // protein or bare-genomic inner still parse (mutalyzer emits these, and
+        // ferro must parse them to re-express as the spec-correct bare form).
+        assert!(parse_accession("NC_000013.11(NP_004110.2):p.Val600Glu").is_ok());
+        assert!(parse_accession("NC_000023.11(LRG_199):g.1A>G").is_ok());
     }
 
     // =========================================================================

--- a/tests/it/issue_963_compound_pairing.rs
+++ b/tests/it/issue_963_compound_pairing.rs
@@ -1,0 +1,76 @@
+//! Compound-reference accession pairing validation (#963).
+//!
+//! A compound reference `outer(inner)` names the annotated transcript/feature
+//! (`inner`) in the context of a genomic/gene reference (`outer`), e.g.
+//! `NC_000013.11(NM_004119.3):c.…` or `NG_012232.1(NM_004006.2):c.…`. The
+//! parser previously accepted *any* pairing, including backwards forms where
+//! the outer is a transcript or protein. These tests pin the end-to-end
+//! behavior at the public `parse_hgvs` API:
+//!
+//! - backwards pairings (transcript/protein outer) are rejected, for both
+//!   RefSeq and Ensembl (symmetric — the Ensembl compound branch was a faithful
+//!   mirror of the permissive RefSeq one, PR #938);
+//! - genuine genomic/gene-outer compounds still parse;
+//! - the *inner* is intentionally left lenient — non-standard but real forms
+//!   such as mutalyzer's `NG_x(NP_y)` protein wrapper must still parse so ferro
+//!   can re-express them as the spec-correct bare form (see the
+//!   `bare-np-protein` conformance cluster).
+
+use ferro_hgvs::parse_hgvs;
+
+/// Backwards compound references — the outer is a transcript or protein — are
+/// rejected at the public parse API, for both RefSeq and Ensembl.
+#[test]
+fn backwards_compound_reference_is_rejected() {
+    let backwards = [
+        // RefSeq: transcript / non-coding / protein outer.
+        "NM_004119.3(NG_012232.1):c.100A>G",
+        "NR_046018.2(NM_000088.3):n.100A>G",
+        "NP_004110.2(NM_000088.3):p.Val600Glu",
+        // Ensembl: transcript / protein outer.
+        "ENST00000375549.8(ENSG00000204370.13):c.100A>G",
+        "ENSP00000012345.1(ENST00000375549.8):c.100A>G",
+    ];
+    for input in backwards {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "expected backwards compound reference to be rejected: {input}"
+        );
+    }
+}
+
+/// Genuine genomic/gene-outer compounds are unaffected and still parse.
+#[test]
+fn genomic_gene_outer_compound_reference_still_parses() {
+    let valid = [
+        "NC_000013.11(NM_004119.3):c.100A>G",
+        "NG_007400.1(NM_000088.3):c.459A>G",
+        "NC_000001.11(NR_046018.2):n.100A>G",
+        "ENSG00000204370.13(ENST00000375549.8):c.100A>G",
+        "LRG_1(NM_000088.3):c.459A>G",
+    ];
+    for input in valid {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "expected genomic/gene-outer compound to parse: {input}"
+        );
+    }
+}
+
+/// The inner is intentionally lenient: a genomic/gene outer with a protein or
+/// bare-genomic inner still parses (mutalyzer emits `NG_x(NP_y)` wrappers and
+/// ferro must parse them to normalize to the spec-correct bare form).
+#[test]
+fn compound_reference_inner_stays_lenient() {
+    let lenient = [
+        "NC_000013.11(NP_004110.2):p.Val600Glu",
+        "NG_007485.1(NP_478102.2):p.Asp68Glu",
+        "NC_000023.11(LRG_199):g.1A>G",
+    ];
+    for input in lenient {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "expected lenient inner compound to parse: {input}"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -203,6 +203,7 @@ mod issue_92_protein_ins_to_dup;
 mod issue_951_circular_normalize_passthrough;
 mod issue_952_protein_consequence_decline;
 mod issue_953_multirepeat_normalization;
+mod issue_963_compound_pairing;
 mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;
 mod issue_l2_w4001_swapped_positions;


### PR DESCRIPTION
Validates compound-reference accession pairings so backwards forms are rejected at parse time, consistently across RefSeq and Ensembl (the Ensembl compound branch added in #938 was a faithful mirror of the permissive RefSeq one, so this fixes the shared pre-existing laxness rather than patching one side).

## What changed

A compound reference `outer(inner)` (e.g. `NC_000013.11(NM_004119.3):c.…`) names the annotated transcript/feature (`inner`) in the context of a genomic/gene reference (`outer`). The parser stores `inner` as the primary accession and `outer` as its `genomic_context`. Validation is centralized in `parse_accession`: after the dispatch, if the result carries a `genomic_context`, the outer must be a genomic/gene reference (`is_valid_compound_outer`, keyed off the accession's inferred coordinate class `g` — RefSeq `NC_`/`NG_`/`NT_`/`NW_`, Ensembl `ENSG`, bare `LRG_<N>`). Backwards pairings are rejected:

- `NM_x(NG_y)` (RefSeq transcript-outer), `NR_x(…)`, `NP_x(…)`
- `ENST…(ENSG…)` (Ensembl transcript-outer), `ENSP…(ENST…)`

Because the fast path bails on any compound (it requires `:` immediately after the accession version), every compound flows through `parse_accession`, so this one choke point covers both the fast and standard entry points — no fast-path change is needed and `fast_path_differential` cannot diverge.

## Why the *inner* is intentionally left lenient

The issue's sketch suggested also restricting the inner to transcripts (`NM_/NR_/XM_/XR_/ENST`). That is deliberately **not** done, because it would break real, required behavior:

- The mutalyzer conformance corpus feeds/expects `NG_x(NP_y):p.` genomic-context-**protein** wrappers (the `bare-np-protein` cluster). ferro must parse these to re-express them as the spec-correct bare-`NP_` form.
- Existing tests pin lenient inners: `NC_(NP_)` protein inner, `NC_(LRG_199p1)` LRG protein inner, `NC_(LRG_199)` bare-genomic inner.

Restricting the inner would reject those and regress conformance. The concrete bad forms the issue calls out are all backwards-**outer**, which the outer check rejects cleanly while keeping inners lenient.

## Conformance (verified, not assumed)

- HGVS spec fixture regenerates and `generate_spec_fixture -- --check` passes (no spec form affected); `hgvs_spec_normalization`, `grammar_conformance`, `idempotency`, and `parser_tests` all green.
- Gated axis conformance against the prepared reference is unchanged before/after this change (113/113, including `comparator_provenance_reference_identity_matches_live`).

## Tests

- Unit (`src/hgvs/parser/accession.rs`): reject backwards transcript/non-coding/protein outers for RefSeq and Ensembl; a guard that lenient inners still parse.
- End-to-end (`tests/it/issue_963_compound_pairing.rs`): rejection and acceptance at the public `parse_hgvs` API, plus the lenient-inner guard.

Closes #963
