### PR TITLE
fix: report an allele's coordinate axis from HgvsVariant

### DIFF
--- a/python/ferro_hgvs/__init__.py
+++ b/python/ferro_hgvs/__init__.py
@@ -122,6 +122,7 @@ __all__ = [
     "build_transcript",
     # Core classes
     "HgvsVariant",
+    "Axis",
     "Normalizer",
     # SPDI classes
     "SpdiVariant",

--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -297,6 +297,44 @@ def build_transcript(config: BuildTranscriptConfig) -> BuildTranscriptReport:
 # Core Classes
 # ============================================================================
 
+class Axis(IntEnum):
+    """The coordinate axis (reference molecule / coordinate system) of a variant.
+
+    Returned by :attr:`HgvsVariant.axis`. Each member carries its single-letter
+    HGVS coordinate code (:meth:`code`) and a molecule-type grouping
+    (:meth:`is_dna` / :meth:`is_rna` / :meth:`is_protein`).
+    """
+
+    Genomic = 0
+    Coding = 1
+    NonCoding = 2
+    Rna = 3
+    Protein = 4
+    Mitochondrial = 5
+    Circular = 6
+
+    def code(self) -> str:
+        """The single-letter HGVS coordinate code (``g``/``c``/``n``/``r``/``p``/``m``/``o``)."""
+        ...
+
+    def is_dna(self) -> bool:
+        """Whether this axis addresses a DNA molecule (``g``/``c``/``n``/``m``/``o``).
+
+        Treats mitochondrial and circular DNA as DNA, unlike the deprecated
+        ``is_genomic()`` predicate (which is ``g.``-only).
+        """
+        ...
+
+    def is_rna(self) -> bool:
+        """Whether this axis addresses an RNA molecule (``r.``)."""
+        ...
+
+    def is_protein(self) -> bool:
+        """Whether this axis addresses a protein (``p.``)."""
+        ...
+
+    def __str__(self) -> str: ...
+
 class HgvsVariant:
     """A parsed HGVS variant.
 
@@ -380,6 +418,23 @@ class HgvsVariant:
         ...
 
     @property
+    def axis(self) -> Axis | None:
+        """The coordinate axis (reference molecule / coordinate system) of this variant.
+
+        Returns an :class:`Axis`, or ``None`` if there is no single well-defined
+        axis. For a leaf variant this is its coordinate kind; for an allele
+        (``ACC:c.[...]``) it is the axis shared by every member, so - unlike the
+        deprecated ``is_*`` predicates - it works consistently whether or not the
+        edit is wrapped in an allele.
+
+        Returns ``None`` for an empty or mixed-axis allele, a bare ``[0]``/``[?]``
+        marker, or an RNA-fusion ``::`` construct joining two different
+        transcripts. A genome ring (``ACC:g.[seg1::seg2]``) is a single genomic
+        accession, so it resolves to :attr:`Axis.Genomic`.
+        """
+        ...
+
+    @property
     def indel_length(self) -> int | None:
         """Get the net indel length (bases gained or lost).
 
@@ -430,27 +485,59 @@ class HgvsVariant:
         ...
 
     def is_genomic(self) -> bool:
-        """Check if this is a genomic variant (g. prefix)."""
+        """Check if this is a genomic variant (g. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.Genomic``).
+            Unlike this predicate, ``axis`` resolves an allele's shared axis rather
+            than returning ``False`` for every allele parent. Emits a
+            ``DeprecationWarning``.
+        """
         ...
 
     def is_coding(self) -> bool:
-        """Check if this is a coding variant (c. prefix)."""
+        """Check if this is a coding variant (c. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.Coding``).
+            Emits a ``DeprecationWarning``.
+        """
         ...
 
     def is_noncoding(self) -> bool:
-        """Check if this is a non-coding variant (n. prefix)."""
+        """Check if this is a non-coding variant (n. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.NonCoding``).
+            Emits a ``DeprecationWarning``.
+        """
         ...
 
     def is_protein(self) -> bool:
-        """Check if this is a protein variant (p. prefix)."""
+        """Check if this is a protein variant (p. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.Protein``).
+            Emits a ``DeprecationWarning``.
+        """
         ...
 
     def is_rna(self) -> bool:
-        """Check if this is an RNA variant (r. prefix)."""
+        """Check if this is an RNA variant (r. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.Rna``).
+            Emits a ``DeprecationWarning``.
+        """
         ...
 
     def is_mitochondrial(self) -> bool:
-        """Check if this is a mitochondrial variant (m. prefix)."""
+        """Check if this is a mitochondrial variant (m. prefix).
+
+        .. deprecated::
+            Use the :attr:`axis` property instead (``variant.axis == Axis.Mitochondrial``).
+            Emits a ``DeprecationWarning``.
+        """
         ...
 
     def is_substitution(self) -> bool:

--- a/src/hgvs/mod.rs
+++ b/src/hgvs/mod.rs
@@ -20,5 +20,5 @@ pub use location::{
 };
 pub use uncertainty::Mu;
 pub use validation::{ParseConfig, ValidationLevel};
-pub use variant::{AllelePhase, AlleleVariant, HgvsVariant};
+pub use variant::{AllelePhase, AlleleVariant, CoordinateAxis, HgvsVariant};
 pub use version::HgvsVersion;

--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1866,6 +1866,75 @@ impl fmt::Display for AlleleVariant {
     }
 }
 
