### PR TITLE
docs: add PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Nightly reference-aware tests](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml/badge.svg?branch=main)](https://github.com/fulcrumgenomics/ferro-hgvs/actions/workflows/nightly-mutalyzer.yml)
 [![Codecov](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs/branch/main/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/ferro-hgvs)
 [![Crates.io](https://img.shields.io/crates/v/ferro-hgvs.svg)](https://crates.io/crates/ferro-hgvs)
+[![PyPI](https://img.shields.io/pypi/v/ferro-hgvs.svg)](https://pypi.org/project/ferro-hgvs/)
 [![Documentation](https://docs.rs/ferro-hgvs/badge.svg)](https://docs.rs/ferro-hgvs)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/ferro-hgvs/README.html)


### PR DESCRIPTION
Adds a **PyPI** badge to the README — the Python bindings now publish to PyPI (`ferro-hgvs` 0.7.1). The crates.io and (Rust CLI) bioconda badges are already present.

Draft, tracking the new Python-bindings bioconda recipe:
- python-ferro-hgvs: https://github.com/bioconda/bioconda-recipes/pull/67061

Once that recipe merges we can optionally add a second bioconda badge for the Python package; for now this just surfaces the PyPI availability. Ready to mark ready-for-review whenever.