### PR TITLE
feat: opt-in protein p. render style (Ter vs * / 3- vs 1-letter)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -1850,7 +1850,33 @@ class VariantProjection:
 
     @property
     def p_name(self) -> str | None:
-        """The p. variant as an HGVS string, or None for intronic/UTR/non-coding variants."""
+        """The p. variant as an HGVS string, or None for intronic/UTR/non-coding variants.
+
+        Rendered in the projector's configured style (#1050; default `Ter` /
+        three-letter). Note that one-letter mode always spells the stop codon as
+        `*` (there is no one-letter `Ter`), overriding `protein_stop="ter"`.
+        """
+        ...
+
+    def p_name_styled(
+        self,
+        protein_stop: str | None = None,
+        amino_acid_code: str | None = None,
+    ) -> str | None:
+        """The p. variant rendered with an explicit style (#1050).
+
+        Overrides the projector's configured default per call. ``None`` for
+        either argument keeps the projector's stored value for that axis, so a
+        single axis can be overridden. Returns ``None`` in exactly the cases
+        ``p_name`` does.
+
+        Args:
+            protein_stop: "ter" or "star", or None to keep the projector default.
+            amino_acid_code: "three" or "one", or None to keep the default.
+
+        Raises:
+            ValueError: If a supplied value is not recognized.
+        """
         ...
 
     @property
@@ -1913,6 +1939,8 @@ class VariantProjector:
         reference_json: str | None = None,
         direction: str = "3prime",
         assembly: str | None = None,
+        protein_stop: str = "ter",
+        amino_acid_code: str = "three",
     ) -> None:
         """Create a variant projector.
 
@@ -1925,10 +1953,14 @@ class VariantProjector:
                 aliases "hg19"/"hg38") for build-agnostic inputs. A bare NG_/LRG_
                 input carries no build; this fills one in. An input whose
                 accession already encodes a build (NC_*.10/.11) keeps it.
+            protein_stop: Stop-codon spelling for rendered p. names — "ter"
+                (default) or "star" (`*`).
+            amino_acid_code: Amino-acid code width for rendered p. names —
+                "three" (default) or "one".
 
         Raises:
-            ValueError: If ``direction`` is not one of
-                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+            ValueError: If ``direction``, ``assembly``, ``protein_stop``, or
+                ``amino_acid_code`` is not a recognized value.
         """
         ...
 
@@ -1937,6 +1969,8 @@ class VariantProjector:
         manifest_path: str,
         direction: str = "3prime",
         assembly: str | None = None,
+        protein_stop: str = "ter",
+        amino_acid_code: str = "three",
     ) -> "VariantProjector":
         """Create a projector from a ferro-prepare manifest.
 
@@ -1945,13 +1979,17 @@ class VariantProjector:
             direction: Shuffle direction ("3prime" or "5prime").
             assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
                 aliases "hg19"/"hg38") for build-agnostic inputs.
+            protein_stop: Stop-codon spelling for rendered p. names — "ter"
+                (default) or "star" (`*`).
+            amino_acid_code: Amino-acid code width for rendered p. names —
+                "three" (default) or "one".
 
         Returns:
             A VariantProjector backed by MultiFastaProvider with cdot data.
 
         Raises:
-            ValueError: If ``direction`` is not one of
-                "3prime"/"5prime"/"3"/"5"/"3'"/"5'" (case-insensitive).
+            ValueError: If ``direction``, ``assembly``, ``protein_stop``, or
+                ``amino_acid_code`` is not a recognized value.
             RuntimeError: If the manifest cannot be loaded.
         """
         ...

--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -1025,14 +1025,23 @@ impl AminoAcidSeq {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    /// Render the residues under `style`.
+    pub fn fmt_styled(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: crate::hgvs::location::ProteinRenderStyle,
+    ) -> fmt::Result {
+        for aa in &self.0 {
+            aa.fmt_styled(f, style)?;
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for AminoAcidSeq {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for aa in &self.0 {
-            write!(f, "{}", aa)?;
-        }
-        Ok(())
+        self.fmt_styled(f, crate::hgvs::location::ProteinRenderStyle::default())
     }
 }
 
@@ -1069,18 +1078,28 @@ impl ProteinInsSeq {
             ProteinInsSeq::Repeat { .. } => false,
         }
     }
+
+    /// Render the inserted sequence under `style`. The `Stop` length form's
+    /// terminator follows [`ProteinRenderStyle::ter_token`].
+    pub fn fmt_styled(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: crate::hgvs::location::ProteinRenderStyle,
+    ) -> fmt::Result {
+        match self {
+            ProteinInsSeq::Literal(seq) => seq.fmt_styled(f, style),
+            ProteinInsSeq::Repeat { aa, count } => {
+                aa.fmt_styled(f, style)?;
+                write!(f, "{}", count)
+            }
+            ProteinInsSeq::Stop { position } => write!(f, "{}{}", style.ter_token(), position),
+        }
+    }
 }
 
 impl fmt::Display for ProteinInsSeq {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProteinInsSeq::Literal(seq) => write!(f, "{}", seq),
-            // `RepeatCount` Display already emits the `[n]` brackets.
-            ProteinInsSeq::Repeat { aa, count } => write!(f, "{}{}", aa, count),
-            // Canonicalize the stop to three-letter `Ter`, matching
-            // frameshift/extension Display (`*` is accepted on input).
-            ProteinInsSeq::Stop { position } => write!(f, "Ter{}", position),
-        }
+        self.fmt_styled(f, crate::hgvs::location::ProteinRenderStyle::default())
     }
 }
 
@@ -1303,17 +1322,19 @@ impl ProteinEdit {
             }
         )
     }
-}
 
