### PR TITLE
feat(python): value equality on projections/effects, idempotency tests, typed-Raises docs

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -20,7 +20,8 @@ def parse(hgvs_string: str) -> HgvsVariant:
         A HgvsVariant object representing the parsed variant
 
     Raises:
-        ValueError: If the HGVS string cannot be parsed
+        ParseError: If the HGVS string cannot be parsed (a subclass of
+            ValueError, so ``except ValueError`` still catches it).
 
     Example:
         >>> variant = parse("NM_000088.3:c.100A>G")
@@ -40,9 +41,11 @@ def normalize(hgvs_string: str, direction: str = "3prime") -> str:
         The normalized HGVS string
 
     Raises:
-        ValueError: If the HGVS string cannot be parsed, or if ``direction`` is
-            not one of "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive)
-        RuntimeError: If normalization fails
+        ParseError: If the HGVS string cannot be parsed (a subclass of
+            ValueError).
+        ValueError: If ``direction`` is not one of
+            "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+        NormalizationError: If normalization fails (a subclass of RuntimeError).
 
     Example:
         >>> normalize("NM_000088.3:c.100delA")
@@ -64,7 +67,8 @@ def parse_spdi(spdi_string: str) -> SpdiVariant:
         A SpdiVariant object representing the parsed variant
 
     Raises:
-        ValueError: If the SPDI string cannot be parsed
+        ParseError: If the SPDI string cannot be parsed (a subclass of
+            ValueError).
     """
     ...
 
@@ -78,7 +82,8 @@ def hgvs_to_spdi(variant: HgvsVariant) -> SpdiVariant:
         A SpdiVariant object
 
     Raises:
-        ValueError: If the conversion fails
+        ProjectionError: If the conversion fails (a subclass of ValueError and
+            RuntimeError).
     """
     ...
 
@@ -92,7 +97,8 @@ def spdi_to_hgvs_variant(spdi: SpdiVariant) -> HgvsVariant:
         An HgvsVariant object
 
     Raises:
-        ValueError: If the conversion fails
+        ProjectionError: If the conversion fails (a subclass of ValueError and
+            RuntimeError).
     """
     ...
 
@@ -123,7 +129,8 @@ def parse_mave_hgvs_variant(hgvs_string: str, context: MaveContext) -> HgvsVaria
         A HgvsVariant object with the accession filled in from context
 
     Raises:
-        ValueError: If parsing fails or context doesn't support the coordinate type
+        ParseError: If parsing fails or the context doesn't support the
+            coordinate type (a subclass of ValueError).
     """
     ...
 
@@ -153,7 +160,8 @@ def parse_lenient(hgvs_string: str, config: ErrorConfig | None = None) -> ParseR
         ParseResultWithWarnings containing the parsed variant and any warnings
 
     Raises:
-        ValueError: If the HGVS string cannot be parsed even after corrections
+        ParseError: If the HGVS string cannot be parsed even after corrections
+            (a subclass of ValueError).
     """
     ...
 
@@ -171,7 +179,7 @@ def parse_rsid_value(rsid: str) -> int:
         Numeric rsID value
 
     Raises:
-        ValueError: If the rsID cannot be parsed
+        ParseError: If the rsID cannot be parsed (a subclass of ValueError).
     """
     ...
 
@@ -201,7 +209,8 @@ def vcf_to_genomic_hgvs(record: VcfRecord, alt_index: int = 0) -> HgvsVariant:
         HgvsVariant object
 
     Raises:
-        ValueError: If conversion fails
+        ProjectionError: If conversion fails (a subclass of ValueError and
+            RuntimeError).
     """
     ...
 
@@ -219,7 +228,8 @@ def prepare_reference_data(config: PrepareConfig) -> ReferenceManifest:
         ReferenceManifest describing the prepared data
 
     Raises:
-        RuntimeError: If preparation fails
+        ReferenceDataError: If preparation fails (a subclass of RuntimeError and
+            ValueError).
     """
     ...
 
@@ -233,7 +243,8 @@ def check_reference_data(directory: str) -> ReferenceManifest:
         ReferenceManifest if manifest.json exists
 
     Raises:
-        RuntimeError: If check fails
+        ReferenceDataError: If check fails (a subclass of RuntimeError and
+            ValueError).
     """
     ...
 
@@ -453,7 +464,8 @@ class Normalizer:
         Raises:
             ValueError: If ``direction`` is not one of
                 "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
-            RuntimeError: If the manifest cannot be loaded.
+            ReferenceDataError: If the manifest cannot be loaded (a subclass of
+                RuntimeError and ValueError).
         """
         ...
 
