### PR TITLE
fix(hgvs): drop the gene-symbol selector on transcript-reference Display

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -373,6 +373,37 @@ impl Accession {
         matches!(&*self.prefix, "NR" | "XR")
     }
 
+    /// Returns true if this accession is a **transcript-level** reference that
+    /// fully specifies `c.`/`n.`/`r.` coordinates on its own: RefSeq mRNA/ncRNA
+    /// (`NM`/`NR`/`XM`/`XR`), an Ensembl transcript (`ENST`), or an LRG
+    /// transcript (`LRG_<N>t<M>`).
+    ///
+    /// This is the discriminator for the gene-symbol selector's Display policy
+    /// (#1051). Per HGVS Nomenclature (`refseq.md`), the parenthetical after a
+    /// reference sequence is a *specification* whose accepted values are
+    /// transcript/protein **accessions**, not gene symbols — and a transcript
+    /// reference needs no such specification at all (bare `NM_…:c.…` is the
+    /// canonical form). So when the reference is itself a transcript, the
+    /// gene-symbol selector is disallowed and Display drops it. Genomic
+    /// (`NC`/`NG`/`NT`/`NW`/`ENSG`/bare `LRG_<N>`), mitochondrial, protein, and
+    /// unclassifiable (custom) references are **not** transcript references:
+    /// there the selector is either the spec-sanctioned exception (a gene with
+    /// no transcript, e.g. mitochondrial) or a value ferro cannot safely drop,
+    /// so Display preserves it.
+    ///
+    /// The check is on `self` only — a compound reference such as
+    /// `NC_(NM_)(GENE)` stores the transcript (`NM`) as `self` with the genomic
+    /// parent in `genomic_context`, so it is correctly classified as a
+    /// transcript reference (the redundant `(GENE)` is dropped, leaving the
+    /// spec-correct `NC_(NM_)` form).
+    pub fn is_transcript_reference(&self) -> bool {
+        match &*self.prefix {
+            "NM" | "NR" | "XM" | "XR" | "ENST" => true,
+            p if Self::is_lrg_prefix(p) => Self::lrg_inferred_variant_type(&self.number) == "c",
+            _ => false,
+        }
+    }
+
     /// Returns true if this is a known human mitochondrial reference accession.
     ///
     /// `NC_012920` is the GRCh38 rCRS mitochondrion; `NC_001807` is the older
@@ -1253,17 +1284,30 @@ fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt:
         .expect("compact form requires an accession; guarded by all_share_accession_and_type");
     write!(f, "{}", accession)?;
     if let Some(gene) = first.gene_symbol() {
-        write!(f, "({})", gene)?;
+        // Same reference-type gate as `write_accession_with_optional_gene`
+        // (#1051): a transcript reference takes no gene-symbol selector.
+        if !accession.is_transcript_reference() {
+            write!(f, "({})", gene)?;
+        }
     }
     write!(f, ":{}.", first.variant_type())
 }
 
-/// Write `accession(gene):` when `gene_symbol` is set, otherwise `accession:`.
+/// Write `accession(gene):` when a gene-symbol selector is set *and* the
+/// reference admits one, otherwise the bare `accession:`.
 ///
-/// Per HGVS Nomenclature, the gene-symbol selector is informational disambiguation.
-/// ferro's round-trip policy is "preserve when present in input; do not synthesize
-/// when absent" (#121). This helper centralizes the selector emission so all
-/// per-kind `Display` impls follow the same rule.
+/// Per HGVS Nomenclature (`refseq.md`), the gene-symbol selector is a
+/// specification whose accepted values are transcript/protein accessions, not
+/// gene symbols; a **transcript** reference is fully specified on its own and
+/// takes no selector at all. ferro therefore:
+/// - **drops** the gene symbol when the reference is a transcript
+///   ([`Accession::is_transcript_reference`]) — the `NM_…(GENE):c.…` →
+///   `NM_…:c.…` normalization of #1051, mirroring the earlier `p.` drop (#310);
+/// - **preserves** it otherwise — genomic references where the gene stands in
+///   for a transcript (resolved elsewhere), the spec-sanctioned mitochondrial
+///   exception, and unclassifiable custom references. The value always remains
+///   on the struct for programmatic access (`variant.<X>.gene_symbol`),
+///   independent of whether Display emits it.
 fn write_accession_with_optional_gene(
     f: &mut fmt::Formatter<'_>,
     accession: &Accession,
@@ -1271,7 +1315,9 @@ fn write_accession_with_optional_gene(
 ) -> fmt::Result {
     write!(f, "{}", accession)?;
     if let Some(gene) = gene_symbol {
-        write!(f, "({})", gene)?;
+        if !accession.is_transcript_reference() {
+            write!(f, "({})", gene)?;
+        }
     }
     Ok(())
 }
@@ -2392,11 +2438,11 @@ pub struct RnaFusionBreakpoint {
 
 impl fmt::Display for RnaFusionBreakpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(ref gene) = self.gene_symbol {
-            write!(f, "{}({}):r.{}", self.accession, gene, self.interval)
-        } else {
-            write!(f, "{}:r.{}", self.accession, self.interval)
-        }
+        // Route through the shared helper so a fusion breakpoint on a
+        // transcript reference drops the gene-symbol selector like every other
+        // `r.` form (#1051).
+        write_accession_with_optional_gene(f, &self.accession, self.gene_symbol.as_deref())?;
+        write!(f, ":r.{}", self.interval)
     }
 }
 
