### PR TITLE
fix(project): describe a decomposed delins as one protein consequence

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -16,10 +16,10 @@ use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
 use crate::project::protein::{
     build_initiator_unknown, build_whole_protein_unknown, cds_has_recognized_start,
-    cds_has_valid_start, edit_reaches_initiation_codon, edit_spans_cds_into_3utr,
-    predict_indel_protein, predict_stop_region_extension, predict_substitution_protein,
-    read_cds_start_codon, try_project_cis_combined_inframe, whole_exon_deletion_span, CisCombined,
-    RefProteinBundle,
+    cds_has_valid_start, combined_cis_residue_changes, edit_reaches_initiation_codon,
+    edit_spans_cds_into_3utr, predict_indel_protein, predict_stop_region_extension,
+    predict_substitution_protein, read_cds_start_codon, try_project_cis_combined_inframe,
+    whole_exon_deletion_span, CisCombined, RefProteinBundle,
 };
 use crate::project::result::VariantProjection;
 use crate::reference::transcript::Transcript;
@@ -614,6 +614,87 @@ fn combine_cis_substitutions_by_codon(
     }
 
     let groups = group_consecutive_residues(changed);
+    Some(render_cis_substitution_groups(
+        &groups,
+        &accession,
+        &gene_symbol,
+    ))
+}
+
+/// Describe an **in-cis** allele of arbitrary length-preserving members as a
+/// single protein consequence over the residues its *combined* product changes
+/// (#1079).
+///
+/// This is the general form of [`combine_cis_substitutions_by_codon`]: it does
+/// not require the members to be single-base substitutions, so it also covers a
+/// `delins` that normalization decomposed into a cis allele of mixed sub-edits
+/// (e.g. `c.415_419delinsATATG` → `c.[415T>A;417_419inv]`). Describing such an
+/// allele member-by-member predicts each member against the *reference* codon,
+/// which yields a spec-forbidden bracketed protein allele
+/// (`protein/substitution.md`: `p.[Arg76Ser;Cys77Trp]` "is not correct") and can
+/// even name the wrong amino acid — exactly the "conflicting and incorrect
+/// predictions" `DNA/delins.md` introduces the coalescing rule to prevent.
+///
+/// The changed residues come from [`combined_cis_residue_changes`] (a
+/// residue-wise diff of the combined product against the reference protein) and
+/// are rendered by the shared [`render_cis_substitution_groups`]: one changed
+/// residue → a substitution, a contiguous run → one delins, no change → the
+/// silent `p.(Xxx{N}=)` at the first affected residue.
+///
+/// Returns `None` — the caller keeps its existing (bracketed / per-member)
+/// behavior — when the combined product is not a length-preserving residue-wise
+/// change (see [`combined_cis_residue_changes`]), or when the changed residues
+/// form **more than one run**: residues separated by an unchanged residue are
+/// described individually (`DNA/delins.md`), which is what the existing bracket
+/// already does (#855).
+fn combine_cis_members_by_residue(
+    transcript: &Transcript,
+    bundle: &RefProteinBundle,
+    members: &[(i64, i64, &NaEdit)],
+    protein_accession: &str,
+) -> Option<HgvsVariant> {
+    use crate::hgvs::edit::ProteinEdit;
+    use crate::hgvs::interval::ProtInterval;
+    use crate::hgvs::location::ProtPos;
+    use crate::hgvs::variant::{LocEdit, ProteinVariant};
+
+    let changed = combined_cis_residue_changes(transcript, bundle, members)?;
+    let accession = parse_accession(protein_accession);
+    let gene_symbol = transcript.gene_symbol.clone();
+
+    // Nothing changed: the combined product is silent → `p.(Xxx{N}=)` at the
+    // 5'-most residue any member touches (substitution.md: `p.Cys123=`).
+    if changed.is_empty() {
+        let lo_min = members.iter().map(|(lo, _, _)| *lo).min()?;
+        let pos = ((lo_min - 1) / 3 + 1) as u64;
+        let ref_aa = *bundle.ref_protein.get((pos - 1) as usize)?;
+        return Some(HgvsVariant::Protein(ProteinVariant {
+            accession,
+            gene_symbol,
+            loc_edit: LocEdit::new_predicted(
+                ProtInterval::point(ProtPos::new(ref_aa, pos)),
+                ProteinEdit::Identity {
+                    predicted: false,
+                    whole_protein: false,
+                },
+            ),
+        }));
+    }
+
+    let spans: Vec<SubSpan> = changed
+        .into_iter()
+        .map(|(pos, ref_aa, alt_aa)| SubSpan {
+            pos,
+            ref_aa,
+            alt_aa,
+        })
+        .collect();
+    let groups = group_consecutive_residues(spans);
+    if groups.len() != 1 {
+        // Separated residues are described individually — the caller's existing
+        // bracketed allele is already the spec-correct rendering (#855).
+        return None;
+    }
     Some(render_cis_substitution_groups(
         &groups,
         &accession,
@@ -3416,6 +3497,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                     if let Some(pv) = combine_cis_substitutions_by_codon(&tx, &subs, &prot_acc) {
                         return Ok((false, Some(pv)));
                     }
+                }
+            }
+        }
+
+        // Decomposed-delins in-cis members (#1079): a `delins` that
+        // normalization split into a cis allele of sub-edits (e.g.
+        // `c.415_419delinsATATG` → `c.[415T>A;417_419inv]`) must still be
+        // described as ONE protein consequence over the residues its *combined*
+        // product changes. Predicting each member against the reference codon
+        // emits the spec-forbidden bracketed protein allele
+        // (substitution.md: `p.[Arg76Ser;Cys77Trp]` "is not correct") and can
+        // name the wrong amino acid — the "conflicting and incorrect
+        // predictions" delins.md's coalescing rule exists to prevent. Runs
+        // itself: the #1076 codon path above is the special case where every
+        // member is a single-base substitution sharing a codon.
+        //
+        // Declines (keeping the existing bracket) when the changed residues are
+        // separated by an unchanged residue — those are described individually
+        // (delins.md, #855) — or when the combined product changes length, which
+        // `try_project_cis_combined_inframe` above already describes.
+        if !base_flag && !has_opaque {
+            let members: Vec<(i64, i64, &NaEdit)> = classes
+                .iter()
+                .filter_map(|c| match c {
+                    CisMemberClass::SimpleExonic { lo, hi, edit, .. } => Some((*lo, *hi, *edit)),
+                    _ => None,
+                })
+                .collect();
+            if members.len() > 1 {
+                let prot_acc = cis_member_protein_accession(inner_projections, transcript_id);
+                if let Some(pv) = combine_cis_members_by_residue(&tx, &bundle, &members, &prot_acc)
+                {
+                    return Ok((false, Some(pv)));
                 }
             }
         }