+/// The coordinate axis (reference molecule / coordinate system) a variant's
+/// positions are expressed in.
+///
+/// Every HGVS description that has a single, well-defined coordinate system maps
+/// to exactly one of these. An allele (`ACC:c.[…]`) maps to the axis shared by
+/// all of its members; see [`HgvsVariant::coordinate_axis`], which returns
+/// `None` when a description has no single axis (an empty or mixed-axis allele,
+/// a bare `[0]`/`[?]` marker, or an RNA-fusion `::` construct joining two
+/// different transcripts).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CoordinateAxis {
+    /// Genomic DNA (`g.`)
+    Genomic,
+    /// Coding DNA (`c.`)
+    Coding,
+    /// Non-coding transcript DNA (`n.`)
+    NonCoding,
+    /// RNA (`r.`)
+    Rna,
+    /// Protein (`p.`)
+    Protein,
+    /// Mitochondrial DNA (`m.`)
+    Mitochondrial,
+    /// Circular DNA (`o.`)
+    Circular,
+}
+
+impl CoordinateAxis {
+    /// The single-letter HGVS coordinate prefix for this axis
+    /// (`g`/`c`/`n`/`r`/`p`/`m`/`o`).
+    pub fn code(self) -> &'static str {
+        match self {
+            CoordinateAxis::Genomic => "g",
+            CoordinateAxis::Coding => "c",
+            CoordinateAxis::NonCoding => "n",
+            CoordinateAxis::Rna => "r",
+            CoordinateAxis::Protein => "p",
+            CoordinateAxis::Mitochondrial => "m",
+            CoordinateAxis::Circular => "o",
+        }
+    }
+
+    /// Whether this axis addresses a DNA molecule (`g`/`c`/`n`/`m`/`o`).
+    ///
+    /// This is the single home for the DNA-vs-RNA-vs-protein grouping: it treats
+    /// mitochondrial and circular DNA as DNA, unlike the narrow legacy
+    /// `is_genomic()` predicate (which is `g.`-only).
+    pub fn is_dna(self) -> bool {
+        matches!(
+            self,
+            CoordinateAxis::Genomic
+                | CoordinateAxis::Coding
+                | CoordinateAxis::NonCoding
+                | CoordinateAxis::Mitochondrial
+                | CoordinateAxis::Circular
+        )
+    }
+
+    /// Whether this axis addresses an RNA molecule (`r.`).
+    pub fn is_rna(self) -> bool {
+        matches!(self, CoordinateAxis::Rna)
+    }
+
+    /// Whether this axis addresses a protein (`p.`).
+    pub fn is_protein(self) -> bool {
+        matches!(self, CoordinateAxis::Protein)
+    }
+}
+
 /// Represents all types of HGVS variants:
 /// - g. (genomic)
 /// - c. (coding DNA)
