### PR TITLE
test(conformance): reclassify c.235_237delinsTAT as spec_citation, not known_bug (#920)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -1163,6 +1163,18 @@ pub enum SpecSection {
     /// allele. ferro's coding-frame expansion is the spec-correct one (#922).
     #[serde(rename = "HGVS §Copy-range delins (coding-frame reference)")]
     CopyRangeCodingFrame,
+    /// delins one-amino-acid exception (`delins.md` L18-19). Two changes
+    /// separated by a single unchanged nucleotide that together affect one
+    /// amino acid MUST be described as a single `delins`, not decomposed into
+    /// per-position substitutions — the spec's own worked example is
+    /// `c.235_237delinsTAT` (codon 79, `p.Lys79Tyr`), and it explicitly marks
+    /// the decomposed `c.[235A>T;237G>T]` incorrect because it makes tools
+    /// predict conflicting per-position consequences (`p.[Lys79*;Lys79Asn]`).
+    /// The exception is reading-frame-specific: ferro keeps the block delins on
+    /// the coding axis (spec-correct) but decomposes on the genomic axis (no
+    /// reading frame), where it matches mutalyzer (#920).
+    #[serde(rename = "HGVS §delins (one-amino-acid exception)")]
+    DelinsOneAminoAcidException,
 }
 
 impl SpecSection {
@@ -1193,6 +1205,7 @@ impl SpecSection {
                 "HGVS §3'-rule (exon/exon-junction exception)"
             }
             SpecSection::CopyRangeCodingFrame => "HGVS §Copy-range delins (coding-frame reference)",
+            SpecSection::DelinsOneAminoAcidException => "HGVS §delins (one-amino-acid exception)",
         }
     }
 }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -2446,10 +2446,10 @@
       "normalized": "LRG_199t1:c.[235A>T;237G>T]",
       "protein_description": "LRG_199p1:p.(Lys79Tyr)",
       "to_test": true,
-      "known_bug": {
+      "spec_citation": {
         "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "ferro keeps the block delins c.235_237delinsTAT; mutalyzer trims the unchanged interior base and decomposes to per-position substitutions c.[235A>T;237G>T]. Canonical edit-form convergence tracked in #920."
+        "section": "HGVS §delins (one-amino-acid exception)",
+        "note": "ferro keeps the block delins c.235_237delinsTAT on the coding axis; mutalyzer decomposes it to per-position substitutions c.[235A>T;237G>T]. delins.md:18-19 uses THIS EXACT variant as its worked example of the exception: two changes separated by one unchanged nucleotide that together affect one amino acid (here codon 79, c.235_237, p.Lys79Tyr) MUST be described as a delins -- the decomposed c.[235A>T;237G>T] is the form the spec explicitly marks incorrect, because it makes tools predict conflicting per-position consequences (p.[Lys79*;Lys79Asn]) instead of the correct p.Lys79Tyr. ferro's coding-axis delins is therefore the spec-correct form (more spec-faithful than mutalyzer). The exception is codon-frame-specific: on the genomic axis (no reading frame) ferro decomposes to g.[499798A>T;499800G>T], matching mutalyzer, so this divergence is coding-axis-only. Reclassified from known_bug (#920)."
       }
     },
     {

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -234,7 +234,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `LRG_199t1:c.11LRG_199t1:c.11` | errors | accepted_divergence | — | — |
 | `LRG_199t1:c.11LRG_199t1:c.11[10]` | normalized | accepted_divergence | — | — |
 | `LRG_199t1:c.11NG_012337.3(NM_003002.4):c.14[10]` | normalized | accepted_divergence | — | — |
-| `LRG_199t1:c.235_237delinsTAT` | normalized | known_bug | — | #920 |
+| `LRG_199t1:c.235_237delinsTAT` | normalized | spec_citation | — | — |
 | `LRG_1t1:52_153CAG[21]CAA[1]CAG[1]CCG[1]CCA[1]CCG[7]CCT[2]` | errors | accepted_divergence | — | — |
 | `NG_007485.1(1787):n.204_205insATC` | errors | accepted_divergence | — | — |
 | `NG_007485.1(CDKN2A):n.204_205insATC` | errors | accepted_divergence | — | — |
@@ -335,6 +335,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 26 | 3 | 1 | 0 | 15 |
+| normalized | 26 | 2 | 1 | 0 | 16 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
## What & why

`LRG_199t1:c.235_237delinsTAT` was tracked as a `normalized`-axis `known_bug` under #920, on the theory that ferro should decompose the block delins into per-position substitutions `c.[235A>T;237G>T]` the way mutalyzer does. **The HGVS spec says the opposite** — ferro is already correct.

`delins.md` L18-19 uses *this exact variant* as its worked example of the **one-amino-acid exception**:

> **exception**: two variants separated by one nucleotide, together affecting one amino acid, should be described as a "delins". **NOTE**: this prevents tools ... making conflicting and incorrect predictions ... (e.g., `c.235_237delinsTAT` (`p.Lys79Tyr`) versus `c.[235A>T;237G>T]` (`p.[Lys79*;Lys79Asn]`)).

c.235_237 is codon 79 (`p.Lys79Tyr`), so the two changes are separated by one unchanged nucleotide and together affect one amino acid → the spec **mandates** the single delins. The decomposed `c.[235A>T;237G>T]` is the form the spec explicitly marks *incorrect*. ferro's coding-axis block delins is therefore the spec-correct form; mutalyzer diverges.

The exception is **reading-frame-specific**, which the existing axis split already reflects: on the **genomic** axis (no reading frame) ferro decomposes to `g.[499798A>T;499800G>T]`, matching mutalyzer (there is no genomic-axis annotation). The divergence is coding-axis-only, and ferro's protein consequence is the correct `p.(Lys79Tyr)` (protein axis matches).

## Change

- Reclassify the `normalized`-axis annotation from `known_bug{#920}` → `spec_citation` (buckets as `spec_overridden` = ferro-is-spec-correct).
- Add the `SpecSection::DelinsOneAminoAcidException` catalog entry (rename `"HGVS §delins (one-amino-acid exception)"`).
- Regenerate `failure-patterns.md`.

Fixtures + conformance-harness only — **no normalizer change**.

## Validation

Re-blessed against the prepared reference: `normalized` / `genomic` / `protein_description` axes pass, no XPASS. Full suite green (7798 tests), clippy `-D warnings` and `fmt --check` clean, `generate_conformance_summary --check` byte-identical.

Resolves the block-delins interior-trim row of #920 (as `spec_citation`, not a fix). Part of #326.

> Note: touches `cases.json` / `failure-patterns.md`, which also change in the sibling #920 PR #983 — whichever merges second needs a trivial rebase + `generate_conformance_summary` regen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of a specific `delins` edge case so results now match the expected HGVS representation more consistently.
  * Updated conformance records to reflect that this case is now treated as spec-compliant rather than a known issue.
  * Adjusted summary statistics in the normalization report to match the updated classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->