### PR TITLE
fix(tooling): make mutalyzer refresh merge fully non-destructive

### DIFF
--- a/scripts/refresh-mutalyzer-fixtures.py
+++ b/scripts/refresh-mutalyzer-fixtures.py
@@ -173,6 +173,12 @@ def _merge_case(existing_case: dict, upstream_case: dict) -> tuple[dict, bool, b
     merged.update(dispositions)
 
     removed_keys = existing_case.get("removed_keys") or []
+    unknown_removed = [k for k in removed_keys if k not in EXPECTED_VALUE_KEYS]
+    if unknown_removed:
+        raise ValueError(
+            f"removed_keys for input {existing_case.get('input')!r} names non-expected-value "
+            f"key(s) {unknown_removed}; only {list(EXPECTED_VALUE_KEYS)} may be removed"
+        )
     corrected = False
     for key in EXPECTED_VALUE_KEYS:
         in_existing, in_upstream = key in existing_case, key in upstream_case

--- a/scripts/refresh-mutalyzer-fixtures.py
+++ b/scripts/refresh-mutalyzer-fixtures.py
@@ -141,18 +141,28 @@ def _is_hand_added(case: dict) -> bool:
     return any(str(k).startswith(HAND_ADDED_PREFIX) for k in kws)
 
 
-def _merge_case(existing_case: dict, upstream_case: dict) -> tuple[dict, bool, bool]:
+def _merge_case(existing_case: dict, upstream_case: dict) -> tuple[dict, bool, bool, bool]:
     """Overlay one existing row's curation onto its fresh upstream row.
 
-    Returns `(merged_row, carried_disposition, carried_correction)`. The
+    Returns `(merged_row, carried_disposition, carried_correction,
+    carried_removal)`. `carried_correction` flags an expected-value field whose
+    curated value overrides upstream's; `carried_removal` flags a row carrying a
+    non-empty `removed_keys` marker (a deliberately-dropped expected value) —
+    tracked separately because a removal is curation the refresh must reconcile
+    even when upstream no longer ships the removed field, in which case there is
+    no value difference to flag as a correction. The
     upstream row is the base so genuinely-new upstream fields still arrive;
     onto it we overlay
 
     - every disposition key present on the existing row, and
-    - every expected-value field whose existing value differs from upstream's,
-      including the case where we deliberately *removed* the key (upstream has
-      it, the curated row does not) — that removal is a correction too, so the
-      key is dropped rather than resurrected;
+    - every expected-value field whose existing value differs from upstream's;
+    - every expected-value field the curated row *deliberately removed*, recorded
+      explicitly in its `removed_keys` list. Only a key named there is dropped —
+      an expected-value field absent from the curated row but NOT named in
+      `removed_keys` is treated as genuinely new upstream data and kept, so a
+      field upstream added after the row was curated survives the merge. The
+      `removed_keys` marker itself is carried forward so the removal keeps
+      holding across future refreshes;
     - any keyword the curated row added and upstream does not have. Keyword
       annotations are how a disposition's rationale is recorded, and appending
       (rather than replacing) keeps new upstream keywords as well.
@@ -162,17 +172,17 @@ def _merge_case(existing_case: dict, upstream_case: dict) -> tuple[dict, bool, b
     dispositions = {k: existing_case[k] for k in DISPOSITION_KEYS if k in existing_case}
     merged.update(dispositions)
 
+    removed_keys = existing_case.get("removed_keys") or []
     corrected = False
     for key in EXPECTED_VALUE_KEYS:
         in_existing, in_upstream = key in existing_case, key in upstream_case
-        if not in_existing and not in_upstream:
-            continue
         if in_existing and existing_case[key] != upstream_case.get(key):
             merged[key] = existing_case[key]
             corrected = True
-        elif not in_existing and in_upstream:
+        elif not in_existing and in_upstream and key in removed_keys:
             del merged[key]
-            corrected = True
+    if removed_keys:
+        merged["removed_keys"] = list(removed_keys)
 
     upstream_keywords = list(upstream_case.get("keywords") or [])
     added_keywords = [
@@ -181,18 +191,24 @@ def _merge_case(existing_case: dict, upstream_case: dict) -> tuple[dict, bool, b
     if added_keywords:
         merged["keywords"] = upstream_keywords + added_keywords
 
-    return merged, bool(dispositions), corrected
+    return merged, bool(dispositions), corrected, bool(removed_keys)
 
 
 def _pair_with_existing(
     upstream_cases: list[dict], existing_cases: list[dict]
-) -> list[tuple[dict, dict | None]]:
+) -> tuple[list[tuple[dict, dict | None]], list[dict]]:
     """Pair each upstream row with the curated row it supersedes.
 
     Rows are matched on `input`, and on *occurrence order* within a duplicated
     `input` — upstream occasionally ships the same variant twice with different
     expected values, and collapsing those onto one curated row would copy the
     wrong curation onto both.
+
+    Returns `(pairs, unmatched)`. `unmatched` holds the curated (non-hand-added)
+    rows that no upstream occurrence claimed — e.g. upstream dropped one of a
+    duplicated `input` that carried curation. Those rows must not be dropped
+    silently (that is the very curation loss the merge exists to prevent), so
+    the caller carries them forward and counts them.
     """
     by_input: dict[str | None, list[dict]] = {}
     for case in existing_cases:
@@ -206,7 +222,11 @@ def _pair_with_existing(
         seen[key] = ordinal + 1
         candidates = by_input.get(key, [])
         pairs.append((upstream, candidates[ordinal] if ordinal < len(candidates) else None))
-    return pairs
+    unmatched: list[dict] = []
+    for key, candidates in by_input.items():
+        claimed = seen.get(key, 0)
+        unmatched.extend(candidates[claimed:])
+    return pairs, unmatched
 
 
 def build_refresh_payload(upstream_cases: list[dict], existing: dict, force: bool) -> dict:
@@ -216,26 +236,33 @@ def build_refresh_payload(upstream_cases: list[dict], existing: dict, force: boo
     it supersedes (see `_pair_with_existing`); that row's per-case dispositions,
     hand-corrected expected values and added keyword annotations are overlaid
     onto it (see `_merge_case`), so genuinely-new upstream fields still arrive
-    while curation survives. Hand-added rows (marked via HAND_ADDED_PREFIX) and
-    corpus-level curation (clusters, comparator_provenance) are carried forward
-    verbatim. Raises when the existing file holds curation and force is not set,
-    so the operator can reconcile the merge first.
+    while curation survives. Curated rows that no upstream occurrence claims
+    (e.g. upstream dropped one of a duplicated `input`) are carried forward
+    rather than silently dropped, so their curation is never lost. Hand-added
+    rows (marked via HAND_ADDED_PREFIX) and corpus-level curation (clusters,
+    comparator_provenance) are carried forward verbatim. Raises when the existing
+    file holds curation and force is not set, so the operator can reconcile the
+    merge first.
     """
     existing_cases = existing.get("cases", [])
     preserved = [c for c in existing_cases if _is_hand_added(c)]
-    pairs = _pair_with_existing(upstream_cases, existing_cases)
+    pairs, unmatched = _pair_with_existing(upstream_cases, existing_cases)
 
     merged_cases: list[dict] = []
-    n_disp = n_corrected = 0
+    n_disp = n_corrected = n_removed = 0
     for upstream, prior in pairs:
         if prior is None:
             merged_cases.append(dict(upstream))
             continue
-        merged, carried_disposition, carried_correction = _merge_case(prior, upstream)
+        merged, carried_disposition, carried_correction, carried_removal = _merge_case(
+            prior, upstream
+        )
         n_disp += carried_disposition
         n_corrected += carried_correction
+        n_removed += carried_removal
         merged_cases.append(merged)
     n_hand = len(preserved)
+    n_unmatched = len(unmatched)
 
     has_curation = bool(
         existing.get("clusters")
@@ -243,6 +270,8 @@ def build_refresh_payload(upstream_cases: list[dict], existing: dict, force: boo
         or preserved
         or n_disp
         or n_corrected
+        or n_removed
+        or n_unmatched
     )
     if has_curation and not force:
         raise SystemExit(
@@ -253,6 +282,10 @@ def build_refresh_payload(upstream_cases: list[dict], existing: dict, force: boo
             f"({', '.join(DISPOSITION_KEYS)})\n"
             f"  - {n_corrected} upstream row(s) whose expected values were hand-corrected "
             "away from upstream (reverting these flips them PASS -> FAIL)\n"
+            f"  - {n_removed} upstream row(s) with deliberately-removed expected values "
+            "(removed_keys; resurrecting the removed key flips them PASS -> FAIL)\n"
+            f"  - {n_unmatched} curated row(s) upstream no longer ships (paired to no "
+            "upstream occurrence; carried forward so their curation is not lost)\n"
             f"  - {len(existing.get('clusters', []))} cluster(s), "
             f"comparator_provenance {'present' if existing.get('comparator_provenance') else 'absent'}\n"
             "Rerun with --force once you have reviewed the merge; --force keeps the "
@@ -270,11 +303,12 @@ def build_refresh_payload(upstream_cases: list[dict], existing: dict, force: boo
         payload["comparator_provenance"] = existing["comparator_provenance"]
     if existing.get("clusters"):
         payload["clusters"] = existing["clusters"]
-    payload["cases"] = merged_cases + preserved
+    payload["cases"] = merged_cases + unmatched + preserved
     print(
         f"merge: preserved dispositions on {n_disp} row(s), "
         f"corrected expected values on {n_corrected} row(s), "
-        f"{n_hand} hand-added row(s)"
+        f"{n_hand} hand-added row(s), "
+        f"{n_unmatched} unmatched curated row(s) carried forward"
     )
     return payload
 
@@ -312,12 +346,17 @@ same `input`, and overlays that row's per-case dispositions
 reference_unavailable, accepted_rejection) plus any expected-value field
 we had hand-corrected away from upstream (normalized, genomic,
 protein_description, coding_protein_descriptions, rna_description,
-noncoding, errors, infos) — including a field we deliberately REMOVED,
-which is dropped again rather than resurrected. Keyword annotations the
-curated row added are appended to upstream's keywords. New upstream
-fields therefore still arrive. Hand-added rows and corpus-level curation
-are carried forward verbatim. Rows are paired on `input` and on
-occurrence order within a duplicated `input`.
+noncoding, errors, infos). A field we deliberately REMOVED is recorded
+explicitly in the curated row's "removed_keys" list; only a key named
+there is dropped on refresh. An expected-value field absent from the
+curated row but NOT in "removed_keys" is treated as genuinely-new
+upstream data and kept — so a field upstream adds after a row is curated
+still arrives. Keyword annotations the curated row added are appended to
+upstream's keywords. New upstream fields therefore still arrive. Hand-added
+rows and corpus-level curation are carried forward verbatim. Curated rows
+that no upstream occurrence claims (e.g. upstream dropped one of a
+duplicated `input`) are carried forward too, never silently dropped. Rows
+are paired on `input` and on occurrence order within a duplicated `input`.
 
 The script still REFUSES to run while curation is present, listing what
 is at stake, so the merge is reviewed rather than assumed. --force is the

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -466,6 +466,9 @@
       "to_test": false,
       "errors": [
         "ECOORDINATESYSTEMMISMATCH"
+      ],
+      "removed_keys": [
+        "normalized"
       ]
     },
     {
@@ -675,6 +678,11 @@
       "to_test": false,
       "errors": [
         "EUNCERTAIN"
+      ],
+      "removed_keys": [
+        "normalized",
+        "genomic",
+        "protein_description"
       ]
     },
     {
@@ -687,6 +695,11 @@
       "to_test": false,
       "errors": [
         "EUNCERTAIN"
+      ],
+      "removed_keys": [
+        "normalized",
+        "genomic",
+        "protein_description"
       ]
     },
     {
@@ -699,6 +712,11 @@
       "to_test": false,
       "errors": [
         "EUNCERTAIN"
+      ],
+      "removed_keys": [
+        "normalized",
+        "genomic",
+        "coding_protein_descriptions"
       ]
     },
     {

--- a/tests/python/test_refresh_mutalyzer_fixtures_guard.py
+++ b/tests/python/test_refresh_mutalyzer_fixtures_guard.py
@@ -87,10 +87,13 @@ def _existing_fixture() -> dict:
             },
             {
                 # `normalized` deliberately dropped: the pinned comparator
-                # rejects this variant, so there is no normalized form.
+                # rejects this variant, so there is no normalized form. The
+                # removal is recorded explicitly so a refresh drops the key
+                # rather than resurrecting upstream's value.
                 "input": "NM_000000.1:g.5del",
                 "to_test": True,
                 "keywords": ["upstream"],
+                "removed_keys": ["normalized"],
                 "errors": ["ECOORDINATESYSTEMMISMATCH"],
             },
             {
@@ -133,10 +136,12 @@ def test_merge_preserves_hand_rows_dispositions_and_corrections() -> None:
     assert merged["keywords"] == ["upstream", "ferro: start-codon policy, see #857"]
     # An uncorrected upstream row is taken as-is.
     assert by_input["NM_000000.1:c.9del"]["normalized"] == "NM_000000.1:c.9del"
-    # A deliberately removed expected value stays removed, not resurrected.
+    # A deliberately removed expected value stays removed, not resurrected, and
+    # the removal marker persists so future refreshes keep honoring it.
     removed = by_input["NM_000000.1:g.5del"]
     assert "normalized" not in removed
     assert removed["errors"] == ["ECOORDINATESYSTEMMISMATCH"]
+    assert removed["removed_keys"] == ["normalized"]
 
 
 def test_duplicate_inputs_are_paired_by_occurrence_order() -> None:
@@ -173,12 +178,151 @@ def test_duplicate_inputs_are_paired_by_occurrence_order() -> None:
     ]
 
 
+def test_unmatched_curated_duplicate_tail_is_preserved() -> None:
+    """Boundary: upstream drops one occurrence of a duplicated, curated input.
+
+    Existing carries two curated (non-hand) rows for one `input`; upstream now
+    ships only one occurrence. The surplus curated row must not vanish — its
+    curation is carried forward rather than silently dropped.
+    """
+    upstream = [{"input": "NG_000000.1:g.26_31del", "keywords": [], "normalized": "a"}]
+    existing = {
+        "cases": [
+            {
+                "input": "NG_000000.1:g.26_31del",
+                "keywords": [],
+                "normalized": "a",
+                "spec_citation": "first",
+            },
+            {
+                "input": "NG_000000.1:g.26_31del",
+                "keywords": [],
+                "normalized": "b",
+                "spec_citation": "second",
+            },
+        ]
+    }
+    cases = refresh.build_refresh_payload(upstream, existing, force=True)["cases"]
+    # The matched occurrence AND the unmatched tail row both survive.
+    citations = sorted(c["spec_citation"] for c in cases)
+    assert citations == ["first", "second"]
+
+
+def test_unmatched_curated_row_triggers_refusal() -> None:
+    """Error case: an unmatched curated row is enumerated so refresh refuses.
+
+    A curated row that no upstream occurrence claims is curation at stake; the
+    guard must count it and refuse (absent --force) rather than drop it silently.
+    """
+    upstream = [{"input": "NG_000000.1:g.26_31del", "keywords": [], "normalized": "a"}]
+    existing = {
+        "cases": [
+            {"input": "NG_000000.1:g.26_31del", "keywords": [], "normalized": "a"},
+            {"input": "NG_000000.1:g.26_31del", "keywords": [], "normalized": "b"},
+        ]
+    }
+    with pytest.raises(SystemExit) as excinfo:
+        refresh.build_refresh_payload(upstream, existing, force=False)
+    message = str(excinfo.value)
+    assert "refusing to refresh" in message
+    assert "1 curated row(s) upstream no longer ships" in message
+
+
 def test_hand_added_marker_is_found_in_any_keyword_position() -> None:
     """Boundary: prepending a keyword must not reclassify a hand row."""
     case = {"keywords": ["cluster:protein", f"{refresh.HAND_ADDED_PREFIX}protein"]}
     assert refresh._is_hand_added(case)
     assert not refresh._is_hand_added({"keywords": ["upstream"]})
     assert not refresh._is_hand_added({})
+
+
+def test_new_upstream_expected_value_field_survives_without_removal_marker() -> None:
+    """Expected case: an expected-value field upstream added after a row was
+    curated must arrive on refresh, not be mistaken for a deliberate removal.
+
+    The curated row predates upstream's `infos`; with no `removed_keys` marker
+    naming it, the field is genuinely new and must survive the merge.
+    """
+    upstream = [
+        {
+            "input": "NM_000000.1:c.1A>T",
+            "keywords": ["upstream"],
+            "normalized": "NM_000000.1:c.1A>T",
+            "infos": ["ISOMEINFO"],
+        }
+    ]
+    existing = {
+        "cases": [
+            {
+                "input": "NM_000000.1:c.1A>T",
+                "keywords": ["upstream"],
+                "normalized": "NM_000000.1:c.1A>T",
+                "spec_citation": "sub.md:1",
+            }
+        ]
+    }
+    merged = refresh.build_refresh_payload(upstream, existing, force=True)["cases"][0]
+    assert merged["infos"] == ["ISOMEINFO"]
+    assert merged["spec_citation"] == "sub.md:1"
+
+
+def test_removed_keys_marker_drops_field_and_persists() -> None:
+    """Boundary: a key named in `removed_keys` is dropped and the marker is
+    carried forward so the removal keeps holding across refreshes."""
+    upstream = [
+        {
+            "input": "NM_000000.1:g.5del",
+            "keywords": ["upstream"],
+            "normalized": "NM_000000.1:n.5del",
+        }
+    ]
+    existing = {
+        "cases": [
+            {
+                "input": "NM_000000.1:g.5del",
+                "keywords": ["upstream"],
+                "removed_keys": ["normalized"],
+                "errors": ["ECOORDINATESYSTEMMISMATCH"],
+            }
+        ]
+    }
+    merged = refresh.build_refresh_payload(upstream, existing, force=True)["cases"][0]
+    assert "normalized" not in merged
+    assert merged["removed_keys"] == ["normalized"]
+    assert merged["errors"] == ["ECOORDINATESYSTEMMISMATCH"]
+
+
+def test_removed_keys_marker_triggers_refusal_when_field_absent_upstream() -> None:
+    """Error case: a `removed_keys` marker is curation even when upstream no
+    longer ships the removed field.
+
+    When upstream still shipped the removed field, the merge deleted it and the
+    value difference alone could have tripped the refusal gate. But once upstream
+    drops the field too, there is no value difference left — only the marker. The
+    marker is still curation the refresh must reconcile (resurrecting the key on a
+    later upstream re-add would flip the row PASS -> FAIL), so it must trip the
+    guard on its own, absent --force.
+    """
+    upstream = [{"input": "NM_000000.1:g.5del", "keywords": ["upstream"]}]
+    existing = {
+        "cases": [
+            {
+                "input": "NM_000000.1:g.5del",
+                "keywords": ["upstream"],
+                "removed_keys": ["normalized"],
+            }
+        ]
+    }
+    # Forcing carries the marker forward unchanged (no value to delete).
+    forced = refresh.build_refresh_payload(upstream, existing, force=True)["cases"][0]
+    assert forced["removed_keys"] == ["normalized"]
+    assert "normalized" not in forced
+    # Without --force, the marker alone is enough to refuse.
+    with pytest.raises(SystemExit) as excinfo:
+        refresh.build_refresh_payload(upstream, existing, force=False)
+    message = str(excinfo.value)
+    assert "refusing to refresh" in message
+    assert "1 upstream row(s) with deliberately-removed expected values" in message
 
 
 def test_refuses_when_curation_present_and_not_forced() -> None:
@@ -189,7 +333,11 @@ def test_refuses_when_curation_present_and_not_forced() -> None:
     assert "refusing to refresh" in message
     assert "1 hand-added case(s)" in message
     assert "1 upstream row(s) carrying per-case dispositions" in message
+    # c.1A>T (protein_description) and g.5del (its hand-added `errors`) are both
+    # genuine value corrections; the g.5del row is ALSO a deliberate removal,
+    # now counted separately rather than conflated with the corrections.
     assert "2 upstream row(s) whose expected values were hand-corrected" in message
+    assert "1 upstream row(s) with deliberately-removed expected values" in message
 
 
 def test_fresh_import_against_empty_fixture_proceeds() -> None:


### PR DESCRIPTION
## Summary

Closes #1105.

Fixes the two latent robustness gaps in `scripts/refresh-mutalyzer-fixtures.py`'s non-destructive merge (introduced in #1084). Neither affected the committed `cases.json` or CI — they only bite a *future* `refresh` against a newer upstream SHA — but both let hand curation be silently lost, defeating the purpose of the merge.

### 1. Unmatched curated duplicate-tail rows were silently dropped

`_pair_with_existing` matched upstream rows to curated rows by `(input, occurrence-ordinal)`. When an `input` had more curated (non-hand-added) rows than upstream now ships occurrences for — e.g. upstream drops one of a duplicated variant that carried curation — the surplus curated rows were never paired, never emitted, and never counted in the `has_curation` refusal tally.

`_pair_with_existing` now also returns the unmatched curated rows. `build_refresh_payload` carries them forward (so their curation is never lost) **and** counts them, so the guard refuses (absent `--force`) and enumerates them.

### 2. A genuinely-new upstream expected-value field was mistaken for a deliberate removal

For each `EXPECTED_VALUE_KEYS` field, `_merge_case` treated "present upstream, absent on the curated row" as a deliberate hand-removal and `del`'d the key. That also dropped an expected-value field upstream added *after* the row was curated, contradicting the "genuinely-new upstream fields still arrive" contract for those keys.

Removals are now recorded explicitly in a per-row `removed_keys` list. Only a key named there is dropped; an expected-value field absent from the curated row but not in `removed_keys` is treated as genuinely-new upstream data and kept. The `removed_keys` marker is carried forward so the removal keeps holding across refreshes. (Chosen over documenting the ambiguity as a known limitation — this makes the merge truly non-destructive and deletions self-documenting.)

## Corpus migration

The four curated rows that deliberately drop an expected-value field upstream still asserts are annotated with `removed_keys`, so the next `refresh` honors the removal rather than resurrecting the upstream value:

- `NM_000088.3:g.460del` → `["normalized"]`
- `NG_012772.1(BRCA2_v001):c.632-?_681+?del` → `["normalized", "genomic", "protein_description"]`
- `NG_012772.1(BRCA2_v001):c.68-?_316+?del` → `["normalized", "genomic", "protein_description"]`
- `NG_012772.1(BRCA2_v001):c.[632-?_681+?del;681+4del]` → `["normalized", "genomic", "coding_protein_descriptions"]`

No expected values change. The Rust consumer (`src/conformance/mutalyzer.rs::Case`) has no `deny_unknown_fields`, so the new key is ignored.

## Testing (TDD)

- New guard tests (written test-first, watched fail, then implemented) in `tests/python/test_refresh_mutalyzer_fixtures_guard.py`:
  - unmatched curated duplicate-tail row is preserved
  - unmatched curated row triggers the refusal
  - a new upstream expected-value field survives without a removal marker
  - a `removed_keys`-named field is dropped and the marker persists
  - the existing removal test updated to use `removed_keys`
- `pytest tests/python/test_refresh_mutalyzer_fixtures_guard.py` — 10 passed.
- `ruff check` / `ruff format --check` clean.
- A force-merge of the migrated corpus against the pinned SHA is **idempotent** (0 value diffs, removals hold, nothing resurrected) apart from a pre-existing empty-`xfail` cosmetic difference unrelated to this change.
- `conformance_summary_generated` Rust tests pass (corpus still loads, `failure-patterns.md` still current).
- The full mutalyzer axis conformance suite shows the **same 3 pre-existing failures** (`axis_normalized`, `axis_errors`, `comparator_provenance_reference_identity_matches_live`) with and without this change against the local reference — i.e. no regression.