@@ -701,7 +713,8 @@ class EquivalenceChecker:
             An EquivalenceChecker backed by a MultiFastaProvider.
 
         Raises:
-            RuntimeError: If the manifest cannot be loaded.
+            ReferenceDataError: If the manifest cannot be loaded (a subclass of
+                RuntimeError and ValueError).
         """
         ...
 
@@ -728,11 +741,21 @@ class EquivalenceChecker:
         ...
 
     def check(self, v1: HgvsVariant, v2: HgvsVariant) -> EquivalenceResult:
-        """Check if two variants are equivalent."""
+        """Check if two variants are equivalent.
+
+        Raises:
+            EquivalenceError: If the check fails, e.g. an input cannot be
+                normalized (a subclass of RuntimeError).
+        """
         ...
 
     def all_equivalent(self, variants: list[HgvsVariant]) -> bool:
-        """Check if multiple variants are all equivalent to each other."""
+        """Check if multiple variants are all equivalent to each other.
+
+        Raises:
+            EquivalenceError: If the check fails, e.g. an input cannot be
+                normalized (a subclass of RuntimeError).
+        """
         ...
 
 # ============================================================================
@@ -806,6 +829,9 @@ class ProteinEffect:
     def is_protein_altering(self) -> bool:
         """Check if this is a protein-altering variant."""
         ...
+
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
 
 class EffectPredictor:
     """Protein effect predictor."""
@@ -960,7 +986,8 @@ class BatchProcessor:
             A BatchProcessor backed by a MultiFastaProvider.
 
         Raises:
-            RuntimeError: If the manifest cannot be loaded.
+            ReferenceDataError: If the manifest cannot be loaded (a subclass of
+                RuntimeError and ValueError).
         """
         ...
 
@@ -1418,7 +1445,8 @@ class CoordinateMapper:
             A CoordinateMapper backed by a MultiFastaProvider.
 
         Raises:
-            RuntimeError: If the manifest cannot be loaded.
+            ReferenceDataError: If the manifest cannot be loaded (a subclass of
+                RuntimeError and ValueError).
         """
         ...
 
@@ -1460,7 +1488,9 @@ class CoordinateMapper:
             without offset support
 
         Raises:
-            ValueError: If transcript not found or has no genomic coordinates
+            ReferenceDataError: If the transcript is not found.
+            ProjectionError: If it has no genomic coordinates (both subclass
+                ValueError).
         """
         ...
 
@@ -1477,8 +1507,9 @@ class CoordinateMapper:
             the distance from the nearest exon boundary.
 
         Raises:
-            ValueError: If transcript not found, position is outside transcript bounds,
-                or conversion fails
+            ReferenceDataError: If the transcript is not found.
+            ProjectionError: If the position is outside transcript bounds or
+                conversion fails (both subclass ValueError).
         """
         ...
 
@@ -1493,7 +1524,9 @@ class CoordinateMapper:
             Protein position (1-based codon number)
 
         Raises:
-            ValueError: If transcript not found or position is in UTR/intronic
+            ReferenceDataError: If the transcript is not found.
+            ProjectionError: If the position is in a UTR or intron (both
+                subclass ValueError).
         """
         ...
 
@@ -1516,7 +1549,8 @@ class CoordinateMapper:
             Tuple of (transcript_position, offset)
 
         Raises:
-            ValueError: If transcript not found
+            ReferenceDataError: If the transcript is not found (a subclass of
+                ValueError).
         """
         ...
 
@@ -1540,7 +1574,8 @@ class CoordinateMapper:
             Tuple of (cds_position, offset, is_utr3)
 
         Raises:
-            ValueError: If transcript not found or has no CDS
+            ReferenceDataError: If the transcript is not found.
+            ProjectionError: If it has no CDS (both subclass ValueError).
         """
         ...
 
@@ -1672,6 +1707,9 @@ class VariantProjection:
         """True if the variant falls in a UTR."""
         ...
 
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+
 class VariantProjector:
     """Projects g. HGVS variants onto transcripts to produce c./p. equivalents."""
 
@@ -1734,7 +1772,8 @@ class VariantProjector:
             VariantProjection with g./c./p. representations and flags.
 
         Raises:
