### PR TITLE
fix(normalize): canonicalize bracketed inserted-repeat counts >= 2 (#920)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5927,14 +5927,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // returns the edit verbatim. Rewrite the degenerate counts, matching
         // mutalyzer:
         //   [0] — zero copies inserted is a no-op → whole-entity identity (`g.=`).
-        //   [1] — a single inserted copy is equivalent to the plain
-        //         `ins<seq>`, which flows through insertion→duplication
-        //         detection below, so rewrite to `Literal` and recurse (a
-        //         single copy of the adjacent reference then becomes `dup`,
-        //         `duplication.md` L17).
-        // Counts >= 2 are a genuine multi-copy repeat, left for the
-        // repeat-tract machinery (out of scope). The rewrite is purely
-        // syntactic on the stated sequence, so it runs before shuffling. See #920.
+        //   [N>=1] — N inserted copies of the unit are equivalent to the plain
+        //         `ins<unit repeated N times>` literal, which the insertion
+        //         path below canonicalizes: 1 copy of the adjacent reference
+        //         becomes `dup` (`insertion_to_duplication`, `duplication.md`
+        //         L17), and >= 2 copies become `[N]` repeat notation merged
+        //         with any abutting reference tract (`insertion_to_repeat`,
+        //         `repeated.md`; e.g. `g.4_5insGT[5]` against an adjacent
+        //         `GT` tract → `g.1_4GT[7]`). Rewrite to the literal and recurse.
+        // The rewrite is purely syntactic on the stated sequence, so it runs
+        // before shuffling; `Literal::bases()` is `Some`, so the recursion
+        // reaches the alt-extraction below without re-entering this
+        // bracketed-count intercept. See #920.
         if let NaEdit::Insertion { sequence } = edit {
             let degenerate = match sequence {
                 InsertedSequence::SequenceRepeat {
@@ -5948,11 +5952,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 _ => None,
             };
             if let Some((count, unit)) = degenerate {
-                match count {
-                    0 => return Ok((start, end, NaEdit::whole_entity_identity(), warnings)),
-                    1 => {
+                if count == 0 {
+                    return Ok((start, end, NaEdit::whole_entity_identity(), warnings));
+                }
+                // Materializing the expansion bounds memory: a pathologically
+                // large count (`insGT[1e12]`, or a `u64` that overflows the
+                // capacity product) is left to fall through to the verbatim
+                // pass-through below — the pre-#920 behavior — rather than
+                // allocating gigabytes or panicking. No real or conformance
+                // repeat approaches this cap.
+                const MAX_INS_REPEAT_EXPANSION: usize = 1 << 20; // 1 MiB of bases
+                if let Some(expanded_len) = unit.len().checked_mul(count as usize) {
+                    if expanded_len <= MAX_INS_REPEAT_EXPANSION {
+                        let mut expanded = Vec::with_capacity(expanded_len);
+                        for _ in 0..count {
+                            expanded.extend_from_slice(unit.bases());
+                        }
                         let literal = NaEdit::Insertion {
-                            sequence: InsertedSequence::Literal(unit),
+                            sequence: InsertedSequence::Literal(Sequence::new(expanded)),
                         };
                         let (new_start, new_end, new_edit, mut child_warnings) = self
                             .normalize_na_edit(
@@ -5961,7 +5978,6 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         warnings.append(&mut child_warnings);
                         return Ok((new_start, new_end, new_edit, warnings));
                     }
-                    _ => {}
                 }
             }
         }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3012,12 +3012,7 @@
       ],
       "input": "LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]",
       "normalized": "LRG_303:g.6908_6932AGCAACGTGATCGCCTCCCTCACCT[3]",
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "two inserted copies plus the existing copy form a 3-copy repeat; mutalyzer renders the repeat. ferro keeps ins[2]. Repeat canonicalization tracked in #920."
-      }
+      "to_test": true
     },
     {
       "keywords": [
@@ -3033,12 +3028,7 @@
       ],
       "input": "LRG_303:g.4_5insGT[5]",
       "normalized": "LRG_303:g.1_4GT[7]",
-      "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "ferro keeps the inserted repeat as ins GT[5]; mutalyzer merges it with the adjacent existing GT tract into g.1_4GT[7]. Tandem-repeat canonicalization tracked in #920."
-      }
+      "to_test": true
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -236,8 +236,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `LRG_199t1:c.11NG_012337.3(NM_003002.4):c.14[10]` | normalized | accepted_divergence | — | — |
 | `LRG_199t1:c.235_237delinsTAT` | normalized | known_bug | — | #920 |
 | `LRG_1t1:52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]` | errors | accepted_divergence | — | — |
-| `LRG_303:g.4_5insGT[5]` | normalized | known_bug | — | #920 |
-| `LRG_303:g.6932_6933insAGCAACGTGATCGCCTCCCTCACCT[2]` | normalized | known_bug | — | #920 |
 | `NG_007485.1(1787):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A_v001):n.204_205insATC` | errors | accepted_divergence | — | — |
@@ -337,6 +335,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 26 | 5 | 1 | 0 | 15 |
+| normalized | 26 | 3 | 1 | 0 | 15 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |

--- a/tests/it/ins_repeat_b1_matrix.rs
+++ b/tests/it/ins_repeat_b1_matrix.rs
@@ -104,6 +104,67 @@ mod genomic {
         let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAC[0]", &[4, 5]));
         assert_eq!(result, "NC_TEST.1:g.=");
     }
+
+    // `ins<seq>[N]` with N >= 2 is N tandem copies of the unit — equivalent to
+    // the plain `ins<unit*N>` literal, which merges with the adjacent reference
+    // tract into `[N]` repeat notation. The bracketed shorthand must
+    // canonicalize identically to that literal form (mutalyzer merges too).
+
+    #[rstest]
+    fn double_copy_bracketed_single_base_ins_repeat_emits_repeat() {
+        // insA[2] = insAA. Must match the plain insAA case above → A[6].
+        let p = provider("ACAAAACG");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insA[2]", &[2, 3]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}A[6]", &[3, 6]));
+    }
+
+    #[rstest]
+    fn double_copy_bracketed_dinucleotide_ins_repeat_emits_repeat() {
+        // insAT[2] = insATAT. Must match the plain insATAT case above → AT[5].
+        let p = provider("CATATATC");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insAT[2]", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}AT[5]", &[2, 7]));
+    }
+
+    #[rstest]
+    fn double_copy_bracketed_codon_ins_repeat_emits_repeat() {
+        // insCAG[2] = insCAGCAG. Must match the plain insCAGCAG case above → CAG[5].
+        let p = provider("CCAGCAGCAGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insCAG[2]", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}CAG[5]", &[2, 10]));
+    }
+
+    #[rstest]
+    fn higher_copy_bracketed_ins_repeat_counts_added_copies() {
+        // insCAG[3] = 3 inserted copies + 3 existing tract copies = CAG[6],
+        // over the same reference tract span (2_10). Locks the count arithmetic.
+        let p = provider("CCAGCAGCAGT");
+        let result = normalize_to_string(p, &hgvs("NC_TEST.1:g.{0}_{1}insCAG[3]", &[1, 2]));
+        assert_eq!(result, hgvs("NC_TEST.1:g.{0}_{1}CAG[6]", &[2, 10]));
+    }
+
+    // Expanding N copies to a literal must not materialize unbounded memory: a
+    // pathologically large bracketed count is left verbatim (valid HGVS) rather
+    // than OOM/overflow-panic. No real or conformance repeat approaches this.
+
+    #[rstest]
+    fn cap_exceeding_bracketed_count_is_left_verbatim() {
+        // AT * 6_000_000 = 12 MB > the expansion cap → not materialized.
+        let p = provider("CATATATC");
+        let input = hgvs("NC_TEST.1:g.{0}_{1}insAT[6000000]", &[1, 2]);
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, input);
+    }
+
+    #[rstest]
+    fn near_u64_max_bracketed_count_does_not_overflow() {
+        // count near u64::MAX overflows `unit.len() * count`; the checked
+        // multiply guards it → verbatim, no panic.
+        let p = provider("CATATATC");
+        let input = hgvs("NC_TEST.1:g.{0}_{1}insAT[18000000000000000000]", &[1, 2]);
+        let result = normalize_to_string(p, &input);
+        assert_eq!(result, input);
+    }
 }
 
 mod cds_plus {


### PR DESCRIPTION
## What

A bracketed inserted repeat with an exact count >= 2 — multi-base `ins<seq>[N]` (`InsertedSequence::SequenceRepeat`) or single-base `ins<base>[N]` (`InsertedSequence::Repeat`) — bypassed normalization entirely: its `bases()` is `None`, so the alt-sequence extraction returned the edit verbatim. #926 intercepted only `[0]` (→ `g.=`) and `[1]` (→ `dup`), explicitly leaving `[N>=2]` "for the repeat-tract machinery" — but nothing routed it there, so ferro kept the non-canonical `ins[N]` where mutalyzer renders the repeat.

## Fix

N inserted copies of a unit are exactly the plain `ins<unit repeated N times>` literal, which the insertion path already canonicalizes: `insertion_to_repeat` discovers the abutting reference tract (`find_tandem_extent`) and merges the added copies into `[total]` repeat notation. So this unifies the `[1]` and `[N>=2]` arms of the degenerate-count intercept: expand N copies to a `Literal` and recurse (N=1 reduces to #926's existing `Literal(unit)` → dup path). One change fixes two #920 rows:

- **ins→repeat:** `LRG_303:g.6932_6933ins<24mer>[2]` → `g.6908_6932<24mer>[3]` (2 inserted + 1 adjacent reference copy = 3).
- **tandem-repeat merge:** `LRG_303:g.4_5insGT[5]` → `g.1_4GT[7]` (5 inserted copies merge with the adjacent `GT` tract).

### Bounded expansion (guards a DoS I'd otherwise introduce)

Materializing the expansion is memory-bounded: a pathological count (`insGT[1e12]`, or a `u64` that overflows the capacity product — which panicked *"attempt to multiply with overflow"*) falls through to the verbatim pass-through rather than allocating gigabytes or crashing. Cap is 1 MiB of bases; no real or conformance repeat approaches it. This matters because ferro parses untrusted input (web-service mode).

## Validation

- Demotes the two now-passing `known_bug` rows (`known_bug` → pass) in `tests/fixtures/mutalyzer-normalize/cases.json`; `failure-patterns.md` regenerated.
- New unit tests in `ins_repeat_b1_matrix.rs`: bracketed `[N>=2]` matches the plain `ins<unit*N>` literal across single-base / dinucleotide / codon units and a higher count, plus two pathological-count guards (cap-exceeding and near-`u64::MAX` overflow).
- Re-blessed against the prepared reference: `normalized` axis passes (no XPASS), no `genomic` ripple, idempotency preserved. Full suite green (7802 tests), clippy `-D warnings` and `fmt --check` clean.
- End-to-end via the CLI: `insGT[5]` → `g.1_4GT[7]`; `insGT[18000000000000000000]` → verbatim, no panic.

Addresses the ins→repeat and tandem-repeat-merge rows of #920. Part of #326.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of repeated insertions so matching repeat patterns are handled more consistently.
  * Large repeat counts now stay unchanged when expansion would be too large, reducing the risk of excessive memory use or overflow.
  * Removed outdated “known issue” flags from several repeat-related test cases and failure summaries.

* **Tests**
  * Added new regression coverage for repeat-count normalization, including multi-copy cases and large-count edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->