### PR TITLE
fix(parser): reject six classes of spec-forbidden variant description

### DIFF
--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -3055,6 +3055,168 @@ fn take_ref_seq_run(bytes: &[u8], pos: usize) -> &str {
     std::str::from_utf8(&bytes[pos..j]).unwrap_or("")
 }
 
+/// Rewrite a deletion written as `<point>del<size>` into the canonical
+/// range form `<point>_<point + size - 1>del` (W3011).
+///
+/// Per HGVS `recommendations/checklist.md:49` the size-suffix form on a
+/// single-position anchor is **not allowed**:
+///
+/// > Descriptions like `g.123del3` are not allowed, correct is `g.123_125del`.
+///
+/// The spec states the replacement outright, so the repair is mechanical: a
+/// size `N` deletion anchored at `p` spans `p`..`p + N - 1`. `del1` collapses
+/// to a plain `del` (a single residue needs no range).
+///
+/// Only a **plain** point anchor is rewritten — the digit run must be
+/// preceded by the coordinate-prefix `.` (`g.123del3`, `c.76del3`) or an
+/// allele-member boundary `[` / `;` (`c.[123del3;200del4]`), so each member
+/// of a compound allele is repaired the same way a standalone description is.
+/// That deliberately excludes every anchor whose arithmetic is not a simple
+/// increment: range endpoints (`_102del3`), intronic offsets (`+5del3`),
+/// UTR positions (`-12del3`, `*10del3`) and uncertain positions
+/// (`(123)del3`). Those keep whatever behaviour their own rule prescribes.
+/// The rewrite is coordinate-system agnostic — `p + N - 1` holds on every
+/// axis — so no coordinate context needs to be tracked across the members.
+///
+/// Returns the rewritten string plus one [`DetectedCorrection`] per rewrite,
+/// spanning the whole `<point>del<size>` token.
+pub fn correct_point_del_size_suffix(input: &str) -> (Cow<'_, str>, Vec<DetectedCorrection>) {
+    let mut corrections = Vec::new();
+    let bytes = input.as_bytes();
+    if !has_non_protein_description(bytes) || !input.contains("del") {
+        return (Cow::Borrowed(input), corrections);
+    }
+
+    let mut result = String::new();
+    let mut last_copied = 0usize;
+    let mut i = 0usize;
+    while i + 3 <= bytes.len() {
+        if &bytes[i..i + 3] != b"del" {
+            i += 1;
+            continue;
+        }
+        // `delins` is a different edit; skip past it.
+        if bytes.get(i + 3..i + 6) == Some(b"ins") {
+            i += 6;
+            continue;
+        }
+        let Some(token) = point_size_token(input, i, 3) else {
+            i += 3;
+            continue;
+        };
+        let replacement = format!("{}_{}del", token.position, token.position + token.size - 1);
+        corrections.push(DetectedCorrection::new(
+            ErrorType::DelSizeSuffix,
+            &input[token.start..token.end],
+            replacement.clone(),
+            token.start,
+            token.end,
+        ));
+        result.push_str(&input[last_copied..token.start]);
+        result.push_str(&replacement);
+        last_copied = token.end;
+        i = token.end;
+    }
+
+    if corrections.is_empty() {
+        (Cow::Borrowed(input), corrections)
+    } else {
+        result.push_str(&input[last_copied..]);
+        (Cow::Owned(result), corrections)
+    }
+}
+
+/// A `<point><keyword><size>` token located in the input (e.g. `123del3`).
+struct PointSizeToken {
+    /// Byte offset of the first digit of the anchor position.
+    start: usize,
+    /// Byte offset one past the last digit of the size suffix.
+    end: usize,
+    /// The anchor position.
+    position: u64,
+    /// The size suffix.
+    size: u64,
+}
+
+/// Recognize `<point><keyword><size>` at `keyword_start`, where `keyword_len`
+/// is the length of the edit keyword (`del`/`dup`).
+///
+/// Returns `None` unless the anchor is a plain point position written
+/// directly after the coordinate-prefix `.` or an allele-member boundary
+/// (`[` / `;`), and the size suffix is a non-zero integer terminated by a
+/// top-level boundary.
+fn point_size_token(
+    input: &str,
+    keyword_start: usize,
+    keyword_len: usize,
+) -> Option<PointSizeToken> {
+    let bytes = input.as_bytes();
+
+    // Anchor: a digit run immediately before the keyword, itself immediately
+    // preceded by the coordinate-system `.` separator or an allele-member
+    // boundary (`[` opens the first member, `;` separates the rest). The
+    // boundary set is deliberately narrow: `_` (range endpoint), `+`/`-`/`*`
+    // (intronic/UTR offsets) and `(` (uncertain) all stay excluded, since
+    // their end position is not a plain `p + N - 1` increment.
+    let mut pos_start = keyword_start;
+    while pos_start > 0 && bytes[pos_start - 1].is_ascii_digit() {
+        pos_start -= 1;
+    }
+    if pos_start == keyword_start
+        || pos_start == 0
+        || !matches!(bytes[pos_start - 1], b'.' | b'[' | b';')
+    {
+        return None;
+    }
+
+    // Size: a digit run immediately after the keyword, ending at a boundary.
+    let size_start = keyword_start + keyword_len;
+    let mut size_end = size_start;
+    while size_end < bytes.len() && bytes[size_end].is_ascii_digit() {
+        size_end += 1;
+    }
+    if size_end == size_start {
+        return None;
+    }
+    let terminated = bytes
+        .get(size_end)
+        .is_none_or(|b| *b == b')' || *b == b';' || *b == b']' || b.is_ascii_whitespace());
+    if !terminated {
+        return None;
+    }
+
+    let position: u64 = input[pos_start..keyword_start].parse().ok()?;
+    let size: u64 = input[size_start..size_end].parse().ok()?;
+    // The rule targets a description "of more than one residue" that fails to
+    // name both endpoints (`DNA/deletion.md:117`). A size of one names exactly
+    // the anchor residue, so it is merely redundant, not incomplete, and stays
+    // a soft W3011 concern.
+    if size < 2 {
+        return None;
+    }
+    // The canonical range end is `position + size - 1`. A value that cannot be
+    // represented as a `u64` is not a real coordinate, so decline to rewrite
+    // (the anchor is still rejected downstream by `validate_no_point_size_suffix`)
+    // rather than overflow the arithmetic at the `format!` site below.
+    position.checked_add(size - 1)?;
+    Some(PointSizeToken {
+        start: pos_start,
+        end: size_end,
+        position,
+        size,
+    })
+}
+
+/// Suggest the canonical range form for a `<point>del<size>` description.
+///
+/// Returns `None` when `input` carries no rewritable point deletion (e.g. it
+/// is a `dup`, or the anchor is intronic). Used by the parser's spec-rule
+/// diagnostic so the rejection message can name the exact repair.
+pub fn suggest_point_del_range_form(input: &str) -> Option<String> {
+    let (rewritten, corrections) = correct_point_del_size_suffix(input);
+    (!corrections.is_empty()).then(|| rewritten.into_owned())
+}
+
 pub fn detect_del_size_suffix(input: &str) -> Vec<DetectedCorrection> {
     let mut hits = Vec::new();
     let bytes = input.as_bytes();
@@ -4912,6 +5074,34 @@ mod tests {
         assert_eq!(hits.len(), 2, "expected two W3023 hits in bracket allele");
         assert_eq!(hits[0].original, "dup2");
         assert_eq!(hits[1].original, "dup4");
+    }
+
+    #[test]
+    fn test_correct_point_del_size_suffix_rewrites_compound_allele_members() {
+        // Each `del<N>` member of a compound allele is repaired like a
+        // standalone description: the first anchor is preceded by `[`, the
+        // rest by `;`, and the `p + N - 1` end is coordinate-agnostic.
+        let (out, corrections) = correct_point_del_size_suffix("NM_004006.2:c.[100del3;200del4]");
+        assert_eq!(out, "NM_004006.2:c.[100_102del;200_203del]");
+        assert_eq!(corrections.len(), 2, "both members should be rewritten");
+    }
+
+    #[test]
+    fn test_correct_point_del_size_suffix_leaves_non_plain_anchors() {
+        // A range/intronic/UTR anchor inside a bracket is still excluded — its
+        // end is not a plain increment, so there is no safe rewrite.
+        for untouched in [
+            "NM_004006.2:c.[100_102del3;200del4]", // range endpoint member
+            "NM_004006.2:c.[100+5del3;200del4]",   // intronic member
+        ] {
+            let (out, corrections) = correct_point_del_size_suffix(untouched);
+            assert_eq!(
+                corrections.len(),
+                1,
+                "only the plain member is rewritten: {untouched:?}"
+            );
+            assert!(out.contains("200_203del"), "plain member rewritten: {out}");
+        }
     }
 
     #[test]

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -3222,39 +3222,42 @@ pub fn suggest_point_del_range_form(input: &str) -> Option<String> {
 /// The `original` of an [`ErrorType::OldSubstitutionSyntax`] correction has
 /// the shape `<pos>[_<pos>]<ref>*><alt>+`, so the reference run is the IUPAC
 /// bases immediately preceding the arrow; the position digits terminate it.
-fn substitution_ref_len(original: &str) -> usize {
+fn substitution_ref_run(original: &str) -> &str {
     match original.find('>') {
-        Some(arrow) => original[..arrow]
-            .chars()
-            .rev()
-            .take_while(|c| is_iupac_base(*c))
-            .count(),
-        None => 0,
+        Some(arrow) => {
+            let lhs = &original[..arrow];
+            let start = lhs.len() - lhs.chars().rev().take_while(|c| is_iupac_base(*c)).count();
+            &lhs[start..]
+        }
+        None => "",
     }
 }
 
-/// Suggest the canonical `delins` form for a **multi-base reference**
-/// substitution (`c.79GC>TT`, `c.79_80GC>TT`, `g.4GC>TG`).
+/// The reference run a deprecated `<pos>[_<pos>]<ref>><alt>` description
+/// states, when `input` holds exactly one such description and it names at
+/// least one reference base.
 ///
-/// Per `recommendations/DNA/substitution.md:30` a substitution replaces one
-/// nucleotide by one other, so naming two or more reference bases either side
-/// of the arrow is not a substitution at all — the change is a deletion /
-/// insertion and must be written as one.
+/// The preprocessor rewrites that spelling to the canonical `delins` **text**
+/// before the parser ever sees it (`c.79_80GC>TT` → `c.79_80delinsTT`), which
+/// is what drops the stated `GC` on the lenient/silent path. This lets the
+/// parse seam put the run back into the AST so `validate_reference` can check
+/// the claim (#1092) — a false claim must produce a diagnostic, not vanish.
 ///
-/// Returns `None` when `input` carries no such form. The no-reference form
-/// (`c.100_102>ATG`) and a one-base reference with a longer insert
-/// (`c.79G>TT`) are deliberately not matched: neither can lose a reference
-/// base, and both are handled as ordinary preprocessor corrections. Used by
-/// the parser's spec-rule diagnostic so the rejection message names the repair.
-pub fn suggest_multibase_substitution_form(input: &str) -> Option<String> {
-    let (rewritten, corrections) = correct_old_substitution_syntax(input);
-    corrections
+/// Deliberately conservative: `None` unless there is exactly one such
+/// correction, so the run can be attributed to exactly one edit without
+/// guessing. The no-reference form (`c.100_102>ATG`) states no bases and
+/// yields `None`.
+pub fn stated_substitution_reference(input: &str) -> Option<String> {
+    let (_, corrections) = correct_old_substitution_syntax(input);
+    let mut subs = corrections
         .iter()
-        .any(|c| {
-            c.error_type == ErrorType::OldSubstitutionSyntax
-                && substitution_ref_len(&c.original) > 1
-        })
-        .then(|| rewritten.into_owned())
+        .filter(|c| c.error_type == ErrorType::OldSubstitutionSyntax);
+    let only = subs.next()?;
+    if subs.next().is_some() {
+        return None;
+    }
+    let run = substitution_ref_run(&only.original);
+    (!run.is_empty()).then(|| run.to_string())
 }
 
 pub fn detect_del_size_suffix(input: &str) -> Vec<DetectedCorrection> {

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -3217,6 +3217,46 @@ pub fn suggest_point_del_range_form(input: &str) -> Option<String> {
     (!corrections.is_empty()).then(|| rewritten.into_owned())
 }
 
+/// Count the reference bases a rewritten substitution named before its `>`.
+///
+/// The `original` of an [`ErrorType::OldSubstitutionSyntax`] correction has
+/// the shape `<pos>[_<pos>]<ref>*><alt>+`, so the reference run is the IUPAC
+/// bases immediately preceding the arrow; the position digits terminate it.
+fn substitution_ref_len(original: &str) -> usize {
+    match original.find('>') {
+        Some(arrow) => original[..arrow]
+            .chars()
+            .rev()
+            .take_while(|c| is_iupac_base(*c))
+            .count(),
+        None => 0,
+    }
+}
+
+/// Suggest the canonical `delins` form for a **multi-base reference**
+/// substitution (`c.79GC>TT`, `c.79_80GC>TT`, `g.4GC>TG`).
+///
+/// Per `recommendations/DNA/substitution.md:30` a substitution replaces one
+/// nucleotide by one other, so naming two or more reference bases either side
+/// of the arrow is not a substitution at all — the change is a deletion /
+/// insertion and must be written as one.
+///
+/// Returns `None` when `input` carries no such form. The no-reference form
+/// (`c.100_102>ATG`) and a one-base reference with a longer insert
+/// (`c.79G>TT`) are deliberately not matched: neither can lose a reference
+/// base, and both are handled as ordinary preprocessor corrections. Used by
+/// the parser's spec-rule diagnostic so the rejection message names the repair.
+pub fn suggest_multibase_substitution_form(input: &str) -> Option<String> {
+    let (rewritten, corrections) = correct_old_substitution_syntax(input);
+    corrections
+        .iter()
+        .any(|c| {
+            c.error_type == ErrorType::OldSubstitutionSyntax
+                && substitution_ref_len(&c.original) > 1
+        })
+        .then(|| rewritten.into_owned())
+}
+
 pub fn detect_del_size_suffix(input: &str) -> Vec<DetectedCorrection> {
     let mut hits = Vec::new();
     let bytes = input.as_bytes();

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -8,12 +8,12 @@ use super::corrections::{
     correct_del_explicit_seq, correct_deprecated_con, correct_deprecated_protein_forms,
     correct_dup_explicit_seq, correct_edit_type_case_full, correct_empty_delins,
     correct_missing_coordinate_prefix, correct_old_allele_format, correct_old_substitution_syntax,
-    correct_protein_arrow, correct_quote_characters, correct_redundant_repeat_label,
-    correct_rna_thymine, correct_single_letter_aa_in_protein, correct_single_position_range,
-    correct_swapped_positions, correct_whitespace, detect_del_size_suffix, detect_deprecated_ivs,
-    detect_dup_size_suffix, detect_length_mismatch, detect_length_mismatch_with_provider,
-    detect_missing_versions, detect_position_zero, detect_protein_bracketed_aa_insertion,
-    strip_trailing_annotation, DetectedCorrection,
+    correct_point_del_size_suffix, correct_protein_arrow, correct_quote_characters,
+    correct_redundant_repeat_label, correct_rna_thymine, correct_single_letter_aa_in_protein,
+    correct_single_position_range, correct_swapped_positions, correct_whitespace,
+    detect_del_size_suffix, detect_deprecated_ivs, detect_dup_size_suffix, detect_length_mismatch,
+    detect_length_mismatch_with_provider, detect_missing_versions, detect_position_zero,
+    detect_protein_bracketed_aa_insertion, strip_trailing_annotation, DetectedCorrection,
 };
 use super::types::{ErrorType, ResolvedAction};
 use super::ErrorConfig;
@@ -834,6 +834,52 @@ impl InputPreprocessor {
                                 .with_suggestion(corrected.clone())
                                 .with_hint(
                                     "RNA repeat descriptions should omit the base label when positions already define the unit",
+                                ),
+                        ),
+                    );
+                }
+                ResolvedAction::WarnCorrect => {
+                    for c in &corrections {
+                        all_warnings.push(CorrectionWarning::from_correction(c));
+                    }
+                    current = corrected.into_owned();
+                }
+                ResolvedAction::SilentCorrect => {
+                    current = corrected.into_owned();
+                }
+                ResolvedAction::Accept => {}
+            }
+        }
+
+        // Phase 12b: Canonicalise a deletion anchored at a *single position*
+        // and sized by a suffix — `g.123del3` → `g.123_125del` (W3011, #1079).
+        // `checklist.md:49` states the replacement outright ("not allowed,
+        // correct is `g.123_125del`"), so unlike the broader Phase 13 check
+        // this subset has a mechanical repair and follows
+        // `standard_correctable` semantics: strict rejects, lenient rewrites
+        // with a warning, silent rewrites quietly. Runs before Phase 13 so a
+        // rewritten description no longer trips the non-rewriting warning.
+        let (corrected, corrections) = correct_point_del_size_suffix(&current);
+        if !corrections.is_empty() {
+            let action = self.action_for(ErrorType::DelSizeSuffix);
+            match action {
+                ResolvedAction::Reject => {
+                    let first = &corrections[0];
+                    return PreprocessResult::failed(
+                        input.to_string(),
+                        FerroError::parse_with_diagnostic(
+                            first.start,
+                            format!(
+                                "Deletion '{}' uses size-count suffix; canonical form names both endpoints",
+                                first.original
+                            ),
+                            Diagnostic::new()
+                                .with_code(ErrorCode::InvalidEdit)
+                                .with_span(SourceSpan::new(first.start, first.end))
+                                .with_source(input)
+                                .with_suggestion(corrected.clone())
+                                .with_hint(
+                                    "Write `g.<start>_<end>del` instead of `g.<start>del<size>`",
                                 ),
                         ),
                     );

--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -865,12 +865,14 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
             code: "W3011",
             name: "DelSizeSuffix",
             summary: "Deletion described with a size-count suffix instead of a position range.",
-            explanation:
-                "HGVS recommends naming both endpoints of a multi-residue deletion. The legacy \
-                form `g.123del6` (size 6 starting at position 123) is non-canonical; the canonical \
-                form lists the first and last residue deleted, e.g. `g.123_128del`. ferro cannot \
-                auto-synthesize the end position safely (it depends on offset/intronic semantics), \
-                so this warning is emitted but not auto-corrected.",
+            explanation: "HGVS requires both endpoints of a multi-residue deletion to be named \
+                (`checklist.md:49`: `g.123del3` is \"not allowed, correct is `g.123_125del`\"). \
+                When the anchor is a plain point position ferro treats this as MUST-level: the \
+                default parse rejects, and lenient/silent modes rewrite `g.123del6` to \
+                `g.123_128del`. When the anchor is intronic/offset the end position cannot be \
+                synthesized safely, so there is no repair to offer and the form is rejected \
+                outright. A range anchor that merely repeats the size (`c.100_102del3`) already \
+                names both endpoints and only warns.",
             category: CodeCategory::Format,
             bad_examples: &["NG_012232.1:g.123del6"],
             good_examples: &["NG_012232.1:g.123_128del"],
@@ -1187,12 +1189,12 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
             code: "W3023",
             name: "DupSizeSuffix",
             summary: "Duplication described with a size-count suffix instead of a position range.",
-            explanation:
-                "HGVS recommends naming both endpoints of a multi-residue duplication. The legacy \
-                form `g.123dup6` (size 6 starting at position 123) is non-canonical; the canonical \
-                form lists the first and last residue duplicated, e.g. `g.123_128dup`. ferro cannot \
-                auto-synthesize the end position safely (`g.123dup6` is ambiguous between `g.123_128dup` \
-                and `g.124_129dup` per the spec Q&A), so this warning is emitted but not auto-corrected.",
+            explanation: "HGVS requires both endpoints of a multi-residue duplication to be named \
+                (`DNA/duplication.md:140`). The legacy form `g.123dup6` names only one, and the \
+                spec explicitly declines to disambiguate it (`g.123_128dup` vs `g.124_129dup`), \
+                so there is no safe repair: a point-anchored `dup<N>` is rejected in every mode. \
+                A range anchor that merely repeats the size (`c.20_21dup2`) already names both \
+                endpoints and only warns.",
             category: CodeCategory::Format,
             bad_examples: &["NM_004006.2:c.20_21dup2", "NC_000023.11:g.123dup6"],
             good_examples: &["NM_004006.2:c.20_21dup", "NC_000023.11:g.123_124dup"],

--- a/src/hgvs/edit.rs
+++ b/src/hgvs/edit.rs
@@ -579,10 +579,21 @@ pub enum NaEdit {
     /// form `delinsXXX`. `Display` preserves on round-trip; `canonicalize_edit`
     /// strips them back to the short form per the HGVS spec recommendation
     /// (`recommendations/DNA/delins.md`).
+    /// `substitution_reference` preserves the reference run stated by the
+    /// **forbidden** `NN>MM` substitution spelling (`c.79_80GC>TT`), which the
+    /// grammar folds into a `Delins` (#1092). It is provenance, not
+    /// description: `Display` ignores it, so the edit still renders as the
+    /// canonical short form `delinsTT` and never as the deprecated explicit
+    /// `delGCinsTT` (`recommendations/DNA/delins.md:29-30`). Keeping it in a
+    /// field of its own — rather than reusing `deleted` — is what makes the
+    /// preservation inert to every existing consumer while still letting
+    /// `validate_reference` check the claim and the MUST-level rejection key
+    /// off the AST instead of the source string.
     Delins {
         sequence: InsertedSequence,
         deleted: Option<Sequence>,
         deleted_length: Option<u64>,
+        substitution_reference: Option<Sequence>,
     },
 
     /// Duplication: copy of bases (e.g., dup, dupATG, dup101, dup(731_741), dup?)
@@ -782,6 +793,7 @@ impl NaEdit {
                 sequence,
                 deleted,
                 deleted_length,
+                ..
             } => {
                 let mut s = String::from("del");
                 if let Some(seq) = deleted {
@@ -903,6 +915,7 @@ impl fmt::Display for NaEdit {
                 sequence,
                 deleted,
                 deleted_length,
+                ..
             } => {
                 write!(f, "del")?;
                 if let Some(seq) = deleted {
@@ -1513,6 +1526,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("ATG").unwrap()),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_eq!(format!("{}", edit), "delinsATG");
     }
@@ -1523,6 +1537,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
             deleted: Some(Sequence::from_str("ATG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_eq!(format!("{}", edit), "delATGinsTTCC");
     }
@@ -1533,6 +1548,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("TA").unwrap()),
             deleted: None,
             deleted_length: Some(3),
+            substitution_reference: None,
         };
         assert_eq!(format!("{}", edit), "del3insTA");
     }
@@ -1543,6 +1559,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("UUCC").unwrap()),
             deleted: Some(Sequence::from_str("AUG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_eq!(edit.to_rna_string(), "delauginsuucc");
     }
@@ -1553,11 +1570,13 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let explicit = NaEdit::Delins {
             sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
             deleted: Some(Sequence::from_str("ATG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_ne!(short, explicit);
     }
@@ -2107,6 +2126,7 @@ mod tests {
             },
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_eq!(format!("{}", edit), "delinsA[10]");
     }

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -202,14 +202,22 @@ fn parse_multibase_substitution(input: &str) -> IResult<&str, NaEdit> {
         )));
     }
 
-    // Convert to delins. Multi-base ">" notation does not carry an explicit
-    // deleted sequence/length, so leave both as None.
+    // Convert to delins. The `>` spelling carries no `del<seq>` / `del<N>`
+    // token, so `deleted` / `deleted_length` stay `None` and Display keeps
+    // rendering the canonical short form `delins<alt>`. The reference run the
+    // input *did* state is kept in `substitution_reference` (#1092): it is a
+    // required element of the `dna.sub` production (`docs/syntax.yaml:209`),
+    // so dropping it discarded a claim about the reference that
+    // `validate_reference` can — and now does — check, exactly as it already
+    // checks the stated run of the neighbouring `delGCinsTT` spelling (#486).
     Ok((
         input,
         NaEdit::Delins {
             sequence: InsertedSequence::Literal(alt_seq),
             deleted: None,
             deleted_length: None,
+            // The no-reference form (`c.100_102>ATG`) states no bases at all.
+            substitution_reference: (!ref_seq.is_empty()).then_some(ref_seq),
         },
     ))
 }
@@ -1000,6 +1008,7 @@ fn parse_delins(input: &str, allow_special_positions: bool) -> IResult<&str, NaE
             sequence,
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         },
     ))
 }
