### PR TITLE
feat(protein): parse insXaa[n] and insTer<n>/ins*<n> inserted sequences

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -2377,8 +2377,33 @@ fn run_effect(
                             ferro_hgvs::hgvs::edit::ProteinEdit::Deletion { .. } => {
                                 predictor.classify_indel(3, 0)
                             }
+                            ferro_hgvs::hgvs::edit::ProteinEdit::Insertion { sequence }
+                                if sequence.introduces_stop() =>
+                            {
+                                // `insTer<n>` / `ins*<n>` (or a literal ending in
+                                // `Ter`) introduces a premature stop.
+                                ProteinEffect {
+                                    consequences: vec![Consequence::StopGained],
+                                    impact: Consequence::StopGained.impact(),
+                                    amino_acid_change: None,
+                                    intronic_offset: None,
+                                }
+                            }
                             ferro_hgvs::hgvs::edit::ProteinEdit::Insertion { .. } => {
                                 predictor.classify_indel(0, 3)
+                            }
+                            ferro_hgvs::hgvs::edit::ProteinEdit::Delins { sequence }
+                                if sequence.ends_with_stop() =>
+                            {
+                                // A delins whose inserted sequence ends in `Ter`
+                                // (`delinsLeuTer`) truncates the protein — a
+                                // premature stop, mirroring the insertion arm.
+                                ProteinEffect {
+                                    consequences: vec![Consequence::StopGained],
+                                    impact: Consequence::StopGained.impact(),
+                                    amino_acid_change: None,
+                                    intronic_offset: None,
+                                }
                             }
                             _ => ProteinEffect {
                                 consequences: vec![Consequence::ProteinAlteringVariant],

--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -1010,6 +1010,14 @@ impl AminoAcidSeq {
         Self(aas)
     }
 
+    /// True when the sequence ends in a translation stop (`Ter`). An
+    /// inserted/delins sequence ending in `Ter` introduces a premature stop
+    /// (nonsense), not a plain in-frame edit — e.g. the spec's
+    /// `p.(Pro578_Lys579delinsLeuTer)`.
+    pub fn ends_with_stop(&self) -> bool {
+        matches!(self.0.last(), Some(AminoAcid::Ter))
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -1025,6 +1033,54 @@ impl fmt::Display for AminoAcidSeq {
             write!(f, "{}", aa)?;
         }
         Ok(())
+    }
+}
+
+/// How an inserted protein sequence is specified in an `ins`/`delins` edit.
+///
+/// Beyond a literal residue string, the spec (`protein/insertion.md:21,45-61`)
+/// allows two length-based shorthands used when the exact inserted residues are
+/// deducible from the DNA/RNA level but too long or unknown to spell out:
+///   - `insXaa[n]` — `n` unknown residues (open reading frame insertion),
+///   - `ins*<n>` / `insTer<n>` — an inserted sequence ending in a translation
+///     stop at 1-based position `n` within the insertion (`n - 1` residues,
+///     then the stop).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProteinInsSeq {
+    /// Literal inserted residues, including a single `Xaa`/`Ter` (e.g. `insGln`,
+    /// `insGlnSerLys`, `insXaa`, `insGlyTer`).
+    Literal(AminoAcidSeq),
+    /// `insXaa[n]` — a single residue (in practice `Xaa`) repeated `count` times.
+    Repeat { aa: AminoAcid, count: RepeatCount },
+    /// `ins*<n>` / `insTer<n>` — inserted sequence ending in a stop at 1-based
+    /// position `n` within the insertion.
+    Stop { position: u64 },
+}
+
+impl ProteinInsSeq {
+    /// True when the inserted sequence introduces a translation stop — either an
+    /// explicit `Stop { .. }` length form or a literal whose last residue is
+    /// `Ter`. Such an insertion gains a premature stop rather than being a plain
+    /// in-frame insertion (`protein/delins.md:28`).
+    pub fn introduces_stop(&self) -> bool {
+        match self {
+            ProteinInsSeq::Stop { .. } => true,
+            ProteinInsSeq::Literal(seq) => seq.ends_with_stop(),
+            ProteinInsSeq::Repeat { .. } => false,
+        }
+    }
+}
+
+impl fmt::Display for ProteinInsSeq {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProteinInsSeq::Literal(seq) => write!(f, "{}", seq),
+            // `RepeatCount` Display already emits the `[n]` brackets.
+            ProteinInsSeq::Repeat { aa, count } => write!(f, "{}{}", aa, count),
+            // Canonicalize the stop to three-letter `Ter`, matching
+            // frameshift/extension Display (`*` is accepted on input).
+            ProteinInsSeq::Stop { position } => write!(f, "Ter{}", position),
+        }
     }
 }
 
