### PR TITLE
test(conformance): reclassify c.[274;600] as accepted_divergence, not known_bug (#920)

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3359,16 +3359,18 @@
       "normalized": "NG_012337.1(NM_003002.2):c.[274;*120]",
       "genomic": "NG_012337.1:g.[7125;13244]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "ferro renders the bare-position allele members with explicit identity and an absolute past-CDS coordinate (c.[274=;600=]); mutalyzer uses the 3'UTR form and drops the identity (c.[274;*120]). Past-CDS coordinate rendering + allele identity tracked in #920."
-      },
-      "accepted_divergence": {
-        "axis": "genomic",
-        "policy": "ferro-policy-654-explicit-identity-rendering",
-        "note": "bare-position allele members (no edit operator) are coerced to the spec no-change form: ferro projects g.[7125=;13244=]; mutalyzer echoes bare positions g.[7125;13244]. A bare member is non-spec (syntax.yaml:8/135 — every allele member is a position_edit; substitution.md:19 — no-change is c.123=), so ferro's explicit identity is at least as spec-faithful; same divergence as the standalone NG_012337.1:274 case (#851)."
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "the normalized (c.) axis diverges from mutalyzer in two ways, both deliberate ferro policy. (1) Explicit identity: the bare-position allele members (no edit operator) are coerced to the spec no-change form -- ferro renders c.[274=;600=], mutalyzer drops the identity (c.[274;*120]). A bare member is non-spec (syntax.yaml:8/135 -- every allele member is a position_edit; substitution.md:19 -- no-change is c.123=), so ferro's explicit = is at least as spec-faithful (same as the genomic axis and the standalone NG_012337.1:274 case, #851). (2) Past-CDS coordinate: c.600 lies past the 480-nt CDS end, so ferro flags it as PositionPastEnd (#336 -- plain c. numbering stops at the stop codon; positions beyond the CDS require the 3'UTR * form) and preserves the input coordinate rather than silently reinterpreting it as mutalyzer's c.*120. Surfacing an out-of-CDS-bounds coordinate as a likely input error, instead of coercing it, is the conservative ferro stance; both forms denote the same locus (c.480+120). Reclassified from known_bug (#920); this aligns the normalized axis with the genomic-axis accepted_divergence below (resolving the #912 axis-inconsistency note for this row)."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "bare-position allele members (no edit operator) are coerced to the spec no-change form: ferro projects g.[7125=;13244=]; mutalyzer echoes bare positions g.[7125;13244]. A bare member is non-spec (syntax.yaml:8/135 — every allele member is a position_edit; substitution.md:19 — no-change is c.123=), so ferro's explicit identity is at least as spec-faithful; same divergence as the standalone NG_012337.1:274 case (#851)."
+        }
+      ]
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -297,7 +297,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.1_4delinsTTGA` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.276C>T` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.[274;600]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #920 |
+| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274del;275=]` | genomic | accepted_divergence | — | — |
@@ -337,6 +337,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 26 | 5 | 1 | 0 | 15 |
+| normalized | 27 | 4 | 1 | 0 | 15 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
## What & why

`NG_012337.1(NM_003002.2):c.[274;600]` was tracked as a `normalized`-axis `known_bug` under #920, expecting ferro to converge on mutalyzer's `c.[274;*120]`. ferro emits `c.[274=;600=]`, and **both differences are deliberate, defensible ferro policy — not bugs.**

**1. Explicit identity (`=`).** The bare-position allele members (no edit operator) are coerced to the spec no-change form: ferro renders `c.[274=;600=]`; mutalyzer drops the identity. A bare member is non-spec (`syntax.yaml:8/135` — every allele member is a `position_edit`; `substitution.md:19` — no-change is `c.123=`), so ferro's explicit `=` is at least as spec-faithful. This is exactly `ferro-policy-654-explicit-identity-rendering`, already the `accepted_divergence` on **this row's genomic axis** and on the standalone `NG_012337.1:274` case (#851).

**2. Past-CDS coordinate (`600` vs `*120`).** `c.600` lies past the 480-nt CDS end. ferro flags it as `PositionPastEnd` (**#336** — plain c. numbering stops at the stop codon; positions beyond the CDS require the 3′UTR `*` form) and *preserves the input coordinate* rather than silently reinterpreting it as mutalyzer's `c.*120`. Surfacing an out-of-CDS-bounds coordinate as a likely input error, instead of coercing it, is the conservative ferro stance; both forms denote the same locus (c.480+120). "Fixing" it by coercing would **remove a `PositionPastEnd` warning #336 deliberately emits.**

## Change

Reclassify the `normalized`-axis annotation from `known_bug{#920}` → `accepted_divergence` (policy-654), matching the genomic-axis entry. This also **resolves the #912 normalized-vs-genomic axis-inconsistency note** for this row (both axes now `accepted_divergence`, same policy). Regenerate `failure-patterns.md`.

Fixtures + generated summary only — **no code change**.

## Validation

Re-blessed against the prepared reference: `normalized` / `genomic` axes pass, no XPASS. Full suite green (7798 tests), `generate_conformance_summary --check` byte-identical.

Resolves the bare-position past-CDS-coordinate row of #920 (as `accepted_divergence`, not a fix). Part of #326.

> Note: touches `cases.json` / `failure-patterns.md`, which also change in sibling #920 PRs #983/#984 — whichever merges later needs a trivial rebase + `generate_conformance_summary` regen.