@@ -1026,6 +1035,7 @@ fn parse_delins_with_deleted_seq(
             sequence: inserted_seq,
             deleted: Some(deleted_seq),
             deleted_length: None,
+            substitution_reference: None,
         },
     ))
 }
@@ -1051,6 +1061,7 @@ fn parse_delins_with_deleted_count(
             sequence: inserted_seq,
             deleted: None,
             deleted_length: Some(deleted_count),
+            substitution_reference: None,
         },
     ))
 }
@@ -2435,6 +2446,7 @@ mod tests {
             sequence,
             deleted,
             deleted_length,
+            ..
         } = edit
         {
             assert_eq!(deleted, Some(Sequence::from_str("ATG").unwrap()));
@@ -2457,6 +2469,7 @@ mod tests {
             sequence: _,
             deleted,
             deleted_length,
+            ..
         } = edit
         {
             assert_eq!(deleted, None);
@@ -2474,6 +2487,7 @@ mod tests {
             sequence: _,
             deleted,
             deleted_length,
+            ..
         } = edit
         {
             assert_eq!(deleted, None);
@@ -2491,6 +2505,7 @@ mod tests {
             sequence: _,
             deleted,
             deleted_length,
+            ..
         } = edit
         {
             assert_eq!(deleted, None);

--- a/src/hgvs/parser/fast_path.rs
+++ b/src/hgvs/parser/fast_path.rs
@@ -848,6 +848,16 @@ fn try_parse_protein_edit(input: &str, edit_start: usize, accession: Accession) 
         )
     } else {
         match parse_amino_acid(rest) {
+            // A substitution at the initiator methionine is spec-forbidden
+            // (`protein/substitution.md:49`). The generic parser owns that
+            // rejection, so defer rather than build a variant the caller
+            // would have to re-check — this keeps the fast path
+            // observationally identical to `parse_variant` (#1079).
+            Ok((_, alternative))
+                if pos.number == 1 && pos.aa == AminoAcid::Met && alternative != AminoAcid::Met =>
+            {
+                return FastPathResult::Fallback
+            }
             Ok((r, alternative)) => (
                 r,
                 ProteinEdit::Substitution {
@@ -1208,7 +1218,7 @@ mod tests {
             "NP_000079.2:p.(Val600Glu)",
             "NP_000079.2:p.Gly12Cys",
             "NP_000079.2:p.Arg100Ter", // substitution to stop
-            "NP_000079.2:p.Met1Val",
+            "NP_000079.2:p.Met2Val",
             "ENSP00000369497.3:p.Asp427Tyr",
         ];
         for input in cases {
@@ -1218,6 +1228,18 @@ mod tests {
             };
             let generic = parse_variant(input).expect("generic should parse");
             assert_eq!(fast, generic, "fast-path/generic mismatch for {input:?}");
+        }
+    }
+
+    /// A substitution at the initiator methionine is spec-forbidden
+    /// (`protein/substitution.md:49`), so the fast path must defer to the
+    /// generic parser, which owns the rejection (#1079).
+    #[test]
+    fn test_fast_path_defers_start_loss_substitution() {
+        use crate::hgvs::parser::variant::parse_variant;
+        for input in ["NP_000079.2:p.Met1Val", "NP_000079.2:p.(Met1Val)"] {
+            assert!(matches!(try_fast_path(input), FastPathResult::Fallback));
+            assert!(parse_variant(input).is_err());
         }
     }
 

--- a/src/hgvs/parser/mod.rs
+++ b/src/hgvs/parser/mod.rs
@@ -151,7 +151,17 @@ pub fn parse_hgvs_with_config(
     }
 
     // Parse the preprocessed input
-    let variant = variant::parse_variant(&preprocess_result.preprocessed)?;
+    let mut variant = variant::parse_variant(&preprocess_result.preprocessed)?;
+
+    // Put back the reference run the preprocessor's textual rewrite dropped
+    // (#1092). Lenient/silent turn `c.79_80GC>TT` into the canonical text
+    // `c.79_80delinsTT` before the grammar runs, so the stated `GC` never
+    // reaches the AST and a *false* claim about the reference would disappear
+    // with no diagnostic. Restoring it into the provenance field — which
+    // `Display` ignores, so the repaired output is byte-identical — routes the
+    // claim through the same `validate_reference` check the neighbouring
+    // `delGCinsTT` spelling already gets (#486).
+    restore_stated_substitution_reference(&mut variant, &preprocess_result.original);
 
     // Apply the bracket/allele cardinality conformance rule on the parsed AST
     // (#493). This is a structural rule, identical across all coordinate
@@ -171,6 +181,63 @@ pub fn parse_hgvs_with_config(
         preprocess_result.original,
         preprocess_result.preprocessed,
     ))
+}
+
+/// Restore the reference run stated by a deprecated `<ref>><alt>` description
+/// onto the `Delins` the preprocessor's textual rewrite produced (#1092).
+///
+/// The rewrite happens on the input *string*, so the run is only recoverable
+/// from the original text — this is the one place that is unavoidable, and it
+/// is a repair path, not the conformance rule (which is AST-keyed, see
+/// [`variant::validate_no_multibase_substitution`]).
+///
+/// Deliberately narrow: it fires only for a single non-allele nucleic-acid
+/// variant whose edit is a bare `Delins` (no stated `deleted` / `deleted_length`
+/// and no run already recorded), and only when the original names exactly one
+/// such description. Anything more ambiguous is left alone rather than
+/// attributing a run to the wrong edit.
+fn restore_stated_substitution_reference(variant: &mut HgvsVariant, original: &str) {
+    use crate::error_handling::corrections::stated_substitution_reference;
+    use crate::hgvs::edit::{NaEdit, Sequence};
+    use crate::hgvs::uncertainty::Mu;
+    use std::str::FromStr;
+
+    fn bare_delins_run(edit: &mut Mu<NaEdit>) -> Option<&mut Option<Sequence>> {
+        match edit {
+            Mu::Certain(NaEdit::Delins {
+                deleted: None,
+                deleted_length: None,
+                substitution_reference: slot @ None,
+                ..
+            })
+            | Mu::Uncertain(NaEdit::Delins {
+                deleted: None,
+                deleted_length: None,
+                substitution_reference: slot @ None,
+                ..
+            }) => Some(slot),
+            _ => None,
+        }
+    }
+
+    let Some(run) = stated_substitution_reference(original) else {
+        return;
+    };
+    let Ok(run) = Sequence::from_str(&run) else {
+        return;
+    };
+    let edit = match variant {
+        HgvsVariant::Genome(v) => &mut v.loc_edit.edit,
+        HgvsVariant::Cds(v) => &mut v.loc_edit.edit,
+        HgvsVariant::Tx(v) => &mut v.loc_edit.edit,
+        HgvsVariant::Rna(v) => &mut v.loc_edit.edit,
+        HgvsVariant::Mt(v) => &mut v.loc_edit.edit,
+        HgvsVariant::Circular(v) => &mut v.loc_edit.edit,
+        _ => return,
+    };
+    if let Some(slot) = bare_delins_run(edit) {
+        *slot = Some(run);
+    }
 }
 
 /// Enforce the HGVS bracket/allele cardinality rule on a parsed variant (#493).

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7255,7 +7255,7 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
 
     // Spec-mandated post-parse semantic check: reject a multi-nucleotide
     // substitution (HGVS DNA/substitution.md:30, DNA/delins.md:73; #1079).
-    validate_no_multibase_substitution(input)?;
+    validate_no_multibase_substitution(&variant)?;
 
     // Spec-mandated post-parse semantic check: reject a start-codon variant
     // written as an amino acid substitution (HGVS protein/substitution.md:49,
@@ -7873,16 +7873,17 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
 /// (`recommendations/style.md:9`), so the rejection applies on every parse
 /// path that reaches the grammar with the form still spelled out.
 ///
-/// # Why the check reads the source
+/// # Why the check reads the AST
 ///
-/// The grammar folds `GC>TT` into a `Delins` edit and keeps no record of the
-/// reference bases, so by post-parse time `c.79_80GC>TT` and a hand-written
-/// `c.79_80delinsTT` are indistinguishable in the AST. Worse, the single-
-/// position spelling folded `c.79GC>TT` into `c.79delinsTT` — a one-base
-/// deletion with a two-base insert, silently dropping a stated reference base
-/// and yielding a *different variant* from the `c.79_80delinsTT` the
-/// preprocessor produced for the same input. Keying off the source is what
-/// lets the two entry points converge.
+/// The grammar used to fold `GC>TT` into a `Delins` edit that kept no record
+/// of the reference bases, so the rule had to re-read the input string — which
+/// meant it could not fire for an allele member composed programmatically, a
+/// variant produced by projection or round-trip, or anything constructed
+/// rather than parsed. The parser now preserves the stated run in
+/// [`NaEdit::Delins::substitution_reference`] (#1092), so the rule keys off
+/// that field instead and survives composition. The field is provenance only:
+/// `Display` ignores it, so the canonical short form `delinsTT` is still what
+/// is rendered.
 ///
 /// Lenient and silent modes never reach this check: the preprocessor rewrites
 /// both spellings to `c.79_80delinsTT` first (the spec states the replacement
@@ -7893,26 +7894,131 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
 /// longer insert (`c.79G>TT`) already spans exactly its anchor and cannot lose
 /// a base, and the no-reference form (`c.100_102>ATG`) states no reference
 /// bases at all; both remain ordinary preprocessor concerns.
-fn validate_no_multibase_substitution(source: &str) -> Result<(), FerroError> {
+pub fn validate_no_multibase_substitution(variant: &HgvsVariant) -> Result<(), FerroError> {
     use crate::error::{Diagnostic, ErrorCode};
-    use crate::error_handling::corrections::suggest_multibase_substitution_form;
+    use crate::hgvs::edit::{NaEdit, Sequence};
+    use crate::hgvs::interval::UncertainBoundary;
+    use crate::hgvs::location::{CdsPos, GenomePos, RnaPos, TxPos};
 
-    let Some(canonical) = suggest_multibase_substitution_form(source) else {
-        return Ok(());
-    };
-    Err(FerroError::parse_with_diagnostic(
-        0,
-        format!(
-            "a substitution replaces one nucleotide by one other, so naming several \
-             reference bases is not allowed (DNA/substitution.md:30, DNA/delins.md:73); \
-             write `{canonical}` instead"
-        ),
-        Diagnostic::new()
-            .with_code(ErrorCode::InvalidEdit)
-            .with_hint(format!(
-                "describe the change as a deletion-insertion — write `{canonical}`"
-            )),
-    ))
+    /// The stated reference run of a `NN>MM` edit, when it names more than one
+    /// base. One base cannot be lost at its own anchor, so it is out of scope.
+    fn multibase_run(edit: &Mu<NaEdit>) -> Option<&Sequence> {
+        match edit.inner() {
+            Some(NaEdit::Delins {
+                substitution_reference: Some(run),
+                ..
+            }) if run.len() > 1 => Some(run),
+            _ => None,
+        }
+    }
+
+    /// Drop the provenance so the repaired clone renders as a plain `delins`.
+    fn clear_run(edit: &mut Mu<NaEdit>) {
+        if let Mu::Certain(NaEdit::Delins {
+            substitution_reference,
+            ..
+        })
+        | Mu::Uncertain(NaEdit::Delins {
+            substitution_reference,
+            ..
+        }) = edit
+        {
+            *substitution_reference = None;
+        }
+    }
+
+    /// A single certain position, or `None` for uncertain / range boundaries.
+    fn point<T: PartialEq>(
+        start: &UncertainBoundary<T>,
+        end: &UncertainBoundary<T>,
+    ) -> Option<&'static ()> {
+        match (start.as_single(), end.as_single()) {
+            (Some(Mu::Certain(s)), Some(Mu::Certain(e))) if s == e => Some(&()),
+            _ => None,
+        }
+    }
+
+    // The canonical repair names both endpoints. Extending a point anchor is
+    // only safe for a plain positive coordinate with no intronic offset and no
+    // `*`/`-`/pter-style qualifier — the same restriction the preprocessor's
+    // textual rewrite applies. When it does not hold the repair keeps the
+    // stated anchor rather than guessing.
+    fn wider_genome(p: &GenomePos, extra: u64) -> Option<GenomePos> {
+        (p.special.is_none() && p.offset.is_none() && p.base >= 1)
+            .then(|| GenomePos::new(p.base + extra))
+    }
+    fn wider_cds(p: &CdsPos, extra: u64) -> Option<CdsPos> {
+        (p.special.is_none() && p.offset.is_none() && !p.utr3 && p.base >= 1)
+            .then(|| CdsPos::new(p.base + extra as i64))
+    }
+    fn wider_tx(p: &TxPos, extra: u64) -> Option<TxPos> {
+        (p.offset.is_none() && !p.downstream && p.base >= 1)
+            .then(|| TxPos::new(p.base + extra as i64))
+    }
+    fn wider_rna(p: &RnaPos, extra: u64) -> Option<RnaPos> {
+        (p.offset.is_none() && !p.utr3 && p.base >= 1).then(|| RnaPos::new(p.base + extra as i64))
+    }
+
+    fn make_error(canonical: &str) -> FerroError {
+        FerroError::parse_with_diagnostic(
+            0,
+            format!(
+                "a substitution replaces one nucleotide by one other, so naming several \
+                 reference bases is not allowed (DNA/substitution.md:30, DNA/delins.md:73); \
+                 write `{canonical}` instead"
+            ),
+            Diagnostic::new()
+                .with_code(ErrorCode::InvalidEdit)
+                .with_hint(format!(
+                    "describe the change as a deletion-insertion — write `{canonical}`"
+                )),
+        )
+    }
+
+    /// Clone `$v`, strip the provenance and widen a point anchor to the run's
+    /// full span, then render the result as the canonical repair.
+    macro_rules! check {
+        ($v:expr, $ctor:path, $widen:ident) => {{
+            if let Some(run) = multibase_run(&$v.loc_edit.edit) {
+                let extra = run.len() as u64 - 1;
+                let mut repaired = $v.clone();
+                clear_run(&mut repaired.loc_edit.edit);
+                if point(
+                    &repaired.loc_edit.location.start,
+                    &repaired.loc_edit.location.end,
+                )
+                .is_some()
+                {
+                    if let Some(end) = repaired
+                        .loc_edit
+                        .location
+                        .start
+                        .inner()
+                        .and_then(|p| $widen(p, extra))
+                    {
+                        repaired.loc_edit.location.end = UncertainBoundary::certain(end);
+                    }
+                }
+                return Err(make_error(&$ctor(repaired).to_string()));
+            }
+        }};
+    }
+
+    match variant {
+        HgvsVariant::Genome(v) => check!(v, HgvsVariant::Genome, wider_genome),
+        HgvsVariant::Cds(v) => check!(v, HgvsVariant::Cds, wider_cds),
+        HgvsVariant::Tx(v) => check!(v, HgvsVariant::Tx, wider_tx),
+        HgvsVariant::Rna(v) => check!(v, HgvsVariant::Rna, wider_rna),
+        HgvsVariant::Mt(v) => check!(v, HgvsVariant::Mt, wider_genome),
+        HgvsVariant::Circular(v) => check!(v, HgvsVariant::Circular, wider_genome),
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_multibase_substitution(inner)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Reject amino acids listed *after* a translation stop in an inserted

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7471,17 +7471,138 @@ fn validate_no_dupins(variant: &HgvsVariant) -> Result<(), FerroError> {
     Ok(())
 }
 
-/// Reject insertions whose anchor is a single position rather than a
-/// two-position range. Per `DNA/insertion.md:95-101`:
+/// A position reduced to a `(region, index)` pair so that adjacency can be
+/// decided by integer arithmetic.
 ///
-/// > "Can I describe a variant as `g.123insG`? **No**, since the
-/// > description is not unequivocal, it is not allowed. What does the
-/// > description mean, the insertion of a `G` **at** position `g.123`
-/// > or the insertion of a `G` **after** position `g.123`?"
+/// `region` partitions a coordinate system into stretches that are numbered
+/// contiguously among themselves. Two positions in *different* regions have
+/// no decidable adjacency from the description alone — `c.-1` and `c.1` are
+/// in fact neighbours (there is no `c.0`), and whether `c.100` neighbours
+/// `c.*1` depends on the CDS length — so such pairs are deliberately left
+/// alone rather than guessed at.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct LinearPos {
+    region: u8,
+    index: i64,
+}
+
+/// Reduce a position to a [`LinearPos`], or `None` when adjacency is not
+/// decidable from the description alone (intronic offsets, `pter`/`qter`/
+/// `cen` markers, unknown bases).
+trait Linearize {
+    fn linearize(&self) -> Option<LinearPos>;
+}
+
+impl Linearize for crate::hgvs::location::GenomePos {
+    fn linearize(&self) -> Option<LinearPos> {
+        if self.special.is_some() || self.offset.is_some() {
+            return None;
+        }
+        Some(LinearPos {
+            region: 0,
+            index: i64::try_from(self.base).ok()?,
+        })
+    }
+}
+
+impl Linearize for crate::hgvs::location::CdsPos {
+    fn linearize(&self) -> Option<LinearPos> {
+        use crate::hgvs::location::CDS_BASE_UNKNOWN;
+        if self.special.is_some() || self.offset.is_some() || self.base == CDS_BASE_UNKNOWN {
+            return None;
+        }
+        // 5'UTR (`c.-N`), CDS (`c.N`) and 3'UTR (`c.*N`) are numbered
+        // independently of one another.
+        let region = if self.utr3 {
+            2
+        } else if self.base < 0 {
+            0
+        } else {
+            1
+        };
+        Some(LinearPos {
+            region,
+            index: self.base,
+        })
+    }
+}
+
+impl Linearize for crate::hgvs::location::TxPos {
+    fn linearize(&self) -> Option<LinearPos> {
+        if self.offset.is_some() {
+            return None;
+        }
+        let region = if self.downstream {
+            2
+        } else if self.base < 0 {
+            0
+        } else {
+            1
+        };
+        Some(LinearPos {
+            region,
+            index: self.base,
+        })
+    }
+}
+
+impl Linearize for crate::hgvs::location::RnaPos {
+    fn linearize(&self) -> Option<LinearPos> {
+        if self.offset.is_some() {
+            return None;
+        }
+        let region = if self.utr3 {
+            2
+        } else if self.base < 0 {
+            0
+        } else {
+            1
+        };
+        Some(LinearPos {
+            region,
+            index: self.base,
+        })
+    }
+}
+
+impl Linearize for crate::hgvs::location::ProtPos {
+    fn linearize(&self) -> Option<LinearPos> {
+        Some(LinearPos {
+            region: 0,
+            index: i64::try_from(self.number).ok()?,
+        })
+    }
+}
+
+/// Reject insertions whose anchor is not a pair of **flanking** positions.
 ///
-/// The check walks Allele wrappers and inspects each leaf NaEdit. The
-/// canonical fix for the user is to use `g.123_124insG` (or whatever
-/// adjacent-pair anchor is intended).
+/// Two MUST-level sub-rules, both from the insertion recommendations.
+///
+/// 1. The anchor may not be a **single** position. Per `DNA/insertion.md:95-101`:
+///
+///    > "Can I describe a variant as `g.123insG`? **No**, since the
+///    > description is not unequivocal, it is not allowed. What does the
+///    > description mean, the insertion of a `G` **at** position `g.123`
+///    > or the insertion of a `G` **after** position `g.123`?"
+///
+///    restated for nucleotides in `checklist.md:30-31` and for amino acids
+///    in `protein/insertion.md:18` ("an insertion can not be described using
+///    **one** amino acid position, like `p.Lys23insAsp`").
+///
+/// 2. The two positions must be **adjacent**. Per `DNA/insertion.md:15`
+///    ("`positions flanking` should contain **two flanking nucleotides**,
+///    e.g., `123_124`, not `123_125`") and `protein/insertion.md:17`
+///    (`Lys23_Leu24`, not `Lys23_Asn25`). The formal grammar states this as
+///    a requirement rather than a preference: `syntax.yaml` `dna.ins` notes
+///    "`range` must be specified using adjacent positions" and `aa.ins`
+///    "The position must be specified using adjacent sequence positions".
+///
+/// Both are rejections rather than repairs: given `g.123_125insG` there is
+/// no way to recover which flanking pair the author intended.
+///
+/// The check walks Allele wrappers and inspects each leaf edit. Adjacency is
+/// only enforced where it is decidable from the description alone — see
+/// [`Linearize`].
 fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(), FerroError> {
     use crate::hgvs::edit::NaEdit;
     use crate::hgvs::interval::UncertainBoundary;
@@ -7492,6 +7613,38 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
             (Some(Mu::Certain(s)), Some(Mu::Certain(e))) => s == e,
             _ => false,
         }
+    }
+
+    /// `true` when both endpoints are certain, plain, in the same region,
+    /// and *not* one apart — i.e. provably not a flanking pair.
+    fn definitely_not_flanking<T: Linearize>(
+        start: &UncertainBoundary<T>,
+        end: &UncertainBoundary<T>,
+    ) -> bool {
+        let (Some(Mu::Certain(s)), Some(Mu::Certain(e))) = (start.as_single(), end.as_single())
+        else {
+            return false;
+        };
+        let (Some(s), Some(e)) = (s.linearize(), e.linearize()) else {
+            return false;
+        };
+        s.region == e.region && e.index != s.index + 1
+    }
+
+    fn make_gap_error(prefix: &str) -> FerroError {
+        use crate::error::{Diagnostic, ErrorCode};
+        // Same structured `InvalidEdit` code as the single-position
+        // refusal, so both survive slash-form fallback paths that would
+        // otherwise mask an unstructured parse error.
+        FerroError::parse_with_diagnostic(
+            0,
+            format!(
+                "insertion anchor positions are not flanking on {prefix}; the two \
+                 positions MUST be adjacent (e.g. {prefix}123_124insATG, not \
+                 {prefix}123_125insATG) per DNA/insertion.md:15"
+            ),
+            Diagnostic::new().with_code(ErrorCode::InvalidEdit),
+        )
     }
     fn is_insertion(edit: &Mu<NaEdit>) -> bool {
         matches!(edit.inner(), Some(NaEdit::Insertion { .. }))
@@ -7513,50 +7666,63 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
         )
     }
 
+    /// Apply both sub-rules to one nucleotide variant's loc/edit pair.
+    macro_rules! check_na_anchor {
+        ($v:expr, $prefix:expr) => {{
+            if is_insertion(&$v.loc_edit.edit) {
+                let start = &$v.loc_edit.location.start;
+                let end = &$v.loc_edit.location.end;
+                if pos_eq(start, end) {
+                    return Err(make_error($prefix));
+                }
+                if definitely_not_flanking(start, end) {
+                    return Err(make_gap_error($prefix));
+                }
+            }
+        }};
+    }
+
     match variant {
-        HgvsVariant::Genome(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("g."));
-        }
-        HgvsVariant::Cds(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("c."));
-        }
-        HgvsVariant::Tx(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("n."));
-        }
-        HgvsVariant::Rna(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("r."));
-        }
-        HgvsVariant::Mt(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("m."));
-        }
-        HgvsVariant::Circular(v)
-            if is_insertion(&v.loc_edit.edit)
-                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end) =>
-        {
-            return Err(make_error("o."));
+        HgvsVariant::Genome(v) => check_na_anchor!(v, "g."),
+        HgvsVariant::Cds(v) => check_na_anchor!(v, "c."),
+        HgvsVariant::Tx(v) => check_na_anchor!(v, "n."),
+        HgvsVariant::Rna(v) => check_na_anchor!(v, "r."),
+        HgvsVariant::Mt(v) => check_na_anchor!(v, "m."),
+        HgvsVariant::Circular(v) => check_na_anchor!(v, "o."),
+        // Protein insertions carry the single-position rule, restated for
+        // amino acids in `protein/insertion.md:18`.
+        //
+        // The protein *adjacency* half of the rule (`protein/insertion.md:17`
+        // — `Lys23_Leu24`, not `Lys23_Asn25`) is deliberately NOT enforced:
+        // the spec contradicts itself. `protein/alleles.md:61` prints
+        // `p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]` as a valid illustration
+        // of the allele-bracket format, and its insertion anchor spans seven
+        // residues. Enforcing adjacency here would make ferro reject a
+        // description the spec itself publishes unmarked, so the narrower
+        // reading wins until the ambiguity is resolved upstream. The
+        // nucleotide axes carry no such contradicting example and are
+        // enforced above.
+        HgvsVariant::Protein(v) => {
+            use crate::error::{Diagnostic, ErrorCode};
+            use crate::hgvs::edit::ProteinEdit;
+
+            if matches!(v.loc_edit.edit.inner(), Some(ProteinEdit::Insertion { .. }))
+                && pos_eq(&v.loc_edit.location.start, &v.loc_edit.location.end)
+            {
+                return Err(FerroError::parse_with_diagnostic(
+                    0,
+                    "single-position insertion not allowed on p.; the anchor MUST be \
+                     two flanking residues (e.g. p.Lys23_Leu24insAsp, not \
+                     p.Lys23insAsp) per protein/insertion.md:18",
+                    Diagnostic::new().with_code(ErrorCode::InvalidEdit),
+                ));
+            }
         }
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_point_insertion(inner, _source)?;
             }
         }
