### PR TITLE
feat(reference): validate manifest schema/version at load, fail loud on an incompatible reference

### DIFF
--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -393,6 +393,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -450,6 +451,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -509,6 +511,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -568,6 +571,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -627,6 +631,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -686,6 +691,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -745,6 +751,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 
@@ -804,6 +811,7 @@ mod tests {
             backfill_transcripts_fasta: None,
             transcript_count: 1,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: dir.path().to_path_buf(),
         };
 

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -7,6 +7,15 @@ use crate::FerroError;
 use std::fs::File;
 use std::path::{Component, Path, PathBuf};
 
+/// Current reference-manifest schema version, written into every manifest by
+/// [`ReferenceManifest::save`]. Bump this on any breaking change to the manifest
+/// or derived-artifact format so an older build refuses a newer, incompatible
+/// reference at load rather than silently misreading it. A manifest whose
+/// `manifest_schema_version` exceeds this value is rejected (see
+/// [`check_schema_version`]); an absent value means the reference predates schema
+/// versioning and is accepted (its structure is still validated on load).
+pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
 /// Manifest of prepared reference data.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ReferenceManifest {
@@ -127,6 +136,12 @@ pub struct ReferenceManifest {
     pub transcript_count: usize,
     /// List of available accession prefixes
     pub available_prefixes: Vec<String>,
+    /// Schema version of this manifest, written by [`ReferenceManifest::save`].
+    /// Absent on references prepared before schema versioning; a value greater
+    /// than [`CURRENT_MANIFEST_SCHEMA_VERSION`] means the reference was prepared
+    /// by a newer, forward-incompatible `ferro` and is refused at load.
+    #[serde(default)]
+    pub manifest_schema_version: Option<u32>,
     /// Directory containing this manifest (runtime property, not serialized)
     #[serde(skip)]
     pub reference_dir: PathBuf,
@@ -167,6 +182,7 @@ impl Default for ReferenceManifest {
             backfill_transcripts_fasta: None,
             transcript_count: 0,
             available_prefixes: Vec::new(),
+            manifest_schema_version: None,
             reference_dir: PathBuf::new(),
         }
     }
@@ -189,6 +205,7 @@ impl ReferenceManifest {
             Self::default()
         };
 
+        check_schema_version(manifest.manifest_schema_version)?;
         manifest.reference_dir = reference_dir.to_path_buf();
         manifest.make_paths_absolute();
         Ok(manifest)
@@ -262,6 +279,7 @@ impl ReferenceManifest {
         self.validate_reference_root_invariant()?;
 
         self.prepared_at = chrono::Utc::now().to_rfc3339();
+        self.manifest_schema_version = Some(CURRENT_MANIFEST_SCHEMA_VERSION);
         self.deduplicate_paths();
 
         // Serialize a relative-path view without mutating the in-memory absolute paths.
@@ -424,6 +442,58 @@ pub fn check_references(reference_dir: &Path) -> Result<ReferenceManifest, Ferro
     }
 
     ReferenceManifest::load_or_default(reference_dir)