@@ -2822,12 +2868,12 @@ mod tests {
     #[test]
     fn test_allele_compact_form_requires_matching_gene_symbol() {
         // Hand-built cis allele: same accession, same coordinate type, but the
-        // sub-variants disagree on gene_symbol. The compact form
-        // (`ACC(GENE):c.[edit1;edit2]`) can only carry one selector on the
-        // prefix, so collapsing two distinct selectors would silently drop
-        // the second. Per the #121 round-trip policy ("preserve when present;
-        // do not synthesize"), we fall back to the expanded form which
-        // emits each sub-variant's selector verbatim.
+        // sub-variants disagree on gene_symbol. The compaction decision still
+        // keys off gene_symbol (a single compact prefix cannot represent two
+        // distinct selectors), so the mismatch forces the expanded bracket
+        // form. On a transcript reference (`NM_`) the selector is not itself
+        // displayed (#1051), but the expanded-vs-compact bracket structure
+        // still differs, so the fallback is observable.
         use crate::hgvs::location::CdsPos;
 
         let acc = Accession::new("NM", "000088", Some(3));
@@ -2857,24 +2903,26 @@ mod tests {
         let cis = AlleleVariant::cis(vec![v_a.clone(), v_b.clone()]);
         assert_eq!(
             format!("{}", HgvsVariant::Allele(cis)),
-            "[NM_000088.3(COL1A1):c.100A>G;NM_000088.3(COL1A2):c.200C>T]",
-            "mismatched gene symbols must use expanded form to preserve both"
+            "[NM_000088.3:c.100A>G;NM_000088.3:c.200C>T]",
+            "mismatched gene symbols must use expanded form (bracket structure \
+             still distinguishes it from the compact form)"
         );
 
         let trans = AlleleVariant::trans(vec![v_a, v_b]);
         assert_eq!(
             format!("{}", HgvsVariant::Allele(trans)),
-            "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A2):c.200C>T]",
-            "trans expanded form already carries per-variant selectors"
+            "[NM_000088.3:c.100A>G];[NM_000088.3:c.200C>T]",
+            "trans is always expanded"
         );
     }
 
     #[test]
     fn test_allele_compact_form_requires_matching_gene_symbol_some_vs_none() {
-        // First sub-variant has Some(gene), second has None. Compact form
-        // would either lose the gene symbol (emit bare prefix) or synthesize
-        // one for the bare sub-variant (emit prefix-with-gene). Both violate
-        // the #121 policy; fall back to expanded form.
+        // First sub-variant has Some(gene), second has None. The gene_symbol
+        // Some/None disagreement forces the expanded bracket form (the
+        // compaction anchor still compares gene_symbol). On a transcript
+        // reference the selector is not displayed (#1051), but the bracket
+        // structure still distinguishes expanded from compact.
         use crate::hgvs::location::CdsPos;
 
         let acc = Accession::new("NM", "000088", Some(3));
@@ -2904,7 +2952,7 @@ mod tests {
         let cis = AlleleVariant::cis(vec![v_with, v_bare]);
         assert_eq!(
             format!("{}", HgvsVariant::Allele(cis)),
-            "[NM_000088.3(COL1A1):c.100A>G;NM_000088.3:c.200C>T]",
+            "[NM_000088.3:c.100A>G;NM_000088.3:c.200C>T]",
             "Some/None gene_symbol mismatch must use expanded form"
         );
     }
@@ -2933,8 +2981,9 @@ mod tests {
         let cis = AlleleVariant::cis(vec![mk(100, Base::G), mk(200, Base::T)]);
         assert_eq!(
             format!("{}", HgvsVariant::Allele(cis)),
-            "NM_000088.3(COL1A1):c.[100A>G;200A>T]",
-            "matching gene symbols must keep compact form"
+            "NM_000088.3:c.[100A>G;200A>T]",
+            "matching gene symbols keep compact form; the selector itself is \
+             dropped on a transcript reference (#1051)"
         );
 
         // All-None: existing compact behavior must be preserved.
@@ -3518,10 +3567,12 @@ mod tests {
             ),
         };
 
-        // Per #121: Display preserves the gene-symbol selector when set.
+        // Per #1051: on a transcript reference (`NM_`) the gene-symbol selector
+        // is disallowed by refseq.md, so Display emits the canonical bare form.
+        // The value stays on the struct for programmatic access.
         assert_eq!(variant.gene_symbol, Some("COL1A1".to_string()));
         let display = format!("{}", variant);
-        assert_eq!(display, "NM_000088.3(COL1A1):c.100A>G");
+        assert_eq!(display, "NM_000088.3:c.100A>G");
     }
 
     #[test]

--- a/tests/issue_500_legacy_gene_selector.rs
+++ b/tests/issue_500_legacy_gene_selector.rs
@@ -112,17 +112,15 @@ fn rewrite_is_idempotent() {
 }
 
 #[test]
-fn nm_gene_selector_is_preserved() {
-    // `NM_(GENE)` is out of scope (#121): the gene symbol stays on the already-named
-    // transcript; it is NOT treated as a legacy selector to resolve away.
+fn nm_gene_selector_is_not_resolved_away() {
+    // `NM_(GENE)` is out of scope for legacy-selector resolution: the accession
+    // is already a named transcript, so it is NOT rewritten to a different
+    // accession. The gene symbol is dropped from Display on the transcript
+    // reference (#1051), so the canonical output is the bare `NM_…:c.…` form.
     let out = normalize_str(provider(), "NM_003002.4(SDHD):c.92A>T");
-    assert!(
-        out.contains("NM_003002.4"),
-        "transcript selector kept: {out}"
-    );
-    assert!(
-        out.contains("(SDHD)"),
-        "gene symbol preserved on NM_(GENE): {out}"
+    assert_eq!(
+        out, "NM_003002.4:c.92A>T",
+        "NM_ accession kept (not resolved away); gene selector dropped on the transcript ref: {out}"
     );
 }
 

--- a/tests/it/gene_selector_display_preserve.rs
+++ b/tests/it/gene_selector_display_preserve.rs
@@ -1,29 +1,26 @@
-//! Display preserves the gene-symbol selector on round-trip (#121).
+//! Display's reference-type policy for the gene-symbol selector (#1051).
 //!
-//! Per HGVS Nomenclature, the gene-symbol selector (e.g. `(COL1A1)` in
-//! `NM_000088.3(COL1A1):c.459A>G`) is informational disambiguation. ferro's
-//! parsing layer captures it into `variant.<X>.gene_symbol: Option<String>`
-//! and normalization propagates it. Until #121, every concrete `Display`
-//! impl except `RnaFusionBreakpoint` dropped the selector.
+//! Per HGVS Nomenclature (`refseq.md`), the parenthetical after a reference is
+//! a *specification* whose accepted values are transcript/protein accessions,
+//! **not** gene symbols; and a transcript reference needs no specification at
+//! all (bare `NM_…:c.…` is canonical). ferro's `Display` therefore splits by
+//! reference type — the parser still captures `gene_symbol` on every family,
+//! but the formatter:
 //!
-//! This file pins the principled round-trip policy:
+//! 1. **Drops** the selector on a **transcript** reference
+//!    (`NM`/`NR`/`XM`/`XR`/`ENST`/`LRG_<n>t<m>`), emitting the canonical bare
+//!    form — the same treatment `p.` has always had (#310).
+//! 2. **Preserves** it on a **non-transcript** reference: genomic
+//!    (`NC`/`NG`/bare `LRG_<n>`) where the gene stands in for a transcript, the
+//!    spec-sanctioned mitochondrial exception, and unclassifiable custom
+//!    references.
+//! 3. **Never synthesizes** it — a bare input stays bare, and normalization
+//!    does not invent a selector from transcript metadata.
 //!
-//! 1. **Preserve when present in input** — Display emits `accession(gene):`
-//!    whenever `gene_symbol` is `Some(g)`, across all coordinate types
-//!    (`g`/`c`/`n`/`r`/`p`/`m`/`o`).
-//! 2. **Do not synthesize when absent** — Display emits the bare
-//!    `accession:` form when `gene_symbol` is `None`, even if the underlying
-//!    transcript provider could supply one.
-//! 3. **Idempotent re-parse** — `parse → display → parse` is byte-stable
-//!    and the second parse sees `gene_symbol = Some(<gene>)`.
-//!
-//! These cases are the inverse of the strip-pinned cases in PR #135's
-//! `tests/gene_selector_roundtrip.rs`; the `// TODO #121` markers there
-//! become preserve-assertions as a small follow-up after this PR lands.
-//!
-//! Spec rationale: <https://hgvs-nomenclature.org>. Mutalyzer and
-//! VariantValidator both preserve the selector on round-trip; ferro
-//! aligns with that policy here.
+//! The value always remains on the struct for programmatic access regardless
+//! of whether Display emits it (`variant.<X>.gene_symbol`). This file targets
+//! the *formatter* per-kind; end-to-end round-trip identity lives in
+//! `tests/gene_selector_roundtrip.rs`.
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
@@ -47,8 +44,28 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
     }
 }
 
-/// Assert that `input` round-trips through `parse → display` byte-stably and
-/// that the selector survives a second parse.
+/// Transcript reference: the parser captures `gene_symbol = Some(gene)`, but
+/// Display drops it, emitting `bare` (input with the `(GENE)` selector removed).
+fn assert_display_drops_gene_selector(input: &str, gene: &str, bare: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(
+        gene_symbol_of(&v),
+        Some(gene),
+        "parse must still capture gene_symbol={gene:?} for {input:?}",
+    );
+    assert_eq!(
+        v.to_string(),
+        bare,
+        "Display must drop the selector on a transcript reference (#1051)",
+    );
+    // The bare form is idempotent and carries no selector on reparse.
+    let reparsed = parse_hgvs(bare).unwrap_or_else(|e| panic!("reparse {bare:?} failed: {e:?}"));
+    assert_eq!(reparsed.to_string(), bare, "bare form must be idempotent");
+    assert_eq!(gene_symbol_of(&reparsed), None);
+}
+
+/// Non-transcript reference: Display preserves the selector verbatim and the
+/// round-trip is byte-stable, with the reparse re-observing it.
 fn assert_display_preserves_gene_selector(input: &str, expected_gene: &str) {
     let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
     assert_eq!(
@@ -60,11 +77,9 @@ fn assert_display_preserves_gene_selector(input: &str, expected_gene: &str) {
     let displayed = v.to_string();
     assert_eq!(
         displayed, input,
-        "Display must preserve the gene-symbol selector verbatim",
+        "Display must preserve the selector on a non-transcript reference",
     );
 
-    // Re-parsing the displayed form must succeed, remain stable, and the
-    // selector must still be present (not synthesized — actually preserved).
     let reparsed =
         parse_hgvs(&displayed).unwrap_or_else(|e| panic!("reparse {displayed:?} failed: {e:?}"));
     assert_eq!(reparsed.to_string(), displayed, "Display is not idempotent");
@@ -76,67 +91,104 @@ fn assert_display_preserves_gene_selector(input: &str, expected_gene: &str) {
 }
 
 // =============================================================================
-// Preserve: every supported accession family emits `(gene)` after the accession.
+// Drop: a transcript reference emits the canonical bare form.
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_refseq_nm_cds() {
+fn display_drops_gene_selector_refseq_nm_cds() {
     // Canonical example from the HGVS Nomenclature page.
-    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):c.459A>G", "COL1A1");
+    assert_display_drops_gene_selector(
+        "NM_000088.3(COL1A1):c.459A>G",
+        "COL1A1",
+        "NM_000088.3:c.459A>G",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_refseq_nr_noncoding() {
-    // NR_ is a non-coding RNA RefSeq accession; coordinate type is `n.`.
-    assert_display_preserves_gene_selector("NR_046018.2(DDX11L1):n.100A>G", "DDX11L1");
+fn display_drops_gene_selector_refseq_nr_noncoding() {
+    // NR_ is a non-coding RNA RefSeq (transcript) accession; coordinate `n.`.
+    assert_display_drops_gene_selector(
+        "NR_046018.2(DDX11L1):n.100A>G",
+        "DDX11L1",
+        "NR_046018.2:n.100A>G",
+    );
 }
 
 #[test]
 fn display_drops_gene_selector_refseq_np_protein() {
-    // Per HGVS syntax.yaml 119–128 the protein-variant grammar has no
-    // parenthesized selector position; the `accession(selector):c.` form
-    // (syntax.yaml 213) is reserved for genomic-to-transcript projection on
-    // c./n., not p. The parser remains permissive and `gene_symbol` round-trips
-    // on the struct, but Display emits the spec-compliant `NP_*:p.` form.
-    // See #310.
-    use ferro_hgvs::hgvs::parser::parse_hgvs;
+    // Protein `p.` has always dropped the selector (#310); #1051 makes the
+    // transcript DNA/RNA forms consistent with it.
     let v = parse_hgvs("NP_000079.2(COL1A1):p.(Arg8Gln)").unwrap();
     assert_eq!(gene_symbol_of(&v), Some("COL1A1"));
     assert_eq!(v.to_string(), "NP_000079.2:p.(Arg8Gln)");
 }
 
 #[test]
-fn display_preserves_gene_selector_genome() {
-    // `(FLT3)` here is a gene-symbol selector, not a compound-ref wrapper.
-    assert_display_preserves_gene_selector("NC_000013.11(FLT3):g.12345A>G", "FLT3");
+fn display_drops_gene_selector_ensembl() {
+    assert_display_drops_gene_selector(
+        "ENST00000380152.7(BRCA2):c.100A>G",
+        "BRCA2",
+        "ENST00000380152.7:c.100A>G",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_ensembl() {
-    assert_display_preserves_gene_selector("ENST00000380152.7(BRCA2):c.100A>G", "BRCA2");
+fn display_drops_gene_selector_rna() {
+    // `r.` form on a transcript reference: dropped like `c.`/`n.`.
+    assert_display_drops_gene_selector(
+        "NM_000088.3(COL1A1):r.100a>g",
+        "COL1A1",
+        "NM_000088.3:r.100a>g",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_lrg() {
-    // LRG references come in three flavors: bare (`LRG_<n>`), transcript
-    // (`LRG_<n>t<m>`), and protein (`LRG_<n>p<m>`). The bare and transcript
-    // forms preserve the gene selector verbatim on `c.`/`n.`. The protein
-    // form does NOT round-trip the selector through Display: the HGVS
-    // protein-variant grammar (syntax.yaml 119–128) has no parenthesized
-    // selector position, so Display emits the spec-compliant `LRG_*p*:p.`
-    // form. See #310.
-    assert_display_preserves_gene_selector("LRG_199(BRCA1):c.100A>G", "BRCA1");
-    assert_display_preserves_gene_selector("LRG_199t1(BRCA1):c.100A>G", "BRCA1");
+fn display_drops_gene_selector_lrg_transcript() {
+    // An LRG transcript (`LRG_<n>t<m>`) is a transcript reference → drop.
+    assert_display_drops_gene_selector("LRG_199t1(BRCA1):c.100A>G", "BRCA1", "LRG_199t1:c.100A>G");
 
-    use ferro_hgvs::hgvs::parser::parse_hgvs;
+    // The LRG protein form drops it via the protein grammar (#310).
     let v = parse_hgvs("LRG_199p1(BRCA1):p.(Arg8Gln)").unwrap();
     assert_eq!(gene_symbol_of(&v), Some("BRCA1"));
     assert_eq!(v.to_string(), "LRG_199p1:p.(Arg8Gln)");
 }
 
+// =============================================================================
+// Preserve: a non-transcript reference keeps the selector.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_genome() {
+    // `(FLT3)` is a gene-symbol selector on a single-segment genomic reference
+    // (no transcript named), so ferro preserves it.
+    assert_display_preserves_gene_selector("NC_000013.11(FLT3):g.12345A>G", "FLT3");
+}
+
+#[test]
+fn display_preserves_gene_selector_mitochondrial() {
+    // `m.` form: the spec explicitly endorses `NC_012920.1(MT-…):m.…` — the
+    // gene has no transcript reference (refseq.md lines 197–203), so the
+    // selector is the only way to specify it.
+    assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
+}
+
+#[test]
+fn display_preserves_gene_selector_circular() {
+    // `o.` form (circular DNA, SVD-WG006) on a genomic reference.
+    assert_display_preserves_gene_selector("NC_001416.1(genE):o.1A>G", "genE");
+}
+
+#[test]
+fn display_preserves_gene_selector_lrg_bare_genome() {
+    // Bare LRG (`LRG_<n>`) is the genomic record — a non-transcript reference,
+    // so the selector is preserved.
+    assert_display_preserves_gene_selector("LRG_199(BRCA1):g.100A>G", "BRCA1");
+}
+
 #[test]
 fn display_preserves_gene_selector_simple_accession() {
-    // Custom (non-RefSeq, non-Ensembl, non-LRG) accession with a selector.
+    // Custom (non-RefSeq, non-Ensembl, non-LRG) accession: unclassifiable, so
+    // ferro conservatively preserves the selector rather than drop information.
     assert_display_preserves_gene_selector("MYREF_SEQ(GENE1):c.100A>G", "GENE1");
 }
 
@@ -144,8 +196,6 @@ fn display_preserves_gene_selector_simple_accession() {
 // Do-not-synthesize: bare input stays bare on Display.
 // =============================================================================
 
-/// Assert Display emits the bare form when the input had no selector and
-/// re-parsing produces a variant with `gene_symbol == None`.
 fn assert_display_does_not_synthesize(input: &str) {
     let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
     assert_eq!(
@@ -186,21 +236,22 @@ fn display_does_not_synthesize_ensembl() {
 }
 
 // =============================================================================
-// Compound-ref + selector: a bare gene selector composes with the existing
-// `outer(inner)` compound-ref wrapper.
+// Compound-ref + selector: `NC_…(NM_…)(GENE):c.…`. The compound ref already
+// names the transcript (the spec-correct specification), so `self` is the
+// transcript `NM_` and the redundant `(GENE)` is dropped, leaving the
+// canonical `NC_(NM_):c.…` (#1051).
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_with_compound_ref() {
-    // `NC_…(NM_…)` is a compound-ref accession (genomic_context); the
-    // trailing `(GENE)` is the gene-symbol selector. Both must round-trip.
-    assert_display_preserves_gene_selector("NC_000013.11(NM_004119.3)(FLT3):c.100A>G", "FLT3");
+fn display_drops_redundant_gene_selector_with_compound_ref() {
+    let v = parse_hgvs("NC_000013.11(NM_004119.3)(FLT3):c.100A>G").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("FLT3"));
+    assert_eq!(v.to_string(), "NC_000013.11(NM_004119.3):c.100A>G");
 }
 
 #[test]
 fn display_compound_ref_without_selector_unchanged() {
-    // Compound-ref alone (no gene selector) must not be confused with a
-    // selector. The display is unchanged from PR #70's behavior.
+    // Compound-ref alone (no gene selector) is unchanged.
     let input = "NC_000013.11(NM_004119.3):c.100A>G";
     let v = parse_hgvs(input).unwrap();
     assert_eq!(gene_symbol_of(&v), None);
@@ -208,28 +259,79 @@ fn display_compound_ref_without_selector_unchanged() {
 }
 
 // =============================================================================
-// Allele compact form: `ACC(GENE):c.[edit1;edit2]` carries the selector once.
+// Allele forms on a transcript reference: the selector is dropped from the
+// compact prefix / expanded members, but the compaction decision still keys
+// off `gene_symbol` equality.
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_in_compact_allele() {
-    // Compact cis allele form: when both sub-variants share an accession
-    // and gene selector, the prefix emits `acc(gene):type.[…]` once.
+fn display_drops_gene_selector_in_compact_allele() {
     let input = "NM_000088.3(COL1A1):c.[100A>G;200C>T]";
-    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
-    assert_eq!(v.to_string(), input);
-
-    // Idempotent re-parse.
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.[100A>G;200C>T]");
     let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed.to_string(), input);
+    assert_eq!(reparsed.to_string(), "NM_000088.3:c.[100A>G;200C>T]");
+}
+
+#[test]
+fn display_drops_gene_selector_in_compact_trans_allele() {
+    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.[100A>G];[200C>T]");
+}
+
+#[test]
+fn display_drops_gene_selector_in_unknown_phase_compact_allele() {
+    let input = "NM_000088.3(COL1A1):c.100A>G(;)200C>T";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.100A>G(;)200C>T");
+}
+
+#[test]
+fn display_drops_gene_selector_in_trans_allele_same_acc_same_gene() {
+    // Same accession + same gene + trans phase → compact-trans, selector
+    // dropped from the transcript-reference prefix. The field survives on each
+    // sub-variant.
+    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.[100A>G];[200C>T]");
+
+    if let HgvsVariant::Allele(a) = &v {
+        for sub in &a.variants {
+            assert_eq!(gene_symbol_of(sub), Some("COL1A1"));
+        }
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
+}
+
+#[test]
+fn display_drops_independent_gene_selectors_in_mixed_acc_trans() {
+    // Different transcript accessions with different gene symbols. Both
+    // selectors are dropped from Display; the fields survive on the members.
+    let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(
+        v.to_string(),
+        "[NM_000088.3:c.100A>G];[NM_000089.3:c.200C>T]"
+    );
+
+    if let HgvsVariant::Allele(a) = &v {
+        assert_eq!(a.variants.len(), 2);
+        assert_eq!(gene_symbol_of(&a.variants[0]), Some("COL1A1"));
+        assert_eq!(gene_symbol_of(&a.variants[1]), Some("COL1A2"));
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
 }
 
 // =============================================================================
-// Normalize → Display: the selector survives both stages.
+// Normalize → Display: the selector survives normalization on the struct, and
+// Display applies the reference-type policy afterward.
 // =============================================================================
 
 #[test]
-fn normalize_then_display_preserves_gene_selector() {
+fn normalize_then_display_drops_gene_selector_on_transcript_ref() {
     let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
@@ -237,12 +339,15 @@ fn normalize_then_display_preserves_gene_selector() {
     let variant = parse_hgvs(input).unwrap();
     let normalized = normalizer.normalize(&variant).unwrap();
 
-    // gene_symbol survives normalization, and Display preserves it on output.
+    // gene_symbol survives normalization on the struct...
     assert_eq!(gene_symbol_of(&normalized), Some("COL1A1"));
-    assert!(
-        normalized.to_string().contains("(COL1A1)"),
-        "normalized Display must preserve the gene selector: {}",
-        normalized
+    // ...but Display drops it on the transcript reference (#1051). Pin the exact
+    // bare form, not just the absence of the selector, so malformed output can't
+    // slip past (a substitution does not shift under normalization).
+    assert_eq!(
+        normalized.to_string(),
+        "NM_000088.3:c.4A>G",
+        "Display on a transcript reference must emit the canonical bare form"
     );
 }
 
@@ -250,9 +355,6 @@ fn normalize_then_display_preserves_gene_selector() {
 fn normalize_does_not_synthesize_gene_selector_in_display() {
     // When the input lacked a selector, normalization must not invent one,
     // even though the underlying transcript record knows the gene symbol.
-    // The byte-equality assertion pins the exact canonical bare form so any
-    // future change that adds parens for an unrelated reason cannot
-    // silently introduce a synthesized selector.
     let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
@@ -269,146 +371,9 @@ fn normalize_does_not_synthesize_gene_selector_in_display() {
 }
 
 // =============================================================================
-// Per-coordinate-type Preserve coverage for the kinds not exercised in the top
-// section (the top section already covers `c`, `n`, `p`, `g`).
-// =============================================================================
-
-#[test]
-fn display_preserves_gene_selector_rna() {
-    // `r.` form (RNA): selector follows the same rule as DNA forms.
-    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):r.100a>g", "COL1A1");
-}
-
-#[test]
-fn display_preserves_gene_selector_mitochondrial() {
-    // `m.` form: spec explicitly endorses `NC_012920.1(MT-…):m.…` — see
-    // assets/hgvs-nomenclature/docs/background/refseq.md lines 197–203.
-    assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
-}
-
-#[test]
-fn display_preserves_gene_selector_circular() {
-    // `o.` form (circular DNA, SVD-WG006). ferro accepts the selector
-    // verbatim; Display preserves it.
-    assert_display_preserves_gene_selector("NC_001416.1(genE):o.1A>G", "genE");
-}
-
-// =============================================================================
-// Trans-allele expanded form: each sub-variant carries its own selector through
-// the `[v1];[v2]` wrapping (no shared prefix; no information loss).
-// =============================================================================
-
-#[test]
-fn display_preserves_gene_selector_in_trans_allele_same_acc_same_gene() {
-    // Same accession + same gene + trans phase. The compact-trans form
-    // `ACC(GENE):c.[a];[b]` is legal here, and ferro emits it because both
-    // sub-variants agree on accession and gene_symbol. The `Allele` wrapper
-    // returns `None` from `gene_symbol()` (selectors live on sub-variants),
-    // so we assert via byte-stable round-trip + per-sub-variant inspection
-    // rather than the generic helper.
-    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
-    let v = parse_hgvs(input).unwrap();
-    assert_eq!(
-        v.to_string(),
-        input,
-        "Display must preserve compact-trans selector"
-    );
-
-    if let HgvsVariant::Allele(a) = &v {
-        for sub in &a.variants {
-            assert_eq!(gene_symbol_of(sub), Some("COL1A1"));
-        }
-    } else {
-        panic!("expected Allele; got {:?}", v);
-    }
-
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed.to_string(), input, "reparse must be byte-stable");
-}
-
-#[test]
-fn display_preserves_gene_selector_in_trans_allele_expanded_form() {
-    // Parse the expanded `[v1];[v2]` notation; each sub-variant captures the
-    // gene_symbol independently. Because both sub-variants share accession and
-    // gene_symbol, `all_share_accession_and_type` permits the compact-trans
-    // output `ACC(GENE):c.[a];[b]`, so this test does NOT exercise the
-    // per-kind expanded-form Display path (that case lives in
-    // `display_preserves_independent_gene_selectors_in_mixed_acc_trans`, where
-    // mismatched accessions force the expanded path). What this test pins is
-    // sub-variant `gene_symbol` capture under the expanded-input → compact-
-    // trans-output normalization, plus byte-stable re-parse of the output.
-    let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A1):c.200C>T]";
-    let v = parse_hgvs(input).unwrap();
-    let s = v.to_string();
-    let reparsed = parse_hgvs(&s).unwrap();
-    assert_eq!(reparsed.to_string(), s, "reparse must be byte-stable");
-
-    // Both inner sub-variants must observe the gene_symbol.
-    if let HgvsVariant::Allele(a) = &v {
-        assert_eq!(a.variants.len(), 2);
-        for sub in &a.variants {
-            assert_eq!(gene_symbol_of(sub), Some("COL1A1"));
-        }
-    } else {
-        panic!("expected Allele; got {:?}", v);
-    }
-}
-
-#[test]
-fn display_preserves_independent_gene_selectors_in_mixed_acc_trans() {
-    // Different accessions, each with its own gene symbol. Per #121 the
-    // expanded trans form must preserve both selectors, one per sub-variant.
-    // This is the round-trip-stability case for cross-gene compound
-    // heterozygosity reports.
-    let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]";
-    let v = parse_hgvs(input).unwrap();
-    assert_eq!(v.to_string(), input);
-
-    if let HgvsVariant::Allele(a) = &v {
-        assert_eq!(a.variants.len(), 2);
-        assert_eq!(gene_symbol_of(&a.variants[0]), Some("COL1A1"));
-        assert_eq!(gene_symbol_of(&a.variants[1]), Some("COL1A2"));
-    } else {
-        panic!("expected Allele; got {:?}", v);
-    }
-
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed.to_string(), input, "reparse must be byte-stable");
-}
-
-// =============================================================================
-// Allele compact forms (cis, trans, unknown-phase) all carry the selector once
-// on the prefix via `write_compact_prefix`.
-// =============================================================================
-
-#[test]
-fn display_preserves_gene_selector_in_compact_trans_allele() {
-    // Compact-trans form: `ACC(GENE):c.[edit1];[edit2]`. The selector lives
-    // on the prefix once (via `write_compact_prefix`); each bracketed group
-    // is a single trans variant.
-    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
-    let v = parse_hgvs(input).unwrap();
-    assert_eq!(v.to_string(), input);
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed.to_string(), input);
-}
-
-#[test]
-fn display_preserves_gene_selector_in_unknown_phase_compact_allele() {
-    // Unknown-phase compact form: `ACC(GENE):c.edit1(;)edit2`. No surrounding
-    // brackets; the selector still lives on the prefix once.
-    let input = "NM_000088.3(COL1A1):c.100A>G(;)200C>T";
-    let v = parse_hgvs(input).unwrap();
-    assert_eq!(v.to_string(), input);
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed.to_string(), input);
-}
-
-// =============================================================================
 // Hash + Eq: gene_symbol participates in the derived Hash/Eq on every variant
-// struct. Two variants with the same accession + edit but different selectors
-// must compare unequal and hash distinctly so set/map deduplication respects
-// the user-supplied disambiguation.
+// struct (parser-level; independent of the Display drop). Two variants with the
+// same accession + edit but different selectors must compare unequal.
 // =============================================================================
 
 #[test]
@@ -446,14 +411,8 @@ fn variants_with_different_gene_symbols_are_distinct() {
 }
 
 // =============================================================================
-// `HgvsVariant::gene_symbol()` accessor contract.
-//
-// The accessor is documented as returning `None` for variant kinds that don't
-// carry a single top-level selector (`Allele`, `RnaFusion`, `NullAllele`,
-// `UnknownAllele`). Selectors on those nested kinds are emitted by their own
-// `Display` impls (e.g. `RnaFusionBreakpoint::Display`). This test pins that
-// contract so a future "surface nested gene_symbol" change is a deliberate
-// API decision rather than an accident.
+// `HgvsVariant::gene_symbol()` accessor contract: `None` for nested kinds
+// (`Allele`, `RnaFusion`, …); selectors on those live on the sub-parts.
 // =============================================================================
 
 #[test]
@@ -476,32 +435,30 @@ fn gene_symbol_accessor_returns_none_for_nested_kinds() {
         None,
         "RnaFusion's top-level gene_symbol() is None; selectors live on breakpoints"
     );
-    // The breakpoint selectors must still appear in the Display output.
+    // Both breakpoints are transcript references (`NM_`), so Display drops the
+    // selectors (#1051) — the breakpoint genes must NOT appear in the output.
     let s = fusion.to_string();
-    assert!(
-        s.contains("(ACTN1)"),
-        "5' breakpoint gene must round-trip: {}",
-        s
+    assert_eq!(
+        s, "NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924",
+        "transcript-reference fusion breakpoints drop their gene selectors: {s}",
     );
-    assert!(
-        s.contains("(BCR)"),
-        "3' breakpoint gene must round-trip: {}",
-        s
-    );
+    // The captured gene_symbol still lives on each breakpoint struct.
+    if let HgvsVariant::RnaFusion(fx) = &fusion {
+        assert_eq!(fx.five_prime.gene_symbol.as_deref(), Some("ACTN1"));
+        assert_eq!(fx.three_prime.gene_symbol.as_deref(), Some("BCR"));
+    } else {
+        unreachable!()
+    }
 }
 
 // =============================================================================
-// Edge cases: empty selector, whitespace padding, casing, special characters.
-// ferro's policy is "preserve verbatim" — the parser does not sanitize
-// gene_symbol, and Display emits whatever was captured. The HGVS spec's
-// canonical form uses approved HGNC symbols (no whitespace, no quotes), but
-// ferro stays bytes-in / bytes-out so callers can detect malformed input.
+// Edge cases: empty selector, whitespace/case (captured verbatim on parse,
+// then subject to the reference-type Display policy).
 // =============================================================================
 
 #[test]
 fn empty_selector_is_treated_as_no_selector() {
-    // `NM_X():c.…` parses with gene_symbol = None (per the parser's
-    // "Treat empty strings as None" rule). Display must emit the bare form.
+    // `NM_X():c.…` parses with gene_symbol = None; Display emits the bare form.
     let v = parse_hgvs("NM_000088.3():c.100A>G").unwrap();
     assert_eq!(gene_symbol_of(&v), None);
     assert_eq!(
@@ -512,31 +469,29 @@ fn empty_selector_is_treated_as_no_selector() {
 }
 
 #[test]
-fn whitespace_padded_selector_round_trips_verbatim() {
-    // Padding is preserved in `gene_symbol` and round-trips on Display.
-    // Spec uses HGNC symbols which contain no whitespace; this pin documents
-    // ferro's bytes-in/bytes-out policy.
+fn whitespace_padded_selector_captured_then_dropped() {
+    // Padding is preserved in `gene_symbol` on parse; a transcript reference
+    // then drops it on Display (#1051).
     let input = "NM_000088.3( COL1A1 ):c.100A>G";
     let v = parse_hgvs(input).unwrap();
     assert_eq!(gene_symbol_of(&v), Some(" COL1A1 "));
-    assert_eq!(v.to_string(), input);
+    assert_eq!(v.to_string(), "NM_000088.3:c.100A>G");
 }
 
 #[test]
-fn lowercase_selector_preserved_verbatim() {
-    // Spec uses uppercase HGNC symbols; ferro does not normalize case.
+fn lowercase_selector_captured_then_dropped() {
+    // ferro does not normalize case; the transcript reference drops it anyway.
     let input = "NM_000088.3(col1a1):c.100A>G";
     let v = parse_hgvs(input).unwrap();
     assert_eq!(gene_symbol_of(&v), Some("col1a1"));
-    assert_eq!(v.to_string(), input);
+    assert_eq!(v.to_string(), "NM_000088.3:c.100A>G");
 }
 
 #[test]
-fn hyphenated_selector_round_trips() {
-    // Mitochondrial genes carry hyphens (MT-ND1, MT-TL1). The selector
-    // parser uses `take_while(c != ')')`, so any non-paren bytes are
-    // accepted verbatim. The spec endorses this exact form (see
-    // assets/hgvs-nomenclature/docs/background/refseq.md lines 197–203).
+fn hyphenated_selector_preserved_on_mitochondrial_reference() {
+    // Mitochondrial genes carry hyphens (MT-ND1, MT-TL1) and have no transcript
+    // reference, so the selector is the spec-sanctioned exception and preserved
+    // (refseq.md lines 197–203).
     assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):m.3243A>G", "MT-TL1");
     assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
     assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):n.14A>G", "MT-TL1");

--- a/tests/it/gene_selector_roundtrip.rs
+++ b/tests/it/gene_selector_roundtrip.rs
@@ -5,31 +5,32 @@
 //! spans multiple genes (e.g. `NM_000088.3(COL1A1):c.459A>G`).
 //!
 //! PR #70 (`b34ce35`) extended the parser so the selector is accepted on
-//! non-RefSeq accessions and is captured into the variant struct's
-//! `gene_symbol: Option<String>`. PR #144 (closes #121) extended Display
-//! to preserve the selector across every concrete variant kind and every
-//! compound-allele form. This file pins the *end-to-end* round-trip
-//! identity (parse → normalize → Display → reparse) across the full
-//! audit matrix: every accession family, every coordinate system, every
-//! allele compound form, every LRG flavor, and the `Hash` + `Eq`
-//! contract.
+//! non-RefSeq accessions and captured into the variant struct's
+//! `gene_symbol: Option<String>`. The parser is unchanged by #1051 and still
+//! captures the selector on every accession family.
 //!
-//! Spec rationale
-//! --------------
-//! Per <https://hgvs-nomenclature.org>, the gene-symbol selector is
-//! informational disambiguation. ferro's round-trip policy is
-//! **preserve when present in input; do not synthesize when absent** —
-//! aligning ferro with Mutalyzer and VariantValidator.
+//! Display policy (#1051)
+//! ----------------------
+//! Per HGVS Nomenclature (`refseq.md`), the parenthetical after a reference is
+//! a *specification* whose accepted values are transcript/protein accessions,
+//! **not** gene symbols; and a transcript reference is fully specified on its
+//! own (bare `NM_…:c.…` is canonical) so it takes no selector at all. ferro
+//! therefore splits by **reference type** on Display:
 //!
-//! Scope split with `tests/gene_selector_display_preserve.rs` (#144):
-//! - That file targets the *formatter*: assert each per-kind `Display`
-//!   impl emits `accession(gene)` when `gene_symbol = Some(g)` and the
-//!   bare form when `None`.
-//! - This file targets *end-to-end identity*: parse + normalize +
-//!   Display + reparse, including the full coordinate-system and
-//!   allele-form matrix and the negative half of the policy
-//!   (no synthesis, multi-pass-normalize idempotency, Hash/Eq
-//!   distinctness on round-trip).
+//! - **Transcript reference** (`NM`/`NR`/`XM`/`XR`/`ENST`/`LRG_<n>t<m>`):
+//!   Display *drops* the selector, emitting the canonical bare form — the
+//!   same treatment `p.` has always had (#310). The value stays on the struct
+//!   for programmatic access; parse → Display → reparse is therefore lossy for
+//!   the selector (by design, mirroring a normalization).
+//! - **Non-transcript reference** (genomic `NC`/`NG`/bare `LRG_<n>`,
+//!   mitochondrial, custom): Display *preserves* the selector — it is either
+//!   the spec-sanctioned exception (a gene with no transcript, e.g.
+//!   mitochondrial) or a value ferro cannot safely drop. Round-trip is
+//!   byte-stable and reparse re-observes the selector.
+//!
+//! The negative half of the policy — "do not synthesize when absent" — is
+//! unchanged: a bare input stays bare and normalization never invents a
+//! selector from transcript metadata.
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
@@ -54,14 +55,38 @@ fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
     }
 }
 
-/// Assert a parse → display → reparse cycle is byte-stable and the selector
-/// survives both the first parse and the reparse.
-///
-/// Use this for any input that should yield a non-`Allele` variant carrying
-/// `gene_symbol = Some(g)`. For nested-kind variants (`Allele`, `RnaFusion`)
-/// the top-level `gene_symbol` is `None` by design — assert the round-trip
-/// directly without this helper.
-fn assert_display_preserves_gene_selector(input: &str) {
+/// Assert the #1051 policy for a **transcript reference**: the parser captures
+/// `gene_symbol = Some(gene)`, but Display drops it, emitting `bare`. The bare
+/// form is idempotent and its reparse observes no selector (the Display leg is
+/// intentionally lossy for the selector, like `p.`).
+fn assert_transcript_ref_drops_selector(input: &str, gene: &str, bare: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(
+        gene_symbol_of(&v),
+        Some(gene),
+        "parse must still capture gene_symbol for {input:?}",
+    );
+
+    let displayed = v.to_string();
+    assert_eq!(
+        displayed, bare,
+        "Display must drop the selector on a transcript reference (#1051)",
+    );
+
+    let reparsed =
+        parse_hgvs(&displayed).unwrap_or_else(|e| panic!("reparse {displayed:?} failed: {e:?}"));
+    assert_eq!(reparsed.to_string(), bare, "bare form must be idempotent");
+    assert_eq!(
+        gene_symbol_of(&reparsed),
+        None,
+        "reparse of the dropped form must observe no selector",
+    );
+}
+
+/// Assert the #1051 policy for a **non-transcript reference** (genomic, mito,
+/// custom): Display preserves the selector verbatim and the round-trip is
+/// byte-stable, with the reparse re-observing it.
+fn assert_nontranscript_ref_preserves_selector(input: &str) {
     let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
     let expected_gene = gene_symbol_of(&v)
         .unwrap_or_else(|| panic!("test bug: input {input:?} must have a gene_symbol after parse"))
@@ -70,7 +95,7 @@ fn assert_display_preserves_gene_selector(input: &str) {
     let displayed = v.to_string();
     assert_eq!(
         displayed, input,
-        "Display must preserve the gene-symbol selector verbatim (#121)",
+        "Display must preserve the selector on a non-transcript reference (#1051)",
     );
 
     let reparsed =
@@ -84,7 +109,8 @@ fn assert_display_preserves_gene_selector(input: &str) {
 }
 
 // =============================================================================
-// Parse: gene_symbol is captured on every supported accession family.
+// Parse: gene_symbol is captured on every supported accession family. The
+// parser is unchanged by #1051 — only Display differs by reference type.
 // =============================================================================
 
 #[test]
@@ -141,47 +167,96 @@ fn parse_without_selector_leaves_gene_symbol_none() {
 }
 
 // =============================================================================
-// Display: every supported accession family preserves the selector verbatim
-// (#121). Replaces the pre-#144 strip-pinned cases.
+// Display on a TRANSCRIPT reference: the selector is dropped to the canonical
+// bare form (#1051), mirroring the long-standing `p.` behavior (#310).
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_refseq_nm() {
-    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):c.459A>G");
+fn display_drops_gene_selector_refseq_nm() {
+    assert_transcript_ref_drops_selector(
+        "NM_000088.3(COL1A1):c.459A>G",
+        "COL1A1",
+        "NM_000088.3:c.459A>G",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_refseq_nr() {
-    assert_display_preserves_gene_selector("NR_046018.2(DDX11L1):n.100A>G");
+fn display_drops_gene_selector_refseq_nr() {
+    assert_transcript_ref_drops_selector(
+        "NR_046018.2(DDX11L1):n.100A>G",
+        "DDX11L1",
+        "NR_046018.2:n.100A>G",
+    );
 }
 
 #[test]
 fn display_drops_gene_selector_refseq_np() {
-    // Per HGVS syntax.yaml 119–128 the `accession(selector):p.` form is not
-    // part of the protein-variant grammar; the parenthesized selector is only
-    // defined for genomic-to-transcript projection on c./n. (syntax.yaml 213).
-    // Parsing remains permissive — `gene_symbol` round-trips on the struct —
-    // but Display emits the spec-compliant `accession:p.` form. See #310.
+    // Protein `p.` has always dropped the selector (#310); #1051 makes the
+    // transcript DNA/RNA forms consistent with it.
     let v = parse_hgvs("NP_000079.2(COL1A1):p.(Arg8Gln)").unwrap();
     assert_eq!(gene_symbol_of(&v), Some("COL1A1"));
     assert_eq!(v.to_string(), "NP_000079.2:p.(Arg8Gln)");
 }
 
 #[test]
-fn display_preserves_gene_selector_ensembl() {
-    assert_display_preserves_gene_selector("ENST00000380152.7(BRCA2):c.100A>G");
+fn display_drops_gene_selector_ensembl() {
+    assert_transcript_ref_drops_selector(
+        "ENST00000380152.7(BRCA2):c.100A>G",
+        "BRCA2",
+        "ENST00000380152.7:c.100A>G",
+    );
+}
+
+#[test]
+fn display_drops_gene_selector_rna() {
+    // `r.` form on a transcript reference: selector dropped like `c.`/`n.`.
+    assert_transcript_ref_drops_selector(
+        "NM_000088.3(COL1A1):r.100a>g",
+        "COL1A1",
+        "NM_000088.3:r.100a>g",
+    );
+}
+
+// =============================================================================
+// Display on a NON-transcript reference: the selector is preserved. Genomic
+// references (`NC`/`NG`/bare `LRG`) carry the gene as an exception/legacy
+// selector; the mitochondrial form is the spec-sanctioned exception; a custom
+// accession cannot be classified so ferro keeps the value.
+// =============================================================================
+
+#[test]
+fn display_preserves_gene_selector_genome() {
+    // `(FLT3)` here is a gene-symbol selector on a single-segment genomic
+    // reference (no transcript named), so ferro preserves it.
+    assert_nontranscript_ref_preserves_selector("NC_000013.11(FLT3):g.12345A>G");
+}
+
+#[test]
+fn display_preserves_gene_selector_mitochondrial() {
+    // `m.` form: spec explicitly endorses `NC_012920.1(MT-…):m.…` — the gene
+    // has no transcript reference (refseq.md lines 197-203), so the selector
+    // is the *only* way to specify it and must be preserved.
+    assert_nontranscript_ref_preserves_selector("NC_012920.1(MT-ND1):m.3460G>A");
+}
+
+#[test]
+fn display_preserves_gene_selector_circular() {
+    // `o.` form (circular DNA, SVD-WG006) on a genomic reference.
+    assert_nontranscript_ref_preserves_selector("NC_001416.1(GENE):o.1A>G");
 }
 
 #[test]
 fn display_preserves_gene_selector_simple_accession() {
-    assert_display_preserves_gene_selector("MYREF_SEQ(GENE1):c.100A>G");
+    // Custom (unclassifiable) accession: ferro cannot prove it is a transcript,
+    // so it conservatively preserves the selector rather than drop information.
+    assert_nontranscript_ref_preserves_selector("MYREF_SEQ(GENE1):c.100A>G");
 }
 
 #[test]
 fn display_no_selector_unchanged() {
     // Sanity check: Display is idempotent when the selector is absent and
     // is not synthesized from somewhere else (e.g. a transcript provider
-    // lookup). This is the negative half of the #121 round-trip policy.
+    // lookup). This is the negative half of the policy.
     let input = "NM_000088.3:c.459A>G";
     let v = parse_hgvs(input).unwrap();
     assert_eq!(v.to_string(), input);
@@ -189,89 +264,71 @@ fn display_no_selector_unchanged() {
 }
 
 // =============================================================================
-// Coordinate-system matrix: every supported `:type.` value round-trips with a
-// selector. `c`, `n`, `p` are exercised in the section above; this section
-// adds `g`, `r`, `m`, `o`.
-// =============================================================================
-
-#[test]
-fn display_preserves_gene_selector_genome() {
-    // `(FLT3)` here is a gene-symbol selector, not a compound-ref wrapper —
-    // a single-segment accession with a selector at the same position.
-    assert_display_preserves_gene_selector("NC_000013.11(FLT3):g.12345A>G");
-}
-
-#[test]
-fn display_preserves_gene_selector_rna() {
-    // `r.` form: lowercase nucleotides, otherwise selector handling is uniform.
-    assert_display_preserves_gene_selector("NM_000088.3(COL1A1):r.100a>g");
-}
-
-#[test]
-fn display_preserves_gene_selector_mitochondrial() {
-    // `m.` form: spec explicitly endorses `NC_012920.1(MT-…):m.…`
-    // (see assets/hgvs-nomenclature/docs/background/refseq.md lines 197-203).
-    // This case flipped from `diverges` to `preserved` in PR #144's spec
-    // fixture; pinning it here gives the audit a direct end-to-end anchor.
-    assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A");
-}
-
-#[test]
-fn display_preserves_gene_selector_circular() {
-    // `o.` form (circular DNA, SVD-WG006). ferro accepts the selector
-    // verbatim across this coordinate type too.
-    assert_display_preserves_gene_selector("NC_001416.1(GENE):o.1A>G");
-}
-
-// =============================================================================
-// LRG flavor matrix: bare (`LRG_<n>` -> g.), transcript (`LRG_<n>t<m>` -> c.,
-// also valid with n. and r.), protein (`LRG_<n>p<m>` -> p.). Each form must
-// round-trip the selector.
+// LRG flavor matrix: bare (`LRG_<n>` -> g., NON-transcript, preserves),
+// transcript (`LRG_<n>t<m>` -> c./n./r., transcript, DROPS), protein
+// (`LRG_<n>p<m>` -> p., drops via the protein grammar).
 // =============================================================================
 
 #[test]
 fn display_preserves_gene_selector_lrg_bare_genome() {
-    assert_display_preserves_gene_selector("LRG_199(BRCA1):g.100A>G");
+    // Bare LRG is the genomic record itself — a non-transcript reference, so
+    // the selector is preserved (it stands in for a transcript that is not
+    // named here).
+    assert_nontranscript_ref_preserves_selector("LRG_199(BRCA1):g.100A>G");
 }
 
 #[test]
-fn display_preserves_gene_selector_lrg_transcript_cds() {
-    // Already covered above; included here for completeness within the LRG
-    // matrix so a future LRG regression surfaces in this section directly.
-    assert_display_preserves_gene_selector("LRG_199t1(BRCA1):c.100A>G");
+fn display_drops_gene_selector_lrg_transcript_cds() {
+    assert_transcript_ref_drops_selector(
+        "LRG_199t1(BRCA1):c.100A>G",
+        "BRCA1",
+        "LRG_199t1:c.100A>G",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_lrg_transcript_noncoding() {
-    assert_display_preserves_gene_selector("LRG_199t1(BRCA1):n.100A>G");
+fn display_drops_gene_selector_lrg_transcript_noncoding() {
+    assert_transcript_ref_drops_selector(
+        "LRG_199t1(BRCA1):n.100A>G",
+        "BRCA1",
+        "LRG_199t1:n.100A>G",
+    );
 }
 
 #[test]
-fn display_preserves_gene_selector_lrg_transcript_rna() {
-    assert_display_preserves_gene_selector("LRG_199t1(BRCA1):r.100a>g");
+fn display_drops_gene_selector_lrg_transcript_rna() {
+    assert_transcript_ref_drops_selector(
+        "LRG_199t1(BRCA1):r.100a>g",
+        "BRCA1",
+        "LRG_199t1:r.100a>g",
+    );
 }
 
 #[test]
 fn display_drops_gene_selector_lrg_protein() {
-    // Per HGVS syntax.yaml 119–128 the protein-variant grammar has no
-    // parenthesized selector position; Display emits the spec-compliant
-    // `LRG_*p*:p.` form even when the parser accepted a `(GENE)` selector.
-    // See #310.
+    // Protein grammar has no selector slot (#310); the LRG protein form drops
+    // it like any other `p.`.
     let v = parse_hgvs("LRG_199p1(BRCA1):p.(Arg8Gln)").unwrap();
     assert_eq!(gene_symbol_of(&v), Some("BRCA1"));
     assert_eq!(v.to_string(), "LRG_199p1:p.(Arg8Gln)");
 }
 
 // =============================================================================
-// Compound-ref + selector: `NC_X(NM_Y)(GENE):c.…` — a genomic-context
-// accession (`NC(NM)`) followed by a gene selector. Both must round-trip
-// independently. Bare-compound-ref negative case pins that no selector is
-// synthesized for the inner accession.
+// Compound-ref + selector: `NC_X(NM_Y)(GENE):c.…`. The `NC_(NM_)` compound
+// reference already names the transcript (the spec-correct specification), so
+// `self` is the transcript `NM_` and the redundant `(GENE)` selector is
+// dropped, leaving the canonical `NC_(NM_):c.…` form (#1051).
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_with_compound_ref() {
-    assert_display_preserves_gene_selector("NC_000013.11(NM_004119.3)(FLT3):c.100A>G");
+fn display_drops_redundant_gene_selector_with_compound_ref() {
+    let v = parse_hgvs("NC_000013.11(NM_004119.3)(FLT3):c.100A>G").unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("FLT3"));
+    assert_eq!(
+        v.to_string(),
+        "NC_000013.11(NM_004119.3):c.100A>G",
+        "the compound ref already names the transcript; the gene selector is redundant and dropped",
+    );
 }
 
 #[test]
@@ -283,62 +340,64 @@ fn display_compound_ref_without_selector_unchanged() {
 }
 
 // =============================================================================
-// Allele compound-form matrix: the compact form (`ACC(GENE):c.[a;b]`,
-// `ACC(GENE):c.[a];[b]`, `ACC(GENE):c.a(;)b`) carries the selector once on
-// the prefix; the expanded form (`[ACC(GENE):c.a];[ACC(GENE):c.b]`) carries
-// it per-sub-variant. PR #144 tightened `all_share_accession_and_type` so
-// the compact form is only used when every sub-variant agrees on
-// `gene_symbol`.
+// Allele compound-form matrix. On a transcript reference the per-sub-variant
+// selector is dropped (#1051), so the compact/expanded prefix loses `(GENE)`.
+// The compaction decision itself still keys off `gene_symbol` equality, so a
+// mismatch still forces the expanded bracket form.
 // =============================================================================
 
 #[test]
-fn display_preserves_gene_selector_in_compact_cis_allele() {
-    // Compact cis: `ACC(GENE):c.[a;b]`. Selector emitted once on the prefix.
-    assert_display_preserves_gene_selector_in_allele(
-        "NM_000088.3(COL1A1):c.[100A>G;200C>T]",
-        &[Some("COL1A1"), Some("COL1A1")],
-    );
+fn display_drops_gene_selector_in_compact_cis_allele() {
+    // Compact cis on a transcript ref: `ACC:c.[a;b]` (selector dropped).
+    let input = "NM_000088.3(COL1A1):c.[100A>G;200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.[100A>G;200C>T]");
+    if let HgvsVariant::Allele(a) = &v {
+        for sub in &a.variants {
+            assert_eq!(
+                gene_symbol_of(sub),
+                Some("COL1A1"),
+                "field preserved on struct"
+            );
+        }
+    } else {
+        panic!("expected Allele; got {:?}", v);
+    }
 }
 
 #[test]
-fn display_preserves_gene_selector_in_compact_trans_allele() {
-    // Compact trans: `ACC(GENE):c.[a];[b]`. Selector emitted once on the prefix.
-    assert_display_preserves_gene_selector_in_allele(
-        "NM_000088.3(COL1A1):c.[100A>G];[200C>T]",
-        &[Some("COL1A1"), Some("COL1A1")],
-    );
+fn display_drops_gene_selector_in_compact_trans_allele() {
+    let input = "NM_000088.3(COL1A1):c.[100A>G];[200C>T]";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.[100A>G];[200C>T]");
 }
 
 #[test]
-fn display_preserves_gene_selector_in_unknown_phase_compact_allele() {
-    // Unknown-phase compact: `ACC(GENE):c.a(;)b`. No surrounding brackets;
-    // selector lives on the prefix once.
-    assert_display_preserves_gene_selector_in_allele(
-        "NM_000088.3(COL1A1):c.100A>G(;)200C>T",
-        &[Some("COL1A1"), Some("COL1A1")],
-    );
+fn display_drops_gene_selector_in_unknown_phase_compact_allele() {
+    let input = "NM_000088.3(COL1A1):c.100A>G(;)200C>T";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(v.to_string(), "NM_000088.3:c.100A>G(;)200C>T");
 }
 
 #[test]
-fn display_canonicalizes_expanded_same_acc_trans_to_compact_with_selector() {
+fn display_canonicalizes_expanded_same_acc_trans_to_compact_dropping_selector() {
     // Same accession + same gene + trans phase: ferro canonicalizes the
-    // expanded `[v1];[v2]` input to the compact-trans form
-    // `ACC(GENE):c.[a];[b]` on Display, since `all_share_accession_and_type`
-    // approves the consensus. The selector survives on every sub-variant
-    // and on the compact prefix; reparse is byte-stable thereafter.
+    // expanded `[v1];[v2]` input to the compact-trans form, and the selector
+    // is dropped from the transcript-reference prefix (#1051). The field
+    // survives on every sub-variant; reparse is byte-stable thereafter.
     let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A1):c.200C>T]";
     let v = parse_hgvs(input).unwrap();
     let displayed = v.to_string();
     assert_eq!(
-        displayed, "NM_000088.3(COL1A1):c.[100A>G];[200C>T]",
-        "matching selectors must canonicalize to compact-trans form",
+        displayed, "NM_000088.3:c.[100A>G];[200C>T]",
+        "matching selectors canonicalize to compact-trans; selector dropped on transcript ref",
     );
 
     let reparsed = parse_hgvs(&displayed).unwrap();
     assert_eq!(
         reparsed.to_string(),
         displayed,
-        "reparse of compact-trans must be byte-stable"
+        "reparse must be byte-stable"
     );
 
     if let HgvsVariant::Allele(a) = &v {
@@ -352,13 +411,17 @@ fn display_canonicalizes_expanded_same_acc_trans_to_compact_with_selector() {
 }
 
 #[test]
-fn display_preserves_independent_gene_selectors_in_mixed_acc_trans() {
-    // Different accessions with different gene symbols — the canonical
-    // compound-heterozygosity report shape. Per #121 the expanded form
-    // preserves both selectors, one per sub-variant.
+fn display_drops_independent_gene_selectors_in_mixed_acc_trans() {
+    // Different transcript accessions with different gene symbols — the
+    // canonical compound-heterozygosity report shape. Both selectors are
+    // dropped from Display (both accessions are transcripts), but the fields
+    // survive on the sub-variants.
     let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]";
     let v = parse_hgvs(input).unwrap();
-    assert_eq!(v.to_string(), input);
+    assert_eq!(
+        v.to_string(),
+        "[NM_000088.3:c.100A>G];[NM_000089.3:c.200C>T]",
+    );
 
     if let HgvsVariant::Allele(a) = &v {
         assert_eq!(a.variants.len(), 2);
@@ -367,24 +430,21 @@ fn display_preserves_independent_gene_selectors_in_mixed_acc_trans() {
     } else {
         panic!("expected Allele; got {:?}", v);
     }
-
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed, v, "structural identity across reparse");
 }
 
 #[test]
 fn display_falls_back_to_expanded_when_gene_symbols_mismatch() {
-    // End-to-end pin of the `all_share_accession_and_type` consensus rule
-    // tightened in #144: same accession but mismatched gene_symbol →
-    // compact form would lose information → emit expanded form so each
-    // sub-variant's selector survives. Parsing the expanded form and
-    // round-tripping must produce the same expanded form.
+    // The `all_share_accession_and_type` consensus rule still keys off
+    // gene_symbol: same accession but mismatched gene_symbol → the compaction
+    // is declined and the expanded bracket form is used. On a transcript
+    // reference the selector itself is not displayed, but the expanded vs
+    // compact bracket structure still differs, so the fallback is observable.
     let input = "[NM_000088.3(COL1A1):c.100A>G];[NM_000088.3(COL1A2):c.200C>T]";
     let v = parse_hgvs(input).unwrap();
     assert_eq!(
         v.to_string(),
-        input,
-        "mismatched selectors must keep expanded form, not collapse to compact"
+        "[NM_000088.3:c.100A>G];[NM_000088.3:c.200C>T]",
+        "mismatched selectors keep expanded bracket structure, not compact",
     );
 
     if let HgvsVariant::Allele(a) = &v {
@@ -396,43 +456,10 @@ fn display_falls_back_to_expanded_when_gene_symbols_mismatch() {
     }
 }
 
-/// Helper for allele-form tests: assert byte-stable round-trip plus per-sub
-/// gene_symbol expectations.
-fn assert_display_preserves_gene_selector_in_allele(input: &str, expected: &[Option<&str>]) {
-    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
-    let displayed = v.to_string();
-    assert_eq!(displayed, input, "Display must preserve verbatim");
-
-    if let HgvsVariant::Allele(a) = &v {
-        assert_eq!(
-            a.variants.len(),
-            expected.len(),
-            "expected {} sub-variants for {input}",
-            expected.len(),
-        );
-        for (i, (sub, want)) in a.variants.iter().zip(expected).enumerate() {
-            assert_eq!(
-                gene_symbol_of(sub),
-                *want,
-                "sub-variant {i} gene_symbol mismatch for {input}",
-            );
-        }
-    } else {
-        panic!("expected Allele for {input}; got {:?}", v);
-    }
-
-    let reparsed = parse_hgvs(&displayed).unwrap();
-    assert_eq!(
-        reparsed, v,
-        "structural identity across reparse for {input}"
-    );
-}
-
 // =============================================================================
-// Edge inputs: empty `()`, whitespace padding, casing, hyphen. ferro's
-// policy is "preserve verbatim" — the parser does not sanitize gene_symbol,
-// and Display emits whatever was captured, except `()` collapses to None
-// per the parser's "treat empty strings as None" rule.
+// Edge inputs: empty `()`, whitespace padding, casing, hyphen. The parser
+// preserves the captured bytes verbatim on the struct; Display then applies
+// the reference-type policy.
 // =============================================================================
 
 #[test]
@@ -455,51 +482,61 @@ fn empty_selector_round_trips_to_bare_form() {
 }
 
 #[test]
-fn whitespace_padded_selector_round_trips_verbatim() {
-    // ferro is bytes-in / bytes-out: the spec uses HGNC symbols (no
-    // whitespace), but ferro does not sanitize so callers can detect
-    // malformed input.
+fn whitespace_padded_selector_captured_verbatim_then_dropped() {
+    // ferro is bytes-in on parse: the captured gene_symbol keeps the padding.
+    // On a transcript reference Display then drops it (#1051), so the output
+    // is the canonical bare form.
     let input = "NM_000088.3( COL1A1 ):c.100A>G";
     let v = parse_hgvs(input).unwrap();
-    assert_eq!(gene_symbol_of(&v), Some(" COL1A1 "));
-    assert_eq!(v.to_string(), input);
-
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed, v);
+    assert_eq!(
+        gene_symbol_of(&v),
+        Some(" COL1A1 "),
+        "parse captures verbatim"
+    );
+    assert_eq!(
+        v.to_string(),
+        "NM_000088.3:c.100A>G",
+        "transcript ref drops selector"
+    );
 }
 
 #[test]
-fn lowercase_selector_round_trips_verbatim() {
-    // ferro does not normalize case on gene_symbol.
+fn lowercase_selector_captured_verbatim_then_dropped() {
+    // ferro does not normalize case on the captured gene_symbol; a transcript
+    // reference then drops it on Display.
     let input = "NM_000088.3(col1a1):c.100A>G";
     let v = parse_hgvs(input).unwrap();
-    assert_eq!(gene_symbol_of(&v), Some("col1a1"));
-    assert_eq!(v.to_string(), input);
-
-    let reparsed = parse_hgvs(&v.to_string()).unwrap();
-    assert_eq!(reparsed, v);
+    assert_eq!(
+        gene_symbol_of(&v),
+        Some("col1a1"),
+        "parse captures verbatim"
+    );
+    assert_eq!(
+        v.to_string(),
+        "NM_000088.3:c.100A>G",
+        "transcript ref drops selector"
+    );
 }
 
 #[test]
-fn hyphenated_selector_round_trips() {
-    // Mitochondrial genes carry hyphens (MT-ND1, MT-TL1). The selector
-    // parser uses `take_while(c != ')')`, so any non-paren bytes are
-    // accepted verbatim. The spec endorses this exact form (see
-    // assets/hgvs-nomenclature/docs/background/refseq.md lines 197-203).
-    assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):m.3243A>G");
-    assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):n.14A>G");
+fn hyphenated_selector_preserved_on_mitochondrial_reference() {
+    // Mitochondrial genes carry hyphens (MT-ND1, MT-TL1) and have no
+    // transcript reference, so the selector is the spec-sanctioned exception
+    // and is preserved verbatim (refseq.md lines 197-203).
+    assert_nontranscript_ref_preserves_selector("NC_012920.1(MT-TL1):m.3243A>G");
+    assert_nontranscript_ref_preserves_selector("NC_012920.1(MT-TL1):n.14A>G");
 }
 
 // =============================================================================
-// Normalize: the gene_symbol field is preserved through normalization, even
-// while Display now also preserves it on output. Multi-pass idempotency
-// pins that gene_symbol does not drift on repeated normalize calls.
+// Normalize: the gene_symbol FIELD is preserved through normalization on every
+// reference type (only Display differs by reference type). Multi-pass
+// idempotency pins that gene_symbol does not drift on repeated normalize.
 // =============================================================================
 
 #[test]
 fn normalize_preserves_gene_symbol_field_cds() {
-    // MockProvider::with_test_data has NM_000088.3 (COL1A1), so this
-    // exercises the real CDS normalize path.
+    // MockProvider::with_test_data has NM_000088.3 (COL1A1), so this exercises
+    // the real CDS normalize path.
     let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
@@ -508,25 +545,25 @@ fn normalize_preserves_gene_symbol_field_cds() {
 
     let normalized = normalizer.normalize(&variant).unwrap();
 
-    // The gene_symbol field must survive normalization, regardless of any
-    // shifting the normalizer might do to the position.
+    // The gene_symbol field must survive normalization on the struct.
     assert_eq!(
         gene_symbol_of(&normalized),
         Some("COL1A1"),
-        "normalize must not drop gene_symbol on CdsVariant",
+        "normalize must not drop the gene_symbol field on CdsVariant",
     );
 
-    // And Display must continue to emit it after normalize.
+    // But Display drops it on the transcript reference (#1051).
     assert!(
-        normalized.to_string().contains("(COL1A1)"),
-        "normalized Display must preserve the gene selector: {}",
+        !normalized.to_string().contains("(COL1A1)"),
+        "Display on a transcript reference must not emit the selector: {}",
         normalized
     );
 }
 
 #[test]
 fn normalize_preserves_gene_symbol_field_genome() {
-    // Genomic substitutions normalize without a transcript lookup.
+    // Genomic substitutions normalize without a transcript lookup; the field
+    // is preserved AND Display emits it (non-transcript reference).
     let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
@@ -537,7 +574,12 @@ fn normalize_preserves_gene_symbol_field_genome() {
     assert_eq!(
         gene_symbol_of(&normalized),
         Some("BRCA1"),
-        "normalize must not drop gene_symbol on GenomeVariant",
+        "normalize must not drop the gene_symbol field on GenomeVariant",
+    );
+    assert!(
+        normalized.to_string().contains("(BRCA1)"),
+        "Display on a genomic reference must preserve the selector: {}",
+        normalized
     );
 }
 
@@ -568,10 +610,7 @@ fn normalize_does_not_synthesize_gene_symbol() {
 #[test]
 fn normalize_is_idempotent_with_gene_symbol() {
     // Multi-pass idempotency: normalize-of-normalize must be a fixed point
-    // under the derived `Eq`. This pins the contract so a future change
-    // that re-routes normalization through a transcript provider (which
-    // knows the gene symbol and could synthesize one) does not silently
-    // alter `gene_symbol`.
+    // under the derived `Eq`, and must not alter `gene_symbol`.
     let provider = MockProvider::with_test_data();
     let normalizer = Normalizer::new(provider);
 
@@ -593,23 +632,20 @@ fn normalize_is_idempotent_with_gene_symbol() {
 }
 
 // =============================================================================
-// Re-parse identity: parse → display → parse a second time produces a
-// structurally equal variant — the second parse observes Some(<gene>),
-// not None. Pins that the round-trip is identity-preserving for the
-// selector.
+// Re-parse identity. For a NON-transcript reference the selector survives
+// Display, so parse → display → parse is identity-preserving. For a TRANSCRIPT
+// reference Display intentionally drops the selector (#1051), so the reparse
+// yields a variant whose `gene_symbol` is None — identity holds only on the
+// struct's non-selector content.
 // =============================================================================
 
 #[test]
-fn reparse_preserves_gene_symbol() {
-    // Only non-protein accession families round-trip byte-stably — `p.`
-    // Display intentionally drops the gene-symbol selector (#310), so a
-    // protein variant is not identity-preserving across Display in this
-    // sense and is covered separately in `display_drops_gene_selector_refseq_np`.
+fn reparse_preserves_gene_symbol_on_nontranscript_reference() {
+    // Only non-transcript references round-trip byte-stably with the selector.
     let cases: &[(&str, &str)] = &[
-        ("NM_000088.3(COL1A1):c.459A>G", "COL1A1"),
-        ("NR_046018.2(DDX11L1):n.100A>G", "DDX11L1"),
-        ("ENST00000380152.7(BRCA2):c.100A>G", "BRCA2"),
-        ("LRG_199t1(BRCA1):c.100A>G", "BRCA1"),
+        ("NC_000013.11(FLT3):g.12345A>G", "FLT3"),
+        ("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1"),
+        ("LRG_199(BRCA1):g.100A>G", "BRCA1"),
         ("MYREF_SEQ(GENE1):c.100A>G", "GENE1"),
     ];
 
@@ -629,8 +665,6 @@ fn reparse_preserves_gene_symbol() {
             Some(*gene),
             "reparse must observe the preserved gene_symbol for {input}"
         );
-
-        // Identity: parse(input) == parse(parse(input).to_string()).
         assert_eq!(
             first, second,
             "structural equality must survive parse → display → parse for {input}"
@@ -638,44 +672,82 @@ fn reparse_preserves_gene_symbol() {
     }
 }
 
+#[test]
+fn reparse_drops_gene_symbol_on_transcript_reference() {
+    // On a transcript reference the Display leg is lossy for the selector, so
+    // the reparse observes None and the round-tripped variant differs from the
+    // original only in `gene_symbol` (like re-reading a `p.` string).
+    let cases: &[(&str, &str)] = &[
+        ("NM_000088.3(COL1A1):c.459A>G", "COL1A1"),
+        ("NR_046018.2(DDX11L1):n.100A>G", "DDX11L1"),
+        ("ENST00000380152.7(BRCA2):c.100A>G", "BRCA2"),
+        ("LRG_199t1(BRCA1):c.100A>G", "BRCA1"),
+    ];
+
+    for (input, gene) in cases {
+        let first = parse_hgvs(input).unwrap();
+        assert_eq!(gene_symbol_of(&first), Some(*gene));
+
+        let second = parse_hgvs(&first.to_string()).unwrap();
+        assert_eq!(
+            gene_symbol_of(&second),
+            None,
+            "reparse of the dropped form must observe no selector for {input}"
+        );
+        assert_ne!(
+            first, second,
+            "the dropped selector makes the round-trip non-identity for {input}"
+        );
+    }
+}
+
 // =============================================================================
-// Hash + Eq round-trip identity: `Some(g)`, `Some(g')`, and `None` are all
-// distinct under the derived Hash/Eq. The round-trip parse → display →
-// parse preserves identity (covered above as part of the per-input
-// asserts via `assert_eq!(first, second, ...)`); this test pins the
-// negative half — that the round-trip does *not* collapse `Some(g)` and
-// `None` to equal values.
+// Hash + Eq distinctness. The derived Hash/Eq still distinguishes `Some(g)`,
+// `Some(g')`, and `None` at the struct level. On a NON-transcript reference the
+// round-trip preserves that distinctness; this pins that the parser itself
+// keeps the three variants distinct before any Display drop.
 // =============================================================================
 
 #[test]
-fn round_trip_identity_distinguishes_selector_presence() {
+fn parsed_variants_distinguish_selector_presence() {
     use std::collections::HashSet;
 
     let with_gene_a = parse_hgvs("NM_000088.3(COL1A1):c.100A>G").unwrap();
     let with_gene_b = parse_hgvs("NM_000088.3(COL1A2):c.100A>G").unwrap();
     let bare = parse_hgvs("NM_000088.3:c.100A>G").unwrap();
 
-    // Round-trip each through Display + reparse and verify identity holds.
-    let with_gene_a_rt = parse_hgvs(&with_gene_a.to_string()).unwrap();
-    let with_gene_b_rt = parse_hgvs(&with_gene_b.to_string()).unwrap();
-    let bare_rt = parse_hgvs(&bare.to_string()).unwrap();
-
-    assert_eq!(with_gene_a, with_gene_a_rt);
-    assert_eq!(with_gene_b, with_gene_b_rt);
-    assert_eq!(bare, bare_rt);
-
-    // After round-trip the three remain distinct.
-    assert_ne!(with_gene_a_rt, bare_rt);
-    assert_ne!(with_gene_a_rt, with_gene_b_rt);
-    assert_ne!(with_gene_b_rt, bare_rt);
+    // The three parsed structs are distinct under derived Hash/Eq.
+    assert_ne!(with_gene_a, bare);
+    assert_ne!(with_gene_a, with_gene_b);
+    assert_ne!(with_gene_b, bare);
 
     let mut set: HashSet<HgvsVariant> = HashSet::new();
-    set.insert(with_gene_a_rt);
-    set.insert(with_gene_b_rt);
-    set.insert(bare_rt);
+    set.insert(with_gene_a);
+    set.insert(with_gene_b);
+    set.insert(bare);
     assert_eq!(
         set.len(),
         3,
-        "round-tripped variants with distinct selector presence must hash distinctly"
+        "variants with distinct selector presence must hash distinctly"
     );
+}
+
+#[test]
+fn round_trip_identity_holds_on_nontranscript_reference() {
+    // On a genomic reference the selector survives Display, so the round-trip
+    // preserves full structural identity for all three selector states.
+    let with_gene_a = parse_hgvs("NC_000013.11(FLT3):g.100A>G").unwrap();
+    let with_gene_b = parse_hgvs("NC_000013.11(KIT):g.100A>G").unwrap();
+    let bare = parse_hgvs("NC_000013.11:g.100A>G").unwrap();
+
+    let a_rt = parse_hgvs(&with_gene_a.to_string()).unwrap();
+    let b_rt = parse_hgvs(&with_gene_b.to_string()).unwrap();
+    let bare_rt = parse_hgvs(&bare.to_string()).unwrap();
+
+    assert_eq!(with_gene_a, a_rt);
+    assert_eq!(with_gene_b, b_rt);
+    assert_eq!(bare, bare_rt);
+
+    assert_ne!(a_rt, bare_rt);
+    assert_ne!(a_rt, b_rt);
 }

--- a/tests/it/issue_218_mixed_accession_alleles.rs
+++ b/tests/it/issue_218_mixed_accession_alleles.rs
@@ -284,14 +284,29 @@ mod gene_selector {
     use super::*;
 
     #[test]
-    fn cis_with_gene_selectors_round_trips() {
-        let v = assert_round_trips("[NM_000088.3(COL1A1):c.100A>G;NM_000089.3(COL1A2):c.200C>T]");
+    fn cis_with_gene_selectors_drops_transcript_selectors() {
+        // Both accessions are transcripts, so Display drops the `(GENE)`
+        // selectors (#1051); the gene fields survive on each sub-variant.
+        let v = assert_canonicalizes_to(
+            "[NM_000088.3(COL1A1):c.100A>G;NM_000089.3(COL1A2):c.200C>T]",
+            "[NM_000088.3:c.100A>G;NM_000089.3:c.200C>T]",
+        );
         expect_phase(&v, AllelePhase::Cis, 2);
+        // The selectors are dropped from Display, but the gene fields survive on
+        // each sub-variant's struct — assert the invariant the comment claims.
+        let HgvsVariant::Allele(allele) = &v else {
+            unreachable!("expect_phase already asserted an allele");
+        };
+        assert_eq!(allele.variants[0].gene_symbol(), Some("COL1A1"));
+        assert_eq!(allele.variants[1].gene_symbol(), Some("COL1A2"));
     }
 
     #[test]
-    fn trans_with_gene_selectors_round_trips() {
-        let v = assert_round_trips("[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]");
+    fn trans_with_gene_selectors_drops_transcript_selectors() {
+        let v = assert_canonicalizes_to(
+            "[NM_000088.3(COL1A1):c.100A>G];[NM_000089.3(COL1A2):c.200C>T]",
+            "[NM_000088.3:c.100A>G];[NM_000089.3:c.200C>T]",
+        );
         expect_phase(&v, AllelePhase::Trans, 2);
     }
 }

--- a/tests/it/issue_247_lrg_roundtrip.rs
+++ b/tests/it/issue_247_lrg_roundtrip.rs
@@ -262,13 +262,19 @@ mod lrg_with_gene_symbol {
     }
 
     #[test]
-    fn transcript_cds_with_gene_round_trips() {
-        assert_round_trips("LRG_199t1(BRCA1):c.100A>G");
+    fn transcript_cds_with_gene_drops_selector_on_display() {
+        // `LRG_<n>t<m>` is a transcript reference, so Display drops the `(GENE)`
+        // selector (#1051); the gene text is retained on the struct.
+        let v = parse_hgvs("LRG_199t1(BRCA1):c.100A>G").unwrap();
+        assert_eq!(v.gene_symbol(), Some("BRCA1"));
+        assert_eq!(format!("{}", v), "LRG_199t1:c.100A>G");
     }
 
     #[test]
-    fn transcript_rna_with_gene_round_trips() {
-        assert_round_trips("LRG_199t1(BRCA1):r.100a>g");
+    fn transcript_rna_with_gene_drops_selector_on_display() {
+        let v = parse_hgvs("LRG_199t1(BRCA1):r.100a>g").unwrap();
+        assert_eq!(v.gene_symbol(), Some("BRCA1"));
+        assert_eq!(format!("{}", v), "LRG_199t1:r.100a>g");
     }
 
     #[test]

--- a/tests/it/issue_879_ng_g_to_c_overlap.rs
+++ b/tests/it/issue_879_ng_g_to_c_overlap.rs
@@ -256,12 +256,13 @@ fn ng_context_coding_input_keeps_pivot_path_unchanged() {
         .expect("c. input with NG_ context projects via the pivot path");
 
     // Today's pivot-path output, pinned verbatim: the single-transcript c. path
-    // renders the coding axis with its gene-symbol selector (not reframed under
-    // the NG_ parent), a bare protein, and an NG_-framed genomic axis. The
+    // renders the coding axis on the bare transcript reference (the gene-symbol
+    // selector is dropped on a transcript ref, #1051; the value still lives on
+    // the struct), a bare protein, and an NG_-framed genomic axis. The
     // Genome-gate must leave every one of these unchanged.
     assert_eq!(
         r.coding.as_ref().map(ToString::to_string).as_deref(),
-        Some("NM_TEST.1(TESTGENE):c.4A>C"),
+        Some("NM_TEST.1:c.4A>C"),
     );
     assert_eq!(
         r.protein.as_ref().map(ToString::to_string).as_deref(),


### PR DESCRIPTION
Per HGVS Nomenclature (`refseq.md`), the parenthetical after a reference sequence is a *specification* whose accepted values are transcript/protein accessions, not gene symbols — and a transcript reference is fully specified on its own, so it takes no selector at all (bare `NM_…:c.…` is canonical). ferro previously emitted `NM_…(GENE):c.…` whenever the reference supplied a `gene_symbol` (e.g. from cdot `gene_name`), which is the mainline output of VCF annotation and genomic→transcript projection.

This makes Display reference-type-aware, via a single `Accession::is_transcript_reference()` gate in the shared formatter helper:

- **Transcript reference** (`NM`/`NR`/`XM`/`XR`/`ENST`/`LRG_<n>t<m>`): the selector is dropped, emitting the canonical bare form — the same treatment `p.` has had since #310.
- **Non-transcript reference** kept: genomic (`NC`/`NG`/bare `LRG`) where the gene stands in for a transcript, the spec-sanctioned mitochondrial exception (`m.`), and unclassifiable custom accessions.

The value always remains on the struct (`variant.<X>.gene_symbol`) and in the VCF `gene_symbol` column, so no information is lost — only the spec-discouraged inline duplication is removed. The parser is unchanged and still accepts the `(GENE)` form on input.

**Behavior change:** output for transcript references parsed/projected with a gene symbol changes from `NM_…(GENE):c.…` to `NM_…:c.…`. No conformance-fixture diffs (verified: zero expected-output fields carry a transcript+gene form).

## Verification

- `cargo nextest run --features dev`: 7963 passed, 0 failed
- `cargo clippy --features dev --all-targets`: clean; `cargo fmt`: clean
- `generate_spec_fixture --check`: up to date (no drift)
- End-to-end CLI: `NM_000088.3(COL1A1):c.459A>G` → `NM_000088.3:c.459A>G`; `NC_012920.1(MT-ND1):m.…` and `NC_…(FLT3):g.…` preserved

Closes #1051