### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.7.0...v0.7.1) - 2026-07-09
+
+### Fixed
+
+- *(ci)* publish wheels directly to PyPI and drop the TestPyPI gate that had failed on every prior release, so Python wheels are published to PyPI for the first time ([#1008](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1008))
+
 ## [0.7.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.6.0...v0.7.0) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION
Cuts **v0.7.1** to ship the release-pipeline fix (#1008) and publish Python wheels to PyPI for the first time.

## Why a manual bump
The only change since v0.7.0 is #1008, which touches `.github/workflows/` — excluded from the published crate — so release-plz sees no crate change and won't auto-open a release PR. Bumping `Cargo.toml` by hand gives release-plz's `release` step a version to publish.

## What merging this does
1. release-plz `release` detects `Cargo.toml = 0.7.1` (no `v0.7.1` tag) → `cargo publish` to crates.io, creates tag `v0.7.1`, publishes the GitHub Release.
2. The published release fires `release-wheels.yml` (now fixed) → builds wheels `0.7.1` → **publishes to PyPI** via the trusted publisher.

## Changes
- `Cargo.toml` / `Cargo.lock`: `0.7.0` → `0.7.1` (lockfile verified with `cargo metadata --locked`).
- `CHANGELOG.md`: `[0.7.1]` section.

## Prerequisite (done)
PyPI trusted publisher registered for `fulcrumgenomics/ferro-hgvs`, workflow `release-wheels.yml`, environment `pypi`.
