### PR TITLE
fix(normalize): validate substitution reference bases and expose error_config to Python (#1052)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -481,12 +481,20 @@ class HgvsVariant:
 class Normalizer:
     """HGVS variant normalizer using a reference provider."""
 
-    def __init__(self, reference_json: str | None = None, direction: str = "3prime") -> None:
+    def __init__(
+        self,
+        reference_json: str | None = None,
+        direction: str = "3prime",
+        error_config: ErrorConfig | None = None,
+    ) -> None:
         """Create a new normalizer.
 
         Args:
             reference_json: Optional path to a transcripts.json file
             direction: Shuffle direction - "3prime" (default) or "5prime"
+            error_config: Optional ErrorConfig controlling reference-mismatch
+                handling (e.g. ``ErrorConfig.strict()`` to reject
+                wrong-reference variants). Defaults to lenient.
 
         Raises:
             ValueError: If ``direction`` is not one of
@@ -495,13 +503,20 @@ class Normalizer:
         ...
 
     @staticmethod
-    def from_manifest(manifest_path: str, direction: str = "3prime") -> Normalizer:
+    def from_manifest(
+        manifest_path: str,
+        direction: str = "3prime",
+        error_config: ErrorConfig | None = None,
+    ) -> Normalizer:
         """Create a normalizer from a reference manifest written by ``ferro prepare``.
 
         Args:
             manifest_path: Path to a manifest.json file (typically inside a
                 directory produced by ``ferro prepare``).
             direction: Shuffle direction - "3prime" (default) or "5prime".
+            error_config: Optional ErrorConfig controlling reference-mismatch
+                handling (e.g. ``ErrorConfig.strict()`` to reject
+                wrong-reference variants). Defaults to lenient.
 
         Returns:
             A Normalizer backed by a MultiFastaProvider.
@@ -1941,6 +1956,7 @@ class VariantProjector:
         assembly: str | None = None,
         protein_stop: str = "ter",
         amino_acid_code: str = "three",
+        error_config: ErrorConfig | None = None,
     ) -> None:
         """Create a variant projector.
 
@@ -1957,6 +1973,9 @@ class VariantProjector:
                 (default) or "star" (`*`).
             amino_acid_code: Amino-acid code width for rendered p. names —
                 "three" (default) or "one".
+            error_config: Optional ErrorConfig controlling reference-mismatch
+                handling (e.g. ``ErrorConfig.strict()`` to reject
+                wrong-reference variants). Defaults to lenient.
 
         Raises:
             ValueError: If ``direction``, ``assembly``, ``protein_stop``, or
@@ -1971,6 +1990,7 @@ class VariantProjector:
         assembly: str | None = None,
         protein_stop: str = "ter",
         amino_acid_code: str = "three",
+        error_config: ErrorConfig | None = None,
     ) -> "VariantProjector":
         """Create a projector from a ferro-prepare manifest.
 
@@ -1983,6 +2003,9 @@ class VariantProjector:
                 (default) or "star" (`*`).
             amino_acid_code: Amino-acid code width for rendered p. names —
                 "three" (default) or "one".
+            error_config: Optional ErrorConfig controlling reference-mismatch
+                handling (e.g. ``ErrorConfig.strict()`` to reject
+                wrong-reference variants). Defaults to lenient.
 
         Returns:
             A VariantProjector backed by MultiFastaProvider with cdot data.

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -136,6 +136,12 @@ impl NormalizeConfig {
         self
     }
 
+    /// Replace the entire error-handling configuration.
+    pub fn with_error_config(mut self, error_config: ErrorConfig) -> Self {
+        self.error_config = error_config;
+        self
+    }
+
     /// Set a specific error type override
     pub fn with_error_override(mut self, error_type: ErrorType, action: ErrorOverride) -> Self {
         self.error_config = self.error_config.with_override(error_type, action);

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -53,7 +53,8 @@ use boundary::Boundaries;
 pub use config::{NormalizeConfig, ShuffleDirection};
 use rules::{
     canonicalize_conversion_to_delins, canonicalize_edit, canonicalize_insertion_expand,
-    needs_normalization, rna_uracil_to_thymine, should_canonicalize, DelinsSubedit, InsCoordKind,
+    is_real_substitution, is_uncertain_real_substitution, needs_normalization,
+    rna_uracil_to_thymine, should_canonicalize, DelinsSubedit, InsCoordKind,
 };
 use shuffle::shuffle;
 
@@ -2073,6 +2074,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if !needs_normalization(edit) {
             return Ok((HV::Genome(variant.clone()), vec![]));
         }
+
+        // #1052: an uncertain/predicted-wrapped substitution must stay a
+        // silent pass-through — see `is_uncertain_real_substitution`'s doc
+        // comment.
+        if is_uncertain_real_substitution(edit, &variant.loc_edit.edit) {
+            return Ok((HV::Genome(variant.clone()), vec![]));
+        }
         let start_pos = match variant.loc_edit.location.start.inner() {
             Some(pos) => pos,
             None => {
@@ -2596,6 +2604,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HV::Cds(variant.clone()), vec![]));
         }
 
+        // #1052: an uncertain/predicted-wrapped substitution must stay a
+        // silent pass-through — see `is_uncertain_real_substitution`'s doc
+        // comment. Must run before the intronic dispatch below too (an
+        // uncertain intronic sub must stay silent regardless of the
+        // intronic guard there).
+        if is_uncertain_real_substitution(edit, &variant.loc_edit.edit) {
+            return Ok((HV::Cds(variant.clone()), vec![]));
+        }
+
         // #760: a UTR offset with no enclosing intron — past a transcript
         // terminus (`c.*824+10`, 3' of the final exon → `c.*834`) or on a
         // transcript whose model has no intron there at all — is not intronic.
@@ -2636,6 +2653,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
 
         // Handle intronic variants specially
         if start_pos.is_intronic() || end_pos.is_intronic() {
+            // #1052: real substitutions are validated on the plain exonic path
+            // only. Intronic-sub validation would require genomic projection
+            // (an explicit non-goal); routing a sub through
+            // `normalize_intronic_cds` / `normalize_boundary_spanning_cds` would
+            // emit `ReducedCapabilityNoGenome` (no genomic data) or a hard
+            // `ConversionError` (unmappable intron) on a variant that previously
+            // passed through unchanged. Preserve that silent pass-through.
+            if is_real_substitution(edit) {
+                return Ok((HV::Cds(variant.clone()), vec![]));
+            }
             // Switch to the accession-aware lookup so an NG/NC-parented input
             // gets the build-correct chromosome. If the accession-aware lookup
             // fails, fall back to the plain transcript we already fetched.
@@ -2831,6 +2858,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
         };
         let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
+
+        // Substitutions are validated-then-returned-unchanged by
+        // `normalize_na_edit`'s `Substitution` arm; nothing downstream (axis
+        // clamps, the #670 junction-crossing shuffle continuation, canonical
+        // split, `LocEdit` reconstruction) applies to a never-shuffled edit
+        // kind, and letting a substitution fall through it anyway causes two
+        // known regressions (#1052 follow-up): spurious genome-capability
+        // rejections at exon boundaries, and silent `Mu::Uncertain` /
+        // allele-member loss in cis alleles. Return the ORIGINAL variant
+        // (not a `LocEdit::new`-reconstructed one) so uncertainty and all
+        // other input structure survive untouched. Guard on
+        // `is_real_substitution` (ref != alt) only — a `ref == alt` sub must
+        // still flow through to the identity (`=`) rewrite below.
+        if is_real_substitution(edit) {
+            return Ok((HV::Cds(variant.clone()), warnings));
+        }
 
         // #670: apply the 3' rule across the exon/intron junction. The
         // exon-confined shuffle above only sees spliced (exon) bases, so a
@@ -3374,7 +3417,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HV::Tx(variant.clone()), vec![]));
         }
 
