### PR TITLE
fix(project): decline unknown intronic offsets instead of overflowing

### DIFF
--- a/src/data/mapping.rs
+++ b/src/data/mapping.rs
@@ -312,6 +312,34 @@ impl CoordinateMapper {
 
         // Handle intronic positions
         if let Some(offset) = cds_pos.offset {
+            // #1087: `c.N-?` / `c.N+?` are parsed as sentinel offsets
+            // (`i64::MIN` / `i64::MAX`), not measured distances — the spec
+            // reads them as an unknown position 5'/3' of `c.N`, unbounded in
+            // that direction (recommendations/DNA/deletion.md), so there is no
+            // genomic coordinate to compute. Decline before any arithmetic:
+            // the sentinels overflow the offset math below (panicking in debug,
+            // wrapping to a plausible-looking garbage coordinate in release,
+            // which has no overflow checks). This is the chokepoint all three
+            // projector entry points funnel through. `UnsupportedProjection`
+            // is deliberate — `cli::project::engine_error_is_unavailable`
+            // renders only that set as a clean `unavailable` decline at exit 0.
+            if cds_pos.has_unknown_offset() {
+                let sign = if offset == crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE {
+                    '-'
+                } else {
+                    '+'
+                };
+                // 3'UTR bases render as `*N` in c. coordinates; keep the marker so
+                // the diagnostic names the actual position (`c.*100-?`, not `c.100-?`).
+                let star = if cds_pos.utr3 { "*" } else { "" };
+                return Err(FerroError::UnsupportedProjection {
+                    reason: format!(
+                        "cannot resolve unknown intronic offset (`{sign}?`) at c.{star}{}",
+                        cds_pos.base
+                    ),
+                });
+            }
+
             // First convert the base position to genomic
             let tx_pos = cds_to_tx_aware(cds_pos.base)?;
 
@@ -1049,6 +1077,66 @@ mod tests {
         };
         cdot.add_transcript("NM_INS.1".to_string(), tx);
         CoordinateMapper::new(cdot)
+    }
+
+    /// `c.N-?` / `c.N+?` carry the parser's unknown-offset sentinels
+    /// (`i64::MIN` / `i64::MAX`), which are not real intronic offsets: the
+    /// spec defines them as an unknown position 5'/3' of `c.N`, unbounded in
+    /// that direction, so no genomic coordinate exists. Feeding them to the
+    /// coordinate arithmetic panicked in debug and silently wrapped to a
+    /// garbage coordinate in release (issue #1087). Decline instead — and
+    /// specifically with `UnsupportedProjection`, the only variant the CLI
+    /// renders as `unavailable` at exit 0 (`cli::project::engine_error_is_unavailable`).
+    #[test]
+    fn cds_to_genome_declines_unknown_offset_sentinels() {
+        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+        let mapper = create_test_mapper();
+
+        // Both strands: the minus-strand arms panicked in debug, while the
+        // plus-strand arms wrapped silently in *both* profiles.
+        for transcript_id in ["NM_TEST.1", "NM_MINUS.1"] {
+            for offset in [OFFSET_UNKNOWN_POSITIVE, OFFSET_UNKNOWN_NEGATIVE] {
+                let err = mapper
+                    .cds_to_genome(
+                        transcript_id,
+                        &CdsPos {
+                            base: 51,
+                            offset: Some(offset),
+                            utr3: false,
+                            special: None,
+                        },
+                    )
+                    .expect_err("unknown intronic offset has no genomic coordinate");
+                assert!(
+                    matches!(err, FerroError::UnsupportedProjection { .. }),
+                    "{transcript_id} offset {offset}: expected UnsupportedProjection, got {err:?}"
+                );
+            }
+        }
+    }
+
+    /// The sentinel guard must key off the sentinel constants themselves, not
+    /// off "the offset looks large" — a real intronic offset still resolves.
+    #[test]
+    fn cds_to_genome_resolves_real_intronic_offset() {
+        let mapper = create_test_mapper();
+        for transcript_id in ["NM_TEST.1", "NM_MINUS.1"] {
+            for offset in [-6, 6] {
+                mapper
+                    .cds_to_genome(
+                        transcript_id,
+                        &CdsPos {
+                            base: 51,
+                            offset: Some(offset),
+                            utr3: false,
+                            special: None,
+                        },
+                    )
+                    .unwrap_or_else(|e| {
+                        panic!("{transcript_id} offset {offset}: expected a mapping, got {e:?}")
+                    });
+            }
+        }
     }
 
     #[test]

--- a/src/hgvs/location.rs
+++ b/src/hgvs/location.rs
@@ -173,8 +173,32 @@ impl CdsPos {
     }
 
     /// Check if this is an unknown position (?)
+    ///
+    /// Note this inspects the *base* only: `c.100-?` has a known base and an
+    /// unknown offset, so it is not "unknown" by this predicate. Use
+    /// [`has_unknown_offset`](Self::has_unknown_offset) for that.
     pub fn is_unknown(&self) -> bool {
         self.base == CDS_BASE_UNKNOWN && !self.utr3 && self.special.is_none()
+    }
+
+    /// Whether the offset is one of the parser's unknown-offset sentinels
+    /// (`+?` → [`OFFSET_UNKNOWN_POSITIVE`], `-?` → [`OFFSET_UNKNOWN_NEGATIVE`])
+    /// rather than a measured intronic distance.
+    ///
+    /// Callers doing coordinate arithmetic MUST check this first: the
+    /// sentinels are `i64::MAX` / `i64::MIN`, so using one as a distance
+    /// overflows (issue #1087). Per the spec these denote an unknown position
+    /// 3'/5' of the base, unbounded in that direction, so no coordinate can be
+    /// derived from them at all.
+    ///
+    /// [`OFFSET_UNKNOWN_POSITIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_POSITIVE
+    /// [`OFFSET_UNKNOWN_NEGATIVE`]: crate::hgvs::parser::position::OFFSET_UNKNOWN_NEGATIVE
+    pub fn has_unknown_offset(&self) -> bool {
+        use crate::hgvs::parser::position::{OFFSET_UNKNOWN_NEGATIVE, OFFSET_UNKNOWN_POSITIVE};
+        matches!(
+            self.offset,
+            Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE)
+        )
     }
 
     /// Create a CDS position with intronic offset

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -60,10 +60,7 @@ use shuffle::shuffle;
 
 /// Check if a CDS position has an unknown (?) offset sentinel value
 fn has_unknown_offset_cds(pos: &CdsPos) -> bool {
-    matches!(
-        pos.offset,
-        Some(OFFSET_UNKNOWN_POSITIVE) | Some(OFFSET_UNKNOWN_NEGATIVE)
-    )
+    pos.has_unknown_offset()
 }
 
 /// Intron length (1-based inclusive base count) at the intron addressed by


