### PR TITLE
feat(python): batch error-isolation on the projector (return_exceptions)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 from enum import IntEnum
-from typing import Any, Callable
+from typing import Any, Callable, Literal, overload
 
 __version__: str
 
@@ -1812,7 +1812,10 @@ class VariantProjector:
         """
         ...
 
-    def project_many(self, hgvs_strings: list[str]) -> list[list[VariantProjection]]:
+    @overload
+    def project_many(
+        self, hgvs_strings: list[str], return_exceptions: Literal[False] = False
+    ) -> list[list[VariantProjection]]:
         """Batched parse + normalize + project_all over a list of g. HGVS strings.
 
         Equivalent to ``[self.project_all(s) for s in hgvs_strings]``, but takes a
@@ -1822,18 +1825,28 @@ class VariantProjector:
 
         Args:
             hgvs_strings: List of g. HGVS variant strings.
+            return_exceptions: When False (default) the first failing input aborts
+                the batch by raising ``ProjectionError``. When True nothing is
+                raised: each output element is either that input's list of
+                projections or the ``ProjectionError`` for its failure, so one bad
+                input does not discard the rest.
 
         Returns:
             List of result lists — one inner list per input, in the same order.
             Each inner list holds the per-transcript projections for that variant
-            in clinical priority order.
+            in clinical priority order. With ``return_exceptions=True`` an element
+            may instead be the ``ProjectionError`` for that input.
 
         Raises:
-            RuntimeError: On the first parse / normalization error. Subsequent
-                inputs are not processed.
+            ProjectionError: On the first parse / projection error, unless
+                ``return_exceptions=True`` (then failures are returned in place).
         """
         ...
 
+    @overload
+    def project_many(
+        self, hgvs_strings: list[str], return_exceptions: Literal[True]
+    ) -> list[list[VariantProjection] | ProjectionError]: ...
     def project_to_genomic(self, variant: HgvsVariant, normalize: bool = True) -> HgvsVariant:
         """Project a transcript-coordinate variant (c./n./r.) onto its parent
         genomic reference and return a Genome-kind HgvsVariant.
@@ -1875,7 +1888,10 @@ class VariantProjector:
         """
         ...
 
-    def project_normalized_many(self, variants: list[HgvsVariant]) -> list[list[VariantProjection]]:
+    @overload
+    def project_normalized_many(
+        self, variants: list[HgvsVariant], return_exceptions: Literal[False] = False
+    ) -> list[list[VariantProjection]]:
         """Batched ``project_normalized_all`` over a list of already-normalized
         g. variants.
 
@@ -1884,15 +1900,25 @@ class VariantProjector:
 
         Args:
             variants: List of HgvsVariant objects (must already be normalized).
+            return_exceptions: When False (default) the first failing input aborts
+                the batch by raising ``ProjectionError``. When True nothing is
+                raised: each output element is either that input's list of
+                projections or the ``ProjectionError`` for its failure.
 
         Returns:
-            List of result lists, one per input.
+            List of result lists, one per input. With ``return_exceptions=True`` an
+            element may instead be the ``ProjectionError`` for that input.
 
         Raises:
-            RuntimeError: On the first projection error.
+            ProjectionError: On the first projection error, unless
+                ``return_exceptions=True`` (then failures are returned in place).
         """
         ...
 
+    @overload
+    def project_normalized_many(
+        self, variants: list[HgvsVariant], return_exceptions: Literal[True]
+    ) -> list[list[VariantProjection] | ProjectionError]: ...
     def has_genomic_data(self) -> bool:
         """Return True if the backing reference provides genomic sequence data.
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -107,6 +107,57 @@ fn ferro_typed(class: &str, message: String, err: &crate::error::FerroError) -> 
     )
 }
 
