### PR TITLE
fix(normalize): render plain past-CDS coordinates in canonical c.*N form (#920/#336)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -34,7 +34,7 @@ pub mod validate;
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
 use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, ProteinEdit, RepeatCount, Sequence};
-use crate::hgvs::interval::{Interval, ProtInterval};
+use crate::hgvs::interval::{CdsInterval, Interval, ProtInterval};
 use crate::hgvs::location::{
     AminoAcid, CdsPos, GenomePos, ProtPos, RnaPos, SpecialPosition, TxPos,
 };
@@ -233,6 +233,43 @@ fn check_cds_pos_past_end(
         });
     }
     None
+}
+
+/// Canonicalize a plain past-CDS coordinate to its 3'UTR `*N` form for output.
+///
+/// A plain `c.<N>` with `N > cds_len` is out-of-scheme HGVS: coding-DNA
+/// numbering ends at the last base of the stop codon, and 3'UTR positions use
+/// the `*` prefix (`background/numbering.md` L21/L30) — so the nucleotide `N -
+/// cds_len` bases past the stop is *named* `c.*(N - cds_len)`, not `c.<N>`.
+/// When `N` maps into the 3'UTR (`1 <= N - cds_len <= utr3_len`) this returns
+/// that canonical `*N` position.
+///
+/// This is a rendering canonicalization only — the same nucleotide, in valid
+/// syntax — so callers still emit the `PositionPastEnd` (W4004) warning to flag
+/// that the input used out-of-scheme numbering, and strict mode still rejects.
+/// A position past the whole transcript (`N - cds_len > utr3_len`) has no valid
+/// `*N` form and is returned unchanged, as are 3'UTR (`*N`), 5'UTR (`-N`),
+/// intronic-offset, special, and unknown positions. See #920/#336.
+fn canonicalize_pastcds_pos_to_utr3(
+    pos: &CdsPos,
+    transcript: &crate::reference::transcript::Transcript,
+) -> CdsPos {
+    if pos.is_unknown() || pos.utr3 || pos.special.is_some() || pos.offset.is_some() || pos.base < 1
+    {
+        return *pos;
+    }
+    let (Some(cds_len), Some(utr3_len)) = (transcript.cds_length(), transcript.utr3_length())
+    else {
+        return *pos;
+    };
+    let base = pos.base as u64;
+    if base > cds_len {
+        let utr3_base = base - cds_len;
+        if utr3_base >= 1 && utr3_base <= utr3_len {
+            return CdsPos::utr3(utr3_base as i64);
+        }
+    }
+    *pos
 }
 
 /// If `pos` (an `n.<N>` transcript position) lies past the transcript's
