### PR TITLE
fix(normalize): coalesce shift-created cis adjacency into a single delins

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -205,6 +205,59 @@ enum GEdit {
     Sub { pos: i64, alt: Base },
     /// `delins` of the inclusive span `[s, e]` with replacement `alt`.
     Delins { s: i64, e: i64, alt: Vec<Base> },
+    /// Tandem duplication of the inclusive span `[s, e]`. Semantically an
+    /// insertion of `ref[s..=e]` at gap `e` (the 3' copy); its alt bases are
+    /// read from the reference window once fetched, so it participates in the
+    /// collapse exactly like an `Ins { gap: e, .. }`.
+    Dup { s: i64, e: i64 },
+}
+
+/// Report whether `variants` contains two or more insertion-like cis members
+/// (`ins` or tandem `dup`) that attach at the **same** reference gap.
+///
+/// Such a pair is order-ambiguous (`[g insA; g insC]` describes `...AC...` or
+/// `...CA...`), so the collapse deliberately refuses it (see the
+/// `seen_insertion_gaps` guard below, issue #487). That refusal keys off the
+/// members' *current* positions, but an independent per-member 3'-shift can
+/// move two originally-same-gap insertions apart — after which a re-collapse
+/// would no longer see the collision and would silently pick an order. Callers
+/// that iterate collapse across shifts (see `normalize_allele`) use this to
+/// detect the ambiguity on the **pre-shift** input and decline the extra
+/// passes, preserving both the #487 refusal and the #180 merge-first invariant.
+///
+/// Conservative: only the head member's axis kind is considered, and any member
+/// that isn't a simple certain `ins`/`dup` on that axis is ignored (it cannot be
+/// half of a same-gap insertion pair).
+pub(crate) fn has_same_gap_insertions(variants: &[HgvsVariant], phase: AllelePhase) -> bool {
+    if phase != AllelePhase::Cis || variants.len() < 2 {
+        return false;
+    }
+    let kind = match &variants[0] {
+        HgvsVariant::Genome(_) => CisKind::Genome,
+        HgvsVariant::Mt(_) => CisKind::Mt,
+        HgvsVariant::Cds(_) => CisKind::Cds,
+        HgvsVariant::Tx(_) => CisKind::Tx,
+        HgvsVariant::Rna(_) => CisKind::Rna,
+        _ => return false,
+    };
+    let mut seen = std::collections::HashSet::new();
+    for v in variants {
+        let Some((_, _, s, e, edit)) = cis_axis_parts(v, kind) else {
+            continue;
+        };
+        let gap = match edit {
+            NaEdit::Insertion { .. } if e == s + 1 => s,
+            NaEdit::Duplication {
+                uncertain_extent: None,
+                ..
+            } => e,
+            _ => continue,
+        };
+        if !seen.insert(gap) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Collapse a contiguous run of *overlapping* cis genomic edits — insertions
@@ -313,7 +366,16 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
                     alt: bases.to_vec(),
                 });
             }
-            // dup / repeat / inversion / identity etc. — not handled here.
+            // A certain, simple tandem duplication is an insertion of its own
+            // reference span at gap `e` (#999/#1000: a per-member 3'-shift can
+            // canonicalise an insertion to a `dup` that lands flush against an
+            // adjacent substitution/deletion). Refuse the uncertain-extent form
+            // (`dup?`, `dup(731_741)`) — its span is not pinned down.
+            NaEdit::Duplication {
+                uncertain_extent: None,
+                ..
+            } => edits.push(GEdit::Dup { s, e }),
+            // repeat / inversion / identity / uncertain dup etc. — not handled.
             _ => return variants,
         }
     }
@@ -322,8 +384,9 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     // replacement (del/sub/delins). This excludes pure-insertion groups (which
     // must stay separate when separated by unchanged bases) and pure-deletion /
     // pure-substitution groups (owned by `merge_consecutive_edits`).
