### PR TITLE
fix(tests): make the failure-expectations blesser merge instead of regenerate

### DIFF
--- a/tests/it/common/failure_expectations.rs
+++ b/tests/it/common/failure_expectations.rs
@@ -116,16 +116,18 @@ pub struct FailureExpectations {
 /// One fixture's parse outcome handed to [`enforce`].
 ///
 /// `failures[input] = parser_error_string`. Inputs that parsed successfully
-/// are simply absent. `total_inputs` is the total number of fixture entries
-/// (used only for diagnostic eprintln output).
+/// are simply absent. `total_inputs` is the total number of fixture entries;
+/// besides diagnostic output it drives the zero-inputs safety guard in
+/// [`bless`] (a run of 0 inputs must not empty a curated snapshot), so it must
+/// reflect the real corpus size, not just the failing subset.
 pub struct FixtureCheck<'a> {
     pub total_inputs: usize,
     pub failures: BTreeMap<&'a str, String>,
 }
 
 /// Compare a fixture's parse outcome against the expectations snapshot at
-/// `expectations_path`, or regenerate the snapshot if `update_env_var` is
-/// set in the environment.
+/// `expectations_path`, or bless (non-destructively merge into) the snapshot if
+/// `update_env_var` is set in the environment.
 ///
 /// Panics on regression, improvement, undefined kind, or `parser_bug` hit
 /// — with a message that explains how to fix it (regenerate the snapshot,
@@ -175,7 +177,8 @@ pub fn enforce(expectations_path: &Path, update_env_var: &str, check: FixtureChe
         }
         msg.push_str(&format!(
             "\nIf the new failure is intended (parser change rejecting more inputs), \
-             regenerate the snapshot:\n  {}=1 cargo nextest run --features dev <test-name>\n",
+             bless the snapshot (a non-destructive merge that keeps curated kinds):\n  \
+             {}=1 cargo nextest run --features dev <test-name>\n",
             update_env_var
         ));
         errors.push(msg);