@@ -2143,8 +2180,86 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         }
                     }
                     if !bounds_warnings.is_empty() {
+                        // Render any plain past-CDS coordinate in canonical
+                        // `c.*N` form (the input used out-of-scheme numbering;
+                        // the W4004 warning above still flags it, and strict
+                        // mode still rejects). Only a simple certain
+                        // single/point interval is rewritten; a
+                        // genuinely-past-transcript position is left untouched
+                        // by the helper. See #920/#336.
+                        let new_start = canonicalize_pastcds_pos_to_utr3(start_pos, transcript);
+                        let new_end = canonicalize_pastcds_pos_to_utr3(end_pos, transcript);
+                        let both_certain = variant
+                            .loc_edit
+                            .location
+                            .start
+                            .as_single()
+                            .is_some_and(|m| m.is_certain())
+                            && variant
+                                .loc_edit
+                                .location
+                                .end
+                                .as_single()
+                                .is_some_and(|m| m.is_certain());
+                        // Only pure positional shuffle edits get the idempotent
+                        // full-normalization treatment. These never carry an
+                        // `ins[...]`/`con` cross-reference payload, so rewriting
+                        // to `c.*N` and recursing cannot re-enter (and fail) the
+                        // `try_expand_cds_ins` expansion the bounds gate is
+                        // ordered to precede. Substitutions don't shuffle;
+                        // ins/delins/dupins/con keep the plain early-return so a
+                        // past-end input still rejects on the coordinate (strict
+                        // mode -> InvalidCoordinates).
+                        let is_shuffle_only_edit = matches!(
+                            edit,
+                            NaEdit::Deletion { .. }
+                                | NaEdit::NPaddedDeletion { .. }
+                                | NaEdit::Duplication { .. }
+                                | NaEdit::Inversion { .. }
+                        );
+                        if both_certain
+                            && is_shuffle_only_edit
+                            && (new_start != *start_pos || new_end != *end_pos)
+                        {
+                            // The plain past-CDS coordinate maps into the 3'UTR:
+                            // rewrite it to the in-bounds `c.*N` form and run
+                            // FULL normalization on the result. Running the
+                            // shuffle here (rather than returning the merely
+                            // position-canonicalized variant) keeps the output
+                            // idempotent — a shufflable `del`/`dup` in a 3'UTR
+                            // repeat would otherwise render `c.*Ndel` on the
+                            // first pass and then 3'-shift again on a second
+                            // normalize pass. The rewritten position is in
+                            // bounds, so this recursion does not re-enter the
+                            // past-end gate. Re-attach the W4004 warning that
+                            // flags the out-of-scheme input. See #920/#336.
+                            let mut v = variant.clone();
+                            v.loc_edit.location = CdsInterval::new(new_start, new_end);
+                            let (normalized, mut warns) = self.normalize_cds(&v)?;
+                            let mut merged = bounds_warnings;
+                            merged.append(&mut warns);
+                            return Ok((normalized, merged));
+                        }
+                        // Non-shuffle edit (substitution, `=`, or an
+                        // ins/delins/dupins/con that must not be expanded on a
+                        // `*N` marker): still render the plain past-CDS
+                        // coordinate in its canonical `c.*N` form when one exists
+                        // (the PR's core feature), canonicalizing only the edit
+                        // body. These edits do not 3'-shift, so no recursion is
+                        // needed for idempotency. A genuinely-past-transcript or
+                        // uncertain position leaves `out_variant == variant`.
+                        let rewritten;
+                        let out_variant =
+                            if both_certain && (new_start != *start_pos || new_end != *end_pos) {
+                                let mut v = variant.clone();
+                                v.loc_edit.location = CdsInterval::new(new_start, new_end);
+                                rewritten = v;
+                                &rewritten
+                            } else {
+                                variant
+                            };
                         return Ok((
-                            HV::Cds(self.canonicalize_cds_variant(variant)),
+                            HV::Cds(self.canonicalize_cds_variant(out_variant)),
                             bounds_warnings,
                         ));
                     }

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -3349,16 +3349,18 @@
       "normalized": "NG_012337.1(NM_003002.2):c.[274;*120]",
       "genomic": "NG_012337.1:g.[7125;13244]",
       "to_test": true,
-      "known_bug": {
-        "axis": "normalized",
-        "tracking_issue": 920,
-        "note": "ferro renders the bare-position allele members with explicit identity and an absolute past-CDS coordinate (c.[274=;600=]); mutalyzer uses the 3'UTR form and drops the identity (c.[274;*120]). Past-CDS coordinate rendering + allele identity tracked in #920."
-      },
-      "accepted_divergence": {
-        "axis": "genomic",
-        "policy": "ferro-policy-654-explicit-identity-rendering",
-        "note": "bare-position allele members (no edit operator) are coerced to the spec no-change form: ferro projects g.[7125=;13244=]; mutalyzer echoes bare positions g.[7125;13244]. A bare member is non-spec (syntax.yaml:8/135 — every allele member is a position_edit; substitution.md:19 — no-change is c.123=), so ferro's explicit identity is at least as spec-faithful; same divergence as the standalone NG_012337.1:274 case (#851)."
-      }
+      "accepted_divergence": [
+        {
+          "axis": "normalized",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "the normalized (c.) axis divergence is now purely the explicit-identity rendering (policy-654), identical to the genomic axis below and the standalone NG_012337.1:274 case: ferro renders the bare-position allele members in the spec no-change form c.[274=;*120=]; mutalyzer drops the identity to c.[274;*120]. The past-CDS coordinate is now canonical on both sides -- ferro renders c.*120 (the 3'UTR form), not the out-of-scheme plain c.600 it previously echoed (fixed in this PR: a plain past-CDS coordinate that maps into the 3'UTR is rendered as c.*N while still emitting the W4004 PositionPastEnd warning; strict mode still rejects, #336). A bare allele member is non-spec (syntax.yaml:8/135 -- every allele member is a position_edit; substitution.md:19 -- no-change is c.123=), so ferro's explicit = is at least as spec-faithful. Reclassified from known_bug (#920)."
+        },
+        {
+          "axis": "genomic",
+          "policy": "ferro-policy-654-explicit-identity-rendering",
+          "note": "bare-position allele members (no edit operator) are coerced to the spec no-change form: ferro projects g.[7125=;13244=]; mutalyzer echoes bare positions g.[7125;13244]. A bare member is non-spec (syntax.yaml:8/135 — every allele member is a position_edit; substitution.md:19 — no-change is c.123=), so ferro's explicit identity is at least as spec-faithful; same divergence as the standalone NG_012337.1:274 case (#851)."
+        }
+      ]
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -295,7 +295,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_012337.1(NM_003002.2):c.1_4delinsTTGA` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.276C>T` | protein_description | spec_citation | — | — |
 | `NG_012337.1(NM_003002.2):c.[274;600]` | genomic | accepted_divergence | — | — |
-| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | known_bug | — | #920 |
+| `NG_012337.1(NM_003002.2):c.[274;600]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | genomic | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274=;275del]` | normalized | accepted_divergence | — | — |
 | `NG_012337.1(NM_003002.2):c.[274del;275=]` | genomic | accepted_divergence | — | — |
@@ -335,6 +335,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 26 | 2 | 1 | 0 | 16 |
+| normalized | 27 | 1 | 1 | 0 | 16 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -224,6 +224,7 @@ mod normalize_property_tests;
 mod normalize_tests;
 mod paraphase_exhaustive_tests;
 mod parser_tests;
+mod pastcds_star_canonicalization;
 mod perf_table;
 mod predicted_cis_allele;
 mod projection;

--- a/tests/it/pastcds_star_canonicalization.rs
+++ b/tests/it/pastcds_star_canonicalization.rs
@@ -1,0 +1,96 @@
+//! A plain past-CDS coordinate that maps into the 3'UTR must render in the
+//! canonical `c.*N` form in lenient/silent mode (not echoed as an out-of-scheme
+//! plain integer such as `c.600`), while the W4004 `PositionPastEnd` warning
+//! still fires. Strict mode still rejects (see `issue_336_position_past_end`).
+//! A position past the whole transcript has no valid `c.*N` form and is left
+//! as-is.
+//!
+//! Motivated by `NG_012337.1(NM_003002.2):c.[274;600]`, where mutalyzer emits
+//! `c.*120` (CDS length 480) and ferro previously echoed the non-canonical,
+//! LOVD-invalid `c.600` (#920/#985).
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Single-exon synthetic transcript (mirrors `issue_336_position_past_end`):
+///   CDS: tx 4..12 (`cds_len = 9`); 3'UTR: tx 13..20 (`c.*1..c.*8`).
+fn provider_short_cds() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let sequence = "AAAATGAAATAGCCCCCCCC".to_string();
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some(4),
+        Some(12),
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// Normalize `input` under the default (lenient) config; return the rendered
+/// variant string and whether a `POSITION_PAST_END` (W4004) warning fired.
+fn norm(input: &str) -> (String, bool) {
+    let provider = provider_short_cds();
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse");
+    let out = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("lenient mode must not error on a past-end position");
+    let warned = out.warnings.iter().any(|w| w.code() == "POSITION_PAST_END");
+    (out.result.to_string(), warned)
+}
+
+#[test]
+fn plain_past_cds_in_3utr_renders_star_and_still_warns() {
+    // c.10 = *1 (cds_len 9; 3'UTR c.*1..c.*8). Canonicalize the plain past-CDS
+    // coordinate to c.*1, but keep the W4004 flag (the input was out-of-scheme).
+    let (s, warned) = norm("NM_TEST.1:c.10=");
+    assert_eq!(s, "NM_TEST.1:c.*1=");
+    assert!(warned, "the W4004 past-CDS warning must still fire");
+}
+
+#[test]
+fn plain_past_cds_last_3utr_base_renders_star() {
+    // c.17 = *8, the last base of the 3'UTR (still in-bounds).
+    let (s, _) = norm("NM_TEST.1:c.17=");
+    assert_eq!(s, "NM_TEST.1:c.*8=");
+}
+
+#[test]
+fn position_past_whole_transcript_is_not_canonicalized() {
+    // c.18 = *9, but the 3'UTR is only 8 long -> past the transcript end. There
+    // is no valid c.*N for it, so leave it echoed (and still warned) rather than
+    // inventing an out-of-range 3'UTR coordinate.
+    let (s, warned) = norm("NM_TEST.1:c.18=");
+    assert_eq!(s, "NM_TEST.1:c.18=");
+    assert!(warned);
+}
+
+#[test]
+fn plain_past_cds_del_in_3utr_homopolymer_is_shuffled_and_idempotent() {
+    // The 3'UTR is CCCCCCCC (c.*1..c.*8) — a homopolymer, so a deletion 3'-shifts
+    // to its 3'-most position (c.*8del). A plain past-CDS `c.10del` (= *1del) must
+    // therefore normalize straight to the fully-shuffled canonical `c.*8del` on
+    // the FIRST pass — not the merely position-rewritten `c.*1del` — otherwise a
+    // second normalize pass would move it again, breaking idempotency.
+    let (s1, warned) = norm("NM_TEST.1:c.10del");
+    assert_eq!(
+        s1, "NM_TEST.1:c.*8del",
+        "past-CDS del must render fully 3'-shifted"
+    );
+    assert!(warned, "the W4004 past-CDS warning must still fire");
+    // Idempotent: normalize(normalize(x)) == normalize(x).
+    let (s2, _) = norm(&s1);
+    assert_eq!(s2, s1, "second normalize pass must not move it again");
+}


