### PR TITLE
fix(normalize): preserve the uncertain/predicted (...) wrapper through normalization (#1063)

### DIFF
--- a/src/hgvs/uncertainty.rs
+++ b/src/hgvs/uncertainty.rs
@@ -99,6 +99,23 @@ impl<T> Mu<T> {
     pub fn unknown() -> Self {
         Mu::Unknown
     }
+
+    /// Build a `Mu<U>` carrying `value`, matching this wrapper's certainty
+    /// (Certain vs Uncertain/predicted). Encodes the #1063 policy: reconstruct
+    /// an edit while preserving the input's predicted/observed status.
+    ///
+    /// `Unknown` maps to `Unknown` (mirroring `map`/`map_ref`) rather than
+    /// carrying `value` — a `Mu::Unknown` has no payload to be "the same
+    /// certainty as", so callers reconstructing from a known `value` should
+    /// not expect this arm to fire on a variant's edit (normalization already
+    /// bails out before reconstruction when the input edit is unknown).
+    pub fn with_same_certainty<U>(&self, value: U) -> Mu<U> {
+        match self {
+            Mu::Certain(_) => Mu::Certain(value),
+            Mu::Uncertain(_) => Mu::Uncertain(value),
+            Mu::Unknown => Mu::Unknown,
+        }
+    }
 }
 
 impl<T: fmt::Display> fmt::Display for Mu<T> {
@@ -179,5 +196,20 @@ mod tests {
         assert_eq!(Mu::Certain(42).into_inner(), Some(42));
         assert_eq!(Mu::Uncertain(42).into_inner(), Some(42));
         assert_eq!(Mu::<i32>::Unknown.into_inner(), None);
+    }
+
+    #[test]
+    fn test_with_same_certainty() {
+        let certain: Mu<i32> = Mu::Certain(1);
+        let rebuilt = certain.with_same_certainty(99);
+        assert_eq!(rebuilt, Mu::Certain(99));
+
+        let uncertain: Mu<i32> = Mu::Uncertain(1);
+        let rebuilt = uncertain.with_same_certainty(99);
+        assert_eq!(rebuilt, Mu::Uncertain(99));
+
+        let unknown: Mu<i32> = Mu::Unknown;
+        let rebuilt = unknown.with_same_certainty(99);
+        assert_eq!(rebuilt, Mu::<i32>::Unknown);
     }
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2170,9 +2170,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
             let resolved = GenomeVariant {
                 accession: variant.accession.clone(),
                 gene_symbol: variant.gene_symbol.clone(),
-                loc_edit: LocEdit::new(
+                loc_edit: LocEdit::with_uncertainty(
                     Interval::new(GenomePos::new(start), GenomePos::new(end)),
-                    edit.clone(),
+                    variant.loc_edit.edit.with_same_certainty(edit.clone()),
                 ),
             };
             return Ok((
@@ -2240,9 +2240,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = GenomeVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(
+            loc_edit: LocEdit::with_uncertainty(
                 Interval::new(GenomePos::new(new_start), GenomePos::new(new_end)),
-                new_edit,
+                variant.loc_edit.edit.with_same_certainty(new_edit),
             ),
         };
 
@@ -2252,9 +2252,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // (#1034: rev-comp sub-runs are not carved out) and/or into separate
         // subs across interior identities. Returns the variant unchanged for
         // non-Delins or no-decomposition cases.
+        let uncertain = new_variant.loc_edit.edit.is_uncertain();
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Genome(new_variant));
         warnings.append(&mut split_warnings);
-        Ok((wrap_allele_if_split(split), warnings))
+        Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
     /// Normalize a CDS variant
@@ -3278,15 +3279,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = CdsVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         // Issue #160 + #165 post-canonicalization split. The codon-frame
         // exception applies only to CDS-proper positions, which the
         // helper filters internally via `simple_cds_pos`.
+        let uncertain = new_variant.loc_edit.edit.is_uncertain();
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Cds(new_variant));
         warnings.append(&mut split_warnings);
-        Ok((wrap_allele_if_split(split), warnings))
+        Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
     /// Normalize a transcript variant
@@ -3588,16 +3593,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(
+            loc_edit: LocEdit::with_uncertainty(
                 Interval::new(TxPos::new(new_start as i64), TxPos::new(new_end as i64)),
-                new_edit,
+                variant.loc_edit.edit.with_same_certainty(new_edit),
             ),
         };
 
         // Issue #160 + #165 post-canonicalization split.
+        let uncertain = new_variant.loc_edit.edit.is_uncertain();
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Tx(new_variant));
         warnings.append(&mut split_warnings);
-        Ok((wrap_allele_if_split(split), warnings))
+        Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
     /// Normalize a protein variant.
@@ -4762,7 +4768,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
             let tx_variant = TxVariant {
                 accession: variant.accession.clone(),
                 gene_symbol: variant.gene_symbol.clone(),
-                loc_edit: LocEdit::new(Interval::new(tx_start, tx_end), edit.clone()),
+                loc_edit: LocEdit::with_uncertainty(
+                    Interval::new(tx_start, tx_end),
+                    variant.loc_edit.edit.with_same_certainty(edit.clone()),
+                ),
             };
 
             // Mirror of the `normalize_tx` intronic dispatch (both intronic in the
@@ -4793,10 +4802,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 });
             };
             let rna_variant = self.txvariant_to_rnavariant(&tv, cds_info)?;
