### PR TITLE
fix(normalize): canonicalize consecutive-residue protein cis substitutions to delins

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1184,6 +1184,13 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
         let HgvsVariant::Protein(pv) = v else {
             return None;
         };
+        // Every member must share the first member's reference. A cis allele
+        // states its accession once, so this normally holds by construction, but
+        // the merged delins is stamped with `accession`/`gene_symbol` below —
+        // guard so a mixed-accession member can never be silently re-labelled.
+        if pv.accession != accession || pv.gene_symbol != gene_symbol {
+            return None;
+        }
         // Exactly one certain residue (a point, start == end, both certain).
         let (Some(Mu::Certain(s)), Some(Mu::Certain(e))) = (
             pv.loc_edit.location.start.as_single(),
@@ -1199,6 +1206,14 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
             Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) => (*alternative, true),
             _ => return None,
         };
+        // A to-`Ter` (nonsense) substitution is out of scope: the spec forbids
+        // listing residues after the stop, so a `delins…Ter…` run would be
+        // unparseable and spec-invalid (protein/substitution.md:20,
+        // protein/delins.md:45). Leave such an allele untouched — collapsing a
+        // nonsense change toward `p.<ref><pos>Ter` is a separate rule.
+        if alternative == AminoAcid::Ter {
+            return None;
+        }
         subs.push(Sub {
             pos: s.number,
             reference: s.aa,
@@ -1258,7 +1273,13 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
     if !changed {
         return None;
     }
-    if merged.len() == 1 {
+    // A full merge to a single member drops the allele wrapper — but only when
+    // the allele carried no whole-bracket uncertainty, so the outer predicted
+    // marker is not silently lost. In practice `allele.uncertain` is always
+    // false here (the `p.(…;…)` whole-allele form does not parse into a live
+    // `AlleleVariant`), so the bare return is what actually fires; the guard is
+    // defensive future-proofing against that parser gap ever closing.
+    if merged.len() == 1 && !allele.uncertain {
         merged.into_iter().next()
     } else {
         let mut coalesced = crate::hgvs::variant::AlleleVariant::new(merged, allele.phase);

--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1123,6 +1123,150 @@ fn build_naedit<P>(
     )
 }
 
+/// Coalesce runs of consecutive-residue substitutions in a **cis protein
+/// allele** into a single delins, per `protein/substitution.md:23`:
+///
+/// > changes involving two or more consecutive amino acids are described as a
+/// > deletion/insertion variant (delins) […] the description
+/// > `p.Arg76_Cys77delinsSerTrp` is correct, the description
+/// > `p.[Arg76Ser;Cys77Trp]` is not correct.
+///
+/// This is the protein-axis counterpart of the nucleotide adjacency merge that
+/// [`merge_consecutive_edits`] performs — the nucleotide path is positional on
+/// a `Base` sequence and never fires on protein members, so the protein axis is
+/// handled here instead.
+///
+/// Only **strictly adjacent** residues (position `n` and `n+1`) coalesce.
+/// A gap of one or more unchanged residues keeps the members separate — the
+/// spec pins that exact non-example (`protein/delins.md:63`: `p.[Ser44Arg;Trp46Arg]`
+/// is *not* described as `p.Ser44_Trp46delinsArgLeuArg`).
+///
+/// Returns `Some` only when at least one run of ≥2 adjacent substitutions is
+/// merged; a fully-merged allele collapses to a bare [`HgvsVariant::Protein`],
+/// a partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
+/// the allele untouched — when it is conservatively out of scope:
+///   - the phase is not cis (trans / unknown / mosaic / … are independent),
+///   - any member is not a single-residue protein substitution (mixed edit
+///     kinds are out of scope for this narrow rule),
+///   - members are not in ascending, duplicate-free residue order (a `n,n`
+///     pair is the contradictory same-residue case, not a delins; an
+///     out-of-order allele is left as the author wrote it), or
+///   - a run would mix predicted `( )` and certain members (ambiguous).
+pub(crate) fn coalesce_protein_adjacent_substitutions(
+    allele: &crate::hgvs::variant::AlleleVariant,
+) -> Option<HgvsVariant> {
+    use crate::hgvs::edit::{AminoAcidSeq, ProteinEdit};
+    use crate::hgvs::interval::ProtInterval;
+    use crate::hgvs::location::{AminoAcid, ProtPos};
+    use crate::hgvs::variant::ProteinVariant;
+
+    if allele.phase != AllelePhase::Cis || allele.variants.len() < 2 {
+        return None;
+    }
+
+    /// One member reduced to a single-residue substitution.
+    struct Sub {
+        pos: u64,
+        reference: AminoAcid,
+        alternative: AminoAcid,
+        predicted: bool,
+    }
+
+    let first = match &allele.variants[0] {
+        HgvsVariant::Protein(pv) => pv,
+        _ => return None,
+    };
+    let accession = first.accession.clone();
+    let gene_symbol = first.gene_symbol.clone();
+
+    let mut subs: Vec<Sub> = Vec::with_capacity(allele.variants.len());
+    for v in &allele.variants {
+        let HgvsVariant::Protein(pv) = v else {
+            return None;
+        };
+        // Exactly one certain residue (a point, start == end, both certain).
+        let (Some(Mu::Certain(s)), Some(Mu::Certain(e))) = (
+            pv.loc_edit.location.start.as_single(),
+            pv.loc_edit.location.end.as_single(),
+        ) else {
+            return None;
+        };
+        if s != e {
+            return None;
+        }
+        let (alternative, predicted) = match &pv.loc_edit.edit {
+            Mu::Certain(ProteinEdit::Substitution { alternative, .. }) => (*alternative, false),
+            Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) => (*alternative, true),
+            _ => return None,
+        };
+        subs.push(Sub {
+            pos: s.number,
+            reference: s.aa,
+            alternative,
+            predicted,
+        });
+    }
+
+    // Require ascending, duplicate-free residue order. A descending or
+    // duplicate (`n,n`) allele is out of scope — do not reorder the author's
+    // description, and the same-residue pair is a contradiction, not a delins.
+    if subs.windows(2).any(|w| w[1].pos <= w[0].pos) {
+        return None;
+    }
+
+    let mut merged: Vec<HgvsVariant> = Vec::new();
+    let mut changed = false;
+    let mut i = 0;
+    while i < subs.len() {
+        let mut j = i;
+        while j + 1 < subs.len() && subs[j + 1].pos == subs[j].pos + 1 {
+            j += 1;
+        }
+        if j > i {
+            // A run of ≥2 strictly-adjacent substitutions → one delins spanning
+            // residues `i..=j`, inserting each member's alternative in order.
+            let all_predicted = subs[i..=j].iter().all(|s| s.predicted);
+            let any_predicted = subs[i..=j].iter().any(|s| s.predicted);
+            if any_predicted && !all_predicted {
+                return None;
+            }
+            let loc = ProtInterval::new(
+                ProtPos::new(subs[i].reference, subs[i].pos),
+                ProtPos::new(subs[j].reference, subs[j].pos),
+            );
+            let edit = ProteinEdit::Delins {
+                sequence: AminoAcidSeq::new(subs[i..=j].iter().map(|s| s.alternative).collect()),
+            };
+            let loc_edit = if all_predicted {
+                LocEdit::new_predicted(loc, edit)
+            } else {
+                LocEdit::new(loc, edit)
+            };
+            merged.push(HgvsVariant::Protein(ProteinVariant {
+                accession: accession.clone(),
+                gene_symbol: gene_symbol.clone(),
+                loc_edit,
+            }));
+            changed = true;
+        } else {
+            // A lone substitution keeps its original member verbatim.
+            merged.push(allele.variants[i].clone());
+        }
+        i = j + 1;
+    }
+
+    if !changed {
+        return None;
+    }
+    if merged.len() == 1 {
+        merged.into_iter().next()
+    } else {
+        let mut coalesced = crate::hgvs::variant::AlleleVariant::new(merged, allele.phase);
+        coalesced.uncertain = allele.uncertain;
+        Some(HgvsVariant::Allele(coalesced))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1676,6 +1676,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HgvsVariant::Allele(preserved), all_warnings));
         }
 
+        // Protein-axis adjacency (protein/substitution.md:23): two or more
+        // consecutive-residue substitutions in one cis allele describe a single
+        // delins (`p.[Arg76Ser;Cys77Trp]` → `p.Arg76_Cys77delinsSerTrp`). The
+        // positional nucleotide merge below never fires on protein members, so
+        // coalesce the protein axis here and re-dispatch the result (a bare
+        // `Protein` when fully merged, else a smaller `Allele`) through the
+        // normal pipeline. The helper is a no-op once no adjacent run remains,
+        // so the re-dispatch cannot loop.
+        if let Some(coalesced) = merge::coalesce_protein_adjacent_substitutions(allele) {
+            let (normalized, mut warnings) = self.normalize_dispatch(&coalesced)?;
+            all_warnings.append(&mut warnings);
+            return Ok((normalized, all_warnings));
+        }
+
         // Collapse → merge → split → per-member normalize, iterated to a fixed
         // point. The per-member 3'-shift (inside `normalize_core`) can move an
         // insertion — or the `dup` it canonicalises to — flush against an

--- a/tests/it/allele_grammar_corners.rs
+++ b/tests/it/allele_grammar_corners.rs
@@ -271,6 +271,32 @@ fn protein_trans_consecutive_changes_stay_separate() {
     );
 }
 
