### PR TITLE
docs(readme): add PyPI version and Python-versions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Nightly reference-aware tests](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml)
 [![Codecov](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs)
 [![Crates.io](https://img.shields.io/crates/v/ferro-hgvs.svg)](https://crates.io/crates/ferro-hgvs)
+[![PyPI](https://img.shields.io/pypi/v/ferro-hgvs.svg)](https://pypi.org/project/ferro-hgvs/)
+[![Python versions](https://img.shields.io/pypi/pyversions/ferro-hgvs.svg)](https://pypi.org/project/ferro-hgvs/)
 [![Documentation](https://docs.rs/ferro-hgvs/badge.svg)](https://docs.rs/ferro-hgvs)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/ferro-hgvs/README.html)


### PR DESCRIPTION
Now that `ferro-hgvs` publishes to PyPI (v0.7.1), add a PyPI version badge and a Python-versions badge next to the existing Crates.io badge, both linking to https://pypi.org/project/ferro-hgvs/.

Note: `README.md` is part of the published crate, so merging this may prompt release-plz to open a patch release PR — merge or ignore that as you prefer.