+            let uncertain = rna_variant.loc_edit.edit.is_uncertain();
             let (split, mut split_warnings) = self.apply_canonical_split(HV::Rna(rna_variant));
             let mut warnings = tx_warnings;
             warnings.append(&mut split_warnings);
-            return Ok((wrap_allele_if_split(split), warnings));
+            return Ok((wrap_allele_if_split(split, uncertain), warnings));
         }
 
         // Try to get transcript (RNA uses the same accession as mRNA transcripts)
@@ -4924,7 +4934,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     let bs_variant = TxVariant {
                         accession: variant.accession.clone(),
                         gene_symbol: variant.gene_symbol.clone(),
-                        loc_edit: LocEdit::new(Interval::new(bs_start, bs_end), edit.clone()),
+                        loc_edit: LocEdit::with_uncertainty(
+                            Interval::new(bs_start, bs_end),
+                            variant.loc_edit.edit.with_same_certainty(edit.clone()),
+                        ),
                     };
                     // Engine errors (no following intron — last exon — no genomic
                     // alignment, …) fall through to the exon-confined result, the
@@ -4952,12 +4965,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 .is_some_and(|p| p.is_intronic());
                         if crossed_into_intron {
                             if let Ok(rna_variant) = self.txvariant_to_rnavariant(&tv, cds_info) {
+                                let uncertain = rna_variant.loc_edit.edit.is_uncertain();
                                 let (split, mut split_warnings) =
                                     self.apply_canonical_split(HV::Rna(rna_variant));
                                 let mut combined = warnings;
                                 combined.extend(boundary_warnings);
                                 combined.append(&mut split_warnings);
-                                return Ok((wrap_allele_if_split(split), combined));
+                                return Ok((wrap_allele_if_split(split, uncertain), combined));
                             }
                         }
                     }
@@ -4985,14 +4999,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = RnaVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(RnaInterval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                RnaInterval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         // Issue #160 + #165 post-canonicalization split (T/U-equivalent
         // comparison for the rev-comp scan and per-position emissions).
+        let uncertain = new_variant.loc_edit.edit.is_uncertain();
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Rna(new_variant));
         warnings.append(&mut split_warnings);
-        Ok((wrap_allele_if_split(split), warnings))
+        Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
     /// Convert an `r.` position to a transcript-numbered [`TxPos`], carrying the
@@ -5081,7 +5099,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         Ok(RnaVariant {
             accession: tv.accession.clone(),
             gene_symbol: tv.gene_symbol.clone(),
-            loc_edit: LocEdit::new(RnaInterval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                RnaInterval::new(new_start, new_end),
+                tv.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         })
     }
 
@@ -5310,8 +5331,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
             if is_reversed {
                 return (HV::Mt(canonical), vec![]);
             }
+            let uncertain = canonical.loc_edit.edit.is_uncertain();
             let (split, warnings) = self.apply_canonical_split(HV::Mt(canonical));
-            (wrap_allele_if_split(split), warnings)
+            (wrap_allele_if_split(split, uncertain), warnings)
         };
 
         let accession = variant.accession.transcript_accession();
@@ -5407,16 +5429,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = MtVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(
+            loc_edit: LocEdit::with_uncertainty(
                 Interval::new(GenomePos::new(new_start), GenomePos::new(new_end)),
-                new_edit,
+                variant.loc_edit.edit.with_same_certainty(new_edit),
             ),
         };
 
         // Issue #160 inv-split post-pass (mirrors normalize_genome).
