### PR TITLE
refactor(reference): rename MockProvider to JsonProvider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Never commit machine-specific absolute paths (e.g. `/Volumes/...`, `/Users/...`,
 - **`reference/`** - Reference sequence providers
   - `provider.rs` - ReferenceProvider trait
   - `fasta.rs` - FASTA file provider
-  - `mock.rs` - MockProvider for testing
+  - `mock.rs` - `JsonProvider` (JSON/`transcripts.json`-backed; also backs `Normalizer(reference_json=...)`). Former name `MockProvider` retained as a compatibility alias.
 
 - **`convert/`** - Coordinate system conversions (c. ↔ g. ↔ n. ↔ p.)
 

--- a/src/benchmark/compare.rs
+++ b/src/benchmark/compare.rs
@@ -334,7 +334,7 @@ use crate::hgvs::parser::parse_hgvs_lenient;
 use crate::normalize::NormalizationWarning;
 use crate::normalize::NormalizeConfig;
 use crate::reference::ReferenceProvider;
-use crate::{FerroError, MockProvider, MultiFastaProvider, Normalizer};
+use crate::{FerroError, JsonProvider, MultiFastaProvider, Normalizer};
 use chrono::{DateTime, Utc};
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
@@ -1442,13 +1442,13 @@ fn run_ferro_normalize(
                 Normalizer::with_config(Box::new(provider) as Box<dyn ReferenceProvider>, config)
             } else {
                 Normalizer::with_config(
-                    Box::new(MockProvider::with_test_data()) as Box<dyn ReferenceProvider>,
+                    Box::new(JsonProvider::with_test_data()) as Box<dyn ReferenceProvider>,
                     config,
                 )
             }
         }
         None => Normalizer::with_config(
-            Box::new(MockProvider::with_test_data()) as Box<dyn ReferenceProvider>,
+            Box::new(JsonProvider::with_test_data()) as Box<dyn ReferenceProvider>,
             config,
         ),
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@
 //! # Example
 //!
 //! ```
-//! use ferro_hgvs::{parse_hgvs, Normalizer, MockProvider};
+//! use ferro_hgvs::{parse_hgvs, Normalizer, JsonProvider};
 //!
 //! // Parse an HGVS variant string
 //! let variant = parse_hgvs("NM_000088.3:c.10A>G").unwrap();
 //!
 //! // Create a normalizer with test data
-//! let provider = MockProvider::with_test_data();
+//! let provider = JsonProvider::with_test_data();
 //! let normalizer = Normalizer::new(provider);
 //!
 //! // Normalize the variant
@@ -76,7 +76,7 @@ pub use hgvs::parser::{parse_hgvs, parse_hgvs_fast};
 pub use hgvs::variant::HgvsVariant;
 pub use normalize::{NormalizeConfig, Normalizer, ShuffleDirection};
 pub use project::{VariantProjection, VariantProjector};
