### PR TITLE
feat(python): expose convert_gff and build_transcript, mirroring prepare_reference_data

### DIFF
--- a/docs/python_reference_guide.md
+++ b/docs/python_reference_guide.md
@@ -11,7 +11,7 @@ harness) before trusting a genome-aware result.
 | You have… | Use | Genome-aware rules run? |
 |---|---|---|
 | A downloaded RefSeq/Ensembl reference + genome | `ferro prepare` → `Normalizer.from_manifest("manifest.json")` | ✅ full |
-| A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro convert-gff --emit-genomic-sequences` (or `ferro build-transcript --emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
+| A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro_hgvs.convert_gff(...)` in-process (or `ferro convert-gff` / `ferro build-transcript`, all with `emit_genomic_sequences=True` / `--emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
 | Transcript-level normalization only (exonic SNV/indel shuffle; no introns, no `g.` axis) | a `transcripts.json` **without** `genomic_sequences` → `Normalizer(reference_json=...)` | ❌ by design (see the boundary below) |
 | Just trying the API | `Normalizer()` (built-in toy data) | ❌ toy data |
 
@@ -79,8 +79,25 @@ in particular needs a genome.
 ## Example 1 — genome-aware normalization of a synthetic construct
 
 Build a **genome-capable** `transcripts.json` from your own FASTA — the