-            RuntimeError: If parsing or projection fails.
+            ProjectionError: If parsing or projection fails (a subclass of
+                ValueError and RuntimeError).
         """
         ...
 
@@ -1757,7 +1796,8 @@ class VariantProjector:
             Empty list when no transcripts overlap the variant.
 
         Raises:
-            RuntimeError: If parsing or normalization fails.
+            ProjectionError: If parsing or normalization fails (a subclass of
+                ValueError and RuntimeError).
         """
         ...
 
@@ -1777,7 +1817,8 @@ class VariantProjector:
             VariantProjection with g./c./p. representations and flags.
 
         Raises:
-            RuntimeError: If normalization or projection fails.
+            ProjectionError: If normalization or projection fails (a subclass of
+                ValueError and RuntimeError).
         """
         ...
 
@@ -1795,7 +1836,8 @@ class VariantProjector:
             Empty list when no transcripts overlap the variant.
 
         Raises:
-            RuntimeError: If normalization or projection fails.
+            ProjectionError: If normalization or projection fails (a subclass of
+                ValueError and RuntimeError).
         """
         ...
 
@@ -1816,7 +1858,8 @@ class VariantProjector:
             VariantProjection with g./c./p. representations and flags.
 
         Raises:
-            RuntimeError: If projection fails.
+            ProjectionError: If projection fails (a subclass of ValueError and
+                RuntimeError).
         """
         ...
 
@@ -1839,7 +1882,8 @@ class VariantProjector:
             Empty list when no transcripts overlap the variant.
 
         Raises:
-            RuntimeError: If projection fails.
+            ProjectionError: If projection fails (a subclass of ValueError and
+                RuntimeError).
         """
         ...
 
@@ -1914,8 +1958,9 @@ class VariantProjector:
             The Genome-kind HgvsVariant for the requested projection.
 
         Raises:
