### PR TITLE
test(conformance): update issue_506 expectation for #1054 transcript-reference selector drop

### DIFF
--- a/tests/it/mutalyzer_normalize_tests.rs
+++ b/tests/it/mutalyzer_normalize_tests.rs
@@ -1358,14 +1358,25 @@ fn issue_506_bare_n_transcript_predicts_protein() {
         "worked example n.206_210del must predict the spec frameshift consequence"
     );
     // The coding axis must reframe n.206_210del to the spec-normalized c. form.
+    // The gene symbol (SDHD) is resolved and carried on the struct
+    // (`coding.gene_symbol`) but is *not* rendered: #1054 drops the gene-symbol
+    // selector on a transcript-reference Display (`NM_`/`NR_`/`XM_`/`XR_`/`ENST`),
+    // since a bare transcript accession already identifies the gene — the
+    // selector is only meaningful on a genomic reference (`NG_(SDHD):c.`).
     let coding = proj
         .coding
         .as_ref()
         .expect("coding (c.) axis should be derived");
     assert_eq!(
         coding.to_string(),
-        "NM_003002.4(SDHD):c.171_175del",
-        "n.206_210del should reframe to c.171_175del"
+        "NM_003002.4:c.171_175del",
+        "n.206_210del should reframe to c.171_175del (gene selector dropped on NM_ per #1054)"
+    );
+    assert_eq!(
+        coding.gene_symbol(),
+        Some("SDHD"),
+        "the gene symbol must still be resolved and available on the struct even though \
+         Display omits it for a transcript reference (#1054)"
     );
     // A bare-NM_ n. input has no genome alignment, so no genomic form.
     assert!(


### PR DESCRIPTION
## Summary

The manifest-gated conformance test `issue_506_bare_n_transcript_predicts_protein` carried a stale expectation. It asserted the coding axis of `NM_003002.4:n.206_210del` renders as `NM_003002.4(SDHD):c.171_175del`, but #1054 ("drop the gene-symbol selector on transcript-reference Display") changed Display to omit the gene-symbol selector on a transcript-reference accession (`NM_`/`NR_`/`XM_`/`XR_`/`ENST`). A bare transcript accession already identifies the gene, so the selector is only meaningful on a genomic reference (e.g. `NG_012337.3(SDHD):c.`). The gene symbol is still resolved and carried on the struct — only Display omits it.

## Why CI didn't catch it

This test only runs when a prepared reference is available (`FERRO_MANIFEST`); on CI (no manifest) it prints `skipping — no manifest` and exits 0. So #1054's green CI never exercised it, and the stale expectation only surfaces in a local conformance run against a prepared reference.

## Change

- Update the expected coding form to the bare `NM_003002.4:c.171_175del`.
- Document the #1054 rationale inline so the missing selector doesn't read as a bug.
- Add `assert_eq!(coding.gene_symbol(), Some("SDHD"))` so a future regression in gene-symbol *resolution* (as opposed to *rendering*) is still caught — the symbol must remain on the struct even though Display drops it.

## Verification

`FERRO_MANIFEST=<prepared-ref> cargo nextest run --features dev -E 'test(issue_506_bare_n_transcript_predicts_protein)'` — passes. Coordinates (`c.171_175del`) and protein prediction (`NP_002993.1:p.(Gly58GlnfsTer9)`) were already correct and are unchanged; only the coding-axis rendering expectation is corrected.