### PR DESCRIPTION
Closes #1087.

`c.N-?` / `c.N+?` are parsed as sentinel offsets (`OFFSET_UNKNOWN_NEGATIVE` = `i64::MIN`, `OFFSET_UNKNOWN_POSITIVE` = `i64::MAX`), not measured distances, and `cds_pos_to_genome_pos` fed them straight into the intronic offset arithmetic. On `v0.9.1`:

```
$ ferro project --axis g --reference <ref> 'NC_000023.11(NM_004006.2):c.4072-?_5154+?del'   # debug
thread 'main' panicked at src/data/mapping.rs:343:25: attempt to subtract with overflow

$ ferro project --axis g --reference <ref> 'NC_000023.11(NM_004006.2):c.4072-?_5154+?del'   # release
NC_000023.11:g.9223372036887140391_9223372036887187721del                                   # exit 0
```

The release profile has no overflow checks, so the wider failure mode is a plausible-looking garbage coordinate rather than a crash. Plus-strand transcripts never panicked even in debug — their arms wrap in the `as u64` cast — so they emitted garbage in **both** profiles (`NC_000013.11(NM_000059.4):c.317-?_425+?del` → `NC_000013.11:g.9223372036887100884_9223372036887100991del`).

## Fix

Guard the sentinels at the top of the mapper's intronic block, before any arithmetic, returning `FerroError::UnsupportedProjection`.

**Why decline rather than resolve.** The spec quotes this exact DMD variant as a description that should not be used (`docs/recommendations/DNA/deletion.md`):

> **NOTE**: previously, the suggestion was made to describe such deletions using the format `NC_000023.11(NM_004006.2):c.4072-?_5154+?del`. However, since `c.4072-?` indicates an unknown position 5' of `c.4072` and `c.5154+?` to an unknown position 3' of `c.5154` this description is not correct when it is known that exons 29 and 37 are present.

