### PR TITLE
fix(convert): CDS<->tx is transcript-native across intra-exon CIGAR insertions (#944)

### DIFF
--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -251,31 +251,13 @@ impl<'a> CoordinateMapper<'a> {
         // Most real transcripts from cdot are contiguous
         let has_gaps = sorted_exons.windows(2).any(|w| w[0].end + 1 != w[1].start);
         if !has_gaps {
-            // No gaps - use simple calculation, adjusted for CIGAR insertions.
-            // This is the inverse of cds_to_tx_exon_aware: subtract the net
-            // CIGAR insertion offset to convert transcript positions back to
-            // CDS positions (which follow genome alignment).
-            let (adj_target, adj_start) = if !self.transcript.exon_cigars.is_empty() {
-                if let (Ok(target_u64), Ok(start_u64)) =
-                    (u64::try_from(target_tx), u64::try_from(start_tx))
-                {
-                    (
-                        self.transcript.cigar_insertion_adjustment(target_u64),
-                        self.transcript.cigar_insertion_adjustment(start_u64),
-                    )
-                } else {
-                    (0, 0)
-                }
-            } else {
-                (0, 0)
-            };
-            let net_adj = adj_target as i64 - adj_start as i64;
-            // For CDS (target >= start), formula is target - start + 1 - net_adj
-            // For 5' UTR (target < start), formula is target - start - net_adj
+            // Inverse of cds_to_tx_exon_aware on the pure-transcript axis: no CIGAR
+            // adjustment (#944 — CDS positions do NOT "follow genome alignment").
+            // target >= start => CDS; target < start => 5' UTR.
             if target_tx >= start_tx {
-                return Ok(target_tx - start_tx + 1 - net_adj);
+                return Ok(target_tx - start_tx + 1);
             } else {
-                return Ok(target_tx - start_tx - net_adj);
+                return Ok(target_tx - start_tx);
             }
         }
 
@@ -1319,6 +1301,19 @@ mod tests {
         assert_eq!(mapper.cds_to_tx(&CdsPos::new(3)).unwrap().base, 3);
         // After the 3bp insertion — must NOT shift by +3 (bug produced 13).
         assert_eq!(mapper.cds_to_tx(&CdsPos::new(10)).unwrap().base, 10);
+    }
+
+    #[test]
+    fn cds_tx_round_trip_across_cigar_insertion() {
+        // tx_to_cds must invert cds_to_tx with no CIGAR adjustment (#944).
+        let tx = make_cigar_insertion_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // Round-trip a post-insertion position: c.10 -> tx 10 -> c.10.
+        let tx_pos = mapper.cds_to_tx(&CdsPos::new(10)).unwrap();
+        assert_eq!(tx_pos.base, 10);
+        assert_eq!(mapper.tx_to_cds(&tx_pos).unwrap().base, 10);
+        // Direct n->c: tx 10 -> c.10 (bug produced c.7).
+        assert_eq!(mapper.tx_to_cds(&TxPos::new(10)).unwrap().base, 10);
     }
 }
 

--- a/src/convert/mapper.rs
+++ b/src/convert/mapper.rs
@@ -104,24 +104,13 @@ impl<'a> CoordinateMapper<'a> {
         // Most real transcripts from cdot are contiguous
         let has_gaps = sorted_exons.windows(2).any(|w| w[0].end + 1 != w[1].start);
         if !has_gaps {
-            // No gaps - use simple calculation, adjusted for CIGAR insertions.
-            // CDS numbering follows the genome alignment (skips CIGAR insertion bases),
-            // so we need to add the net CIGAR insertion offset between start and target.
-            let raw_tx = start_tx + offset;
-            if !self.transcript.exon_cigars.is_empty() && offset >= 0 {
-                // Only apply CIGAR adjustment when offset is non-negative (within
-                // or after CDS). Negative offsets point into the 5' UTR before the
-                // CDS start, where CIGAR insertions within exons don't apply.
-                if let (Ok(start_u64), Ok(raw_u64)) =
-                    (u64::try_from(start_tx), u64::try_from(raw_tx))
-                {
-                    let adj_start = self.transcript.cigar_insertion_adjustment(start_u64);
-                    let adj_target = self.transcript.cigar_insertion_adjustment(raw_u64);
-                    let net_adj = adj_target as i64 - adj_start as i64;
-                    return Ok(raw_tx + net_adj);
-                }
-            }
-            return Ok(raw_tx);
+            // No tx-coordinate gaps: c./n. numbering and the transcript sequence
+            // both count every base — including bases inserted relative to the
+            // genome via a CIGAR `I` — so CDS<->tx on this pure-transcript axis is
+            // naive `start_tx + offset`, with NO CIGAR adjustment. Adjusting here
+            // was a genome-centric error that shifted every position 3' of an
+            // intra-exon insertion (#944; NM_015120.4 c.87 -> n.198, not n.201).
+            return Ok(start_tx + offset);
         }
 
         // Exons have gaps - use exon-aware mapping
@@ -772,6 +761,7 @@ pub struct GenomicLocation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data::CigarOp;
     use crate::reference::transcript::{Exon, ManeStatus, Strand};
     use std::sync::OnceLock;
 
@@ -1290,6 +1280,45 @@ mod tests {
                 cds_pos, tx_pos.base, back.base
             );
         }
+    }
+
+    fn make_cigar_insertion_transcript() -> Transcript {
+        Transcript {
+            id: "NM_INS.1".to_string(),
+            gene_symbol: Some("INS".to_string()),
+            strand: Strand::Plus,
+            sequence: Some("A".repeat(40)),
+            cds_start: Some(1),
+            cds_end: Some(40),
+            exons: vec![Exon::new(1, 1, 40)],
+            chromosome: None,
+            genomic_start: None,
+            genomic_end: None,
+            genome_build: Default::default(),
+            mane_status: ManeStatus::default(),
+            refseq_match: None,
+            ensembl_match: None,
+            protein_id: None,
+            // M5 I3 M32: 3 inserted transcript bases at tx 6,7,8.
+            exon_cigars: vec![Some(vec![
+                CigarOp::Match(5),
+                CigarOp::Insertion(3),
+                CigarOp::Match(32),
+            ])],
+            cached_introns: OnceLock::new(),
+        }
+    }
+
+    #[test]
+    fn cds_to_tx_is_transcript_native_across_cigar_insertion() {
+        // #944: c./n. numbering counts inserted transcript bases, so CDS->tx is
+        // naive with NO CIGAR adjustment. cds_start=1 => c.N -> tx N (1-based).
+        let tx = make_cigar_insertion_transcript();
+        let mapper = CoordinateMapper::new(&tx);
+        // Before the insertion — unaffected.
+        assert_eq!(mapper.cds_to_tx(&CdsPos::new(3)).unwrap().base, 3);
+        // After the 3bp insertion — must NOT shift by +3 (bug produced 13).
+        assert_eq!(mapper.cds_to_tx(&CdsPos::new(10)).unwrap().base, 10);
     }
 }
 

