### PR TITLE
fix(python): reject an unrecognized direction argument instead of defaulting to 3'

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -39,7 +39,8 @@ def normalize(hgvs_string: str, direction: str = "3prime") -> str:
         The normalized HGVS string
 
     Raises:
-        ValueError: If the HGVS string cannot be parsed
+        ValueError: If the HGVS string cannot be parsed, or if ``direction`` is
+            not one of "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive)
         RuntimeError: If normalization fails
 
     Example:
@@ -352,7 +353,15 @@ class HgvsVariant:
         ...
 
     def normalize(self, direction: str = "3prime") -> HgvsVariant:
-        """Normalize this variant."""
+        """Normalize this variant.
+
+        Args:
+            direction: Shuffle direction - "3prime" (default) or "5prime".
+
+        Raises:
+            ValueError: If ``direction`` is not one of
+                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+        """
         ...
 
     def to_dict(self) -> dict[str, Any]:
@@ -421,6 +430,10 @@ class Normalizer:
         Args:
             reference_json: Optional path to a transcripts.json file
             direction: Shuffle direction - "3prime" (default) or "5prime"
+
+        Raises:
+            ValueError: If ``direction`` is not one of
+                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         """
         ...
 
@@ -437,6 +450,8 @@ class Normalizer:
             A Normalizer backed by a MultiFastaProvider.
 
         Raises:
+            ValueError: If ``direction`` is not one of
+                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
             RuntimeError: If the manifest cannot be loaded.
         """
         ...
@@ -1645,6 +1660,10 @@ class VariantProjector:
                 aliases "hg19"/"hg38") for build-agnostic inputs. A bare NG_/LRG_
                 input carries no build; this fills one in. An input whose
                 accession already encodes a build (NC_*.10/.11) keeps it.
