### PR TITLE
fix(normalize): preserve co-located insertion overlaps instead of a non-idempotent merge

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1557,6 +1557,32 @@ impl<P: ReferenceProvider> Normalizer<P> {
             &allele.variants,
             allele.phase,
         ));
+
+        // Two separate insertions at the *same* junction (`g.[4_5insT;4_5insA]`)
+        // are an order-ambiguous overlap conflict, not a normalizable form:
+        // there is no canonical order for the two inserted sequences, so the
+        // HGVS spec expresses "insert both" as a single ordered compound payload
+        // (`ins[T;A]`), not two members (general.md:79). Every reference agrees —
+        // mutalyzer rejects it (`EOVERLAP`), VariantValidator rejects it
+        // (`AlleleSyntaxError: … ranges overlap`), and ferro's own strict mode
+        // rejects it via the W5002 warning emitted just above (#486).
+        //
+        // In the non-strict modes the strict reject is not applied, so *preserve*
+        // the allele as authored here rather than falling through to the
+        // collapse/merge/shift pipeline below. That pipeline fabricated an
+        // order-dependent merged insertion (`insAC`) which no other tool
+        // produces and which then 3'-shifted flush against a neighbour and
+        // collapsed to a `delins` only on re-normalization — leaving
+        // `normalize` non-idempotent (#1004). Declining to canonicalize an
+        // unresolvable overlap is both spec-consistent and idempotent, and it
+        // still carries the W5002 warning so strict mode rejects unchanged.
+        if merge::has_same_gap_insertions(&allele.variants, allele.phase) {
+            let mut preserved =
+                crate::hgvs::variant::AlleleVariant::new(allele.variants.clone(), allele.phase);
+            preserved.uncertain = allele.uncertain;
+            return Ok((HgvsVariant::Allele(preserved), all_warnings));
+        }
+
         // Collapse → merge → split → per-member normalize, iterated to a fixed
         // point. The per-member 3'-shift (inside `normalize_core`) can move an
         // insertion — or the `dup` it canonicalises to — flush against an
@@ -1584,15 +1610,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
         //     `infos` axis, so members use `normalize_core` (skipping the
         //     per-member `detect_shuffle_infos` cost).
         let is_cis = allele.phase == crate::hgvs::variant::AllelePhase::Cis;