--- a/src/data/cdot.rs
+++ b/src/data/cdot.rs
@@ -1265,42 +1265,6 @@ pub fn parse_cigar(cigar_str: &str) -> Result<Vec<CigarOp>, FerroError> {
         .collect()
 }
 
-/// Compute the cumulative insertion offset at a given 1-based transcript position.
-///
-/// Walks through the CIGAR operations and counts insertion bases that occur
-/// before `tx_pos`. Insertions add bases to the transcript that do not exist
-/// in the genome, so CDS numbering (which follows the genome) must account
-/// for them.
-///
-/// Returns the total number of insertion bases encountered before `tx_pos`.
-pub fn cumulative_insertion_offset(ops: &[CigarOp], tx_pos: u64) -> u64 {
-    let mut current_tx: u64 = 0;
-    let mut cumulative: u64 = 0;
-
-    for op in ops {
-        match op {
-            CigarOp::Match(len) => {
-                current_tx += len;
-            }
-            CigarOp::Insertion(len) => {
-                // If the entire insertion is before tx_pos, count it all
-                if current_tx + len <= tx_pos {
-                    cumulative += len;
-                }
-                current_tx += len;
-            }
-            CigarOp::Deletion(_) => {
-                // Deletions don't advance the transcript position
-            }
-        }
-        if current_tx >= tx_pos {
-            break;
-        }
-    }
-
-    cumulative
-}
-
 /// Raw cdot JSON file structure (as it appears on disk).
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)] // Fields used for serde deserialization
@@ -5182,80 +5146,6 @@ mod tests {
     fn test_parse_cigar_too_short_token() {
         let result = parse_cigar("M");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_before_insertion() {
-        // CIGAR: M185 I3 M250 — 3bp insertion at tx position 186-188
-        // At tx position 100 (before insertion): offset = 0
-        let cigar = vec![
-            CigarOp::Match(185),
-            CigarOp::Insertion(3),
-            CigarOp::Match(250),
-        ];
-        assert_eq!(cumulative_insertion_offset(&cigar, 100), 0);
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_after_insertion() {
-        // At tx position 200 (after insertion): offset = 3
-        let cigar = vec![
-            CigarOp::Match(185),
-            CigarOp::Insertion(3),
-            CigarOp::Match(250),
-        ];
-        assert_eq!(cumulative_insertion_offset(&cigar, 200), 3);
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_at_end() {
-        // At tx position 437 (end of exon, 185+3+250-1): offset = 3
-        let cigar = vec![
-            CigarOp::Match(185),
-            CigarOp::Insertion(3),
-            CigarOp::Match(250),
-        ];
-        assert_eq!(cumulative_insertion_offset(&cigar, 437), 3);
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_no_insertions() {
-        let cigar = vec![CigarOp::Match(500)];
-        assert_eq!(cumulative_insertion_offset(&cigar, 250), 0);
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_multiple_insertions() {
-        // M100 I2 M100 I5 M100 — two insertions
-        let cigar = vec![
-            CigarOp::Match(100),
-            CigarOp::Insertion(2),
-            CigarOp::Match(100),
-            CigarOp::Insertion(5),
-            CigarOp::Match(100),
-        ];
-        // Before first insertion
-        assert_eq!(cumulative_insertion_offset(&cigar, 50), 0);
-        // After first insertion, before second
-        assert_eq!(cumulative_insertion_offset(&cigar, 150), 2);
-        // After both insertions
-        assert_eq!(cumulative_insertion_offset(&cigar, 300), 7);
-    }
-
-    #[test]
-    fn test_cumulative_insertion_offset_with_deletion() {
-        // M100 D5 M100 I3 M100 — deletion doesn't affect insertion offset
-        let cigar = vec![
-            CigarOp::Match(100),
-            CigarOp::Deletion(5),
-            CigarOp::Match(100),
-            CigarOp::Insertion(3),
-            CigarOp::Match(100),
-        ];
-        // Before insertion (deletions don't advance tx position)
-        assert_eq!(cumulative_insertion_offset(&cigar, 150), 0);
-        // After insertion
-        assert_eq!(cumulative_insertion_offset(&cigar, 250), 3);
     }
 
     // -------------------------------------------------------------------------

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -30,8 +30,7 @@ pub mod mapping;
 pub mod projection;
 
 pub use cdot::{
-    cumulative_insertion_offset, parse_cigar, CdotFile, CdotLoadSource, CdotMapper, CdotTranscript,
-    CdsPosition, CigarOp, Exon,
+    parse_cigar, CdotFile, CdotLoadSource, CdotMapper, CdotTranscript, CdsPosition, CigarOp, Exon,
 };
 pub use mapping::{CoordinateMapper, MappingInfo, MappingResult};
 pub use projection::{ManeStatus, ProjectionResult, Projector, TranscriptProjection};

--- a/src/project/transcript_axis.rs
+++ b/src/project/transcript_axis.rs
@@ -153,12 +153,13 @@ mod tests {
     }
 
     #[test]
-    fn cigar_insertion_shifts_n_coordinate_vs_flat() {
-        // M1 regression: the n. derivation must route through the exon/CIGAR-aware
-        // `cds_to_tx`, not a flat CDS-offset shift. With a CIGAR insertion of 2
-        // bases before the variant, c.6 maps to n.8 — a flat `cds_start + base -
-        // 1` (= 6) would be wrong and would disagree with the c. form's true
-        // transcript position.
+    fn cigar_insertion_n_coordinate_is_transcript_native() {
+        // #944: HGVS c./n. numbering is transcript-native — a CIGAR insertion adds
+        // transcript bases that BOTH the CDS and n. coordinate already count, so
+        // c.6 maps to n.6 with NO shift (the 2 inserted bases are c.4/c.5). The n.
+        // derivation must still route through the same CIGAR-aware `cds_to_tx` as
+        // the c. form (c/n consistency — this test's original #592 intent); after
+        // the #944 fix both agree at n.6.
         let tx = Transcript {
             id: "NM_CIGAR.1".to_string(),
             gene_symbol: None,
@@ -183,13 +184,13 @@ mod tests {
             ])],
             cached_introns: OnceLock::new(),
         };
-        // Exon/CIGAR-aware: c.6 → n.8 (the 2 inserted bases shift it up by 2).
+        // Transcript-native: c.6 -> n.6.
         assert_eq!(
             n_string(CdsPos::new(6), &tx, "NM_CIGAR.1"),
-            "NM_CIGAR.1:n.8A>G"
+            "NM_CIGAR.1:n.6A>G"
         );
-        // Consistency: matches the authoritative mapper exactly.
+        // Consistency: the mapper agrees.
         let mapper = CoordinateMapper::new(&tx);
-        assert_eq!(mapper.cds_to_tx(&CdsPos::new(6)).unwrap().base, 8);
+        assert_eq!(mapper.cds_to_tx(&CdsPos::new(6)).unwrap().base, 6);
     }
 }

--- a/src/reference/transcript.rs
+++ b/src/reference/transcript.rs
@@ -13,7 +13,7 @@
 //!
 //! For type-safe coordinate handling, see [`crate::coords`].
 
-use crate::data::{cumulative_insertion_offset, CigarOp};
+use crate::data::CigarOp;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::sync::OnceLock;
@@ -553,56 +553,6 @@ impl Transcript {
     /// Check if this is any type of MANE transcript
     pub fn is_mane(&self) -> bool {
         self.mane_status.is_mane()
-    }
-
-    /// Compute the cumulative CIGAR insertion offset at a raw transcript position.
-    ///
-    /// When CDS positions are mapped to transcript positions using simple arithmetic
-    /// (`cds_start + offset`), the result doesn't account for CIGAR insertion bases.
-    /// This method computes the number of insertion bases across all exons up to the
-    /// given raw position, which should be added to get the correct transcript position.
-    ///
-    /// The `raw_tx_pos` is in "mixed" coordinates: the CDS start (in tx coords) plus
-    /// a genome-aligned offset. Insertions before this position need to be counted.
-    pub fn cigar_insertion_adjustment(&self, raw_tx_pos: u64) -> u64 {
-        if self.exon_cigars.is_empty() {
-            return 0;
-        }
-
-        let mut adjustment: u64 = 0;
-        let mut sorted_indices: Vec<usize> = (0..self.exons.len()).collect();
-        sorted_indices.sort_by_key(|&i| self.exons[i].start);
-
-        for &idx in &sorted_indices {
-            let exon = &self.exons[idx];
-            let cigar = match self.exon_cigars.get(idx) {
-                Some(Some(ops)) if !ops.is_empty() => ops,
-                _ => continue,
-            };
-
-            // If the exon starts past our adjusted target, stop
-            if exon.start > raw_tx_pos + adjustment {
-                break;
-            }
-
-            // Compute position within this exon for the cumulative_insertion_offset function
-            let exon_tx_len = exon.end - exon.start + 1;
-            let adjusted_target = raw_tx_pos + adjustment;
-
-            let pos_in_exon = if adjusted_target >= exon.end {
-                // Past this exon — count all insertions
-                exon_tx_len
-            } else if adjusted_target >= exon.start {
-                // Within this exon
-                adjusted_target - exon.start + 1
-            } else {
-                continue;
-            };
-
-            adjustment += cumulative_insertion_offset(cigar, pos_in_exon);
-        }
-
-        adjustment
     }
 
     /// Get cached introns, computing them lazily if not already cached

--- a/tests/it/issue_944_cds_to_tx_transcript_native.rs
+++ b/tests/it/issue_944_cds_to_tx_transcript_native.rs
@@ -1,0 +1,102 @@
+//! Issue #944: CDS<->tx is transcript-native across intra-exon CIGAR indels.
+//!
+//! Reference-backed (skips unless `FERRO_MANIFEST` points at a prepared
+//! reference). Ground truth confirmed against the RefSeq mRNA and
+//! VariantValidator: NM_015120.4 exon 0 CIGAR `M185 I3 M250`, so c./n.
+//! numbering counts the 3 inserted bases and positions 3' of the insertion
+//! must NOT shift by +3.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use ferro_hgvs::convert::CoordinateMapper;
+use ferro_hgvs::hgvs::location::{CdsPos, TxPos};
+use ferro_hgvs::reference::multi_fasta::MultiFastaProvider;
+use ferro_hgvs::reference::ReferenceProvider;
+
+fn manifest_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+#[test]
+fn nm_015120_cds_to_tx_transcript_native_across_insertion() {
+    let Some(provider) = provider() else {
+        eprintln!("issue_944: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let tx = provider
+        .get_transcript("NM_015120.4")
+        .expect("NM_015120.4 present in reference");
+    let mapper = CoordinateMapper::new(&tx);
+
+    // c.1 -> n.112 (pre-insertion control); c.76 -> n.187 (unaffected).
+    assert_eq!(mapper.cds_to_tx(&CdsPos::new(1)).unwrap().base, 112);
+    assert_eq!(mapper.cds_to_tx(&CdsPos::new(76)).unwrap().base, 187);
+    // c.77 -> n.188, c.87 -> n.198 (would be n.191/n.201 under the +3 bug).
+    assert_eq!(mapper.cds_to_tx(&CdsPos::new(77)).unwrap().base, 188);
+    assert_eq!(mapper.cds_to_tx(&CdsPos::new(87)).unwrap().base, 198);
+
+    // Round-trip: tx 198 -> c.87.
+    assert_eq!(mapper.tx_to_cds(&TxPos::new(198)).unwrap().base, 87);
+
+    // Base-exactness: c.87 reference base is G (transcript 0-based index 197).
+    let base = provider
+        .get_sequence("NM_015120.4", 197, 198)
+        .expect("read c.87 base");
+    assert_eq!(base.to_ascii_uppercase(), "G");
+}
+
+#[test]
+fn nm_000277_cds_to_tx_naive_across_deletion() {
+    // PAH — carries a CIGAR deletion; the transcript axis must stay naive
+    // (deletions add no transcript bases), i.e. contiguous with no shift.
+    let Some(provider) = provider() else {
+        eprintln!("issue_944: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let tx = provider
+        .get_transcript("NM_000277.3")
+        .expect("NM_000277.3 present in reference");
+    let mapper = CoordinateMapper::new(&tx);
+    // Independent oracle: hardcoded expected transcript positions (not derived
+    // from the method under test). c.1 anchors at n.115; a naive,
+    // deletion-transparent axis places c.N at exactly n.(114 + N) with no
+    // CIGAR-deletion shift. Under the pre-#944 bug, positions past the deletion
+    // were pulled 5' by the deletion length and would miss these anchors.
+    for (n, expected_tx) in [
+        (1_i64, 115_i64),
+        (50, 164),
+        (100, 214),
+        (300, 414),
+        (500, 614),
+    ] {
+        assert_eq!(
+            mapper.cds_to_tx(&CdsPos::new(n)).unwrap().base,
+            expected_tx,
+            "c.{n} must map to n.{expected_tx} (naive across the deletion)",
+        );
+        // Round-trip through the inverse re-derives c.N.
+        assert_eq!(mapper.tx_to_cds(&TxPos::new(expected_tx)).unwrap().base, n);
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -200,6 +200,7 @@ mod issue_91_protein_three_prime_shift;
 mod issue_920_allele_sub_collapse;
 mod issue_92_protein_delins_to_dup;
 mod issue_92_protein_ins_to_dup;
+mod issue_944_cds_to_tx_transcript_native;
 mod issue_951_circular_normalize_passthrough;
 mod issue_952_protein_consequence_decline;
 mod issue_953_multirepeat_normalization;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -4366,7 +4366,7 @@ mod cigar_aware_normalization {
     // =========================================================================
 
     #[rstest]
-    // NM_015120.4 (ABHD12): CIGAR has I3 in exon 0 — 3bp insertion shifts CDS
+    // NM_015120.4 (ABHD12): has I3 in exon 0 (CIGAR-complex transcript)
     #[case("NM_015120.4:c.1433-12_1433-10dup", "NM_015120.4:c.1433-12_1433-10dup")]
     #[case("NM_015120.4:c.450+22_450+25del", "NM_015120.4:c.450+22_450+25del")]
     #[case("NM_015120.4:c.9540-7dup", "NM_015120.4:c.9540-7dup")]
@@ -4630,18 +4630,18 @@ mod lrg_intronic_normalization {
 #[cfg(test)]
 mod cigar_cds_mapping {
     // =========================================================================
-    // Unit tests for CIGAR-aware CDS→transcript mapping.
-    // These verify that CDS positions are correctly adjusted when CIGAR
-    // insertions/deletions exist in the alignment.
+    // Unit tests for transcript-native CDS↔tx mapping. Inserted transcript
+    // bases (CIGAR `I`) ARE numbered by c./n., so `CdotTranscript::cds_to_tx`
+    // applies NO CIGAR adjustment.
     // =========================================================================
 
-    use ferro_hgvs::data::{CdotTranscript, CigarOp};
+    use ferro_hgvs::data::CdotTranscript;
     use ferro_hgvs::reference::Strand;
 
     /// Create a transcript that models NM_015120.4's exon 0:
     /// CIGAR = M185 I3 M250, start_codon=111
-    /// The 3bp insertion at tx pos 186-188 means CDS numbering (which follows
-    /// the genome) should account for these extra transcript bases.
+    /// The 3 inserted bases are themselves numbered by c./n. (transcript-native);
+    /// CDS↔tx does not shift across them.
     fn transcript_with_cigar_insertion() -> CdotTranscript {
         // Exon 0: 438bp on transcript (185+3+250), 435bp on genome (185+250)
         // Exon 1: next exon starting after intron
@@ -4684,59 +4684,28 @@ mod cigar_cds_mapping {
     }
 
     #[test]
-    #[ignore] // Until CIGAR-aware CDS mapping is implemented
     fn test_cds_to_tx_with_cigar_insertion() {
+        // #944: CDS numbering is transcript-native. `CdotTranscript::cds_to_tx`
+        // is pure arithmetic `cds_start + (cds_pos - 1)` and is already correct;
+        // an intra-exon insertion does NOT shift it (the inserted bases are part
+        // of the transcript and are themselves numbered). This documents the
+        // convention; the mapper-level guard lives in the #944 mapper tests.
         let tx = transcript_with_cigar_insertion();
-        let _cigar = [
-            CigarOp::Match(185),
-            CigarOp::Insertion(3),
-            CigarOp::Match(250),
-        ];
-
-        // Without CIGAR awareness: c.1 maps to tx 111, c.100 maps to tx 210
-        // These are before the insertion point (tx 185), so should be unchanged
+        // cds_start = 111 (0-based). c.1 -> 111, c.75 -> 185, c.76 -> 186.
         assert_eq!(tx.cds_to_tx(1), Some(111));
         assert_eq!(tx.cds_to_tx(75), Some(185));
-
-        // With CIGAR awareness: positions past the insertion should shift by +3
-        // c.76 should map to tx 189 (not 186), because insertion adds 3 bases
-        // Currently: cds_to_tx(76) = 111 + 75 = 186 (WRONG — in insertion)
-        // Expected: cds_to_tx(76) = 111 + 75 + 3 = 189 (after insertion)
-
-        // This test documents the desired behavior for CIGAR-aware mapping.
-        // The simple cds_to_tx doesn't account for CIGAR, so positions after
-        // the insertion are off by the cumulative insertion count.
-        //
-        // A CIGAR-aware version would need to:
-        // 1. Convert CDS pos to raw tx pos: tx_raw = cds_start + (cds_pos - 1)
-        // 2. Walk CIGAR ops, adjusting for insertions before tx_raw
-        // 3. Return adjusted tx pos
-
-        // For now, verify basic mapping works for pre-insertion positions
-        assert_eq!(tx.cds_to_tx(1), Some(111));
+        assert_eq!(tx.cds_to_tx(76), Some(186)); // NOT 189 — no +3 for the insertion.
     }
 
     #[test]
-    #[ignore] // Until CIGAR-aware CDS mapping is implemented
     fn test_cds_to_tx_with_cigar_deletion() {
+        // #944: a CIGAR deletion removes GENOME bases the transcript lacks, so it
+        // adds no transcript bases — CDS->tx is naive and unshifted across the D.
         let tx = transcript_with_cigar_deletion();
-        let _cigar = [
-            CigarOp::Match(504),
-            CigarOp::Deletion(2),
-            CigarOp::Match(123),
-        ];
-
-        // Without CIGAR awareness: c.1 maps to tx 100
+        // cds_start = 100 (0-based).
         assert_eq!(tx.cds_to_tx(1), Some(100));
-
-        // D2 means genome has 2 extra bases that aren't in the transcript.
-        // Positions before the deletion boundary (tx 504) are unaffected.
-        // Positions after should NOT shift (deletion doesn't add tx bases).
-        //
-        // However, CDS numbering follows genome numbering, so CDS positions
-        // spanning the deletion may reference genome positions that have no
-        // transcript counterpart. The CDS→tx conversion needs to account
-        // for this gap.
+        assert_eq!(tx.cds_to_tx(405), Some(504)); // last CDS base before the D boundary
+        assert_eq!(tx.cds_to_tx(406), Some(505)); // just after — no shift
     }
 
     #[test]


### PR DESCRIPTION
Closes #944.
Related: #972 (a separate, orthogonal CDS-numbering bug — incomplete 5′ start codon — in the same neighborhood; not addressed here).

## Summary

Issue #944's remaining half was described with an inverted expected value. HGVS c./n./r. numbering is transcript-native — bases inserted in the transcript relative to the genome (CIGAR `I`) are part of the mRNA and ARE counted — so CDS↔tx needs NO CIGAR adjustment. `CoordinateMapper::cds_to_tx`/`tx_to_cds` were adding/subtracting a phantom insertion offset, silently shifting every c./n./r./SPDI position 3′ of an intra-exon insertion by the insertion length.

Proven against `NM_015120.4` (exon 0 `M185 I3 M250`): `c.87` reference base is G, mapping to `n.198` / `NC_000002.12:g.73385952` (VariantValidator-confirmed — positive `c.87G>A` valid, negative `c.87T>A` rejected). Before this fix `ferro project c.87 --axis n` returned `n.201`.

## Changes

- Remove the CIGAR insertion adjustment from both `cds_to_tx_exon_aware` and `tx_to_cds_exon_aware` (no-gaps path) so they are transcript-native and round-trip.
- Invert the #592 test that codified the shift (`c.6 → n.6`, not `n.8`); its c/n-consistency intent is preserved.
- Add mapper-level and reference-backed (`FERRO_MANIFEST`-guarded) regression tests, including a deletion case (`NM_000277.3`).
- Un-ignore + correct the two synthetic `CdotTranscript::cds_to_tx` tests to transcript-native truth.
- Delete the now-dead `cigar_insertion_adjustment` / `cumulative_insertion_offset` primitives (drops a pre-1.0 `pub` re-export of `cumulative_insertion_offset`).

The tx↔genome axis already uses the naive `CdotTranscript::cds_to_tx` and is unaffected.

## Validation

Full suite green; all reference-driven conformance axes (mutalyzer / biocommons / hgvs_rs — coding, noncoding, protein, rna, genomic, normalized) pass against the prepared reference with no baseline flips.