@@ -1941,6 +2010,74 @@ impl HgvsVariant {
             HgvsVariant::Supernumerary(inner) => inner.accession(),
             HgvsVariant::Allele(a) => a.variants.first().and_then(|v| v.accession()),
             HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => None,
+        }
+    }
+
+    /// Get the [`CoordinateAxis`] (reference molecule / coordinate system) this
+    /// variant's positions are expressed in, if it has a single well-defined one.
+    ///
+    /// For a leaf variant this is simply its coordinate kind. For an allele
+    /// (`ACC:c.[…]`) it is the axis shared by every member — HGVS alleles are
+    /// single-coordinate-system by construction, so this is normally
+    /// well-defined; the method recurses into nested (and/or) sub-alleles and
+    /// skips bare `[0]`/`[?]` markers, which carry no axis of their own.
+    ///
+    /// Returns `None` when there is no single axis:
+    /// - an empty allele, or a (programmatically constructed) allele whose
+    ///   members disagree on axis;
+    /// - a bare `[0]` / `[?]` allele marker; or
+    /// - an RNA-fusion `::` construct, which joins two different transcripts
+    ///   rather than expressing one coordinate system.
+    ///
+    /// A genome ring (`ACC:g.[seg1::seg2]`), by contrast, is a single genomic
+    /// accession whose `::` are intra-molecule ISCN2020 break junctions, so it
+    /// resolves to [`CoordinateAxis::Genomic`].
+    pub fn coordinate_axis(&self) -> Option<CoordinateAxis> {
+        match self {
+            HgvsVariant::Genome(_) => Some(CoordinateAxis::Genomic),
+            HgvsVariant::Cds(_) => Some(CoordinateAxis::Coding),
+            HgvsVariant::Tx(_) => Some(CoordinateAxis::NonCoding),
+            HgvsVariant::Rna(_) => Some(CoordinateAxis::Rna),
+            HgvsVariant::Protein(_) => Some(CoordinateAxis::Protein),
+            HgvsVariant::Mt(_) => Some(CoordinateAxis::Mitochondrial),
+            HgvsVariant::Circular(_) => Some(CoordinateAxis::Circular),
+            HgvsVariant::Supernumerary(inner) => inner.coordinate_axis(),
+            HgvsVariant::Allele(a) => {
+                let mut axis: Option<CoordinateAxis> = None;
+                for member in &a.variants {
+                    match member.coordinate_axis() {
+                        // `[0]`/`[?]` markers carry no axis; skip them so a
+                        // `c.[X];[?]`-style allele still resolves to `X`'s axis.
+                        // Any other axis-less member (e.g. a nested fusion) makes
+                        // the whole allele's axis undefined.
+                        None => {
+                            if matches!(
+                                member,
+                                HgvsVariant::NullAllele | HgvsVariant::UnknownAllele
+                            ) {
+                                continue;
+                            }
+                            return None;
+                        }
+                        Some(member_axis) => match axis {
+                            None => axis = Some(member_axis),
+                            Some(prev) if prev == member_axis => {}
+                            Some(_) => return None,
+                        },
+                    }
+                }
+                axis
+            }
+            // A genome ring (`ACC:g.[seg1::seg2]`) is a single genomic accession
+            // whose `::` are intra-molecule ISCN2020 break junctions, not a
+            // fusion of two frames — every segment is `g.`, so its axis is
+            // Genomic. (Cross-chromosome `::` is rejected at parse time.) An
+            // RNA fusion, by contrast, joins two *different* transcripts and has
+            // no single reference molecule.
+            HgvsVariant::GenomeRing(_) => Some(CoordinateAxis::Genomic),
+            HgvsVariant::RnaFusion(_) | HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => {
+                None
+            }
         }
     }
 
@@ -3969,9 +4106,120 @@ mod tests {
         assert_eq!(compound.transcript_accession(), "ENST00000241453.7");
     }
 
-    // ----- Issue #115: self-cancelling allele detection (E3006) -----
+    // ----- Issue #1059: coordinate-axis resolution -----
 
     use crate::hgvs::parser::variant::parse_variant;
