### PR TITLE
feat(reference): reject unknown manifest fields at load, fail loud on a misread reference

### DIFF
--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -18,6 +18,7 @@ pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
 /// Manifest of prepared reference data.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReferenceManifest {
     /// When the data was prepared
     pub prepared_at: String,
@@ -476,9 +477,10 @@ pub fn check_schema_version(version: Option<u32>) -> Result<(), FerroError> {
 /// 1. refuses a manifest from a newer, forward-incompatible `ferro`
 ///    ([`check_schema_version`]); and
 /// 2. validates the value against the [`ReferenceManifest`] schema, catching a
-///    missing required field or a wrong-typed field. Unknown/extra fields are
-///    tolerated (no `deny_unknown_fields`), so a real reference carrying
-///    additional metadata (e.g. a content fingerprint) still loads.
+///    missing required field, a wrong-typed field, or an unknown/typo'd field
+///    (`#[serde(deny_unknown_fields)]`, #1001) — an unmodeled optional key would
+///    otherwise silently deserialize as `None` and the run would proceed on
+///    missing data.
 pub fn validate_loaded_manifest(value: &serde_json::Value) -> Result<(), FerroError> {
     let version = value
         .get("manifest_schema_version")
@@ -1020,8 +1022,7 @@ mod tests {
         );
     }
 
-    /// A realistic minimal manifest as `save()` writes it, plus an extra unknown
-    /// field (a content fingerprint) that real prepared references carry.
+    /// A minimal but schema-valid manifest as a JSON value, for load-gate tests.
     fn minimal_manifest_json() -> serde_json::Value {
         serde_json::json!({
             "prepared_at": "2024-01-01T00:00:00Z",
@@ -1030,8 +1031,7 @@ mod tests {
             "cdot_json": null,
             "transcript_count": 0,
             "available_prefixes": [],
-            "manifest_schema_version": CURRENT_MANIFEST_SCHEMA_VERSION,
-            "reference_identity": "deadbeefdeadbeef"
+            "manifest_schema_version": CURRENT_MANIFEST_SCHEMA_VERSION
         })
     }
 
@@ -1079,9 +1079,32 @@ mod tests {
     }
 
     #[test]
-    fn validate_loaded_manifest_accepts_valid_manifest_with_unknown_fields() {
+    fn validate_loaded_manifest_accepts_clean_manifest() {
         validate_loaded_manifest(&minimal_manifest_json())
-            .expect("a valid manifest carrying an unknown extra field must load");
+            .expect("a schema-valid manifest must load");
+    }
+
+    #[test]
+    fn validate_loaded_manifest_rejects_unknown_field() {
+        // A manifest carrying a key the struct does not model — e.g. a typo'd
+        // optional key (`cdot_jsonn`) or drift-era metadata — must now be rejected,
+        // not silently tolerated (#1001: an unmodeled optional key otherwise
+        // deserializes as `None` and the run proceeds on missing data).
+        let mut v = minimal_manifest_json();
+        v.as_object_mut()
+            .unwrap()
+            .insert("cdot_jsonn".to_string(), serde_json::json!("typo.json"));
+        let err = validate_loaded_manifest(&v)
+            .expect_err("a manifest with an unknown field must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("does not match the expected schema"),
+            "actionable schema message: {msg}"
+        );
+        assert!(
+            msg.contains("ferro prepare"),
+            "message points to the remedy: {msg}"
+        );
     }
 
     #[test]

--- a/src/prepare/manifest.rs
+++ b/src/prepare/manifest.rs
@@ -14,6 +14,15 @@ use std::path::{Component, Path, PathBuf};
 /// `manifest_schema_version` exceeds this value is rejected (see
 /// [`check_schema_version`]); an absent value means the reference predates schema
 /// versioning and is accepted (its structure is still validated on load).
+///
+/// Invariant: `ReferenceManifest` uses `#[serde(deny_unknown_fields)]`, so any
+/// *new* manifest field is an unknown field to older binaries. Every field
+/// addition MUST bump this constant, so an older binary reading a newer
+/// reference reports the actionable "prepared by a newer ferro — upgrade"
+/// version message (the version gate runs before the strict deserialize) rather
+/// than an opaque serde "unknown field" error. A future `MIN_SUPPORTED` floor
+/// (currently unneeded — there is no older incompatible schema yet) would refuse
+/// references older than this build can safely read.
 pub const CURRENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
 
 /// Manifest of prepared reference data.
@@ -195,18 +204,34 @@ impl ReferenceManifest {
         let manifest_path = reference_dir.join("manifest.json");
 
         let mut manifest = if manifest_path.exists() {
-            let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
+            let bytes = std::fs::read(&manifest_path).map_err(|e| FerroError::Io {
                 msg: format!("Failed to open manifest: {}", e),
             })?;
-
-            serde_json::from_reader(file).map_err(|e| FerroError::Io {
+            // Parse untyped first so the load gate can check the schema VERSION
+            // before the strict typed deserialize. A newer reference then reports
+            // the actionable "upgrade ferro" message instead of an opaque serde
+            // "unknown field" error (which `deny_unknown_fields` would raise first
+            // if we deserialized straight into the struct). This mirrors the
+            // runtime provider path (`MultiFastaProvider::from_manifest`), which
+            // also validates the value before reading it.
+            let value: serde_json::Value =
+                serde_json::from_slice(&bytes).map_err(|e| FerroError::Io {
+                    msg: format!("Failed to parse manifest: {}", e),
+                })?;
+            validate_loaded_manifest(&value)?;
+            // Do the authoritative typed deserialize from the ORIGINAL BYTES, not
+            // from `value`: a `serde_json::Value` round-trip silently collapses
+            // duplicate JSON keys (last-wins), so `from_value` would lose serde's
+            // duplicate-field rejection. Reading the bytes keeps a duplicate-key
+            // manifest a hard error, consistent with this feature's "fail loud on
+            // a misread reference" intent (#1001).
+            serde_json::from_slice(&bytes).map_err(|e| FerroError::Io {
                 msg: format!("Failed to parse manifest: {}", e),
             })?
         } else {
             Self::default()
         };
 
-        check_schema_version(manifest.manifest_schema_version)?;
         manifest.reference_dir = reference_dir.to_path_buf();
         manifest.make_paths_absolute();
         Ok(manifest)
@@ -1140,5 +1165,58 @@ mod tests {
         v["transcript_fastas"] = serde_json::json!("not-an-array");
         let err = validate_loaded_manifest(&v).expect_err("a wrong-typed field must be rejected");
         assert!(format!("{err}").contains("does not match the expected schema"));
+    }
+
+    #[test]
+    fn load_or_default_reports_version_message_for_newer_schema_with_new_field() {
+        // A reference prepared by a *newer* ferro carries both a higher schema
+        // version and fields this build doesn't model. The version gate must win,
+        // so the user sees an actionable "upgrade ferro" message rather than an
+        // opaque serde "unknown field" error.
+        let dir = tempfile::tempdir().unwrap();
+        let mut v = minimal_manifest_json();
+        let obj = v.as_object_mut().unwrap();
+        obj.insert(
+            "manifest_schema_version".to_string(),
+            serde_json::json!(CURRENT_MANIFEST_SCHEMA_VERSION as u64 + 1),
+        );
+        obj.insert("a_future_field".to_string(), serde_json::json!("x"));
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            serde_json::to_string_pretty(&v).unwrap(),
+        )
+        .unwrap();
+
+        let err = ReferenceManifest::load_or_default(dir.path())
+            .expect_err("a newer-schema manifest must be refused");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("newer than this build"),
+            "version gate must win over the unknown-field error: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_or_default_rejects_duplicate_json_keys() {
+        // A literal duplicate JSON key is a malformed manifest. `load_or_default`
+        // runs its authoritative typed deserialize over the ORIGINAL BYTES, so
+        // serde's duplicate-field rejection fires. (A `serde_json::Value`
+        // round-trip would instead silently collapse the duplicate, last-wins —
+        // the regression this guards against.) Fail loud on a misread reference
+        // (#1001).
+        let dir = tempfile::tempdir().unwrap();
+        // Minimal schema-valid manifest, but with `transcript_count` given twice.
+        let raw = format!(
+            r#"{{"prepared_at":"2024-01-01T00:00:00Z","transcript_fastas":[],"genome_fasta":null,"cdot_json":null,"transcript_count":0,"transcript_count":1,"available_prefixes":[],"manifest_schema_version":{}}}"#,
+            CURRENT_MANIFEST_SCHEMA_VERSION
+        );
+        std::fs::write(dir.path().join("manifest.json"), raw).unwrap();
+
+        let err = ReferenceManifest::load_or_default(dir.path())
+            .expect_err("a manifest with a duplicate JSON key must be rejected");
+        assert!(
+            format!("{err}").contains("Failed to parse manifest"),
+            "a duplicate key must surface as a parse error: {err}"
+        );
     }
 }

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -3259,6 +3259,28 @@ mod tests {
         assert!(format!("{err}").contains("does not match the expected schema"));
     }
 
+    /// A typo'd OPTIONAL key (`cdot_jsonn` instead of `cdot_json`) previously
+    /// deserialized as `None` and the run proceeded without cdot; with
+    /// `deny_unknown_fields` the runtime provider load path now fails loud
+    /// (#1001). This is an end-to-end lock on `from_manifest` itself, not just
+    /// the lower-level `validate_loaded_manifest` it calls.
+    #[test]
+    fn from_manifest_rejects_typoed_optional_key() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("manifest.json"),
+            format!(
+                r#"{{"prepared_at":"","transcript_fastas":[],"genome_fasta":null,"cdot_jsonn":"typo.json","transcript_count":0,"available_prefixes":[],"manifest_schema_version":{}}}"#,
+                crate::prepare::manifest::CURRENT_MANIFEST_SCHEMA_VERSION
+            ),
+        )
+        .unwrap();
+        let Err(err) = MultiFastaProvider::from_manifest(dir.path().join("manifest.json")) else {
+            panic!("a manifest with a typo'd optional key must fail to load");
+        };
+        assert!(format!("{err}").contains("does not match the expected schema"));
+    }
+
     // ----------------------------------------------------------------------
     // LRG placement parsing (#480)
     // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the one remaining "silent misread" hole in the reference-manifest loader (issue #1001; the core schema/version gate already landed in #1003). Previously, an *optional* manifest key that was renamed, removed, or typo'd deserialized as `None` — serde treats `Option<T>` fields as implicitly absent — so the loader proceeded on missing data and could produce wrong output across an entire run. #1003 already fails loud on *required* fields; this closes the optional-field case.

## What changed

- **`#[serde(deny_unknown_fields)]` on `ReferenceManifest`** — an unknown/typo'd key is now a hard, actionable load error instead of a silent `None`. This is a read-side change only: `save()` serializes the struct directly, so the on-disk format is unchanged and `CURRENT_MANIFEST_SCHEMA_VERSION` is deliberately **not** bumped.
- **`load_or_default` now runs the schema-version gate before the strict typed deserialize** (routing through `validate_loaded_manifest`, mirroring the runtime provider path). Because unknown fields are now rejected, a reference prepared by a *newer* ferro carries fields this build does not model; checking the version first means it reports the actionable "newer than this build — upgrade ferro" message rather than an opaque serde "unknown field" error.
- **Documents the resulting forward-compat invariant:** every future manifest field addition must bump `CURRENT_MANIFEST_SCHEMA_VERSION`, so an older binary reading a newer reference reports the version message rather than the opaque one.

## Backward compatibility

Older/sparser manifests still load: optional fields carry `#[serde(default)]` (or are bare `Option`, which serde fills with `None` when absent), and `deny_unknown_fields` rejects only *extra* keys, never *missing* ones. Real prepared manifests carry no unknown keys, since `save()` writes only struct fields.

## Testing

- Unit: an unknown field is rejected at validate time; a clean manifest and a pre-versioning manifest still load; the version gate wins over the unknown-field error for a newer-schema-plus-new-field manifest.
- End-to-end: the runtime provider (`MultiFastaProvider::from_manifest`) rejects a typo'd optional key.
- Full suite green (lib + integration), `cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean.

## Scope

This is one increment of the layered hardening in #1001; deferred to follow-ups: promoting the content fingerprint to a load-time check, recording provenance (`prepared_by` / cdot data version) + a `MIN_SUPPORTED` floor, a CI test that enforces the field-addition → schema-bump invariant, and surfacing content-identity in `ferro check`.

Part of #1001.
