### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.9.0...v0.9.1) - 2026-07-20
+
+### Fixed
+
+- *(project)* wrong protein consequence for same-codon in-cis substitutions ([#1077](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1077))
+
+### Other
+
+- point Zenodo DOI badge at the concept DOI ([#1075](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1075))
+
 ## [0.9.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.8.1...v0.9.0) - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.9.0...v0.9.1) - 2026-07-20

### Fixed

- *(project)* wrong protein consequence for same-codon in-cis substitutions ([#1077](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1077))

### Other

- point Zenodo DOI badge at the concept DOI ([#1075](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1075))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).