### PR TITLE
test: build generate_spec_fixture example into the outer target dir

### DIFF
--- a/tests/it/issue_1046_generator_gitdir_leak.rs
+++ b/tests/it/issue_1046_generator_gitdir_leak.rs
@@ -34,8 +34,21 @@ fn rev_parse(dir: &Path, rev: &str) -> Option<String> {
     Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
-/// Path to the built `generate_spec_fixture` example, derived from the running
-/// test binary's location (`<target>/<profile>/deps/<test-exe>` →
+/// The target directory root of the running test binary
+/// (`<target>/<profile>/deps/<test-exe>` → `<target>`). This tracks whatever
+/// `--target-dir` / `CARGO_TARGET_DIR` the outer `cargo test` used, including
+/// the `target/llvm-cov-target` override that the coverage job passes on the
+/// command line (which nested cargo invocations do *not* otherwise inherit).
+fn target_dir() -> PathBuf {
+    let mut p = std::env::current_exe().expect("current_exe");
+    p.pop(); // drop the test-exe filename → .../deps/
+    p.pop(); // drop deps → .../<profile>/
+    p.pop(); // drop <profile> → .../<target>/
+    p
+}
+
+/// Path to the built `generate_spec_fixture` example under the profile that the
+/// running test binary was built with (`<target>/<profile>/deps/<test-exe>` →
 /// `<target>/<profile>/examples/generate_spec_fixture`). This is robust to
 /// `CARGO_TARGET_DIR` and the active profile, and avoids invoking the example
 /// through `cargo run` (which would leak our hostile GIT env into cargo too).
@@ -85,7 +98,11 @@ fn commit_sha_is_submodule_pin_under_hook_git_env() {
         String::from_utf8_lossy(&out.stdout).trim().to_string()
     };
 
-    // Build the example with a clean env (a fast no-op when already built).
+    // Build the example (a fast no-op when already built). Pin `--target-dir`
+    // to the outer test binary's target root so the example lands exactly where
+    // `example_binary()` looks: the coverage job passes `--target-dir` on the
+    // command line, and that override is not inherited by this nested cargo
+    // invocation (which would otherwise build into the default `target/`).
     let build = Command::new(env!("CARGO"))
         .current_dir(&root)
         .args([
@@ -96,6 +113,8 @@ fn commit_sha_is_submodule_pin_under_hook_git_env() {
             "--example",
             "generate_spec_fixture",
         ])
+        .arg("--target-dir")
+        .arg(target_dir())
         .status()
         .expect("build generate_spec_fixture example");
     assert!(build.success(), "example build failed");


### PR DESCRIPTION
## Problem

The Coverage job on `main` is red ([run 29663920075](https://github.com/fulcrumgenomics/ferro-hgvs/actions/runs/29663920075/job/88131063847)). The issue #1046 regression test panics:

```
thread '...commit_sha_is_submodule_pin_under_hook_git_env' panicked at tests/it/issue_1046_generator_gitdir_leak.rs:104:5:
example binary not found at .../target/llvm-cov-target/debug/examples/generate_spec_fixture
```

## Root cause

The test builds the `generate_spec_fixture` example via a nested `cargo build`, then locates the resulting binary with `example_binary()`, which is derived from the test binary's `current_exe()`.

Under the coverage job, `cargo llvm-cov` passes `--target-dir target/llvm-cov-target` **on the command line**. A command-line `--target-dir` is not inherited by nested cargo invocations, so the nested `cargo build` wrote the example into the default `target/debug/examples/`, while `example_binary()` (correctly tracking the outer run's target root) looked under `target/llvm-cov-target/debug/examples/`. The two disagreed only when a `--target-dir` override was in play — i.e. exactly the coverage job — which is why a plain `cargo test` stayed green and this surfaced only on `main`'s Coverage run.

## Fix

Pin the nested build's `--target-dir` to the running test binary's own target root (a new `target_dir()` helper, same `current_exe()` derivation `example_binary()` already uses). The example now always lands where the test looks, regardless of any `--target-dir` / `CARGO_TARGET_DIR` the outer test run used.

## Verification

Test passes under all three paths:
- plain `cargo test --features dev --test it commit_sha_is_submodule_pin_under_hook_git_env`
- an explicit `--target-dir` override (the failure reproducer)
- the real `cargo llvm-cov --no-report --features dev --test it -- commit_sha_...` (the exact CI path)

`cargo fmt` clean, `cargo clippy --features dev --test it` clean.