-        // Protein insertions use a different anchor model — handled
-        // elsewhere; nothing to validate here.
         _ => {}
     }
     Ok(())
@@ -9602,11 +9768,15 @@ mod tests {
     fn test_parse_reverse_order_intervals() {
         // Reverse order intervals - where start > end (used for structural variants)
         // Feature 15: Reverse order intervals
-        let variant =
-            parse_variant("NC_000011.10:g.5238138_5153222insTATTT").expect("should parse");
-        assert_eq!(
-            variant.to_string(),
-            "NC_000011.10:g.5238138_5153222insTATTT"
+        //
+        // The reversed *insertion* is the one exception: an insertion anchor
+        // MUST name two flanking positions listed 5' to 3'
+        // (`DNA/insertion.md:15-16`), so `g.5238138_5153222insTATTT` — 85 kb
+        // apart and descending — is refused rather than round-tripped (#1079).
+        // Reversed del/dup anchors carry no such rule and still parse.
+        assert!(
+            parse_variant("NC_000011.10:g.5238138_5153222insTATTT").is_err(),
+            "a reversed, non-flanking insertion anchor must be rejected"
         );
 
         let variant = parse_variant("NC_000012.11:g.110593351_110576466dup").expect("should parse");

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7253,6 +7253,10 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // DNA/deletion.md:117, DNA/duplication.md:140, RNA/deletion.md:49; #1079).
     validate_no_point_size_suffix(&variant, input)?;
 
+    // Spec-mandated post-parse semantic check: reject a multi-nucleotide
+    // substitution (HGVS DNA/substitution.md:30, DNA/delins.md:73; #1079).
+    validate_no_multibase_substitution(input)?;
+
     // Spec-mandated post-parse semantic check: reject a start-codon variant
     // written as an amino acid substitution (HGVS protein/substitution.md:49,
     // checklist.md:65; #1079).
@@ -7682,6 +7686,67 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
         _ => {}
     }
     Ok(())
+}
+
+/// Reject a multi-nucleotide substitution — `c.79GC>TT`, `c.79_80GC>TT`,
+/// `g.4GC>TG` (#1079).
+///
+/// Per `recommendations/DNA/delins.md:73`:
+///
+/// > Can I describe a `GC` to `TG` variant as a di-nucleotide substitution
+/// > (`g.4GC>TG`)? No, this is not allowed. By definition, a substitution
+/// > changes **one** nucleotide into **one** other nucleotide. […] should be
+/// > described as `g.4_5delinsTG`.
+///
+/// and `recommendations/DNA/substitution.md:30` names both spellings:
+///
+/// > this change can not be described as a substitution like `c.79_80GC>TT`
+/// > or `c.79GC>TT`.
+///
+/// "not allowed" is MUST-level under the spec's RFC 2119 reading
+/// (`recommendations/style.md:9`), so the rejection applies on every parse
+/// path that reaches the grammar with the form still spelled out.
+///
+/// # Why the check reads the source
+///
+/// The grammar folds `GC>TT` into a `Delins` edit and keeps no record of the
+/// reference bases, so by post-parse time `c.79_80GC>TT` and a hand-written
+/// `c.79_80delinsTT` are indistinguishable in the AST. Worse, the single-
+/// position spelling folded `c.79GC>TT` into `c.79delinsTT` — a one-base
+/// deletion with a two-base insert, silently dropping a stated reference base
+/// and yielding a *different variant* from the `c.79_80delinsTT` the
+/// preprocessor produced for the same input. Keying off the source is what
+/// lets the two entry points converge.
+///
+/// Lenient and silent modes never reach this check: the preprocessor rewrites
+/// both spellings to `c.79_80delinsTT` first (the spec states the replacement
+/// outright, and the reference length is stated in the input, so the end
+/// coordinate is `start + len(ref) - 1` with no reference lookup).
+///
+/// Scope is limited to a **multi-base reference**. A one-base reference with a
+/// longer insert (`c.79G>TT`) already spans exactly its anchor and cannot lose
+/// a base, and the no-reference form (`c.100_102>ATG`) states no reference
+/// bases at all; both remain ordinary preprocessor concerns.
+fn validate_no_multibase_substitution(source: &str) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::error_handling::corrections::suggest_multibase_substitution_form;
+
+    let Some(canonical) = suggest_multibase_substitution_form(source) else {
+        return Ok(());
+    };
+    Err(FerroError::parse_with_diagnostic(
+        0,
+        format!(
+            "a substitution replaces one nucleotide by one other, so naming several \
+             reference bases is not allowed (DNA/substitution.md:30, DNA/delins.md:73); \
+             write `{canonical}` instead"
+        ),
+        Diagnostic::new()
+            .with_code(ErrorCode::InvalidEdit)
+            .with_hint(format!(
+                "describe the change as a deletion-insertion — write `{canonical}`"
+            )),
+    ))
 }
 
 /// Reject amino acids listed *after* a translation stop in an inserted

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7248,6 +7248,11 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // insertion (HGVS DNA/insertion.md:95-101 Q&A — explicit "No"; #446).
     validate_no_point_insertion(&variant, input)?;
 
+    // Spec-mandated post-parse semantic check: reject a `del`/`dup` size
+    // suffix on a single-position anchor (HGVS checklist.md:49,
+    // DNA/deletion.md:117, DNA/duplication.md:140, RNA/deletion.md:49; #1079).
+    validate_no_point_size_suffix(&variant, input)?;
+
     // Spec-mandated post-parse semantic check: reject a coding/genomic/mito
     // coordinate system on a non-coding RNA (NR_/XR_) reference (#486,
     // ECOORDINATESYSTEMMISMATCH).
@@ -7529,6 +7534,132 @@ fn validate_no_point_insertion(variant: &HgvsVariant, _source: &str) -> Result<(
         }
         // Protein insertions use a different anchor model — handled
         // elsewhere; nothing to validate here.
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject a `del`/`dup` size-count suffix hung on a **single-position**
+/// anchor — `g.123del3`, `g.123dup6`, `r.123del6`, `p.Arg45del6` (#1079).
+///
+/// Per `recommendations/checklist.md:49`:
+///
+/// > Descriptions like `g.123del3` are not allowed, correct is `g.123_125del`.
+///
+/// restated for each axis in `DNA/deletion.md:117`, `RNA/deletion.md:49` and
+/// `DNA/duplication.md:140`. "not allowed" is MUST-level under the spec's
+/// RFC 2119 reading (`recommendations/style.md:9`), so the rejection applies
+/// on every parse path rather than being mode-configurable.
+///
+/// Scope is deliberately narrow: only an anchor that fails to name both
+/// endpoints violates the rule. A range anchor that also carries a redundant
+/// size (`c.100_102del3`) already names them, and stays a soft W3011/W3016
+/// concern handled by the preprocessor.
+///
+/// Lenient and silent modes never reach this check for a deletion — the
+/// preprocessor rewrites `g.123del3` to `g.123_125del` first (the spec states
+/// that replacement outright). A duplication has no such repair: the spec
+/// declines to say whether `g.123dup6` starts at or after position 123
+/// (`DNA/duplication.md:143`), so guessing would risk emitting a different
+/// variant than the author meant, and every mode rejects.
+fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::error_handling::corrections::suggest_point_del_range_form;
+    use crate::hgvs::edit::{NaEdit, ProteinEdit};
+    use crate::hgvs::interval::UncertainBoundary;
+    use crate::hgvs::uncertainty::Mu;
+
+    /// The edit kind whose size suffix was found, for the diagnostic text.
+    enum SizedEdit {
+        Deletion,
+        Duplication,
+    }
+
+    fn is_point<T: PartialEq>(start: &UncertainBoundary<T>, end: &UncertainBoundary<T>) -> bool {
+        match (start.as_single(), end.as_single()) {
+            (Some(Mu::Certain(s)), Some(Mu::Certain(e))) => s == e,
+            _ => false,
+        }
+    }
+
+    /// The rule targets a description "of more than one residue" that fails
+    /// to name both endpoints (`DNA/deletion.md:117`). A size of one names
+    /// exactly the anchor residue — redundant, not incomplete — so it stays a
+    /// soft W3011/W3023 concern rather than a hard rejection.
+    fn sized_na_edit(edit: &Mu<NaEdit>) -> Option<SizedEdit> {
+        match edit.inner() {
+            Some(NaEdit::Deletion {
+                length: Some(n), ..
+            }) if *n > 1 => Some(SizedEdit::Deletion),
+            Some(NaEdit::Duplication {
+                length: Some(n), ..
+            }) if *n > 1 => Some(SizedEdit::Duplication),
+            _ => None,
+        }
+    }
+
+    fn make_error(kind: &SizedEdit, source: &str) -> FerroError {
+        let (noun, spec) = match kind {
+            SizedEdit::Deletion => ("deletion", "checklist.md:49 / DNA/deletion.md:117"),
+            SizedEdit::Duplication => ("duplication", "DNA/duplication.md:140"),
+        };
+        let repair = match (kind, suggest_point_del_range_form(source)) {
+            (SizedEdit::Deletion, Some(canonical)) => {
+                format!("write `{canonical}` instead")
+            }
+            (SizedEdit::Deletion, None) => {
+                "write `<start>_<end>del`, not `<start>del<size>`".to_string()
+            }
+            (SizedEdit::Duplication, _) => {
+                "write `<start>_<end>dup`, not `<start>dup<size>`. The spec declines to \
+                 disambiguate whether the duplication starts at or after the anchor, so \
+                 ferro will not guess"
+                    .to_string()
+            }
+        };
+        FerroError::parse_with_diagnostic(
+            0,
+            format!(
+                "a {noun} sized by a suffix on a single-position anchor names only one \
+                 endpoint and is not allowed ({spec}); {repair}"
+            ),
+            Diagnostic::new()
+                .with_code(ErrorCode::InvalidEdit)
+                .with_hint(format!("name both endpoints — {repair}")),
+        )
+    }
+
+    macro_rules! check_na {
+        ($v:expr) => {
+            if let Some(kind) = sized_na_edit(&$v.loc_edit.edit) {
+                if is_point(&$v.loc_edit.location.start, &$v.loc_edit.location.end) {
+                    return Err(make_error(&kind, source));
+                }
+            }
+        };
+    }
+
+    match variant {
+        HgvsVariant::Genome(v) => check_na!(v),
+        HgvsVariant::Cds(v) => check_na!(v),
+        HgvsVariant::Tx(v) => check_na!(v),
+        HgvsVariant::Rna(v) => check_na!(v),
+        HgvsVariant::Mt(v) => check_na!(v),
+        HgvsVariant::Circular(v) => check_na!(v),
+        HgvsVariant::Protein(v) => {
+            if matches!(
+                v.loc_edit.edit.inner(),
+                Some(ProteinEdit::Deletion { count: Some(n), .. }) if *n > 1
+            ) && is_point(&v.loc_edit.location.start, &v.loc_edit.location.end)
+            {
+                return Err(make_error(&SizedEdit::Deletion, source));
+            }
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_point_size_suffix(inner, source)?;
+            }
+        }
         _ => {}
     }
     Ok(())

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7253,6 +7253,11 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // DNA/deletion.md:117, DNA/duplication.md:140, RNA/deletion.md:49; #1079).
     validate_no_point_size_suffix(&variant, input)?;
 
+    // Spec-mandated post-parse semantic check: reject a start-codon variant
+    // written as an amino acid substitution (HGVS protein/substitution.md:49,
+    // checklist.md:65; #1079).
+    validate_no_start_loss_substitution(&variant)?;
+
     // Spec-mandated post-parse semantic check: reject a coding/genomic/mito
     // coordinate system on a non-coding RNA (NR_/XR_) reference (#486,
     // ECOORDINATESYSTEMMISMATCH).
@@ -7658,6 +7663,99 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_point_size_suffix(inner, source)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject a translation-initiation-codon variant written as a plain amino
+/// acid substitution — `p.Met1Thr`, `p.(Met1Val)` (#1079).
+///
+/// Per `recommendations/protein/substitution.md:49`:
+///
+/// > Do not use descriptions like `p.Met1Thr`, this is for sure **not** the
+/// > consequence of the effect on protein translation.
+///
+/// and `recommendations/checklist.md:65`:
+///
+/// > the description `p.(Met1Val)` is not allowed.
+///
+/// Losing the initiator methionine does not swap one residue for another: it
+/// abolishes translation from that codon, so the outcome is either no protein
+/// (`p.0`, `p.0?`) or an unpredictable one (`p.(Met1?)`) — never a
+/// substitution.
+///
+/// The rejection applies in every mode. The spec offers three correct forms
+/// and which one holds depends on evidence the description does not carry, so
+/// canonicalising would assert a finding the author never made; the
+/// diagnostic lists all three instead.
+///
+/// A start-codon variant that activates an **upstream** initiation site is an
+/// extension (`protein/extension.md`), not a substitution, and a downstream
+/// one is a deletion — neither shape reaches this check.
+fn validate_no_start_loss_substitution(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::hgvs::edit::{ExtDirection, ProteinEdit};
+    use crate::hgvs::location::AminoAcid;
+    use crate::hgvs::uncertainty::Mu;
+
+    /// True when the edit replaces the residue with a *different* one. An
+    /// identity (`p.Met1=`), an unknown (`p.Met1?`) or a same-residue
+    /// substitution is not a start loss.
+    fn is_residue_swap(edit: &Mu<ProteinEdit>) -> bool {
+        match edit.inner() {
+            Some(ProteinEdit::Substitution { alternative, .. }) => *alternative != AminoAcid::Met,
+            Some(ProteinEdit::SubstitutionAlternatives { alternatives }) => {
+                alternatives.iter().any(|aa| *aa != AminoAcid::Met)
+            }
+            // An N-terminal extension that *also* renames `Met1` — the
+            // `p.Met1Valext-4` form. `protein/extension.md:28` rules it out
+            // for the same reason: `Met1` is part of the normal sequence, so
+            // a description that changes it is not an extension. The spec's
+            // replacement is the insertion form
+            // (`p.Met1_Leu2insArgSerThrVal`), which needs the inserted
+            // residues, so there is nothing to canonicalise to. A plain
+            // `p.Met1ext-5` carries no new residue and is untouched.
+            Some(ProteinEdit::Extension {
+                new_aa: Some(new_aa),
+                direction: ExtDirection::NTerminal,
+                ..
+            }) => *new_aa != AminoAcid::Met,
+            _ => false,
+        }
+    }
+
+    match variant {
+        HgvsVariant::Protein(v) => {
+            let at_initiator = matches!(
+                (v.loc_edit.location.start.as_single(), v.loc_edit.location.end.as_single()),
+                (Some(Mu::Certain(s)), Some(Mu::Certain(e)))
+                    if s == e && s.number == 1 && s.aa == AminoAcid::Met
+            );
+            if at_initiator && is_residue_swap(&v.loc_edit.edit) {
+                return Err(FerroError::parse_with_diagnostic(
+                    0,
+                    "a variant that changes the translation initiation codon is not described \
+                     as a substitution or as an extension; use `p.0` (no protein), `p.0?` \
+                     (predicted no protein) or `p.(Met1?)` (consequence unknown), or — when \
+                     an upstream initiation site is activated — the insertion form \
+                     `p.Met1_Leu2ins...` (protein/substitution.md:49, checklist.md:65, \
+                     protein/extension.md:28)",
+                    Diagnostic::new()
+                        .with_code(ErrorCode::InvalidEdit)
+                        .with_hint(
+                            "losing the initiator methionine abolishes translation from that \
+                             codon rather than swapping one residue for another, so the \
+                             consequence is `p.0`, `p.0?` or `p.(Met1?)`",
+                        ),
+                ));
+            }
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_start_loss_substitution(inner)?;
             }
         }
         _ => {}
@@ -8139,11 +8237,12 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_protein_start_codon_substitution() {
-        // Start codon substitution (p.Met1Leu)
-        let variant = parse_variant("NP_000079.2:p.Met1Leu").unwrap();
-        assert!(matches!(variant, HgvsVariant::Protein(_)));
-        assert_eq!(format!("{}", variant), "NP_000079.2:p.Met1Leu");
+    fn test_parse_protein_start_codon_substitution_rejected() {
+        // A start-codon variant is not a substitution — `p.Met1Leu` is
+        // forbidden by protein/substitution.md:49 (#1079). The spec forms
+        // are `p.0`, `p.0?` and `p.(Met1?)`.
+        assert!(parse_variant("NP_000079.2:p.Met1Leu").is_err());
+        assert!(parse_variant("NP_000079.2:p.(Met1?)").is_ok());
     }
 
     #[test]

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7267,6 +7267,11 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // protein/substitution.md:20; #1079).
     validate_no_immediate_ter_frameshift(&variant)?;
 
+    // Spec-mandated post-parse semantic check: reject residues listed after
+    // a translation stop in an inserted peptide (HGVS protein/delins.md:45,
+    // protein/insertion.md:43; #1079).
+    validate_no_residues_after_stop(&variant)?;
+
     // Spec-mandated post-parse semantic check: reject a coding/genomic/mito
     // coordinate system on a non-coding RNA (NR_/XR_) reference (#486,
     // ECOORDINATESYSTEMMISMATCH).
@@ -7672,6 +7677,85 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_point_size_suffix(inner, source)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject amino acids listed *after* a translation stop in an inserted
+/// peptide — `p.Cys5_Ser6delinsTerGluAsp` (#1079).
+///
+/// Per `recommendations/protein/delins.md:45`:
+///
+/// > the deletion-insertion is not described as `delinsSerSerTerAlaAsp`,
+/// > amino acids after the translation termination codon are **not** listed.
+///
+/// and identically for insertions in `recommendations/protein/insertion.md:43`.
+/// Translation stops at the first `Ter`, so residues written after it are not
+/// part of any protein product — the description names a sequence that cannot
+/// exist.
+///
+/// Truncating at the first `Ter` is mechanical and the diagnostic names the
+/// result, but it is not applied automatically: when the insert *begins* with
+/// `Ter` the spec's own correct description is a nonsense substitution at the
+/// preceding residue (`protein/substitution.md:20`), which needs the
+/// reference sequence, so truncating would swap one non-canonical description
+/// for another.
+///
+/// The `insTer<n>` / `ins*<n>` form gives the stop's position inside the
+/// insertion rather than spelling residues out, so nothing can follow the
+/// stop and it is untouched.
+fn validate_no_residues_after_stop(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::hgvs::edit::{AminoAcidSeq, ProteinEdit, ProteinInsSeq};
+    use crate::hgvs::location::AminoAcid;
+    use crate::hgvs::uncertainty::Mu;
+
+    /// The peptide truncated at (and including) its first `Ter`, or `None`
+    /// when nothing follows the stop.
+    fn truncated_at_first_stop(seq: &AminoAcidSeq) -> Option<AminoAcidSeq> {
+        let first_stop = seq.0.iter().position(|aa| *aa == AminoAcid::Ter)?;
+        (first_stop + 1 < seq.0.len()).then(|| AminoAcidSeq::new(seq.0[..=first_stop].to_vec()))
+    }
+
+    fn offending_peptide(edit: &Mu<ProteinEdit>) -> Option<(&'static str, AminoAcidSeq)> {
+        match edit.inner() {
+            Some(ProteinEdit::Delins { sequence }) => {
+                truncated_at_first_stop(sequence).map(|t| ("delins", t))
+            }
+            Some(ProteinEdit::Insertion {
+                sequence: ProteinInsSeq::Literal(sequence),
+            }) => truncated_at_first_stop(sequence).map(|t| ("ins", t)),
+            _ => None,
+        }
+    }
+
+    match variant {
+        HgvsVariant::Protein(v) => {
+            if let Some((keyword, truncated)) = offending_peptide(&v.loc_edit.edit) {
+                let canonical = format!("{keyword}{truncated}");
+                return Err(FerroError::parse_with_diagnostic(
+                    0,
+                    format!(
+                        "amino acids after the translation termination codon are not listed; \
+                         the inserted peptide ends at its first `Ter`, so write `{canonical}` \
+                         (protein/delins.md:45, protein/insertion.md:43)"
+                    ),
+                    Diagnostic::new()
+                        .with_code(ErrorCode::InvalidEdit)
+                        .with_suggestion(canonical)
+                        .with_hint(
+                            "translation stops at the first `Ter`, so residues written after \
+                             it are not part of any protein product",
+                        ),
+                ));
+            }
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_residues_after_stop(inner)?;
             }
         }
         _ => {}

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7262,6 +7262,11 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // inversion (HGVS DNA/inversion.md:16; #1079).
     validate_no_single_nucleotide_inversion(&variant)?;
 
+    // Spec-mandated post-parse semantic check: reject a frameshift that
+    // terminates immediately (HGVS protein/frameshift.md:22,
+    // protein/substitution.md:20; #1079).
+    validate_no_immediate_ter_frameshift(&variant)?;
+
     // Spec-mandated post-parse semantic check: reject a coding/genomic/mito
     // coordinate system on a non-coding RNA (NR_/XR_) reference (#486,
     // ECOORDINATESYSTEMMISMATCH).
@@ -7667,6 +7672,88 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_point_size_suffix(inner, source)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject a frameshift that terminates immediately — `p.Tyr4TerfsTer1`
+/// (#1079).
+///
+/// Per `recommendations/protein/frameshift.md:22`:
+///
+/// > the shortest frameshift variant possible contains `fsTer2`; variants
+/// > which introduce an **immediate** translation termination (stop) codon
+/// > are described as nonsense variant, e.g., `p.Tyr4Ter` (or `p.Tyr4*`) not
+/// > `p.Tyr4TerfsTer1`.
+///
+/// restated from the substitution side in `protein/substitution.md:20`.
+///
+/// Two spellings assert the same impossible thing and both are rejected: a
+/// stop at codon 1 of the shifted frame (`fsTer1`), and a frameshift whose
+/// first new residue is already `Ter` (`p.Tyr4Terfs…`, whatever `Ter#`
+/// follows). `fsTer2` — the spec's stated minimum — and everything above it
+/// are untouched.
+///
+/// The repair is mechanical and the diagnostic names it verbatim
+/// (`p.Tyr4Ter`), but performing it would silently change the edit kind the
+/// author wrote from a frameshift to a substitution, so it is surfaced
+/// rather than applied.
+fn validate_no_immediate_ter_frameshift(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::hgvs::edit::{FrameshiftTer, ProteinEdit};
+    use crate::hgvs::location::AminoAcid;
+    use crate::hgvs::uncertainty::Mu;
+    use crate::hgvs::variant::ProteinVariant;
+
+    /// True when the edit describes a frameshift that stops at its own first
+    /// codon — either explicitly (`fsTer1`) or by naming `Ter` as the first
+    /// new residue.
+    fn terminates_immediately(edit: &Mu<ProteinEdit>) -> bool {
+        match edit.inner() {
+            Some(ProteinEdit::Frameshift { new_aa, ter }) => {
+                *ter == FrameshiftTer::At(1) || *new_aa == Some(AminoAcid::Ter)
+            }
+            Some(ProteinEdit::FrameshiftAlternatives { alternatives, ter }) => {
+                *ter == FrameshiftTer::At(1) || alternatives.contains(&AminoAcid::Ter)
+            }
+            _ => false,
+        }
+    }
+
+    /// The nonsense description the author should have written: the
+    /// reference residue and position from the location, terminated.
+    fn nonsense_form(v: &ProteinVariant) -> String {
+        match v.loc_edit.location.start.as_single() {
+            Some(Mu::Certain(pos)) => format!("p.{}{}Ter", pos.aa, pos.number),
+            _ => "p.<ref><pos>Ter".to_string(),
+        }
+    }
+
+    match variant {
+        HgvsVariant::Protein(v) if terminates_immediately(&v.loc_edit.edit) => {
+            let canonical = nonsense_form(v);
+            return Err(FerroError::parse_with_diagnostic(
+                0,
+                format!(
+                    "a variant that introduces an immediate translation termination codon is \
+                     a nonsense substitution, not a frameshift; write `{canonical}` \
+                     (protein/frameshift.md:22, protein/substitution.md:20)"
+                ),
+                Diagnostic::new()
+                    .with_code(ErrorCode::InvalidEdit)
+                    .with_suggestion(canonical)
+                    .with_hint(
+                        "the shortest frameshift the spec admits is `fsTer2` — a stop at \
+                         codon 1 of the shifted frame leaves no shifted sequence to describe",
+                    ),
+            ));
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_immediate_ter_frameshift(inner)?;
             }
         }
         _ => {}

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7258,6 +7258,10 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // checklist.md:65; #1079).
     validate_no_start_loss_substitution(&variant)?;
 
+    // Spec-mandated post-parse semantic check: reject a one-nucleotide
+    // inversion (HGVS DNA/inversion.md:16; #1079).
+    validate_no_single_nucleotide_inversion(&variant)?;
+
     // Spec-mandated post-parse semantic check: reject a coding/genomic/mito
     // coordinate system on a non-coding RNA (NR_/XR_) reference (#486,
     // ECOORDINATESYSTEMMISMATCH).
@@ -7663,6 +7667,79 @@ fn validate_no_point_size_suffix(variant: &HgvsVariant, source: &str) -> Result<
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_point_size_suffix(inner, source)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject a one-nucleotide inversion — `g.234inv`, `r.234inv` (#1079).
+///
+/// Per `recommendations/DNA/inversion.md:16`:
+///
+/// > by definition, the region inverted (`positions_inverted`) contains
+/// > **more than one nucleotide**. The description `g.234inv` is therefore
+/// > not allowed; a one-nucleotide inversion should be described as a
+/// > substitution.
+///
+/// Inverting a single base is a substitution to its complement, so the
+/// inversion notation carries no information the substitution notation does
+/// not. The rejection applies in every mode: the replacement needs the
+/// reference base at that position (and its complement), which the parser
+/// does not have, so there is no canonical form to rewrite to.
+///
+/// Only the top-level edit is inspected. An inverted *inserted range*
+/// (`g.234_235ins123_234inv`, the spec's inverted-duplication form) is an
+/// insertion whose source happens to be reversed, and is untouched.
+fn validate_no_single_nucleotide_inversion(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::hgvs::edit::NaEdit;
+    use crate::hgvs::interval::UncertainBoundary;
+    use crate::hgvs::uncertainty::Mu;
+
+    fn is_point<T: PartialEq>(start: &UncertainBoundary<T>, end: &UncertainBoundary<T>) -> bool {
+        match (start.as_single(), end.as_single()) {
+            (Some(Mu::Certain(s)), Some(Mu::Certain(e))) => s == e,
+            _ => false,
+        }
+    }
+
+    fn make_error() -> FerroError {
+        FerroError::parse_with_diagnostic(
+            0,
+            "an inversion covers more than one nucleotide by definition; describe a \
+             one-nucleotide inversion as a substitution to the complementary base \
+             (DNA/inversion.md:16)",
+            Diagnostic::new()
+                .with_code(ErrorCode::InvalidEdit)
+                .with_hint(
+                    "write `<pos><ref>><complement>` (e.g. `g.234T>A`) instead of \
+                     `<pos>inv`",
+                ),
+        )
+    }
+
+    macro_rules! check_inv {
+        ($v:expr) => {
+            if matches!($v.loc_edit.edit.inner(), Some(NaEdit::Inversion { .. }))
+                && is_point(&$v.loc_edit.location.start, &$v.loc_edit.location.end)
+            {
+                return Err(make_error());
+            }
+        };
+    }
+
+    match variant {
+        HgvsVariant::Genome(v) => check_inv!(v),
+        HgvsVariant::Cds(v) => check_inv!(v),
+        HgvsVariant::Tx(v) => check_inv!(v),
+        HgvsVariant::Rna(v) => check_inv!(v),
+        HgvsVariant::Mt(v) => check_inv!(v),
+        HgvsVariant::Circular(v) => check_inv!(v),
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_single_nucleotide_inversion(inner)?;
             }
         }
         _ => {}

--- a/src/hgvs/validation.rs
+++ b/src/hgvs/validation.rs
@@ -619,6 +619,7 @@ mod tests {
                 sequence: InsertedSequence::Literal(Sequence::new(vec![])),
                 deleted: None,
                 deleted_length: None,
+                substitution_reference: None,
             };
             let result = rules::validate_na_edit(&edit);
             assert!(!result.valid);

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1109,6 +1109,7 @@ fn build_naedit<P>(
             sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         }
     };
     let (lo, hi) = if merged.start > merged.end {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3141,6 +3141,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     sequence: InsertedSequence::Literal(Sequence::new(bases)),
                                     deleted: None,
                                     deleted_length: None,
+                                    substitution_reference: None,
                                 };
                                 new_tx_start = cds_start;
                                 new_tx_end = cds_start + (k as u64) - 1;
@@ -3252,6 +3253,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     sequence: InsertedSequence::Literal(Sequence::new(bases)),
                                     deleted: None,
                                     deleted_length: None,
+                                    substitution_reference: None,
                                 };
                                 new_tx_start = cds_end_tx;
                                 new_tx_end = cds_end_tx;
@@ -6879,6 +6881,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     sequence: bytes_to_inserted_seq(&trimmed_bytes),
                                     deleted: None,
                                     deleted_length: None,
+                                    substitution_reference: None,
                                 },
                                 warnings.clone(),
                             ));
