### PR TITLE
fix(parser): reject a frameshift anchored at an unchanged residue

### DIFF
--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -7271,6 +7271,11 @@ pub fn parse_variant(input: &str) -> Result<HgvsVariant, FerroError> {
     // protein/substitution.md:20; #1079).
     validate_no_immediate_ter_frameshift(&variant)?;
 
+    // Spec-mandated post-parse semantic check: reject a frameshift anchored at
+    // an unchanged residue — it must start at the first amino acid *changed*
+    // (HGVS protein/frameshift.md:47-49; #1079).
+    validate_no_unchanged_anchor_frameshift(&variant)?;
+
     // Spec-mandated post-parse semantic check: reject residues listed after
     // a translation stop in an inserted peptide (HGVS protein/delins.md:45,
     // protein/insertion.md:43; #1079).
@@ -8175,6 +8180,83 @@ fn validate_no_immediate_ter_frameshift(variant: &HgvsVariant) -> Result<(), Fer
         HgvsVariant::Allele(allele) => {
             for inner in &allele.variants {
                 validate_no_immediate_ter_frameshift(inner)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Reject a frameshift anchored at an **unchanged** amino acid —
+/// `p.His150HisfsTer10` / `p.His150Hisfs*10` (#1079).
+///
+/// Per `recommendations/protein/frameshift.md:47-49`:
+///
+/// > Since frameshift variants start with the **first amino acid changed**, the
+/// > description `p.His150HisfsTer10` (or `p.His150Hisfs*10`) is not correct.
+///
+/// A frameshift is anchored at the first residue the shifted reading frame
+/// alters. When the description names the anchor's new residue equal to the
+/// reference (`His150His…`) it anchors at an unchanged residue, which the spec
+/// forbids.
+///
+/// This is a rejection rather than a rewrite: the correct form
+/// (`p.Gln151Thrfs*9`) names the first *changed* residue and the shifted-tail
+/// length, neither of which is recoverable from the description alone — it
+/// needs the shifted protein sequence. That mirrors the immediate-stop
+/// (`fsTer1`) and initiator-loss rules, which reject for the same reason.
+///
+/// Scope: only a frameshift that **states** its new anchor residue is checked —
+/// the short form `p.Arg97fs` (no stated residue) makes no unchanged-anchor
+/// claim and is untouched, as is any genuine change (`p.Gln151Thr…`). A
+/// `FrameshiftAlternatives` (`p.Gly719(Ala^Ser)fs…`) is rejected only when
+/// *every* alternative equals the reference, i.e. no alternative is a change.
+fn validate_no_unchanged_anchor_frameshift(variant: &HgvsVariant) -> Result<(), FerroError> {
+    use crate::error::{Diagnostic, ErrorCode};
+    use crate::hgvs::edit::ProteinEdit;
+    use crate::hgvs::location::AminoAcid;
+    use crate::hgvs::uncertainty::Mu;
+
+    /// True when the frameshift names a new anchor residue and it equals the
+    /// reference residue `reference` (an unchanged anchor).
+    fn names_unchanged_anchor(edit: &Mu<ProteinEdit>, reference: AminoAcid) -> bool {
+        match edit.inner() {
+            Some(ProteinEdit::Frameshift {
+                new_aa: Some(new_aa),
+                ..
+            }) => *new_aa == reference,
+            Some(ProteinEdit::FrameshiftAlternatives { alternatives, .. }) => {
+                !alternatives.is_empty() && alternatives.iter().all(|aa| *aa == reference)
+            }
+            _ => false,
+        }
+    }
+
+    match variant {
+        HgvsVariant::Protein(v) => {
+            if let Some(Mu::Certain(pos)) = v.loc_edit.location.start.as_single() {
+                if names_unchanged_anchor(&v.loc_edit.edit, pos.aa) {
+                    return Err(FerroError::parse_with_diagnostic(
+                        0,
+                        format!(
+                            "a frameshift is anchored at the first amino acid changed, but \
+                             `{}{}` names an unchanged residue; anchor the description at the \
+                             first residue the shifted frame alters (protein/frameshift.md:47-49)",
+                            pos.aa, pos.number
+                        ),
+                        Diagnostic::new()
+                            .with_code(ErrorCode::InvalidEdit)
+                            .with_hint(
+                                "e.g. `p.Gln151ThrfsTer9`, not `p.His150HisfsTer10` — the anchor \
+                             residue must differ from the reference",
+                            ),
+                    ));
+                }
+            }
+        }
+        HgvsVariant::Allele(allele) => {
+            for inner in &allele.variants {
+                validate_no_unchanged_anchor_frameshift(inner)?;
             }
         }
         _ => {}

--- a/src/hgvs/parser/variant.rs
+++ b/src/hgvs/parser/variant.rs
@@ -8234,7 +8234,13 @@ fn validate_no_unchanged_anchor_frameshift(variant: &HgvsVariant) -> Result<(), 
 
     match variant {
         HgvsVariant::Protein(v) => {
-            if let Some(Mu::Certain(pos)) = v.loc_edit.location.start.as_single() {
+            // Read the anchor position through `.inner()` so an *uncertain*
+            // position (`p.(His150)HisfsTer10`) is validated too, not only a
+            // certain one — mirroring how `names_unchanged_anchor` reads the
+            // edit. Gating on `Mu::Certain` here would silently let an
+            // uncertain-position unchanged anchor slip through.
+            let anchor = v.loc_edit.location.start.as_single();
+            if let Some(pos) = anchor.as_ref().and_then(|mu| mu.inner()) {
                 if names_unchanged_anchor(&v.loc_edit.edit, pos.aa) {
                     return Err(FerroError::parse_with_diagnostic(
                         0,

--- a/tests/it/issue_1079_immediate_ter_frameshift.rs
+++ b/tests/it/issue_1079_immediate_ter_frameshift.rs
@@ -88,7 +88,11 @@ fn shortest_legal_frameshift_still_parses() {
         "NP_003997.1:p.Glu5ValfsTer5",
         "NP_003997.1:p.Ile327ArgfsTer?",
         "NP_003997.1:p.Arg97fs",
-        "NP_003997.1:p.His150HisfsTer10",
+        // NB: `p.His150HisfsTer10` was previously listed here as "legal" — it
+        // clears the immediate-stop rule (`Ter10` ≥ `Ter2`) but violates the
+        // frameshift-anchor rule (`His150→His` is unchanged; frameshift.md:47-49).
+        // It is now rejected by `validate_no_unchanged_anchor_frameshift`
+        // (see issue_1079_unchanged_anchor_frameshift).
     ] {
         assert!(
             parse_hgvs(input).is_ok(),

--- a/tests/it/issue_1079_unchanged_anchor_frameshift.rs
+++ b/tests/it/issue_1079_unchanged_anchor_frameshift.rs
@@ -37,12 +37,30 @@ fn rejects_unchanged_anchor_frameshift() {
     for input in [
         "NP_003997.1:p.His150HisfsTer10",
         "NP_003997.1:p.His150HisfsTer?",
+        // 1-letter spelling: `AminoAcid` is a normalized enum, so `H` == `His`.
+        "NP_003997.1:p.H150HfsTer10",
+        // Predicted `( )` wraps the edit; the anchor is still unchanged.
+        "NP_003997.1:p.(His150HisfsTer10)",
+        // `FrameshiftAlternatives` where *every* alternative equals the
+        // reference — no reading is a change, so it is an unchanged anchor.
+        "NP_003997.1:p.His150(His^His)fsTer23",
     ] {
         assert!(
             parse_hgvs(input).is_err(),
             "frameshift.md:47-49 forbids the unchanged anchor in {input:?}"
         );
     }
+}
+
+#[test]
+fn rejects_uncertain_position_unchanged_anchor() {
+    // The anchor validator must read the position through `.inner()`, not gate
+    // on `Mu::Certain`, so an *uncertain-position* unchanged anchor is caught
+    // too rather than silently slipping through.
+    assert!(
+        parse_hgvs("NP_003997.1:p.(His150)HisfsTer10").is_err(),
+        "an uncertain-position unchanged anchor is still spec-invalid"
+    );
 }
 
 #[test]
@@ -63,6 +81,10 @@ fn changed_anchor_frameshift_still_parses() {
         "NP_003997.1:p.Gln151ThrfsTer9",
         "NP_003997.1:p.Arg97ProfsTer23",
         "NP_003997.1:p.Tyr4ValfsTer2",
+        // `FrameshiftAlternatives` with at least one changed reading is a valid
+        // frameshift — only an all-unchanged set is rejected.
+        "NP_003997.1:p.His150(His^Ala)fsTer23",
+        "NP_003997.1:p.Gly719(Ala^Ser)fsTer23",
     ] {
         assert!(
             parse_hgvs(input).is_ok(),

--- a/tests/it/issue_1079_unchanged_anchor_frameshift.rs
+++ b/tests/it/issue_1079_unchanged_anchor_frameshift.rs
@@ -1,0 +1,84 @@
+//! MUST-level rejection of a frameshift anchored at an **unchanged** amino
+//! acid — `p.His150HisfsTer10` / `p.His150Hisfs*10` — issue #1079.
+//!
+//! # Spec
+//!
+//! `recommendations/protein/frameshift.md:47-49`:
+//!
+//! > `p.Gln151Thrfs*9` (not `p.His150Hisfs*10`) — […] Since frameshift variants
+//! > start with the **first amino acid changed**, the description
+//! > `p.His150HisfsTer10` (or `p.His150Hisfs*10`) is not correct.
+//!
+//! A frameshift must anchor at the first residue the shifted reading frame
+//! actually changes. `p.His150His…` names `His150` as both the reference and
+//! the new residue — an unchanged anchor — so the description is spec-invalid.
+//!
+//! # Rejection, not repair
+//!
+//! The correct form (`p.Gln151Thrfs*9`) names the first *changed* residue and
+//! the length of the shifted tail; recovering it needs the shifted protein
+//! sequence, which the description does not carry. So — like the immediate-stop
+//! (`fsTer1`) and initiator-loss rules — this is a hard rejection, not a
+//! rewrite.
+//!
+//! # Scope
+//!
+//! Only a frameshift that **states** its new anchor residue and makes it equal
+//! the reference is rejected. The short form `p.Arg97fs` (no stated residue)
+//! and any genuine change (`p.Gln151ThrfsTer9`) are untouched.
+
+use ferro_hgvs::parse_hgvs;
+
+#[test]
+fn rejects_unchanged_anchor_frameshift() {
+    // `His150` → `His150` is no change; the anchor must be the first *changed*
+    // residue (frameshift.md:47-49). The `Ter#` spelling currently parses and
+    // must now be rejected.
+    for input in [
+        "NP_003997.1:p.His150HisfsTer10",
+        "NP_003997.1:p.His150HisfsTer?",
+    ] {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "frameshift.md:47-49 forbids the unchanged anchor in {input:?}"
+        );
+    }
+}
+
+#[test]
+fn rejection_names_the_spec_rule() {
+    let msg = parse_hgvs("NP_003997.1:p.His150HisfsTer10")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        msg.contains("frameshift.md:47-49"),
+        "the diagnostic should cite the frameshift-anchor rule; got: {msg}"
+    );
+}
+
+#[test]
+fn changed_anchor_frameshift_still_parses() {
+    // A genuine change at the anchor (`Gln151` → `Thr`) is a legal frameshift.
+    for input in [
+        "NP_003997.1:p.Gln151ThrfsTer9",
+        "NP_003997.1:p.Arg97ProfsTer23",
+        "NP_003997.1:p.Tyr4ValfsTer2",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} changes the anchor residue and must parse"
+        );
+    }
+}
+
+#[test]
+fn short_form_frameshift_still_parses() {
+    // The short form names no new residue, so it makes no unchanged-anchor
+    // claim and must not be rejected (frameshift.md short format).
+    for input in ["NP_003997.1:p.Arg97fs", "NP_003997.1:p.His150fs"] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "{input:?} states no anchor residue and must parse"
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -99,6 +99,7 @@ mod issue_1079_point_size_suffix;
 mod issue_1079_residues_after_stop;
 mod issue_1079_single_nucleotide_inversion;
 mod issue_1079_start_loss_substitution;
+mod issue_1079_unchanged_anchor_frameshift;
 mod issue_1086_c_axis_genomic_context;
 mod issue_1086_cross_axis_projection;
 mod issue_1092_stated_substitution_reference;


### PR DESCRIPTION
## What

A frameshift starts at the **first amino acid changed**, so an anchor whose stated new residue equals the reference is spec-invalid. Per `protein/frameshift.md:47-49`:

> Since frameshift variants start with the **first amino acid changed**, the description `p.His150HisfsTer10` (or `p.His150Hisfs*10`) is not correct.

`His150`→`His` is no change. ferro accepted and round-tripped the form; it now rejects it, naming the rule. The correct description (`p.Gln151Thrfs*9`) anchors at the first residue the shifted frame alters.

## How

Adds `validate_no_unchanged_anchor_frameshift`, a sibling of the existing `validate_no_immediate_ter_frameshift` (#1091), wired into the same post-parse `parse_variant` check list. It rejects a protein frameshift (or each protein member of an allele) whose stated new anchor residue equals the reference residue.

**Rejection, not rewrite:** the correct anchor and shifted-tail length need the shifted protein sequence, which the description does not carry — the same reason the immediate-stop and initiator-loss rules reject rather than repair.

## Scope

- Only a frameshift that **states** its new residue is checked. The short form `p.Arg97fs` (no stated residue) and any genuine change (`p.Gln151ThrfsTer9`, `p.Arg97ProfsTer23`) are untouched.
- `FrameshiftAlternatives` (`p.Gly719(Ala^Ser)fs…`) is rejected only when *every* alternative equals the reference.

## Tests

New `issue_1079_unchanged_anchor_frameshift` module (reject + diagnostic-cites-rule + changed-anchor-parses + short-form-parses). Also corrects `shortest_legal_frameshift_still_parses`, which had listed `p.His150HisfsTer10` as legal — it clears the immediate-stop rule (`Ter10` ≥ `Ter2`) but violates this anchor rule. Full suite green; `clippy --all-features --all-targets -D warnings` clean.

Part of #1079 (HGVS spec-divergence burn-down); follows the six rejections merged in #1091.