-impl fmt::Display for ProteinEdit {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /// Render this edit under `style` (see [`ProteinRenderStyle`]). The default
+    /// style reproduces [`Display`](Self) byte-for-byte.
+    pub fn fmt_styled(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: crate::hgvs::location::ProteinRenderStyle,
+    ) -> fmt::Result {
         match self {
             ProteinEdit::Substitution {
                 reference: _,
                 alternative,
-            } => {
-                write!(f, "{}", alternative)
-            }
+            } => alternative.fmt_styled(f, style),
             ProteinEdit::SubstitutionAlternatives { alternatives } => {
                 // Bare alternative residues joined by `^`; the reference +
                 // position are rendered by the location.
@@ -1321,34 +1342,40 @@ impl fmt::Display for ProteinEdit {
                     if i > 0 {
                         write!(f, "^")?;
                     }
-                    write!(f, "{}", aa)?;
+                    aa.fmt_styled(f, style)?;
                 }
                 Ok(())
             }
             ProteinEdit::Deletion { sequence, count } => {
                 write!(f, "del")?;
                 if let Some(seq) = sequence {
-                    write!(f, "{}", seq)?;
+                    seq.fmt_styled(f, style)?;
                 } else if let Some(n) = count {
                     write!(f, "{}", n)?;
                 }
                 Ok(())
             }
-            ProteinEdit::Insertion { sequence } => write!(f, "ins{}", sequence),
-            ProteinEdit::Delins { sequence } => write!(f, "delins{}", sequence),
+            ProteinEdit::Insertion { sequence } => {
+                write!(f, "ins")?;
+                sequence.fmt_styled(f, style)
+            }
+            ProteinEdit::Delins { sequence } => {
+                write!(f, "delins")?;
+                sequence.fmt_styled(f, style)
+            }
             ProteinEdit::Duplication => write!(f, "dup"),
             ProteinEdit::Frameshift { new_aa, ter } => {
                 if let Some(aa) = new_aa {
-                    write!(f, "{}", aa)?;
+                    aa.fmt_styled(f, style)?;
                 }
                 write!(f, "fs")?;
-                // Three-letter `Ter` is the spec-preferred form for the
-                // termination codon (`*` is an accepted input alternative);
-                // Display canonicalizes both to `Ter`.
+                // The termination token follows `style` (three-letter `Ter`
+                // by default, `*` under `TerStyle::Star`); `*` is also an
+                // accepted input alternative regardless of style.
                 match ter {
                     FrameshiftTer::Unspecified => {}
-                    FrameshiftTer::Unknown => write!(f, "Ter?")?,
-                    FrameshiftTer::At(pos) => write!(f, "Ter{}", pos)?,
+                    FrameshiftTer::Unknown => write!(f, "{}?", style.ter_token())?,
+                    FrameshiftTer::At(pos) => write!(f, "{}{}", style.ter_token(), pos)?,
                 }
                 Ok(())
             }
@@ -1360,13 +1387,13 @@ impl fmt::Display for ProteinEdit {
                     if i > 0 {
                         write!(f, "^")?;
                     }
-                    write!(f, "{}", aa)?;
+                    aa.fmt_styled(f, style)?;
                 }
                 write!(f, ")fs")?;
                 match ter {
                     FrameshiftTer::Unspecified => {}
-                    FrameshiftTer::Unknown => write!(f, "Ter?")?,
-                    FrameshiftTer::At(pos) => write!(f, "Ter{}", pos)?,
+                    FrameshiftTer::Unknown => write!(f, "{}?", style.ter_token())?,
+                    FrameshiftTer::At(pos) => write!(f, "{}{}", style.ter_token(), pos)?,
                 }
                 Ok(())
             }
@@ -1376,19 +1403,16 @@ impl fmt::Display for ProteinEdit {
                 count,
             } => {
                 if let Some(aa) = new_aa {
-                    write!(f, "{}", aa)?;
+                    aa.fmt_styled(f, style)?;
                 }
                 write!(f, "ext")?;
-                // Three-letter `Ter` is the spec-preferred canonical form
-                // for the translation termination codon
-                // (`background/standards.md`); `*` is an accepted
-                // alternative on input. Display emits `Ter` for both
-                // C-terminal extensions and frameshifts so the
-                // canonical Display form is uniform across edit kinds.
+                // The termination token follows `style` for C-terminal
+                // extensions, matching frameshift Display so the canonical
+                // form is uniform across edit kinds.
                 match (direction, count) {
                     (ExtDirection::NTerminal, Some(n)) => write!(f, "{}", n)?,
-                    (ExtDirection::CTerminal, Some(n)) => write!(f, "Ter{}", n)?,
-                    (ExtDirection::CTerminal, None) => write!(f, "Ter?")?,
+                    (ExtDirection::CTerminal, Some(n)) => write!(f, "{}{}", style.ter_token(), n)?,
+                    (ExtDirection::CTerminal, None) => write!(f, "{}?", style.ter_token())?,
                     (ExtDirection::NTerminal, None) => {} // No suffix for unknown N-terminal
                 }
                 Ok(())
@@ -1408,15 +1432,37 @@ impl fmt::Display for ProteinEdit {
             ProteinEdit::NoProtein { predicted: false } => write!(f, "0"),
             ProteinEdit::NoProtein { predicted: true } => write!(f, "0?"),
             ProteinEdit::Repeat { sequence, count } => {
-                write!(f, "{}{}", sequence, count)
+                sequence.fmt_styled(f, style)?;
+                write!(f, "{}", count)
             }
             ProteinEdit::MultiRepeat { units } => {
                 for (sequence, count) in units {
-                    write!(f, "{}{}", sequence, count)?;
+                    sequence.fmt_styled(f, style)?;
+                    write!(f, "{}", count)?;
                 }
                 Ok(())
             }
         }
+    }
+}
+
+impl fmt::Display for ProteinEdit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_styled(f, crate::hgvs::location::ProteinRenderStyle::default())
+    }
+}
+
+/// A `&ProteinEdit` paired with a style so it can be wrapped in the generic
+/// `Mu<T>` `Display` (uncertainty parens / `?`) without duplicating that logic.
+#[allow(dead_code)] // consumed by Task 4's ProteinVariant styled rendering
+pub(crate) struct StyledProteinEdit<'a>(
+    pub &'a ProteinEdit,
+    pub crate::hgvs::location::ProteinRenderStyle,
+);
+
+impl fmt::Display for StyledProteinEdit<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt_styled(f, self.1)
     }
 }
 
@@ -2178,5 +2224,128 @@ mod tests {
             sequence: AminoAcidSeq(vec![AminoAcid::Val]),
         };
         assert_eq!(format!("{}", edit), "delinsVal");
+    }
+
+    #[test]
+    fn test_protein_edit_fmt_styled_all_ter_sites() {
+        use crate::hgvs::location::{AaCode, AminoAcid, ProteinRenderStyle, TerStyle};
+
+        fn render(edit: &ProteinEdit, style: ProteinRenderStyle) -> String {
+            struct W<'a>(&'a ProteinEdit, ProteinRenderStyle);
+            impl std::fmt::Display for W<'_> {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    self.0.fmt_styled(f, self.1)
+                }
+            }
+            format!("{}", W(edit, style))
+        }
+
+        let three = ProteinRenderStyle::default();
+        let three_star = ProteinRenderStyle {
+            stop: TerStyle::Star,
+            aa_code: AaCode::Three,
+        };
+        let one = ProteinRenderStyle {
+            stop: TerStyle::Ter,
+            aa_code: AaCode::One,
+        };
+
+        // Substitution (missense): reference is not emitted by the edit
+        let sub = ProteinEdit::Substitution {
+            reference: AminoAcid::Ser,
+            alternative: AminoAcid::Thr,
+        };
+        assert_eq!(render(&sub, three), "Thr");
+        assert_eq!(render(&sub, one), "T");
+
+        // Substitution to stop
+        let stopgain = ProteinEdit::Substitution {
+            reference: AminoAcid::Ile,
+            alternative: AminoAcid::Ter,
+        };
+        assert_eq!(render(&stopgain, three), "Ter");
+        assert_eq!(render(&stopgain, three_star), "*");
+        assert_eq!(render(&stopgain, one), "*");
+
+        // Frameshift with a new residue and Ter position
+        let fs = ProteinEdit::Frameshift {
+            new_aa: Some(AminoAcid::Leu),
+            ter: FrameshiftTer::At(76),
+        };
+        assert_eq!(render(&fs, three), "LeufsTer76");
+        assert_eq!(render(&fs, three_star), "Leufs*76");
+        assert_eq!(render(&fs, one), "Lfs*76");
+
+        // Frameshift unknown termination
+        let fs_unk = ProteinEdit::Frameshift {
+            new_aa: None,
+            ter: FrameshiftTer::Unknown,
+        };
+        assert_eq!(render(&fs_unk, three), "fsTer?");
+        assert_eq!(render(&fs_unk, one), "fs*?");
+
+        // FrameshiftAlternatives
+        let fs_alt = ProteinEdit::FrameshiftAlternatives {
+            alternatives: vec![AminoAcid::Ala, AminoAcid::Ser],
+            ter: FrameshiftTer::At(23),
+        };
+        assert_eq!(render(&fs_alt, three), "(Ala^Ser)fsTer23");
+        assert_eq!(render(&fs_alt, three_star), "(Ala^Ser)fs*23");
+        assert_eq!(render(&fs_alt, one), "(A^S)fs*23");
+
+        // Extension, C-terminal
+        let ext = ProteinEdit::Extension {
+            new_aa: Some(AminoAcid::Gln),
+            direction: ExtDirection::CTerminal,
+            count: Some(17),
+        };
+        assert_eq!(render(&ext, three), "GlnextTer17");
+        assert_eq!(render(&ext, three_star), "Glnext*17");
+        assert_eq!(render(&ext, one), "Qext*17");
+
+        // Extension unknown C-terminal
+        let ext_unk = ProteinEdit::Extension {
+            new_aa: None,
+            direction: ExtDirection::CTerminal,
+            count: None,
+        };
+        assert_eq!(render(&ext_unk, three), "extTer?");
+        assert_eq!(render(&ext_unk, one), "ext*?");
+
+        // Insertion ending in a stop (ProteinInsSeq::Stop)
+        let ins_stop = ProteinEdit::Insertion {
+            sequence: ProteinInsSeq::Stop { position: 12 },
+        };
+        assert_eq!(render(&ins_stop, three), "insTer12");
+        assert_eq!(render(&ins_stop, three_star), "ins*12");
+        assert_eq!(render(&ins_stop, one), "ins*12");
+
+        // Delins containing a Ter residue in the sequence
+        let delins = ProteinEdit::Delins {
+            sequence: AminoAcidSeq(vec![AminoAcid::Gly, AminoAcid::Ter]),
+        };
+        assert_eq!(render(&delins, three), "delinsGlyTer");
+        assert_eq!(render(&delins, one), "delinsG*");
+
+        // SubstitutionAlternatives containing a Ter alternative
+        let sub_alt = ProteinEdit::SubstitutionAlternatives {
+            alternatives: vec![AminoAcid::Ala, AminoAcid::Ter],
+        };
+        assert_eq!(render(&sub_alt, three), "Ala^Ter");
+        assert_eq!(render(&sub_alt, three_star), "Ala^*");
+        assert_eq!(render(&sub_alt, one), "A^*");
+
+        // Insertion of a literal sequence containing a Ter residue
+        let ins_lit = ProteinEdit::Insertion {
+            sequence: ProteinInsSeq::Literal(AminoAcidSeq(vec![AminoAcid::Gly, AminoAcid::Ter])),
+        };
+        assert_eq!(render(&ins_lit, three), "insGlyTer");
+        assert_eq!(render(&ins_lit, one), "insG*");
+
+        // Default equals plain Display for a representative edit
+        assert_eq!(
+            render(&fs, ProteinRenderStyle::default()),
+            format!("{}", fs)
+        );
     }
 }

