### PR TITLE
fix(convert-gff): fail fast when the FASTA cannot cover an exon, instead of masking it

### DIFF
--- a/src/reference/annotation/convert.rs
+++ b/src/reference/annotation/convert.rs
@@ -52,7 +52,12 @@ pub struct ConvertGffConfig {
     pub strict: bool,
     /// Suppress loader diagnostic warnings (still counted in the report).
     pub silent: bool,
-    /// Skip CDS-length / start-codon FASTA-aware validation even when a FASTA is supplied.
+    /// Skip CDS-length / start-codon FASTA-aware validation even when a FASTA is
+    /// supplied. Also restores the tolerant handling of a FASTA that cannot cover
+    /// an exon's genomic coordinates (a missing contig, an assembly mismatch, or a
+    /// sub-region FASTA with whole-genome coordinates) instead of failing: an
+    /// unreadable exon is filled with an N-run, and an exon the FASTA only
+    /// partially covers keeps the covered bases as-is (#1039).
     pub no_validate_fasta: bool,
     /// Embed the referenced contig sequences under `genomic_sequences` so the
     /// output is genome-capable. Requires a FASTA (`fasta` argument of
@@ -122,8 +127,12 @@ pub struct ConvertGffOutcome {
 ///
 /// Returns [`FerroError`] if the annotation file cannot be read/parsed (or, in
 /// strict mode, records an error diagnostic), if a supplied FASTA cannot be
-/// opened, or if `emit_genomic_sequences` is set but a required contig is
-/// absent from — or too short in — the FASTA to cover a transcript placement.
+/// opened, if a supplied FASTA cannot cover an exon's genomic coordinates during
+/// sequence extraction — whether the read fails outright or is silently truncated
+/// to fewer bases than the exon span (unless [`ConvertGffConfig::no_validate_fasta`]
+/// is set, which restores the tolerant handling), or if `emit_genomic_sequences` is set but
+/// a required contig is absent from — or too short in — the FASTA to cover a
+/// transcript placement.
 pub fn convert_gff(
     gff: &Path,
     fasta: Option<&Path>,
@@ -216,9 +225,60 @@ pub fn convert_gff(
             for exon in &tx.exons {
                 if let (Some(g_start), Some(g_end)) = (exon.genomic_start, exon.genomic_end) {
                     // FASTA uses 0-based coordinates, GFF uses 1-based.
+                    let expected_len = (g_end - g_start + 1) as usize;
                     match fasta.get_sequence(chrom, g_start - 1, g_end) {
-                        Ok(seq) => exon_seqs.push(seq),
-                        Err(_) => exon_seqs.push("N".repeat((g_end - g_start + 1) as usize)),
+                        // The FASTA covered the whole exon: use the real bases.
+                        Ok(seq) if seq.len() == expected_len => exon_seqs.push(seq),
+                        // The contig is present but shorter than the exon needs, so
+                        // `get_sequence` clamped the read and returned fewer bases
+                        // than the exon span — a silent truncation, not a real
+                        // N-masked region. Treat it exactly like a hard extraction
+                        // failure: fail fast by default, keep the partial bases only
+                        // under the `no_validate_fasta` opt-out (#1039).
+                        Ok(partial) if config.no_validate_fasta => exon_seqs.push(partial),
+                        Ok(partial) => {
+                            return Err(FerroError::Io {
+                                msg: format!(
+                                    "convert-gff: the FASTA covers only {} of the {} bases of the \
+                                     exon of transcript '{}' at {}:{}-{}. The FASTA does not cover \
+                                     the annotation's coordinates (a sub-region FASTA with \
+                                     whole-genome coordinates, or a different assembly?). Pass \
+                                     --no-validate-fasta to keep the partial sequence instead of \
+                                     failing.",
+                                    partial.len(),
+                                    expected_len,
+                                    id,
+                                    chrom,
+                                    g_start,
+                                    g_end
+                                ),
+                            });
+                        }
+                        // A real extraction failure — a contig missing from the
+                        // FASTA, coordinates past the contig end, a corrupt index,
+                        // or an assembly mismatch — is NOT a legitimately N-masked
+                        // region. Fail fast by default (as the
+                        // `--emit-genomic-sequences` path does, #1026) so a wrong or
+                        // sub-region FASTA cannot silently degrade the transcript to
+                        // an N-run (#1039). Only when the user has opted out of
+                        // FASTA-aware validation via `no_validate_fasta` do we keep
+                        // the tolerant N-fill.
+                        Err(_) if config.no_validate_fasta => {
+                            exon_seqs.push("N".repeat(expected_len));
+                        }
+                        Err(source) => {
+                            return Err(FerroError::Io {
+                                msg: format!(
+                                    "convert-gff: could not extract exon sequence for transcript \
+                                     '{}' at {}:{}-{} from the FASTA: {}. The FASTA does not cover \
+                                     the annotation's coordinates (a wrong FASTA, a sub-region FASTA \
+                                     with whole-genome coordinates, or a different assembly?). Pass \
+                                     --no-validate-fasta to fill uncovered regions with Ns instead \
+                                     of failing.",
+                                    id, chrom, g_start, g_end, source
+                                ),
+                            });
+                        }
                     }
                 }
             }

--- a/tests/it/issue_1039_convert_gff_fasta_error.rs
+++ b/tests/it/issue_1039_convert_gff_fasta_error.rs
@@ -1,0 +1,176 @@
+//! #1039: `convert_gff` must not silently emit a wrong transcript sequence when
+//! a supplied FASTA cannot cover an exon's genomic coordinates.
+//!
+//! Two failure shapes exist, and the tolerant default masked both:
+//!
+//! 1. **Hard extraction error** — the contig is absent from the FASTA, or the
+//!    exon starts past the contig end. `FastaProvider::get_sequence` returns
+//!    `Err`, and the old code replaced it with `"N".repeat(len)`.
+//! 2. **Silent truncation** — the exon overhangs the contig end. The default
+//!    `FastaProvider` clamps the read and returns *fewer* real bases than the
+//!    exon span (an `Ok` shorter than requested), which the old code pushed
+//!    verbatim.
+//!
+//! Either way the emitted `transcripts.json` carried a plausible-but-wrong
+//! reference (a wrong FASTA, a sub-region FASTA paired with whole-genome
+//! coordinates, or a mismatched assembly) with no error and no diagnostic. The
+//! default path must now fail fast for BOTH shapes (mirroring the `#1026`
+//! `--emit-genomic-sequences` coverage check); the tolerant behavior must be
+//! reachable only when the user opts out of FASTA validation via
+//! `no_validate_fasta`.
+
+use std::io::Write;
+
+use ferro_hgvs::reference::annotation::{convert_gff, ConvertGffConfig};
+use ferro_hgvs::reference::transcript::GenomeBuild;
+use tempfile::NamedTempFile;
+
+fn write_gff3(content: &str) -> NamedTempFile {
+    let mut tf = tempfile::Builder::new().suffix(".gff3").tempfile().unwrap();
+    tf.write_all(content.as_bytes()).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+/// Write a single-contig FASTA of `len` deterministic bases to a temp file.
+fn write_fasta(name: &str, len: usize) -> NamedTempFile {
+    let bases = b"ACGT";
+    let mut tf = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
+    let seq: String = (0..len).map(|i| bases[i % 4] as char).collect();
+    writeln!(tf, ">{}", name).unwrap();
+    writeln!(tf, "{}", seq).unwrap();
+    tf.flush().unwrap();
+    tf
+}
+
+/// A single-exon transcript on `chr1` spanning genomic 100..500. Paired below
+/// with a FASTA that lacks `chr1`, so extracting the exon sequence fails — the
+/// stand-in for a wrong FASTA / mismatched assembly.
+fn single_exon_chr1_gff3() -> NamedTempFile {
+    write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t500\t.\t+\t.\tID=g1;Name=GENE1\n\
+         chr1\t.\tmRNA\t100\t500\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n\
+         chr1\t.\texon\t100\t500\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n",
+    )
+}
+
+/// A single-exon transcript on `chr1` spanning genomic 100..900, with its CDS
+/// (150..450) safely inside a 520-base contig. Loader CDS/start-codon validation
+/// therefore passes, but the exon overhangs the contig end (900 > 520), so the
+/// FASTA read is clamped to fewer bases than the exon span — the stand-in for a
+/// sub-region FASTA paired with whole-genome coordinates.
+fn exon_overhangs_contig_gff3() -> NamedTempFile {
+    write_gff3(
+        "##gff-version 3\n\
+         chr1\t.\tgene\t100\t900\t.\t+\t.\tID=g1;Name=GENE1\n\
+         chr1\t.\tmRNA\t100\t900\t.\t+\t.\tID=tx1;Parent=g1;gene=GENE1\n\
+         chr1\t.\texon\t100\t900\t.\t+\t.\tParent=tx1\n\
+         chr1\t.\tCDS\t150\t450\t.\t+\t0\tParent=tx1\n\
+         chr1\t.\tstop_codon\t448\t450\t.\t+\t0\tParent=tx1\n",
+    )
+}
+
+#[test]
+fn extraction_error_fails_fast_by_default() {
+    let gff = single_exon_chr1_gff3();
+    // FASTA has chr2 only — the exon's chr1 contig is absent (wrong FASTA).
+    let fasta = write_fasta("chr2", 520);
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        ..ConvertGffConfig::new()
+    };
+
+    let err = convert_gff(gff.path(), Some(fasta.path()), &config)
+        .expect_err("a FASTA missing the exon's contig must be a hard error, not an N-run");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tx1"),
+        "error should name the offending transcript, got: {msg}"
+    );
+    assert!(
+        msg.contains("does not cover the annotation"),
+        "error should explain the coverage mismatch (as the #1026 emit path does), got: {msg}"
+    );
+}
+
+#[test]
+fn extraction_error_tolerated_with_no_validate_fasta() {
+    // The user has explicitly opted out of FASTA-aware validation, so the tolerant
+    // N-fill is preserved: convert-gff succeeds and the transcript sequence is the
+    // all-`N` placeholder covering the exon span (500 - 100 + 1 = 401 bases).
+    let gff = single_exon_chr1_gff3();
+    let fasta = write_fasta("chr2", 520);
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        no_validate_fasta: true,
+        ..ConvertGffConfig::new()
+    };
+
+    let outcome = convert_gff(gff.path(), Some(fasta.path()), &config)
+        .expect("no_validate_fasta opts into the tolerant N-fill");
+    let sequence = outcome.json["transcripts"][0]["sequence"]
+        .as_str()
+        .expect("transcript sequence emitted");
+    assert_eq!(sequence.len(), 401, "N-fill covers the full exon span");
+    assert!(
+        sequence.chars().all(|c| c == 'N'),
+        "the tolerated placeholder is an all-N run, got: {sequence}"
+    );
+}
+
+#[test]
+fn partial_coverage_fails_fast_by_default() {
+    // The exon spans chr1:100..900 but the contig is only 520 bases, so the FASTA
+    // read is clamped to 421 real bases — a silent truncation, not an N-run. It
+    // must still fail: the FASTA does not cover the annotation's coordinates.
+    let gff = exon_overhangs_contig_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        ..ConvertGffConfig::new()
+    };
+
+    let err = convert_gff(gff.path(), Some(fasta.path()), &config)
+        .expect_err("a FASTA too short to cover the exon must be a hard error, not a truncation");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("tx1"),
+        "error should name the offending transcript, got: {msg}"
+    );
+    assert!(
+        msg.contains("does not cover the annotation"),
+        "error should explain the coverage mismatch (as the #1026 emit path does), got: {msg}"
+    );
+}
+
+#[test]
+fn partial_coverage_tolerated_with_no_validate_fasta() {
+    // Opted out of FASTA validation, the historical best-effort behavior is
+    // preserved: the transcript keeps the real bases the FASTA *does* cover
+    // (chr1:100..520 = 421 bases), rather than failing or being blanked to Ns.
+    let gff = exon_overhangs_contig_gff3();
+    let fasta = write_fasta("chr1", 520);
+    let config = ConvertGffConfig {
+        genome_build: GenomeBuild::GRCh38,
+        no_validate_fasta: true,
+        ..ConvertGffConfig::new()
+    };
+
+    let outcome = convert_gff(gff.path(), Some(fasta.path()), &config)
+        .expect("no_validate_fasta tolerates partial coverage");
+    let sequence = outcome.json["transcripts"][0]["sequence"]
+        .as_str()
+        .expect("transcript sequence emitted");
+    // The FASTA fills base `ACGT[i % 4]` at each absolute 0-based index `i`. The
+    // clamped read covers indices 99..=519 (chr1:100..520): index 99 → `T`, then
+    // indices 100..=519 are 420 bases = `ACGT` × 105. Pin the exact bases so a
+    // wrong-offset extraction (not just an N-run) would fail the test too.
+    let expected: String = format!("T{}", "ACGT".repeat(105));
+    assert_eq!(
+        sequence, expected,
+        "the covered bases (chr1:100..520) are kept as-is, in order"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -84,6 +84,7 @@ mod issue_1004_samegap_insertion_idempotency;
 mod issue_1012_reduced_capability_no_genome;
 mod issue_1026_genome_capable_json;
 mod issue_1034_inv_subspan_delins;
+mod issue_1039_convert_gff_fasta_error;
 mod issue_1040_inv_overrecognition_probes;
 mod issue_1041_repro;
 mod issue_1044_mito_window_clamp;


### PR DESCRIPTION
## Summary

`convert_gff` (the shared library function behind the `ferro convert-gff` CLI and the Python `convert_gff` binding) silently emitted a plausible-but-wrong `transcripts.json` whenever a supplied FASTA could not cover an exon's genomic coordinates. There were two distinct silent-degradation paths, and this PR closes both.

1. **Hard extraction failure** — a contig absent from the FASTA, coordinates past the contig end, a corrupt index, or an assembly mismatch. `FastaProvider::get_sequence` returns `Err`, and the old code swallowed it with `"N".repeat(len)`. The emitted transcript sequence became an N-run indistinguishable from a legitimately N-masked region — no error, no diagnostic.

2. **Silent truncation** — an exon overhanging the contig end. The default `FastaProvider` *clamps* the read and returns fewer real bases than the exon span (an `Ok` shorter than requested), which the old code pushed verbatim. This is the issue's motivating "sub-region FASTA with whole-genome coordinates" scenario, and it never even reached the `Err` arm — so a naive N-fill-only fix would have missed it.

A user who paired the wrong FASTA, a sub-region FASTA, or a mismatched assembly got a degraded reference with a success exit code rather than a failure.

## Fix

Both shapes now **fail fast by default** with a diagnostic that names the transcript, contig, and coordinates and points at the likely cause — mirroring the deliberate fail-fast coverage check on the `--emit-genomic-sequences` path (#1026), so `convert-gff` can no longer emit a reference its own loader would consider degraded.

The tolerant behavior is retained behind `no_validate_fasta` (`--no-validate-fasta`), the flag by which the user already opts out of FASTA-aware validation:

- an unreadable exon is filled with an N-run (historical behavior), and
- a partially covered exon keeps the covered bases as-is (historical best-effort behavior).

## Tests

New `tests/it/issue_1039_convert_gff_fasta_error.rs`, four library-level cases:

- `extraction_error_fails_fast_by_default` — missing contig → hard error (was: all-N run).
- `extraction_error_tolerated_with_no_validate_fasta` — missing contig + opt-out → N-fill preserved.
- `partial_coverage_fails_fast_by_default` — exon overhangs contig → hard error (was: silent truncation to real-but-short bases).
- `partial_coverage_tolerated_with_no_validate_fasta` — exon overhangs contig + opt-out → covered bases kept as-is.

Each default-path test was confirmed RED against the pre-fix code before the fix landed. Full suite: `cargo nextest run --features dev` → 7965 passed, 0 failed, 145 skipped; `clippy --features dev -- -D warnings` and `cargo fmt --all --check` clean.

Closes #1039