### PR TITLE
fix(ci): publish wheels directly to PyPI, drop the TestPyPI gate

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -288,33 +288,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh release upload "$TAG_NAME" dist/* --repo "$REPO" --clobber
 
-  publish-testpypi:
-    name: Publish to TestPyPI
-    needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
-    runs-on: ubuntu-latest
-    # Only publish on release events (not workflow_dispatch dry-runs)
-    if: github.event_name == 'release'
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/ferro-hgvs
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: dist
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist/
-          attestations: true
-          print-hash: true
-          verbose: true
-
   publish-pypi:
     name: Publish to PyPI
-    needs: [publish-testpypi]
+    # Publish straight to PyPI on release. The per-platform smoke tests (real
+    # import + parse on every OS/Python) and `twine check` are the validation
+    # gate; the former TestPyPI dry-run only added a second trusted-publisher
+    # config to maintain and a hard `needs` failure that blocked real releases
+    # on every tag (v0.4.0 through v0.7.0 all failed here).
+    needs: [check-metadata, smoke-test, smoke-test-musllinux, sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     environment:


### PR DESCRIPTION
## Problem

The Python wheels workflow has **failed on every release — v0.4.0, v0.4.1, v0.5.0, v0.6.0, and v0.7.0** — and `ferro-hgvs` has never appeared on PyPI. Root cause: `publish-pypi` has `needs: [publish-testpypi]`, and the `publish-testpypi` step fails with `invalid-publisher` because no TestPyPI trusted publisher was ever configured. TestPyPI failing therefore hard-blocks the real PyPI publish, which is `skipped`.

(The wheels themselves build fine and are attached to each GitHub Release; only PyPI distribution was broken.)

## Change

Drop the TestPyPI dry-run and publish straight to PyPI on release. Every wheel is already validated before publish by:
- **per-platform smoke tests** — real `import ferro_hgvs` + parse on every OS × Python 3.10–3.14 (glibc, musl, macOS, Windows), and
- **`twine check`** on the built artifacts.

So the TestPyPI hop added only a second trusted-publisher config to maintain and a hard failure gate, with no consumer (nobody installs from TestPyPI). Net: `-25/+6` lines, one job removed, `publish-pypi` now depends on the real validation jobs.

## Required manual setup (one-time, operator)

PyPI trusted publishing needs a publisher registered on **pypi.org** for this repo. Because the project doesn't exist there yet, use the **pending publisher** flow (https://pypi.org/manage/account/publishing/):

| Field | Value |
|---|---|
| PyPI project name | `ferro-hgvs` |
| Owner | `fulcrumgenomics` |
| Repository name | `ferro-hgvs` |
| Workflow filename | `release-wheels.yml` |
| Environment name | `pypi` |

No secrets/tokens needed (OIDC trusted publishing). The `pypi` GitHub environment auto-creates on first publish; TestPyPI setup is no longer required.

After this merges and the publisher is registered, cutting **v0.7.1** will publish to PyPI.
