### PR TITLE
test(conformance): reclassify NM_017668.3 c.CAA[5] repeat as accepted_divergence, not known_bug (#920)

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -599,6 +599,22 @@ pub enum Policy {
     /// ferro is wrong to withhold. Accepted divergence (#938).
     #[serde(rename = "ferro-policy-938-ensembl-version-required")]
     EnsemblVersionRequired938,
+    /// On the `normalized` axis, ferro normalizes a `c.`/`n.` variant against the
+    /// authoritative RefSeq transcript sequence, whereas mutalyzer reads the
+    /// transcript bases through a mis-placed/partial NG_ genomic annotation. For
+    /// `NG_009299.1(NM_017668.3)` (the same partial-coverage defect that makes the
+    /// genomic axis `accepted_rejection` under `ferro-policy-853-...-declined`),
+    /// the authoritative RefSeq NM_017668.3 sequence at c.33-45 is
+    /// `GGAGGAAGAAGCT` — it contains no `CAA`/`AAC` tandem tract — so ferro
+    /// cannot 3'-shift the input `c.33_35CAA[5]` and correctly leaves it
+    /// unchanged. mutalyzer resolves the transcript bases through NG_009299.1's
+    /// mis-placed partial annotation (~60 kb off, minus strand), where a CAA/AAC
+    /// tract does appear, and 3'-shifts it to `c.34_39AAC[6]`. ferro's use of the
+    /// authoritative transcript sequence is correct; the divergence is a
+    /// reference-basis artifact, not a repeat-normalization defect. Accepted
+    /// divergence (#853/#920).
+    #[serde(rename = "ferro-policy-853-refseq-transcript-sequence-authoritative")]
+    RefseqTranscriptSequenceAuthoritative853,
 }
 
 impl Policy {
@@ -619,6 +635,9 @@ impl Policy {
             }
             Policy::BareNpNoParentContext923 => "ferro-policy-923-bare-np-no-parent-context",
             Policy::EnsemblVersionRequired938 => "ferro-policy-938-ensembl-version-required",
+            Policy::RefseqTranscriptSequenceAuthoritative853 => {
+                "ferro-policy-853-refseq-transcript-sequence-authoritative"
+            }
             Policy::WholeCdsDeletionMet1 => "ferro-policy-whole-cds-del-met1",
             Policy::HomopolymerRepeatContraction745 => {
                 "ferro-policy-745-homopolymer-repeat-contraction"

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3082,10 +3082,10 @@
       "normalized": "NG_009299.1(NM_017668.3):c.34_39AAC[6]",
       "genomic": "NG_009299.1:g.137803_137808TTG[6]",
       "to_test": true,
-      "known_bug": {
+      "accepted_divergence": {
         "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "ferro keeps the input repeat anchor (c.33_35CAA[5]); mutalyzer 3'-shifts the repeat unit to c.34_39AAC[6]. Repeat 3' normalization tracked in #920."
+        "policy": "ferro-policy-853-refseq-transcript-sequence-authoritative",
+        "note": "NOT a repeat-3'-normalization gap: the CAA/AAC tract does not exist in ferro's authoritative RefSeq NM_017668.3 sequence. The RefSeq mRNA at c.33-45 is GGAGGAAGAAGCT (CDS start c.1 = ATG at RefSeq tx offset 93), so there is no CAA tract at c.33_35 (GGA) nor an AAC tract at c.34_39 (GAGGAA) to 3'-shift; ferro correctly leaves c.33_35CAA[5] unchanged (normalize_repeat finds no matching tract at the anchor and returns Unchanged). mutalyzer resolves the transcript bases through NG_009299.1's mis-placed partial annotation -- the same defect that makes the genomic axis accepted_rejection below (cdot places NM_017668.3 ~60 kb outside the NG_'s span, minus strand) -- where a CAA/AAC tract does appear, and 3'-shifts it to c.34_39AAC[6]. ferro's use of the authoritative RefSeq transcript sequence is correct; the divergence is a reference-basis artifact, not a normalization defect. Reclassified from known_bug (#920); shares the #853 root cause with the genomic-axis accepted_rejection."
       },
       "accepted_rejection": {
         "axis": "genomic",

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -275,7 +275,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_008939.1:g.5207_5212delins[GTCCTGTGCT;4310_4320inv]` | coding_protein_descriptions | accepted_divergence | — | — |
 | `NG_009299.1(NM_002474.3):c.[310del;295G>A]` | normalized | spec_citation | — | — |
 | `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | genomic | accepted_divergence | — | — |
-| `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | normalized | known_bug | — | #920 |
+| `NG_009299.1(NM_017668.3):c.33_35CAA[5]` | normalized | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.41A>C` | genomic | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | infos | accepted_divergence | — | — |
 | `NG_009299.1(NM_017668.3):c.[250del;41>CA]` | normalized | accepted_divergence | — | — |
@@ -335,6 +335,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 26 | 2 | 1 | 0 | 16 |
+| normalized | 27 | 1 | 1 | 0 | 16 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
## What & why

`NG_009299.1(NM_017668.3):c.33_35CAA[5]` was tracked as a `normalized`-axis `known_bug` under #920, on the theory that ferro fails to 3′-shift the repeat to mutalyzer's `c.34_39AAC[6]`. Instrumenting `normalize_repeat` shows the real cause: **the CAA/AAC tract does not exist in ferro's authoritative RefSeq NM_017668.3 sequence.**

The RefSeq mRNA at c.33-45 is `GGAGGAAGAAGCT` (verified: CDS start `c.1 = ATG` at RefSeq tx offset 93). There is **no** CAA tract at c.33_35 (the reference is `GGA`) nor an AAC tract at c.34_39 (`GAGGAA`), so `normalize_repeat` finds no matching tract at the anchor and returns `Unchanged`. ferro correctly leaves the input unchanged — there is nothing to 3′-shift.

mutalyzer resolves the transcript bases through NG_009299.1's **mis-placed partial annotation** — the *same* defect that already makes this row's **genomic axis `accepted_rejection`** (cdot places NM_017668.3 ~60 kb outside the NG_'s span, minus strand; `ferro-policy-853`). Read through that placement a CAA/AAC tract appears, which mutalyzer 3′-shifts to `c.34_39AAC[6]`. ferro's use of the authoritative RefSeq transcript sequence is correct; the divergence is a **reference-basis artifact, not a repeat-normalization defect.**

## Change

Reclassify the `normalized`-axis annotation from `known_bug{#920}` → `accepted_divergence`, adding `Policy::RefseqTranscriptSequenceAuthoritative853` (`ferro-policy-853-refseq-transcript-sequence-authoritative`) so it shares the documented **#853** root cause with the genomic-axis `accepted_rejection`.

Fixtures + conformance-harness only — **no normalizer change**.

## Validation

Re-blessed against the prepared reference: `normalized` / `genomic` axes pass, no XPASS. Full suite green (7798 tests), clippy `-D warnings` and `fmt --check` clean, `generate_conformance_summary --check` byte-identical.

Resolves the last repeat-3′-shift row of #920 (as `accepted_divergence`, not a fix). Part of #326.

> Note: touches `cases.json` / `failure-patterns.md`, shared with sibling #920 PRs #983/#984/#985 — whichever merges later needs a trivial rebase + `generate_conformance_summary` regen. **After all four merge, #920 has zero remaining rows and can be closed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new accepted divergence category in Mutalyzer normalization checks.
  * Updated tracked results to classify one case as an accepted divergence instead of a known bug.

* **Bug Fixes**
  * Refined the reported normalization status for a specific transcript-related repeat case.
  * Adjusted the overall conformance tallies to match the updated classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->