+        let uncertain = new_variant.loc_edit.edit.is_uncertain();
         let (split, mut split_warnings) = self.apply_canonical_split(HV::Mt(new_variant));
         warnings.append(&mut split_warnings);
-        Ok((wrap_allele_if_split(split), warnings))
+        Ok((wrap_allele_if_split(split, uncertain), warnings))
     }
 
     /// Apply minimal notation to an mt variant without full normalization.
@@ -5695,7 +5718,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = CdsVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         Ok((HV::Cds(new_variant), warnings))
@@ -5875,7 +5901,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         Ok((HV::Tx(new_variant), warnings))
@@ -6042,7 +6071,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = CdsVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         Ok((HV::Cds(new_variant), warnings))
@@ -6481,7 +6513,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
-            loc_edit: LocEdit::new(Interval::new(new_start, new_end), new_edit),
+            loc_edit: LocEdit::with_uncertainty(
+                Interval::new(new_start, new_end),
+                variant.loc_edit.edit.with_same_certainty(new_edit),
+            ),
         };
 
         Ok((HV::Tx(new_variant), warnings))
@@ -8620,11 +8655,19 @@ fn is_transcript_accession(id: &str) -> bool {
         || id.starts_with("ENST")
 }
 
-/// If `variants` has 1 element return it directly; if >1 wrap in a cis Allele.
-fn wrap_allele_if_split(mut variants: Vec<HgvsVariant>) -> HgvsVariant {
+/// If `variants` has 1 element return it directly; if >1 wrap in a cis
+/// Allele. `uncertain` is the pre-split variant's edit certainty (#1063):
+/// a single predicted/uncertain edit that canonically decomposes into a
+/// multi-member allele carries its `(...)` wrapper onto the whole allele
+/// (`g.[(200C>T;202C>G)]`), never onto the individual members — members
+/// built by `build_variant_at` are always `Mu::Certain`. Ignored when the
+/// split doesn't fire (single-element `variants`).
+fn wrap_allele_if_split(mut variants: Vec<HgvsVariant>, uncertain: bool) -> HgvsVariant {
     debug_assert!(!variants.is_empty(), "wrap_allele_if_split: empty input");
     if variants.len() == 1 {
         variants.pop().unwrap()
+    } else if uncertain {
+        HgvsVariant::Allele(AlleleVariant::new_uncertain(variants, AllelePhase::Cis))
     } else {
         HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Cis))
     }

