### PR TITLE
fix(normalize): only type a maximal contiguous run as inv, not a sub-run

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1695,9 +1695,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
         //     non-overlapping edits (#487).
         //   - split (#160 + #165, cis only): a merged/pre-existing delins may
         //     decompose into higher-priority forms per `general.md:56` —
-        //     `[..., inv, ...]` for an inv-eligible sub-span (#160) and/or into
-        //     separate substitutions where interior positions match the
-        //     reference (#165). The helper is a no-op otherwise.
+        //     `[..., inv, ...]` when a whole maximal contiguous run is a
+        //     reverse complement (#160, corrected by #1034; sub-runs are not
+        //     carved out) and/or into separate substitutions where interior
+        //     positions match the reference (#165). The helper is a no-op
+        //     otherwise.
         //   - per-member pipeline: the single canonical place where the 3' rule,
         //     ins→dup canonicalization, ref validation, etc. apply — a merged
         //     variant is semantically a new variant and goes through the same
@@ -2204,8 +2206,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
         // Issue #160 + #165: a normalized Delins may decompose under the
         // spec's edit-priority rule (`general.md:56`) — into `[..., inv,
-        // ...]` for rev-comp sub-spans and/or into separate subs across
-        // interior identities. Returns the variant unchanged for
+        // ...]` when a whole maximal contiguous run is a reverse complement
+        // (#1034: rev-comp sub-runs are not carved out) and/or into separate
+        // subs across interior identities. Returns the variant unchanged for
         // non-Delins or no-decomposition cases.
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Genome(new_variant));
         warnings.append(&mut split_warnings);
@@ -7495,8 +7498,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///
     /// Implements two spec-priority rules from `general.md:56`
     /// (substitution > deletion > inversion > duplication > insertion):
-    /// - Inversion priority: a delins whose span contains a rev-comp
-    ///   sub-span splits into `[…; inv; …]` (issue #160).
+    /// - Inversion priority: a delins whose whole *maximal contiguous run*
+    ///   is a reverse complement splits out that run as `inv` (issue #160,
+    ///   corrected by issue #1034). A reverse-complement *sub-run* of a
+    ///   longer contiguous change is NOT carved out — that change stays a
+    ///   single `delins`.
     /// - Substitution priority: a delins whose post-trim span contains
     ///   two or more independent single-base mismatches separated by at
     ///   least one unchanged nucleotide splits into separate substitutions
@@ -8040,8 +8046,10 @@ fn unflip_intronic_positions(
 // produces a Delins variant, the resulting span may be expressible in a
 // higher-priority form under `general.md:56` (sub > del > inv > dup > ins).
 // Two cases fire here:
-// - Inversion sub-span: the delins span contains a rev-comp sub-region —
-//   split into `[…; inv; …]` (issue #160).
+// - Inversion: a whole maximal contiguous run within the delins span is a
+//   reverse complement — split that run out as `inv` (issue #160, corrected
+//   by issue #1034; a rev-comp sub-run of a longer contiguous change is not
+//   carved out).
 // - Independent substitutions: the delins span contains two or more
 //   single-base mismatches separated by at least one unchanged nucleotide
 //   — split each into its own sub variant (issue #165 / tracking issue

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -921,18 +921,21 @@ pub enum DelinsSubedit {
     },
 }
 
-/// Decompose a delins into a sequence of canonical sub-edits when the
-/// span has at least one inv-eligible sub-span or contains at least one
-/// position whose alt byte equals the ref byte (an interior identity).
-/// Returns `Some(edits)` only when the resulting decomposition has more
-/// than one element AND at least one element is an `Inversion` or an
+/// Decompose a delins into a sequence of canonical sub-edits when a maximal
+/// contiguous mismatch run is *entirely* an inversion, or the span contains
+/// at least one position whose alt byte equals the ref byte (an interior
+/// identity). Returns `Some(edits)` only when the resulting decomposition has
+/// more than one element AND at least one element is an `Inversion` or an
 /// `IdentityAt`.
 ///
 /// Implements:
-/// - Issue #160 (item A2 + A10 inv-branch of tracking issue #81):
-///   reverse-complement sub-spans within a delins are emitted as
-///   `Inversion` per the HGVS edit-priority rule (`general.md:56`:
-///   `inv > delins`).
+/// - Issue #160 (item A2 + A10 inv-branch of tracking issue #81), as
+///   corrected by issue #1034: an `Inversion` is emitted only when a whole
+///   maximal contiguous mismatch run is a reverse complement, per the HGVS
+///   edit-priority rule (`general.md:56`: `inv > delins`) applied to the
+///   *maximal contiguous run* (`DNA/inversion.md`). A reverse-complement
+///   sub-run of a longer contiguous change is NOT carved out — that change
+///   stays a single `delins`.
 /// - Issue #165 (item A10 sub-only branch of #81): an interior position
 ///   matching the reference (an `IdentityAt`) is the spec's signal that
 ///   the surrounding mismatches are independent variants under