+
+    #[test]
+    fn test_coordinate_axis_leaf_kinds() {
+        let cases = [
+            ("NM_000088.3:c.459A>G", CoordinateAxis::Coding),
+            ("NC_000001.11:g.12345A>G", CoordinateAxis::Genomic),
+            ("NR_003286.2:n.100A>G", CoordinateAxis::NonCoding),
+            ("NM_000088.3:r.100a>g", CoordinateAxis::Rna),
+            ("NP_000079.2:p.Arg8Gln", CoordinateAxis::Protein),
+            ("NC_012920.1:m.100A>G", CoordinateAxis::Mitochondrial),
+        ];
+        for (input, expected) in cases {
+            let v = parse_variant(input).unwrap();
+            assert_eq!(
+                v.coordinate_axis(),
+                Some(expected),
+                "{input} should resolve to axis {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_coordinate_axis_allele_shares_member_axis() {
+        // The reported case: an allele's parent must report its members' shared axis.
+        let coding = parse_variant("NM_000000.1:c.[6G>C;16_18del]").unwrap();
+        assert_eq!(coding.coordinate_axis(), Some(CoordinateAxis::Coding));
+
+        let genomic = parse_variant("NC_000000.1:g.[6G>C;16_18del]").unwrap();
+        assert_eq!(genomic.coordinate_axis(), Some(CoordinateAxis::Genomic));
+
+        let protein = parse_variant("NP_000000.1:p.[(Arg8Gln);(Ser10Gly)]").unwrap();
+        assert_eq!(protein.coordinate_axis(), Some(CoordinateAxis::Protein));
+    }
+
+    #[test]
+    fn test_coordinate_axis_mixed_allele_is_none() {
+        // A synthesized allele whose members disagree on axis has no single axis.
+        let cds = parse_variant("NM_004006.2:c.100_150del").unwrap();
+        let tx = parse_variant("NM_004006.2:n.100_150dup").unwrap();
+        let mixed = HgvsVariant::Allele(AlleleVariant::new(vec![cds, tx], AllelePhase::Cis));
+        assert_eq!(mixed.coordinate_axis(), None);
+    }
+
+    #[test]
+    fn test_coordinate_axis_markers_contribute_no_axis() {
+        // Bare [0] / [?] markers have no axis at all.
+        assert_eq!(HgvsVariant::NullAllele.coordinate_axis(), None);
+        assert_eq!(HgvsVariant::UnknownAllele.coordinate_axis(), None);
+
+        // A trans allele mixing a concrete coding member with a [?] marker still
+        // resolves to the concrete member's axis (the marker is skipped).
+        let concrete = parse_variant("NM_000088.3:c.459A>G").unwrap();
+        let with_marker = HgvsVariant::Allele(AlleleVariant::new(
+            vec![concrete, HgvsVariant::UnknownAllele],
+            AllelePhase::Trans,
+        ));
+        assert_eq!(with_marker.coordinate_axis(), Some(CoordinateAxis::Coding));
+    }
+
+    #[test]
+    fn test_coordinate_axis_nested_allele() {
+        // and/or alleles nest one level: the parent must recurse into sub-alleles.
+        let a = parse_variant("NM_000088.3:c.459A>G").unwrap();
+        let b = parse_variant("NM_000088.3:c.500A>G").unwrap();
+        let inner = HgvsVariant::Allele(AlleleVariant::new(vec![a, b], AllelePhase::Cis));
+        let outer = HgvsVariant::Allele(AlleleVariant::new(vec![inner], AllelePhase::Cis));
+        assert_eq!(outer.coordinate_axis(), Some(CoordinateAxis::Coding));
+    }
+
+    #[test]
+    fn test_coordinate_axis_genome_ring_is_genomic() {
+        // A genome ring (`ACC:g.[seg1::seg2]`) is a single genomic accession
+        // whose `::` are intra-molecule ISCN2020 break junctions — not a fusion
+        // of two frames — so it resolves to Genomic, unlike an RNA fusion.
+        let ring = parse_variant("NC_000022.11:g.pter_1000del::2000_qterdel").unwrap();
+        assert!(
+            matches!(ring, HgvsVariant::GenomeRing(_)),
+            "expected a GenomeRing, got {ring:?}"
+        );
+        assert_eq!(ring.coordinate_axis(), Some(CoordinateAxis::Genomic));
+    }
+
+    #[test]
+    fn test_coordinate_axis_enum_groupings() {
+        assert_eq!(CoordinateAxis::Coding.code(), "c");
+        assert_eq!(CoordinateAxis::Genomic.code(), "g");
+        assert_eq!(CoordinateAxis::NonCoding.code(), "n");
+        assert_eq!(CoordinateAxis::Rna.code(), "r");
+        assert_eq!(CoordinateAxis::Protein.code(), "p");
+        assert_eq!(CoordinateAxis::Mitochondrial.code(), "m");
+        assert_eq!(CoordinateAxis::Circular.code(), "o");
+
+        // DNA axes: g / c / n / m / o. RNA: r. Protein: p.
+        for dna in [
+            CoordinateAxis::Genomic,
+            CoordinateAxis::Coding,
+            CoordinateAxis::NonCoding,
+            CoordinateAxis::Mitochondrial,
+            CoordinateAxis::Circular,
+        ] {
+            assert!(dna.is_dna(), "{dna:?} should be DNA");
+            assert!(!dna.is_rna());
+            assert!(!dna.is_protein());
+        }
+        assert!(CoordinateAxis::Rna.is_rna());
+        assert!(!CoordinateAxis::Rna.is_dna());
+        assert!(CoordinateAxis::Protein.is_protein());
+        assert!(!CoordinateAxis::Protein.is_dna());
+    }
+
+    // ----- Issue #115: self-cancelling allele detection (E3006) -----
 
     #[test]
     fn test_self_cancelling_detect_spec_example() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub mod vcf;
 pub use error::FerroError;
 pub use hgvs::location::{AaCode, ProteinRenderStyle, TerStyle};
 pub use hgvs::parser::{parse_hgvs, parse_hgvs_fast};
-pub use hgvs::variant::HgvsVariant;
+pub use hgvs::variant::{CoordinateAxis, HgvsVariant};
 pub use normalize::{NormalizeConfig, Normalizer, ShuffleDirection};
 pub use project::{VariantProjection, VariantProjector};
 pub use reference::{JsonProvider, MockProvider, MultiFastaProvider, ReferenceProvider};

--- a/src/python.rs
+++ b/src/python.rs
@@ -3,7 +3,7 @@
 //! This module provides Python bindings for the HGVS parser and normalizer.
 //! Enable with the `python` feature flag.
 
-use pyo3::exceptions::{PyRuntimeError, PyUserWarning, PyValueError};
+use pyo3::exceptions::{PyDeprecationWarning, PyRuntimeError, PyUserWarning, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::collections::hash_map::DefaultHasher;
@@ -22,7 +22,7 @@ use crate::error_handling::{
     ferro_to_mutalyzer, CorrectionWarning, ErrorConfig, ErrorMode, ErrorOverride, ErrorType,
 };
 use crate::hgvs::location::{AminoAcid, CdsPos, TxPos};
-use crate::hgvs::variant::HgvsVariant;
+use crate::hgvs::variant::{CoordinateAxis, HgvsVariant};
 use crate::mave::{is_mave_short_form, parse_mave_hgvs, MaveContext};
 use crate::normalize::ShuffleDirection;
 use crate::prepare::{check_references, prepare_references, PrepareConfig, ReferenceManifest};
@@ -516,6 +516,93 @@ fn normalize(py: Python<'_>, hgvs_string: &str, direction: &str) -> PyResult<Str
     Ok(normalized.to_string())
 }
 
+/// The coordinate axis (reference molecule / coordinate system) a variant's
+/// positions are expressed in.
+///
+/// Returned by :attr:`HgvsVariant.axis`. Each member carries its single-letter
+/// HGVS coordinate code (:meth:`code`) and a molecule-type grouping
+/// (:meth:`is_dna` / :meth:`is_rna` / :meth:`is_protein`).
+#[pyclass(name = "Axis", eq, eq_int, frozen, hash, from_py_object)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PyCoordinateAxis {
+    Genomic = 0,
+    Coding = 1,
+    NonCoding = 2,
+    Rna = 3,
+    Protein = 4,
+    Mitochondrial = 5,
+    Circular = 6,
+}
+
+impl From<CoordinateAxis> for PyCoordinateAxis {
+    fn from(axis: CoordinateAxis) -> Self {
+        match axis {
+            CoordinateAxis::Genomic => PyCoordinateAxis::Genomic,
+            CoordinateAxis::Coding => PyCoordinateAxis::Coding,
+            CoordinateAxis::NonCoding => PyCoordinateAxis::NonCoding,
+            CoordinateAxis::Rna => PyCoordinateAxis::Rna,
+            CoordinateAxis::Protein => PyCoordinateAxis::Protein,
+            CoordinateAxis::Mitochondrial => PyCoordinateAxis::Mitochondrial,
+            CoordinateAxis::Circular => PyCoordinateAxis::Circular,
+        }
+    }
+}
+
+impl From<PyCoordinateAxis> for CoordinateAxis {
+    fn from(axis: PyCoordinateAxis) -> Self {
+        match axis {
+            PyCoordinateAxis::Genomic => CoordinateAxis::Genomic,
+            PyCoordinateAxis::Coding => CoordinateAxis::Coding,
+            PyCoordinateAxis::NonCoding => CoordinateAxis::NonCoding,
+            PyCoordinateAxis::Rna => CoordinateAxis::Rna,
+            PyCoordinateAxis::Protein => CoordinateAxis::Protein,
+            PyCoordinateAxis::Mitochondrial => CoordinateAxis::Mitochondrial,
+            PyCoordinateAxis::Circular => CoordinateAxis::Circular,
+        }
+    }
+}
+
+#[pymethods]
+impl PyCoordinateAxis {
+    /// The single-letter HGVS coordinate code (``g``/``c``/``n``/``r``/``p``/``m``/``o``).
+    fn code(&self) -> &'static str {
+        CoordinateAxis::from(*self).code()
+    }
+
+    /// Whether this axis addresses a DNA molecule (``g``/``c``/``n``/``m``/``o``).
+    ///
+    /// Treats mitochondrial and circular DNA as DNA, unlike the deprecated
+    /// ``is_genomic()`` predicate (which is ``g.``-only).
+    fn is_dna(&self) -> bool {
+        CoordinateAxis::from(*self).is_dna()
+    }
+
+    /// Whether this axis addresses an RNA molecule (``r.``).
+    fn is_rna(&self) -> bool {
+        CoordinateAxis::from(*self).is_rna()
+    }
+
+    /// Whether this axis addresses a protein (``p.``).
+    fn is_protein(&self) -> bool {
+        CoordinateAxis::from(*self).is_protein()
+    }
+
+    fn __str__(&self) -> &'static str {
+        CoordinateAxis::from(*self).code()
+    }
+}
+
+/// Emit a `DeprecationWarning` for a deprecated axis boolean predicate,
+/// steering callers to the `axis` property.
+fn warn_axis_predicate_deprecated(py: Python<'_>, name: &str) -> PyResult<()> {
+    let message = std::ffi::CString::new(format!(
+        "HgvsVariant.{name}() is deprecated; use the `axis` property instead \
+         (e.g. `variant.axis`), which resolves an allele's shared coordinate axis."
+    ))
+    .map_err(|e| PyRuntimeError::new_err(format!("invalid warning message: {e}")))?;
+    PyErr::warn(py, &py.get_type::<PyDeprecationWarning>(), &message, 1)
+}
+
 /// Python wrapper for HgvsVariant
 #[pyclass(name = "HgvsVariant", from_py_object)]
 #[derive(Clone)]