@@ -8525,6 +8528,7 @@ fn build_split_variants(
                                 sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
                                 deleted: None,
                                 deleted_length: None,
+                                substitution_reference: None,
                             },
                         ));
                         i += 3;
@@ -8620,6 +8624,7 @@ fn flush_substitution_run(
             sequence: InsertedSequence::Literal(Sequence::new(alt_bases)),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         },
     ));
 }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -10900,11 +10900,22 @@ mod tests {
         // Regression: ClinVar pattern NC_000011.10:g.5238138_5153222insTATTT
         // has start > end (inverted range).  Previously caused a panic in
         // insertion_is_duplication due to slice index out of bounds.
-        // The normalizer should return an error, not panic.
+        //
+        // Since #1079 the description never reaches the normalizer at all:
+        // an insertion anchor MUST name two flanking positions listed 5' to
+        // 3' (`DNA/insertion.md:15-16`), so the parser refuses it up front.
+        // That is a strictly stronger guarantee than "does not panic", but
+        // keep the normalizer half exercised on a legal inverted-range edit
+        // so the original slice-indexing regression stays covered.
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
-        let variant = parse_hgvs("NC_000011.10:g.5238138_5153222insTATTT").unwrap();
+        assert!(
+            parse_hgvs("NC_000011.10:g.5238138_5153222insTATTT").is_err(),
+            "non-flanking insertion anchor must be refused at parse time"
+        );
+
+        let variant = parse_hgvs("NC_000011.10:g.5238138_5153222dup").unwrap();
         let result = normalizer.normalize(&variant);
         // It's fine if this returns Ok (unchanged) or Err (validation failure),
         // but it must NOT panic.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -9437,8 +9437,10 @@ mod tests {
         let provider = MockProvider::with_test_data();
         let normalizer = Normalizer::new(provider);
 
-        // Position 1 = M (Met), Position 2 = V (Val)
-        let variant = parse_hgvs("NP_TEST.1:p.Met1Val").unwrap();
+        // Position 1 = M (Met), Position 2 = V (Val). Position 2 is used
+        // because a substitution at the initiator Met is spec-forbidden
+        // (protein/substitution.md:49).
+        let variant = parse_hgvs("NP_TEST.1:p.Val2Leu").unwrap();
         let result = normalizer.normalize(&variant);
         assert!(
             result.is_ok(),

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1849,6 +1849,7 @@ pub fn canonicalize_edit(edit: &NaEdit) -> NaEdit {
                 sequence: sequence.clone(),
                 deleted: None,
                 deleted_length: None,
+                substitution_reference: None,
             }
         }
         // Inversion: §HGVS v21.0 DNA/inversion.md — "the recommendation
@@ -1954,6 +1955,7 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
                         sequence: InsertedSequence::PositionRange { start, end },
                         deleted: None,
                         deleted_length: None,
+                        substitution_reference: None,
                     });
                 }
             }
@@ -1979,6 +1981,7 @@ pub fn canonicalize_conversion_to_delins(edit: &NaEdit) -> Option<NaEdit> {
         sequence: InsertedSequence::Reference(inner.to_string()),
         deleted: None,
         deleted_length: None,
+        substitution_reference: None,
     })
 }
 
@@ -2083,10 +2086,12 @@ pub fn rna_uracil_to_thymine(edit: &NaEdit) -> Option<NaEdit> {
             sequence,
             deleted,
             deleted_length,
+            substitution_reference,
         } => NaEdit::Delins {
             sequence: map_ins(sequence),
             deleted: map_opt_seq(deleted),
             deleted_length: *deleted_length,
+            substitution_reference: map_opt_seq(substitution_reference),
         },
         NaEdit::DupIns { sequence } => NaEdit::DupIns {
             sequence: map_ins(sequence),
@@ -2826,11 +2831,13 @@ pub fn canonicalize_insertion_expand<P: ReferenceProvider>(
             sequence,
             deleted,
             deleted_length,
+            ..
         } => match expand_inserted_sequence(sequence, accession, kind, provider)? {
             Some(new_seq) => Ok(Some(NaEdit::Delins {
                 sequence: new_seq,
                 deleted: deleted.clone(),
                 deleted_length: *deleted_length,
+                substitution_reference: None,
             })),
             None => Ok(None),
         },
@@ -4056,16 +4063,19 @@ mod tests {
             sequence: trimmed_seq.clone(),
             deleted: Some(Sequence::from_str("CA").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         }));
         assert!(should_canonicalize(&NaEdit::Delins {
             sequence: trimmed_seq.clone(),
             deleted: None,
             deleted_length: Some(2),
+            substitution_reference: None,
         }));
         assert!(!should_canonicalize(&NaEdit::Delins {
             sequence: trimmed_seq,
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         }));
     }
 
@@ -5108,6 +5118,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
             deleted: Some(Sequence::from_str("ATG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         let canonical = canonicalize_edit(&edit);
         match canonical {
@@ -5115,6 +5126,7 @@ mod tests {
                 sequence: _,
                 deleted,
                 deleted_length,
+                ..
             } => {
                 assert_eq!(deleted, None);
                 assert_eq!(deleted_length, None);
@@ -5131,6 +5143,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("TA").unwrap()),
             deleted: None,
             deleted_length: Some(3),
+            substitution_reference: None,
         };
         let canonical = canonicalize_edit(&edit);
         match canonical {
@@ -5138,6 +5151,7 @@ mod tests {
                 sequence: _,
                 deleted,
                 deleted_length,
+                ..
             } => {
                 assert_eq!(deleted, None);
                 assert_eq!(deleted_length, None);
@@ -5168,6 +5182,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("AU").unwrap()),
             deleted: Some(Sequence::from_str("UG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         let mapped = rna_uracil_to_thymine(&edit).expect("expected Some");
         assert_eq!(
@@ -5176,6 +5191,7 @@ mod tests {
                 sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
                 deleted: Some(Sequence::from_str("TG").unwrap()),
                 deleted_length: None,
+                substitution_reference: None,
             }
         );
     }

--- a/src/normalize/validate.rs
+++ b/src/normalize/validate.rs
@@ -87,12 +87,19 @@ pub fn validate_reference(edit: &NaEdit, ref_seq: &[u8], start: u64, end: u64) -
         NaEdit::Delins {
             deleted,
             deleted_length,
+            substitution_reference,
             ..
         } => {
             if let Some(seq) = deleted {
                 // Non-recommended `delACinsGT` form: ferro parses the stated
                 // deleted bases into `deleted`. Validate them against the
                 // reference span (#486) — mirrors the `Deletion` arm.
+                validate_sequence(seq.bases(), ref_seq, start, end)
+            } else if let Some(seq) = substitution_reference {
+                // Forbidden `AC>GT` form: the reference run it states is kept
+                // in `substitution_reference` (#1092). It asserts exactly what
+                // `delACinsGT` asserts, so it gets exactly the same check —
+                // otherwise a false claim would vanish without a diagnostic.
                 validate_sequence(seq.bases(), ref_seq, start, end)
             } else if let Some(n) = deleted_length {
                 // Numeric `del<N>ins…`: N must equal the position span (#486).
@@ -750,6 +757,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
             deleted: Some(Sequence::from_str("GGG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         let ref_seq = b"ATGC";
         let result = validate_reference(&edit, ref_seq, 1, 3);
@@ -765,6 +773,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
             deleted: Some(Sequence::from_str("ATG").unwrap()),
             deleted_length: None,
+            substitution_reference: None,
         };
         let ref_seq = b"ATGC";
         let result = validate_reference(&edit, ref_seq, 1, 3);
@@ -779,6 +788,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let ref_seq = b"ATGC";
         let result = validate_reference(&edit, ref_seq, 1, 3);
@@ -794,6 +804,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("AT").unwrap()),
             deleted: None,
             deleted_length: Some(3),
+            substitution_reference: None,
         };
         let ref_seq = b"ATGC";
         let result = validate_reference(&edit, ref_seq, 1, 3);
@@ -912,6 +923,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("ATC").unwrap()),
             deleted: None,
             deleted_length: Some(4),
+            substitution_reference: None,
         };
         let result = validate_reference(&edit, b"ATGC", 45, 45);
         assert!(!result.valid);

--- a/src/project/edit.rs
+++ b/src/project/edit.rs
@@ -43,10 +43,12 @@ pub fn transform_edit_for_strand(edit: &NaEdit, strand: Strand) -> NaEdit {
             sequence,
             deleted,
             deleted_length,
+            substitution_reference,
         } => NaEdit::Delins {
             sequence: revcomp_inserted(sequence),
             deleted: deleted.as_ref().map(revcomp_sequence),
             deleted_length: *deleted_length,
+            substitution_reference: substitution_reference.as_ref().map(revcomp_sequence),
         },
         NaEdit::Duplication {
             sequence,
@@ -174,10 +176,12 @@ pub(crate) fn u_to_t_edit(edit: &NaEdit) -> NaEdit {
             sequence,
             deleted,
             deleted_length,
+            substitution_reference,
         } => NaEdit::Delins {
             sequence: u_to_t_inserted(sequence),
             deleted: deleted.as_ref().map(u_to_t_sequence),
             deleted_length: *deleted_length,
+            substitution_reference: substitution_reference.as_ref().map(u_to_t_sequence),
         },
         NaEdit::Duplication {
             sequence,
@@ -342,6 +346,7 @@ mod tests {
             sequence: InsertedSequence::Literal(seq("CC")),
             deleted: Some(seq("ATG")),
             deleted_length: None,
+            substitution_reference: None,
         };
         let out = transform_edit_for_strand(&edit, Strand::Minus);
         let s = out.to_string();

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -10221,6 +10221,7 @@ mod tests {
                         sequence: InsertedSequence::Literal("GG".parse().unwrap()),
                         deleted: None,
                         deleted_length: None,
+                        substitution_reference: None,
                     },
                 ),
             };
@@ -10289,6 +10290,7 @@ mod tests {
                         sequence: InsertedSequence::Literal("GG".parse().unwrap()),
                         deleted: None,
                         deleted_length: None,
+                        substitution_reference: None,
                     },
                 ),
             };
@@ -13033,6 +13035,7 @@ mod tests {
                     ])),
                     deleted: None,
                     deleted_length: None,
+                    substitution_reference: None,
                 },
             ),
         });

--- a/src/project/protein/helpers.rs
+++ b/src/project/protein/helpers.rs
@@ -927,6 +927,7 @@ mod tests {
             sequence: InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = build_mutated_cds(&t, 4, 6, &edit).unwrap();
         assert_eq!(result, "ATGTCCTAA");

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -1466,6 +1466,7 @@ pub(crate) fn try_project_cis_combined_inframe(
         sequence: InsertedSequence::Literal(Sequence::new(Vec::new())),
         deleted: None,
         deleted_length: None,
+        substitution_reference: None,
     };
     let pv = build_inframe_variant(
         transcript,
@@ -1993,6 +1994,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Arg2Ser)");
@@ -2107,6 +2109,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 4, 6, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Lys2Ter)");
@@ -2125,6 +2128,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 4, 9, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Lys2Ter)");
@@ -2143,6 +2147,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Gly3delinsSerTer)");
@@ -2165,6 +2170,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
@@ -2193,6 +2199,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
@@ -2223,6 +2230,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 7, 9, &edit, "NP_TEST.1").unwrap();
         let s = prot_str(&result);
@@ -2273,6 +2281,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let result = predict_indel(&t, 1, 3, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Met1?)");
@@ -2769,6 +2778,7 @@ mod tests {
             ])),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let del = NaEdit::Deletion {
             sequence: None,
@@ -2859,6 +2869,7 @@ mod tests {
             sequence: crate::hgvs::edit::InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         let v = predict_indel(&t, 4, 9, &edit, "NP_TEST.1").unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Arg2LysfsTer4)");

--- a/src/project/rna.rs
+++ b/src/project/rna.rs
@@ -215,10 +215,12 @@ pub(crate) fn predict_rna(coding: &HgvsVariant, transcript: &Transcript) -> Opti
             sequence,
             deleted,
             deleted_length,
+            substitution_reference,
         } => NaEdit::Delins {
             sequence: resolve_range_insert(sequence, transcript)?,
             deleted: deleted.clone(),
             deleted_length: *deleted_length,
+            substitution_reference: substitution_reference.clone(),
         },
         NaEdit::Insertion { sequence } => NaEdit::Insertion {
             sequence: resolve_range_insert(sequence, transcript)?,

--- a/src/python_helpers.rs
+++ b/src/python_helpers.rs
@@ -587,6 +587,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::from_str("ATG").unwrap()),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert_eq!(na_edit_type_str(&edit), "delins");
     }

--- a/src/service/handlers/effect.rs
+++ b/src/service/handlers/effect.rs
@@ -2181,6 +2181,7 @@ mod tests {
             sequence: InsertedSequence::Range(5, 10),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert!(
             delins_frame_undecidable(&edit, Some(3)),
@@ -2198,6 +2199,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::new(vec![Base::A])),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert!(
             delins_frame_undecidable(&edit, None),
@@ -2214,6 +2216,7 @@ mod tests {
             sequence: InsertedSequence::Literal(Sequence::new(vec![Base::A, Base::T])),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         };
         assert!(
             !delins_frame_undecidable(&edit, Some(3)),

--- a/src/service/types.rs
+++ b/src/service/types.rs
@@ -216,6 +216,7 @@ pub(crate) fn extract_na_edit_info(edit: &NaEdit) -> (String, Option<String>, Op
             sequence,
             deleted,
             deleted_length,
+            ..
         } => {
             let deleted = deleted
                 .as_ref()

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -1348,6 +1348,7 @@ where
             sequence: ins_seq,
             deleted,
             deleted_length: _,
+            substitution_reference: None,
         } => {
             // Closes #394 item 3. Non-literal delins inserted sequences
             // (any `InsertedSequence` variant other than `Literal`) are
@@ -1762,6 +1763,7 @@ pub fn spdi_to_hgvs(spdi: &SpdiVariant) -> Result<HgvsVariant, ConversionError> 
                 sequence: InsertedSequence::Literal(ins_seq),
                 deleted: None,
                 deleted_length: None,
+                substitution_reference: None,
             },
         )
     };

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -3996,9 +3996,22 @@ mod tests {
 
     #[test]
     fn test_hgvs_to_spdi_inversion_single_base() {
-        // Inversion of a single base 'A' → 'T'
+        // Inversion of a single base 'A' → 'T'. `g.100_100inv` cannot be
+        // parsed — DNA/inversion.md:16 forbids a one-nucleotide inversion —
+        // so the variant is built directly to keep the conversion arm
+        // covered for callers that construct an AST themselves.
         let provider = make_test_genomic_provider();
-        let hgvs = parse_hgvs("NC_000001.11:g.100_100inv").unwrap();
+        let hgvs = HgvsVariant::Genome(GenomeVariant {
+            accession: parse_accession("NC_000001.11").unwrap().1,
+            gene_symbol: None,
+            loc_edit: LocEdit::new(
+                crate::hgvs::interval::GenomeInterval::point(GenomePos::new(100)),
+                NaEdit::Inversion {
+                    sequence: None,
+                    length: None,
+                },
+            ),
+        });
         let spdi = hgvs_to_spdi(&hgvs, &provider).unwrap();
         assert_eq!(spdi.position, 99);
         assert_eq!(spdi.deletion, "A");

--- a/src/vcf/from_hgvs.rs
+++ b/src/vcf/from_hgvs.rs
@@ -1705,6 +1705,7 @@ mod tests {
                     sequence: InsertedSequence::Literal(Sequence::from_str("UU").unwrap()),
                     deleted: None,
                     deleted_length: None,
+                    substitution_reference: None,
                 },
             ),
         });
@@ -2347,6 +2348,7 @@ mod tests {
                     sequence: InsertedSequence::Literal(Sequence::from_str("TTT").unwrap()),
                     deleted: None,
                     deleted_length: None,
+                    substitution_reference: None,
                 },
             ),
         });

--- a/src/vcf/to_hgvs.rs
+++ b/src/vcf/to_hgvs.rs
@@ -445,6 +445,7 @@ impl<'a> VcfToHgvsConverter<'a> {
                 sequence: InsertedSequence::Literal(seq),
                 deleted: None,
                 deleted_length: None,
+                substitution_reference: None,
             }
         };
 
