### PR TITLE
fix(spec-fixture): drop prose position references from the harvester and repoint the tracker

### DIFF
--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -840,26 +840,70 @@ mod runner {
         "?".to_string()
     }
 
-    /// True when `input` is a bare coordinate reference: a coordinate-system
-    /// prefix (`c.`/`g.`/`m.`/`n.`/`o.`/`p.`/`r.`) followed only by position
-    /// characters (digits, `_ + - * ?`) with no edit operator.
+    /// Chromosome landmarks the spec uses in place of a numeric position.
+    /// They carry no edit meaning, so a coordinate built only from them (e.g.
+    /// `g.pter`) is still edit-less.
+    const POSITION_LANDMARKS: [&str; 3] = ["pter", "qter", "cen"];
+
+    /// True when `input` carries no edit operator: a coordinate-system prefix
+    /// (`c.`/`g.`/`m.`/`n.`/`o.`/`p.`/`r.`) followed only by position tokens —
+    /// position characters (digits, `+ - * ?`) or a chromosome landmark
+    /// (`pter`/`qter`/`cen`) — joined by `_`.
     ///
     /// The spec formats position references in prose (e.g. "the A-stretch
     /// running from position `c.5690` to `c.5697`") with the same inline-code
     /// markup as variant examples, so the harvester scrapes them; a bare