@@ -1083,8 +1139,9 @@ pub enum ProteinEdit {
         count: Option<u64>,
     },
 
-    /// Insertion: addition of amino acids (e.g., p.Lys23_Leu24insGln)
-    Insertion { sequence: AminoAcidSeq },
+    /// Insertion: addition of amino acids (e.g., p.Lys23_Leu24insGln,
+    /// p.Lys2_Leu3insXaa[34], p.Lys2_Leu3insTer12). See [`ProteinInsSeq`].
+    Insertion { sequence: ProteinInsSeq },
 
     /// Deletion-insertion: replacement of amino acids
     Delins { sequence: AminoAcidSeq },
@@ -2083,7 +2140,7 @@ mod tests {
     #[test]
     fn test_protein_edit_insertion() {
         let edit = ProteinEdit::Insertion {
-            sequence: AminoAcidSeq(vec![AminoAcid::Ala, AminoAcid::Gly]),
+            sequence: ProteinInsSeq::Literal(AminoAcidSeq(vec![AminoAcid::Ala, AminoAcid::Gly])),
         };
         assert_eq!(format!("{}", edit), "insAlaGly");
     }

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -4,7 +4,7 @@
 
 use crate::hgvs::edit::{
     AminoAcidSeq, Base, ExtDirection, FrameshiftTer, InsertedPart, InsertedSequence,
-    MethylationStatus, NaEdit, ProteinEdit, RepeatCount, RepeatUnit, Sequence,
+    MethylationStatus, NaEdit, ProteinEdit, ProteinInsSeq, RepeatCount, RepeatUnit, Sequence,
 };
 use crate::hgvs::location::AminoAcid;
 use crate::hgvs::parser::position::{
@@ -1937,12 +1937,71 @@ fn parse_amino_acid_seq(input: &str) -> IResult<&str, AminoAcidSeq> {
     map(many1(parse_amino_acid), AminoAcidSeq::new).parse(input)
 }
 
-/// Parse protein insertion (e.g., insGln, insGlnProArg)
+/// Parse protein insertion (e.g., insGln, insGlnProArg, insXaa[5], insTer12, ins*63)
 fn parse_protein_insertion(input: &str) -> IResult<&str, ProteinEdit> {
-    map(preceded(tag("ins"), parse_amino_acid_seq), |sequence| {
+    map(preceded(tag("ins"), parse_protein_ins_seq), |sequence| {
         ProteinEdit::Insertion { sequence }
     })
     .parse(input)
+}
+
+/// Parse the inserted-sequence payload of a protein `ins` edit.
+///
+/// Ordering matters: the stop form (`Ter<n>` / `*<n>`) must be tried before the
+/// literal form, because `parse_amino_acid` greedily reads a leading `Ter`/`*`
+/// as a stop *residue* and would otherwise swallow it and leave the digits
+/// dangling. The repeat form (`Xaa[n]`) is tried before a multi-residue literal.
+fn parse_protein_ins_seq(input: &str) -> IResult<&str, ProteinInsSeq> {
+    alt((
+        parse_protein_ins_stop,
+        parse_protein_ins_repeat,
+        map(parse_amino_acid_seq, ProteinInsSeq::Literal),
+    ))
+    .parse(input)
+}
+
+/// Parse `Ter<n>` / `*<n>` — an inserted sequence ending in a stop at 1-based
+/// position `n`. `n == 0` is rejected (like frameshift/extension positions), so
+/// a bare `insTer` / `ins*` falls through to the literal parser instead.
+fn parse_protein_ins_stop(input: &str) -> IResult<&str, ProteinInsSeq> {
+    let (rest, _) = alt((tag("Ter"), tag("*"))).parse(input)?;
+    let (rest, position) = map_res(digit1, |s: &str| {
+        let n = s
+            .parse::<u64>()
+            .map_err(|_| "inserted-stop position overflow")?;
+        if n == 0 {
+            return Err("inserted-stop position must be >= 1");
+        }
+        Ok::<u64, &'static str>(n)
+    })
+    .parse(rest)?;
+    Ok((rest, ProteinInsSeq::Stop { position }))
+}
+
+/// Parse `Xaa[n]` — an unknown residue (`Xaa`) repeated an exact positive number
+/// of times. The spec sanctions only this form (`insertion.md` L21, examples
+/// `Xaa[23]`/`Xaa[5]`): the residue must be the unknown `Xaa` and the count an
+/// exact `n >= 1`. So a known residue (`insGln[5]`), a stop (`insTer[5]` — that
+/// is the `insTer<n>` stop form, not a repeat), and non-exact/zero counts
+/// (`[0]`, `[?]`, `[2_5]`) are rejected here; they fall through to the literal
+/// parser, which then rejects the trailing `[...]` as unconsumed input. A
+/// multi-residue literal (e.g. `insGlnProArg`) has no `[` and also falls through.
+fn parse_protein_ins_repeat(input: &str) -> IResult<&str, ProteinInsSeq> {
+    let (rest, aa) = parse_amino_acid(input)?;
+    if aa != AminoAcid::Xaa {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+    let (rest, count) = parse_repeat_count(rest)?;
+    match &count {
+        RepeatCount::Exact(n) if *n >= 1 => Ok((rest, ProteinInsSeq::Repeat { aa, count })),
+        _ => Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        ))),
+    }
 }
 
 /// Parse protein delins (e.g., delinsGlu, delinsTrpVal)
@@ -2787,20 +2846,80 @@ mod tests {
         // Single amino acid
         let (remaining, edit) = parse_protein_edit("insGln").unwrap();
         assert_eq!(remaining, "");
-        if let ProteinEdit::Insertion { sequence } = edit {
-            assert_eq!(sequence.len(), 1);
+        if let ProteinEdit::Insertion {
+            sequence: ProteinInsSeq::Literal(seq),
+        } = edit
+        {
+            assert_eq!(seq.len(), 1);
         } else {
-            panic!("Expected insertion");
+            panic!("Expected literal insertion, got {edit:?}");
         }
 
         // Multiple amino acids
         let (remaining, edit) = parse_protein_edit("insGlyPro").unwrap();
         assert_eq!(remaining, "");
-        if let ProteinEdit::Insertion { sequence } = edit {
-            assert_eq!(sequence.len(), 2);
+        if let ProteinEdit::Insertion {
+            sequence: ProteinInsSeq::Literal(seq),
+        } = edit
+        {
+            assert_eq!(seq.len(), 2);
         } else {
-            panic!("Expected insertion");
+            panic!("Expected literal insertion, got {edit:?}");
         }
+    }
+
+    #[test]
+    fn test_parse_protein_insertion_special_sequences() {
+        use crate::hgvs::edit::RepeatCount;
+
+        // insXaa[n] — repeated unknown residue.
+        let (remaining, edit) = parse_protein_edit("insXaa[5]").unwrap();
+        assert_eq!(remaining, "");
+        assert!(
+            matches!(
+                edit,
+                ProteinEdit::Insertion {
+                    sequence: ProteinInsSeq::Repeat {
+                        aa: AminoAcid::Xaa,
+                        count: RepeatCount::Exact(5)
+                    }
+                }
+            ),
+            "got {edit:?}"
+        );
+
+        // insTer<n> and ins*<n> — inserted stop at 1-based position n.
+        for s in ["insTer12", "ins*12"] {
+            let (remaining, edit) = parse_protein_edit(s).unwrap();
+            assert_eq!(remaining, "");
+            assert!(
+                matches!(
+                    edit,
+                    ProteinEdit::Insertion {
+                        sequence: ProteinInsSeq::Stop { position: 12 }
+                    }
+                ),
+                "{s} -> {edit:?}"
+            );
+        }
+
+        // Bare `insTer` (no digits) stays a literal Ter residue, not a Stop.
+        let (_, edit) = parse_protein_edit("insTer").unwrap();
+        assert!(
+            matches!(
+                edit,
+                ProteinEdit::Insertion {
+                    sequence: ProteinInsSeq::Literal(_)
+                }
+            ),
+            "bare insTer should be literal, got {edit:?}"
+        );
+
+        // `insTer0` has no valid Stop reading (0 rejected); `Ter` parses as a
+        // literal residue and the `0` is left unconsumed, so the enclosing
+        // variant parser rejects the trailing `0` rather than accepting `Ter0`.
+        let (remaining, _) = parse_protein_edit("insTer0").unwrap();
+        assert_eq!(remaining, "0");
     }
 
     #[test]

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -33,7 +33,9 @@ pub mod validate;
 
 use crate::coords::{hgvs_pos_to_index, index_to_hgvs_pos};
 use crate::error::FerroError;
-use crate::hgvs::edit::{Base, InsertedSequence, NaEdit, ProteinEdit, RepeatCount, Sequence};
+use crate::hgvs::edit::{
+    Base, InsertedSequence, NaEdit, ProteinEdit, ProteinInsSeq, RepeatCount, Sequence,
+};
 use crate::hgvs::interval::{CdsInterval, Interval, ProtInterval};
 use crate::hgvs::location::{
     AminoAcid, CdsPos, GenomePos, ProtPos, RnaPos, SpecialPosition, TxPos,
@@ -3295,8 +3297,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // (anchored at p.X) is canonicalized to `<a>_<b>dup` over
             // that upstream range. The 3'-shift pass that follows will
             // then walk the dup to its canonical anchor. (#92)
-            ProteinEdit::Insertion { sequence } => self
-                .try_protein_ins_to_dup(variant, sequence)
+            // Only a literal inserted sequence can duplicate upstream residues.
+            // `insXaa[n]` / `insTer<n>` have no concrete residues to compare, so
+            // they pass through unchanged via the catch-all arm below.
+            ProteinEdit::Insertion {
+                sequence: ProteinInsSeq::Literal(seq),
+            } => self
+                .try_protein_ins_to_dup(variant, seq)
                 .unwrap_or_else(|| (edit.clone(), variant.loc_edit.location.clone())),
             // HGVS Prioritization: delins is the last-resort form. A
             // delins whose inserted residues share an affix with the
@@ -3828,7 +3835,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     loc_edit: crate::hgvs::variant::LocEdit::with_uncertainty(
                         Interval::new(synth_start, synth_end),
                         variant.loc_edit.edit.map_ref(|_| ProteinEdit::Insertion {
-                            sequence: residual_seq.clone(),
+                            sequence: ProteinInsSeq::Literal(residual_seq.clone()),
                         }),
                     ),
                 };
@@ -3855,7 +3862,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             let ins_end = ProtPos::new(flank_aas[1], new_start);
             return Some((
                 ProteinEdit::Insertion {
-                    sequence: residual_seq,
+                    sequence: ProteinInsSeq::Literal(residual_seq),
                 },
                 Interval::new(ins_start, ins_end),
             ));

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -2,7 +2,7 @@
 //! deletion-insertion, inversion) in the CDS.
 
 use crate::error::FerroError;
-use crate::hgvs::edit::{AminoAcidSeq, FrameshiftTer, NaEdit, ProteinEdit};
+use crate::hgvs::edit::{AminoAcidSeq, FrameshiftTer, NaEdit, ProteinEdit, ProteinInsSeq};
 use crate::hgvs::interval::ProtInterval;
 use crate::hgvs::location::{AminoAcid, ProtPos};
 use crate::hgvs::variant::{HgvsVariant, LocEdit, ProteinVariant};
@@ -443,7 +443,7 @@ fn build_inframe_insertion(
     }
 
     let protein_edit = ProteinEdit::Insertion {
-        sequence: AminoAcidSeq::new(inserted_aas),
+        sequence: ProteinInsSeq::Literal(AminoAcidSeq::new(inserted_aas)),
     };
 
     let loc = ProtInterval::new(
@@ -699,7 +699,7 @@ fn build_inframe_delins(
             loc_edit: LocEdit::new_predicted(
                 loc,
                 ProteinEdit::Insertion {
-                    sequence: AminoAcidSeq::new(inserted),
+                    sequence: ProteinInsSeq::Literal(AminoAcidSeq::new(inserted)),
                 },
             ),
         };

--- a/src/vcf/annotate.rs
+++ b/src/vcf/annotate.rs
@@ -292,7 +292,19 @@ pub fn determine_consequence(ann: &HgvsAnnotation) -> Consequence {
                     Consequence::Nonsense
                 }
                 Some(ProteinEdit::Substitution { .. }) => Consequence::Missense,
+                // An insertion that carries a translation stop (`insTer<n>` /
+                // `ins*<n>`, or a literal ending in `Ter`) introduces a
+                // premature stop — nonsense, not a plain in-frame insertion.
+                Some(ProteinEdit::Insertion { sequence }) if sequence.introduces_stop() => {
+                    Consequence::Nonsense
+                }
                 Some(ProteinEdit::Insertion { .. }) => Consequence::InframeInsertion,
+                // A delins whose inserted sequence ends in a stop
+                // (`delinsLeuTer`) truncates the protein — nonsense, mirroring
+                // the stop-carrying insertion arm above.
+                Some(ProteinEdit::Delins { sequence }) if sequence.ends_with_stop() => {
+                    Consequence::Nonsense
+                }
                 Some(ProteinEdit::Deletion { .. }) | Some(ProteinEdit::Delins { .. }) => {
                     Consequence::InframeDeletion
                 }
@@ -985,6 +997,32 @@ mod tests {
 
         let consequence = determine_consequence(&ann);
         assert_eq!(consequence, Consequence::InframeInsertion);
+    }
+
+    #[test]
+    fn test_determine_consequence_protein_insertion_with_stop() {
+        use crate::hgvs::parser::parse_hgvs;
+
+        // An insertion that carries a translation stop (`insTer<n>` / `ins*<n>`)
+        // introduces a premature stop → nonsense, not an in-frame insertion.
+        for hgvs in [
+            "NP_000079.2:p.Lys2_Leu3insTer12",
+            "NP_000079.2:p.Lys2_Leu3ins*63",
+        ] {
+            let variant = parse_hgvs(hgvs).unwrap();
+            let ann = HgvsAnnotation {
+                variant,
+                gene_symbol: Some("COL1A1".to_string()),
+                transcript_accession: Some("NP_000079.2".to_string()),
+                is_coding: true,
+                is_intronic: false,
+                mane_status: ManeStatus::None,
+                intron_number: None,
+                intron_position: None,
+                intronic_consequence: None,
+            };
+            assert_eq!(determine_consequence(&ann), Consequence::Nonsense, "{hgvs}");
+        }
     }
 
     #[test]

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -105,6 +105,10 @@
     "p.Met1extMet-5": {
       "spec_expected": null,
       "note": "The spec's deprecated *before* form: extension.md:24 writes it inside \"modified from `p.Met1ext`<code class=\"spot1\">Met</code>`-5`\", where the highlighted `Met` marks the residue removed to reach the correct `p.Met1ext-5`. The harvester's spot-span reassembly faithfully rebuilds the pre-modification string; ferro correctly rejects it. Force spec-rejects so it reads as `correctly-rejected`, not `parse-error` (#955)."
+    },
+    "NP_060250.2:p.Gln746_Lys747ins*63": {
+      "spec_expected": "NP_060250.2:p.Gln746_Lys747insTer63",
+      "note": "Spec writes the inserted stop as `*63` (insertion.md:49); ferro parses it and Display canonicalizes `*` to three-letter `Ter`, matching frameshift/extension stop rendering (background/standards.md). Pin the canonical `insTer63` output so this reads as `preserved` rather than a spurious `diverges`. (#955)"
     }
   }
 }

--- a/tests/it/issue_228_vcf_annotate_extension_stop_loss.rs
+++ b/tests/it/issue_228_vcf_annotate_extension_stop_loss.rs
@@ -121,6 +121,24 @@ mod nonsense_classification {
         let ann = protein_annotation("NP_003997.1:p.(Tyr4Ter)");
         assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
     }
+
+    /// A delins whose inserted sequence ends in `Ter` truncates the protein —
+    /// nonsense, not an in-frame deletion (spec `p.(Pro578_Lys579delinsLeuTer)`).
+    /// Mirrors the stop-carrying insertion classification.
+    #[test]
+    fn delins_ending_in_ter_classifies_as_nonsense() {
+        let ann = protein_annotation("NP_003997.1:p.Pro578_Lys579delinsLeuTer");
+        assert_eq!(determine_consequence(&ann), Consequence::Nonsense);
+        let predicted = protein_annotation("NP_003997.1:p.(Asn47delinsSerSerTer)");
+        assert_eq!(determine_consequence(&predicted), Consequence::Nonsense);
+    }
+
+    /// Guardrail: a delins with NO trailing stop stays an in-frame deletion.
+    #[test]
+    fn delins_without_stop_stays_inframe_deletion() {
+        let ann = protein_annotation("NP_003997.1:p.Pro578_Lys579delinsLeu");
+        assert_eq!(determine_consequence(&ann), Consequence::InframeDeletion);
+    }
 }
 
 // =============================================================================

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -233,6 +233,7 @@ mod property_tests;
 mod protein_construct_boundaries;
 mod protein_frameshift_alternatives;
 mod protein_frameshift_legacy_stop_modes;
+mod protein_insertion_special;
 mod protein_no_protein_roundtrip;
 mod protein_predicted_trans;
 mod protein_silent_eq;

--- a/tests/it/protein_insertion_special.rs
+++ b/tests/it/protein_insertion_special.rs
@@ -1,0 +1,94 @@
+//! Protein insertion special inserted-sequences (issue #955).
+//!
+//! The spec (`protein/insertion.md:21,45-61`) allows an inserted protein
+//! sequence to be described by `insXaa[n]` (n unknown residues, open reading
+//! frame insertion) or `ins*<n>` / `insTer<n>` (an inserted sequence ending in a
+//! translation stop at 1-based position n within the insertion). Stop is
+//! canonicalized to `Ter<n>` on Display, matching frameshift/extension.
+
+use ferro_hgvs::parse_hgvs;
+
+/// Parse `input`, render it back, and assert the canonical Display equals
+/// `expected` (equal to `input` for forms already in canonical shape).
+fn assert_canonical(input: &str, expected: &str) {
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("failed to parse {input:?}: {e}"));
+    assert_eq!(
+        variant.to_string(),
+        expected,
+        "canonical Display mismatch for {input:?}"
+    );
+}
+
+#[test]
+fn ins_xaa_repeat_count_round_trips() {
+    assert_canonical(
+        "NP_003997.1:p.(Val582_Asn583insXaa[5])",
+        "NP_003997.1:p.(Val582_Asn583insXaa[5])",
+    );
+    assert_canonical(
+        "NP_003997.1:p.Arg78_Gly79insXaa[23]",
+        "NP_003997.1:p.Arg78_Gly79insXaa[23]",
+    );
+    assert_canonical(
+        "NP_003997.1:p.Lys2_Leu3insXaa[34]",
+        "NP_003997.1:p.Lys2_Leu3insXaa[34]",
+    );
+}
+
+#[test]
+fn ins_xaa_with_uncertain_interval_parses() {
+    // Parens wrap the *interval* here (edit outside): `(Ala123_Pro131)insXaa[4]`.
+    // Confirm the enriched inserted-sequence parses and round-trips byte-exactly
+    // under an uncertain interval (not just a substring match).
+    assert_canonical(
+        "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
+        "NP_003997.1:p.(Ala123_Pro131)insXaa[4]",
+    );
+}
+
+#[test]
+fn ins_stop_length_round_trips_and_canonicalizes_to_ter() {
+    // `insTer<n>` is already canonical.
+    assert_canonical(
+        "NP_003997.1:p.Lys2_Leu3insTer12",
+        "NP_003997.1:p.Lys2_Leu3insTer12",
+    );
+    // `ins*<n>` is an accepted input alternative; Display canonicalizes `*` to
+    // `Ter`, matching frameshift/extension stop rendering.
+    assert_canonical(
+        "NP_060250.2:p.Gln746_Lys747ins*63",
+        "NP_060250.2:p.Gln746_Lys747insTer63",
+    );
+}
+
+#[test]
+fn ins_repeat_rejects_non_spec_forms() {
+    // The spec sanctions only `insXaa[n]` with an unknown residue and an exact
+    // positive count. Everything else must be rejected, not silently accepted as
+    // a `Repeat` (which would, e.g., let `insTer[5]` evade stop detection).
+    for bad in [
+        "NP_003997.1:p.Lys2_Leu3insXaa[0]",   // zero count
+        "NP_003997.1:p.Lys2_Leu3insXaa[?]",   // uncertain count
+        "NP_003997.1:p.Lys2_Leu3insXaa[2_5]", // range count
+        "NP_003997.1:p.Lys2_Leu3insTer[5]",   // stop is insTer<n>, not a repeat
+        "NP_003997.1:p.Lys2_Leu3insGln[5]",   // known residue is not the Xaa repeat form
+    ] {
+        assert!(
+            parse_hgvs(bad).is_err(),
+            "non-spec protein insertion repeat form must be rejected: {bad:?}"
+        );
+    }
+}
+
+#[test]
+fn plain_amino_acid_insertion_still_round_trips() {
+    // Regression: ordinary literal insertions (incl. single Xaa / Ter) unchanged.
+    assert_canonical(
+        "NP_003997.1:p.Lys2_Leu3insGlnSerLys",
+        "NP_003997.1:p.Lys2_Leu3insGlnSerLys",
+    );
+    assert_canonical(
+        "NP_003997.1:p.Ser332_Ser333insXaa",
+        "NP_003997.1:p.Ser332_Ser333insXaa",
+    );
+}


### PR DESCRIPTION
**Stack 2 of 4 for #955** (base: `chore/issue-955-spec-fixture-harvest-noise`, PR #990).

The spec (`protein/insertion.md:21,45-61`) lets a protein insertion describe its inserted sequence by length when the exact residues are deducible from the DNA/RNA level but too long or unknown to spell out:
- `insXaa[n]` — n unknown residues (open reading frame insertion)
- `insTer<n>` / `ins*<n>` — inserted sequence ending in a stop at 1-based position n within the insertion

ferro previously parsed only a literal residue string, so all six such spec examples were rejected. This introduces a `ProteinInsSeq` enum (`Literal` / `Repeat{aa,count}` / `Stop{position}`) as the `ProteinEdit::Insertion` payload, mirroring the DNA `InsertedSequence` + `RepeatCount` shape. Display canonicalizes the inserted stop to three-letter `Ter<n>` (accepting `*<n>` on input), matching frameshift/extension stop rendering.

Normalization skips dup-canonicalization for the length-based forms (no concrete residues to compare); projection still emits literal sequences. Consequence classification routes an inserted stop (`Stop`, or a literal ending in `Ter`) to nonsense / stop_gained rather than inframe_insertion — the one place semantics genuinely change.

Blast radius is ~10 production sites across `edit.rs`, `parser/edit.rs`, `normalize/mod.rs`, `project/protein/indel.rs`, `vcf/annotate.rs`, `bin/ferro.rs`; no Python bindings. Serde shape of `ProteinEdit::Insertion` changes (payload is now a tagged enum, not a bare array).

Closes the six protein insertion parse gaps (parse-error 24 → 18; `ins*63` documented as canonical `insTer63` via override).

Refs #955.