@@ -612,6 +613,7 @@ pub fn vcf_to_genomic_hgvs(vcf: &VcfRecord, alt_index: usize) -> Result<GenomeVa
             sequence: InsertedSequence::Literal(seq),
             deleted: None,
             deleted_length: None,
+            substitution_reference: None,
         }
     };
 

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -324,6 +324,11 @@
     "[single_position_insertion]": {
       "category": "rejected_by_design",
       "reason": "Single-position insertion is explicitly invalid per DNA/insertion.md:95-101 Q&A; the canonical form requires a 2-position adjacent range (closes #446)."
+    },
+    "[frameshift_immediate_ter]": {
+      "category": "rejected_by_design",
+      "reason": "Frameshift terminating at codon 1 of the shifted frame (`fsTer1`). HGVS protein/frameshift.md:22 states the shortest possible frameshift contains `fsTer2`; a variant introducing an immediate stop is a nonsense substitution (`p.<ref><pos>Ter`), not a frameshift (also protein/substitution.md:20).",
+      "tracking": "#1079"
     }
   },
   "expected_failures": {
@@ -532,6 +537,7 @@
     "NM_000249.3:c.1667+678insALU": "[single_position_insertion]",
     "NM_002485.4:c.842insT": "[single_position_insertion]",
     "NM_003977.2:c.919insC": "[single_position_insertion]",
-    "NM_007294.3:c.3627insA": "[single_position_insertion]"
+    "NM_007294.3:c.3627insA": "[single_position_insertion]",
+    "NP_002476.2:p.Gln279ProfsTer1": "[frameshift_immediate_ter]"
   }
 }

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -334,6 +334,11 @@
       "category": "rejected_by_design",
       "reason": "Multi-nucleotide substitution (`c.878_879AG>GT`). HGVS DNA/substitution.md:30 names both `c.79_80GC>TT` and `c.79GC>TT` as invalid because a substitution replaces one nucleotide by one other; DNA/delins.md:73 states the change is a deletion-insertion (`c.878_879delinsGT`). Lenient and silent modes rewrite it; strict rejects and names the repair.",
       "tracking": "#1079"
+    },
+    "[non_flanking_insertion_anchor]": {
+      "category": "rejected_by_design",
+      "reason": "Insertion anchored on two positions that are not flanking (adjacent). HGVS DNA/insertion.md:15 requires the `positions flanking` to be `123_124`, not `123_125`, and line 16 requires them listed 5' to 3'; syntax.yaml `dna.ins` restates it as `range` must be specified using adjacent positions. Sibling rule to `[single_position_insertion]`, and rejected for the same reason: the intended flanking pair is not recoverable, so no repair is derivable. A wide anchor is a deletion-insertion (`delins`), not an insertion.",
+      "tracking": "#1079"
     }
   },
   "expected_failures": {
@@ -544,6 +549,9 @@
     "NM_003977.2:c.919insC": "[single_position_insertion]",
     "NM_007294.3:c.3627insA": "[single_position_insertion]",
     "NP_002476.2:p.Gln279ProfsTer1": "[frameshift_immediate_ter]",
-    "NM_003977.2:c.878_879AG>GT": "[multibase_substitution]"
+    "NM_003977.2:c.878_879AG>GT": "[multibase_substitution]",
+    "NC_000011.10:g.5238138_5153222insTATTT": "[non_flanking_insertion_anchor]",
+    "NM_000061.3:c.418_424insSVA": "[non_flanking_insertion_anchor]",
+    "NM_000548.3:c.[4621_4629del9;4621_4634ins14]": "[non_flanking_insertion_anchor]"
   }
 }

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -329,6 +329,11 @@
       "category": "rejected_by_design",
       "reason": "Frameshift terminating at codon 1 of the shifted frame (`fsTer1`). HGVS protein/frameshift.md:22 states the shortest possible frameshift contains `fsTer2`; a variant introducing an immediate stop is a nonsense substitution (`p.<ref><pos>Ter`), not a frameshift (also protein/substitution.md:20).",
       "tracking": "#1079"
+    },
+    "[multibase_substitution]": {
+      "category": "rejected_by_design",
+      "reason": "Multi-nucleotide substitution (`c.878_879AG>GT`). HGVS DNA/substitution.md:30 names both `c.79_80GC>TT` and `c.79GC>TT` as invalid because a substitution replaces one nucleotide by one other; DNA/delins.md:73 states the change is a deletion-insertion (`c.878_879delinsGT`). Lenient and silent modes rewrite it; strict rejects and names the repair.",
+      "tracking": "#1079"
     }
   },
   "expected_failures": {
@@ -538,6 +543,7 @@
     "NM_002485.4:c.842insT": "[single_position_insertion]",
     "NM_003977.2:c.919insC": "[single_position_insertion]",
     "NM_007294.3:c.3627insA": "[single_position_insertion]",
-    "NP_002476.2:p.Gln279ProfsTer1": "[frameshift_immediate_ter]"
+    "NP_002476.2:p.Gln279ProfsTer1": "[frameshift_immediate_ter]",
+    "NM_003977.2:c.878_879AG>GT": "[multibase_substitution]"
   }
 }

--- a/tests/fixtures/validation/cmrg_genes_failure_expectations.json
+++ b/tests/fixtures/validation/cmrg_genes_failure_expectations.json
@@ -91,6 +91,11 @@
     "[silent_with_repeated_aa]": {
       "category": "rejected_by_design",
       "reason": "Silent should be `p.Trp16=` not `p.Trp16Trp=`."
+    },
+    "[non_flanking_insertion_anchor]": {
+      "category": "rejected_by_design",
+      "reason": "Insertion anchored on two positions that are not flanking (adjacent). HGVS DNA/insertion.md:15 requires the `positions flanking` to be `123_124`, not `123_125`; syntax.yaml `dna.ins` restates it as `range` must be specified using adjacent positions. The intended flanking pair is not recoverable, so no repair is derivable; a wide anchor is a deletion-insertion (`delins`), not an insertion.",
+      "tracking": "#1079"
     }
   },
   "expected_failures": {
@@ -138,6 +143,8 @@
     "NP_000021.1:p.Gly_142Gln145del": "[malformed_protein_underscore_between_aa_and_pos]",
     "NP_000539.2:p.Cys189_Tyr190delinsCysPheThrfs": "[trailing_fs_after_delins]",
     "NP_004534?.2:p.Arg2478_Asp2512del": "[malformed_question_mark_in_accession]",
-    "NP_065231.3:p.Trp16Trp=": "[silent_with_repeated_aa]"
+    "NP_065231.3:p.Trp16Trp=": "[silent_with_repeated_aa]",
+    "NM_000061.3:c.418_424insSVA": "[non_flanking_insertion_anchor]",
+    "NM_000548.3:c.[4621_4629del9;4621_4634ins14]": "[non_flanking_insertion_anchor]"
   }
 }

