### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.7.1...v0.8.0) - 2026-07-15
+
+### Added
+
+- *(reference,cli)* validate transcripts.json version and check it standalone ([#1031](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1031))
+- *(normalize)* warn-and-degrade when genomic data is unavailable ([#1015](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1015))
+- *(cli)* genome-capable transcripts.json via --emit-genomic-sequences ([#1029](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1029))
+- *(python)* value equality on projections/effects, idempotency tests, typed-Raises docs ([#1022](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1022))
+- *(python)* surface normalization warnings on projections ([#1021](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1021))
+- *(python)* batch error-isolation on the projector (return_exceptions) ([#1020](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1020))
+- *(python)* typed exception hierarchy, py.typed, and structured error codes ([#1019](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1019))
+- *(python)* surface reference capability and warn on reduced-capability build ([#1014](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1014))
+
+### Fixed
+
+- *(python)* reject an unrecognized direction argument instead of defaulting to 3' ([#1017](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1017))
+
+### Other
+
+- make public error/projection API robust to additive changes ([#1033](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1033))
+- *(pre-commit)* fix the broken mypy hook (bump to v2.2.0, check by directory) ([#1023](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1023))
+- *(reference)* rename MockProvider to JsonProvider ([#1030](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1030))
+- *(readme)* add PyPI version and Python-versions badges ([#1010](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1010))
+
 ## [0.7.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.7.0...v0.7.1) - 2026-07-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `ferro-hgvs` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum ErrorCode in /tmp/.tmpW431Si/ferro-hgvs/src/error.rs:19
  enum FerroError in /tmp/.tmpW431Si/ferro-hgvs/src/error.rs:340
  enum FerroError in /tmp/.tmpW431Si/ferro-hgvs/src/error.rs:340

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct VariantProjection in /tmp/.tmpW431Si/ferro-hgvs/src/project/result.rs:17
  struct VariantProjection in /tmp/.tmpW431Si/ferro-hgvs/src/project/result.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.7.1...v0.8.0) - 2026-07-15

### Added

- *(reference,cli)* validate transcripts.json version and check it standalone ([#1031](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1031))
- *(normalize)* warn-and-degrade when genomic data is unavailable ([#1015](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1015))
- *(cli)* genome-capable transcripts.json via --emit-genomic-sequences ([#1029](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1029))
- *(python)* value equality on projections/effects, idempotency tests, typed-Raises docs ([#1022](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1022))
- *(python)* surface normalization warnings on projections ([#1021](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1021))
- *(python)* batch error-isolation on the projector (return_exceptions) ([#1020](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1020))
- *(python)* typed exception hierarchy, py.typed, and structured error codes ([#1019](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1019))
- *(python)* surface reference capability and warn on reduced-capability build ([#1014](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1014))

### Fixed

- *(python)* reject an unrecognized direction argument instead of defaulting to 3' ([#1017](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1017))

### Other

- make public error/projection API robust to additive changes ([#1033](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1033))
- *(pre-commit)* fix the broken mypy hook (bump to v2.2.0, check by directory) ([#1023](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1023))
- *(reference)* rename MockProvider to JsonProvider ([#1030](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1030))
- *(readme)* add PyPI version and Python-versions badges ([#1010](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1010))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).