-    let has_ins = edits.iter().any(|e| matches!(e, GEdit::Ins { .. }));
-    let has_repl = edits.iter().any(|e| !matches!(e, GEdit::Ins { .. }));
+    let is_insertion_like = |e: &GEdit| matches!(e, GEdit::Ins { .. } | GEdit::Dup { .. });
+    let has_ins = edits.iter().any(&is_insertion_like);
+    let has_repl = edits.iter().any(|e| !is_insertion_like(e));
     if !has_ins || !has_repl {
         return variants;
     }
@@ -334,7 +397,7 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
         .filter_map(|e| match e {
             GEdit::Del { s, e } | GEdit::Delins { s, e, .. } => Some((*s, *e)),
             GEdit::Sub { pos, .. } => Some((*pos, *pos)),
-            GEdit::Ins { .. } => None,
+            GEdit::Ins { .. } | GEdit::Dup { .. } => None,
         })
         .collect();
     let c_lo = covered.iter().map(|(s, _)| *s).min().unwrap();
@@ -350,26 +413,38 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
     // making the collapsed result order-dependent (e.g. `[gap insA; gap insB]`
     // vs the reverse yields `...AB...` vs `...BA...`). Refuse such a group —
     // matches the conservative all-or-nothing philosophy and preserves the
-    // member-order invariance the collapse otherwise guarantees.
+    // member-order invariance the collapse otherwise guarantees. A `Dup { s, e }`
+    // attaches at gap `e` (the 3' copy) and reads its source span `[s, e]`.
     let mut seen_insertion_gaps = std::collections::HashSet::new();
     for e in &edits {
-        if let GEdit::Ins { gap, .. } = e {
-            if *gap < c_lo - 1 || *gap > c_hi {
-                return variants;
-            }
-            if !seen_insertion_gaps.insert(*gap) {
-                return variants;
-            }
+        let gap = match e {
+            GEdit::Ins { gap, .. } => *gap,
+            GEdit::Dup { e, .. } => *e,
+            _ => continue,
+        };
+        if gap < c_lo - 1 || gap > c_hi {
+            return variants;
+        }
+        if !seen_insertion_gaps.insert(gap) {
+            return variants;
         }
     }
 
-    // Window covers the changed interval plus all insertion flanks.
+    // Window covers the changed interval plus all insertion flanks (and, for a
+    // dup, its full duplicated source span so its alt bases can be read).
     let mut w_lo = c_lo;
     let mut w_hi = c_hi;
     for e in &edits {
-        if let GEdit::Ins { gap, .. } = e {
-            w_lo = w_lo.min(*gap);
-            w_hi = w_hi.max(*gap + 1);
+        match e {
+            GEdit::Ins { gap, .. } => {
+                w_lo = w_lo.min(*gap);
+                w_hi = w_hi.max(*gap + 1);
+            }
+            GEdit::Dup { s, e } => {
+                w_lo = w_lo.min(*s);
+                w_hi = w_hi.max(*e + 1);
+            }
+            _ => {}
         }
     }
     if w_lo < 1 {
@@ -451,6 +526,11 @@ pub(crate) fn collapse_overlapping_cis_edits<P: ReferenceProvider>(
                 } else {
                     before.extend(bytes);
                 }
+            }
+            GEdit::Dup { s, e } => {
+                // Tandem copy of ref[s..=e] inserted immediately 3' of `e`.
+                let bytes: Vec<u8> = (*s..=*e).map(|p| ref_bytes[idx(p)]).collect();
+                after[idx(*e)].extend(bytes);
             }
         }
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1557,28 +1557,59 @@ impl<P: ReferenceProvider> Normalizer<P> {
             &allele.variants,
             allele.phase,
         ));
