### PR TITLE
perf(benchmark): refresh measured performance tables for 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ correctness or stability.
 
 - **Full HGVS Parsing**: All coordinate systems (g/c/n/r/p/m/o) and edit types
 - **Variant Normalization**: 3'/5' shifting per HGVS specification
-- **High Performance**: ~3M variants/sec single-threaded parsing (>10M/s parallel), zero-copy with nom
+- **High Performance**: ~5M variants/sec single-threaded parsing (>12M/s parallel), zero-copy with nom
 - **Type-Safe**: Leverages Rust's type system for correctness
 
 ## Installation
@@ -249,17 +249,17 @@ ferro-hgvs provides the most comprehensive HGVS variant normalization across all
 
 <!-- DO NOT EDIT — generated from data/benchmark/perf_results.json by `generate_perf_tables`. -->
 
-_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval — fast cells (e.g. ferro/hgvs-rs parse) draw from millions of patterns, while slower cells (e.g. the per-tool normalize columns) draw from as few as tens to thousands. All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Only ferro parallelizes natively (rayon); the other tools are single-threaded libraries, so their normalize *@8 workers* figures come from the benchmark harness running 8 independent instances in parallel, while parsing is not sharded for them — hence the `single-threaded` label in their parse *@8 workers* column (mutalyzer normalize likewise shows no gain at 8 workers: per-call cache and IPC overhead dominate, so sharding does not help). Every tool runs fully offline against local reference data — a local UTA database and SeqRepo, with mutalyzer's network lookups disabled — the configuration ferro's `prepare` command enables; the figures therefore reflect compute throughput, not per-variant network latency. Reference-data load is excluded for all tools. ferro full-population peak: parse 11.2M/s, normalize 74.5k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
+_Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools draw from one stratified ClinVar population; per-tool sample sizes are calibrated so each tool is measured over a meaningful interval — fast cells (e.g. ferro/hgvs-rs parse) draw from millions of patterns, while slower cells (e.g. the per-tool normalize columns) draw from as few as tens to thousands. All tools exclude process/interpreter startup from the timed region — the mutalyzer/biocommons Python subprocesses are timed by their own internal startup-excluded timer, matching ferro/hgvs-rs. Only ferro parallelizes natively (rayon); the other tools are single-threaded libraries, so their normalize *@8 workers* figures come from the benchmark harness running 8 independent instances in parallel, while parsing is not sharded for them — hence the `single-threaded` label in their parse *@8 workers* column (mutalyzer normalize likewise shows no gain at 8 workers: per-call cache and IPC overhead dominate, so sharding does not help). Every tool runs fully offline against local reference data — a local UTA database and SeqRepo, with mutalyzer's network lookups disabled — the configuration ferro's `prepare` command enables; the figures therefore reflect compute throughput, not per-variant network latency. Reference-data load is excluded for all tools. ferro full-population peak: parse 20.0M/s, normalize 77.0k/s. See `docs/BENCHMARK_RUNBOOK.md` for the full method._
 
 **Parse**
 
 <!-- BEGIN perf:parse -->
 | Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
 |------|----------------------:|-----------------------:|-------------------:|
-| ferro | 3.1M/s | 10.3M/s | — |
-| mutalyzer | 336/s | single-threaded | 31,000× |
-| biocommons | 3.6k/s | single-threaded | 2,800× |
-| hgvs-rs | 3.5M/s | single-threaded | 3× |
+| ferro | 5.1M/s | 12.2M/s | — |
+| mutalyzer | 352/s | single-threaded | 35,000× |
+| biocommons | 3.9k/s | single-threaded | 3,100× |
+| hgvs-rs | 3.6M/s | single-threaded | 3× |
 <!-- END perf:parse -->
 
 **Normalize**
@@ -267,10 +267,10 @@ _Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools dr
 <!-- BEGIN perf:normalize -->
 | Tool | Throughput @ 1 worker | Throughput @ 8 workers | ferro speedup @ 8w |
 |------|----------------------:|-----------------------:|-------------------:|