+/// Wrap the projector's raw projections for one input into the Python-facing
+/// `PyVariantProjection` newtypes. Shared by both batch entry points.
+fn wrap_projections(
+    projections: Vec<crate::project::VariantProjection>,
+) -> Vec<PyVariantProjection> {
+    projections
+        .into_iter()
+        .map(|inner| PyVariantProjection { inner })
+        .collect()
+}
+
+/// Turn a `(input_index, error)` pair into the batch's `ProjectionError`, whose
+/// message pinpoints the failing entry via an `input[i]:` prefix.
+fn projection_error_at(i: usize, e: &crate::error::FerroError) -> PyErr {
+    ferro_typed(
+        "ProjectionError",
+        format!("Projection error at input[{i}]: {e}"),
+        e,
+    )
+}
+
+/// Convert a list of per-input projection lists into the Python return value —
+/// a `list[list[VariantProjection]]`.
+fn projections_to_pylist(
+    py: Python<'_>,
+    outer: Vec<Vec<PyVariantProjection>>,
+) -> PyResult<Vec<Py<PyAny>>> {
+    outer
+        .into_iter()
+        .map(|projections| Ok(projections.into_pyobject(py)?.into_any().unbind()))
+        .collect()
+}
+
+/// Assemble the output for isolation mode (`return_exceptions == true`): never
+/// raises. Each element is, per input and in order, either that input's
+/// `list[VariantProjection]` or the `ProjectionError` instance describing its
+/// failure, so one bad input can no longer discard results for the rest.
+fn build_isolated_batch(
+    py: Python<'_>,
+    raw: Vec<Result<Vec<PyVariantProjection>, (usize, crate::error::FerroError)>>,
+) -> PyResult<Vec<Py<PyAny>>> {
+    let mut out = Vec::with_capacity(raw.len());
+    for item in raw {
+        match item {
+            Ok(projections) => out.push(projections.into_pyobject(py)?.into_any().unbind()),
+            Err((i, e)) => out.push(projection_error_at(i, &e).into_value(py).into_any()),
+        }
+    }
+    Ok(out)
+}
+
 /// Validate a shuffle-direction argument at the Python boundary.
 ///
 /// Mirrors the `assembly` argument's validate-and-raise pattern: an unrecognized