@@ -12545,6 +12659,100 @@ mod tests {
         use crate::hgvs::edit::Base;
         let s = combine_by_codon_str("ATGGATTATTAA", &[(4, Base::C)]);
         assert_eq!(s, None);
+    }
+
+    /// Literal `delins` edit over `[lo, hi]` replacing it with `alt`.
+    fn delins_edit(alt: &str) -> NaEdit {
+        use crate::hgvs::edit::{Base, InsertedSequence, Sequence};
+        NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(
+                alt.chars()
+                    .map(|c| Base::from_char(c).expect("ACGT literal"))
+                    .collect(),
+            )),
+            deleted: None,
+            deleted_length: None,
+            substitution_reference: None,
+        }
+    }
+
+    /// Run the residue-level in-cis combiner over `seq` (the whole sequence is
+    /// the CDS) with `(lo, hi, replacement)` members.
+    fn combine_by_residue_str(seq: &str, members: &[(i64, i64, &str)]) -> Option<String> {
+        let tx = tx_with_cds_seq("NM_X.1", seq);
+        let bundle = RefProteinBundle::from_transcript(&tx).expect("ref bundle");
+        let edits: Vec<NaEdit> = members.iter().map(|(_, _, alt)| delins_edit(alt)).collect();
+        let spans: Vec<(i64, i64, &NaEdit)> = members
+            .iter()
+            .zip(edits.iter())
+            .map(|((lo, hi, _), edit)| (*lo, *hi, edit))
+            .collect();
+        combine_cis_members_by_residue(&tx, &bundle, &spans, "NP_X.1").map(|v| v.to_string())
+    }
+
+    /// #1079 (unit): the reported shape — a decomposed `delins` whose members
+    /// touch a shared residue. CDS `ATGGATTATTGCTAA` (Met-Asp-Tyr-Cys-Ter);
+    /// members `c.4G>C` (inside codon 2) and `c.6_8delinsAGC` (spanning codons 2
+    /// and 3) give the combined CDS `ATG CAA GCT TGC TAA` = Met-Gln-Ala-Cys-Ter.
+    /// Both residues are read off the *combined* CDS, never from per-member
+    /// predictions against the reference codon.
+    #[test]
+    fn combine_by_residue_shared_residue_forms_one_delins() {
+        let s = combine_by_residue_str("ATGGATTATTGCTAA", &[(4, 4, "C"), (6, 8, "AGC")]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Asp2_Tyr3delinsGlnAla)"));
+    }
+
+    /// #1079 (unit): when only ONE residue ends up changed — the other member is
+    /// silent — the consequence is a plain substitution, not a delins spanning
+    /// the unchanged residue (substitution.md). CDS `ATGCGATGGTAA`
+    /// (Met-Arg-Trp-Ter); `c.6A>G` is silent (`CGA`→`CGG`, still Arg) and
+    /// `c.9G>T` changes `TGG`→`TGT` (Cys).
+    #[test]
+    fn combine_by_residue_silent_member_drops_out() {
+        let s = combine_by_residue_str("ATGCGATGGTAA", &[(6, 6, "G"), (9, 9, "T")]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Trp3Cys)"));
+    }
+
+    /// #1079 (unit): an all-silent combination is `p.(Xxx{N}=)` at the 5'-most
+    /// residue any member touches (substitution.md `p.Cys123=`), not a bracketed
+    /// pair of `(=)` members (alleles.md). CDS `ATGCGACGCTAA`: `c.6A>G`
+    /// (`CGA`→`CGG`, Arg) and `c.9C>T` (`CGC`→`CGT`, Arg) are both silent.
+    #[test]
+    fn combine_by_residue_all_silent_is_identity_at_first_residue() {
+        let s = combine_by_residue_str("ATGCGACGCTAA", &[(6, 6, "G"), (9, 9, "T")]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2=)"));
+    }
+
+    /// #1079 (unit): residues separated by an UNCHANGED residue are described
+    /// individually (delins.md), so the combiner declines and the caller keeps
+    /// its existing bracketed allele. CDS `ATGGATTATTGCTAA`: codon 2 `GAT`→`TAT`
+    /// and codon 4 `TGC`→`TAC`, codon 3 untouched.
+    #[test]
+    fn combine_by_residue_separated_residues_decline() {
+        let s = combine_by_residue_str("ATGGATTATTGCTAA", &[(4, 4, "T"), (11, 11, "A")]);
+        assert_eq!(s, None);
+    }
+
+    /// #1079 (unit): a length-changing combination is out of scope — the in-frame
+    /// indel path (`try_project_cis_combined_inframe`) owns those forms.
+    #[test]
+    fn combine_by_residue_length_change_declines() {
+        let s = combine_by_residue_str("ATGGATTATTGCTAA", &[(4, 6, ""), (8, 8, "G")]);
+        assert_eq!(s, None);
+    }
+
+    /// #1079 (unit): overlapping members are contradictory in cis (two alts on one
+    /// molecule) and a single member has nothing to combine — both decline.
+    #[test]
+    fn combine_by_residue_overlap_and_single_member_decline() {
+        assert_eq!(
+            combine_by_residue_str("ATGGATTATTGCTAA", &[(4, 6, "CAT"), (5, 5, "G")]),
+            None
+        );
+        assert_eq!(
+            combine_by_residue_str("ATGGATTATTGCTAA", &[(4, 4, "C")]),
+            None
+        );
     }
 
     /// #855: an in-cis frameshift allele collapses to the whole-protein-unknown

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -1481,6 +1481,97 @@ pub(crate) fn try_project_cis_combined_inframe(
     Ok(CisCombined::InFrame(Box::new(pv)))
 }
 