@@ -670,34 +757,83 @@ impl PyHgvsVariant {
         is_frameshift(&self.inner)
     }
 
-    /// Check if this is a genomic variant (g. prefix)
-    fn is_genomic(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Genome(_))
+    /// The coordinate axis (reference molecule / coordinate system) of this
+    /// variant, or ``None`` if it has no single well-defined one.
+    ///
+    /// Returns an :class:`Axis` enum member. For a leaf variant this is its
+    /// coordinate kind; for an allele (``ACC:c.[…]``) it is the axis shared by
+    /// every member — so, unlike the deprecated ``is_*`` predicates, this works
+    /// consistently whether or not the edit is wrapped in an allele.
+    ///
+    /// Returns ``None`` when there is no single axis: an empty or mixed-axis
+    /// allele, a bare ``[0]``/``[?]`` marker, or an RNA-fusion ``::`` construct
+    /// joining two different transcripts. A genome ring (``ACC:g.[seg1::seg2]``)
+    /// is a single genomic accession, so it resolves to ``Axis.Genomic``.
+    #[getter]
+    fn axis(&self) -> Option<PyCoordinateAxis> {
+        self.inner.coordinate_axis().map(PyCoordinateAxis::from)
     }
 
-    /// Check if this is a coding variant (c. prefix)
-    fn is_coding(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Cds(_))
+    /// Check if this is a genomic variant (g. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.Genomic``. Unlike this predicate, ``axis``
+    ///     resolves the shared axis of an allele (``g.[…]``) rather than
+    ///     returning ``False`` for every allele parent.
+    fn is_genomic(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_genomic")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::Genomic))
     }
 