@@ -960,14 +963,28 @@ pub enum DelinsSubedit {
 /// - Out-of-bounds or empty ranges (`start >= end` or
 ///   `end > ref_seq.len()`).
 ///
-/// Algorithm (left-to-right longest-greedy scan over `start..end`):
-/// - At each position `i`, find the largest `j ∈ (i+2 ..= N)` with
-///   `alt[i..j] == revcomp(ref[i..j])`. If found: emit `Inversion(i, j)`,
-///   advance `i = j`.
-/// - Else if `alt[i] != ref[i]`: emit `Substitution(i)`, advance `i += 1`.
-/// - Else (`alt[i] == ref[i]`): emit `IdentityAt(i, ref[i])`, advance
-///   `i += 1`. The byte is recorded so a downstream codon-frame
-///   preservation pass can reconstruct a 3-base delins's alt sequence.
+/// Algorithm (left-to-right scan over maximal contiguous mismatch runs):
+/// - At an identity position (`alt[i] == ref[i]`): emit `IdentityAt(i,
+///   ref[i])`, advance `i += 1`. The byte is recorded so a downstream
+///   codon-frame preservation pass can reconstruct a 3-base delins's alt
+///   sequence. An identity also bounds the maximal contiguous run — variants
+///   separated by ≥1 unchanged nt are independent (`general.md:34`).
+/// - Otherwise collect the maximal contiguous run `[rs, re)` of positions
+///   where `alt != ref`, then:
+///   - If the **whole** run is an inversion (`re - rs >= 2` and
+///     `alt[rs..re] == revcomp(ref[rs..re])`): emit `Inversion(rs, re)`.
+///   - Else: emit a `Substitution` for each position in the run.
+///
+/// A reverse-complement **sub-run** is never carved out of a longer
+/// contiguous change: only a run that is *entirely* a reverse complement is
+/// typed as `inv`, per `DNA/inversion.md` and the issue #1034 fix. The
+/// surrounding `Substitution`s re-merge into a single `delins` under the
+/// caller's adjacency rule (`substitution.md` / issue #182).
+///
+/// `shorten_inversion`'s complementary-outer-pair peeling is not applied
+/// here: within a pure mismatch run a peelable outer pair would imply
+/// `alt == ref` at the boundary (an identity, not a mismatch), so the run
+/// bounds are already minimal for a full-run inversion.
 pub fn decompose_delins(
     ref_seq: &[u8],
     start: usize,
@@ -992,51 +1009,15 @@ pub fn decompose_delins(
     let mut has_identity = false;
     let mut i = 0;
     while i < n {
-        // Longest j in (i+2 ..= n) with alt[i..j] == revcomp(ref[i..j]) AND
-        // whose ref window does not collapse to identity under
-        // shorten_inversion (which peels complementary outer pairs). A
-        // candidate that fully collapses (e.g. palindromic ATAT) is skipped
-        // so the unchanged bases fall through to the IdentityAt branch
-        // instead of being emitted as a no-op inv. Track both the raw end
-        // (for advancing `i` past the consumed window — outer-pair bases that
-        // shorten away are unchanged so they need no emit) and the shortened
-        // [s..e) absolute span (for emission).
-        let mut longest: Option<(usize, usize, usize)> = None;
-        let mut j = i + 2;
-        while j <= n {
-            if is_revcomp(&deleted[i..j], &inserted_seq[i..j]) {
-                if let Some((s, e)) = shorten_inversion(ref_seq, start + i, start + j) {
-                    longest = Some((j, s, e));
-                }
-            }
-            j += 1;
-        }
-
-        if let Some((j, s, e)) = longest {
-            emitted.push(DelinsSubedit::Inversion { start: s, end: e });
-            has_inv = true;
-            i = j;
-        } else if deleted[i] != inserted_seq[i] {
-            // Substitution at this position. Bases must be IUPAC; non-IUPAC
-            // bytes cannot be expressed as `Base`, so abandon the whole
-            // decomposition (the caller will keep the delins as-is). Mirrors
-            // the `canonicalize_delins` 1-base substitution branch.
-            let r = Base::from_char(deleted[i] as char)?;
-            let a = Base::from_char(inserted_seq[i] as char)?;
-            emitted.push(DelinsSubedit::Substitution {
-                position: start + i,
-                reference: r,
-                alternative: a,
-            });
-            i += 1;
-        } else {
-            // Record the unchanged ref byte so the caller can rebuild a
-            // codon-frame triplet's alt sequence (issue #165). Abandon
-            // the whole decomposition on non-IUPAC bytes, mirroring the
-            // substitution branch above: an identity position with a
-            // non-IUPAC byte cannot be re-rendered as a 3-base delins
-            // alt without silently coercing the unknown byte to `N`,
-            // which would diverge from the next round-trip's input.
+        if deleted[i] == inserted_seq[i] {
+            // Identity position: record the unchanged ref byte so the caller
+            // can rebuild a codon-frame triplet's alt sequence (issue #165),
+            // and let it bound the maximal contiguous run. Abandon the whole
+            // decomposition on a non-IUPAC byte, mirroring the substitution
+            // branch below: an identity at a non-IUPAC byte cannot be
+            // re-rendered as a 3-base delins alt without silently coercing the
+            // unknown byte to `N`, which would diverge from the next
+            // round-trip's input.
             let b = Base::from_char(deleted[i] as char)?;
             emitted.push(DelinsSubedit::IdentityAt {
                 position: start + i,
@@ -1044,7 +1025,48 @@ pub fn decompose_delins(
             });
             has_identity = true;
             i += 1;
+            continue;
         }
+
+        // Maximal contiguous run of mismatches `[run_start, run_end)`.
+        let run_start = i;
+        let mut run_end = i + 1;
+        while run_end < n && deleted[run_end] != inserted_seq[run_end] {
+            run_end += 1;
+        }
+
+        // Only type the run as `inv` when the ENTIRE run is a reverse
+        // complement (issue #1034). A reverse-complement sub-run is never
+        // carved out of a longer contiguous change — the surrounding
+        // substitutions re-merge into a single `delins` under the caller's
+        // adjacency rule.
+        if run_end - run_start >= 2
+            && is_revcomp(
+                &deleted[run_start..run_end],
+                &inserted_seq[run_start..run_end],
+            )
+        {
+            emitted.push(DelinsSubedit::Inversion {
+                start: start + run_start,
+                end: start + run_end,
+            });
+            has_inv = true;
+        } else {
+            // Emit a per-position substitution for each mismatch. Bases must
+            // be IUPAC; a non-IUPAC byte cannot be expressed as `Base`, so
+            // abandon the whole decomposition (the caller keeps the delins
+            // as-is). Mirrors the `canonicalize_delins` substitution branch.
+            for k in run_start..run_end {
+                let r = Base::from_char(deleted[k] as char)?;
+                let a = Base::from_char(inserted_seq[k] as char)?;
+                emitted.push(DelinsSubedit::Substitution {
+                    position: start + k,
+                    reference: r,
+                    alternative: a,
+                });
+            }
+        }
+        i = run_end;
     }
 
     // Trigger: commit only if the decomposition has > 1 element AND it
@@ -4147,19 +4169,24 @@ mod tests {
     }
 
     #[test]
-    fn decompose_inv_subspan_at_start() {
-        // ref=TCC, alt=GAG: positions 0-1 are inv (revcomp(TC)=GA), position
-        // 2 is sub C>G. Mirrors the issue #160 row-2 example.
+    fn decompose_leading_revcomp_subrun_stays_delins() {
+        // ref=TCC, alt=GAG: the 2-nt prefix TC->GA satisfies revcomp(TC)=GA,
+        // but the whole run TCC->GAG is a single contiguous change and
+        // revcomp(TCC)=GGA != GAG, so it is NOT an inversion. A reverse-
+        // complement sub-run may not be carved out (issue #1034): emit three
+        // substitutions, which the caller re-merges into one delins → None.
+        // This is the exact issue #160 row-2 example, now spec-corrected.
         let result = decompose_delins(b"TCC", 0, 3, b"GAG");
-        assert_eq!(result, Some(vec![inv_at(0, 2), sub_at(2, 'C', 'G')]));
+        assert_eq!(result, None);
     }
 
     #[test]
-    fn decompose_inv_subspan_at_end() {
-        // ref=AAG, alt=GCT: position 0 is sub A>G, positions 1-2 are inv
-        // (revcomp(AG)=CT).
+    fn decompose_trailing_revcomp_subrun_stays_delins() {
+        // ref=AAG, alt=GCT: the 2-nt suffix AG->CT satisfies revcomp(AG)=CT,
+        // but the whole contiguous run revcomp(AAG)=CTT != GCT is not an
+        // inversion. No sub-run carve-out (issue #1034) → None.
         let result = decompose_delins(b"AAG", 0, 3, b"GCT");
-        assert_eq!(result, Some(vec![sub_at(0, 'A', 'G'), inv_at(1, 3)]));
+        assert_eq!(result, None);
     }
 
     #[test]
@@ -4179,16 +4206,15 @@ mod tests {
     }
 
     #[test]
-    fn decompose_disjoint_inv_runs() {
-        // ref=AGACC, alt=CTTGG:
-        //   inv(0,2): revcomp(AG)=CT ✓
-        //   sub(2): A>T (no inv possible spanning here)
-        //   inv(3,5): revcomp(CC)=GG ✓
+    fn decompose_contiguous_run_with_multiple_revcomp_subruns_stays_delins() {
+        // ref=AGACC, alt=CTTGG: the sub-runs AG->CT (revcomp(AG)=CT) and
+        // CC->GG (revcomp(CC)=GG) each look like inversions in isolation, but
+        // they belong to ONE contiguous mismatch run (all five positions
+        // differ). revcomp(AGACC)=GGTCT != CTTGG, so the whole run is not an
+        // inversion and no sub-run may be carved out (issue #1034). Emits
+        // five substitutions → None.
         let result = decompose_delins(b"AGACC", 0, 5, b"CTTGG");
-        assert_eq!(
-            result,
-            Some(vec![inv_at(0, 2), sub_at(2, 'A', 'T'), inv_at(3, 5)])
-        );
+        assert_eq!(result, None);
     }
 
     #[test]
@@ -4235,14 +4261,22 @@ mod tests {
 
     #[test]
     fn decompose_offset_start_propagates_position() {
-        // Same TCC -> GAG pattern but at offset 100. Positions in the result
-        // are 0-indexed offsets into the input ref_seq slice.
+        // A full-run inv (AG->CT) separated by an identity from a trailing
+        // non-inv run (CC->GT), placed at offset 100. Positions in the result
+        // are 0-indexed offsets into the input ref_seq slice, so the inv and
+        // substitution positions must all carry the +100 offset.
         let mut seq = vec![b'A'; 200];
-        seq[100] = b'T';
-        seq[101] = b'C';
-        seq[102] = b'C';
-        let result = decompose_delins(&seq, 100, 103, b"GAG");
-        assert_eq!(result, Some(vec![inv_at(100, 102), sub_at(102, 'C', 'G')]));
+        seq[100..105].copy_from_slice(b"AGACC");
+        let result = decompose_delins(&seq, 100, 105, b"CTAGT");
+        assert_eq!(
+            result,
+            Some(vec![
+                inv_at(100, 102),
+                ident_at(102, 'A'),
+                sub_at(103, 'C', 'G'),
+                sub_at(104, 'C', 'T'),
+            ])
+        );
     }
 
     #[test]
@@ -4280,12 +4314,29 @@ mod tests {
     }
 
     #[test]
-    fn decompose_inv_subspan_shortened_outer_pair() {
-        // CTATGC -> CATAGG: revcomp(CTATG)=CATAG matches over [0..5], but
-        // outer C/G complement and shorten_inversion peels them off, leaving
-        // inv at [1..4] (TAT). The trailing C>G stays as a substitution.
+    fn decompose_inv_run_bounded_by_identities() {
+        // CTATGC -> CATAGG:
+        //   pos 0 C==C : identity (bounds the run on the left)
+        //   pos 1-3 TAT -> ATA : revcomp(TAT)=ATA ✓ full-run inv
+        //   pos 4 G==G : identity (bounds the run on the right)
+        //   pos 5 C -> G : substitution
+        // The inv run [1..4) is maximal — it is bounded by identities on both
+        // sides, so no complementary-outer-pair shortening is needed (a
+        // peelable outer pair would imply an identity, which is already a run
+        // boundary here). Regression note: the old greedy scan folded the
+        // flanking identities into a [0..5) revcomp window and shortened it
+        // back to [1..4); the run-based scan reaches [1..4) directly and
+        // reports the flanking identities explicitly.
         let result = decompose_delins(b"CTATGC", 0, 6, b"CATAGG");
-        assert_eq!(result, Some(vec![inv_at(1, 4), sub_at(5, 'C', 'G')]));
+        assert_eq!(
+            result,
+            Some(vec![
+                ident_at(0, 'C'),
+                inv_at(1, 4),
+                ident_at(4, 'G'),
+                sub_at(5, 'C', 'G'),
+            ])
+        );
     }
 
     #[test]

--- a/tests/it/issue_1034_inv_subspan_delins.rs
+++ b/tests/it/issue_1034_inv_subspan_delins.rs
@@ -1,0 +1,75 @@
+//! Issue #1034: ferro must not fragment a contiguous `delins` to expose an
+//! internal reverse-complement sub-run as an `inv`.
+//!
+//! Per HGVS an inversion describes a *maximal contiguous run* whose alt equals
+//! the reverse complement of the reference. A reverse-complement **sub-run**
+//! may not be carved out of a longer contiguous change — that change must stay
+//! a single `delins` (`DNA/inversion.md`, `DNA/delins.md`,
+//! `general.md:34` + `:56`).
+//!
+//! v0.8.0 regressed here: the `#160`/`#166` sub-span inv typer matched
+//! reverse-complement identity on sub-runs of a contiguous mismatch run rather
+//! than requiring the whole run to be a reverse complement, so a contiguous
+//! `delins` fragmented into `[…; inv; …]`. This suite pins the spec-correct
+//! single-`delins` output while confirming genuine full-run inversions (whole
+//! maximal run is a reverse complement) still normalize to `inv`.
+
+use crate::common::synthetic::{normalize_to_string, SyntheticBuilder};
+
+const SEQID: &str = "NC_TEST.1";
+
+// ---------------------------------------------------------------------------
+// The exact minimal example from issue #1034.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contiguous_delins_with_internal_revcomp_subrun_stays_delins() {
+    // Core "CTG" at 257-259 (ref 257C 258T 259G).
+    //   raw:  [257C>A; 258T>C; 259G>A]
+    //   window 257_259: ref CTG -> alt ACA (length-preserving).
+    //   revcomp(CTG) = CAG != ACA  =>  the whole run is NOT an inversion.
+    //   The 2-nt sub-run 258_259 (TG -> CA) satisfies revcomp(TG)=CA, but it
+    //   may NOT be carved out of the contiguous change.
+    // Expected: a single delins, NOT `[257C>A; 258_259inv]`.
+    let p = SyntheticBuilder::genomic("CTG").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257C>A;258T>C;259G>A]", SEQID));
+    assert_eq!(result, format!("{}:g.257_259delinsACA", SEQID));
+}
+
+#[test]
+fn contiguous_delins_with_leading_revcomp_subrun_stays_delins() {
+    // Core "TCC" at 257-259.
+    //   raw:  [257T>G; 258C>A; 259C>G]  ->  window ref TCC / alt GAG.
+    //   revcomp(TCC) = GGA != GAG  =>  not a full inversion.
+    //   The 2-nt prefix 257_258 (TC -> GA) satisfies revcomp(TC)=GA but must
+    //   not be split out. This is the exact `#160` CHANGELOG example, now
+    //   spec-corrected.
+    let p = SyntheticBuilder::genomic("TCC").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257T>G;258C>A;259C>G]", SEQID));
+    assert_eq!(result, format!("{}:g.257_259delinsGAG", SEQID));
+}
+
+// ---------------------------------------------------------------------------
+// Guard: a genuine full-run inversion (whole maximal run is a reverse
+// complement) must STILL normalize to `inv`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_run_reverse_complement_still_emits_inv() {
+    // Core "GCT" at 257-259.
+    //   raw:  [257G>A; 258C>G; 259T>C]  ->  window ref GCT / alt AGC.
+    //   revcomp(GCT) = AGC == alt  =>  the whole run IS an inversion.
+    let p = SyntheticBuilder::genomic("GCT").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257G>A;258C>G;259T>C]", SEQID));
+    assert_eq!(result, format!("{}:g.257_259inv", SEQID));
+}
+
+#[test]
+fn two_base_full_run_reverse_complement_still_emits_inv() {
+    // Core "GG" at 257-258.
+    //   raw:  [257G>C; 258G>C]  ->  window ref GG / alt CC.
+    //   revcomp(GG) = CC == alt  =>  the whole run IS an inversion.
+    let p = SyntheticBuilder::genomic("GG").build();
+    let result = normalize_to_string(p, &format!("{}:g.[257G>C;258G>C]", SEQID));
+    assert_eq!(result, format!("{}:g.257_258inv", SEQID));
+}

--- a/tests/it/issue_182_postcanon_adjacency.rs
+++ b/tests/it/issue_182_postcanon_adjacency.rs
@@ -1,116 +1,78 @@
-//! Issue #182: post-canonicalization adjacency of substitution flanks
-//! produced by the inv-split pass (#160 / #166).
+//! Issue #182: post-canonicalization adjacency grouping of substitution runs
+//! produced by `decompose_delins` (as corrected by issue #1034).
 //!
-//! When `decompose_delins` splits a merged delins into `[…; inv; …]`,
-//! the non-inv positions are emitted as per-position `Substitution`
-//! sub-edits. Two or more strictly-adjacent (no gap) Substitutions in that
-//! emission stream represent a multi-nucleotide substitution and must
-//! render as a single `delins` per HGVS spec — `substitution.md`: "changes
-//! involving two or more consecutive nucleotides are described as
-//! deletion/insertion (delins)" / `delins.md`: same rule.
+//! `decompose_delins` splits a delins only where a *maximal contiguous run* is
+//! entirely an inversion (`inv`) or where an interior identity separates
+//! independent variants (`general.md:34`). A reverse-complement **sub-run** of
+//! a longer contiguous change is never carved out — that change stays a single
+//! `delins` (issue #1034). So a run of two or more strictly-adjacent
+//! `Substitution` sub-edits only ever arises between an identity boundary and
+//! another edit (an `inv`, an identity, or the span edge).
 //!
-//! The fix is local to `build_split_variants` (in `src/normalize/mod.rs`):
-//! it now groups runs of strictly-adjacent `Substitution` sub-edits into a
-//! single `Delins` variant. `Inversion` sub-edits remain a hard barrier —
-//! sub flanks on either side of an inv stay split, preserving the
-//! sub > del > **inv** > dup > ins priority rule (`general.md:45`) and the
-//! mutalyzer-aligned position adopted in #166. `IdentityAt` also breaks a
-//! run (a position-gap means the flanking subs are no longer "consecutive"
-//! per the spec's wording).
-//!
-//! Scope (deliberately narrow): this fix does NOT re-merge across an `inv`
-//! to re-form a flat delins. The broader "should adjacency to inv force
-//! delins?" question is tracked separately, gated on what SVD-WG010
-//! settles — see the pushback comment on issue #182 for rationale.
+//! When it does arise, those adjacent substitutions represent a
+//! multi-nucleotide change and must render as a single `delins` per HGVS
+//! (`substitution.md`: "changes involving two or more consecutive nucleotides
+//! are described as deletion/insertion (delins)"). The grouping is local to
+//! `build_split_variants` (in `src/normalize/mod.rs`). `Inversion` sub-edits
+//! remain a hard barrier — sub flanks on either side of an inv stay split,
+//! preserving the sub > del > **inv** > dup > ins priority (`general.md:56`).
+//! `IdentityAt` also breaks a run and drops cleanly (no `=` emission).
 
 use crate::common::synthetic::{normalize_to_string, SyntheticBuilder};
 
 const SEQID: &str = "NC_TEST.1";
 
 // ---------------------------------------------------------------------------
-// Two adjacent sub flanks AFTER an inv → group into one delins
+// Two adjacent sub flanks AFTER a full-run inv (identity between) → group
 // ---------------------------------------------------------------------------
 
 #[test]
 fn two_subs_trailing_an_inv_merge_to_delins() {
-    // Core "GACTTTTGAAG" places:
-    //   pos 257 G  258 A  259 C  (first sub run, no inv)
-    //   pos 260-263 TTTT (gap of 4 — barrier between the two runs)
-    //   pos 264 G  265 A  266 A  267 G  (second run, with 264_265 inv-eligible)
-    //
-    // Input merges to two delins after #80:
-    //   257_259delinsCCT, 264_267delinsTCCC
-    //
-    // 264_267delins: ref GAAG, alt TCCC.
-    //   - 264_265 ref GA / alt TC: revcomp(GA)=TC ✓ INV.
-    //   - 266 A → C : SUB.
-    //   - 267 G → C : SUB.
-    // The two trailing subs are strictly adjacent (266→267, gap=0) and
-    // must render as a single delinsCC per spec. The inv stays between
-    // the leading delins and the new trailing delins.
-    let p = SyntheticBuilder::genomic("GACTTTTGAAG").build();
-    let result = normalize_to_string(
-        p,
-        &format!(
-            "{}:g.[257G>C;258A>C;259C>T;264G>T;265A>C;266A>C;267G>C]",
-            SEQID
-        ),
-    );
-    assert_eq!(
-        result,
-        format!("{}:g.[257_259delinsCCT;264_265inv;266_267delinsCC]", SEQID)
-    );
+    // Core "GATCC" at 257-261:
+    //   257 G  258 A : full-run inv (revcomp(GA)=TC)
+    //   259 T        : identity (bounds the run; dropped, no `259=`)
+    //   260 C  261 C : two strictly-adjacent subs (CC→AA; revcomp(CC)=GG, so
+    //                  NOT an inv) → group into one delins.
+    // User-typed delins carries the interior identity so the decomposition
+    // reaches build_split_variants.
+    let p = SyntheticBuilder::genomic("GATCC").build();
+    let result = normalize_to_string(p, &format!("{}:g.257_261delinsTCTAA", SEQID));
+    assert_eq!(result, format!("{}:g.[257_258inv;260_261delinsAA]", SEQID));
 }
 
 // ---------------------------------------------------------------------------
-// Two adjacent sub flanks BEFORE an inv → group into one delins
+// Two adjacent sub flanks BEFORE a full-run inv (identity between) → group
 // ---------------------------------------------------------------------------
 
 #[test]
 fn two_subs_leading_an_inv_merge_to_delins() {
-    // Core "TCGACG" places ref T C G A C G at 257-262.
-    //   257 T>A  258 C>G  : two-base sub flank to the left of the inv
-    //   259 G>T  260 A>C  : 259_260 inv (revcomp(GA)=TC)
-    //   261 C>X  262 G>X  : (omitted to keep this test focused on the leading flank)
-    //
-    // Inputs cover only 257-260 so the trailing positions are unedited.
-    // Step #80 merges to 257_260delinsAGTC. Decompose:
-    //   - 257_258 TC→AG: revcomp(TC)=GA, no.
-    //   - 259_260 GA→TC: revcomp(GA)=TC ✓ INV.
-    //   Sub(257 T→A); Sub(258 C→G); Inv(259_260).
-    // The two leading subs (257, 258) are strictly adjacent → delinsAG.
-    let p = SyntheticBuilder::genomic("TCGACG").build();
-    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258C>G;259G>T;260A>C]", SEQID));
-    assert_eq!(result, format!("{}:g.[257_258delinsAG;259_260inv]", SEQID));
+    // Core "CCTGA" at 257-261:
+    //   257 C  258 C : two adjacent subs (CC→AA) → group into one delins
+    //   259 T        : identity (dropped)
+    //   260 G  261 A : full-run inv (revcomp(GA)=TC)
+    let p = SyntheticBuilder::genomic("CCTGA").build();
+    let result = normalize_to_string(p, &format!("{}:g.257_261delinsAATTC", SEQID));
+    assert_eq!(result, format!("{}:g.[257_258delinsAA;260_261inv]", SEQID));
 }
 
 // ---------------------------------------------------------------------------
-// Inv flanked on BOTH sides by two-sub runs → both flanks group, inv stays
+// Inv flanked on BOTH sides by two-sub runs (identities between) → both group
 // ---------------------------------------------------------------------------
 
 #[test]
 fn inv_flanked_by_two_sub_runs_each_side_groups_both_flanks() {
-    // Core "TCGACG" places ref T C G A C G at 257-262.
-    //   257 T>A  258 C>G  : two-base leading flank
-    //   259 G>T  260 A>C  : 259_260 inv (revcomp(GA)=TC)
-    //   261 C>A  262 G>T  : two-base trailing flank
-    //
-    // Step #80 merges to 257_262delinsAGTCAT. Decompose:
-    //   - 259_260 GA→TC ✓ INV (longest, picked greedily at i=259).
-    //   - i=257: no inv → Sub(257 T→A).
-    //   - i=258: no inv → Sub(258 C→G).
-    //   - i=261: no inv → Sub(261 C→A).
-    //   - i=262: out of range for inv (i+2 > n) → Sub(262 G→T).
-    // Both flanks are length-2 strictly-adjacent runs → each becomes a delins.
-    // The inv stays between them (not re-merged across — see #166 / general.md:45).
-    let p = SyntheticBuilder::genomic("TCGACG").build();
-    let result = normalize_to_string(
-        p,
-        &format!("{}:g.[257T>A;258C>G;259G>T;260A>C;261C>A;262G>T]", SEQID),
-    );
+    // Core "CCTGATCC" at 257-264:
+    //   257 C  258 C : leading two-sub run (CC→AA) → delins
+    //   259 T        : identity (dropped)
+    //   260 G  261 A : full-run inv (revcomp(GA)=TC)
+    //   262 T        : identity (dropped)
+    //   263 C  264 C : trailing two-sub run (CC→AA) → delins
+    // The inv stays between the two grouped flanks (not re-merged across it).
+    let p = SyntheticBuilder::genomic("CCTGATCC").build();
+    let result = normalize_to_string(p, &format!("{}:g.257_264delinsAATTCTAA", SEQID));
     assert_eq!(
         result,
-        format!("{}:g.[257_258delinsAG;259_260inv;261_262delinsAT]", SEQID)
+        format!("{}:g.[257_258delinsAA;260_261inv;263_264delinsAA]", SEQID)
     );
 }
 
@@ -120,51 +82,33 @@ fn inv_flanked_by_two_sub_runs_each_side_groups_both_flanks() {
 
 #[test]
 fn single_sub_flank_stays_as_substitution() {
-    // Core "TGAGC" at 257-261:
-    //   257 T  258 G  259 A  260 G  261 C
-    //
-    // Inputs cover 257-260 only. Step #80 merges to 257_260delinsATCC.
-    // Decompose: Sub(257 T→A); Inv(258_259); Sub(260 G→C). Each flank is a
-    // length-1 run → emits as Substitution, not delins (the spec rule
-    // requires "two or more consecutive nucleotides").
-    //
-    // 258_259 is non-palindromic (GA, revcomp TC). Length-2 palindromic
-    // candidates (CG, AT, GC, TA) collapse under `shorten_inversion` and
-    // are not emitted as Inversion sub-edits.
-    let p = SyntheticBuilder::genomic("TGAGC").build();
-    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258G>T;259A>C;260G>C]", SEQID));
-    assert_eq!(result, format!("{}:g.[257T>A;258_259inv;260G>C]", SEQID));
+    // Core "CTGA" at 257-260:
+    //   257 C        : length-1 sub run (C→A) → stays a substitution, NOT a
+    //                  delins (the spec rule requires "two or more consecutive
+    //                  nucleotides")
+    //   258 T        : identity (dropped)
+    //   259 G  260 A : full-run inv (revcomp(GA)=TC)
+    let p = SyntheticBuilder::genomic("CTGA").build();
+    let result = normalize_to_string(p, &format!("{}:g.257_260delinsATTC", SEQID));
+    assert_eq!(result, format!("{}:g.[257C>A;259_260inv]", SEQID));
 }
 
 // ---------------------------------------------------------------------------
-// IdentityAt breaks a substitution run
+// IdentityAt breaks a substitution run (subs across an identity do not group)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn identity_at_in_decomposition_breaks_sub_run() {
-    // Core "TGAGCC" at 257-262 produces a delins where the decomposer
-    // emits an IdentityAt between two Substitution sub-edits. The IdentityAt
-    // both (a) drops cleanly (no `g.<pos>=` emission) and (b) breaks the
-    // sub run so the bracketing subs do NOT group into a delins.
-    //
-    //   pos 257 T  258 G  259 A  260 G  261 C  262 C
-    //
-    // Inputs:
-    //   257 T>A     : leading sub flank (length 1)
-    //   258 G>T     : start of inv 258_259 (alt T)
-    //   259 A>C     : end   of inv 258_259 (alt C; revcomp(GA)=TC ✓)
-    //   260 G>G     : alt = ref → IdentityAt at 260
-    //   261 C>A     : trailing sub at 261
-    //   262 C>T     : (omitted — keeping the trailing run length 1 isolates
-    //                  the identity-breaks-run case from the run-grouping case)
-    //
-    // Expected merged delins: 257_261delinsATCGA.
-    // Decompose: Sub(257 T→A); Inv(258_259); IdentityAt(260); Sub(261 C→A).
-    // Output: [257T>A; 258_259inv; 261C>A] — IdentityAt drops, no spurious
-    // `260=` emission, and 261 stays a singleton Substitution (no run to
-    // group with — it's bracketed by the inv on the left and end-of-allele
-    // on the right).
-    let p = SyntheticBuilder::genomic("TGAGCC").build();
-    let result = normalize_to_string(p, &format!("{}:g.[257T>A;258G>T;259A>C;261C>A]", SEQID));
-    assert_eq!(result, format!("{}:g.[257T>A;258_259inv;261C>A]", SEQID));
+fn identity_at_between_subs_prevents_grouping() {
+    // Core "GATCTC" at 257-262:
+    //   257 G  258 A : full-run inv (revcomp(GA)=TC)
+    //   259 T        : identity (dropped; bounds the inv run)
+    //   260 C        : sub (C→A), length-1 run
+    //   261 T        : identity (dropped; breaks the run)
+    //   262 C        : sub (C→A), length-1 run
+    // The subs at 260 and 262 are separated by the identity at 261, so they
+    // must NOT group into a delins; each stays a singleton substitution and
+    // no spurious `259=` / `261=` is emitted.
+    let p = SyntheticBuilder::genomic("GATCTC").build();
+    let result = normalize_to_string(p, &format!("{}:g.257_262delinsTCTATA", SEQID));
+    assert_eq!(result, format!("{}:g.[257_258inv;260C>A;262C>A]", SEQID));
 }

--- a/tests/it/issue_291_rna_axis_convention.rs
+++ b/tests/it/issue_291_rna_axis_convention.rs
@@ -158,15 +158,19 @@ fn rna_first_coding_base_maps_to_cds_start() {
 /// Pins that `fetch_ref_for_canonical_split` reads the r. ref window
 /// CDS-relative (through `cds_start`, exactly like the `c.` arm — #469).
 /// The 3-base `delins` below targets `r.10_12` = tx 109..=111 = the `GGG`
-/// at the start of the CDS-interior G-run; alt `ccu` (→ `CCT`) decomposes
-/// via the revcomp scan into `[Inv; Sub g>u]`, rendering as a cis-allele.
+/// at the start of the CDS-interior G-run; alt `ccc` (→ `CCC`) is the reverse
+/// complement of the WHOLE run (`revcomp(GGG)=CCC`), so it canonicalizes to
+/// `inv`. This still proves the fetch reads `GGG`: a wrong (non-CDS-relative)
+/// window would not be a revcomp of `ccc` and would stay a delins. A revcomp
+/// *sub-run* of a longer contiguous change would not split (issue #1034), so
+/// a full-run inversion is used here.
 #[test]
 fn rna_canonical_split_fetch_is_cds_relative() {
-    let out = normalize_to_string("NM_TESTCDS100.1:r.10_12delinsccu");
+    let out = normalize_to_string("NM_TESTCDS100.1:r.10_12delinsccc");
     assert_eq!(
-        out, "NM_TESTCDS100.1:r.[10_11inv;12g>u]",
+        out, "NM_TESTCDS100.1:r.10_12inv",
         "fetch_ref_for_canonical_split must slice tx 109..=111 (= GGG) for \
-         r.10_12 via cds_start, mirroring the c. arm"
+         r.10_12 via cds_start, mirroring the c. arm; revcomp(GGG)=CCC → inv"
     );
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -81,6 +81,7 @@ mod inverted_uncertain_range_insertion;
 mod issue_1004_samegap_insertion_idempotency;
 mod issue_1012_reduced_capability_no_genome;
 mod issue_1026_genome_capable_json;
+mod issue_1034_inv_subspan_delins;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -4732,13 +4732,19 @@ mod cigar_cds_mapping {
 }
 
 // =============================================================================
-// Issue #160: revcomp inv sub-span detection within compound variants
+// Issue #160 (as corrected by issue #1034): revcomp inv detection within
+// compound variants
 // =============================================================================
-// HGVS spec: a delins span containing an inv-eligible sub-span (length >= 2,
-// alt = revcomp(ref)) decomposes to [..., inv, ...] per the edit-priority
-// rule (sub > del > inv > dup > ins). Applies to:
+// HGVS spec: an inversion describes a *maximal contiguous run* whose alt is
+// the reverse complement of the reference (`DNA/inversion.md`,
+// `general.md:56`). A delins whose WHOLE contiguous run is a revcomp becomes
+// an `inv`; a revcomp SUB-run of a longer contiguous change is NOT carved out
+// — that change stays a single `delins` (issue #1034 regression fix). A run
+// that is a full inversion but separated from other edits by an unchanged
+// nucleotide (an identity, `general.md:34`) still decomposes independently.
+// Applies to:
 //   - Cis allele inputs that merge into a delins, then decompose.
-//   - User-typed delins inputs whose post-trim range contains an inv sub-span.
+//   - User-typed delins inputs whose contiguous run is a full-run inversion.
 // Function: rules::decompose_delins() in src/normalize/rules.rs
 // (item A10 of tracking issue #81; sub-only branch tracked in #165)
 mod issue_160_revcomp_inv_subspans {
@@ -4777,43 +4783,42 @@ mod issue_160_revcomp_inv_subspans {
     }
 
     #[test]
-    fn sub_span_revcomp_splits_into_inv_plus_sub() {
-        // g.[1150T>G;1151C>A;1152C>G] over TCC → g.[1150_1151inv;1152C>G].
-        // The headline sub-span case from issue #160.
+    fn sub_span_revcomp_stays_single_delins() {
+        // g.[1150T>G;1151C>A;1152C>G] over TCC → g.1150_1152delinsGAG.
+        // The 2-nt sub-run 1150_1151 (TC→GA) is a revcomp, but the whole
+        // contiguous run TCC→GAG is not (revcomp(TCC)=GGA != GAG), so it must
+        // NOT split into [1150_1151inv;1152C>G]. Issue #1034 regression fix;
+        // this is the exact #160 headline example, now spec-corrected.
         let provider = provider_with_genomic("NC_000001.11", 1150, "TCC");
         let result = normalize_to_string(provider, "NC_000001.11:g.[1150T>G;1151C>A;1152C>G]");
-        assert_eq!(result, "NC_000001.11:g.[1150_1151inv;1152C>G]");
+        assert_eq!(result, "NC_000001.11:g.1150_1152delinsGAG");
     }
 
     #[test]
-    fn user_typed_delins_with_inv_subspan_splits_symmetric() {
+    fn user_typed_delins_with_revcomp_subspan_stays_delins_symmetric() {
         // User-typed g.1150_1152delinsGAG over TCC produces the same
         // canonical form as the cis-allele input above. The canonical form
         // depends on (ref, position, alt), not on input shape.
         let provider = provider_with_genomic("NC_000001.11", 1150, "TCC");
         let result = normalize_to_string(provider, "NC_000001.11:g.1150_1152delinsGAG");
-        assert_eq!(result, "NC_000001.11:g.[1150_1151inv;1152C>G]");
+        assert_eq!(result, "NC_000001.11:g.1150_1152delinsGAG");
     }
 
     #[test]
-    fn three_nt_inv_run_flanked_by_subs() {
+    fn three_nt_revcomp_subrun_in_contiguous_change_stays_delins() {
         // ref bases at 1099-1103: T G C T C
-        //   1099 T>A : sub (alt[0]=A)
-        //   1100 G>A : start of inv (alt[1]=A)
-        //   1101 C>G : middle of inv (alt[2]=G)
-        //   1102 T>C : end of inv  (alt[3]=C; revcomp("GCT")="AGC")
-        //   1103 C>T : sub (alt[4]=T)
-        // Merged delins is `g.1099_1103delinsAAGCT`. revcomp("TGCTC")=
-        // "GAGCA" != "AAGCT", so the full span is NOT inv (avoiding the
-        // palindromic-full-span hazard). The inv-eligible sub-span is
-        // positions [1100..1102]; flanked subs at 1099 and 1103 stay
-        // separate.
+        //   1099 T>A ; 1100 G>A ; 1101 C>G ; 1102 T>C ; 1103 C>T
+        // The interior 3-nt sub-run 1100_1102 (GCT→AGC) is a revcomp
+        // (revcomp("GCT")="AGC"), but all five positions differ so this is ONE
+        // contiguous change. revcomp("TGCTC")="GAGCA" != "AAGCT", so the whole
+        // run is not an inversion and the revcomp sub-run may not be carved
+        // out (issue #1034). It stays a single delins.
         let provider = provider_with_genomic("NC_000001.11", 1099, "TGCTC");
         let result = normalize_to_string(
             provider,
             "NC_000001.11:g.[1099T>A;1100G>A;1101C>G;1102T>C;1103C>T]",
         );
-        assert_eq!(result, "NC_000001.11:g.[1099T>A;1100_1102inv;1103C>T]");
+        assert_eq!(result, "NC_000001.11:g.1099_1103delinsAAGCT");
     }
 
     #[test]
@@ -4869,8 +4874,9 @@ mod issue_160_revcomp_inv_subspans {
     // Positions 13-14-15 = "CTG":
     //   c.13C>A, c.14T>G, c.15G>T merges to delinsAGT;
     //   full span revcomp(CTG)=CAG != AGT → no full inv;
-    //   sub-span [13..14]: revcomp(CT)=AG ✓ → inv;
-    //   pos 15 stays as separate sub.
+    //   sub-span [13..14] (CT→AG) is a revcomp but is part of the ONE
+    //   contiguous change 13_15, so it may not be carved out (issue #1034):
+    //   the whole run stays a single delins.
     // -------------------------------------------------------------------------
 
     #[test]
@@ -4883,21 +4889,21 @@ mod issue_160_revcomp_inv_subspans {
     }
 
     #[test]
-    fn cds_sub_span_revcomp_splits_into_inv_plus_sub() {
+    fn cds_sub_span_revcomp_stays_single_delins() {
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
         let parsed = parse_hgvs("NM_000088.3:c.[13C>A;14T>G;15G>T]").unwrap();
         let normalized = normalizer.normalize(&parsed).unwrap();
-        assert_eq!(format!("{}", normalized), "NM_000088.3:c.[13_14inv;15G>T]");
+        assert_eq!(format!("{}", normalized), "NM_000088.3:c.13_15delinsAGT");
     }
 
     #[test]
-    fn cds_user_typed_delins_with_inv_subspan_splits_symmetric() {
+    fn cds_user_typed_delins_with_revcomp_subspan_stays_delins_symmetric() {
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
         let parsed = parse_hgvs("NM_000088.3:c.13_15delinsAGT").unwrap();
         let normalized = normalizer.normalize(&parsed).unwrap();
-        assert_eq!(format!("{}", normalized), "NM_000088.3:c.[13_14inv;15G>T]");
+        assert_eq!(format!("{}", normalized), "NM_000088.3:c.13_15delinsAGT");
     }
 
     #[test]
@@ -4914,28 +4920,31 @@ mod issue_160_revcomp_inv_subspans {
     }
 
     #[test]
-    fn rna_sub_span_split_preserves_u_in_substitution() {
-        // r. inputs use U; ref is in transcript T-form. The inv-split scan
-        // T/U-normalizes both sides for revcomp detection, but the emitted
-        // Substitution sub-edit must preserve the user-typed U so r. output
-        // doesn't silently coerce u→t. NM_000088.3 r.13_15 transcript is
-        // "cug"; input r.13_15delinsagu decomposes to [13_14inv; 15g>u].
+    fn rna_sub_span_revcomp_stays_single_delins() {
+        // r. inputs use U; ref is in transcript T-form. The revcomp scan
+        // T/U-normalizes both sides. NM_000088.3 r.13_15 transcript is "cug";
+        // input r.13_15delinsagu: the 2-nt sub-run 13_14 (cu→ag, revcomp) is
+        // part of the ONE contiguous change 13_15 (revcomp(CUG)=CAG != AGU),
+        // so it may not be carved out (issue #1034). The whole run stays a
+        // single delins, preserving the user-typed U alphabet.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
         let parsed = parse_hgvs("NM_000088.3:r.13_15delinsagu").expect("r. delins parses");
         let normalized = normalizer.normalize(&parsed).unwrap();
-        assert_eq!(format!("{}", normalized), "NM_000088.3:r.[13_14inv;15g>u]");
+        assert_eq!(format!("{}", normalized), "NM_000088.3:r.13_15delinsagu");
     }
 
     #[test]
-    fn mt_user_typed_delins_with_inv_subspan_splits() {
-        // m. variants must reach apply_inv_split (issue #160). Mt has its own
-        // normalize_mt() which historically returned the variant unchanged;
-        // a user-typed Mt delins over a sub-span revcomp must still
-        // decompose to [..; inv; ..]. Mirrors the g. headline case.
-        let provider = provider_with_genomic("NC_012920.1", 1150, "TCC");
-        let result = normalize_to_string(provider, "NC_012920.1:m.1150_1152delinsGAG");
-        assert_eq!(result, "NC_012920.1:m.[1150_1151inv;1152C>G]");
+    fn mt_user_typed_full_span_revcomp_delins_becomes_inv() {
+        // m. variants must reach the delins inv-canonicalization path. Mt has
+        // its own normalize_mt() which historically returned the variant
+        // unchanged; a user-typed Mt delins whose WHOLE contiguous run is a
+        // revcomp must still canonicalize to inv. ref TC → alt GA
+        // (revcomp(TC)=GA). A sub-run revcomp of a longer change would NOT
+        // split (issue #1034); this full-run case still becomes an inv.
+        let provider = provider_with_genomic("NC_012920.1", 1150, "TC");
+        let result = normalize_to_string(provider, "NC_012920.1:m.1150_1151delinsGA");
+        assert_eq!(result, "NC_012920.1:m.1150_1151inv");
     }
 
     #[test]

--- a/tests/python/test_core.py
+++ b/tests/python/test_core.py
@@ -106,7 +106,13 @@ class TestVersion:
 
 
 class TestNormalizeIssue160RevcompInvSubspans:
-    """Issue #160: revcomp inv sub-span detection within compound variants.
+    """Issue #160 (as corrected by issue #1034): revcomp inv detection.
+
+    Per HGVS an inversion describes a *maximal contiguous run* whose alt is the
+    reverse complement of the reference (`DNA/inversion.md`, `general.md:56`).
+    A delins whose WHOLE contiguous run is a revcomp becomes an `inv`; a revcomp
+    SUB-run of a longer contiguous change is NOT carved out — that change stays
+    a single `delins` (issue #1034 regression fix).
 
     Uses a temporary JSON reference so the test can pin specific genomic bases
     at the positions referenced by the variant strings (the bundled
@@ -138,22 +144,25 @@ class TestNormalizeIssue160RevcompInvSubspans:
         result = normalizer.normalize("NC_000001.11:g.[1092G>C;1093G>C]")
         assert result == "NC_000001.11:g.1092_1093inv"
 
-    def test_sub_span_revcomp_splits_into_inv_plus_sub(self, tmp_path) -> None:
-        # Headline issue #160 case: cis allele over TCC at 1150-1152
-        # decomposes the merged delinsGAG into [1150_1151inv;1152C>G].
+    def test_sub_span_revcomp_stays_single_delins(self, tmp_path) -> None:
+        # Headline issue #160 case, spec-corrected by issue #1034: cis allele
+        # over TCC at 1150-1152 merges to delinsGAG. The 2-nt sub-run 1150_1151
+        # (TC->GA) is a revcomp, but the whole contiguous run TCC->GAG is not
+        # (revcomp(TCC)=GGA != GAG), so it must NOT split into
+        # [1150_1151inv;1152C>G] — it stays a single delins.
         ref = self._make_reference_json(tmp_path, "NC_000001.11", 1150, "TCC")
         normalizer = ferro_hgvs.Normalizer(reference_json=ref)
         result = normalizer.normalize("NC_000001.11:g.[1150T>G;1151C>A;1152C>G]")
-        assert result == "NC_000001.11:g.[1150_1151inv;1152C>G]"
+        assert result == "NC_000001.11:g.1150_1152delinsGAG"
 
-    def test_user_typed_delins_with_inv_subspan_splits_symmetric(self, tmp_path) -> None:
+    def test_user_typed_delins_with_revcomp_subspan_stays_delins_symmetric(self, tmp_path) -> None:
         # User-typed `g.1150_1152delinsGAG` produces the same canonical
         # form as the cis-allele input — the rule depends only on
-        # (ref, position, alt), not input shape.
+        # (ref, position, alt), not input shape (issue #1034).
         ref = self._make_reference_json(tmp_path, "NC_000001.11", 1150, "TCC")
         normalizer = ferro_hgvs.Normalizer(reference_json=ref)
         result = normalizer.normalize("NC_000001.11:g.1150_1152delinsGAG")
-        assert result == "NC_000001.11:g.[1150_1151inv;1152C>G]"
+        assert result == "NC_000001.11:g.1150_1152delinsGAG"
 
     def test_cds_full_span_revcomp_in_cis_merges_to_inv(self) -> None:
         # NM_000088.3 c.9-10 = "GG" (in the bundled mock); revcomp = "CC".
@@ -161,11 +170,13 @@ class TestNormalizeIssue160RevcompInvSubspans:
         result = ferro_hgvs.normalize("NM_000088.3:c.[9G>C;10G>C]")
         assert result == "NM_000088.3:c.9_10inv"
 
-    def test_cds_sub_span_revcomp_splits_into_inv_plus_sub(self) -> None:
-        # NM_000088.3 c.13-15 = "CTG"; revcomp(CT)=AG → inv at 13-14;
-        # 15G>T stays separate.
+    def test_cds_sub_span_revcomp_stays_single_delins(self) -> None:
+        # NM_000088.3 c.13-15 = "CTG"; the 2-nt sub-run c.13-14 (CT->AG) is a
+        # revcomp, but the whole contiguous run CTG->AGT is not
+        # (revcomp(CTG)=CAG != AGT), so no sub-run is carved out (issue #1034):
+        # it stays a single delins, not [13_14inv;15G>T].
         result = ferro_hgvs.normalize("NM_000088.3:c.[13C>A;14T>G;15G>T]")
-        assert result == "NM_000088.3:c.[13_14inv;15G>T]"
+        assert result == "NM_000088.3:c.13_15delinsAGT"
 
     def test_rna_full_span_revcomp_in_cis_merges_to_inv(self) -> None:
         # NM_000088.3 r.9-10 over "GG" → revcomp "CC" → r.9_10inv.


### PR DESCRIPTION
Closes #1034

## Problem

Since v0.8.0 (#160/#166), ferro fragments a contiguous multi-nucleotide change to expose an internal reverse-complement sub-run as an `inv`, even when the change as a whole is not an inversion. Per HGVS an inversion must describe a *maximal contiguous run* whose alt equals the reverse complement of the reference (`DNA/inversion.md`, `general.md:56`); a reverse-complement sub-run may not be carved out of a longer contiguous change — that change must stay a single `delins`.

Minimal example from the issue (ref window `100_102 = CTG`):

| | HGVS |
|---|---|
| raw | `REF:g.[100C>A;101T>C;102G>A]` |
| expected | `REF:g.100_102delinsACA` |
| v0.8.0 (wrong) | `REF:g.[100C>A;101_102inv]` |

`revcomp(CTG) = CAG != ACA`, so the whole run is not an inversion; the 2-nt sub-run `101_102` (`TG→CA`) is a revcomp but must not be split out. Both forms round-trip to the same allele, but only the single delins is spec-compliant. Per the issue, this over-recognition was the dominant source of v0.7.0 → v0.8.0 normalization regressions.

## Fix

`rules::decompose_delins` previously used a longest-greedy scan that matched reverse-complement identity on *sub-runs*. It is rewritten as a scan over **maximal contiguous mismatch runs** (bounded by interior identities per `general.md:34`):

- an identity position emits `IdentityAt` and bounds the run;
- a run is typed as `Inversion` only when the **whole** run (length ≥ 2) is a reverse complement;
- otherwise the run emits per-position `Substitution`s, which re-merge into a single `delins` under the caller's adjacency rule (`substitution.md` / #182).

`shorten_inversion`'s complementary-outer-pair peeling is no longer applied inside the decomposition: within a pure mismatch run a peelable outer pair would imply an identity at the boundary, so a full-run inversion's bounds are already minimal.

Preserved unchanged: full-span inversions (`canonicalize_delins`), full-run inversions separated from other edits by an identity, identity-gap substitution splitting (#165), the codon-frame exception (#79), and the #182 adjacency grouping of substitution runs.

## Tests (TDD)

- New `tests/it/issue_1034_inv_subspan_delins.rs` pins the issue example and the `#160` CHANGELOG example to a single `delins`, plus guards that genuine full-run inversions still emit `inv`.
- Updated the `decompose_delins` unit tests, the `issue_160_revcomp_inv_subspans` module, `issue_182_postcanon_adjacency`, and one `issue_291` fetch-window assertion to reflect the corrected (non-carving) behavior; every changed expectation was verified against the maximal-contiguous-run rule, not just accepted from actual output.

Full suite green (`cargo nextest run --features dev`: 7936 passed), `cargo clippy --features dev --all-targets -- -D warnings` clean, `cargo fmt` applied, doctests pass.

> [!NOTE]
> Manifest-gated conformance ledgers (skipped without `FERRO_MANIFEST`) are expected to *improve* under this change but are re-blessed separately against the prepared reference.