-        // Collapse overlapping cis edits (insertions flanking a deletion/sub at
-        // one locus) into a single delins first; `merge_consecutive_edits` only
-        // handles strictly-consecutive non-overlapping edits (#487).
-        let pre_collapsed = merge::collapse_overlapping_cis_edits(
-            allele.variants.clone(),
-            allele.phase,
-            &self.provider,
-        );
-        let merged_raw =
-            merge::merge_consecutive_edits(pre_collapsed, allele.phase, &self.provider);
-
-        // Issue #160 + #165: any merged delins (or pre-existing delins
-        // that survived merge unchanged) may decompose into a sequence of
-        // higher-priority forms per `general.md:56` — `[..., inv, ...]`
-        // when an inv-eligible sub-span is present (#160) and/or into
-        // separate substitutions when interior positions match the
-        // reference (#165). Run the split per merged variant; the helper
-        // is a no-op for non-Delins variants and for Delins with nothing
-        // to split out. Only applies in cis phase — trans alleles aren't
-        // collapsible in the first place.
-        let merged_split: Vec<HgvsVariant> =
-            if allele.phase == crate::hgvs::variant::AllelePhase::Cis {
+        // Collapse → merge → split → per-member normalize, iterated to a fixed
+        // point. The per-member 3'-shift (inside `normalize_core`) can move an
+        // insertion — or the `dup` it canonicalises to — flush against an
+        // adjacent substitution/deletion. That *shift-created* adjacency is only
+        // visible to `collapse_overlapping_cis_edits`, which runs on its input
+        // members, on the *next* iteration; running a single pass left the two
+        // as separate members (#999) and made `normalize` non-idempotent (#1000).
+        //
+        // Termination: each iteration's collapse/merge either strictly reduces
+        // the member count or the per-member results already equal the input, so
+        // the loop settles in at most a few passes. `max_passes` is a defensive
+        // backstop against pathological oscillation, never the normal exit.
+        //   - collapse: insertions flanking a deletion/sub at one locus → one
+        //     delins; `merge_consecutive_edits` only handles strictly-consecutive
+        //     non-overlapping edits (#487).
+        //   - split (#160 + #165, cis only): a merged/pre-existing delins may
+        //     decompose into higher-priority forms per `general.md:56` —
+        //     `[..., inv, ...]` for an inv-eligible sub-span (#160) and/or into
+        //     separate substitutions where interior positions match the
+        //     reference (#165). The helper is a no-op otherwise.
+        //   - per-member pipeline: the single canonical place where the 3' rule,
+        //     ins→dup canonicalization, ref validation, etc. apply — a merged
+        //     variant is semantically a new variant and goes through the same
+        //     pipeline as any direct input. `normalize()` discards the diagnostic
+        //     `infos` axis, so members use `normalize_core` (skipping the
+        //     per-member `detect_shuffle_infos` cost).
+        let is_cis = allele.phase == crate::hgvs::variant::AllelePhase::Cis;
+        // Iterating collapse across per-member shifts is only sound when the
+        // input has no two insertion-like members at the same gap: those are
+        // order-ambiguous and must not collapse (#487), but a shift can move
+        // them apart and hide the collision from a later collapse. When present,
+        // fall back to the single-pass behavior (collapse-on-raw only), which
+        // still refuses them. This preserves the #180 merge-first invariant.
+        let allow_refixpoint =
+            is_cis && !merge::has_same_gap_insertions(&allele.variants, allele.phase);
+        let max_passes = if allow_refixpoint {
+            allele.variants.len().max(1) + 2
+        } else {
+            1
+        };
+        let mut current = allele.variants.clone();
+        let mut normalized: Vec<HgvsVariant>;
+        let settled_warnings: Vec<NormalizationWarning>;
+        let mut pass = 0;
+        loop {
+            let pre_collapsed = merge::collapse_overlapping_cis_edits(
+                current.clone(),
+                allele.phase,
+                &self.provider,
+            );
+            let merged_raw =
+                merge::merge_consecutive_edits(pre_collapsed, allele.phase, &self.provider);
+            let merged_split: Vec<HgvsVariant> = if is_cis {
                 merged_raw
                     .into_iter()
                     .flat_map(|v| self.canonical_split_for_variant(v))
@@ -1587,19 +1618,27 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 merged_raw
             };
 
-        // Per-variant pipeline on every merged result. This is the single
-        // canonical place where the 3' rule, ins→dup canonicalization, ref
-        // validation, etc. apply — a merged variant is semantically a new
-        // variant and goes through the same pipeline as any direct input.
-        let mut normalized: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
-        for v in merged_split {
-            // `normalize()` discards the diagnostic `infos` axis, so allele
-            // members go through `normalize_core` (skipping the per-member
-            // `detect_shuffle_infos` cost) rather than `normalize_with_diagnostics`.
-            let (result, warnings) = self.normalize_core(&v)?;
-            all_warnings.extend(warnings);
-            normalized.push(result);
+            let mut result: Vec<HgvsVariant> = Vec::with_capacity(merged_split.len());
+            let mut pass_warnings: Vec<NormalizationWarning> = Vec::new();
+            for v in merged_split {
+                let (r, warnings) = self.normalize_core(&v)?;
+                pass_warnings.extend(warnings);
+                result.push(r);
+            }
+
+            pass += 1;
+            // Stable once a full pass leaves the member set unchanged.
+            // `max_passes == 1` (non-cis, or same-gap-ambiguous input) forces the
+            // original single-pass behavior; otherwise iterate until the fixed
+            // point, with `max_passes` as a defensive backstop.
+            if result == current || pass >= max_passes {
+                normalized = result;
+                settled_warnings = pass_warnings;
+                break;
+            }
+            current = result;
         }
+        all_warnings.extend(settled_warnings);
 
         // Overlap detection runs post-shift so collisions caused by the
         // 3' shift surface alongside input-time ones. Overlap *prevention*

--- a/tests/it/issue_999_shift_created_adjacency_collapse.rs
+++ b/tests/it/issue_999_shift_created_adjacency_collapse.rs
@@ -1,0 +1,97 @@
+//! Regression coverage for issues #999 and #1000 — one root cause.
+//!
+//! When a cis allele member is an insertion that 3'-shifts to become
+//! directly adjacent (0-nt gap) to a downstream substitution, the two
+//! must coalesce into a single `delins` (HGVS: adjacent changes with no
+//! intervening nucleotide are one edit). ferro left them as two bracketed
+//! members because the cross-member collapse
+//! (`merge::collapse_overlapping_cis_edits`) ran on the *raw input*
+//! members, before the per-member 3'-shift that creates the adjacency, and
+//! was never re-run afterwards.
+//!
+//! Two observable symptoms, same defect:
+//!
+//!   #999  — `NC_000001.11:g.[305_306insC;307G>T]`
+//!           was: `g.[306dup;307G>T]`   want: `g.307delinsCT`
+//!
+//!   #1000 — `NC_000001.11:g.[611_612insCG;613C>A]` was non-idempotent:
+//!           pass 1 gave `g.[612_613insGC;613C>A]`, pass 2 gave
+//!           `g.613delinsGCA`. A single pass must reach the fixed point.
+//!
+//! These pins use synthetic MockProvider sequences so future refactors of
+//! the merge/collapse/shift pipeline can't silently regress the rule.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Build a MockProvider whose genomic contig `NC_000001.11` carries
+/// `substantive` starting at 1-based `start`, padded to 1000 bases of
+/// filler `A` so the default normalize window always lands inside.
+fn provider_with(start: usize, substantive: &str) -> MockProvider {
+    let mut seq = vec![b'A'; 1000];
+    for (i, b) in substantive.bytes().enumerate() {
+        seq[start - 1 + i] = b;
+    }
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_000001.11", String::from_utf8(seq).unwrap());
+    provider
+}
+
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+#[test]
+fn cis_insertion_shifted_adjacent_to_substitution_coalesces_to_delins() {
+    // #999. The inserted `C` matches ref[306]=C, so it 3'-shifts to a dup
+    // at gap 306, landing directly 5' of the `307G>T` substitution. With no
+    // intervening nucleotide the two describe one contiguous change: the
+    // inserted `C` then the substituted `T` at 307 -> `307delinsCT`.
+    let out = normalize(
+        provider_with(300, "CATCCTCGCTCCT"),
+        "NC_000001.11:g.[305_306insC;307G>T]",
+    );
+    assert_eq!(out, "NC_000001.11:g.307delinsCT");
+}
+
+#[test]
+fn cis_shift_created_adjacency_reaches_fixed_point_in_one_pass() {
+    // #1000. `insCG` at 611_612 legitimately 3'-shifts to `insGC` at
+    // 612_613 (ref[612]=C lets the dinucleotide roll one position; 613
+    // blocks a second roll), landing adjacent to `613C>A`. The collapse
+    // must fire on the *same* pass: inserted `GC` then substituted `A` at
+    // 613 -> `613delinsGCA`.
+    let out = normalize(
+        provider_with(600, "TGACTTCAGTCACCTGACTGACTG"),
+        "NC_000001.11:g.[611_612insCG;613C>A]",
+    );
+    assert_eq!(out, "NC_000001.11:g.613delinsGCA");
+}
+
+#[test]
+fn cis_shift_created_adjacency_is_idempotent() {
+    // #1000, stated as the invariant: normalize(normalize(x)) == normalize(x).
+    let input = "NC_000001.11:g.[611_612insCG;613C>A]";
+    let pass1 = normalize(provider_with(600, "TGACTTCAGTCACCTGACTGACTG"), input);
+    let pass2 = normalize(provider_with(600, "TGACTTCAGTCACCTGACTGACTG"), &pass1);
+    assert_eq!(pass1, pass2, "normalize must be idempotent; pass1 != pass2");
+}
+
+#[test]
+fn cis_insertion_shifted_to_non_adjacent_stays_separate() {
+    // Negative control: when the shift does NOT bring the insertion flush
+    // against the substitution (an unchanged base remains between them),
+    // the two must stay as separate members — the collapse is for
+    // adjacent/overlapping edits only. Here ins `C` at 305_306 shifts to a
+    // dup at 306 (gap 306), but the substitution is at 308, leaving ref[307]
+    // untouched between them.
+    let out = normalize(
+        provider_with(300, "CATCCTCGCTCCT"),
+        "NC_000001.11:g.[305_306insC;308C>A]",
+    );
+    assert_eq!(out, "NC_000001.11:g.[306dup;308C>A]");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -208,6 +208,7 @@ mod issue_963_compound_pairing;
 mod issue_972_cds_start_nf_decline;
 mod issue_97_utr_del_position;
 mod issue_98_minus_strand_intronic_orientation;
+mod issue_999_shift_created_adjacency_collapse;
 mod issue_l2_w4001_swapped_positions;
 mod legacy_integration;
 mod lrg_inference_tests;


### PR DESCRIPTION
## Summary

In a cis allele, an insertion whose 3′-shift lands it directly adjacent (0-nt gap) to a downstream substitution/deletion was left as two separate bracketed members instead of being coalesced into a single `delins`. This produced two symptoms from one root cause:

- **#999** — `NC_000001.11:g.[305_306insC;307G>T]` normalized to `g.[306dup;307G>T]` instead of `g.307delinsCT`.
- **#1000** — `NC_000001.11:g.[611_612insCG;613C>A]` was non-idempotent: pass 1 gave `g.[612_613insGC;613C>A]`, pass 2 gave `g.613delinsGCA`.

The cross-member collapse (`collapse_overlapping_cis_edits`) ran only on the raw input members, before the per-member 3′-shift, so an adjacency *created by* the shift was never collapsed on the same pass.

## Fix

- **Iterate `collapse → merge → split → per-member normalize` to a fixed point** in `normalize_allele`, so a shift-created adjacency is collapsed on the same pass and the output is idempotent. Termination is bounded by the member count; `max_passes` is a defensive backstop.
- **Teach the collapse to treat a certain tandem `dup` as an insertion** of its own reference span. A shifted insertion is canonicalized to `dup` before it can be re-collapsed, so the collapse must understand it (a `dup` adjacent to a sub/del genuinely is a `delins` per HGVS).
- **Guard the extra passes with `has_same_gap_insertions`.** Two insertion-like members at the same original gap are order-ambiguous and must not collapse (#487); independent shifting can move them apart and hide the collision, so such inputs fall back to the original single-pass behavior, preserving the #180 merge-first invariant.

## Tests

`tests/it/issue_999_shift_created_adjacency_collapse.rs` pins both reproducers plus a fixed-point/idempotence assertion and a negative control (a shift that stops one base short must stay two members). All existing tests pass, including the #487 same-gap refusal.

Closes #999
Closes #1000
