### PR TITLE
feat(normalize): warn-and-degrade when genomic data is unavailable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,10 @@ pub enum ErrorCode {
     UnsupportedVariant = 4002,
     /// Unsupported projection between coordinate systems
     UnsupportedProjection = 4003,
+    /// A genome-requiring normalization step could not run because the
+    /// reference carries no genomic data, and strict mode rejects the
+    /// resulting reduced-capability (degraded) result.
+    ReducedReferenceCapability = 4004,
 
     // Conversion errors (E5xxx)
     /// Coordinate conversion failed
@@ -150,6 +154,9 @@ impl ErrorCode {
             ErrorCode::IntronicVariant => "intronic variant not supported",
             ErrorCode::UnsupportedVariant => "unsupported variant type",
             ErrorCode::UnsupportedProjection => "unsupported projection between coordinate systems",
+            ErrorCode::ReducedReferenceCapability => {
+                "reference lacks genomic data for full normalization (strict mode)"
+            }
             ErrorCode::ConversionFailed => "coordinate conversion failed",
             ErrorCode::NoOverlappingTranscript => "no overlapping transcript",
             ErrorCode::IoError => "file I/O error",
@@ -418,6 +425,19 @@ pub enum FerroError {
         detail: Option<String>,
     },
 
+    /// A genome-requiring normalization step (intronic / boundary-spanning /
+    /// exon-junction 3'-shuffle) could not run because the reference provider
+    /// carries no genomic data. In lenient/silent mode this surfaces as the
+    /// `ReducedCapabilityNoGenome` warning with a best-effort result; strict
+    /// mode promotes it to this error rather than return a degraded result.
+    /// `capability` names the step that was skipped (e.g. "intronic
+    /// normalization"). #1012 item 2.
+    #[error(
+        "Cannot fully normalize {variant} without genomic reference data \
+         ({capability}); strict mode rejects a reduced-capability result"
+    )]
+    ReducedReferenceCapability { variant: String, capability: String },
+
     /// Genomic reference data is not available
     #[error("Genomic reference not available for {contig}:{start}-{end}")]
     GenomicReferenceNotAvailable {
@@ -538,6 +558,9 @@ impl FerroError {
             FerroError::AlignmentGap { .. } => Some(ErrorCode::AlignmentGap),
             FerroError::UnsupportedVariant { .. } => Some(ErrorCode::UnsupportedVariant),
             FerroError::IntronicVariant { .. } => Some(ErrorCode::IntronicVariant),
+            FerroError::ReducedReferenceCapability { .. } => {
+                Some(ErrorCode::ReducedReferenceCapability)
+            }
             FerroError::ReferenceMismatch { .. } => Some(ErrorCode::ReferenceMismatch),
             FerroError::VariantExceedsReference { .. } => Some(ErrorCode::PositionOutOfBounds),
             FerroError::ConversionError { .. } => Some(ErrorCode::ConversionFailed),

--- a/src/error_handling/mutalyzer_map.rs
+++ b/src/error_handling/mutalyzer_map.rs
@@ -411,6 +411,7 @@ pub fn ferro_to_mutalyzer(err: &FerroError) -> &'static [&'static str] {
         | FerroError::VariantExceedsReference { .. }
         | FerroError::TranscriptVersionNotExact { .. }
         | FerroError::TranscriptSequenceUnreconstructable { .. }
+        | FerroError::ReducedReferenceCapability { .. }
         | FerroError::Io { .. }
         | FerroError::Json { .. } => &[],
     }
@@ -605,6 +606,7 @@ mod tests {
             FerroError::InvalidCoordinates { .. } => "InvalidCoordinates",
             FerroError::UnsupportedVariant { .. } => "UnsupportedVariant",
             FerroError::IntronicVariant { .. } => "IntronicVariant",
+            FerroError::ReducedReferenceCapability { .. } => "ReducedReferenceCapability",
             FerroError::GenomicReferenceNotAvailable { .. } => "GenomicReferenceNotAvailable",
             FerroError::ProteinReferenceNotAvailable { .. } => "ProteinReferenceNotAvailable",
             FerroError::AminoAcidMismatch { .. } => "AminoAcidMismatch",

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -212,6 +212,16 @@ impl NormalizeConfig {
         self.position_past_end_action().should_reject()
     }
 
+    /// Returns true if a reduced-capability (no-genomic-data) degradation
+    /// should be rejected — i.e. strict mode. Unlike the registry-backed
+    /// spec warnings, `ReducedCapabilityNoGenome` is an *environmental*
+    /// limitation rather than an input defect, so it is not user-overridable
+    /// per errors-axis; it is simply promoted to an error in strict mode and
+    /// surfaced as a warning-plus-best-effort otherwise (#1012 item 2).
+    pub fn should_reject_reduced_capability(&self) -> bool {
+        self.error_config.mode == ErrorMode::Strict
+    }
+
     /// Returns true if past-end positions should emit warnings (lenient mode).
     pub fn should_warn_position_past_end(&self) -> bool {
         self.position_past_end_action().should_warn()

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -631,6 +631,40 @@ pub enum NormalizationWarning {
         /// Coordinate system of the input variant: `"c"`, `"p"`, or `"r"`.
         coordinate_system: String,
     },
+
+    /// A genome-requiring normalization step could not run because the
+    /// configured reference provider carries no genomic sequence data
+    /// (`ReferenceProvider::has_genomic_data() == false`, e.g. a
+    /// transcripts-only provider). The best-effort result is returned
+    /// UNCHANGED from the point the step would have refined it, and this
+    /// warning marks the output as degraded so a reduced-capability result
+    /// is never mistaken for a fully-normalized one. This is an
+    /// environmental limitation, not a defect in the variant: it means a
+    /// genome-requiring step was reached but could not be run. The same input
+    /// against a genome-backed reference *may* normalize further — the
+    /// intronic / boundary-spanning paths genuinely could; the exon-junction
+    /// 3'-shuffle landing only *might*, since whether the pattern extends into
+    /// the intron is exactly what could not be checked without a genome.
+    /// Code: `REDUCED_CAPABILITY_NO_GENOME`.
+    ///
+    /// Emitted by both the formerly-silent exon/intron junction 3'-shuffle
+    /// enhancement (`#670`/`#704`) and the formerly-erroring intronic /
+    /// boundary-spanning genomic normalization paths — item 2 of the #1012
+    /// warn-and-degrade unification.
+    ///
+    /// Mode interaction: lenient/silent return the best-effort variant with
+    /// this advisory; strict mode promotes it to
+    /// `FerroError::ReducedReferenceCapability` (via
+    /// `NormalizeConfig::should_reject_reduced_capability`) so a strict caller
+    /// never receives a knowingly-degraded result.
+    ReducedCapabilityNoGenome {
+        /// Full variant Display, e.g. `"NM_INT.1:c.10+5del"`.
+        variant: String,
+        /// Short description of the genome-requiring step that was skipped,
+        /// e.g. `"intronic normalization"` or
+        /// `"exon/intron junction 3'-shuffle"`.
+        capability: String,
+    },
 }
 
 /// True iff any concrete position reachable from `boundary` is intronic —
@@ -725,6 +759,7 @@ impl NormalizationWarning {
             Self::PositionPastEnd { .. } => "POSITION_PAST_END",
             Self::IntronicOnBareTranscript { .. } => "INTRONIC_ON_BARE_TRANSCRIPT",
             Self::IncompleteCdsStartReference { .. } => "INCOMPLETE_CDS_START_REFERENCE",
+            Self::ReducedCapabilityNoGenome { .. } => "REDUCED_CAPABILITY_NO_GENOME",
         }
     }
 
@@ -860,6 +895,15 @@ impl std::fmt::Display for NormalizationWarning {
                  (cds_start_NF); not an HGVS-recommended reference for {coordinate_system}. \
                  description — use the genomic (g.) or non-coding (n.) representation instead \
                  (IncompleteCdsStartReference / W5004)",
+            ),
+            Self::ReducedCapabilityNoGenome {
+                variant,
+                capability,
+            } => write!(
+                f,
+                "{variant}: {capability} requires genomic sequence data, which the configured \
+                 reference provider does not carry; returning the best-effort result unchanged \
+                 (ReducedCapabilityNoGenome)",
             ),
         }
     }
