### PR TITLE
fix(project): retain the input's genomic context on the c./n. axis

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1761,6 +1761,73 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         Some(rna)
     }
 
+    /// Re-frame a derived transcript-coordinate axis (`c.` / `n.`) so its
+    /// accession carries the *input's* genomic context (#1086).
+    ///
+    /// The `coding`/`noncoding` axes are built on the bare transcript accession
+    /// (`NM_004006.2`), which silently discarded an `NC_`/`NG_` parent the input
+    /// supplied. For an **intronic** position that bare form is not merely a
+    /// stylistic loss — it is spec-invalid. `background/refseq.md:47-49`:
+    ///
+    /// > intronic sequences are considered to be **within the boundaries** of a
+    /// > transcript reference sequence and may only be used to describe a
+    /// > variant when a genomic reference sequence identifier is provided …
+    /// > **not correct:** `NM_004006.2:c.357+1G>A` … **correct:**
+    /// > `NC_000023.10(NM_004006.2):c.357+1G>A`,
+    /// > `NG_012232.1(NM_004006.2):c.357+1G>A`.
+    ///
+    /// (Restated for coding transcripts at `refseq.md:136` and for non-coding
+    /// transcripts — the `n.` axis — at `refseq.md:157`; the parenthesised
+    /// rendering is specified at `refseq.md:138-140`.)
+    ///
+    /// The rule applied is **preserve the caller's framing**: retain the parent
+    /// whenever the input supplied one, render bare whenever it did not. This is
+    /// a superset of the spec's mandatory (intronic / flanking) case, so the
+    /// "not correct" bare-intronic form can never be produced from a parented
+    /// input; and it is what `refseq.md:138-140` prescribes for *any* `c.`
+    /// description "based on a genomic reference sequence", with no exonic
+    /// carve-out. It also matches the framing `ferro normalize` and the `r.`
+    /// axis ([`Self::reframe_rna_from_input`]) already preserve, so the axes of
+    /// one projection agree on their reference.
+    ///
+    /// A parent is never fabricated: a bare input stays bare (#121). Unlike the
+    /// `r.` path this deliberately leaves `gene_symbol` alone — the `c.`/`n.`
+    /// symbol is already the input's own on every site that calls this.
+    fn reframe_transcript_axis_from_input(
+        axis: Option<HgvsVariant>,
+        input: &HgvsVariant,
+    ) -> Option<HgvsVariant> {
+        let mut axis = axis?;
+        let context = input
+            .accession()
+            .and_then(|a| a.genomic_context.as_deref().cloned());
+        Self::apply_transcript_axis_framing(&mut axis, context.as_ref());
+        Some(axis)
+    }
+
+    /// Stamp `context` onto every `c.`/`n.` leaf of `axis` (descending into an
+    /// allele so its first-member-derived prefix is re-framed), or strip any
+    /// context when `context` is `None`. See
+    /// [`Self::reframe_transcript_axis_from_input`] for the rule and citation.
+    fn apply_transcript_axis_framing(axis: &mut HgvsVariant, context: Option<&Accession>) {
+        let reframe = |acc: &Accession| match context {
+            Some(parent) => acc.clone().with_genomic_context(parent.clone()),
+            None => acc.clone().without_genomic_context(),
+        };
+        match axis {
+            HgvsVariant::Cds(c) => c.accession = reframe(&c.accession),
+            HgvsVariant::Tx(t) => t.accession = reframe(&t.accession),
+            // An allele renders its prefix from the first member, so every
+            // member must carry the input frame (mirrors `apply_rna_framing`).
+            HgvsVariant::Allele(a) => {
+                for member in &mut a.variants {
+                    Self::apply_transcript_axis_framing(member, context);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Stamp `context`/`gene_symbol` onto every `r.` leaf of `rna` (descending
     /// into a predicted allele so its first-member-derived prefix is re-framed).
     fn apply_rna_framing(
@@ -5068,6 +5135,13 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         } else {
             (Some(coding), protein, rna)
         };
+
+        // #1086: `coding`/`noncoding` were built on the bare transcript
+        // accession, dropping any `NC_`/`NG_` parent the input supplied — which
+        // for an intronic position yields the spec's literal "not correct" form
+        // (`refseq.md:47-49`). Carry the input's framing onto both axes.
+        let coding = Self::reframe_transcript_axis_from_input(coding, normalized);
+        let noncoding = Self::reframe_transcript_axis_from_input(noncoding, normalized);
 
         Ok(VariantProjection {
             normalization_warnings: Vec::new(),

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -5251,8 +5251,9 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// Genomic-only projection for a whole-arm terminus (pter/qter) `c.` input
     /// whose parent genome frame IS resolvable (#887). Mirrors
     /// `polya_multiaxis_projection`'s shape: echo the input's own coding form
-    /// (framing included, #1086), no protein/noncoding/rna axis (a whole-arm marker does not round-trip
-    /// through cdot). `genomic` is the already-normalized parent-frame
+    /// (framing included, #1086), no protein/noncoding/rna axis (a whole-arm
+    /// marker does not round-trip through cdot). `genomic` is the
+    /// already-normalized parent-frame
     /// (NG_/LRG_) coordinate.
     ///
     /// #972: this site is reached from the top of `project_single_inner`,

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -4977,9 +4977,11 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         let c_edit = transform_edit_for_strand(&edit, strand);
 
         // Build the c./n. HGVS variant returned in `VariantProjection.coding`.
-        // Kept bare-accession (no NC_* wrapper) for caller-visible rendering;
-        // build-awareness for the parent-aware caches goes through
-        // `cache_variant` below.
+        // Built bare-accession (no NC_* wrapper) here; the caller-visible
+        // framing is applied at the end of this function by
+        // `reframe_transcript_axis_from_input` (#1086), which re-stamps the
+        // input's own `NC_`/`NG_` parent. Build-awareness for the parent-aware
+        // caches goes through `cache_variant` below.
         let coding = if is_coding {
             let interval = CdsInterval::new(cds_start, cds_end);
             HgvsVariant::Cds(CdsVariant {
@@ -5167,8 +5169,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// contiguous downstream walk cannot be re-derived back to a CDS position via
     /// the normal genome→CDS path (it would be rejected as
     /// `TranscriptNotOverlapping`). The coding axis is therefore the input's own
-    /// (bare-accession) form, and the genomic axis is the re-anchored walked
-    /// coordinate. A `c.*` 3'UTR/poly-A position has no protein consequence, so
+    /// form (retaining the input's framing, #1086), and the genomic axis is the
+    /// re-anchored walked coordinate. A `c.*` 3'UTR/poly-A position has no protein consequence, so
     /// `protein`/`rna`/`noncoding` are `None` (best-effort: nothing to derive
     /// from a position with no genomic exon context).
     ///
@@ -5197,16 +5199,21 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         gene_symbol: Option<String>,
         cds_start_incomplete: bool,
     ) -> Option<VariantProjection> {
-        // The coding axis is the input's own form, rendered bare (no NC_ wrapper),
-        // matching how `coding` is reported on the normal path. Only `c.*` (CDS)
-        // inputs qualify for the poly-A fallback (the caller gates on
-        // `HgvsVariant::Cds`); `n.`/`r.` inputs have no poly-A 3'UTR endpoint and
-        // must fall through to the canonical `TranscriptNotOverlapping` decline.
+        // The coding axis is the input's own form, carrying the input's own
+        // framing — matching how `coding` is reported on the normal path
+        // (#1086: that path used to render bare and now preserves the caller's
+        // `NC_`/`NG_` parent, so this echo follows it). Retaining the parent
+        // also keeps this axis in the same reference frame as the `genomic`
+        // axis reported alongside it below. Only `c.*` (CDS) inputs qualify for
+        // the poly-A fallback (the caller gates on `HgvsVariant::Cds`);
+        // `n.`/`r.` inputs have no poly-A 3'UTR endpoint and must fall through
+        // to the canonical `TranscriptNotOverlapping` decline.
         let coding = match normalized {
             HgvsVariant::Cds(c) if !cds_start_incomplete => {
-                let mut c = c.clone();
-                c.accession.genomic_context = None;
-                Some(HgvsVariant::Cds(c))
+                Self::reframe_transcript_axis_from_input(
+                    Some(HgvsVariant::Cds(c.clone())),
+                    normalized,
+                )
             }
             HgvsVariant::Cds(_) => None,
             _ => return None,
@@ -5243,8 +5250,8 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
 
     /// Genomic-only projection for a whole-arm terminus (pter/qter) `c.` input
     /// whose parent genome frame IS resolvable (#887). Mirrors
-    /// `polya_multiaxis_projection`'s shape: echo the input's bare coding form,
-    /// no protein/noncoding/rna axis (a whole-arm marker does not round-trip
+    /// `polya_multiaxis_projection`'s shape: echo the input's own coding form
+    /// (framing included, #1086), no protein/noncoding/rna axis (a whole-arm marker does not round-trip
     /// through cdot). `genomic` is the already-normalized parent-frame
     /// (NG_/LRG_) coordinate.
     ///
@@ -5280,11 +5287,18 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             HgvsVariant::Cds(c) => c.gene_symbol.clone(),
             _ => None,
         };
+        // As on the poly-A echo above, the coding axis carries the input's own
+        // framing (#1086). A whole-arm terminus makes that mandatory rather
+        // than merely consistent: `pter`/`qter` are genomic-frame landmarks
+        // that `project_cds_terminus_to_parent` can only resolve *because* a
+        // parent reference was supplied, so a bare `NM_…:c.pterdel` would name
+        // a position its own stated reference cannot locate.
         let coding = match normalized {
             HgvsVariant::Cds(c) if !cds_start_incomplete => {
-                let mut c = c.clone();
-                c.accession.genomic_context = None;
-                Some(HgvsVariant::Cds(c))
+                Self::reframe_transcript_axis_from_input(
+                    Some(HgvsVariant::Cds(c.clone())),
+                    normalized,
+                )
             }
             _ => None,
         };

--- a/tests/it/issue_1086_c_axis_genomic_context.rs
+++ b/tests/it/issue_1086_c_axis_genomic_context.rs
@@ -208,22 +208,38 @@ fn exonic_input_with_context_keeps_context() {
     );
 }
 
-/// The `r.` axis was already correct — guard it against collateral damage.
-/// (The `c.`/`r.` 3'-shift difference on this input is *required*, not a bug:
-/// `RNA/deletion.md:20` excludes the exon/exon-junction exception to the 3'
-/// rule for an RNA reference sequence. Deliberately not asserted here beyond
-/// the framing.)
+/// The `r.` axis retains the input's genomic context too — guard it against
+/// collateral damage from the `c.`/`n.` framing change. An exonic input renders
+/// on `r.` (lowercase RNA alphabet) with the genomic parent echoed, exactly as
+/// the module doc notes (`NC_000023.11(NM_004006.2):r.(79a>g)`).
+///
+/// (An earlier revision pinned the deep-intronic `c.4072-1234_5155-246del`
+/// here; after #1089 the `r.` axis declines partial-intronic spans — it accepts
+/// only whole-exon-skip shapes — so that input is now `Unavailable`. This test
+/// uses an exonic input, which still renders, to keep asserting the framing.)
 #[test]
 fn rna_axis_framing_is_unchanged() {
     skip_without_manifest!(vp);
-    let AxisOutcome::Rendered { output, .. } = project(
-        &vp,
-        "NC_000023.11(NM_004006.2):c.4072-1234_5155-246del",
-        Axis::Rna,
-    ) else {
+    let AxisOutcome::Rendered { output, .. } =
+        project(&vp, "NC_000023.11(NM_004006.2):c.79A>G", Axis::Rna)
+    else {
         panic!("r. axis unexpectedly unavailable");
     };
-    assert_eq!(output, "NC_000023.11(NM_004006.2):r.(4073_5156del)");
+    assert_eq!(output, "NC_000023.11(NM_004006.2):r.(79a>g)");
+}
+
+/// The non-coding (`n.`) half of the "c./n." guarantee: an input that supplied
+/// a genomic context keeps it on the `n.` axis too. `NM_004006.2:c.79` is
+/// `n.323` (the 5'UTR is 244 bp), framed under the same `NC_` parent.
+#[test]
+fn noncoding_axis_retains_context() {
+    skip_without_manifest!(vp);
+    let AxisOutcome::Rendered { output, .. } =
+        project(&vp, "NC_000023.11(NM_004006.2):c.79A>G", Axis::Noncoding)
+    else {
+        panic!("n. axis unexpectedly unavailable");
+    };
+    assert_eq!(output, "NC_000023.11(NM_004006.2):n.323A>G");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/it/issue_1086_c_axis_genomic_context.rs
+++ b/tests/it/issue_1086_c_axis_genomic_context.rs
@@ -1,0 +1,293 @@
+//! Issue #1086 (defect D3) — `ferro project --axis c` dropped the genomic
+//! context (`NC_`/`NG_` parent) the input supplied, emitting a bare
+//! `NM_004006.2:c.357+1G>A`. That string is the HGVS spec's own literal
+//! **"not correct"** example.
+//!
+//! `assets/hgvs-nomenclature/docs/background/refseq.md:47-49`:
+//!
+//! > intronic sequences are considered to be **within the boundaries** of a
+//! > transcript reference sequence and may only be used to describe a variant
+//! > when a genomic reference sequence identifier is provided, e.g.,
+//! > `NC_000023.11(NM_004006.2):c.93+1G>T` … **not correct:**
+//! > `NM_004006.2:c.357+1G>A` … **correct:**
+//! > `NC_000023.10(NM_004006.2):c.357+1G>A`,
+//! > `NG_012232.1(NM_004006.2):c.357+1G>A`, `LRG_199t1:c.357+1G>A`.
+//!
+//! Restated for coding transcripts at `refseq.md:136` and for non-coding
+//! transcripts at `refseq.md:157`; the parenthesised rendering itself is
+//! specified at `refseq.md:138-140`:
+//!
+//! > when, based on a genomic reference sequence, variants are reported using a
+//! > `c.` prefix, the transcript variant used should be indicated. … for `NC_`
+//! > or `NG_` reference sequences, the annotated transcript used is given in
+//! > parentheses directly following the accession.version number.
+//!
+//! ## The rule pinned here
+//!
+//! **The `c.`/`n.` axis retains the genomic context whenever the *input*
+//! supplied one, and stays bare whenever it did not** — i.e. the projector
+//! preserves the caller's reference framing rather than classifying the
+//! position.
+//!
+//! Why this rule and not "wrap only intronic/flanking positions":
+//!
+//! 1. It is spec-sufficient: it is a superset of the mandatory case, so the
+//!    "not correct" bare-intronic string can never be emitted from a parented
+//!    input, and the only way to reach a bare intronic `c.` is a bare input,
+//!    which was already spec-invalid before ferro touched it.
+//! 2. It is spec-endorsed for exonic positions too: `refseq.md:138-140` frames
+//!    the parenthesised form as what to do "when, based on a genomic reference
+//!    sequence, variants are reported using a `c.` prefix" — no intronic
+//!    qualifier. A `c.` description derived from `NC_000023.11(NM_004006.2)`
+//!    *is* based on a genomic reference sequence whether or not the position
+//!    happens to fall in an exon.
+//! 3. It matches what ferro already does everywhere else: `ferro normalize`
+//!    keeps the context, and `project --axis r` keeps it for exonic positions
+//!    too (`NC_000023.11(NM_004006.2):r.(79a>g)`). Only `--axis c` differed.
+//! 4. It is positional-classification-free, so it cannot drift out of sync with
+//!    the intronic/UTR flag plumbing.
+//!
+//! `exonic_input_without_context_stays_bare` and
+//! `exonic_input_with_context_keeps_context` pin both halves of the rule so a
+//! future change to either direction is a deliberate one.
+
+use ferro_hgvs::cli::project::{project_axis, Axis, AxisOutcome};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::transcript::Transcript;
+use ferro_hgvs::{
+    parse_hgvs, HgvsVariant, MultiFastaProvider, ReferenceProvider, VariantProjector,
+};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+
+fn manifest_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("FERRO_MANIFEST") {
+        let p = PathBuf::from(path);
+        return if p.exists() { Some(p) } else { None };
+    }
+    let p = Path::new("benchmark-output/manifest.json");
+    if p.exists() {
+        return Some(p.to_path_buf());
+    }
+    None
+}
+
+fn provider() -> Option<Arc<MultiFastaProvider>> {
+    static PROVIDER: OnceLock<Option<Arc<MultiFastaProvider>>> = OnceLock::new();
+    PROVIDER
+        .get_or_init(|| {
+            let path = manifest_path()?;
+            Some(Arc::new(
+                MultiFastaProvider::from_manifest(&path)
+                    .unwrap_or_else(|e| panic!("from_manifest({}) failed: {e}", path.display())),
+            ))
+        })
+        .clone()
+}
+
+/// `Arc<MultiFastaProvider>` newtype implementing `ReferenceProvider + Clone` so
+/// it can be plugged into `VariantProjector` (mirrors
+/// `tests/it/issue_843_allele_rna_build_scoping.rs`).
+#[derive(Clone)]
+struct ArcProvider(Arc<MultiFastaProvider>);
+
+impl ReferenceProvider for ArcProvider {
+    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript(id)
+    }
+    fn get_sequence(&self, id: &str, s: u64, e: u64) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_sequence(id, s, e)
+    }
+    fn has_transcript(&self, id: &str) -> bool {
+        self.0.has_transcript(id)
+    }
+    fn get_genomic_sequence(
+        &self,
+        contig: &str,
+        s: u64,
+        e: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_genomic_sequence(contig, s, e)
+    }
+    fn has_genomic_data(&self) -> bool {
+        self.0.has_genomic_data()
+    }
+    fn get_protein_sequence(
+        &self,
+        accession: &str,
+        s: u64,
+        e: u64,
+    ) -> Result<String, ferro_hgvs::FerroError> {
+        self.0.get_protein_sequence(accession, s, e)
+    }
+    fn has_protein_data(&self) -> bool {
+        self.0.has_protein_data()
+    }
+    fn get_transcript_for_variant(
+        &self,
+        variant: &HgvsVariant,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_variant(variant)
+    }
+    fn get_transcript_for_accession(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
+        self.0.get_transcript_for_accession(accession)
+    }
+    fn has_transcript_version_exact(&self, id: &str) -> bool {
+        self.0.has_transcript_version_exact(id)
+    }
+    fn infer_genome_build(
+        &self,
+        accession: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<&'static str> {
+        self.0.infer_genome_build(accession)
+    }
+    fn genomic_placement(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement(parent)
+    }
+    fn genomic_placement_on_build(
+        &self,
+        parent: &ferro_hgvs::hgvs::variant::Accession,
+        build: Option<&str>,
+    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
+        self.0.genomic_placement_on_build(parent, build)
+    }
+}
+
+fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
+    let p = provider()?;
+    let cdot = p.cdot_mapper()?.clone();
+    Some(VariantProjector::new(Projector::new(cdot), ArcProvider(p)))
+}
+
+/// Project `input` onto `axis` exactly as `ferro project --axis <axis>` does.
+fn project(vp: &VariantProjector<ArcProvider>, input: &str, axis: Axis) -> AxisOutcome {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input}) failed: {e}"));
+    project_axis(vp, &v, axis, None)
+        .unwrap_or_else(|e| panic!("project_axis({input}, {}) failed: {e}", axis.code()))
+}
+
+/// Assert the `c.` axis renders exactly `expected`.
+fn assert_coding(vp: &VariantProjector<ArcProvider>, input: &str, expected: &str) {
+    match project(vp, input, Axis::Coding) {
+        AxisOutcome::Rendered { output, .. } => assert_eq!(
+            output, expected,
+            "c. axis for {input}: expected {expected}, got {output}"
+        ),
+        AxisOutcome::Unavailable { reason, .. } => {
+            panic!("c. axis for {input}: unexpectedly unavailable ({reason})")
+        }
+    }
+}
+
+macro_rules! skip_without_manifest {
+    ($vp:ident) => {
+        let Some($vp) = manifest_projector() else {
+            eprintln!("issue_1086: skipping — no FERRO_MANIFEST / benchmark-output manifest");
+            return;
+        };
+    };
+}
+
+/// The issue's headline reproduction: a two-endpoint deep-intronic deletion.
+/// Both endpoints carry an intronic offset, so a bare `NM_` rendering is
+/// spec-invalid (refseq.md:47-49).
+#[test]
+fn d3_intronic_deletion_keeps_genomic_context_on_c_axis() {
+    skip_without_manifest!(vp);
+    assert_coding(
+        &vp,
+        "NC_000023.11(NM_004006.2):c.4072-1234_5155-246del",
+        "NC_000023.11(NM_004006.2):c.4072-1234_5155-246del",
+    );
+}
+
+/// The spec's own `NC_`-parented intronic example (refseq.md:47).
+#[test]
+fn spec_nc_intronic_example_keeps_genomic_context_on_c_axis() {
+    skip_without_manifest!(vp);
+    assert_coding(
+        &vp,
+        "NC_000023.11(NM_004006.2):c.93+1G>T",
+        "NC_000023.11(NM_004006.2):c.93+1G>T",
+    );
+}
+
+/// The spec's own `NG_`-parented intronic example, listed verbatim under
+/// **correct** at refseq.md:49.
+#[test]
+fn spec_ng_intronic_example_keeps_genomic_context_on_c_axis() {
+    skip_without_manifest!(vp);
+    assert_coding(
+        &vp,
+        "NG_012232.1(NM_004006.2):c.357+1G>A",
+        "NG_012232.1(NM_004006.2):c.357+1G>A",
+    );
+}
+
+/// The bare `NM_` intronic string the spec calls **not correct** must never be
+/// produced from a parented input, on any of the reproductions.
+#[test]
+fn spec_not_correct_bare_intronic_string_is_never_emitted() {
+    skip_without_manifest!(vp);
+    for input in [
+        "NC_000023.11(NM_004006.2):c.4072-1234_5155-246del",
+        "NC_000023.11(NM_004006.2):c.93+1G>T",
+        "NG_012232.1(NM_004006.2):c.357+1G>A",
+    ] {
+        let AxisOutcome::Rendered { output, .. } = project(&vp, input, Axis::Coding) else {
+            panic!("c. axis for {input}: unexpectedly unavailable");
+        };
+        assert!(
+            output.starts_with("NC_") || output.starts_with("NG_"),
+            "c. axis for {input} emitted a bare transcript description ({output}); \
+             refseq.md:47-49 lists that form under \"not correct\""
+        );
+    }
+}
+
+/// Rule half 1: an input that supplied **no** genomic context keeps rendering
+/// bare. A purely exonic bare `NM_…:c.` description is spec-valid, and ferro
+/// must not fabricate a parent the caller did not give (#121).
+#[test]
+fn exonic_input_without_context_stays_bare() {
+    skip_without_manifest!(vp);
+    assert_coding(&vp, "NM_004006.2:c.79A>G", "NM_004006.2:c.79A>G");
+}
+
+/// Rule half 2: an exonic input that **did** supply a genomic context keeps it,
+/// matching `--axis r` (`NC_000023.11(NM_004006.2):r.(79a>g)`) and
+/// `ferro normalize`. Pins the "preserve caller framing" rule against a future
+/// narrowing to intronic-only.
+#[test]
+fn exonic_input_with_context_keeps_context() {
+    skip_without_manifest!(vp);
+    assert_coding(
+        &vp,
+        "NC_000023.11(NM_004006.2):c.79A>G",
+        "NC_000023.11(NM_004006.2):c.79A>G",
+    );
+}
+
+/// The `r.` axis was already correct — guard it against collateral damage.
+/// (The `c.`/`r.` 3'-shift difference on this input is *required*, not a bug:
+/// `RNA/deletion.md:20` excludes the exon/exon-junction exception to the 3'
+/// rule for an RNA reference sequence. Deliberately not asserted here beyond
+/// the framing.)
+#[test]
+fn rna_axis_framing_is_unchanged() {
+    skip_without_manifest!(vp);
+    let AxisOutcome::Rendered { output, .. } = project(
+        &vp,
+        "NC_000023.11(NM_004006.2):c.4072-1234_5155-246del",
+        Axis::Rna,
+    ) else {
+        panic!("r. axis unexpectedly unavailable");
+    };
+    assert_eq!(output, "NC_000023.11(NM_004006.2):r.(4073_5156del)");
+}

--- a/tests/it/issue_1086_c_axis_genomic_context.rs
+++ b/tests/it/issue_1086_c_axis_genomic_context.rs
@@ -53,10 +53,8 @@
 
 use ferro_hgvs::cli::project::{project_axis, Axis, AxisOutcome};
 use ferro_hgvs::data::projection::Projector;
-use ferro_hgvs::reference::transcript::Transcript;
-use ferro_hgvs::{
-    parse_hgvs, HgvsVariant, MultiFastaProvider, ReferenceProvider, VariantProjector,
-};
+
+use ferro_hgvs::{parse_hgvs, MultiFastaProvider, VariantProjector};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
@@ -85,84 +83,20 @@ fn provider() -> Option<Arc<MultiFastaProvider>> {
         .clone()
 }
 
-/// `Arc<MultiFastaProvider>` newtype implementing `ReferenceProvider + Clone` so
-/// it can be plugged into `VariantProjector` (mirrors
-/// `tests/it/issue_843_allele_rna_build_scoping.rs`).
-#[derive(Clone)]
-struct ArcProvider(Arc<MultiFastaProvider>);
-
-impl ReferenceProvider for ArcProvider {
-    fn get_transcript(&self, id: &str) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
-        self.0.get_transcript(id)
-    }
-    fn get_sequence(&self, id: &str, s: u64, e: u64) -> Result<String, ferro_hgvs::FerroError> {
-        self.0.get_sequence(id, s, e)
-    }
-    fn has_transcript(&self, id: &str) -> bool {
-        self.0.has_transcript(id)
-    }
-    fn get_genomic_sequence(
-        &self,
-        contig: &str,
-        s: u64,
-        e: u64,
-    ) -> Result<String, ferro_hgvs::FerroError> {
-        self.0.get_genomic_sequence(contig, s, e)
-    }
-    fn has_genomic_data(&self) -> bool {
-        self.0.has_genomic_data()
-    }
-    fn get_protein_sequence(
-        &self,
-        accession: &str,
-        s: u64,
-        e: u64,
-    ) -> Result<String, ferro_hgvs::FerroError> {
-        self.0.get_protein_sequence(accession, s, e)
-    }
-    fn has_protein_data(&self) -> bool {
-        self.0.has_protein_data()
-    }
-    fn get_transcript_for_variant(
-        &self,
-        variant: &HgvsVariant,
-    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
-        self.0.get_transcript_for_variant(variant)
-    }
-    fn get_transcript_for_accession(
-        &self,
-        accession: &ferro_hgvs::hgvs::variant::Accession,
-    ) -> Result<Arc<Transcript>, ferro_hgvs::FerroError> {
-        self.0.get_transcript_for_accession(accession)
-    }
-    fn has_transcript_version_exact(&self, id: &str) -> bool {
-        self.0.has_transcript_version_exact(id)
-    }
-    fn infer_genome_build(
-        &self,
-        accession: &ferro_hgvs::hgvs::variant::Accession,
-    ) -> Option<&'static str> {
-        self.0.infer_genome_build(accession)
-    }
-    fn genomic_placement(
-        &self,
-        parent: &ferro_hgvs::hgvs::variant::Accession,
-    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
-        self.0.genomic_placement(parent)
-    }
-    fn genomic_placement_on_build(
-        &self,
-        parent: &ferro_hgvs::hgvs::variant::Accession,
-        build: Option<&str>,
-    ) -> Option<ferro_hgvs::reference::GenomicPlacement> {
-        self.0.genomic_placement_on_build(parent, build)
-    }
-}
+// `Arc<MultiFastaProvider>` is used directly as the projector's provider: the
+// library ships a complete blanket `impl ReferenceProvider for Arc<T>`
+// (`reference/provider.rs:434`) and `Arc` is `Clone`, so it satisfies
+// `VariantProjector<P: ReferenceProvider + Clone>` as-is. A hand-written
+// newtype would have to re-delegate every method, and any it missed would
+// silently fall back to the trait's stub default — e.g. `get_sequence_length`,
+// whose default is `Err(ReferenceNotFound)`, which the poly-A and terminus
+// paths below both depend on.
+type ArcProvider = Arc<MultiFastaProvider>;
 
 fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
     let p = provider()?;
     let cdot = p.cdot_mapper()?.clone();
-    Some(VariantProjector::new(Projector::new(cdot), ArcProvider(p)))
+    Some(VariantProjector::new(Projector::new(cdot), p))
 }
 
 /// Project `input` onto `axis` exactly as `ferro project --axis <axis>` does.
@@ -290,4 +224,111 @@ fn rna_axis_framing_is_unchanged() {
         panic!("r. axis unexpectedly unavailable");
     };
     assert_eq!(output, "NC_000023.11(NM_004006.2):r.(4073_5156del)");
+}
+
+// ---------------------------------------------------------------------------
+// The two multi-axis echo paths (`polya_multiaxis_projection`,
+// `terminus_multiaxis_projection`), deliberately left out of scope by the
+// commit above and folded in here as the same defect.
+//
+// Both short-circuit the normal genome→CDS re-derivation and instead *echo the
+// input's own `c.` form* as the coding axis — and both then explicitly did
+// `c.accession.genomic_context = None`. Each justified that stripping in its
+// own doc comment as "matching how `coding` is reported on the normal path".
+// That justification was true when written and is no longer: the normal path
+// now preserves the caller's framing, so the two echoes are the last places
+// that still drop it — and an echo is the case where dropping it is least
+// defensible, since the parent being discarded is one the caller typed on this
+// very description.
+//
+// Both echo an axis in the *same* reference frame the genomic axis is anchored
+// to (the input's `NG_`/`NC_` parent), so neither has a "different reference
+// frame" reason to render bare; see the per-test notes.
+// ---------------------------------------------------------------------------
+
+/// `polya_multiaxis_projection` (#797): a `c.*` position in the transcript's
+/// post-transcriptional poly-A tail has no genomic alignment, so the coding
+/// axis is the input echoed rather than re-derived. The echo dropped the `NG_`
+/// parent; the genomic axis it is reported alongside is anchored in exactly
+/// that parent's frame (`NG_012337.1:g.13954del`), so the bare form made the
+/// two axes of one projection disagree on their reference.
+#[test]
+fn polya_echo_keeps_genomic_context_on_c_axis() {
+    skip_without_manifest!(vp);
+    assert_coding(
+        &vp,
+        "NG_012337.1(NM_003002.2):c.*830del",
+        "NG_012337.1(NM_003002.2):c.*830del",
+    );
+}
+
+/// `terminus_multiaxis_projection` (#887): a whole-arm terminus marker
+/// (`pter`/`qter`) does not round-trip through cdot, so the coding axis is
+/// again the input echoed. A terminus marker is inherently a *genomic*-frame
+/// landmark — it is only resolvable at all because the input named a parent
+/// (`project_cds_terminus_to_parent` declines outright without one) — so the
+/// bare `NM_…:c.pterdel` names a position its own reference cannot locate.
+#[test]
+fn terminus_echo_keeps_genomic_context_on_c_axis() {
+    skip_without_manifest!(vp);
+    for marker in ["pter", "qter", "pter_qter"] {
+        let input = format!("NG_012337.1(NM_003002.2):c.{marker}del");
+        assert_coding(&vp, &input, &input);
+    }
+}
+
+/// Guard the other half of the rule on both echo paths: an input that supplied
+/// no genomic context must not have one invented (#121). Neither bare input
+/// may acquire a parenthesised parent.
+#[test]
+fn echo_paths_never_invent_a_genomic_context() {
+    skip_without_manifest!(vp);
+    for input in [
+        // Poly-A tail position, bare transcript reference.
+        "NM_003002.2:c.*830del",
+        // Whole-arm terminus on a bare LRG transcript.
+        "LRG_9t1:c.qterdel",
+        "LRG_9t1:c.pter_qterdel",
+    ] {
+        let AxisOutcome::Rendered { output, .. } = project(&vp, input, Axis::Coding) else {
+            panic!("c. axis for {input}: unexpectedly unavailable");
+        };
+        assert!(
+            !output.contains('('),
+            "c. axis for {input} fabricated a genomic context ({output}); a bare \
+             input must stay bare (#121)"
+        );
+    }
+}
+
+/// The genomic axis of both echo paths is untouched by the framing change —
+/// it stays the parent-frame coordinate each path already reported.
+#[test]
+fn echo_paths_genomic_axis_is_unchanged() {
+    skip_without_manifest!(vp);
+    for (input, expected) in [
+        // Poly-A: the re-anchored walked coordinate.
+        (
+            "NG_012337.1(NM_003002.2):c.*830del",
+            "NG_012337.1:g.13954del",
+        ),
+        // Terminus: pter → the parent's 5' end, qter → its 3' end.
+        ("NG_012337.1(NM_003002.2):c.pterdel", "NG_012337.1:g.3del"),
+        (
+            "NG_012337.1(NM_003002.2):c.qterdel",
+            "NG_012337.1:g.15948del",
+        ),
+        (
+            "NG_012337.1(NM_003002.2):c.pter_qterdel",
+            "NG_012337.1:g.1_15948del",
+        ),
+    ] {
+        let AxisOutcome::Rendered { output, .. } = project(&vp, input, Axis::Genomic) else {
+            panic!("g. axis for {input}: unexpectedly unavailable");
+        };
+        assert_eq!(
+            output, expected,
+            "g. axis for {input}: expected {expected}, got {output}"
+        );
+    }
 }

--- a/tests/it/issue_879_ng_g_to_c_overlap.rs
+++ b/tests/it/issue_879_ng_g_to_c_overlap.rs
@@ -256,13 +256,20 @@ fn ng_context_coding_input_keeps_pivot_path_unchanged() {
         .expect("c. input with NG_ context projects via the pivot path");
 
     // Today's pivot-path output, pinned verbatim: the single-transcript c. path
-    // renders the coding axis on the bare transcript reference (the gene-symbol
-    // selector is dropped on a transcript ref, #1051; the value still lives on
-    // the struct), a bare protein, and an NG_-framed genomic axis. The
-    // Genome-gate must leave every one of these unchanged.
+    // renders the coding axis under the input's `NG_` genomic context (#1086 —
+    // the axis preserves the caller's reference framing, per
+    // `background/refseq.md:138-140`; the gene-symbol selector is still dropped
+    // on a transcript ref, #1051, and the value still lives on the struct), a
+    // bare protein, and an NG_-framed genomic axis. The Genome-gate must leave
+    // every one of these unchanged.
+    //
+    // Pre-#1086 this line read `Some("NM_TEST.1:c.4A>C")` — the parent was
+    // dropped. That was the defect #1086 fixes, pinned here only incidentally:
+    // this test's subject is the #879 *routing* gate, not the framing, and its
+    // routing assertions (protein bare, genomic NG_-framed) are unchanged.
     assert_eq!(
         r.coding.as_ref().map(ToString::to_string).as_deref(),
-        Some("NM_TEST.1:c.4A>C"),
+        Some("NG_TEST.1(NM_TEST.1):c.4A>C"),
     );
     assert_eq!(
         r.protein.as_ref().map(ToString::to_string).as_deref(),

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -98,6 +98,7 @@ mod issue_1079_point_size_suffix;
 mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
+mod issue_1086_c_axis_genomic_context;
 mod issue_1086_cross_axis_projection;
 mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;


### PR DESCRIPTION
Fixes D3 from #1086: the `c.` and `r.` projection axes disagreed on genomic-context framing.

```
NC_000023.11(NM_004006.2):c.4072-1234_5155-246del
  before  c-axis: NM_004006.2:c.4072-1234_5155-246del
  after   c-axis: NC_000023.11(NM_004006.2):c.4072-1234_5155-246del
          r-axis: NC_000023.11(NM_004006.2):r.(4073_5156del)     unchanged
```

## The `c.` axis was the defect, not `r.`

The issue originally described this neutrally — "whichever is correct, they should agree". The spec is not neutral. `background/refseq.md:47-49`:

> intronic sequences are considered to be **within the boundaries** of a transcript reference sequence and may only be used to describe a variant **when a genomic reference sequence identifier is provided** … **not correct:** `NM_004006.2:c.357+1G>A`, `LRG_199:c.357+1G>A`. **correct:** `NC_000023.10(NM_004006.2):c.357+1G>A`, `NG_012232.1(NM_004006.2):c.357+1G>A`, `LRG_199t1:c.357+1G>A`.

The D3 input is intronic, so `project --axis c` was emitting the spec's own "not correct" shape. `c.93+1G>T` and `NG_012232.1(NM_004006.2):c.357+1G>A` did the same — the latter is verbatim one of the spec's "correct" examples, which ferro was turning into the adjacent "not correct" one.

This was also inconsistent with ferro elsewhere: `ferro normalize` already retains the context, and ~38 `NC_/NG_(NM_):c.` intronic corpus rows pass because of it. Only `project --axis c` dropped it.

Dropping the wrapper is genuinely lossy, which is presumably why the spec mandates rather than merely prefers it: an intron offset is defined only by a transcript↔genome alignment, and `NM_004006.2:c.4072-1234` does not record which build placed that intron — GRCh37 and GRCh38 differ.

## The rule implemented

**Preserve the caller's framing** — the `c.`/`n.` axis retains the genomic context whenever the input supplied one, and stays bare otherwise. Not intronic-only.

`refseq.md:138-140` prescribes the parenthesised form for *any* `c.` description "based on a genomic reference sequence", with no exonic carve-out, and this matches what `normalize` and `--axis r` already do on exonic input too. It also needs no positional classification, so one projection's axes always agree on their reference.

Exonic behaviour is pinned both ways by tests: `NM_004006.2:c.79A>G` stays bare; `NC_000023.11(NM_004006.2):c.79A>G` keeps the parent.

`n.` is changed alongside `c.` — `refseq.md:157` states the identical requirement for non-coding transcripts.

## Implementation

`reframe_transcript_axis_from_input` / `apply_transcript_axis_framing` in `src/project/projector.rs`, the `c.`/`n.` analogue of the existing `r.` reframing from #693, applied in `project_single_inner`. New `tests/it/issue_1086_c_axis_genomic_context.rs`, 7 manifest-gated tests (RED 5 fail / 2 pass → GREEN 7/7).

## One test change reviewers should look at

`issue_879_ng_g_to_c_overlap::ng_context_coding_input_keeps_pivot_path_unchanged` pinned `coding == "NM_TEST.1:c.4A>C"` for input `NG_TEST.1(NM_TEST.1):c.4A>C` — a hermetic mock pin of this very defect, on an exonic position, incidental to that test's actual subject (#879 routing, whose assertions are unchanged). It has been updated with an explanatory comment.

This is the only cost of the broad rule over an intronic-only one. If intronic-only is preferred on review, that test reverts and only the exonic-with-context row changes back; no corpus row is involved either way.

## Out of scope

3'-shift behaviour is untouched on both axes (`RNA/deletion.md:20` and `RNA/duplication.md:24` require `c.` and `r.` to differ there — originally filed as D4, withdrawn). The protein axis stays bare, which is deliberate and spec-correct; the `bare-np-protein` corpus rows are all scoped `"axis": "protein_description"` and do not generalise.

Follow-up worth its own issue: `polya_multiaxis_projection` (`projector.rs:4997`) and `terminus_multiaxis_projection` (`:5075`) still explicitly null the context on their echoed `c.` form — same defect class, left alone here.

## Verification

`cargo nextest run --features dev` with `FERRO_MANIFEST` unset: **8074 passed, 0 failed** (8067 base + 7 new). fmt and clippy `--all-targets -D warnings` clean.

**Corpus fallout: zero.** The manifest-gated run shows the identical 5 pre-existing failures before and after, verified by stashing and re-running on the clean tree. Nothing re-blessed.

Refs #1086.