@@ -184,8 +187,8 @@ pub fn enforce(expectations_path: &Path, update_env_var: &str, check: FixtureChe
     if !improvements.is_empty() {
         let mut msg = format!(
             "{} fixture input(s) used to fail but now parse — \"improvement\". \
-             Update the snapshot to remove these entries (regenerate):\n  {}=1 cargo nextest run \
-             --features dev <test-name>\n\nShowing up to 20:\n",
+             Bless the snapshot to drop these entries (a merge; curated kinds are kept):\n  \
+             {}=1 cargo nextest run --features dev <test-name>\n\nShowing up to 20:\n",
             improvements.len(),
             update_env_var
         );
@@ -198,8 +201,8 @@ pub fn enforce(expectations_path: &Path, update_env_var: &str, check: FixtureChe
     if !undefined_kinds.is_empty() {
         let mut msg = format!(
             "{} expected_failures entry/entries reference an undefined kind. \
-             Either define the kind under \"kinds\" or regenerate the snapshot. \
-             Showing up to 20:\n",
+             Either define the kind under \"kinds\" or bless the snapshot (which writes a \
+             needs_triage placeholder). Showing up to 20:\n",
             undefined_kinds.len()
         );
         for (input, kind_id) in undefined_kinds.iter().take(20) {
@@ -332,6 +335,17 @@ pub fn bless(path: &Path, check: &FixtureCheck<'_>) -> BlessReport {
 
 /// Pure merge step of [`bless`]: updates `snapshot` in place and describes
 /// what changed. Kept separate from all I/O so it is directly testable.
+/// Merge this run's failures into `snapshot`, returning a [`BlessReport`].
+///
+/// Contract (what "merge" preserves): the hand-curated **kinds** (their
+/// category / reason / tracking prose) are never deleted — that is the whole
+/// point over the old destructive regenerate. `expected_failures`, by contrast,
+/// is rebuilt from the current run: a curated mapping whose input still fails is
+/// carried over verbatim, a newly-failing input gets an `auto:` needs-triage
+/// kind, and an input **absent from this run is treated as resolved and its
+/// mapping dropped** (its kind is kept). This assumes the run covers the full
+/// corpus; a wholly-missing dataset is caught by [`bless`]'s zero-inputs guard,
+/// but a *partial* run would silently drop the absent inputs' mappings.
 fn merge_into(snapshot: &mut FailureExpectations, check: &FixtureCheck<'_>) -> BlessReport {
     let mut report = BlessReport::default();
     let mut next_expected: BTreeMap<String, String> = BTreeMap::new();
@@ -422,11 +436,16 @@ fn print_bless_report(path: &Path, snapshot: &FailureExpectations, report: &Bles
         snapshot.kinds.len(),
         report.preserved_inputs
     );
-    let sections: [(&str, &Vec<String>); 4] = [
+    let sections: [(&str, &Vec<String>); 5] = [
         (
             "NEW failure(s) added (kind id prefixed `auto:`, category `needs_triage` — \
              rename and categorize before merge)",
             &report.new_inputs,
+        ),
+        (
+            "NEW kind id(s) synthesized for those failures (the `auto:`-prefixed ids to \
+             rename and give a real category/tracking before merge)",
+            &report.new_kinds,
         ),
         (
             "input(s) NO LONGER failing — removed from expected_failures (their kind \

--- a/tests/it/common/failure_expectations.rs
+++ b/tests/it/common/failure_expectations.rs
@@ -42,11 +42,37 @@
 //!    real category before merge (Phase 2 of #174 enforced this; new
 //!    kinds discovered after that point need triage in the same PR).
 //!
-//! Set `UPDATE_FAILURE_EXPECTATIONS=1` to regenerate the snapshot from the
-//! current parse output. Newly-observed kinds are written with category
-//! `needs_triage` and the parser's verbatim error string as `reason`;
-//! existing kinds' categories are preserved so manual triage is sticky.
-//! Any new kinds force a triage decision before the test passes.
+//! ## Re-blessing (`UPDATE_FAILURE_EXPECTATIONS=1`)
+//!
+//! Set `UPDATE_FAILURE_EXPECTATIONS=1` to update the snapshot from the
+//! current parse output. The snapshots are hand-curated — the kind ids are
+//! human-chosen names, and each `reason` is prose citing the HGVS spec.
+//! None of that is recoverable from a parser error string, so the blesser
+//! is a **merge**, never a regeneration:
+//!
+//! - An input that is already in `expected_failures` and still fails keeps
+//!   its curated kind id verbatim. Its kind's `category`, `reason`, and
+//!   `tracking` are never rewritten.
+//! - An input that fails and is *not* in `expected_failures` is added under
+//!   a synthetic kind id prefixed [`AUTO_KIND_PREFIX`] (derived from the
+//!   normalized error string) with category `needs_triage`. The prefix
+//!   makes machine-written ids obvious next to curated ones, and
+//!   `needs_triage` fails the build until a human names and categorizes it.
+//! - An input that no longer fails is removed from `expected_failures` —
+//!   leaving it would permanently fail the "improvement" check — but its
+//!   *kind* is kept, so the curated prose survives, and the removal is
+//!   printed in the bless report.
+//! - Kinds are **never deleted**, even when nothing references them any
+//!   more. Unreferenced kinds are reported so a human can delete them
+//!   deliberately; the blesser will not throw prose away on its own.
+//! - The blesser refuses to run (panics) when it cannot guarantee the
+//!   above: an unparseable snapshot, a snapshot carrying fields this
+//!   framework does not model (`deny_unknown_fields`), or a fixture run
+//!   that produced zero inputs (dataset missing/skipped — blessing would
+//!   wipe the file).
+//!
+//! Merge behaviour is covered directly by
+//! `tests/it/failure_expectations_blesser_tests.rs`.
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -72,6 +98,7 @@ pub enum Category {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Kind {
     pub category: Category,
     pub reason: String,
@@ -80,6 +107,7 @@ pub struct Kind {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct FailureExpectations {
     pub kinds: BTreeMap<String, Kind>,
     pub expected_failures: BTreeMap<String, String>,
@@ -104,7 +132,7 @@ pub struct FixtureCheck<'a> {
 /// update a category, etc.).
 pub fn enforce(expectations_path: &Path, update_env_var: &str, check: FixtureCheck<'_>) {
     if std::env::var_os(update_env_var).is_some() {
-        regenerate_snapshot(expectations_path, &check);
+        bless(expectations_path, &check);
         return;
     }
 
@@ -235,57 +263,198 @@ fn read_snapshot(path: &Path) -> FailureExpectations {
     serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {}", path.display(), e))
 }
 
-fn regenerate_snapshot(path: &Path, check: &FixtureCheck<'_>) {
-    // Preserve any existing categories/tracking so manual triage is sticky:
-    // re-read the current snapshot (if any) and only insert *new* kinds.
-    let mut existing: FailureExpectations = if path.exists() {
+/// Prefix on kind ids the blesser invents for newly-observed failures, so
+/// machine-written ids are never mistaken for hand-curated ones.
+pub const AUTO_KIND_PREFIX: &str = "auto:";
+
+/// What a bless changed, returned so callers (and tests) can inspect it
+/// instead of scraping stderr.
+#[derive(Debug, Default)]
+pub struct BlessReport {
+    /// Failing inputs whose curated kind mapping was carried over as-is.
+    pub preserved_inputs: usize,
+    /// Newly-failing inputs added to `expected_failures`.
+    pub new_inputs: Vec<String>,
+    /// Kind ids invented for those new inputs (all `needs_triage`).
+    pub new_kinds: Vec<String>,
+    /// Inputs that no longer fail; removed from `expected_failures`.
+    pub resolved_inputs: Vec<String>,
+    /// Kinds no longer referenced by any expected failure. Kept on disk.
+    pub orphaned_kinds: Vec<String>,
+    /// Kinds referenced by an expected failure but never defined; given a
+    /// `needs_triage` placeholder so the enforcing test can explain itself.
+    pub synthesized_kinds: Vec<String>,
+}
+
+/// Merge the current parse outcome into the snapshot at `path`, preserving
+/// every piece of human-authored content (see the module docs for the exact
+/// semantics), write it back, and print a report of what changed.
+///
+/// Panics rather than proceeding whenever curated content would be at risk:
+/// an unreadable/unparseable snapshot, a snapshot with fields this framework
+/// does not model, or a fixture run that produced no inputs at all.
+pub fn bless(path: &Path, check: &FixtureCheck<'_>) -> BlessReport {
+    let mut snapshot: FailureExpectations = if path.exists() {
         let raw = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
-        serde_json::from_str(&raw)
-            .unwrap_or_else(|e| panic!("parse existing {}: {}", path.display(), e))
+        serde_json::from_str(&raw).unwrap_or_else(|e| {
+            panic!(
+                "refusing to bless {}: the existing snapshot could not be parsed \
+                 ({e}). Rewriting it would destroy hand-curated kinds and reasons; \
+                 fix the file (or the framework's schema) first.",
+                path.display()
+            )
+        })
     } else {
         FailureExpectations::default()
     };
 
-    // Group failing inputs by *normalized* error string so per-input variability
-    // (position numbers and the unparsed-remainder substring inside the nom
-    // error) collapses into a small set of kinds. Phase 2 triage will rename
-    // these to nicer ids and assign categories.
-    let mut next_expected: BTreeMap<String, String> = BTreeMap::new();
-    let mut new_kinds_seen: BTreeMap<String, ()> = BTreeMap::new();
-    for (input, err) in &check.failures {
-        let kind_id = normalize_error_for_kind(err);
-        next_expected.insert((*input).to_string(), kind_id.clone());
-        new_kinds_seen.insert(kind_id, ());
+    // A fixture that yielded zero inputs means the dataset was missing or
+    // skipped, not that everything now parses. Blessing would empty the file.
+    if check.total_inputs == 0 && !snapshot.expected_failures.is_empty() {
+        panic!(
+            "refusing to bless {}: the fixture produced 0 inputs, so this run \
+             carries no evidence about the {} curated expected failure(s). \
+             Check that the fixture data is present (Git LFS) and re-run.",
+            path.display(),
+            snapshot.expected_failures.len()
+        );
     }
 
-    // Add any newly-observed kinds with NeedsTriage; preserve existing ones.
-    for kind_id in new_kinds_seen.keys() {
-        existing
-            .kinds
-            .entry(kind_id.clone())
-            .or_insert_with(|| Kind {
-                category: Category::NeedsTriage,
-                reason: kind_id.clone(),
-                tracking: None,
-            });
-    }
+    let report = merge_into(&mut snapshot, check);
 
-    // Drop kinds no longer referenced by any expected failure.
-    existing
-        .kinds
-        .retain(|kind_id, _| next_expected.values().any(|v| v == kind_id));
-
-    existing.expected_failures = next_expected;
-
-    let json = serde_json::to_string_pretty(&existing).expect("serialize FailureExpectations");
+    let json = serde_json::to_string_pretty(&snapshot).expect("serialize FailureExpectations");
     std::fs::write(path, json + "\n").unwrap_or_else(|e| panic!("write {}: {}", path.display(), e));
+
+    print_bless_report(path, &snapshot, &report);
+    report
+}
+
+/// Pure merge step of [`bless`]: updates `snapshot` in place and describes
+/// what changed. Kept separate from all I/O so it is directly testable.
+fn merge_into(snapshot: &mut FailureExpectations, check: &FixtureCheck<'_>) -> BlessReport {
+    let mut report = BlessReport::default();
+    let mut next_expected: BTreeMap<String, String> = BTreeMap::new();
+
+    for (input, err) in &check.failures {
+        match snapshot.expected_failures.get(*input) {
+            // Curated (or previously blessed) mapping: carry it over verbatim.
+            Some(kind_id) => {
+                next_expected.insert((*input).to_string(), kind_id.clone());
+                report.preserved_inputs += 1;
+            }
+            // Genuinely new failure: invent an obviously-machine-written kind
+            // id from the normalized error, awaiting human triage.
+            None => {
+                let normalized = normalize_error_for_kind(err);
+                let kind_id = format!("{}{}", AUTO_KIND_PREFIX, normalized);
+                if !snapshot.kinds.contains_key(&kind_id) {
+                    snapshot.kinds.insert(
+                        kind_id.clone(),
+                        Kind {
+                            category: Category::NeedsTriage,
+                            reason: normalized,
+                            tracking: None,
+                        },
+                    );
+                    report.new_kinds.push(kind_id.clone());
+                }
+                next_expected.insert((*input).to_string(), kind_id);
+                report.new_inputs.push((*input).to_string());
+            }
+        }
+    }
+
+    // Inputs that no longer fail: drop the mapping (keeping it would fail the
+    // "improvement" check forever) but keep the kind, so the curated reason
+    // survives and the change is visible in the report.
+    for input in snapshot.expected_failures.keys() {
+        if !next_expected.contains_key(input) {
+            report.resolved_inputs.push(input.clone());
+        }
+    }
+    snapshot.expected_failures = next_expected;
+
+    // Dangling kind references (a typo, or a hand-edit that removed a kind):
+    // give them a placeholder so the enforcing test reports `needs_triage`
+    // rather than a bare "undefined kind".
+    let dangling: Vec<String> = snapshot
+        .expected_failures
+        .values()
+        .filter(|kind_id| !snapshot.kinds.contains_key(*kind_id))
+        .cloned()
+        .collect();
+    for kind_id in dangling {
+        if snapshot.kinds.contains_key(&kind_id) {
+            continue;
+        }
+        snapshot.kinds.insert(
+            kind_id.clone(),
+            Kind {
+                category: Category::NeedsTriage,
+                reason: format!(
+                    "Referenced by expected_failures but never defined; needs a category and reason ({kind_id})."
+                ),
+                tracking: None,
+            },
+        );
+        report.synthesized_kinds.push(kind_id);
+    }
+
+    // Report — never delete — kinds nothing references any more.
+    report.orphaned_kinds = snapshot
+        .kinds
+        .keys()
+        .filter(|kind_id| !snapshot.expected_failures.values().any(|v| v == *kind_id))
+        .cloned()
+        .collect();
+
+    report
+}
+
+/// Print a human-readable summary of a bless to stderr.
+fn print_bless_report(path: &Path, snapshot: &FailureExpectations, report: &BlessReport) {
     eprintln!(
-        "Updated failure-expectations snapshot: {} ({} expected failures, {} kinds)",
+        "Blessed failure-expectations snapshot: {} ({} expected failures, {} kinds; \
+         {} mapping(s) preserved)",
         path.display(),
-        existing.expected_failures.len(),
-        existing.kinds.len()
+        snapshot.expected_failures.len(),
+        snapshot.kinds.len(),
+        report.preserved_inputs
     );
+    let sections: [(&str, &Vec<String>); 4] = [
+        (
+            "NEW failure(s) added (kind id prefixed `auto:`, category `needs_triage` — \
+             rename and categorize before merge)",
+            &report.new_inputs,
+        ),
+        (
+            "input(s) NO LONGER failing — removed from expected_failures (their kind \
+             definitions were kept)",
+            &report.resolved_inputs,
+        ),
+        (
+            "kind(s) now UNREFERENCED — kept so the curated reason is not lost; delete \
+             by hand if truly obsolete",
+            &report.orphaned_kinds,
+        ),
+        (
+            "kind(s) referenced but UNDEFINED — a `needs_triage` placeholder was written",
+            &report.synthesized_kinds,
+        ),
+    ];
+    for (label, items) in sections {
+        if items.is_empty() {
+            continue;
+        }
+        eprintln!("  {} {}:", items.len(), label);
+        for item in items.iter().take(20) {
+            eprintln!("    {}", item);
+        }
+        if items.len() > 20 {
+            eprintln!("    ... and {} more", items.len() - 20);
+        }
+    }
 }
 
 /// Normalize a parser error string to use as a kind identifier so that

--- a/tests/it/failure_expectations_blesser_tests.rs
+++ b/tests/it/failure_expectations_blesser_tests.rs
@@ -1,0 +1,335 @@
+//! Merge semantics of the failure-expectations blesser
+//! (`UPDATE_FAILURE_EXPECTATIONS=1`).
+//!
+//! The blesser rewrites a committed `*_failure_expectations.json` snapshot
+//! from the current parse output. Those snapshots carry hand-curated
+//! content — named kind ids, their `category`, their prose `reason` citing
+//! the spec, and the input -> kind mapping. None of that is recoverable
+//! from a parser error string, so the binding property is: **a bless must
+//! never lose human-authored content.** These tests pin that property.
+
+use crate::common::failure_expectations::{bless, FailureExpectations, FixtureCheck};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// A curated snapshot: two named kinds with spec-citing reasons, three
+/// inputs mapped onto them.
+const CURATED: &str = r##"{
+  "kinds": {
+    "spec_self_cancelling_allele": {
+      "category": "rejected_by_design",
+      "reason": "Overlapping del+dup in the same cis-allele that partially undo each other.",
+      "tracking": "#115"
+    },
+    "single_position_insertion": {
+      "category": "rejected_by_design",
+      "reason": "Insertion must name the two flanking positions."
+    }
+  },
+  "expected_failures": {
+    "NM_1.1:c.[1del;1_3dup]": "spec_self_cancelling_allele",
+    "NM_1.1:c.[4del;4_6dup]": "spec_self_cancelling_allele",
+    "NM_1.1:c.5insA": "single_position_insertion"
+  }
+}
+"##;
+
+/// Scratch directory for this test module's temp snapshots.
+fn scratch(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join("ferro-blesser-tests");
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    let path = dir.join(name);
+    let _ = std::fs::remove_file(&path);
+    path
+}
+
+fn write_curated(name: &str) -> PathBuf {
+    let path = scratch(name);
+    std::fs::write(&path, CURATED).expect("write curated snapshot");
+    path
+}
+
+fn read_back(path: &Path) -> FailureExpectations {
+    let raw = std::fs::read_to_string(path).expect("read blessed snapshot");
+    serde_json::from_str(&raw).expect("parse blessed snapshot")
+}
+
+fn check<'a>(failures: &[(&'a str, &str)], total_inputs: usize) -> FixtureCheck<'a> {
+    let map: BTreeMap<&'a str, String> = failures
+        .iter()
+        .map(|(input, err)| (*input, (*err).to_string()))
+        .collect();
+    FixtureCheck {
+        total_inputs,
+        failures: map,
+    }
+}
+
+/// The core case: a bless where some curated inputs still fail, one new
+/// input fails, and one curated input now passes. Curated kind ids,
+/// categories, reasons, tracking, and the input -> kind mapping for the
+/// still-failing inputs must all survive verbatim.
+#[test]
+fn bless_preserves_curated_kinds_and_mappings() {
+    let path = write_curated("mixed.json");
+    let report = bless(
+        &path,
+        &check(
+            &[
+                // (a) still-failing curated inputs
+                ("NM_1.1:c.[1del;1_3dup]", "E3006 SelfCancellingAllele"),
+                ("NM_1.1:c.5insA", "E1234 single position insertion"),
+                // (b) a new, previously-unseen failure
+                (
+                    "NM_1.1:c.9zzz",
+                    r#"Parse error at position 7: input: "zzz""#,
+                ),
+                // (c) "NM_1.1:c.[4del;4_6dup]" now passes -> absent here
+            ],
+            100,
+        ),
+    );
+    let after = read_back(&path);
+
+    // Curated kinds survive byte-for-byte.
+    let cancelling = after
+        .kinds
+        .get("spec_self_cancelling_allele")
+        .expect("curated kind `spec_self_cancelling_allele` was destroyed by the bless");
+    assert_eq!(
+        cancelling.reason,
+        "Overlapping del+dup in the same cis-allele that partially undo each other."
+    );
+    assert_eq!(cancelling.tracking.as_deref(), Some("#115"));
+    assert!(
+        after.kinds.contains_key("single_position_insertion"),
+        "curated kind `single_position_insertion` was destroyed by the bless"
+    );
+
+    // Curated mappings for still-failing inputs survive.
+    assert_eq!(
+        after
+            .expected_failures
+            .get("NM_1.1:c.[1del;1_3dup]")
+            .map(String::as_str),
+        Some("spec_self_cancelling_allele")
+    );
+    assert_eq!(
+        after
+            .expected_failures
+            .get("NM_1.1:c.5insA")
+            .map(String::as_str),
+        Some("single_position_insertion")
+    );
+
+    // The new failure is recorded under a clearly-auto kind needing triage.
+    let new_kind = after
+        .expected_failures
+        .get("NM_1.1:c.9zzz")
+        .expect("new failure was not added");
+    assert!(
+        new_kind.starts_with("auto:"),
+        "new kind id `{}` is not distinguishable from curated ids",
+        new_kind
+    );
+    assert_eq!(report.new_inputs, vec!["NM_1.1:c.9zzz".to_string()]);
+
+    // The now-passing input is removed from the mapping but reported...
+    assert!(!after
+        .expected_failures
+        .contains_key("NM_1.1:c.[4del;4_6dup]"));
+    assert_eq!(
+        report.resolved_inputs,
+        vec!["NM_1.1:c.[4del;4_6dup]".to_string()]
+    );
+    // ...and its kind is still referenced by the other input, so not orphaned.
+    assert!(
+        report.orphaned_kinds.is_empty(),
+        "{:?}",
+        report.orphaned_kinds
+    );
+}
+
+/// A kind whose every input now passes becomes unreferenced. Its prose is
+/// human-authored, so the blesser keeps the definition and reports it
+/// rather than deleting it.
+#[test]
+fn bless_retains_and_reports_orphaned_kinds() {
+    let path = write_curated("orphan.json");
+    let report = bless(
+        &path,
+        &check(
+            &[("NM_1.1:c.5insA", "E1234 single position insertion")],
+            100,
+        ),
+    );
+    let after = read_back(&path);
+
+    assert!(
+        after.kinds.contains_key("spec_self_cancelling_allele"),
+        "orphaned curated kind was deleted, losing its curated reason"
+    );
+    assert_eq!(
+        report.orphaned_kinds,
+        vec!["spec_self_cancelling_allele".to_string()]
+    );
+}
+
+/// Blessing twice with the same input set must be a no-op on disk.
+#[test]
+fn bless_is_idempotent() {
+    let path = write_curated("idempotent.json");
+    let failures = [
+        ("NM_1.1:c.[1del;1_3dup]", "E3006 SelfCancellingAllele"),
+        ("NM_1.1:c.[4del;4_6dup]", "E3006 SelfCancellingAllele"),
+        ("NM_1.1:c.5insA", "E1234 single position insertion"),
+        (
+            "NM_1.1:c.9zzz",
+            r#"Parse error at position 7: input: "zzz""#,
+        ),
+    ];
+    bless(&path, &check(&failures, 100));
+    let first = std::fs::read_to_string(&path).expect("read first bless");
+    let report = bless(&path, &check(&failures, 100));
+    let second = std::fs::read_to_string(&path).expect("read second bless");
+    assert_eq!(first, second, "second bless mutated the snapshot");
+    assert!(report.new_inputs.is_empty());
+    assert!(report.resolved_inputs.is_empty());
+}
+
+/// If the fixture iteration produced no inputs at all (dataset missing or
+/// skipped), a bless would wipe the whole snapshot. Refuse instead.
+#[test]
+#[should_panic(expected = "refusing to bless")]
+fn bless_refuses_when_fixture_produced_no_inputs() {
+    let path = write_curated("empty.json");
+    bless(&path, &check(&[], 0));
+}
+
+/// An unknown field in a curated snapshot is human-authored content the
+/// blesser cannot round-trip. Fail loudly rather than silently drop it.
+#[test]
+#[should_panic(expected = "unknown field")]
+fn bless_refuses_snapshot_with_unknown_fields() {
+    let path = scratch("unknown_field.json");
+    std::fs::write(
+        &path,
+        r#"{"kinds":{"k":{"category":"malformed_input","reason":"r","note":"curated note"}},
+            "expected_failures":{"x":"k"}}"#,
+    )
+    .expect("write snapshot");
+    bless(&path, &check(&[("x", "boom")], 1));
+}
+
+/// An input mapped to a kind id that is not defined gets a placeholder
+/// definition (so the enforcing test can explain itself) and is reported.
+#[test]
+fn bless_synthesizes_placeholder_for_undefined_kind() {
+    let path = scratch("undefined_kind.json");
+    std::fs::write(
+        &path,
+        r#"{"kinds":{},"expected_failures":{"NM_1.1:c.5insA":"typo_kind_id"}}"#,
+    )
+    .expect("write snapshot");
+    let report = bless(
+        &path,
+        &check(&[("NM_1.1:c.5insA", "E1234 single position insertion")], 1),
+    );
+    let after = read_back(&path);
+    assert!(after.kinds.contains_key("typo_kind_id"));
+    assert_eq!(report.synthesized_kinds, vec!["typo_kind_id".to_string()]);
+}
+
+/// Round-trip proof against a copy of the real, hand-curated ClinVar
+/// unique snapshot: blessing it with exactly its own expected failures
+/// must leave every kind id, category, reason, and tracking untouched.
+#[test]
+fn bless_roundtrips_real_clinvar_unique_snapshot() {
+    let source = Path::new("tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json");
+    if !source.exists() {
+        eprintln!("Skipping: {} not found", source.display());
+        return;
+    }
+    let raw = std::fs::read_to_string(source).expect("read real snapshot");
+    let before: FailureExpectations = serde_json::from_str(&raw).expect("parse real snapshot");
+    assert!(before.kinds.len() > 50, "fixture unexpectedly small");
+
+    // Work on a copy — never touch the committed fixture.
+    let path = scratch("clinvar_unique_copy.json");
+    std::fs::write(&path, &raw).expect("write copy");
+
+    // Simulate the real bless: every curated input still fails, with an
+    // error string that bears no relation to its curated kind id.
+    let inputs: Vec<String> = before.expected_failures.keys().cloned().collect();
+    let failures: BTreeMap<&str, String> = inputs
+        .iter()
+        .map(|i| {
+            (
+                i.as_str(),
+                "Parse error at position 3: some error".to_string(),
+            )
+        })
+        .collect();
+    let report = bless(
+        &path,
+        &FixtureCheck {
+            total_inputs: 4_000_000,
+            failures,
+        },
+    );
+
+    let after = read_back(&path);
+    assert_eq!(
+        after.kinds.len(),
+        before.kinds.len(),
+        "kind count changed during bless"
+    );
+    for (id, kind) in &before.kinds {
+        let got = after
+            .kinds
+            .get(id)
+            .unwrap_or_else(|| panic!("curated kind `{}` lost", id));
+        assert_eq!(got.category, kind.category, "category changed for `{}`", id);
+        assert_eq!(got.reason, kind.reason, "reason changed for `{}`", id);
+        assert_eq!(got.tracking, kind.tracking, "tracking changed for `{}`", id);
+    }
+    assert_eq!(after.expected_failures, before.expected_failures);
+    assert!(report.new_inputs.is_empty());
+    assert!(report.resolved_inputs.is_empty());
+    assert!(report.orphaned_kinds.is_empty());
+
+    // Every curated reason string survives verbatim in the rewritten text
+    // (the committed file is not in canonical key order, so the bytes may
+    // be reordered; the human-authored content may not change).
+    let rewritten = std::fs::read_to_string(&path).expect("read blessed copy");
+    for kind in before.kinds.values() {
+        let escaped = serde_json::to_string(&kind.reason).expect("escape reason");
+        assert!(
+            rewritten.contains(&escaped),
+            "curated reason not found verbatim after bless: {}",
+            kind.reason
+        );
+    }
+
+    // A second bless over the same inputs is byte-identical.
+    bless(
+        &path,
+        &FixtureCheck {
+            total_inputs: 4_000_000,
+            failures: inputs
+                .iter()
+                .map(|i| {
+                    (
+                        i.as_str(),
+                        "Parse error at position 3: some error".to_string(),
+                    )
+                })
+                .collect(),
+        },
+    );
+    assert_eq!(
+        rewritten,
+        std::fs::read_to_string(&path).expect("read second bless"),
+        "second bless mutated the snapshot"
+    );
+}

--- a/tests/it/failure_expectations_blesser_tests.rs
+++ b/tests/it/failure_expectations_blesser_tests.rs
@@ -245,12 +245,14 @@ fn bless_synthesizes_placeholder_for_undefined_kind() {
 /// must leave every kind id, category, reason, and tracking untouched.
 #[test]
 fn bless_roundtrips_real_clinvar_unique_snapshot() {
-    let source = Path::new("tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json");
-    if !source.exists() {
-        eprintln!("Skipping: {} not found", source.display());
-        return;
-    }
-    let raw = std::fs::read_to_string(source).expect("read real snapshot");
+    // Anchor on CARGO_MANIFEST_DIR so the path resolves regardless of the
+    // test's working directory (repo convention). The fixture is a committed
+    // file, so it must be present — a silent skip here would turn the most
+    // valuable test into a no-op that still reports green.
+    let source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json");
+    let raw = std::fs::read_to_string(&source)
+        .unwrap_or_else(|e| panic!("read committed snapshot {}: {e}", source.display()));
     let before: FailureExpectations = serde_json::from_str(&raw).expect("parse real snapshot");
     assert!(before.kinds.len() > 50, "fixture unexpectedly small");
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -61,6 +61,7 @@ mod error_mode_tests;
 mod exac_validation;
 mod external_pattern_analysis;
 mod external_pattern_tests;
+mod failure_expectations_blesser_tests;
 mod fast_path_differential;
 mod fast_path_drift_scope;
 mod fast_path_flip_bench;


### PR DESCRIPTION
`UPDATE_FAILURE_EXPECTATIONS=1` destroyed the hand-curated failure taxonomy every time it ran. Three separate agents this week hand-appended entries specifically to avoid invoking it — a tool nobody dares run is broken.

## What it actually did

Not partial loss. **Total.** `regenerate_snapshot` rebuilt `expected_failures` by keying every input on its normalized error string, then `retain`ed only the kinds referenced by that new map. The single preservation path (`kinds.entry().or_insert`) fires only when a kind id happens to *equal* the normalized error text — true only for never-renamed auto-generated ids, i.e. none that survived triage.

Simulating the old algorithm against the real `clinvar_hgvs_unique` fixture (81 kinds / 206 mappings):

> **81/81 kinds deleted, 0/206 mappings preserved**, collapsed into a single `needs_triage` kind.

Same outcome for all four fixtures. What was at stake: 39 `rejected_by_design` kinds with hand-written prose and spec citations (`spec_self_cancelling_allele` — "Overlapping del+dup in the same cis-allele", `deprecated_repeat_paren_no_brackets`, `single_position_insertion`, …). None of it is recoverable from an error string.

## Merge semantics now

- A still-failing curated input **keeps its kind id verbatim**; `category`, `reason` and `tracking` are never rewritten.
- A new failure gets `auto:<normalized error>` under a `needs_triage` kind — obviously machine-written, and it keeps the build red until a human names and categorises it.
- **Kinds are never deleted.**

The blesser now refuses to run rather than proceed when it cannot guarantee that:
- an unparseable snapshot;
- a snapshot carrying fields the framework does not model (`deny_unknown_fields`) — a hand-added field can no longer be silently dropped;
- a fixture that yielded zero inputs, which previously wiped the file whenever LFS data was missing.

## Entries that no longer fail

The mapping is removed — keeping it fails the "improvement" check forever and makes the snapshot unusable — but **the kind definition is kept**, so the curated prose survives. Removals and newly-orphaned kinds are printed in a bless report for deliberate human deletion, rather than vanishing.

## Proof

7 tests in `tests/it/failure_expectations_blesser_tests.rs`, including `bless_roundtrips_real_clinvar_unique_snapshot`: blessing a **copy** of the real fixture leaves all 81 kinds identical in category/reason/tracking, `expected_failures` identical, reasons verbatim in the output, and a second bless byte-identical.

End-to-end, the real `UPDATE_FAILURE_EXPECTATIONS=1 cmrg_exhaustive` run reported "45 expected failures, 23 kinds; 45 mapping(s) preserved" with JSON content identical (diff was canonical key reordering only), then reverted.

**No fixture is modified by this PR** — the fix is to the tool, proven against copies. `git status` is clean.

## Verification

`cargo nextest run --features dev` with `FERRO_MANIFEST` unset: **8074 passed** (8067 base + 7 new). fmt and clippy `-D warnings` clean.

## Known consequences

The first real bless of each fixture will produce a large but **content-identical** reordering diff, since keys are now written canonically. And an untriaged `auto:` kind will orphan itself if the parser's error text later changes — reported in the bless output, not deleted.
