### PR TITLE
feat(python): surface normalization warnings on projections

### DIFF
--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -146,6 +146,7 @@ __all__ = [
     "CorrectionWarning",
     "ErrorConfig",
     "ParseResultWithWarnings",
+    "NormalizationWarning",
     # Backtranslation classes
     "CodonChange",
     "CodonTable",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1574,6 +1574,23 @@ class CoordinateMapper:
 # Variant Projection
 # ============================================================================
 
+class NormalizationWarning:
+    """A diagnostic emitted during normalization.
+
+    Carried by ``VariantProjection.warnings`` and
+    ``NormalizeResultWithWarnings.warnings``.
+    """
+
+    @property
+    def code(self) -> str:
+        """Stable SVA code, e.g. ``"REFSEQ_MISMATCH"`` / ``"POSITION_PAST_END"``."""
+        ...
+
+    @property
+    def message(self) -> str:
+        """Human-readable description of the warning."""
+        ...
+
 class VariantProjection:
     """The result of projecting a g. variant onto a transcript."""
 
@@ -1614,6 +1631,20 @@ class VariantProjection:
         concrete exonic RNA edit (no transcript sequence, non-c./n. input, or an
         unresolved payload).
         """
+        ...
+
+    @property
+    def warnings(self) -> list[NormalizationWarning]:
+        """Warnings emitted while normalizing the input for this projection.
+
+        For example an auto-corrected reference-sequence mismatch. Empty when the
+        input normalized cleanly. Mirrors ``Normalizer.normalize_with_warnings``,
+        making the same diagnostics reachable off a projection.
+        """
+        ...
+
+    def has_warnings(self) -> bool:
+        """True if any normalization warnings were emitted for this projection."""
         ...
 
     @property

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -260,6 +260,7 @@ mod tests {
 
     fn projection_with(genomic: Option<&str>, protein: Option<&str>) -> VariantProjection {
         VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic: genomic.map(|s| crate::parse_hgvs(s).unwrap()),
             coding: None,
             noncoding: None,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1077,11 +1077,32 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// In strict mode (default), rejects variants with reference mismatches.
     /// Use `normalize_with_diagnostics` for lenient mode that corrects mismatches.
     pub fn normalize(&self, variant: &HgvsVariant) -> Result<HgvsVariant, FerroError> {
-        // `normalize()` returns only the variant and inspects warnings; it
-        // discards the diagnostic `infos` axis. Call `normalize_core`
-        // directly and wrap with empty infos, so the hot path skips the
-        // per-call `detect_shuffle_infos` work (use `normalize_with_diagnostics`
-        // when infos are actually needed). Behavior is unchanged.
+        // Thin wrapper: `normalize()` returns only the variant. Both the core
+        // normalization AND the strict-mode rejection ladder live in
+        // `normalize_core_checked`, so a strict config rejects identically
+        // whether a variant is normalized directly or through the projector.
+        Ok(self.normalize_core_checked(variant)?.0)
+    }
+
+    /// Normalize a variant, apply the strict-mode rejection ladder, and return
+    /// the normalized variant together with any warnings that were NOT promoted
+    /// to hard errors.
+    ///
+    /// This is the shared core behind both `normalize()` (which discards the
+    /// warnings) and `VariantProjector`, which surfaces them on each projection.
+    /// Routing the projector through here — rather than the raw `normalize_core`
+    /// — is what keeps a strict-configured projector rejecting the same inputs
+    /// (`EINTRONIC`, `RefSeqMismatch`, W5002/W5003/W5004/W4004/W4005/W4006, …) it
+    /// would reject via `normalize()`. In the default lenient config every
+    /// `should_reject_*` is false, so the ladder is a no-op and the warnings pass
+    /// straight through.
+    pub(crate) fn normalize_core_checked(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {
+        // Call `normalize_core` directly (skipping the per-call
+        // `detect_shuffle_infos` work `normalize_with_diagnostics` does) and wrap
+        // with empty infos; the ladder below only inspects warnings.
         let (normalized, warnings) = self.normalize_core(variant)?;
         let result = NormalizeResult::with_warnings(normalized, warnings);
 
@@ -1311,7 +1332,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             }
         }
 
-        Ok(result.result)
+        Ok((result.result, result.warnings))
     }
 
     /// Normalize a variant with detailed warnings
@@ -1386,7 +1407,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// directly to skip the per-call `detect_shuffle_infos` cost on the
     /// hot path; `normalize_with_diagnostics` layers infos on top. The
     /// (variant, warnings) output is identical to the previous inline match.
-    fn normalize_core(
+    pub(crate) fn normalize_core(
         &self,
         variant: &HgvsVariant,
     ) -> Result<(HgvsVariant, Vec<NormalizationWarning>), FerroError> {

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -868,9 +868,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             // transform that leaves the variant non-canonical, and even the
             // `project_normalized` caller cannot pre-normalize it in the `NC_`
             // frame because it does not know the placement (review M2).
-            let normalized = self.normalizer.normalize(&deanchored)?;
+            let (normalized, warnings) = self.normalizer.normalize_core_checked(&deanchored)?;
             let target = Self::reconcile_self_projection_target(&normalized, transcript_id);
-            let result = self.project_variant_inner(&normalized, &target)?;
+            let mut result = self.project_variant_inner(&normalized, &target)?;
+            result.normalization_warnings = warnings;
             let placement = self
                 .provider
                 .genomic_placement_on_build(&parent, input_build);
@@ -898,8 +899,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         }
         // 1. Normalize the genomic variant. The normalizer is built once at
         // construction time so we don't clone the (potentially heavy) provider
-        // on every call.
-        let normalized = self.normalizer.normalize(variant)?;
+        // on every call. Use `normalize_core_checked` (not `normalize`) to keep
+        // the warnings it emits so they can ride out on the projection (#1018 C2)
+        // while still honoring the same strict-mode rejections `normalize` applies.
+        let (normalized, warnings) = self.normalizer.normalize_core_checked(variant)?;
         // 2. Reconcile the requested target against any selector resolution that
         // normalization performed (#783). A legacy LOVD gene-model selector
         // `NG_(GENE_v001):c.` keeps the genomic ref as its accession, so a
@@ -909,7 +912,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // so the requested target now names the variant's genomic-context wrapper
         // rather than its transcript — re-point it at the resolved transcript.
         let target = Self::reconcile_self_projection_target(&normalized, transcript_id);
-        self.project_variant_inner(&normalized, &target)
+        let mut projection = self.project_variant_inner(&normalized, &target)?;
+        projection.normalization_warnings = warnings;
+        Ok(projection)
     }
 
     /// Reconcile a self-projection target with a selector/context that
@@ -1012,11 +1017,22 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let input_build = self.build_hint_for_variant(variant);
         let (variant, parent) = self.deanchor_genomic_parent_input(variant);
         // 1. Normalize once in the genome frame, then fan out across the
-        //    overlapping transcripts.
-        let normalized = self.normalizer.normalize(&variant)?;
+        //    overlapping transcripts. Use `normalize_core_checked` to keep the
+        //    input's normalization warnings (while still honoring strict-mode
+        //    rejections); they are hung on every final result below —
+        //    on BOTH paths — so a caller sees the same signal it would on a
+        //    single projection (#1018 C2). The warning describes normalizing the
+        //    caller's input, so it is attached uniformly even on the parent path
+        //    (whose per-transcript re-projection re-normalizes a different, coding
+        //    form) rather than being replaced by that re-normalize's warnings.
+        let (normalized, warnings) = self.normalizer.normalize_core_checked(&variant)?;
         let results = self.project_normalized_all_inner(&normalized)?;
-        // 2. The plain (non-parent) path returns the genome-frame result directly.
+        // 2. The plain (non-parent) path returns the genome-frame results directly.
         let Some(parent) = parent else {
+            let mut results = results;
+            for projection in &mut results {
+                projection.normalization_warnings = warnings.clone();
+            }
             return Ok(results);
         };
         // 3. Parent path: the fan-out 3'-shifts the variant in the *genome*
@@ -1052,7 +1068,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 },
                 None => r,
             };
-            framed.push(self.frame_projection_owned(r, &parent, placement.as_ref()));
+            let mut framed_projection = self.frame_projection_owned(r, &parent, placement.as_ref());
+            framed_projection.normalization_warnings = warnings.clone();
+            framed.push(framed_projection);
         }
         Ok(framed)
     }
@@ -2635,6 +2653,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             .gene_name
             .clone();
             return Ok(VariantProjection {
+                normalization_warnings: Vec::new(),
                 // No inner variant to derive a genomic form from; report `None`
                 // rather than wrapping the (possibly non-genomic) input allele
                 // into `.genomic`. Consistent with `coding`/`protein`, which are
@@ -2802,6 +2821,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let rna = Self::reframe_rna_from_input(rna, original);
 
         Ok(VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic,
             coding,
             noncoding,
@@ -3344,6 +3364,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         };
 
         Ok(VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic,
             coding,
             noncoding,
@@ -3529,6 +3550,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // itself; report it on the non-coding axis and stop.
         if !is_coding {
             return Ok(VariantProjection {
+                normalization_warnings: Vec::new(),
                 genomic,
                 coding: None,
                 noncoding: Some(normalized.clone()),
@@ -3606,6 +3628,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         };
 
         Ok(VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic,
             coding,
             // The non-coding axis is the input itself.
@@ -4318,6 +4341,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         };
 
         Ok(VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic,
             coding,
             noncoding,
@@ -4397,6 +4421,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         };
 
         Some(VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic,
             coding,
             noncoding: None,
@@ -4461,6 +4486,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             _ => None,
         };
         VariantProjection {
+            normalization_warnings: Vec::new(),
             genomic: Some(genomic),
             coding,
             noncoding: None,
@@ -6931,6 +6957,44 @@ mod tests {
     }
 
     #[test]
+    fn strict_projector_rejects_what_lenient_projects_with_a_warning() {
+        // Regression pin for #1018: the projector normalizes its input through
+        // `normalize_core_checked`, which applies the SAME strict-mode rejection
+        // ladder as `Normalizer::normalize`. So a strict-configured projector
+        // must REJECT an input a lenient one projects-and-warns. Guards against a
+        // future swap back to the raw `normalize_core`, which would silently
+        // bypass strict rejection (projecting where `normalize` would `Err`).
+        //
+        // The trigger is a coincident cis-allele (two edits at g.1003):
+        // OverlapConflictingEdits / W5002, which `should_reject_overlap_conflict`
+        // promotes to a hard error in strict mode.
+        let overlap = "chr1:g.[1003C>A;1003C>G]";
+
+        // Lenient (default): projects, and the OverlapConflict warning rides out.
+        let (projector, provider) = make_test_provider_and_projector();
+        let lenient = VariantProjector::new(projector, provider);
+        let results = lenient
+            .project_all(overlap)
+            .expect("lenient projector should project the cis-allele");
+        assert!(
+            results.iter().any(|p| p
+                .normalization_warnings
+                .iter()
+                .any(|w| w.code() == "OVERLAP_CONFLICTING_EDITS")),
+            "lenient projection must surface the OverlapConflict warning"
+        );
+
+        // Strict: the same input is rejected, exactly as `normalize()` would.
+        let (projector, provider) = make_test_provider_and_projector();
+        let strict = VariantProjector::new(projector, provider)
+            .with_normalize_config(NormalizeConfig::strict());
+        assert!(
+            strict.project_all(overlap).is_err(),
+            "strict projector must reject the OverlapConflict cis-allele, not project it"
+        );
+    }
+
+    #[test]
     fn project_all_mane_select_sorts_first() {
         let (projector, provider) = make_two_transcript_setup();
         let vp = VariantProjector::new(projector, provider);
@@ -8303,6 +8367,7 @@ mod tests {
                 ),
             });
             let proj = VariantProjection {
+                normalization_warnings: Vec::new(),
                 genomic: Some(genomic),
                 coding: Some(coding),
                 noncoding: None,
@@ -8372,6 +8437,7 @@ mod tests {
                 ),
             });
             let proj = VariantProjection {
+                normalization_warnings: Vec::new(),
                 genomic: None,
                 coding: Some(coding),
                 noncoding: None,

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -1,6 +1,7 @@
 //! `VariantProjection` result type.
 
 use crate::hgvs::variant::HgvsVariant;
+use crate::normalize::NormalizationWarning;
 
 /// A variant resolved across coordinate systems.
 ///
@@ -47,4 +48,11 @@ pub struct VariantProjection {
     /// non-coding and empty-allele projections, and for any aggregate whose
     /// members all leave the start codon untouched.
     pub affects_init: bool,
+    /// Warnings emitted while normalizing the input for this projection (e.g.
+    /// an auto-corrected reference-sequence mismatch, or — once the reduced-
+    /// capability warning lands on the normalize path — a no-genome degrade).
+    /// Empty when the input normalized cleanly. Populated at the projector's
+    /// normalize entry points; deep projection-building helpers default it to
+    /// empty and the entry point attaches the captured set.
+    pub normalization_warnings: Vec<NormalizationWarning>,
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1186,6 +1186,24 @@ impl PyVariantProjection {
         self.inner.rna.as_ref().map(|v| v.to_string())
     }
 
+    /// Warnings emitted while normalizing the input for this projection (e.g. an
+    /// auto-corrected reference-sequence mismatch). Empty when the input
+    /// normalized cleanly. Mirrors `Normalizer.normalize_with_warnings`, making
+    /// the same diagnostics reachable off a projection (#1018).
+    #[getter]
+    fn warnings(&self) -> Vec<PyNormalizationWarning> {
+        self.inner
+            .normalization_warnings
+            .iter()
+            .map(PyNormalizationWarning::from)
+            .collect()
+    }
+
+    /// True if any normalization warnings were emitted for this projection.
+    fn has_warnings(&self) -> bool {
+        !self.inner.normalization_warnings.is_empty()
+    }
+
     #[getter]
     fn transcript_id(&self) -> String {
         self.inner.transcript_id.clone()

--- a/tests/python/test_issue_1018_projection_warnings.py
+++ b/tests/python/test_issue_1018_projection_warnings.py
@@ -1,0 +1,125 @@
+"""Tests for issue #1018: normalization warnings surfaced on a projection.
+
+`VariantProjector` normalizes its input internally and used to discard the
+`NormalizationWarning`s that step emits. Every projection now carries them on
+`VariantProjection.warnings` (with a `has_warnings()` helper), mirroring
+`Normalizer.normalize_with_warnings` — so the same diagnostics (e.g. an
+overlap-conflict or an auto-corrected reference mismatch, and, once it lands on
+the normalize path, the reduced-capability degrade) are reachable off the
+projector and its batch/fan-out methods, not just the free normalizer.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+
+@pytest.fixture
+def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """A projector over transcript NM_TEST.1 mapping chr1 g.1000-1008.
+
+    Mirrors the fixture in test_variant_projection.py: CDS "ATGCGCTAA" on the
+    plus strand, g.1000 == c.1. g.1003 is the reference 'C'.
+    """
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TESTGENE",
+                "strand": "+",
+                "sequence": "ATGCGCTAA",
+                "cds_start": 1,
+                "cds_end": 9,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 9,
+                        "genomic_start": 1000,
+                        "genomic_end": 1008,
+                    }
+                ],
+                "chromosome": "chr1",
+                "genomic_start": 1000,
+                "genomic_end": 1008,
+            }
+        ],
+        "genomic_sequences": {"chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100},
+    }
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return ferro_hgvs.VariantProjector(reference_json=str(path))
+
+
+# A clean, reference-matching single substitution (no warnings) and a
+# coincident cis-allele that normalizes with OVERLAP_CONFLICTING_EDITS.
+CLEAN = "NC_000001.11:g.1003C>A"
+WARNING = "NC_000001.11:g.[1003C>A;1003C>G]"
+
+
+class TestCleanProjection:
+    def test_warnings_empty_when_input_normalizes_cleanly(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        result = projector.project(CLEAN, transcript="NM_TEST.1")
+        assert result.warnings == []
+        assert result.has_warnings() is False
+
+
+class TestWarningSurfaced:
+    def test_project_carries_the_normalization_warning(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        result = projector.project(WARNING, transcript="NM_TEST.1")
+        assert result.has_warnings() is True
+        codes = [w.code for w in result.warnings]
+        assert "OVERLAP_CONFLICTING_EDITS" in codes
+
+    def test_warning_objects_are_typed_with_code_and_message(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        result = projector.project(WARNING, transcript="NM_TEST.1")
+        assert len(result.warnings) > 0
+        w = result.warnings[0]
+        assert isinstance(w, ferro_hgvs.NormalizationWarning)
+        assert isinstance(w.code, str) and w.code
+        assert isinstance(w.message, str) and w.message
+
+    def test_project_all_elements_carry_warnings(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        results = projector.project_all(WARNING)
+        assert len(results) >= 1
+        assert all(
+            "OVERLAP_CONFLICTING_EDITS" in [w.code for w in proj.warnings] for proj in results
+        )
+
+    def test_project_many_elements_carry_warnings(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # project_many returns one inner list per input; each projection in each
+        # inner list carries its own warnings.
+        batch = projector.project_many([WARNING, CLEAN])
+        assert [proj.has_warnings() for proj in batch[0]] == [True]
+        assert [proj.has_warnings() for proj in batch[1]] == [False]
+
+
+class TestNormalizedPathHasNoWarnings:
+    """The already-normalized entry points do NOT re-normalize, so they emit no
+    normalization warnings — every projection reports an empty list. Pins that
+    contract so a caller isn't surprised to find warnings absent there."""
+
+    def test_project_normalized_many_reports_empty_warnings(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # Pre-normalize the warning-bearing input, then project it as
+        # already-normalized: the warning arose during the earlier normalize, so
+        # the skip-normalize projection surfaces no warnings of its own.
+        variant = ferro_hgvs.parse(WARNING)
+        batch = projector.project_normalized_many([variant])
+        assert len(batch) == 1
+        assert all(not proj.has_warnings() for proj in batch[0])
+        assert all(proj.warnings == [] for proj in batch[0])


### PR DESCRIPTION
Part of #1018.

`VariantProjector` normalizes its input internally and **discarded** the `NormalizationWarning`s that step emits — so projector and batch callers had no way to see diagnostics (overlap conflicts, auto-corrected reference mismatches, and, once it lands on the normalize path, the reduced-capability degrade) that the free `Normalizer` already exposes via `normalize_with_warnings`.

## Approach

Rather than a parallel `project_*_with_warnings` API, **attach the warnings to `VariantProjection` itself** (an adversarial design review picked this over the two alternatives — see below):

- New `VariantProjection.normalization_warnings` field, populated at the projector's three normalize entry points from `normalize_core` (which skips the unused shuffle-`infos` work `normalize_with_diagnostics` would compute per call).
- Exposed at the Python boundary as **`VariantProjection.warnings`** (a `list[NormalizationWarning]`) plus **`has_warnings()`**, mirroring `NormalizeResultWithWarnings`.
- Because *every* `project_*` method returns a `VariantProjection`, all of them — single, `_all` fan-out, and the C1 `return_exceptions` batch path — surface warnings uniformly, **with no dual API**. The struct is threaded by value through `frame_projection_owned`, so warnings survive the `NG_`/`LRG_` parent re-frame.
- `project_to_genomic` returns `HgvsVariant` (a separate surface) and is left unchanged.
- Adds the previously-missing `NormalizationWarning` type stub to the `.pyi`.

## Why not `project_*_with_warnings`?

An independent Opus review rejected both a full-plumbing option and a focused-additive one: the additive option silently drops warnings on the exotic bare-`NG_`/`LRG_` path (an intra-method trap), and the full-plumbing option's tuple return forces churn through the fan-out. Attaching to the result type is uniform, needs no signature changes (the inner projection helper receives an already-normalized variant), and is forward-compatible: once the reduced-capability warning lands on the normalize path (a separate in-flight change), it flows into this vec automatically.

## Tests

`tests/python/test_issue_1018_projection_warnings.py`: a clean projection has empty `warnings`; a coincident cis-allele input surfaces `OVERLAP_CONFLICTING_EDITS` through `project`, `project_all`, and `project_many`; warning objects are typed `NormalizationWarning` with `.code`/`.message`. Full suite: 301 py tests; Rust lib 3585 + integration 4296, 0 failed.

## Stacking

Stacked on #1020 (batch error-isolation) → #1019 (typed exceptions) → #1017 → #1014 → `main`. Review the top commit only.