### PR TITLE
fix(normalize): clamp genome fetch window to contig length

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2150,16 +2150,43 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // 0-based half-open offsets into the contig even though they derive from
         // 1-based `base`; the reconciliation `rel = base - window_start` then
         // `hgvs_pos_to_index(rel) = rel - 1` is the same one the non-special
-        // path uses (do not "fix" this as a bug). On the resolved-special path
-        // clamp the upper bound to the contig length so the read is well-formed
-        // against providers that error on past-EOF reads (MockProvider); the
-        // ordinary path keeps the provider-clamped behavior byte-identical.
+        // path uses (do not "fix" this as a bug).
+        //
+        // Clamp the upper bound to the contig length so the read is well-formed:
+        // every current provider (MultiFastaProvider, FastaProvider,
+        // JsonProvider) ERRORS on a past-EOF read rather than clamping, so an
+        // unclamped `end + window_size` that runs past the contig 3' end makes
+        // `get_sequence` fail and drops the whole variant into the
+        // minimal-notation fallback below — skipping 3' shift AND the
+        // delins->inv/sub/dup canonicalization. That left an indel within
+        // `window_size` of the contig end unnormalized: e.g. a whole-span
+        // reverse-complement delins stayed `delins` instead of becoming `inv`
+        // (#1041).
+        //
+        // Special path (unchanged): it already resolved `resolved_len` and
+        // clamps unconditionally — a mixed special/plain past-end span like
+        // `g.pter_<past-end>del` fetches the whole contig and relies on
+        // `shuffle`'s per-index bounds guard to echo the input verbatim
+        // (see `genome_mixed_special_plain_past_end_matches_plain_path`).
+        //
+        // Ordinary path: fetch the length here (a cheap in-memory index lookup)
+        // and clamp ONLY when the variant itself fits within the contig
+        // (`end <= len`). If the variant *span* runs past the contig end
+        // (`end > len`), clamping would fetch a window shorter than the span and
+        // `normalize_na_edit` would read a truncated reference and mis-normalize
+        // — e.g. `g.99_103inv` on a 100 bp contig collapsing to `g.99_103=`. For
+        // those inputs keep the raw window so the read errors into the
+        // minimal-notation fallback (the pre-#1041 pass-through). When the
+        // length is unavailable, likewise fall back to the raw window.
         let window_start = start.saturating_sub(self.config.window_size);
         let raw_end = end.saturating_add(self.config.window_size);
         let fetch_end = if had_special {
             raw_end.min(resolved_len)
         } else {
-            raw_end
+            match self.provider.get_sequence_length(&accession) {
+                Ok(len) if end <= len => raw_end.min(len),
+                _ => raw_end,
+            }
         };
         let seq_result = self
             .provider