+/// A run containing a nonsense (to-`Ter`) substitution must NOT coalesce: the
+/// spec forbids listing residues after the stop, so `delins…Ter…` would be
+/// spec-invalid AND unparseable (a round-trip break). The allele is left as
+/// authored. Asserting the output equals the (parseable) input also pins that
+/// normalize does not emit a string it cannot re-read.
+#[test]
+fn protein_to_ter_run_is_not_coalesced() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ter;Cys77Trp]",
+        "NP_003997.1:p.[Arg76Ter;Cys77Trp]",
+        "protein/substitution.md:20, protein/delins.md:45 — no residues after Ter; do not merge",
+    );
+}
+
+/// Members authored in descending residue order are left untouched (the rule
+/// only merges strictly-ascending runs; it never reorders the author's
+/// description — #395 preserve-authored-order).
+#[test]
+fn protein_descending_order_members_stay_as_authored() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Cys77Trp;Arg76Ser]",
+        "NP_003997.1:p.[Cys77Trp;Arg76Ser]",
+        "ascending-only: a descending allele is not reordered into a delins",
+    );
+}
+
 // =====================================================================
 // Single-bracket allele description (misleading per spec)
 // =====================================================================

--- a/tests/it/allele_grammar_corners.rs
+++ b/tests/it/allele_grammar_corners.rs
@@ -181,8 +181,9 @@ fn allele_adjacent_two_variants_must_be_delins() {
 fn protein_consecutive_aa_changes_must_be_delins() {
     pin_canonicalizes_to(
         "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
-        "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
-        "protein/delins.md:62-64 — spec says delins; ferro currently keeps the allele (divergence)",
+        "NP_003997.1:p.Arg76_Cys77delinsSerTrp",
+        "protein/substitution.md:23 + delins.md:62-64 — two consecutive-residue cis \
+         substitutions canonicalize to a single delins",
     );
     // The spec-canonical delins form itself round-trips unchanged.
     pin_round_trip(
@@ -199,6 +200,74 @@ fn protein_separated_changes_stay_as_allele() {
     pin_accept(
         "NP_003997.1:p.[Ser44Arg;Trp46Arg]",
         "protein/delins.md:62-64 — stays as allele (separated by unchanged res)",
+    );
+}
+
+/// A predicted (`( )`) cis pair of consecutive-residue substitutions
+/// canonicalizes to a predicted delins — the wrapper is carried onto the
+/// combined form (protein/substitution.md:23).
+#[test]
+fn protein_predicted_consecutive_changes_canonicalize_to_predicted_delins() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[(Arg76Ser);(Cys77Trp)]",
+        "NP_003997.1:p.(Arg76_Cys77delinsSerTrp)",
+        "protein/substitution.md:23 — predicted consecutive subs → predicted delins",
+    );
+}
+
+/// A run of three or more consecutive-residue substitutions merges into one
+/// delins spanning the whole run.
+#[test]
+fn protein_three_consecutive_changes_merge_into_one_delins() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser;Cys77Trp;Gly78Asp]",
+        "NP_003997.1:p.Arg76_Gly78delinsSerTrpAsp",
+        "protein/substitution.md:23 — a maximal adjacent run collapses to one delins",
+    );
+}
+
+/// A partial allele — one adjacent run plus a separated member — merges only
+/// the run and keeps the distant member as its own allele arm.
+#[test]
+fn protein_partial_run_merges_only_the_adjacent_pair() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser;Cys77Trp;Gly90Asp]",
+        "NP_003997.1:p.[Arg76_Cys77delinsSerTrp;Gly90Asp]",
+        "protein/substitution.md:23 — only the strictly-adjacent 76_77 run coalesces",
+    );
+}
+
+/// Separated changes survive **normalization** unchanged — the coalescing
+/// pass must not reach across the unchanged residue at 45 (delins.md:63).
+#[test]
+fn protein_separated_changes_survive_normalization() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Ser44Arg;Trp46Arg]",
+        "NP_003997.1:p.[Ser44Arg;Trp46Arg]",
+        "protein/delins.md:63 — a one-residue gap keeps the members separate",
+    );
+}
+
+/// Two substitutions at the **same** residue are contradictory (one residue
+/// cannot be two things in cis), not a consecutive-residue delins — the allele
+/// survives normalization untouched rather than coalescing.
+#[test]
+fn protein_same_residue_changes_are_not_coalesced() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Asp2His;Asp2Glu]",
+        "NP_003997.1:p.[Asp2His;Asp2Glu]",
+        "protein/substitution.md:23 — same-residue pair is not a consecutive delins",
+    );
+}
+
+/// A `trans` allele (`];[`) describes two different physical alleles, so its
+/// members are never coalesced into one cis delins.
+#[test]
+fn protein_trans_consecutive_changes_stay_separate() {
+    pin_canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser];[Cys77Trp]",
+        "NP_003997.1:p.[Arg76Ser];[Cys77Trp]",
+        "protein/substitution.md:23 — trans members are independent, never a cis delins",
     );
 }
 


