### PR TITLE
fix(normalize): clamp the mitochondrial fetch window to contig length

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5249,13 +5249,29 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         // Window-based fetch around the variant. Non-origin-crossing
-        // path: identical to genomic.
+        // path: identical to genomic, including the contig-length clamp
+        // (#1044, mirroring #1042 on `normalize_genome`). Every provider
+        // ERRORS on a past-EOF read rather than clamping, so an unclamped
+        // `end + window_size` past the contig 3' end made `get_sequence`
+        // fail and dropped the variant into `mt_fallback` — skipping 3'
+        // shift AND the delins->inv/sub/dup canonicalization. Clamp
+        // `fetch_end` to the contig length, but ONLY when the variant fits
+        // within the contig (`end <= len`): a span running past the end
+        // must keep the raw window so the read errors into the safe
+        // fallback rather than feeding a truncated reference to
+        // `normalize_na_edit` and mis-normalizing. When the length is
+        // unavailable, likewise fall back to the raw window. Wraparound
+        // (`start > end`) already returned above, so `end` here is the
+        // linear span end.
         let window_start = start.saturating_sub(self.config.window_size);
-        let seq_result = self.provider.get_sequence(
-            &accession,
-            window_start,
-            end.saturating_add(self.config.window_size),
-        );
+        let raw_end = end.saturating_add(self.config.window_size);
+        let fetch_end = match self.provider.get_sequence_length(&accession) {
+            Ok(len) if end <= len => raw_end.min(len),
+            _ => raw_end,
+        };
+        let seq_result = self
+            .provider
+            .get_sequence(&accession, window_start, fetch_end);
 
         let ref_seq = match seq_result {
             Ok(s) => s,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1999,6 +1999,33 @@ fn resolve_special_genome_pos<P: ReferenceProvider>(
 }
 
 impl<P: ReferenceProvider> Normalizer<P> {
+    /// Clamp a window-fetch upper bound to the contig length.
+    ///
+    /// The `±window_size` fetch window around a variant can run past the
+    /// contig 3' end for a variant near the end. Every provider ERRORS on a
+    /// past-EOF read rather than clamping, so an unclamped `raw_end` drops the
+    /// whole variant into the minimal-notation fallback — skipping 3' shifting
+    /// and the `delins -> inv/sub/dup` canonicalization (#1041).
+    ///
+    /// Clamp to the contig length, but ONLY when the variant itself fits within
+    /// the contig (`end <= len`). If the variant *span* runs past the contig
+    /// end (`end > len`), clamping would fetch a window shorter than the span
+    /// and `normalize_na_edit` would read a truncated reference and
+    /// mis-normalize (e.g. `g.99_103inv` on a 100 bp contig collapsing to
+    /// `g.99_103=`); keep the raw window so the read errors into the safe
+    /// pass-through fallback instead. When the length is unavailable, likewise
+    /// keep the raw window.
+    ///
+    /// Shared by `normalize_genome` (#1042) and the mitochondrial/circular
+    /// path (#1044) so the two cannot silently drift — the divergence that
+    /// caused #1044 in the first place.
+    fn clamp_fetch_end_to_contig(&self, accession: &str, end: u64, raw_end: u64) -> u64 {
+        match self.provider.get_sequence_length(accession) {
+            Ok(len) if end <= len => raw_end.min(len),
+            _ => raw_end,
+        }
+    }
+
     /// Normalize a genomic variant
     fn normalize_genome(
         &self,
@@ -2152,41 +2179,21 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `hgvs_pos_to_index(rel) = rel - 1` is the same one the non-special
         // path uses (do not "fix" this as a bug).
         //
-        // Clamp the upper bound to the contig length so the read is well-formed:
-        // every current provider (MultiFastaProvider, FastaProvider,
-        // JsonProvider) ERRORS on a past-EOF read rather than clamping, so an
-        // unclamped `end + window_size` that runs past the contig 3' end makes
-        // `get_sequence` fail and drops the whole variant into the
-        // minimal-notation fallback below — skipping 3' shift AND the
-        // delins->inv/sub/dup canonicalization. That left an indel within
-        // `window_size` of the contig end unnormalized: e.g. a whole-span
-        // reverse-complement delins stayed `delins` instead of becoming `inv`
-        // (#1041).
+        // Clamp the upper bound to the contig length so the read is well-formed
+        // against providers that ERROR on a past-EOF read (#1041); see
+        // `clamp_fetch_end_to_contig` for the `end <= len` gate and rationale.
         //
         // Special path (unchanged): it already resolved `resolved_len` and
         // clamps unconditionally — a mixed special/plain past-end span like
         // `g.pter_<past-end>del` fetches the whole contig and relies on
         // `shuffle`'s per-index bounds guard to echo the input verbatim
         // (see `genome_mixed_special_plain_past_end_matches_plain_path`).
-        //
-        // Ordinary path: fetch the length here (a cheap in-memory index lookup)
-        // and clamp ONLY when the variant itself fits within the contig
-        // (`end <= len`). If the variant *span* runs past the contig end
-        // (`end > len`), clamping would fetch a window shorter than the span and
-        // `normalize_na_edit` would read a truncated reference and mis-normalize
-        // — e.g. `g.99_103inv` on a 100 bp contig collapsing to `g.99_103=`. For
-        // those inputs keep the raw window so the read errors into the
-        // minimal-notation fallback (the pre-#1041 pass-through). When the
-        // length is unavailable, likewise fall back to the raw window.
         let window_start = start.saturating_sub(self.config.window_size);
         let raw_end = end.saturating_add(self.config.window_size);
         let fetch_end = if had_special {
             raw_end.min(resolved_len)
         } else {
-            match self.provider.get_sequence_length(&accession) {
-                Ok(len) if end <= len => raw_end.min(len),
-                _ => raw_end,
-            }
+            self.clamp_fetch_end_to_contig(&accession, end, raw_end)
         };
         let seq_result = self
             .provider
@@ -5254,21 +5261,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // ERRORS on a past-EOF read rather than clamping, so an unclamped
         // `end + window_size` past the contig 3' end made `get_sequence`
         // fail and dropped the variant into `mt_fallback` — skipping 3'
-        // shift AND the delins->inv/sub/dup canonicalization. Clamp
-        // `fetch_end` to the contig length, but ONLY when the variant fits
-        // within the contig (`end <= len`): a span running past the end
-        // must keep the raw window so the read errors into the safe
-        // fallback rather than feeding a truncated reference to
-        // `normalize_na_edit` and mis-normalizing. When the length is
-        // unavailable, likewise fall back to the raw window. Wraparound
+        // shift AND the delins->inv/sub/dup canonicalization. The shared
+        // `clamp_fetch_end_to_contig` helper clamps only when the variant
+        // fits within the contig (`end <= len`); a span past the end keeps
+        // the raw window and errors into the safe fallback. Wraparound
         // (`start > end`) already returned above, so `end` here is the
         // linear span end.
         let window_start = start.saturating_sub(self.config.window_size);
         let raw_end = end.saturating_add(self.config.window_size);
-        let fetch_end = match self.provider.get_sequence_length(&accession) {
-            Ok(len) if end <= len => raw_end.min(len),
-            _ => raw_end,
-        };
+        let fetch_end = self.clamp_fetch_end_to_contig(&accession, end, raw_end);
         let seq_result = self
             .provider
             .get_sequence(&accession, window_start, fetch_end);

--- a/tests/it/issue_1044_mito_window_clamp.rs
+++ b/tests/it/issue_1044_mito_window_clamp.rs
@@ -1,0 +1,108 @@
+//! Issue #1044 — the mitochondrial / circular (`m.`/`o.`) normalization path
+//! had the same unclamped genome-fetch window as the genomic path did before
+//! #1041/#1042: a non-wraparound variant within `window_size` (100 bp) of the
+//! contig's 3' end fetched past EOF, `get_sequence` errored, and the variant
+//! dropped into `mt_fallback` — skipping 3' shifting AND the
+//! `delins -> inv/sub/dup` canonicalization. A whole-span reverse-complement
+//! `delins` near the 3' end therefore stayed `delins` instead of becoming `inv`.
+//!
+//! This mirrors `issue_1041_repro.rs` on the `m.` axis. The fix clamps
+//! `fetch_end` to the contig length, gated on `end <= len` so a span that runs
+//! *past* the contig end still passes through the safe fallback unchanged.
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// Mitochondrial-capable provider: one `contig` of `len` cyclic ACGT bytes with
+/// `payload` written 1-based at `pos1` (mirrors the #1041 repro harness).
+fn provider_len(contig: &str, len: usize, pos1: usize, payload: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(len).collect();
+    for (i, b) in payload.bytes().enumerate() {
+        bases[pos1 - 1 + i] = b;
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+fn norm(p: &JsonProvider, input: &str) -> String {
+    Normalizer::new(p.clone())
+        .normalize(&parse_hgvs(input).unwrap())
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn issue_1044_mt_whole_run_revcomp_is_inv_regardless_of_3prime_proximity() {
+    // ref[200..202] = GCA, revcomp = TGC. Same variant, two contig lengths.
+    let contig = "NC_012920.1";
+
+    // Far from the end (600 bp): window [100, 302] fits comfortably.
+    let far = provider_len(contig, 600, 200, "GCA");
+    assert_eq!(
+        norm(&far, &format!("{contig}:m.200_202delinsTGC")),
+        format!("{contig}:m.200_202inv"),
+    );
+
+    // Within window_size (100) of the 3' end (250 bp): the window upper bound
+    // 202 + 100 = 302 exceeds the contig length. Before the clamp fix this
+    // errored and left the variant as `delins`; now it still canonicalizes.
+    let near = provider_len(contig, 250, 200, "GCA");
+    assert_eq!(
+        norm(&near, &format!("{contig}:m.200_202delinsTGC")),
+        format!("{contig}:m.200_202inv"),
+    );
+}
+
+#[test]
+fn issue_1044_mt_root_cause_also_restores_3prime_shift_near_end() {
+    // The clamp also restores ordinary 3' shifting near the contig end,
+    // confirming the root cause is the window fetch, not anything inv-specific.
+    // A homopolymer run of A's at 1-based 195..=205; delete one A at 196 on a
+    // 250 bp contig (196 + window overruns EOF before the clamp).
+    let contig = "NC_012920.1";
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(250).collect();
+    for b in bases.iter_mut().take(205).skip(194) {
+        *b = b'A';
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    let p = JsonProvider::from_json(f.path()).unwrap();
+    // 3'-shifts to the rightmost equivalent position (m.205), not m.196.
+    assert_eq!(
+        norm(&p, &format!("{contig}:m.196del")),
+        format!("{contig}:m.205del"),
+    );
+}
+
+#[test]
+fn issue_1044_mt_span_past_contig_end_passes_through_unchanged() {
+    // The clamp must NOT truncate a variant whose span runs past the contig
+    // end: fetching a window shorter than the span would feed a truncated
+    // reference to normalize_na_edit and mis-normalize. The clamp is gated on
+    // `end <= len`, so these fall through to the safe fallback instead.
+    let contig = "NC_012920.1";
+    let p = provider_len(contig, 100, 1, "A"); // 100 bp contig, payload irrelevant
+    for suffix in ["m.99_103inv", "m.105del", "m.105A>T"] {
+        let input = format!("{contig}:{suffix}");
+        assert_eq!(
+            norm(&p, &input),
+            input,
+            "past-contig-end mt variant must pass through",
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -86,6 +86,7 @@ mod issue_1026_genome_capable_json;
 mod issue_1034_inv_subspan_delins;
 mod issue_1040_inv_overrecognition_probes;
 mod issue_1041_repro;
+mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
Closes #1044.

## Problem

The mitochondrial / circular (`m.`/`o.`) normalization path had the same unclamped `±window_size` genome fetch that `normalize_genome` had before #1041/#1042 — its own comment even said "Non-origin-crossing path: identical to genomic." Every provider errors on a past-EOF read rather than clamping, so a **non-wraparound** variant within `window_size` (100 bp) of the contig 3' end fetched past EOF, `get_sequence` errored, and the variant fell into `mt_fallback` — skipping 3' shifting **and** the `delins → inv/sub/dup` canonicalization.

So a whole-span reverse-complement `delins` near the 3' end stayed `delins` instead of becoming `inv`, and ordinary 3' shifting was skipped. This is reachable in practice: the mtDNA control region / D-loop sits within 100 bp of the 16,569 bp `NC_012920.1` contig's 3' end.

## Fix

Apply the same guarded clamp #1042 used on the genomic path: fetch the contig length (cheap in-memory lookup) and clamp `fetch_end` to it, **but only when the variant fits within the contig (`end <= len`)**. A span running past the contig end keeps the raw window so the read errors into the safe `mt_fallback` rather than feeding a truncated reference to `normalize_na_edit` and mis-normalizing. Wraparound (`start > end`) ranges already return earlier and are unchanged (circular-aware shift across the origin remains out of scope per #129).

## Tests

`tests/it/issue_1044_mito_window_clamp.rs` (mirrors `issue_1041_repro.rs` on the `m.` axis):
- a whole-span revcomp `delins` far from vs. within `window_size` of the 3' end — was `delins` near the end, now `inv` in both positions;
- a homopolymer deletion whose 3' shift is restored near the contig end (`m.196del` → `m.205del`);
- a guard test that spans running *past* the contig end still pass through unchanged (preserves the `end <= len` gate).

Verified RED before the fix (near-end stayed `delins`, no 3' shift) and GREEN after. Full `cargo nextest run --features dev` green (7960 passed); `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt` applied.

## Update — shared clamp helper (from dual review)

Added a second commit extracting `clamp_fetch_end_to_contig`, shared by the genomic (#1042) and mito (#1044) paths so the clamp cannot silently drift again — the exact divergence that caused #1044. Behavior-preserving; full suite (7961) green.
