### PR TITLE
feat(mosaic): parse predicted-wrapper and whole-entity-LHS =/ forms

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -1974,6 +1974,54 @@ fn inner_is_protein_residue_alternatives(prefix: &str, inner: &str) -> bool {
     })
 }
 
+/// Detect a predicted (`(...)`-wrapped) mosaic / chimeric group, e.g.
+/// `LRG_199t1:p.(Trp24=/Cys)` or `LRG_199t1:r.(=/6_8del)`, returning
+/// `(prefix, inner)` where `prefix` ends in the coord-type stem (`p.`, `r.`, …)
+/// and `inner` is the un-wrapped mosaic body (`Trp24=/Cys`).
+///
+/// This is the slash counterpart of [`find_uncertain_and_or_group`]. It is
+/// needed because the top-level slash scanners are `[]`-aware but not
+/// `()`-aware, so a `/` inside the predicted wrapper would otherwise be
+/// mis-routed to the plain (non-predicted) mosaic path and split the wrapper
+/// into unbalanced-paren chunks.
+pub(crate) fn find_uncertain_mosaic_group(input: &str) -> Option<(&str, &str)> {
+    let input = input.trim();
+    let bytes = input.as_bytes();
+    if bytes.last() != Some(&b')') {
+        return None;
+    }
+    // Find the `(` matching the final `)` by reverse depth scan.
+    let mut depth: i32 = 0;
+    let mut open: Option<usize> = None;
+    for i in (0..bytes.len()).rev() {
+        match bytes[i] {
+            b')' => depth += 1,
+            b'(' => {
+                depth -= 1;
+                if depth == 0 {
+                    open = Some(i);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let open = open?;
+    let prefix = &input[..open];
+    // The uncertainty wrapper opens immediately after the coordinate-type stem
+    // (`p.`, `r.`, …), so the char before `(` is `.`.
+    if !prefix.ends_with('.') {
+        return None;
+    }
+    let inner = &input[open + 1..input.len() - 1];
+    // The wrapper must contain a top-level (mosaic `/` or chimeric `//`) slash.
+    if find_top_level_slash(inner, false).is_some() || find_top_level_slash(inner, true).is_some() {
+        Some((prefix, inner))
+    } else {
+        None
+    }
+}
+
 /// Result of `scan_allele_separators`: top-level depth-0 allele-separator
 /// flags plus the depth-aware members.
 #[derive(Debug)]
@@ -5415,6 +5463,31 @@ fn is_lhs_position_identity(variant: &HgvsVariant) -> bool {
     }
 }
 
+/// True iff `variant` carries a whole-entity `=` identity (`r.=`, `c.=`, …) —
+/// the LHS shape of a whole-entity-reference mosaic (`r.=/6_8del`), where the
+/// RHS carries its own position rather than inheriting the LHS's.
+fn is_lhs_whole_entity_identity(variant: &HgvsVariant) -> bool {
+    use crate::hgvs::edit::NaEdit;
+    let edit_is_whole = |edit: &Mu<NaEdit>| {
+        matches!(
+            edit.inner(),
+            Some(NaEdit::Identity {
+                whole_entity: true,
+                ..
+            })
+        )
+    };
+    match variant {
+        HgvsVariant::Genome(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Cds(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Tx(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Rna(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Mt(v) => edit_is_whole(&v.loc_edit.edit),
+        HgvsVariant::Circular(v) => edit_is_whole(&v.loc_edit.edit),
+        _ => false,
+    }
+}
+
 /// Create an identity variant based on the type of the reference variant.
 /// Used for mosaic/chimeric notation where "=" means reference allele.
 fn create_identity_variant_from(reference: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
@@ -6230,6 +6303,47 @@ fn parse_uncertain_and_or_allele(input: &str) -> Result<HgvsVariant, FerroError>
     )))
 }
 
+/// Parse a predicted (`(...)`-wrapped) mosaic / chimeric allele
+/// (`p.(Trp24=/Cys)`, `r.(=/6_8del)`). Strip the wrapper, parse the inner
+/// non-predicted mosaic — reusing the full compact-mosaic machinery — and mark
+/// the result `uncertain` so the wrapper round-trips on Display.
+fn parse_uncertain_mosaic_allele(input: &str) -> Result<HgvsVariant, FerroError> {
+    let (prefix, inner) = find_uncertain_mosaic_group(input).ok_or_else(|| FerroError::Parse {
+        pos: 0,
+        msg: "Not an uncertain mosaic group".to_string(),
+        diagnostic: None,
+    })?;
+    let reconstructed = format!("{}{}", prefix, inner);
+    match parse_variant(&reconstructed)? {
+        HgvsVariant::Allele(mut allele)
+            if matches!(allele.phase, AllelePhase::Mosaic | AllelePhase::Chimeric) =>
+        {
+            // The predicted `(...)` wrapper is only defined for a 2-member
+            // mosaic/chimeric — the sole shape the spec documents and the only
+            // one the compact Display renders with its parens. A >2-member
+            // predicted wrapper would round-trip WITHOUT the parens (the
+            // long-form Display join ignores `uncertain`), silently changing
+            // observed-vs-predicted meaning, so reject it here rather than emit a
+            // lossy form.
+            if allele.variants.len() != 2 {
+                return Err(FerroError::Parse {
+                    pos: 0,
+                    msg: "predicted mosaic/chimeric wrapper supports exactly two members"
+                        .to_string(),
+                    diagnostic: None,
+                });
+            }
+            allele.uncertain = true;
+            Ok(HgvsVariant::Allele(allele))
+        }
+        _ => Err(FerroError::Parse {
+            pos: 0,
+            msg: "Predicted wrapper does not enclose a mosaic/chimeric allele".to_string(),
+            diagnostic: None,
+        }),
+    }
+}
+
 /// Whether a chunk-level `parse_variant` error carries a structured
 /// `Diagnostic.code` — i.e. it's a semantic violation that
 /// `parse_phase_allele`'s syntactic-recovery fallback chain should
@@ -6440,6 +6554,20 @@ fn parse_phase_allele(input: &str, phase: AllelePhase) -> Result<HgvsVariant, Fe
                     match parse_variant_with_inherited_accession(chunk, acc, gs.as_ref()) {
                         Ok(v) => v,
                         Err(prefix_err) => {
+                            // Fallback 1b: whole-entity `=` LHS (`r.=/6_8del`).
+                            // The RHS carries its own position but no coord-type
+                            // prefix, so inherit accession AND coord type from the
+                            // LHS and re-parse (`6_8del` -> `LRG_199t1:r.6_8del`).
+                            if is_lhs_whole_entity_identity(lhs) {
+                                let stem = format!("{}:{}.", acc, lhs.variant_type());
+                                if let Ok(v) = parse_variant(&format!("{}{}", stem, chunk)) {
+                                    variants.push(v.clone());
+                                    if first_variant.is_none() {
+                                        first_variant = Some(v);
+                                    }
+                                    continue;
+                                }
+                            }
                             // Fallback 2: HGVS spec compact form — bare
                             // NaEdit RHS inheriting accession + coord
                             // type + position from `<pos>=` LHS.
@@ -6656,6 +6784,15 @@ fn detect_allele_type(input: &str) -> Option<&'static str> {
     // transcript-product form `[(a,b)]`.
     if find_predicted_cis_bracket(input).is_some() {
         return Some("predicted_cis");
+    }
+
+    // Predicted (`(...)`-wrapped) mosaic / chimeric group, e.g.
+    // `p.(Trp24=/Cys)` / `r.(=/6_8del)`. Checked BEFORE the plain slash checks:
+    // the slash scanners are `[]`-aware but not `()`-aware, so the wrapped `/`
+    // would otherwise route to the non-predicted mosaic path and split the
+    // wrapper into unbalanced-paren chunks.
+    if find_uncertain_mosaic_group(input).is_some() {
+        return Some("uncertain_mosaic");
     }
 
     // Top-level slash check happens BEFORE the bracket-wrapping checks
@@ -7038,6 +7175,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
             "and_or" => parse_and_or_allele(input)?,
             "products" => parse_products_allele(input)?,
             "uncertain_and_or" => parse_uncertain_and_or_allele(input)?,
+            "uncertain_mosaic" => parse_uncertain_mosaic_allele(input)?,
             "predicted_cis" => parse_predicted_cis_allele(input)?,
             _ => unreachable!(),
         }

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1363,6 +1363,13 @@ fn is_whole_entity_identity_rhs(variant: &HgvsVariant) -> bool {
     }
 }
 
+/// True iff `variant` is a whole-entity NA identity (`r.=`, `c.=`, …) — the LHS
+/// shape of a whole-entity-reference mosaic (`r.=/6_8del`). Same predicate as
+/// [`is_whole_entity_identity_rhs`]; named for its role as the mosaic LHS.
+fn is_whole_entity_identity_lhs(variant: &HgvsVariant) -> bool {
+    is_whole_entity_identity_rhs(variant)
+}
+
 /// True iff `a` and `b` carry the same coord-system arm AND their
 /// `loc_edit.location` values compare equal. Used to decide whether
 /// the spec compact mosaic Display form applies to a 2-variant Allele.
@@ -1385,51 +1392,74 @@ fn intervals_match_for_compact_mosaic(a: &HgvsVariant, b: &HgvsVariant) -> bool 
     }
 }
 
+/// How the RHS of a compact mosaic / chimeric form is rendered.
+enum CompactMosaicRhs {
+    /// Spec compact: RHS inherits accession/type/position from a position-identity LHS; emit its edit alone (`Cys`, `del`, `dup`).
+    BareEdit,
+    /// Whole-entity-`=` LHS: the RHS carries its own position; emit its position+edit (`6_8del`), no accession/type prefix.
+    LocEdit,
+    /// `var/=` cleanup: the RHS is a whole-entity identity; emit a bare `=`.
+    Identity,
+}
+
+/// Classify a 2-member compact mosaic / chimeric form, or `None` when it must
+/// fall back to the long-form join.
+fn compact_mosaic_rhs_kind(lhs: &HgvsVariant, rhs: &HgvsVariant) -> Option<CompactMosaicRhs> {
+    if is_position_identity_lhs(lhs) && intervals_match_for_compact_mosaic(lhs, rhs) {
+        Some(CompactMosaicRhs::BareEdit)
+    } else if is_whole_entity_identity_lhs(lhs) && !is_whole_entity_identity_rhs(rhs) {
+        Some(CompactMosaicRhs::LocEdit)
+    } else if !is_position_identity_lhs(lhs) && is_whole_entity_identity_rhs(rhs) {
+        Some(CompactMosaicRhs::Identity)
+    } else {
+        None
+    }
+}
+
 /// Shared Display path for `Mosaic` (`/`) and `Chimeric` (`//`) phases.
 ///
-/// Three branches in priority order (mutually exclusive on each input):
-///
-/// 1. **Spec compact mosaic / chimeric** — LHS is a position-bound `=`
-///    identity edit, RHS shares accession + coord type + interval.
-///    Emits `<lhs-full>=/<rhs-bare-edit>`. Per
-///    `recommendations/DNA/{substitution,deletion,duplication}.md`.
-///
-/// 2. **`var/=` shorthand cleanup** — LHS is a non-identity variant,
-///    RHS is a whole-entity identity edit (the synthetic shape
-///    produced by `create_identity_variant_from`), and the two share
-///    accession + coord type. Emits `<lhs-full>/=` instead of
-///    expanding the synthetic identity to its `<acc>:<type>.1=` form.
-///
-/// 3. **Long form** — fallback per-variant join.
+/// A 2-member allele is rendered compactly when `compact_mosaic_rhs_kind`
+/// classifies it (spec compact `<lhs>=/<rhs-edit>`, whole-entity-`=` LHS
+/// `<lhs>=/<rhs-loc-edit>`, or `var/=` cleanup); otherwise it falls back to the
+/// long-form per-variant join. When `uncertain` is set (a predicted `(...)`
+/// wrapper), the compact body is bracketed after the shared coord-type prefix,
+/// e.g. `LRG_199t1:p.(Trp24=/Cys)`.
 fn write_mosaic_or_chimeric(
     f: &mut fmt::Formatter<'_>,
     variants: &[HgvsVariant],
     sep: &str,
+    uncertain: bool,
 ) -> fmt::Result {
     if variants.len() == 2 && use_compact_form(variants) {
         let lhs = &variants[0];
         let rhs = &variants[1];
 
-        // Branch 1: spec compact (LHS pos-identity, intervals match).
-        if is_position_identity_lhs(lhs) && intervals_match_for_compact_mosaic(lhs, rhs) {
-            write!(f, "{}", lhs)?;
-            write!(f, "{}", sep)?;
-            // Emit the RHS edit alone (no accession, no type prefix, no
-            // position) — that is the spec compact RHS shape.
-            return write_bare_edit(f, rhs);
-        }
-
-        // Branch 2: var/= cleanup. LHS must NOT be position-identity
-        // (otherwise branch 1 owns it); RHS must be whole-entity Identity.
-        if !is_position_identity_lhs(lhs) && is_whole_entity_identity_rhs(rhs) {
-            write!(f, "{}", lhs)?;
-            write!(f, "{}", sep)?;
-            write!(f, "=")?;
-            return Ok(());
+        if let Some(kind) = compact_mosaic_rhs_kind(lhs, rhs) {
+            if uncertain {
+                // Predicted wrapper: `<prefix>(<lhs-bare><sep><rhs-part>)`, e.g.
+                // `LRG_199t1:p.(Trp24=/Cys)` / `LRG_199t1:r.(=/6_8del)`.
+                write_compact_prefix(f, lhs)?;
+                write!(f, "(")?;
+                lhs.fmt_loc_edit(f)?;
+                write!(f, "{}", sep)?;
+                match kind {
+                    CompactMosaicRhs::BareEdit => write_bare_edit(f, rhs)?,
+                    CompactMosaicRhs::LocEdit => rhs.fmt_loc_edit(f)?,
+                    CompactMosaicRhs::Identity => write!(f, "=")?,
+                }
+                return write!(f, ")");
+            }
+            // Non-predicted compact form.
+            write!(f, "{}{}", lhs, sep)?;
+            return match kind {
+                CompactMosaicRhs::BareEdit => write_bare_edit(f, rhs),
+                CompactMosaicRhs::LocEdit => rhs.fmt_loc_edit(f),
+                CompactMosaicRhs::Identity => write!(f, "="),
+            };
         }
     }
 
-    // Branch 3: long-form join.
+    // Long-form join (predicted wrappers only arise for the compact forms above).
     for (i, v) in variants.iter().enumerate() {
         if i > 0 {
             write!(f, "{}", sep)?;
@@ -1644,8 +1674,10 @@ impl fmt::Display for AlleleVariant {
                     write!(f, "]")
                 }
             }
-            AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/"),
-            AllelePhase::Chimeric => write_mosaic_or_chimeric(f, &self.variants, "//"),
+            AllelePhase::Mosaic => write_mosaic_or_chimeric(f, &self.variants, "/", self.uncertain),
+            AllelePhase::Chimeric => {
+                write_mosaic_or_chimeric(f, &self.variants, "//", self.uncertain)
+            }
             AllelePhase::AndOr => {
                 if self.uncertain && use_compact_form(&self.variants) {
                     // Uncertainty-wrapped, shared accession + coord type:

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -216,6 +216,7 @@ mod merge_consecutive_edits_tests;
 mod mito_circular_audit;
 mod mito_heteroplasmy_audit;
 mod mosaic_chimeric_compact;
+mod mosaic_predicted_eqslash;
 mod mutalyzer_grammar_tests;
 mod mutalyzer_normalize_tests;
 mod mutalyzer_tests;

--- a/tests/it/mosaic_predicted_eqslash.rs
+++ b/tests/it/mosaic_predicted_eqslash.rs
@@ -1,0 +1,94 @@
+//! Predicted-wrapper and whole-entity-LHS mosaic `=/` forms (issue #955).
+//!
+//! Two gaps beyond the already-supported position-bound compact mosaic
+//! (`p.Trp24=/Cys`, `r.85=/u>c`):
+//!   - Gap A: the predicted `(...)` wrapper — `p.(Trp24=/Cys)` (protein
+//!     substitution/deletion/duplication), `r.(=/6_8del)` (RNA). The
+//!     slash-splitters are `[]`-aware but not `()`-aware, so the wrapped `/`
+//!     was mis-routed.
+//!   - Gap B: a whole-entity `=` LHS with a positioned RHS — `r.=/6_8del`.
+
+use ferro_hgvs::hgvs::AllelePhase;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+fn assert_round_trips(input: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("failed to parse {input:?}: {e}"));
+    assert_eq!(v.to_string(), input, "round-trip mismatch for {input:?}");
+}
+
+/// Independent structural check (not just round-trip): confirm a parsed
+/// predicted `(...)` mosaic/chimeric built the expected AST — an `Allele` with
+/// the right phase, the predicted-uncertain wrapper flag set, and the expected
+/// member count — verifying the parse itself is correct, not merely that
+/// Display inverts it.
+fn assert_predicted_allele(input: &str, phase: AllelePhase, members: usize) {
+    match parse_hgvs(input).unwrap_or_else(|e| panic!("failed to parse {input:?}: {e}")) {
+        HgvsVariant::Allele(a) => {
+            assert_eq!(a.phase, phase, "phase for {input:?}");
+            assert!(
+                a.uncertain,
+                "predicted `(...)` wrapper must set the uncertain flag for {input:?}"
+            );
+            assert_eq!(a.variants.len(), members, "member count for {input:?}");
+        }
+        other => panic!("{input:?} must parse as an Allele, got {other:?}"),
+    }
+}
+
+#[test]
+fn predicted_mosaic_parses_to_expected_ast() {
+    assert_predicted_allele("LRG_199t1:p.(Trp24=/Cys)", AllelePhase::Mosaic, 2);
+    assert_predicted_allele("LRG_199t1:r.(=/6_8del)", AllelePhase::Mosaic, 2);
+    assert_predicted_allele("NM_004006.3:r.(85=//u>c)", AllelePhase::Chimeric, 2);
+}
+
+#[test]
+fn predicted_protein_mosaic_round_trips() {
+    // Gap A — protein substitution / deletion / duplication under `p.(...)`.
+    assert_round_trips("LRG_199t1:p.(Trp24=/Cys)");
+    assert_round_trips("NP_003997.1:p.(Val7=/del)");
+    assert_round_trips("NP_003997.1:p.(Val7=/dup)");
+}
+
+#[test]
+fn whole_entity_lhs_rna_mosaic_round_trips() {
+    // Gap B — whole-entity `r.=` LHS with a positioned RHS.
+    assert_round_trips("LRG_199t1:r.=/6_8del");
+}
+
+#[test]
+fn predicted_rna_whole_entity_mosaic_round_trips() {
+    // Gap A + Gap B — predicted wrapper around a whole-entity-LHS RNA mosaic.
+    assert_round_trips("LRG_199t1:r.(=/6_8del)");
+}
+
+#[test]
+fn existing_compact_mosaic_still_round_trips() {
+    // Regression: position-bound compact mosaic (already supported).
+    assert_round_trips("LRG_199t1:p.Trp24=/Cys");
+    assert_round_trips("NM_004006.3:r.85=/u>c");
+}
+
+#[test]
+fn predicted_chimeric_round_trips() {
+    // Gap A for the chimeric `//` separator (was untested): the predicted
+    // wrapper around a 2-member chimeric substitution must round-trip.
+    assert_round_trips("NM_004006.3:r.(85=//u>c)");
+}
+
+#[test]
+fn predicted_wrapper_rejects_more_than_two_members() {
+    // The predicted `(...)` wrapper is only defined for a 2-member mosaic. A
+    // 3-member predicted wrapper must be rejected, not silently accepted and
+    // then rendered WITHOUT the parens (which would change observed-vs-predicted
+    // meaning).
+    for bad in [
+        "LRG_199t1:r.(=/6_8del/10_12del)",
+        "LRG_199t1:p.(Trp24=/Cys/Ser)",
+    ] {
+        assert!(
+            parse_hgvs(bad).is_err(),
+            ">2-member predicted mosaic wrapper must be rejected: {bad:?}"
+        );
+    }
+}


### PR DESCRIPTION
**Stack 3 of 4 for #955** (base: `feat/issue-955-protein-inserted-seq`, PR #991).

Two mosaic `=/` gaps from the v21 spec audit, beyond the already-supported position-bound compact form (`p.Trp24=/Cys`, `r.85=/u>c`):

**Gap A — predicted `(...)` wrapper** (`p.(Trp24=/Cys)`, `p.(Val7=/del)`, `p.(Val7=/dup)`, `r.(=/6_8del)`). The top-level slash scanners are `[]`-aware but not `()`-aware, so the wrapped `/` was mis-routed to the non-predicted mosaic path and split into unbalanced-paren chunks. Adds `find_uncertain_mosaic_group` + `parse_uncertain_mosaic_allele` (mirroring the and/or handling): strip the wrapper, parse the inner non-predicted mosaic, and mark the allele `uncertain` so it round-trips.

**Gap B — whole-entity `=` LHS with a positioned RHS** (`r.=/6_8del`). The RHS carries its own position but no coord-type prefix; adds a `parse_phase_allele` fallback that inherits accession AND coord type from a whole-entity-identity LHS and re-parses.

Display: `write_mosaic_or_chimeric` gains a whole-entity-LHS compact branch (`<lhs>=/<rhs-loc-edit>`) and an `uncertain` path that brackets the compact body after the shared coord-type prefix. No new AST — reuses `AlleleVariant { phase, uncertain }`, so no match-exhaustiveness breakage.

This PR calls into `parse_protein_edit` / matches `ProteinEdit`, so it is stacked after the protein-insertion enum change (PR #991) to avoid a rebase.

Closes the five mosaic parse gaps (parse-error 18 → 13).

Refs #955.