### PR TITLE
fix(project): decline the r. axis for intronic spans; emit genuine n. for r. inputs

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -4239,6 +4239,28 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // U→T mapping. This is a no-op for n. (DNA) inputs.
         let c_edit = transform_edit_for_strand(&edit, RefStrand::Plus);
 
+        // #1086 (D2): `.noncoding` is contracted to always mean the `n.` form.
+        // For an `n.` input that IS the input; for an `r.` input the input is an
+        // RNA description (`r.` prefix, lowercase RNA alphabet with `u`), and
+        // returning it verbatim reports the wrong coordinate system on the `n.`
+        // axis. Numbering is shared between the two — `RnaPos` and `TxPos` have
+        // the same base/offset/downstream shape, which is exactly how
+        // `start_tx`/`end_tx` were derived above — so re-expressing an `r.` input
+        // as `n.` is a prefix + alphabet change only (`c_edit`'s U→T mapping).
+        // The edit's certainty is carried through so a predicted `r.(11u>g)`
+        // stays predicted on the `n.` axis.
+        let noncoding_axis = match normalized {
+            HgvsVariant::Rna(_) => HgvsVariant::Tx(TxVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit: LocEdit::with_uncertainty(
+                    TxInterval::new(start_tx, end_tx),
+                    edit_mu.map_ref(|e| transform_edit_for_strand(e, RefStrand::Plus)),
+                ),
+            }),
+            _ => normalized.clone(),
+        };
+
         // #886: a bare LRG transcript has a structurally derivable genomic
         // parent, so its genomic axis IS resolvable; a bare NM_/NR_ has no
         // genome alignment -> stays None. Use `project_to_genomic_normalized`
@@ -4259,7 +4281,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 normalization_warnings: Vec::new(),
                 genomic,
                 coding: None,
-                noncoding: Some(normalized.clone()),
+                noncoding: Some(noncoding_axis),
                 protein: None,
                 // No coding form on a non-coding transcript; the RNA prediction
                 // surface (#485) predicts from the c. form, so it's unavailable here.
@@ -4337,8 +4359,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             normalization_warnings: Vec::new(),
             genomic,
             coding,
-            // The non-coding axis is the input itself.
-            noncoding: Some(normalized.clone()),
+            // The non-coding axis is the input itself for an `n.` input, and the
+            // `n.`-reframed form of an `r.` input (#1086).
+            noncoding: Some(noncoding_axis),
             protein,
             rna,
             transcript_id: transcript_id.to_string(),

--- a/src/project/rna.rs
+++ b/src/project/rna.rs
@@ -1,7 +1,17 @@
 //! Predicted RNA consequence surface: `c.`/`n.` → `r.(…)`.
 //!
-//! Numbering is CDS-relative (identical to `c.`); the 3′ shift, intron-clamp,
-//! and range-reference resolution are performed in transcript-sequence space.
+//! Numbering is CDS-relative (identical to `c.`); the 3′ shift and
+//! range-reference resolution are performed in transcript-sequence space.
+//!
+//! Intronic positions have no `r.` representation of their own: an RNA
+//! reference sequence is the *spliced* transcript, and the spec is explicit
+//! that it therefore "can … **not be used** to describe variants affecting
+//! these sequences" (`background/numbering.md`). An edit with an intronic
+//! endpoint is only rendered when its exonic span is itself the consequence —
+//! a whole-exon skip, which `RNA/splicing.md` spells with plain exonic
+//! positions. Otherwise the axis declines rather than re-anchor onto the
+//! neighbouring exonic base, which exists on the mature RNA and would silently
+//! describe a different nucleotide. See `exonic_span`.
 //! RNA rendering (T→U, lowercase, predicted `( )` wrapper) is handled by the
 //! existing `RnaVariant` Display path; this module only builds the value.
 