--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -1454,7 +1454,6 @@ impl fmt::Display for ProteinEdit {
 
 /// A `&ProteinEdit` paired with a style so it can be wrapped in the generic
 /// `Mu<T>` `Display` (uncertainty parens / `?`) without duplicating that logic.
-#[allow(dead_code)] // consumed by Task 4's ProteinVariant styled rendering
 pub(crate) struct StyledProteinEdit<'a>(
     pub &'a ProteinEdit,
     pub crate::hgvs::location::ProteinRenderStyle,

--- a/src/hgvs/interval.rs
+++ b/src/hgvs/interval.rs
@@ -87,6 +87,21 @@ impl<T: Clone> UncertainBoundary<T> {
     }
 }
 
+impl<T> UncertainBoundary<T> {
+    /// Map over the inner position(s) by reference, preserving the
+    /// Single/Range shape and each `Mu`'s certainty. Used to lift a
+    /// `UncertainBoundary<ProtPos>` into a styled boundary for rendering.
+    pub fn map_ref<U, F: Fn(&T) -> U>(&self, f: F) -> UncertainBoundary<U> {
+        match self {
+            Self::Single(mu) => UncertainBoundary::Single(mu.map_ref(&f)),
+            Self::Range { start, end } => UncertainBoundary::Range {
+                start: start.map_ref(&f),
+                end: end.map_ref(&f),
+            },
+        }
+    }
+}
+
 impl<T: fmt::Display> fmt::Display for UncertainBoundary<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -288,5 +303,43 @@ mod tests {
             Mu::Uncertain(GenomePos::new(200)),
         );
         assert_eq!(format!("{}", interval), "(100)_(200)");
+    }
+}
+
+#[cfg(test)]
+mod map_tests {
+    use super::*;
+
+    #[test]
+    fn test_uncertain_boundary_map_ref() {
+        let single = UncertainBoundary::certain(5u32);
+        assert_eq!(single.map_ref(|n| n * 2), UncertainBoundary::certain(10u32));
+
+        let range = UncertainBoundary::range(Mu::Certain(1u32), Mu::Unknown);
+        match range.map_ref(|n| n + 100) {
+            UncertainBoundary::Range { start, end } => {
+                assert_eq!(start, Mu::Certain(101));
+                assert_eq!(end, Mu::Unknown);
+            }
+            _ => panic!("expected range"),
+        }
+
+        // The `Uncertain` (parenthesized-position) variant must also survive
+        // map_ref with its inner value mapped — the case above only exercised
+        // `Certain`/`Unknown`.
+        let uncertain_range = UncertainBoundary::range(Mu::Uncertain(7u32), Mu::Certain(9u32));
+        match uncertain_range.map_ref(|n| n + 1) {
+            UncertainBoundary::Range { start, end } => {
+                assert_eq!(start, Mu::Uncertain(8));
+                assert_eq!(end, Mu::Certain(10));
+            }
+            _ => panic!("expected range"),
+        }
+
+        let single_uncertain = UncertainBoundary::Single(Mu::Uncertain(3u32));
+        assert_eq!(
+            single_uncertain.map_ref(|n| n * 10),
+            UncertainBoundary::Single(Mu::Uncertain(30)),
+        );
     }
 }

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -466,6 +466,55 @@ pub enum AminoAcid {
     Xaa, // X (unknown)
 }
 
+/// How protein (`p.`) names spell the translation stop codon and amino acids.
+///
+/// HGVS sanctions both `Ter`/`*` for the stop and three-/one-letter amino-acid
+/// codes; this selects which conformant style to emit. `Default` is the
+/// spec-preferred `Ter` + three-letter form, so default rendering is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ProteinRenderStyle {
+    /// Stop-codon spelling (only distinguishable in three-letter mode).
+    pub stop: TerStyle,
+    /// Amino-acid code width.
+    pub aa_code: AaCode,
+}
+
+/// Stop-codon spelling: `Ter` (three-letter only) or `*` (both widths).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TerStyle {
+    /// `Ter` — spec-preferred, three-letter only.
+    #[default]
+    Ter,
+    /// `*` — valid in one- and three-letter descriptions.
+    Star,
+}
+
+/// Amino-acid code width: three-letter (`Ser`) or one-letter (`S`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AaCode {
+    /// Three-letter codes (`Ser`, `Leu`, …).
+    #[default]
+    Three,
+    /// One-letter codes (`S`, `L`, …).
+    One,
+}
+
+impl ProteinRenderStyle {
+    /// The spelling for the translation stop codon under this style.
+    ///
+    /// `Ter` is a three-letter-only token per the HGVS spec ("`Ter`
+    /// (three-letter code)… `*` (three- and one-letter code)"). There is no
+    /// one-letter `Ter`, so one-letter mode always yields `*`; three-letter
+    /// mode honors the `stop` toggle.
+    pub fn ter_token(&self) -> &'static str {
+        if self.aa_code == AaCode::One || self.stop == TerStyle::Star {
+            "*"
+        } else {
+            "Ter"
+        }
+    }
+}
+
 impl AminoAcid {
     /// Parse from 3-letter code
     pub fn from_three_letter(s: &str) -> Option<Self> {
@@ -558,6 +607,16 @@ impl AminoAcid {
         }
     }
 
+    /// Render this amino acid under `style` (used by all protein `p.`
+    /// rendering). The stop codon follows [`ProteinRenderStyle::ter_token`].
+    pub fn fmt_styled(&self, f: &mut fmt::Formatter<'_>, style: ProteinRenderStyle) -> fmt::Result {
+        match self {
+            Self::Ter => write!(f, "{}", style.ter_token()),
+            _ if style.aa_code == AaCode::One => write!(f, "{}", self.to_one_letter()),
+            _ => write!(f, "{}", self.to_three_letter()),
+        }
+    }
+
     /// Parse from 1-letter code (uppercase only)
     ///
     /// HGVS notation uses uppercase for 1-letter amino acid codes.
@@ -606,7 +665,7 @@ impl AminoAcid {
 
 impl fmt::Display for AminoAcid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_three_letter())
+        self.fmt_styled(f, ProteinRenderStyle::default())
     }
 }
 
