### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.8.0...v0.8.1) - 2026-07-16
+
+### Added
+
+- *(python)* expose convert_gff and build_transcript, mirroring prepare_reference_data ([#1037](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1037))
+
+### Fixed
+
+- *(normalize)* only type a maximal contiguous run as inv, not a sub-run ([#1036](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1036))
+
 ## [0.8.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.7.1...v0.8.0) - 2026-07-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.8.0...v0.8.1) - 2026-07-16

### Added

- *(python)* expose convert_gff and build_transcript, mirroring prepare_reference_data ([#1037](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1037))

### Fixed

- *(normalize)* only type a maximal contiguous run as inv, not a sub-run ([#1036](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1036))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).