### PR TITLE
feat(cli): genome-capable transcripts.json via --emit-genomic-sequences

### DIFF
--- a/docs/python_reference_guide.md
+++ b/docs/python_reference_guide.md
@@ -1,0 +1,166 @@
+# Python guide: setting up a reference for normalization (without footguns)
+
+This guide shows the **recommended** way to give `ferro_hgvs.Normalizer` a
+reference in Python, and how to verify you got the capability you expect. The
+short version: the easiest constructors can silently run in a reduced-capability
+mode, so **always check `has_genomic_data()`** (or let the warning fail your
+harness) before trusting a genome-aware result.
+
+## Which path do I use?
+
+| You have… | Use | Genome-aware rules run? |
+|---|---|---|
+| A downloaded RefSeq/Ensembl reference + genome | `ferro prepare` → `Normalizer.from_manifest("manifest.json")` | ✅ full |
+| A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro convert-gff --emit-genomic-sequences` (or `ferro build-transcript --emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
+| Transcript-level normalization only (exonic SNV/indel shuffle; no introns, no `g.` axis) | a `transcripts.json` **without** `genomic_sequences` → `Normalizer(reference_json=...)` | ❌ by design (see the boundary below) |
+| Just trying the API | `Normalizer()` (built-in toy data) | ❌ toy data |
+
+"Genome-aware rules" = intronic positions (`c.10+5del`), the cross-exon/intron
+3′-shift (#670), and the genomic (`g.`) axis / `project_to_genomic`. See
+[the capability boundary](transcripts_json_schema.md#capability-boundary-transcriptsjson-vs-a-prepared-manifest).
+
+## The one footgun to remember
+
+`Normalizer(reference_json=...)` and `Normalizer()` are the most discoverable
+constructors, and a transcript-only reference makes them run **reduced-capability**
+— genome-dependent rules are skipped. This is not silent: a reduced-capability
+build reports `has_genomic_data() == False` **and** emits a one-time
+`UserWarning` at construction. There are two safe ways to handle it: either leave
+the warning on as a safety net (if you don't otherwise check), or check capability
+explicitly (recommended) — the two examples below show both.
+
+```python
+import ferro_hgvs
+
+n = ferro_hgvs.Normalizer(reference_json="transcripts.json")
+n.has_genomic_data()    # False → genome-dependent rules will NOT run
+n.has_protein_data()    # protein sequences present?
+n.reference_summary()   # {"provider_kind": "json"|"manifest"|"test_data", "has_genomic_data": ..., "has_protein_data": ...}
+```
+
+### Recommended: check capability explicitly and fail loud
+
+Assert the capability you actually need, so a mis-provisioned reference fails at
+load rather than producing quietly-degraded results across a whole batch. Because
+you're checking `has_genomic_data()` yourself, the one-time reduced-capability
+warning is redundant here and is silenced to keep logs clean — a `require_genome`
+mismatch raises a clear error instead:
+
+```python
+import warnings
+import ferro_hgvs
+
+
+def load_normalizer(reference_json: str, *, require_genome: bool) -> ferro_hgvs.Normalizer:
+    """Load a Normalizer, refusing a reference that lacks a capability you need."""
+    with warnings.catch_warnings():
+        # The reduced-capability UserWarning is a safety net for callers who do NOT
+        # check; we check has_genomic_data() below, so silence the (redundant) warning.
+        warnings.simplefilter("ignore", UserWarning)
+        normalizer = ferro_hgvs.Normalizer(reference_json=reference_json)
+
+    if require_genome and not normalizer.has_genomic_data():
+        raise SystemExit(
+            f"{reference_json} is not genome-capable: {normalizer.reference_summary()}. "
+            "Re-emit it with `--emit-genomic-sequences`, or use Normalizer.from_manifest(...)."
+        )
+    return normalizer
+```
+
+This handles both cases correctly: `require_genome=True` on a transcript-only
+reference raises, while `require_genome=False` (you *want* transcript-level only)
+loads quietly.
+
+The same `has_genomic_data()` / `reference_summary()` methods exist on
+`VariantProjector`, `EquivalenceChecker`, `BatchProcessor`, and
+`CoordinateMapper` — apply the same check. `VariantProjector.project_to_genomic`
+in particular needs a genome.
+
+## Example 1 — genome-aware normalization of a synthetic construct
+
+Build a **genome-capable** `transcripts.json` from your own FASTA — the
+`--emit-genomic-sequences` flag embeds the contig bytes so the genome-dependent
+rules can run:
+
+```bash
+# Single synthetic construct (one contig):
+ferro build-transcript \
+  --fasta construct.fa --cds-start 1 --cds-end 900 \
+  --emit-genomic-sequences \
+  -o construct.json
+
+# Or many transcripts from an annotation + FASTA:
+ferro convert-gff \
+  --gff constructs.gff3 --fasta constructs.fa \
+  --emit-genomic-sequences \
+  -o constructs.json
+```
+
+```python
+import ferro_hgvs
+
+n = load_normalizer("construct.json", require_genome=True)   # asserts genome capability
+assert n.reference_summary()["provider_kind"] == "json"
+
+# Intronic / exon-junction / g.-axis normalization now runs. Use the transcript
+# id from your reference (build-transcript defaults it to the FASTA contig name).
+print(n.normalize("CONSTRUCT1:c.10+5del"))
+```
+
+If you forget `--emit-genomic-sequences`, `construct.json` carries the placement
+but no genome; `load_normalizer(..., require_genome=True)` will refuse it (rather
+than silently returning exon-confined results).
+
+## Example 2 — a downloaded production reference
+
+```bash
+ferro prepare --output-dir ferro-reference     # downloads RefSeq + genome + cdot
+ferro check   --reference ferro-reference       # sanity-check the prepared set
+```
+
+```python
+import ferro_hgvs
+
+n = ferro_hgvs.Normalizer.from_manifest("ferro-reference/manifest.json")
+assert n.has_genomic_data()
+print(n.normalize("NM_000088.3:c.589-1G>T"))    # intronic, genome-aware
+```
+
+## Example 3 — transcript-level only (no genome needed)
+
+If your inputs are exonic SNVs/indels and you do **not** need introns or the `g.`
+axis, a transcript-only reference is correct and lighter — just be explicit that
+you expect reduced capability so it isn't mistaken for a genome-backed run:
+
+```python
+import ferro_hgvs
+
+n = ferro_hgvs.Normalizer(reference_json="transcripts_only.json")
+assert not n.has_genomic_data()                 # expected: transcript-level only
+print(n.normalize("CONSTRUCT1:c.1152del"))      # exonic 3′-shuffle works
+# n.normalize("CONSTRUCT1:c.10+5del")           # intronic → cannot normalize without a genome
+```
+
+## Verify from the shell
+
+`ferro check` reports what a reference can do — point it at a prepared directory
+or a standalone `transcripts.json`:
+
+```bash
+ferro check --reference construct.json
+# === transcripts.json Check ===
+#   Status: OK
+#   Transcripts: 1
+#   Genome-capable: yes
+#   Protein data: no
+```
+
+## The capability boundary in one line
+
+- **Any `transcripts.json`:** reference-allele checks, exonic 3′/5′ shuffle,
+  dup/repeat canonicalization.
+- **Needs `genomic_sequences` (genome-capable) or a prepared manifest:** intronic
+  positions, cross-exon/intron 3′-shift, the `g.` axis / `project_to_genomic`.
+
+Full details, the schema, and what the load-time validation does and does not
+guarantee are in [`transcripts_json_schema.md`](transcripts_json_schema.md).

--- a/docs/transcripts_json_schema.md
+++ b/docs/transcripts_json_schema.md
@@ -32,6 +32,29 @@ For simple use cases, a flat array of transcript objects is also supported:
 ]
 ```
 
+### Optional `genomic_sequences` map
+
+The container form may also carry a top-level `genomic_sequences` map — the raw
+forward (plus-strand) chromosome/contig bytes, keyed by the same chromosome name
+the transcripts are placed on:
+
+```json
+{
+  "version": "1.0",
+  "genome_build": "GRCh38",
+  "transcripts": [ { /* ... */ } ],
+  "genomic_sequences": {
+    "chr17": "ACGT...ACGT"
+  }
+}
+```
+
+This is what makes a `transcripts.json` **genome-capable** — see
+[Capability boundary](#capability-boundary-transcriptsjson-vs-a-prepared-manifest)
+below. It is emitted by `convert-gff --emit-genomic-sequences` and
+`build-transcript --emit-genomic-sequences`; it may also be written by hand. A
+`proteins` map (protein accession → sequence) is accepted in the same position.
+
 ## Transcript Object
 
 Each transcript object has the following fields:
@@ -196,6 +219,110 @@ For basic HGVS normalization without genomic coordinates:
 ]
 ```
 
+## Capability boundary: transcripts.json vs a prepared manifest
+
+ferro can normalize against two kinds of reference, and they are **not**
+equivalent. Knowing which one you have determines which normalization rules run.
+
+- **A `transcripts.json`** (this schema) — loaded via
+  `Normalizer(reference_json="transcripts.json")` (Python) or
+  `MockProvider::from_json` (Rust). Built by hand, by `convert-gff`, or by
+  `build-transcript`.
+- **A prepared manifest** — a `manifest.json` produced by `ferro prepare`,
+  loaded via `Normalizer.from_manifest("manifest.json")`. It references a full
+  genome FASTA, cdot metadata, and RefSeqGene/LRG alignments.
+
+### What a `transcripts.json` can always do
+
+Transcript-**sequence**-level normalization, using each transcript's own
+`sequence` and `exons`:
+
+- reference-allele checks;
+- 3′/5′ shuffling of del/ins/dup within the transcript (e.g. rolling a deletion
+  across a homopolymer: `c.1152del → c.1158del`);
+- duplication and repeat canonicalization.
+
+For an **intron-free / single-exon** reference with no `g.` axis, this is the
+*complete* set of applicable rules — results match a full prepared manifest,
+because the genome-dependent rules below are no-ops there.
+
+### What additionally requires genomic data
+
+Rules gated on `has_genomic_data()` only run when the reference carries genomic
+sequence **and** a placement (each transcript's `chromosome` + per-exon
+`genomic_start`/`genomic_end`):
+
+- the cross-exon/intron 3′-shift (#670);
+- normalization of intronic positions (`c.10+5del`, boundary-spanning edits);
+- the genomic (`g.`) axis and `project_to_genomic`.
+
+A plain `transcripts.json` from `convert-gff`/`build-transcript` carries the
+**placement** but not the genomic **bytes**, so these rules are skipped and only
+the transcript-level rules run. To make a `transcripts.json` genome-capable, add
+the [`genomic_sequences` map](#optional-genomic_sequences-map) — most easily with
+`--emit-genomic-sequences` (below).
+
+### How to tell which mode is active
+
+The `Normalizer` exposes its reference capability. From Python:
+
+```python
+n = ferro_hgvs.Normalizer(reference_json="transcripts.json")
+n.has_genomic_data()   # False for a transcript-only reference; True once genomic_sequences is present
+n.has_protein_data()   # True if the reference carries protein sequences
+n.reference_summary()  # {"provider_kind": "json", "has_genomic_data": ..., "has_protein_data": ...}
+```
+
+A genome-capable emit (`--emit-genomic-sequences`) flips `has_genomic_data()` to
+`True`; a transcript-only reference reports `False` **and** emits a one-time
+reduced-capability `UserWarning` at construction, so a degraded mode is never
+silent. (These methods are also available on `VariantProjector`,
+`EquivalenceChecker`, `BatchProcessor`, and `CoordinateMapper`.)
+
+From the CLI, `ferro check <transcripts.json>` reports the same (transcript count
+and whether the reference is genome-capable).
+
+**What the load-time check does and does not guarantee.** When
+`genomic_sequences` is present, ferro validates the reference at load in two ways:
+
+- **Structure** — every placed transcript's contig must be present in
+  `genomic_sequences` and long enough to cover its coordinates (byte 0 = genomic
+  position 1). A missing or too-short contig is rejected. This is a **per-file**
+  rule: once *any* `genomic_sequences` are present, *every* placed transcript must
+  be backed, so a partially-genomic reference is rejected rather than silently
+  giving genome capability to only some transcripts. (If you want genome-aware
+  behavior for only some transcripts, split them into a separate reference.)
+- **Content** — for each placed transcript whose exons all carry genomic
+  coordinates, ferro reconstructs the transcript sequence from the genomic bytes at
+  that placement (concatenating the forward exon slices, reverse-complementing on
+  the minus strand) and requires it to equal the stated `sequence`. This rejects
+  genomic bytes that are the right length but the **wrong bases** — a padded junk
+  blob, a different assembly, or shifted coordinates — which would otherwise
+  silently corrupt genome-aware normalization of `del`/`dup`/`inv`/intronic edits
+  (whose recommended forms carry no stated reference bases, so nothing downstream
+  would flag the wrong genome).
+
+Two residual cases cannot be validated at load and remain the emitter's
+responsibility: bytes in the **intronic gaps** between exons (there is no
+independent copy to check them against), and a coordinate frame that is
+**self-consistently wrong** (the transcript sequence and genomic bytes agree
+because both were sliced from the same mismatched FASTA).
+`convert-gff`/`build-transcript --emit-genomic-sequences` avoid both by
+construction (they read the same FASTA the coordinates are relative to), and
+`convert-gff` additionally fails fast at emit time if the FASTA does not cover the
+annotation's coordinates — so it never writes a file its own loader rejects.
+
+### Synthetic / local references
+
+For a **synthetic** construct (plasmid, reporter, custom amplicon) there is no
+cdot or RefSeqGene alignment to prepare, so a full `ferro prepare` manifest does
+not apply. The supported path for genome-aware normalization of such references
+is a genome-capable `transcripts.json` via `--emit-genomic-sequences` — the
+placement rides on the transcript records and the contig bytes come from your
+FASTA. (This is the resolution of issue #1027: the lightweight
+`genomic_sequences` path covers synthetic local references; a
+`MultiFastaProvider`/manifest built from local files is not required for them.)
+
 ## Generating transcripts.json
 
 ### From GFF3/GTF with FASTA
@@ -216,6 +343,25 @@ ferro convert-gff \
   --genes BRCA1,BRCA2,TP53 \
   --fasta reference.fa \
   -o clinical_genes.json
+
+# Genome-capable output: also embed the referenced contig bytes so the genome-
+# dependent rules (intronic, exon/intron 3'-shift, g. axis) can run. Emits full
+# contig sequences, so it is intended for small / synthetic references.
+ferro convert-gff \
+  --gff construct.gff3 \
+  --fasta construct.fa \
+  --emit-genomic-sequences \
+  -o construct.json
+```
+
+For a single synthetic contig, `build-transcript` takes the same flag:
+
+```bash
+ferro build-transcript \
+  --fasta construct.fa \
+  --cds-start 1 --cds-end 900 \
+  --emit-genomic-sequences \
+  -o construct.json
 ```
 
 ### Programmatically
@@ -281,6 +427,8 @@ The schema is validated when loading. Common validation errors:
 | `ReferenceNotFound` | Transcript ID not in database |
 | `InvalidCoordinates` | Position exceeds sequence length |
 | `Parse error` | Malformed JSON or missing required fields |
+| `genomic_sequences … has no entry for …` / `… too short for the placement …` | The reference declares genomic capability (`genomic_sequences` present) but the bytes do not back a placed transcript's `chromosome` / genomic coordinates. Fixed by emitting with `--emit-genomic-sequences` (which is consistent by construction) or by supplying the correct contig bytes. |
+| `… do not reconstruct transcript '…'s sequence …` | `genomic_sequences` are long enough but the bytes at a transcript's exon placement do not reproduce its stated `sequence` — a wrong assembly, shifted coordinates, or placeholder/junk bytes. Supply the genome the transcript coordinates are relative to. |
 
 ## Best Practices
 

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -396,6 +396,15 @@ enum Commands {
         #[arg(long)]
         no_validate_fasta: bool,
 
+        /// Also emit a top-level `genomic_sequences` map (the referenced contig bytes
+        /// from --fasta, keyed by chromosome) so the resulting transcripts.json is
+        /// genome-capable: `Normalizer(reference_json=...)` can then run the
+        /// genome-aware normalization rules that need genomic sequence (#1026).
+        /// Requires --fasta. Emits full contig sequences, so it can be large for a
+        /// whole-genome FASTA — intended for small/synthetic references.
+        #[arg(long, requires = "fasta")]
+        emit_genomic_sequences: bool,
+
         /// Write the bounded sample of loader diagnostics as JSON to this path.
         #[arg(long, value_name = "PATH")]
         diagnostics_json: Option<PathBuf>,
@@ -635,6 +644,13 @@ enum Commands {
         /// Genome build name embedded in the output (default: GRCh38).
         #[arg(long, default_value = "GRCh38")]
         genome_build: String,
+
+        /// Also emit a top-level `genomic_sequences` map (the contig's forward bytes,
+        /// keyed by chromosome) so the resulting transcripts.json is genome-capable:
+        /// `Normalizer(reference_json=...)` can then run the genome-aware
+        /// normalization rules that need genomic sequence (#1026).
+        #[arg(long)]
+        emit_genomic_sequences: bool,
     },
 }
 
@@ -812,6 +828,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             strict,
             silent,
             no_validate_fasta,
+            emit_genomic_sequences,
             diagnostics_json,
         } => run_convert_gff(
             &gff,
@@ -824,6 +841,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             strict,
             silent,
             no_validate_fasta,
+            emit_genomic_sequences,
             diagnostics_json.as_ref(),
         ),
         Commands::Generate {
@@ -924,6 +942,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             contig,
             gene,
             genome_build,
+            emit_genomic_sequences,
         } => run_build_transcript(
             &fasta,
             cds_start,
@@ -934,6 +953,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             contig.as_deref(),
             gene.as_deref(),
             &genome_build,
+            emit_genomic_sequences,
         ),
     }
 }
@@ -1885,6 +1905,25 @@ fn run_parse(
     }
 }
 
+/// Byte threshold above which embedding genomic sequence into a `transcripts.json`
+/// is flagged as heavy — the file becomes large to store and parse, and a
+/// genome-scale reference is better served by `ferro prepare` + `from_manifest`.
+const LARGE_GENOMIC_SEQUENCES_WARN_BYTES: u64 = 50_000_000; // 50 MB
+
+/// Warn on stderr when `--emit-genomic-sequences` embeds a large amount of
+/// genomic sequence, so a user does not silently produce a multi-hundred-MB
+/// `transcripts.json` from whole-chromosome (or whole-genome) coordinates.
+fn warn_if_genomic_sequences_large(total_bytes: u64) {
+    if total_bytes > LARGE_GENOMIC_SEQUENCES_WARN_BYTES {
+        eprintln!(
+            "warning: --emit-genomic-sequences embedded {:.1} MB of genomic sequence; the \
+             transcripts.json will be large to store and slow to parse. For a genome-scale \
+             reference prefer `ferro prepare` + `Normalizer.from_manifest(...)`.",
+            total_bytes as f64 / 1_000_000.0
+        );
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_convert_gff(
     gff: &PathBuf,
@@ -1897,11 +1936,12 @@ fn run_convert_gff(
     strict: bool,
     silent: bool,
     no_validate_fasta: bool,
+    emit_genomic_sequences: bool,
     diagnostics_json: Option<&PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::reference::annotation::{load_annotations, LoaderConfig};
     use ferro_hgvs::reference::transcript::ManeStatus;
-    use std::collections::HashSet;
+    use std::collections::{BTreeMap, HashSet};
 
     // Parse genome build
     let genome_build = parse_genome_build(build);
@@ -1950,6 +1990,16 @@ fn run_convert_gff(
 
     // Collect transcripts to output
     let mut output_transcripts: Vec<serde_json::Value> = Vec::new();
+
+    // For each contig an emitted transcript is placed on, the highest 1-based
+    // genomic coordinate its placement references (max over exon `genomic_end` and
+    // the transcript's own `genomic_end`). Used to emit `genomic_sequences` when
+    // --emit-genomic-sequences is set, and — crucially — to fail fast at emit time
+    // if the FASTA contig cannot cover the placement, using the SAME invariant
+    // `MockProvider::from_json` enforces at load, so convert-gff can never emit a
+    // file its own loader would reject (#1026). BTreeMap keeps the output
+    // deterministic.
+    let mut contig_required_len: BTreeMap<String, u64> = BTreeMap::new();
 
     for (id, tx) in db.iter() {
         // Apply filters
@@ -2042,6 +2092,18 @@ fn run_convert_gff(
         }
         if let Some(ref chrom) = tx.chromosome {
             tx_obj["chromosome"] = serde_json::json!(chrom);
+            // Track the highest genomic coordinate this transcript's placement
+            // needs on its contig, mirroring the loader's `required_len`.
+            let required = tx
+                .exons
+                .iter()
+                .filter_map(|e| e.genomic_end)
+                .chain(tx.genomic_end)
+                .max();
+            if let Some(required) = required {
+                let entry = contig_required_len.entry(chrom.clone()).or_insert(0);
+                *entry = (*entry).max(required);
+            }
         }
         if let Some(start) = tx.genomic_start {
             tx_obj["genomic_start"] = serde_json::json!(start);
@@ -2081,7 +2143,7 @@ fn run_convert_gff(
     }
 
     // Create output JSON
-    let output_json = serde_json::json!({
+    let mut output_json = serde_json::json!({
         "version": "1.0",
         "genome_build": match genome_build {
             GenomeBuild::GRCh37 => "GRCh37",
@@ -2090,6 +2152,60 @@ fn run_convert_gff(
         },
         "transcripts": output_transcripts,
     });
+
+    // Optionally emit the referenced contig sequences so the transcripts.json is
+    // genome-capable. The exon `genomic_start`/`genomic_end` coordinates are
+    // absolute contig positions, so we emit each referenced contig's full forward
+    // sequence keyed by chromosome name — this is exactly what `MockProvider`
+    // slices by genomic coordinate when running the genome-aware rules (#1026).
+    if emit_genomic_sequences {
+        let fasta = fasta_provider
+            .as_ref()
+            .ok_or("--emit-genomic-sequences requires --fasta to read the contig sequences")?;
+        if contig_required_len.is_empty() {
+            // The flag was requested but no emitted transcript carries a genomic
+            // placement, so there is nothing to back a genome with. Warn rather than
+            // write an empty `genomic_sequences` map that would look genome-capable
+            // but report `has_genomic_data() == false`.
+            eprintln!(
+                "warning: --emit-genomic-sequences was set but no emitted transcript has a \
+                 genomic placement; genomic_sequences not written (reference stays \
+                 transcript-only)"
+            );
+        } else {
+            let mut genomic_sequences = serde_json::Map::new();
+            let mut total_bytes: u64 = 0;
+            for (contig, required_len) in &contig_required_len {
+                let length = fasta.sequence_length(contig).ok_or_else(|| {
+                    format!(
+                        "--emit-genomic-sequences: a transcript is placed on contig '{}', \
+                         but it is not present in the FASTA",
+                        contig
+                    )
+                })?;
+                // Fail fast, with the SAME invariant the loader enforces, so the
+                // emitted file always loads. A shorter contig means the FASTA does
+                // not cover the annotation's coordinates — typically a sub-region
+                // FASTA paired with whole-genome coordinates, or a mismatched
+                // assembly.
+                if length < *required_len {
+                    return Err(format!(
+                        "--emit-genomic-sequences: contig '{}' is {} bases in the FASTA, but a \
+                         transcript placement needs genomic coordinate {}. The FASTA does not \
+                         cover the annotation's coordinates (a sub-region FASTA with whole-genome \
+                         coordinates, or a different assembly?).",
+                        contig, length, required_len
+                    )
+                    .into());
+                }
+                let sequence = fasta.get_sequence(contig, 0, length)?;
+                total_bytes += sequence.len() as u64;
+                genomic_sequences.insert(contig.clone(), serde_json::json!(sequence));
+            }
+            warn_if_genomic_sequences_large(total_bytes);
+            output_json["genomic_sequences"] = serde_json::Value::Object(genomic_sequences);
+        }
+    }
 
     // Write output
     let mut writer: Box<dyn Write> = if let Some(out_path) = output {
@@ -3495,6 +3611,7 @@ fn run_build_transcript(
     contig: Option<&str>,
     gene: Option<&str>,
     genome_build: &str,
+    emit_genomic_sequences: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let fasta = FastaProvider::new(fasta_path)?;
 
@@ -3544,15 +3661,22 @@ fn run_build_transcript(
         return Err(format!("Invalid strand '{}'; expected + or -", strand).into());
     }
 
-    // Read the full contig sequence (0-based half-open for get_sequence)
+    // Read the full contig sequence (0-based half-open for get_sequence). This is
+    // the forward genomic sequence; the exon `genomic_start`/`genomic_end`
+    // coordinates index into it, so it is what we emit under `genomic_sequences`.
     use ferro_hgvs::reference::provider::ReferenceProvider;
-    let sequence = fasta.get_sequence(&contig_name, 0, contig_length)?;
+    let mut genomic_forward = fasta.get_sequence(&contig_name, 0, contig_length)?;
 
-    // Reverse-complement for minus-strand transcripts
+    // Reverse-complement for minus-strand transcripts (transcript-space `sequence`).
+    // On the plus strand the transcript sequence equals the forward contig: clone it
+    // only when we still need `genomic_forward` for `genomic_sequences`, otherwise
+    // move it out to avoid duplicating the whole contig.
     let final_sequence = if strand == "-" {
-        reverse_complement(&sequence)
+        reverse_complement(&genomic_forward)
+    } else if emit_genomic_sequences {
+        genomic_forward.clone()
     } else {
-        sequence
+        std::mem::take(&mut genomic_forward)
     };
 
     let tx_id = id.unwrap_or(&contig_name).to_string();
@@ -3586,11 +3710,23 @@ fn run_build_transcript(
         tx_obj["gene_symbol"] = serde_json::json!(g);
     }
 
-    let output_json = serde_json::json!({
+    let mut output_json = serde_json::json!({
         "version": "1.0",
         "genome_build": genome_build,
         "transcripts": [tx_obj],
     });
+
+    // Optionally emit the contig's forward sequence so the transcripts.json is
+    // genome-capable (#1026): the single exon's genomic coordinates index into it.
+    // Note this repeats the contig bytes already carried in the transcript
+    // `sequence` (identical on plus strand; reverse-complemented there on minus),
+    // which is the price of a self-contained genome-capable reference.
+    if emit_genomic_sequences {
+        warn_if_genomic_sequences_large(genomic_forward.len() as u64);
+        let mut genomic_sequences = serde_json::Map::new();
+        genomic_sequences.insert(contig_name.clone(), serde_json::json!(genomic_forward));
+        output_json["genomic_sequences"] = serde_json::Value::Object(genomic_sequences);
+    }
 
     std::fs::write(output, serde_json::to_string_pretty(&output_json)?)?;
     eprintln!("Wrote 1 transcript ({}) to {}", tx_id, output.display());

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -3,7 +3,7 @@
 use crate::error::FerroError;
 use crate::hgvs::variant::Accession;
 use crate::reference::provider::{GenomicPlacement, ReferenceProvider};
-use crate::reference::transcript::Transcript;
+use crate::reference::transcript::{Strand, Transcript};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -51,6 +51,140 @@ pub struct MockProvider {
     /// parent); falls back to the build-agnostic `transcripts` map otherwise.
     /// Empty by default, so an unconfigured mock is build-agnostic as before.
     build_transcripts: HashMap<(String, &'static str), Arc<Transcript>>,
+}
+
+/// Validate that a JSON reference declaring genomic capability actually backs
+/// every placed transcript with genomic sequence bytes that are the *right length*
+/// **and** the *right bases*.
+///
+/// Only enforced when `genomic_sequences` is non-empty — i.e. the reference claims
+/// `has_genomic_data() == true`, which arms the genome-aware normalization rules.
+/// Note this is a **per-file** requirement: once any `genomic_sequences` are
+/// present, every placed transcript must be backed, so a partially-genomic
+/// reference is rejected rather than silently granting genome capability to only
+/// some transcripts. Two checks per placed transcript:
+///
+/// 1. **Structure** — the transcript's contig must be present in `genomic_sequences`
+///    and long enough to contain its maximal genomic coordinate. Catches a missing
+///    or too-short contig (#1012 comment 1).
+/// 2. **Content** — when every exon carries genomic coordinates and the transcript
+///    has a `sequence`, the transcript sequence is *reconstructed* from the genomic
+///    bytes at the exon placement (concatenating the forward exon slices, then
+///    reverse-complementing on the minus strand — exactly how
+///    `convert-gff`/`build-transcript` build it) and must equal the stated
+///    `sequence`. This catches genomic bytes that are the right length but the
+///    **wrong bases** — a padded junk blob, a different assembly, or shifted
+///    coordinates — which would otherwise silently corrupt genome-aware
+///    normalization of del/dup/inv/intronic edits (whose recommended forms carry no
+///    stated reference bases, so nothing downstream flags the wrong genome).
+///
+/// Two residual cases are the emitter's responsibility and cannot be caught here:
+/// bytes in the *intronic* gaps between exons (no independent copy to check
+/// against), and a coordinate frame that is *self-consistently* wrong (the
+/// transcript sequence and genomic bytes agree because both were sliced from the
+/// same mismatched FASTA). `convert-gff --emit-genomic-sequences` avoids both by
+/// construction.
+fn validate_genomic_placement_backing(
+    transcripts: &[Transcript],
+    genomic_sequences: &HashMap<String, String>,
+) -> Result<(), FerroError> {
+    if genomic_sequences.is_empty() {
+        return Ok(());
+    }
+
+    for tx in transcripts {
+        let Some(chromosome) = tx.chromosome.as_deref() else {
+            continue;
+        };
+        // Highest 1-based genomic coordinate this transcript's placement references.
+        let required_len = tx
+            .exons
+            .iter()
+            .filter_map(|exon| exon.genomic_end)
+            .chain(tx.genomic_end)
+            .max();
+        let Some(required_len) = required_len else {
+            continue;
+        };
+
+        // (1) Structure.
+        let contig = match genomic_sequences.get(chromosome) {
+            None => {
+                return Err(FerroError::Json {
+                    msg: format!(
+                        "reference declares genomic sequences but transcript '{}' is placed on \
+                         contig '{}', which has no entry in `genomic_sequences` (once any \
+                         genomic_sequences are present, every placed transcript must be backed)",
+                        tx.id, chromosome
+                    ),
+                });
+            }
+            Some(sequence) if (sequence.len() as u64) < required_len => {
+                return Err(FerroError::Json {
+                    msg: format!(
+                        "`genomic_sequences` for contig '{}' has length {}, too short for the \
+                         placement of transcript '{}' (needs at least {})",
+                        chromosome,
+                        sequence.len(),
+                        tx.id,
+                        required_len
+                    ),
+                });
+            }
+            Some(sequence) => sequence,
+        };
+
+        // (2) Content.
+        validate_reconstructed_transcript_sequence(tx, chromosome, contig)?;
+    }
+
+    Ok(())
+}
+
+/// Reconstruct a transcript's sequence from the genomic contig bytes at its exon
+/// placement and confirm it equals the stated `sequence`. See
+/// [`validate_genomic_placement_backing`] for the rationale. Skips (returns `Ok`)
+/// when the transcript has no `sequence`, or any exon lacks genomic coordinates, or
+/// an exon's coordinates are malformed or out of the contig's range — there is
+/// nothing to reconstruct against in those cases, and the structural check has
+/// already bounded the maximal coordinate.
+fn validate_reconstructed_transcript_sequence(
+    tx: &Transcript,
+    chromosome: &str,
+    contig: &str,
+) -> Result<(), FerroError> {
+    let Some(tx_sequence) = tx.sequence.as_deref() else {
+        return Ok(());
+    };
+
+    let mut reconstructed = String::with_capacity(tx_sequence.len());
+    for exon in &tx.exons {
+        let (Some(g_start), Some(g_end)) = (exon.genomic_start, exon.genomic_end) else {
+            return Ok(()); // partial placement — cannot fully reconstruct.
+        };
+        if g_start < 1 || g_end < g_start || g_end as usize > contig.len() {
+            return Ok(()); // malformed / out-of-range coords — not this check's job.
+        }
+        reconstructed.push_str(&contig[(g_start - 1) as usize..g_end as usize]);
+    }
+
+    if tx.strand == Strand::Minus {
+        reconstructed = crate::sequence::reverse_complement(&reconstructed);
+    }
+
+    if !reconstructed.eq_ignore_ascii_case(tx_sequence) {
+        return Err(FerroError::Json {
+            msg: format!(
+                "`genomic_sequences` for contig '{}' do not reconstruct transcript '{}'s \
+                 sequence from its exon placement: the genomic bytes are not the reference the \
+                 transcript sequence was built from (wrong assembly, shifted coordinates, or \
+                 placeholder/junk bytes)",
+                chromosome, tx.id
+            ),
+        });
+    }
+
+    Ok(())
 }
 
 impl MockProvider {
@@ -127,6 +261,14 @@ impl MockProvider {
     ///
     /// Accepts either a bare array of `Transcript` records or an object
     /// of the form `{ transcripts, proteins, genomic_sequences }`.
+    ///
+    /// When `genomic_sequences` is present (the reference declares genomic
+    /// capability), the placement of every placed transcript must be backed by
+    /// bytes: its contig must appear in `genomic_sequences` and be long enough to
+    /// contain the transcript's maximal genomic coordinate. A missing or too-short
+    /// contig is rejected here rather than producing a silently-degraded
+    /// genome-aware normalization (#1012 comment 1). See
+    /// [`validate_genomic_placement_backing`].
     pub fn from_json(path: &Path) -> Result<Self, FerroError> {
         // `deny_unknown_fields` so a typo'd key (e.g. `transripts`) produces
         // a clear error rather than silently defaulting to an empty provider.
@@ -179,6 +321,17 @@ impl MockProvider {
                     .to_string(),
             });
         }
+
+        // When the reference declares genomic capability (a non-empty
+        // `genomic_sequences` map, so `has_genomic_data()` is true and the
+        // genome-aware normalization rules will run), fail loud if that capability
+        // is not actually backed by bytes for every placed transcript. Without this,
+        // a reference that claims a genome but whose `genomic_sequences` does not
+        // cover a transcript's placement produces a genome-aware result silently
+        // computed against absent/short bytes (#1012 comment 1). We can only check
+        // structure, not content, but a missing or too-short contig is a real,
+        // detectable footgun.
+        validate_genomic_placement_backing(&transcripts, &genomic_sequences)?;
 
         let map: HashMap<String, Arc<Transcript>> = transcripts
             .into_iter()
@@ -984,6 +1137,192 @@ mod tests {
         );
         assert!(provider.has_genomic_data());
         assert_eq!(provider.get_genomic_sequence("chr1", 0, 4).unwrap(), "ACGT");
+    }
+
+    /// A genomic reference whose `genomic_sequences` fully backs the placement of
+    /// every placed transcript loads and reports genomic capability (#1026).
+    #[test]
+    fn from_json_accepts_consistent_genomic_reference() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // chr1 genomic sequence of length 12; the transcript exon spans genomic 3..8,
+        // so its sequence must be the contig bytes there: "ACGTACGTACGT"[2..8] = "GTACGT".
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "+",
+        "sequence": "GTACGT",
+        "chromosome": "chr1",
+        "genomic_start": 3,
+        "genomic_end": 8,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 3, "genomic_end": 8}]
+      }],
+      "genomic_sequences": { "chr1": "ACGTACGTACGT" }
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider = MockProvider::from_json(file.path()).expect("consistent reference loads");
+        assert!(provider.has_genomic_data());
+    }
+
+    /// A reference whose `genomic_sequences` are long enough but do NOT reconstruct
+    /// the transcript's stated sequence (wrong/junk bases) is rejected at load — the
+    /// wrong-content half of the #1012 comment 1 footgun. Without this, genome-aware
+    /// normalization of del/dup/inv/intronic edits (which carry no stated reference
+    /// bases) would silently run against the wrong genome.
+    #[test]
+    fn from_json_rejects_genomic_content_that_does_not_match_transcript() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // The exon at genomic 3..8 reconstructs to "GTACGT", but the transcript
+        // claims "ACGTAC" — a plausible-but-wrong (junk) genome.
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "+",
+        "sequence": "ACGTAC",
+        "chromosome": "chr1",
+        "genomic_start": 3,
+        "genomic_end": 8,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 3, "genomic_end": 8}]
+      }],
+      "genomic_sequences": { "chr1": "ACGTACGTACGT" }
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let err = match MockProvider::from_json(file.path()) {
+            Ok(_) => panic!("expected rejection of genomic bytes that don't match the transcript"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("do not reconstruct transcript"),
+            "error should explain the content mismatch: {err}"
+        );
+    }
+
+    /// The content check reverse-complements the genomic bytes for a minus-strand
+    /// transcript, so a correctly-placed minus-strand reference loads.
+    #[test]
+    fn from_json_accepts_minus_strand_reconstruction() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // contig[0..6] = "ACGTAC"; on the minus strand the transcript sequence is its
+        // reverse-complement: revcomp("ACGTAC") = "GTACGT".
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "-",
+        "sequence": "GTACGT",
+        "chromosome": "chr1",
+        "genomic_start": 1,
+        "genomic_end": 6,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 1, "genomic_end": 6}]
+      }],
+      "genomic_sequences": { "chr1": "ACGTACGTACGT" }
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider =
+            MockProvider::from_json(file.path()).expect("consistent minus-strand reference loads");
+        assert!(provider.has_genomic_data());
+    }
+
+    /// A reference that declares genomic capability but has no contig entry backing a
+    /// placed transcript is rejected at load, rather than silently normalizing against
+    /// absent bytes (#1012 comment 1).
+    #[test]
+    fn from_json_rejects_placement_without_backing_contig() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // Transcript is placed on chr1, but genomic_sequences only carries chr2.
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "+",
+        "sequence": "ATGCAT",
+        "chromosome": "chr1",
+        "genomic_start": 3,
+        "genomic_end": 8,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 3, "genomic_end": 8}]
+      }],
+      "genomic_sequences": { "chr2": "ACGTACGTACGT" }
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let err = match MockProvider::from_json(file.path()) {
+            Ok(_) => panic!("expected an error for an unbacked placement"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("chr1"),
+            "error should name the unbacked contig: {err}"
+        );
+    }
+
+    /// A contig present but too short to contain the placement is rejected.
+    #[test]
+    fn from_json_rejects_too_short_genomic_sequence() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        // Exon needs genomic coordinate 50 but chr1 is only 12 bases long.
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "+",
+        "sequence": "ATGCAT",
+        "chromosome": "chr1",
+        "genomic_start": 45,
+        "genomic_end": 50,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 45, "genomic_end": 50}]
+      }],
+      "genomic_sequences": { "chr1": "ACGTACGTACGT" }
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let err = match MockProvider::from_json(file.path()) {
+            Ok(_) => panic!("expected an error for a too-short contig"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("too short"),
+            "error should explain the contig is too short: {err}"
+        );
+    }
+
+    /// A transcripts-only reference (no `genomic_sequences`) is not subject to the
+    /// placement-backing check even when transcripts carry genomic coordinates, so
+    /// the pre-#1026 transcript-only references keep loading unchanged.
+    #[test]
+    fn from_json_skips_backing_check_without_genomic_sequences() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+      "transcripts": [{
+        "id": "NM_TEST.1",
+        "strand": "+",
+        "sequence": "ATGCAT",
+        "chromosome": "chr1",
+        "genomic_start": 3,
+        "genomic_end": 8,
+        "exons": [{"number": 1, "start": 1, "end": 6, "genomic_start": 3, "genomic_end": 8}]
+      }]
+    }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider = MockProvider::from_json(file.path()).expect("transcripts-only loads");
+        assert!(!provider.has_genomic_data());
     }
 
     #[test]

--- a/tests/it/cli_build_transcript.rs
+++ b/tests/it/cli_build_transcript.rs
@@ -100,6 +100,131 @@ fn build_transcript_rejects_cds_beyond_contig() {
 }
 
 #[test]
+fn build_transcript_emit_genomic_sequences_makes_reference_genome_capable() {
+    // A synthetic construct. With --emit-genomic-sequences the output carries the
+    // forward contig bytes under `genomic_sequences`, so the resulting
+    // transcripts.json is genome-capable (#1026).
+    let seq = "ATGAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCGGGTTTAAACCCTAA";
+    let (_keep, fasta_path) = write_fasta("construct1", seq);
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "60",
+            "--emit-genomic-sequences",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "build-transcript failed: stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+    // The forward contig bytes are emitted keyed by chromosome name.
+    assert_eq!(json["genomic_sequences"]["construct1"], seq);
+
+    // And the emitted JSON round-trips into a genome-capable provider.
+    let provider = ferro_hgvs::reference::mock::MockProvider::from_json(&out_path).expect("loads");
+    use ferro_hgvs::reference::provider::ReferenceProvider;
+    assert!(
+        provider.has_genomic_data(),
+        "reference emitted with --emit-genomic-sequences must report genomic data"
+    );
+}
+
+#[test]
+fn build_transcript_emit_genomic_sequences_stores_forward_bytes_on_minus_strand() {
+    // For a minus-strand construct the transcript `sequence` is reverse-complemented,
+    // but `genomic_sequences` must hold the FORWARD contig bytes so the exon genomic
+    // coordinates index into it correctly.
+    let forward = "ATGAAACCCGGGTTTAAACCCGGGTTTTAA"; // 30 bp
+    let (_keep, fasta_path) = write_fasta("construct2", forward);
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "30",
+            "--strand",
+            "-",
+            "--emit-genomic-sequences",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        status.status.success(),
+        "build-transcript failed: stderr={}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+    // genomic_sequences holds the forward bytes...
+    assert_eq!(json["genomic_sequences"]["construct2"], forward);
+    // ...while the transcript `sequence` is the reverse-complement (transcript space).
+    assert_eq!(
+        json["transcripts"][0]["sequence"],
+        "TTAAAACCCGGGTTTAAACCCGGGTTTCAT"
+    );
+}
+
+#[test]
+fn build_transcript_without_flag_omits_genomic_sequences() {
+    let (_keep, fasta_path) = write_fasta("c3", "ATGAAACCCTAA");
+    let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+    let out_path = out.path().to_path_buf();
+    drop(out);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let status = Command::new(bin)
+        .args([
+            "build-transcript",
+            "--fasta",
+            fasta_path.to_str().unwrap(),
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "12",
+            "--output",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+    assert!(
+        json.get("genomic_sequences").is_none(),
+        "genomic_sequences must not be emitted without the flag"
+    );
+}
+
+#[test]
 fn build_transcript_supports_minus_strand_and_custom_id() {
     let (_keep, fasta_path) = write_fasta("construct2", "ATGAAACCCGGGTTTAAACCCGGGTTTTAA");
     let out = tempfile::Builder::new().suffix(".json").tempfile().unwrap();

--- a/tests/it/cli_convert_gff_flags.rs
+++ b/tests/it/cli_convert_gff_flags.rs
@@ -11,6 +11,24 @@ fn write_gff3(content: &str) -> NamedTempFile {
     tf
 }
 
+/// Write a single-contig FASTA of `len` deterministic bases to a temp file.
+fn write_fasta(name: &str, len: usize) -> NamedTempFile {
+    write_multi_fasta(&[(name, len)])
+}
+
+/// Write a multi-contig FASTA (each `(name, len)`) of deterministic bases.
+fn write_multi_fasta(contigs: &[(&str, usize)]) -> NamedTempFile {
+    let bases = b"ACGT";
+    let mut tf = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
+    for (name, len) in contigs {
+        let seq: String = (0..*len).map(|i| bases[i % 4] as char).collect();
+        writeln!(tf, ">{}", name).unwrap();
+        writeln!(tf, "{}", seq).unwrap();
+    }
+    tf.flush().unwrap();
+    tf
+}
+
 #[test]
 fn strict_mode_fails_on_malformed_coordinate() {
     let f = write_gff3(
@@ -71,5 +89,269 @@ fn diagnostics_json_writes_file() {
             .any(|d| d.get("code").and_then(|v| v.as_str()) == Some("W-LOAD-100")),
         "expected diagnostic with code=W-LOAD-100, got: {}",
         body
+    );
+}
+
+/// A single-exon transcript on chr1, plus a chr1 FASTA long enough to cover it.
+fn single_exon_gff3() -> NamedTempFile {
+    write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=GENE1\n\
+         chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n\
+         chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n",
+    )
+}
+
+#[test]
+fn emit_genomic_sequences_makes_output_genome_capable() {
+    let gff = single_exon_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--fasta",
+            fasta.path().to_str().unwrap(),
+            "--no-validate-fasta",
+            "--emit-genomic-sequences",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "convert-gff failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    let genomic = &json["genomic_sequences"]["chr1"];
+    let genomic = genomic.as_str().expect("chr1 genomic sequence emitted");
+    // Full contig bytes are emitted, matching the FASTA contig exactly (not just
+    // its length — a wrong-offset or N-filled slice would share the length).
+    let expected: String = (0..520).map(|i| b"ACGT"[i % 4] as char).collect();
+    assert_eq!(genomic, expected);
+    // The exon spans genomic 100..500, so the transcript placement is fully backed.
+    let provider =
+        ferro_hgvs::reference::mock::MockProvider::from_json(&out).expect("loads and validates");
+    use ferro_hgvs::reference::provider::ReferenceProvider;
+    assert!(provider.has_genomic_data());
+}
+
+#[test]
+fn without_emit_flag_no_genomic_sequences() {
+    let gff = single_exon_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--fasta",
+            fasta.path().to_str().unwrap(),
+            "--no-validate-fasta",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(result.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    assert!(
+        json.get("genomic_sequences").is_none(),
+        "genomic_sequences must be absent without --emit-genomic-sequences"
+    );
+    // A transcripts-only reference stays transcript-capable only.
+    let provider = ferro_hgvs::reference::mock::MockProvider::from_json(&out).unwrap();
+    use ferro_hgvs::reference::provider::ReferenceProvider;
+    assert!(!provider.has_genomic_data());
+}
+
+#[test]
+fn emit_genomic_sequences_warns_when_nothing_is_placed() {
+    // A transcript filter that matches nothing leaves no emitted transcript with a
+    // chromosome, so --emit-genomic-sequences has nothing to back: convert-gff must
+    // succeed, warn, and NOT write an empty (misleading) genomic_sequences map.
+    let gff = single_exon_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--fasta",
+            fasta.path().to_str().unwrap(),
+            "--no-validate-fasta",
+            "--transcripts",
+            "NO_SUCH_TRANSCRIPT",
+            "--emit-genomic-sequences",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "convert-gff failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&result.stderr)
+            .contains("no emitted transcript has a genomic placement"),
+        "expected a warning about nothing to place, stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    assert!(
+        json.get("genomic_sequences").is_none(),
+        "an empty genomic_sequences map must not be written"
+    );
+}
+
+#[test]
+fn emit_genomic_sequences_fails_fast_when_fasta_too_short() {
+    // The GFF places the exon at chr1:100..500, but the FASTA contig is only 200
+    // bases (a sub-region FASTA with whole-genome coordinates). convert-gff must
+    // FAIL AT EMIT — not produce a file the loader would later reject (#1026).
+    let gff = single_exon_gff3(); // exon 100..500 on chr1
+    let fasta = write_fasta("chr1", 200);
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--fasta",
+            fasta.path().to_str().unwrap(),
+            "--no-validate-fasta",
+            "--emit-genomic-sequences",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !result.status.success(),
+        "convert-gff must fail when the FASTA cannot cover the placement"
+    );
+    assert!(
+        String::from_utf8_lossy(&result.stderr).contains("does not cover the annotation"),
+        "expected a coordinate-coverage error, got: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+#[test]
+fn emit_genomic_sequences_handles_multiple_contigs() {
+    // Two transcripts on two contigs; both contigs must be emitted and the result
+    // must load as genome-capable.
+    let gff = write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t200\t.\t+\t.\tID=g1\n\
+         chr1\t.\tmRNA\t100\t200\t.\t+\t.\tID=tx1;Parent=g1\n\
+         chr1\t.\texon\t100\t200\t.\t+\t.\tParent=tx1\n\
+         chr2\t.\tgene\t50\t150\t.\t+\t.\tID=g2\n\
+         chr2\t.\tmRNA\t50\t150\t.\t+\t.\tID=tx2;Parent=g2\n\
+         chr2\t.\texon\t50\t150\t.\t+\t.\tParent=tx2\n",
+    );
+    let fasta = write_multi_fasta(&[("chr1", 260), ("chr2", 200)]);
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--fasta",
+            fasta.path().to_str().unwrap(),
+            "--no-validate-fasta",
+            "--emit-genomic-sequences",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "convert-gff failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&out).unwrap()).unwrap();
+    // Assert exact per-contig bytes (using the same deterministic generator as
+    // write_multi_fasta), so a contig-swap or wrong-offset read can't pass.
+    let expect = |len: usize| -> String { (0..len).map(|i| b"ACGT"[i % 4] as char).collect() };
+    assert_eq!(
+        json["genomic_sequences"]["chr1"].as_str().unwrap(),
+        expect(260)
+    );
+    assert_eq!(
+        json["genomic_sequences"]["chr2"].as_str().unwrap(),
+        expect(200)
+    );
+
+    let provider = ferro_hgvs::reference::mock::MockProvider::from_json(&out).expect("loads");
+    use ferro_hgvs::reference::provider::ReferenceProvider;
+    assert!(provider.has_genomic_data());
+}
+
+#[test]
+fn emit_genomic_sequences_requires_fasta() {
+    let gff = single_exon_gff3();
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let result = Command::new(bin)
+        .args([
+            "convert-gff",
+            "--gff",
+            gff.path().to_str().unwrap(),
+            "--emit-genomic-sequences",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !result.status.success(),
+        "--emit-genomic-sequences without --fasta should be rejected by the CLI"
     );
 }

--- a/tests/it/issue_1026_genome_capable_json.rs
+++ b/tests/it/issue_1026_genome_capable_json.rs
@@ -1,0 +1,109 @@
+//! Issue #1026: a `transcripts.json` that carries a top-level `genomic_sequences`
+//! map (as emitted by `ferro convert-gff --emit-genomic-sequences` /
+//! `ferro build-transcript --emit-genomic-sequences`) is genome-capable: a
+//! `Normalizer` built from it via `MockProvider::from_json` runs the genome-aware
+//! normalization rules, whereas the same reference without `genomic_sequences`
+//! does not.
+//!
+//! `Normalizer(reference_json=…)` (Python) and
+//! `Normalizer::new(MockProvider::from_json(…))` (Rust) go through the same
+//! normalize pipeline, so proving the Rust path covers the Python binding too.
+
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::provider::ReferenceProvider;
+use ferro_hgvs::{parse_hgvs, FerroError, Normalizer};
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+/// Build a two-exon, plus-strand non-coding transcript with a small intron and
+/// (optionally) the backing genomic contig, then serialize it to a temp JSON file
+/// in the same object form the CLI emits.
+///
+/// Geometry (plus strand):
+///   Exon 1: tx 1..20,  genomic 1001..1020
+///   Exon 2: tx 21..40, genomic 1101..1120   (intron genomic 1021..1100)
+fn write_reference_json(with_genomic_sequences: bool) -> NamedTempFile {
+    // 40-base transcript sequence.
+    let tx_seq = "ACGT".repeat(10);
+
+    let transcript = serde_json::json!({
+        "id": "NM_1026TEST.1",
+        "gene_symbol": "GENE1026",
+        "strand": "+",
+        "sequence": tx_seq,
+        "chromosome": "chrT",
+        "genomic_start": 1001,
+        "genomic_end": 1120,
+        "exons": [
+            {"number": 1, "start": 1,  "end": 20, "genomic_start": 1001, "genomic_end": 1020},
+            {"number": 2, "start": 21, "end": 40, "genomic_start": 1101, "genomic_end": 1120}
+        ]
+    });
+
+    let mut obj = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [transcript],
+    });
+
+    if with_genomic_sequences {
+        // 1200-base contig, long enough to back the placement (max coord 1120).
+        let contig = "ACGT".repeat(300);
+        let mut genomic = serde_json::Map::new();
+        genomic.insert("chrT".to_string(), serde_json::json!(contig));
+        obj["genomic_sequences"] = serde_json::Value::Object(genomic);
+    }
+
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(serde_json::to_string_pretty(&obj).unwrap().as_bytes())
+        .unwrap();
+    file.flush().unwrap();
+    file
+}
+
+/// Without `genomic_sequences`, the reference is transcript-only: `has_genomic_data`
+/// is false and an intronic normalization cannot run the genome-aware path — it
+/// reports the intronic variant as unresolvable (the pre-#1015 main behavior).
+#[test]
+fn transcripts_only_reference_cannot_normalize_intronic() {
+    let file = write_reference_json(false);
+    let provider = MockProvider::from_json(file.path()).unwrap();
+    assert!(
+        !provider.has_genomic_data(),
+        "a reference without genomic_sequences must not report genomic data"
+    );
+
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs("NM_1026TEST.1:n.20+3del").expect("parse");
+    let result = normalizer.normalize(&variant);
+    assert!(
+        matches!(result, Err(FerroError::IntronicVariant { .. })),
+        "transcript-only reference should report the intronic variant as unresolvable, got: {result:?}"
+    );
+}
+
+/// With `genomic_sequences` present, the same reference is genome-capable: the
+/// intronic normalization reaches the genome-aware path and no longer fails with
+/// `IntronicVariant`. This is exactly the capability `--emit-genomic-sequences`
+/// unlocks (#1026).
+#[test]
+fn genome_capable_reference_normalizes_intronic() {
+    let file = write_reference_json(true);
+    let provider = MockProvider::from_json(file.path()).unwrap();
+    assert!(
+        provider.has_genomic_data(),
+        "a reference with genomic_sequences must report genomic data"
+    );
+
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs("NM_1026TEST.1:n.20+3del").expect("parse");
+    // The genome-aware intronic path runs and SUCCEEDS (vs the transcript-only
+    // reference above, which errors with IntronicVariant). On this synthetic
+    // reference the deletion is already in canonical position, so the normalized
+    // value is the input unchanged — but critically it is an Ok result from the
+    // genome-aware path, not an error.
+    let normalized = normalizer
+        .normalize(&variant)
+        .expect("genome-capable reference must reach the genome-aware path and succeed");
+    assert_eq!(normalized.to_string(), "NM_1026TEST.1:n.20+3del");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -78,6 +78,7 @@ mod inserted_range_special_positions;
 mod integration_tests;
 mod inverted_uncertain_range_insertion;
 mod issue_1004_samegap_insertion_idempotency;
+mod issue_1026_genome_capable_json;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/python/test_issue_1026_genome_capable.py
+++ b/tests/python/test_issue_1026_genome_capable.py
@@ -1,0 +1,118 @@
+"""Issue #1026: a genome-capable transcripts.json (the shape emitted by
+`ferro convert-gff --emit-genomic-sequences`) drives genome-aware normalization
+through `Normalizer(reference_json=...)` and reports full capability with no
+reduced-capability warning.
+
+This exercises the exact Python surface an integrator uses.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import ferro_hgvs
+
+
+def _genome_capable_reference() -> dict:
+    """A transcript carrying a placement (chromosome + exon genomic coords) plus
+    the backing contig bytes — the object form `--emit-genomic-sequences` writes."""
+    return {
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [
+            {
+                "id": "NM_1026.1",
+                "strand": "+",
+                "sequence": "ACGTACGT",
+                "chromosome": "chr1",
+                "genomic_start": 1,
+                "genomic_end": 8,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 8,
+                        "genomic_start": 1,
+                        "genomic_end": 8,
+                    }
+                ],
+            }
+        ],
+        "genomic_sequences": {"chr1": "ACGTACGTACGTACGT"},
+    }
+
+
+def test_genome_capable_reference_reports_full_capability(tmp_path: Path) -> None:
+    ref_path = tmp_path / "transcripts.json"
+    ref_path.write_text(json.dumps(_genome_capable_reference()))
+
+    n = ferro_hgvs.Normalizer(reference_json=str(ref_path))
+    assert n.has_genomic_data() is True
+    summary = n.reference_summary()
+    assert summary["provider_kind"] == "json"
+    assert summary["has_genomic_data"] is True
+
+
+def test_genome_capable_reference_emits_no_reduced_capability_warning(tmp_path: Path) -> None:
+    # The once-per-process warning must be checked in a fresh interpreter.
+    ref_path = tmp_path / "transcripts.json"
+    ref_path.write_text(json.dumps(_genome_capable_reference()))
+
+    code = """
+    import sys
+    import warnings
+    import ferro_hgvs
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        n = ferro_hgvs.Normalizer(reference_json=sys.argv[1])
+    assert n.has_genomic_data() is True
+    user = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user) == 0, f"expected no UserWarning for a genome-capable reference, got {len(user)}"
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code), str(ref_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+
+
+def test_transcript_only_reference_reports_reduced_capability(tmp_path: Path) -> None:
+    ref = _genome_capable_reference()
+    del ref["genomic_sequences"]  # placement without bytes → transcript-only
+    ref_path = tmp_path / "transcripts_only.json"
+    ref_path.write_text(json.dumps(ref))
+
+    n = ferro_hgvs.Normalizer(reference_json=str(ref_path))
+    assert n.has_genomic_data() is False
+    assert n.reference_summary()["has_genomic_data"] is False
+
+
+def test_transcript_only_reference_emits_reduced_capability_warning(tmp_path: Path) -> None:
+    # The reduced-capability UserWarning must actually FIRE for a transcript-only
+    # reference. Checked in a fresh interpreter because the warning is once-per-
+    # process and shared across surfaces (an in-process check would be order-flaky).
+    ref = _genome_capable_reference()
+    del ref["genomic_sequences"]
+    ref_path = tmp_path / "transcripts_only.json"
+    ref_path.write_text(json.dumps(ref))
+
+    code = """
+    import sys
+    import warnings
+    import ferro_hgvs
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        n = ferro_hgvs.Normalizer(reference_json=sys.argv[1])
+    assert n.has_genomic_data() is False
+    user = [w for w in caught if issubclass(w.category, UserWarning)]
+    assert len(user) == 1, f"expected exactly one reduced-capability UserWarning, got {len(user)}"
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code), str(ref_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"


### PR DESCRIPTION
## Summary

Makes genome-aware normalization reachable through the Python bindings for a **local / synthetic** reference (the gap Matt reported in #1026). A `transcripts.json` from `convert-gff`/`build-transcript` already carries each transcript's genomic placement (chromosome + per-exon genomic coordinates) but not the contig bytes those coordinates index into, so `Normalizer(reference_json=...)` builds a provider with `has_genomic_data() == false` and the genome-dependent rules (intronic, cross-exon/intron 3′-shift, the `g.` axis) silently skip.

Adds an opt-in `--emit-genomic-sequences` flag to `ferro convert-gff` and `ferro build-transcript` that writes a top-level `genomic_sequences` map — the referenced contigs' forward bytes from the input FASTA, keyed by chromosome — so the emitted reference is genuinely genome-capable. Placement was already emitted; this supplies the one missing ingredient, which `MockProvider::from_json` already knows how to read.

> **Stacking:** this PR is based on #1014 (reference-capability surfacing), so a genome-capable emit reports `has_genomic_data() == true` / `provider_kind == "json"` with no reduced-capability warning, while a transcript-only reference still warns. Merge #1014 first.

## What's in it

- **`--emit-genomic-sequences`** on both subcommands. Off by default (full contig bytes can be large — intended for small/synthetic references); `convert-gff` requires `--fasta`. A 50 MB size warning fires on large emissions.
- **Fail-loud load validation** in `MockProvider::from_json` when `genomic_sequences` is present: every placed transcript's contig must be present and long enough (structure), **and** the genomic bytes must *reconstruct* the transcript's stated `sequence` from its exon placement (content — reverse-complemented on the minus strand). This closes the #1012-comment-1 false-positive: a padded junk `genomic_sequences` blob is rejected at load instead of silently corrupting genome-aware normalization of `del`/`dup`/`inv`/intronic edits (whose recommended forms carry no stated reference bases, so nothing downstream would flag the wrong genome).
- **Emit-time backing check** so `convert-gff` fails fast if the FASTA cannot cover the annotation's coordinates, rather than writing a file its own loader would reject.
- **Docs:** a "capability boundary" section in `docs/transcripts_json_schema.md` (what a transcripts.json can/cannot do vs a prepared manifest, and what the load-time validation does and does not guarantee), plus a new **`docs/python_reference_guide.md`** — the recommended, footgun-free way to set up a reference from Python, with a fail-loud `load_normalizer` helper and worked examples (all verified against the built extension).

## Testing

- Rust: emission (single/multi-contig, minus-strand forward bytes), fail-fast on short FASTA, empty-placement warning, and load-time structure + content validation (junk-content rejected, minus-strand reconstruction accepted). Full suite green; clippy `-D warnings` and fmt clean.
- End-to-end: the same reference JSON, differing only by `genomic_sequences`, flips normalization from "IntronicVariant unresolvable" to a genome-aware result.
- Python: a genome-capable reference reports `has_genomic_data() == True` / `provider_kind == "json"` with no reduced-capability warning; transcript-only reports `False` + warning.

Closes #1026.
Closes #1028.