--- a/tests/it/issue_1063_preserve_uncertain_wrapper.rs
+++ b/tests/it/issue_1063_preserve_uncertain_wrapper.rs
@@ -1,0 +1,272 @@
+//! Issue #1063 — the predicted/uncertain `(...)` wrapper (`Mu::Uncertain`)
+//! was silently dropped by the shift/canonicalization pipeline.
+//!
+//! Root cause: the final-result reconstructions in the `normalize_*`
+//! functions (one per coordinate system) rebuild the output variant with
+//! `LocEdit::new(...)`, which hardcodes `Mu::Certain` — discarding whatever
+//! certainty the input variant's edit carried. So `g.(8del)` normalized to
+//! `g.12del` instead of `g.(12del)`.
+//!
+//! The policy (per the design doc): uncertainty is the epistemic status of
+//! the *described event*.
+//! - For single-edit outputs it attaches to the edit: `g.(12del)`.
+//! - For canonical-split outputs (a delins that decomposes into a
+//!   multi-member allele) it attaches to the *whole allele*, not to the
+//!   individual members: `g.[(200C>T;202C>G)]` (the predicted cis-allele
+//!   notation from `recommendations/uncertain.md`, already exercised by
+//!   `tests/it/predicted_cis_allele.rs`), never `g.[(200C>T);(202C>G)]`.
+//!
+//! This suite exercises all three shapes (3' shift, delins->inv
+//! canonicalization, delins->split) plus idempotency, using the genomic
+//! `JsonProvider` helper pattern from `issue_1041_repro.rs`.
+
+use ferro_hgvs::{parse_hgvs, JsonProvider, Normalizer};
+use std::io::Write;
+
+/// Genome-capable provider: one contig named `c` of `len` cyclic ACGT bytes
+/// with `payload` written 1-based at `pos1`. Mirrors the helper in
+/// `issue_1041_repro.rs`.
+fn provider_len(len: usize, pos1: usize, payload: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(len).collect();
+    for (i, b) in payload.bytes().enumerate() {
+        bases[pos1 - 1 + i] = b;
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { "c": seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// A contig named `contig` with a homopolymer run of `A`s at 1-based [195, 205]
+/// in an otherwise cyclic-ACGT 250bp contig. Used to exercise 3' shifting.
+fn provider_homopolymer_named(contig: &str) -> JsonProvider {
+    let mut bases: Vec<u8> = "ACGT".bytes().cycle().take(250).collect();
+    for b in bases.iter_mut().take(205).skip(194) {
+        *b = b'A';
+    }
+    let seq = String::from_utf8(bases).unwrap();
+    let doc = serde_json::json!({
+        "version": "1.0",
+        "genome_build": "GRCh38",
+        "transcripts": [],
+        "genomic_sequences": { contig: seq },
+    });
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    f.write_all(doc.to_string().as_bytes()).unwrap();
+    JsonProvider::from_json(f.path()).unwrap()
+}
+
+/// The genome-axis homopolymer provider (contig `c`).
+fn provider_homopolymer() -> JsonProvider {
+    provider_homopolymer_named("c")
+}
+
+fn norm(p: &JsonProvider, input: &str) -> String {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e}"));
+    Normalizer::new(p.clone())
+        .normalize(&v)
+        .unwrap_or_else(|e| panic!("normalize {input:?} failed: {e}"))
+        .to_string()
+}
+
+#[track_caller]
+fn assert_idempotent(p: &JsonProvider, input: &str) {
+    let once = norm(p, input);
+    let twice = norm(p, &once);
+    assert_eq!(
+        twice, once,
+        "not idempotent for {input:?}: {once:?} -> {twice:?}"
+    );
+}
+
+// =============================================================================
+// Shift: uncertain del/dup 3'-shifts and keeps its wrapper.
+// =============================================================================
+
+#[test]
+fn certain_del_shifts_unwrapped() {
+    let p = provider_homopolymer();
+    assert_eq!(norm(&p, "c:g.196del"), "c:g.205del");
+}
+
+#[test]
+fn uncertain_del_shifts_and_stays_wrapped() {
+    let p = provider_homopolymer();
+    assert_eq!(norm(&p, "c:g.(196del)"), "c:g.(205del)");
+}
+
+#[test]
+fn uncertain_del_shift_is_idempotent() {
+    let p = provider_homopolymer();
+    assert_idempotent(&p, "c:g.(196del)");
+}
+
+#[test]
+fn certain_dup_shifts_unwrapped() {
+    // A single-base dup inside the [195,205] `A` run 3'-shifts to the 3'-most
+    // position (g.205dup). Assert the exact form directly so a wrong shift is
+    // caught — not just "ends in dup, no parens".
+    let p = provider_homopolymer();
+    assert_eq!(norm(&p, "c:g.196dup"), "c:g.205dup");
+}
+
+#[test]
+fn uncertain_dup_shifts_and_stays_wrapped() {
+    // Assert the exact 3'-shifted, wrapped form directly (not derived from the
+    // certain output) so both tests fail independently if the dup shift breaks.
+    let p = provider_homopolymer();
+    assert_eq!(norm(&p, "c:g.(196dup)"), "c:g.(205dup)");
+}
+
+#[test]
+fn uncertain_dup_shift_is_idempotent() {
+    let p = provider_homopolymer();
+    assert_idempotent(&p, "c:g.(196dup)");
+}
+
+// =============================================================================
+// Canonicalization: uncertain whole-run-revcomp delins -> inv, still wrapped.
+// =============================================================================
+
+#[test]
+fn certain_revcomp_delins_canonicalizes_to_inv_unwrapped() {
+    // ref[200..202] = GCA, revcomp = TGC.
+    let p = provider_len(600, 200, "GCA");
+    assert_eq!(norm(&p, "c:g.200_202delinsTGC"), "c:g.200_202inv");
+}
+
+#[test]
+fn uncertain_revcomp_delins_canonicalizes_to_inv_and_stays_wrapped() {
+    let p = provider_len(600, 200, "GCA");
+    assert_eq!(norm(&p, "c:g.(200_202delinsTGC)"), "c:g.(200_202inv)");
+}
+
+#[test]
+fn uncertain_revcomp_delins_to_inv_is_idempotent() {
+    let p = provider_len(600, 200, "GCA");
+    assert_idempotent(&p, "c:g.(200_202delinsTGC)");
+}
+
+// =============================================================================
+// Canonical split: uncertain delins that decomposes into a 2-member allele.
+// The wrapper moves to the WHOLE ALLELE, not to individual members.
+// =============================================================================
+
+#[test]
+fn certain_delins_splits_into_unwrapped_allele() {
+    // ref[200..202] = CAC, alt = TAG: pos0 C->T (diff), pos1 A==A (identity,
+    // gap), pos2 C->G (diff) -> decomposes into two independent subs
+    // (general.md:56 edit-priority / #165 sub-only decomposition).
+    let p = provider_len(600, 200, "CAC");
+    assert_eq!(norm(&p, "c:g.200_202delinsTAG"), "c:g.[200C>T;202C>G]");
+}
+
+#[test]
+fn uncertain_delins_splits_into_allele_level_wrapped_form() {
+    let p = provider_len(600, 200, "CAC");
+    // Predicted cis-allele notation (`recommendations/uncertain.md`):
+    // `[(<members>)]`, matching `tests/it/predicted_cis_allele.rs`.
+    assert_eq!(norm(&p, "c:g.(200_202delinsTAG)"), "c:g.[(200C>T;202C>G)]");
+}
+
+#[test]
+fn uncertain_delins_split_members_are_not_individually_wrapped() {
+    let p = provider_len(600, 200, "CAC");
+    let out = norm(&p, "c:g.(200_202delinsTAG)");
+    // The member bodies (`200C>T`, `202C>G`) must not carry their own
+    // parens; only the allele-level `[(...)]` wrapper is present.
+    assert!(
+        !out.contains("(200C>T)") && !out.contains("(202C>G)"),
+        "members must not be individually wrapped: {out}"
+    );
+}
+
+#[test]
+fn uncertain_delins_split_is_idempotent() {
+    let p = provider_len(600, 200, "CAC");
+    assert_idempotent(&p, "c:g.(200_202delinsTAG)");
+}
+
+// =============================================================================
+// Axis coverage: the wrapper reconstruction is per-coordinate-system (one
+// `LocEdit::with_uncertainty(... with_same_certainty ...)` site per axis, each
+// with its own position type). The genome cases above exercise `normalize_genome`
+// (GenomePos); these exercise the `normalize_mt` (GenomePos, distinct function)
+// and `normalize_cds` (CdsPos, distinct position type) reconstruction sites so a
+// copy-paste slip in one axis can't hide behind the genome tests.
+// =============================================================================
+
+#[test]
+fn uncertain_mito_del_shifts_and_stays_wrapped() {
+    // `m.` axis (`normalize_mt`): a del in the [195,205] `A` run 3'-shifts to
+    // g.205 and must keep its `(...)` wrapper.
+    let p = provider_homopolymer_named("NC_012920.1");
+    assert_eq!(norm(&p, "NC_012920.1:m.(196del)"), "NC_012920.1:m.(205del)");
+}
+
+#[test]
+fn uncertain_mito_del_shift_is_idempotent() {
+    let p = provider_homopolymer_named("NC_012920.1");
+    assert_idempotent(&p, "NC_012920.1:m.(196del)");
+}
+
+mod cds_axis {
+    use super::{assert_idempotent, norm};
+    use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+    use ferro_hgvs::MockProvider;
+
+    /// Single-exon plus-strand coding transcript `ATGGCATAA` (ATG·GCA·TAA):
+    /// c.4_6 = `GCA`, whose reverse-complement is `TGC`, so
+    /// `c.4_6delinsTGC` canonicalizes to `c.4_6inv` — a deterministic
+    /// (shift-free) exercise of the `normalize_cds` wrapper reconstruction.
+    fn tx_provider() -> MockProvider {
+        let mut p = MockProvider::new();
+        let seq = "ATGGCATAA".to_string();
+        let len = seq.len() as u64;
+        let tx = Transcript::new(
+            "NM_TEST.1".to_string(),
+            Some("TEST".to_string()),
+            Strand::Plus,
+            seq,
+            Some(1),
+            Some(len),
+            vec![Exon::new(1, 1, len)],
+            None,
+            None,
+            None,
+            Default::default(),
+            ManeStatus::None,
+            None,
+            None,
+        );
+        p.add_transcript(tx);
+        p
+    }
+
+    #[test]
+    fn certain_cds_revcomp_delins_canonicalizes_to_inv_unwrapped() {
+        let p = tx_provider();
+        assert_eq!(norm(&p, "NM_TEST.1:c.4_6delinsTGC"), "NM_TEST.1:c.4_6inv");
+    }
+
+    #[test]
+    fn uncertain_cds_revcomp_delins_canonicalizes_to_inv_and_stays_wrapped() {
+        let p = tx_provider();
+        assert_eq!(
+            norm(&p, "NM_TEST.1:c.(4_6delinsTGC)"),
+            "NM_TEST.1:c.(4_6inv)"
+        );
+    }
+
+    #[test]
+    fn uncertain_cds_revcomp_delins_to_inv_is_idempotent() {
+        let p = tx_provider();
+        assert_idempotent(&p, "NM_TEST.1:c.(4_6delinsTGC)");
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -90,6 +90,7 @@ mod issue_1041_repro;
 mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
+mod issue_1063_preserve_uncertain_wrapper;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Closes #1063.

## Summary

`Normalizer.normalize()` silently dropped the uncertain/predicted `(...)` wrapper (`Mu::Uncertain`) from any `del`/`dup`/`inv`/`repeat`/`delins` routed through the shift pipeline — the predicted-vs-observed distinction is meaning-bearing in HGVS, and it vanished with no warning. This preserves it.

```
before:  TEST:g.(8del)   -> TEST:g.12del       # wrapper dropped (silent)
after:   TEST:g.(8del)   -> TEST:g.(12del)      # wrapper preserved
```

## Root cause

The final-result reconstructions in the five `normalize_*` functions rebuilt the variant with `LocEdit::new(...)`, which hardcodes `Mu::Certain`, discarding the input's `variant.loc_edit.edit` wrapper. (The file already had ~19 sites that correctly preserved certainty and ~18 that dropped it — the drift this fixes.)

## Principled model

Uncertainty is the epistemic status of the described *event*; normalization changes the representation, never the status. So the wrapper is:

- **preserved on the edit** for single-edit outputs (3′-shift, `delins→inv/dup/sub`): `c.(10del)` → `c.(14del)`;
- **attached to the whole allele** when a canonical split (#160/#165) decomposes the variant into members: `c.(10_12delinsAA)` → `c.([10A>T;12C>G])` (via the existing `AlleleVariant.uncertain` flag);
- **never distributed per-member** (`c.[(a);(b)]` would falsely assert each sub-change is independently predicted);
- **never dropped**.

## Implementation

- New `Mu::with_same_certainty` carries the input wrapper's Certain/Uncertain status onto the reconstructed edit.
- The final-result reconstructions across g./c./n./r./m. use it; per-member split builders keep members `Certain`.
- `wrap_allele_if_split` marks the resulting `AlleleVariant` uncertain when its (now-preserved) input was predicted.

Substitutions are unaffected — #1060 already carves them out of this path.

## Tests

- New `tests/it/issue_1063_preserve_uncertain_wrapper.rs`: single-edit round-trip (shift, `delins→inv`), split-to-allele (`([a;b])` with members unwrapped), certain-inputs-unchanged, idempotency, and a `Mu::with_same_certainty` unit test.
- `cargo nextest run --features dev` — 7993 passed, 0 failed (no existing test needed updating). `cargo fmt` / `clippy --all-targets -- -D warnings` clean.

## Conformance

- **Mutalyzer conformance run — done, clean.** Full `cargo nextest run --features dev` with the manifest-gated prepared reference active (145 manifest-gated tests activated). All mutalyzer axes (`normalized`, `genomic`, `protein_description`, `coding_protein_descriptions`, `rna_description`, `noncoding`, `errors`, `infos`) + both idempotent axes pass, as do the biocommons, hgvs-rs-projection, legacy-gene-selector, and reference-snapshot suites. `comparator_provenance_reference_identity_matches_live` passes, so the empty-projection gate enforced and held. Despite this change touching uncertain-wrapped indels, it moved **zero** FAIL-set ledger rows — every `baseline-failures/*.txt` stays empty — so no re-blessing was required.

## Still open (optional, does not block review)

- A direct RNA-intronic uncertain test (the path is correct by construction and covered transitively by the CDS/Tx equivalents; the new suite is genome-axis).

