### PR TITLE
refactor: make public error/projection API robust to additive changes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 /// and for documentation lookup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u16)]
+#[non_exhaustive]
 pub enum ErrorCode {
     // Parse errors (E1xxx)
     /// Invalid accession format
@@ -335,6 +336,7 @@ fn ensembl_prepare_hint(id: &str) -> &'static str {
 
 /// Main error type for ferro-hgvs operations
 #[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FerroError {
     /// Parse error with position and message
     #[error("Parse error at position {pos}: {msg}")]
@@ -425,19 +427,6 @@ pub enum FerroError {
         detail: Option<String>,
     },
 
-    /// A genome-requiring normalization step (intronic / boundary-spanning /
-    /// exon-junction 3'-shuffle) could not run because the reference provider
-    /// carries no genomic data. In lenient/silent mode this surfaces as the
-    /// `ReducedCapabilityNoGenome` warning with a best-effort result; strict
-    /// mode promotes it to this error rather than return a degraded result.
-    /// `capability` names the step that was skipped (e.g. "intronic
-    /// normalization"). #1012 item 2.
-    #[error(
-        "Cannot fully normalize {variant} without genomic reference data \
-         ({capability}); strict mode rejects a reduced-capability result"
-    )]
-    ReducedReferenceCapability { variant: String, capability: String },
-
     /// Genomic reference data is not available
     #[error("Genomic reference not available for {contig}:{start}-{end}")]
     GenomicReferenceNotAvailable {
@@ -513,6 +502,22 @@ pub enum FerroError {
     /// JSON parsing error
     #[error("JSON error: {msg}")]
     Json { msg: String },
+
+    /// A genome-requiring normalization step (intronic / boundary-spanning /
+    /// exon-junction 3'-shuffle) could not run because the reference provider
+    /// carries no genomic data. In lenient/silent mode this surfaces as the
+    /// `ReducedCapabilityNoGenome` warning with a best-effort result; strict
+    /// mode promotes it to this error rather than return a degraded result.
+    /// `capability` names the step that was skipped (e.g. "intronic
+    /// normalization"). #1012 item 2.
+    ///
+    /// Kept last in the enum so its addition does not shift the implicit
+    /// discriminants of the variants declared before it.
+    #[error(
+        "Cannot fully normalize {variant} without genomic reference data \
+         ({capability}); strict mode rejects a reduced-capability result"
+    )]
+    ReducedReferenceCapability { variant: String, capability: String },
 }
 
 impl FerroError {

--- a/src/project/result.rs
+++ b/src/project/result.rs
@@ -13,6 +13,7 @@ use crate::normalize::NormalizationWarning;
 /// is still predicted directly from the transcript's CDS (#498). For a
 /// genome-anchored input `genomic` is the canonical g. representation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct VariantProjection {
     pub genomic: Option<HgvsVariant>,
     pub coding: Option<HgvsVariant>,


### PR DESCRIPTION
## What

release-plz's `cargo-semver-checks` run in #1032 (the `v0.8.0` release PR) reported three API-breaking changes that landed on `main`:

- **`enum_variant_added`** — `ErrorCode::ReducedReferenceCapability` and `FerroError::ReducedReferenceCapability` were added to two exhaustive (`#[non_exhaustive]`-less) public enums.
- **`enum_no_repr_variant_discriminant_changed`** — `FerroError::ReducedReferenceCapability` was inserted *mid-enum* (before `GenomicReferenceNotAvailable`), shifting the implicit discriminants of the 11 variants declared after it (10→11, 11→12, …).
- **`constructible_struct_adds_field`** — `VariantProjection` (a public struct with all-public fields and no `#[non_exhaustive]`) gained `normalization_warnings`, breaking any downstream struct literal.

These were intentional feature additions (#1014/#1015/#1021), so the `0.7.1 → 0.8.0` breaking bump is correct. This PR does not try to undo that bump; it makes the same categories of change **non-breaking going forward**, and cleans up the one avoidable finding.

## Changes

- Mark `ErrorCode`, `FerroError`, and `VariantProjection` `#[non_exhaustive]`. Future added error variants / projection fields will no longer be breaking API changes, and downstream `match`/struct-literal code must account for future additions.
- Move `FerroError::ReducedReferenceCapability` to the **end** of the enum. Its addition no longer shifts the implicit discriminants of the pre-existing variants, eliminating the `enum_no_repr_variant_discriminant_changed` finding. Behavior is unchanged (struct-variant; no `as`-casts depend on order).

## Notes

- `ErrorCode` has explicit `#[repr(u16)]` discriminants (`… = 4004`), so its new variant never shifted others — `#[non_exhaustive]` is purely future-proofing there.
- Since `0.8.0` is already a breaking release, adding `#[non_exhaustive]` now (itself a one-time breaking change) is free to absorb here rather than costing a future major bump.

## Test plan

- `cargo build --features dev` ✅
- `cargo clippy --features dev --all-targets -- -D warnings` ✅
- `cargo check --features python` ✅
- `cargo fmt --all --check` ✅
- `cargo nextest run --features dev` — 7932 passed, 145 skipped ✅