--- a/tests/it/issue_1041_repro.rs
+++ b/tests/it/issue_1041_repro.rs
@@ -1,0 +1,109 @@
+//! Issue #1041 — a whole-run reverse-complement delins near a contig's 3' end
+//! was left as `delins` instead of canonicalizing to `inv`.
+//!
+//! Root cause: `normalize_genome` fetches a `+/-window_size` window around the
+//! variant. On the ordinary (non-special) path the upper bound was not clamped
+//! to the contig length, and every provider ERRORS on a past-EOF read rather
+//! than clamping. So an indel within `window_size` (100 bp) of the contig 3'
+//! end fetched past EOF, `get_sequence` errored, and the whole variant dropped
+//! into the minimal-notation fallback — skipping 3' shift AND the
+//! delins->inv/sub/dup canonicalization. Clamping `fetch_end` to the contig
+//! length fixes it.
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// Genome-capable provider: one `contig` of `len` cyclic ACGT bytes with
+/// `payload` written 1-based at `pos1`.
+fn provider_len(contig: &str, len: usize, pos1: usize, payload: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(len).collect();
+    for (i, b) in payload.bytes().enumerate() {
+        bases[pos1 - 1 + i] = b;
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+fn norm(p: &JsonProvider, input: &str) -> String {
+    let v = parse_hgvs(input).unwrap();
+    Normalizer::new(p.clone())
+        .normalize(&v)
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn issue_1041_whole_run_revcomp_is_inv_regardless_of_3prime_proximity() {
+    // ref[200..202] = GCA, revcomp = TGC. Same variant, two contig lengths.
+
+    // Far from the end (600 bp): window [100, 302] fits comfortably.
+    let far = provider_len("c", 600, 200, "GCA");
+    assert_eq!(norm(&far, "c:g.200_202delinsTGC"), "c:g.200_202inv");
+
+    // Within window_size (100) of the 3' end (250 bp): the window upper bound
+    // 202 + 100 = 302 exceeds the contig length. Before the clamp fix this
+    // errored and left the variant as `delins`; now it still canonicalizes.
+    let near = provider_len("c", 250, 200, "GCA");
+    assert_eq!(norm(&near, "c:g.200_202delinsTGC"), "c:g.200_202inv");
+}
+
+#[test]
+fn issue_1041_compound_subs_near_3prime_end_merge_to_inv() {
+    // The reported shape: a compound of adjacent substitutions whose merged
+    // span is a reverse complement, sited near the 3' end.
+    let near = provider_len("c", 250, 200, "GCA");
+    assert_eq!(norm(&near, "c:g.[200G>T;201C>G;202A>C]"), "c:g.200_202inv");
+}
+
+#[test]
+fn issue_1041_root_cause_also_restores_3prime_shift() {
+    // The clamp also restores ordinary 3' shifting near the contig end,
+    // confirming the root cause is the window fetch, not anything inv-specific.
+    // A homopolymer run of A's at 1-based 195..=205; delete one A at 196.
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(250).collect();
+    for b in bases.iter_mut().take(205).skip(194) {
+        *b = b'A';
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { "c": seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    let p = JsonProvider::from_json(f.path()).unwrap();
+    // 3'-shifts to the rightmost equivalent position (g.205), not g.196.
+    assert_eq!(norm(&p, "c:g.196del"), "c:g.205del");
+}
+
+#[test]
+fn issue_1041_span_past_contig_end_passes_through_unchanged() {
+    // The clamp must NOT truncate a variant whose span runs past the contig
+    // end: fetching a window shorter than the span would feed a truncated
+    // reference to normalize_na_edit and mis-normalize (e.g. `g.99_103inv`
+    // collapsing to `g.99_103=`). The clamp is gated on `end <= len`, so these
+    // fall through to the safe minimal-notation pass-through instead.
+    let p = provider_len("c", 100, 1, "A"); // 100 bp contig, payload irrelevant
+    for input in [
+        "c:g.99_103inv",
+        "c:g.105del",
+        "c:g.98_105delinsGGGGGGGG",
+        "c:g.105A>T",
+    ] {
+        assert_eq!(
+            norm(&p, input),
+            input,
+            "past-contig-end variant must pass through"
+        );
+    }
+}

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -84,7 +84,14 @@ fn same_accession_bare_cross_reference_expands_to_literal() {
 #[test]
 fn cross_chromosome_cross_reference_expands_to_literal() {
     let mut p = MockProvider::new();
-    p.add_genomic_sequence("NC_000002.12", "A".repeat(100));
+    // Outer ref is a poly-C tract (not poly-A): the inner range at
+    // NC_000011.10:g.20_25 is `TAAAAG`, so a poly-A outer ref would make the
+    // flattened `CCCCCC`→`TAAAAG` delins share interior A-identities and
+    // canonicalize to separate substitutions (spec-correct per #165, but not
+    // what this test is checking). Poly-C differs from every inserted base, so
+    // the flattened form stays a genuine `delins` and the test stays focused on
+    // cross-reference flattening.
+    p.add_genomic_sequence("NC_000002.12", "C".repeat(100));
     p.add_genomic_sequence("NC_000011.10", "GGGGTTTTAAAA".repeat(10));
     let out = normalize("NC_000002.12:g.5_10delins[NC_000011.10:g.20_25]", p)
         .expect("must normalize cleanly with both contigs in provider");
@@ -92,7 +99,10 @@ fn cross_chromosome_cross_reference_expands_to_literal() {
         !out.contains("[NC_"),
         "cross-chromosome reference must be flattened; got {out}",
     );
-    assert!(out.contains("delins"));
+    // Inner range NC_000011.10:g.20_25 = `TAAAAG`; against the poly-C outer ref
+    // it stays a literal delins over the full span. Pin the exact flattened
+    // form, not just the `delins` keyword.
+    assert_eq!(out, "NC_000002.12:g.5_10delinsTAAAAG");
 }
 
 // =============================================================================

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -84,6 +84,7 @@ mod issue_1004_samegap_insertion_idempotency;
 mod issue_1012_reduced_capability_no_genome;
 mod issue_1026_genome_capable_json;
 mod issue_1034_inv_subspan_delins;
+mod issue_1041_repro;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Problem

Closes #1041.

An indel within `window_size` (100 bp) of a contig's 3' end was left unnormalized: a whole-run reverse-complement `delins` stayed `delins` instead of canonicalizing to `inv`, and ordinary 3' shifting was skipped too. This is why the issue's coordinate-anonymized example (sited on an unbounded synthetic contig) did not reproduce, while the real ferro-vs-mutalyzer comparison — which uses short NG_ RefSeqGene contigs where variants land near the 3' end — did.

## Root cause

`normalize_genome` fetches a `±window_size` window around the variant before normalizing. On the ordinary (non-special) path the window's upper bound was **not clamped** to the contig length. The old comment claimed the ordinary path "keeps the provider-clamped behavior", but every provider (`MultiFastaProvider`, `FastaProvider`, `JsonProvider`) **errors** on a past-EOF read rather than clamping. So `end + window_size` past the 3' end made `get_sequence` return `InvalidCoordinates`, dropping the variant into the minimal-notation fallback (`canonicalize_genome_variant`), which runs neither 3' shifting nor the `delins → inv/sub/dup` canonicalization.

## Fix

On the ordinary path, fetch the contig length (cheap in-memory lookup) and clamp `fetch_end` to it — **but only when the variant fits within the contig (`end <= len`)**. A variant whose span runs *past* the contig end (`end > len`) must not be clamped: a window shorter than the span would feed a truncated reference to `normalize_na_edit` and mis-normalize (e.g. `g.99_103inv` on a 100 bp contig collapsing to `g.99_103=`). Those keep the raw window and fall through to the safe pass-through fallback, exactly as before. The special (pter/qter) path is unchanged — it already clamps unconditionally and relies on `shuffle`'s per-index bounds guard.

Variants not near the 3' end are unaffected (`raw_end < len`, so `min` is a no-op).

## Tests

- New `tests/it/issue_1041_repro.rs`: the same whole-span revcomp delins near vs. far from the 3' end (was `delins`, now `inv`); the reported compound-substitution shape; a homopolymer deletion whose 3' shift is restored near the contig end; and a guard test that spans running past the contig end still pass through unchanged.
- `tests/it/issue_422_cross_reference_ins.rs`: its all-A, 100 bp fixture placed the variant near the 3' end, so its flattened `AAAAAA→TAAAAG` payload now correctly splits into substitutions (`[5A>T;10A>G]`) per #165 rather than echoing a raw `delins`. Changed the outer ref to a poly-C tract (keeps the test focused on cross-reference flattening) and pinned the exact flattened form.

Full `cargo test --features dev` green; `cargo clippy --features dev --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Note

The `end <= len` guard was added after a self-review pass found that an unconditional clamp regressed past-contig-end `inv` inputs (`g.99_103inv` → `g.99_103=`); the guard and its regression test close that. Couldn't run the manifest-gated mutalyzer conformance corpus locally (reference volumes offline), so I haven't quantified how many real comparison rows this recovers — but the mechanism and fix are confirmed by the hermetic tests above.