### PR TITLE
chore: bump minor version for feature commits on 0.x releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,6 @@
+[workspace]
+# For a 0.x crate, release-plz's default bumps the patch version for feature
+# commits and reserves the minor bump for breaking changes. This project treats
+# pre-1.0 feature additions as minor bumps, so increment the minor version on
+# features even while the major version is 0.
+features_always_increment_minor = true


### PR DESCRIPTION
Adds a `release-plz.toml` that enables `features_always_increment_minor`, so pre-1.0 feature commits bump the **minor** version (e.g. `0.8.x` → `0.9.0`) instead of the patch version.

## Why

release-plz has no config today, so it runs on defaults. For a `0.x` crate the default reserves the minor bump for breaking changes and bumps the **patch** for `feat:` commits — which is why the pending release PR ([#1045](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1045)) proposed `0.8.1 → 0.8.2` even though [#1055](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1055) and [#1056](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1056) are feature additions. This project treats pre-1.0 feature additions as minor bumps, so we opt into `features_always_increment_minor`.

Once this merges, release-plz will recompute the pending release on the next push to `main` and update #1045 from `0.8.2` to `0.9.0` automatically — no manual version/changelog edits.

## Scope

Intentionally minimal — a single-field config in the `[workspace]` section (the global-defaults section, even for this single-crate repo). It does **not** adopt the other fields used in sibling repos' `release-plz.toml` (`changelog_config`, `git_release_enable`, `semver_check`), because those would change ferro-hgvs's current behavior: there is no `cliff.toml` here, GitHub releases are actively created via the default, and `cargo-semver-checks` is on (the "✓ API compatible changes" note in release PRs). Keeping this to one field avoids mixing an unrelated behavior change into a versioning tweak.

## Tradeoff

This deviates from Cargo's convention that a `0.x` minor bump signals a breaking change: after this, a minor bump no longer distinguishes "breaking" from "new feature" until 1.0.