-| ferro | 12.2k/s | 88.9k/s | — |
-| mutalyzer | 4/s | 3/s | 26,000× |
-| biocommons | 314/s | 302/s | 290× |
-| hgvs-rs | 162/s | 934/s | 95× |
+| ferro | 78.1k/s | 260.2k/s | — |
+| mutalyzer | 4/s | 4/s | 73,000× |
+| biocommons | 368/s | 818/s | 320× |
+| hgvs-rs | 195/s | 1.3k/s | 200× |
 <!-- END perf:normalize -->
 
 **ferro thread scaling**
@@ -278,7 +278,7 @@ _Median patterns/sec over 5 reps on an Apple M2 Max, local/offline. All tools dr
 <!-- BEGIN perf:ferro_scaling -->
 | Threads | 1 | 2 | 4 | 8 |
 |---------|--:|--:|--:|--:|
-| ferro parse | 3.0M/s | 5.1M/s | 8.0M/s | 9.3M/s |
+| ferro parse | 5.1M/s | 9.4M/s | 16.0M/s | 12.0M/s |
 <!-- END perf:ferro_scaling -->
 
 **Input ordering matters for batch throughput.** Resolving a transcript (reading its full sequence from the reference and rebuilding its CDS/exon metadata) dominates per-variant cost. ferro memoizes resolved transcripts in a bounded in-memory cache, so repeated lookups of the same transcript are near-free. Providing variants **sorted by transcript accession — or by genomic position, which clusters variants onto the same transcripts** — maximizes the cache hit rate and can speed up large batches by an order of magnitude versus randomly-ordered input. Ordering matters most when the number of distinct transcripts in the run exceeds the cache capacity (very large or genome-wide inputs); below that, the working set stays resident regardless of order.