@@ -1113,9 +1157,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // a bare intronic-and-past-intron-end input rejects as EINTRONIC, not
         // W4004. Reuses `FerroError::IntronicVariant` because only that variant
         // carries the EINTRONIC tag in mutalyzer_map.rs (the runner
-        // substring-matches the `IntronicVariant` variant name); the
-        // capability-failure guard in normalize_intronic_cds (no genomic data)
-        // uses the same variant but is reached on a different path.
+        // substring-matches the `IntronicVariant` variant name). This is a
+        // spec-form rejection and is distinct from the reduced-capability path
+        // in `normalize_intronic_cds`/`_tx` (no genomic data), which since
+        // #1012 no longer errors — it warn-and-degrades with
+        // `ReducedCapabilityNoGenome`.
         if self.config.should_reject_intronic_bare_transcript() {
             if let Some(err) = result.warnings.iter().find_map(|w| match w {
                 NormalizationWarning::IntronicOnBareTranscript {
@@ -1326,6 +1372,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         ),
                     })
                 }
+                _ => None,
+            }) {
+                return Err(err);
+            }
+        }
+
+        // In strict mode, reject a reduced-capability (no-genomic-data)
+        // degradation. Lenient/silent return the best-effort variant with the
+        // `ReducedCapabilityNoGenome` advisory, but strict mode must not hand
+        // back a knowingly-degraded result, so promote it to a typed error —
+        // the same reject-in-strict contract the intronic/boundary genomic
+        // paths carried before #1012 (now unified across every genome-requiring
+        // step). #1012 item 2.
+        //
+        // Ordering: this runs LAST, after every spec-validity rejection above.
+        // A variant that is both genuinely invalid (e.g. past the CDS end,
+        // W4004) *and* degraded must report the input defect first — the
+        // reduced-capability limit is environmental, so it is the lowest-
+        // priority strict rejection.
+        if self.config.should_reject_reduced_capability() {
+            if let Some(err) = result.warnings.iter().find_map(|w| match w {
+                NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant,
+                    capability,
+                } => Some(FerroError::ReducedReferenceCapability {
+                    variant: variant.clone(),
+                    capability: capability.clone(),
+                }),
                 _ => None,
             }) {
                 return Err(err);
@@ -2739,41 +2813,52 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // 3'-direction `c.` workload regresses, this is the place to memoize.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && new_tx_end == exon_only.right
-            && self.provider.has_genomic_data()
         {
-            // Prefer the accession-aware transcript so an NG/NC-parented input
-            // resolves the build-correct chromosome; fall back to the plain
-            // transcript. Clone keeps `transcript` available for the fall-through.
-            let boundary_transcript =
-                transcript_for_intronic().unwrap_or_else(|_| transcript.clone());
-            if boundary_transcript.chromosome.is_some() {
-                // Engine errors (no following intron — e.g. last exon — no
-                // genomic alignment, …) fall through to the exon-confined
-                // result, the safe pre-#670 behavior. The exon/EXON suppression
-                // rule is preserved structurally: the genomic shuffle boundary
-                // is capped at the adjacent intron's far edge (never the next
-                // exon), so a homopolymer spanning an exon/exon junction can
-                // shift into the intron but never bridge into the downstream
-                // exon.
-                if let Ok((boundary_variant, boundary_warnings)) = self
-                    .normalize_boundary_spanning_cds(
-                        variant,
-                        &boundary_transcript,
-                        start_pos,
-                        end_pos,
-                        edit,
-                    )
-                {
-                    let crossed_into_intron = matches!(
-                        &boundary_variant,
-                        HV::Cds(cv)
-                            if cv.loc_edit.location.start.inner().is_some_and(|p| p.is_intronic())
-                                || cv.loc_edit.location.end.inner().is_some_and(|p| p.is_intronic())
-                    );
-                    if crossed_into_intron {
-                        let mut combined = warnings;
-                        combined.extend(boundary_warnings);
-                        return Ok((boundary_variant, combined));
+            if !self.provider.has_genomic_data() {
+                // #1012: the junction-crossing 3'-shuffle is a genome-requiring
+                // enhancement. With no genomic data we cannot even attempt it,
+                // so the exon-confined result flows through as before — but mark
+                // it degraded rather than silently returning a less-normalized
+                // variant.
+                warnings.push(NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "exon/intron junction 3'-shuffle".to_string(),
+                });
+            } else {
+                // Prefer the accession-aware transcript so an NG/NC-parented input
+                // resolves the build-correct chromosome; fall back to the plain
+                // transcript. Clone keeps `transcript` available for the fall-through.
+                let boundary_transcript =
+                    transcript_for_intronic().unwrap_or_else(|_| transcript.clone());
+                if boundary_transcript.chromosome.is_some() {
+                    // Engine errors (no following intron — e.g. last exon — no
+                    // genomic alignment, …) fall through to the exon-confined
+                    // result, the safe pre-#670 behavior. The exon/EXON suppression
+                    // rule is preserved structurally: the genomic shuffle boundary
+                    // is capped at the adjacent intron's far edge (never the next
+                    // exon), so a homopolymer spanning an exon/exon junction can
+                    // shift into the intron but never bridge into the downstream
+                    // exon.
+                    if let Ok((boundary_variant, boundary_warnings)) = self
+                        .normalize_boundary_spanning_cds(
+                            variant,
+                            &boundary_transcript,
+                            start_pos,
+                            end_pos,
+                            edit,
+                        )
+                    {
+                        let crossed_into_intron = matches!(
+                            &boundary_variant,
+                            HV::Cds(cv)
+                                if cv.loc_edit.location.start.inner().is_some_and(|p| p.is_intronic())
+                                    || cv.loc_edit.location.end.inner().is_some_and(|p| p.is_intronic())
+                        );
+                        if crossed_into_intron {
+                            let mut combined = warnings;
+                            combined.extend(boundary_warnings);
+                            return Ok((boundary_variant, combined));
+                        }
                     }
                 }
             }
@@ -3347,38 +3432,47 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // stay exon-confined), exactly as the `c.` path.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && new_end == boundaries.right
-            && self.provider.has_genomic_data()
         {
-            // Prefer the accession-aware transcript so an NG/NC-parented input
-            // resolves the build-correct chromosome; fall back to the plain
-            // transcript. Clone keeps `transcript` available for the fall-through.
-            let boundary_transcript =
-                transcript_for_intronic().unwrap_or_else(|_| transcript.clone());
-            if boundary_transcript.chromosome.is_some() {
-                // Engine errors (no following intron — e.g. last exon — no genomic
-                // alignment, …) fall through to the exon-confined result, the safe
-                // pre-#704 behavior. The exon/EXON suppression rule is preserved
-                // structurally: the genomic shuffle window is capped at the
-                // adjacent intron's far edge (never the next exon).
-                if let Ok((boundary_variant, boundary_warnings)) = self
-                    .normalize_boundary_spanning_tx(
-                        variant,
-                        &boundary_transcript,
-                        start_pos,
-                        end_pos,
-                        edit,
-                    )
-                {
-                    let crossed_into_intron = matches!(
-                        &boundary_variant,
-                        HV::Tx(tv)
-                            if tv.loc_edit.location.start.inner().is_some_and(|p| p.is_intronic())
-                                || tv.loc_edit.location.end.inner().is_some_and(|p| p.is_intronic())
-                    );
-                    if crossed_into_intron {
-                        let mut combined = warnings;
-                        combined.extend(boundary_warnings);
-                        return Ok((boundary_variant, combined));
+            if !self.provider.has_genomic_data() {
+                // #1012: mirror of the `normalize_cds` reduced-capability guard.
+                // The junction-crossing 3'-shuffle needs a genome; without one
+                // the exon-confined result flows through, marked degraded.
+                warnings.push(NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "exon/intron junction 3'-shuffle".to_string(),
+                });
+            } else {
+                // Prefer the accession-aware transcript so an NG/NC-parented input
+                // resolves the build-correct chromosome; fall back to the plain
+                // transcript. Clone keeps `transcript` available for the fall-through.
+                let boundary_transcript =
+                    transcript_for_intronic().unwrap_or_else(|_| transcript.clone());
+                if boundary_transcript.chromosome.is_some() {
+                    // Engine errors (no following intron — e.g. last exon — no genomic
+                    // alignment, …) fall through to the exon-confined result, the safe
+                    // pre-#704 behavior. The exon/EXON suppression rule is preserved
+                    // structurally: the genomic shuffle window is capped at the
+                    // adjacent intron's far edge (never the next exon).
+                    if let Ok((boundary_variant, boundary_warnings)) = self
+                        .normalize_boundary_spanning_tx(
+                            variant,
+                            &boundary_transcript,
+                            start_pos,
+                            end_pos,
+                            edit,
+                        )
+                    {
+                        let crossed_into_intron = matches!(
+                            &boundary_variant,
+                            HV::Tx(tv)
+                                if tv.loc_edit.location.start.inner().is_some_and(|p| p.is_intronic())
+                                    || tv.loc_edit.location.end.inner().is_some_and(|p| p.is_intronic())
+                        );
+                        if crossed_into_intron {
+                            let mut combined = warnings;
+                            combined.extend(boundary_warnings);
+                            return Ok((boundary_variant, combined));
+                        }
                     }
                 }
             }
@@ -4674,51 +4768,63 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // (offset-less) `TxPos`. 3'-only; the hot path is untouched.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && new_tx_end == boundaries.right
-            && self.provider.has_genomic_data()
         {
-            use crate::hgvs::variant::{LocEdit, TxVariant};
-            let boundary_transcript = self
-                .provider
-                .get_transcript_for_accession(&variant.accession)
-                .unwrap_or_else(|_| transcript.clone());
-            if boundary_transcript.chromosome.is_some() {
-                let bs_start = TxPos::new(tx_start as i64);
-                let bs_end = TxPos::new(tx_end as i64);
-                let bs_variant = TxVariant {
-                    accession: variant.accession.clone(),
-                    gene_symbol: variant.gene_symbol.clone(),
-                    loc_edit: LocEdit::new(Interval::new(bs_start, bs_end), edit.clone()),
-                };
-                // Engine errors (no following intron — last exon — no genomic
-                // alignment, …) fall through to the exon-confined result, the
-                // safe pre-#704 behavior.
-                if let Ok((HV::Tx(tv), boundary_warnings)) = self.normalize_boundary_spanning_tx(
-                    &bs_variant,
-                    &boundary_transcript,
-                    &bs_start,
-                    &bs_end,
-                    edit,
-                ) {
-                    let crossed_into_intron = tv
-                        .loc_edit
-                        .location
-                        .start
-                        .inner()
-                        .is_some_and(|p| p.is_intronic())
-                        || tv
+            if !self.provider.has_genomic_data() {
+                // #1012: mirror of the `normalize_cds`/`normalize_tx` reduced-
+                // capability guard for the `r.` axis. The junction-crossing
+                // 3'-shuffle needs a genome; without one the exon-confined result
+                // flows through, marked degraded.
+                warnings.push(NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "exon/intron junction 3'-shuffle".to_string(),
+                });
+            } else {
+                use crate::hgvs::variant::{LocEdit, TxVariant};
+                let boundary_transcript = self
+                    .provider
+                    .get_transcript_for_accession(&variant.accession)
+                    .unwrap_or_else(|_| transcript.clone());
+                if boundary_transcript.chromosome.is_some() {
+                    let bs_start = TxPos::new(tx_start as i64);
+                    let bs_end = TxPos::new(tx_end as i64);
+                    let bs_variant = TxVariant {
+                        accession: variant.accession.clone(),
+                        gene_symbol: variant.gene_symbol.clone(),
+                        loc_edit: LocEdit::new(Interval::new(bs_start, bs_end), edit.clone()),
+                    };
+                    // Engine errors (no following intron — last exon — no genomic
+                    // alignment, …) fall through to the exon-confined result, the
+                    // safe pre-#704 behavior.
+                    if let Ok((HV::Tx(tv), boundary_warnings)) = self
+                        .normalize_boundary_spanning_tx(
+                            &bs_variant,
+                            &boundary_transcript,
+                            &bs_start,
+                            &bs_end,
+                            edit,
+                        )
+                    {
+                        let crossed_into_intron = tv
                             .loc_edit
                             .location
-                            .end
+                            .start
                             .inner()
-                            .is_some_and(|p| p.is_intronic());
-                    if crossed_into_intron {
-                        if let Ok(rna_variant) = self.txvariant_to_rnavariant(&tv, cds_info) {
-                            let (split, mut split_warnings) =
-                                self.apply_canonical_split(HV::Rna(rna_variant));
-                            let mut combined = warnings;
-                            combined.extend(boundary_warnings);
-                            combined.append(&mut split_warnings);
-                            return Ok((wrap_allele_if_split(split), combined));
+                            .is_some_and(|p| p.is_intronic())
+                            || tv
+                                .loc_edit
+                                .location
+                                .end
+                                .inner()
+                                .is_some_and(|p| p.is_intronic());
+                        if crossed_into_intron {
+                            if let Ok(rna_variant) = self.txvariant_to_rnavariant(&tv, cds_info) {
+                                let (split, mut split_warnings) =
+                                    self.apply_canonical_split(HV::Rna(rna_variant));
+                                let mut combined = warnings;
+                                combined.extend(boundary_warnings);
+                                combined.append(&mut split_warnings);
+                                return Ok((wrap_allele_if_split(split), combined));
+                            }
                         }
                     }
                 }
@@ -5246,12 +5352,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         use crate::convert::CoordinateMapper;
 
-        // Check if we have genomic data available
+        // #1012: warn-and-degrade when the reference carries no genomic data.
+        // Intronic normalization projects the variant into genomic space to
+        // shuffle across the intron; without a genome that step cannot run, so
+        // return the canonicalized input unchanged and mark the result degraded
+        // rather than erroring. (This is an environmental limitation, not a
+        // spec violation — the same variant against a genome-backed reference
+        // normalizes further. Distinct from the EINTRONIC spec-form rejection
+        // in `normalize_core`, which still errors on a bare transcript.)
         if !self.provider.has_genomic_data() {
-            return Err(FerroError::IntronicVariant {
-                variant: format!("{}", variant),
-                detail: None,
-            });
+            return Ok((
+                HV::Cds(self.canonicalize_cds_variant(variant)),
+                vec![NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "intronic normalization".to_string(),
+                }],
+            ));
         }
 
         // Get the chromosome for this transcript. Issue #332: include the
@@ -5448,12 +5564,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         use crate::convert::CoordinateMapper;
 
-        // Check if we have genomic data available
+        // #1012: warn-and-degrade when the reference carries no genomic data —
+        // the `n.` mirror of the `normalize_intronic_cds` guard. Intronic
+        // normalization needs the genome to shuffle in genomic space; without
+        // one, return the canonicalized input unchanged, marked degraded.
         if !self.provider.has_genomic_data() {
-            return Err(FerroError::IntronicVariant {
-                variant: format!("{}", variant),
-                detail: None,
-            });
+            return Ok((
+                HV::Tx(self.canonicalize_tx_variant(variant)),
+                vec![NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "intronic normalization".to_string(),
+                }],
+            ));
         }
 
         // Get the chromosome for this transcript. Issue #332: include the
@@ -5625,12 +5747,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         use crate::convert::CoordinateMapper;
 
-        // Require genomic data for boundary spanning normalization
+        // #1012: warn-and-degrade when the reference carries no genomic data.
+        // Boundary-spanning normalization shuffles the exon∪intron extent in
+        // genomic space; without a genome that cannot run, so return the
+        // canonicalized input unchanged and mark the result degraded rather
+        // than erroring with `ExonIntronBoundary`.
         if !self.provider.has_genomic_data() {
-            return Err(FerroError::ExonIntronBoundary {
-                exon: 0,
-                variant: format!("{}", variant),
-            });
+            return Ok((
+                HV::Cds(self.canonicalize_cds_variant(variant)),
+                vec![NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "exon/intron boundary normalization".to_string(),
+                }],
+            ));
         }
 
         // Issue #332: same improved error shape as the intronic paths.
@@ -6097,11 +6226,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
         use crate::convert::CoordinateMapper;
 
+        // #1012: warn-and-degrade when the reference carries no genomic data —
+        // the `n.` mirror of the `normalize_boundary_spanning_cds` guard.
         if !self.provider.has_genomic_data() {
-            return Err(FerroError::ExonIntronBoundary {
-                exon: 0,
-                variant: format!("{}", variant),
-            });
+            return Ok((
+                HV::Tx(self.canonicalize_tx_variant(variant)),
+                vec![NormalizationWarning::ReducedCapabilityNoGenome {
+                    variant: format!("{variant}"),
+                    capability: "exon/intron boundary normalization".to_string(),
+                }],
+            ));
         }
 
         let chromosome =
@@ -9242,14 +9376,26 @@ mod tests {
     }
 
     #[test]
-    fn test_normalize_rna_intronic_returns_error() {
+    fn test_normalize_rna_intronic_warns_and_degrades_without_genome() {
+        // #1012: an intronic RNA variant used to error when the provider had
+        // no genomic data (`with_test_data` registers no genomic sequences).
+        // It now warn-and-degrades — returning the best-effort (unchanged)
+        // variant plus a `ReducedCapabilityNoGenome` warning — so a degraded
+        // result is distinguishable from a genuinely-final one.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
-        // Intronic RNA variants should return an error
         let variant = parse_hgvs("NM_001234.1:r.10+5del").unwrap();
-        let result = normalizer.normalize(&variant);
-        assert!(result.is_err(), "Intronic RNA variant should return error");
+        let diag = normalizer
+            .normalize_with_diagnostics(&variant)
+            .expect("intronic RNA without a genome must warn-and-degrade, not error");
+        assert!(
+            diag.warnings
+                .iter()
+                .any(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME"),
+            "expected REDUCED_CAPABILITY_NO_GENOME warning, got {:?}",
+            diag.warnings,
+        );
     }
 
     #[test]

--- a/tests/it/issue_1012_reduced_capability_no_genome.rs
+++ b/tests/it/issue_1012_reduced_capability_no_genome.rs
@@ -1,0 +1,232 @@
+//! Issue #1012 item 2 — warn-and-degrade when a genome-requiring
+//! normalization step cannot run because the reference provider carries no
+//! genomic sequence data.
+//!
+//! Before this change the behavior was inconsistent: some genome-requiring
+//! enhancements were *silently* skipped (a less-normalized result with no
+//! warning), while the intronic / boundary-spanning genomic paths returned a
+//! hard `Err`. The agreed design surfaces a *uniform* signal on every
+//! genome-requiring step: lenient/silent return the best-effort result AND a
+//! structured `ReducedCapabilityNoGenome` warning, while strict mode promotes
+//! that warning to `FerroError::ReducedReferenceCapability` — so a degraded
+//! result is never mistaken for a fully-normalized one in any mode.
+//!
+//! These tests build a `MockProvider` that knows a transcript with genomic
+//! exon coordinates and a chromosome (so intronic/boundary dispatch is
+//! reachable) but *no genomic sequence* — hence
+//! `ReferenceProvider::has_genomic_data() == false`. They assert that the
+//! relevant normalization now returns `Ok` with a best-effort variant and a
+//! `REDUCED_CAPABILITY_NO_GENOME` warning, covering both a former-silent path
+//! (exon/intron junction 3'-shuffle) and a former-error path (intronic
+//! genomic normalization).
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, FerroError, NormalizeConfig, Normalizer, ReferenceProvider};
+
+/// 2-exon plus-strand coding transcript with explicit genomic coordinates on
+/// each exon and a chromosome, but with NO genomic sequence registered on the
+/// provider. The genomic exon coords make the intronic / boundary-spanning
+/// dispatch reachable; the absent genomic sequence makes
+/// `has_genomic_data()` false, so the genome-requiring steps must
+/// warn-and-degrade.
+///
+/// Transcript layout (identical shape to issue_392's fixture):
+/// ```text
+///   tx:   1234567890 ⇢⇢ 1234567890 12
+///   seq:  AAAATGCCCC    GGGGTAGAAT AA
+///   exon 1 genomic: 100-109   (10 bp)
+///   intron 1:       110-129   (20 bp)
+///   exon 2 genomic: 130-141   (12 bp)
+/// ```
+/// `cds_start = 1`, `cds_end = 22`, so `c.<N>` maps 1:1 to tx `<N>`. The
+/// `CCCC` homopolymer sits at c.7..=c.10 (the 3' edge of exon 1).
+fn provider_no_genomic_sequence() -> MockProvider {
+    let mut provider = MockProvider::new();
+    let transcript = Transcript::new(
+        "NM_INT.1".to_string(),
+        Some("INT".to_string()),
+        Strand::Plus,
+        Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+        Some(1),
+        Some(22),
+        vec![
+            Exon::with_genomic(1, 1, 10, 100, 109),
+            Exon::with_genomic(2, 11, 22, 130, 141),
+        ],
+        Some("chr_int".to_string()),
+        Some(100),
+        Some(141),
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    // Deliberately do NOT call `add_genomic_sequence` — has_genomic_data() == false.
+    provider
+}
+
+#[test]
+fn provider_reports_no_genomic_data() {
+    // Guards the premise of every test below: the fixture genuinely lacks
+    // genomic sequence data even though its exons carry genomic coordinates.
+    assert!(
+        !provider_no_genomic_sequence().has_genomic_data(),
+        "fixture must not carry genomic sequence data",
+    );
+}
+
+/// Former-ERROR path: an intronic variant used to return
+/// `Err(FerroError::IntronicVariant)` when the provider had no genomic data.
+/// It must now succeed with the best-effort (unchanged) variant plus the
+/// reduced-capability warning. The genomic-context (`NG_(NM_)`) form is used
+/// so the input is spec-valid and does not also raise the EINTRONIC
+/// bare-transcript warning — isolating the capability signal.
+#[test]
+fn intronic_variant_warns_and_degrades_without_genome() {
+    let normalizer =
+        Normalizer::with_config(provider_no_genomic_sequence(), NormalizeConfig::lenient());
+    let variant = parse_hgvs("NG_012337.1(NM_INT.1):c.10+5del").expect("parse");
+
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("intronic normalization without a genome must not error (warn-and-degrade)");
+
+    // Best-effort result: the input is echoed UNCHANGED (cannot shuffle without
+    // a genome). Compare against the parsed input's own Display — an independent
+    // oracle — rather than a substring/literal.
+    assert_eq!(
+        diag.result.to_string(),
+        variant.to_string(),
+        "best-effort output must preserve the input exactly",
+    );
+
+    // The reduced-capability warning is surfaced.
+    let reduced = diag
+        .warnings
+        .iter()
+        .find(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME");
+    assert!(
+        reduced.is_some(),
+        "expected REDUCED_CAPABILITY_NO_GENOME warning, got {:?}",
+        diag.warnings,
+    );
+    // The message is human-readable and names the missing capability.
+    let message = reduced.unwrap().message();
+    assert!(
+        message.contains("genomic sequence data") && message.contains("intronic normalization"),
+        "warning message should describe the missing capability, got {message:?}",
+    );
+
+    // This spec-valid genomic-context form must NOT raise EINTRONIC.
+    assert!(
+        !diag
+            .warnings
+            .iter()
+            .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+        "genomic-context intronic form must not raise EINTRONIC, got {:?}",
+        diag.warnings,
+    );
+}
+
+/// Former-SILENT path: a purely-exonic deletion that comes to rest at an
+/// exon's 3' boundary triggers the #670 exon/intron junction 3'-shuffle, which
+/// requires a genome. Previously that enhancement was skipped with NO warning
+/// when the provider lacked genomic data, so the caller could not tell the
+/// exon-confined result apart from a genuinely-final one. It must now emit the
+/// reduced-capability warning while still returning the exon-confined result.
+#[test]
+fn exon_boundary_del_warns_and_degrades_without_genome() {
+    let normalizer =
+        Normalizer::with_config(provider_no_genomic_sequence(), NormalizeConfig::lenient());
+    // `c.10del` deletes the 3'-most base of the `CCCC` homopolymer (c.7..=c.10),
+    // which is also the last base of exon 1 — the exon 3' boundary landing that
+    // arms the junction-crossing 3'-shuffle.
+    let variant = parse_hgvs("NM_INT.1:c.10del").expect("parse");
+
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("exonic normalization must succeed");
+
+    // Best-effort result is the exon-confined deletion — the input echoed
+    // unchanged (compare against the parsed input's own Display, not a literal).
+    assert_eq!(
+        diag.result.to_string(),
+        variant.to_string(),
+        "best-effort output must be the exon-confined deletion, unchanged",
+    );
+
+    assert!(
+        diag.warnings
+            .iter()
+            .any(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME"),
+        "expected REDUCED_CAPABILITY_NO_GENOME warning on the exon-boundary landing, got {:?}",
+        diag.warnings,
+    );
+}
+
+/// A plain exonic deletion that does NOT land at an exon boundary must not be
+/// flagged — the reduced-capability warning is scoped to genome-requiring
+/// steps that were actually reached, not every transcript-only normalization.
+#[test]
+fn interior_exonic_del_is_not_flagged() {
+    let normalizer =
+        Normalizer::with_config(provider_no_genomic_sequence(), NormalizeConfig::lenient());
+    // `c.5del` (the `T` at position 5) sits in the interior of exon 1, far from
+    // the exon 3' boundary — no junction shuffle is armed.
+    let variant = parse_hgvs("NM_INT.1:c.5del").expect("parse");
+
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("interior exonic normalization must succeed");
+
+    assert!(
+        !diag
+            .warnings
+            .iter()
+            .any(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME"),
+        "interior exonic deletion must not raise REDUCED_CAPABILITY_NO_GENOME, got {:?}",
+        diag.warnings,
+    );
+}
+
+/// Strict mode REJECTS a reduced-capability degradation rather than returning a
+/// best-effort result. The signal is uniform across every genome-requiring
+/// step: `ReducedCapabilityNoGenome` is promoted to
+/// `FerroError::ReducedReferenceCapability` in strict mode (like the sibling
+/// `CanonicalSplitSkipped`→`VariantExceedsReference` promotion), so a strict
+/// caller — which typically inspects only the `Result`, not the warnings vec —
+/// never silently accepts a knowingly-degraded variant.
+///
+/// This covers BOTH categories the warning spans: the former-error intronic
+/// path (rejected in strict pre-#1012 too — behavior preserved) and the
+/// former-silent exon-junction path (which strict used to accept silently —
+/// now uniformly rejected, so strict never accepts a degraded result).
+#[test]
+fn strict_mode_rejects_reduced_capability() {
+    let normalizer =
+        Normalizer::with_config(provider_no_genomic_sequence(), NormalizeConfig::strict());
+
+    // Former-ERROR path: an intronic variant with no genome.
+    let intronic = parse_hgvs("NG_012337.1(NM_INT.1):c.10+5del").expect("parse");
+    assert!(
+        matches!(
+            normalizer.normalize(&intronic),
+            Err(FerroError::ReducedReferenceCapability { .. })
+        ),
+        "strict mode must reject the intronic reduced-capability path",
+    );
+
+    // Former-SILENT path: an exon-3'-boundary deletion that arms the
+    // junction-crossing shuffle. Strict used to accept this silently; it is now
+    // rejected too, so strict never returns a degraded result.
+    let boundary = parse_hgvs("NM_INT.1:c.10del").expect("parse");
+    assert!(
+        matches!(
+            normalizer.normalize(&boundary),
+            Err(FerroError::ReducedReferenceCapability { .. })
+        ),
+        "strict mode must reject the exon-boundary reduced-capability path",
+    );
+}

--- a/tests/it/issue_1026_genome_capable_json.rs
+++ b/tests/it/issue_1026_genome_capable_json.rs
@@ -11,7 +11,7 @@
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::reference::provider::ReferenceProvider;
-use ferro_hgvs::{parse_hgvs, FerroError, Normalizer};
+use ferro_hgvs::{parse_hgvs, Normalizer};
 use std::io::Write;
 use tempfile::NamedTempFile;
 
@@ -62,8 +62,10 @@ fn write_reference_json(with_genomic_sequences: bool) -> NamedTempFile {
 }
 
 /// Without `genomic_sequences`, the reference is transcript-only: `has_genomic_data`
-/// is false and an intronic normalization cannot run the genome-aware path — it
-/// reports the intronic variant as unresolvable (the pre-#1015 main behavior).
+/// is false and an intronic normalization cannot run the genome-aware path. Rather
+/// than hard-error, it warns-and-degrades — echoing the input unchanged and
+/// surfacing a `REDUCED_CAPABILITY_NO_GENOME` warning (#1015). (Before #1015 this
+/// returned `Err(FerroError::IntronicVariant)`.)
 #[test]
 fn transcripts_only_reference_cannot_normalize_intronic() {
     let file = write_reference_json(false);
@@ -75,10 +77,26 @@ fn transcripts_only_reference_cannot_normalize_intronic() {
 
     let normalizer = Normalizer::new(provider);
     let variant = parse_hgvs("NM_1026TEST.1:n.20+3del").expect("parse");
-    let result = normalizer.normalize(&variant);
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("intronic normalization without a genome must warn-and-degrade, not error");
+
+    // Best-effort: the input is echoed unchanged (the intronic offset cannot be
+    // resolved without a genome).
+    assert_eq!(
+        diag.result.to_string(),
+        variant.to_string(),
+        "best-effort output must preserve the input exactly, got: {:?}",
+        diag.result,
+    );
+
+    // The degrade is not silent: the reduced-capability signal is surfaced.
     assert!(
-        matches!(result, Err(FerroError::IntronicVariant { .. })),
-        "transcript-only reference should report the intronic variant as unresolvable, got: {result:?}"
+        diag.warnings
+            .iter()
+            .any(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME"),
+        "expected REDUCED_CAPABILITY_NO_GENOME warning, got: {:?}",
+        diag.warnings,
     );
 }
 

--- a/tests/it/issue_486_eintronic.rs
+++ b/tests/it/issue_486_eintronic.rs
@@ -300,33 +300,45 @@ fn silent_accepts_bare_nm_intronic_substitution_without_warning() {
 }
 
 #[test]
-fn silent_propagates_error_when_intronic_indel_cannot_resolve() {
+fn silent_warns_and_degrades_when_intronic_indel_cannot_resolve() {
     // Silent-mode counterpart to `lenient_warns_and_keeps_value_when_intronic_indel_cannot_resolve`.
-    // Silent mode produces no EINTRONIC warning, so the `None => return Err(e)` arm in
-    // `normalize_core` must still propagate the capability error for an intronic *indel* that
-    // reaches the genomic-sequence-dependent resolution pass — no echo, no W4007 (#682).
+    // Pre-#1012 the capability error propagated in silent mode (the `None => return Err(e)` arm in
+    // `normalize_core`, no EINTRONIC warning to recover with). Under #1012 the intronic /
+    // boundary-spanning genomic paths no longer error when the provider lacks genomic data — they
+    // warn-and-degrade in EVERY mode, so silent mode now returns the best-effort (unchanged)
+    // variant with a `ReducedCapabilityNoGenome` warning (an environmental limitation, always
+    // surfaced — like the sibling `CrossAxisVariantNotShuffled`/`AxisClampApplied` advisories).
     //
     // `provider_intronic_nr` has the transcript but no genomic sequence, so the intronic
-    // deletion cannot resolve.
+    // deletion cannot resolve without a genome.
     let normalizer = Normalizer::with_config(provider_intronic_nr(), NormalizeConfig::silent());
     let variant = parse_hgvs("NR_INT.1:n.10+2_10+3del").expect("parse");
 
-    // Silent mode has no EINTRONIC warning to recover with, so the capability error propagates.
-    assert!(
-        normalizer.normalize(&variant).is_err(),
-        "silent mode must propagate the resolve-failure error for an intronic indel (#682)"
-    );
+    // Warn-and-degrade: no error, best-effort input echoed unchanged. Compare
+    // against the parsed input's own Display (an independent oracle), not a literal.
+    let out = normalizer
+        .normalize(&variant)
+        .expect("silent mode must warn-and-degrade, not propagate a capability error (#1012)");
+    assert_eq!(out.to_string(), variant.to_string());
 
-    // And it must not emit the INTRONIC_ON_BARE_TRANSCRIPT warning (no echo path taken).
-    let diag = normalizer.normalize_with_diagnostics(&variant);
-    if let Ok(diag) = diag {
-        assert!(
-            !diag
-                .warnings
-                .iter()
-                .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
-            "silent mode must not emit INTRONIC_ON_BARE_TRANSCRIPT, got {:?}",
-            diag.warnings
-        );
-    }
+    let diag = normalizer
+        .normalize_with_diagnostics(&variant)
+        .expect("silent diagnostics");
+    // The reduced-capability signal is surfaced even in silent mode.
+    assert!(
+        diag.warnings
+            .iter()
+            .any(|w| w.code() == "REDUCED_CAPABILITY_NO_GENOME"),
+        "expected REDUCED_CAPABILITY_NO_GENOME warning, got {:?}",
+        diag.warnings
+    );
+    // But silent mode still emits no EINTRONIC (bare-transcript) warning.
+    assert!(
+        !diag
+            .warnings
+            .iter()
+            .any(|w| w.code() == "INTRONIC_ON_BARE_TRANSCRIPT"),
+        "silent mode must not emit INTRONIC_ON_BARE_TRANSCRIPT, got {:?}",
+        diag.warnings
+    );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -78,6 +78,7 @@ mod inserted_range_special_positions;
 mod integration_tests;
 mod inverted_uncertain_range_insertion;
 mod issue_1004_samegap_insertion_idempotency;
+mod issue_1012_reduced_capability_no_genome;
 mod issue_1026_genome_capable_json;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
## Summary

Unifies how genome-requiring normalization steps behave when the configured reference provider carries no genomic sequence data (`ReferenceProvider::has_genomic_data() == false`, e.g. a transcripts-only `MockProvider`). Previously the behavior was inconsistent: some enhancements were **silently** skipped (returning a less-normalized result with no warning), while other paths returned a **hard error**. This made a degraded result indistinguishable from a genuine one in the silent case, and surfaced an environmental limitation as a variant-level error in the other.

Per the agreed design (item 2 of #1012), every such step now **warn-and-degrades**: it returns the best-effort result AND surfaces a structured `ReducedCapabilityNoGenome` warning, so a reduced-capability result is never mistaken for a fully-normalized one. This is an environmental limitation, not a defect in the variant — the same input against a genome-backed reference normalizes further.

## New warning

`NormalizationWarning::ReducedCapabilityNoGenome { variant, capability }` — code `REDUCED_CAPABILITY_NO_GENOME`. It carries the full variant Display and a short description of the genome-requiring step that could not run (e.g. `"intronic normalization"`, `"exon/intron boundary normalization"`, `"exon/intron junction 3'-shuffle"`). It flows through `code()` / `Display` / `message()` and the generic `PyNormalizationWarning` binding automatically. It is emitted unconditionally (in every error-handling mode), matching the sibling warning-only advisories `CrossAxisVariantNotShuffled` / `AxisClampApplied`, so it has no `ErrorType`/registry W-code — consistent with those precedents (the error-code-audit tests confirm this is allowed).

## Paths changed

**Silent → warn** (the `#670`/`#704` exon/intron junction 3'-shuffle enhancement, which only fires when a del/dup lands exactly at an exon's 3' boundary in 3'-shuffle mode). When the enhancement is armed but the genome is absent, push the warning; the hot path with genomic data present is untouched:
- `normalize_cds` (c.)
- `normalize_tx` (n.)
- `normalize_rna` (r.)

**Error → warn** (return the canonicalized input unchanged — the correct "cannot normalize further without a genome" fallback — plus the warning, instead of erroring):
- `normalize_intronic_cds` — was `Err(IntronicVariant)`
- `normalize_intronic_tx` — was `Err(IntronicVariant)`
- `normalize_boundary_spanning_cds` — was `Err(ExonIntronBoundary)`
- `normalize_boundary_spanning_tx` — was `Err(ExonIntronBoundary)`

**Left as errors** (deliberately not converted — these are not "missing genome capability"): the EINTRONIC bare-transcript spec-form rejection (`IntronicOnBareTranscript` → `FerroError::IntronicVariant`), which flags a genuinely spec-invalid description regardless of provider capability, and the transcript-not-found / position-not-mappable errors in the `r.` intronic dispatch.

## Tests

New `tests/it/issue_1012_reduced_capability_no_genome.rs` builds a `MockProvider` with genomic exon coordinates + chromosome but **no** genomic sequence (so `has_genomic_data()` is false while intronic/boundary dispatch is still reachable), and asserts warn-and-degrade for both a former-error path (intronic `NG_(NM_):c.10+5del`) and a former-silent path (exon-boundary `c.10del`), plus a negative case (an interior exonic del is not flagged).

Two existing tests that pinned the old behavior are updated to the new contract (both are correct consequences of this change, not regressions):
- `normalize::tests::test_normalize_rna_intronic_returns_error` → `..._warns_and_degrades_without_genome`
- `issue_486_eintronic::silent_propagates_error_when_intronic_indel_cannot_resolve` → `..._warns_and_degrades...` (the #682 silent-mode error-propagation becomes a warn-and-degrade)

## Validation

- `cargo test --features dev` — pass (all binaries green)
- `cargo clippy --features dev --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Conformance axis ran with `FERRO_MANIFEST` pointed at the blessing-safe backup reference: **all `axis_*` tests pass (incl. `axis_errors`, `axis_normalized`) with zero ledger movement** — no `baseline-failures/*` file changed. Expected, since the conformance corpus uses a genome-backed reference, so the reduced-capability paths are never exercised there.

Part of #1012

---

**Mode semantics (strict rejects a degraded result).** When a genome-requiring step cannot run because the reference has no genomic data, the behavior is now uniform across every such step and depends only on the error mode:

| Mode | Behavior |
|------|----------|
| lenient / silent | best-effort variant + `ReducedCapabilityNoGenome` warning (always surfaced) |
| strict | promoted to `FerroError::ReducedReferenceCapability` (E4004) — strict never returns a knowingly-degraded result |

The strict promotion is the lowest-priority strict rejection: a variant that is both genuinely invalid (e.g. past the CDS end, W4004) *and* degraded reports the input defect first. This preserves the pre-#1012 reject-in-strict contract the intronic/boundary paths already had, and extends it to the formerly-silent exon-junction path so strict is consistent. Locked by `strict_mode_rejects_reduced_capability`. Zero conformance-axis movement (the corpus is genome-backed).

**Note for strict-mode integrators on transcript-only references.** A consequence of the uniform strict promotion above: a strict-configured normalizer backed by a **transcript-only** provider (no genomic data) will now hard-fail some *ordinary exon-terminal* variants that previously succeeded silently. When a variant's 3′-shift lands exactly on an exon's 3′ edge, the normalizer cannot tell — without a genome — whether the pattern would extend across the junction into the intron, so strict mode conservatively rejects rather than risk returning an under-normalized result. This is the **safe** direction (it never emits wrong coordinates; the refusal simply says "cannot confirm without a genome"), and the **default mode is Lenient**, so this only affects callers that explicitly opt into strict *and* use a genome-less reference. Strict integrators who want these to pass should point at a genome-backed (`from_manifest`) reference. Flagged so it is a conscious contract, not a surprise.