-    /// coordinate is not a describable variant. The spec's edit-less
-    /// whole-variant markers (`p.?`, `p.0`, `r.?`, …) share this shape but parse
-    /// successfully, so the caller gates the drop on a *parse failure* and never
-    /// removes them.
+    /// coordinate is not a describable variant. Edit-less strings are not all
+    /// prose references, though: the spec's whole-variant markers (`p.?`, `p.0`,
+    /// `r.?`, …) and its edit-less negatives (`c.123-65_-50`, an incomplete
+    /// range the spec requires be *rejected*) share this shape. So the caller
+    /// pairs this test with evidence that the string is only a position — see
+    /// [`is_position_reference`].
     fn is_edit_less_coordinate(input: &str) -> bool {
-        // Strip any leading accession: the coordinate lives after the last colon.
-        let core = input.rsplit(':').next().unwrap_or(input);
+        // Strip a leading accession: the coordinate follows the *first* colon.
+        // Splitting on the last colon instead would look past the junctions of a
+        // chimeric description (`NC_1:g.pter_100::NC_2:g.200_cen_qter`) and judge
+        // only its tail, wrongly calling the whole string edit-less.
+        let core = input.split_once(':').map_or(input, |(_, rest)| rest);
         let rest = match core.get(0..2) {
             Some("c." | "g." | "m." | "n." | "o." | "p." | "r.") => &core[2..],
             _ => return false,
         };
-        rest.chars()
-            .all(|ch| matches!(ch, '0'..='9' | '_' | '+' | '-' | '*' | '?'))
+        // A bare prefix (`c.`) is edit-less; but past that, an empty token from
+        // `_`-splitting means a malformed range (`c.1_`, `c.1__2`) — not a clean
+        // position, so it is not treated as an edit-less coordinate.
+        rest.is_empty()
+            || rest.split('_').all(|token| {
+                !token.is_empty()
+                    && (POSITION_LANDMARKS.contains(&token)
+                        || token
+                            .chars()
+                            .all(|ch| matches!(ch, '0'..='9' | '+' | '-' | '*' | '?')))
+            })
+    }
+
+    /// True when a harvested string is a position reference lifted out of spec
+    /// prose rather than a variant, and so should not become a fixture row.
+    ///
+    /// Two signals, both requiring [`is_edit_less_coordinate`] (no edit
+    /// operator) to hold:
+    ///
+    /// * ferro cannot parse it at all — a position cited in a sentence, e.g.
+    ///   `c.` or a truncated fragment; or
+    /// * ferro normalizes it by merely appending `=` (e.g. `g.12345678` →
+    ///   `NC_000023.11:g.12345678=`), i.e. it invented the "identity" edit the
+    ///   string never had. Scoring that as a divergence is noise.
+    ///
+    /// Edit-less strings that ferro parses *and* leaves alone are kept: the
+    /// whole-variant markers (`p.?`, `p.0`) and the spec's edit-less negatives
+    /// such as `c.123-65_-50`, which the checklist requires be rejected.
+    ///
+    /// `parse_ok`/`current` come from `target` (the accession-prefixed form)
+    /// while the shape test reads the raw `input`. These are equivalent here:
+    /// prefixing only prepends an accession, and `is_edit_less_coordinate`
+    /// strips any accession before testing, so both forms share the shape.
+    fn is_position_reference(input: &str, target: &str, current: &str, parse_ok: bool) -> bool {
+        is_edit_less_coordinate(input) && (!parse_ok || current == format!("{target}="))
     }
 
     pub fn build_rows(
@@ -919,19 +963,11 @@ mod runner {
             let (current, parse_ok, normalize_ok, expected_warnings) =
                 run_ferro(&normalizer, target);
 
-            // Drop bare coordinate references harvested from spec prose (e.g.
-            // "position `c.5690`"): an edit-less coordinate that ferro also
-            // rejects is not a describable variant, just a position cited in a
-            // sentence. Edit-less whole-variant markers (`p.?`, `p.0`) share the
-            // shape but parse, so they survive. An explicit override keeps the
-            // row regardless (the auditor deliberately classified it).
-            //
-            // `parse_ok` is from `target` (the prefixed form) but the shape test
-            // reads the raw `input`. These are equivalent here: prefixing only
-            // prepends an accession, and `is_edit_less_coordinate` strips any
-            // accession (`rsplit(':')`) before testing, so the bare/prefixed
-            // forms have the same edit-less shape.
-            if ov.is_none() && !parse_ok && is_edit_less_coordinate(&input) {
+            // Drop position references harvested from spec prose (e.g.
+            // "position `c.5690`"): they are not describable variants, just
+            // positions cited in a sentence. An explicit override keeps the row
+            // regardless (the auditor deliberately classified it).
+            if ov.is_none() && is_position_reference(&input, target, &current, parse_ok) {
                 continue;
             }
 
@@ -1044,7 +1080,7 @@ mod runner {
 
     #[cfg(test)]
     mod tests {
-        use super::is_edit_less_coordinate;
+        use super::{is_edit_less_coordinate, is_position_reference};
 
         #[test]
         fn flags_bare_position_references() {
@@ -1057,7 +1093,8 @@ mod runner {
                 "c.", // bare prefix
                 "c.*",
                 "g.12345678",
-                "p.?", // edit-less marker — shape matches; caller's parse gate keeps it
+                "g.pter", // chromosome landmark, still no edit operator
+                "p.?",    // edit-less marker — shape matches; caller's gate keeps it
             ] {
                 assert!(
                     is_edit_less_coordinate(bare),
@@ -1076,12 +1113,73 @@ mod runner {
                 "LRG_199t1:c.11T>G",
                 "p.Met1ext-5", // has an edit token (`ext`), not bare
                 "g.1234=",
+                // Malformed ranges: an empty `_`-token is not a clean position,
+                // so these are not classified as edit-less (would otherwise be
+                // wrongly dropped as prose if ferro rejects them).
+                "c.1_",
+                "c.1__2",
+                // Chimeric junctions: edit-less-looking tail, but the whole
+                // string is a (spec-rejected) description, not a position.
+                "NC_000002.12:g.pter_8247756::NC_000011.10:g.15825273_cen_qter",
+                "g.[chr11:pter_15825272::chr2:8247757_cen_qter]",
             ] {
                 assert!(
                     !is_edit_less_coordinate(variant),
                     "{variant:?} is a real variant, not a bare coordinate"
                 );
             }
+        }
+
+        #[test]
+        fn drops_coordinates_ferro_merely_stamps_with_equals() {
+            assert!(is_position_reference(
+                "g.12345678",
+                "NC_000023.11:g.12345678",
+                "NC_000023.11:g.12345678=",
+                true,
+            ));
+            assert!(is_position_reference(
+                "g.pter",
+                "NC_000023.11:g.pter",
+                "NC_000023.11:g.pter=",
+                true,
+            ));
+        }
+
+        #[test]
+        fn drops_unparsable_prose_fragments() {
+            assert!(is_position_reference(
+                "c.",
+                "NM_004006.2:c.",
+                "parse error",
+                false
+            ));
+        }
+
+        #[test]
+        fn keeps_edit_less_spec_negatives_and_markers() {
+            // `c.123-65_-50` is an incomplete range the spec requires be
+            // rejected: edit-less, but ferro leaves it untouched, so it stays.
+            assert!(!is_position_reference(
+                "c.123-65_-50",
+                "NM_004006.2:c.123-65_-50",
+                "NM_004006.2:c.123-65_-50",
+                true,
+            ));
+            // Whole-variant markers parse and round-trip unchanged.
+            assert!(!is_position_reference(
+                "p.?",
+                "NP_000079.2:p.?",
+                "NP_000079.2:p.?",
+                true
+            ));
+            // Real variants never match, whatever ferro does with them.
+            assert!(!is_position_reference(
+                "g.123del",
+                "NC_000023.11:g.123del",
+                "NC_000023.11:g.123del",
+                true,
+            ));
         }
     }
 }

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -716,8 +716,6 @@ mod overrides {
         pub status: Option<String>,
         #[serde(default, deserialize_with = "deserialize_some")]
         pub spec_expected: Option<Option<String>>,
-        #[serde(default)]
-        pub todo: Option<String>,
         /// Free-form note attached to the row in the emitted fixture.
         /// Used to capture nuances where the auto-classified `status`
         /// doesn't fully convey ferro's behavior — e.g. rows whose
@@ -786,8 +784,6 @@ mod runner {
         pub source_paths: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub working_group: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub todo: Option<String>,
         /// Free-form clarifying note. Surfaced from the override file
         /// for rows where the `status` bucket doesn't fully capture
         /// ferro's behavior (e.g. canonical form emitted from a
@@ -1000,24 +996,6 @@ mod runner {
                 .and_then(|o| o.status.clone())
                 .unwrap_or_else(|| auto_status.to_string());
 
-            // Audit todo attaches whenever status flags a row as needing
-            // review: ferro accepts a string the spec rejects (false-acceptance),
-            // ferro rejects a string the spec accepts (parse-error), ferro
-            // rewrites a canonical form (diverges), or normalization needs
-            // reference data we can't run yet (needs-reference). Override wins.
-            const ISSUE_83: &str = "https://github.com/fulcrumgenomics/ferro-hgvs/issues/83";
-            let needs_todo = matches!(
-                status.as_str(),
-                "false-acceptance" | "parse-error" | "needs-reference" | "diverges"
-            );
-            let todo = ov.and_then(|o| o.todo.clone()).or_else(|| {
-                if needs_todo {
-                    Some(ISSUE_83.to_string())
-                } else {
-                    None
-                }
-            });
-
             rows.push(Row {
                 coordinate_system: coord_system(&input),
                 input: input.clone(),
@@ -1028,7 +1006,6 @@ mod runner {
                 source_kind: source_kind_str(kind).to_string(),
                 source_paths: paths,
                 working_group: agg.wg,
-                todo,
                 note: ov.and_then(|o| o.note.clone()),
                 requires_reference: ov.and_then(|o| o.requires_reference),
                 expected_warnings,

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -98,3 +98,14 @@ Smaller fixtures (<1 MB) are tracked directly in git. Key categories:
 - **`transcripts/`** — Mock transcript metadata
 
 See `SCHEMAS.md` for JSON format documentation.
+
+## Spec-divergence tracking
+
+`grammar/hgvs_spec_normalization.json` (generated, gitignored) classifies every harvested spec string
+with a `status`. Rows whose status is `diverges`, `false-acceptance`, `needs-reference`, or
+`parse-error` are the outstanding spec-divergence work.
+
+The umbrella tracking issue is <https://github.com/fulcrumgenomics/ferro-hgvs/issues/1079>. It is
+deliberately recorded here — in prose a human edits — rather than stamped onto each generated row,
+so that a superseded tracker cannot silently rot inside the generator (which is what happened with
+the previous tracker, #83).

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -100,25 +100,34 @@ fn harvester_yields_only_real_variants() {
         );
     }
 
-    // Outcome check over *every* parse-error row: an edit-less coordinate ferro
-    // rejects is spec prose, not a variant, and is dropped. This must scan all
-    // rows, not fixed examples — whether a bare-shaped coordinate is dropped
-    // depends on ferro's parse result (`!parse_ok`), not shape alone: e.g.
-    // `g.12345678` is bare-shaped but PARSES, so it legitimately survives. The
-    // predicate below only pins the outcome; the predicate's char-set is
-    // unit-tested independently in the generator (`is_edit_less_coordinate`
-    // tests). The generator's drop is also gated on `ov.is_none()` — an explicit
-    // override deliberately keeps its row; no current override is a bare
-    // coordinate, so this asserts over every parse-error row; if one is ever
-    // added, exempt overridden inputs here.
+    // Outcome check over *every* row: a bare coordinate is spec prose, not a
+    // variant, whenever ferro either rejects it outright or "normalizes" it by
+    // inventing an identity `=` it never had (`g.12345678` →
+    // `NC_000023.11:g.12345678=`). Both shapes are dropped. This must scan all
+    // rows, not fixed examples. Bare coordinates ferro parses and leaves alone
+    // legitimately survive — the whole-variant markers (`p.?`, `p.0`) and the
+    // spec's edit-less negatives such as `c.123-65_-50`. The predicate below
+    // only pins the outcome; its char-set is unit-tested independently in the
+    // generator (`is_edit_less_coordinate` tests). The generator's drop is also
+    // gated on `ov.is_none()` — an explicit override deliberately keeps its row;
+    // no current override is a bare coordinate, so this asserts over every row;
+    // if one is ever added, exempt overridden inputs here.
     for row in &fx.rows {
-        if row.status == "parse-error" {
-            assert!(
-                !is_bare_coordinate(&row.input),
-                "bare coordinate reference should have been dropped, not left as parse-error: {:?}",
-                row.input
-            );
+        if !is_bare_coordinate(&row.input) {
+            continue;
         }
+        assert_ne!(
+            row.status, "parse-error",
+            "bare coordinate reference should have been dropped, not left as parse-error: {:?}",
+            row.input
+        );
+        let target = row.input_prefixed.as_deref().unwrap_or(&row.input);
+        assert_ne!(
+            row.current,
+            format!("{target}="),
+            "bare coordinate reference stamped with an identity `=` should have been dropped: {:?}",
+            row.input
+        );
     }
 
     // Variants the spec split across a `<code class="spotN">` highlight are


### PR DESCRIPTION
The spec-normalization fixture reports 243 rows with a divergent status (`diverges` / `false-acceptance` / `needs-reference`). An audit found that 99 of those are not variants at all: they are bare coordinate references lifted out of spec prose (for example "positions `g.12345678` to `g.12345901`"), which ferro normalizes to `NC_000023.11:g.12345678=` — appending `=` — after which the row is scored `diverges`. Only 144 are genuine.

The generator's module docs already claimed edit-less coordinates were dropped. The filter existed but was gated on `!parse_ok && is_edit_less_coordinate(input)`, and prose position references parse successfully, so they sailed past the first conjunct. The predicate is now edit-less AND (`!parse_ok` OR the normalized output merely appends `=`).

Two supporting fixes were required: `pter` / `qter` / `cen` are now accepted as position tokens (catches `g.pter`), and the accession is stripped at the first colon rather than the last — with `rsplit`, the broadened landmark matching judged chimeric `::` descriptions by their trailing junction alone and wrongly dropped two genuine `correctly-rejected` rows.

Row counts, before → after:

| status | before | after |
|---|---:|---:|
| total | 1033 | 934 |
| `diverges` | 133 | 34 |
| `false-acceptance` | 76 | 76 |
| `needs-reference` | 34 | 34 |
| `correctly-rejected` | 75 | 75 |
| `preserved` | 715 | 715 |

Exactly the audited 99, all drawn from `diverges`; no other bucket moved. `c.123-65_-50` survives as `false-acceptance` — it has no edit operator but is a genuine spec negative (`checklist.md:26` calls it an incomplete range that must be rejected), which is why "no edit operator" alone is not a sufficient exclusion test. No override entries were orphaned, so the unknown-inputs guard never fired and was not weakened.

The second commit repoints the hardcoded divergence-tracker link. Issue #83 was closed on 2026-05-19 with all 22 checkboxes unticked, superseded by #72/#73/#74/#75/#81/#82/#84/#87, yet every regeneration re-stamped live rows with that dead link. All 144 todo-bearing rows now cite #1079 via a module-level `DIVERGENCE_TRACKER_URL` constant, so the next repoint is a one-line change.

Consumer tests moved by exactly 99: spec-normalization tested 999 → 900; reference-free idempotency tested 944 → 845. A stale comment in `tests/it/hgvs_spec_normalization_tests.rs` asserting the old rationale was updated and its assertion strengthened to also reject identity-`=` rows.

Verification: `generate_spec_fixture -- --check` exits 0; `cargo nextest run --features dev` 8067/8067 with `FERRO_MANIFEST` unset; rustfmt and clippy clean. The generated fixture remains gitignored.

Suggested reading order: `36767df` (the filter fix and its rationale), then `45093dc` (the one-line tracker repoint).

Refs #1079.