@@ -37,8 +47,8 @@ fn cds_interval_to_rna(iv: &CdsInterval) -> Option<RnaInterval> {
 
 /// 3′-shift a single deletion interval along the spliced transcript sequence,
 /// in CDS coordinates. Exonic deletions only; the intronic/special/utr3 guard is
-/// a safety fallback (intronic offsets are already stripped by `clamp_intronic`
-/// before this runs) — such intervals are returned unchanged.
+/// a safety fallback (`exonic_span` already stripped or declined every intronic
+/// endpoint before this runs) — such intervals are returned unchanged.
 fn shift_deletion_3prime(iv: &CdsInterval, transcript: &Transcript) -> Option<CdsInterval> {
     let start_cds = iv.start.inner()?;
     let end_cds = iv.end.inner()?;
@@ -76,38 +86,60 @@ fn shift_deletion_3prime(iv: &CdsInterval, transcript: &Transcript) -> Option<Cd
     Some(CdsInterval::new(new_start, new_end))
 }
 
-/// Strip non-zero intronic offsets from a CDS interval, keeping the exon-anchor
-/// `base`. Collapses an intron-spanning edit to its exonic span on the RNA
-/// (introns are not present in the spliced transcript). Must run before any
-/// 3′ shift, which is undefined on intronic-offset positions.
-fn clamp_intronic(iv: &CdsInterval) -> Option<CdsInterval> {
-    // Collapsing to the exonic span: the output is always exon-anchored, so the
-    // intronic offset is dropped unconditionally (an exonic input already has
-    // `None`; a `Some(0)` boundary offset would otherwise render as `+0`).
+/// Reduce a CDS interval to the exonic span the `r.` axis may name, declining
+/// (`None`) when no such span exists.
+///
+/// A non-zero intronic offset (`c.3675-45`, `c.831+2`) names a nucleotide that
+/// is spliced out of the mature RNA, so it has no `r.` position of its own.
+/// Dropping the offset re-anchors the description onto the exon-boundary base —
+/// which *does* exist on the RNA — so the output stays well-formed while
+/// describing a different nucleotide. That is only acceptable when the exonic
+/// span is itself the thing being described, which is true for exactly one
+/// shape:
+///
+/// **Whole exon(s).** A span reaching 5′ into the intron *preceding* its start
+/// exon and 3′ into the intron *following* its end exon removes complete exons,
+/// and the spec spells that consequence with plain exonic positions —
+/// `RNA/splicing.md`: "`NC_000023.11(NM_004006.2):r.650_831del` … the sequence
+/// from nucleotide `r.650` to `r.831` (exon 8) is deleted from the transcript".
+/// HGVS intron numbering makes the test purely local: a **negative** offset is
+/// anchored on the first base of the downstream exon and a **positive** offset
+/// on the last base of the upstream exon (`background/numbering.md`), so
+/// `start.offset < 0 && end.offset > 0` means `start.base ..= end.base` is
+/// exactly a whole number of exons.
+///
+/// Everything else declines: a partial-exon edit with one intronic endpoint
+/// (`c.3675-45_3692del` — #1086 D5) has no exon-sized RNA consequence to name,
+/// and a purely intronic edit (`c.100+5_100+10del`, `c.831+2T>A`) touches no
+/// exonic base at all. For those, `background/numbering.md` is explicit that an
+/// RNA reference "can therefore **not be used** to describe variants affecting
+/// these sequences"; the spec's remedy is a genome-anchored `r.` carrying the
+/// offsets, which this surface does not emit.
+///
+/// Note this is *not* a general "make `r.` agree with `c.`" rule: the 3′-shift
+/// difference between the two axes is spec-mandated (`RNA/deletion.md`) and is
+/// deliberately left alone — only exonic spans reach the shift, exactly as
+/// before.
+fn exonic_span(iv: &CdsInterval) -> Option<CdsInterval> {
+    let start_in = iv.start.inner()?;
+    let end_in = iv.end.inner()?;
+    if start_in.is_intronic() || end_in.is_intronic() {
+        let spans_whole_exons =
+            start_in.offset.is_some_and(|o| o < 0) && end_in.offset.is_some_and(|o| o > 0);
+        if !spans_whole_exons {
+            return None;
+        }
+    }
+    // A `Some(0)` offset is exonic but would render as a spurious `+0`; the
+    // whole-exon offsets above are deliberately dropped (that is the exon-span
+    // reduction). Either way the output is exon-anchored.
     let strip = |p: &CdsPos| CdsPos {
         base: p.base,
         offset: None,
         utr3: p.utr3,
         special: p.special,
     };
-    let start_in = iv.start.inner()?;
-    let end_in = iv.end.inner()?;
-    let start = strip(start_in);
-    let end = strip(end_in);
-    // A purely intronic edit (both endpoints carry a non-zero intronic offset)
-    // that lies wholly within a single intron has no exonic component and hence no
-    // RNA consequence — decline rather than fabricate a spurious exonic span. This
-    // covers two shapes:
-    //   * shared exon anchor — `c.100+5_100+10del` collapses to `c.100_100del`;
-    //   * adjacent exon anchors — `c.100+5_101-3del` (the span sits in the lone
-    //     intron between bases 100 and 101, which are consecutive exonic positions)
-    //     collapses to `c.100_101del`.
-    // Both endpoints intronic with `end.base - start.base <= 1` means no exonic base
-    // falls inside the span.
-    if end.base.saturating_sub(start.base) <= 1 && start_in.is_intronic() && end_in.is_intronic() {
-        return None;
-    }
-    Some(CdsInterval::new(start, end))
+    Some(CdsInterval::new(strip(start_in), strip(end_in)))
 }
 
 /// Resolve a CDS position range to literal DNA bases against `transcript.sequence`.
@@ -200,12 +232,12 @@ pub(crate) fn predict_rna(coding: &HgvsVariant, transcript: &Transcript) -> Opti
         _ => return None, // non-c. inputs unsupported (alleles handled above)
     };
     let edit: &NaEdit = cds.loc_edit.edit.inner()?;
-    // Clamp intronic offsets to the exonic span first, then 3′-shift deletions
-    // along the spliced sequence (shifting an intronic-offset edit is undefined).
-    let clamped = clamp_intronic(&cds.loc_edit.location)?;
+    // Reduce to the exonic span the r. axis may name (declining an intronic
+    // endpoint that has none), then 3′-shift deletions along the spliced sequence.
+    let exonic = exonic_span(&cds.loc_edit.location)?;
     let location = match edit {
-        NaEdit::Deletion { .. } => shift_deletion_3prime(&clamped, transcript)?,
-        _ => clamped,
+        NaEdit::Deletion { .. } => shift_deletion_3prime(&exonic, transcript)?,
+        _ => exonic,
     };
     let rna_interval = cds_interval_to_rna(&location)?;
     // Resolve position-range/inversion inserts against the transcript sequence to
@@ -373,25 +405,30 @@ mod tests {
     }
 
     #[test]
-    fn intronic_endpoints_clamp_to_exonic_span() {
+    fn whole_exon_span_reduces_to_its_exonic_positions() {
         use crate::hgvs::edit::NaEdit;
         use crate::hgvs::interval::CdsInterval;
         use crate::hgvs::location::CdsPos;
         use crate::hgvs::variant::{Accession, CdsVariant, LocEdit};
 
-        // sequence present, cds_start = 1; needs >=704 nt in-bounds. Make
-        // position 705 distinct from the deleted run so the post-clamp 3′ shift
-        // leaves `677_704del` in place rather than shuffling rightward.
+        // `c.677-18_704+65del` brackets whole exon(s): the start offset is
+        // negative (anchored on the exon's FIRST base) and the end offset is
+        // positive (anchored on the exon's LAST base), so c.677..704 is exactly
+        // the skipped exon. RNA/splicing.md spells that consequence with plain
+        // exonic positions (`r.650_831del`, "exon 8 is deleted from the
+        // transcript"), so the offsets are dropped here by design — this is the
+        // one intronic shape #1086 keeps.
         let mut tx = coding_tx();
         let mut s = vec![b'A'; 900];
-        s[704] = b'C'; // 0-based 704 == c.705 differs from the deleted `A` run end
+        s[704] = b'C'; // c.705 differs from the deleted `A` run end => no 3' shift
         tx.sequence = Some(String::from_utf8(s).unwrap());
         tx.cds_end = Some(900);
         tx.exons = vec![Exon::new(1, 1, 900)];
 
-        let start = CdsPos::with_offset(677, -18); // c.677-18
-        let end = CdsPos::with_offset(704, 65); // c.704+65
-        let iv = CdsInterval::new(start, end);
+        let iv = CdsInterval::new(
+            CdsPos::with_offset(677, -18), // c.677-18
+            CdsPos::with_offset(704, 65),  // c.704+65
+        );
         let cds = CdsVariant {
             accession: Accession::new("NM", "000001", Some(1)),
             gene_symbol: None,
@@ -405,6 +442,90 @@ mod tests {
         };
         let out = predict_rna(&HgvsVariant::Cds(cds), &tx).expect("some");
         assert_eq!(out.to_string(), "NM_000001.1:r.(677_704del)");
+    }
+
+    #[test]
+    fn partial_exon_span_with_intronic_endpoints_declines() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{Accession, CdsVariant, LocEdit};
+
+        // Both endpoints intronic, but bracketed the WRONG way round:
+        // `c.677+18_704-65del` starts in the intron *following* exon-base 677
+        // and ends in the intron *preceding* exon-base 704, so it clips the
+        // flanking exons rather than removing whole ones. There is no exon-sized
+        // RNA consequence to name — decline (#1086).
+        let tx = coding_tx();
+        let iv = CdsInterval::new(CdsPos::with_offset(150, 18), CdsPos::with_offset(180, -65));
+        let cds = CdsVariant {
+            accession: Accession::new("NM", "000001", Some(1)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                iv,
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        };
+        assert!(predict_rna(&HgvsVariant::Cds(cds), &tx).is_none());
+    }
+
+    #[test]
+    fn single_intronic_endpoint_declines() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{Accession, CdsVariant, LocEdit};
+
+        // #1086 D5, the reported shape: only the *start* is intronic
+        // (`c.150-45_180del`), so the span clips into an exon rather than
+        // removing whole ones. Stripping the offset would name r.150 — an exonic
+        // base that exists, but is not `c.150-45`.
+        let tx = coding_tx();
+        let iv = CdsInterval::new(CdsPos::with_offset(150, -45), CdsPos::new(180));
+        let cds = CdsVariant {
+            accession: Accession::new("NM", "000001", Some(1)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                iv,
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        };
+        assert!(predict_rna(&HgvsVariant::Cds(cds), &tx).is_none());
+    }
+
+    #[test]
+    fn zero_offset_endpoint_is_exonic_and_renders() {
+        use crate::hgvs::edit::NaEdit;
+        use crate::hgvs::interval::CdsInterval;
+        use crate::hgvs::location::CdsPos;
+        use crate::hgvs::variant::{Accession, CdsVariant, LocEdit};
+
+        // A `Some(0)` offset is exonic, not intronic: it must still render (and
+        // without a spurious `+0`). Pins that the #1086 guard keys off
+        // `is_intronic()` rather than `offset.is_some()`.
+        let tx = coding_tx();
+        let mut start = CdsPos::new(141);
+        start.offset = Some(0);
+        let iv = CdsInterval::new(start, CdsPos::new(142));
+        let cds = CdsVariant {
+            accession: Accession::new("NM", "000001", Some(1)),
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                iv,
+                NaEdit::Deletion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        };
+        let out = predict_rna(&HgvsVariant::Cds(cds), &tx).expect("some");
+        assert_eq!(out.to_string(), "NM_000001.1:r.(141_142del)");
     }
 
     #[test]
@@ -513,9 +634,10 @@ mod tests {
         use crate::hgvs::variant::{Accession, CdsVariant, LocEdit};
 
         // An intron-only deletion whose endpoints share an exon anchor —
-        // c.100+5_100+10del — has no RNA consequence. Clamping its offsets would
+        // c.100+5_100+10del — has no RNA consequence. Stripping its offsets would
         // otherwise collapse it to a spurious single-base c.100_100del; predict_rna
-        // must decline (return None) instead.
+        // must decline (return None) instead. Covered by `exonic_span` since #1086
+        // (offset `+5` is not the whole-exon `-`/`+` bracketing shape).
         let tx = coding_tx();
         let start = CdsPos::with_offset(100, 5); // c.100+5
         let end = CdsPos::with_offset(100, 10); // c.100+10
@@ -545,7 +667,7 @@ mod tests {
         // *adjacent* exonic bases — c.100+5_101-3del. The span never touches an
         // exonic base, so it has no RNA consequence. Stripping the offsets would
         // otherwise fabricate a spurious two-base exonic c.100_101del; predict_rna
-        // must decline (return None) instead.
+        // must decline (return None) instead. Covered by `exonic_span` since #1086.
         let tx = coding_tx();
         let start = CdsPos::with_offset(100, 5); // c.100+5
         let end = CdsPos::with_offset(101, -3); // c.101-3

--- a/tests/it/issue_1086_cross_axis_projection.rs
+++ b/tests/it/issue_1086_cross_axis_projection.rs
@@ -1,4 +1,4 @@
-//! Issue #1086: cross-axis projection defects.
+//! Issue #1086: two cross-axis projection defects.
 //!
 //! **D5** — the `r.` axis silently discarded intronic offsets, mapping an
 //! intronic position onto a *different, existing* exonic RNA base
@@ -9,6 +9,11 @@
 //! therefore **not be used** to describe variants affecting these
 //! sequences"). The correct behaviour is to decline the `r.` axis rather
 //! than fabricate an exonic coordinate.
+//!
+//! **D2** — `VariantProjection::noncoding` is documented as "a single field
+//! that always means the `n.` form", but for an `r.` input it returned the
+//! `r.` form unchanged (wrong coordinate system, lowercase alphabet, `u`
+//! rather than `t`).
 //!
 //! Reference-backed: skips unless `FERRO_MANIFEST` points at a prepared
 //! reference (the same manifest gate the other axis tests use).
@@ -215,5 +220,47 @@ fn exonic_edit_still_projects_to_rna_axis() {
     assert_eq!(
         proj.rna.expect("exonic edits keep an r. axis").to_string(),
         "NM_004006.2:r.(897u>g)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// D2 — the n. axis must be a genuine n. description for an r. input.
+// ---------------------------------------------------------------------------
+
+/// `LRG_199t1:r.11u>g` (the spec's own example, `background/refseq.md`) must
+/// yield a real `n.` description on the non-coding axis. Before the fix the
+/// field held the `r.` input verbatim.
+#[test]
+fn rna_input_noncoding_axis_is_an_n_description() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let proj = project(&vp, "LRG_199t1:r.11u>g", "LRG_199t1");
+    let noncoding = proj.noncoding.expect("noncoding axis");
+    assert!(
+        matches!(noncoding, ferro_hgvs::HgvsVariant::Tx(_)),
+        "noncoding axis must hold an n. (Tx) variant, got {noncoding}",
+    );
+    assert_eq!(noncoding.to_string(), "LRG_199t1:n.11T>G");
+    // The c. axis already handled this input and must stay correct.
+    assert_eq!(
+        proj.coding.expect("coding axis").to_string(),
+        "LRG_199t1:c.-234T>G",
+    );
+}
+
+/// An `n.` input keeps its own form on the non-coding axis (no regression from
+/// the D2 fix, which only reshapes the `r.` case).
+#[test]
+fn noncoding_input_noncoding_axis_unchanged() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let proj = project(&vp, "LRG_199t1:n.11T>G", "LRG_199t1");
+    assert_eq!(
+        proj.noncoding.expect("noncoding axis").to_string(),
+        "LRG_199t1:n.11T>G",
     );
 }

--- a/tests/it/issue_1086_cross_axis_projection.rs
+++ b/tests/it/issue_1086_cross_axis_projection.rs
@@ -1,0 +1,219 @@
+//! Issue #1086: cross-axis projection defects.
+//!
+//! **D5** — the `r.` axis silently discarded intronic offsets, mapping an
+//! intronic position onto a *different, existing* exonic RNA base
+//! (`c.3675-45` → `r.3676`). Per the HGVS spec, an RNA reference sequence
+//! contains no intron sequence and therefore cannot be used to describe a
+//! variant affecting intronic bases (`background/numbering.md`, "RNA
+//! reference sequences … do **not contain** intron sequences and can
+//! therefore **not be used** to describe variants affecting these
+//! sequences"). The correct behaviour is to decline the `r.` axis rather
+//! than fabricate an exonic coordinate.
+//!
+//! Reference-backed: skips unless `FERRO_MANIFEST` points at a prepared
+//! reference (the same manifest gate the other axis tests use).
+
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::{MultiFastaProvider, ReferenceProvider, VariantProjection, VariantProjector};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Manifest-gated provider — mirrors issue_498_whole_exon_deletion.rs
+// ---------------------------------------------------------------------------
+
+fn manifest_path() -> Option<PathBuf> {
+    // FERRO_MANIFEST, when set, is authoritative — no fallback to well-known
+    // paths, so CI can disable the runner with `FERRO_MANIFEST=/nonexistent`.
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+/// `Arc<MultiFastaProvider>` newtype implementing `ReferenceProvider + Clone`
+/// so it can be plugged into [`VariantProjector`], which requires `Clone`.
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(
+        &self,
+        id: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_sequence(id, start, end)
+    }
+    fn has_transcript(&self, id: &str) -> bool {
+        self.0.has_transcript(id)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_genomic_sequence(contig, start, end)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_protein_sequence(accession, start, end)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.0.has_protein_data()
+    }
+    fn genomic_placement(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement(parent)
+    }
+    fn get_transcript_for_variant(
+        &self,
+        variant: &ferro_hgvs::hgvs::variant::HgvsVariant,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_variant(variant)
+    }
+    fn get_transcript_for_accession(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_accession(accession)
+    }
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        self.0.has_transcript_version_exact(id)
+    }
+    fn genomic_placement_on_build(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement_on_build(parent, build)
+    }
+    fn resolve_legacy_gene_selector(
+        &self,
+        selector: &str,
+        ng_parent: Option<&ferro_hgvs::hgvs::variant::Accession>,
+    ) -> Option<String> {
+        self.0.resolve_legacy_gene_selector(selector, ng_parent)
+    }
+    fn sole_hosted_transcript(
+        &self,
+        ng_parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<String> {
+        self.0.sole_hosted_transcript(ng_parent)
+    }
+    fn get_protein_length(&self, accession: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_protein_length(accession)
+    }
+    fn get_sequence_length(&self, id: &str) -> Result<u64, ferro_hgvs::FerroError> {
+        self.0.get_sequence_length(id)
+    }
+}
+
+fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
+    let p = provider()?;
+    let cdot = p.cdot_mapper()?.clone();
+    let projector = Projector::new(cdot);
+    Some(VariantProjector::new(projector, ArcProvider(p)))
+}
+
+/// Project `input` onto `tx` and hand back the whole projection.
+fn project(vp: &VariantProjector<ArcProvider>, input: &str, tx: &str) -> VariantProjection {
+    let v = ferro_hgvs::parse_hgvs(input).expect("parse");
+    vp.project_variant(&v, tx).expect("project")
+}
+
+// ---------------------------------------------------------------------------
+// D5 — the r. axis must never silently map an intronic offset onto a plain
+//      exonic r. position.
+// ---------------------------------------------------------------------------
+
+/// `NM_000552.3:c.3675-45_3692del` starts 45 nt inside an intron. That
+/// nucleotide is absent from the mature RNA, so no plain exonic `r.` position
+/// can name it: the projector must decline the `r.` axis. Before the fix it
+/// emitted `NM_000552.3:r.(3676_3694del)` — a well-formed description of a
+/// *different*, existing base.
+#[test]
+fn intronic_start_offset_declines_rna_axis() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let proj = project(&vp, "NM_000552.3:c.3675-45_3692del", "NM_000552.3");
+    assert!(
+        proj.rna.is_none(),
+        "intronic c.3675-45 must not project to a plain exonic r. position, got {:?}",
+        proj.rna.map(|r| r.to_string()),
+    );
+    // The c. axis is correct here and must stay correct.
+    assert_eq!(
+        proj.coding.expect("coding axis").to_string(),
+        "NM_000552.3:c.3675-44_3693del",
+    );
+}
+
+/// `NM_004006.2:c.123-65_-50` likewise carries an intronic start offset; the
+/// pre-fix output was the nonsensical `NM_004006.2:r.(123_-50)`.
+#[test]
+fn intronic_offset_utr_span_declines_rna_axis() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let proj = project(&vp, "NM_004006.2:c.123-65_-50", "NM_004006.2");
+    assert!(
+        proj.rna.is_none(),
+        "intronic c.123-65 must not project to a plain exonic r. position, got {:?}",
+        proj.rna.map(|r| r.to_string()),
+    );
+    assert_eq!(
+        proj.coding.expect("coding axis").to_string(),
+        "NM_004006.2:c.123-65_-50",
+    );
+}
+
+/// Guard against over-declining: a wholly exonic edit on the same transcript
+/// still projects to `r.`, with the 3'-shift behaviour untouched.
+#[test]
+fn exonic_edit_still_projects_to_rna_axis() {
+    let Some(vp) = manifest_projector() else {
+        eprintln!("issue_1086: skipping — no manifest at FERRO_MANIFEST");
+        return;
+    };
+    let proj = project(&vp, "NM_004006.2:c.897T>G", "NM_004006.2");
+    assert_eq!(
+        proj.rna.expect("exonic edits keep an r. axis").to_string(),
+        "NM_004006.2:r.(897u>g)",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -98,6 +98,7 @@ mod issue_1079_point_size_suffix;
 mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
+mod issue_1086_cross_axis_projection;
 mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;
 mod issue_129_mt_circular_wraparound;


### PR DESCRIPTION
Fixes two of the three open defects in #1086. D3 (genomic-context framing) is left for a follow-up; D4 was withdrawn as not-a-defect.

## D5 — the `r.` axis silently discarded intronic offsets

```
NM_000552.3:c.3675-45_3692del
  before  r-axis: NM_000552.3:r.(3676_3694del)      offset dropped, names a different base
  after   r-axis: unavailable: no r. representation for this variant
          c-axis: NM_000552.3:c.3675-44_3693del     unchanged
```

`c.3675-45` is 45 nucleotides inside an intron, so it has no position on the mature RNA. The old output was well-formed and silently wrong, which is worse than an error.

`background/numbering.md:62` settles it: "coding/non-coding RNA reference sequences do **not contain** intron sequences and can therefore **not be used** to describe variants affecting these sequences."

But a blanket decline is too strong, and the test suite caught that — it broke two whole-exon rows in the mutalyzer corpus. `RNA/splicing.md:28-29` explicitly sanctions plain exonic positions for an exon skip: `NC_000023.11(NM_004006.2):r.650_831del`, "the sequence from nucleotide `r.650` to `r.831` (exon 8) is deleted from the transcript". So whole-exon spans keep their reduction, and those two rows were **not** re-blessed.

The discriminator needs no exon table. Per `numbering.md:34-35` a `-` offset anchors an exon's first base and `+` its last, so `start.offset < 0 && end.offset > 0` is exactly the whole-exon case. Preserved: `NG_008835.1(NM_022153.2):c.677-21_704+62del` → `r.(677_704del)`.

## D2 — the `n.` axis returned an `r.` string for `r.` inputs

```
LRG_199t1:r.11u>g
  before  n-axis: LRG_199t1:r.11u>g     an r. string, unchanged
  after   n-axis: LRG_199t1:n.11T>G
```

`VariantProjection::noncoding` is documented as always meaning the `n.` form, but passed `r.` through unchanged — wrong coordinate system, lowercase alphabet, and `u` for `t`. The `c.` axis already handled the same input correctly.

## Scope

3'-shift behaviour is deliberately untouched on both axes. `RNA/deletion.md:20` and `RNA/duplication.md:24` state the exon/exon-junction exception to the 3' rule does **not** apply for an RNA reference sequence, so `c.3921del` and `r.(3922del)` are both correct and are required to differ — that was originally filed as D4 and has been withdrawn. The `c.` axis output is byte-identical in every case examined here.

## Verification

`cargo nextest run --features dev` with `FERRO_MANIFEST` unset: **8075 passed, 0 failed** (8067 base plus 8 net-new tests). rustfmt and clippy `-D warnings` clean. The manifest-gated conformance run shows the same 5 pre-existing failures as `origin/main`, verified by running the identical filter at `6d39853`.

## Known gaps

The decline surfaces through the generic `no r. representation for this variant` reason; threading a more specific one needs an axis-path signature change. Separately, a genome-anchored `r.` could legally carry the offsets per `numbering.md:63`, which ferro does not emit — an enhancement, not a defect.

Refs #1086.