@@ -775,6 +834,80 @@ mod tests {
     fn test_prot_pos_display() {
         let pos = ProtPos::new(AminoAcid::Met, 1);
         assert_eq!(format!("{}", pos), "Met1");
+    }
+
+    #[test]
+    fn test_protein_render_style_ter_token() {
+        use ProteinRenderStyle as S;
+        assert_eq!(
+            S {
+                stop: TerStyle::Ter,
+                aa_code: AaCode::Three
+            }
+            .ter_token(),
+            "Ter"
+        );
+        assert_eq!(
+            S {
+                stop: TerStyle::Star,
+                aa_code: AaCode::Three
+            }
+            .ter_token(),
+            "*"
+        );
+        // one-letter forces `*` regardless of the stop toggle
+        assert_eq!(
+            S {
+                stop: TerStyle::Ter,
+                aa_code: AaCode::One
+            }
+            .ter_token(),
+            "*"
+        );
+        assert_eq!(
+            S {
+                stop: TerStyle::Star,
+                aa_code: AaCode::One
+            }
+            .ter_token(),
+            "*"
+        );
+        assert_eq!(S::default().ter_token(), "Ter");
+    }
+
+    #[test]
+    fn test_amino_acid_fmt_styled() {
+        fn render(aa: AminoAcid, style: ProteinRenderStyle) -> String {
+            struct W(AminoAcid, ProteinRenderStyle);
+            impl std::fmt::Display for W {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    self.0.fmt_styled(f, self.1)
+                }
+            }
+            format!("{}", W(aa, style))
+        }
+        let three = ProteinRenderStyle {
+            stop: TerStyle::Ter,
+            aa_code: AaCode::Three,
+        };
+        let three_star = ProteinRenderStyle {
+            stop: TerStyle::Star,
+            aa_code: AaCode::Three,
+        };
+        let one = ProteinRenderStyle {
+            stop: TerStyle::Ter,
+            aa_code: AaCode::One,
+        };
+        assert_eq!(render(AminoAcid::Ser, three), "Ser");
+        assert_eq!(render(AminoAcid::Ser, one), "S");
+        assert_eq!(render(AminoAcid::Ter, three), "Ter");
+        assert_eq!(render(AminoAcid::Ter, three_star), "*");
+        assert_eq!(render(AminoAcid::Ter, one), "*");
+        // default equals plain Display
+        assert_eq!(
+            render(AminoAcid::Gln, ProteinRenderStyle::default()),
+            format!("{}", AminoAcid::Gln)
+        );
     }
 
     #[test]

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -682,11 +682,33 @@ impl ProtPos {
     pub fn new(aa: AminoAcid, number: u64) -> Self {
         Self { aa, number }
     }
+
+    /// Render this position under `style`, delegating the amino-acid spelling
+    /// (including a position-side stop) to [`AminoAcid::fmt_styled`].
+    pub fn fmt_styled(&self, f: &mut fmt::Formatter<'_>, style: ProteinRenderStyle) -> fmt::Result {
+        self.aa.fmt_styled(f, style)?;
+        write!(f, "{}", self.number)
+    }
 }
 
 impl fmt::Display for ProtPos {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.aa, self.number)
+        self.fmt_styled(f, ProteinRenderStyle::default())
+    }
+}
+
+/// A [`ProtPos`] paired with a render style so it can be dropped into the
+/// generic `Interval<T>` / `Mu<T>` `Display` machinery without duplicating that
+/// structural logic. `PartialEq` compares the position AND the style; within one
+/// render both interval endpoints carry the same style, so the interval's
+/// point-collapse (`start == end`) still reduces to position equality.
+#[allow(dead_code)] // consumed by a later task's Interval<ProtPos> styled rendering
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct StyledProtPos(pub ProtPos, pub ProteinRenderStyle);
+
+impl fmt::Display for StyledProtPos {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt_styled(f, self.1)
     }
 }
 