@@ -1505,49 +1556,48 @@ impl PyVariantProjector {
     ///
     /// Args:
     ///     hgvs_strings: List of g. HGVS variant strings.
+    ///     return_exceptions: When ``False`` (default) the first failing input
+    ///         aborts the batch by raising ``ProjectionError``. When ``True``
+    ///         nothing is raised: each output element is either that input's
+    ///         list of projections or the ``ProjectionError`` for its failure,
+    ///         so one bad input does not discard the rest.
     ///
     /// Returns:
     ///     List of result lists — one inner list per input, in the same order.
     ///     Each inner list contains the projections for that variant in
-    ///     clinical priority order.
+    ///     clinical priority order. With ``return_exceptions=True`` an element
+    ///     may instead be the ``ProjectionError`` for that input.
     ///
     /// Raises:
-    ///     RuntimeError: On the first parse / normalization error. Subsequent
-    ///         inputs are not processed.
+    ///     ProjectionError: On the first parse / projection error, unless
+    ///         ``return_exceptions=True`` (then failures are returned in place).
+    #[pyo3(signature = (hgvs_strings, return_exceptions=false))]
     fn project_many(
         &self,
         py: Python<'_>,
         hgvs_strings: Vec<String>,
-    ) -> PyResult<Vec<Vec<PyVariantProjection>>> {
-        // Capture the input index alongside the error so callers can isolate
-        // which entry in the batch failed; the underlying error is preserved
-        // unchanged after the `input[i]:` prefix.
-        let result: Result<Vec<Vec<_>>, (usize, crate::error::FerroError)> = py.detach(|| {
-            hgvs_strings
-                .iter()
-                .enumerate()
-                .map(|(i, s)| self.inner.project_all(s).map_err(|e| (i, e)))
-                .collect()
-        });
-        result
-            .map(|outer| {
-                outer
-                    .into_iter()
-                    .map(|projections| {
-                        projections
-                            .into_iter()
-                            .map(|inner| PyVariantProjection { inner })
-                            .collect()
-                    })
-                    .collect()
-            })
-            .map_err(|(i, e)| {
-                ferro_typed(
-                    "ProjectionError",
-                    format!("Projection error at input[{i}]: {e}"),
-                    &e,
-                )
-            })
+        return_exceptions: bool,
+    ) -> PyResult<Vec<Py<PyAny>>> {
+        // Project one input, wrapping its results and carrying the index on
+        // error so the `input[i]:` prefix can pinpoint the failing entry.
+        let project = |(i, s): (usize, &String)| {
+            self.inner
+                .project_all(s)
+                .map(wrap_projections)
+                .map_err(|e| (i, e))
+        };
+        if return_exceptions {
+            // Isolation mode: compute EVERY input (no short-circuit) so each
+            // failure can be surfaced in place.
+            let raw = py.detach(|| hgvs_strings.iter().enumerate().map(project).collect());
+            build_isolated_batch(py, raw)
+        } else {
+            // Fail-fast default: collect into a `Result`, which short-circuits
+            // at the first failing input — later inputs are never projected.
+            let outer: Result<Vec<_>, _> =
+                py.detach(|| hgvs_strings.iter().enumerate().map(project).collect());
+            projections_to_pylist(py, outer.map_err(|(i, e)| projection_error_at(i, &e))?)
+        }
     }
 
     /// Batched `project_normalized_all` over a list of already-normalized g.
@@ -1556,47 +1606,43 @@ impl PyVariantProjector {
     ///
     /// Args:
     ///     variants: List of HgvsVariant objects (must already be normalized).
+    ///     return_exceptions: When ``False`` (default) the first failing input
+    ///         aborts the batch by raising ``ProjectionError``. When ``True``
+    ///         nothing is raised: each output element is either that input's
+    ///         list of projections or the ``ProjectionError`` for its failure.
     ///
     /// Returns:
-    ///     List of result lists, one per input.
+    ///     List of result lists, one per input. With ``return_exceptions=True``
+    ///     an element may instead be the ``ProjectionError`` for that input.
     ///
     /// Raises:
-    ///     RuntimeError: On the first projection error.
+    ///     ProjectionError: On the first projection error, unless
+    ///         ``return_exceptions=True`` (then failures are returned in place).
+    #[pyo3(signature = (variants, return_exceptions=false))]
     fn project_normalized_many(
         &self,
         py: Python<'_>,
         variants: Vec<PyHgvsVariant>,
-    ) -> PyResult<Vec<Vec<PyVariantProjection>>> {
+        return_exceptions: bool,
+    ) -> PyResult<Vec<Py<PyAny>>> {
         let inner_variants: Vec<HgvsVariant> = variants.into_iter().map(|v| v.inner).collect();
-        // Capture the input index alongside the error so callers can isolate
-        // which entry in the batch failed; the underlying error is preserved
-        // unchanged after the `input[i]:` prefix.
-        let result: Result<Vec<Vec<_>>, (usize, crate::error::FerroError)> = py.detach(|| {
-            inner_variants
-                .iter()
-                .enumerate()
-                .map(|(i, v)| self.inner.project_normalized_all(v).map_err(|e| (i, e)))
-                .collect()
-        });
-        result
-            .map(|outer| {
-                outer
-                    .into_iter()
-                    .map(|projections| {
-                        projections
-                            .into_iter()
-                            .map(|inner| PyVariantProjection { inner })
-                            .collect()
-                    })
-                    .collect()
-            })
-            .map_err(|(i, e)| {
-                ferro_typed(
-                    "ProjectionError",
-                    format!("Projection error at input[{i}]: {e}"),
-                    &e,
-                )
-            })
+        // Project one already-normalized input, carrying the index on error.
+        let project = |(i, v): (usize, &HgvsVariant)| {
+            self.inner
+                .project_normalized_all(v)
+                .map(wrap_projections)
+                .map_err(|e| (i, e))
+        };
+        if return_exceptions {
+            // Isolation mode: compute EVERY input so failures surface in place.
+            let raw = py.detach(|| inner_variants.iter().enumerate().map(project).collect());
+            build_isolated_batch(py, raw)
+        } else {
+            // Fail-fast default: short-circuit at the first failing input.
+            let outer: Result<Vec<_>, _> =
+                py.detach(|| inner_variants.iter().enumerate().map(project).collect());
+            projections_to_pylist(py, outer.map_err(|(i, e)| projection_error_at(i, &e))?)
+        }
     }
 }
 

--- a/tests/python/test_issue_1018_batch_error_isolation.py
+++ b/tests/python/test_issue_1018_batch_error_isolation.py
@@ -1,0 +1,141 @@
+"""Tests for issue #1018: batch error-isolation on the projector.
+
+``VariantProjector.project_many`` / ``project_normalized_many`` historically
+aborted the whole batch on the first bad input, raising ``ProjectionError`` and
+discarding every other result. The new ``return_exceptions=True`` mode (mirroring
+``asyncio.gather(return_exceptions=True)``) instead returns, per input and in
+order, either that input's list of projections or the ``ProjectionError``
+describing its failure — so one malformed variant no longer loses the batch.
+The default (``return_exceptions=False``) keeps the abort-and-raise behavior.
+"""
+
+import warnings
+
+import pytest
+
+import ferro_hgvs
+
+# A syntactically valid g. variant (projects to a possibly-empty list — a
+# success, not an error) and an unparseable string (fails inside project_all).
+GOOD = "NC_000017.11:g.50198002C>T"
+BAD = "totally not a variant"
+
+# A parseable coding variant: it is NOT a genomic variant, so the
+# already-normalized projection path (`project_normalized_all`) fails on it —
+# used to exercise the isolation/fail-fast branches of `project_normalized_many`.
+BAD_NORMALIZED = "NM_000088.3:c.4C>G"
+
+
+def _projector() -> ferro_hgvs.VariantProjector:
+    # Built-in test data has no genome; that emits a reduced-capability warning
+    # (deduplicated by Python's warning registry across the session, so it is
+    # not asserted here) and does not affect batch error-isolation semantics.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return ferro_hgvs.VariantProjector()
+
+
+class TestProjectManyDefault:
+    """The default keeps the historical abort-on-first-error behavior."""
+
+    def test_default_aborts_and_raises_on_bad_input(self) -> None:
+        proj = _projector()
+        with pytest.raises(ferro_hgvs.ProjectionError):
+            proj.project_many([GOOD, BAD, GOOD])
+
+    def test_default_returns_list_of_lists_when_all_good(self) -> None:
+        proj = _projector()
+        out = proj.project_many([GOOD, GOOD])
+        assert isinstance(out, list)
+        assert all(isinstance(inner, list) for inner in out)
+
+
+class TestProjectManyReturnExceptions:
+    """``return_exceptions=True`` isolates failures per input."""
+
+    def test_isolates_failures_in_order(self) -> None:
+        proj = _projector()
+        out = proj.project_many([GOOD, BAD, GOOD], return_exceptions=True)
+        assert len(out) == 3
+        assert isinstance(out[0], list)
+        assert isinstance(out[1], ferro_hgvs.ProjectionError)
+        assert isinstance(out[2], list)
+
+    def test_returned_exception_is_typed_and_backcompat(self) -> None:
+        proj = _projector()
+        out = proj.project_many([BAD], return_exceptions=True)
+        exc = out[0]
+        # Returned in place, not raised — but still a real ProjectionError, and
+        # still a RuntimeError so existing except-clauses recognize it.
+        assert isinstance(exc, ferro_hgvs.ProjectionError)
+        assert isinstance(exc, RuntimeError)
+        assert isinstance(exc, ferro_hgvs.FerroError)
+        assert "input[0]" in str(exc)
+
+    def test_returned_exception_preserves_structured_payload(self) -> None:
+        # Returning the typed object (rather than a stringified error) exists so
+        # the structured payload survives capture: mutalyzer_codes is a tuple and
+        # code is either a populated E#### string or None — never lost.
+        proj = _projector()
+        exc = proj.project_many([BAD], return_exceptions=True)[0]
+        assert isinstance(exc, ferro_hgvs.ProjectionError)
+        assert isinstance(exc.mutalyzer_codes, tuple)
+        assert exc.code is None or (isinstance(exc.code, str) and exc.code.startswith(("E", "W")))
+
+    def test_all_good_returns_no_exceptions(self) -> None:
+        proj = _projector()
+        out = proj.project_many([GOOD, GOOD], return_exceptions=True)
+        assert all(isinstance(inner, list) for inner in out)
+
+    def test_all_fail_batch_isolates_every_input(self) -> None:
+        proj = _projector()
+        out = proj.project_many([BAD, BAD, BAD], return_exceptions=True)
+        assert len(out) == 3
+        assert all(isinstance(item, ferro_hgvs.ProjectionError) for item in out)
+        # The index in each message tracks its position.
+        assert [f"input[{i}]" in str(item) for i, item in enumerate(out)] == [True, True, True]
+
+    def test_empty_batch_returns_empty_list(self) -> None:
+        proj = _projector()
+        assert proj.project_many([], return_exceptions=True) == []
+        assert proj.project_many([]) == []
+
+
+class TestProjectNormalizedManyReturnExceptions:
+    """The already-normalized variant path isolates failures the same way."""
+
+    def test_default_returns_list_of_lists(self) -> None:
+        proj = _projector()
+        variant = ferro_hgvs.parse(GOOD)
+        out = proj.project_normalized_many([variant])
+        assert isinstance(out, list)
+        assert all(isinstance(inner, list) for inner in out)
+
+    def test_return_exceptions_isolates(self) -> None:
+        proj = _projector()
+        variant = ferro_hgvs.parse(GOOD)
+        out = proj.project_normalized_many([variant], return_exceptions=True)
+        assert len(out) == 1
+        assert isinstance(out[0], list)
+
+    def test_return_exceptions_isolates_a_real_failure_in_order(self) -> None:
+        # Exercises the ERROR-capture branch of project_normalized_many (not just
+        # project_many): a coding variant cannot be projected as a genomic one, so
+        # its slot must hold a ProjectionError while the good slots stay lists.
+        proj = _projector()
+        good = ferro_hgvs.parse(GOOD)
+        bad = ferro_hgvs.parse(BAD_NORMALIZED)
+        out = proj.project_normalized_many([good, bad, good], return_exceptions=True)
+        assert len(out) == 3
+        assert isinstance(out[0], list)
+        assert isinstance(out[1], ferro_hgvs.ProjectionError)
+        assert "input[1]" in str(out[1])
+        assert isinstance(out[2], list)
+
+    def test_default_aborts_and_raises_on_bad_input(self) -> None:
+        # The fail-fast default must still raise on the normalized path.
+        proj = _projector()
+        good = ferro_hgvs.parse(GOOD)
+        bad = ferro_hgvs.parse(BAD_NORMALIZED)
+        with pytest.raises(ferro_hgvs.ProjectionError):
+            proj.project_normalized_many([good, bad])


### PR DESCRIPTION
Part of #1018.

`VariantProjector.project_many` / `project_normalized_many` aborted the whole batch on the first bad input — raising `ProjectionError` and discarding every other result. For fan-out workloads (thousands of variants) one malformed entry loses the entire run.

## What's new

Adds an opt-in **`return_exceptions`** parameter to both methods, mirroring `asyncio.gather(return_exceptions=True)`:

- **`return_exceptions=False`** (default) — unchanged: the first failing input raises `ProjectionError` and aborts, with the same runtime shape as before (`list[list[VariantProjection]]`).
- **`return_exceptions=True`** — nothing is raised. The result holds, per input and in order, either that input's `list[VariantProjection]` or the `ProjectionError` describing its failure. One bad variant no longer discards the rest.

`.pyi` `@overload`s type the return precisely per flag (`list[list[VariantProjection]]` vs `list[list[VariantProjection] | ProjectionError]`).

## Scope

`PyBatchProcessor` already isolates per-item errors via `BatchResult`, so only these two `VariantProjector` batch methods aborted; both are converted through a shared `build_isolated_batch` helper.

## Tests

`tests/python/test_issue_1018_batch_error_isolation.py`: default still raises on a bad input; `return_exceptions=True` isolates failures in order; the returned exception is a real `ProjectionError` (and a `RuntimeError`, for backcompat); all-good batches return no exceptions; the normalized path behaves the same. Full suite: 296 passed.

## Stacking

Stacked on #1019 (typed exceptions — `ProjectionError` comes from there) → #1017 → #1014 → `main`. Review the top commit only. PR C2 (projector/batch warning surface) will stack on this.