### PR DESCRIPTION
## What

Two or more substitutions at **consecutive residues** in a cis protein allele describe a single deletion-insertion, not a bracketed list. Per `protein/substitution.md:23`:

> changes involving two or more consecutive amino acids are described as a deletion/insertion variant (delins) […] the description `p.Arg76_Cys77delinsSerTrp` is correct, the description `p.[Arg76Ser;Cys77Trp]` is **not correct**.

ferro parsed the bracketed form and kept it unchanged through normalization. It now coalesces it to the canonical delins:

```
NP_003997.1:p.[Arg76Ser;Cys77Trp]  →  NP_003997.1:p.Arg76_Cys77delinsSerTrp
```

This is the protein-axis counterpart of the nucleotide adjacency merge already performed by `merge_consecutive_edits` (the nucleotide path is positional on a `Base` sequence and never fires on protein members).

## Scope — only strictly-adjacent residues merge

A gap of one or more unchanged residues keeps the members separate, matching the spec's pinned non-example (`protein/delins.md:63`): `p.[Ser44Arg;Trp46Arg]` is *not* described as `p.Ser44_Trp46delinsArgLeuArg`.

Conservatively left untouched (return `None`, allele unchanged):

- non-cis phase (trans / unknown / mosaic / …) — independent alleles
- any member that is not a single-residue substitution (mixed edit kinds out of scope)
- non-ascending or duplicate residue order — a same-residue `n,n` pair is a contradiction, not a delins; an out-of-order allele is left as authored
- a run that would mix predicted `( )` and certain members

All-predicted runs carry the `( )` wrapper onto the combined delins (`p.[(Arg76Ser);(Cys77Trp)]` → `p.(Arg76_Cys77delinsSerTrp)`).

## Tests

Promotes the previously-pinned divergence in `allele_grammar_corners.rs` (which anticipated exactly this: "promote to `pin_canonicalizes_to(..., delins)` once protein adjacency canonicalization is implemented") and adds guards for the predicted, three-residue-run, partial-merge, same-residue, separated (normalize-level), and trans cases. Full suite green; `clippy --all-features --all-targets -D warnings` clean.

Part of #1079 (HGVS spec-divergence burn-down); input-side companion to the projection-side canonicalization from #855.