and directs users to `c.(4071+1_4072-1)_(5154+1_5155-1)del` instead (`docs/consultation/SVD-WG003.md` is blunter: the `-?/+?` format "conflicts with basic HGVS recommendations and should not be used"). Because `-?` / `+?` are **unbounded** in their direction — not "somewhere in the flanking intron" — there is no genomic coordinate to compute and no spec-sanctioned genomic rendering. Resolving them to intron boundaries and emitting `g.(a_b)_(c_d)del` would be wrong twice over: that notation means an uncertain breakpoint within a *positively tested* window (`docs/recommendations/DNA/uncertain.md`), which is exactly the flanking evidence `-?/+?` asserts it does not have, and it would not round-trip.

**Why `UnsupportedProjection` specifically.** It is the only variant in `engine_error_is_unavailable` (`src/cli/project.rs`) that renders as a clean `unavailable` decline at exit 0. `ConversionError` (what the neighbouring `Strand::Unknown` arm returns) or `InvalidCoordinates` would convert the panic into an exit-1 hard failure that aborts a batch run — a regression against `c.?_5154del`, which already declines cleanly today. The new test asserts the error *variant*, not just `is_err()`, because that distinction is the user-visible contract.

**Where the guard lives.** The mapper is the chokepoint all three projector entry points funnel through (`extract_contig_and_pos`, `map_cnr_position_to_genome`, `project_to_genomic`), so one guard covers every axis — this was never a `g.`-specific bug; `c`/`n`/`r`/`p` panicked identically.

**Why #887's `?` guard missed it.** `CdsPos::is_unknown()` tests `base == CDS_BASE_UNKNOWN` and never inspects `offset`, so `c.4072-?` (known base, unknown offset) sailed through. This PR adds `CdsPos::has_unknown_offset()` alongside it, notes the distinction in both doc comments, and collapses `normalize`'s private duplicate predicate onto it so one predicate owns the question.

`normalize` already handled these correctly (passes them through unchanged) and is otherwise untouched.

## Verification

After the fix, all five axes decline at exit 0, on both strands:

```
$ ferro project --axis g --reference <ref> 'NC_000023.11(NM_004006.2):c.4072-?_5154+?del'
# NC_000023.11(NM_004006.2):c.4072-?_5154+?del [g]: unavailable: unsupported projection: cannot resolve unknown intronic offset (`-?`) at c.4072
$ echo $?
0
```

Real intronic offsets are byte-identical to the unpatched binary (`c.4072-10del` → `g.32411923del`, `c.317-10del` → `g.32325066del`, `c.4072_5154del` → `g.32364584_32411915del`), and `normalize` still round-trips the input unchanged.

Full suite: 8069 passed / 0 failed. With a prepared reference wired in (`FERRO_MANIFEST`), 5 tests fail — `issue_972_cds_start_nf_decline` (×3), `mutalyzer_normalize_tests::{axis_normalized, comparator_provenance_reference_identity_matches_live}` — but a baseline run of the same tests on unpatched `origin/main` against the same reference fails byte-identically (same 4 Ensembl `normalized` rows), so that is pre-existing local reference/ledger drift, unrelated to this change.

## Tests

Both in `src/data/mapping.rs`'s existing mock-based test module — no prepared reference needed:

- `cds_to_genome_declines_unknown_offset_sentinels` — both strands × both sentinels, asserting `UnsupportedProjection`. Both dimensions matter: plus strand never panicked (it would have shipped the silent wrap), and the error variant is the exit-code contract. Verified to fail before the fix, with the plus-strand case returning `GenomePos { base: 9223372036854777807 }` rather than erroring.
- `cds_to_genome_resolves_real_intronic_offset` — guard rail: the check must key off the sentinel constants, not off "the offset looks large".

The exit-0 half is already locked by the existing `unsupported_projection_is_unavailable_not_hard` in `src/cli/project.rs`.

## Follow-ups (filed in #1087, not addressed here)

- Latent `offset.abs()` panics on `i64::MIN` in `src/convert/coding.rs` and `src/convert/noncoding.rs`. Not reachable from user `?` input today — the `noncoding.rs` sites are reached only from `src/vcf/to_hgvs.rs`, which synthesizes offsets from VCF coordinates, and the `coding.rs` sites have no callers outside their module — but they should use `unsigned_abs()`.
- `ferro` hard-fails (exit 1) on `c.(4071+1_4072-1)_(5154+1_5155-1)del`, the exact form the spec directs users to use instead. Accepting it on input is the real feature gap here.
- Consider enabling `overflow-checks` in `[profile.release]` so wrap bugs of this class surface instead of emitting plausible garbage.