+        // #1052: an uncertain/predicted-wrapped substitution must stay a
+        // silent pass-through — see `is_uncertain_real_substitution`'s doc
+        // comment. Must run before the intronic dispatch below too.
+        if is_uncertain_real_substitution(edit, &variant.loc_edit.edit) {
+            return Ok((HV::Tx(variant.clone()), vec![]));
+        }
+
         if start_pos.is_intronic() || end_pos.is_intronic() {
+            // #1052: real substitutions are validated on the plain exonic path
+            // only. Intronic-sub validation would require genomic projection
+            // (an explicit non-goal); routing a sub through
+            // `normalize_intronic_tx` / `normalize_boundary_spanning_tx` would
+            // emit `ReducedCapabilityNoGenome` (no genomic data) or a hard
+            // `ConversionError` (unmappable intron) on a variant that previously
+            // passed through unchanged. Preserve that silent pass-through.
+            if is_real_substitution(edit) {
+                return Ok((HV::Tx(variant.clone()), vec![]));
+            }
             // Switch to the accession-aware lookup so an NG/NC-parented input
             // gets the build-correct chromosome.
             let transcript = transcript_for_intronic().unwrap_or(transcript);
@@ -3454,6 +3514,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         };
         let (new_start, new_end, new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
+
+        // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
+        // substitutions are validated-then-returned-unchanged by
+        // `normalize_na_edit`; nothing downstream applies to a never-shuffled
+        // edit kind, so return the ORIGINAL variant to preserve `Mu::Uncertain`
+        // and all other input structure. `ref == alt` still flows through to
+        // the identity (`=`) rewrite below.
+        if is_real_substitution(edit) {
+            return Ok((HV::Tx(variant.clone()), warnings));
+        }
 
         // #704 sub-problem A (mirror of the `normalize_cds` block, #670): apply
         // the 3' rule across the exon/intron junction for `n.`. The exon-confined
@@ -4624,6 +4694,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HV::Rna(variant.clone()), vec![]));
         }
 
+        // #1052: an uncertain/predicted-wrapped substitution must stay a
+        // silent pass-through — see `is_uncertain_real_substitution`'s doc
+        // comment. Must run before the intronic dispatch below too.
+        if is_uncertain_real_substitution(edit, &variant.loc_edit.edit) {
+            return Ok((HV::Rna(variant.clone()), vec![]));
+        }
+
         // Check for intronic variants or unknown positions
         let start_pos = match variant.loc_edit.location.start.inner() {
             Some(pos) => pos,
@@ -4643,6 +4720,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `normalize_boundary_spanning_tx`), then convert the result back to
         // `r.`. Pre-#704 this errored for any intronic `r.`.
         if start_pos.is_intronic() || end_pos.is_intronic() {
+            // #1052: real substitutions are validated on the plain exonic path
+            // only. Intronic-sub validation would require genomic projection
+            // (an explicit non-goal); routing a sub through the tx intronic
+            // dispatch this block delegates to would emit
+            // `ReducedCapabilityNoGenome` (no genomic data) or a hard
+            // `ConversionError` (unmappable intron) on a variant that previously
+            // passed through unchanged. Preserve that silent pass-through.
+            if is_real_substitution(edit) {
+                return Ok((HV::Rna(variant.clone()), vec![]));
+            }
             use crate::hgvs::variant::{LocEdit, TxVariant};
             // Accession-aware lookup so an NG/NC-parented input resolves the
             // build-correct chromosome; fall back to the plain transcript. A
@@ -4792,6 +4879,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         };
         let (new_tx_start, new_tx_end, new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
+
+        // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
+        // substitutions are validated-then-returned-unchanged by
+        // `normalize_na_edit`; nothing downstream applies to a never-shuffled
+        // edit kind, so return the ORIGINAL variant to preserve `Mu::Uncertain`
+        // and all other input structure. `ref == alt` still flows through to
+        // the identity (`=`) rewrite below.
+        if is_real_substitution(edit) {
+            return Ok((HV::Rna(variant.clone()), warnings));
+        }
 
         // #704 sub-problem A (mirror of the `normalize_cds`/`normalize_tx`
         // post-check, #670): apply the 3' rule across the exon/intron junction
@@ -5172,6 +5269,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // Only normalize indels; substitutions / identity / repeat-with-
         // count pass through unchanged. Mirrors `normalize_genome`.
         if !needs_normalization(edit) {
+            return Ok((HV::Mt(variant.clone()), vec![]));
+        }
+
+        // #1052: an uncertain/predicted-wrapped substitution must stay a
+        // silent pass-through — see `is_uncertain_real_substitution`'s doc
+        // comment.
+        if is_uncertain_real_substitution(edit, &variant.loc_edit.edit) {
             return Ok((HV::Mt(variant.clone()), vec![]));
         }
 
@@ -6408,22 +6512,26 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // (the Inversion arm in `normalize_na_edit` emits
             // `sequence: None` when `shorten_inversion` rewrites the
             // span, and otherwise still drops the stated bases in the
-            // canonical path). `Substitution` does not reach here at
-            // all — `needs_normalization` returns `false` for real
-            // substitutions and only the degenerate `ref == alt` case
-            // routes through this function, where the validator's
-            // single-base check is satisfied by construction.
+            // canonical path).
             //
             // False for `Repeat` / `MultiRepeat` consistency mismatches
             // (issues #214 / #279): the per-unit declaration is part of
             // the user's form and the normalizer passes the description
-            // through verbatim.
+            // through verbatim. Also false for `Substitution` (#1052):
+            // real substitutions now DO reach here (routed by
+            // `needs_normalization` for validation only, see rules.rs)
+            // and are returned unchanged by the `Substitution` arm below
+            // — the canonical Display keeps the stated ref base, so
+            // reporting `corrected: true` would be dishonest.
             //
             // `delins` with a stated `deleted` sequence is validated by
             // `validate_reference`'s `NaEdit::Delins` arm (#486); the
             // canonical form drops `deleted` / `deleted_length` (see the
             // Delins arm in `canonicalize_edit`), so `corrected` is `true`.
-            let corrected = !matches!(edit, NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. });
+            let corrected = !matches!(
+                edit,
+                NaEdit::Repeat { .. } | NaEdit::MultiRepeat { .. } | NaEdit::Substitution { .. }
+            );
             warnings.push(NormalizationWarning::RefSeqMismatch {
                 stated_ref: validation.stated_ref.unwrap_or_default(),
                 actual_ref: validation.actual_ref.unwrap_or_default(),
@@ -6909,6 +7017,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // below — makes this pass-through intentional and documented, not a
             // silent contradiction of the `needs_normalization` flag (#953).
             NaEdit::MultiRepeat { .. } => return Ok((start, end, edit.clone(), warnings.clone())),
+            // A real substitution reaches here only via `needs_normalization`'s
+            // validation routing (#1052). The reference-base check already ran
+            // at the top of this function; substitutions are never shuffled, so
+            // return the (validated) edit unchanged. Explicit arm — not the
+            // generic `_` — to make the pass-through intentional and documented
+            // (mirrors the `MultiRepeat` arm, #953).
+            NaEdit::Substitution { .. } => return Ok((start, end, edit.clone(), warnings.clone())),
             _ => return Ok((start, end, edit.clone(), warnings.clone())), // Other edits don't need shuffling
         };
 

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -28,13 +28,17 @@ use crate::reference::ReferenceProvider;
 ///
 /// "Needs normalization" gates entry into `normalize_na_edit`, which performs
 /// both reference-allele validation AND 3'-shifting. Most listed kinds need the
-/// shift; `MultiRepeat` is the exception — it is flagged `true` for the
-/// *validation* half (`validate_multirepeat_tract`), not the shift. A compound
+/// shift; `MultiRepeat` and `Substitution` are exceptions — both are flagged
+/// `true` for the *validation* half only, not the shift. A compound
 /// multi-unit tract has no canonical shuffle target, so `normalize_na_edit`'s
-/// `MultiRepeat` arm passes it through unchanged after validating (#953). If
-/// that arm ever gains a real canonicalization, this flag already routes it
-/// correctly; until then the two are reconciled and documented, not silently
-/// contradictory.
+/// `MultiRepeat` arm passes it through unchanged after validating
+/// (`validate_multirepeat_tract`, #953). Substitutions are never shuffled
+/// either way; routing them through validates the stated reference base
+/// against the loaded reference (#1052) and returns the edit unchanged (see
+/// the `Substitution` arm in `normalize_na_edit`'s `alt_seq` match). If the
+/// `MultiRepeat` arm ever gains a real canonicalization, this flag already
+/// routes it correctly; until then the two are reconciled and documented, not
+/// silently contradictory.
 pub fn needs_normalization(edit: &NaEdit) -> bool {
     if matches!(
         edit,
@@ -48,13 +52,47 @@ pub fn needs_normalization(edit: &NaEdit) -> bool {
     ) {
         return true;
     }
-    // A substitution with ref == alt is degenerate and must be rewritten to
-    // identity (`=`); route it through normalization so the rule fires.
-    // Real substitutions (ref != alt) keep the fast no-op path.
+    // Substitutions are routed through `normalize_na_edit` for the *validation*
+    // half only (reference-base check), like `MultiRepeat` — never for shuffling.
+    // A `ref == alt` sub additionally rewrites to identity (`=`); a real sub is
+    // returned unchanged after validation (see the `Substitution` arm in
+    // `normalize_na_edit`'s `alt_seq` match). Intronic subs are held OUT of this
+    // path by the per-axis guards (they cannot be validated without genomic
+    // projection and must not error) — see #1052.
+    matches!(edit, NaEdit::Substitution { .. })
+}
+
+/// A substitution whose stated reference and alternative bases differ (i.e. not
+/// the degenerate `ref == alt` identity case). Used by the per-axis intronic
+/// guards to hold real substitutions out of the genomic intronic projection.
+pub fn is_real_substitution(edit: &NaEdit) -> bool {
     matches!(
         edit,
-        NaEdit::Substitution { reference, alternative } if reference == alternative
+        NaEdit::Substitution { reference, alternative } if reference != alternative
     )
+}
+
+/// A real substitution (see [`is_real_substitution`]) whose `LocEdit` wraps
+/// it in `Mu::Uncertain` (HGVS `(...)`, e.g. `c.(10A>G)`).
+///
+/// Used by every axis normalizer (`normalize_genome`, `normalize_mt`,
+/// `normalize_cds`, `normalize_tx`, `normalize_rna`) as a single shared
+/// definition for the pre-validation carve-out: an uncertain/predicted-
+/// wrapped substitution must stay a silent pass-through in every mode,
+/// regardless of whether the stated ref matches the reference — validating
+/// it would emit a new `RefSeqMismatch` (lenient) or a hard
+/// `ReferenceMismatch` rejection (strict) on input that normalized silently
+/// before #1052. `Mu::inner()` unwraps both `Certain` and `Uncertain`, so
+/// the unwrapped `edit` alone can't distinguish them; the caller must pass
+/// the `Mu` wrapper (typically `variant.loc_edit.edit`) alongside it.
+///
+/// This also protects against a second, independent hazard: every axis's
+/// post-validation result construction (`LocEdit::new(...)`) unconditionally
+/// emits `Mu::Certain`, silently dropping an `Uncertain` wrapper on
+/// reconstruction. Short-circuiting here — before that reconstruction runs —
+/// avoids relying on a fix to that (separate, pre-existing) defect.
+pub fn is_uncertain_real_substitution(edit: &NaEdit, edit_mu: &crate::hgvs::Mu<NaEdit>) -> bool {
+    is_real_substitution(edit) && edit_mu.is_uncertain()
 }
 
 /// Check if an insertion should be represented as a duplication
@@ -3054,8 +3092,9 @@ mod tests {
             sequence: None,
             length: None,
         }));
