### PR TITLE
chore(conformance): regenerate stale mutalyzer failure-patterns summary

### DIFF
--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -335,6 +335,6 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |
-| normalized | 27 | 1 | 1 | 0 | 16 |
+| normalized | 28 | 0 | 1 | 0 | 16 |
 | protein_description | 9 | 0 | 0 | 0 | 60 |
 | rna_description | 0 | 0 | 0 | 0 | 1 |


### PR DESCRIPTION
The sequential squash-merges of #984 / #986 / #987 — each reclassifying a normalized-axis case out of `known_bug` — left the generated `tests/fixtures/mutalyzer-normalize/failure-patterns.md` one count stale relative to `cases.json`: the `normalized` row read `27 | 1` where the disposition annotations now sum to `28 | 0`. This regenerates it so the `conformance_summary_generated` gate is green on `main` again.

Generated artifact only (no source/behavior change); produced by `cargo run --features dev --example generate_conformance_summary`.