### PR TITLE
docs: point Zenodo DOI badge at the concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Documentation](https://docs.rs/ferro-hgvs/badge.svg)](https://docs.rs/ferro-hgvs)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/ferro-hgvs/README.html)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18703104-blue.svg)](https://doi.org/10.5281/zenodo.18703104)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.18703103-blue.svg)](https://doi.org/10.5281/zenodo.18703103)
 
 # ferro-hgvs
 


### PR DESCRIPTION
The DOI badge referenced `10.5281/zenodo.18703104`, a version DOI pinned to `v0.1.0`. The repository has since shipped through `v0.9.0`, so the badge has been advertising the first release for eight versions.

This switches the badge to `10.5281/zenodo.18703103`, the concept DOI covering all versions. A concept DOI always resolves to the latest release, so the badge stays current without a manual bump each time.

Verified: `https://zenodo.org/api/records/18703103` → `10.5281/zenodo.21436038`, title `fulcrumgenomics/ferro-hgvs: v0.9.0`.
