### PR TITLE
feat(python): surface reference capability and warn on reduced-capability build

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -441,6 +441,28 @@ class Normalizer:
         """
         ...
 
+    def has_genomic_data(self) -> bool:
+        """Return True if the backing reference provides genomic sequence data.
+
+        A build with no genomic data (built-in test data or a transcripts.json
+        reference) cannot perform genome-dependent normalization; use
+        ``Normalizer.from_manifest(...)`` for full capability.
+        """
+        ...
+
+    def has_protein_data(self) -> bool:
+        """Return True if the backing reference provides protein sequence data."""
+        ...
+
+    def reference_summary(self) -> dict[str, Any]:
+        """Summarize the reference backend's capabilities.
+
+        Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
+        ``"transcripts_json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``has_protein_data``.
+        """
+        ...
+
     def parse(self, hgvs_string: str) -> HgvsVariant:
         """Parse an HGVS string."""
         ...

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -458,7 +458,7 @@ class Normalizer:
         """Summarize the reference backend's capabilities.
 
         Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
-        ``"transcripts_json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``"json"``, or ``"manifest"``), ``has_genomic_data``, and
         ``has_protein_data``.
         """
         ...
@@ -686,6 +686,28 @@ class EquivalenceChecker:
 
         Raises:
             RuntimeError: If the manifest cannot be loaded.
+        """
+        ...
+
+    def has_genomic_data(self) -> bool:
+        """Return True if the backing reference provides genomic sequence data.
+
+        A checker with no genomic data (built-in test data or a transcript-only
+        ``reference_json``) has limited genome-dependent capability; use
+        ``EquivalenceChecker.from_manifest(...)`` for full capability.
+        """
+        ...
+
+    def has_protein_data(self) -> bool:
+        """Return True if the backing reference provides protein sequence data."""
+        ...
+
+    def reference_summary(self) -> dict[str, Any]:
+        """Summarize the reference backend's capabilities.
+
+        Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
+        ``"json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``has_protein_data``.
         """
         ...
 
@@ -923,6 +945,28 @@ class BatchProcessor:
 
         Raises:
             RuntimeError: If the manifest cannot be loaded.
+        """
+        ...
+
+    def has_genomic_data(self) -> bool:
+        """Return True if the backing reference provides genomic sequence data.
+
+        A processor with no genomic data (built-in test data or a transcript-only
+        ``reference_json``) has limited genome-dependent capability; use
+        ``BatchProcessor.from_manifest(...)`` for full capability.
+        """
+        ...
+
+    def has_protein_data(self) -> bool:
+        """Return True if the backing reference provides protein sequence data."""
+        ...
+
+    def reference_summary(self) -> dict[str, Any]:
+        """Summarize the reference backend's capabilities.
+
+        Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
+        ``"json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``has_protein_data``.
         """
         ...
 
@@ -1359,6 +1403,28 @@ class CoordinateMapper:
 
         Raises:
             RuntimeError: If the manifest cannot be loaded.
+        """
+        ...
+
+    def has_genomic_data(self) -> bool:
+        """Return True if the backing reference provides genomic sequence data.
+
+        A mapper with no genomic data (built-in test data or a transcript-only
+        ``reference_json``) cannot resolve genomic coordinates; use
+        ``CoordinateMapper.from_manifest(...)`` for full capability.
+        """
+        ...
+
+    def has_protein_data(self) -> bool:
+        """Return True if the backing reference provides protein sequence data."""
+        ...
+
+    def reference_summary(self) -> dict[str, Any]:
+        """Summarize the reference backend's capabilities.
+
+        Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
+        ``"json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``has_protein_data``.
         """
         ...
 
@@ -1799,5 +1865,27 @@ class VariantProjector:
 
         Raises:
             RuntimeError: On the first projection error.
