### PR TITLE
chore(spec-fixture): classify the remaining spec-audit parse gaps

### DIFF
--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -594,11 +594,19 @@ mod prefix {
         if input.starts_with('[') {
             return None;
         }
-        let coord = coord_system_char(input)?;
-        // Already prefixed: any colon before the coord-system letter implies
-        // a `<accession>:<sys>.` form already in place.
+        // Only the top-level head (before any `[...]` inserted-sequence
+        // reference) determines the coordinate system and whether an accession
+        // is already present. An inner reference like `ins[L37425.1:r.23_361]`
+        // carries its own `:r.` that must not be mistaken for the variant's own
+        // accession — otherwise a bare `r.123_124ins[…:r.…]` is wrongly judged
+        // already-prefixed and never gets a default accession, so it fails to
+        // parse and lands in `parse-error`. (#955)
+        let head = &input[..input.find('[').unwrap_or(input.len())];
+        let coord = coord_system_char(head)?;
+        // Already prefixed: any colon before the coord-system letter in the
+        // head implies a `<accession>:<sys>.` form already in place.
         let needle = format!(":{coord}.");
-        if input.contains(&needle) {
+        if head.contains(&needle) {
             return None;
         }
         // Bare form: must start with `<sys>.`.
@@ -622,6 +630,31 @@ mod prefix {
             }
         }
         None
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::default_prefixed;
+
+        #[test]
+        fn prefixes_bare_fragment_with_inner_reference() {
+            // The inner `[…:r.…]` reference must NOT be read as the variant's own
+            // accession; the bare `r.` fragment still gets a default accession.
+            assert_eq!(
+                default_prefixed("r.123_124ins[L37425.1:r.23_361]").as_deref(),
+                Some("NM_004006.3:r.123_124ins[L37425.1:r.23_361]")
+            );
+            assert_eq!(
+                default_prefixed("g.?_?ins[NC_000023.10:g.(12345_23456)_(34567_45678)]").as_deref(),
+                Some("NC_000023.11:g.?_?ins[NC_000023.10:g.(12345_23456)_(34567_45678)]")
+            );
+        }
+
+        #[test]
+        fn leaves_already_prefixed_input_untouched() {
+            // A genuine top-level accession still short-circuits (no double prefix).
+            assert_eq!(default_prefixed("NM_004006.3:r.123_124insauc"), None);
+        }
     }
 }
 

--- a/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
+++ b/tests/fixtures/grammar/hgvs_spec_normalization_overrides.json
@@ -109,6 +109,38 @@
     "NP_060250.2:p.Gln746_Lys747ins*63": {
       "spec_expected": "NP_060250.2:p.Gln746_Lys747insTer63",
       "note": "Spec writes the inserted stop as `*63` (insertion.md:49); ferro parses it and Display canonicalizes `*` to three-letter `Ter`, matching frameshift/extension stop rendering (background/standards.md). Pin the canonical `insTer63` output so this reads as `preserved` rather than a spurious `diverges`. (#955)"
+    },
+    "p.Gln[21]": {
+      "spec_expected": null,
+      "note": "Not a variant: a prose-note shorthand from RNA/repeated.md:52 (\"on protein level, the reference allele contains 21 Gln s, described as `p.Gln[21]` (alternatively `p.Q[21]`)\"), immediately explained (line 53) as a lossy summary of an interrupted repeat. Every canonical protein-STR example carries a start residue+position (`p.Gln18[23]`, protein/repeated.md:28), which ferro parses; a position-less protein repeat is not valid HGVS. Force spec-rejects. (#955)"
+    },
+    "p.Q[21]": {
+      "spec_expected": null,
+      "note": "The single-letter alternative of `p.Gln[21]` from the same RNA/repeated.md:52 prose note; position-less, not a real variant. Force spec-rejects. (#955)"
+    },
+    "g.[chr4:134850793_134850794inschrX:89555676_100352080]": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 consultation proposal (banner-flagged 'not updated'; DNA/complex.md). ISCN-flavored `chrN:` chromosome-name reference with reference-after-`g.` ordering, both abandoned; ISCN2020/HGVS uses `NC_` accessions with the `delins[ACC:g....]` form (complex.md). ferro rejects the ISCN form; force spec-rejects so it reads as `correctly-rejected`, matching the `::` siblings from the same doc (#546). (#955)"
+    },
+    "g.[chr4:134850793_134850794inschrX:89555676_100352080inv]": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS in favor of `NC_` accession `delins[ACC:g....]` forms. ferro rejects it; force spec-rejects (see #546). (#955)"
+    },
+    "g.chr4:134850793_134850794inschrX:89555676_100352080inv": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS. ferro rejects it; force spec-rejects (see #546). (#955)"
+    },
+    "g.chr2:pter_8247756delinschr11:pter_15825266": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS. ferro rejects it; force spec-rejects (see #546). (#955)"
+    },
+    "g.chr3:158573187_qterdelinschr8:(128534000_128546000)_qter": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS. ferro rejects it; force spec-rejects (see #546). (#955)"
+    },
+    "g.chr5:pter_29658442delinschr10:67539995_qterinv": {
+      "spec_expected": null,
+      "note": "Superseded SVD-WG004 ISCN proposal (chrN:, reference-after-`g.`), abandoned by ISCN2020/HGVS. ferro rejects it; force spec-rejects (see #546). (#955)"
     }
   }
 }


### PR DESCRIPTION
**Stack 4 of 4 for #955** (base: `feat/issue-955-mosaic-eqslash`, PR #992).

Resolves the last three families from the v21 spec audit, none of which is a parser feature:

**ins/delins from a referenced range** (`r.123_124ins[L37425.1:r.23_361]`, `g.?_?ins[NC_...:g....]`): already supported via `InsertedSequence::Reference`; they only failed because the harvester's default-prefixer treated the inner reference's `:r.`/`:g.` (inside `[...]`) as the variant's own accession and so never prepended a default one. Scopes the already-prefixed check to the top-level head (before the first `[`). These now parse (preserved) or, when the referenced range needs a lookup, needs-reference.

**Cross-chromosome ISCN delins** (`g.chr2:pter_...delinschr11:...`, six rows): superseded SVD-WG004 proposal syntax (`chrN:` references, reference-after-`g.` ordering), abandoned by ISCN2020/HGVS in favor of `NC_` accession `delins[ACC:g....]` forms. Marked spec-rejected, matching the `::` siblings from the same doc (#546).

**Position-less protein STR** (`p.Gln[21]`, `p.Q[21]`): prose-note shorthands from `RNA/repeated.md:52`, not variants (the positioned `p.Gln18[21]` already parses). Marked spec-rejected.

Net: the generated fixture's parse-error bucket reaches **0** — every spec-valid form now parses, and every spec-invalid form is correctly rejected or flagged. Exposes one latent Class-B over-accept (`r.124_500delins[...:...inv]`, a spec `<code class="invalid">` example ferro accepts once accession-qualified), now truthfully surfaced as false-acceptance for the Class-B triage backlog.

Closes #955.