--- a/data/benchmark/perf_results.json
+++ b/data/benchmark/perf_results.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "placeholder": false,
   "provenance": {
-    "generated": "2026-06-14T01:47:23.095282+00:00",
+    "generated": "2026-07-09T07:11:44.900800+00:00",
     "corpus_id": "clinvar_patterns",
     "corpus_sha": "2382f8f849b749ae",
     "machine": "Apple M2 Max (12 cores)",
@@ -14,46 +14,45 @@
       "mutalyzer": "3.1.1"
     },
     "notes": [
-      "All tools exclude process/interpreter startup from the timed region: the mutalyzer/biocommons subprocesses are timed by their own internal (startup-excluded) timer for both parse and normalize, matching ferro/hgvs-rs (#609). For mutalyzer normalize at >1 worker under the pre-sharded cache, the internal time is the slowest shard's critical path — a lower bound that still excludes the dominant per-process startup term.",
-      "Known anomaly: operations.normalize.ferro_scaling['2'] (~221515 pps) is a transient single-rep measurement outlier — ~13x the 1-thread value and higher than the 4- and 8-thread values, which is physically impossible for thread scaling. The ferro_scaling series is single-rep (no median/min/max), so it is vulnerable to a one-off outlier rep. Treat the normalize 2-thread scaling figure as unreliable; the parse ferro_scaling series and all by_workers blocks are unaffected. To be resolved by a re-run of the benchmark matrix (see docs/BENCHMARK_RUNBOOK.md)."
+      "All tools exclude process/interpreter startup from the timed region: the mutalyzer/biocommons subprocesses are timed by their own internal (startup-excluded) timer for both parse and normalize, matching ferro/hgvs-rs (#609). For mutalyzer normalize at >1 worker under the pre-sharded cache, the internal time is the slowest shard's critical path — a lower bound that still excludes the dominant per-process startup term."
     ]
   },
   "operations": {
     "normalize": {
       "sample_size_slow": 50,
       "ferro_full_population_n": 1000000,
-      "ferro_full_population_pps": 74504.55471894334,
+      "ferro_full_population_pps": 76993.26122009287,
       "by_workers": {
         "1": {
           "tools": {
             "biocommons": {
-              "median_pps": 314.0610024944673,
-              "min_pps": 162.7770502467187,
-              "max_pps": 326.6881045966133,
+              "median_pps": 368.18082318568804,
+              "min_pps": 358.672862392076,
+              "max_pps": 374.54293274678434,
               "reps": 5,
-              "success_rate": 0.6521246458923512,
+              "success_rate": 0.6638623326959847,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 12202.390927599748,
-              "min_pps": 12043.348194992586,
-              "max_pps": 17732.148629240502,
+              "median_pps": 78092.05034157442,
+              "min_pps": 29884.95763227468,
+              "max_pps": 96009.66457514084,
               "reps": 5,
-              "success_rate": 0.9990671641791046,
+              "success_rate": 0.9999640490986594,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 162.28888942477965,
-              "min_pps": 158.78540769464283,
-              "max_pps": 171.86633164318854,
+              "median_pps": 195.4308213163976,
+              "min_pps": 188.80607999284177,
+              "max_pps": 202.12070624817207,
               "reps": 5,
-              "success_rate": 0.6635814889336016,
+              "success_rate": 0.6590425531914894,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 3.7847514219736875,
-              "min_pps": 2.2000254161280237,
-              "max_pps": 7.624112594997838,
+              "median_pps": 4.033380472007517,
+              "min_pps": 2.3122207832386965,
+              "max_pps": 8.078556802781733,
               "reps": 5,
               "success_rate": 0.78,
               "not_run": false
@@ -63,33 +62,33 @@
         "8": {
           "tools": {
             "biocommons": {
-              "median_pps": 302.4743883745074,
-              "min_pps": 281.186390298519,
-              "max_pps": 352.5645387635826,
+              "median_pps": 817.8799823787473,
+              "min_pps": 789.6392183652272,
+              "max_pps": 833.771352874952,
               "reps": 5,
-              "success_rate": 0.6453257790368271,
+              "success_rate": 0.6638623326959847,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 88850.05750906999,
-              "min_pps": 63629.20555308756,
-              "max_pps": 108856.66232983212,
+              "median_pps": 260218.6296224891,
+              "min_pps": 249531.89861184856,
+              "max_pps": 263622.4454873672,
               "reps": 5,
-              "success_rate": 0.9990671641791046,
+              "success_rate": 0.9999640490986594,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 934.269796251172,
-              "min_pps": 682.767414921551,
-              "max_pps": 975.9562763733405,
+              "median_pps": 1321.6251939948506,
+              "min_pps": 1225.2453494749632,
+              "max_pps": 1364.5026826286044,
               "reps": 5,
-              "success_rate": 0.6635814889336016,
+              "success_rate": 0.6590425531914894,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 3.459116095913316,
-              "min_pps": 1.0744647382362809,
-              "max_pps": 6.794467274050015,
+              "median_pps": 3.5436300067067683,
+              "min_pps": 2.1377571795372385,
+              "max_pps": 7.31440849603656,
               "reps": 5,
               "success_rate": 0.78,
               "not_run": false
@@ -98,55 +97,55 @@
         }
       },
       "ferro_scaling": {
-        "1": 17119.094259064434,
-        "2": 221515.01807765051,
-        "4": 50145.96182042237,
-        "8": 86348.17527507598
+        "1": 137708.81966924685,
+        "2": 203596.6102957659,
+        "4": 267627.28427381546,
+        "8": 268391.37196242524
       },
       "sample_sizes": {
-        "biocommons": 353,
-        "ferro": 8576,
-        "hgvs-rs": 497,
+        "biocommons": 523,
+        "ferro": 38942,
+        "hgvs-rs": 752,
         "mutalyzer": 50
       }
     },
     "parse": {
-      "sample_size_slow": 795,
+      "sample_size_slow": 833,
       "ferro_full_population_n": 1000000,
-      "ferro_full_population_pps": 11243071.41507894,
+      "ferro_full_population_pps": 19993951.829571553,
       "by_workers": {
         "1": {
           "tools": {
             "biocommons": {
-              "median_pps": 3616.998433534247,
-              "min_pps": 3524.071655764142,
-              "max_pps": 3872.246837174446,
+              "median_pps": 3911.34435691175,
+              "min_pps": 3847.426126208224,
+              "max_pps": 3950.811647425595,
               "reps": 5,
-              "success_rate": 0.9913817486066051,
+              "success_rate": 0.9913509832297608,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 3081456.4938758854,
-              "min_pps": 2693023.189901545,
-              "max_pps": 3102989.4961899845,
+              "median_pps": 5053132.549736092,
+              "min_pps": 5001780.915899687,
+              "max_pps": 5097348.0007807575,
               "reps": 5,
-              "success_rate": 0.9999877752988799,
+              "success_rate": 0.9999890822613077,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 3537316.103535877,
-              "min_pps": 3442493.3635182623,
-              "max_pps": 3579113.27915898,
+              "median_pps": 3586634.4090267424,
+              "min_pps": 3575177.4578211247,
+              "max_pps": 3594817.8881164948,
               "reps": 5,
               "success_rate": 0.9911977000000001,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 335.9756077870706,
-              "min_pps": 323.96841067460633,
-              "max_pps": 339.1216371682769,
+              "median_pps": 352.113525628236,
+              "min_pps": 337.11012919066593,
+              "max_pps": 353.4532044027174,
               "reps": 5,
-              "success_rate": 0.9987421383647799,
+              "success_rate": 0.9987995198079231,
               "not_run": false
             }
           }
@@ -154,51 +153,51 @@
         "8": {
           "tools": {
             "biocommons": {
-              "median_pps": 3692.446437194751,
-              "min_pps": 3588.7909811958298,
-              "max_pps": 3829.1619811835394,
+              "median_pps": 3937.8128330663662,
+              "min_pps": 3877.3135644505105,
+              "max_pps": 3961.9687812503516,
               "reps": 5,
-              "success_rate": 0.9913817486066051,
+              "success_rate": 0.9913509832297608,
               "not_run": false
             },
             "ferro": {
-              "median_pps": 10324710.298715437,
-              "min_pps": 9220947.324262096,
-              "max_pps": 10401746.144627254,
+              "median_pps": 12199002.675462134,
+              "min_pps": 12073896.574754072,
+              "max_pps": 12214449.12132314,
               "reps": 5,
-              "success_rate": 0.9999877752988799,
+              "success_rate": 0.9999890822613077,
               "not_run": false
             },
             "hgvs-rs": {
-              "median_pps": 3525264.651664404,
-              "min_pps": 3504675.198162922,
-              "max_pps": 3551151.8620938864,
+              "median_pps": 3633746.7903091894,
+              "min_pps": 3604921.6214065785,
+              "max_pps": 3670162.4964445303,
               "reps": 5,
               "success_rate": 0.9911977000000001,
               "not_run": false
             },
             "mutalyzer": {
-              "median_pps": 335.7832841866961,
-              "min_pps": 163.99244807644243,
-              "max_pps": 336.92885399858403,
+              "median_pps": 353.5825238288752,
+              "min_pps": 351.9349831962715,
+              "max_pps": 354.30984551055275,
               "reps": 5,
-              "success_rate": 0.9987421383647799,
+              "success_rate": 0.9987995198079231,
               "not_run": false
             }
           }
         }
       },
       "ferro_scaling": {
-        "1": 3025491.785910047,
-        "2": 5066775.747067773,
-        "4": 7958707.101128423,
-        "8": 9259498.654412013
+        "1": 5148075.744029918,
+        "2": 9430053.064870352,
+        "4": 16009476.102487199,
+        "8": 11977143.34063749
       },
       "sample_sizes": {
-        "biocommons": 12021,
-        "ferro": 1079781,
+        "biocommons": 11747,
+        "ferro": 1557099,
         "hgvs-rs": 2000000,
-        "mutalyzer": 795
+        "mutalyzer": 833
       }
     }
   }

--- a/docs/BENCHMARK_GUIDE.md
+++ b/docs/BENCHMARK_GUIDE.md
@@ -29,10 +29,12 @@ This guide walks through running a complete benchmark comparing ferro-hgvs again
 
 | Tool | Type | Language | Speed (local) | Speed (network) | ferro Speedup |
 |------|------|----------|---------------|-----------------|---------------|
-| **ferro-hgvs** | Parser + Normalizer | Rust | ~4M patterns/sec | N/A | N/A |
+| **ferro-hgvs** | Parser + Normalizer | Rust | ~5M patterns/sec | N/A | N/A |
 | **mutalyzer** | Parser + Normalizer | Python | ~20 patterns/sec | ~1 pattern/sec | **20x** |
 | **biocommons/hgvs** | Parser + Normalizer | Python | ~20 patterns/sec | ~0.2 patterns/sec | **100x** |
 | **hgvs-rs** | Parser + Normalizer | Rust | ~2 patterns/sec | ~0.2 patterns/sec | **10x** |
+
+_These are rough order-of-magnitude figures for orientation only. The authoritative, methodology-controlled measured tables — regenerated per release from `data/benchmark/perf_results.json` — live in the [README Performance Comparison](../README.md#performance-comparison)._
 
 ### Versions Used in This Guide
 


### PR DESCRIPTION
Refreshes the published performance numbers ahead of the 0.7.0 release from a fresh cross-tool benchmark run.

## What changed

- **`data/benchmark/perf_results.json`** — new confident run: reps 5, calibrated per-tool sampling, ferro full-population = 1M, on an Apple M2 Max (matches the file's provenance), fully offline against the local UTA/SeqRepo stack. Competitor tools (mutalyzer/biocommons/hgvs-rs) run under the same methodology as before.
- **`README.md`** — the three generated perf-table blocks (parse cross-tool, normalize cross-tool, ferro thread-scaling) re-rendered from the new JSON via `generate_perf_tables`, plus two hand-maintained prose figures: the Features throughput bullet and the full-population footnote (parse 20.0M/s, normalize 77.0k/s).
- **`docs/BENCHMARK_GUIDE.md`** — refreshed the ferro throughput figure in the orientation table and marked that table as illustrative, pointing readers at the README's authoritative, per-release generated tables.

## Headline deltas (median pps, M2 Max, offline)

| op | tool | W1 | W8 |
|----|------|----|----|
| parse | ferro | 3.1M → **5.1M** | 10.3M → **12.2M** |
| normalize | ferro | 12.2k → **78.1k** | 88.9k → **260.2k** |
| normalize | biocommons | 314 → 368 | 302 → 818 |
| normalize | hgvs-rs | 162 → 195 | 934 → 1.3k |

ferro full-population peak: parse 11.2M → **20.0M/s**, normalize 74.5k → **77.0k/s**.

## Why the normalize numbers moved so much

The prior results were the run whose `ferro_scaling` block carried a documented, non-monotonic anomaly (`{1:17k, 2:221k, 4:50k, 8:86k}`) and drew ferro normalize from a small ~8.6k sample. This run is clean and monotonic (`{1:138k, 2:204k, 4:268k, 8:268k}`) over a ~39k sample at reps 5. Competitor numbers are unchanged within noise, so the shift reflects a better ferro measurement (and real gains since 0.6.0), not a methodology change.

## Notes for review

- **Sampled vs full-population normalize** now diverge (~260k sampled W8 vs 77k full-pop) where they used to agree; the full-population 77k is the honest headline and barely moved. The sampled cells reflect a lighter calibrated variant mix.
- **parse 4-thread (16.0M) > 8-thread (12.0M)** — a memory-bandwidth / E-core effect on the M2 Max (8P+4E), not a measurement error.
- Provenance still reads `ferro 0.6.0` (the crate version at HEAD; release-plz bumps it at release). Same as the prior file.
- Numbers were measured on the commit just before #1005 merged; #1005 is a rare-case normalize short-circuit with no measurable throughput impact.

Both drift gates pass: `generate_perf_tables --check` and `generate_tool_support_tables --check` (capability tables untouched).

The tool-support **capability** matrix (which pattern types each tool supports, incl. the web "HGVS Support" tab) is a separate concern owned by the `docs/tool-support-matrix-0.7.0` branch and is intentionally not touched here.