+
+        Raises:
+            ValueError: If ``direction`` is not one of
+                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
         """
         ...
 
@@ -1664,6 +1683,11 @@ class VariantProjector:
 
         Returns:
             A VariantProjector backed by MultiFastaProvider with cdot data.
+
+        Raises:
+            ValueError: If ``direction`` is not one of
+                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+            RuntimeError: If the manifest cannot be loaded.
         """
         ...
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -22,6 +22,7 @@ use crate::error_handling::{CorrectionWarning, ErrorConfig, ErrorMode, ErrorOver
 use crate::hgvs::location::{AminoAcid, CdsPos, TxPos};
 use crate::hgvs::variant::HgvsVariant;
 use crate::mave::{is_mave_short_form, parse_mave_hgvs, MaveContext};
+use crate::normalize::ShuffleDirection;
 use crate::prepare::{check_references, prepare_references, PrepareConfig, ReferenceManifest};
 use crate::python_helpers::{
     get_indel_length, get_num_variants, get_substitution_bases, get_variant_edit_type,
@@ -35,6 +36,20 @@ use crate::rsid::{format_rsid, parse_rsid as rust_parse_rsid, InMemoryRsIdLookup
 use crate::spdi::{hgvs_to_spdi_simple, parse_spdi as rust_parse_spdi, spdi_to_hgvs, SpdiVariant};
 use crate::vcf::{vcf_to_genomic_hgvs as rust_vcf_to_hgvs, VcfRecord};
 use crate::{parse_hgvs, NormalizeConfig, Normalizer};
+
+/// Validate a shuffle-direction argument at the Python boundary.
+///
+/// Mirrors the `assembly` argument's validate-and-raise pattern: an unrecognized
+/// spelling raises `ValueError` naming the accepted values instead of silently
+/// defaulting to 3' (#1016).
+fn parse_direction_or_raise(direction: &str) -> PyResult<ShuffleDirection> {
+    parse_direction(direction).ok_or_else(|| {
+        PyValueError::new_err(format!(
+            "unrecognized direction {direction:?}; expected one of \"3prime\", \"5prime\", \
+             \"3\", \"5\", \"3'\", \"5'\" (case-insensitive)"
+        ))
+    })
+}
 
 /// Reference provider used by the Python wrappers.
 ///
@@ -305,7 +320,7 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
     let variant = parse_hgvs(hgvs_string)
         .map_err(|e| PyValueError::new_err(format!("Parse error: {}", e)))?;
 
-    let config = NormalizeConfig::default().with_direction(parse_direction(direction));
+    let config = NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
     // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
     let provider = MockProvider::with_test_data();
     // This free function always uses genome-less test data; surface the
@@ -544,7 +559,8 @@ impl PyHgvsVariant {
     ///     A new PyHgvsVariant representing the normalized variant
     #[pyo3(signature = (direction="3prime"))]
     fn normalize(&self, py: Python<'_>, direction: &str) -> PyResult<PyHgvsVariant> {
-        let config = NormalizeConfig::default().with_direction(parse_direction(direction));
+        let config =
+            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
         // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
         let provider = MockProvider::with_test_data();
         // Genome-less test data; surface the reduced-capability signal once per
@@ -735,6 +751,13 @@ impl PyNormalizer {
     #[new]
     #[pyo3(signature = (reference_json=None, direction="3prime"))]
     fn new(py: Python<'_>, reference_json: Option<&str>, direction: &str) -> PyResult<Self> {
+        // Validate the `direction` argument BEFORE loading any reference, so an
+        // invalid direction always raises `ValueError` regardless of whether the
+        // reference path is valid — a bad/missing path must not mask (or be
+        // masked by) the argument error.
+        let config =
+            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+
         let (provider, kind) = match reference_json {
             Some(path) => (
                 PyProvider::from_json(Path::new(path))?,
@@ -742,8 +765,6 @@ impl PyNormalizer {
             ),
             None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-
-        let config = NormalizeConfig::default().with_direction(parse_direction(direction));
 
         let normalizer = Self {
             provider,
@@ -766,8 +787,11 @@ impl PyNormalizer {
     #[staticmethod]
     #[pyo3(signature = (manifest_path, direction="3prime"))]
     fn from_manifest(py: Python<'_>, manifest_path: &str, direction: &str) -> PyResult<Self> {
+        // Validate `direction` before loading the manifest (see `new`): a bad
+        // manifest path must not mask an invalid-direction `ValueError`.
+        let config =
+            NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        let config = NormalizeConfig::default().with_direction(parse_direction(direction));
         let normalizer = Self {
             provider,
             config,
@@ -1069,6 +1093,9 @@ impl PyVariantProjector {
         direction: &str,
         assembly: Option<&str>,
     ) -> PyResult<Self> {
+        // Validate boundary args BEFORE loading any reference (a bad path must
+        // not mask an invalid direction/assembly ValueError).
+        let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
         let (provider, kind) = match reference_json {
             Some(path) => (
                 PyProvider::from_json(Path::new(path))?,
@@ -1076,7 +1103,7 @@ impl PyVariantProjector {
             ),
             None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-        Self::from_provider(py, provider, direction, assembly, kind)
+        Self::from_provider(py, provider, config, assembly_build, kind)
     }
 
     /// Create a projector from a ferro-prepare manifest (preferred for
@@ -1089,8 +1116,10 @@ impl PyVariantProjector {
         direction: &str,
         assembly: Option<&str>,
     ) -> PyResult<Self> {
+        // Validate boundary args before loading the manifest (see `new`).
+        let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Self::from_provider(py, provider, direction, assembly, ProviderKind::Manifest)
+        Self::from_provider(py, provider, config, assembly_build, ProviderKind::Manifest)
     }
 
     /// Return `True` if the backing reference provides genomic sequence data.
@@ -1449,12 +1478,36 @@ impl PyVariantProjector {
     }
 }
 
+/// Parse the projector's boundary args (`direction`, `assembly`) into their
+/// validated forms. Split out so callers validate them BEFORE loading a
+/// reference — a bad/missing reference path must not mask (or be masked by) an
+/// invalid direction/assembly `ValueError`. The assembly name is normalized to a
+/// canonical "GRCh37"/"GRCh38" at the boundary so the core only sees that (#715).
+fn parse_projector_boundary_args(
+    direction: &str,
+    assembly: Option<&str>,
+) -> PyResult<(NormalizeConfig, Option<&'static str>)> {
+    let config = NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+    let assembly_build = match assembly {
+        Some(name) => Some(
+            crate::liftover::aliases::normalize_assembly_name(name).ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "unrecognized assembly {name:?}; expected GRCh37 or GRCh38 \
+                     (aliases hg19/hg38 accepted)"
+                ))
+            })?,
+        ),
+        None => None,
+    };
+    Ok((config, assembly_build))
+}
+
 impl PyVariantProjector {
     fn from_provider(
         py: Python<'_>,
         provider: PyProvider,
-        direction: &str,
-        assembly: Option<&str>,
+        config: NormalizeConfig,
+        assembly_build: Option<&'static str>,
         kind: ProviderKind,
     ) -> PyResult<Self> {
         // Capture capability before the provider is moved into the projector.
@@ -1462,20 +1515,6 @@ impl PyVariantProjector {
         let has_protein_data = provider.has_protein_data();
         let cdot = provider.cdot_mapper();
         let projector = crate::data::projection::Projector::new(cdot);
-        let config = NormalizeConfig::default().with_direction(parse_direction(direction));
-        // Validate/normalize the assembly name at the boundary so the core only
-        // ever sees a canonical "GRCh37"/"GRCh38" (#715).
-        let assembly_build = match assembly {
-            Some(name) => Some(
-                crate::liftover::aliases::normalize_assembly_name(name).ok_or_else(|| {
-                    PyValueError::new_err(format!(
-                        "unrecognized assembly {name:?}; expected GRCh37 or GRCh38 \
-                         (aliases hg19/hg38 accepted)"
-                    ))
-                })?,
-            ),
-            None => None,
-        };
         let projector = Self {
             inner: crate::project::VariantProjector::new(projector, provider)
                 .with_normalize_config(config)

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -83,11 +83,14 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
     }
 }
 
-/// Parse a direction string into ShuffleDirection
+/// Parse a direction string into a [`ShuffleDirection`].
 ///
-/// Accepts various common formats:
-/// - 3prime, 3', 3 -> ThreePrime (default)
-/// - 5prime, 5', 5 -> FivePrime
+/// Recognizes only the documented aliases (case-insensitively). Returns `None`
+/// for anything else so callers can reject unrecognized input loudly rather than
+/// silently defaulting (#1016):
+/// - `3prime`, `3'`, `3` -> `Some(ThreePrime)`
+/// - `5prime`, `5'`, `5` -> `Some(FivePrime)`
+/// - anything else -> `None`
 ///
 /// # Examples
 ///
@@ -95,13 +98,15 @@ pub fn na_edit_type_str(edit: &NaEdit) -> &'static str {
 /// use ferro_hgvs::python_helpers::parse_direction;
 /// use ferro_hgvs::ShuffleDirection;
 ///
-/// assert!(matches!(parse_direction("3prime"), ShuffleDirection::ThreePrime));
-/// assert!(matches!(parse_direction("5'"), ShuffleDirection::FivePrime));
+/// assert!(matches!(parse_direction("3prime"), Some(ShuffleDirection::ThreePrime)));
+/// assert!(matches!(parse_direction("5'"), Some(ShuffleDirection::FivePrime)));
+/// assert!(parse_direction("5prim").is_none());
 /// ```
-pub fn parse_direction(direction: &str) -> ShuffleDirection {
+pub fn parse_direction(direction: &str) -> Option<ShuffleDirection> {
     match direction.to_lowercase().as_str() {
-        "5prime" | "5'" | "5" => ShuffleDirection::FivePrime,
-        _ => ShuffleDirection::ThreePrime,
+        "3prime" | "3'" | "3" => Some(ShuffleDirection::ThreePrime),
+        "5prime" | "5'" | "5" => Some(ShuffleDirection::FivePrime),
+        _ => None,
     }
 }
 
@@ -655,43 +660,58 @@ mod tests {
     fn test_parse_direction_three_prime() {
         assert!(matches!(
             parse_direction("3prime"),
-            ShuffleDirection::ThreePrime
+            Some(ShuffleDirection::ThreePrime)
         ));
         assert!(matches!(
             parse_direction("3'"),
-            ShuffleDirection::ThreePrime
+            Some(ShuffleDirection::ThreePrime)
         ));
-        assert!(matches!(parse_direction("3"), ShuffleDirection::ThreePrime));
+        assert!(matches!(
+            parse_direction("3"),
+            Some(ShuffleDirection::ThreePrime)
+        ));
     }
 
     #[test]
     fn test_parse_direction_five_prime() {
         assert!(matches!(
             parse_direction("5prime"),
-            ShuffleDirection::FivePrime
+            Some(ShuffleDirection::FivePrime)
         ));
-        assert!(matches!(parse_direction("5'"), ShuffleDirection::FivePrime));
-        assert!(matches!(parse_direction("5"), ShuffleDirection::FivePrime));
+        assert!(matches!(
+            parse_direction("5'"),
+            Some(ShuffleDirection::FivePrime)
+        ));
+        assert!(matches!(
+            parse_direction("5"),
+            Some(ShuffleDirection::FivePrime)
+        ));
     }
 
     #[test]
-    fn test_parse_direction_default() {
-        assert!(matches!(
-            parse_direction("unknown"),
-            ShuffleDirection::ThreePrime
-        ));
-        assert!(matches!(parse_direction(""), ShuffleDirection::ThreePrime));
+    fn test_parse_direction_unrecognized_is_none() {
+        // Unrecognized spellings must return None so the Python boundary can
+        // reject them rather than silently defaulting to 3' (#1016).
+        assert!(parse_direction("unknown").is_none());
+        assert!(parse_direction("").is_none());
+        assert!(parse_direction("5prim").is_none());
+        assert!(parse_direction("3prine").is_none());
+        assert!(parse_direction("five").is_none());
     }
 
     #[test]
     fn test_parse_direction_case_insensitive() {
         assert!(matches!(
             parse_direction("5PRIME"),
-            ShuffleDirection::FivePrime
+            Some(ShuffleDirection::FivePrime)
         ));
         assert!(matches!(
             parse_direction("5Prime"),
-            ShuffleDirection::FivePrime
+            Some(ShuffleDirection::FivePrime)
+        ));
+        assert!(matches!(
+            parse_direction("3PRIME"),
+            Some(ShuffleDirection::ThreePrime)
         ));
     }
 

--- a/tests/python/test_issue_1016_direction_validation.py
+++ b/tests/python/test_issue_1016_direction_validation.py
@@ -1,0 +1,158 @@
+"""Tests for issue #1016: the ``direction`` argument is validated instead of
+silently defaulting to 3'.
+
+Previously any unrecognized shuffle-direction string (``"5prim"``, ``"five"``,
+``"3prine"``, ...) was silently mapped to 3', quietly changing normalization
+output. The only documented values are ``"3prime"`` and ``"5prime"`` (plus the
+``3``/``5``/``3'``/``5'`` short forms); anything else must now raise
+``ValueError`` at the Python boundary, mirroring the ``assembly`` argument's
+validate-and-raise behavior.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+# A variant that parses and normalizes cleanly against the built-in test data
+# (bundled ``NM_000088.3`` transcript), so a successful call reflects an
+# accepted direction rather than a coincidental normalization failure.
+_VALID_HGVS = "NM_000088.3:c.4C>G"
+
+# Every documented/accepted spelling, case-insensitively.
+_ACCEPTED_DIRECTIONS = [
+    "3prime",
+    "5prime",
+    "3",
+    "5",
+    "3'",
+    "5'",
+    "3PRIME",
+    "5Prime",
+]
+
+# Representative unrecognized spellings (typos and unsupported words).
+_UNRECOGNIZED_DIRECTIONS = ["5prim", "five", "3prine", "", "left", "threeprime"]
+
+
+class TestNormalizerConstructor:
+    """The ``Normalizer`` constructor validates ``direction``."""
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_unrecognized_direction_raises(self, direction: str) -> None:
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.Normalizer(direction=direction)
+
+    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
+    def test_accepted_direction_ok(self, direction: str) -> None:
+        # Construction must succeed for every documented alias.
+        ferro_hgvs.Normalizer(direction=direction)
+
+
+class TestModuleLevelNormalize:
+    """The module-level ``normalize()`` free function validates ``direction``."""
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_unrecognized_direction_raises(self, direction: str) -> None:
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.normalize(_VALID_HGVS, direction=direction)
+
+    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
+    def test_accepted_direction_ok(self, direction: str) -> None:
+        result = ferro_hgvs.normalize(_VALID_HGVS, direction=direction)
+        assert isinstance(result, str)
+
+
+class TestHgvsVariantNormalize:
+    """``HgvsVariant.normalize()`` validates ``direction``."""
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_unrecognized_direction_raises(self, direction: str) -> None:
+        variant = ferro_hgvs.parse(_VALID_HGVS)
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            variant.normalize(direction=direction)
+
+    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
+    def test_accepted_direction_ok(self, direction: str) -> None:
+        variant = ferro_hgvs.parse(_VALID_HGVS)
+        result = variant.normalize(direction=direction)
+        # A recognized direction normalizes to a non-empty rendered variant
+        # (`isinstance(str(x), str)` is vacuously true — assert real content).
+        assert str(result)
+
+
+class TestVariantProjectorConstructor:
+    """The ``VariantProjector`` constructor validates ``direction`` too — it is
+    the fifth Python entry point that routes through the same boundary helper."""
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_unrecognized_direction_raises(self, direction: str) -> None:
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.VariantProjector(direction=direction)
+
+    @pytest.mark.parametrize("direction", _ACCEPTED_DIRECTIONS)
+    def test_accepted_direction_ok(self, direction: str) -> None:
+        # Constructs against built-in test data; a recognized direction must not
+        # raise (construction alone exercises the boundary validation).
+        ferro_hgvs.VariantProjector(direction=direction)
+
+
+# The two `from_manifest` entry points route through the same boundary helper, so
+# an invalid direction must raise there too — and, crucially, BEFORE the manifest
+# is loaded, so the reject path needs no real reference data.
+MANIFEST_TINY = (
+    Path(__file__).parent.parent / "fixtures" / "python" / "manifest_tiny" / "manifest.json"
+)
+
+
+class TestFromManifestDirection:
+    """`Normalizer.from_manifest` / `VariantProjector.from_manifest` validate
+    ``direction`` — the two entry points that were otherwise uncovered."""
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_normalizer_from_manifest_unrecognized_raises(self, direction: str) -> None:
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY), direction=direction)
+
+    @pytest.mark.parametrize("direction", _UNRECOGNIZED_DIRECTIONS)
+    def test_projector_from_manifest_unrecognized_raises(self, direction: str) -> None:
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.VariantProjector.from_manifest(str(MANIFEST_TINY), direction=direction)
+
+    def test_normalizer_from_manifest_accepted_ok(self) -> None:
+        # A recognized direction loads the (tiny) manifest without raising.
+        ferro_hgvs.Normalizer.from_manifest(str(MANIFEST_TINY), direction="5prime")
+
+
+class TestDirectionValidatedBeforeReferenceLoad:
+    """``direction`` (and ``assembly``) are validated BEFORE any reference is
+    loaded, so a bad/missing reference path cannot mask an invalid argument: the
+    boundary ``ValueError`` must win over the load's reference error. Uses a
+    nonexistent path so the load *would* fail if it were reached first."""
+
+    def test_normalizer_new_bad_json_and_bad_direction(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.Normalizer(reference_json=str(missing), direction="sideways")
+
+    def test_normalizer_from_manifest_bad_path_and_bad_direction(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.Normalizer.from_manifest(str(missing), direction="sideways")
+
+    def test_projector_new_bad_json_and_bad_direction(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.VariantProjector(reference_json=str(missing), direction="sideways")
+
+    def test_projector_from_manifest_bad_path_and_bad_direction(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="unrecognized direction"):
+            ferro_hgvs.VariantProjector.from_manifest(str(missing), direction="sideways")
+
+    def test_projector_bad_assembly_validated_before_bad_path(self, tmp_path: Path) -> None:
+        # The `assembly` argument carries the same before-load guarantee.
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(ValueError, match="unrecognized assembly"):
+            ferro_hgvs.VariantProjector.from_manifest(str(missing), assembly="bogus")


### PR DESCRIPTION
## Problem

`parse_direction` in `src/python_helpers.rs` silently mapped any unrecognized shuffle-direction string to `ThreePrime`:

```rust
match direction.to_lowercase().as_str() {
    "5prime" | "5'" | "5" => ShuffleDirection::FivePrime,
    _ => ShuffleDirection::ThreePrime,   // anything unrecognized -> 3' SILENTLY
}
```

So `Normalizer(direction="5prim")`, `"five"`, `"3prine"`, etc. were silently accepted as 3', quietly changing normalization output. The only documented values are `"3prime"` and `"5prime"` (plus the `3`/`5`/`3'`/`5'` short forms). A typo therefore produced wrong-but-plausible output with no signal — a real footgun.

## Fix

Mirror the existing `assembly`-argument pattern in `VariantProjector::from_provider`, which validates at the Python boundary and raises `PyValueError` naming the accepted values.

- `parse_direction` is now fallible: it returns `Option<ShuffleDirection>`, listing the accepted 3' aliases (`3prime`/`3'`/`3`) and 5' aliases (`5prime`/`5'`/`5`) explicitly and returning `None` for anything else (case-insensitive as before).
- A small boundary helper `parse_direction_or_raise` maps `None` to `PyValueError: unrecognized direction "…"; expected "3prime" or "5prime"`.
- Every Python-facing call site now validates via `?`: the module-level `normalize()` free function, `HgvsVariant.normalize()`, and `Normalizer` `new` / `from_manifest` / `from_provider`.

`parse_direction` has no non-Python (pure-Rust/CLI) callers, so no core path needed changes.

## Tests

- Rust unit tests for `parse_direction`: every accepted alias resolves to the right `ShuffleDirection`, and unrecognized strings return `None`.
- New `tests/python/test_issue_1016_direction_validation.py`: an unrecognized `direction` raises `ValueError` on the `Normalizer` constructor, the module-level `normalize()` free function, and `HgvsVariant.normalize()`; every documented alias (`3prime`, `5prime`, `3`, `5`, `3'`, `5'`, and mixed case) is accepted without error.

Closes #1016

---

**Stacked on #1014.** This PR touches the same `src/python.rs` constructors as #1014 (reference-capability surfacing), so it is stacked on top of `feat/1012-reference-capability-surfacing` rather than racing it on `main`. Review/merge #1014 first; GitHub will auto-retarget this PR to `main` once #1014 merges. The direction validation is applied on top of #1014's extended (`py`-token) constructor bodies.