-        // Real substitutions stay on the no-op fast path.
-        assert!(!needs_normalization(&NaEdit::Substitution {
+        // Real substitutions are now routed for validation (never shuffling)
+        // — see #1052.
+        assert!(needs_normalization(&NaEdit::Substitution {
             reference: Base::A,
             alternative: Base::G,
         }));
@@ -3065,6 +3104,56 @@ mod tests {
             reference: Base::A,
             alternative: Base::A,
         }));
+    }
+
+    #[test]
+    fn test_is_real_substitution() {
+        use crate::hgvs::edit::Base;
+
+        assert!(is_real_substitution(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        }));
+        assert!(!is_real_substitution(&NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::A,
+        }));
+        assert!(!is_real_substitution(&NaEdit::Deletion {
+            sequence: None,
+            length: None,
+        }));
+    }
+
+    #[test]
+    fn test_is_uncertain_real_substitution() {
+        use crate::hgvs::edit::Base;
+        use crate::hgvs::Mu;
+
+        let real = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::G,
+        };
+        // Only the `Uncertain`-wrapped real substitution qualifies.
+        assert!(!is_uncertain_real_substitution(
+            &real,
+            &Mu::Certain(real.clone())
+        ));
+        assert!(is_uncertain_real_substitution(
+            &real,
+            &Mu::Uncertain(real.clone())
+        ));
+        assert!(!is_uncertain_real_substitution(&real, &Mu::Unknown));
+
+        // A degenerate (`ref == alt`) substitution is never a *real* sub, even
+        // wrapped in `Uncertain` — it must still route to the identity rewrite.
+        let identity = NaEdit::Substitution {
+            reference: Base::A,
+            alternative: Base::A,
+        };
+        assert!(!is_uncertain_real_substitution(
+            &identity,
+            &Mu::Uncertain(identity.clone())
+        ));
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -936,15 +936,28 @@ impl PyNormalizer {
     ///         If not provided, uses built-in test data (limited coverage,
     ///         **not suitable for production use**).
     ///     direction: Shuffle direction - "3prime" (default) or "5prime"
+    ///     error_config: Optional ErrorConfig controlling reference-mismatch
+    ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
+    ///         variants). Defaults to lenient (warn and continue; a
+    ///         wrong-reference substitution is preserved unchanged, not
+    ///         auto-corrected).
     #[new]
-    #[pyo3(signature = (reference_json=None, direction="3prime"))]
-    fn new(py: Python<'_>, reference_json: Option<&str>, direction: &str) -> PyResult<Self> {
+    #[pyo3(signature = (reference_json=None, direction="3prime", error_config=None))]
+    fn new(
+        py: Python<'_>,
+        reference_json: Option<&str>,
+        direction: &str,
+        error_config: Option<&PyErrorConfig>,
+    ) -> PyResult<Self> {
         // Validate the `direction` argument BEFORE loading any reference, so an
         // invalid direction always raises `ValueError` regardless of whether the
         // reference path is valid — a bad/missing path must not mask (or be
         // masked by) the argument error.
-        let config =
+        let mut config =
             NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+        if let Some(ec) = error_config {
+            config = config.with_error_config(ec.inner.clone());
+        }
 
         let (provider, kind) = match reference_json {
             Some(path) => (
@@ -969,16 +982,29 @@ impl PyNormalizer {
     ///     manifest_path: Path to a manifest.json file (typically inside a
     ///         directory produced by `ferro prepare`).
     ///     direction: Shuffle direction - "3prime" (default) or "5prime"
+    ///     error_config: Optional ErrorConfig controlling reference-mismatch
+    ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
+    ///         variants). Defaults to lenient (warn and continue; a
+    ///         wrong-reference substitution is preserved unchanged, not
+    ///         auto-corrected).
     ///
     /// Returns:
     ///     A Normalizer backed by a MultiFastaProvider.
     #[staticmethod]
-    #[pyo3(signature = (manifest_path, direction="3prime"))]
-    fn from_manifest(py: Python<'_>, manifest_path: &str, direction: &str) -> PyResult<Self> {
+    #[pyo3(signature = (manifest_path, direction="3prime", error_config=None))]
+    fn from_manifest(
+        py: Python<'_>,
+        manifest_path: &str,
+        direction: &str,
+        error_config: Option<&PyErrorConfig>,
+    ) -> PyResult<Self> {
         // Validate `direction` before loading the manifest (see `new`): a bad
         // manifest path must not mask an invalid-direction `ValueError`.
-        let config =
+        let mut config =
             NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+        if let Some(ec) = error_config {
+            config = config.with_error_config(ec.inner.clone());
+        }
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
         let normalizer = Self {
             provider,
@@ -1372,8 +1398,13 @@ impl PyVariantProjector {
     ///         (default) or "star" (`*`).
     ///     amino_acid_code: Amino-acid code width for rendered p. names —
     ///         "three" (default) or "one".
+    ///     error_config: Optional ErrorConfig controlling reference-mismatch
+    ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
+    ///         variants). Defaults to lenient (warn and continue; a
+    ///         wrong-reference substitution is preserved unchanged, not
+    ///         auto-corrected).
     #[new]
-    #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three"))]
+    #[pyo3(signature = (reference_json=None, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
     fn new(
         py: Python<'_>,
         reference_json: Option<&str>,
@@ -1381,11 +1412,13 @@ impl PyVariantProjector {
         assembly: Option<&str>,
         protein_stop: &str,
         amino_acid_code: &str,
+        error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
         // Validate boundary args BEFORE loading any reference (a bad path must
         // not mask an invalid direction/assembly/protein_stop/amino_acid_code
         // ValueError).
-        let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
+        let (config, assembly_build) =
+            parse_projector_boundary_args(direction, assembly, error_config)?;
         let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let (provider, kind) = match reference_json {
             Some(path) => (
@@ -1410,8 +1443,13 @@ impl PyVariantProjector {
     ///         (default) or "star" (`*`).
     ///     amino_acid_code: Amino-acid code width for rendered p. names —
     ///         "three" (default) or "one".
+    ///     error_config: Optional ErrorConfig controlling reference-mismatch
+    ///         handling (e.g. `ErrorConfig.strict()` to reject wrong-reference
+    ///         variants). Defaults to lenient (warn and continue; a
+    ///         wrong-reference substitution is preserved unchanged, not
+    ///         auto-corrected).
     #[staticmethod]
-    #[pyo3(signature = (manifest_path, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three"))]
+    #[pyo3(signature = (manifest_path, direction="3prime", assembly=None, protein_stop="ter", amino_acid_code="three", error_config=None))]
     fn from_manifest(
         py: Python<'_>,
         manifest_path: &str,
@@ -1419,9 +1457,11 @@ impl PyVariantProjector {
         assembly: Option<&str>,
         protein_stop: &str,
         amino_acid_code: &str,
+        error_config: Option<&PyErrorConfig>,
     ) -> PyResult<Self> {
         // Validate boundary args before loading the manifest (see `new`).
-        let (config, assembly_build) = parse_projector_boundary_args(direction, assembly)?;
+        let (config, assembly_build) =
+            parse_projector_boundary_args(direction, assembly, error_config)?;
         let render_style = parse_render_style_or_raise(protein_stop, amino_acid_code)?;
         let provider = PyProvider::from_manifest(Path::new(manifest_path))?;
         Self::from_provider(
@@ -1819,8 +1859,13 @@ impl PyVariantProjector {
 fn parse_projector_boundary_args(
     direction: &str,
     assembly: Option<&str>,
+    error_config: Option<&PyErrorConfig>,
 ) -> PyResult<(NormalizeConfig, Option<&'static str>)> {
-    let config = NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+    let mut config =
+        NormalizeConfig::default().with_direction(parse_direction_or_raise(direction)?);
+    if let Some(ec) = error_config {
+        config = config.with_error_config(ec.inner.clone());
+    }
     let assembly_build = match assembly {
         Some(name) => Some(
             crate::liftover::aliases::normalize_assembly_name(name).ok_or_else(|| {

--- a/tests/it/issue_1052_substitution_refseq.rs
+++ b/tests/it/issue_1052_substitution_refseq.rs
@@ -1,0 +1,486 @@
+//! Issue #1052 — a substitution asserting a reference base that disagrees with
+//! the loaded reference (`g.8A>C` where g.8 is `T`) must surface a
+//! `RefSeqMismatch` warning in lenient mode and reject in strict mode. Before
+//! this fix, real substitutions skipped `normalize_na_edit` entirely
+//! (`needs_normalization` returned `false` for them), so the reference-base
+//! assertion was never validated on any axis.
+//!
+//! Regression guard (adversarial review): intronic substitutions must stay on
+//! their pre-#1052 silent pass-through — no warning, no `ConversionError`, no
+//! `ReducedCapabilityNoGenome` — because routing them through the genomic
+//! intronic projection would error on variants that used to normalize cleanly.
+
+use ferro_hgvs::{parse_hgvs, FerroError, JsonProvider, NormalizeConfig, Normalizer};
+use std::io::Write;
+
+/// Genome-capable provider: one `contig` of `len` cyclic ACGT bytes with
+/// `payload` written 1-based at `pos1`. (Mirrors tests/it/issue_1041_repro.rs.)
+fn g_provider(contig: &str, len: usize, pos1: usize, payload: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(len).collect();
+    for (i, b) in payload.bytes().enumerate() {
+        bases[pos1 - 1 + i] = b;
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+#[test]
+fn wrong_ref_genomic_sub_warns_in_lenient() {
+    // 300 bp cyclic ACGT: base at 1-based pos 8 is `T` (ACGTACG|T). Assert `A>C`.
+    let p = g_provider("c", 300, 8, "T");
+    let v = parse_hgvs("c:g.8A>C").unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient must not reject");
+    assert_eq!(
+        r.result.to_string(),
+        "c:g.8A>C",
+        "output unchanged in lenient"
+    );
+    assert!(
+        r.warnings.iter().any(|w| matches!(
+            w,
+            ferro_hgvs::normalize::NormalizationWarning::RefSeqMismatch { .. }
+        )),
+        "expected RefSeqMismatch; got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn correct_ref_genomic_sub_no_warning() {
+    let p = g_provider("c", 300, 8, "T");
+    let v = parse_hgvs("c:g.8T>C").unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient");
+    assert_eq!(r.result.to_string(), "c:g.8T>C");
+    assert!(
+        r.warnings.is_empty(),
+        "correct ref → no warning; got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn wrong_ref_genomic_sub_rejects_in_strict() {
+    let p = g_provider("c", 300, 8, "T");
+    let v = parse_hgvs("c:g.8A>C").unwrap();
+    let err = Normalizer::with_config(p, NormalizeConfig::strict())
+        .normalize(&v)
+        .expect_err("strict must reject wrong-ref sub");
+    assert!(
+        matches!(err, FerroError::ReferenceMismatch { .. }),
+        "expected ReferenceMismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn uncertain_wrong_ref_genomic_sub_stays_silent_in_lenient_and_strict() {
+    // Regression guard (whole-branch review): the uncertain/predicted-
+    // wrapped-substitution carve-out was initially added only to
+    // normalize_cds/tx/rna, missing normalize_genome — the primary axis
+    // this issue targets. `g.(8A>C)` (wrong ref, uncertain) must stay a
+    // silent pass-through in EVERY mode, exactly like the c./n./r. cases in
+    // `transcript_axis`: no RefSeqMismatch in lenient, no ReferenceMismatch
+    // rejection in strict.
+    let p = g_provider("c", 300, 8, "T");
+    let v = parse_hgvs("c:g.(8A>C)").unwrap();
+
+    let r = Normalizer::with_config(p.clone(), NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient must not reject an uncertain sub");
+    assert_eq!(r.result.to_string(), "c:g.(8A>C)", "unchanged in lenient");
+    assert!(
+        r.warnings.is_empty(),
+        "uncertain sub must stay silent regardless of ref mismatch; got {:?}",
+        r.warnings
+    );
+
+    let out = Normalizer::with_config(p, NormalizeConfig::strict())
+        .normalize(&v)
+        .expect("strict mode must not reject an uncertain sub (no ReferenceMismatch)");
+    assert_eq!(out.to_string(), "c:g.(8A>C)", "unchanged in strict");
+}
+
+#[test]
+fn uncertain_correct_ref_genomic_sub_preserves_wrapper() {
+    // Silent-data-loss guard: `g.(8T>C)` has a CORRECT stated ref (g.8 is
+    // `T`). Before the genome-axis carve-out, this uncertain substitution
+    // still reached `normalize_na_edit`'s validation-then-pass-through arm,
+    // which returns the edit unchanged — but the CALLING function
+    // (`normalize_genome`) then reconstructed the result via
+    // `LocEdit::new(...)`, which unconditionally emits `Mu::Certain`,
+    // silently dropping the `(...)` predicted-change wrapper even though
+    // the ref matched and zero warnings fired. That's silent semantic data
+    // loss on entirely valid input. The carve-out returns the ORIGINAL
+    // variant, so the wrapper survives.
+    let p = g_provider("c", 300, 8, "T");
+    let v = parse_hgvs("c:g.(8T>C)").unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient must not reject");
+    assert_eq!(
+        r.result.to_string(),
+        "c:g.(8T>C)",
+        "the uncertain wrapper must survive normalization"
+    );
+    assert!(
+        r.warnings.is_empty(),
+        "correct-ref uncertain sub → no warnings; got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn uncertain_wrong_ref_mito_sub_stays_silent() {
+    // `m.` axis counterpart (`normalize_mt`), mirroring the `g.` guards
+    // above. Mirrors the provider pattern from
+    // `tests/it/issue_1044_mito_window_clamp.rs` (a plain `JsonProvider`
+    // genomic-sequence entry keyed by the mitochondrial accession).
+    let contig = "NC_012920.1";
+    let p = g_provider(contig, 300, 8, "T");
+    let v = parse_hgvs(&format!("{contig}:m.(8A>C)")).unwrap();
+
+    let r = Normalizer::with_config(p.clone(), NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient must not reject an uncertain mito sub");
+    assert_eq!(
+        r.result.to_string(),
+        format!("{contig}:m.(8A>C)"),
+        "unchanged in lenient"
+    );
+    assert!(
+        r.warnings.is_empty(),
+        "uncertain mito sub must stay silent regardless of ref mismatch; got {:?}",
+        r.warnings
+    );
+
+    let out = Normalizer::with_config(p, NormalizeConfig::strict())
+        .normalize(&v)
+        .expect("strict mode must not reject an uncertain mito sub (no ReferenceMismatch)");
+    assert_eq!(
+        out.to_string(),
+        format!("{contig}:m.(8A>C)"),
+        "unchanged in strict"
+    );
+}
+
+#[test]
+fn wrong_ref_mito_sub_warns_in_lenient() {
+    // Certain `m.` counterpart of `wrong_ref_genomic_sub_warns_in_lenient`.
+    // A plain (non-uncertain, non-intronic) mitochondrial substitution flows
+    // through `normalize_mt`'s window fetch into `normalize_na_edit`, exactly
+    // like `g.`, so a mismatched stated ref must surface `RefSeqMismatch`.
+    // m.8 is `T` (cyclic ACGT); assert `A>C`.
+    let contig = "NC_012920.1";
+    let p = g_provider(contig, 300, 8, "T");
+    let v = parse_hgvs(&format!("{contig}:m.8A>C")).unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient must not reject");
+    assert_eq!(
+        r.result.to_string(),
+        format!("{contig}:m.8A>C"),
+        "output unchanged in lenient"
+    );
+    assert!(
+        r.warnings.iter().any(|w| matches!(
+            w,
+            ferro_hgvs::normalize::NormalizationWarning::RefSeqMismatch { .. }
+        )),
+        "expected RefSeqMismatch on m. sub; got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn wrong_ref_mito_sub_rejects_in_strict() {
+    let contig = "NC_012920.1";
+    let p = g_provider(contig, 300, 8, "T");
+    let v = parse_hgvs(&format!("{contig}:m.8A>C")).unwrap();
+    let err = Normalizer::with_config(p, NormalizeConfig::strict())
+        .normalize(&v)
+        .expect_err("strict must reject a wrong-ref mito sub");
+    assert!(
+        matches!(err, FerroError::ReferenceMismatch { .. }),
+        "expected ReferenceMismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn correct_ref_mito_sub_no_warning() {
+    let contig = "NC_012920.1";
+    let p = g_provider(contig, 300, 8, "T");
+    let v = parse_hgvs(&format!("{contig}:m.8T>C")).unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient");
+    assert_eq!(r.result.to_string(), format!("{contig}:m.8T>C"));
+    assert!(
+        r.warnings.is_empty(),
+        "correct ref → no warning; got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn genomic_sub_without_reference_passes_through() {
+    // Provider with a DIFFERENT contig → fetch fails for `nc` → pass-through.
+    let p = g_provider("other", 300, 8, "T");
+    let v = parse_hgvs("nc:g.8A>C").unwrap();
+    let r = Normalizer::with_config(p, NormalizeConfig::lenient())
+        .normalize_with_diagnostics(&v)
+        .expect("lenient");
+    assert_eq!(r.result.to_string(), "nc:g.8A>C");
+    assert!(
+        r.warnings.is_empty(),
+        "no reference → no warning; got {:?}",
+        r.warnings
+    );
+}
+
+mod transcript_axis {
+    use super::*;
+    use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+    use ferro_hgvs::MockProvider;
+
+    // 60 bp transcript; c.5 = 'A' (ATGCA…). Build a genomic backing so intronic
+    // guard tests can run WITH and WITHOUT genomic data.
+    fn tx_only() -> MockProvider {
+        let mut p = MockProvider::new();
+        let seq = "ATGCAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGTTTTTAAAAACCCCCGGGGGT".to_string();
+        let len = seq.len() as u64;
+        let tx = Transcript::new(
+            "NM_TEST.1".to_string(),
+            Some("TEST".to_string()),
+            Strand::Plus,
+            seq,
+            Some(1),
+            Some(len),
+            vec![Exon::new(1, 1, len)],
+            None,
+            None,
+            None,
+            Default::default(),
+            ManeStatus::None,
+            None,
+            None,
+        );
+        p.add_transcript(tx);
+        p
+    }
+
+    /// 2-exon plus-strand transcript with genomic exon coordinates + a
+    /// chromosome, but NO genomic sequence loaded (mirrors
+    /// `tests/it/issue_1012_reduced_capability_no_genome.rs`'s
+    /// `provider_no_genomic_sequence`). `has_genomic_data()` is false, so
+    /// pre-#1052 this shape is exactly what made a former-error intronic path
+    /// emit `ReducedCapabilityNoGenome` (#1012) once it was reachable.
+    fn intronic_tx_no_genomic_sequence() -> MockProvider {
+        let mut p = MockProvider::new();
+        let tx = Transcript::new(
+            "NM_INTR.1".to_string(),
+            Some("INTR".to_string()),
+            Strand::Plus,
+            Some("AAAATGCCCCGGGGTAGAATAA".to_string()),
+            Some(1),
+            Some(22),
+            vec![
+                Exon::with_genomic(1, 1, 10, 100, 109),
+                Exon::with_genomic(2, 11, 22, 130, 141),
+            ],
+            Some("chr_intr".to_string()),
+            Some(100),
+            Some(141),
+            Default::default(),
+            ManeStatus::None,
+            None,
+            None,
+        );
+        p.add_transcript(tx);
+        // Deliberately no add_genomic_sequence — has_genomic_data() == false.
+        p
+    }
+
+    #[test]
+    fn wrong_ref_cds_sub_warns() {
+        // c.5 is 'A'; assert 'G>C' (wrong ref).
+        let v = parse_hgvs("NM_TEST.1:c.5G>C").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&v)
+            .expect("lenient");
+        assert!(
+            r.warnings.iter().any(|w| matches!(
+                w,
+                ferro_hgvs::normalize::NormalizationWarning::RefSeqMismatch { .. }
+            )),
+            "expected RefSeqMismatch on c. sub; got {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn uncertain_wrong_ref_cds_sub_stays_silent_in_lenient() {
+        // Regression guard: an uncertain/predicted-wrapped substitution
+        // (`c.(5G>C)`) with a MISMATCHED stated ref must stay a silent
+        // pass-through — no `RefSeqMismatch` warning — even though the
+        // CERTAIN counterpart (`wrong_ref_cds_sub_warns`, same mismatch)
+        // does warn. `Mu::inner()` unwraps both `Certain` and `Uncertain`,
+        // so without the certainty-gated carve-out this would validate and
+        // emit a NEW warning on input that previously normalized cleanly.
+        // c.5 is 'A'; stated ref 'G' mismatches.
+        let v = parse_hgvs("NM_TEST.1:c.(5G>C)").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&v)
+            .expect("lenient must not reject an uncertain sub");
+        assert_eq!(r.result.to_string(), "NM_TEST.1:c.(5G>C)", "unchanged");
+        assert!(
+            r.warnings.is_empty(),
+            "uncertain sub must stay silent regardless of ref mismatch; got {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn uncertain_wrong_ref_cds_sub_stays_silent_in_strict() {
+        // Strict-mode counterpart: before the certainty gate, this would
+        // have escalated to a hard `FerroError::ReferenceMismatch` — a new
+        // rejection of input that previously normalized cleanly.
+        let v = parse_hgvs("NM_TEST.1:c.(5G>C)").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::strict())
+            .normalize(&v)
+            .expect("strict mode must not reject an uncertain sub (no ReferenceMismatch)");
+        assert_eq!(r.to_string(), "NM_TEST.1:c.(5G>C)", "unchanged");
+    }
+
+    #[test]
+    fn correct_ref_cds_sub_no_warning() {
+        // c.5 is 'A'.
+        let v = parse_hgvs("NM_TEST.1:c.5A>C").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&v)
+            .expect("lenient");
+        assert!(
+            r.warnings.is_empty(),
+            "correct c. ref → no warning; got {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn correct_ref_exonic_sub_at_transcript_boundary_no_capability_warning() {
+        // Regression guard (#1052 follow-up finding 1): a correct-ref
+        // substitution at the LAST base of a single-exon transcript
+        // (`tx_only()`'s exon spans the whole 60bp transcript, so c.60 sits
+        // exactly at `exon_only.right`) used to spuriously trip the #670
+        // exon/intron junction 3'-shuffle-continuation check inside
+        // `normalize_cds` — a check that only makes sense for shuffle-capable
+        // edit kinds (del/dup/etc.), never for a point substitution. Before
+        // the post-`normalize_na_edit` short-circuit, this fixture (no
+        // genomic sequence loaded) emitted a spurious `ReducedCapabilityNoGenome`
+        // warning in lenient mode even though the substitution is entirely
+        // valid and needs no shuffle. c.60 is `T` in
+        // "ATGC...GGGGGT" — assert the matching ref.
+        let v = parse_hgvs("NM_TEST.1:c.60T>C").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&v)
+            .expect("lenient must not reject a valid boundary substitution");
+        assert_eq!(r.result.to_string(), "NM_TEST.1:c.60T>C", "unchanged");
+        assert!(
+            r.warnings.is_empty(),
+            "correct-ref boundary sub must have zero warnings \
+             (specifically no ReducedCapabilityNoGenome); got {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn correct_ref_exonic_sub_at_transcript_boundary_passes_strict() {
+        // Strict-mode counterpart: before the fix, the spurious
+        // `ReducedCapabilityNoGenome` warning above would have escalated to a
+        // hard `FerroError::ReducedReferenceCapability`, rejecting a
+        // perfectly valid, in-bounds, correct-ref substitution.
+        let v = parse_hgvs("NM_TEST.1:c.60T>C").unwrap();
+        Normalizer::with_config(tx_only(), NormalizeConfig::strict())
+            .normalize(&v)
+            .expect(
+                "strict mode must accept a valid boundary substitution \
+                 (no ReducedReferenceCapability)",
+            );
+    }
+
+    #[test]
+    fn intronic_sub_bare_nm_stays_on_pre_existing_eintronic_warning_only() {
+        // `NM_TEST.1:c.10+2A>G` is a bare (no genomic-context) NM_ accession
+        // at an intronic offset. The pre-existing #486 EINTRONIC/W4007 check
+        // (`intronic_on_bare_transcript_warning`) runs in `normalize_core`
+        // BEFORE dispatch and fires for ANY edit type on this shape — see
+        // `tests/it/issue_486_eintronic.rs::
+        // lenient_warns_and_keeps_value_for_bare_nm_intronic_substitution`.
+        // That warning is orthogonal to #1052. The regression this guards
+        // against is specifically the sub ALSO tripping `ReducedCapabilityNoGenome`
+        // or a hard error by falling into the genomic intronic dispatch — so
+        // assert the warning set is *exactly* the one pre-existing warning,
+        // not "any warning at all".
+        let v = parse_hgvs("NM_TEST.1:c.10+2A>G").unwrap();
+        let r = Normalizer::with_config(tx_only(), NormalizeConfig::lenient())
+            .normalize_with_diagnostics(&v)
+            .expect("intronic sub must not error in lenient");
+        assert_eq!(r.result.to_string(), "NM_TEST.1:c.10+2A>G", "unchanged");
+        assert_eq!(
+            r.warnings.len(),
+            1,
+            "expected exactly the pre-existing EINTRONIC warning, got {:?}",
+            r.warnings
+        );
+        assert!(
+            matches!(
+                &r.warnings[0],
+                ferro_hgvs::normalize::NormalizationWarning::IntronicOnBareTranscript { .. }
+            ),
+            "expected IntronicOnBareTranscript, got {:?}",
+            r.warnings
+        );
+    }
+
+    #[test]
+    fn intronic_sub_without_genomic_sequence_is_silent_passthrough() {
+        // True regression guard (adversarial review, HIGH): before the #1052
+        // intronic guard, a real substitution reaching this genomic-context
+        // (`NG_(NM_)`) intronic form — spec-valid, so it does NOT also raise
+        // the orthogonal EINTRONIC warning (mirrors
+        // `tests/it/issue_1012_reduced_capability_no_genome.rs`'s
+        // `intronic_variant_warns_and_degrades_without_genome`, but for a
+        // deletion) — would have been routed through
+        // `normalize_intronic_cds`/`normalize_boundary_spanning_cds`, which
+        // requires genomic sequence data. With none loaded, that would emit
+        // `ReducedCapabilityNoGenome`: a NEW warning on a variant that
+        // previously normalized cleanly. The guard must keep this silent.
+        let v = parse_hgvs("NG_012337.1(NM_INTR.1):c.10+5A>G").unwrap();
+        let r = Normalizer::with_config(
+            intronic_tx_no_genomic_sequence(),
+            NormalizeConfig::lenient(),
+        )
+        .normalize_with_diagnostics(&v)
+        .expect("intronic sub must not error in lenient");
+        assert_eq!(
+            r.result.to_string(),
+            "NG_012337.1(NM_INTR.1):c.10+5A>G",
+            "unchanged"
+        );
+        assert!(
+            r.warnings.is_empty(),
+            "intronic sub without genomic sequence → zero warnings; got {:?}",
+            r.warnings
+        );
+    }
+}

--- a/tests/it/issue_280_refseqmismatch_corrected_flag.rs
+++ b/tests/it/issue_280_refseqmismatch_corrected_flag.rs
@@ -34,6 +34,8 @@
 //!   (`canonicalize_edit` strips `length`).
 //! - SECTION 7c: `del<N>ins` numeric deleted-length mismatch → `corrected: true`
 //!   (`canonicalize_edit` strips `deleted_length`).
+//! - SECTION 8: `Substitution` with mismatched stated-ref (#1052) →
+//!   `corrected: false` (canonical Display keeps the stated ref base).
 
 use ferro_hgvs::normalize::NormalizationWarning;
 use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
@@ -443,6 +445,40 @@ mod delins_numeric_deleted_length_mismatch {
         assert!(
             corrected_flag(&r.warnings),
             "numeric del<N>ins deleted-length mismatch must report corrected=true; output={}, warnings={:?}",
+            r.result,
+            r.warnings
+        );
+    }
+}
+
+// =============================================================================
+// SECTION 8 — Substitution with mismatched stated-ref → corrected: false (#1052)
+// =============================================================================
+//
+// `c.5G>C` against a transcript where c.5 = `A` triggers `validate_single_base`
+// → mismatch. The canonical Display KEEPS the substitution's stated ref base
+// (`c.5G>C` stays `c.5G>C`), so the flag is honest only at `false`.
+
+mod sub_mismatched_stated_ref {
+    use super::*;
+
+    #[test]
+    fn sub_mismatched_stated_ref_corrected_false() {
+        let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
+        let v = parse_hgvs("NM_TEST.1:c.5G>C").expect("parse");
+        let r = normalizer
+            .normalize_with_diagnostics(&v)
+            .expect("normalize must not reject in lenient");
+        // The canonical Display must keep the stated ref base verbatim — a
+        // rewritten base (`c.5A>C`) would make `corrected: false` a lie.
+        assert_eq!(
+            r.result.to_string(),
+            "NM_TEST.1:c.5G>C",
+            "canonical form must preserve the stated (mismatched) ref base"
+        );
+        assert!(
+            !corrected_flag(&r.warnings),
+            "sub with mismatched stated-ref must report corrected=false; output={}, warnings={:?}",
             r.result,
             r.warnings
         );

--- a/tests/it/issue_336_position_past_end.rs
+++ b/tests/it/issue_336_position_past_end.rs
@@ -231,10 +231,12 @@ fn strict_mode_rejects_utr3_position_past_transcript_end() {
 
 #[test]
 fn strict_mode_accepts_utr3_position_at_transcript_end() {
-    // c.*8 → tx 20 (last base of transcript). In-bounds.
+    // c.*8 → tx 20 (last base of transcript, `C` in "AAAATGAAATAGCCCCCCCC").
+    // In-bounds; stated ref must match so strict mode's #1052 reference-base
+    // check doesn't also fire (this test isolates the bounds check).
     let provider = provider_with_short_cds_transcript();
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
-    let variant = parse_hgvs("NM_TEST.1:c.*8G>C").expect("parse");
+    let variant = parse_hgvs("NM_TEST.1:c.*8C>G").expect("parse");
     normalizer
         .normalize(&variant)
         .expect("c.*8 must pass strict-mode bounds check");
@@ -316,10 +318,12 @@ fn strict_mode_rejects_c_minus_position_past_5utr_start() {
 
 #[test]
 fn strict_mode_accepts_c_minus_position_at_5utr_start() {
-    // `c.-5` = the first 5'UTR base. In-bounds.
+    // `c.-5` = the first 5'UTR base (tx 1, `A` in "AAAAAATGAAATAGCCCCCC").
+    // In-bounds; stated ref must match so strict mode's #1052 reference-base
+    // check doesn't also fire (this test isolates the bounds check).
     let provider = provider_with_short_5utr_transcript();
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
-    let variant = parse_hgvs("NM_5UTR.1:c.-5G>C").expect("parse");
+    let variant = parse_hgvs("NM_5UTR.1:c.-5A>C").expect("parse");
     normalizer
         .normalize(&variant)
         .expect("c.-5 must pass strict-mode bounds check");
@@ -393,10 +397,12 @@ fn strict_mode_rejects_n_position_past_transcript_end() {
 
 #[test]
 fn strict_mode_accepts_n_position_at_transcript_end() {
-    // n.20 = the last base of the transcript. In-bounds.
+    // n.20 = the last base of the transcript (`T` in cyclic "ACGTACGT...").
+    // In-bounds; stated ref must match so strict mode's #1052 reference-base
+    // check doesn't also fire (this test isolates the bounds check).
     let provider = provider_with_short_noncoding_transcript();
     let normalizer = Normalizer::with_config(provider, NormalizeConfig::strict());
-    let variant = parse_hgvs("NR_TEST.1:n.20G>C").expect("parse");
+    let variant = parse_hgvs("NR_TEST.1:n.20T>C").expect("parse");
     normalizer
         .normalize(&variant)
         .expect("n.20 must pass strict-mode bounds check");

--- a/tests/it/issue_486_eintronic.rs
+++ b/tests/it/issue_486_eintronic.rs
@@ -196,11 +196,14 @@ fn ng_nm_intronic_substitution_not_rejected_strict() {
 
 #[test]
 fn bare_nm_exonic_substitution_unaffected_strict() {
-    // An exonic position on a bare NM_ is fine — no EINTRONIC.
+    // An exonic position on a bare NM_ is fine — no EINTRONIC. c.5 = `A`
+    // (exon1 = "ATGCATGCATGCATGCATGCATGCATGCAT"); stated ref must match so
+    // strict mode's #1052 reference-base check doesn't also fire (this test
+    // isolates the EINTRONIC check).
     normalize(
         provider_intronic_nm(),
         NormalizeConfig::strict(),
-        "NM_INTRON.1:c.5C>A",
+        "NM_INTRON.1:c.5A>C",
     )
     .expect("exonic substitution on a bare NM must not be rejected as EINTRONIC");
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -89,6 +89,7 @@ mod issue_1040_inv_overrecognition_probes;
 mod issue_1041_repro;
 mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
+mod issue_1052_substitution_refseq;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/python/test_issue_1052_error_config.py
+++ b/tests/python/test_issue_1052_error_config.py
@@ -1,0 +1,72 @@
+"""Issue #1052: ErrorConfig can be passed to Normalizer / VariantProjector, and
+strict mode rejects a wrong-reference-base variant."""
+
+import tempfile
+
+import pytest
+
+import ferro_hgvs
+
+
+def _genomic_reference() -> str:
+    """Build a tiny genomic transcripts.json via convert_gff (mirrors the issue)."""
+    seq = "GGGG" + "ATGTCTACGCTGGGATAA" + "CCCC"  # 1-based g.8 == 'T'
+    ctg, gs, ge = "TEST", 5, 22
+    d = tempfile.mkdtemp()
+    fasta, gff, out = f"{d}/r.fa", f"{d}/r.gff3", f"{d}/transcripts.json"
+    with open(fasta, "w") as fh:
+        fh.write(f">{ctg}\n{seq}\n")
+    with open(gff, "w") as fh:
+        fh.write("##gff-version 3\n")
+        fh.write(f"##sequence-region {ctg} 1 {len(seq)}\n")
+        fh.write(
+            f"{ctg}\tx\tregion\t1\t{len(seq)}\t.\t+\t.\tID={ctg}:1..{len(seq)};Name={ctg};chromosome={ctg};gbkey=Src;mol_type=genomic DNA\n"
+        )
+        fh.write(f"{ctg}\tx\tgene\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene;Name={ctg}-gene\n")
+        fh.write(
+            f"{ctg}\tx\tmRNA\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene.1;Parent={ctg}-gene;transcript_id=1\n"
+        )
+        fh.write(
+            f"{ctg}\tx\tCDS\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene.1.cds;Parent={ctg}-gene.1;protein_id=1\n"
+        )
+    ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=gff, fasta=fasta, output=out, emit_genomic_sequences=True)
+    )
+    return out
+
+
+def test_normalizer_accepts_error_config_and_rejects_wrong_ref_sub():
+    out = _genomic_reference()
+    strict = ferro_hgvs.ErrorConfig.strict()
+    norm = ferro_hgvs.Normalizer(reference_json=out, error_config=strict)
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        norm.normalize("TEST:g.8A>C")  # g.8 is 'T'
+
+
+def test_normalizer_lenient_default_unchanged():
+    out = _genomic_reference()
+    norm = ferro_hgvs.Normalizer(reference_json=out)  # no error_config
+    assert norm.normalize("TEST:g.8A>C") == "TEST:g.8A>C"
+    warnings = list(norm.normalize_with_warnings("TEST:g.8A>C").warnings)
+    assert any("REFSEQ_MISMATCH" in str(w) for w in warnings), warnings
+
+
+def test_projector_error_config_flows_through_to_normalization():
+    # Constructor must accept the keyword AND actually apply it: a strict
+    # projector must reject a wrong-reference g. variant during its
+    # normalize-then-project step, while the default (lenient) projector must
+    # not. Asserting both directions means the test fails if VariantProjector
+    # silently discards error_config. g.8 is 'T'; assert 'A>C'.
+    out = _genomic_reference()
+
+    strict_projector = ferro_hgvs.VariantProjector(
+        reference_json=out, error_config=ferro_hgvs.ErrorConfig.strict()
+    )
+    with pytest.raises(ferro_hgvs.ProjectionError):
+        strict_projector.project_all("TEST:g.8A>C")
+
+    # Default (lenient) projector: the same wrong-ref variant normalizes with a
+    # warning and projects without raising — proving the strict rejection above
+    # came from error_config, not from an unrelated failure.
+    lenient_projector = ferro_hgvs.VariantProjector(reference_json=out)
+    lenient_projector.project_all("TEST:g.8A>C")

--- a/tests/python/test_issue_1052_substitution.py
+++ b/tests/python/test_issue_1052_substitution.py
@@ -1,0 +1,62 @@
+"""Issue #1052: end-to-end repro — substitution reference-base validation is
+surfaced via ``normalize_with_warnings`` in lenient mode, and rejected by
+strict mode alongside the already-validated deletion half (#1042)."""
+
+import tempfile
+
+import pytest
+
+import ferro_hgvs
+
+
+def _genomic_reference() -> str:
+    """Build a tiny genomic transcripts.json via convert_gff (mirrors the issue)."""
+    seq = "GGGG" + "ATGTCTACGCTGGGATAA" + "CCCC"  # 1-based g.8 == 'T'
+    ctg, gs, ge = "TEST", 5, 22
+    d = tempfile.mkdtemp()
+    fasta, gff, out = f"{d}/r.fa", f"{d}/r.gff3", f"{d}/transcripts.json"
+    with open(fasta, "w") as fh:
+        fh.write(f">{ctg}\n{seq}\n")
+    with open(gff, "w") as fh:
+        fh.write("##gff-version 3\n")
+        fh.write(f"##sequence-region {ctg} 1 {len(seq)}\n")
+        fh.write(
+            f"{ctg}\tx\tregion\t1\t{len(seq)}\t.\t+\t.\tID={ctg}:1..{len(seq)};Name={ctg};chromosome={ctg};gbkey=Src;mol_type=genomic DNA\n"
+        )
+        fh.write(f"{ctg}\tx\tgene\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene;Name={ctg}-gene\n")
+        fh.write(
+            f"{ctg}\tx\tmRNA\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene.1;Parent={ctg}-gene;transcript_id=1\n"
+        )
+        fh.write(
+            f"{ctg}\tx\tCDS\t{gs}\t{ge}\t.\t+\t0\tID={ctg}-gene.1.cds;Parent={ctg}-gene.1;protein_id=1\n"
+        )
+    ferro_hgvs.convert_gff(
+        ferro_hgvs.ConvertGffConfig(gff=gff, fasta=fasta, output=out, emit_genomic_sequences=True)
+    )
+    return out
+
+
+def test_wrong_ref_substitution_surfaces_refseq_mismatch():
+    out = _genomic_reference()
+    norm = ferro_hgvs.Normalizer(reference_json=out)
+    assert norm.has_genomic_data() is True
+    res = norm.normalize_with_warnings("TEST:g.8A>C")  # g.8 is 'T'
+    assert norm.normalize("TEST:g.8A>C") == "TEST:g.8A>C"  # unchanged in lenient
+    assert any("REFSEQ_MISMATCH" in str(w) for w in res.warnings), list(res.warnings)
+
+
+def test_correct_ref_substitution_no_warning():
+    out = _genomic_reference()
+    norm = ferro_hgvs.Normalizer(reference_json=out)
+    res = norm.normalize_with_warnings("TEST:g.8T>C")
+    assert list(res.warnings) == []
+
+
+def test_strict_rejects_wrong_ref_sub_and_del():
+    out = _genomic_reference()
+    strict = ferro_hgvs.ErrorConfig.strict()
+    norm = ferro_hgvs.Normalizer(reference_json=out, error_config=strict)
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        norm.normalize("TEST:g.8A>C")
+    with pytest.raises(ferro_hgvs.NormalizationError):
+        norm.normalize("TEST:g.8delA")  # del half already validated (#1042)


### PR DESCRIPTION
Closes #1052.

## Summary

Two fixes for the reference-validation gaps reported in #1052:

1. **Substitution reference bases are now validated.** Previously a `g.8A>C` whose asserted reference base disagreed with the loaded reference (actual base `T`) was accepted silently — `needs_normalization()` returned `false` for real substitutions, so they skipped the fetch → `normalize_na_edit` validation path that del/dup/ins already used. Substitutions now flow through that path for validation on every axis (g./c./n./r./m.): a mismatch surfaces a `RefSeqMismatch` warning in lenient mode and rejects as a hard `ReferenceMismatch` in strict mode. Substitutions are never shuffled — they are validated and returned unchanged.

2. **`ErrorConfig` can be passed to the Python constructors.** `Normalizer(...)`, `Normalizer.from_manifest(...)`, `VariantProjector(...)`, and `VariantProjector.from_manifest(...)` now accept an optional `error_config` (appended after the existing params for positional back-compat), wired through a new `NormalizeConfig::with_error_config`. Callers can opt into strict rejection: `Normalizer(reference_json=..., error_config=ferro_hgvs.ErrorConfig.strict())`.

The reporter's third item — explicit-sequence `del`/`dup` validation (`g.8delA`) — was already fixed on `main` by #1042 (clamp the genome fetch window to contig length); it is not in the 0.8.1 wheel the reporter tested. This PR does not touch that path.

## Behavior

| Input (reference base at the position is `T`) | lenient `normalize()` | lenient `normalize_with_warnings()` | strict |
|---|---|---|---|
| `g.8A>C` (wrong ref, exonic) | `g.8A>C` (unchanged) | `RefSeqMismatch` | raises `ReferenceMismatch` |
| `g.8T>C` (correct ref, exonic) | `g.8T>C` (unchanged) | (none) | ok |
| exonic sub, no reference data | unchanged | (none) | ok |
| intronic / uncertain-wrapped sub (e.g. `c.100+2A>G`, `g.(8A>C)`) | unchanged | (none) | ok |

The stated reference base is never silently rewritten; lenient warns, strict rejects. Strict rejection reuses the existing `should_reject_ref_mismatch()` ladder — no new rejection machinery.

## Scope

Substitution validation is **exonic only** by design. Intronic substitutions (any offset position), `n.` downstream / `base < 1`, uncertain-wrapped substitutions, and substitutions with no fetchable reference remain silent pass-through — never a new warning or error. Validating intronic/uncertain substitutions would require genomic projection and is a deliberate non-goal (see the follow-up note below). A shared `is_uncertain_real_substitution` predicate gates the uncertain carve-out identically across all five axes.

## Tests

- Rust: `cargo nextest run --features dev` — 7996 passed, 0 failed.
- Python: `pytest tests/python/` — 409 passed.
- `cargo fmt`, `cargo clippy --features dev/python --all-targets -- -D warnings`, and `mypy` all clean.
- New coverage: wrong-ref vs correct-ref substitutions per axis (warn in lenient, reject in strict, unchanged output); intronic and uncertain-wrapped subs stay silent on all axes (including the g./m. correct-ref case that would otherwise silently drop the predicted-change wrapper); the `#280` `corrected=false` audit for substitutions; and an end-to-end Python repro of the issue.

## Conformance

- **Mandatory conformance run — done, clean.** Full `cargo nextest run --features dev` with the manifest-gated prepared reference active (145 manifest-gated tests activated). All mutalyzer axes (`normalized`, `genomic`, `protein_description`, `coding_protein_descriptions`, `rna_description`, `noncoding`, `errors`, `infos`) + both idempotent axes pass, as do the biocommons, hgvs-rs-projection, legacy-gene-selector, and reference-snapshot suites. `comparator_provenance_reference_identity_matches_live` passes, so the empty-projection gate enforced (not skipped) and held. The substitution fix moved **zero** FAIL-set ledger rows — every `baseline-failures/*.txt` stays empty — so no re-blessing was required.

## Still open (optional, does not block review)

- **Benchmark**: a substitution-heavy before/after (real substitutions now incur one reference fetch where they were previously a no-op) — to be measured and reported.

## Known follow-up (pre-existing, not introduced here)

`LocEdit::new` result reconstruction in `normalize_cds`/`normalize_tx`/`normalize_rna` always emits `Mu::Certain`, silently dropping an input `Mu::Uncertain` wrapper for del/dup/inv/repeat routed through the full pipeline (reproduces on `main`: `c.(10del)` → `c.14del`). This branch carves substitutions around it on all five axes; the general case is worth a separate issue.