-        // Iterating collapse across per-member shifts is only sound when the
-        // input has no two insertion-like members at the same gap: those are
-        // order-ambiguous and must not collapse (#487), but a shift can move
-        // them apart and hide the collision from a later collapse. When present,
-        // fall back to the single-pass behavior (collapse-on-raw only), which
-        // still refuses them. This preserves the #180 merge-first invariant.
-        let allow_refixpoint =
-            is_cis && !merge::has_same_gap_insertions(&allele.variants, allele.phase);
-        let max_passes = if allow_refixpoint {
+        // Iterate the pipeline to a fixed point in cis; non-cis alleles are never
+        // collapsible, so a single pass suffices. Iterating is sound here because
+        // the one input that made it unsound — two insertion-like members at the
+        // same gap, which are order-ambiguous and must not collapse (#487) and
+        // whose per-member shift could move them apart to hide the collision — is
+        // preserved-and-returned above as an overlap conflict (#1004) and so never
+        // reaches this loop. `max_passes` is a defensive backstop.
+        let max_passes = if is_cis {
             allele.variants.len().max(1) + 2
         } else {
             1
@@ -1628,9 +1653,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
             pass += 1;
             // Stable once a full pass leaves the member set unchanged.
-            // `max_passes == 1` (non-cis, or same-gap-ambiguous input) forces the
-            // original single-pass behavior; otherwise iterate until the fixed
-            // point, with `max_passes` as a defensive backstop.
+            // `max_passes == 1` (non-cis) forces the original single-pass
+            // behavior; otherwise iterate until the fixed point, with
+            // `max_passes` as a defensive backstop.
             if result == current || pass >= max_passes {
                 normalized = result;
                 settled_warnings = pass_warnings;

--- a/tests/it/issue_1004_samegap_insertion_idempotency.rs
+++ b/tests/it/issue_1004_samegap_insertion_idempotency.rs
@@ -1,0 +1,175 @@
+//! Regression coverage for issue #1004.
+//!
+//! Two separate insertions at the **same reference junction** in a cis allele
+//! (`g.[4_5insT;4_5insA]`) are an order-ambiguous *overlap conflict*, not a
+//! normalizable form. Every reference agrees:
+//!   - the HGVS spec expresses "insert both" as a single ordered compound
+//!     payload `ins[T;A]` (general.md:79 / DNA/insertion.md), not two members;
+//!   - mutalyzer rejects it (`EOVERLAP`);
+//!   - VariantValidator rejects it (`AlleleSyntaxError: ... ranges overlap`);
+//!   - ferro's strict mode rejects it (W5002 / OverlapConflictingEdits, #486).
+//!
+//! So in strict mode the input is rejected (covered by #486). In the non-strict
+//! modes ferro must **warn and preserve** the allele as authored rather than
+//! fabricating a merged/collapsed `delins` — the old behavior invented an
+//! order-dependent form no other tool produces and, worse, was **not
+//! idempotent** (`normalize(normalize(x)) != normalize(x)`): the fabricated
+//! insertion 3'-shifted flush against a neighbour on the second pass and
+//! collapsed. Preserving the overlap is both spec-consistent and idempotent.
+//!
+//! A pair of insertions at *different* junctions flanking an edit is a distinct
+//! case — two changes less than two nucleotides apart (general.md:34-39) — and
+//! still collapses to a single `delins`.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Build a MockProvider whose genomic contig `NC_000001.11` carries
+/// `substantive` starting at 1-based `start`, padded to 1000 bases of filler
+/// `A` so the default normalize window always lands inside.
+fn provider_with(start: usize, substantive: &str) -> MockProvider {
+    let mut seq = vec![b'A'; 1000];
+    for (i, b) in substantive.bytes().enumerate() {
+        seq[start - 1 + i] = b;
+    }
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence("NC_000001.11", String::from_utf8(seq).unwrap());
+    provider
+}
+
+/// Non-strict (default) 3'-shifting normalizer over `substantive` at `start`.
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+/// Non-strict normalize that also returns the emitted warning codes, so the
+/// *warn* half of "warn-and-preserve" can be asserted alongside the output.
+fn normalize_with_warnings(provider: MockProvider, input: &str) -> (String, Vec<String>) {
+    let normalizer = Normalizer::with_config(
+        provider,
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    let variant = parse_hgvs(input).expect("parse");
+    let result = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("normalize");
+    let codes = result
+        .warnings
+        .iter()
+        .map(|w| w.code().to_string())
+        .collect();
+    (format!("{}", result.result), codes)
+}
+
+fn ref_mono() -> MockProvider {
+    provider_with(300, "CATCCTCGCTCCT")
+}
+fn ref_di() -> MockProvider {
+    provider_with(600, "TGACTTCAGTCACCTGACTGACTG")
+}
+
+// --- idempotency: normalize(normalize(x)) == normalize(x) -----------------
+
+#[test]
+fn samegap_insertion_pair_with_sub_is_idempotent() {
+    let input = "NC_000001.11:g.[305_306insC;305_306insA;307G>T]";
+    let pass1 = normalize(ref_mono(), input);
+    let pass2 = normalize(ref_mono(), &pass1);
+    assert_eq!(pass1, pass2, "normalize must be idempotent; pass1 != pass2");
+}
+
+#[test]
+fn samegap_dinucleotide_insertion_pair_with_sub_is_idempotent() {
+    let input = "NC_000001.11:g.[611_612insCG;611_612insGC;613C>A]";
+    let pass1 = normalize(ref_di(), input);
+    let pass2 = normalize(ref_di(), &pass1);
+    assert_eq!(pass1, pass2, "normalize must be idempotent; pass1 != pass2");
+}
+
+#[test]
+fn samegap_insertion_pair_with_deletion_is_idempotent() {
+    let input = "NC_000001.11:g.[305_306insC;305_306insA;306del]";
+    let pass1 = normalize(ref_mono(), input);
+    let pass2 = normalize(ref_mono(), &pass1);
+    assert_eq!(pass1, pass2, "normalize must be idempotent; pass1 != pass2");
+}
+
+// --- warn-and-preserve: the co-located overlap is left as authored, never
+// fabricated into a merged insertion or a `delins` ---------------------------
+
+#[test]
+fn samegap_insertion_pair_with_sub_is_preserved_as_authored() {
+    let input = "NC_000001.11:g.[305_306insC;305_306insA;307G>T]";
+    let (out, warnings) = normalize_with_warnings(ref_mono(), input);
+    assert_eq!(
+        out, input,
+        "a co-located insertion overlap must be preserved as authored, not canonicalized"
+    );
+    assert!(
+        !out.contains("delins"),
+        "must not collapse to a delins; got: {out}"
+    );
+    assert!(
+        warnings.iter().any(|c| c == "OVERLAP_CONFLICTING_EDITS"),
+        "warn-and-preserve: expected an OVERLAP_CONFLICTING_EDITS warning, got {warnings:?}"
+    );
+}
+
+#[test]
+fn samegap_insertion_pair_with_deletion_is_preserved_as_authored() {
+    let input = "NC_000001.11:g.[305_306insC;305_306insA;306del]";
+    let (out, warnings) = normalize_with_warnings(ref_mono(), input);
+    assert_eq!(
+        out, input,
+        "a co-located insertion overlap must be preserved as authored"
+    );
+    assert!(
+        !out.contains("delins"),
+        "must not collapse to a delins; got: {out}"
+    );
+    assert!(
+        warnings.iter().any(|c| c == "OVERLAP_CONFLICTING_EDITS"),
+        "warn-and-preserve: expected an OVERLAP_CONFLICTING_EDITS warning, got {warnings:?}"
+    );
+}
+
+// --- strict mode still rejects the overlap (spec / mutalyzer / VV consensus,
+// #486). This locks the contract against my non-strict change. --------------
+
+#[test]
+fn strict_mode_still_rejects_samegap_insertion_overlap() {
+    let normalizer = Normalizer::with_config(ref_mono(), NormalizeConfig::strict());
+    let v = parse_hgvs("NC_000001.11:g.[305_306insC;305_306insA;307G>T]").expect("parse");
+    let err = normalizer
+        .normalize(&v)
+        .expect_err("strict mode must reject a co-located insertion overlap");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("W5002")
+            || msg.contains("OverlapConflictingEdits")
+            || msg.contains("coincident"),
+        "expected an overlap-conflict rejection; got: {msg}"
+    );
+}
+
+// --- regression guard: a pair at DIFFERENT junctions flanking an edit is a
+// distinct-position case and still collapses to a single `delins` (spec
+// general.md:34-39), and is idempotent. -------------------------------------
+
+#[test]
+fn different_junction_flanking_insertions_still_collapse_to_delins() {
+    // insA at gap 304, insC at gap 305, deletion at 305: two changes less than
+    // two nucleotides apart -> a single delins over the affected span.
+    let input = "NC_000001.11:g.[304_305insA;305_306insC;305del]";
+    let out = normalize(ref_mono(), input);
+    assert!(
+        out.contains("delins"),
+        "distinct-junction insertions flanking an edit must collapse to a delins; got: {out}"
+    );
+    let again = normalize(ref_mono(), &out);
+    assert_eq!(out, again, "the collapsed delins must itself be idempotent");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -77,6 +77,7 @@ mod ins_shift_matrix;
 mod inserted_range_special_positions;
 mod integration_tests;
 mod inverted_uncertain_range_insertion;
+mod issue_1004_samegap_insertion_idempotency;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/merge_consecutive_edits_tests.rs
+++ b/tests/it/merge_consecutive_edits_tests.rs
@@ -161,12 +161,18 @@ fn test_merge_ins_then_del() {
 }
 
 #[test]
-fn test_merge_two_ins_same_boundary_preserves_input_order() {
-    // Two ins at the same boundary p|p+1 collapse into a single ins; bases
-    // are concatenated in input order (T then A -> TA).
+fn test_two_ins_same_boundary_preserved_as_overlap() {
+    // Two separate insertions at the same boundary p|p+1 are an order-ambiguous
+    // overlap conflict, not a merge: there is no canonical order for the two
+    // inserted sequences (HGVS expresses "insert both" as a single ordered
+    // compound payload `ins[T;A]`, not two members — general.md:79). mutalyzer
+    // rejects this as `EOVERLAP` and VariantValidator as `AlleleSyntaxError`;
+    // ferro's strict mode rejects it (W5002, #486) and the non-strict path
+    // warn-and-preserves it as authored rather than fabricating an
+    // order-dependent, non-idempotent `insTA` (#1004).
     assert_eq!(
         normalize_to_string("NC_000001.11:g.[100_101insT;100_101insA]"),
-        "NC_000001.11:g.100_101insTA",
+        "NC_000001.11:g.[100_101insT;100_101insA]",
     );
 }
 


### PR DESCRIPTION
## Summary

`normalize` was not idempotent for a cis allele containing **two insertions at the same reference junction** next to a substitution/deletion — e.g. `NC_000001.11:g.[305_306insC;305_306insA;307G>T]` gave `g.[306_307insAC;307G>T]` on pass 1 and `g.307delinsACT` on pass 2.

Two separate insertions at the identical junction are an **order-ambiguous overlap conflict, not a normalizable form**. This is unanimous across the reference tools:

| Source | Verdict on `g.[X_YinsA;X_YinsB]` |
|--------|----------------------------------|
| HGVS spec | "insert both" is a single ordered compound payload `ins[A;B]`, not two members (`general.md:79`, `DNA/insertion.md`) |
| mutalyzer | `EOVERLAP` — error |
| VariantValidator | `AlleleSyntaxError: … ranges overlap` — error/unsupported |
| ferro `strict` | rejects (W5002 / OverlapConflictingEdits, #486) ✅ |
| ferro `lenient`/`default` | fabricated `insAC`, then collapsed → **non-idempotent** (the bug) |

Strict mode already did the right thing (reject). Only the non-strict path did not apply the reject; it fell through to the collapse/merge/shift pipeline and fabricated an order-dependent merged insertion (`insAC`) that no other tool produces, which then 3'-shifted flush against its neighbour and collapsed to a `delins` on the second pass.

## Fix

Preserve the allele as authored when a same-junction insertion overlap is detected, before the collapse/merge/shift pipeline runs. Declining to canonicalize an unresolvable overlap is spec-consistent, matches mutalyzer/VariantValidator, and is idempotent. The W5002 warning is still carried, so **strict mode rejects unchanged**. With same-gap inputs now short-circuited, the fixed-point loop's `has_same_gap_insertions` guard (#1002) is redundant and is removed.

Untouched: a pair of insertions at **different** junctions flanking an edit (two changes < 2 nt apart, `general.md:34-39`) still collapses to a single `delins` (#487).

## Tests

`tests/it/issue_1004_samegap_insertion_idempotency.rs` pins idempotency, warn-and-preserve (round-trips as authored, never a `delins`), strict-mode rejection, and a different-junction regression guard (still collapses to `delins`, itself idempotent). One existing test (`merge_consecutive_edits_tests`) asserted the old fabricated `insTA` merge and is updated to the corrected preserve semantics — it was the only test in the suite encoding that behavior. Full suite green; `cargo clippy --all-features -- -D warnings` and `cargo fmt --check` clean.

Closes #1004