+}
+
+/// Reject a manifest prepared by a newer, forward-incompatible `ferro`.
+///
+/// An absent version (`None`) predates schema versioning and is accepted; a
+/// version at or below [`CURRENT_MANIFEST_SCHEMA_VERSION`] is accepted; a higher
+/// version is refused, because an older build cannot be trusted to read a newer
+/// format correctly (it would otherwise silently misread it).
+pub fn check_schema_version(version: Option<u32>) -> Result<(), FerroError> {
+    if let Some(v) = version {
+        if v > CURRENT_MANIFEST_SCHEMA_VERSION {
+            return Err(FerroError::Io {
+                msg: format!(
+                    "reference manifest schema version {v} is newer than this build of ferro \
+                     supports (maximum {CURRENT_MANIFEST_SCHEMA_VERSION}). Upgrade ferro, or \
+                     re-run `ferro prepare` to regenerate the reference."
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Validate a raw manifest JSON value before the permissive field reads in the
+/// runtime loader ([`crate::reference::multi_fasta::MultiFastaProvider::from_manifest`]).
+///
+/// The runtime loader reads the manifest as an untyped `serde_json::Value` and
+/// accesses each field with `.get(...).and_then(...)`, so a renamed, removed, or
+/// wrong-typed field would otherwise degrade to `None` and be silently treated as
+/// absent — producing wrong output across a run instead of failing. This gate:
+///
+/// 1. refuses a manifest from a newer, forward-incompatible `ferro`
+///    ([`check_schema_version`]); and
+/// 2. validates the value against the [`ReferenceManifest`] schema, catching a
+///    missing required field or a wrong-typed field. Unknown/extra fields are
+///    tolerated (no `deny_unknown_fields`), so a real reference carrying
+///    additional metadata (e.g. a content fingerprint) still loads.
+pub fn validate_loaded_manifest(value: &serde_json::Value) -> Result<(), FerroError> {
+    let version = value
+        .get("manifest_schema_version")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+    check_schema_version(version)?;
+
+    serde_json::from_value::<ReferenceManifest>(value.clone()).map_err(|e| FerroError::Io {
+        msg: format!(
+            "reference manifest does not match the expected schema: {e}. The reference may have \
+             been prepared by an incompatible version of ferro — re-run `ferro prepare` to \
+             regenerate it."
+        ),
+    })?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -597,6 +667,7 @@ mod tests {
             backfill_transcripts_fasta: Some(ref_dir.join("backfill/backfill_transcripts.fna")),
             transcript_count: 100,
             available_prefixes: vec!["NM".to_string()],
+            manifest_schema_version: None,
             reference_dir: ref_dir.to_path_buf(),
         };
 
@@ -947,5 +1018,104 @@ mod tests {
             manifest.prepared_at, saved_prepared_at,
             "save() should refresh in-memory prepared_at to match what was persisted"
         );
+    }
+
+    /// A realistic minimal manifest as `save()` writes it, plus an extra unknown
+    /// field (a content fingerprint) that real prepared references carry.
+    fn minimal_manifest_json() -> serde_json::Value {
+        serde_json::json!({
+            "prepared_at": "2024-01-01T00:00:00Z",
+            "transcript_fastas": ["transcripts.fa"],
+            "genome_fasta": null,
+            "cdot_json": null,
+            "transcript_count": 0,
+            "available_prefixes": [],
+            "manifest_schema_version": CURRENT_MANIFEST_SCHEMA_VERSION,
+            "reference_identity": "deadbeefdeadbeef"
+        })
+    }
+
+    #[test]
+    fn save_stamps_current_schema_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut m = ReferenceManifest {
+            reference_dir: dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        m.save().unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("manifest.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            json["manifest_schema_version"].as_u64(),
+            Some(CURRENT_MANIFEST_SCHEMA_VERSION as u64),
+            "save() must stamp the current schema version into the manifest"
+        );
+        assert_eq!(
+            m.manifest_schema_version,
+            Some(CURRENT_MANIFEST_SCHEMA_VERSION),
+            "save() must also update the in-memory schema version"
+        );
+    }
+
+    #[test]
+    fn check_schema_version_accepts_absent_and_current_but_rejects_newer() {
+        assert!(
+            check_schema_version(None).is_ok(),
+            "a pre-versioning reference (absent version) is accepted"
+        );
+        assert!(check_schema_version(Some(CURRENT_MANIFEST_SCHEMA_VERSION)).is_ok());
+        let err = check_schema_version(Some(CURRENT_MANIFEST_SCHEMA_VERSION + 1))
+            .expect_err("a newer schema version must be refused");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("newer than this build"),
+            "actionable message: {msg}"
+        );
+        assert!(
+            msg.contains("ferro prepare"),
+            "message points to the remedy: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_loaded_manifest_accepts_valid_manifest_with_unknown_fields() {
+        validate_loaded_manifest(&minimal_manifest_json())
+            .expect("a valid manifest carrying an unknown extra field must load");
+    }
+
+    #[test]
+    fn validate_loaded_manifest_accepts_pre_versioning_manifest() {
+        let mut v = minimal_manifest_json();
+        v.as_object_mut().unwrap().remove("manifest_schema_version");
+        validate_loaded_manifest(&v).expect("a manifest without a schema version must load");
+    }
+
+    #[test]
+    fn validate_loaded_manifest_rejects_newer_schema_version() {
+        let mut v = minimal_manifest_json();
+        v["manifest_schema_version"] =
+            serde_json::json!(CURRENT_MANIFEST_SCHEMA_VERSION as u64 + 1);
+        let err = validate_loaded_manifest(&v).expect_err("a newer schema must be refused");
+        assert!(format!("{err}").contains("newer than this build"));
+    }
+
+    #[test]
+    fn validate_loaded_manifest_rejects_missing_required_field() {
+        let mut v = minimal_manifest_json();
+        v.as_object_mut().unwrap().remove("transcript_count");
+        let err = validate_loaded_manifest(&v)
+            .expect_err("a missing required field must be a hard error, not a silent None");
+        assert!(format!("{err}").contains("does not match the expected schema"));
+    }
+
+    #[test]
+    fn validate_loaded_manifest_rejects_wrong_typed_field() {
+        let mut v = minimal_manifest_json();
+        // transcript_fastas as a string instead of an array — the exact class the
+        // untyped runtime loader would otherwise silently read as `None`.
+        v["transcript_fastas"] = serde_json::json!("not-an-array");
+        let err = validate_loaded_manifest(&v).expect_err("a wrong-typed field must be rejected");
+        assert!(format!("{err}").contains("does not match the expected schema"));
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -559,6 +559,11 @@ impl MultiFastaProvider {
                 msg: format!("Failed to parse manifest: {}", e),
             })?;
 
+        // Fail loud on an incompatible/misread reference before the permissive
+        // field reads below, which would otherwise silently treat a renamed,
+        // removed, or wrong-typed field as absent (#1001).
+        crate::prepare::manifest::validate_loaded_manifest(&manifest)?;
+
         let mut dirs = Vec::new();
 
         // Get transcript directory (paths in manifest are relative to manifest location)
@@ -3213,6 +3218,45 @@ mod tests {
     /// Tests pass it so their per-build expectations stay pinned to the heuristic.
     fn heuristic_infer(acc: &crate::hgvs::variant::Accession) -> Option<&'static str> {
         crate::liftover::aliases::infer_genome_build_from_accession(acc)
+    }
+
+    // ----------------------------------------------------------------------
+    // Reference schema/version validation at load (#1001)
+    // ----------------------------------------------------------------------
+
+    /// A manifest prepared by a newer, forward-incompatible ferro must be refused
+    /// at load, not silently misread.
+    #[test]
+    fn from_manifest_rejects_newer_schema_version() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            format!(
+                r#"{{"prepared_at":"","transcript_fastas":[],"genome_fasta":null,"cdot_json":null,"transcript_count":0,"available_prefixes":[],"manifest_schema_version":{}}}"#,
+                crate::prepare::manifest::CURRENT_MANIFEST_SCHEMA_VERSION + 1
+            ),
+        )
+        .unwrap();
+        let Err(err) = MultiFastaProvider::from_manifest(dir.path().join("manifest.json")) else {
+            panic!("a newer-schema manifest must be refused at load");
+        };
+        assert!(format!("{err}").contains("newer than this build"));
+    }
+
+    /// A wrong-typed manifest field (the class the untyped loader would silently
+    /// read as `None`) must fail the load with a clear error.
+    #[test]
+    fn from_manifest_rejects_wrong_typed_field() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            r#"{"prepared_at":"","transcript_fastas":"not-an-array","genome_fasta":null,"cdot_json":null,"transcript_count":0,"available_prefixes":[]}"#,
+        )
+        .unwrap();
+        let Err(err) = MultiFastaProvider::from_manifest(dir.path().join("manifest.json")) else {
+            panic!("a wrong-typed manifest field must be rejected at load");
+        };
+        assert!(format!("{err}").contains("does not match the expected schema"));
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The runtime reference loader parses the manifest as an untyped `serde_json::Value` and reads every field with `.get("…").and_then(|v| v.as_str()/.as_array())` (`src/reference/multi_fasta.rs`), so a key that is renamed, removed, or present with the wrong JSON type silently yields `None` and the loader proceeds as if that data were absent — producing wrong output across an entire run instead of failing. There was no schema/version check at load.

## Fix

- Add `manifest_schema_version` to `ReferenceManifest`, stamped into every manifest by `save()` (`CURRENT_MANIFEST_SCHEMA_VERSION = 1`).
- Add a load-time gate, `validate_loaded_manifest`, that:
  - refuses a manifest whose schema version exceeds what this build supports (a newer, forward-incompatible reference — fail-closed, since an older build can't be trusted to read a newer format); and
  - validates the JSON against the `ReferenceManifest` schema via `serde_json::from_value`, turning a missing-required or wrong-typed field into a hard, actionable error. Unknown/extra fields are **tolerated** (no `deny_unknown_fields`), so a real reference carrying additional metadata (e.g. a content fingerprint) still loads.
- Wire the gate into the runtime loader (`MultiFastaProvider::from_manifest`, before the permissive reads) and the schema-version check into `load_or_default`.

Existing un-versioned manifests continue to load (their structure is still validated); the forward-compat gate only fires on a *newer* reference.

## Scope

This is the first increment of the layered proposal in the issue — the version handshake plus schema-shaped validation, which closes the reported silent-misread class. Deferred to follow-ups (kept small and reviewable):

- promoting the existing `reference_identity` content fingerprint into a load-time content check;
- extending a per-artifact `schema_version` (as `ng_hosted_transcripts` already does) to the other derived artifacts, and recording the pinned cdot data version;
- surfacing the gate in `ferro check --reference`;
- routing the loader fully through the typed struct with `deny_unknown_fields` (needs the extra manifest fields modeled first, so it doesn't reject real references).

## Testing

- Unit tests (`src/prepare/manifest.rs`): `save()` stamps the current version; `check_schema_version` accepts absent/current and rejects newer; `validate_loaded_manifest` accepts a valid manifest with unknown extra fields and a pre-versioning manifest, and rejects a newer schema, a missing required field, and a wrong-typed field.
- Integration tests (`src/reference/multi_fasta.rs`): `from_manifest` rejects a newer-schema manifest and a wrong-typed field at load.
- Backward-compatibility regressions (pre-#842, pre-#716, GRCh37, save/load roundtrip) all still pass; `cargo clippy --features dev -- -D warnings` clean.

Part of #1001.