@@ -834,6 +856,32 @@ mod tests {
     fn test_prot_pos_display() {
         let pos = ProtPos::new(AminoAcid::Met, 1);
         assert_eq!(format!("{}", pos), "Met1");
+    }
+
+    #[test]
+    fn test_prot_pos_fmt_styled() {
+        let pos = ProtPos::new(AminoAcid::Ser, 4);
+        let one = ProteinRenderStyle {
+            stop: TerStyle::Ter,
+            aa_code: AaCode::One,
+        };
+        assert_eq!(
+            format!("{}", StyledProtPos(pos, ProteinRenderStyle::default())),
+            "Ser4"
+        );
+        assert_eq!(format!("{}", StyledProtPos(pos, one)), "S4");
+        // position-side stop styles via the same rule
+        let ter = ProtPos::new(AminoAcid::Ter, 110);
+        let three_star = ProteinRenderStyle {
+            stop: TerStyle::Star,
+            aa_code: AaCode::Three,
+        };
+        assert_eq!(format!("{}", StyledProtPos(ter, three_star)), "*110");
+        // default equals plain Display
+        assert_eq!(
+            format!("{}", StyledProtPos(pos, ProteinRenderStyle::default())),
+            format!("{}", pos)
+        );
     }
 
     #[test]

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -702,7 +702,6 @@ impl fmt::Display for ProtPos {
 /// structural logic. `PartialEq` compares the position AND the style; within one
 /// render both interval endpoints carry the same style, so the interval's
 /// point-collapse (`start == end`) still reduces to position equality.
-#[allow(dead_code)] // consumed by a later task's Interval<ProtPos> styled rendering
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct StyledProtPos(pub ProtPos, pub ProteinRenderStyle);
 

--- a/src/hgvs/mod.rs
+++ b/src/hgvs/mod.rs
@@ -15,7 +15,9 @@ pub mod version;
 // Re-export commonly used types
 pub use edit::{FrameshiftTer, NaEdit, ProteinEdit, RepeatUnit};
 pub use interval::{CdsInterval, GenomeInterval, ProtInterval, TxInterval};
-pub use location::{CdsPos, GenomePos, ProtPos, SpecialPosition, TxPos};
+pub use location::{
+    AaCode, CdsPos, GenomePos, ProtPos, ProteinRenderStyle, SpecialPosition, TerStyle, TxPos,
+};
 pub use uncertainty::Mu;
 pub use validation::{ParseConfig, ValidationLevel};
 pub use variant::{AllelePhase, AlleleVariant, HgvsVariant};

--- a/src/hgvs/uncertainty.rs
+++ b/src/hgvs/uncertainty.rs
@@ -72,7 +72,12 @@ impl<T> Mu<T> {
     ///
     /// This is useful when you want to transform the value but don't want to
     /// consume the original Mu.
-    pub fn map_ref<U, F: FnOnce(&T) -> U>(&self, f: F) -> Mu<U> {
+    ///
+    /// The lifetime is named (rather than elided) so `U` may itself borrow
+    /// from `self` for the caller's lifetime `'a` — e.g. wrapping the inner
+    /// reference in a newtype for styled `Display` — instead of being
+    /// restricted to a higher-ranked, per-call lifetime that can't escape.
+    pub fn map_ref<'a, U, F: FnOnce(&'a T) -> U>(&'a self, f: F) -> Mu<U> {
         match self {
             Mu::Certain(v) => Mu::Certain(f(v)),
             Mu::Uncertain(v) => Mu::Uncertain(f(v)),

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1925,6 +1925,22 @@ impl HgvsVariant {
         matches!(self, HgvsVariant::UnknownAllele)
     }
 
+    /// Render this variant under a protein render `style`. Only `p.` variants
+    /// are affected; every other coordinate system renders identically to
+    /// [`Display`](Self) (the style has no meaning there).
+    ///
+    /// Styles only a single `HgvsVariant::Protein`; compound/allele forms
+    /// fall through to `to_string()` unstyled. That is acceptable — the
+    /// projector's `.protein` field is always a single
+    /// `HgvsVariant::Protein(ProteinVariant)`, never an allele, so `p_name`
+    /// styling is unaffected.
+    pub fn to_styled_string(&self, style: crate::hgvs::location::ProteinRenderStyle) -> String {
+        match self {
+            HgvsVariant::Protein(v) => v.to_styled_string(style),
+            other => other.to_string(),
+        }
+    }
+
     /// Format just the position+edit portion (without accession and coordinate prefix).
     ///
     /// For `NM_000088.3:c.459A>G`, this writes `459A>G`. Used by `AlleleVariant::Display`
@@ -2312,25 +2328,88 @@ pub struct ProteinVariant {
 }
 
 impl ProteinVariant {
-    /// Format just the position+edit portion (without `accession:p.` prefix).
-    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // For whole-protein identity (p.= or p.(=)), no-protein (p.0), or whole-protein unknown (p.?), skip the position
+    /// Render the full `p.` HGVS string under `style`. The default style
+    /// reproduces [`Display`](Self) byte-for-byte.
+    pub fn to_styled_string(&self, style: crate::hgvs::location::ProteinRenderStyle) -> String {
+        struct StyledProtein<'a>(
+            &'a ProteinVariant,
+            crate::hgvs::location::ProteinRenderStyle,
+        );
+        impl fmt::Display for StyledProtein<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt_styled(f, self.1)
+            }
+        }
+        format!("{}", StyledProtein(self, style))
+    }
+
+    /// Styled twin of [`Display`](Self): `accession:p.` prefix + styled loc/edit.
+    fn fmt_styled(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: crate::hgvs::location::ProteinRenderStyle,
+    ) -> fmt::Result {
+        write!(f, "{}:p.", self.accession)?;
+        self.fmt_loc_edit_styled(f, style)
+    }
+
+    /// The single implementation of the position+edit rendering (whole-protein
+    /// short-circuit, predicted parens, default), parameterized by style.
+    /// [`fmt_loc_edit`](Self::fmt_loc_edit) delegates here with the default
+    /// style. The location reuses the generic `Interval`/`Mu` `Display` via the
+    /// `StyledProtPos`/`StyledProteinEdit` newtypes, so no structural logic is
+    /// duplicated.
+    fn fmt_loc_edit_styled(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: crate::hgvs::location::ProteinRenderStyle,
+    ) -> fmt::Result {
+        use crate::hgvs::edit::StyledProteinEdit;
+        use crate::hgvs::interval::Interval;
+        use crate::hgvs::location::StyledProtPos;
+
+        // A styled copy of the location interval that reuses Interval's Display.
+        let styled_location = |loc: &crate::hgvs::interval::ProtInterval| Interval {
+            start: loc.start.map_ref(|p| StyledProtPos(*p, style)),
+            end: loc.end.map_ref(|p| StyledProtPos(*p, style)),
+        };
+        // A styled copy of the edit that reuses Mu's Display (parens / `?`).
+        let styled_edit = self.loc_edit.edit.map_ref(|e| StyledProteinEdit(e, style));
+
+        // Whole-protein identity / no-protein / whole-protein unknown: edit only.
         if let Some(edit) = self.loc_edit.edit.inner() {
             if edit.is_whole_protein_identity()
                 || edit.is_no_protein()
                 || edit.is_whole_protein_unknown()
             {
-                return write!(f, "{}", self.loc_edit.edit);
+                return write!(f, "{}", styled_edit);
             }
         }
-        // For predicted protein changes (uncertain edit), wrap position+edit in parentheses
-        // e.g., p.(Arg248Gln) instead of p.Arg248(Gln)
+        // Predicted (uncertain edit): wrap position+edit in parens.
         if self.loc_edit.edit.is_uncertain() {
             if let Some(edit) = self.loc_edit.edit.inner() {
-                return write!(f, "({}{})", self.loc_edit.location, edit);
+                return write!(
+                    f,
+                    "({}{})",
+                    styled_location(&self.loc_edit.location),
+                    StyledProteinEdit(edit, style)
+                );
             }
         }
-        write!(f, "{}", self.loc_edit)
+        write!(
+            f,
+            "{}{}",
+            styled_location(&self.loc_edit.location),
+            styled_edit
+        )
+    }
+
+    /// Format just the position+edit portion (without `accession:p.` prefix).
+    /// Delegates to [`fmt_loc_edit_styled`](Self::fmt_loc_edit_styled) with the
+    /// default style, so the default (and the compound/allele path that calls
+    /// this) renders exactly as before.
+    fn fmt_loc_edit(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_loc_edit_styled(f, crate::hgvs::location::ProteinRenderStyle::default())
     }
 }
 
@@ -2345,8 +2424,7 @@ impl fmt::Display for ProteinVariant {
         // parser (which is permissive about the legacy `NP_*(GENE):p.`
         // form) can round-trip the value; it is just not emitted here. See
         // #310.
-        write!(f, "{}:p.", self.accession)?;
-        self.fmt_loc_edit(f)
+        self.fmt_styled(f, crate::hgvs::location::ProteinRenderStyle::default())
     }
 }
 
@@ -3910,5 +3988,98 @@ mod tests {
             AlleleVariant::detect_self_cancelling_pair(&[del, dup]).is_none(),
             "g. and m. variants with matching numeric ranges must NOT collide"
         );
+    }
+
+    #[test]
+    fn test_protein_variant_to_styled_string() {
+        use crate::hgvs::location::{AaCode, ProteinRenderStyle, TerStyle};
+        use crate::parse_hgvs;
+
+        let three_star = ProteinRenderStyle {
+            stop: TerStyle::Star,
+            aa_code: AaCode::Three,
+        };
+        let one = ProteinRenderStyle {
+            stop: TerStyle::Ter,
+            aa_code: AaCode::One,
+        };
+
+        let cases = [
+            // (input, three_star expected, one expected)
+            (
+                "NP_000079.2:p.(Ser4Thr)",
+                "NP_000079.2:p.(Ser4Thr)",
+                "NP_000079.2:p.(S4T)",
+            ),
+            (
+                "NP_000079.2:p.(Ile50Ter)",
+                "NP_000079.2:p.(Ile50*)",
+                "NP_000079.2:p.(I50*)",
+            ),
+            (
+                "NP_000079.2:p.(Ser4LeufsTer76)",
+                "NP_000079.2:p.(Ser4Leufs*76)",
+                "NP_000079.2:p.(S4Lfs*76)",
+            ),
+            (
+                "NP_000079.2:p.Met1ext-5",
+                "NP_000079.2:p.Met1ext-5",
+                "NP_000079.2:p.M1ext-5",
+            ),
+        ];
+        for (input, want_star, want_one) in cases {
+            let v = parse_hgvs(input).expect("parse");
+            assert_eq!(v.to_styled_string(three_star), want_star, "star: {input}");
+            assert_eq!(v.to_styled_string(one), want_one, "one: {input}");
+            // default equals Display
+            assert_eq!(
+                v.to_styled_string(ProteinRenderStyle::default()),
+                v.to_string(),
+                "default: {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_hgvs_variant_to_styled_string_non_protein_passthrough() {
+        use crate::hgvs::location::{AaCode, ProteinRenderStyle, TerStyle};
+        use crate::parse_hgvs;
+        // Non-protein variants ignore the style and equal Display.
+        let one = ProteinRenderStyle {
+            stop: TerStyle::Star,
+            aa_code: AaCode::One,
+        };
+        let v = parse_hgvs("NM_000088.3:c.459A>G").expect("parse");
+        assert_eq!(v.to_styled_string(one), v.to_string());
+    }
+
+    #[test]
+    fn test_styled_default_equals_display_corpus() {
+        use crate::hgvs::location::ProteinRenderStyle;
+        use crate::parse_hgvs;
+        let corpus = [
+            "NP_000079.2:p.(Ser4Thr)",
+            "NP_000079.2:p.Ile50Ter",
+            "NP_000079.2:p.Ser4LeufsTer76",
+            "NP_000079.2:p.Gly719(Ala^Ser)fsTer23",
+            "NP_000079.2:p.Ter110GlnextTer17",
+            "NP_000079.2:p.Met1ext-5",
+            "NP_000079.2:p.Lys23_Leu24insTer12",
+            // Same interval-deletion shape as the spec's delQRGEPG example, but
+            // parser-accepted (the explicit deleted-sequence form is rejected).
+            "NP_000079.2:p.Gln367_Gly372del",
+            "NP_000079.2:p.=",
+            "NP_000079.2:p.0",
+            "NP_000079.2:p.(=)",
+            "NP_000079.2:p.?",
+        ];
+        for input in corpus {
+            let v = parse_hgvs(input).expect("parse");
+            assert_eq!(
+                v.to_styled_string(ProteinRenderStyle::default()),
+                v.to_string(),
+                "default style must equal Display for {input}"
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub mod vcf;
 
 // Re-export commonly used types
 pub use error::FerroError;
+pub use hgvs::location::{AaCode, ProteinRenderStyle, TerStyle};
 pub use hgvs::parser::{parse_hgvs, parse_hgvs_fast};
 pub use hgvs::variant::HgvsVariant;
 pub use normalize::{NormalizeConfig, Normalizer, ShuffleDirection};

--- a/src/python.rs
+++ b/src/python.rs
@@ -111,10 +111,14 @@ fn ferro_typed(class: &str, message: String, err: &crate::error::FerroError) -> 
 /// `PyVariantProjection` newtypes. Shared by both batch entry points.
 fn wrap_projections(
     projections: Vec<crate::project::VariantProjection>,
+    render_style: crate::hgvs::location::ProteinRenderStyle,
 ) -> Vec<PyVariantProjection> {
     projections
         .into_iter()
-        .map(|inner| PyVariantProjection { inner })
+        .map(|inner| PyVariantProjection {
+            inner,
+            render_style,
+        })
         .collect()
 }
 
@@ -169,6 +173,39 @@ fn parse_direction_or_raise(direction: &str) -> PyResult<ShuffleDirection> {
             "unrecognized direction {direction:?}; expected one of \"3prime\", \"5prime\", \
              \"3\", \"5\", \"3'\", \"5'\" (case-insensitive)"
         ))
+    })
+}
+
+/// Validate the `protein_stop` argument at the Python boundary → `TerStyle`.
+fn parse_protein_stop_or_raise(value: &str) -> PyResult<crate::hgvs::location::TerStyle> {
+    match value {
+        "ter" => Ok(crate::hgvs::location::TerStyle::Ter),
+        "star" => Ok(crate::hgvs::location::TerStyle::Star),
+        other => Err(PyValueError::new_err(format!(
+            "unrecognized protein_stop {other:?}; expected \"ter\" or \"star\""
+        ))),
+    }
+}
+
+/// Validate the `amino_acid_code` argument at the Python boundary → `AaCode`.
+fn parse_amino_acid_code_or_raise(value: &str) -> PyResult<crate::hgvs::location::AaCode> {
+    match value {
+        "three" => Ok(crate::hgvs::location::AaCode::Three),
+        "one" => Ok(crate::hgvs::location::AaCode::One),
+        other => Err(PyValueError::new_err(format!(
+            "unrecognized amino_acid_code {other:?}; expected \"three\" or \"one\""
+        ))),
+    }
+}
+
+/// Build a `ProteinRenderStyle` from the two Python string args, validating both.
+fn parse_render_style_or_raise(
+    protein_stop: &str,
+    amino_acid_code: &str,
+) -> PyResult<crate::hgvs::location::ProteinRenderStyle> {
+    Ok(crate::hgvs::location::ProteinRenderStyle {
+        stop: parse_protein_stop_or_raise(protein_stop)?,
+        aa_code: parse_amino_acid_code_or_raise(amino_acid_code)?,
     })
 }
 
@@ -1146,6 +1183,9 @@ impl PyNormalizeResultWithWarnings {
 #[pyclass(name = "VariantProjection")]
 pub struct PyVariantProjection {
     inner: crate::project::VariantProjection,
+    /// Render style copied from the producing projector (#1050); used by
+    /// `p_name` and as the fallback for `p_name_styled`.
+    render_style: crate::hgvs::location::ProteinRenderStyle,
 }
 
 #[pymethods]
@@ -1173,11 +1213,41 @@ impl PyVariantProjection {
         self.inner.noncoding.as_ref().map(|v| v.to_string())
     }
 
-    /// The p. variant as an HGVS string (None for intronic, UTR, non-coding,
-    /// or non-substitution edits).
+    /// The p. variant as an HGVS string (None for intronic, UTR, non-coding, or
+    /// non-substitution edits). Rendered in the projector's configured style
+    /// (#1050; default `Ter` / three-letter).
     #[getter]
     fn p_name(&self) -> Option<String> {
-        self.inner.protein.as_ref().map(|v| v.to_string())
+        self.inner
+            .protein
+            .as_ref()
+            .map(|v| v.to_styled_string(self.render_style))
+    }
+
+    /// The p. variant rendered with an explicit style, overriding the
+    /// projector's default per call (#1050). `None` arguments fall back to the
+    /// stored style, so callers can override just one axis. Returns `None` in
+    /// exactly the cases `p_name` does.
+    #[pyo3(signature = (protein_stop=None, amino_acid_code=None))]
+    fn p_name_styled(
+        &self,
+        protein_stop: Option<&str>,
+        amino_acid_code: Option<&str>,
+    ) -> PyResult<Option<String>> {
+        let stop = match protein_stop {
+            Some(s) => parse_protein_stop_or_raise(s)?,
+            None => self.render_style.stop,
+        };
+        let aa_code = match amino_acid_code {
+            Some(s) => parse_amino_acid_code_or_raise(s)?,
+            None => self.render_style.aa_code,
+        };
+        let style = crate::hgvs::location::ProteinRenderStyle { stop, aa_code };
+        Ok(self
+            .inner
+            .protein
+            .as_ref()
+            .map(|v| v.to_styled_string(style)))
     }
 
     /// The predicted r. variant as an HGVS string, or `None`.
@@ -1251,6 +1321,11 @@ impl PyVariantProjection {
     /// currently need them (`NormalizationWarning`). The same `Debug`-key
     /// approach is used for `ProteinEffect`, whose `AminoAcidChange` field is
     /// likewise not `Eq`.
+    ///
+    /// `render_style` is deliberately excluded from the key (#1050): it is a
+    /// rendering preference for `p_name`/`p_name_styled`, not part of the
+    /// variant's identity, so two projections that differ only in render style
+    /// compare equal and hash the same.
     fn __eq__(&self, other: &Self) -> bool {
         format!("{:?}", self.inner) == format!("{:?}", other.inner)
     }
@@ -1275,6 +1350,9 @@ pub struct PyVariantProjector {
     has_genomic_data: bool,
     /// Whether the backing reference carries protein sequence data.
     has_protein_data: bool,
+    /// Default protein render style applied to `p_name` on projections this
+    /// projector produces (#1050).
+    render_style: crate::hgvs::location::ProteinRenderStyle,
 }
 
 #[pymethods]
@@ -1290,17 +1368,25 @@ impl PyVariantProjector {
     ///         aliases "hg19"/"hg38") for build-agnostic inputs. A bare NG_/LRG_
     ///         input carries no build; this fills one in. An input whose
     ///         accession already encodes a build (NC_*.10/.11) keeps it.
+    ///     protein_stop: Stop-codon spelling for rendered p. names — "ter"
+    ///         (default) or "star" (`*`).
+    ///     amino_acid_code: Amino-acid code width for rendered p. names —
+    ///         "three" (default) or "one".
     #[new]
-    #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None))]
+    #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three"))]
     fn new(
         py: Python<'_>,
         reference_json: Option<&str>,
         direction: &str,
         assembly: Option<&str>,
+        protein_stop: &str,
+        amino_acid_code: &str,
     ) -> PyResult<Self> {
         // Validate boundary args BEFORE loading any reference (a bad path must
-        // not mask an invalid direction/assembly ValueError).
+        // not mask an invalid direction/assembly/protein_stop/amino_acid_code
+        // ValueError).
         let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
+        let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let (provider, kind) = match reference_json {
             Some(path) => (
                 PyProvider::from_json(Path::new(path))?,
@@ -1308,23 +1394,44 @@ impl PyVariantProjector {
             ),
             None => (PyProvider::test_data(), ProviderKind::TestData),
         };
-        Self::from_provider(py, provider, config, assembly_build, kind)
+        Self::from_provider(py, provider, config, assembly_build, kind, render_style)
     }
 
     /// Create a projector from a ferro-prepare manifest (preferred for
     /// production — uses MultiFastaProvider with cdot data).
+    ///
+    /// Args:
+    ///     manifest_path: Path to a ferro-prepare manifest.json.
+    ///     direction: Shuffle direction passed to the internal normalizer
+    ///         ("3prime" or "5prime").
+    ///     assembly: Optional genome-build override ("GRCh37"/"GRCh38", or the
+    ///         aliases "hg19"/"hg38") for build-agnostic inputs.
+    ///     protein_stop: Stop-codon spelling for rendered p. names — "ter"
+    ///         (default) or "star" (`*`).
+    ///     amino_acid_code: Amino-acid code width for rendered p. names —
+    ///         "three" (default) or "one".
     #[staticmethod]
-    #[pyo3(signature = (manifest_path, direction="3prime", assembly=None))]
+    #[pyo3(signature = (manifest_path, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three"))]
     fn from_manifest(
         py: Python<'_>,
         manifest_path: &str,
         direction: &str,
         assembly: Option<&str>,
+        protein_stop: &str,
+        amino_acid_code: &str,
     ) -> PyResult<Self> {
         // Validate boundary args before loading the manifest (see `new`).
         let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
+        let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
-        Self::from_provider(py, provider, config, assembly_build, ProviderKind::Manifest)
+        Self::from_provider(
+            py,
+            provider,
+            config,
+            assembly_build,
+            ProviderKind::Manifest,
+            render_style,
+        )
     }
 
     /// Return `True` if the backing reference provides genomic sequence data.
@@ -1366,7 +1473,10 @@ impl PyVariantProjector {
         let transcript = transcript.to_string();
         let result = py.detach(|| self.inner.project(&hgvs_string, &transcript));
         result
-            .map(|inner| PyVariantProjection { inner })
+            .map(|inner| PyVariantProjection {
+                inner,
+                render_style: self.render_style,
+            })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
     }
 
@@ -1392,7 +1502,10 @@ impl PyVariantProjector {
             .map(|projections| {
                 projections
                     .into_iter()
-                    .map(|inner| PyVariantProjection { inner })
+                    .map(|inner| PyVariantProjection {
+                        inner,
+                        render_style: self.render_style,
+                    })
                     .collect()
             })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
@@ -1424,7 +1537,10 @@ impl PyVariantProjector {
         let transcript = transcript.to_string();
         let result = py.detach(|| self.inner.project_variant(&inner_variant, &transcript));
         result
-            .map(|inner| PyVariantProjection { inner })
+            .map(|inner| PyVariantProjection {
+                inner,
+                render_style: self.render_style,
+            })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
     }
 
@@ -1453,7 +1569,10 @@ impl PyVariantProjector {
             .map(|projections| {
                 projections
                     .into_iter()
-                    .map(|inner| PyVariantProjection { inner })
+                    .map(|inner| PyVariantProjection {
+                        inner,
+                        render_style: self.render_style,
+                    })
                     .collect()
             })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
@@ -1487,7 +1606,10 @@ impl PyVariantProjector {
         let transcript = transcript.to_string();
         let result = py.detach(|| self.inner.project_normalized(&inner_variant, &transcript));
         result
-            .map(|inner| PyVariantProjection { inner })
+            .map(|inner| PyVariantProjection {
+                inner,
+                render_style: self.render_style,
+            })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
     }
 
@@ -1517,7 +1639,10 @@ impl PyVariantProjector {
             .map(|projections| {
                 projections
                     .into_iter()
-                    .map(|inner| PyVariantProjection { inner })
+                    .map(|inner| PyVariantProjection {
+                        inner,
+                        render_style: self.render_style,
+                    })
                     .collect()
             })
             .map_err(|e| ferro_typed("ProjectionError", format!("Projection error: {e}"), &e))
@@ -1623,7 +1748,7 @@ impl PyVariantProjector {
         let project = |(i, s): (usize, &String)| {
             self.inner
                 .project_all(s)
-                .map(wrap_projections)
+                .map(|p| wrap_projections(p, self.render_style))
                 .map_err(|e| (i, e))
         };
         if return_exceptions {
@@ -1670,7 +1795,7 @@ impl PyVariantProjector {
         let project = |(i, v): (usize, &HgvsVariant)| {
             self.inner
                 .project_normalized_all(v)
-                .map(wrap_projections)
+                .map(|p| wrap_projections(p, self.render_style))
                 .map_err(|e| (i, e))
         };
         if return_exceptions {
@@ -1717,6 +1842,7 @@ impl PyVariantProjector {
         config: NormalizeConfig,
         assembly_build: Option<&'static str>,
         kind: ProviderKind,
+        render_style: crate::hgvs::location::ProteinRenderStyle,
     ) -> PyResult<Self> {
         // Capture capability before the provider is moved into the projector.
         let has_genomic_data = provider.has_genomic_data();
@@ -1730,6 +1856,7 @@ impl PyVariantProjector {
             kind,
             has_genomic_data,
             has_protein_data,
+            render_style,
         };
         // project_to_genomic needs a genome a transcripts-only reference lacks,
         // so surface the reduced-capability signal once per process (#1012).

--- a/tests/python/test_issue_1050_protein_render_style.py
+++ b/tests/python/test_issue_1050_protein_render_style.py
@@ -1,0 +1,224 @@
+"""Tests for #1050: protein render-style bindings.
+
+Covers the constructor default (Option A: ``VariantProjector(protein_stop=...,
+amino_acid_code=...)``) and the per-call override (Option B:
+``VariantProjection.p_name_styled(protein_stop=..., amino_acid_code=...)``).
+
+The stop-codon axis (``protein_stop``: "ter" vs "star") is only
+distinguishable in three-letter mode, and only on a variant whose p. name
+actually carries a stop token — a plain missense substitution never does. So
+``G_FS_INPUT`` (a frameshift, ``NC_000001.11:g.1003del`` → p. name containing
+``...fsTer?)``/``...fs*?)``) is used everywhere the ``protein_stop`` axis needs
+to be exercised; ``G_INPUT`` (missense, ``NC_000001.11:g.1003C>A`` →
+``p.(Arg2Ser)``) is kept only as a plain default-rendering sanity check. Both
+reuse ``NM_TEST.1`` and its minimal single-exon reference JSON, taken verbatim
+from ``tests/python/test_variant_projection.py``'s ``projector`` fixture (whose
+``test_missense_substitution_plus_strand`` / ``test_deletion_frameshift_protein``
+assert the same two p. names off the same fixture).
+
+``G_UTR_INPUT`` / ``TRANSCRIPT_LONG`` (for the genuine-``None`` case) reuse
+``NM_LONG.1`` and its reference JSON from the same file's ``long_projector``
+fixture, which — unlike ``NM_TEST.1`` (no UTR: cds spans the whole transcript)
+— has a 5'UTR (tx positions 1-3, cds_start=4), so a genomic substitution there
+projects to a real UTR variant with a genuinely ``None`` p_name (verified
+empirically: ``g.2001A>G`` gives ``is_utr=True``, ``p_name=None``).
+
+The built-in test-data projector (``VariantProjector()`` with no
+``reference_json``) is *not* usable for any of this: every transcript in
+``JsonProvider::with_test_data`` (src/reference/mock.rs) carries no
+``chromosome``/``genomic_start``/``genomic_end``, so ``.project()`` against it
+always raises "Reference not found" regardless of input — there is no
+(genomic_string, transcript) pair in the built-in test data that yields any
+p_name at all.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ferro_hgvs
+
+G_INPUT = "NC_000001.11:g.1003C>A"
+G_FS_INPUT = "NC_000001.11:g.1003del"
+TRANSCRIPT = "NM_TEST.1"
+
+G_UTR_INPUT = "NC_000002.12:g.2001A>G"
+TRANSCRIPT_LONG = "NM_LONG.1"
+
+
+def _reference_json(tmp_path: Path) -> str:
+    """Write the minimal single-exon reference used by test_variant_projection.py's
+    ``projector`` fixture (NM_TEST.1, CDS "ATGCGCTAA", g.1000-1008 on chr1,
+    codon 2 "CGC"=Arg). ``g.1003C>A`` mutates it to "AGC"=Ser (missense,
+    p.(Arg2Ser), no stop token); ``g.1003del`` deletes the codon's first base,
+    shifting the frame into "GCT AA" (frameshift, p.(Arg2AlafsTer?), carries a
+    stop token). Returns the fixture's path.
+    """
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_TEST.1",
+                "gene_symbol": "TESTGENE",
+                "strand": "+",
+                "sequence": "ATGCGCTAA",
+                "cds_start": 1,
+                "cds_end": 9,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 9,
+                        "genomic_start": 1000,
+                        "genomic_end": 1008,
+                    }
+                ],
+                "chromosome": "chr1",
+                "genomic_start": 1000,
+                "genomic_end": 1008,
+            }
+        ],
+        "genomic_sequences": {
+            "chr1": "N" * 999 + "ATGCGCTAA" + "N" * 100,
+        },
+    }
+    path = tmp_path / "transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return str(path)
+
+
+def _long_reference_json(tmp_path: Path) -> str:
+    """Write the NM_LONG.1 reference used by test_variant_projection.py's
+    ``long_projector`` fixture: 3bp 5'UTR + 18bp CDS + 3bp 3'UTR on chr2,
+    g.2000-2023. Unlike NM_TEST.1 (no UTR), this carries a real 5'UTR (tx
+    positions 1-3, cds_start=4), so a genomic variant there (``g.2001A>G``)
+    projects to a genuine UTR variant with p_name == None. Returns the
+    fixture's path.
+    """
+    cds_seq = "ATGCGCAAAGGGTTTTAA"  # 18 bp
+    full_seq = "AAA" + cds_seq + "CCC"  # 24 bp
+    fixture = {
+        "transcripts": [
+            {
+                "id": "NM_LONG.1",
+                "gene_symbol": "LONGGENE",
+                "strand": "+",
+                "sequence": full_seq,
+                "cds_start": 4,
+                "cds_end": 21,
+                "exons": [
+                    {
+                        "number": 1,
+                        "start": 1,
+                        "end": 24,
+                        "genomic_start": 2000,
+                        "genomic_end": 2023,
+                    }
+                ],
+                "chromosome": "chr2",
+                "genomic_start": 2000,
+                "genomic_end": 2023,
+            }
+        ],
+        "genomic_sequences": {
+            "chr2": "N" * 1999 + full_seq + "N" * 100,
+        },
+    }
+    path = tmp_path / "long_transcripts.json"
+    path.write_text(json.dumps(fixture))
+    return str(path)
+
+
+def _proj(
+    tmp_path: Path, hgvs_string: str = G_INPUT, **kwargs: object
+) -> ferro_hgvs.VariantProjection:
+    projector = ferro_hgvs.VariantProjector(reference_json=_reference_json(tmp_path), **kwargs)
+    return projector.project(hgvs_string, TRANSCRIPT)
+
+
+def test_default_missense_unchanged(tmp_path: Path) -> None:
+    # Sanity/backward-compat: a plain missense (no stop token) default-renders
+    # exactly as it did before #1050 — matches
+    # test_variant_projection.py::test_missense_substitution_plus_strand.
+    p = _proj(tmp_path).p_name
+    assert p == "NM_TEST.1:p.(Arg2Ser)"
+
+
+def test_default_is_three_letter_ter(tmp_path: Path) -> None:
+    p = _proj(tmp_path, G_FS_INPUT).p_name
+    assert p == "NM_TEST.1:p.(Arg2AlafsTer?)"
+    assert "Ter" in p
+    assert "*" not in p
+
+
+def test_constructor_protein_stop_star_switches_stop_token(tmp_path: Path) -> None:
+    # Same frameshift variant; only the stop spelling changes (three-letter
+    # residue codes are kept) — proves the protein_stop axis actually does
+    # something, not just amino_acid_code.
+    p = _proj(tmp_path, G_FS_INPUT, protein_stop="star").p_name
+    assert p == "NM_TEST.1:p.(Arg2Alafs*?)"
+    assert "*" in p
+    assert "Ter" not in p
+    assert "Arg" in p  # residues still three-letter
+
+
+def test_constructor_option_a_one_letter_star(tmp_path: Path) -> None:
+    p = _proj(tmp_path, G_FS_INPUT, protein_stop="star", amino_acid_code="one").p_name
+    assert p == "NM_TEST.1:p.(R2Afs*?)"
+    assert "*" in p
+    assert "Ter" not in p
+    assert "Arg" not in p and "Ala" not in p  # three-letter codes gone
+
+
+def test_per_call_option_b_overrides_default(tmp_path: Path) -> None:
+    proj = _proj(tmp_path, G_FS_INPUT)  # default projector
+    default_p = proj.p_name
+    assert default_p == "NM_TEST.1:p.(Arg2AlafsTer?)"
+    styled = proj.p_name_styled(protein_stop="star", amino_acid_code="one")
+    assert styled == "NM_TEST.1:p.(R2Afs*?)"
+    assert styled != default_p
+
+
+def test_option_b_none_falls_back_to_constructor(tmp_path: Path) -> None:
+    proj = _proj(tmp_path, G_FS_INPUT, protein_stop="star", amino_acid_code="one")
+    # p_name_styled() with no args returns the constructor style
+    assert proj.p_name_styled() == proj.p_name == "NM_TEST.1:p.(R2Afs*?)"
+
+
+def test_option_b_partial_override(tmp_path: Path) -> None:
+    proj = _proj(tmp_path, G_FS_INPUT, protein_stop="star", amino_acid_code="one")
+    assert proj.p_name == "NM_TEST.1:p.(R2Afs*?)"
+    # override only aa_code back to three-letter, keep constructor's star stop
+    styled = proj.p_name_styled(amino_acid_code="three")
+    assert styled == "NM_TEST.1:p.(Arg2Alafs*?)"
+    assert "Arg" in styled  # three-letter residues restored
+    assert "*" in styled  # constructor's star stop retained
+    assert "Ter" not in styled
+
+
+@pytest.mark.parametrize("value", ["nope", "Ter", "TER", "*", "", "THREE"])
+def test_invalid_protein_stop_raises(value: str) -> None:
+    # Validated before any reference is loaded, so no reference_json is needed.
+    # Includes formerly-accepted aliases ("Ter"/"TER"/"*") that #1050 review
+    # dropped so the accepted set matches the documented "ter"|"star" contract
+    # exactly.
+    with pytest.raises(ValueError):
+        ferro_hgvs.VariantProjector(protein_stop=value)
+
+
+@pytest.mark.parametrize("value", ["nope", "3", "1", "", "ONE"])
+def test_invalid_amino_acid_code_raises(value: str) -> None:
+    # Includes formerly-accepted aliases ("3"/"1") dropped for the same reason.
+    with pytest.raises(ValueError):
+        ferro_hgvs.VariantProjector(amino_acid_code=value)
+
+
+def test_p_name_styled_none_passthrough(tmp_path: Path) -> None:
+    # A genuine None-p_name projection: NM_LONG.1 has a real 5'UTR (unlike
+    # NM_TEST.1, which has none), so a genomic substitution there projects to
+    # a UTR variant with p_name == None. p_name_styled must stay None too.
+    projector = ferro_hgvs.VariantProjector(reference_json=_long_reference_json(tmp_path))
+    proj = projector.project(G_UTR_INPUT, TRANSCRIPT_LONG)
+    assert proj.is_utr is True
+    assert proj.p_name is None
+    assert proj.p_name_styled(protein_stop="star") is None


### PR DESCRIPTION
## Summary

Adds an opt-in style for rendering protein (`p.`) HGVS names, letting callers emit `*` instead of `Ter` for the stop codon and one-letter instead of three-letter amino-acid codes. Both are HGVS-conformant; this only chooses which conformant style to emit. Defaults are unchanged (`Ter`, three-letter), so it is fully backward compatible.

Closes #1050.

## Motivation

`VariantProjection.p_name` always rendered three-letter + `Ter`. Downstream consumers that expect `*` / one-letter output (pipelines migrating off other HGVS engines, or matching an established report format) had to string-munge `p_name`, which is brittle — e.g. it must avoid touching `Ter` inside `fs`/`ext` tokens. This exposes the choice at the API instead.

## What changed

**Rust core**
- New `ProteinRenderStyle { stop: TerStyle, aa_code: AaCode }` value type (`TerStyle::{Ter,Star}`, `AaCode::{Three,One}`), re-exported at the crate root.
- Effective-stop rule: the stop codon renders as `*` whenever one-letter **or** `Star`, and `Ter` only in three-letter + `Ter` mode (there is no one-letter `Ter` per the spec).
- `fmt_styled(&self, f, style)` on every style-sensitive leaf (`AminoAcid`, `ProtPos`, `AminoAcidSeq`, `ProteinInsSeq`, `ProteinEdit`); each `Display` now delegates to `fmt_styled(default)`, so default output is byte-for-byte identical by construction and there is one source of truth per token.
- The generic `Interval<ProtPos>` structural walk is reused (not duplicated) via a `StyledProtPos` newtype + `UncertainBoundary::map_ref`.
- Public entry points `ProteinVariant::to_styled_string(style)` and `HgvsVariant::to_styled_string(style)`.

**Python**
- `VariantProjector(..., protein_stop="ter"|"star", amino_acid_code="three"|"one")` sets the projector default (Option A); `VariantProjection.p_name_styled(protein_stop=None, amino_acid_code=None)` overrides per call with `None`→stored-style fallback (Option B). Bad values raise `ValueError`, validated before any reference I/O. Style is threaded onto every projection. `.pyi` stubs updated.

## Backward compatibility

Defaults are unchanged. The default render path delegates to `fmt_styled(default)`, and a corpus property test asserts `to_styled_string(default) == to_string()` across all edit shapes. The full existing suite passes unchanged.

## Testing

- Rust: 7969 passing — styled tests for all seven `Ter` sites (`Frameshift`, `FrameshiftAlternatives`, `Extension`, `ProteinInsSeq::Stop`) plus position-side stop, `SubstitutionAlternatives`, N-terminal extension, and both style axes; backward-compat corpus test.
- Python: 403 passing — Option A, Option B, A+B precedence, partial override, `ValueError` validation, `None` passthrough (via a genuine UTR-`None` fixture and a frameshift fixture exercising `Ter`↔`*`).

## Suggested reading order

1. `e592d66` — core `ProteinRenderStyle` types + `AminoAcid::fmt_styled`
2. `4173fb4` — `ProtPos` styling + interval-reuse plumbing (`StyledProtPos`, `UncertainBoundary::map_ref`)
3. `3768d04` — styled rendering for the edit leaf types (the seven `Ter` sites)
4. `3c024d4` — `to_styled_string` entry points + backward-compat corpus proof
5. `9b9fcf7` — Python bindings (constructor default + `p_name_styled`)