### PR TITLE
fix(ci): satisfy Rust 1.97 clippy lints and pin the toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]

--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -3119,7 +3119,7 @@ pub fn enhance_lrg_annotations(
 
     for i in 1..=LRG_MAX_ID {
         let lrg_id = format!("LRG_{}", i);
-        let seq_path = cache_dir.join(format!("{}.sequence", &lrg_id));
+        let seq_path = cache_dir.join(format!("{}.sequence", lrg_id));
 
         // Skip if no sequence file exists (LRG doesn't exist)
         if !seq_path.exists() {
@@ -3127,7 +3127,7 @@ pub fn enhance_lrg_annotations(
         }
 
         // Check if already has enhanced annotations (has "features" with transcript selectors)
-        let ann_path = cache_dir.join(format!("{}.annotations", &lrg_id));
+        let ann_path = cache_dir.join(format!("{}.annotations", lrg_id));
         if ann_path.exists() {
             if let Ok(content) = std::fs::read_to_string(&ann_path) {
                 // Check if it has proper exon structure (more than just gene features)

--- a/src/benchmark/translate.rs
+++ b/src/benchmark/translate.rs
@@ -27,18 +27,12 @@ pub fn translate_cds_to_protein(cds_sequence: &str) -> Option<String> {
     for i in 0..codon_count {
         let start = i * 3;
         let codon_str = &cds_sequence[start..start + 3];
-        if let Some(codon) = Codon::parse(codon_str) {
-            if table.is_stop(&codon) {
-                break; // Stop at stop codon
-            }
-            if let Some(aa) = table.amino_acid_for(&codon) {
-                protein.push(aa.to_one_letter());
-            } else {
-                return None; // Unknown codon
-            }
-        } else {
-            return None; // Invalid nucleotide (e.g., N)
+        let codon = Codon::parse(codon_str)?; // None => invalid nucleotide (e.g., N)
+        if table.is_stop(&codon) {
+            break; // Stop at stop codon
         }
+        let aa = table.amino_acid_for(&codon)?; // None => unknown codon
+        protein.push(aa.to_one_letter());
     }
 
     Some(protein)


### PR DESCRIPTION
Rust **1.97.0** (released 2026-07-09) added two clippy lints that fire on pre-existing code and fail the `-D warnings` clippy gate, turning CI red across **all open PRs** and `main`'s next run. The repo has no `rust-toolchain.toml`, so CI floats on `dtolnay/rust-toolchain@stable` and silently picked up 1.97 mid-day (main was green on the prior stable at 06:29 UTC; PRs run after the release went red).

## Fixes

- **`src/benchmark/translate.rs`** — `clippy::question_mark`: collapse two `if let Some(..) { .. } else { return None }` blocks in `translate_cds_to_protein` into `?`. Behavior-preserving (both still return `None` on an invalid nucleotide / unknown codon).
- **`src/benchmark/cache.rs`** — `clippy::useless_borrows_in_formatting`: drop the useless `&` on `lrg_id` in two `format!` args.

## Prevent recurrence

- **`rust-toolchain.toml`** pins `channel = "1.97.0"` with the `clippy`/`rustfmt` components, so the build is reproducible and a future compiler release can't silently break CI again. (This also brings the repo in line with the "pin the toolchain via rust-toolchain.toml" convention it was previously missing.)

## Verification

Under the pinned **1.97.0** toolchain, all green:
- `cargo clippy --features dev --all-targets -- -D warnings` ✓
- `cargo clippy --all-features --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓
- `cargo test --features dev` (translate/protein tests) ✓

Merging this first unblocks the other open PRs (e.g. #1006), which rebase onto it and go green.