-    /// Check if this is a non-coding variant (n. prefix)
-    fn is_noncoding(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Tx(_))
+    /// Check if this is a coding variant (c. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.Coding``.
+    fn is_coding(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_coding")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::Coding))
     }
 
-    /// Check if this is a protein variant (p. prefix)
-    fn is_protein(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Protein(_))
+    /// Check if this is a non-coding variant (n. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.NonCoding``.
+    fn is_noncoding(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_noncoding")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::NonCoding))
     }
 
-    /// Check if this is an RNA variant (r. prefix)
-    fn is_rna(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Rna(_))
+    /// Check if this is a protein variant (p. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.Protein``.
+    fn is_protein(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_protein")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::Protein))
     }
 
-    /// Check if this is a mitochondrial variant (m. prefix)
-    fn is_mitochondrial(&self) -> bool {
-        matches!(self.inner, HgvsVariant::Mt(_))
+    /// Check if this is an RNA variant (r. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.Rna``.
+    fn is_rna(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_rna")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::Rna))
+    }
+
+    /// Check if this is a mitochondrial variant (m. prefix).
+    ///
+    /// .. deprecated::
+    ///     Use the :attr:`axis` property instead, e.g.
+    ///     ``variant.axis == Axis.Mitochondrial``.
+    fn is_mitochondrial(&self, py: Python<'_>) -> PyResult<bool> {
+        warn_axis_predicate_deprecated(py, "is_mitochondrial")?;
+        Ok(self.inner.coordinate_axis() == Some(CoordinateAxis::Mitochondrial))
     }
 
     /// Check if this is a substitution
@@ -5370,6 +5506,7 @@ fn ferro_hgvs(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Core classes
     m.add_class::<PyHgvsVariant>()?;
+    m.add_class::<PyCoordinateAxis>()?;
     m.add_class::<PyNormalizer>()?;
 
     // SPDI classes

--- a/tests/python/test_issue_1059_coordinate_axis.py
+++ b/tests/python/test_issue_1059_coordinate_axis.py
@@ -1,0 +1,128 @@
+"""Issue #1059: expose an allele's coordinate axis on the top-level variant.
+
+Before this change, the axis predicates (``is_coding``/``is_genomic``/...) returned
+``False`` for *every* allele parent, so an allele's coordinate system could only be
+discovered by iterating ``variants()``. This adds a first-class ``axis`` property (an
+``Axis`` enum, or ``None`` when there is no single axis) and deprecates the boolean
+predicates in favour of it.
+"""
+
+import warnings
+
+import pytest
+
+import ferro_hgvs
+from ferro_hgvs import Axis
+
+
+class TestAxisProperty:
+    """The ``axis`` property resolves the coordinate system of any variant."""
+
+    @pytest.mark.parametrize(
+        ("desc", "expected"),
+        [
+            ("NM_000088.3:c.100A>G", Axis.Coding),
+            ("NC_000001.11:g.12345A>G", Axis.Genomic),
+            ("NR_046018.2:n.100A>G", Axis.NonCoding),
+            ("NM_000088.3:r.100a>g", Axis.Rna),
+            ("NP_000079.2:p.Glu6Val", Axis.Protein),
+            ("NC_012920.1:m.100A>G", Axis.Mitochondrial),
+        ],
+    )
+    def test_leaf_variants_report_their_axis(self, desc: str, expected: Axis) -> None:
+        assert ferro_hgvs.parse(desc).axis == expected
+
+    @pytest.mark.parametrize(
+        ("desc", "expected"),
+        [
+            # The reported bug: an allele parent must report its members' shared axis.
+            ("NM_000000.1:c.[6G>C;16_18del]", Axis.Coding),
+            ("NC_000000.1:g.[6G>C;16_18del]", Axis.Genomic),
+            ("NP_000000.1:p.[(Arg8Gln);(Ser10Gly)]", Axis.Protein),
+        ],
+    )
+    def test_allele_parent_reports_shared_axis(self, desc: str, expected: Axis) -> None:
+        variant = ferro_hgvs.parse(desc)
+        assert variant.num_variants > 1  # this is genuinely an allele
+        assert variant.axis == expected
+
+    def test_no_single_axis_returns_none(self) -> None:
+        # An RNA fusion spans two partner frames -> no single coordinate axis.
+        fusion = ferro_hgvs.parse("NM_152263.2:r.-115_775::NM_002609.3:r.1580_*1924")
+        assert fusion.axis is None
+
+    def test_genome_ring_is_genomic(self) -> None:
+        # A genome ring (`ACC:g.[seg1::seg2]`) is a single genomic accession whose
+        # `::` are intra-molecule ISCN2020 break junctions, not a two-frame fusion,
+        # so it resolves to Genomic (unlike the RNA fusion above).
+        ring = ferro_hgvs.parse("NC_000022.11:g.pter_1000del::2000_qterdel")
+        assert ring.axis == Axis.Genomic
+
+    def test_single_and_allele_are_consistent(self) -> None:
+        # The inconsistency from the issue: wrapping an edit in an allele must not
+        # change the reported axis.
+        single = ferro_hgvs.parse("NM_000000.1:c.6G>C")
+        allele = ferro_hgvs.parse("NM_000000.1:c.[6G>C;16_18del]")
+        assert single.axis == allele.axis == Axis.Coding
+
+
+class TestAxisEnum:
+    """The ``Axis`` enum carries its HGVS code and molecule-type groupings."""
+
+    @pytest.mark.parametrize(
+        ("axis", "code"),
+        [
+            (Axis.Genomic, "g"),
+            (Axis.Coding, "c"),
+            (Axis.NonCoding, "n"),
+            (Axis.Rna, "r"),
+            (Axis.Protein, "p"),
+            (Axis.Mitochondrial, "m"),
+            (Axis.Circular, "o"),
+        ],
+    )
+    def test_code(self, axis: Axis, code: str) -> None:
+        assert axis.code() == code
+        assert str(axis) == code
+
+    def test_dna_grouping_includes_mito_and_circular(self) -> None:
+        for axis in (Axis.Genomic, Axis.Coding, Axis.NonCoding, Axis.Mitochondrial, Axis.Circular):
+            assert axis.is_dna()
+            assert not axis.is_rna()
+            assert not axis.is_protein()
+
+    def test_rna_and_protein_groupings(self) -> None:
+        assert Axis.Rna.is_rna()
+        assert not Axis.Rna.is_dna()
+        assert Axis.Protein.is_protein()
+        assert not Axis.Protein.is_dna()
+
+    def test_reporter_is_dna_usecase(self) -> None:
+        # The workaround in the issue collapses to one expression, and now works
+        # for coding alleles (which previously returned all-False).
+        def is_dna(v: "ferro_hgvs.HgvsVariant") -> bool:
+            return v.axis is not None and v.axis.is_dna()
+
+        assert is_dna(ferro_hgvs.parse("NM_000000.1:c.[6G>C;16_18del]"))
+        assert is_dna(ferro_hgvs.parse("NC_012920.1:m.100A>G"))
+        assert not is_dna(ferro_hgvs.parse("NP_000000.1:p.[(Arg8Gln);(Ser10Gly)]"))
+
+
+class TestLegacyBooleanDeprecation:
+    """The boolean axis predicates still work (now allele-aware) but are deprecated."""
+
+    def test_allele_predicate_now_matches_single_edit(self) -> None:
+        allele = ferro_hgvs.parse("NM_000000.1:c.[6G>C;16_18del]")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            assert allele.is_coding() is True
+            assert allele.is_genomic() is False
+
+    @pytest.mark.parametrize(
+        "predicate",
+        ["is_genomic", "is_coding", "is_noncoding", "is_protein", "is_rna", "is_mitochondrial"],
+    )
+    def test_predicates_emit_deprecation_warning(self, predicate: str) -> None:
+        variant = ferro_hgvs.parse("NM_000088.3:c.100A>G")
+        with pytest.warns(DeprecationWarning, match="axis"):
+            getattr(variant, predicate)()


### PR DESCRIPTION
Closes #1059

## Problem

Every axis predicate (`is_coding()` / `is_genomic()` / `is_noncoding()` / `is_protein()` / `is_rna()` / `is_mitochondrial()`) returned `False` on an **allele** parent — e.g. `NM_000000.1:c.[6G>C;16_18del]` reported all axis flags `False` even though the allele is unambiguously coding. An `HgvsVariant::Allele` is its own enum arm, so it matched none of the leaf coordinate kinds. This is inconsistent with the single-edit case (`NM_000000.1:c.6G>C` reports `is_coding() == True`) and forced callers to reach into `variants()` and risk divergence.

## Fix

Introduce a first-class coordinate axis as the single source of truth, and express the predicates in terms of it.

- **Rust core** (`src/hgvs/variant.rs`): a `CoordinateAxis` enum (`Genomic`/`Coding`/`NonCoding`/`Rna`/`Protein`/`Mitochondrial`/`Circular`) with `code()` / `is_dna()` / `is_rna()` / `is_protein()`, and `HgvsVariant::coordinate_axis() -> Option<CoordinateAxis>`. It recurses through alleles (including and/or nesting) and `Supernumerary`, skips bare `[0]`/`[?]` markers, and returns `None` when there is no single axis (empty or mixed-axis allele, or a `::` fusion/ring spanning two partner frames). Exported from the crate root.
- **Python** (`src/python.rs`): an `Axis` enum and a `HgvsVariant.axis` property that mirror the core type, plus type stubs.

The six axis booleans now **delegate** to `coordinate_axis()` — so they finally report an allele's shared axis instead of `False` — and are **deprecated** (they emit `DeprecationWarning`) in favour of `.axis`. This is a behavior change to those predicates: `is_coding()` on `c.[…]` now returns `True`.

The DNA/RNA/protein grouping now lives in one place on `Axis.is_dna()`, which — unlike the old `g.`-only `is_genomic()` — also treats mitochondrial and circular DNA as DNA. The reporter's workaround collapses to `v.axis is not None and v.axis.is_dna()`.

## Design notes / decisions for review

- **Legacy predicates change behavior (recurse into alleles) rather than being frozen.** They are deprecated anyway, and this directly resolves the reported inconsistency. If preferred, they could instead stay leaf-only with only `.axis` recursing.
- **`GenomeRing` / `RnaFusion` return `None`** (no single axis) — conservative, since a fusion spans two partner frames. Easy to revisit if a single axis is wanted for the single-accession ring case.

## Testing

- Rust: 6 new unit tests for `coordinate_axis()` (leaf kinds, shared-axis alleles, synthesized mixed allele → `None`, `[0]`/`[?]` markers, and/or nesting, enum groupings). Full suite: 7985 passed.
- Python: 28 new tests (the reporter's five cases, `Axis` groupings/`code`, the `is_dna` use-case, and deprecation-warning coverage for all six predicates). Full suite: 431 passed.
- `clippy --all-targets -D warnings`, `cargo fmt`, `ruff`, and `mypy` all clean.