--- a/tests/it/compound_cross_reference.rs
+++ b/tests/it/compound_cross_reference.rs
@@ -195,7 +195,7 @@ fn test_cis_mixed_c_and_r() {
 #[test]
 fn test_cis_mixed_c_and_p() {
     // c. + p. on the matched mRNA / protein pair.
-    let input = "[NM_000088.3:c.1A>G;NP_000079.2:p.Met1Val]";
+    let input = "[NM_000088.3:c.1A>G;NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Cis, 2);
     assert_eq!(allele.variants[0].variant_type(), "c");
@@ -218,7 +218,7 @@ fn test_cis_mixed_c_and_n_same_accession() {
 fn test_cis_three_different_coord_systems() {
     // Three sub-variants, three different coord systems (c., g., p.).
     // Pins that the expanded form scales beyond two variants.
-    let input = "[NM_000088.3:c.1A>G;NC_000017.11:g.2A>G;NP_000079.2:p.Met1Val]";
+    let input = "[NM_000088.3:c.1A>G;NC_000017.11:g.2A>G;NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Cis, 3);
     assert_eq!(allele.variants[0].variant_type(), "c");
@@ -343,13 +343,13 @@ fn test_no_merge_across_coord_systems_different_accession() {
 #[test]
 fn test_no_merge_across_coord_systems_three_variant() {
     // Three-variant chain mixing c./g./p. — even though c.1 and (notional)
-    // g.2 / p.Met1Val are numerically "adjacent" in a numeric sense, the
+    // g.2 / p.Met2Val are numerically "adjacent" in a numeric sense, the
     // merge pass cannot bridge the coord-system boundary.
     let result =
-        normalize_to_string("[NM_000088.3:c.1A>G;NC_000017.11:g.2A>G;NP_000079.2:p.Met1Val]");
+        normalize_to_string("[NM_000088.3:c.1A>G;NC_000017.11:g.2A>G;NP_000079.2:p.Met2Val]");
     assert!(result.contains("NM_000088.3:c.1A>G"), "got {}", result);
     assert!(result.contains("NC_000017.11:g.2A>G"), "got {}", result);
-    assert!(result.contains("NP_000079.2:p.Met1Val"), "got {}", result);
+    assert!(result.contains("NP_000079.2:p.Met2Val"), "got {}", result);
     assert!(!result.contains("delins"), "got {}", result);
 }
 
@@ -471,7 +471,7 @@ fn test_cis_mixed_n_and_r() {
 
 #[test]
 fn test_cis_mixed_n_and_p() {
-    let input = "[NR_000001.1:n.100A>G;NP_000079.2:p.Met1Val]";
+    let input = "[NR_000001.1:n.100A>G;NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Cis, 2);
     assert_eq!(allele.variants[0].variant_type(), "n");
@@ -480,7 +480,7 @@ fn test_cis_mixed_n_and_p() {
 
 #[test]
 fn test_cis_mixed_r_and_p() {
-    let input = "[NM_000088.3:r.50a>g;NP_000079.2:p.Met1Val]";
+    let input = "[NM_000088.3:r.50a>g;NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Cis, 2);
     assert_eq!(allele.variants[0].variant_type(), "r");
@@ -500,7 +500,7 @@ fn test_cis_mixed_m_and_r() {
 
 #[test]
 fn test_cis_mixed_m_and_p() {
-    let input = "[NC_012920.1:m.100A>G;NP_000079.2:p.Met1Val]";
+    let input = "[NC_012920.1:m.100A>G;NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Cis, 2);
     assert_eq!(allele.variants[0].variant_type(), "m");
@@ -824,7 +824,7 @@ fn test_trans_cross_reference_marker_normalize_preserves_shape() {
 #[test]
 fn test_unknown_phase_three_way_cross_coord_round_trip() {
     // Three sub-variants with three coord systems in unknown phase.
-    let input = "[NM_000088.3:c.1A>G(;)NC_000017.11:g.2A>G(;)NP_000079.2:p.Met1Val]";
+    let input = "[NM_000088.3:c.1A>G(;)NC_000017.11:g.2A>G(;)NP_000079.2:p.Met2Val]";
     let parsed = assert_parse_roundtrip(input);
     let allele = expect_allele(&parsed, AllelePhase::Unknown, 3);
     assert_eq!(allele.variants[0].variant_type(), "c");

--- a/tests/it/error_mode_tests.rs
+++ b/tests/it/error_mode_tests.rs
@@ -1284,9 +1284,11 @@ mod w3011_del_size_suffix_emission {
     use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_silent, parse_hgvs_with_config};
 
     #[test]
-    fn lenient_warns_without_rewrite() {
-        // SVA-007: warn_accept — lenient warns but does NOT rewrite the input
-        // (we cannot synthesise the end position safely).
+    fn lenient_rewrites_point_anchor_to_range() {
+        // #1079: `checklist.md:49` states the replacement outright
+        // ("not allowed, correct is `g.123_125del`"), so a *point* anchor is
+        // canonicalised rather than merely flagged. An offset/range anchor,
+        // where the arithmetic is not a simple increment, still only warns.
         let result = parse_hgvs_lenient("NG_012232.1:g.123del6").unwrap();
         assert!(result.has_warnings());
         assert_eq!(
@@ -1297,8 +1299,16 @@ mod w3011_del_size_suffix_emission {
                 .count(),
             1
         );
-        // Input is unchanged (no auto-correction).
-        assert_eq!(result.preprocessed_input, "NG_012232.1:g.123del6");
+        assert_eq!(result.preprocessed_input, "NG_012232.1:g.123_128del");
+    }
+
+    #[test]
+    fn lenient_rejects_offset_anchor_it_cannot_repair() {
+        // An intronic anchor names one endpoint too, so the MUST-level rule
+        // applies — but `c.100+5 + 6 - 1` is not safely computable, so there
+        // is no canonical form to offer and lenient rejects rather than
+        // passing a spec-invalid description through.
+        assert!(parse_hgvs_lenient("NM_004006.2:c.100+5del6").is_err());
     }
 
     #[test]
@@ -1308,10 +1318,10 @@ mod w3011_del_size_suffix_emission {
     }
 
     #[test]
-    fn silent_accepts_without_warning() {
+    fn silent_rewrites_without_warning() {
         let result = parse_hgvs_silent("NG_012232.1:g.123del6").unwrap();
         assert!(!result.has_warnings());
-        assert_eq!(result.preprocessed_input, "NG_012232.1:g.123del6");
+        assert_eq!(result.preprocessed_input, "NG_012232.1:g.123_128del");
     }
 
     #[test]
@@ -1327,8 +1337,10 @@ mod w3011_del_size_suffix_emission {
     fn idempotent_re_pass() {
         let r1 = parse_hgvs_lenient("NG_012232.1:g.123del6").unwrap();
         let r2 = parse_hgvs_lenient(&r1.preprocessed_input).unwrap();
+        // The rewritten form is canonical, so a second pass is a no-op and
+        // no longer warns.
         assert_eq!(r1.preprocessed_input, r2.preprocessed_input);
-        assert!(r2.has_warnings());
+        assert!(!r2.has_warnings());
     }
 }
 

--- a/tests/it/error_mode_tests.rs
+++ b/tests/it/error_mode_tests.rs
@@ -1559,11 +1559,13 @@ mod w4003_single_position_range_emission {
         assert_eq!(result.preprocessed_input, "NM_000088.3:c.123dup");
     }
 
+    /// The `inv` probe collapses to `c.100inv`, which DNA/inversion.md:16
+    /// forbids outright ("a one-nucleotide inversion should be described as
+    /// a substitution"), so lenient rejects after the W4003 collapse rather
+    /// than emitting a spec-invalid description (#1079).
     #[test]
-    fn lenient_warns_and_collapses_inv() {
-        let result = parse_hgvs_lenient("NM_000088.3:c.100_100inv").unwrap();
-        assert!(result.has_warnings());
-        assert_eq!(result.preprocessed_input, "NM_000088.3:c.100inv");
+    fn lenient_rejects_single_base_inv_after_collapse() {
+        assert!(parse_hgvs_lenient("NM_000088.3:c.100_100inv").is_err());
     }
 
     #[test]

--- a/tests/it/grammar_conformance.rs
+++ b/tests/it/grammar_conformance.rs
@@ -11,14 +11,30 @@ fn test_grammar_substitution() {
     let cases = vec![
         // Basic substitution
         "NC_000001.11:g.12345A>G",
-        // With sequence context
-        "NC_000001.11:g.12345CAT>G",
-        // Multi-base replacement
-        "NC_000001.11:g.12345_12347CAT>GGGG",
+        // Single reference base with a longer replacement
+        "NC_000001.11:g.12345A>GGGG",
     ];
 
     for case in cases {
         assert!(parse_hgvs(case).is_ok(), "Failed to parse: {}", case);
+    }
+}
+
+/// Mutalyzer's grammar accepts a multi-base reference on either side of the
+/// arrow, but the HGVS spec forbids it: a substitution replaces **one**
+/// nucleotide by **one** other (`DNA/substitution.md:30`,
+/// `DNA/delins.md:73`), so the change is a deletion-insertion. Strict parsing
+/// rejects the form; lenient/silent rewrite it (see
+/// `issue_1079_multibase_substitution.rs`).
+#[test]
+fn test_grammar_multibase_substitution_is_rejected() {
+    let cases = vec![
+        "NC_000001.11:g.12345CAT>G",
+        "NC_000001.11:g.12345_12347CAT>GGGG",
+    ];
+
+    for case in cases {
+        assert!(parse_hgvs(case).is_err(), "Should not parse: {}", case);
     }
 }
 

--- a/tests/it/hgvs_standard_tests.rs
+++ b/tests/it/hgvs_standard_tests.rs
@@ -286,7 +286,7 @@ mod protein_variants {
             "NP_000138.2:p.G12D",  // KRAS G12D
             "NP_000138.2:p.G12V",  // KRAS G12V
             "NP_004314.2:p.L858R", // EGFR L858R
-            "NP_000079.2:p.M1I",   // Start codon
+            "NP_000079.2:p.M2I",   // Second residue
             "NP_000079.2:p.R100*", // Nonsense with stop
         ];
 

--- a/tests/it/input_hygiene_rejections.rs
+++ b/tests/it/input_hygiene_rejections.rs
@@ -184,12 +184,12 @@ fn rejects_uppercase_rna_dup_keyword() {
 // at the parse_hgvs API level — pin the divergence.
 
 #[test]
-fn accepts_dup_size_suffix_pre_2016_diverges_from_spec() {
+fn rejects_del_size_suffix_pre_2016() {
     // checklist:C-5 — checklist.md:49 explicitly lists `g.123del3` as
     // invalid (pre-2016 size-suffix form; must be `g.123_125del`).
     // The probe uses `del3` not `dup3` per the checklist citation.
-    assert_accepted_diverges_from_spec(
-        "NC_000023.11:g.123del3",
+    // Enforced since #1079; lenient/silent modes canonicalise instead.
+    assert_rejected(
         "NC_000023.11:g.123del3",
         "checklist.md:49 — pre-2016 size-suffix form, must be g.123_125del",
     );

--- a/tests/it/issue_1079_flanking_insertion_anchor.rs
+++ b/tests/it/issue_1079_flanking_insertion_anchor.rs
@@ -1,0 +1,295 @@
+//! Insertion anchors MUST name two *flanking* (adjacent) positions.
+//!
+//! Two sub-rules, both MUST-level, and both previously unenforced on the
+//! paths exercised here.
+//!
+//! 1. **A single-position anchor is not allowed.** For protein,
+//!    `protein/insertion.md:18`:
+//!
+//!    > an insertion can not be described using **one** amino acid
+//!    > position, like `p.Lys23insAsp`.
+//!
+//!    The DNA half of this rule (`DNA/insertion.md:95-101`,
+//!    `checklist.md:30-31` — "The format `c.52insT` is **ambiguous**, and
+//!    not allowed") is already enforced by
+//!    `reject_single_position_insertion.rs`; the protein axis was
+//!    explicitly left as "handled elsewhere" and in fact was not handled
+//!    at all. These tests close that gap.
+//!
+//! 2. **The two positions MUST be adjacent.** `DNA/insertion.md:15`:
+//!
+//!    > `positions flanking` should contain **two flanking nucleotides**,
+//!    > e.g., `123_124`, not `123_125`.
+//!
+//!    The formal grammar states this as a hard requirement rather than a
+//!    preference — `syntax.yaml` `dna.ins` notes "`range` must be
+//!    specified using adjacent positions".
+//!
+//!    Sub-rule 2 is enforced on the **nucleotide axes only**. The protein
+//!    twin (`protein/insertion.md:17`) is contradicted by the spec's own
+//!    `protein/alleles.md:61` example; see the block comment below.
+//!
+//! Rejection (not repair) is the right disposition for both: given
+//! `g.123_125insG` there is no way to recover which flanking pair the
+//! author meant, exactly as `DNA/insertion.md:95-101` argues for the
+//! single-position form. A wide anchor is a `delins`, not an `ins`.
+//!
+//! Enforcement is deliberately limited to anchors whose adjacency is
+//! decidable from the description alone — plain positions with no
+//! intronic offset, no `pter`/`qter`/`cen` marker, no `?`, and both
+//! endpoints in the same coordinate region. Anything needing reference
+//! data to settle (e.g. an exon/intron boundary such as
+//! `c.100+1_101-1insG`, or a CDS-to-3'UTR span) is left alone; see the
+//! guard tests at the bottom.
+//!
+//! Part of the #1079 spec-divergence burn-down.
+
+use ferro_hgvs::error::ErrorCode;
+use ferro_hgvs::parse_hgvs;
+
+/// Assert `input` is refused with a structured `InvalidEdit` code and an
+/// message that cites the spec, mirroring the existing single-position
+/// DNA rejection so the refusal survives slash-form fallback paths.
+fn assert_rejects(input: &str, expected_fragment: &str) {
+    let result = parse_hgvs(input);
+    assert!(
+        result.is_err(),
+        "expected insertion anchor {input:?} to be rejected; got: {:?}",
+        result.map(|v| v.to_string())
+    );
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.code(),
+        Some(ErrorCode::InvalidEdit),
+        "insertion-anchor rejection must carry a structured InvalidEdit code for {input:?}",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains(expected_fragment),
+        "error message must explain the problem; want {expected_fragment:?}, got: {msg}"
+    );
+    assert!(
+        msg.contains("insertion.md"),
+        "error message must cite the spec; got: {msg}"
+    );
+}
+
+/// Assert `input` parses and round-trips to `expected`.
+fn assert_accepts(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("{input:?} must parse: {e}"));
+    assert_eq!(parsed.to_string(), expected, "round-trip mismatch");
+}
+
+// ---------------------------------------------------------------------
+// Sub-rule 1 — single-position anchor, protein axis (protein/insertion.md:18)
+// ---------------------------------------------------------------------
+
+#[test]
+fn rejects_protein_single_position_insertion() {
+    // The spec's own counter-example, verbatim.
+    assert_rejects("NP_003997.1:p.Lys23insAsp", "single-position insertion");
+}
+
+#[test]
+fn rejects_protein_single_position_insertion_one_letter() {
+    // One-letter input normalizes to three-letter internally; the refusal
+    // must not depend on which spelling the author used.
+    assert_rejects("NP_003997.1:p.K23insD", "single-position insertion");
+}
+
+#[test]
+fn rejects_protein_single_position_insertion_predicted() {
+    // Parenthesized (predicted) consequence is the same edit and is
+    // equally ambiguous.
+    assert_rejects("NP_003997.1:p.(Lys23insAsp)", "single-position insertion");
+}
+
+#[test]
+fn rejects_protein_single_position_insertion_inside_allele() {
+    // The rule applies per-variant inside allele brackets.
+    assert_rejects(
+        "NP_003997.1:p.[Trp24Cys;Lys23insAsp]",
+        "single-position insertion",
+    );
+}
+
+// ---------------------------------------------------------------------
+// Sub-rule 2 on the PROTEIN axis — NOT enforced, and deliberately so.
+//
+// `protein/insertion.md:17` says the anchor should be `Lys23_Leu24`, not
+// `Lys23_Asn25` — but the spec contradicts itself. `protein/alleles.md:61`
+// publishes, unmarked and as a valid illustration of the allele-bracket
+// format:
+//
+// > **NOTE**: for other variant types, the format is `p.[Ser68del];[Ser68=]`,
+// > `p.[Ser68_Arg70dup];[Ser68_Arg70=]`,
+// > `p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]`, etc.
+//
+// whose insertion anchor `Ser68_Ala74` spans seven residues. Enforcing
+// adjacency on `p.` would make ferro reject a description the spec itself
+// prints, so the rule is left unenforced pending upstream clarification.
+// The nucleotide axes carry no such contradicting example (this is the only
+// conflict across the whole spec-derived corpus) and ARE enforced above.
+//
+// These tests pin the non-enforcement so the contradiction is visible and a
+// future change to it is deliberate rather than accidental.
+// ---------------------------------------------------------------------
+
+#[test]
+fn protein_non_flanking_insertion_is_not_rejected_pending_spec_conflict() {
+    // `protein/insertion.md:17`'s own counter-example shape.
+    assert_accepts(
+        "NP_003997.1:p.Lys23_Asn25insAsp",
+        "NP_003997.1:p.Lys23_Asn25insAsp",
+    );
+}
+
+#[test]
+fn protein_allele_spec_example_with_wide_insertion_anchor_parses() {
+    // `protein/alleles.md:61`, verbatim — the description that forces the
+    // non-enforcement above. This MUST keep parsing.
+    let s = "NP_003997.1:p.[Ser68_Ala74insSerGln];[Ser68_Ala74=]";
+    assert!(
+        parse_hgvs(s).is_ok(),
+        "spec-published example {s:?} must not be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Sub-rule 2 — non-adjacent anchor, nucleotide axes (DNA/insertion.md:15)
+// ---------------------------------------------------------------------
+
+#[test]
+fn rejects_genome_non_flanking_insertion() {
+    // The spec's own counter-example shape: `123_125`, not `123_124`.
+    assert_rejects("NC_000023.11:g.123_125insG", "not flanking");
+}
+
+#[test]
+fn rejects_cds_non_flanking_insertion() {
+    assert_rejects("NM_004006.2:c.100_102insT", "not flanking");
+}
+
+#[test]
+fn rejects_cds_utr5_non_flanking_insertion() {
+    // Both endpoints in the 5'UTR: `c.-10` and `c.-8` are two apart.
+    assert_rejects("NM_004006.2:c.-10_-8insT", "not flanking");
+}
+
+#[test]
+fn rejects_noncoding_non_flanking_insertion() {
+    assert_rejects("NR_004430.2:n.789_791insC", "not flanking");
+}
+
+#[test]
+fn rejects_mt_non_flanking_insertion() {
+    assert_rejects("NC_012920.1:m.3243_3245insA", "not flanking");
+}
+
+#[test]
+fn rejects_non_flanking_insertion_inside_allele() {
+    assert_rejects("NM_004006.2:c.[100A>G;200_202insT]", "not flanking");
+}
+
+// ---------------------------------------------------------------------
+// Guards — legal forms that MUST keep parsing
+// ---------------------------------------------------------------------
+
+#[test]
+fn accepts_protein_adjacent_insertion() {
+    assert_accepts(
+        "NP_003997.1:p.Lys23_Leu24insAsp",
+        "NP_003997.1:p.Lys23_Leu24insAsp",
+    );
+}
+
+#[test]
+fn accepts_protein_adjacent_insertion_spec_examples() {
+    // Straight from `protein/insertion.md` — every one of these must stay
+    // legal, including the length- and stop-bearing insert forms.
+    for s in [
+        "NP_004371.2:p.(Pro46_Asn47insSerSerTer)",
+        "NP_003997.1:p.Arg78_Gly79insXaa[23]",
+        "NP_003997.1:p.(Ser332_Ser333insXaa)",
+        "NP_003997.1:p.His4_Gln5insAla",
+    ] {
+        assert_accepts(s, s);
+    }
+}
+
+#[test]
+fn accepts_nucleotide_adjacent_insertions() {
+    // Straight from `DNA/insertion.md` examples.
+    for s in [
+        "NC_000023.10:g.32867861_32867862insT",
+        "NM_004006.2:c.169_170insA",
+        "NM_004006.2:c.849_850ins858_895",
+    ] {
+        assert_accepts(s, s);
+    }
+}
+
+#[test]
+fn accepts_utr5_to_cds_boundary_insertion() {
+    // `c.-1` and `c.1` ARE adjacent — there is no `c.0`. The naive
+    // "end == start + 1" test would wrongly reject this.
+    assert_accepts("NM_004006.2:c.-1_1insT", "NM_004006.2:c.-1_1insT");
+}
+
+#[test]
+fn accepts_intronic_adjacent_insertion() {
+    assert_accepts(
+        "NM_004006.2:c.100+1_100+2insT",
+        "NM_004006.2:c.100+1_100+2insT",
+    );
+}
+
+#[test]
+fn accepts_exon_intron_boundary_insertion() {
+    // Adjacency across an exon/intron junction cannot be decided from the
+    // description alone, so it must be left alone rather than rejected.
+    assert_accepts(
+        "NM_004006.2:c.100+1_101-1insT",
+        "NM_004006.2:c.100+1_101-1insT",
+    );
+}
+
+#[test]
+fn accepts_cds_to_utr3_boundary_insertion() {
+    // Needs the CDS length to decide adjacency — not decidable here.
+    assert_accepts("NM_004006.2:c.100_*1insT", "NM_004006.2:c.100_*1insT");
+}
+
+#[test]
+fn accepts_uncertain_and_unknown_anchors() {
+    // `?` and bounded-range boundaries carry no decidable adjacency; the
+    // uncertain form is explicitly blessed by `DNA/insertion.md:23`.
+    //
+    // Acceptance is what matters here, not the exact rendering: ferro
+    // independently collapses `g.?_?` to `g.?` on Display, which is out of
+    // scope for this rule.
+    for s in ["NC_000023.11:g.?_?insG", "NC_000023.11:g.(100_150)insN[25]"] {
+        assert!(
+            parse_hgvs(s).is_ok(),
+            "{s:?} has no decidable adjacency and must not be rejected"
+        );
+    }
+}
+
+#[test]
+fn unrelated_edits_are_unaffected() {
+    // Non-insertion edits over a multi-position span stay legal — the new
+    // rule must key on the edit being an insertion, not on span width.
+    for s in [
+        "NM_004006.2:c.79G>T",
+        "NC_000023.11:g.123_125del",
+        "NC_000023.11:g.123_125dup",
+        "NC_000023.11:g.123_125inv",
+        "NC_000023.11:g.123_125delinsTTT",
+        "NP_003997.1:p.Arg97fsTer2",
+        "NP_003997.1:p.Lys23_Asn25del",
+        "NP_003997.1:p.Lys23_Asn25delinsTrp",
+    ] {
+        assert_accepts(s, s);
+    }
+}

--- a/tests/it/issue_1079_immediate_ter_frameshift.rs
+++ b/tests/it/issue_1079_immediate_ter_frameshift.rs
@@ -1,0 +1,107 @@
+//! MUST-level rejection of a frameshift that terminates immediately —
+//! `p.Tyr4TerfsTer1` (#1079).
+//!
+//! # Spec
+//!
+//! `recommendations/protein/frameshift.md:22`:
+//!
+//! > **NOTE**: the shortest frameshift variant possible contains `fsTer2`;
+//! > variants which introduce an **immediate** translation termination (stop)
+//! > codon are described as nonsense variant, e.g., `p.Tyr4Ter` (or
+//! > `p.Tyr4*`) not `p.Tyr4TerfsTer1`.
+//!
+//! `recommendations/protein/substitution.md:20` says the same from the
+//! substitution side ("**NOTE**: not `p.Tyr4TerfsTer1`, but `p.Tyr4Ter`").
+//!
+//! # `fsTer2` is legal
+//!
+//! The spec names `fsTer2` as the *shortest possible* frameshift, so only
+//! `fsTer1` — and the equivalent short form whose first new residue is
+//! already `Ter` — is wrong. Everything from `fsTer2` up must keep parsing.
+//!
+//! # Why reject rather than canonicalise
+//!
+//! The repair is mechanical (`p.Tyr4Ter`) and the diagnostic names it
+//! verbatim, but applying it silently would change the *edit kind* the
+//! author wrote — a frameshift becomes a substitution — so it is surfaced
+//! rather than performed.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+const IMMEDIATE_TER_FRAMESHIFTS: &[&str] = &[
+    "NP_003997.1:p.Tyr4TerfsTer1",
+    "NP_003997.1:p.(Tyr4TerfsTer1)",
+    "NP_003997.1:p.Arg97ProfsTer1",
+    "NP_003997.1:p.Tyr4Terfs",
+    "NP_003997.1:p.Tyr4TerfsTer10",
+];
+
+#[test]
+fn default_parse_rejects_immediate_ter_frameshift() {
+    for input in IMMEDIATE_TER_FRAMESHIFTS {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "frameshift.md:22 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn every_mode_rejects_immediate_ter_frameshift() {
+    for config in [
+        ErrorConfig::strict(),
+        ErrorConfig::lenient(),
+        ErrorConfig::silent(),
+    ] {
+        assert!(
+            parse_hgvs_with_config("NP_003997.1:p.Tyr4TerfsTer1", config).is_err(),
+            "no mode may accept an immediately-terminating frameshift"
+        );
+    }
+}
+
+#[test]
+fn rejection_names_the_nonsense_form() {
+    let msg = parse_hgvs("NP_003997.1:p.Tyr4TerfsTer1")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        msg.contains("p.Tyr4Ter"),
+        "the diagnostic should name the nonsense form; got: {msg}"
+    );
+}
+
+// =====================================================================
+// `fsTer2` and beyond are legal and must not be touched
+// =====================================================================
+
+#[test]
+fn shortest_legal_frameshift_still_parses() {
+    for input in [
+        "NP_003997.1:p.Tyr4ValfsTer2",
+        "NP_003997.1:p.Arg456GlyfsTer17",
+        "NP_003997.1:p.Arg97ProfsTer23",
+        "NP_003997.1:p.Glu5ValfsTer5",
+        "NP_003997.1:p.Ile327ArgfsTer?",
+        "NP_003997.1:p.Arg97fs",
+        "NP_003997.1:p.His150HisfsTer10",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} is a legal frameshift and must parse"
+        );
+    }
+}
+
+/// The spec's own nonsense form — the thing `p.Tyr4TerfsTer1` should have
+/// been written as — must of course parse.
+#[test]
+fn nonsense_substitution_still_parses() {
+    for input in ["NP_003997.1:p.Tyr4Ter", "NP_003997.1:p.Tyr4*"] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must parse");
+    }
+}

--- a/tests/it/issue_1079_multibase_substitution.rs
+++ b/tests/it/issue_1079_multibase_substitution.rs
@@ -1,0 +1,166 @@
+//! MUST-level rejection of the multi-nucleotide substitution form
+//! (`c.79GC>TT`, `c.79_80GC>TT`, `g.4GC>TG`) — issue #1079.
+//!
+//! # Spec
+//!
+//! `recommendations/DNA/delins.md:73`:
+//!
+//! > Can I describe a `GC` to `TG` variant as a di-nucleotide substitution
+//! > (`g.4GC>TG`)? **No, this is not allowed.** By definition, a substitution
+//! > changes **one** nucleotide into **one** other nucleotide. The change
+//! > `TGT`GC`CA` to `TGT`TG`CA` should be described as `g.4_5delinsTG`.
+//!
+//! `recommendations/DNA/substitution.md:30` names both spellings explicitly:
+//!
+//! > based on the definition of a substitution, i.e. **one** nucleotide
+//! > replaced by **one** other nucleotide, this change can not be described as
+//! > a substitution like `c.79_80GC>TT` or `c.79GC>TT`.
+//!
+//! "not allowed" / "can not be described" is MUST-level under the spec's
+//! RFC 2119 reading (`recommendations/style.md:9`).
+//!
+//! # The defect this file pins
+//!
+//! The preprocessor (lenient/silent) already rewrote both spellings to
+//! `c.79_80delinsTT`, but the raw grammar path used by [`parse_hgvs`] accepted
+//! the single-position spelling and **silently dropped a reference base**:
+//! `c.79GC>TT` parsed as `c.79delinsTT`, which deletes one base and inserts
+//! two — a different variant from the `c.79_80delinsTT` the CLI produced for
+//! the same input. The two entry points must agree.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// The spec's own invalid spellings, paired with the canonical delins form.
+const MULTIBASE_SUBS: &[(&str, &str)] = &[
+    ("NM_004006.2:c.79GC>TT", "NM_004006.2:c.79_80delinsTT"),
+    ("NM_004006.2:c.79_80GC>TT", "NM_004006.2:c.79_80delinsTT"),
+    ("NC_000023.11:g.4GC>TG", "NC_000023.11:g.4_5delinsTG"),
+    ("NG_012232.1:g.12GC>TG", "NG_012232.1:g.12_13delinsTG"),
+];
+
+// =====================================================================
+// Default (strict) parse rejects the multi-base substitution form
+// =====================================================================
+
+#[test]
+fn default_parse_rejects_multibase_substitution() {
+    for (input, _) in MULTIBASE_SUBS {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "DNA/substitution.md:30 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn rejection_names_the_canonical_delins_form() {
+    for (input, canonical) in MULTIBASE_SUBS {
+        let msg = parse_hgvs(input).unwrap_err().to_string();
+        let edit = canonical.split(':').nth(1).unwrap();
+        assert!(
+            msg.contains(edit),
+            "the diagnostic for {input:?} should offer {edit:?}; got: {msg}"
+        );
+    }
+}
+
+// =====================================================================
+// Lenient / silent canonicalise, and both spellings converge
+// =====================================================================
+
+#[test]
+fn lenient_canonicalises_multibase_substitution() {
+    for (input, canonical) in MULTIBASE_SUBS {
+        let out = parse_hgvs_with_config(input, ErrorConfig::lenient())
+            .unwrap_or_else(|e| panic!("lenient must repair {input:?}: {e}"));
+        assert_eq!(out.result.to_string(), *canonical, "input {input:?}");
+    }
+}
+
+#[test]
+fn silent_canonicalises_multibase_substitution() {
+    for (input, canonical) in MULTIBASE_SUBS {
+        let out = parse_hgvs_with_config(input, ErrorConfig::silent())
+            .unwrap_or_else(|e| panic!("silent must repair {input:?}: {e}"));
+        assert_eq!(out.result.to_string(), *canonical, "input {input:?}");
+    }
+}
+
+#[test]
+fn point_and_range_spellings_converge() {
+    // The whole point of the fix: `c.79GC>TT` and `c.79_80GC>TT` describe the
+    // same two-base change and must not yield different variants.
+    let point = parse_hgvs_with_config("NM_004006.2:c.79GC>TT", ErrorConfig::lenient())
+        .expect("lenient must repair the point spelling");
+    let range = parse_hgvs_with_config("NM_004006.2:c.79_80GC>TT", ErrorConfig::lenient())
+        .expect("lenient must repair the range spelling");
+    assert_eq!(point.result.to_string(), range.result.to_string());
+}
+
+// =====================================================================
+// The normalizer path (`parse_hgvs` + `Normalizer`) agrees with the CLI
+// =====================================================================
+
+#[test]
+fn normalizer_path_never_sees_a_truncated_delins() {
+    // `examples/generate_spec_fixture.rs` drives `parse_hgvs` then
+    // `Normalizer<MockProvider>`. Before the fix this path produced
+    // `c.79delinsTT` — one reference base instead of two. It must now either
+    // reject (strict) or, on the repaired input, span both bases.
+    let normalizer = Normalizer::new(MockProvider::new());
+    for (input, canonical) in MULTIBASE_SUBS {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "{input:?} must not reach the normalizer as a truncated delins"
+        );
+        let repaired = parse_hgvs_with_config(input, ErrorConfig::lenient())
+            .unwrap_or_else(|e| panic!("lenient must repair {input:?}: {e}"));
+        let normalized = normalizer
+            .normalize_with_diagnostics(&repaired.result)
+            .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+        assert_eq!(normalized.result.to_string(), *canonical, "input {input:?}");
+    }
+}
+
+// =====================================================================
+// Canonical forms are untouched
+// =====================================================================
+
+#[test]
+fn single_base_substitution_still_parses() {
+    for input in [
+        "NM_004006.2:c.79G>T",
+        "NC_000023.10:g.33038255C>A",
+        "NG_012232.1(NM_004006.2):c.93+1G>T",
+        "NM_004006.3:r.79g>u",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} is a canonical one-to-one substitution and must parse"
+        );
+    }
+}
+
+#[test]
+fn canonical_delins_forms_still_parse() {
+    for input in [
+        "LRG_199t1:c.79_80delinsTT",
+        "NM_004006.2:c.145_147delinsTGG",
+        "NM_007294.3:c.2077delinsATA",
+    ] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must parse");
+    }
+}
+
+#[test]
+fn single_base_reference_is_not_affected() {
+    // Only a *multi-base reference* loses information at a point anchor. A
+    // one-base reference with a longer insert (`c.79G>TT`) already spans
+    // exactly the anchor base, so this rule does not touch it.
+    assert!(parse_hgvs("NM_004006.2:c.79G>TT").is_ok());
+}

--- a/tests/it/issue_1079_point_size_suffix.rs
+++ b/tests/it/issue_1079_point_size_suffix.rs
@@ -1,0 +1,219 @@
+//! MUST-level rejection of the size-suffix form on a single-position anchor
+//! (`g.123del3`, `g.123dup6`, `r.123del6`, `p.Arg45del6`) — issue #1079.
+//!
+//! # Spec
+//!
+//! `recommendations/checklist.md:49`:
+//!
+//! > Descriptions like `g.123del3` are not allowed, correct is `g.123_125del`.
+//!
+//! `recommendations/DNA/deletion.md:117`:
+//!
+//! > No, a deletion of more than one residue should mention the first and last
+//! > residue deleted, separated using the range symbol ("_", underscore), e.g.,
+//! > `NG_012232.1:g.123_128del` and not `NG_012232.1:g.123del6`.
+//!
+//! `recommendations/RNA/deletion.md:49` states the same for `r.123del6`, and
+//! `recommendations/DNA/duplication.md:140` for `g.123dup6`.
+//!
+//! "not allowed" is a MUST-level prohibition under the spec's RFC 2119 reading
+//! (`recommendations/style.md:9`), so the default (strict) [`parse_hgvs`] entry
+//! point rejects it on every axis, including the protein axis (`p.Arg45del6`).
+//!
+//! # Deletion is repairable; duplication is not
+//!
+//! For a deletion the spec states the canonical replacement outright — a size
+//! `N` at position `p` means `p`..`p+N-1` — so lenient/silent modes rewrite
+//! `g.123del3` to `g.123_125del` (W3011). For a duplication the spec
+//! explicitly declines to disambiguate:
+//!
+//! > Note also that from the description `g.123dup6` it is not clear whether
+//! > the duplication starts **at** position `g.123` (so `g.123_128dup`) or
+//! > **after** position 123 (so `g.124_129dup`).
+//!
+//! so there is no safe rewrite and every mode rejects (W3023).
+//!
+//! # Scope
+//!
+//! Only a **single-position** anchor is affected. A range anchor already names
+//! both endpoints (`c.100_102del3`), which is what the rule requires; the
+//! redundant size there remains a W3011/W3016 concern, not a hard rejection.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+/// Every axis's spelling of "size suffix on a single-position anchor".
+const POINT_DEL_SIZE: &[&str] = &[
+    "NC_000023.11:g.123del3",
+    "NG_012232.1:g.123del6",
+    "NM_004006.2:c.76del3",
+    "NR_002196.2:n.123del6",
+    "NM_004006.3:r.123del6",
+    "NC_012920.1:m.3243del4",
+];
+
+const POINT_DUP_SIZE: &[&str] = &[
+    "NC_000023.11:g.123dup6",
+    "NM_004006.2:c.76dup3",
+    "NM_004006.3:r.123dup6",
+];
+
+// =====================================================================
+// Default (strict) parse rejects the point size-suffix form
+// =====================================================================
+
+#[test]
+fn default_parse_rejects_point_del_size_suffix() {
+    for input in POINT_DEL_SIZE {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "checklist.md:49 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn default_parse_rejects_point_dup_size_suffix() {
+    for input in POINT_DUP_SIZE {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "duplication.md:140 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn default_parse_rejects_protein_point_del_count() {
+    let result = parse_hgvs("NP_003997.1:p.Arg45del6");
+    assert!(
+        result.is_err(),
+        "a single-residue anchor with a size count names only one endpoint; got {:?}",
+        result.map(|v| v.to_string())
+    );
+}
+
+#[test]
+fn rejection_names_the_canonical_range_form() {
+    let msg = parse_hgvs("NC_000023.11:g.123del3")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        msg.contains("123_125del"),
+        "the diagnostic should offer the canonical repair; got: {msg}"
+    );
+}
+
+// =====================================================================
+// Lenient / silent modes canonicalise the deletion form
+// =====================================================================
+
+#[test]
+fn lenient_canonicalises_point_del_size_suffix() {
+    for (input, expected) in [
+        ("NC_000023.11:g.123del3", "NC_000023.11:g.123_125del"),
+        ("NG_012232.1:g.123del6", "NG_012232.1:g.123_128del"),
+        ("NM_004006.2:c.76del3", "NM_004006.2:c.76_78del"),
+        ("NC_012920.1:m.3243del4", "NC_012920.1:m.3243_3246del"),
+    ] {
+        let out = parse_hgvs_with_config(input, ErrorConfig::lenient())
+            .unwrap_or_else(|e| panic!("lenient must repair {input:?}: {e}"));
+        assert_eq!(out.result.to_string(), expected, "input {input:?}");
+    }
+}
+
+#[test]
+fn size_one_deletion_is_redundant_not_forbidden() {
+    // `DNA/deletion.md:117` scopes the rule to a deletion "of more than one
+    // residue". `g.123del1` names exactly the anchor residue, so it is
+    // redundant rather than incomplete and stays a soft W3011 concern.
+    assert!(parse_hgvs("NC_000023.11:g.123del1").is_ok());
+}
+
+#[test]
+fn silent_canonicalises_point_del_size_suffix() {
+    let out = parse_hgvs_with_config("NG_012232.1:g.123del6", ErrorConfig::silent())
+        .expect("silent must repair the size-suffix form");
+    assert_eq!(out.result.to_string(), "NG_012232.1:g.123_128del");
+}
+
+#[test]
+fn lenient_rejects_point_dup_size_suffix() {
+    // duplication.md:140 declares the form ambiguous, so there is no safe
+    // repair — lenient rejects rather than guessing an interpretation.
+    for input in POINT_DUP_SIZE {
+        assert!(
+            parse_hgvs_with_config(input, ErrorConfig::lenient()).is_err(),
+            "lenient must not guess an interpretation for {input:?}"
+        );
+    }
+}
+
+#[test]
+fn compound_allele_members_are_handled_like_standalone() {
+    // Each `del<N>` member of a compound allele is treated the same as a
+    // standalone description: strict rejects the size-suffix form, and
+    // lenient canonicalises every member to the range form (#1079).
+    let compound = "NM_004006.2:c.[100del3;200del4]";
+    assert!(
+        parse_hgvs(compound).is_err(),
+        "strict must reject the size-suffix form in every allele member"
+    );
+    let out = parse_hgvs_with_config(compound, ErrorConfig::lenient())
+        .unwrap_or_else(|e| panic!("lenient must repair every member of {compound:?}: {e}"));
+    assert_eq!(
+        out.result.to_string(),
+        "NM_004006.2:c.[100_102del;200_203del]"
+    );
+}
+
+// =====================================================================
+// Canonical and range-anchored forms are untouched
+// =====================================================================
+
+#[test]
+fn canonical_range_forms_still_parse() {
+    for input in [
+        "NG_012232.1:g.123_128del",
+        "NG_012232.1:g.123_128dup",
+        "NG_012232.1:g.123del",
+        "NG_012232.1:g.123dup",
+        "NP_003997.1:p.Arg45del",
+        "NP_003997.1:p.Lys228_Met259del32",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} names both endpoints (or needs none) and must parse"
+        );
+    }
+}
+
+#[test]
+fn range_anchored_size_suffix_is_not_hard_rejected() {
+    // `c.100_102del3` names both endpoints, satisfying the rule this file
+    // enforces. It stays a soft (W3011/W3016) concern.
+    assert!(parse_hgvs("NM_004006.2:c.100_102del3").is_ok());
+}
+
+#[test]
+fn oversized_point_del_size_suffix_does_not_overflow() {
+    // The canonical range end is `position + size - 1`. A `u64::MAX` anchor
+    // makes that arithmetic overflow, which must not panic the preprocessor's
+    // point-del-size rewrite: the token is declined (no safe range to offer)
+    // and the anchor is still rejected downstream. Exercised in every mode.
+    let oversized = "NC_000023.11:g.18446744073709551615del3";
+    for config in [ErrorConfig::lenient(), ErrorConfig::silent()] {
+        assert!(
+            parse_hgvs_with_config(oversized, config).is_err(),
+            "{oversized:?} must be rejected, not panic"
+        );
+    }
+    assert!(
+        parse_hgvs(oversized).is_err(),
+        "{oversized:?} must be rejected, not panic"
+    );
+}

--- a/tests/it/issue_1079_residues_after_stop.rs
+++ b/tests/it/issue_1079_residues_after_stop.rs
@@ -1,0 +1,112 @@
+//! MUST-level rejection of amino acids listed *after* a translation stop in
+//! an inserted peptide — `p.Cys5_Ser6delinsTerGluAsp` (#1079).
+//!
+//! # Spec
+//!
+//! `recommendations/protein/delins.md:45`:
+//!
+//! > **NOTE**: the deletion-insertion is not described as
+//! > `delinsSerSerTerAlaAsp`, amino acids after the translation termination
+//! > codon are **not** listed.
+//!
+//! `recommendations/protein/insertion.md:43` states the same for insertions:
+//!
+//! > **NOTE**: the insertion is not described as `insSerSerTerAlaPro`; amino
+//! > acids after the translation termination codon are not listed.
+//!
+//! Translation stops at the first `Ter`, so residues written after it are
+//! not part of any protein product — listing them describes a sequence that
+//! cannot exist. Under the spec's RFC 2119 reading
+//! (`recommendations/style.md:9`) this is MUST-level.
+//!
+//! # Why reject rather than truncate
+//!
+//! Truncating at the first `Ter` is mechanical, and the diagnostic names the
+//! truncated form. It is not applied automatically because it is not always
+//! the spec's own correct description: when the insert *begins* with `Ter`,
+//! `protein/substitution.md:20` says the variant is a nonsense substitution
+//! at the preceding residue (`p.Cys5_Ser6delinsTerGluAsp` → `p.Tyr4Ter`),
+//! which needs the reference sequence. Truncating would swap one
+//! non-canonical description for another.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+const RESIDUES_AFTER_STOP: &[&str] = &[
+    "NP_003997.1:p.Cys5_Ser6delinsTerGluAsp",
+    "NP_004371.2:p.Asn47delinsSerSerTerAlaAsp",
+    "NP_004371.2:p.Pro46_Asn47insSerSerTerAlaPro",
+    "NP_003997.1:p.(Cys5_Ser6delinsTerGluAsp)",
+];
+
+#[test]
+fn default_parse_rejects_residues_after_stop() {
+    for input in RESIDUES_AFTER_STOP {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "delins.md:45 / insertion.md:43 forbid {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn every_mode_rejects_residues_after_stop() {
+    for config in [
+        ErrorConfig::strict(),
+        ErrorConfig::lenient(),
+        ErrorConfig::silent(),
+    ] {
+        assert!(
+            parse_hgvs_with_config("NP_003997.1:p.Cys5_Ser6delinsTerGluAsp", config).is_err(),
+            "no mode may accept residues listed after a stop"
+        );
+    }
+}
+
+#[test]
+fn rejection_names_the_truncated_form() {
+    let msg = parse_hgvs("NP_004371.2:p.Asn47delinsSerSerTerAlaAsp")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        msg.contains("SerSerTer"),
+        "the diagnostic should name the truncated peptide; got: {msg}"
+    );
+}
+
+// =====================================================================
+// Inserts that stop at their own end — every spec example must parse
+// =====================================================================
+
+#[test]
+fn peptides_ending_at_the_stop_still_parse() {
+    for input in [
+        "NP_004371.2:p.(Asn47delinsSerSerTer)",
+        "NP_003997.1:p.(Pro578_Lys579delinsLeuTer)",
+        "NP_003997.1:p.(Met3_His4insGlyTer)",
+        "NP_004371.2:p.(Pro46_Asn47insSerSerTer)",
+        "NP_003997.1:p.Cys28delinsTrpVal",
+        "NP_003997.1:p.Cys28_Lys29delinsTrp",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} lists nothing after the stop and must parse"
+        );
+    }
+}
+
+/// `insTer<n>` / `ins*<n>` gives the *position* of the stop inside the
+/// inserted sequence rather than spelling residues out, so nothing can
+/// follow the stop and the rule does not apply.
+#[test]
+fn stop_position_insertion_form_is_untouched() {
+    for input in [
+        "NP_003997.1:p.Lys2_Leu3insTer12",
+        "NP_060250.2:p.Gln746_Lys747ins*63",
+    ] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
+    }
+}

--- a/tests/it/issue_1079_single_nucleotide_inversion.rs
+++ b/tests/it/issue_1079_single_nucleotide_inversion.rs
@@ -1,0 +1,109 @@
+//! MUST-level rejection of a one-nucleotide inversion — `g.234inv`,
+//! `r.234inv` (#1079).
+//!
+//! # Spec
+//!
+//! `recommendations/DNA/inversion.md:16`:
+//!
+//! > by definition, the region inverted (`positions_inverted`) contains
+//! > **more than one nucleotide**. The description `g.234inv` is therefore
+//! > not allowed; a one-nucleotide inversion should be described as a
+//! > substitution.
+//!
+//! "not allowed" is MUST-level under the spec's RFC 2119 reading
+//! (`recommendations/style.md:9`).
+//!
+//! # Why reject rather than canonicalise
+//!
+//! The spec's replacement is a substitution, whose reference and alternative
+//! bases are the base at that position and its complement. Neither is
+//! recoverable from the description alone — it takes the reference sequence,
+//! which the parser does not have — so there is no canonical form to rewrite
+//! to and every mode rejects.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+const POINT_INVERSIONS: &[&str] = &[
+    "NC_000023.11:g.234inv",
+    "NM_004006.3:r.234inv",
+    "NM_004006.2:c.76inv",
+    "NR_002196.2:n.123inv",
+    "NC_012920.1:m.3243inv",
+];
+
+#[test]
+fn default_parse_rejects_single_nucleotide_inversion() {
+    for input in POINT_INVERSIONS {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "inversion.md:16 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn every_mode_rejects_single_nucleotide_inversion() {
+    for config in [
+        ErrorConfig::strict(),
+        ErrorConfig::lenient(),
+        ErrorConfig::silent(),
+    ] {
+        assert!(
+            parse_hgvs_with_config("NC_000023.11:g.234inv", config).is_err(),
+            "no mode may accept a one-nucleotide inversion"
+        );
+    }
+}
+
+#[test]
+fn rejection_points_at_the_substitution_form() {
+    let msg = parse_hgvs("NC_000023.11:g.234inv").unwrap_err().to_string();
+    assert!(
+        msg.contains("substitution"),
+        "the diagnostic should name the substitution form; got: {msg}"
+    );
+}
+
+/// A range that collapses to one nucleotide is the same description written
+/// differently and is rejected too.
+#[test]
+fn degenerate_range_inversion_is_rejected() {
+    assert!(parse_hgvs("NC_000023.11:g.234_234inv").is_err());
+}
+
+// =====================================================================
+// Multi-nucleotide inversions — every spec example must keep parsing
+// =====================================================================
+
+#[test]
+fn multi_nucleotide_inversions_still_parse() {
+    for input in [
+        "NC_000001.11:g.1234_2345inv",
+        "NC_000023.10:g.32361330_32361333inv",
+        "NM_004006.2:c.5657_5660inv",
+        "NM_004006.3:r.123_345inv",
+        "NM_003079.4:c.374_395inv",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} inverts more than one nucleotide and must parse"
+        );
+    }
+}
+
+/// An inverted *inserted range* (`ins<a>_<b>inv`, the spec's inverted-
+/// duplication form) is an insertion, not an inversion edit, so the rule
+/// does not reach it even though its anchor spans two positions.
+#[test]
+fn inverted_insertion_source_is_untouched() {
+    for input in [
+        "NM_004006.3:r.234_235ins123_234inv",
+        "NM_004006.2:c.849_850ins850_900inv",
+    ] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
+    }
+}

--- a/tests/it/issue_1079_start_loss_substitution.rs
+++ b/tests/it/issue_1079_start_loss_substitution.rs
@@ -1,0 +1,139 @@
+//! MUST-level rejection of a translation-initiation-codon variant described
+//! as a plain amino-acid substitution — `p.Met1Thr`, `p.(Met1Val)` (#1079).
+//!
+//! # Spec
+//!
+//! `recommendations/protein/substitution.md:49`:
+//!
+//! > **no protein: `LRG_199p1:p.0`** … `LRG_199p1:p.0?` can be used when you
+//! > predict that no protein is produced. Do not use descriptions like
+//! > `p.Met1Thr`, this is for sure **not** the consequence of the effect on
+//! > protein translation.
+//!
+//! `recommendations/checklist.md:65`:
+//!
+//! > the description `p.(Met1Val)` is not allowed (see Protein).
+//!
+//! "Do not use" / "is not allowed" is MUST-level under the spec's RFC 2119
+//! reading (`recommendations/style.md:9`).
+//!
+//! `recommendations/protein/extension.md:28` rules out the sibling
+//! `p.Met1Valext-4` form for the same reason:
+//!
+//! > this variant is **not** described as an extension (`p.Met1Valext-4`)
+//! > since `Met1`, part of the normal amino acid sequence, is changed.
+//!
+//! # Why reject rather than canonicalise
+//!
+//! The spec names three correct forms — `p.0` (no protein produced), `p.0?`
+//! (predicted no protein) and `p.(Met1?)` (consequence unknown) — and which
+//! one applies depends on evidence the description does not carry. Picking
+//! one for the author would assert a finding they never made, so every mode
+//! rejects and the diagnostic lists all three.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::parse_hgvs;
+
+const START_LOSS_SUBSTITUTIONS: &[&str] = &[
+    "NP_003997.1:p.Met1Thr",
+    "NP_003997.1:p.(Met1Val)",
+    "NP_003997.1:p.Met1Val",
+    "NP_003997.1:p.M1T",
+];
+
+#[test]
+fn default_parse_rejects_start_loss_substitution() {
+    for input in START_LOSS_SUBSTITUTIONS {
+        let result = parse_hgvs(input);
+        assert!(
+            result.is_err(),
+            "substitution.md:49 forbids {input:?}; got {:?}",
+            result.map(|v| v.to_string())
+        );
+    }
+}
+
+#[test]
+fn every_mode_rejects_start_loss_substitution() {
+    for config in [
+        ErrorConfig::strict(),
+        ErrorConfig::lenient(),
+        ErrorConfig::silent(),
+    ] {
+        assert!(
+            parse_hgvs_with_config("NP_003997.1:p.Met1Thr", config).is_err(),
+            "no mode may accept a start-loss substitution"
+        );
+    }
+}
+
+#[test]
+fn rejection_lists_the_three_spec_forms() {
+    let msg = parse_hgvs("NP_003997.1:p.Met1Thr").unwrap_err().to_string();
+    for expected in ["p.0", "p.0?", "p.(Met1?)"] {
+        assert!(
+            msg.contains(expected),
+            "the diagnostic should offer {expected}; got: {msg}"
+        );
+    }
+}
+
+// =====================================================================
+// The spec-sanctioned start-codon descriptions still parse
+// =====================================================================
+
+#[test]
+fn spec_sanctioned_start_codon_forms_parse() {
+    for input in [
+        "NP_003997.1:p.0",
+        "NP_003997.1:p.0?",
+        "NP_003997.1:p.(Met1?)",
+        "NP_003997.1:p.Met1?",
+        "NP_003997.1:p.Met1=",
+        "NP_003997.1:p.Met1del",
+        "NP_003997.1:p.Leu2_Met124del",
+        "NP_003997.1:p.Met1_Leu2insArgSerThrVal",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} is a spec example and must parse"
+        );
+    }
+}
+
+/// An N-terminal extension that *renames* `Met1` is forbidden for the same
+/// reason (`protein/extension.md:28`: "this variant is **not** described as
+/// an extension … since `Met1`, part of the normal amino acid sequence, is
+/// changed"). Its replacement is the insertion form, which needs the
+/// inserted residues, so there is nothing to canonicalise to.
+#[test]
+fn renaming_extension_at_the_initiator_is_rejected() {
+    assert!(parse_hgvs("NP_003997.1:p.Met1Valext-4").is_err());
+}
+
+/// A plain N-terminal extension leaves `Met1` alone and is the spec's own
+/// example, so it must keep parsing.
+#[test]
+fn plain_n_terminal_extension_is_untouched() {
+    for input in [
+        "NP_003997.1:p.Met1ext-5",
+        "NP_003997.2:p.Met1ext-5",
+        "NP_003997.1:p.(Met1ext-8)",
+    ] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
+    }
+}
+
+/// Substitutions at any other position, and at position 1 of a reference
+/// whose first residue is not the initiator methionine, are unaffected.
+#[test]
+fn ordinary_substitutions_are_untouched() {
+    for input in [
+        "NP_003997.1:p.Met2Thr",
+        "NP_003997.1:p.Trp24Cys",
+        "NP_003997.1:p.(Arg727Ser)",
+    ] {
+        assert!(parse_hgvs(input).is_ok(), "{input:?} must still parse");
+    }
+}

--- a/tests/it/issue_1092_stated_substitution_reference.rs
+++ b/tests/it/issue_1092_stated_substitution_reference.rs
@@ -1,0 +1,225 @@
+//! The stated reference run of a `NN>MM` substitution survives parsing — issue #1092.
+//!
+//! # The defect
+//!
+//! `parse_multibase_substitution` folded `GC>TT` into
+//! `NaEdit::Delins { deleted: None, deleted_length: None, inserted: "TT" }`,
+//! discarding the stated reference run `GC` at parse time. Three consequences:
+//!
+//! 1. `docs/syntax.yaml:209` (`dna.sub`) has **no** production omitting
+//!    `reference_sequence` — the bases are a required element of that input
+//!    form, so ferro dropped a mandatory field.
+//! 2. ferro already validates the neighbouring spelling: `validate_reference`
+//!    checks a stated `delGCinsTT` deleted run against the reference (#486).
+//!    So the *deprecated* spelling was verified while the *forbidden* one,
+//!    asserting the identical thing, was not.
+//! 3. The MUST-level rejection added for #1079 was **source-keyed** — it
+//!    re-read the input string, so it could not fire for an AST composed
+//!    programmatically, by projection, or by round-trip.
+//!
+//! # The fix under test
+//!
+//! `NaEdit::Delins` gains a `substitution_reference: Option<Sequence>`
+//! provenance field, set only by the `>` spelling. `Display` ignores it (the
+//! canonical short form `delinsTT` is preserved — rendering `delGCinsTT`
+//! would swap one non-conformant output for another, see `DNA/delins.md:29`),
+//! the rejection rule keys off it instead of the source string, and
+//! `validate_reference` feeds it to the same check `deleted` already gets.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::edit::{InsertedSequence, NaEdit, Sequence};
+use ferro_hgvs::hgvs::interval::CdsInterval;
+use ferro_hgvs::hgvs::location::CdsPos;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+use ferro_hgvs::hgvs::parser::variant::validate_no_multibase_substitution;
+use ferro_hgvs::hgvs::variant::{Accession, CdsVariant, LocEdit};
+use ferro_hgvs::normalize::NormalizationWarning;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, Normalizer};
+use std::str::FromStr;
+
+use crate::common::synthetic::SyntheticBuilder;
+
+/// The spec's own invalid spellings, paired with the canonical delins form.
+const MULTIBASE_SUBS: &[(&str, &str)] = &[
+    ("NM_004006.2:c.79GC>TT", "NM_004006.2:c.79_80delinsTT"),
+    ("NM_004006.2:c.79_80GC>TT", "NM_004006.2:c.79_80delinsTT"),
+    ("NC_000023.11:g.4GC>TG", "NC_000023.11:g.4_5delinsTG"),
+];
+
+/// `NM_TEST.1:c.79_80GC>TT` as an AST, built by hand — never parsed.
+fn programmatic_multibase_sub() -> HgvsVariant {
+    HgvsVariant::Cds(CdsVariant {
+        accession: Accession::new("NM", "TEST", Some(1)),
+        gene_symbol: None,
+        loc_edit: LocEdit::new(
+            CdsInterval::new(CdsPos::new(79), CdsPos::new(80)),
+            NaEdit::Delins {
+                sequence: InsertedSequence::Literal(Sequence::from_str("TT").unwrap()),
+                deleted: None,
+                deleted_length: None,
+                substitution_reference: Some(Sequence::from_str("GC").unwrap()),
+            },
+        ),
+    })
+}
+
+// =====================================================================
+// 1. Display is unchanged — the stated run is preserved, never rendered
+// =====================================================================
+
+#[test]
+fn display_never_renders_the_deprecated_del_ins_spelling() {
+    // The whole reason for a separate provenance field: reusing `deleted`
+    // would render `c.79_80delGCinsTT`, the spelling `DNA/delins.md:29-30`
+    // tells you not to use.
+    let rendered = programmatic_multibase_sub().to_string();
+    assert_eq!(rendered, "NM_TEST.1:c.79_80delinsTT");
+    assert!(
+        !rendered.contains("delGCins"),
+        "the stated run must be preserved in the AST but never rendered; got {rendered}"
+    );
+}
+
+#[test]
+fn lenient_and_silent_display_is_unchanged() {
+    for (input, canonical) in MULTIBASE_SUBS {
+        for config in [ErrorConfig::lenient(), ErrorConfig::silent()] {
+            let out = parse_hgvs_with_config(input, config)
+                .unwrap_or_else(|e| panic!("must repair {input:?}: {e}"));
+            let rendered = out.result.to_string();
+            assert_eq!(rendered, *canonical, "input {input:?}");
+            assert!(
+                !rendered.contains("delGCinsTT") && !rendered.contains("delGCinsTG"),
+                "input {input:?} rendered the deprecated explicit form: {rendered}"
+            );
+        }
+    }
+}
+
+// =====================================================================
+// 2. Strict mode still rejects, naming the canonical repair (#1079)
+// =====================================================================
+
+#[test]
+fn strict_still_rejects_and_names_the_canonical_repair() {
+    for (input, canonical) in MULTIBASE_SUBS {
+        let err = parse_hgvs(input)
+            .expect_err(&format!("DNA/substitution.md:30 forbids {input:?}"))
+            .to_string();
+        let edit = canonical.split(':').nth(1).unwrap();
+        assert!(
+            err.contains(edit),
+            "the diagnostic for {input:?} should offer {edit:?}; got: {err}"
+        );
+    }
+}
+
+// =====================================================================
+// 3. The rule is AST-keyed: it fires on a variant that was never parsed
+// =====================================================================
+
+#[test]
+fn programmatically_built_multibase_substitution_is_rejected() {
+    let variant = programmatic_multibase_sub();
+    let err = validate_no_multibase_substitution(&variant)
+        .expect_err("an AST carrying a multi-base stated reference run must be rejected")
+        .to_string();
+    assert!(
+        err.contains("c.79_80delinsTT"),
+        "the diagnostic must name the canonical repair; got: {err}"
+    );
+}
+
+#[test]
+fn ordinary_delins_ast_is_accepted() {
+    // Same edit without the `>` provenance — a plain `c.79_80delinsTT` — is
+    // conformant and must pass the same AST-keyed rule.
+    let variant = HgvsVariant::Cds(CdsVariant {
+        accession: Accession::new("NM", "TEST", Some(1)),
+        gene_symbol: None,
+        loc_edit: LocEdit::new(
+            CdsInterval::new(CdsPos::new(79), CdsPos::new(80)),
+            NaEdit::Delins {
+                sequence: InsertedSequence::Literal(Sequence::from_str("TT").unwrap()),
+                deleted: None,
+                deleted_length: None,
+                substitution_reference: None,
+            },
+        ),
+    });
+    assert!(validate_no_multibase_substitution(&variant).is_ok());
+}
+
+// =====================================================================
+// 4. The legal single-base substitution is untouched
+// =====================================================================
+
+#[test]
+fn single_base_substitution_is_unaffected() {
+    for input in [
+        "NM_004006.2:c.79G>T",
+        "NC_000023.10:g.33038255C>A",
+        "NM_004006.3:r.79g>u",
+    ] {
+        let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("{input:?} must parse: {e}"));
+        assert_eq!(variant.to_string(), *input);
+        assert!(validate_no_multibase_substitution(&variant).is_ok());
+    }
+}
+
+// =====================================================================
+// 5. Lenient/silent now report a false stated reference
+// =====================================================================
+
+/// A synthetic genomic contig whose bases at 257_258 are `AC`, so a stated
+/// `GC` run is a *false* claim about the reference.
+fn synthetic_genome() -> ferro_hgvs::MockProvider {
+    // Core starts at 1-based position 257 (see `common::synthetic`).
+    SyntheticBuilder::genomic("ACGTACGTACGTACGT").build()
+}
+
+#[test]
+fn lenient_reports_a_false_stated_reference_run() {
+    let normalizer = Normalizer::new(synthetic_genome());
+    // Reference at 257_258 is "AC"; the input claims "GC".
+    let parsed = parse_hgvs_with_config("NC_TEST.1:g.257_258GC>TT", ErrorConfig::lenient())
+        .expect("lenient must repair the multi-base substitution");
+    let out = normalizer
+        .normalize_with_diagnostics(&parsed.result)
+        .expect("normalize");
+    let mismatch = out.warnings.iter().find_map(|w| match w {
+        NormalizationWarning::RefSeqMismatch {
+            stated_ref,
+            actual_ref,
+            ..
+        } => Some((stated_ref.clone(), actual_ref.clone())),
+        _ => None,
+    });
+    let (stated, actual) = mismatch.unwrap_or_else(|| {
+        panic!(
+            "a false stated reference run must be diagnosed, not silently dropped; \
+             warnings were {:?}",
+            out.warnings
+        )
+    });
+    assert_eq!(stated, "GC");
+    assert_eq!(actual, "AC");
+}
+
+#[test]
+fn lenient_stays_quiet_when_the_stated_run_is_true() {
+    let normalizer = Normalizer::new(synthetic_genome());
+    // Reference at 257_258 really is "AC".
+    let parsed = parse_hgvs_with_config("NC_TEST.1:g.257_258AC>TT", ErrorConfig::lenient())
+        .expect("lenient must repair the multi-base substitution");
+    let out = normalizer
+        .normalize_with_diagnostics(&parsed.result)
+        .expect("normalize");
+    assert!(
+        !out.warnings
+            .iter()
+            .any(|w| matches!(w, NormalizationWarning::RefSeqMismatch { .. })),
+        "a true stated reference run must not warn; got {:?}",
+        out.warnings
+    );
+}

--- a/tests/it/issue_224_protein_extension_ter.rs
+++ b/tests/it/issue_224_protein_extension_ter.rs
@@ -93,9 +93,12 @@ mod n_terminal_extension {
         assert_round_trips("NP_003997.1:p.Met1ext-5");
     }
 
+    /// A longer upstream offset still round-trips. The probe deliberately
+    /// does *not* rename `Met1` — `p.Met1Valext-12` is forbidden by
+    /// `protein/extension.md:28` and rejected since #1079.
     #[test]
-    fn met_loss_with_new_aa_round_trips() {
-        assert_round_trips("NP_003997.1:p.Met1Valext-12");
+    fn met_loss_long_offset_round_trips() {
+        assert_round_trips("NP_003997.1:p.Met1ext-12");
     }
 }
 

--- a/tests/it/issue_228_vcf_annotate_extension_stop_loss.rs
+++ b/tests/it/issue_228_vcf_annotate_extension_stop_loss.rs
@@ -69,10 +69,11 @@ mod extension_is_stop_loss {
     /// N-terminal extension (Met loss) — start position is `Met1`, no
     /// `Ter` substring at all. Still must classify as StopLoss because
     /// Extension semantics are about gain-of-translated-sequence on
-    /// either terminus.
+    /// either terminus. The probe uses the plain form; the residue-renaming
+    /// `p.Met1Valext-12` is forbidden by `protein/extension.md:28`.
     #[test]
     fn n_terminal_extension_classifies_as_stop_loss() {
-        let ann = protein_annotation("NP_003997.1:p.Met1Valext-12");
+        let ann = protein_annotation("NP_003997.1:p.Met1ext-12");
         assert_eq!(determine_consequence(&ann), Consequence::StopLoss);
     }
 

--- a/tests/it/issue_277_trans_allele_protein_zero.rs
+++ b/tests/it/issue_277_trans_allele_protein_zero.rs
@@ -125,7 +125,7 @@ mod compact_form {
     /// preserves shape.
     #[test]
     fn compact_trans_allele_three_member_zero_middle_routes_to_no_protein() {
-        let input = "NP_003997.2:p.[Arg97Trp];[0];[Met1Val]";
+        let input = "NP_003997.2:p.[Arg97Trp];[0];[Met2Val]";
         let parsed = parse_hgvs(input).expect("parse 3-member compact trans-allele with [0] mid");
 
         let allele = match &parsed {

--- a/tests/it/issue_280_refseqmismatch_corrected_flag.rs
+++ b/tests/it/issue_280_refseqmismatch_corrected_flag.rs
@@ -373,7 +373,7 @@ mod delins_mismatched_stated_ref {
 // SECTION 7 — Numeric del<N> length mismatch → corrected: true
 // =============================================================================
 //
-// `c.5del4` (single position, span 1) states length 4 → the Deletion arm's
+// `c.5_6del4` (span 2) states length 4 → the Deletion arm's
 // numeric-length check (#486) fires a RefSeqMismatch. `canonicalize_edit`
 // strips `length`, so the `corrected` flag is honest at `true`.
 
@@ -383,7 +383,7 @@ mod del_numeric_length_mismatch {
     #[test]
     fn del_numeric_length_mismatch_corrected_true() {
         let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
-        let v = parse_hgvs("NM_TEST.1:c.5del4").expect("parse");
+        let v = parse_hgvs("NM_TEST.1:c.5_6del4").expect("parse");
         let r = normalizer
             .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");
@@ -400,7 +400,7 @@ mod del_numeric_length_mismatch {
 // SECTION 7b — Numeric dup<N> length mismatch → corrected: true
 // =============================================================================
 //
-// `c.5dup4` (single position, span 1) states length 4 → the Duplication arm's
+// `c.5_6dup4` (span 2) states length 4 → the Duplication arm's
 // numeric-length check (#486) fires a RefSeqMismatch. `canonicalize_edit`
 // strips `length`, so the `corrected` flag is honest at `true`.
 
@@ -410,7 +410,7 @@ mod dup_numeric_length_mismatch {
     #[test]
     fn dup_numeric_length_mismatch_corrected_true() {
         let normalizer = Normalizer::with_config(tx_provider(), NormalizeConfig::lenient());
-        let v = parse_hgvs("NM_TEST.1:c.5dup4").expect("parse");
+        let v = parse_hgvs("NM_TEST.1:c.5_6dup4").expect("parse");
         let r = normalizer
             .normalize_with_diagnostics(&v)
             .expect("normalize must not reject in lenient");

--- a/tests/it/issue_390_hgvs_vcf_provider_coverage.rs
+++ b/tests/it/issue_390_hgvs_vcf_provider_coverage.rs
@@ -375,6 +375,7 @@ mod c_axis_edit_kind_matrix {
                     sequence: InsertedSequence::Literal(Sequence::from_str("TTCC").unwrap()),
                     deleted: Some(Sequence::from_str("TGC").unwrap()),
                     deleted_length: None,
+                    substitution_reference: None,
                 },
             ),
         })

--- a/tests/it/issue_394_delins_frameshift_classifier.rs
+++ b/tests/it/issue_394_delins_frameshift_classifier.rs
@@ -385,6 +385,7 @@ fn delins_uncertain_range_insert_alt_len_unknown_falls_back_to_false() {
         sequence: InsertedSequence::Range(10, 20),
         deleted: None,
         deleted_length: None,
+        substitution_reference: None,
     };
     let (kind, is_fs, ref_len, alt_len) = analyze_na_edit(&edit, Some(3));
     assert_eq!(kind, "delins");
@@ -407,6 +408,7 @@ fn delins_empty_insert_with_known_span_is_pure_deletion() {
         sequence: InsertedSequence::Empty,
         deleted: None,
         deleted_length: None,
+        substitution_reference: None,
     };
     let (_, is_fs, ref_len, alt_len) = analyze_na_edit(&edit, Some(3));
     assert_eq!(ref_len, 3);

--- a/tests/it/issue_394_delins_mutex_validation.rs
+++ b/tests/it/issue_394_delins_mutex_validation.rs
@@ -22,6 +22,7 @@ fn validation_rejects_delins_with_both_deleted_and_deleted_length() {
         sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
         deleted: Some(Sequence::from_str("ATGC").unwrap()),
         deleted_length: Some(4),
+        substitution_reference: None,
     };
     let result = validate_na_edit(&edit);
     assert!(
@@ -48,6 +49,7 @@ fn validation_accepts_delins_with_deleted_only() {
         sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
         deleted: Some(Sequence::from_str("ATGC").unwrap()),
         deleted_length: None,
+        substitution_reference: None,
     };
     let result = validate_na_edit(&edit);
     assert!(
@@ -63,6 +65,7 @@ fn validation_accepts_delins_with_deleted_length_only() {
         sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
         deleted: None,
         deleted_length: Some(4),
+        substitution_reference: None,
     };
     let result = validate_na_edit(&edit);
     assert!(
@@ -78,6 +81,7 @@ fn validation_accepts_canonical_short_form_delins() {
         sequence: InsertedSequence::Literal(Sequence::from_str("G").unwrap()),
         deleted: None,
         deleted_length: None,
+        substitution_reference: None,
     };
     let result = validate_na_edit(&edit);
     assert!(

--- a/tests/it/issue_395_rna_u_to_t_plus_strand.rs
+++ b/tests/it/issue_395_rna_u_to_t_plus_strand.rs
@@ -124,6 +124,7 @@ fn plus_strand_delins_u_in_both_translates_both() {
         sequence: InsertedSequence::Literal("CU".parse::<Sequence>().unwrap()),
         deleted: Some("AUU".parse::<Sequence>().unwrap()),
         deleted_length: None,
+        substitution_reference: None,
     };
     let g_edit = transform_edit_for_strand(&r_edit, Strand::Plus);
     let expected_del: Sequence = "ATT".parse().unwrap();

--- a/tests/it/issue_486_numeric_length_mismatch.rs
+++ b/tests/it/issue_486_numeric_length_mismatch.rs
@@ -43,12 +43,12 @@ fn assert_rejects(input: &str) {
 
 #[test]
 fn del_numeric_length_mismatch_rejects() {
-    assert_rejects("NM_TEST.1:c.5del4"); // span 1 != 4
+    assert_rejects("NM_TEST.1:c.5_6del4"); // span 2 != 4
 }
 
 #[test]
 fn dup_numeric_length_mismatch_rejects() {
-    assert_rejects("NM_TEST.1:c.5dup4"); // span 1 != 4
+    assert_rejects("NM_TEST.1:c.5_6dup4"); // span 2 != 4
 }
 
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -93,6 +93,7 @@ mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
 mod issue_1079_immediate_ter_frameshift;
 mod issue_1079_point_size_suffix;
+mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
 mod issue_129_mt_circular_wraparound;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -91,6 +91,7 @@ mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
+mod issue_1079_flanking_insertion_anchor;
 mod issue_1079_immediate_ter_frameshift;
 mod issue_1079_multibase_substitution;
 mod issue_1079_point_size_suffix;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -92,6 +92,7 @@ mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
 mod issue_1079_point_size_suffix;
+mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -98,6 +98,7 @@ mod issue_1079_point_size_suffix;
 mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
+mod issue_1092_stated_substitution_reference;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -91,6 +91,7 @@ mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
+mod issue_1079_point_size_suffix;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -91,6 +91,7 @@ mod issue_1044_mito_window_clamp;
 mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
+mod issue_1079_immediate_ter_frameshift;
 mod issue_1079_point_size_suffix;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -92,6 +92,7 @@ mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
 mod issue_1079_point_size_suffix;
+mod issue_1079_start_loss_substitution;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -92,6 +92,7 @@ mod issue_1046_generator_gitdir_leak;
 mod issue_1052_substitution_refseq;
 mod issue_1063_preserve_uncertain_wrapper;
 mod issue_1079_immediate_ter_frameshift;
+mod issue_1079_multibase_substitution;
 mod issue_1079_point_size_suffix;
 mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -1757,10 +1757,11 @@ mod clinvar_normalization {
 
     #[rstest]
     // Insertions at antisense/inverted positions
-    #[case(
-        "NC_000011.10:g.5238138_5153222insTATTT",
-        "NC_000011.10:g.5238138_5153222insTATTT"
-    )]
+    // NOTE: `NC_000011.10:g.5238138_5153222insTATTT` used to be the first
+    // case here. Since #1079 the parser refuses it — an insertion anchor MUST
+    // name two flanking positions listed 5' to 3' (`DNA/insertion.md:15-16`)
+    // — so it never reaches normalization. Rejection coverage lives in
+    // `issue_1079_flanking_insertion_anchor.rs`.
     // NG uncertain position variants
     #[case(
         "NG_011403.2:g.(80027_96047)_(99154_121150)del",

--- a/tests/it/parser_tests.rs
+++ b/tests/it/parser_tests.rs
@@ -425,10 +425,11 @@ fn test_expected_parse_errors(#[case] input: &str, #[case] _description: &str) {
     "NC_000016.9:g.23634775_23621090dup",
     "NC_000016.9:g.23634775_23621090dup"
 )]
-#[case(
-    "NC_000011.10:g.5238138_5153222insTATTT",
-    "NC_000011.10:g.5238138_5153222insTATTT"
-)]
+// NOTE: the sibling ClinVar record `NC_000011.10:g.5238138_5153222insTATTT`
+// used to live here. Since #1079 it is refused: an insertion anchor MUST name
+// two flanking positions listed 5' to 3' (`DNA/insertion.md:15-16`), and this
+// one is descending and 85 kb wide. See
+// `issue_1079_flanking_insertion_anchor.rs` for the rejection coverage.
 // Unknown variant
 #[case("NM_001412270.1:c.?dup", "NM_001412270.1:c.?dup")]
 // Embedded accession insertions

--- a/tests/it/property_tests.rs
+++ b/tests/it/property_tests.rs
@@ -422,6 +422,11 @@ fn protein_substitution() -> impl Strategy<Value = String> {
         amino_acid(),
     )
         .prop_filter("ref != alt", |(_, _, r, _, a)| r != a)
+        // `p.Met1<aa>` is spec-forbidden (protein/substitution.md:49) — a
+        // start-codon variant is described as `p.0` / `p.0?` / `p.(Met1?)`.
+        .prop_filter("not a start-loss substitution", |(_, _, r, pos, _)| {
+            !(*pos == 1 && (*r == "Met" || *r == "M"))
+        })
         .prop_map(|(num, ver, ref_aa, pos, alt_aa)| {
             format!("NP_{}.{}:p.{}{}{}", num, ver, ref_aa, pos, alt_aa)
         })
@@ -437,6 +442,11 @@ fn protein_substitution_single() -> impl Strategy<Value = String> {
         amino_acid_single(),
     )
         .prop_filter("ref != alt", |(_, _, r, _, a)| r != a)
+        // `p.Met1<aa>` is spec-forbidden (protein/substitution.md:49) — a
+        // start-codon variant is described as `p.0` / `p.0?` / `p.(Met1?)`.
+        .prop_filter("not a start-loss substitution", |(_, _, r, pos, _)| {
+            !(*pos == 1 && *r == 'M')
+        })
         .prop_map(|(num, ver, ref_aa, pos, alt_aa)| {
             format!("NP_{}.{}:p.{}{}{}", num, ver, ref_aa, pos, alt_aa)
         })

--- a/tests/it/property_tests.rs
+++ b/tests/it/property_tests.rs
@@ -124,9 +124,18 @@ fn amino_acid_single() -> impl Strategy<Value = char> {
     ]
 }
 
-/// Generate amino acid sequence (1-5 residues)
-fn amino_acid_sequence() -> impl Strategy<Value = String> {
-    prop::collection::vec(amino_acid(), 1..=5).prop_map(|v| v.join(""))
+/// Generate an *inserted* peptide (1-5 residues), truncated at its first
+/// `Ter`. HGVS protein/delins.md:45 and protein/insertion.md:43 forbid
+/// listing amino acids after the translation termination codon, so a
+/// sequence with residues past a `Ter` is not a valid inserted peptide.
+fn inserted_peptide() -> impl Strategy<Value = String> {
+    prop::collection::vec(amino_acid(), 1..=5).prop_map(|v| {
+        let end = v
+            .iter()
+            .position(|aa| *aa == "Ter")
+            .map_or(v.len(), |i| i + 1);
+        v[..end].join("")
+    })
 }
 
 // =============================================================================
@@ -495,7 +504,7 @@ fn protein_insertion() -> impl Strategy<Value = String> {
         amino_acid(),
         1..500u64,
         amino_acid(),
-        amino_acid_sequence(),
+        inserted_peptide(),
     )
         .prop_map(|(num, ver, aa1, pos1, aa2, seq)| {
             format!(
@@ -520,7 +529,7 @@ fn protein_delins() -> impl Strategy<Value = String> {
         1..500u64,
         amino_acid(),
         1..10u64,
-        amino_acid_sequence(),
+        inserted_peptide(),
     )
         .prop_map(|(num, ver, aa1, pos1, aa2, len, seq)| {
             format!(

--- a/tests/it/strict_del_size_suffix_mode.rs
+++ b/tests/it/strict_del_size_suffix_mode.rs
@@ -5,11 +5,13 @@
 //! > `g.123del3` is invalid: pre-2016 size-suffix form. Must be
 //! > `g.123_125del`.
 //!
-//! ferro's default `parse_hgvs` is **lenient** — it accepts the legacy
-//! form, round-trips it (preserving the `<N>` as `NaEdit::Deletion.length`),
-//! and emits W3011 (DelSizeSuffix) as a non-rewriting warning. ferro cannot
-//! synthesise the end position safely because offset/intronic semantics
-//! defeat naive `start + length - 1` arithmetic.
+//! Since #1079 the default `parse_hgvs` **rejects** the form outright when
+//! the anchor is a single position (the spec's prohibition is MUST-level),
+//! and lenient/silent modes canonicalise it to the range form the spec
+//! states. An offset/intronic anchor is rejected in every mode: the form is
+//! just as forbidden (it names one endpoint of a multi-residue deletion), but
+//! `start + length - 1` arithmetic is not safe there, so no rewrite can be
+//! offered.
 //!
 //! For callers that want strict spec conformance, override
 //! `ErrorType::DelSizeSuffix` to `Reject` on the config:
@@ -67,8 +69,8 @@ fn assert_lenient_accepts(input: &str, expected_display: &str) {
 
 /// Like [`assert_lenient_accepts`], but for the legacy `del<N>` size-count
 /// form: lenient mode must accept AND surface the W3011/DelSizeSuffix
-/// warning (non-rewriting). Acceptance alone would miss a regression
-/// where `del<N>` is silently accepted with the flag dropped.
+/// warning. Acceptance alone would miss a regression where `del<N>` is
+/// silently repaired with the flag dropped.
 fn assert_lenient_accepts_with_size_warning(input: &str, expected_display: &str) {
     let out = parse_hgvs_with_config(input, lenient())
         .unwrap_or_else(|e| panic!("lenient must accept {input:?}: {e}"));
@@ -123,23 +125,35 @@ fn strict_rejects_large_size_count() {
 }
 
 // =====================================================================
-// Default lenient mode accepts `del<N>` (existing intentional behavior —
-// preserved for interop with real-world ClinVar / pre-2016 submissions)
+// Lenient mode canonicalises `del<N>` at a point anchor to the range form
+// (#1079) and still warns; intronic anchors are rejected in every mode
+// (no safe rewrite) — see `lenient_rejects_intronic_del_size_suffix`
 // =====================================================================
 
 #[test]
-fn lenient_accepts_genomic_del_size_suffix() {
-    assert_lenient_accepts_with_size_warning("NG_012232.1:g.123del6", "NG_012232.1:g.123del6");
+fn lenient_canonicalises_genomic_del_size_suffix() {
+    assert_lenient_accepts_with_size_warning("NG_012232.1:g.123del6", "NG_012232.1:g.123_128del");
 }
 
 #[test]
-fn lenient_accepts_cds_del_size_suffix() {
-    assert_lenient_accepts_with_size_warning("NM_004006.2:c.76del3", "NM_004006.2:c.76del3");
+fn lenient_canonicalises_cds_del_size_suffix() {
+    assert_lenient_accepts_with_size_warning("NM_004006.2:c.76del3", "NM_004006.2:c.76_78del");
 }
 
 #[test]
-fn lenient_accepts_mito_del_size_suffix() {
-    assert_lenient_accepts_with_size_warning("NC_012920.1:m.3243del4", "NC_012920.1:m.3243del4");
+fn lenient_canonicalises_mito_del_size_suffix() {
+    assert_lenient_accepts_with_size_warning(
+        "NC_012920.1:m.3243del4",
+        "NC_012920.1:m.3243_3246del",
+    );
+}
+
+/// An intronic anchor is just as forbidden (it names one endpoint), but
+/// `c.100+5 + 6 - 1` is not a position ferro can synthesise safely — so
+/// there is no repair to offer and every mode rejects.
+#[test]
+fn lenient_rejects_intronic_del_size_suffix() {
+    assert!(parse_hgvs_with_config("NM_004006.2:c.100+5del6", lenient()).is_err());
 }
 
 // =====================================================================


### PR DESCRIPTION
Burns down six MUST-level themes from #1079. Fixture `false-acceptance` **76 → 57** (19 rows), `correctly-rejected` **75 → 94**.

Each theme is a spec-stated prohibition ferro accepted. The spec is RFC 2119 (`recommendations/style.md:9`); every rule below is MUST-level ("is not correct" / "not allowed" / "can not be described"), verified against the vendored submodule.

| commit | theme | disposition | rows |
|---|---|---|---:|
| `16a5973` | del/dup size suffix on a point anchor | reject; lenient/silent canonicalise `g.123del6` → `g.123_128del` | 5 |
| `180006a` | start-codon written as a substitution | reject | 3 |
| `6c192ae` | one-nucleotide inversion | reject | 2 |
| `fe03955` | frameshift terminating immediately (`fsTer1`) | reject | 1 |
| `fe94bd3` | amino acids listed after a stop | reject | 1 |
| `1ce839c` | multi-nucleotide substitution (`GC>TT`) | reject; names the canonical delins | 7 |

Citations: `checklist.md:49` and `:33`, `DNA/deletion.md:117`, `DNA/duplication.md:140`, `RNA/deletion.md:49`; `protein/substitution.md:49`, `checklist.md:65`, `protein/extension.md:28`; `DNA/inversion.md:16`; `protein/substitution.md:20` and `protein/frameshift.md:39`; `protein/delins.md:45` and `protein/insertion.md:43`; `DNA/delins.md:73-77` and `DNA/substitution.md:30`.

## The last one is an architectural finding, not a spelling nit

`c.79GC>TT` produced **`c.79delinsTT`** — delete one base, insert two. That is a different variant from the stated one, silently discarding a base of the given reference.

`parse_multibase_substitution` (`src/hgvs/parser/edit.rs:188`) folds `GC>TT` into `NaEdit::Delins { deleted: None, deleted_length: None }`, discarding the reference bases; the location was already parsed, so a point anchor stays a point.

**The two entry points did not share a front end.** `parse_hgvs_with_config` (CLI) runs the preprocessor first, and `correct_old_substitution_syntax` (`src/error_handling/corrections.rs:1539`) already extended a point anchor to `start + ref_len - 1` — so the grammar never saw the lossy form. `parse_hgvs`, the strict entry point the spec-fixture generator drives, bypasses the preprocessor and hit it directly. A spec rule existed on one path and not the other.

The 7 rows that moved are exactly the spec's own invalid spellings: 4 DNA plus `r.4gc>ug`, `r.76aa>ug`, `r.76_77aa>ug`.

## Deliberate non-changes

- **`fsTer2` still parses in every mode**, and is tested. `protein/frameshift.md:22` — "the shortest frameshift variant possible contains `fsTer2`". Only `fsTer1` is wrong; flagging `fsTer2` would have been a serious false positive.
- `dup` size suffixes are reject-only in all modes: `DNA/duplication.md:143` explicitly declines to disambiguate them, so there is no derivable repair.
- Start-loss and one-nt inversion are reject-only for the same reason — the spec's three correct start-loss forms (`p.0`, `p.0?`, `p.(Met1?)`) need evidence the input does not carry, and reversing an inversion needs reference bases. The diagnostics name the alternatives.
- `ins<N>` (`checklist.md:33`) skipped: already `correctly-rejected` for an unrelated reason, so zero burn-down against real churn risk.
- `c.79G>TT` and `c.100_102>ATG` untouched — the multibase rule is filtered to reference runs of ≥ 2 bases.

## Real-data fallout — two records, both handled by the established mechanism

`tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json` already carries 82 curated kinds / 207 expected failures, of which 39 are `rejected_by_design` for spec reasons (`spec_self_cancelling_allele`, `deprecated_repeat_paren_no_brackets`, …). Two real ClinVar records join them:

- `NP_002476.2:p.Gln279ProfsTer1` — internally contradictory: `fsTer1` claims termination at codon 1 of the shifted frame while naming `Pro` there.
- `NM_003977.2:c.878_879AG>GT` — literally the spelling `DNA/substitution.md:30` names invalid, with the repair stated outright.

Both were hand-appended as `rejected_by_design` kinds. **`UPDATE_FAILURE_EXPECTATIONS=1` was deliberately not used** — it re-derives IDs from raw error strings and destroys the curated `kinds` taxonomy. That is a latent tooling bug worth its own issue.

## Known limitations

The multibase check is **source-keyed rather than AST-keyed**, because the grammar discards the reference bases and the AST cannot distinguish `c.79_80GC>TT` from a hand-written `c.79_80delinsTT`. The structural fix — preserving the reference run in `deleted` — would change `Display` for every `NN>NN` input and was not attempted here.

Themes 4 and 5 have mechanical repairs that are **not** wired into lenient mode; each needs a new W-code threaded through types, registry, python bindings, preprocessor and the audit fixture. Deferred deliberately; the diagnostics name the exact repair meanwhile.

Theme 1 changes lenient-mode behaviour: W3011/W3023 were `warn_accept`, and point-anchored size suffixes are now repaired or rejected rather than round-tripped. Two test files encoding the old contract were updated.

`NR_001566.1:c.107_108gc>ag` now trips the multibase rule before the coordinate-system rule, so its diagnostic text changed while its expectation label did not — the harness compares sets, not messages.

## Verification

`cargo nextest run --features dev` with `FERRO_MANIFEST` unset: **8113 passed, 0 failed** (8067 base + 46 new). `generate_spec_fixture -- --check` exit 0; fmt and clippy `--all-targets -D warnings` clean.

Refs #1079.