-            RuntimeError: If the input lacks a parent reference, carries an
-                unknown (`?`) position, or is otherwise unsupported.
+            ProjectionError: If the input lacks a parent reference, carries an
+                unknown (`?`) position, or is otherwise unsupported (a subclass
+                of ValueError and RuntimeError).
         """
         ...
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -1240,6 +1240,28 @@ impl PyVariantProjection {
             self.transcript_id()
         )
     }
+
+    /// Value equality over the full projection contents (all projected axes,
+    /// flags, and normalization warnings), so projections compare by value
+    /// rather than identity.
+    ///
+    /// The canonical key is the inner value's `Debug` rendering: it is complete
+    /// and deterministic within a build, and avoids deriving `Eq`/`Hash` on the
+    /// whole `VariantProjection` — which would cascade onto types that do not
+    /// currently need them (`NormalizationWarning`). The same `Debug`-key
+    /// approach is used for `ProteinEffect`, whose `AminoAcidChange` field is
+    /// likewise not `Eq`.
+    fn __eq__(&self, other: &Self) -> bool {
+        format!("{:?}", self.inner) == format!("{:?}", other.inner)
+    }
+
+    /// Hash consistent with `__eq__`, making projections usable as dict keys and
+    /// set members.
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        format!("{:?}", self.inner).hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 #[pyclass(name = "VariantProjector")]
@@ -2506,6 +2528,25 @@ impl PyProteinEffect {
                 .map(|c| c.so_term())
                 .collect::<Vec<_>>()
         )
+    }
+
+    /// Value equality over the full effect (consequences, impact, amino-acid
+    /// change, and intronic offset), so effects compare by value.
+    ///
+    /// Uses the inner value's `Debug` rendering as the canonical key (see
+    /// `VariantProjection.__eq__`): the `AminoAcidChange` field is not `Eq`, so
+    /// a `Debug`-key avoids cascading `Eq`/`Hash` derives while staying
+    /// deterministic within a build.
+    fn __eq__(&self, other: &Self) -> bool {
+        format!("{:?}", self.inner) == format!("{:?}", other.inner)
+    }
+
+    /// Hash consistent with `__eq__`, making effects usable as dict keys and set
+    /// members.
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        format!("{:?}", self.inner).hash(&mut hasher);
+        hasher.finish()
     }
 }
 

--- a/tests/python/test_issue_1018_value_semantics.py
+++ b/tests/python/test_issue_1018_value_semantics.py
@@ -1,0 +1,172 @@
+"""Tests for issue #1018 (P3 polish): parse idempotency + value equality.
+
+Two things:
+
+* A round-trip/idempotency property mirroring the Rust idempotency suite:
+  ``parse(str(parse(x))) == parse(x)`` for a corpus of variants across axes.
+* ``__eq__`` / ``__hash__`` on the value types that lacked them
+  (``VariantProjection``, ``ProteinEffect``), so projection/effect results are
+  usable as ``dict`` keys and ``set`` members — matching ``HgvsVariant`` and
+  ``SpdiVariant`` which already compared by value.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+CORPUS = [
+    "NM_000088.3:c.459A>G",
+    "NC_000001.11:g.1000A>T",
+    "NM_000088.3:c.100_102del",
+    "NM_000088.3:c.100dup",
+    "NP_000079.2:p.Gly100Ala",
+    "NM_000088.3:c.100+5G>A",
+    "NR_003051.3:n.100A>G",
+]
+
+
+class TestParseIdempotency:
+    """``parse(str(parse(x))) == parse(x)`` — re-parsing a rendered variant is a
+    fixed point, by value and by hash."""
+
+    @pytest.mark.parametrize("variant", CORPUS)
+    def test_roundtrip_is_a_fixed_point(self, variant: str) -> None:
+        once = ferro_hgvs.parse(variant)
+        twice = ferro_hgvs.parse(str(once))
+        assert once == twice
+        assert hash(once) == hash(twice)
+
+    def test_hgvs_variant_is_set_usable(self) -> None:
+        variants = [ferro_hgvs.parse(v) for v in CORPUS]
+        # Each parsed once and again; the set collapses the duplicates.
+        again = [ferro_hgvs.parse(str(v)) for v in variants]
+        assert len(set(variants + again)) == len(CORPUS)
+
+
+class TestCrossTypeEqualityDoesNotRaise:
+    """`__eq__` against `None` or an unrelated type must return `False`, never
+    raise. This rests on PyO3 returning `NotImplemented` when the argument
+    cannot be extracted to `&Self`; pin it so a future switch to an explicit
+    `__richcmp__` that forgets the mismatch case is caught."""
+
+    def test_hgvs_variant_cross_type(self) -> None:
+        v = ferro_hgvs.parse("NM_000088.3:c.459A>G")
+        assert (v == None) is False  # noqa: E711 — testing == against None, not `is`
+        assert v != "NM_000088.3:c.459A>G"
+        assert (v == 5) is False
+
+    def test_protein_effect_cross_type(self) -> None:
+        effect = ferro_hgvs.EffectPredictor().classify_indel(3, 0)
+        assert (effect == None) is False  # noqa: E711
+        assert effect != "frameshift"
+        assert (effect == 5) is False
+
+    def test_projection_cross_type(self, projector: ferro_hgvs.VariantProjector) -> None:
+        proj = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        assert (proj == None) is False  # noqa: E711
+        assert proj != "NM_TEST.1"
+        assert (proj == 5) is False
+        # A projection and an effect are different types → not equal, no raise.
+        effect = ferro_hgvs.EffectPredictor().classify_indel(3, 0)
+        assert proj != effect
+
+
+class TestProteinEffectValueSemantics:
+    """``ProteinEffect`` compares and hashes by value."""
+
+    def test_equal_effects_are_equal_and_hash_equal(self) -> None:
+        predictor = ferro_hgvs.EffectPredictor()
+        a = predictor.classify_indel(3, 0)
+        b = predictor.classify_indel(3, 0)
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_distinct_effects_differ(self) -> None:
+        predictor = ferro_hgvs.EffectPredictor()
+        inframe = predictor.classify_indel(3, 0)
+        frameshift = predictor.classify_indel(1, 0)
+        assert inframe != frameshift
+
+    def test_effect_is_set_usable(self) -> None:
+        predictor = ferro_hgvs.EffectPredictor()
+        effects = [
+            predictor.classify_indel(3, 0),
+            predictor.classify_indel(3, 0),
+            predictor.classify_indel(1, 0),
+        ]
+        assert len(set(effects)) == 2
+
+
+@pytest.fixture
+def projector(tmp_path: Path) -> ferro_hgvs.VariantProjector:
+    """Projector over NM_TEST.1 (chr1 g.1000-1008, CDS 'ATGCGCTAA', + strand)."""
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TESTGENE",
+                "strand": "+",
+                "sequence": "ATGCGCTAA",
+                "cds_start": 1,
+                "cds_end": 9,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 9,
+                        "genomic_start": 1000,
+                        "genomic_end": 1008,
+                    }
+                ],
+                "chromosome": "chr1",
+                "genomic_start": 1000,
+                "genomic_end": 1008,
+            }
+        ],
+        "genomic_sequences": {"chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100},
+    }
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return ferro_hgvs.VariantProjector(reference_json=str(path))
+
+
+class TestVariantProjectionValueSemantics:
+    """``VariantProjection`` compares and hashes by value."""
+
+    def test_equal_projections_are_equal_and_hash_equal(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        a = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        b = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_distinct_projections_differ(self, projector: ferro_hgvs.VariantProjector) -> None:
+        a = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        c = projector.project("NC_000001.11:g.1004G>T", transcript="NM_TEST.1")
+        assert a != c
+
+    def test_projection_is_set_usable(self, projector: ferro_hgvs.VariantProjector) -> None:
+        a = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        b = projector.project("NC_000001.11:g.1003C>A", transcript="NM_TEST.1")
+        c = projector.project("NC_000001.11:g.1004G>T", transcript="NM_TEST.1")
+        assert len({a, b, c}) == 2
+
+    def test_warning_carrying_projection_is_hashable(
+        self, projector: ferro_hgvs.VariantProjector
+    ) -> None:
+        # The eq/hash key is the inner value's Debug string, so a projection that
+        # carries a `NormalizationWarning` (which is itself unhashable) is still
+        # hashable — the Debug-key design's whole point. A coincident cis-allele
+        # emits OVERLAP_CONFLICTING_EDITS, giving a warning-bearing projection.
+        results = projector.project_all("NC_000001.11:g.[1003C>A;1003C>G]")
+        warned = [p for p in results if p.has_warnings()]
+        assert warned, "expected a warning-carrying projection from the cis-allele"
+        proj = warned[0]
+        # Must not raise TypeError, and must be usable in a set.
+        assert isinstance(hash(proj), int)
+        assert len({proj}) == 1
+        assert proj == proj


### PR DESCRIPTION
Part of #1018. Final PR of the Python-API ergonomics series (P3 polish).

## Value equality (`__eq__`/`__hash__`)

`VariantProjection` and `ProteinEffect` were the two value types that still compared by **identity** — so results could not be deduplicated in a `set` or used as `dict` keys, unlike `HgvsVariant` / `SpdiVariant` which already compared by value. Both now implement `__eq__`/`__hash__` over their full contents (a canonical debug key, consistent with the existing `to_string()`-based pattern), with matching `.pyi` dunder stubs.

## Parse idempotency

Adds a Python round-trip property test mirroring the Rust idempotency suite: `parse(str(parse(x))) == parse(x)` (by value **and** hash) across a multi-axis corpus (c./g./n./p., del/dup/intronic), plus value-semantics tests (equality, hashing, set-dedup) for the two newly-comparable types.

## Typed-exception `.pyi` docs (folds in the P2 exception-mapping doc item)

Every `.pyi` `Raises:` now names the typed exception it raises (`ParseError` / `NormalizationError` / `ProjectionError` / `ReferenceError` / `EquivalenceError` from #1019) instead of a bare `ValueError`/`RuntimeError`, each documented as a subclass of the builtin it replaced so `except ValueError`/`except RuntimeError` still catches:

- **Module-level functions:** `parse`, `normalize`, `parse_spdi`, `hgvs_to_spdi`, `spdi_to_hgvs_variant`, `parse_mave_hgvs_variant`, `parse_lenient`, `parse_rsid_value`, `vcf_to_genomic_hgvs`, `prepare_reference_data`, `check_reference_data`.
- **Methods:** `*.from_manifest` → `ReferenceError`; `CoordinateMapper` conversions → `ReferenceError`/`ProjectionError`; `VariantProjector.project*` → `ProjectionError`; `EquivalenceChecker.check`/`all_equivalent` → `EquivalenceError`.
- The only bare `ValueError`s that remain are the 3 pure argument-validation sites (`OneBasedPos`, `MaveContext.supports_coordinate_type`, `VcfRecord.snv`), which are intentionally outside the typed hierarchy.

## Tests

315 py tests (14 new); Rust lib 3585 + integration 4296, 0 failed.

## Stacking

Stacked on #1021 → #1020 → #1019 → #1017 → #1014 → `main`. Review the top commit only. Closes out the #1018 series.