-`--emit-genomic-sequences` flag embeds the contig bytes so the genome-dependent
-rules can run:
+`emit_genomic_sequences` option embeds the contig bytes so the genome-dependent
+rules can run. You can do this entirely in-process (no `ferro` CLI required):
+
+```python
+import ferro_hgvs
+
+# Many transcripts from an annotation + FASTA, without shelling out to the CLI:
+ferro_hgvs.convert_gff(
+    ferro_hgvs.ConvertGffConfig(
+        gff="constructs.gff3",
+        fasta="constructs.fa",
+        output="constructs.json",
+        emit_genomic_sequences=True,
+    )
+)
+# Pass output=None instead to get the JSON back as report.transcripts_json.
+```
+
+or via the CLI:
 
 ```bash
 # Single synthetic construct (one contig):

--- a/docs/python_reference_guide.md
+++ b/docs/python_reference_guide.md
@@ -11,7 +11,7 @@ harness) before trusting a genome-aware result.
 | You have… | Use | Genome-aware rules run? |
 |---|---|---|
 | A downloaded RefSeq/Ensembl reference + genome | `ferro prepare` → `Normalizer.from_manifest("manifest.json")` | ✅ full |
-| A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro_hgvs.convert_gff(...)` in-process (or `ferro convert-gff` / `ferro build-transcript`, all with `emit_genomic_sequences=True` / `--emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
+| A **synthetic / local** construct (your own FASTA + annotation) and you need intronic / `g.` / exon-junction rules | `ferro_hgvs.convert_gff(...)` / `ferro_hgvs.build_transcript(...)` in-process (or the `ferro convert-gff` / `ferro build-transcript` CLIs, all with `emit_genomic_sequences=True` / `--emit-genomic-sequences`) → `Normalizer(reference_json="transcripts.json")` | ✅ yes |
 | Transcript-level normalization only (exonic SNV/indel shuffle; no introns, no `g.` axis) | a `transcripts.json` **without** `genomic_sequences` → `Normalizer(reference_json=...)` | ❌ by design (see the boundary below) |
 | Just trying the API | `Normalizer()` (built-in toy data) | ❌ toy data |
 
@@ -94,7 +94,18 @@ ferro_hgvs.convert_gff(
         emit_genomic_sequences=True,
     )
 )
-# Pass output=None instead to get the JSON back as report.transcripts_json.
+
+# Or a single construct straight from a FASTA + CDS bounds:
+ferro_hgvs.build_transcript(
+    ferro_hgvs.BuildTranscriptConfig(
+        fasta="construct.fa",
+        cds_start=1,
+        cds_end=900,
+        output="construct.json",
+        emit_genomic_sequences=True,
+    )
+)
+# Pass output=None on either to get the JSON back as report.transcripts_json.
 ```
 
 or via the CLI:

--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -118,6 +118,8 @@ __all__ = [
     "check_reference_data",
     # Convert-GFF functions
     "convert_gff",
+    # Build-Transcript functions
+    "build_transcript",
     # Core classes
     "HgvsVariant",
     "Normalizer",
@@ -164,6 +166,9 @@ __all__ = [
     # Convert-GFF classes
     "ConvertGffConfig",
     "ConvertGffReport",
+    # Build-Transcript classes
+    "BuildTranscriptConfig",
+    "BuildTranscriptReport",
     # Reference classes
     "GenomeBuild",
     "Strand",

--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -116,6 +116,8 @@ __all__ = [
     # Prepare functions
     "prepare_reference_data",
     "check_reference_data",
+    # Convert-GFF functions
+    "convert_gff",
     # Core classes
     "HgvsVariant",
     "Normalizer",
@@ -159,6 +161,9 @@ __all__ = [
     # Prepare classes
     "PrepareConfig",
     "ReferenceManifest",
+    # Convert-GFF classes
+    "ConvertGffConfig",
+    "ConvertGffReport",
     # Reference classes
     "GenomeBuild",
     "Strand",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -248,6 +248,29 @@ def check_reference_data(directory: str) -> ReferenceManifest:
     """
     ...
 
+def convert_gff(config: ConvertGffConfig) -> ConvertGffReport:
+    """Convert a GFF3/GTF annotation into the ``transcripts.json`` format.
+
+    In-process equivalent of ``ferro convert-gff``; both call the same library
+    serializer, so the output is byte-identical for the same inputs and flags.
+    Use it to build a reference for ``Normalizer(reference_json=...)`` without
+    shelling out to the CLI.
+
+    Args:
+        config: A ConvertGffConfig describing the inputs and options.
+
+    Returns:
+        ConvertGffReport with the loader summary, the written output path (or the
+        JSON text when ``output`` is ``None``), and any warnings.
+
+    Raises:
+        ValueError: If ``error_mode`` is not recognized, or
+            ``emit_genomic_sequences`` is set without a ``fasta``.
+        ReferenceDataError: If the annotation or FASTA cannot be read/parsed, or
+            (in strict mode) an error diagnostic is recorded.
+    """
+    ...
+
 # ============================================================================
 # Core Classes
 # ============================================================================
@@ -1396,6 +1419,85 @@ class ReferenceManifest:
     def cdot_grch37_json(self) -> str | None: ...
     @property
     def available_prefixes(self) -> list[str]: ...
+
+# ============================================================================
+# Convert-GFF Classes
+# ============================================================================
+
+class ConvertGffConfig:
+    """Configuration for :func:`convert_gff`, mirroring the ``ferro convert-gff``
+    CLI flags."""
+
+    def __init__(
+        self,
+        gff: str,
+        fasta: str | None = None,
+        output: str | None = None,
+        build: str = "GRCh38",
+        mane_only: bool = False,
+        transcripts: list[str] | str | None = None,
+        genes: list[str] | str | None = None,
+        error_mode: str = "lenient",
+        validate_fasta: bool = True,
+        emit_genomic_sequences: bool = False,
+        diagnostics_json: str | None = None,
+    ) -> None:
+        """Create a convert-gff configuration.
+
+        Args:
+            gff: Path to the input GFF3/GTF annotation file.
+            fasta: Optional reference FASTA, used to extract exonic sequences and
+                (with ``emit_genomic_sequences``) the embedded contig sequences.
+            output: Optional output path for the ``transcripts.json``. If ``None``
+                (default), the JSON is returned in
+                ``ConvertGffReport.transcripts_json`` instead of written to disk.
+            build: Genome build recorded in the output ("GRCh38" or "GRCh37").
+            mane_only: Emit only MANE Select / MANE Plus Clinical transcripts.
+            transcripts: Optional transcript-ID filter — a list of IDs or a single
+                comma-separated string.
+            genes: Optional gene-symbol filter — a list of symbols or a single
+                comma-separated string.
+            error_mode: "lenient" (default), "strict", or "silent".
+            validate_fasta: Run CDS-length / start-codon FASTA validation when a
+                FASTA is supplied (default True; inverse of ``--no-validate-fasta``).
+            emit_genomic_sequences: Embed referenced contig sequences so the output
+                is genome-capable. Requires ``fasta``.
+            diagnostics_json: Optional path to write the sampled loader diagnostics.
+        """
+        ...
+
+class ConvertGffReport:
+    """Result of a :func:`convert_gff` run."""
+
+    @property
+    def summary(self) -> str:
+        """One-line loader summary (records read, transcripts built, diagnostics)."""
+        ...
+    @property
+    def transcripts_json(self) -> str | None:
+        """The serialized ``transcripts.json`` text, present only when the config's
+        ``output`` was ``None`` (otherwise the JSON was written to that path and
+        this is ``None``)."""
+        ...
+    @property
+    def output_path(self) -> str | None:
+        """The path the ``transcripts.json`` was written to, or ``None`` if it was
+        returned in ``transcripts_json`` instead."""
+        ...
+    @property
+    def transcript_count(self) -> int:
+        """Number of transcripts emitted."""
+        ...
+    @property
+    def emitted_genomic_bytes(self) -> int:
+        """Total bytes of genomic sequence embedded under ``genomic_sequences``
+        (0 when ``emit_genomic_sequences`` was off or nothing was placed)."""
+        ...
+    @property
+    def warnings(self) -> list[str]:
+        """Non-fatal warnings raised during conversion (also emitted as
+        ``UserWarning``)."""
+        ...
 
 # ============================================================================
 # Reference Classes

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -271,6 +271,28 @@ def convert_gff(config: ConvertGffConfig) -> ConvertGffReport:
     """
     ...
 
+def build_transcript(config: BuildTranscriptConfig) -> BuildTranscriptReport:
+    """Build a single-construct ``transcripts.json`` from a FASTA + CDS bounds.
+
+    In-process equivalent of ``ferro build-transcript``; both call the same
+    library builder, so the output is byte-identical for the same inputs and
+    flags. Use it to wrap a synthetic construct's FASTA as a reference for
+    ``Normalizer(reference_json=...)`` without shelling out to the CLI.
+
+    Args:
+        config: A BuildTranscriptConfig describing the inputs and options.
+
+    Returns:
+        BuildTranscriptReport with the transcript id, the written output path (or
+        the JSON text when ``output`` is ``None``), and any warnings.
+
+    Raises:
+        ValueError: If ``strand`` is not "+"/"-", or the CDS bounds are invalid.
+        ReferenceDataError: If the FASTA cannot be read or the contig cannot be
+            resolved.
+    """
+    ...
+
 # ============================================================================
 # Core Classes
 # ============================================================================
@@ -1496,6 +1518,77 @@ class ConvertGffReport:
     @property
     def warnings(self) -> list[str]:
         """Non-fatal warnings raised during conversion (also emitted as
+        ``UserWarning``)."""
+        ...
+
+# ============================================================================
+# Build-Transcript Classes
+# ============================================================================
+
+class BuildTranscriptConfig:
+    """Configuration for :func:`build_transcript`, mirroring the
+    ``ferro build-transcript`` CLI flags."""
+
+    def __init__(
+        self,
+        fasta: str,
+        cds_start: int,
+        cds_end: int,
+        output: str | None = None,
+        id: str | None = None,
+        strand: str = "+",
+        contig: str | None = None,
+        gene: str | None = None,
+        genome_build: str = "GRCh38",
+        emit_genomic_sequences: bool = False,
+    ) -> None:
+        """Create a build-transcript configuration.
+
+        Args:
+            fasta: Path to the FASTA (indexed or plain; the index is built on the
+                fly if absent).
+            cds_start: CDS start position (1-based inclusive, transcript coordinates).
+            cds_end: CDS end position (1-based inclusive, transcript coordinates).
+            output: Optional output path for the ``transcripts.json``. If ``None``
+                (default), the JSON is returned in
+                ``BuildTranscriptReport.transcripts_json`` instead of written to disk.
+            id: Transcript ID; defaults to the FASTA contig name.
+            strand: "+" (default) or "-". Minus-strand sequences are reverse-
+                complemented, so the CDS positions are relative to that sequence.
+            contig: Contig to use when the FASTA has multiple contigs.
+            gene: Optional gene symbol to embed in the transcript record.
+            genome_build: Genome build name embedded verbatim (default "GRCh38").
+            emit_genomic_sequences: Embed the contig's forward bytes so the output
+                is genome-capable.
+        """
+        ...
+
+class BuildTranscriptReport:
+    """Result of a :func:`build_transcript` run."""
+
+    @property
+    def transcript_id(self) -> str:
+        """The transcript ID that was emitted (the configured id or contig name)."""
+        ...
+    @property
+    def transcripts_json(self) -> str | None:
+        """The serialized ``transcripts.json`` text, present only when the config's
+        ``output`` was ``None`` (otherwise the JSON was written to that path and
+        this is ``None``)."""
+        ...
+    @property
+    def output_path(self) -> str | None:
+        """The path the ``transcripts.json`` was written to, or ``None`` if it was
+        returned in ``transcripts_json`` instead."""
+        ...
+    @property
+    def emitted_genomic_bytes(self) -> int:
+        """Total bytes of genomic sequence embedded under ``genomic_sequences``
+        (0 when ``emit_genomic_sequences`` was off)."""
+        ...
+    @property
+    def warnings(self) -> list[str]:
+        """Non-fatal warnings raised during the build (also emitted as
         ``UserWarning``)."""
         ...
 

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -15,12 +15,11 @@ use ferro_hgvs::error_handling::{
     get_code_info, list_all_codes, list_error_codes, list_warning_codes, ErrorConfig, ErrorMode,
     ErrorType,
 };
-use ferro_hgvs::reference::transcript::GenomeBuild;
 use ferro_hgvs::reference::FastaProvider;
 use ferro_hgvs::reference::TranscriptDb;
 use ferro_hgvs::sequence::reverse_complement;
 use ferro_hgvs::vcf::{generate_info_header_lines, open_vcf, VcfAnnotator, VcfRecord};
-use ferro_hgvs::{parse_hgvs, FerroError, NormalizeConfig, Normalizer, ReferenceProvider};
+use ferro_hgvs::{parse_hgvs, FerroError, NormalizeConfig, Normalizer};
 use flate2::read::MultiGzDecoder;
 use rayon::prelude::*;
 use std::collections::HashSet;
@@ -1910,12 +1909,11 @@ fn run_parse(
 /// Byte threshold above which embedding genomic sequence into a `transcripts.json`
 /// is flagged as heavy — the file becomes large to store and parse, and a
 /// genome-scale reference is better served by `ferro prepare` + `from_manifest`.
-const LARGE_GENOMIC_SEQUENCES_WARN_BYTES: u64 = 50_000_000; // 50 MB
-
 /// Warn on stderr when `--emit-genomic-sequences` embeds a large amount of
 /// genomic sequence, so a user does not silently produce a multi-hundred-MB
 /// `transcripts.json` from whole-chromosome (or whole-genome) coordinates.
 fn warn_if_genomic_sequences_large(total_bytes: u64) {
+    use ferro_hgvs::reference::annotation::convert::LARGE_GENOMIC_SEQUENCES_WARN_BYTES;
     if total_bytes > LARGE_GENOMIC_SEQUENCES_WARN_BYTES {
         eprintln!(
             "warning: --emit-genomic-sequences embedded {:.1} MB of genomic sequence; the \
@@ -1926,9 +1924,17 @@ fn warn_if_genomic_sequences_large(total_bytes: u64) {
     }
 }
 
+/// Split a comma-separated CLI filter value (`--transcripts`, `--genes`) into
+/// trimmed items. Empty items are preserved so the behavior matches the
+/// previous inline split; [`convert_gff`](ferro_hgvs::reference::annotation::convert_gff)
+/// trims again defensively.
+fn split_comma_list(s: &str) -> Vec<String> {
+    s.split(',').map(|t| t.trim().to_string()).collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_convert_gff(
-    gff: &PathBuf,
+    gff: &Path,
     fasta: Option<&PathBuf>,
     output: Option<&PathBuf>,
     build: &str,
@@ -1941,282 +1947,52 @@ fn run_convert_gff(
     emit_genomic_sequences: bool,
     diagnostics_json: Option<&PathBuf>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use ferro_hgvs::reference::annotation::{load_annotations, LoaderConfig};
-    use ferro_hgvs::reference::transcript::ManeStatus;
-    use std::collections::{BTreeMap, HashSet};
+    use ferro_hgvs::reference::annotation::{convert_gff, ConvertGffConfig};
 
-    // Parse genome build
-    let genome_build = parse_genome_build(build);
+    // Build the conversion config, mirroring the CLI flags one-to-one. The
+    // serialization itself lives in `ferro_hgvs::reference::annotation::convert_gff`
+    // so this command and the Python binding produce byte-identical output.
+    let config = ConvertGffConfig {
+        genome_build: parse_genome_build(build),
+        mane_only,
+        transcripts: transcripts.map(split_comma_list),
+        genes: genes.map(split_comma_list),
+        strict,
+        silent,
+        no_validate_fasta,
+        emit_genomic_sequences,
+    };
 
-    // Build loader config with error mode, genome build, and optional FASTA validation.
-    let mut cfg = LoaderConfig::new().with_genome_build(genome_build);
-    if strict {
-        cfg = cfg.with_strict();
-    } else if silent {
-        cfg = cfg.with_silent();
-    }
-    // Pass a FASTA provider to load_annotations for CDS-length / start-codon validation.
-    // A second FastaProvider is constructed below for sequence extraction; FastaProvider::new
-    // is cheap (reads only the index), so the double construction is acceptable.
-    if let Some(fasta_path) = fasta {
-        cfg = cfg.with_fasta(FastaProvider::new(fasta_path)?);
-    }
-    if no_validate_fasta {
-        cfg = cfg.with_no_validate_fasta();
-    }
+    let outcome = convert_gff(gff, fasta.map(PathBuf::as_path), &config)?;
 
-    // Load GFF/GTF file via load_annotations
-    let (mut db, report) = load_annotations(gff, &cfg)?;
-    db.genome_build = genome_build;
-    eprintln!("{}", report.summary_line());
+    // Surface the loader summary line, as before.
+    eprintln!("{}", outcome.report.summary_line());
 
-    // Write diagnostics JSON if requested
+    // Write diagnostics JSON if requested.
     if let Some(path) = diagnostics_json {
-        let json = serde_json::to_string_pretty(&report.sample_diagnostics)
+        let json = serde_json::to_string_pretty(&outcome.report.sample_diagnostics)
             .map_err(|e| format!("serialize diagnostics: {}", e))?;
         std::fs::write(path, json).map_err(|e| format!("write {}: {}", path.display(), e))?;
     }
 
-    // Load FASTA if provided and extract sequences
-    let fasta_provider = if let Some(fasta_path) = fasta {
-        Some(FastaProvider::new(fasta_path)?)
-    } else {
-        None
-    };
-
-    // Parse transcript and gene filters
-    let transcript_filter: Option<HashSet<&str>> =
-        transcripts.map(|s| s.split(',').map(|t| t.trim()).collect());
-    let gene_filter: Option<HashSet<&str>> =
-        genes.map(|s| s.split(',').map(|g| g.trim()).collect());
-
-    // Collect transcripts to output
-    let mut output_transcripts: Vec<serde_json::Value> = Vec::new();
-
-    // For each contig an emitted transcript is placed on, the highest 1-based
-    // genomic coordinate its placement references (max over exon `genomic_end` and
-    // the transcript's own `genomic_end`). Used to emit `genomic_sequences` when
-    // --emit-genomic-sequences is set, and — crucially — to fail fast at emit time
-    // if the FASTA contig cannot cover the placement, using the SAME invariant
-    // `MockProvider::from_json` enforces at load, so convert-gff can never emit a
-    // file its own loader would reject (#1026). BTreeMap keeps the output
-    // deterministic.
-    let mut contig_required_len: BTreeMap<String, u64> = BTreeMap::new();
-
-    for (id, tx) in db.iter() {
-        // Apply filters
-        if mane_only && tx.mane_status == ManeStatus::None {
-            continue;
-        }
-
-        if let Some(ref filter) = transcript_filter {
-            if !filter.contains(id.as_str()) {
-                continue;
-            }
-        }
-
-        if let Some(ref filter) = gene_filter {
-            if let Some(ref gene) = tx.gene_symbol {
-                if !filter.contains(gene.as_str()) {
-                    continue;
-                }
-            } else {
-                continue;
-            }
-        }
-
-        // Extract sequence from FASTA if available
-        let sequence = if let (Some(ref fasta), Some(ref chrom), Some(_start), Some(_end)) = (
-            &fasta_provider,
-            &tx.chromosome,
-            tx.genomic_start,
-            tx.genomic_end,
-        ) {
-            // Extract exonic sequences
-            let mut exon_seqs = Vec::new();
-            for exon in &tx.exons {
-                if let (Some(g_start), Some(g_end)) = (exon.genomic_start, exon.genomic_end) {
-                    // FASTA uses 0-based coordinates, GFF uses 1-based
-                    match fasta.get_sequence(chrom, g_start - 1, g_end) {
-                        Ok(seq) => exon_seqs.push(seq),
-                        Err(_) => exon_seqs.push("N".repeat((g_end - g_start + 1) as usize)),
-                    }
-                }
-            }
-
-            // Join exons and handle strand
-            let mut full_seq = exon_seqs.join("");
-            if tx.strand == ferro_hgvs::reference::transcript::Strand::Minus {
-                full_seq = reverse_complement(&full_seq);
-            }
-            full_seq
-        } else if let Some(seq) = tx
-            .sequence
-            .as_deref()
-            .filter(|s| !s.is_empty() && !s.chars().all(|c| c == 'N'))
-        {
-            seq.to_string()
-        } else {
-            // No FASTA, use placeholder
-            "N".repeat(tx.exons.iter().map(|e| e.end - e.start + 1).sum::<u64>() as usize)
-        };
-
-        // Build exon objects
-        let exons: Vec<serde_json::Value> = tx
-            .exons
-            .iter()
-            .map(|e| {
-                let mut exon_obj = serde_json::json!({
-                    "number": e.number,
-                    "start": e.start,
-                    "end": e.end,
-                });
-                if let Some(g_start) = e.genomic_start {
-                    exon_obj["genomic_start"] = serde_json::json!(g_start);
-                }
-                if let Some(g_end) = e.genomic_end {
-                    exon_obj["genomic_end"] = serde_json::json!(g_end);
-                }
-                exon_obj
-            })
-            .collect();
-
-        // Build transcript object
-        let mut tx_obj = serde_json::json!({
-            "id": id,
-            "sequence": sequence,
-            "exons": exons,
-        });
-
-        // Add optional fields
-        if let Some(ref gene) = tx.gene_symbol {
-            tx_obj["gene_symbol"] = serde_json::json!(gene);
-        }
-        if let Some(ref chrom) = tx.chromosome {
-            tx_obj["chromosome"] = serde_json::json!(chrom);
-            // Track the highest genomic coordinate this transcript's placement
-            // needs on its contig, mirroring the loader's `required_len`.
-            let required = tx
-                .exons
-                .iter()
-                .filter_map(|e| e.genomic_end)
-                .chain(tx.genomic_end)
-                .max();
-            if let Some(required) = required {
-                let entry = contig_required_len.entry(chrom.clone()).or_insert(0);
-                *entry = (*entry).max(required);
-            }
-        }
-        if let Some(start) = tx.genomic_start {
-            tx_obj["genomic_start"] = serde_json::json!(start);
-        }
-        if let Some(end) = tx.genomic_end {
-            tx_obj["genomic_end"] = serde_json::json!(end);
-        }
-        if let Some(cds_start) = tx.cds_start {
-            tx_obj["cds_start"] = serde_json::json!(cds_start);
-        }
-        if let Some(cds_end) = tx.cds_end {
-            tx_obj["cds_end"] = serde_json::json!(cds_end);
-        }
-
-        tx_obj["strand"] = serde_json::json!(match tx.strand {
-            ferro_hgvs::reference::transcript::Strand::Plus => "+",
-            ferro_hgvs::reference::transcript::Strand::Minus => "-",
-            ferro_hgvs::reference::transcript::Strand::Unknown => ".",
-            _ => ".",
-        });
-
-        tx_obj["genome_build"] = serde_json::json!(match genome_build {
-            GenomeBuild::GRCh37 => "GRCh37",
-            GenomeBuild::GRCh38 => "GRCh38",
-            GenomeBuild::Unknown => "unknown",
-        });
-
-        if tx.mane_status != ManeStatus::None {
-            tx_obj["mane_status"] = serde_json::json!(match tx.mane_status {
-                ManeStatus::Select => "MANE_Select",
-                ManeStatus::PlusClinical => "MANE_Plus_Clinical",
-                ManeStatus::None => "none",
-            });
-        }
-
-        output_transcripts.push(tx_obj);
+    // Reproduce the --emit-genomic-sequences stderr warnings from the outcome.
+    if outcome.emit_requested_no_placement {
+        eprintln!(
+            "warning: --emit-genomic-sequences was set but no emitted transcript has a \
+             genomic placement; genomic_sequences not written (reference stays \
+             transcript-only)"
+        );
     }
+    warn_if_genomic_sequences_large(outcome.emitted_genomic_bytes);
 
-    // Create output JSON
-    let mut output_json = serde_json::json!({
-        "version": "1.0",
-        "genome_build": match genome_build {
-            GenomeBuild::GRCh37 => "GRCh37",
-            GenomeBuild::GRCh38 => "GRCh38",
-            GenomeBuild::Unknown => "unknown",
-        },
-        "transcripts": output_transcripts,
-    });
-
-    // Optionally emit the referenced contig sequences so the transcripts.json is
-    // genome-capable. The exon `genomic_start`/`genomic_end` coordinates are
-    // absolute contig positions, so we emit each referenced contig's full forward
-    // sequence keyed by chromosome name — this is exactly what `MockProvider`
-    // slices by genomic coordinate when running the genome-aware rules (#1026).
-    if emit_genomic_sequences {
-        let fasta = fasta_provider
-            .as_ref()
-            .ok_or("--emit-genomic-sequences requires --fasta to read the contig sequences")?;
-        if contig_required_len.is_empty() {
-            // The flag was requested but no emitted transcript carries a genomic
-            // placement, so there is nothing to back a genome with. Warn rather than
-            // write an empty `genomic_sequences` map that would look genome-capable
-            // but report `has_genomic_data() == false`.
-            eprintln!(
-                "warning: --emit-genomic-sequences was set but no emitted transcript has a \
-                 genomic placement; genomic_sequences not written (reference stays \
-                 transcript-only)"
-            );
-        } else {
-            let mut genomic_sequences = serde_json::Map::new();
-            let mut total_bytes: u64 = 0;
-            for (contig, required_len) in &contig_required_len {
-                let length = fasta.sequence_length(contig).ok_or_else(|| {
-                    format!(
-                        "--emit-genomic-sequences: a transcript is placed on contig '{}', \
-                         but it is not present in the FASTA",
-                        contig
-                    )
-                })?;
-                // Fail fast, with the SAME invariant the loader enforces, so the
-                // emitted file always loads. A shorter contig means the FASTA does
-                // not cover the annotation's coordinates — typically a sub-region
-                // FASTA paired with whole-genome coordinates, or a mismatched
-                // assembly.
-                if length < *required_len {
-                    return Err(format!(
-                        "--emit-genomic-sequences: contig '{}' is {} bases in the FASTA, but a \
-                         transcript placement needs genomic coordinate {}. The FASTA does not \
-                         cover the annotation's coordinates (a sub-region FASTA with whole-genome \
-                         coordinates, or a different assembly?).",
-                        contig, length, required_len
-                    )
-                    .into());
-                }
-                let sequence = fasta.get_sequence(contig, 0, length)?;
-                total_bytes += sequence.len() as u64;
-                genomic_sequences.insert(contig.clone(), serde_json::json!(sequence));
-            }
-            warn_if_genomic_sequences_large(total_bytes);
-            output_json["genomic_sequences"] = serde_json::Value::Object(genomic_sequences);
-        }
-    }
-
-    // Write output
+    // Write output.
     let mut writer: Box<dyn Write> = if let Some(out_path) = output {
         Box::new(std::fs::File::create(out_path)?)
     } else {
         Box::new(io::stdout())
     };
 
-    writeln!(writer, "{}", serde_json::to_string_pretty(&output_json)?)?;
+    writeln!(writer, "{}", serde_json::to_string_pretty(&outcome.json)?)?;
 
     Ok(())
 }

--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -15,9 +15,7 @@ use ferro_hgvs::error_handling::{
     get_code_info, list_all_codes, list_error_codes, list_warning_codes, ErrorConfig, ErrorMode,
     ErrorType,
 };
-use ferro_hgvs::reference::FastaProvider;
 use ferro_hgvs::reference::TranscriptDb;
-use ferro_hgvs::sequence::reverse_complement;
 use ferro_hgvs::vcf::{generate_info_header_lines, open_vcf, VcfAnnotator, VcfRecord};
 use ferro_hgvs::{parse_hgvs, FerroError, NormalizeConfig, Normalizer};
 use flate2::read::MultiGzDecoder;
@@ -3446,7 +3444,7 @@ fn run_cds_consistency_check(
 /// against the reverse-complemented (transcript) sequence.
 #[allow(clippy::too_many_arguments)]
 fn run_build_transcript(
-    fasta_path: &PathBuf,
+    fasta_path: &Path,
     cds_start: u64,
     cds_end: u64,
     output: &PathBuf,
@@ -3457,123 +3455,33 @@ fn run_build_transcript(
     genome_build: &str,
     emit_genomic_sequences: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let fasta = FastaProvider::new(fasta_path)?;
+    use ferro_hgvs::reference::annotation::{build_transcript, BuildTranscriptConfig};
 
-    // Collect contig names; HashMap iteration order is non-deterministic but we
-    // only need the names to detect single vs. multi-contig.
-    let contig_names: Vec<String> = fasta.sequence_names().cloned().collect();
-
-    let contig_name: String = match (contig, contig_names.as_slice()) {
-        (Some(c), _) => {
-            if !fasta.has_sequence(c) {
-                return Err(format!(
-                    "Contig '{}' not found in FASTA; available: {}",
-                    c,
-                    contig_names.join(", ")
-                )
-                .into());
-            }
-            c.to_string()
-        }
-        (None, [single]) => single.clone(),
-        (None, []) => return Err("FASTA contains no contigs".into()),
-        (None, _) => {
-            return Err(format!(
-                "FASTA has {} contigs; pass --contig to select one (available: {})",
-                contig_names.len(),
-                contig_names.join(", ")
-            )
-            .into())
-        }
+    // Build the config, mirroring the CLI flags. The construction and
+    // serialization live in `ferro_hgvs::reference::annotation::build_transcript`
+    // so this command and the Python binding produce byte-identical output.
+    let config = BuildTranscriptConfig {
+        cds_start,
+        cds_end,
+        id: id.map(str::to_string),
+        strand: strand.to_string(),
+        contig: contig.map(str::to_string),
+        gene: gene.map(str::to_string),
+        genome_build: genome_build.to_string(),
+        emit_genomic_sequences,
     };
 
-    let contig_length = fasta
-        .sequence_length(&contig_name)
-        .ok_or_else(|| format!("Could not determine length of contig '{}'", contig_name))?;
+    let outcome = build_transcript(fasta_path, &config)?;
 
-    // Validate CDS bounds (1-based inclusive)
-    if cds_start < 1 || cds_end < cds_start || cds_end > contig_length {
-        return Err(format!(
-            "Invalid CDS bounds: cds_start={}, cds_end={}, contig length={}",
-            cds_start, cds_end, contig_length
-        )
-        .into());
-    }
+    // Warn if a large genome was embedded (a no-op when nothing was emitted).
+    warn_if_genomic_sequences_large(outcome.emitted_genomic_bytes);
 
-    // Parse and validate strand
-    if strand != "+" && strand != "-" {
-        return Err(format!("Invalid strand '{}'; expected + or -", strand).into());
-    }
-
-    // Read the full contig sequence (0-based half-open for get_sequence). This is
-    // the forward genomic sequence; the exon `genomic_start`/`genomic_end`
-    // coordinates index into it, so it is what we emit under `genomic_sequences`.
-    use ferro_hgvs::reference::provider::ReferenceProvider;
-    let mut genomic_forward = fasta.get_sequence(&contig_name, 0, contig_length)?;
-
-    // Reverse-complement for minus-strand transcripts (transcript-space `sequence`).
-    // On the plus strand the transcript sequence equals the forward contig: clone it
-    // only when we still need `genomic_forward` for `genomic_sequences`, otherwise
-    // move it out to avoid duplicating the whole contig.
-    let final_sequence = if strand == "-" {
-        reverse_complement(&genomic_forward)
-    } else if emit_genomic_sequences {
-        genomic_forward.clone()
-    } else {
-        std::mem::take(&mut genomic_forward)
-    };
-
-    let tx_id = id.unwrap_or(&contig_name).to_string();
-
-    // Build the exon object: single exon spanning the full contig. For a
-    // single-exon synthetic construct, plus-strand transcript coordinates equal
-    // genomic coordinates; for minus-strand the emitted `sequence` is
-    // reverse-complemented and CDS positions are in transcript space.
-    let exon = serde_json::json!({
-        "number": 1,
-        "start": 1_u64,
-        "end": contig_length,
-        "genomic_start": 1_u64,
-        "genomic_end": contig_length,
-    });
-
-    let mut tx_obj = serde_json::json!({
-        "id": tx_id,
-        "strand": strand,
-        "sequence": final_sequence,
-        "cds_start": cds_start,
-        "cds_end": cds_end,
-        "exons": [exon],
-        "chromosome": contig_name,
-        "genomic_start": 1_u64,
-        "genomic_end": contig_length,
-        "genome_build": genome_build,
-    });
-
-    if let Some(g) = gene {
-        tx_obj["gene_symbol"] = serde_json::json!(g);
-    }
-
-    let mut output_json = serde_json::json!({
-        "version": "1.0",
-        "genome_build": genome_build,
-        "transcripts": [tx_obj],
-    });
-
-    // Optionally emit the contig's forward sequence so the transcripts.json is
-    // genome-capable (#1026): the single exon's genomic coordinates index into it.
-    // Note this repeats the contig bytes already carried in the transcript
-    // `sequence` (identical on plus strand; reverse-complemented there on minus),
-    // which is the price of a self-contained genome-capable reference.
-    if emit_genomic_sequences {
-        warn_if_genomic_sequences_large(genomic_forward.len() as u64);
-        let mut genomic_sequences = serde_json::Map::new();
-        genomic_sequences.insert(contig_name.clone(), serde_json::json!(genomic_forward));
-        output_json["genomic_sequences"] = serde_json::Value::Object(genomic_sequences);
-    }
-
-    std::fs::write(output, serde_json::to_string_pretty(&output_json)?)?;
-    eprintln!("Wrote 1 transcript ({}) to {}", tx_id, output.display());
+    std::fs::write(output, serde_json::to_string_pretty(&outcome.json)?)?;
+    eprintln!(
+        "Wrote 1 transcript ({}) to {}",
+        outcome.transcript_id,
+        output.display()
+    );
 
     Ok(())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -4147,6 +4147,306 @@ fn check_reference_data(directory: &str) -> PyResult<PyReferenceManifest> {
 }
 
 // ============================================================================
+// Convert-GFF (GFF3/GTF -> transcripts.json)
+// ============================================================================
+
+/// Coerce a `--transcripts` / `--genes` filter argument, accepted as either a
+/// single comma-separated string (`"NM_1.1,NM_2.1"`, matching the CLI flag) or
+/// a Python list of strings (`["NM_1.1", "NM_2.1"]`), into the trimmed
+/// `Vec<String>` the library filter expects. `None` (or Python `None`) means
+/// "no filter".
+fn coerce_filter(obj: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Vec<String>>> {
+    let Some(obj) = obj else { return Ok(None) };
+    if obj.is_none() {
+        return Ok(None);
+    }
+    // Try a single string first: a Python str also extracts as `Vec<String>`
+    // (iterating its characters), so the list branch must not see it.
+    if let Ok(s) = obj.extract::<String>() {
+        Ok(Some(s.split(',').map(|t| t.trim().to_string()).collect()))
+    } else if let Ok(v) = obj.extract::<Vec<String>>() {
+        Ok(Some(v.into_iter().map(|t| t.trim().to_string()).collect()))
+    } else {
+        Err(PyValueError::new_err(
+            "transcripts/genes must be a string or a list of strings",
+        ))
+    }
+}
+
+/// Configuration for [`convert_gff`], mirroring the `ferro convert-gff` CLI
+/// flags. Construct it, then pass it to `convert_gff`.
+#[pyclass(name = "ConvertGffConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyConvertGffConfig {
+    gff: String,
+    fasta: Option<String>,
+    output: Option<String>,
+    build: String,
+    mane_only: bool,
+    transcripts: Option<Vec<String>>,
+    genes: Option<Vec<String>>,
+    error_mode: String,
+    validate_fasta: bool,
+    emit_genomic_sequences: bool,
+    diagnostics_json: Option<String>,
+}
+
+#[pymethods]
+impl PyConvertGffConfig {
+    /// Create a convert-gff configuration.
+    ///
+    /// Args:
+    ///     gff: Path to the input GFF3/GTF annotation file.
+    ///     fasta: Optional reference FASTA, used to extract exonic sequences and
+    ///         (with ``emit_genomic_sequences``) the embedded contig sequences.
+    ///     output: Optional output path for the ``transcripts.json``. If ``None``
+    ///         (the default), the JSON is returned in ``ConvertGffReport.transcripts_json``
+    ///         instead of written to disk (mirrors the CLI's stdout default).
+    ///     build: Genome build recorded in the output ("GRCh38" or "GRCh37").
+    ///     mane_only: Emit only MANE Select / MANE Plus Clinical transcripts.
+    ///     transcripts: Optional transcript-ID filter — a list of IDs or a single
+    ///         comma-separated string.
+    ///     genes: Optional gene-symbol filter — a list of symbols or a single
+    ///         comma-separated string.
+    ///     error_mode: "lenient" (default), "strict", or "silent".
+    ///     validate_fasta: Run CDS-length / start-codon FASTA validation when a
+    ///         FASTA is supplied (default True; the inverse of ``--no-validate-fasta``).
+    ///     emit_genomic_sequences: Embed referenced contig sequences so the output
+    ///         is genome-capable. Requires ``fasta``.
+    ///     diagnostics_json: Optional path to write the sampled loader diagnostics.
+    #[new]
+    #[pyo3(signature = (
+        gff,
+        fasta=None,
+        output=None,
+        build="GRCh38".to_string(),
+        mane_only=false,
+        transcripts=None,
+        genes=None,
+        error_mode="lenient".to_string(),
+        validate_fasta=true,
+        emit_genomic_sequences=false,
+        diagnostics_json=None
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        gff: String,
+        fasta: Option<String>,
+        output: Option<String>,
+        build: String,
+        mane_only: bool,
+        transcripts: Option<Bound<'_, PyAny>>,
+        genes: Option<Bound<'_, PyAny>>,
+        error_mode: String,
+        validate_fasta: bool,
+        emit_genomic_sequences: bool,
+        diagnostics_json: Option<String>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            gff,
+            fasta,
+            output,
+            build,
+            mane_only,
+            transcripts: coerce_filter(transcripts.as_ref())?,
+            genes: coerce_filter(genes.as_ref())?,
+            error_mode,
+            validate_fasta,
+            emit_genomic_sequences,
+            diagnostics_json,
+        })
+    }
+}
+
+/// Result of a [`convert_gff`] run.
+#[pyclass(name = "ConvertGffReport")]
+pub struct PyConvertGffReport {
+    summary: String,
+    transcripts_json: Option<String>,
+    output_path: Option<String>,
+    transcript_count: usize,
+    emitted_genomic_bytes: u64,
+    warnings: Vec<String>,
+}
+
+#[pymethods]
+impl PyConvertGffReport {
+    /// One-line loader summary (records read, transcripts built, diagnostics).
+    #[getter]
+    fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    /// The serialized ``transcripts.json`` text, present only when the config's
+    /// ``output`` was ``None`` (otherwise the JSON was written to that path and
+    /// this is ``None``). Feed it to a normalizer by writing it to a file:
+    /// ``Normalizer(reference_json=path)`` reads a path, not inline JSON.
+    #[getter]
+    fn transcripts_json(&self) -> Option<&str> {
+        self.transcripts_json.as_deref()
+    }
+
+    /// The path the ``transcripts.json`` was written to, or ``None`` if it was
+    /// returned in ``transcripts_json`` instead.
+    #[getter]
+    fn output_path(&self) -> Option<&str> {
+        self.output_path.as_deref()
+    }
+
+    /// Number of transcripts emitted.
+    #[getter]
+    fn transcript_count(&self) -> usize {
+        self.transcript_count
+    }
+
+    /// Total bytes of genomic sequence embedded under ``genomic_sequences``
+    /// (0 when ``emit_genomic_sequences`` was off or nothing was placed).
+    #[getter]
+    fn emitted_genomic_bytes(&self) -> u64 {
+        self.emitted_genomic_bytes
+    }
+
+    /// Non-fatal warnings raised during conversion (also emitted as
+    /// ``UserWarning``), e.g. an ``emit_genomic_sequences`` request with nothing
+    /// to place, or an unusually large embedded genome.
+    #[getter]
+    fn warnings(&self) -> Vec<String> {
+        self.warnings.clone()
+    }
+}
+
+/// Convert a GFF3/GTF annotation into the ``transcripts.json`` format.
+///
+/// This is the in-process equivalent of `ferro convert-gff`; both call the same
+/// library serializer, so the output is byte-identical for the same inputs and
+/// flags. Use it to build a reference for `Normalizer(reference_json=...)`
+/// without shelling out to the CLI.
+///
+/// Args:
+///     config: A ConvertGffConfig describing the inputs and options.
+///
+/// Returns:
+///     ConvertGffReport with the loader summary, the written path (or the JSON
+///     text when ``output`` is ``None``), and any warnings.
+///
+/// Raises:
+///     ValueError: If ``error_mode`` is not recognized, or
+///         ``emit_genomic_sequences`` is set without a ``fasta``.
+///     ReferenceDataError: If the annotation or FASTA cannot be read/parsed, or
+///         (in strict mode) an error diagnostic is recorded.
+#[pyfunction]
+fn convert_gff(py: Python<'_>, config: &PyConvertGffConfig) -> PyResult<PyConvertGffReport> {
+    use crate::reference::annotation::{
+        convert::LARGE_GENOMIC_SEQUENCES_WARN_BYTES, convert_gff as lib_convert_gff,
+        ConvertGffConfig,
+    };
+
+    // Map the string error mode to the library's strict/silent flags.
+    let (strict, silent) = match config.error_mode.to_ascii_lowercase().as_str() {
+        "lenient" => (false, false),
+        "strict" => (true, false),
+        "silent" => (false, true),
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "invalid error_mode {other:?}; expected 'lenient', 'strict', or 'silent'"
+            )));
+        }
+    };
+
+    // Fail fast with a clear Python error rather than deep in the library.
+    if config.emit_genomic_sequences && config.fasta.is_none() {
+        return Err(PyValueError::new_err(
+            "emit_genomic_sequences=True requires a fasta to read the contig sequences",
+        ));
+    }
+
+    let lib_config = ConvertGffConfig {
+        genome_build: crate::cli::parse_genome_build(&config.build),
+        mane_only: config.mane_only,
+        transcripts: config.transcripts.clone(),
+        genes: config.genes.clone(),
+        strict,
+        silent,
+        no_validate_fasta: !config.validate_fasta,
+        emit_genomic_sequences: config.emit_genomic_sequences,
+    };
+
+    let fasta_path = config.fasta.as_deref().map(Path::new);
+    let outcome = lib_convert_gff(Path::new(&config.gff), fasta_path, &lib_config)
+        .map_err(|e| ferro_typed("ReferenceDataError", format!("convert-gff failed: {e}"), &e))?;
+
+    // Serialize exactly as the CLI does: pretty JSON. The CLI appends a trailing
+    // newline via `writeln!`, so a written file matches byte-for-byte.
+    let json_text = serde_json::to_string_pretty(&outcome.json)
+        .map_err(|e| PyRuntimeError::new_err(format!("serialize transcripts.json: {e}")))?;
+
+    let output_path = match config.output.as_deref() {
+        Some(path) => {
+            std::fs::write(path, format!("{json_text}\n"))
+                .map_err(|e| PyRuntimeError::new_err(format!("write {path}: {e}")))?;
+            Some(path.to_string())
+        }
+        None => None,
+    };
+
+    // Write diagnostics JSON if requested, matching the CLI (no trailing newline).
+    if let Some(path) = config.diagnostics_json.as_deref() {
+        let diagnostics = serde_json::to_string_pretty(&outcome.report.sample_diagnostics)
+            .map_err(|e| PyRuntimeError::new_err(format!("serialize diagnostics: {e}")))?;
+        std::fs::write(path, diagnostics)
+            .map_err(|e| PyRuntimeError::new_err(format!("write {path}: {e}")))?;
+    }
+
+    // Collect the same conditions the CLI reports on stderr, and surface them as
+    // Python UserWarnings (idiomatic for a binding) as well as in the report.
+    let mut warnings: Vec<String> = Vec::new();
+    if outcome.emit_requested_no_placement {
+        warnings.push(
+            "emit_genomic_sequences was set but no emitted transcript has a genomic placement; \
+             genomic_sequences not written (reference stays transcript-only)"
+                .to_string(),
+        );
+    }
+    if outcome.emitted_genomic_bytes > LARGE_GENOMIC_SEQUENCES_WARN_BYTES {
+        warnings.push(format!(
+            "emit_genomic_sequences embedded {:.1} MB of genomic sequence; the transcripts.json \
+             will be large to store and slow to parse. For a genome-scale reference prefer \
+             `prepare_reference_data(...)` + `Normalizer.from_manifest(...)`.",
+            outcome.emitted_genomic_bytes as f64 / 1_000_000.0
+        ));
+    }
+    for message in &warnings {
+        let message = std::ffi::CString::new(message.as_str())
+            .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
+        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)?;
+    }
+
+    // Return the JSON in-memory only when it was not written to a file, matching
+    // the CLI's stdout-by-default behavior and keeping large payloads off-heap
+    // when the caller asked for a file.
+    let transcripts_json = if output_path.is_none() {
+        Some(json_text)
+    } else {
+        None
+    };
+    let transcript_count = outcome
+        .json
+        .get("transcripts")
+        .and_then(|t| t.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    Ok(PyConvertGffReport {
+        summary: outcome.report.summary_line(),
+        transcripts_json,
+        output_path,
+        transcript_count,
+        emitted_genomic_bytes: outcome.emitted_genomic_bytes,
+        warnings,
+    })
+}
+
+// ============================================================================
 // Reference Module
 // ============================================================================
 
@@ -4653,6 +4953,9 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(prepare_reference_data, m)?)?;
     m.add_function(wrap_pyfunction!(check_reference_data, m)?)?;
 
+    // Convert-GFF function
+    m.add_function(wrap_pyfunction!(convert_gff, m)?)?;
+
     // Core classes
     m.add_class::<PyHgvsVariant>()?;
     m.add_class::<PyNormalizer>()?;
@@ -4708,6 +5011,10 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Prepare classes
     m.add_class::<PyPrepareConfig>()?;
     m.add_class::<PyReferenceManifest>()?;
+
+    // Convert-GFF classes
+    m.add_class::<PyConvertGffConfig>()?;
+    m.add_class::<PyConvertGffReport>()?;
 
     // Reference classes
     m.add_class::<PyGenomeBuild>()?;

--- a/src/python.rs
+++ b/src/python.rs
@@ -4447,6 +4447,243 @@ fn convert_gff(py: Python<'_>, config: &PyConvertGffConfig) -> PyResult<PyConver
 }
 
 // ============================================================================
+// Build-Transcript (single FASTA construct -> transcripts.json)
+// ============================================================================
+
+/// Configuration for [`build_transcript`], mirroring the `ferro build-transcript`
+/// CLI flags. Construct it, then pass it to `build_transcript`.
+#[pyclass(name = "BuildTranscriptConfig", from_py_object)]
+#[derive(Clone)]
+pub struct PyBuildTranscriptConfig {
+    fasta: String,
+    cds_start: u64,
+    cds_end: u64,
+    output: Option<String>,
+    id: Option<String>,
+    strand: String,
+    contig: Option<String>,
+    gene: Option<String>,
+    genome_build: String,
+    emit_genomic_sequences: bool,
+}
+
+#[pymethods]
+impl PyBuildTranscriptConfig {
+    /// Create a build-transcript configuration.
+    ///
+    /// Args:
+    ///     fasta: Path to the FASTA (indexed or plain; the index is built on the
+    ///         fly if absent).
+    ///     cds_start: CDS start position (1-based inclusive, transcript coordinates).
+    ///     cds_end: CDS end position (1-based inclusive, transcript coordinates).
+    ///     output: Optional output path for the ``transcripts.json``. If ``None``
+    ///         (the default), the JSON is returned in
+    ///         ``BuildTranscriptReport.transcripts_json`` instead of written to disk.
+    ///     id: Transcript ID; defaults to the FASTA contig name.
+    ///     strand: "+" (default) or "-". Minus-strand sequences are reverse-
+    ///         complemented, so the CDS positions are relative to that sequence.
+    ///     contig: Contig to use when the FASTA has multiple contigs.
+    ///     gene: Optional gene symbol to embed in the transcript record.
+    ///     genome_build: Genome build name embedded verbatim (default "GRCh38").
+    ///     emit_genomic_sequences: Embed the contig's forward bytes so the output
+    ///         is genome-capable.
+    #[new]
+    #[pyo3(signature = (
+        fasta,
+        cds_start,
+        cds_end,
+        output=None,
+        id=None,
+        strand="+".to_string(),
+        contig=None,
+        gene=None,
+        genome_build="GRCh38".to_string(),
+        emit_genomic_sequences=false
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        fasta: String,
+        cds_start: u64,
+        cds_end: u64,
+        output: Option<String>,
+        id: Option<String>,
+        strand: String,
+        contig: Option<String>,
+        gene: Option<String>,
+        genome_build: String,
+        emit_genomic_sequences: bool,
+    ) -> Self {
+        Self {
+            fasta,
+            cds_start,
+            cds_end,
+            output,
+            id,
+            strand,
+            contig,
+            gene,
+            genome_build,
+            emit_genomic_sequences,
+        }
+    }
+}
+
+/// Result of a [`build_transcript`] run.
+#[pyclass(name = "BuildTranscriptReport")]
+pub struct PyBuildTranscriptReport {
+    transcript_id: String,
+    transcripts_json: Option<String>,
+    output_path: Option<String>,
+    emitted_genomic_bytes: u64,
+    warnings: Vec<String>,
+}
+
+#[pymethods]
+impl PyBuildTranscriptReport {
+    /// The transcript ID that was emitted (the configured id or the contig name).
+    #[getter]
+    fn transcript_id(&self) -> &str {
+        &self.transcript_id
+    }
+
+    /// The serialized ``transcripts.json`` text, present only when the config's
+    /// ``output`` was ``None`` (otherwise the JSON was written to that path and
+    /// this is ``None``). Feed it to a normalizer by writing it to a file:
+    /// ``Normalizer(reference_json=path)`` reads a path, not inline JSON.
+    #[getter]
+    fn transcripts_json(&self) -> Option<&str> {
+        self.transcripts_json.as_deref()
+    }
+
+    /// The path the ``transcripts.json`` was written to, or ``None`` if it was
+    /// returned in ``transcripts_json`` instead.
+    #[getter]
+    fn output_path(&self) -> Option<&str> {
+        self.output_path.as_deref()
+    }
+
+    /// Total bytes of genomic sequence embedded under ``genomic_sequences``
+    /// (0 when ``emit_genomic_sequences`` was off).
+    #[getter]
+    fn emitted_genomic_bytes(&self) -> u64 {
+        self.emitted_genomic_bytes
+    }
+
+    /// Non-fatal warnings raised during the build (also emitted as ``UserWarning``),
+    /// e.g. an unusually large embedded genome.
+    #[getter]
+    fn warnings(&self) -> Vec<String> {
+        self.warnings.clone()
+    }
+}
+
+/// Build a single-construct ``transcripts.json`` from a FASTA + CDS bounds.
+///
+/// In-process equivalent of `ferro build-transcript`; both call the same library
+/// builder, so the output is byte-identical for the same inputs and flags. Use
+/// it to wrap a synthetic construct's FASTA as a reference for
+/// `Normalizer(reference_json=...)` without shelling out to the CLI.
+///
+/// Args:
+///     config: A BuildTranscriptConfig describing the inputs and options.
+///
+/// Returns:
+///     BuildTranscriptReport with the transcript id, the written path (or the
+///     JSON text when ``output`` is ``None``), and any warnings.
+///
+/// Raises:
+///     ValueError: If ``strand`` is not "+"/"-", or the CDS bounds are invalid.
+///     ReferenceDataError: If the FASTA cannot be read or the contig cannot be
+///         resolved.
+#[pyfunction]
+fn build_transcript(
+    py: Python<'_>,
+    config: &PyBuildTranscriptConfig,
+) -> PyResult<PyBuildTranscriptReport> {
+    use crate::reference::annotation::{
+        build_transcript as lib_build_transcript, convert::LARGE_GENOMIC_SEQUENCES_WARN_BYTES,
+        BuildTranscriptConfig,
+    };
+
+    // Fail fast with a clear Python error rather than deep in the library.
+    if config.strand != "+" && config.strand != "-" {
+        return Err(PyValueError::new_err(format!(
+            "invalid strand {:?}; expected '+' or '-'",
+            config.strand
+        )));
+    }
+
+    let lib_config = BuildTranscriptConfig {
+        cds_start: config.cds_start,
+        cds_end: config.cds_end,
+        id: config.id.clone(),
+        strand: config.strand.clone(),
+        contig: config.contig.clone(),
+        gene: config.gene.clone(),
+        genome_build: config.genome_build.clone(),
+        emit_genomic_sequences: config.emit_genomic_sequences,
+    };
+
+    let outcome = lib_build_transcript(Path::new(&config.fasta), &lib_config).map_err(|e| {
+        // Invalid CDS bounds are a caller error (ValueError); everything else is a
+        // reference-data failure.
+        match &e {
+            crate::error::FerroError::InvalidCoordinates { msg } => {
+                PyValueError::new_err(msg.clone())
+            }
+            _ => ferro_typed(
+                "ReferenceDataError",
+                format!("build-transcript failed: {e}"),
+                &e,
+            ),
+        }
+    })?;
+
+    // Serialize exactly as the CLI does: pretty JSON with NO trailing newline
+    // (the CLI writes via `std::fs::write`), so a written file matches byte-for-byte.
+    let json_text = serde_json::to_string_pretty(&outcome.json)
+        .map_err(|e| PyRuntimeError::new_err(format!("serialize transcripts.json: {e}")))?;
+
+    let output_path = match config.output.as_deref() {
+        Some(path) => {
+            std::fs::write(path, &json_text)
+                .map_err(|e| PyRuntimeError::new_err(format!("write {path}: {e}")))?;
+            Some(path.to_string())
+        }
+        None => None,
+    };
+
+    let mut warnings: Vec<String> = Vec::new();
+    if outcome.emitted_genomic_bytes > LARGE_GENOMIC_SEQUENCES_WARN_BYTES {
+        warnings.push(format!(
+            "emit_genomic_sequences embedded {:.1} MB of genomic sequence; the transcripts.json \
+             will be large to store and slow to parse. For a genome-scale reference prefer \
+             `prepare_reference_data(...)` + `Normalizer.from_manifest(...)`.",
+            outcome.emitted_genomic_bytes as f64 / 1_000_000.0
+        ));
+    }
+    for message in &warnings {
+        let message = std::ffi::CString::new(message.as_str())
+            .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
+        PyErr::warn(py, &py.get_type::<PyUserWarning>(), &message, 1)?;
+    }
+
+    let transcripts_json = if output_path.is_none() {
+        Some(json_text)
+    } else {
+        None
+    };
+
+    Ok(PyBuildTranscriptReport {
+        transcript_id: outcome.transcript_id,
+        transcripts_json,
+        output_path,
+        emitted_genomic_bytes: outcome.emitted_genomic_bytes,
+        warnings,
+    })
+}
+
+// ============================================================================
 // Reference Module
 // ============================================================================
 
@@ -4956,6 +5193,9 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Convert-GFF function
     m.add_function(wrap_pyfunction!(convert_gff, m)?)?;
 
+    // Build-Transcript function
+    m.add_function(wrap_pyfunction!(build_transcript, m)?)?;
+
     // Core classes
     m.add_class::<PyHgvsVariant>()?;
     m.add_class::<PyNormalizer>()?;
@@ -5015,6 +5255,10 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Convert-GFF classes
     m.add_class::<PyConvertGffConfig>()?;
     m.add_class::<PyConvertGffReport>()?;
+
+    // Build-Transcript classes
+    m.add_class::<PyBuildTranscriptConfig>()?;
+    m.add_class::<PyBuildTranscriptReport>()?;
 
     // Reference classes
     m.add_class::<PyGenomeBuild>()?;

--- a/src/reference/annotation/build_transcript.rs
+++ b/src/reference/annotation/build_transcript.rs
@@ -1,0 +1,234 @@
+//! Single-construct `transcripts.json` builder from a FASTA + CDS bounds.
+//!
+//! [`build_transcript`] is the library entry point behind the
+//! `ferro build-transcript` CLI command and the `ferro_hgvs.build_transcript`
+//! Python binding. It reads one contig from a FASTA, wraps it as a single-exon
+//! transcript with the given CDS bounds, and serializes the `transcripts.json`
+//! object shape consumed by [`JsonProvider`] and `Normalizer(reference_json=...)`.
+//!
+//! Both the CLI (`run_build_transcript`) and the Python binding call this one
+//! function so their output is byte-identical for the same inputs/flags — the
+//! only difference is I/O framing (where the JSON is written) and the stderr
+//! messages the CLI emits.
+//!
+//! [`JsonProvider`]: crate::reference::mock::JsonProvider
+
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+
+use crate::error::FerroError;
+use crate::reference::fasta::FastaProvider;
+use crate::reference::provider::ReferenceProvider;
+use crate::sequence::reverse_complement;
+
+/// Configuration for [`build_transcript`], mirroring the `ferro build-transcript`
+/// CLI flags.
+///
+/// Construct with [`BuildTranscriptConfig::new`] and set fields as needed, or
+/// build one directly with a struct literal; all fields are public.
+#[derive(Debug, Clone)]
+pub struct BuildTranscriptConfig {
+    /// CDS start position (1-based inclusive, in transcript coordinates).
+    pub cds_start: u64,
+    /// CDS end position (1-based inclusive, in transcript coordinates).
+    pub cds_end: u64,
+    /// Transcript ID; defaults to the FASTA contig name when `None`.
+    pub id: Option<String>,
+    /// Strand: `"+"` or `"-"`. Minus-strand sequences are reverse-complemented,
+    /// so `cds_start`/`cds_end` are relative to the reverse-complemented sequence.
+    pub strand: String,
+    /// Contig to use when the FASTA has multiple contigs; `None` requires a
+    /// single-contig FASTA.
+    pub contig: Option<String>,
+    /// Optional gene symbol to embed in the transcript record.
+    pub gene: Option<String>,
+    /// Genome build name embedded verbatim in the output.
+    pub genome_build: String,
+    /// Also emit a top-level `genomic_sequences` map (the contig's forward bytes)
+    /// so the output is genome-capable (#1026).
+    pub emit_genomic_sequences: bool,
+}
+
+impl BuildTranscriptConfig {
+    /// A default configuration for the given CDS bounds: plus strand, GRCh38,
+    /// contig/id/gene auto-selected, no genomic-sequence embedding.
+    pub fn new(cds_start: u64, cds_end: u64) -> Self {
+        Self {
+            cds_start,
+            cds_end,
+            id: None,
+            strand: "+".to_string(),
+            contig: None,
+            gene: None,
+            genome_build: "GRCh38".to_string(),
+            emit_genomic_sequences: false,
+        }
+    }
+}
+
+/// Result of a [`build_transcript`] run.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct BuildTranscriptOutcome {
+    /// The `transcripts.json` document (a JSON object with `version`,
+    /// `genome_build`, `transcripts`, and — when emitted — `genomic_sequences`).
+    pub json: Value,
+    /// The transcript ID that was emitted (the configured `id` or the contig name).
+    pub transcript_id: String,
+    /// Total bytes of genomic sequence embedded under `genomic_sequences`
+    /// (`0` when `emit_genomic_sequences` was not requested). Callers may warn
+    /// when this is large.
+    pub emitted_genomic_bytes: u64,
+}
+
+/// Build a single-construct `transcripts.json` from a FASTA contig + CDS bounds.
+///
+/// # Arguments
+///
+/// * `fasta_path` - Path to the FASTA (indexed or plain; the index is built on
+///   the fly if absent).
+/// * `config` - CDS bounds, strand, contig/id/gene selection, and genome build;
+///   see [`BuildTranscriptConfig`].
+///
+/// # Errors
+///
+/// Returns [`FerroError`] if the FASTA cannot be opened, the requested/implied
+/// contig cannot be resolved, the CDS bounds are out of range, or the strand is
+/// not `"+"`/`"-"`.
+pub fn build_transcript(
+    fasta_path: &Path,
+    config: &BuildTranscriptConfig,
+) -> Result<BuildTranscriptOutcome, FerroError> {
+    let fasta = FastaProvider::new(fasta_path)?;
+
+    // Collect contig names; HashMap iteration order is non-deterministic but we
+    // only need the names to detect single vs. multi-contig.
+    let contig_names: Vec<String> = fasta.sequence_names().cloned().collect();
+
+    let contig_name: String = match (config.contig.as_deref(), contig_names.as_slice()) {
+        (Some(c), _) => {
+            if !fasta.has_sequence(c) {
+                return Err(FerroError::Io {
+                    msg: format!(
+                        "Contig '{}' not found in FASTA; available: {}",
+                        c,
+                        contig_names.join(", ")
+                    ),
+                });
+            }
+            c.to_string()
+        }
+        (None, [single]) => single.clone(),
+        (None, []) => {
+            return Err(FerroError::Io {
+                msg: "FASTA contains no contigs".to_string(),
+            })
+        }
+        (None, _) => {
+            return Err(FerroError::Io {
+                msg: format!(
+                    "FASTA has {} contigs; set `contig` to select one (available: {})",
+                    contig_names.len(),
+                    contig_names.join(", ")
+                ),
+            })
+        }
+    };
+
+    let contig_length = fasta
+        .sequence_length(&contig_name)
+        .ok_or_else(|| FerroError::Io {
+            msg: format!("Could not determine length of contig '{}'", contig_name),
+        })?;
+
+    // Validate CDS bounds (1-based inclusive).
+    if config.cds_start < 1 || config.cds_end < config.cds_start || config.cds_end > contig_length {
+        return Err(FerroError::InvalidCoordinates {
+            msg: format!(
+                "Invalid CDS bounds: cds_start={}, cds_end={}, contig length={}",
+                config.cds_start, config.cds_end, contig_length
+            ),
+        });
+    }
+
+    // Parse and validate strand.
+    if config.strand != "+" && config.strand != "-" {
+        return Err(FerroError::InvalidCoordinates {
+            msg: format!("Invalid strand '{}'; expected + or -", config.strand),
+        });
+    }
+
+    // Read the full contig sequence (0-based half-open for get_sequence). This is
+    // the forward genomic sequence; the exon `genomic_start`/`genomic_end`
+    // coordinates index into it, so it is what we emit under `genomic_sequences`.
+    let mut genomic_forward = fasta.get_sequence(&contig_name, 0, contig_length)?;
+
+    // Reverse-complement for minus-strand transcripts (transcript-space `sequence`).
+    // On the plus strand the transcript sequence equals the forward contig: clone it
+    // only when we still need `genomic_forward` for `genomic_sequences`, otherwise
+    // move it out to avoid duplicating the whole contig.
+    let final_sequence = if config.strand == "-" {
+        reverse_complement(&genomic_forward)
+    } else if config.emit_genomic_sequences {
+        genomic_forward.clone()
+    } else {
+        std::mem::take(&mut genomic_forward)
+    };
+
+    let tx_id = config.id.clone().unwrap_or_else(|| contig_name.clone());
+
+    // Build the exon object: single exon spanning the full contig. For a
+    // single-exon synthetic construct, plus-strand transcript coordinates equal
+    // genomic coordinates; for minus-strand the emitted `sequence` is
+    // reverse-complemented and CDS positions are in transcript space.
+    let exon = json!({
+        "number": 1,
+        "start": 1_u64,
+        "end": contig_length,
+        "genomic_start": 1_u64,
+        "genomic_end": contig_length,
+    });
+
+    let mut tx_obj = json!({
+        "id": tx_id,
+        "strand": config.strand,
+        "sequence": final_sequence,
+        "cds_start": config.cds_start,
+        "cds_end": config.cds_end,
+        "exons": [exon],
+        "chromosome": contig_name,
+        "genomic_start": 1_u64,
+        "genomic_end": contig_length,
+        "genome_build": config.genome_build,
+    });
+
+    if let Some(ref g) = config.gene {
+        tx_obj["gene_symbol"] = json!(g);
+    }
+
+    let mut output_json = json!({
+        "version": "1.0",
+        "genome_build": config.genome_build,
+        "transcripts": [tx_obj],
+    });
+
+    // Optionally emit the contig's forward sequence so the transcripts.json is
+    // genome-capable (#1026): the single exon's genomic coordinates index into it.
+    // Note this repeats the contig bytes already carried in the transcript
+    // `sequence` (identical on plus strand; reverse-complemented there on minus),
+    // which is the price of a self-contained genome-capable reference.
+    let mut emitted_genomic_bytes: u64 = 0;
+    if config.emit_genomic_sequences {
+        emitted_genomic_bytes = genomic_forward.len() as u64;
+        let mut genomic_sequences = Map::new();
+        genomic_sequences.insert(contig_name.clone(), json!(genomic_forward));
+        output_json["genomic_sequences"] = Value::Object(genomic_sequences);
+    }
+
+    Ok(BuildTranscriptOutcome {
+        json: output_json,
+        transcript_id: tx_id,
+        emitted_genomic_bytes,
+    })
+}

--- a/src/reference/annotation/convert.rs
+++ b/src/reference/annotation/convert.rs
@@ -1,0 +1,401 @@
+//! GFF3/GTF → `transcripts.json` conversion.
+//!
+//! [`convert_gff`] is the library entry point behind the `ferro convert-gff`
+//! CLI command and the `ferro_hgvs.convert_gff` Python binding. It loads an
+//! annotation file via [`load_annotations`], applies the transcript/gene/MANE
+//! filters, extracts (or synthesizes) each transcript's spliced sequence, and
+//! serializes the result into the `transcripts.json` object shape consumed by
+//! [`JsonProvider`] and `Normalizer(reference_json=...)`.
+//!
+//! Both the CLI (`run_convert_gff`) and the Python binding call this one
+//! function so their output is byte-identical for the same inputs/flags — the
+//! only difference is I/O framing (where the JSON is written) and the stderr
+//! warnings the CLI emits from the returned [`ConvertGffOutcome`] fields.
+//!
+//! [`JsonProvider`]: crate::reference::mock::JsonProvider
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use serde_json::{json, Map, Value};
+
+use crate::error::FerroError;
+use crate::reference::annotation::{load_annotations, LoaderConfig, LoaderReport};
+use crate::reference::fasta::FastaProvider;
+use crate::reference::provider::ReferenceProvider;
+use crate::reference::transcript::{GenomeBuild, ManeStatus, Strand};
+use crate::sequence::reverse_complement;
+
+/// Threshold above which embedding genomic sequence into a `transcripts.json`
+/// is worth warning about: a `genomic_sequences` map this large makes the file
+/// slow to store and parse. Shared by the CLI's stderr warning and the Python
+/// binding so both use the same cutoff.
+pub const LARGE_GENOMIC_SEQUENCES_WARN_BYTES: u64 = 50_000_000; // 50 MB
+
+/// Configuration for [`convert_gff`], mirroring the `ferro convert-gff` CLI
+/// flags one-to-one.
+///
+/// Construct with [`ConvertGffConfig::new`] and set fields as needed, or build
+/// one directly with a struct literal; all fields are public so callers (the
+/// CLI, the Python binding) can populate it however is convenient.
+#[derive(Debug, Clone)]
+pub struct ConvertGffConfig {
+    /// Genome build recorded in the output and used when constructing transcripts.
+    pub genome_build: GenomeBuild,
+    /// Only emit MANE Select / MANE Plus Clinical transcripts.
+    pub mane_only: bool,
+    /// Restrict output to these transcript IDs (already split; `None` = no filter).
+    pub transcripts: Option<Vec<String>>,
+    /// Restrict output to these gene symbols (already split; `None` = no filter).
+    pub genes: Option<Vec<String>>,
+    /// Promote loader warnings to errors and fail if any error diagnostic is recorded.
+    pub strict: bool,
+    /// Suppress loader diagnostic warnings (still counted in the report).
+    pub silent: bool,
+    /// Skip CDS-length / start-codon FASTA-aware validation even when a FASTA is supplied.
+    pub no_validate_fasta: bool,
+    /// Embed the referenced contig sequences under `genomic_sequences` so the
+    /// output is genome-capable. Requires a FASTA (`fasta` argument of
+    /// [`convert_gff`]); see #1026.
+    pub emit_genomic_sequences: bool,
+}
+
+impl ConvertGffConfig {
+    /// A default configuration: GRCh38, no filters, lenient errors, FASTA
+    /// validation on, no genomic-sequence embedding.
+    pub fn new() -> Self {
+        Self {
+            genome_build: GenomeBuild::GRCh38,
+            mane_only: false,
+            transcripts: None,
+            genes: None,
+            strict: false,
+            silent: false,
+            no_validate_fasta: false,
+            emit_genomic_sequences: false,
+        }
+    }
+}
+
+impl Default for ConvertGffConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Result of a [`convert_gff`] run.
+///
+/// The serialized `transcripts.json` lives in [`json`](Self::json); the other
+/// fields carry the information the CLI needs to reproduce its stderr side
+/// effects (a loader summary line and the `--emit-genomic-sequences` warnings)
+/// without the library itself writing to stderr.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ConvertGffOutcome {
+    /// The `transcripts.json` document (a JSON object with `version`,
+    /// `genome_build`, `transcripts`, and — when emitted — `genomic_sequences`).
+    pub json: Value,
+    /// Diagnostics aggregated while loading the annotation file.
+    pub report: LoaderReport,
+    /// Total bytes of genomic sequence embedded under `genomic_sequences`
+    /// (`0` when `emit_genomic_sequences` was not requested or nothing was
+    /// emitted). Callers may warn when this is large.
+    pub emitted_genomic_bytes: u64,
+    /// `true` when `emit_genomic_sequences` was requested but no emitted
+    /// transcript carried a genomic placement, so `genomic_sequences` was not
+    /// written and the reference stays transcript-only. Callers may warn.
+    pub emit_requested_no_placement: bool,
+}
+
+/// Convert a GFF3/GTF annotation file into the `transcripts.json` object shape.
+///
+/// # Arguments
+///
+/// * `gff` - Path to the GFF3 or GTF annotation file.
+/// * `fasta` - Optional reference FASTA used to extract exonic sequences and,
+///   when [`ConvertGffConfig::emit_genomic_sequences`] is set, the embedded
+///   contig sequences. Also drives CDS-length / start-codon validation unless
+///   [`ConvertGffConfig::no_validate_fasta`] is set.
+/// * `config` - Filters, error mode, and genome build; see [`ConvertGffConfig`].
+///
+/// # Errors
+///
+/// Returns [`FerroError`] if the annotation file cannot be read/parsed (or, in
+/// strict mode, records an error diagnostic), if a supplied FASTA cannot be
+/// opened, or if `emit_genomic_sequences` is set but a required contig is
+/// absent from — or too short in — the FASTA to cover a transcript placement.
+pub fn convert_gff(
+    gff: &Path,
+    fasta: Option<&Path>,
+    config: &ConvertGffConfig,
+) -> Result<ConvertGffOutcome, FerroError> {
+    let genome_build = config.genome_build;
+
+    // Build loader config with error mode, genome build, and optional FASTA validation.
+    let mut cfg = LoaderConfig::new().with_genome_build(genome_build);
+    if config.strict {
+        cfg = cfg.with_strict();
+    } else if config.silent {
+        cfg = cfg.with_silent();
+    }
+    // Pass a FASTA provider to load_annotations for CDS-length / start-codon validation.
+    // A second FastaProvider is constructed below for sequence extraction; FastaProvider::new
+    // is cheap (reads only the index), so the double construction is acceptable.
+    if let Some(fasta_path) = fasta {
+        cfg = cfg.with_fasta(FastaProvider::new(fasta_path)?);
+    }
+    if config.no_validate_fasta {
+        cfg = cfg.with_no_validate_fasta();
+    }
+
+    // Load GFF/GTF file via load_annotations.
+    let (mut db, report) = load_annotations(gff, &cfg)?;
+    db.genome_build = genome_build;
+
+    // Load FASTA if provided and extract sequences.
+    let fasta_provider = if let Some(fasta_path) = fasta {
+        Some(FastaProvider::new(fasta_path)?)
+    } else {
+        None
+    };
+
+    // Parse transcript and gene filters.
+    let transcript_filter: Option<HashSet<&str>> = config
+        .transcripts
+        .as_ref()
+        .map(|ids| ids.iter().map(|t| t.trim()).collect());
+    let gene_filter: Option<HashSet<&str>> = config
+        .genes
+        .as_ref()
+        .map(|gs| gs.iter().map(|g| g.trim()).collect());
+
+    // Collect transcripts to output.
+    let mut output_transcripts: Vec<Value> = Vec::new();
+
+    // For each contig an emitted transcript is placed on, the highest 1-based
+    // genomic coordinate its placement references (max over exon `genomic_end` and
+    // the transcript's own `genomic_end`). Used to emit `genomic_sequences` when
+    // `emit_genomic_sequences` is set, and — crucially — to fail fast at emit time
+    // if the FASTA contig cannot cover the placement, using the SAME invariant
+    // `JsonProvider::from_json` enforces at load, so convert-gff can never emit a
+    // file its own loader would reject (#1026). BTreeMap keeps the output
+    // deterministic.
+    let mut contig_required_len: BTreeMap<String, u64> = BTreeMap::new();
+
+    for (id, tx) in db.iter() {
+        // Apply filters.
+        if config.mane_only && tx.mane_status == ManeStatus::None {
+            continue;
+        }
+
+        if let Some(ref filter) = transcript_filter {
+            if !filter.contains(id.as_str()) {
+                continue;
+            }
+        }
+
+        if let Some(ref filter) = gene_filter {
+            if let Some(ref gene) = tx.gene_symbol {
+                if !filter.contains(gene.as_str()) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        // Extract sequence from FASTA if available.
+        let sequence = if let (Some(ref fasta), Some(ref chrom), Some(_start), Some(_end)) = (
+            &fasta_provider,
+            &tx.chromosome,
+            tx.genomic_start,
+            tx.genomic_end,
+        ) {
+            // Extract exonic sequences.
+            let mut exon_seqs = Vec::new();
+            for exon in &tx.exons {
+                if let (Some(g_start), Some(g_end)) = (exon.genomic_start, exon.genomic_end) {
+                    // FASTA uses 0-based coordinates, GFF uses 1-based.
+                    match fasta.get_sequence(chrom, g_start - 1, g_end) {
+                        Ok(seq) => exon_seqs.push(seq),
+                        Err(_) => exon_seqs.push("N".repeat((g_end - g_start + 1) as usize)),
+                    }
+                }
+            }
+
+            // Join exons and handle strand.
+            let mut full_seq = exon_seqs.join("");
+            if tx.strand == Strand::Minus {
+                full_seq = reverse_complement(&full_seq);
+            }
+            full_seq
+        } else if let Some(seq) = tx
+            .sequence
+            .as_deref()
+            .filter(|s| !s.is_empty() && !s.chars().all(|c| c == 'N'))
+        {
+            seq.to_string()
+        } else {
+            // No FASTA, use placeholder.
+            "N".repeat(tx.exons.iter().map(|e| e.end - e.start + 1).sum::<u64>() as usize)
+        };
+
+        // Build exon objects.
+        let exons: Vec<Value> = tx
+            .exons
+            .iter()
+            .map(|e| {
+                let mut exon_obj = json!({
+                    "number": e.number,
+                    "start": e.start,
+                    "end": e.end,
+                });
+                if let Some(g_start) = e.genomic_start {
+                    exon_obj["genomic_start"] = json!(g_start);
+                }
+                if let Some(g_end) = e.genomic_end {
+                    exon_obj["genomic_end"] = json!(g_end);
+                }
+                exon_obj
+            })
+            .collect();
+
+        // Build transcript object.
+        let mut tx_obj = json!({
+            "id": id,
+            "sequence": sequence,
+            "exons": exons,
+        });
+
+        // Add optional fields.
+        if let Some(ref gene) = tx.gene_symbol {
+            tx_obj["gene_symbol"] = json!(gene);
+        }
+        if let Some(ref chrom) = tx.chromosome {
+            tx_obj["chromosome"] = json!(chrom);
+            // Track the highest genomic coordinate this transcript's placement
+            // needs on its contig, mirroring the loader's `required_len`.
+            let required = tx
+                .exons
+                .iter()
+                .filter_map(|e| e.genomic_end)
+                .chain(tx.genomic_end)
+                .max();
+            if let Some(required) = required {
+                let entry = contig_required_len.entry(chrom.clone()).or_insert(0);
+                *entry = (*entry).max(required);
+            }
+        }
+        if let Some(start) = tx.genomic_start {
+            tx_obj["genomic_start"] = json!(start);
+        }
+        if let Some(end) = tx.genomic_end {
+            tx_obj["genomic_end"] = json!(end);
+        }
+        if let Some(cds_start) = tx.cds_start {
+            tx_obj["cds_start"] = json!(cds_start);
+        }
+        if let Some(cds_end) = tx.cds_end {
+            tx_obj["cds_end"] = json!(cds_end);
+        }
+
+        tx_obj["strand"] = json!(match tx.strand {
+            Strand::Plus => "+",
+            Strand::Minus => "-",
+            // `Strand` is `#[non_exhaustive]`, but all variants are matched
+            // within the defining crate; `Unknown` and any future variant map
+            // to the GFF3 unspecified-strand marker.
+            _ => ".",
+        });
+
+        tx_obj["genome_build"] = json!(match genome_build {
+            GenomeBuild::GRCh37 => "GRCh37",
+            GenomeBuild::GRCh38 => "GRCh38",
+            GenomeBuild::Unknown => "unknown",
+        });
+
+        if tx.mane_status != ManeStatus::None {
+            tx_obj["mane_status"] = json!(match tx.mane_status {
+                ManeStatus::Select => "MANE_Select",
+                ManeStatus::PlusClinical => "MANE_Plus_Clinical",
+                ManeStatus::None => "none",
+            });
+        }
+
+        output_transcripts.push(tx_obj);
+    }
+
+    // Create output JSON.
+    let mut output_json = json!({
+        "version": "1.0",
+        "genome_build": match genome_build {
+            GenomeBuild::GRCh37 => "GRCh37",
+            GenomeBuild::GRCh38 => "GRCh38",
+            GenomeBuild::Unknown => "unknown",
+        },
+        "transcripts": output_transcripts,
+    });
+
+    // Optionally emit the referenced contig sequences so the transcripts.json is
+    // genome-capable. The exon `genomic_start`/`genomic_end` coordinates are
+    // absolute contig positions, so we emit each referenced contig's full forward
+    // sequence keyed by chromosome name — this is exactly what `JsonProvider`
+    // slices by genomic coordinate when running the genome-aware rules (#1026).
+    let mut emitted_genomic_bytes: u64 = 0;
+    let mut emit_requested_no_placement = false;
+    if config.emit_genomic_sequences {
+        let fasta = fasta_provider.as_ref().ok_or_else(|| FerroError::Io {
+            msg: "--emit-genomic-sequences requires a FASTA to read the contig sequences"
+                .to_string(),
+        })?;
+        if contig_required_len.is_empty() {
+            // The flag was requested but no emitted transcript carries a genomic
+            // placement, so there is nothing to back a genome with. Signal the
+            // caller to warn rather than write an empty `genomic_sequences` map
+            // that would look genome-capable but report `has_genomic_data() == false`.
+            emit_requested_no_placement = true;
+        } else {
+            let mut genomic_sequences = Map::new();
+            let mut total_bytes: u64 = 0;
+            for (contig, required_len) in &contig_required_len {
+                let length = fasta
+                    .sequence_length(contig)
+                    .ok_or_else(|| FerroError::Io {
+                        msg: format!(
+                            "--emit-genomic-sequences: a transcript is placed on contig '{}', \
+                         but it is not present in the FASTA",
+                            contig
+                        ),
+                    })?;
+                // Fail fast, with the SAME invariant the loader enforces, so the
+                // emitted file always loads. A shorter contig means the FASTA does
+                // not cover the annotation's coordinates — typically a sub-region
+                // FASTA paired with whole-genome coordinates, or a mismatched
+                // assembly.
+                if length < *required_len {
+                    return Err(FerroError::Io {
+                        msg: format!(
+                            "--emit-genomic-sequences: contig '{}' is {} bases in the FASTA, but a \
+                             transcript placement needs genomic coordinate {}. The FASTA does not \
+                             cover the annotation's coordinates (a sub-region FASTA with whole-genome \
+                             coordinates, or a different assembly?).",
+                            contig, length, required_len
+                        ),
+                    });
+                }
+                let sequence = fasta.get_sequence(contig, 0, length)?;
+                total_bytes += sequence.len() as u64;
+                genomic_sequences.insert(contig.clone(), json!(sequence));
+            }
+            emitted_genomic_bytes = total_bytes;
+            output_json["genomic_sequences"] = Value::Object(genomic_sequences);
+        }
+    }
+
+    Ok(ConvertGffOutcome {
+        json: output_json,
+        report,
+        emitted_genomic_bytes,
+        emit_requested_no_placement,
+    })
+}

--- a/src/reference/annotation/mod.rs
+++ b/src/reference/annotation/mod.rs
@@ -20,6 +20,7 @@
 //! for the full design.
 
 pub(crate) mod builder;
+pub mod convert;
 pub mod diagnostics;
 pub(crate) mod feature;
 pub mod format_detect;
@@ -27,6 +28,7 @@ pub(crate) mod graph;
 pub(crate) mod record;
 pub(crate) mod validate;
 
+pub use convert::{convert_gff, ConvertGffConfig, ConvertGffOutcome};
 pub use diagnostics::{
     DiagnosticPayload, LoaderDiagnostic, LoaderReport, Severity, SourceLocation,
 };

--- a/src/reference/annotation/mod.rs
+++ b/src/reference/annotation/mod.rs
@@ -19,6 +19,7 @@
 //! See `docs/superpowers/specs/2026-05-13-gff-gtf-loader-rewrite-design.md`
 //! for the full design.
 
+pub(crate) mod build_transcript;
 pub(crate) mod builder;
 pub mod convert;
 pub mod diagnostics;
@@ -28,6 +29,7 @@ pub(crate) mod graph;
 pub(crate) mod record;
 pub(crate) mod validate;
 
+pub use build_transcript::{build_transcript, BuildTranscriptConfig, BuildTranscriptOutcome};
 pub use convert::{convert_gff, ConvertGffConfig, ConvertGffOutcome};
 pub use diagnostics::{
     DiagnosticPayload, LoaderDiagnostic, LoaderReport, Severity, SourceLocation,

--- a/tests/it/build_transcript_library_parity.rs
+++ b/tests/it/build_transcript_library_parity.rs
@@ -1,0 +1,129 @@
+//! The extracted library `build_transcript`
+//! (`ferro_hgvs::reference::annotation::build_transcript`) must produce output
+//! byte-identical to the `ferro build-transcript` CLI for the same inputs and
+//! flags. The CLI is now a thin wrapper over this function, and the Python
+//! binding wraps the same function — so this test pins the shared serializer
+//! that guarantees CLI ↔ library ↔ Python parity (#1035).
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use ferro_hgvs::reference::annotation::{build_transcript, BuildTranscriptConfig};
+use tempfile::NamedTempFile;
+
+/// Write a single-contig FASTA of `len` deterministic bases to a temp file.
+fn write_fasta(name: &str, len: usize) -> NamedTempFile {
+    let bases = b"ACGT";
+    let mut tf = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
+    let seq: String = (0..len).map(|i| bases[i % 4] as char).collect();
+    writeln!(tf, ">{}", name).unwrap();
+    writeln!(tf, "{}", seq).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+/// Run `ferro build-transcript` and return the exact bytes it writes to `-o`.
+fn cli_output_bytes(fasta: &Path, extra: &[&str]) -> Vec<u8> {
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let mut args: Vec<&str> = vec!["build-transcript", "--fasta", fasta.to_str().unwrap()];
+    args.extend_from_slice(extra);
+    args.extend_from_slice(&["-o", out.to_str().unwrap()]);
+    let result = Command::new(bin).args(&args).output().unwrap();
+    assert!(
+        result.status.success(),
+        "build-transcript failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    std::fs::read(&out).unwrap()
+}
+
+/// Serialize a library `build_transcript` outcome exactly as the CLI writes it:
+/// pretty JSON with NO trailing newline (the CLI's `std::fs::write`).
+fn library_output_bytes(fasta: &Path, config: &BuildTranscriptConfig) -> Vec<u8> {
+    let outcome = build_transcript(fasta, config).expect("library build_transcript succeeds");
+    serde_json::to_string_pretty(&outcome.json)
+        .unwrap()
+        .into_bytes()
+}
+
+#[test]
+fn library_matches_cli_plus_strand() {
+    let fasta = write_fasta("construct1", 60);
+    let config = BuildTranscriptConfig::new(1, 60);
+
+    let cli = cli_output_bytes(fasta.path(), &["--cds-start", "1", "--cds-end", "60"]);
+    let lib = library_output_bytes(fasta.path(), &config);
+
+    assert_eq!(
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+        "library output must be byte-identical to the CLI"
+    );
+}
+
+#[test]
+fn library_matches_cli_minus_strand_custom_id_gene() {
+    let fasta = write_fasta("chrX", 90);
+    let config = BuildTranscriptConfig {
+        id: Some("MYTX.1".to_string()),
+        strand: "-".to_string(),
+        gene: Some("GENEX".to_string()),
+        ..BuildTranscriptConfig::new(4, 87)
+    };
+
+    let cli = cli_output_bytes(
+        fasta.path(),
+        &[
+            "--cds-start",
+            "4",
+            "--cds-end",
+            "87",
+            "--strand",
+            "-",
+            "--id",
+            "MYTX.1",
+            "--gene",
+            "GENEX",
+        ],
+    );
+    let lib = library_output_bytes(fasta.path(), &config);
+
+    assert_eq!(
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+        "library output (minus strand, custom id/gene) must be byte-identical to the CLI"
+    );
+}
+
+#[test]
+fn library_matches_cli_with_emit_genomic_sequences() {
+    let fasta = write_fasta("construct1", 120);
+    let config = BuildTranscriptConfig {
+        emit_genomic_sequences: true,
+        ..BuildTranscriptConfig::new(1, 120)
+    };
+
+    let cli = cli_output_bytes(
+        fasta.path(),
+        &[
+            "--cds-start",
+            "1",
+            "--cds-end",
+            "120",
+            "--emit-genomic-sequences",
+        ],
+    );
+    let lib = library_output_bytes(fasta.path(), &config);
+
+    assert_eq!(
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+        "library output with --emit-genomic-sequences must be byte-identical to the CLI"
+    );
+}

--- a/tests/it/convert_gff_library_parity.rs
+++ b/tests/it/convert_gff_library_parity.rs
@@ -1,0 +1,154 @@
+//! The extracted library `convert_gff` (`ferro_hgvs::reference::annotation::convert_gff`)
+//! must produce output byte-identical to the `ferro convert-gff` CLI for the
+//! same inputs and flags. The CLI is now a thin wrapper over this function, and
+//! the Python binding wraps the same function — so this test pins the shared
+//! serializer that guarantees CLI ↔ library ↔ Python parity (#1035).
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+use ferro_hgvs::reference::annotation::{convert_gff, ConvertGffConfig};
+use ferro_hgvs::reference::transcript::GenomeBuild;
+use tempfile::NamedTempFile;
+
+fn write_gff3(content: &str) -> NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(".gff3").tempfile().unwrap();
+    tf.write_all(content.as_bytes()).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+/// Write a single-contig FASTA of `len` deterministic bases to a temp file.
+fn write_fasta(name: &str, len: usize) -> NamedTempFile {
+    let bases = b"ACGT";
+    let mut tf = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
+    let seq: String = (0..len).map(|i| bases[i % 4] as char).collect();
+    writeln!(tf, ">{}", name).unwrap();
+    writeln!(tf, "{}", seq).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+/// A single-exon transcript on chr1 with a CDS.
+fn single_exon_gff3() -> NamedTempFile {
+    write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=GENE1\n\
+         chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n\
+         chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n",
+    )
+}
+
+/// Run `ferro convert-gff` and return the exact bytes it writes to `--output`.
+fn cli_output_bytes(args: &[&str]) -> Vec<u8> {
+    let out = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .unwrap()
+        .into_temp_path();
+    let bin = env!("CARGO_BIN_EXE_ferro");
+    let mut full: Vec<&str> = vec!["convert-gff"];
+    full.extend_from_slice(args);
+    full.extend_from_slice(&["--output", out.to_str().unwrap()]);
+    let result = Command::new(bin).args(&full).output().unwrap();
+    assert!(
+        result.status.success(),
+        "convert-gff failed: stderr={}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    std::fs::read(&out).unwrap()
+}
+
+/// Serialize a library `convert_gff` outcome exactly as the CLI writes it:
+/// pretty JSON followed by a trailing newline (the CLI's `writeln!`).
+fn library_output_bytes(gff: &Path, fasta: Option<&Path>, config: &ConvertGffConfig) -> Vec<u8> {
+    let outcome = convert_gff(gff, fasta, config).expect("library convert_gff succeeds");
+    let mut bytes = serde_json::to_string_pretty(&outcome.json)
+        .unwrap()
+        .into_bytes();
+    bytes.push(b'\n');
+    bytes
+}
+
+#[test]
+fn library_matches_cli_transcript_only() {
+    let gff = single_exon_gff3();
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        ..ConvertGffConfig::new()
+    };
+
+    let cli = cli_output_bytes(&["--gff", gff.path().to_str().unwrap()]);
+    let lib = library_output_bytes(gff.path(), None, &config);
+
+    assert_eq!(
+        lib,
+        cli,
+        "library output must be byte-identical to the CLI\nlib:\n{}\ncli:\n{}",
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+    );
+}
+
+#[test]
+fn library_matches_cli_with_emit_genomic_sequences() {
+    let gff = single_exon_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        no_validate_fasta: true,
+        emit_genomic_sequences: true,
+        ..ConvertGffConfig::new()
+    };
+
+    let cli = cli_output_bytes(&[
+        "--gff",
+        gff.path().to_str().unwrap(),
+        "--fasta",
+        fasta.path().to_str().unwrap(),
+        "--no-validate-fasta",
+        "--emit-genomic-sequences",
+    ]);
+    let lib = library_output_bytes(gff.path(), Some(fasta.path()), &config);
+
+    assert_eq!(
+        lib,
+        cli,
+        "library output with --emit-genomic-sequences must be byte-identical to the CLI\nlib:\n{}\ncli:\n{}",
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+    );
+}
+
+#[test]
+fn library_matches_cli_with_gene_filter() {
+    let gff = single_exon_gff3();
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        genes: Some(vec!["GENE1".to_string()]),
+        ..ConvertGffConfig::new()
+    };
+
+    let cli = cli_output_bytes(&["--gff", gff.path().to_str().unwrap(), "--genes", "GENE1"]);
+    let lib = library_output_bytes(gff.path(), None, &config);
+
+    assert_eq!(
+        lib,
+        cli,
+        "library output with a gene filter must be byte-identical to the CLI\nlib:\n{}\ncli:\n{}",
+        String::from_utf8_lossy(&lib),
+        String::from_utf8_lossy(&cli),
+    );
+
+    // The filter is real: a non-matching gene yields zero transcripts.
+    let empty = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        genes: Some(vec!["NOSUCHGENE".to_string()]),
+        ..ConvertGffConfig::new()
+    };
+    let outcome = convert_gff(gff.path(), None, &empty).unwrap();
+    assert_eq!(outcome.json["transcripts"].as_array().unwrap().len(), 0);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -27,6 +27,7 @@ mod biocommons_tests;
 mod boundary_tests;
 mod bracket_cardinality_conformance;
 mod breakpoint_insertion;
+mod build_transcript_library_parity;
 mod bulk_fixture_tests;
 mod civic_validation;
 mod cli_build_transcript;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -47,6 +47,7 @@ mod comprehensive_edge_case_tests;
 mod comprehensive_external_tests;
 mod con_conversion_audit;
 mod conformance_summary_generated;
+mod convert_gff_library_parity;
 mod convert_tests;
 mod coordinate_boundary_tests;
 mod coverage_gap_tests;

--- a/tests/python/test_issue_1035_build_transcript_binding.py
+++ b/tests/python/test_issue_1035_build_transcript_binding.py
@@ -1,0 +1,173 @@
+"""Issue #1035 (sibling command): `ferro build-transcript` is exposed in the
+Python bindings as `ferro_hgvs.build_transcript` / `ferro_hgvs.BuildTranscriptConfig`.
+
+A synthetic single-construct reference (own FASTA + CDS bounds) can be built and
+normalized entirely in-process via the PyPI wheel — no shelling out to the CLI.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+
+def _write_fasta(tmp_path: Path, name: str = "construct1", length: int = 60, seq: str = "") -> Path:
+    fasta = tmp_path / "construct.fa"
+    if not seq:
+        seq = "".join("ACGT"[i % 4] for i in range(length))
+    fasta.write_text(f">{name}\n{seq}\n")
+    return fasta
+
+
+def test_symbols_are_exported() -> None:
+    assert "build_transcript" in ferro_hgvs.__all__
+    assert "BuildTranscriptConfig" in ferro_hgvs.__all__
+    assert "BuildTranscriptReport" in ferro_hgvs.__all__
+    assert hasattr(ferro_hgvs, "build_transcript")
+
+
+def test_build_writes_transcripts_json_to_output_path(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    out = tmp_path / "transcripts.json"
+
+    cfg = ferro_hgvs.BuildTranscriptConfig(
+        fasta=str(fasta), cds_start=1, cds_end=60, output=str(out)
+    )
+    report = ferro_hgvs.build_transcript(cfg)
+
+    assert report.output_path == str(out)
+    assert report.transcripts_json is None
+    assert report.transcript_id == "construct1"
+
+    doc = json.loads(out.read_text())
+    assert doc["version"] == "1.0"
+    assert doc["genome_build"] == "GRCh38"
+    tx = doc["transcripts"][0]
+    assert tx["id"] == "construct1"
+    assert tx["cds_start"] == 1
+    assert tx["cds_end"] == 60
+    assert tx["strand"] == "+"
+
+
+def test_build_returns_json_in_memory_when_output_is_none(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+
+    report = ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60)
+    )
+    assert report.output_path is None
+    assert report.transcripts_json is not None
+    assert json.loads(report.transcripts_json)["transcripts"][0]["id"] == "construct1"
+
+
+def test_written_file_equals_in_memory_json(tmp_path: Path) -> None:
+    """build-transcript writes the pretty JSON with NO trailing newline (the CLI
+    uses `std::fs::write`), so the file equals the in-memory JSON exactly."""
+    fasta = _write_fasta(tmp_path)
+
+    in_memory = ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60)
+    )
+    out = tmp_path / "transcripts.json"
+    ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60, output=str(out))
+    )
+    assert out.read_text() == in_memory.transcripts_json
+
+
+def test_custom_id_and_gene(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    report = ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(
+            fasta=str(fasta), cds_start=1, cds_end=60, id="MYTX.1", gene="GENE1"
+        )
+    )
+    tx = json.loads(report.transcripts_json)["transcripts"][0]
+    assert report.transcript_id == "MYTX.1"
+    assert tx["id"] == "MYTX.1"
+    assert tx["gene_symbol"] == "GENE1"
+
+
+def test_minus_strand_reverse_complements(tmp_path: Path) -> None:
+    # Use an ASYMMETRIC forward sequence. An "ACGT" repeat is its own reverse
+    # complement, so it cannot distinguish "revcomp applied" from "revcomp
+    # skipped" — this block sequence's revcomp differs from its forward strand.
+    forward = "A" * 20 + "C" * 20 + "G" * 20
+    complement = {"A": "T", "C": "G", "G": "C", "T": "A"}
+    expected = "".join(complement[b] for b in reversed(forward))
+    # Guard: the fixture actually exercises reverse-complementation.
+    assert expected != forward
+
+    fasta = _write_fasta(tmp_path, seq=forward)
+    report = ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60, strand="-")
+    )
+    tx = json.loads(report.transcripts_json)["transcripts"][0]
+    assert tx["strand"] == "-"
+    assert tx["sequence"] == expected
+    assert tx["sequence"] != forward
+
+
+def test_emit_genomic_sequences_makes_reference_genome_capable(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    out = tmp_path / "genome_capable.json"
+
+    report = ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(
+            fasta=str(fasta),
+            cds_start=1,
+            cds_end=60,
+            output=str(out),
+            emit_genomic_sequences=True,
+        )
+    )
+    assert report.emitted_genomic_bytes == 60
+
+    doc = json.loads(out.read_text())
+    assert doc["genomic_sequences"]["construct1"] == "".join("ACGT"[i % 4] for i in range(60))
+
+    normalizer = ferro_hgvs.Normalizer(reference_json=str(out))
+    assert normalizer.has_genomic_data() is True
+
+
+def test_built_reference_normalizes_in_process(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    out = tmp_path / "transcripts.json"
+    ferro_hgvs.build_transcript(
+        ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60, output=str(out))
+    )
+
+    tx = json.loads(out.read_text())["transcripts"][0]
+    ref_base = tx["sequence"][tx["cds_start"] - 1]  # base at c.1
+
+    normalizer = ferro_hgvs.Normalizer(reference_json=str(out))
+    normalized = normalizer.normalize(f"construct1:c.1{ref_base}>N")
+    assert normalized.startswith("construct1:c.1")
+
+
+def test_invalid_strand_raises_value_error(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    with pytest.raises(ValueError, match="strand"):
+        ferro_hgvs.build_transcript(
+            ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=60, strand="*")
+        )
+
+
+def test_invalid_cds_bounds_raises_value_error(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)  # 60 bases
+    with pytest.raises(ValueError, match="CDS bounds"):
+        ferro_hgvs.build_transcript(
+            ferro_hgvs.BuildTranscriptConfig(fasta=str(fasta), cds_start=1, cds_end=999)
+        )
+
+
+def test_missing_contig_raises_reference_data_error(tmp_path: Path) -> None:
+    fasta = _write_fasta(tmp_path)
+    with pytest.raises(ferro_hgvs.ReferenceDataError):
+        ferro_hgvs.build_transcript(
+            ferro_hgvs.BuildTranscriptConfig(
+                fasta=str(fasta), cds_start=1, cds_end=60, contig="nope"
+            )
+        )

--- a/tests/python/test_issue_1035_convert_gff_binding.py
+++ b/tests/python/test_issue_1035_convert_gff_binding.py
@@ -1,0 +1,222 @@
+"""Issue #1035: `ferro convert-gff` is exposed in the Python bindings as
+`ferro_hgvs.convert_gff` / `ferro_hgvs.ConvertGffConfig`, mirroring
+`prepare_reference_data` / `PrepareConfig`.
+
+A synthetic/local reference (own GFF3 + FASTA) can be built and normalized
+entirely in-process via the PyPI wheel — no shelling out to the `ferro` CLI.
+This exercises the exact Python surface a saturation-mutagenesis pipeline uses.
+"""
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+# A single-exon transcript on chr1 with a CDS, mirroring the Rust integration
+# fixtures. Built programmatically (no committed test-data files).
+GFF3 = (
+    "##gff-version 3\n"
+    "chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=GENE1\n"
+    "chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n"
+    "chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n"
+    "chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n"
+    "chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n"
+)
+
+
+def _write_gff(tmp_path: Path) -> Path:
+    gff = tmp_path / "constructs.gff3"
+    gff.write_text(GFF3)
+    return gff
+
+
+def _write_fasta(tmp_path: Path, name: str = "chr1", length: int = 520) -> Path:
+    fasta = tmp_path / "constructs.fa"
+    seq = "".join("ACGT"[i % 4] for i in range(length))
+    fasta.write_text(f">{name}\n{seq}\n")
+    return fasta
+
+
+def test_symbols_are_exported() -> None:
+    assert "convert_gff" in ferro_hgvs.__all__
+    assert "ConvertGffConfig" in ferro_hgvs.__all__
+    assert "ConvertGffReport" in ferro_hgvs.__all__
+    assert hasattr(ferro_hgvs, "convert_gff")
+    assert hasattr(ferro_hgvs, "ConvertGffConfig")
+    assert hasattr(ferro_hgvs, "ConvertGffReport")
+
+
+def test_convert_writes_transcripts_json_to_output_path(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    out = tmp_path / "transcripts.json"
+
+    cfg = ferro_hgvs.ConvertGffConfig(gff=str(gff), output=str(out), build="GRCh38")
+    report = ferro_hgvs.convert_gff(cfg)
+
+    assert report.output_path == str(out)
+    # When written to a file, the JSON is not also returned in-memory.
+    assert report.transcripts_json is None
+    assert report.transcript_count == 1
+
+    doc = json.loads(out.read_text())
+    assert doc["version"] == "1.0"
+    assert doc["genome_build"] == "GRCh38"
+    assert [t["id"] for t in doc["transcripts"]] == ["tx1"]
+
+
+def test_convert_returns_json_in_memory_when_output_is_none(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+
+    cfg = ferro_hgvs.ConvertGffConfig(gff=str(gff))  # output defaults to None
+    report = ferro_hgvs.convert_gff(cfg)
+
+    assert report.output_path is None
+    assert report.transcripts_json is not None
+    doc = json.loads(report.transcripts_json)
+    assert doc["transcripts"][0]["id"] == "tx1"
+
+
+def test_written_file_equals_in_memory_json_plus_newline(tmp_path: Path) -> None:
+    """The file written for output=<path> is the in-memory JSON followed by a
+    trailing newline — same bytes the CLI writes via `writeln!`."""
+    gff = _write_gff(tmp_path)
+
+    in_memory = ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(gff)))
+    out = tmp_path / "transcripts.json"
+    ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(gff), output=str(out)))
+
+    assert out.read_text() == in_memory.transcripts_json + "\n"
+
+
+def test_built_reference_normalizes_in_process(tmp_path: Path) -> None:
+    """The whole point of #1035: build a reference with convert_gff (no
+    subprocess) and normalize a real variant against it."""
+    gff = _write_gff(tmp_path)
+    fasta = _write_fasta(tmp_path)  # FASTA-backed so the transcript sequence is real
+    out = tmp_path / "transcripts.json"
+    ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(
+            gff=str(gff), fasta=str(fasta), output=str(out), validate_fasta=False
+        )
+    )
+
+    tx = json.loads(out.read_text())["transcripts"][0]
+    ref_base = tx["sequence"][tx["cds_start"] - 1]  # base at c.1
+
+    normalizer = ferro_hgvs.Normalizer(reference_json=str(out))
+    normalized = normalizer.normalize(f"tx1:c.1{ref_base}>G")
+    assert normalized == "tx1:c.1{}>G".format(ref_base)
+
+
+def test_emit_genomic_sequences_makes_reference_genome_capable(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    fasta = _write_fasta(tmp_path)
+    out = tmp_path / "genome_capable.json"
+
+    cfg = ferro_hgvs.ConvertGffConfig(
+        gff=str(gff),
+        fasta=str(fasta),
+        output=str(out),
+        validate_fasta=False,
+        emit_genomic_sequences=True,
+    )
+    report = ferro_hgvs.convert_gff(cfg)
+    assert report.emitted_genomic_bytes == 520
+
+    doc = json.loads(out.read_text())
+    assert "genomic_sequences" in doc
+    assert doc["genomic_sequences"]["chr1"] == "".join("ACGT"[i % 4] for i in range(520))
+
+    normalizer = ferro_hgvs.Normalizer(reference_json=str(out))
+    assert normalizer.has_genomic_data() is True
+    assert normalizer.reference_summary()["has_genomic_data"] is True
+
+
+def test_transcript_only_reference_reports_reduced_capability(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    out = tmp_path / "transcript_only.json"
+    ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(gff), output=str(out)))
+
+    normalizer = ferro_hgvs.Normalizer(reference_json=str(out))
+    assert normalizer.has_genomic_data() is False
+
+
+def test_gene_filter_accepts_string_and_list_equivalently(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+
+    as_string = ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=str(gff), genes="GENE1")
+    ).transcripts_json
+    as_list = ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=str(gff), genes=["GENE1"])
+    ).transcripts_json
+    assert as_string == as_list
+    assert len(json.loads(as_string)["transcripts"]) == 1
+
+    # A non-matching gene filters everything out.
+    none_match = ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=str(gff), genes="NOSUCHGENE")
+    )
+    assert none_match.transcript_count == 0
+
+
+def test_transcript_filter_selects_by_id(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    report = ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(gff), transcripts=["tx1"]))
+    assert report.transcript_count == 1
+    report_miss = ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=str(gff), transcripts=["tx_absent"])
+    )
+    assert report_miss.transcript_count == 0
+
+
+def test_invalid_error_mode_raises_value_error(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    with pytest.raises(ValueError, match="error_mode"):
+        ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(gff), error_mode="loud"))
+
+
+def test_emit_genomic_sequences_without_fasta_raises_value_error(tmp_path: Path) -> None:
+    gff = _write_gff(tmp_path)
+    with pytest.raises(ValueError, match="fasta"):
+        ferro_hgvs.convert_gff(
+            ferro_hgvs.ConvertGffConfig(gff=str(gff), emit_genomic_sequences=True)
+        )
+
+
+def test_strict_mode_raises_on_malformed_record(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.gff3"
+    bad.write_text("##gff-version 3\nchr1\t.\tgene\tnot_a_number\t500\t.\t+\t.\tID=g1\n")
+    with pytest.raises(ferro_hgvs.ReferenceDataError):
+        ferro_hgvs.convert_gff(ferro_hgvs.ConvertGffConfig(gff=str(bad), error_mode="strict"))
+
+
+def test_emit_with_nothing_placed_warns_and_stays_transcript_only(tmp_path: Path) -> None:
+    """emit_genomic_sequences with nothing left to place (every transcript
+    filtered out) warns and does not write genomic_sequences — mirroring the
+    CLI's stderr warning."""
+    gff = _write_gff(tmp_path)
+    fasta = _write_fasta(tmp_path)
+    out = tmp_path / "out.json"
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        report = ferro_hgvs.convert_gff(
+            ferro_hgvs.ConvertGffConfig(
+                gff=str(gff),
+                fasta=str(fasta),
+                output=str(out),
+                validate_fasta=False,
+                emit_genomic_sequences=True,
+                genes="NOSUCHGENE",  # filter everything out -> nothing placed
+            )
+        )
+
+    assert report.transcript_count == 0
+    assert any("no emitted transcript" in w for w in report.warnings)
+    assert any(issubclass(c.category, UserWarning) for c in caught)
+    doc = json.loads(out.read_text())
+    assert "genomic_sequences" not in doc


### PR DESCRIPTION
## Summary

Exposes the two reference-*building* commands, `ferro convert-gff` and `ferro build-transcript`, in the Python bindings as `ferro_hgvs.convert_gff(ConvertGffConfig)` and `ferro_hgvs.build_transcript(BuildTranscriptConfig)` — mirroring how `prepare_reference_data(PrepareConfig)` already exposes `ferro prepare`. A synthetic/local reference (your own GFF3/FASTA + CDS) can now be built and normalized entirely in-process through the PyPI wheel, without pulling the `ferro` CLI solely for this step.

Closes #1035.

## What was needed

For both commands the conversion *loading* half was already in the library, but the `transcripts.json` *serialization* — the artifact a Python integrator actually wants — lived inline in the CLI binary (`run_convert_gff` / `run_build_transcript`), unreachable from `src/python.rs`. So each is two steps:

1. **`refactor(reference)`** — extract the serialization into `ferro_hgvs::reference::annotation::{convert_gff, build_transcript}`. `run_convert_gff` / `run_build_transcript` become thin wrappers. Because the CLI and the binding now share one serializer per command, byte-identical output is guaranteed by construction rather than by a fragile re-implementation.
2. **`feat(python)`** — add the `*Config` + function wrapping that same code.

Four commits, in reading order: convert-gff refactor → convert-gff binding → build-transcript refactor → build-transcript binding. Start with a refactor commit (the extracted `*.rs` + the shrunken CLI handler), then its binding commit.

## API

```python
import ferro_hgvs

# Many transcripts from an annotation + FASTA:
ferro_hgvs.convert_gff(
    ferro_hgvs.ConvertGffConfig(
        gff="constructs.gff3", fasta="constructs.fa",
        output="transcripts.json",           # None -> returned in report.transcripts_json
        emit_genomic_sequences=True,
    )
)

# Or a single construct straight from a FASTA + CDS bounds:
ferro_hgvs.build_transcript(
    ferro_hgvs.BuildTranscriptConfig(
        fasta="construct.fa", cds_start=1, cds_end=900,
        output="construct.json", emit_genomic_sequences=True,
    )
)

ferro_hgvs.Normalizer(reference_json="transcripts.json")
```

Params map 1:1 to the CLI flags. `output=None` returns the JSON in-memory (mirroring the CLI's stdout / file default); `convert_gff`'s stderr warnings surface as `UserWarning` and on `report.warnings`. Errors map to the typed `ReferenceDataError`; caller mistakes (unrecognized `error_mode`/`strand`, `emit_genomic_sequences` without a `fasta`, invalid CDS bounds) raise `ValueError`.

## Acceptance criteria

- [x] `ferro_hgvs.convert_gff(...)` (and `build_transcript(...)`) produce a `transcripts.json` byte-identical to the respective CLI for the same inputs/flags (including `--emit-genomic-sequences`) — pinned by two new integration tests that diff the library output against the CLI binary across the strand / emit / filter paths.
- [x] Result is directly consumable by `Normalizer(reference_json=...)` via the written path; also returned in-memory.
- [x] `.pyi` stubs + `__all__` updated.
- [x] Python tests analogous to `test_issue_1026_genome_capable.py` build a reference via each function (no subprocess) and normalize.

## Testing

- New `tests/it/convert_gff_library_parity.rs` and `tests/it/build_transcript_library_parity.rs` (library ↔ CLI byte-identity), plus `tests/python/test_issue_1035_convert_gff_binding.py` (13 cases) and `tests/python/test_issue_1035_build_transcript_binding.py` (11 cases).
- The existing `cli_convert_gff_flags` and `cli_build_transcript` integration tests still pass, confirming the refactors preserved CLI behavior.
- Full local runs green: 213 relevant Rust tests, 384 Python tests, `clippy --all-targets --features dev`, `cargo fmt`, `ruff`, `mypy`.