### PR TITLE
feat(reference,cli): validate transcripts.json version and check it standalone

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -571,7 +571,9 @@ enum Commands {
 
     /// Check reference data setup
     Check {
-        /// Reference directory to check
+        /// Reference to check: a prepared reference directory (containing
+        /// `manifest.json`), or a standalone `transcripts.json` file produced by
+        /// `convert-gff`/`build-transcript`.
         #[arg(long, default_value = "ferro-reference")]
         reference: PathBuf,
 
@@ -3431,17 +3433,83 @@ fn run_check(
     validate_cds: bool,
     cds_allowlist: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use ferro_hgvs::check::{check_reference, print_check_summary};
+    use ferro_hgvs::check::{
+        check_reference, check_transcripts_json, print_check_summary,
+        print_transcripts_json_failure, print_transcripts_json_summary,
+    };
+    use std::ffi::OsStr;
 
-    let result = check_reference(reference);
-    print_check_summary(&result, reference);
+    // A path that doesn't exist is a user error (typically a typo) — say so, rather
+    // than telling the user to run `ferro prepare` for a missing directory.
+    if !reference.exists() {
+        return Err(format!(
+            "reference path does not exist: {} (pass a prepared reference directory or a \
+             standalone transcripts.json file)",
+            reference.display()
+        )
+        .into());
+    }
+
+    // A standalone `transcripts.json` file (the convert-gff/build-transcript output)
+    // has no manifest; check it directly instead of reporting it as missing
+    // reference data (#1012 comment 2). A `manifest.json` file is really the
+    // prepared-reference directory case, so route it to its parent — users
+    // naturally point at either. The manifest-only options (`--validate-cds`,
+    // `--build-cache`, cdot cache source) do not apply to a standalone file.
+    let is_manifest_file =
+        reference.is_file() && reference.file_name() == Some(OsStr::new("manifest.json"));
+    if reference.is_file() && !is_manifest_file {
+        let ignored: Vec<&str> = [
+            ("--validate-cds", validate_cds),
+            ("--build-cache", build_cache),
+            ("--cds-allowlist", cds_allowlist.is_some()),
+        ]
+        .iter()
+        .filter(|(_, set)| *set)
+        .map(|(name, _)| *name)
+        .collect();
+        if !ignored.is_empty() {
+            eprintln!(
+                "warning: {} do{} not apply to a standalone transcripts.json file and {} ignored",
+                ignored.join(" / "),
+                if ignored.len() == 1 { "es" } else { "" },
+                if ignored.len() == 1 { "is" } else { "are" },
+            );
+        }
+        return match check_transcripts_json(reference) {
+            Ok(summary) => {
+                print_transcripts_json_summary(&summary);
+                Ok(())
+            }
+            Err(e) => {
+                print_transcripts_json_failure(reference, &e);
+                Err("Reference data check failed".into())
+            }
+        };
+    }
+
+    // Directory path (or a `manifest.json` file → its parent directory).
+    let reference_dir: &Path = if is_manifest_file {
+        // `Path::new("manifest.json").parent()` is `Some("")` (an empty path),
+        // NOT `None` — so a bare relative `manifest.json` would otherwise resolve
+        // the directory to "" and print an empty dir name. Map empty → ".".
+        reference
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."))
+    } else {
+        reference
+    };
+
+    let result = check_reference(reference_dir);
+    print_check_summary(&result, reference_dir);
 
     if !result.valid {
         return Err("Reference data check failed".into());
     }
 
     if validate_cds {
-        run_cds_consistency_check(reference, cds_allowlist)?;
+        run_cds_consistency_check(reference_dir, cds_allowlist)?;
     }
 
     if build_cache {
@@ -3451,7 +3519,7 @@ fn run_check(
         use ferro_hgvs::commands::create_reference_provider;
         eprintln!("Building/refreshing reference cache (one-time)...");
         let started = std::time::Instant::now();
-        let _provider = create_reference_provider(Some(reference))?;
+        let _provider = create_reference_provider(Some(reference_dir))?;
         eprintln!("Reference cache ready in {:.1?}.", started.elapsed());
     }
 
@@ -3460,7 +3528,7 @@ fn run_check(
     // showing up as a slow startup. The nightly perf gate parses this line as a
     // timing-free co-assertion that the prepared cache is on the fast path.
     // Printed after `--build-cache` so it reflects the freshly built cache.
-    match ferro_hgvs::commands::cdot_cache_load_source(reference) {
+    match ferro_hgvs::commands::cdot_cache_load_source(reference_dir) {
         Ok(Some(ferro_hgvs::data::CdotLoadSource::Archive)) => {
             println!("cdot cache: archive");
         }

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -3,8 +3,11 @@
 //! This module provides functionality to verify that reference data
 //! is properly configured and available for normalization.
 
+use crate::error::FerroError;
 use crate::prepare::ReferenceManifest;
-use std::path::Path;
+use crate::reference::mock::MockProvider;
+use crate::reference::provider::ReferenceProvider;
+use std::path::{Path, PathBuf};
 
 /// Result of checking reference data.
 #[derive(Debug, Clone)]
@@ -45,6 +48,87 @@ impl CheckResult {
         self.warnings.push(warning);
         self
     }
+}
+
+/// Summary of a standalone `transcripts.json` reference (the
+/// `convert-gff`/`build-transcript` → `MockProvider` path), as opposed to a
+/// prepared manifest directory.
+#[derive(Debug, Clone)]
+pub struct TranscriptsJsonSummary {
+    /// Path to the checked JSON file.
+    pub path: PathBuf,
+    /// Number of transcripts loaded.
+    pub transcript_count: usize,
+    /// Whether the reference carries **usable** genomic sequence (at least one
+    /// non-empty contig), so the genome-dependent normalization rules can run — see
+    /// the capability boundary in `docs/transcripts_json_schema.md`. An empty
+    /// contig string does not count.
+    pub genome_capable: bool,
+    /// Whether the reference carries protein sequences.
+    pub has_protein_data: bool,
+}
+
+/// Check a standalone `transcripts.json` file (rather than a prepared reference
+/// directory). Loads it through [`MockProvider::from_json`], so it enforces the
+/// same schema and version validation the runtime load does, and reports what
+/// capability the reference has (#1012 comment 2).
+///
+/// Fails if the reference resolves nothing (no transcripts, no genomic bases, no
+/// proteins) rather than green-lighting a dead reference.
+pub fn check_transcripts_json(path: &Path) -> Result<TranscriptsJsonSummary, FerroError> {
+    let provider = MockProvider::from_json(path)?;
+    let transcript_count = provider.len();
+    let genome_capable = provider.total_genomic_bases() > 0;
+    let has_protein_data = provider.has_protein_data();
+
+    if transcript_count == 0 && !genome_capable && !has_protein_data {
+        return Err(FerroError::Json {
+            msg: "reference has no usable data: no transcripts, genomic sequence, or proteins"
+                .to_string(),
+        });
+    }
+
+    Ok(TranscriptsJsonSummary {
+        path: path.to_path_buf(),
+        transcript_count,
+        genome_capable,
+        has_protein_data,
+    })
+}
+
+/// Print a summary of a successful standalone `transcripts.json` check.
+pub fn print_transcripts_json_summary(summary: &TranscriptsJsonSummary) {
+    eprintln!("=== transcripts.json Check ===");
+    eprintln!("  File: {}", summary.path.display());
+    eprintln!("  Status: OK");
+    eprintln!();
+    eprintln!("=== Contents ===");
+    eprintln!("  Transcripts: {}", summary.transcript_count);
+    eprintln!(
+        "  Genome-capable: {}",
+        if summary.genome_capable {
+            "yes"
+        } else {
+            "no (transcript-level normalization only)"
+        }
+    );
+    eprintln!(
+        "  Protein data: {}",
+        if summary.has_protein_data {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+}
+
+/// Print a clean failure block for a standalone `transcripts.json` check, mirroring
+/// the prepared-directory path's presentation instead of a raw error dump.
+pub fn print_transcripts_json_failure(path: &Path, error: &FerroError) {
+    eprintln!("=== transcripts.json Check ===");
+    eprintln!("  File: {}", path.display());
+    eprintln!("  Status: FAILED");
+    eprintln!("  ERROR: {}", error);
 }
 
 /// Check reference data and return detailed result.
@@ -351,6 +435,116 @@ mod tests {
         let result = check_reference(dir.path());
         assert!(!result.valid);
         assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn check_transcripts_json_reports_transcript_only_reference() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("transcripts.json");
+        let json = r#"{
+            "version": "1.0",
+            "genome_build": "GRCh38",
+            "transcripts": [
+                {"id": "NM_1.1", "strand": "+", "sequence": "ACGTACGT",
+                 "exons": [{"number": 1, "start": 1, "end": 8}]}
+            ]
+        }"#;
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(json.as_bytes())
+            .unwrap();
+
+        let summary = check_transcripts_json(&path).expect("loads");
+        assert_eq!(summary.transcript_count, 1);
+        assert!(
+            !summary.genome_capable,
+            "no genomic_sequences → not genome-capable"
+        );
+        assert!(!summary.has_protein_data);
+    }
+
+    #[test]
+    fn check_transcripts_json_reports_genome_capable_reference() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("transcripts.json");
+        let json = r#"{
+            "version": "1.0",
+            "transcripts": [
+                {"id": "NM_1.1", "strand": "+", "sequence": "ACGT",
+                 "chromosome": "chr1", "genomic_start": 1, "genomic_end": 4,
+                 "exons": [{"number": 1, "start": 1, "end": 4,
+                            "genomic_start": 1, "genomic_end": 4}]}
+            ],
+            "genomic_sequences": {"chr1": "ACGTACGT"}
+        }"#;
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(json.as_bytes())
+            .unwrap();
+
+        let summary = check_transcripts_json(&path).expect("loads");
+        assert_eq!(summary.transcript_count, 1);
+        assert!(
+            summary.genome_capable,
+            "genomic_sequences present → genome-capable"
+        );
+    }
+
+    #[test]
+    fn check_transcripts_json_rejects_empty_reference() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("transcripts.json");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(br#"{"transcripts": []}"#)
+            .unwrap();
+        assert!(
+            check_transcripts_json(&path).is_err(),
+            "a reference with no usable data must fail the check, not be green-lit"
+        );
+    }
+
+    #[test]
+    fn check_transcripts_json_empty_contig_is_not_genome_capable() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("transcripts.json");
+        // An empty contig string keeps a transcript present but carries no bases.
+        let json = r#"{
+            "transcripts": [
+                {"id": "NM_1.1", "strand": "+", "sequence": "ACGT",
+                 "exons": [{"number": 1, "start": 1, "end": 4}]}
+            ],
+            "genomic_sequences": {"chr1": ""}
+        }"#;
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(json.as_bytes())
+            .unwrap();
+        let summary = check_transcripts_json(&path).expect("loads (has a transcript)");
+        assert!(
+            !summary.genome_capable,
+            "an empty genomic contig must not be reported as genome-capable"
+        );
+    }
+
+    #[test]
+    fn check_transcripts_json_propagates_incompatible_version_error() {
+        use std::io::Write;
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("transcripts.json");
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(br#"{"version": "2.0", "transcripts": []}"#)
+            .unwrap();
+
+        assert!(
+            check_transcripts_json(&path).is_err(),
+            "an incompatible schema version must surface as a check failure"
+        );
     }
 
     #[test]

--- a/src/reference/mock.rs
+++ b/src/reference/mock.rs
@@ -209,6 +209,72 @@ fn validate_reconstructed_transcript_sequence(
     Ok(())
 }
 
+/// Highest `transcripts.json` container **major** schema version this build can
+/// interpret. The container `version` is `"MAJOR.MINOR"` (e.g. `"1.0"`). A newer
+/// **major** is rejected because it may reinterpret existing fields. A newer
+/// *minor* is only accepted if it adds no fields: the object form uses
+/// `deny_unknown_fields`, so a minor that introduces a new key is still rejected
+/// (with an "unknown field" error) by an older build — minor-forward-compatibility
+/// is therefore limited to value-only changes, not new fields.
+const SUPPORTED_TRANSCRIPTS_JSON_MAJOR: u32 = 1;
+
+/// Validate the container `version` from a `transcripts.json` object.
+///
+/// Accepts a JSON string (`"1.0"`) or number (`1`) — both are natural hand-written
+/// forms. `None` (a bare-array reference, or an object with no `version`) is
+/// accepted for backward compatibility. A present version must be `MAJOR[.MINOR…]`
+/// with every dot-separated component numeric, and its major must not exceed
+/// [`SUPPORTED_TRANSCRIPTS_JSON_MAJOR`]; anything else is a clear load-time error.
+///
+/// This is validated against the **raw** JSON value before the `deny_unknown_fields`
+/// deserialize, so a newer-major file gets this friendly "upgrade" message even when
+/// it also carries fields this build does not recognize.
+fn validate_transcripts_json_version(
+    version: Option<&serde_json::Value>,
+) -> Result<(), FerroError> {
+    let Some(version) = version else {
+        return Ok(());
+    };
+
+    let unrecognized = || FerroError::Json {
+        msg: format!(
+            "unrecognized transcripts.json schema version {} (expected e.g. \"1.0\")",
+            version
+        ),
+    };
+
+    // Accept a string ("1.0") or a bare number (1 / 1.0).
+    let version_str = match version {
+        serde_json::Value::String(s) => s.trim().to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        _ => return Err(unrecognized()),
+    };
+
+    // Every dot-separated component must be a non-empty run of ASCII digits, so
+    // suffixes like "1.0-draft", "v1", "1a" are rejected consistently.
+    let mut components = version_str.split('.');
+    let major_str = components.next().unwrap_or("");
+    let all_numeric = std::iter::once(major_str)
+        .chain(components)
+        .all(|c| !c.is_empty() && c.bytes().all(|b| b.is_ascii_digit()));
+    if !all_numeric {
+        return Err(unrecognized());
+    }
+    let major: u32 = major_str.parse().map_err(|_| unrecognized())?;
+
+    if major > SUPPORTED_TRANSCRIPTS_JSON_MAJOR {
+        return Err(FerroError::Json {
+            msg: format!(
+                "transcripts.json schema version {} is newer than this build supports \
+                 (max major version {}); upgrade ferro-hgvs",
+                version_str, SUPPORTED_TRANSCRIPTS_JSON_MAJOR
+            ),
+        });
+    }
+
+    Ok(())
+}
+
 impl JsonProvider {
     /// Create an empty mock provider
     pub fn new() -> Self {
@@ -291,6 +357,10 @@ impl JsonProvider {
     /// contig is rejected here rather than producing a silently-degraded
     /// genome-aware normalization (#1012 comment 1). See
     /// [`validate_genomic_placement_backing`].
+    ///
+    /// For the object form, an incompatible container `version` (a major newer
+    /// than this build supports) is rejected at load — see
+    /// [`validate_transcripts_json_version`].
     pub fn from_json(path: &Path) -> Result<Self, FerroError> {
         // `deny_unknown_fields` so a typo'd key (e.g. `transripts`) produces
         // a clear error rather than silently defaulting to an empty provider.
@@ -303,17 +373,34 @@ impl JsonProvider {
             proteins: HashMap<String, String>,
             #[serde(default)]
             genomic_sequences: HashMap<String, String>,
-            /// Container metadata emitted by `ferro convert-gff`; accepted but ignored.
+            /// Container metadata emitted by `ferro convert-gff`; accepted but
+            /// ignored here (validated from the raw value before this deserialize).
+            /// Typed as `Value` so a string ("1.0") or number (1) both parse.
             #[serde(default, rename = "version")]
-            _version: Option<String>,
+            _version: Option<serde_json::Value>,
             /// Container metadata emitted by `ferro convert-gff`; per-transcript
             /// `genome_build` on each `Transcript` is authoritative.
             #[serde(default, rename = "genome_build")]
-            _genome_build: Option<String>,
+            _genome_build: Option<serde_json::Value>,
         }
 
-        let content = std::fs::read_to_string(path)?;
-        let value: serde_json::Value = serde_json::from_str(&content)?;
+        // Parse straight from a buffered reader rather than reading the whole
+        // file into a `String` first: a genome-capable transcripts.json can carry
+        // whole-chromosome sequences, and `read_to_string` + `from_str` would hold
+        // the raw text, the `Value` DOM, AND the final typed structures alive
+        // simultaneously (~3x the file size at peak).
+        let file = std::fs::File::open(path)?;
+        let value: serde_json::Value = serde_json::from_reader(std::io::BufReader::new(file))?;
+
+        // Fail loud on an incompatible container schema version rather than silently
+        // loading a file this build cannot correctly interpret (#1012 comment 2).
+        // The `MockProvider`/`reference_json` path previously did only
+        // `deny_unknown_fields` and never checked the version, unlike the manifest
+        // path (`validate_loaded_manifest`). Validated against the RAW value (before
+        // the `deny_unknown_fields` deserialize) so a newer-major file gets the
+        // friendly "upgrade" message even if it also carries unknown fields.
+        // `Value::get` returns `None` for a bare array, which is accepted.
+        validate_transcripts_json_version(value.get("version"))?;
 
         let (transcripts, proteins, genomic_sequences) = match value {
             serde_json::Value::Array(_) => {
@@ -574,6 +661,17 @@ impl JsonProvider {
     /// Get the number of transcripts
     pub fn len(&self) -> usize {
         self.transcripts.len()
+    }
+
+    /// Total number of genomic sequence bases across all contigs. Zero when the
+    /// reference carries no genomic sequence, or only empty contig strings — so a
+    /// caller can distinguish real genomic capability from a merely-present but
+    /// empty `genomic_sequences` map (which `has_genomic_data()` still reports true).
+    pub fn total_genomic_bases(&self) -> u64 {
+        self.genomic_sequences
+            .values()
+            .map(|s| s.len() as u64)
+            .sum()
     }
 
     /// Check if provider is empty
@@ -1558,6 +1656,111 @@ mod tests {
         let provider = JsonProvider::from_json(file.path())
             .expect("convert-gff JSON with version/genome_build metadata should load");
         assert!(provider.has_transcript("NM_000001.1"));
+    }
+
+    #[test]
+    fn validate_transcripts_json_version_accepts_supported_and_missing() {
+        use serde_json::json;
+        // Missing (bare array or object without `version`) is accepted.
+        validate_transcripts_json_version(None).expect("missing version accepted");
+        // Current major, any (value-only) minor. String or number form.
+        validate_transcripts_json_version(Some(&json!("1.0"))).expect("1.0 accepted");
+        validate_transcripts_json_version(Some(&json!("1.5"))).expect("newer minor accepted");
+        validate_transcripts_json_version(Some(&json!("1"))).expect("bare major accepted");
+        validate_transcripts_json_version(Some(&json!(1))).expect("numeric 1 accepted");
+        validate_transcripts_json_version(Some(&json!(1.0))).expect("numeric 1.0 accepted");
+    }
+
+    #[test]
+    fn validate_transcripts_json_version_rejects_newer_major_and_garbage() {
+        use serde_json::json;
+        let newer = validate_transcripts_json_version(Some(&json!("2.0"))).unwrap_err();
+        assert!(
+            format!("{newer}").contains("newer than this build supports"),
+            "got: {newer}"
+        );
+        // A newer major as a number is caught too.
+        let newer_num = validate_transcripts_json_version(Some(&json!(2))).unwrap_err();
+        assert!(format!("{newer_num}").contains("newer than this build supports"));
+        // Non-numeric components / suffixes are rejected consistently.
+        for bad in [
+            json!("banana"),
+            json!("v1"),
+            json!("1.0-draft"),
+            json!("1a"),
+            json!(""),
+        ] {
+            let err = validate_transcripts_json_version(Some(&bad)).unwrap_err();
+            assert!(
+                format!("{err}").contains("unrecognized transcripts.json schema version"),
+                "expected unrecognized for {bad}, got: {err}"
+            );
+        }
+        // A non-string, non-number version is rejected.
+        let wrong_type = validate_transcripts_json_version(Some(&json!(["1.0"]))).unwrap_err();
+        assert!(format!("{wrong_type}").contains("unrecognized"));
+    }
+
+    #[test]
+    fn from_json_rejects_incompatible_container_version() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{
+            "version": "2.0",
+            "genome_build": "GRCh38",
+            "transcripts": []
+        }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let err = match MockProvider::from_json(file.path()) {
+            Ok(_) => panic!("expected an error for an incompatible schema version"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("newer than this build supports"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn from_json_reports_version_before_unknown_field_for_newer_major() {
+        // A newer-major file that ALSO carries a field this build doesn't know must
+        // surface the friendly "upgrade" message (version validated on the raw value
+        // before `deny_unknown_fields`), not a cryptic "unknown field" error.
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{ "version": "2.0", "brand_new_v2_field": 42, "transcripts": [] }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let err = match MockProvider::from_json(file.path()) {
+            Ok(_) => panic!("expected rejection of a newer-major schema"),
+            Err(e) => e,
+        };
+        assert!(
+            format!("{err}").contains("newer than this build supports"),
+            "newer-major must report the version error, not unknown-field: {err}"
+        );
+    }
+
+    #[test]
+    fn from_json_accepts_numeric_version() {
+        // `"version": 1` (a JSON number, the natural hand-written form) is accepted.
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let json = r#"{ "version": 1, "transcripts": [
+            {"id": "NM_1.1", "strand": "+", "sequence": "ACGT",
+             "exons": [{"number": 1, "start": 1, "end": 4}]}
+        ] }"#;
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(json.as_bytes()).unwrap();
+
+        let provider = MockProvider::from_json(file.path()).expect("numeric version 1 loads");
+        assert!(provider.has_transcript("NM_1.1"));
     }
 
     #[test]

--- a/tests/it/cli_check_transcripts_json.rs
+++ b/tests/it/cli_check_transcripts_json.rs
@@ -1,0 +1,150 @@
+//! Integration tests for `ferro check` on a standalone transcripts.json file
+//! (#1012 comment 2): it must check the file directly instead of reporting
+//! "Run 'ferro prepare' first".
+
+use std::io::Write;
+use std::process::Command;
+
+fn write_json(name: &str, body: &str) -> tempfile::NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(name).tempfile().unwrap();
+    tf.write_all(body.as_bytes()).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+#[test]
+fn check_accepts_a_standalone_transcripts_json() {
+    let json = r#"{
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [
+            {"id": "NM_1.1", "strand": "+", "sequence": "ACGTACGT",
+             "exons": [{"number": 1, "start": 1, "end": 8}]}
+        ]
+    }"#;
+    let file = write_json(".transcripts.json", json);
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args(["check", "--reference", file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "check on a transcripts.json should succeed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("transcripts.json Check") && stderr.contains("Transcripts: 1"),
+        "expected a transcripts.json summary, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Run 'ferro prepare'"),
+        "must not tell the user to run ferro prepare for a valid transcripts.json"
+    );
+}
+
+#[test]
+fn check_fails_on_incompatible_transcripts_json_version() {
+    let file = write_json(
+        ".transcripts.json",
+        r#"{"version": "2.0", "transcripts": []}"#,
+    );
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args(["check", "--reference", file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "check must fail on an incompatible schema version"
+    );
+    // A nonzero exit alone also passes for unrelated failures; confirm it's the
+    // schema-version diagnostic (not a parse/arg error) that reached the user.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("newer than this build supports"),
+        "expected the incompatible-version diagnostic, got: {stderr}"
+    );
+}
+
+#[test]
+fn check_nonexistent_path_reports_not_found_not_prepare() {
+    // A typo'd path must say "does not exist", not tell the user to run prepare.
+    // Build a missing path under a real tempdir (no committed absolute paths).
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("no-such-transcripts.json");
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args(["check", "--reference"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "expected a 'does not exist' error, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Run 'ferro prepare'"),
+        "must not suggest ferro prepare for a nonexistent path: {stderr}"
+    );
+}
+
+#[test]
+fn check_empty_transcripts_json_fails() {
+    let file = write_json(".transcripts.json", r#"{"transcripts": []}"#);
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args(["check", "--reference", file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "an empty reference must fail the check, not be green-lit"
+    );
+    // #1014's `from_json` rejects a wholly-empty reference at load with "no usable
+    // reference data", which preempts (and is equivalent to) `check`'s own
+    // "no usable data" message — either way an empty reference is rejected.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no usable reference data"),
+        "expected a 'no usable reference data' failure, got: {stderr}"
+    );
+}
+
+#[test]
+fn check_manifest_json_file_routes_to_directory() {
+    // Pointing at a `manifest.json` file (not the directory) must be treated as the
+    // prepared-reference directory case, not shoved through the transcripts.json
+    // loader. A malformed manifest.json therefore yields the manifest-path error,
+    // not a transcripts.json "unknown field" serde error.
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("manifest.json");
+    std::fs::write(&manifest, b"not valid json").unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let out = Command::new(bin)
+        .args(["check", "--reference", manifest.to_str().unwrap()])
+        .output()
+        .unwrap();
+    // The malformed manifest must FAIL (a bare non-zero-status check would also
+    // pass on an accidental success), and it must fail through the manifest/
+    // reference path — not the transcripts.json check.
+    assert!(
+        !out.status.success(),
+        "a malformed manifest.json must make the check fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Reference data check failed"),
+        "a manifest.json path must fail via the reference-data check: {stderr}"
+    );
+    assert!(
+        !stderr.contains("transcripts.json Check"),
+        "a manifest.json path must route to the directory path, not the transcripts.json check: {stderr}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -30,6 +30,7 @@ mod breakpoint_insertion;
 mod bulk_fixture_tests;
 mod civic_validation;
 mod cli_build_transcript;
+mod cli_check_transcripts_json;
 mod cli_convert_gff_flags;
 mod cli_parallel_annotate;
 mod cli_parallel_normalize;


### PR DESCRIPTION
## Summary

Addresses the schema-validation and `ferro check` follow-ups from #1012 (comment 2). The `transcripts.json` / `MockProvider` load path (used by `Normalizer(reference_json=...)`) previously did only serde `deny_unknown_fields` — it never validated the container schema version the way the manifest path does — and `ferro check` refused a standalone `transcripts.json` ("Run 'ferro prepare' first").

## What's in it

- **Schema-version validation on the load path.** `MockProvider::from_json` now validates the container `version` against the raw JSON *before* the deserialize (so a newer-major file gets a friendly "upgrade ferro-hgvs" message even when it also carries unknown fields). A bare-array or version-less object still loads; a `version` accepts a string or number, must be strictly numeric `MAJOR[.MINOR…]`, and its major must not exceed the supported major.
- **`ferro check` for a standalone `transcripts.json`.** It now detects a file reference and checks it directly through `MockProvider::from_json` (reusing the same validation the runtime load applies), reporting the transcript count and whether the reference is genome-capable / carries protein data. A nonexistent path says "does not exist" rather than suggesting `ferro prepare`; a `manifest.json` file routes to its parent directory; an empty/dead reference fails; failures print a clean `Status: FAILED` block; the manifest-only options warn that they don't apply to a standalone file.

> Based on `main`, independent of the #1026 stack. The two touch `from_json` in disjoint, order-independent ways.

## Testing

Unit + CLI integration tests for version parsing (string/number/suffix/newer-major-with-unknown-field), standalone `ferro check` (accept, reject empty, incompatible version, nonexistent path, manifest routing), and genome-capable reporting. Full suite green; clippy `-D warnings` and fmt clean.

Refs #1012.