+        """
+        ...
+
+    def has_genomic_data(self) -> bool:
+        """Return True if the backing reference provides genomic sequence data.
+
+        A projector with no genomic data (built-in test data or a transcript-only
+        ``reference_json``) cannot ``project_to_genomic``; use
+        ``VariantProjector.from_manifest(...)`` for full capability.
+        """
+        ...
+
+    def has_protein_data(self) -> bool:
+        """Return True if the backing reference provides protein sequence data."""
+        ...
+
+    def reference_summary(self) -> dict[str, Any]:
+        """Summarize the reference backend's capabilities.
+
+        Returns a dict with keys ``provider_kind`` (one of ``"test_data"``,
+        ``"json"``, or ``"manifest"``), ``has_genomic_data``, and
+        ``has_protein_data``.
         """
         ...

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -21,7 +21,11 @@ pub(crate) use helpers::{
     read_cds_start_codon, whole_exon_deletion_span, RefProteinBundle,
 };
 pub(crate) use indel::{predict_indel_protein, predict_stop_region_extension};
+pub(crate) use substitution::predict_substitution_protein;
 // `read_ref_codon` / `translate` are the position-level CDS primitives reused by
 // the service effect handler to resolve real amino-acid residues (issue #806);
-// `read_ref_codon` is also the seam #498 (full c.→p.) inherits.
-pub(crate) use substitution::{predict_substitution_protein, read_ref_codon, translate};
+// `read_ref_codon` is also the seam #498 (full c.→p.) inherits. They are only
+// consumed by the `web-service` handlers today, so gate the re-export to that
+// feature to keep non-service builds (e.g. `--features python`) warning-clean.
+#[cfg(feature = "web-service")]
+pub(crate) use substitution::{read_ref_codon, translate};

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,12 +3,13 @@
 //! This module provides Python bindings for the HGVS parser and normalizer.
 //! Enable with the `python` feature flag.
 
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::backtranslate::{Backtranslator, CodonChange, CodonTable};
@@ -588,11 +589,42 @@ impl PyHgvsVariant {
     }
 }
 
+/// Which reference backend a [`PyNormalizer`] was built from.
+///
+/// Surfaced to Python via `reference_summary()["provider_kind"]` so callers can
+/// tell a limited, no-genomic build (`test_data` / `transcripts_json`) apart
+/// from a full manifest-backed build.
+#[derive(Clone, Copy)]
+enum ProviderKind {
+    /// Built-in test data (`Normalizer()` with no arguments).
+    TestData,
+    /// A `transcripts.json` file (`Normalizer(reference_json=...)`).
+    TranscriptsJson,
+    /// A `ferro prepare` manifest (`Normalizer.from_manifest(...)`).
+    Manifest,
+}
+
+impl ProviderKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            ProviderKind::TestData => "test_data",
+            ProviderKind::TranscriptsJson => "transcripts_json",
+            ProviderKind::Manifest => "manifest",
+        }
+    }
+}
+
+/// Set once the reduced-capability `UserWarning` has been emitted, so it fires
+/// at most once per process regardless of how many limited normalizers are
+/// constructed (#1012 item 1).
+static REDUCED_CAPABILITY_WARNED: AtomicBool = AtomicBool::new(false);
+
 /// HGVS variant normalizer using a reference provider
 #[pyclass(name = "Normalizer")]
 pub struct PyNormalizer {
     provider: PyProvider,
     config: NormalizeConfig,
+    kind: ProviderKind,
 }
 
 #[pymethods]
@@ -606,15 +638,24 @@ impl PyNormalizer {
     ///     direction: Shuffle direction - "3prime" (default) or "5prime"
     #[new]
     #[pyo3(signature = (reference_json=None, direction="3prime"))]
-    fn new(reference_json: Option<&str>, direction: &str) -> PyResult<Self> {
-        let provider = match reference_json {
-            Some(path) => PyProvider::from_json(Path::new(path))?,
-            None => PyProvider::test_data(),
+    fn new(py: Python<'_>, reference_json: Option<&str>, direction: &str) -> PyResult<Self> {
+        let (provider, kind) = match reference_json {
+            Some(path) => (
+                PyProvider::from_json(Path::new(path))?,
+                ProviderKind::TranscriptsJson,
+            ),
+            None => (PyProvider::test_data(), ProviderKind::TestData),
         };
 
         let config = NormalizeConfig::default().with_direction(parse_direction(direction));
 
-        Ok(Self { provider, config })
+        let normalizer = Self {
+            provider,
+            config,
+            kind,
+        };
+        normalizer.warn_if_reduced_capability(py)?;
+        Ok(normalizer)
     }
 
     /// Create a normalizer from a reference manifest written by `ferro prepare`.
@@ -628,10 +669,44 @@ impl PyNormalizer {
     ///     A Normalizer backed by a MultiFastaProvider.
     #[staticmethod]
     #[pyo3(signature = (manifest_path, direction="3prime"))]
-    fn from_manifest(manifest_path: &str, direction: &str) -> PyResult<Self> {
+    fn from_manifest(py: Python<'_>, manifest_path: &str, direction: &str) -> PyResult<Self> {
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
         let config = NormalizeConfig::default().with_direction(parse_direction(direction));
-        Ok(Self { provider, config })
+        let normalizer = Self {
+            provider,
+            config,
+            kind: ProviderKind::Manifest,
+        };
+        normalizer.warn_if_reduced_capability(py)?;
+        Ok(normalizer)
+    }
+
+    /// Return `True` if the backing reference provides genomic sequence data.
+    ///
+    /// A build with no genomic data (`Normalizer()` test data or
+    /// `Normalizer(reference_json=...)`) cannot perform genome-dependent
+    /// normalization; use `Normalizer.from_manifest(...)` for full capability.
+    fn has_genomic_data(&self) -> bool {
+        self.provider.has_genomic_data()
+    }
+
+    /// Return `True` if the backing reference provides protein sequence data.
+    fn has_protein_data(&self) -> bool {
+        self.provider.has_protein_data()
+    }
+
+    /// Summarize the reference backend's capabilities as a dict.
+    ///
+    /// Keys:
+    ///     provider_kind: One of "test_data", "transcripts_json", or "manifest".
+    ///     has_genomic_data: Whether genomic sequences are available.
+    ///     has_protein_data: Whether protein sequences are available.
+    fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("provider_kind", self.kind.as_str())?;
+        dict.set_item("has_genomic_data", self.provider.has_genomic_data())?;
+        dict.set_item("has_protein_data", self.provider.has_protein_data())?;
+        Ok(dict)
     }
 
     /// Parse an HGVS string
@@ -694,6 +769,43 @@ impl PyNormalizer {
                 .map(PyNormalizationWarning::from)
                 .collect(),
         })
+    }
+}
+
+impl PyNormalizer {
+    /// Emit a one-time `UserWarning` when the backing provider has no genomic
+    /// data, so users silently landing on a reduced-capability build get a
+    /// runtime signal (#1012 item 1). Fires at most once per process; the
+    /// `MockProvider` test-data and `transcripts.json` paths both lack genomic
+    /// data, so both trigger it.
+    fn warn_if_reduced_capability(&self, py: Python<'_>) -> PyResult<()> {
+        if self.provider.has_genomic_data() {
+            return Ok(());
+        }
+        // Only the first limited normalizer in the process warns.
+        if REDUCED_CAPABILITY_WARNED.swap(true, Ordering::Relaxed) {
+            return Ok(());
+        }
+        // Tailor the guidance to how the reference was built. Pointing a
+        // `from_manifest(...)` caller back at `from_manifest(...)` is nonsense,
+        // so a genome-less manifest gets a manifest-specific message; the
+        // test-data and transcripts.json paths point at `from_manifest`.
+        let message = match self.kind {
+            ProviderKind::Manifest => {
+                "Normalizer manifest reference provides no genomic data: \
+                 genome-dependent normalization will be limited. Ensure the \
+                 prepared reference includes a genome FASTA."
+            }
+            ProviderKind::TestData | ProviderKind::TranscriptsJson => {
+                "Normalizer reference lacks genomic data: genome-dependent \
+                 normalization will be limited (built-in test data and \
+                 transcripts.json references carry no genome). Use \
+                 Normalizer.from_manifest(...) for full reference capability."
+            }
+        };
+        let message = std::ffi::CString::new(message)
+            .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
+        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -301,13 +301,23 @@ fn parse(hgvs_string: &str) -> PyResult<PyHgvsVariant> {
 ///     RuntimeError: If normalization fails
 #[pyfunction]
 #[pyo3(signature = (hgvs_string, direction="3prime"))]
-fn normalize(hgvs_string: &str, direction: &str) -> PyResult<String> {
+fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<String> {
     let variant = parse_hgvs(hgvs_string)
         .map_err(|e| PyValueError::new_err(format!("Parse error: {}", e)))?;
 
     let config = NormalizeConfig::default().with_direction(parse_direction(direction));
     // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
     let provider = MockProvider::with_test_data();
+    // This free function always uses genome-less test data; surface the
+    // reduced-capability signal once per process (#1012), pointing callers at a
+    // full manifest-backed Normalizer.
+    emit_reduced_capability_warning(
+        py,
+        provider.has_genomic_data(),
+        ProviderKind::TestData,
+        "normalize()",
+        "Normalizer.from_manifest(...)",
+    )?;
     let normalizer = Normalizer::with_config(provider, config);
 
     let normalized = normalizer
@@ -533,10 +543,19 @@ impl PyHgvsVariant {
     /// Returns:
     ///     A new PyHgvsVariant representing the normalized variant
     #[pyo3(signature = (direction="3prime"))]
-    fn normalize(&self, direction: &str) -> PyResult<PyHgvsVariant> {
+    fn normalize(&self, py: Python<'_>, direction: &str) -> PyResult<PyHgvsVariant> {
         let config = NormalizeConfig::default().with_direction(parse_direction(direction));
         // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
         let provider = MockProvider::with_test_data();
+        // Genome-less test data; surface the reduced-capability signal once per
+        // process (#1012), pointing callers at a full manifest-backed Normalizer.
+        emit_reduced_capability_warning(
+            py,
+            provider.has_genomic_data(),
+            ProviderKind::TestData,
+            "HgvsVariant.normalize()",
+            "Normalizer.from_manifest(...)",
+        )?;
         let normalizer = Normalizer::with_config(provider, config);
 
         let normalized = normalizer
@@ -589,18 +608,22 @@ impl PyHgvsVariant {
     }
 }
 
-/// Which reference backend a [`PyNormalizer`] was built from.
+/// Which reference backend a capability-surfacing pyclass was built from.
 ///
 /// Surfaced to Python via `reference_summary()["provider_kind"]` so callers can
-/// tell a limited, no-genomic build (`test_data` / `transcripts_json`) apart
-/// from a full manifest-backed build.
+/// tell a limited build (`test_data` / `json`) apart from a full manifest-backed
+/// build. Shared by every reference-backed surface: `Normalizer`,
+/// `VariantProjector`, `EquivalenceChecker`, `BatchProcessor`, and
+/// `CoordinateMapper`.
 #[derive(Clone, Copy)]
 enum ProviderKind {
-    /// Built-in test data (`Normalizer()` with no arguments).
+    /// Built-in test data (constructed with no arguments).
     TestData,
-    /// A `transcripts.json` file (`Normalizer(reference_json=...)`).
+    /// A `reference_json` file (`reference_json=...`). Labeled `"json"` because
+    /// such a file may carry genomic-only data as well as transcripts;
+    /// `has_genomic_data` remains the source of truth for capability.
     TranscriptsJson,
-    /// A `ferro prepare` manifest (`Normalizer.from_manifest(...)`).
+    /// A `ferro prepare` manifest (`from_manifest(...)`).
     Manifest,
 }
 
@@ -608,16 +631,89 @@ impl ProviderKind {
     fn as_str(self) -> &'static str {
         match self {
             ProviderKind::TestData => "test_data",
-            ProviderKind::TranscriptsJson => "transcripts_json",
+            ProviderKind::TranscriptsJson => "json",
             ProviderKind::Manifest => "manifest",
         }
     }
 }
 
-/// Set once the reduced-capability `UserWarning` has been emitted, so it fires
-/// at most once per process regardless of how many limited normalizers are
-/// constructed (#1012 item 1).
-static REDUCED_CAPABILITY_WARNED: AtomicBool = AtomicBool::new(false);
+/// Set once the reduced-capability `UserWarning` has been emitted for each
+/// distinct message *variant*, so each variant fires at most once per process
+/// regardless of how many limited reference-backed surfaces are constructed
+/// (#1012 item 1). Keyed by variant — a throwaway test-data / `reference_json`
+/// surface warning first must NOT suppress a genome-less *manifest* (a real
+/// production misconfiguration) later in the same process, or vice versa: the
+/// two carry different guidance and are independently actionable.
+static REDUCED_CAPABILITY_WARNED_GENERIC: AtomicBool = AtomicBool::new(false);
+static REDUCED_CAPABILITY_WARNED_MANIFEST: AtomicBool = AtomicBool::new(false);
+
+/// Emit the shared one-time reduced-capability `UserWarning` used by every
+/// Python entry point that can silently fall back to a genome-less reference
+/// (#1012). Mirrors [`PyNormalizer::warn_if_reduced_capability`] but is reused
+/// by the sibling surfaces (`VariantProjector`, `EquivalenceChecker`,
+/// `BatchProcessor`, `CoordinateMapper`) and the free `normalize` functions.
+///
+/// `subject` names the surface in the message (e.g. `"VariantProjector"`);
+/// `manifest_ctor` is the fully-qualified constructor to point callers at for
+/// full capability (e.g. `"VariantProjector.from_manifest(...)"`). Each message
+/// variant fires at most once per process, keyed by the per-variant flags
+/// ([`REDUCED_CAPABILITY_WARNED_GENERIC`] / [`REDUCED_CAPABILITY_WARNED_MANIFEST`]),
+/// so a limited test-data surface cannot mask a later genome-less manifest.
+fn emit_reduced_capability_warning(
+    py: Python<'_>,
+    has_genomic_data: bool,
+    kind: ProviderKind,
+    subject: &str,
+    manifest_ctor: &str,
+) -> PyResult<()> {
+    if has_genomic_data {
+        return Ok(());
+    }
+    // Each message variant warns at most once — keyed on the same partition as
+    // the message below (manifest vs test-data/reference_json), so a limited
+    // test-data / reference_json surface does not consume the manifest variant's
+    // one-shot slot (and vice versa).
+    let warned_flag = match kind {
+        ProviderKind::Manifest => &REDUCED_CAPABILITY_WARNED_MANIFEST,
+        ProviderKind::TestData | ProviderKind::TranscriptsJson => {
+            &REDUCED_CAPABILITY_WARNED_GENERIC
+        }
+    };
+    if warned_flag.swap(true, Ordering::Relaxed) {
+        return Ok(());
+    }
+    // Tailor the guidance to how the reference was built. Pointing a
+    // `from_manifest(...)` caller back at `from_manifest(...)` is nonsense, so a
+    // genome-less manifest gets a manifest-specific message; the test-data and
+    // reference_json paths point at `from_manifest`.
+    let message = match kind {
+        ProviderKind::Manifest => format!(
+            "{subject} manifest reference provides no genomic data: \
+             genome-dependent operations will be limited. Ensure the prepared \
+             reference includes a genome FASTA."
+        ),
+        ProviderKind::TestData | ProviderKind::TranscriptsJson => format!(
+            "{subject} reference lacks genomic data: genome-dependent operations \
+             will be limited (built-in test data and transcript-only reference_json \
+             files carry no genome). Use {manifest_ctor} for full reference capability."
+        ),
+    };
+    // If emitting the warning fails — most importantly when the process runs
+    // under `warnings.simplefilter("error")`, so the warning is raised as an
+    // exception — reset the once-per-process flag. Otherwise `swap(true, …)` above
+    // would leave the flag set for a warning that never actually surfaced, and the
+    // configured warning policy could be silently bypassed on a later attempt.
+    let emit = || -> PyResult<()> {
+        let message = std::ffi::CString::new(message)
+            .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
+        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)
+    };
+    let result = emit();
+    if result.is_err() {
+        warned_flag.store(false, Ordering::Relaxed);
+    }
+    result
+}
 
 /// HGVS variant normalizer using a reference provider
 #[pyclass(name = "Normalizer")]
@@ -698,7 +794,7 @@ impl PyNormalizer {
     /// Summarize the reference backend's capabilities as a dict.
     ///
     /// Keys:
-    ///     provider_kind: One of "test_data", "transcripts_json", or "manifest".
+    ///     provider_kind: One of "test_data", "json", or "manifest".
     ///     has_genomic_data: Whether genomic sequences are available.
     ///     has_protein_data: Whether protein sequences are available.
     fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
@@ -779,33 +875,13 @@ impl PyNormalizer {
     /// `MockProvider` test-data and `transcripts.json` paths both lack genomic
     /// data, so both trigger it.
     fn warn_if_reduced_capability(&self, py: Python<'_>) -> PyResult<()> {
-        if self.provider.has_genomic_data() {
-            return Ok(());
-        }
-        // Only the first limited normalizer in the process warns.
-        if REDUCED_CAPABILITY_WARNED.swap(true, Ordering::Relaxed) {
-            return Ok(());
-        }
-        // Tailor the guidance to how the reference was built. Pointing a
-        // `from_manifest(...)` caller back at `from_manifest(...)` is nonsense,
-        // so a genome-less manifest gets a manifest-specific message; the
-        // test-data and transcripts.json paths point at `from_manifest`.
-        let message = match self.kind {
-            ProviderKind::Manifest => {
-                "Normalizer manifest reference provides no genomic data: \
-                 genome-dependent normalization will be limited. Ensure the \
-                 prepared reference includes a genome FASTA."
-            }
-            ProviderKind::TestData | ProviderKind::TranscriptsJson => {
-                "Normalizer reference lacks genomic data: genome-dependent \
-                 normalization will be limited (built-in test data and \
-                 transcripts.json references carry no genome). Use \
-                 Normalizer.from_manifest(...) for full reference capability."
-            }
-        };
-        let message = std::ffi::CString::new(message)
-            .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
-        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)
+        emit_reduced_capability_warning(
+            py,
+            self.provider.has_genomic_data(),
+            self.kind,
+            "Normalizer",
+            "Normalizer.from_manifest(...)",
+        )
     }
 }
 
@@ -962,6 +1038,14 @@ impl PyVariantProjection {
 #[pyclass(name = "VariantProjector")]
 pub struct PyVariantProjector {
     inner: crate::project::VariantProjector<PyProvider>,
+    /// How the backing reference was built (#1012). Captured at construction
+    /// because the provider is moved into `inner`.
+    kind: ProviderKind,
+    /// Whether the backing reference carries genomic sequence data. Captured at
+    /// construction so `reference_summary()` need not reach into `inner`.
+    has_genomic_data: bool,
+    /// Whether the backing reference carries protein sequence data.
+    has_protein_data: bool,
 }
 
 #[pymethods]
@@ -980,15 +1064,19 @@ impl PyVariantProjector {
     #[new]
     #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None))]
     fn new(
+        py: Python<'_>,
         reference_json: Option<&str>,
         direction: &str,
         assembly: Option<&str>,
     ) -> PyResult<Self> {
-        let provider = match reference_json {
-            Some(path) => PyProvider::from_json(Path::new(path))?,
-            None => PyProvider::test_data(),
+        let (provider, kind) = match reference_json {
+            Some(path) => (
+                PyProvider::from_json(Path::new(path))?,
+                ProviderKind::TranscriptsJson,
+            ),
+            None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-        Self::from_provider(provider, direction, assembly)
+        Self::from_provider(py, provider, direction, assembly, kind)
     }
 
     /// Create a projector from a ferro-prepare manifest (preferred for
@@ -996,12 +1084,41 @@ impl PyVariantProjector {
     #[staticmethod]
     #[pyo3(signature = (manifest_path, direction="3prime", assembly=None))]
     fn from_manifest(
+        py: Python<'_>,
         manifest_path: &str,
         direction: &str,
         assembly: Option<&str>,
     ) -> PyResult<Self> {
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Self::from_provider(provider, direction, assembly)
+        Self::from_provider(py, provider, direction, assembly, ProviderKind::Manifest)
+    }
+
+    /// Return `True` if the backing reference provides genomic sequence data.
+    ///
+    /// A projector without genomic data (built-in test data or a transcript-only
+    /// `reference_json`) cannot `project_to_genomic`; use
+    /// `VariantProjector.from_manifest(...)` for full capability.
+    fn has_genomic_data(&self) -> bool {
+        self.has_genomic_data
+    }
+
+    /// Return `True` if the backing reference provides protein sequence data.
+    fn has_protein_data(&self) -> bool {
+        self.has_protein_data
+    }
+
+    /// Summarize the reference backend's capabilities as a dict.
+    ///
+    /// Keys:
+    ///     provider_kind: One of "test_data", "json", or "manifest".
+    ///     has_genomic_data: Whether genomic sequences are available.
+    ///     has_protein_data: Whether protein sequences are available.
+    fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("provider_kind", self.kind.as_str())?;
+        dict.set_item("has_genomic_data", self.has_genomic_data)?;
+        dict.set_item("has_protein_data", self.has_protein_data)?;
+        Ok(dict)
     }
 
     /// Project a g. HGVS string onto a target transcript.
@@ -1334,10 +1451,15 @@ impl PyVariantProjector {
 
 impl PyVariantProjector {
     fn from_provider(
+        py: Python<'_>,
         provider: PyProvider,
         direction: &str,
         assembly: Option<&str>,
+        kind: ProviderKind,
     ) -> PyResult<Self> {
+        // Capture capability before the provider is moved into the projector.
+        let has_genomic_data = provider.has_genomic_data();
+        let has_protein_data = provider.has_protein_data();
         let cdot = provider.cdot_mapper();
         let projector = crate::data::projection::Projector::new(cdot);
         let config = NormalizeConfig::default().with_direction(parse_direction(direction));
@@ -1354,11 +1476,24 @@ impl PyVariantProjector {
             ),
             None => None,
         };
-        Ok(Self {
+        let projector = Self {
             inner: crate::project::VariantProjector::new(projector, provider)
                 .with_normalize_config(config)
                 .with_assembly(assembly_build),
-        })
+            kind,
+            has_genomic_data,
+            has_protein_data,
+        };
+        // project_to_genomic needs a genome a transcripts-only reference lacks,
+        // so surface the reduced-capability signal once per process (#1012).
+        emit_reduced_capability_warning(
+            py,
+            has_genomic_data,
+            kind,
+            "VariantProjector",
+            "VariantProjector.from_manifest(...)",
+        )?;
+        Ok(projector)
     }
 }
 
@@ -1807,6 +1942,13 @@ impl From<EquivalenceResult> for PyEquivalenceResult {
 #[pyclass(name = "EquivalenceChecker")]
 pub struct PyEquivalenceChecker {
     checker: EquivalenceChecker<PyProvider>,
+    /// How the backing reference was built (#1012). Captured at construction
+    /// because the provider is moved into `checker`.
+    kind: ProviderKind,
+    /// Whether the backing reference carries genomic sequence data.
+    has_genomic_data: bool,
+    /// Whether the backing reference carries protein sequence data.
+    has_protein_data: bool,
 }
 
 #[pymethods]
@@ -1818,15 +1960,15 @@ impl PyEquivalenceChecker {
     ///         If not provided, uses built-in test data.
     #[new]
     #[pyo3(signature = (reference_json=None))]
-    fn new(reference_json: Option<&str>) -> PyResult<Self> {
-        let provider = match reference_json {
-            Some(path) => PyProvider::from_json(Path::new(path))?,
-            None => PyProvider::test_data(),
+    fn new(py: Python<'_>, reference_json: Option<&str>) -> PyResult<Self> {
+        let (provider, kind) = match reference_json {
+            Some(path) => (
+                PyProvider::from_json(Path::new(path))?,
+                ProviderKind::TranscriptsJson,
+            ),
+            None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-
-        Ok(Self {
-            checker: EquivalenceChecker::new(provider),
-        })
+        Self::from_provider(py, provider, kind)
     }
 
     /// Create an equivalence checker from a reference manifest.
@@ -1837,11 +1979,37 @@ impl PyEquivalenceChecker {
     /// Returns:
     ///     An EquivalenceChecker backed by a MultiFastaProvider.
     #[staticmethod]
-    fn from_manifest(manifest_path: &str) -> PyResult<Self> {
+    fn from_manifest(py: Python<'_>, manifest_path: &str) -> PyResult<Self> {
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Ok(Self {
-            checker: EquivalenceChecker::new(provider),
-        })
+        Self::from_provider(py, provider, ProviderKind::Manifest)
+    }
+
+    /// Return `True` if the backing reference provides genomic sequence data.
+    ///
+    /// A checker without genomic data (built-in test data or a transcript-only
+    /// `reference_json`) has limited genome-dependent capability; use
+    /// `EquivalenceChecker.from_manifest(...)` for full capability.
+    fn has_genomic_data(&self) -> bool {
+        self.has_genomic_data
+    }
+
+    /// Return `True` if the backing reference provides protein sequence data.
+    fn has_protein_data(&self) -> bool {
+        self.has_protein_data
+    }
+
+    /// Summarize the reference backend's capabilities as a dict.
+    ///
+    /// Keys:
+    ///     provider_kind: One of "test_data", "json", or "manifest".
+    ///     has_genomic_data: Whether genomic sequences are available.
+    ///     has_protein_data: Whether protein sequences are available.
+    fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("provider_kind", self.kind.as_str())?;
+        dict.set_item("has_genomic_data", self.has_genomic_data)?;
+        dict.set_item("has_protein_data", self.has_protein_data)?;
+        Ok(dict)
     }
 
     /// Check if two variants are equivalent
@@ -1871,6 +2039,30 @@ impl PyEquivalenceChecker {
         self.checker
             .all_equivalent(&rust_variants)
             .map_err(|e| PyRuntimeError::new_err(format!("Equivalence check failed: {}", e)))
+    }
+}
+
+impl PyEquivalenceChecker {
+    /// Build a checker from a provider, capturing capability before the provider
+    /// is moved into the inner checker, and emit the one-time reduced-capability
+    /// warning (#1012).
+    fn from_provider(py: Python<'_>, provider: PyProvider, kind: ProviderKind) -> PyResult<Self> {
+        let has_genomic_data = provider.has_genomic_data();
+        let has_protein_data = provider.has_protein_data();
+        let checker = Self {
+            checker: EquivalenceChecker::new(provider),
+            kind,
+            has_genomic_data,
+            has_protein_data,
+        };
+        emit_reduced_capability_warning(
+            py,
+            has_genomic_data,
+            kind,
+            "EquivalenceChecker",
+            "EquivalenceChecker.from_manifest(...)",
+        )?;
+        Ok(checker)
     }
 }
 
@@ -2414,6 +2606,13 @@ impl PyBatchResult {
 #[pyclass(name = "BatchProcessor")]
 pub struct PyBatchProcessor {
     processor: BatchProcessor<PyProvider>,
+    /// How the backing reference was built (#1012). Captured at construction
+    /// because the provider is moved into `processor`.
+    kind: ProviderKind,
+    /// Whether the backing reference carries genomic sequence data.
+    has_genomic_data: bool,
+    /// Whether the backing reference carries protein sequence data.
+    has_protein_data: bool,
 }
 
 #[pymethods]
@@ -2425,15 +2624,15 @@ impl PyBatchProcessor {
     ///         If not provided, uses built-in test data.
     #[new]
     #[pyo3(signature = (reference_json=None))]
-    fn new(reference_json: Option<&str>) -> PyResult<Self> {
-        let provider = match reference_json {
-            Some(path) => PyProvider::from_json(Path::new(path))?,
-            None => PyProvider::test_data(),
+    fn new(py: Python<'_>, reference_json: Option<&str>) -> PyResult<Self> {
+        let (provider, kind) = match reference_json {
+            Some(path) => (
+                PyProvider::from_json(Path::new(path))?,
+                ProviderKind::TranscriptsJson,
+            ),
+            None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-
-        Ok(Self {
-            processor: BatchProcessor::new(provider),
-        })
+        Self::from_provider(py, provider, kind)
     }
 
     /// Create a batch processor from a reference manifest.
@@ -2444,11 +2643,37 @@ impl PyBatchProcessor {
     /// Returns:
     ///     A BatchProcessor backed by a MultiFastaProvider.
     #[staticmethod]
-    fn from_manifest(manifest_path: &str) -> PyResult<Self> {
+    fn from_manifest(py: Python<'_>, manifest_path: &str) -> PyResult<Self> {
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Ok(Self {
-            processor: BatchProcessor::new(provider),
-        })
+        Self::from_provider(py, provider, ProviderKind::Manifest)
+    }
+
+    /// Return `True` if the backing reference provides genomic sequence data.
+    ///
+    /// A processor without genomic data (built-in test data or a transcript-only
+    /// `reference_json`) has limited genome-dependent capability; use
+    /// `BatchProcessor.from_manifest(...)` for full capability.
+    fn has_genomic_data(&self) -> bool {
+        self.has_genomic_data
+    }
+
+    /// Return `True` if the backing reference provides protein sequence data.
+    fn has_protein_data(&self) -> bool {
+        self.has_protein_data
+    }
+
+    /// Summarize the reference backend's capabilities as a dict.
+    ///
+    /// Keys:
+    ///     provider_kind: One of "test_data", "json", or "manifest".
+    ///     has_genomic_data: Whether genomic sequences are available.
+    ///     has_protein_data: Whether protein sequences are available.
+    fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("provider_kind", self.kind.as_str())?;
+        dict.set_item("has_genomic_data", self.has_genomic_data)?;
+        dict.set_item("has_protein_data", self.has_protein_data)?;
+        Ok(dict)
     }
 
     /// Parse multiple HGVS strings.
@@ -2516,6 +2741,30 @@ impl PyBatchProcessor {
             let _ = callback.call1((py_progress,));
         });
         Ok(PyBatchResult { inner: result })
+    }
+}
+
+impl PyBatchProcessor {
+    /// Build a processor from a provider, capturing capability before the
+    /// provider is moved into the inner processor, and emit the one-time
+    /// reduced-capability warning (#1012).
+    fn from_provider(py: Python<'_>, provider: PyProvider, kind: ProviderKind) -> PyResult<Self> {
+        let has_genomic_data = provider.has_genomic_data();
+        let has_protein_data = provider.has_protein_data();
+        let processor = Self {
+            processor: BatchProcessor::new(provider),
+            kind,
+            has_genomic_data,
+            has_protein_data,
+        };
+        emit_reduced_capability_warning(
+            py,
+            has_genomic_data,
+            kind,
+            "BatchProcessor",
+            "BatchProcessor.from_manifest(...)",
+        )?;
+        Ok(processor)
     }
 }
 
@@ -3668,6 +3917,8 @@ impl PyStrand {
 #[pyclass(name = "CoordinateMapper")]
 pub struct PyCoordinateMapper {
     provider: PyProvider,
+    /// How the backing reference was built (#1012).
+    kind: ProviderKind,
 }
 
 #[pymethods]
@@ -3679,13 +3930,18 @@ impl PyCoordinateMapper {
     ///         If not provided, uses built-in test data.
     #[new]
     #[pyo3(signature = (reference_json=None))]
-    fn new(reference_json: Option<&str>) -> PyResult<Self> {
-        let provider = match reference_json {
-            Some(path) => PyProvider::from_json(Path::new(path))?,
-            None => PyProvider::test_data(),
+    fn new(py: Python<'_>, reference_json: Option<&str>) -> PyResult<Self> {
+        let (provider, kind) = match reference_json {
+            Some(path) => (
+                PyProvider::from_json(Path::new(path))?,
+                ProviderKind::TranscriptsJson,
+            ),
+            None => (PyProvider::test_data(), ProviderKind::TestData),
         };
 
-        Ok(Self { provider })
+        let mapper = Self { provider, kind };
+        mapper.warn_if_reduced_capability(py)?;
+        Ok(mapper)
     }
 
     /// Create a coordinate mapper from a reference manifest.
@@ -3696,9 +3952,42 @@ impl PyCoordinateMapper {
     /// Returns:
     ///     A CoordinateMapper backed by a MultiFastaProvider.
     #[staticmethod]
-    fn from_manifest(manifest_path: &str) -> PyResult<Self> {
+    fn from_manifest(py: Python<'_>, manifest_path: &str) -> PyResult<Self> {
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Ok(Self { provider })
+        let mapper = Self {
+            provider,
+            kind: ProviderKind::Manifest,
+        };
+        mapper.warn_if_reduced_capability(py)?;
+        Ok(mapper)
+    }
+
+    /// Return `True` if the backing reference provides genomic sequence data.
+    ///
+    /// A mapper without genomic data (built-in test data or a transcript-only
+    /// `reference_json`) cannot resolve genomic coordinates; use
+    /// `CoordinateMapper.from_manifest(...)` for full capability.
+    fn has_genomic_data(&self) -> bool {
+        self.provider.has_genomic_data()
+    }
+
+    /// Return `True` if the backing reference provides protein sequence data.
+    fn has_protein_data(&self) -> bool {
+        self.provider.has_protein_data()
+    }
+
+    /// Summarize the reference backend's capabilities as a dict.
+    ///
+    /// Keys:
+    ///     provider_kind: One of "test_data", "json", or "manifest".
+    ///     has_genomic_data: Whether genomic sequences are available.
+    ///     has_protein_data: Whether protein sequences are available.
+    fn reference_summary<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item("provider_kind", self.kind.as_str())?;
+        dict.set_item("has_genomic_data", self.provider.has_genomic_data())?;
+        dict.set_item("has_protein_data", self.provider.has_protein_data())?;
+        Ok(dict)
     }
 
     /// Convert a CDS position to genomic position
@@ -3947,6 +4236,20 @@ impl PyCoordinateMapper {
     /// Check if a transcript exists in the reference
     fn has_transcript(&self, transcript_id: &str) -> bool {
         self.provider.get_transcript(transcript_id).is_ok()
+    }
+}
+
+impl PyCoordinateMapper {
+    /// Emit the one-time reduced-capability warning when the backing provider
+    /// has no genomic data (#1012), pointing callers at `from_manifest(...)`.
+    fn warn_if_reduced_capability(&self, py: Python<'_>) -> PyResult<()> {
+        emit_reduced_capability_warning(
+            py,
+            self.provider.has_genomic_data(),
+            self.kind,
+            "CoordinateMapper",
+            "CoordinateMapper.from_manifest(...)",
+        )
     }
 }
 

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -167,6 +167,19 @@ impl MockProvider {
             }
         };
 
+        // A reference with no transcripts, proteins, or genomic sequences can
+        // resolve nothing; fail loud rather than silently construct an empty,
+        // useless provider (#1012 item 5). A genomic-only reference (zero
+        // transcripts but populated `genomic_sequences`) is still valid for
+        // `g.` normalization, so only a wholly-empty file is rejected.
+        if transcripts.is_empty() && proteins.is_empty() && genomic_sequences.is_empty() {
+            return Err(FerroError::Json {
+                msg: "reference JSON has no usable reference data: it defines no \
+                      transcripts, proteins, or genomic sequences"
+                    .to_string(),
+            });
+        }
+
         let map: HashMap<String, Arc<Transcript>> = transcripts
             .into_iter()
             .map(|tx| (tx.id.clone(), Arc::new(tx)))
@@ -1020,18 +1033,93 @@ mod tests {
     }
 
     #[test]
-    fn test_from_json_empty_object_form() {
+    fn test_from_json_empty_object_is_rejected() {
+        // An empty object has no usable reference data, so it must be rejected
+        // rather than loaded as a useless empty provider (#1012 item 5).
         use std::io::Write;
         use tempfile::NamedTempFile;
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(b"{}").unwrap();
 
-        let provider = MockProvider::from_json(file.path()).unwrap();
+        match MockProvider::from_json(file.path()) {
+            Err(FerroError::Json { msg }) => assert!(
+                msg.contains("no usable reference data"),
+                "expected error to mention no usable reference data, got: {msg}",
+            ),
+            Err(e) => panic!("expected FerroError::Json, got {e}"),
+            Ok(_) => panic!("expected a wholly-empty reference file to be rejected"),
+        }
+    }
 
-        assert!(provider.is_empty());
-        assert!(!provider.has_protein_data());
+    #[test]
+    fn from_json_rejects_wholly_empty_forms() {
+        // A bare empty array and an explicit `"transcripts": []` with no other
+        // data are equally unusable and must be rejected (#1012 item 5).
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        for body in [&b"[]"[..], br#"{"transcripts": []}"#] {
+            let mut file = NamedTempFile::new().unwrap();
+            file.write_all(body).unwrap();
+            match MockProvider::from_json(file.path()) {
+                Err(FerroError::Json { msg }) => assert!(
+                    msg.contains("no usable reference data"),
+                    "expected error to mention no usable reference data, got: {msg}",
+                ),
+                Err(e) => panic!("expected FerroError::Json, got {e}"),
+                Ok(_) => panic!("expected a wholly-empty reference file to be rejected"),
+            }
+        }
+    }
+
+    #[test]
+    fn from_json_accepts_genomic_only_reference() {
+        // A reference with zero transcripts but populated `genomic_sequences` is
+        // still valid for `g.` normalization and must load (#1012 item 5): the
+        // empty-file guard only rejects a wholly-empty reference.
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+            "transcripts": [],
+            "genomic_sequences": {"NC_000001.11": "ACGTACGTACGT"}
+        }"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider =
+            MockProvider::from_json(file.path()).expect("a genomic-only reference should load");
+        assert!(provider.is_empty()); // no transcripts
+        assert!(provider.has_genomic_data());
+        assert_eq!(
+            provider.get_genomic_sequence("NC_000001.11", 0, 4).unwrap(),
+            "ACGT"
+        );
+    }
+
+    #[test]
+    fn from_json_accepts_protein_only_reference() {
+        // A reference with zero transcripts and no genomic sequence but populated
+        // `proteins` is still usable (protein queries) and must load — the
+        // empty-file guard only rejects a wholly-empty reference (#1012 item 5).
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+            "transcripts": [],
+            "proteins": {"NP_000001.1": "MAPLE"}
+        }"#;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider =
+            MockProvider::from_json(file.path()).expect("a protein-only reference should load");
+        assert!(provider.is_empty()); // no transcripts
         assert!(!provider.has_genomic_data());
+        assert!(provider.has_protein_data());
     }
 
     #[test]
@@ -1075,14 +1163,23 @@ mod tests {
 
     #[test]
     fn from_json_accepts_convert_gff_output_with_metadata_keys() {
-        // The container shape produced by `ferro convert-gff`.
+        // The container shape produced by `ferro convert-gff`: the `version` and
+        // `genome_build` container-metadata keys must be accepted (not rejected
+        // by `deny_unknown_fields`) alongside transcript records.
         use std::io::Write;
         use tempfile::NamedTempFile;
 
         let json = r#"{
             "version": "1.0",
             "genome_build": "GRCh38",
-            "transcripts": []
+            "transcripts": [
+                {
+                    "id": "NM_000001.1",
+                    "strand": "+",
+                    "sequence": "ATGC",
+                    "exons": [{"number": 1, "start": 1, "end": 4}]
+                }
+            ]
         }"#;
 
         let mut file = NamedTempFile::new().unwrap();
@@ -1090,7 +1187,7 @@ mod tests {
 
         let provider = MockProvider::from_json(file.path())
             .expect("convert-gff JSON with version/genome_build metadata should load");
-        assert!(provider.is_empty());
+        assert!(provider.has_transcript("NM_000001.1"));
     }
 
     #[test]

--- a/tests/python/test_issue_1012_reference_capability.py
+++ b/tests/python/test_issue_1012_reference_capability.py
@@ -73,7 +73,10 @@ class TestReferenceSummary:
     def test_transcripts_json_reports_kind(self, tmp_path: Path) -> None:
         norm = ferro_hgvs.Normalizer(reference_json=_transcript_ref(tmp_path))
         summary = norm.reference_summary()
-        assert summary["provider_kind"] == "transcripts_json"
+        # A reference_json build is labeled "json": such a file may carry
+        # genomic-only data, so has_genomic_data (not the label) is the source
+        # of truth for capability.
+        assert summary["provider_kind"] == "json"
         assert summary["has_genomic_data"] is False
 
     def test_manifest_reports_kind(self) -> None:
@@ -136,6 +139,56 @@ class TestReducedCapabilityWarning:
             ferro_hgvs.Normalizer()  # a second reduced-capability build
         user = [w for w in caught if issubclass(w.category, UserWarning)]
         assert len(user) == 1, f"expected exactly one UserWarning, got {len(user)}"
+        """
+        result = _run_child(code)
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    def test_manifest_warning_not_masked_by_earlier_generic_warning(self) -> None:
+        # The generic (test-data / reference_json) and manifest reduced-capability
+        # warnings carry different guidance and are keyed on SEPARATE once-flags:
+        # a throwaway test-data Normalizer warning first must NOT suppress a
+        # genuinely genome-less manifest warning later in the same process — a
+        # real production misconfiguration that would otherwise go unwarned.
+        code = f"""
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.Normalizer()                                     # generic variant warns
+            ferro_hgvs.Normalizer.from_manifest({str(MANIFEST_TINY)!r})  # manifest variant must ALSO warn
+        msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+        generic = [m for m in msgs if "reference lacks genomic data" in m]
+        manifest = [m for m in msgs if "manifest reference provides no genomic data" in m]
+        assert len(generic) == 1, f"expected one generic warning, got {{msgs}}"
+        assert len(manifest) == 1, f"expected one manifest warning, got {{msgs}}"
+        """
+        result = _run_child(code)
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    def test_failed_warning_emission_does_not_consume_the_once_flag(self) -> None:
+        # Under warnings.simplefilter("error") the reduced-capability warning is
+        # raised as an exception. That must NOT consume the once-per-process flag:
+        # a later construction under a normal filter must still warn. (Regression:
+        # the flag was set before emitting, so a raised warning permanently
+        # suppressed all future ones.)
+        code = """
+        import warnings
+        import ferro_hgvs
+        # First build with warnings-as-errors: construction raises, flag must reset.
+        raised = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            try:
+                ferro_hgvs.Normalizer()
+            except UserWarning:
+                raised = True
+        assert raised, "expected the reduced-capability warning to raise under simplefilter('error')"
+        # Now a normal build must still emit the warning (flag was not consumed).
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.Normalizer()
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected the warning to still fire, got {len(user)}"
         """
         result = _run_child(code)
         assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"