### PR DESCRIPTION
## What & why

A plain `c.<N>` with `N > cds_len` is **out-of-scheme HGVS** — coding-DNA numbering ends at the last base of the stop codon, and 3′UTR positions use the `*` prefix (`numbering.md` L21/L30). ferro accepted such inputs in lenient mode but **echoed them verbatim**: e.g. `NM_003002.2:c.600` (CDS length 480) came back as `c.600`, a string LOVD / VariantValidator reject as *syntactically invalid* — instead of the canonical `c.*120`.

This came out of the #985 adversarial review: ferro's *flag-don't-coerce* stance is defensible (VariantValidator agrees), but **emitting the invalid string** was the one genuine defect.

## Fix

Render the position ferro already computed in canonical `*N` form when it maps into the 3′UTR (`1 ≤ N − cds_len ≤ utr3_len`), via a new `canonicalize_pastcds_pos_to_utr3` applied in the lenient bounds-check pass (which already has the transcript, `cds_len`, and `utr3_len`). It's a **rendering canonicalization only — the same nucleotide, in valid syntax** — so it does *not* adopt mutalyzer's silent coercion:

- The **W4004 `PositionPastEnd` warning still fires** (the input used out-of-scheme numbering) — ferro flags rather than silently coerces.
- **Strict mode still rejects** (unchanged) — consistent with ferro's strict-refuses / lenient-recovers contract, and with VariantValidator's flag posture. Both #336 strict tests pass **unchanged** (neither asserts the lenient output string).
- A position **past the whole transcript** (`N − cds_len > utr3_len`) has no valid `*N` form and is left untouched. 3′UTR / 5′UTR / intronic / special / unknown positions are untouched; only a simple certain point interval is rewritten.

New MockProvider unit tests cover in-3′UTR → `*N` (+ warning still fires), the last 3′UTR base, and the past-transcript guard.

## Conformance

`NG_012337.1(NM_003002.2):c.[274;600]` now normalizes to **`c.[274=;*120=]`** — the coordinate matches mutalyzer's `c.[274;*120]`, leaving only the explicit-identity `=` divergence. That row's `normalized` axis is reclassified `known_bug{#920}` → `accepted_divergence` (`ferro-policy-654`), now **identical to its genomic-axis entry** and the standalone `NG_012337.1:274` case.

### Supersedes #985
#985 reclassified this same row *without* fixing the coordinate (two-part `=`+coordinate note). This PR fixes the coordinate and leaves a clean `=`-only reclassification, so **#985 should be closed** in favor of this one.

## Validation

Re-blessed against the prepared reference: `normalized` / `genomic` axes pass, no XPASS, idempotent. Full suite green (7801), clippy `-D warnings` + `fmt --check` clean, `generate_conformance_summary --check` byte-identical.

Part of #326.

> Note: touches `cases.json` / `failure-patterns.md`, shared with #920 PRs #983/#984/#986 — whichever merges later needs a trivial rebase + summary regen.