+/// The residues whose amino acid changes when a cis compound's members are
+/// applied **together** to the reference CDS (#1079).
+///
+/// This is the length-preserving companion of
+/// [`try_project_cis_combined_inframe`]: it does not build a description, it
+/// just reports which residues moved and to what, so the caller can render them
+/// with the spec's grouping rules (one contiguous run → a single
+/// substitution / delins; runs separated by an unchanged residue stay
+/// individual — `protein/substitution.md`, `DNA/delins.md`).
+///
+/// It exists because a `delins` that normalization decomposes into a cis allele
+/// (e.g. `c.415_419delinsATATG` → `c.[415T>A;417_419inv]`) must not be described
+/// member-by-member: each member would be predicted against the *reference*
+/// codon, which both yields the spec-forbidden bracketed protein allele and can
+/// name the wrong amino acid. Combining first is what fixes the amino acid.
+///
+/// `members` are the pre-classified `SimpleExonic` members as `(lo, hi, edit)`
+/// with insertion spans already collapsed to `hi == lo`, in any order.
+///
+/// Returns the changed residues as `(1-based position, reference AA,
+/// alternative AA)` in ascending order — empty when the combined product is
+/// silent. Returns `None` (caller keeps its existing behavior) when the combined
+/// product cannot be compared residue-for-residue against the reference:
+///
+/// - fewer than two members, an out-of-bounds or overlapping span (overlapping
+///   members are contradictory in cis), or an unreadable CDS;
+/// - the combined CDS changes length — an in-frame indel is a length-changing
+///   consequence that [`try_project_cis_combined_inframe`] already describes;
+/// - the combined protein changes length, i.e. a premature stop (nonsense) or a
+///   stop-loss, both of which need their own spec forms (a stop-delins or a
+///   C-terminal extension) rather than a residue-wise diff.
+pub(crate) fn combined_cis_residue_changes(
+    transcript: &Transcript,
+    ref_bundle: &RefProteinBundle,
+    members: &[(i64, i64, &NaEdit)],
+) -> Option<Vec<(u64, AminoAcid, AminoAcid)>> {
+    if members.len() < 2 {
+        return None;
+    }
+
+    // Bounds guard, mirroring `try_project_cis_combined_inframe`: a `lo < 1`
+    // would underflow the `lo - 1` usize cast in `build_mutated_cds_with_ref`
+    // into an out-of-bounds slice panic.
+    let ref_cds_len = ref_bundle.ref_cds.len() as i64;
+    for (lo, hi, _) in members {
+        if *lo < 1 || *hi < *lo || *hi > ref_cds_len {
+            return None;
+        }
+    }
+
+    // Sort ascending by `lo` for the overlap guard and the 3'→5' fold.
+    let mut sorted: Vec<(i64, i64, &NaEdit)> = members.to_vec();
+    sorted.sort_by_key(|(lo, _, _)| *lo);
+    for pair in sorted.windows(2) {
+        if pair[1].0 <= pair[0].1 {
+            return None; // overlapping members: contradictory in cis
+        }
+    }
+
+    // Fold the members onto the reference CDS in *descending* `lo` order so a 3'
+    // splice never invalidates a not-yet-applied 5' member's coordinates.
+    let mut mut_cds = ref_bundle.ref_cds.clone();
+    for (lo, hi, edit) in sorted.iter().rev() {
+        mut_cds = build_mutated_cds_with_ref(&mut_cds, transcript, *lo, *hi, edit).ok()?;
+    }
+    if mut_cds.len() != ref_bundle.ref_cds.len() {
+        return None; // length-changing: not a residue-wise substitution set
+    }
+
+    // Translate the combined product; force residue 1 to Met on a recognized
+    // initiator so it agrees with the Met-forced reference protein.
+    let mut alt_protein = translate_full_cds(&mut_cds);
+    if cds_has_recognized_start(&ref_bundle.ref_cds) {
+        force_initiator_met(&mut alt_protein);
+    }
+    if alt_protein.len() != ref_bundle.ref_protein.len() {
+        return None; // premature stop or stop-loss: needs its own spec form
+    }
+
+    Some(
+        ref_bundle
+            .ref_protein
+            .iter()
+            .zip(alt_protein.iter())
+            .enumerate()
+            .filter(|(_, (ref_aa, alt_aa))| ref_aa != alt_aa)
+            .map(|(i, (ref_aa, alt_aa))| ((i + 1) as u64, *ref_aa, *alt_aa))
+            .collect(),
+    )
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -21,8 +21,8 @@ pub(crate) use helpers::{
     read_cds_start_codon, whole_exon_deletion_span, RefProteinBundle,
 };
 pub(crate) use indel::{
-    predict_indel_protein, predict_stop_region_extension, try_project_cis_combined_inframe,
-    CisCombined,
+    combined_cis_residue_changes, predict_indel_protein, predict_stop_region_extension,
+    try_project_cis_combined_inframe, CisCombined,
 };
 pub(crate) use substitution::predict_substitution_protein;
 // `apply_substitution` / `read_ref_codon` / `translate` are the position-level

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -255,6 +255,7 @@ mod predicted_cis_allele;
 mod projection;
 mod projection_coverage;
 mod property_tests;
+mod protein_cis_delins_decomposition;
 mod protein_construct_boundaries;
 mod protein_frameshift_alternatives;
 mod protein_frameshift_legacy_stop_modes;

--- a/tests/it/protein_cis_delins_decomposition.rs
+++ b/tests/it/protein_cis_delins_decomposition.rs
@@ -1,0 +1,137 @@
+//! A `delins` that normalization decomposes into an in-cis allele of sub-edits
+//! must still project to **one** protein consequence over the affected residue
+//! range — never a bracketed protein allele.
+//!
+//! Spec basis (vendored `assets/hgvs-nomenclature/docs/recommendations/`):
+//!
+//! - `DNA/delins.md` — the coalescing rule exists to stop tools "making
+//!   conflicting and incorrect predictions of two different substitutions at one
+//!   position (e.g., `c.235_237delinsTAT` (`p.Lys79Tyr`) versus
+//!   `c.[235A>T;237G>T]` (`p.[Lys79*;Lys79Asn]`)".
+//! - `protein/substitution.md` — "the description `p.Arg76_Cys77delinsSerTrp` is
+//!   correct, the description `p.[Arg76Ser;Cys77Trp]` is not correct".
+//! - `DNA/alleles.md` — an allele must not mark a position both changed and
+//!   unchanged (`c.[2376G>C;3103=]` is "not correct"), which rules out a
+//!   bracketed protein allele carrying an `(=)` member.
+//!
+//! Describing each decomposed member independently is not merely mis-rendered:
+//! each member is predicted against the *reference* codon, so the reported amino
+//! acids can be wrong outright (the first case below yielded `Leu` where the
+//! combined codon encodes `Ile`).
+//!
+//! Ground truth is Mutalyzer 3.1.1 on the same transcript. (Mutalyzer prints the
+//! bare `p.(...)`; ferro prefixes the protein accession and, per #310, never
+//! emits a `(GENE)` selector on a `p.` variant.)
+//!
+//! Reference-backed: skips unless `FERRO_MANIFEST` points at a prepared
+//! reference (same gate as the other real-reference projection tests).
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::parse_hgvs;
+use ferro_hgvs::reference::multi_fasta::MultiFastaProvider;
+use ferro_hgvs::VariantProjector;
+
+/// WT1 — the transcript the four reported reproductions are on.
+const WT1_TX: &str = "NM_024426.4";
+
+fn manifest_path() -> Option<PathBuf> {
+    // FERRO_MANIFEST, when set, is authoritative — no fallback to the
+    // repo-relative default, so a deliberate `FERRO_MANIFEST=/nonexistent`
+    // skips rather than silently picking up a stray local reference.
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+/// A projector over the manifest-loaded reference. `Arc<P>` has a blanket
+/// `ReferenceProvider` impl and is `Clone`, so it plugs straight into
+/// `VariantProjector` (same wiring as the `ferro project` CLI).
+fn manifest_projector() -> Option<VariantProjector<Arc<MultiFastaProvider>>> {
+    let provider = provider()?;
+    let cdot = provider.cdot_mapper()?.clone();
+    Some(VariantProjector::new(Projector::new(cdot), provider))
+}
+
+/// The projected protein consequence of `hgvs`, rendered.
+fn project_protein(
+    projector: &VariantProjector<Arc<MultiFastaProvider>>,
+    hgvs: &str,
+) -> Option<String> {
+    let parsed = parse_hgvs(hgvs).unwrap_or_else(|e| panic!("parse {hgvs}: {e}"));
+    let projection = projector
+        .project_variant(&parsed, WT1_TX)
+        .unwrap_or_else(|e| panic!("project {hgvs}: {e}"));
+    projection.protein.map(|p| p.to_string())
+}
+
+/// Every reported `delins` must project to a single protein consequence matching
+/// Mutalyzer 3.1.1 — and, whatever the rendering, never to a bracketed allele.
+#[test]
+fn decomposed_delins_projects_to_one_combined_protein_consequence() {
+    let Some(projector) = manifest_projector() else {
+        eprintln!("protein_cis_delins_decomposition: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+
+    // (input, expected protein consequence per Mutalyzer 3.1.1)
+    let cases = [
+        // Two members at one residue (Phe139) plus an adjacent one: the exact
+        // shape delins.md forbids. Per-member prediction also reported `Leu`
+        // where the combined codon encodes `Ile`.
+        (
+            "NM_024426.4:c.415_419delinsATATG",
+            "NP_077744.3:p.(Phe139_Ile140delinsIleCys)",
+        ),
+        // One member is silent: the unchanged residue is context, not a bracket
+        // member (alleles.md), so only Lys141 is described — as a substitution.
+        (
+            "NM_024426.4:c.418_422delinsATTAC",
+            "NP_077744.3:p.(Lys141Thr)",
+        ),
+        // Overlapping per-member ranges (both name Glu143) must collapse into one
+        // delins across the whole affected range.
+        (
+            "NM_024426.4:c.426_430delinsCCATG",
+            "NP_077744.3:p.(Gln142_Pro144delinsHisHisAla)",
+        ),
+        // A whole-protein `(=)` member must not be bracketed alongside a changed
+        // one (alleles.md: no "changed and unchanged" allele).
+        (
+            "NM_024426.4:c.429_434delinsTACCTC",
+            "NP_077744.3:p.(Glu143_Pro144delinsAspThr)",
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let actual = project_protein(&projector, input)
+            .unwrap_or_else(|| panic!("{input}: no protein consequence projected"));
+        assert!(
+            !actual.contains('['),
+            "{input}: a decomposed delins must not project to a bracketed protein \
+             allele (substitution.md, delins.md), got {actual}"
+        );
+        assert_eq!(actual, expected, "{input}: protein consequence");
+    }
+}


### PR DESCRIPTION
Closes #1080.

When a `delins` decomposes under normalization into a cis allele of sub-edits, the projector described each member independently and emitted a bracketed protein allele. This is forbidden by the spec and, in at least one case, substantively wrong rather than merely mis-rendered.

| input | before | after | mutalyzer 3.1.1 |
|---|---|---|---|
| `NM_024426.4:c.415_419delinsATATG` | `p.[(Phe139Ile);(Phe139_Ile140delinsLeuCys)]` | `p.(Phe139_Ile140delinsIleCys)` | matches |
| `NM_024426.4:c.418_422delinsATTAC` | `p.[(Ile140=);(Lys141Thr)]` | `p.(Lys141Thr)` | matches |
| `NM_024426.4:c.426_430delinsCCATG` | `p.[(Gln142_Glu143delinsHisGln);(Glu143_Pro144delinsAspAla)]` | `p.(Gln142_Pro144delinsHisHisAla)` | matches |
| `NM_024426.4:c.429_434delinsTACCTC` | `p.[(Glu143_Pro144delinsAspThr);(=)]` | `p.(Glu143_Pro144delinsAspThr)` | matches |

Note the first row reported `Leu` where the comparator gives `Ile`, so this was a correctness defect, not only a rendering one.

Three spec rules were violated. `DNA/delins.md:19` states the coalescing rule exists precisely to stop tools making "conflicting and incorrect predictions of two different substitutions at one position", and gives its own counterexample `c.235_237delinsTAT` (`p.Lys79Tyr`) versus `c.[235A>T;237G>T]` (`p.[Lys79*;Lys79Asn]`) — the shape of row 1, whose two members are both anchored at residue 139. `protein/substitution.md:23` states "`p.[Arg76Ser;Cys77Trp]` is not correct". `DNA/alleles.md:18-19` forbids a cis allele that marks one position changed alongside a bare unchanged member, which is row 4.

Root cause: all three combined-protein paths in `project_cis_flag_and_protein` were too narrowly gated. #1070's path needs a member that individually frameshifts; #1076/#1077's needs every member to be a single-base substitution sharing a codon; #855's merges already-predicted descriptions. A length-preserving mixed-edit cis allele — what a decomposed `delins` becomes — matched none of them and fell through to the bracketed all-or-nothing fallback, where each member is predicted against the *reference* codon. That per-member prediction against the reference is the source of the `Leu` error.

Fix: `combined_cis_residue_changes` (`src/project/protein/indel.rs`) diffs the translated combined edited CDS against the reference protein, and `combine_cis_members_by_residue` (`src/project/projector.rs`) renders a single contiguous run as a substitution, delins, or `=`. It declines — keeping the existing bracketed form — for multi-run or length-changing results, which is what preserves the correct bracketed output for genuinely separated in-frame deletions.

This extends #1077 rather than replacing it; that fix covered the substitution-input route into the same bug family, and its behaviour is unchanged here (216/216 on the `issue_1076`/`same_codon`/`cis` filter).

Known limitations, deliberately left on the existing paths: length-changing combinations, premature stops, and stop-loss. Also note the `(WT1)` selector no longer appears, because `ProteinVariant::Display` never emits a gene selector on `p.` (#310) — it only surfaced via the allele compact-prefix writer, so collapsing to a single variant matches every other single protein consequence.

Verification: `cargo nextest run --features dev` 8074/8074 with `FERRO_MANIFEST` unset (base 8067, plus 6 unit and 1 integration test); rustfmt and clippy clean. With a manifest set, 5 failures reproduce identically on base `6d39853` and are pre-existing and normalizer-side.