--- a/tests/python/test_issue_1012_reference_capability.py
+++ b/tests/python/test_issue_1012_reference_capability.py
@@ -1,0 +1,180 @@
+"""Tests for #1012: reference-capability introspection and the reduced-capability warning.
+
+Covers:
+  * Item 3 — ``Normalizer.has_genomic_data`` / ``has_protein_data`` /
+    ``reference_summary`` introspection.
+  * Item 1 — the one-time ``UserWarning`` emitted when a reduced-capability
+    (no-genomic) reference is loaded.
+  * Item 5 — a wholly-empty ``reference_json`` is rejected at load.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+MANIFEST_TINY = FIXTURES / "python" / "manifest_tiny" / "manifest.json"
+
+
+def _run_child(code: str) -> subprocess.CompletedProcess[str]:
+    """Run ``code`` in a fresh interpreter.
+
+    The reduced-capability ``UserWarning`` fires at most once per process, so it
+    cannot be asserted reliably in-process alongside other tests that also build
+    reduced-capability normalizers. A fresh interpreter starts with the
+    warn-once flag unset.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _transcript_ref(tmp_path: Path) -> str:
+    """Write a minimal transcript-only reference and return its path."""
+    ref = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TEST",
+                "strand": "+",
+                "sequence": "ATGCCCAAGGTGCTGCCC",
+                "cds_start": 1,
+                "cds_end": 18,
+                "exons": [{"number": 1, "start": 1, "end": 18}],
+            }
+        ]
+    }
+    path = tmp_path / "ref.json"
+    path.write_text(json.dumps(ref))
+    return str(path)
+
+
+class TestReferenceSummary:
+    """Item 3: capability introspection getters."""
+
+    def test_test_data_reports_no_genomic(self) -> None:
+        norm = ferro_hgvs.Normalizer()
+        assert norm.has_genomic_data() is False
+        summary = norm.reference_summary()
+        assert summary["provider_kind"] == "test_data"
+        assert summary["has_genomic_data"] is False
+        assert isinstance(summary["has_protein_data"], bool)
+
+    def test_transcripts_json_reports_kind(self, tmp_path: Path) -> None:
+        norm = ferro_hgvs.Normalizer(reference_json=_transcript_ref(tmp_path))
+        summary = norm.reference_summary()
+        assert summary["provider_kind"] == "transcripts_json"
+        assert summary["has_genomic_data"] is False
+
+    def test_manifest_reports_kind(self) -> None:
+        norm = ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY))
+        summary = norm.reference_summary()
+        assert summary["provider_kind"] == "manifest"
+        assert isinstance(norm.has_genomic_data(), bool)
+        assert isinstance(norm.has_protein_data(), bool)
+
+    def test_protein_bearing_reference_reports_has_protein_data(self, tmp_path: Path) -> None:
+        # A reference that carries protein sequences reports has_protein_data() True
+        # (the positive case — the other tests only cover the False / bool shape).
+        ref = {
+            "transcripts": [],
+            "proteins": {"NP_000001.1": "MAPLE"},
+        }
+        ref_path = tmp_path / "protein_ref.json"
+        ref_path.write_text(json.dumps(ref))
+        norm = ferro_hgvs.Normalizer(reference_json=str(ref_path))
+        assert norm.has_protein_data() is True
+        assert norm.reference_summary()["has_protein_data"] is True
+
+
+class TestReducedCapabilityWarning:
+    """Item 1: one-time UserWarning on a no-genomic build."""
+
+    def test_warns_on_test_data_build(self) -> None:
+        code = """
+        import pytest
+        import ferro_hgvs
+        with pytest.warns(UserWarning):
+            ferro_hgvs.Normalizer()
+        """
+        result = _run_child(code)
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    def test_warning_message_points_at_from_manifest(self) -> None:
+        code = """
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.Normalizer()
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected one UserWarning, got {len(user)}"
+        msg = str(user[0].message)
+        assert "genomic data" in msg, msg
+        assert "from_manifest" in msg, msg
+        """
+        result = _run_child(code)
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    def test_warns_at_most_once_per_process(self) -> None:
+        code = """
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.Normalizer()
+            ferro_hgvs.Normalizer()  # a second reduced-capability build
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected exactly one UserWarning, got {len(user)}"
+        """
+        result = _run_child(code)
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+    def test_genomic_reference_does_not_warn(self, tmp_path: Path) -> None:
+        # A reference that DOES carry genomic data has full capability, so it
+        # must not trigger the reduced-capability warning.
+        ref = {
+            "transcripts": [],
+            "genomic_sequences": {"NC_000001.11": "ACGTACGTACGTACGT"},
+        }
+        ref_path = tmp_path / "gref.json"
+        ref_path.write_text(json.dumps(ref))
+        # Pass the reference path via argv so the child body needs no
+        # interpolation (avoids nesting f-strings).
+        code = """
+        import sys
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            norm = ferro_hgvs.Normalizer(reference_json=sys.argv[1])
+        assert norm.has_genomic_data() is True
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 0, f"expected no UserWarning, got {len(user)}"
+        """
+        result = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(code), str(ref_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+class TestEmptyReferenceRejected:
+    """Item 5: a wholly-empty reference_json is rejected at load."""
+
+    def test_wholly_empty_reference_json_raises(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.json"
+        empty.write_text("{}")
+        with pytest.raises(RuntimeError):
+            ferro_hgvs.Normalizer(reference_json=str(empty))

--- a/tests/python/test_issue_1012_sibling_surfaces.py
+++ b/tests/python/test_issue_1012_sibling_surfaces.py
@@ -1,0 +1,209 @@
+"""Tests for #1012 (sibling scope): reference-capability surfacing on the
+classes and free functions that mirror ``Normalizer``.
+
+The identical ``reference_json`` / no-args footgun (silent no-genomic fallback,
+no introspection) lives on ``VariantProjector``, ``EquivalenceChecker``,
+``BatchProcessor``, ``CoordinateMapper``, the free ``normalize()`` function, and
+``HgvsVariant.normalize()``. These tests assert:
+
+  * introspection getters (``has_genomic_data`` / ``has_protein_data`` /
+    ``reference_summary``) on each of the four classes;
+  * the one-time reduced-capability ``UserWarning`` fires at construction / call
+    on each surface (asserted in fresh subprocesses, since the warn-once flag is
+    process-global and shared across every surface);
+  * the ``provider_kind`` label is ``"json"`` (not ``"transcripts_json"``) for a
+    ``reference_json`` build.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+MANIFEST_TINY = FIXTURES / "python" / "manifest_tiny" / "manifest.json"
+
+
+def _run_child(code: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run ``code`` in a fresh interpreter.
+
+    The reduced-capability ``UserWarning`` fires at most once per process and the
+    flag is shared across every surface, so it must be asserted in a fresh
+    interpreter that starts with the warn-once flag unset.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_child_ok(code: str, *args: str) -> None:
+    """Run ``code`` in a fresh interpreter and assert it exited cleanly."""
+    result = _run_child(code, *args)
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+def _transcript_ref(tmp_path: Path) -> str:
+    """Write a minimal transcript-only (no-genomic) reference; return its path."""
+    ref = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TEST",
+                "strand": "+",
+                "sequence": "ATGCCCAAGGTGCTGCCC",
+                "cds_start": 1,
+                "cds_end": 18,
+                "exons": [{"number": 1, "start": 1, "end": 18}],
+            }
+        ]
+    }
+    path = tmp_path / "ref.json"
+    path.write_text(json.dumps(ref))
+    return str(path)
+
+
+# Each entry: (class-name, no-arg constructor callable). Every one falls back to
+# built-in test data with no genomic sequences.
+_CLASSES = [
+    ("VariantProjector", lambda: ferro_hgvs.VariantProjector()),
+    ("EquivalenceChecker", lambda: ferro_hgvs.EquivalenceChecker()),
+    ("BatchProcessor", lambda: ferro_hgvs.BatchProcessor()),
+    ("CoordinateMapper", lambda: ferro_hgvs.CoordinateMapper()),
+]
+
+
+class TestSiblingIntrospection:
+    """Capability getters on the sibling classes."""
+
+    @pytest.mark.parametrize("name,ctor", _CLASSES, ids=[c[0] for c in _CLASSES])
+    def test_test_data_reports_no_genomic(self, name: str, ctor) -> None:  # noqa: ANN001
+        obj = ctor()
+        assert obj.has_genomic_data() is False
+        assert isinstance(obj.has_protein_data(), bool)
+        summary = obj.reference_summary()
+        assert summary["provider_kind"] == "test_data"
+        assert summary["has_genomic_data"] is False
+        assert isinstance(summary["has_protein_data"], bool)
+
+    def test_projector_reference_json_labeled_json(self, tmp_path: Path) -> None:
+        proj = ferro_hgvs.VariantProjector(reference_json=_transcript_ref(tmp_path))
+        summary = proj.reference_summary()
+        assert summary["provider_kind"] == "json"
+        assert summary["has_genomic_data"] is False
+
+    def test_checker_reference_json_labeled_json(self, tmp_path: Path) -> None:
+        checker = ferro_hgvs.EquivalenceChecker(reference_json=_transcript_ref(tmp_path))
+        assert checker.reference_summary()["provider_kind"] == "json"
+
+    def test_batch_reference_json_labeled_json(self, tmp_path: Path) -> None:
+        batch = ferro_hgvs.BatchProcessor(reference_json=_transcript_ref(tmp_path))
+        assert batch.reference_summary()["provider_kind"] == "json"
+
+    def test_mapper_reference_json_labeled_json(self, tmp_path: Path) -> None:
+        mapper = ferro_hgvs.CoordinateMapper(reference_json=_transcript_ref(tmp_path))
+        assert mapper.reference_summary()["provider_kind"] == "json"
+
+    def test_projector_manifest_reports_kind(self) -> None:
+        proj = ferro_hgvs.VariantProjector.from_manifest(str(MANIFEST_TINY))
+        summary = proj.reference_summary()
+        assert summary["provider_kind"] == "manifest"
+        assert isinstance(summary["has_genomic_data"], bool)
+
+
+class TestSiblingConstructionWarnings:
+    """The reduced-capability UserWarning fires once, per surface."""
+
+    @pytest.mark.parametrize(
+        "ctor_expr",
+        [
+            "ferro_hgvs.VariantProjector()",
+            "ferro_hgvs.EquivalenceChecker()",
+            "ferro_hgvs.BatchProcessor()",
+            "ferro_hgvs.CoordinateMapper()",
+        ],
+    )
+    def test_warns_on_test_data_build(self, ctor_expr: str) -> None:
+        code = f"""
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            {ctor_expr}
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected one UserWarning, got {{len(user)}}"
+        msg = str(user[0].message)
+        assert "genomic data" in msg, msg
+        assert "from_manifest" in msg, msg
+        """
+        _assert_child_ok(code)
+
+    def test_shared_global_warns_at_most_once_across_surfaces(self) -> None:
+        # The warn-once flag is shared across every surface, so building a
+        # projector and then a normalizer must yield exactly one warning.
+        code = """
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.VariantProjector()
+            ferro_hgvs.EquivalenceChecker()
+            ferro_hgvs.Normalizer()
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected exactly one UserWarning, got {len(user)}"
+        """
+        _assert_child_ok(code)
+
+    def test_projector_reference_json_warns(self, tmp_path: Path) -> None:
+        ref = _transcript_ref(tmp_path)
+        code = """
+        import sys
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.VariantProjector(reference_json=sys.argv[1])
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected one UserWarning, got {len(user)}"
+        """
+        _assert_child_ok(code, ref)
+
+
+class TestFreeFunctionWarnings:
+    """The free normalize() and HgvsVariant.normalize() also warn."""
+
+    def test_free_normalize_warns(self) -> None:
+        code = """
+        import warnings
+        import ferro_hgvs
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ferro_hgvs.normalize("NM_000088.3:c.100delA")
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected one UserWarning, got {len(user)}"
+        msg = str(user[0].message)
+        assert "genomic data" in msg, msg
+        assert "from_manifest" in msg, msg
+        """
+        _assert_child_ok(code)
+
+    def test_hgvsvariant_normalize_warns(self) -> None:
+        code = """
+        import warnings
+        import ferro_hgvs
+        variant = ferro_hgvs.parse("NM_000088.3:c.100delA")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            variant.normalize()
+        user = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert len(user) == 1, f"expected one UserWarning, got {len(user)}"
+        """
+        _assert_child_ok(code)


### PR DESCRIPTION
## Summary

The Python `Normalizer` can be built two ways: `Normalizer(reference_json="transcripts.json")` builds a limited `MockProvider` (no genomic data) and `Normalizer.from_manifest("manifest.json")` builds a full `MultiFastaProvider`. Users could silently land on the reduced-capability path with no runtime signal. This surfaces the gap on the Python side.

Part of #1012 (items 1, 3, 5).

## Changes

**Item 3 — capability introspection on `Normalizer`.** Adds three Python-visible methods: `has_genomic_data()`, `has_protein_data()`, and `reference_summary()` (returns a dict with `provider_kind`, `has_genomic_data`, `has_protein_data`). `provider_kind` distinguishes the three build paths, tracked via a small internal `ProviderKind` tag on `PyNormalizer`.

**Item 1 — warn once on a reduced-capability build.** When a `Normalizer` is constructed and the backing provider reports `!has_genomic_data()` (covering both the no-args test-data path and the `reference_json` path), it emits a Python `UserWarning` explaining that genome-dependent normalization will be limited and pointing at `Normalizer.from_manifest(...)`. A process-global `AtomicBool` ensures it fires at most once per process. The `#[new]` constructor and `from_manifest` now take a `Python` token to emit the warning.

**Item 5 — validate the reference at load.** `MockProvider::from_json` now rejects a wholly-empty reference (no transcripts, proteins, or genomic sequences) with a clear `FerroError` instead of silently building a useless provider. A genomic-only reference (zero transcripts but populated `genomic_sequences`) remains valid for `g.` normalization, so only a truly-empty file is rejected — this keeps the existing genomic-only object-form references working.

## Sibling surfaces (#1012 sibling scope)

The identical footgun lived on every other reference-backed Python surface. Extends the same capability-surfacing to them, sharing the process-global warn-once flag (`REDUCED_CAPABILITY_WARNED`) so at most one warning fires per process across all surfaces:

- **`VariantProjector`**, **`EquivalenceChecker`**, **`BatchProcessor`**, and **`CoordinateMapper`** each gain `has_genomic_data()` / `has_protein_data()` / `reference_summary()`, a `ProviderKind` tag, and emit the one-time reduced-capability `UserWarning` at construction (in both the constructor and `from_manifest`). `VariantProjector` is the most consequential — `project_to_genomic` needs a genome a transcripts-only reference lacks. Capability is captured before the provider is moved into the inner wrapper.
- The module-level **`normalize()`** free function and **`HgvsVariant.normalize()`** both silently used `MockProvider::with_test_data()`; they now emit the same one-time warning (the `Python` token is injected by pyo3 and is not part of the Python signature).
- A single `emit_reduced_capability_warning` helper builds the message (manifest-specific for a genome-less manifest; otherwise pointing at `from_manifest(...)`).

**`provider_kind` label change.** The `ProviderKind::TranscriptsJson` label changed from `"transcripts_json"` to `"json"`. A `reference_json` file may carry genomic-only data, so the old label was misleading for a genomic-only build that reports `has_genomic_data == True`. `has_genomic_data` remains the source of truth for capability. Docs, type stubs, and the affected test are updated accordingly.

## Build hygiene

`read_ref_codon` / `translate` in `src/project/protein/mod.rs` are consumed only by the `web-service` effect handler, so their re-export was unused under `--features python` and tripped `clippy::unused-imports` with `-D warnings` (a pre-existing latent issue). Gated the re-export on the `web-service` feature so non-service builds are warning-clean. Committed separately from the feature.

## Testing

- `cargo clippy --features python --all-targets -- -D warnings` — clean
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo test --features dev` — all pass
- `pytest tests/python/` — 218 pass; `ruff check`, `ruff format --check`, `mypy` — clean

Rust unit tests cover the empty/genomic-only `from_json` cases; Python tests cover the introspection methods and the construction/call warning on every surface — the four sibling classes plus the free `normalize()` and `HgvsVariant.normalize()` — asserted in fresh subprocesses since the warning is once-per-process.