-pub use reference::{MockProvider, MultiFastaProvider, ReferenceProvider};
+pub use reference::{JsonProvider, MockProvider, MultiFastaProvider, ReferenceProvider};
 pub use spdi::{
     hgvs_to_spdi_simple, parse_spdi, spdi_to_hgvs, spdi_to_hgvs_with_ref, ConversionError,
     SpdiVariant,

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -9,7 +9,7 @@
 //! # #[cfg(feature = "parallel")]
 //! # fn main() {
 //! use ferro_hgvs::parallel::{parse_hgvs_parallel, normalize_parallel};
-//! use ferro_hgvs::{MockProvider, Normalizer};
+//! use ferro_hgvs::{JsonProvider, Normalizer};
 //!
 //! let variants = vec![
 //!     "NM_000088.3:c.459A>G",
@@ -24,7 +24,7 @@
 //!     .collect();
 //!
 //! // Normalize in parallel (requires a provider)
-//! let provider = MockProvider::with_test_data();
+//! let provider = JsonProvider::with_test_data();
 //! let normalizer = Normalizer::new(provider);
 //! let _normalized = normalize_parallel(&normalizer, &parsed);
 //! # }

--- a/src/python.rs
+++ b/src/python.rs
@@ -33,7 +33,7 @@ use crate::python_helpers::{
 };
 use crate::reference::provider::ReferenceProvider;
 use crate::reference::transcript::{GenomeBuild, Strand};
-use crate::reference::{MockProvider, MultiFastaProvider};
+use crate::reference::{JsonProvider, MultiFastaProvider};
 use crate::rsid::{format_rsid, parse_rsid as rust_parse_rsid, InMemoryRsIdLookup, RsIdResult};
 use crate::spdi::{hgvs_to_spdi_simple, parse_spdi as rust_parse_spdi, spdi_to_hgvs, SpdiVariant};
 use crate::vcf::{vcf_to_genomic_hgvs as rust_vcf_to_hgvs, VcfRecord};
@@ -177,12 +177,12 @@ fn parse_direction_or_raise(direction: &str) -> PyResult<ShuffleDirection> {
 /// `MultiFasta` is wrapped in `Arc` because `MultiFastaProvider` is large and
 /// is cloned on every Python call to construct a fresh `Normalizer<P>`.
 ///
-/// `Mock` is boxed because `MockProvider` is itself large (it owns the test
+/// `Mock` is boxed because `JsonProvider` is itself large (it owns the test
 /// reference maps); without the box this variant dwarfs the 8-byte `Arc`
 /// `MultiFasta` variant and trips `clippy::large_enum_variant`.
 #[derive(Clone)]
 enum PyProvider {
-    Mock(Box<MockProvider>),
+    Mock(Box<JsonProvider>),
     MultiFasta(Arc<MultiFastaProvider>),
 }
 
@@ -369,9 +369,9 @@ impl ReferenceProvider for PyProvider {
 }
 
 impl PyProvider {
-    /// Load from a JSON file (delegates to MockProvider::from_json).
+    /// Load from a JSON file (delegates to JsonProvider::from_json).
     fn from_json(path: &Path) -> PyResult<Self> {
-        MockProvider::from_json(path)
+        JsonProvider::from_json(path)
             .map(|p| PyProvider::Mock(Box::new(p)))
             .map_err(|e| {
                 ferro_typed(
@@ -397,7 +397,7 @@ impl PyProvider {
 
     /// Default: built-in test data.
     fn test_data() -> Self {
-        PyProvider::Mock(Box::new(MockProvider::with_test_data()))
+        PyProvider::Mock(Box::new(JsonProvider::with_test_data()))
     }
 
     /// Build / extract a CdotMapper for this provider.
@@ -455,7 +455,7 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
 
     let config = NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
     // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
-    let provider = MockProvider::with_test_data();
+    let provider = JsonProvider::with_test_data();
     // This free function always uses genome-less test data; surface the
     // reduced-capability signal once per process (#1012), pointing callers at a
     // full manifest-backed Normalizer.
@@ -703,7 +703,7 @@ impl PyHgvsVariant {
         let config =
             NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
         // Note: Uses built-in test data. For production use, create a Normalizer with reference_json.
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         // Genome-less test data; surface the reduced-capability signal once per
         // process (#1012), pointing callers at a full manifest-backed Normalizer.
         emit_reduced_capability_warning(
@@ -1061,7 +1061,7 @@ impl PyNormalizer {
     /// Emit a one-time `UserWarning` when the backing provider has no genomic
     /// data, so users silently landing on a reduced-capability build get a
     /// runtime signal (#1012 item 1). Fires at most once per process; the
-    /// `MockProvider` test-data and `transcripts.json` paths both lack genomic
+    /// `JsonProvider` test-data and `transcripts.json` paths both lack genomic
     /// data, so both trigger it.
     fn warn_if_reduced_capability(&self, py: Python<'_>) -> PyResult<()> {
         emit_reduced_capability_warning(

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -1,4 +1,15 @@
-//! Mock reference provider for testing
+//! In-memory, JSON-backed reference provider.
+//!
+//! [`JsonProvider`] loads transcripts (and optional protein and genomic
+//! sequences) from a `transcripts.json` document — the output of
+//! `ferro convert-gff` / `ferro build-transcript`, or a hand-authored file — and
+//! serves them for normalization and projection. It also backs the Python
+//! `Normalizer(reference_json=...)` path, so despite living in the historically
+//! `mock`-named module it is a real, production-facing provider (transcript-level
+//! normalization is genuine and correct; add a `genomic_sequences` map to make it
+//! genome-capable — see `docs/transcripts_json_schema.md`). Its
+//! [`JsonProvider::with_test_data`] constructor is the only genuinely test-only
+//! part. The former name `MockProvider` remains as a compatibility alias.
 
 use crate::error::FerroError;
 use crate::hgvs::variant::Accession;
@@ -8,9 +19,11 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
-/// Mock reference provider that loads transcripts from JSON
+/// In-memory reference provider that loads transcripts, proteins, and optional
+/// genomic sequences from a `transcripts.json` document. Backs
+/// `Normalizer(reference_json=...)`. See the module documentation.
 #[derive(Clone)]
-pub struct MockProvider {
+pub struct JsonProvider {
     transcripts: HashMap<String, Arc<Transcript>>,
     proteins: HashMap<String, String>,
     /// Genomic sequences keyed by contig name
@@ -37,7 +50,7 @@ pub struct MockProvider {
     /// `"NM_002001.2"`) → the *different*-version accession the provider should
     /// actually serve for it (e.g. `"NM_002001.4"`). Lets tests model the #785
     /// silent version-strip substitution that a real `MultiFastaProvider`
-    /// performs via `resolve_name`'s base→latest fallback, which `MockProvider`
+    /// performs via `resolve_name`'s base→latest fallback, which `JsonProvider`
     /// otherwise refuses by design. Empty by default, so an unconfigured mock
     /// never substitutes a version.
     version_substitutions: HashMap<String, String>,
@@ -52,6 +65,15 @@ pub struct MockProvider {
     /// Empty by default, so an unconfigured mock is build-agnostic as before.
     build_transcripts: HashMap<(String, &'static str), Arc<Transcript>>,
 }
+
+/// Backwards-compatible alias for the former name of [`JsonProvider`].
+///
+/// The provider was renamed from `MockProvider` because it is not a test mock — it
+/// backs the production `Normalizer(reference_json=...)` path. This alias keeps
+/// existing code compiling; prefer [`JsonProvider`] in new code. (Not marked
+/// `#[deprecated]` yet, to avoid warning-storming the many existing call sites; a
+/// follow-up can migrate them and then deprecate.)
+pub type MockProvider = JsonProvider;
 
 /// Validate that a JSON reference declaring genomic capability actually backs
 /// every placed transcript with genomic sequence bytes that are the *right length*
@@ -187,7 +209,7 @@ fn validate_reconstructed_transcript_sequence(
     Ok(())
 }
 
-impl MockProvider {
+impl JsonProvider {
     /// Create an empty mock provider
     pub fn new() -> Self {
         Self {
@@ -304,7 +326,7 @@ impl MockProvider {
             }
             _ => {
                 return Err(FerroError::Json {
-                    msg: "MockProvider JSON root must be an array or object".to_string(),
+                    msg: "JsonProvider JSON root must be an array or object".to_string(),
                 })
             }
         };
@@ -584,13 +606,13 @@ impl MockProvider {
     }
 }
 
-impl Default for MockProvider {
+impl Default for JsonProvider {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ReferenceProvider for MockProvider {
+impl ReferenceProvider for JsonProvider {
     fn genomic_placement(&self, parent: &Accession) -> Option<GenomicPlacement> {
         self.genomic_placement_on_build(parent, None)
     }
@@ -911,9 +933,18 @@ mod tests {
 
     #[test]
     fn test_mock_provider_with_test_data() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         assert!(!provider.is_empty());
         assert!(provider.len() >= 2);
+    }
+
+    /// The former name `MockProvider` remains a working alias for [`JsonProvider`]
+    /// so existing code keeps compiling after the rename.
+    #[test]
+    fn mock_provider_alias_is_json_provider() {
+        let via_alias: MockProvider = MockProvider::with_test_data();
+        let via_new: JsonProvider = via_alias; // same type — assignment compiles
+        assert!(!via_new.is_empty());
     }
 
     /// #653: an NG_ parent with both a GRCh37 and a GRCh38 RefSeqGene placement
@@ -930,7 +961,7 @@ mod tests {
             nc_end: 1008,
             strand: Strand::Plus,
         };
-        let mut provider = MockProvider::new();
+        let mut provider = JsonProvider::new();
         provider.add_genomic_placement("NG_900.1", mk(11)); // GRCh38
         provider.add_genomic_placement("NG_900.1", mk(10)); // GRCh37
         let ng = Accession::new("NG", "900", Some(1));
@@ -958,7 +989,7 @@ mod tests {
         );
 
         // An NG_ with only a GRCh37 placement declines a GRCh38 request (guard).
-        let mut grch37_only = MockProvider::new();
+        let mut grch37_only = JsonProvider::new();
         grch37_only.add_genomic_placement("NG_901.1", mk(10));
         let ng2 = Accession::new("NG", "901", Some(1));
         assert!(grch37_only
@@ -972,7 +1003,7 @@ mod tests {
     }
 
     /// #843: the build-keyed transcript lookup must honor the same unversioned
-    /// → versioned base-accession rule that [`MockProvider::get_transcript`]
+    /// → versioned base-accession rule that [`JsonProvider::get_transcript`]
     /// applies (`NM_123` resolves to a stored `NM_123.1`). Without it, a bare
     /// `g.` allele whose transcript accession is unversioned would miss the
     /// build-specific record and silently fall back to the build-agnostic
@@ -1005,7 +1036,7 @@ mod tests {
             cached_introns: OnceLock::new(),
         };
 
-        let mut provider = MockProvider::new();
+        let mut provider = JsonProvider::new();
         // Build-keyed records (versioned ids) with build-divergent bases.
         provider.add_transcript_on_build("GRCh37", mk(GenomeBuild::GRCh37, "AAAA"));
         provider.add_transcript_on_build("GRCh38", mk(GenomeBuild::GRCh38, "CCCC"));
@@ -1037,21 +1068,21 @@ mod tests {
 
     #[test]
     fn test_get_transcript() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         let tx = provider.get_transcript("NM_000088.3").unwrap();
         assert_eq!(tx.gene_symbol, Some("COL1A1".to_string()));
     }
 
     #[test]
     fn test_get_transcript_not_found() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         let result = provider.get_transcript("NM_NONEXISTENT.1");
         assert!(result.is_err());
     }
 
     #[test]
     fn with_test_data_includes_a_noncoding_transcript() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         let tx = provider
             .get_transcript("NR_000123.1")
             .expect("NR_000123.1 should be present in test data");
@@ -1061,7 +1092,7 @@ mod tests {
 
     #[test]
     fn test_get_sequence() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         let seq = provider.get_sequence("NM_000088.3", 0, 3).unwrap();
         assert_eq!(seq, "ATG");
     }
@@ -1070,7 +1101,7 @@ mod tests {
     fn test_get_sequence_falls_through_to_contig() {
         // Regression: get_sequence should fall through to contig lookup
         // when the id is not a transcript, matching FastaProvider behavior.
-        let mut provider = MockProvider::new();
+        let mut provider = JsonProvider::new();
         provider.add_genomic_sequence("chr1", "ACGTACGT");
         let seq = provider.get_sequence("chr1", 0, 4).unwrap();
         assert_eq!(seq, "ACGT");
@@ -1078,7 +1109,7 @@ mod tests {
 
     #[test]
     fn test_has_transcript() {
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         assert!(provider.has_transcript("NM_000088.3"));
         assert!(!provider.has_transcript("NONEXISTENT"));
     }
@@ -1090,7 +1121,7 @@ mod tests {
         // the blanket boxed impl does not forward `has_transcript_version_exact`,
         // it silently falls through to the trait default `true` and the gate is
         // inert in production. Pin the forwarding here.
-        let mut inner = MockProvider::new();
+        let mut inner = JsonProvider::new();
         inner.mark_non_version_exact("NM_TEST.1");
         let boxed: Box<dyn ReferenceProvider> = Box::new(inner);
         assert!(
@@ -1127,7 +1158,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path()).unwrap();
+        let provider = JsonProvider::from_json(file.path()).unwrap();
 
         assert!(provider.has_transcript("NM_TEST.1"));
         assert!(provider.has_protein_data());
@@ -1163,7 +1194,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path()).expect("consistent reference loads");
+        let provider = JsonProvider::from_json(file.path()).expect("consistent reference loads");
         assert!(provider.has_genomic_data());
     }
 
@@ -1194,7 +1225,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let err = match MockProvider::from_json(file.path()) {
+        let err = match JsonProvider::from_json(file.path()) {
             Ok(_) => panic!("expected rejection of genomic bytes that don't match the transcript"),
             Err(e) => e,
         };
@@ -1229,7 +1260,7 @@ mod tests {
         file.write_all(json.as_bytes()).unwrap();
 
         let provider =
-            MockProvider::from_json(file.path()).expect("consistent minus-strand reference loads");
+            JsonProvider::from_json(file.path()).expect("consistent minus-strand reference loads");
         assert!(provider.has_genomic_data());
     }
 
@@ -1257,7 +1288,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let err = match MockProvider::from_json(file.path()) {
+        let err = match JsonProvider::from_json(file.path()) {
             Ok(_) => panic!("expected an error for an unbacked placement"),
             Err(e) => e,
         };
@@ -1289,7 +1320,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let err = match MockProvider::from_json(file.path()) {
+        let err = match JsonProvider::from_json(file.path()) {
             Ok(_) => panic!("expected an error for a too-short contig"),
             Err(e) => e,
         };
@@ -1321,13 +1352,13 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path()).expect("transcripts-only loads");
+        let provider = JsonProvider::from_json(file.path()).expect("transcripts-only loads");
         assert!(!provider.has_genomic_data());
     }
 
     #[test]
     fn test_get_protein_length_resolves_and_falls_back() {
-        let mut provider = MockProvider::new();
+        let mut provider = JsonProvider::new();
         provider.add_protein("NP_TEST.1", "MAPLE");
 
         // Exact (versioned) match returns the stored length.
@@ -1342,7 +1373,7 @@ mod tests {
         // length of `0` (matching the trait's default probe semantics),
         // NOT an error — otherwise `normalize()` is not behavior-preserving
         // when a provider switches from the probe loop to this API.
-        let provider = MockProvider::with_test_data();
+        let provider = JsonProvider::with_test_data();
         assert_eq!(provider.get_protein_length("NP_NONEXISTENT.1").unwrap(), 0);
     }
 
@@ -1364,7 +1395,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path()).unwrap();
+        let provider = JsonProvider::from_json(file.path()).unwrap();
 
         assert!(provider.has_transcript("NM_TEST.1"));
         assert!(!provider.has_protein_data());
@@ -1381,7 +1412,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(b"{}").unwrap();
 
-        match MockProvider::from_json(file.path()) {
+        match JsonProvider::from_json(file.path()) {
             Err(FerroError::Json { msg }) => assert!(
                 msg.contains("no usable reference data"),
                 "expected error to mention no usable reference data, got: {msg}",
@@ -1401,7 +1432,7 @@ mod tests {
         for body in [&b"[]"[..], br#"{"transcripts": []}"#] {
             let mut file = NamedTempFile::new().unwrap();
             file.write_all(body).unwrap();
-            match MockProvider::from_json(file.path()) {
+            match JsonProvider::from_json(file.path()) {
                 Err(FerroError::Json { msg }) => assert!(
                     msg.contains("no usable reference data"),
                     "expected error to mention no usable reference data, got: {msg}",
@@ -1429,7 +1460,7 @@ mod tests {
         file.write_all(json.as_bytes()).unwrap();
 
         let provider =
-            MockProvider::from_json(file.path()).expect("a genomic-only reference should load");
+            JsonProvider::from_json(file.path()).expect("a genomic-only reference should load");
         assert!(provider.is_empty()); // no transcripts
         assert!(provider.has_genomic_data());
         assert_eq!(
@@ -1469,7 +1500,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(b"42").unwrap();
 
-        match MockProvider::from_json(file.path()) {
+        match JsonProvider::from_json(file.path()) {
             Err(FerroError::Json { msg }) => {
                 assert!(
                     msg.contains("array or object"),
@@ -1491,7 +1522,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(br#"{"transripts": []}"#).unwrap();
 
-        match MockProvider::from_json(file.path()) {
+        match JsonProvider::from_json(file.path()) {
             Err(e) => assert!(
                 format!("{e}").contains("transripts"),
                 "expected error to mention the unknown field, got {e}",
@@ -1524,21 +1555,21 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path())
+        let provider = JsonProvider::from_json(file.path())
             .expect("convert-gff JSON with version/genome_build metadata should load");
         assert!(provider.has_transcript("NM_000001.1"));
     }
 
     #[test]
     fn test_mock_provider_returns_sequence_length_for_added_sequence() {
-        let mut provider = MockProvider::new();
+        let mut provider = JsonProvider::new();
         provider.add_genomic_sequence("NC_012920.1", "A".repeat(16569));
         assert_eq!(provider.get_sequence_length("NC_012920.1").unwrap(), 16569);
     }
 
     #[test]
     fn test_mock_provider_sequence_length_errors_for_unknown_id() {
-        let provider = MockProvider::new();
+        let provider = JsonProvider::new();
         let err = provider.get_sequence_length("missing").unwrap_err();
         assert!(matches!(err, FerroError::ReferenceNotFound { .. }));
     }
@@ -1564,7 +1595,7 @@ mod tests {
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(json.as_bytes()).unwrap();
 
-        let provider = MockProvider::from_json(file.path())
+        let provider = JsonProvider::from_json(file.path())
             .expect("convert-gff JSON with transcript should load");
         let tx = provider
             .get_transcript("NM_000001.1")

--- a/src/reference/mod.rs
+++ b/src/reference/mod.rs
@@ -21,7 +21,7 @@ pub mod validate;
 pub use annotation::{load_annotations, AnnotationFormat, LoaderConfig, LoaderReport};
 pub use fasta::FastaProvider;
 pub use loader::{detect_genome_build, TranscriptDb};
-pub use mock::MockProvider;
+pub use mock::{JsonProvider, MockProvider};
 pub use multi_fasta::MultiFastaProvider;
 pub use protein::ProteinCache;
 pub use provider::{GenomicPlacement, ReferenceProvider};


### PR DESCRIPTION
## Summary

Renames `MockProvider` to `JsonProvider`, addressing the rename request in #1012 (comment) and #1028. Despite the "mock … for testing" naming, this provider backs the production `Normalizer(reference_json=...)` path — transcript-level normalization through it is genuine, and with a `genomic_sequences` map it is fully genome-capable (#1026). The old name oversold the limitation while its API prominence undersold it.

## What's in it

- `struct MockProvider` → `struct JsonProvider`, with docs rewritten to describe the real, production-facing role (`with_test_data()` remains the only genuinely test-only part).
- A `pub type MockProvider = JsonProvider;` compatibility alias so existing code — including the ~120 test call sites — keeps compiling unchanged. The alias is intentionally **not** `#[deprecated]` yet (that would warning-storm those sites under `-D warnings`); a follow-up can migrate call sites and then deprecate.
- The production Python binding (`python.rs`) and the crate re-exports (`lib.rs`, `reference/mod.rs`) use the new name.

> **Stacking:** based on #1026. Cosmetic and non-blocking — merge last.

## Testing

Full suite green (the alias keeps every existing usage working), plus a regression test that the `MockProvider` alias resolves to `JsonProvider`. Python tests green. clippy `-D warnings` (dev + python) and fmt clean.

Refs #1012, #1028.
