### PR TITLE
refactor(conformance): type spec-enumeration row vocabularies

### DIFF
--- a/examples/generate_spec_enumeration.rs
+++ b/examples/generate_spec_enumeration.rs
@@ -33,6 +33,7 @@ use std::process::ExitCode;
 use clap::Parser as ClapParser;
 use ferro_hgvs::conformance::reference_window::WindowFixture;
 use ferro_hgvs::conformance::spec_projection;
+use ferro_hgvs::conformance::{Expectation, NormativeLevel, Status};
 use serde::{Deserialize, Serialize};
 
 #[path = "common/spec_harvest.rs"]
@@ -203,15 +204,15 @@ pub struct Row {
     /// `spec-mandated` when the spec states the expected value outright;
     /// `pinned-baseline` when it does not and the row records current
     /// behaviour instead. **Never** invent a spec expectation.
-    pub expectation: String,
+    pub expectation: Expectation,
     /// RFC 2119 level. Only `must` rows may ever hard-fail.
-    pub normative_level: String,
+    pub normative_level: NormativeLevel,
     /// The spec-stated expected value, when there is one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected: Option<String>,
     /// Ferro's behaviour at generation time.
     pub observed: String,
-    pub status: String,
+    pub status: Status,
     /// `docs/recommendations/<file>.md:<line>@<sha>` — or the artifact the row
     /// was derived from when the spec has no single line to cite.
     pub spec_citation: String,
@@ -383,7 +384,7 @@ mod overrides {
         /// `docs/…md:<line>` for the sentence that states the pair.
         pub citation: String,
         /// RFC 2119 level of the sentence: `must` or `should`.
-        pub normative_level: String,
+        pub normative_level: NormativeLevel,
         #[serde(default)]
         pub note: Option<String>,
     }
@@ -397,7 +398,7 @@ mod overrides {
         /// `docs/…md:<line>` for the sentence that states the pair.
         pub citation: String,
         /// RFC 2119 level of the sentence: `must` or `should`.
-        pub normative_level: String,
+        pub normative_level: NormativeLevel,
         /// Set when evaluating the repair needs real reference bases (e.g. any
         /// 3'-rule example). Such rows are emitted but marked, and the driver
         /// does not assert them under the hermetic mock provider.
@@ -411,7 +412,7 @@ mod overrides {
     #[serde(deny_unknown_fields)]
     pub struct RowOverride {
         #[serde(default)]
-        pub status: Option<String>,
+        pub status: Option<Status>,
         #[serde(default)]
         pub note: Option<String>,
     }
@@ -500,7 +501,7 @@ mod invariants {
     #[derive(Debug, Clone)]
     pub struct Violation {
         pub rule_id: &'static str,
-        pub level: &'static str,
+        pub level: NormativeLevel,
         pub message: String,
         pub citation: &'static str,
     }
@@ -596,7 +597,7 @@ mod invariants {
         if rendered.contains("dupinv") || rendered.contains("dupins") {
             v.push(Violation {
                 rule_id: "B7-no-composite-dup",
-                level: "must",
+                level: NormativeLevel::Must,
                 message: format!("composite dup edit in {rendered}"),
                 citation: "docs/recommendations/DNA/duplication.md:92",
             });
@@ -607,7 +608,7 @@ mod invariants {
             if cap.0.chars().count() != 1 || cap.1.chars().count() != 1 {
                 v.push(Violation {
                     rule_id: "B4-substitution-one-to-one",
-                    level: "must",
+                    level: NormativeLevel::Must,
                     message: format!("`{}>{}` is not a 1-to-1 substitution", cap.0, cap.1),
                     citation: "docs/recommendations/DNA/delins.md:73",
                 });
@@ -615,7 +616,7 @@ mod invariants {
                 // B13 — an unchanged residue is `=`, never X>X.
                 v.push(Violation {
                     rule_id: "B13-silent-is-equals",
-                    level: "must",
+                    level: NormativeLevel::Must,
                     message: format!("unchanged residue written as `{}>{}`", cap.0, cap.1),
                     citation: "docs/recommendations/checklist.md:64",
                 });
@@ -628,7 +629,7 @@ mod invariants {
         if has_ter_count_one(rendered) {
             v.push(Violation {
                 rule_id: "S6-no-fsTer1",
-                level: "must",
+                level: NormativeLevel::Must,
                 message: format!("`fsTer1` in {rendered}; a nonsense change is `Ter`/`*`"),
                 citation: "docs/recommendations/protein/frameshift.md:22",
             });
@@ -646,7 +647,7 @@ mod invariants {
                 {
                     v.push(Violation {
                         rule_id: "B11-start-loss-not-met1xxx",
-                        level: "must",
+                        level: NormativeLevel::Must,
                         message: format!(
                             "start-loss written as {rendered}; use p.0/p.0?/p.(Met1?)"
                         ),
@@ -660,7 +661,7 @@ mod invariants {
             if rest.replace("Xaa", "").contains('X') {
                 v.push(Violation {
                     rule_id: "B10-no-X-for-stop",
-                    level: "must",
+                    level: NormativeLevel::Must,
                     message: format!("`X` used as an amino-acid code in {rendered}"),
                     citation: "docs/recommendations/checklist.md:63",
                 });
@@ -672,7 +673,7 @@ mod invariants {
         if axes.len() > 1 {
             v.push(Violation {
                 rule_id: "B15-no-mixed-reference-types",
-                level: "must",
+                level: NormativeLevel::Must,
                 message: format!("mixed coordinate types in one allele: {rendered}"),
                 citation: "docs/recommendations/DNA/alleles.md:23",
             });
@@ -693,7 +694,7 @@ mod invariants {
                 if n > 1 {
                     v.push(Violation {
                         rule_id: "S1-no-conflicting-cis-members",
-                        level: "must",
+                        level: NormativeLevel::Must,
                         message: format!("{n} cis members at position `{loc}` in {rendered}"),
                         citation: "docs/recommendations/DNA/delins.md:19",
                     });
@@ -706,7 +707,7 @@ mod invariants {
                 // B5 — an inversion is at least two residues.
                 "inv" if is_plain_position(&m.loc) => v.push(Violation {
                     rule_id: "B5-inversion-min-length",
-                    level: "must",
+                    level: NormativeLevel::Must,
                     message: format!("single-position inversion `{}inv`", m.loc),
                     citation: "docs/recommendations/DNA/inversion.md:16",
                 }),
@@ -715,7 +716,7 @@ mod invariants {
                     if is_plain_position(&m.loc) {
                         v.push(Violation {
                             rule_id: "S5-insertion-spans-two-positions",
-                            level: "must",
+                            level: NormativeLevel::Must,
                             message: format!("insertion at one position `{}ins`", m.loc),
                             citation: "docs/recommendations/protein/insertion.md:18",
                         });
@@ -723,7 +724,7 @@ mod invariants {
                         if b != a + 1 {
                             v.push(Violation {
                                 rule_id: "B16-insertion-flanks-adjacent",
-                                level: "must",
+                                level: NormativeLevel::Must,
                                 message: format!("insertion flanks {a}_{b} are not adjacent"),
                                 citation: "docs/recommendations/protein/insertion.md:17",
                             });
@@ -740,14 +741,14 @@ mod invariants {
                     if a == b {
                         v.push(Violation {
                             rule_id: "B6-range-two-distinct-positions",
-                            level: "must",
+                            level: NormativeLevel::Must,
                             message: format!("range `{a}_{b}` repeats one position"),
                             citation: "docs/recommendations/DNA/deletion.md:15",
                         });
                     } else if a > b && !matches!(m.axis, 'o' | 'm') {
                         v.push(Violation {
                             rule_id: "B6-range-two-distinct-positions",
-                            level: "must",
+                            level: NormativeLevel::Must,
                             message: format!("range `{a}_{b}` is not ordered 5'->3'"),
                             citation: "docs/recommendations/DNA/deletion.md:17",
                         });
@@ -762,7 +763,7 @@ mod invariants {
             {
                 v.push(Violation {
                     rule_id: "B8-no-size-number-forms",
-                    level: "must",
+                    level: NormativeLevel::Must,
                     message: format!("size-number form `{}{}`", m.kw, m.arg),
                     citation: "docs/recommendations/checklist.md:49",
                 });
@@ -776,7 +777,7 @@ mod invariants {
                     if tail.chars().next().is_some_and(|c| c.is_ascii_alphabetic()) {
                         v.push(Violation {
                             rule_id: "B9-nothing-after-stop",
-                            level: "must",
+                            level: NormativeLevel::Must,
                             message: format!("residues listed after `Ter` in `{}`", m.arg),
                             citation: "docs/recommendations/protein/delins.md:45",
                         });
@@ -792,7 +793,7 @@ mod invariants {
             {
                 v.push(Violation {
                     rule_id: "A1-no-longform-del-dup",
-                    level: "should",
+                    level: NormativeLevel::Should,
                     message: format!("long form `{}{}`", m.kw, m.arg),
                     citation: "docs/recommendations/DNA/deletion.md:30",
                 });
@@ -805,7 +806,7 @@ mod invariants {
         if is_lone_single_member_allele(rendered) {
             v.push(Violation {
                 rule_id: "A2-lone-single-member-bracket",
-                level: "should",
+                level: NormativeLevel::Should,
                 message: format!("lone single-member allele bracket in {rendered}"),
                 citation: "docs/recommendations/DNA/alleles.md:99",
             });
@@ -934,7 +935,7 @@ mod invariants {
             ] {
                 let musts: Vec<&str> = check(legal)
                     .into_iter()
-                    .filter(|v| v.level == "must")
+                    .filter(|v| v.level == NormativeLevel::Must)
                     .map(|v| v.rule_id)
                     .collect();
                 assert!(musts.is_empty(), "{legal} wrongly flagged: {musts:?}");
@@ -947,7 +948,7 @@ mod invariants {
         fn trans_genotype_single_member_brackets_are_legal() {
             let musts: Vec<&str> = check("NM_004006.2:c.[2376G>C];[3103del]")
                 .into_iter()
-                .filter(|v| v.level == "must")
+                .filter(|v| v.level == NormativeLevel::Must)
                 .map(|v| v.rule_id)
                 .collect();
             assert!(musts.is_empty(), "{musts:?}");
@@ -1130,15 +1131,15 @@ mod builder {
         rows: &mut Vec<Row>,
         cens: &mut Census,
     ) {
-        let mut all: BTreeMap<String, (String, Option<usize>, &'static str)> = BTreeMap::new();
+        let mut all: BTreeMap<String, (String, Option<usize>, NormativeLevel)> = BTreeMap::new();
         for (input, path, line) in raw_negatives {
             all.entry(input.clone())
-                .or_insert((path.clone(), Some(*line), "must"));
+                .or_insert((path.clone(), Some(*line), NormativeLevel::Must));
         }
         for p in prose {
             let level = match p.normative_level {
-                negatives::NormativeLevel::Must => "must",
-                negatives::NormativeLevel::Should => "should",
+                negatives::NormativeLevel::Must => NormativeLevel::Must,
+                negatives::NormativeLevel::Should => NormativeLevel::Should,
             };
             for s in &p.invalid_spans {
                 all.entry(s.clone())
@@ -1156,9 +1157,9 @@ mod builder {
             }
             let observed = observe(normalizer, &target);
             let status = if observed.starts_with("parse error") {
-                "correctly-rejected"
+                Status::CorrectlyRejected
             } else {
-                "false-acceptance"
+                Status::FalseAcceptance
             };
             net += 1;
             rows.push(Row {
@@ -1168,11 +1169,11 @@ mod builder {
                 error_mode: "default".to_string(),
                 input,
                 target,
-                expectation: "spec-mandated".to_string(),
-                normative_level: level.to_string(),
+                expectation: Expectation::SpecMandated,
+                normative_level: level,
                 expected: None,
                 observed,
-                status: status.to_string(),
+                status,
                 spec_citation: cite(&path, line, sha),
                 dedup_note: "spec-marked negative the normalization fixture's harvester drops \
                              (escaped underscores / bare bracket allele list), so its rejection \
@@ -1250,14 +1251,14 @@ mod builder {
             // Accepting it and rendering something other than the canonical form
             // the spec names is the genuine violation.
             let status = if rep.requires_reference {
-                "requires-reference"
+                Status::RequiresReference
             } else if observed == repaired {
-                "repaired"
+                Status::Repaired
             } else if observed.starts_with("parse error") || observed.starts_with("normalize error")
             {
-                "rejected-not-repaired"
+                Status::RejectedNotRepaired
             } else {
-                "repair-diverges"
+                Status::RepairDiverges
             };
             rows.push(Row {
                 id: format!("negative-repair/{input}"),
@@ -1266,11 +1267,11 @@ mod builder {
                 error_mode: "default".to_string(),
                 input: input.clone(),
                 target,
-                expectation: "spec-mandated".to_string(),
-                normative_level: rep.normative_level.clone(),
+                expectation: Expectation::SpecMandated,
+                normative_level: rep.normative_level,
                 expected: Some(repaired),
                 observed,
-                status: status.to_string(),
+                status,
                 spec_citation: format!("{}@{sha}", rep.citation),
                 dedup_note: "the normalization fixture records only that ferro rejects this \
                              string; the canonical form the spec names on the same line is \
@@ -1342,11 +1343,11 @@ mod builder {
                     target: target.clone(),
                     // The spec says nothing about ferro's error modes: this is
                     // ferro policy, pinned, never a spec expectation.
-                    expectation: "pinned-baseline".to_string(),
-                    normative_level: "n/a".to_string(),
+                    expectation: Expectation::PinnedBaseline,
+                    normative_level: NormativeLevel::Na,
                     expected: None,
                     observed,
-                    status: "mode-divergence-pinned".to_string(),
+                    status: Status::ModeDivergencePinned,
                     spec_citation: cite(path, *line, sha),
                     dedup_note: "the three error modes disagree on this input; the normalization \
                                  fixture pins only the default mode"
@@ -1439,11 +1440,11 @@ mod builder {
                 let expected = format!("axis={a}");
                 let spec_stated = a == axis;
                 let status = if observed == expected {
-                    "form-axis-ok"
+                    Status::FormAxisOk
                 } else if spec_stated {
-                    "form-axis-diverges"
+                    Status::FormAxisDiverges
                 } else {
-                    "form-axis-pinned"
+                    Status::FormAxisPinned
                 };
                 rows.push(Row {
                     id: format!("grammar-form/{a}/{}", c.input),
@@ -1453,14 +1454,18 @@ mod builder {
                     input: c.input.clone(),
                     target: derived,
                     expectation: if spec_stated {
-                        "spec-mandated".to_string()
+                        Expectation::SpecMandated
                     } else {
-                        "pinned-baseline".to_string()
+                        Expectation::PinnedBaseline
                     },
-                    normative_level: if spec_stated { "must" } else { "n/a" }.to_string(),
+                    normative_level: if spec_stated {
+                        NormativeLevel::Must
+                    } else {
+                        NormativeLevel::Na
+                    },
                     expected: Some(expected),
                     observed,
-                    status: status.to_string(),
+                    status,
                     spec_citation: format!("docs/syntax.yaml@{sha}"),
                     dedup_note: "the normalization fixture pins this example's normalized \
                                  rendering; nothing asserts which coordinate axis it parses into"
@@ -1537,14 +1542,14 @@ mod builder {
                     error_mode: "default".to_string(),
                     input: target.clone(),
                     target: rendered.clone(),
-                    expectation: "spec-mandated".to_string(),
-                    normative_level: v.level.to_string(),
+                    expectation: Expectation::SpecMandated,
+                    normative_level: v.level,
                     expected: Some("no violation".to_string()),
                     observed: v.message.clone(),
-                    status: if v.level == "must" {
-                        "invariant-violation-must".to_string()
+                    status: if v.level == NormativeLevel::Must {
+                        Status::InvariantViolationMust
                     } else {
-                        "invariant-violation-should".to_string()
+                        Status::InvariantViolationShould
                     },
                     spec_citation: format!("{}@{sha}", v.citation),
                     dedup_note: "no existing test asserts any property of the string ferro \
@@ -1713,24 +1718,24 @@ mod builder {
                 }
                 let (expectation, normative_level, expected, status, citation) = match stated {
                     Some(o) => (
-                        "spec-mandated",
-                        o.normative_level.clone(),
+                        Expectation::SpecMandated,
+                        o.normative_level,
                         Some(o.expected.clone()),
                         if projection_matches(&observed, &o.expected) {
-                            "preserved"
+                            Status::Preserved
                         } else {
-                            "projection-diverges"
+                            Status::ProjectionDiverges
                         },
                         format!("{}@{sha}", o.citation),
                     ),
                     None => (
-                        "pinned-baseline",
-                        "n/a".to_string(),
+                        Expectation::PinnedBaseline,
+                        NormativeLevel::Na,
                         None,
                         match result {
-                            AxisResult::Rendered(_) => "projection-pinned",
-                            AxisResult::Unavailable(_) => "projection-unavailable-pinned",
-                            AxisResult::Error(_) => "projection-error-pinned",
+                            AxisResult::Rendered(_) => Status::ProjectionPinned,
+                            AxisResult::Unavailable(_) => Status::ProjectionUnavailablePinned,
+                            AxisResult::Error(_) => Status::ProjectionErrorPinned,
                             AxisResult::NotApplicable(_) => unreachable!("filtered above"),
                         },
                         cite(path, *line, sha),
@@ -1747,11 +1752,11 @@ mod builder {
                     error_mode: "default".to_string(),
                     input: input.clone(),
                     target: target.clone(),
-                    expectation: expectation.to_string(),
+                    expectation,
                     normative_level,
                     expected,
                     observed,
-                    status: status.to_string(),
+                    status,
                     spec_citation: citation,
                     dedup_note: "the existing suite is entirely within-axis (parse / normalize / \
                                  render in the input's own coordinate system); nothing asserts \
@@ -1915,14 +1920,17 @@ mod render {
         };
         for r in &build.rows {
             *summary.by_dimension.entry(r.dimension.clone()).or_default() += 1;
-            *summary.by_status.entry(r.status.clone()).or_default() += 1;
+            *summary
+                .by_status
+                .entry(r.status.as_str().to_string())
+                .or_default() += 1;
             *summary
                 .by_expectation
-                .entry(r.expectation.clone())
+                .entry(r.expectation.as_str().to_string())
                 .or_default() += 1;
             *summary
                 .by_normative_level
-                .entry(r.normative_level.clone())
+                .entry(r.normative_level.as_str().to_string())
                 .or_default() += 1;
         }
         let doc = Document {

--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -17,7 +17,9 @@ pub mod mutalyzer;
 pub mod reference_snapshot;
 pub mod reference_window;
 pub mod schema;
+pub mod spec_enumeration;
 pub mod spec_projection;
 pub mod summary;
 
 pub use schema::{validate_cluster_refs, Cluster};
+pub use spec_enumeration::{Expectation, NormativeLevel, Status};

--- a/src/conformance/spec_enumeration.rs
+++ b/src/conformance/spec_enumeration.rs
@@ -1,0 +1,304 @@
+//! Typed classification vocabularies for the spec-enumeration corpus.
+//!
+//! The exhaustive HGVS spec enumeration (`examples/generate_spec_enumeration.rs`)
+//! emits one JSON `Row` per assertion, and the test driver
+//! (`tests/it/spec_enumeration_tests.rs`) reads those rows back. Three of a
+//! row's classification fields draw from small, closed vocabularies:
+//!
+//! * [`Status`] — the outcome class (`repaired`, `false-acceptance`, …);
+//! * [`Expectation`] — whether the row pins a spec expectation or ferro's
+//!   current behaviour;
+//! * [`NormativeLevel`] — the RFC 2119 force of the row.
+//!
+//! Modelling them as enums shared by the generator and the driver turns a typo
+//! or a drift between the two — previously caught only at runtime — into a
+//! compile error. The generator and driver stay decoupled through the JSON
+//! fixture, so the runtime "is every observed status accounted for?" guard from
+//! issue #1107 remains valuable: [`Status`] therefore keeps an
+//! [`Unknown`](Status::Unknown) fallback so a *new* status the generator starts
+//! emitting deserializes and is named by that guard, rather than degrading into
+//! an opaque serde "unknown variant" error.
+
+use std::fmt;
+
+use serde::de::Deserializer;
+use serde::{Deserialize, Serialize, Serializer};
+
+/// The outcome class recorded for one enumerated assertion.
+///
+/// The wire form is the kebab-case string the generator has always emitted, so
+/// the generated fixture is byte-for-byte unchanged. Any string that is not a
+/// known variant deserializes into [`Unknown`](Status::Unknown), preserving the
+/// offending name for the #1107 accounted-for diagnostic instead of failing the
+/// whole parse.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Status {
+    /// Spec-forbidden string that ferro rejected outright (parse error) — the
+    /// conformant counterpart of [`FalseAcceptance`](Status::FalseAcceptance).
+    CorrectlyRejected,
+    /// Spec-forbidden string that ferro parses and renders anyway.
+    FalseAcceptance,
+    /// Bad string repaired to the canonical form the spec names.
+    Repaired,
+    /// Spec names a canonical replacement; ferro rejects the bad string instead
+    /// of repairing it. Spec-conformant — rejection is always permitted.
+    RejectedNotRepaired,
+    /// Spec names a canonical replacement; ferro accepts the bad string and
+    /// renders something else. A genuine violation.
+    RepairDiverges,
+    /// Repair that needs real reference bases; not assertable hermetically.
+    RequiresReference,
+    /// Per-error-mode outcome pinned as ferro policy (the spec says nothing
+    /// about ferro's error modes).
+    ModeDivergencePinned,
+    /// Grammar example that parses into the coordinate axis the spec declares.
+    FormAxisOk,
+    /// syntax.yaml example that does not parse into its declared axis.
+    FormAxisDiverges,
+    /// Grammar example whose axis the spec does not state; ferro's parsed axis
+    /// is pinned as a baseline.
+    FormAxisPinned,
+    /// MUST-level output invariant violated by a string ferro emits.
+    InvariantViolationMust,
+    /// SHOULD-level (advisory) output invariant. Never a hard failure.
+    InvariantViolationShould,
+    /// Projection that matches the form the spec states — the conformant
+    /// counterpart of [`ProjectionDiverges`](Status::ProjectionDiverges).
+    Preserved,
+    /// Projection whose rendered form differs from the one the spec states.
+    ProjectionDiverges,
+    /// Projection with no spec-stated expectation, rendered and pinned as a
+    /// baseline.
+    ProjectionPinned,
+    /// Projection with no spec-stated expectation that ferro declined /
+    /// reported unavailable, pinned as a baseline.
+    ProjectionUnavailablePinned,
+    /// Projection with no spec-stated expectation that errored, pinned as a
+    /// baseline.
+    ProjectionErrorPinned,
+    /// A status string the generator emitted that is not (yet) a known variant.
+    /// Its name is preserved so the #1107 accounted-for guard can report it.
+    Unknown(String),
+}
+
+impl Status {
+    /// The kebab-case wire string for this status. For
+    /// [`Unknown`](Status::Unknown) this is the preserved original name.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Status::CorrectlyRejected => "correctly-rejected",
+            Status::FalseAcceptance => "false-acceptance",
+            Status::Repaired => "repaired",
+            Status::RejectedNotRepaired => "rejected-not-repaired",
+            Status::RepairDiverges => "repair-diverges",
+            Status::RequiresReference => "requires-reference",
+            Status::ModeDivergencePinned => "mode-divergence-pinned",
+            Status::FormAxisOk => "form-axis-ok",
+            Status::FormAxisDiverges => "form-axis-diverges",
+            Status::FormAxisPinned => "form-axis-pinned",
+            Status::InvariantViolationMust => "invariant-violation-must",
+            Status::InvariantViolationShould => "invariant-violation-should",
+            Status::Preserved => "preserved",
+            Status::ProjectionDiverges => "projection-diverges",
+            Status::ProjectionPinned => "projection-pinned",
+            Status::ProjectionUnavailablePinned => "projection-unavailable-pinned",
+            Status::ProjectionErrorPinned => "projection-error-pinned",
+            Status::Unknown(s) => s,
+        }
+    }
+
+    /// Parse a wire string into a status, mapping any unrecognised value to
+    /// [`Unknown`](Status::Unknown) so the name survives for diagnostics.
+    pub fn from_wire(s: &str) -> Self {
+        match s {
+            "correctly-rejected" => Status::CorrectlyRejected,
+            "false-acceptance" => Status::FalseAcceptance,
+            "repaired" => Status::Repaired,
+            "rejected-not-repaired" => Status::RejectedNotRepaired,
+            "repair-diverges" => Status::RepairDiverges,
+            "requires-reference" => Status::RequiresReference,
+            "mode-divergence-pinned" => Status::ModeDivergencePinned,
+            "form-axis-ok" => Status::FormAxisOk,
+            "form-axis-diverges" => Status::FormAxisDiverges,
+            "form-axis-pinned" => Status::FormAxisPinned,
+            "invariant-violation-must" => Status::InvariantViolationMust,
+            "invariant-violation-should" => Status::InvariantViolationShould,
+            "preserved" => Status::Preserved,
+            "projection-diverges" => Status::ProjectionDiverges,
+            "projection-pinned" => Status::ProjectionPinned,
+            "projection-unavailable-pinned" => Status::ProjectionUnavailablePinned,
+            "projection-error-pinned" => Status::ProjectionErrorPinned,
+            other => Status::Unknown(other.to_string()),
+        }
+    }
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for Status {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Status {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Status::from_wire(&s))
+    }
+}
+
+/// Whether a row states a spec expectation or merely pins ferro's current
+/// behaviour. A `pinned-baseline` row must never carry MUST-level force.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Expectation {
+    /// The spec states the expected value outright.
+    SpecMandated,
+    /// The spec states nothing; the row records current behaviour instead.
+    PinnedBaseline,
+}
+
+impl Expectation {
+    /// The kebab-case wire string for this expectation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Expectation::SpecMandated => "spec-mandated",
+            Expectation::PinnedBaseline => "pinned-baseline",
+        }
+    }
+}
+
+impl fmt::Display for Expectation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// RFC 2119 normative force of a row. Only [`Must`](NormativeLevel::Must) rows
+/// may ever hard-fail; [`Na`](NormativeLevel::Na) marks a pinned baseline the
+/// spec places no obligation on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum NormativeLevel {
+    /// RFC 2119 MUST.
+    #[serde(rename = "must")]
+    Must,
+    /// RFC 2119 SHOULD.
+    #[serde(rename = "should")]
+    Should,
+    /// No normative force (pinned baseline).
+    #[serde(rename = "n/a")]
+    Na,
+}
+
+impl NormativeLevel {
+    /// The wire string for this level (`must` / `should` / `n/a`).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            NormativeLevel::Must => "must",
+            NormativeLevel::Should => "should",
+            NormativeLevel::Na => "n/a",
+        }
+    }
+}
+
+impl fmt::Display for NormativeLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every known status must round-trip name → variant → name unchanged, and
+    /// serialize to exactly that wire string.
+    #[test]
+    fn status_known_variants_round_trip() {
+        let names = [
+            "correctly-rejected",
+            "false-acceptance",
+            "repaired",
+            "rejected-not-repaired",
+            "repair-diverges",
+            "requires-reference",
+            "mode-divergence-pinned",
+            "form-axis-ok",
+            "form-axis-diverges",
+            "form-axis-pinned",
+            "invariant-violation-must",
+            "invariant-violation-should",
+            "preserved",
+            "projection-diverges",
+            "projection-pinned",
+            "projection-unavailable-pinned",
+            "projection-error-pinned",
+        ];
+        for name in names {
+            let status = Status::from_wire(name);
+            assert!(
+                !matches!(status, Status::Unknown(_)),
+                "{name} should map to a known variant"
+            );
+            assert_eq!(status.as_str(), name);
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(json, format!("\"{name}\""));
+            let back: Status = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, status);
+        }
+    }
+
+    /// An unknown status deserializes into `Unknown` with its name preserved,
+    /// rather than failing the parse — this is what keeps the #1107 diagnostic
+    /// able to name the offender.
+    #[test]
+    fn status_unknown_preserves_name() {
+        let status: Status = serde_json::from_str("\"projection panicked\"").unwrap();
+        assert_eq!(status, Status::Unknown("projection panicked".to_string()));
+        assert_eq!(status.as_str(), "projection panicked");
+        // And round-trips back out verbatim.
+        assert_eq!(
+            serde_json::to_string(&status).unwrap(),
+            "\"projection panicked\""
+        );
+    }
+
+    #[test]
+    fn expectation_round_trips() {
+        for (variant, wire) in [
+            (Expectation::SpecMandated, "\"spec-mandated\""),
+            (Expectation::PinnedBaseline, "\"pinned-baseline\""),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), wire);
+            assert_eq!(serde_json::from_str::<Expectation>(wire).unwrap(), variant);
+        }
+    }
+
+    #[test]
+    fn normative_level_round_trips() {
+        for (variant, wire) in [
+            (NormativeLevel::Must, "\"must\""),
+            (NormativeLevel::Should, "\"should\""),
+            (NormativeLevel::Na, "\"n/a\""),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), wire);
+            assert_eq!(
+                serde_json::from_str::<NormativeLevel>(wire).unwrap(),
+                variant
+            );
+        }
+    }
+
+    /// An unknown expectation / normative level fails loudly (naming the value),
+    /// since these small closed vocabularies have no decoupled runtime guard.
+    #[test]
+    fn strict_enums_reject_unknown() {
+        assert!(serde_json::from_str::<Expectation>("\"made-up\"").is_err());
+        assert!(serde_json::from_str::<NormativeLevel>("\"maybe\"").is_err());
+    }
+}

--- a/tests/it/spec_enumeration_tests.rs
+++ b/tests/it/spec_enumeration_tests.rs
@@ -23,6 +23,7 @@ use std::path::PathBuf;
 
 use ferro_hgvs::conformance::reference_window::WindowProvider;
 use ferro_hgvs::conformance::spec_projection;
+use ferro_hgvs::conformance::{Expectation, NormativeLevel, Status};
 use ferro_hgvs::data::cdot::CdotMapper;
 use ferro_hgvs::data::projection::Projector;
 use ferro_hgvs::error_handling::ErrorConfig;
@@ -53,12 +54,12 @@ struct Row {
     operation: String,
     error_mode: String,
     target: String,
-    expectation: String,
-    normative_level: String,
+    expectation: Expectation,
+    normative_level: NormativeLevel,
     #[serde(default)]
     expected: Option<String>,
     observed: String,
-    status: String,
+    status: Status,
     spec_citation: String,
 }
 
@@ -210,7 +211,10 @@ fn enumeration_replays_recorded_behavior() {
 }
 
 /// Every row must carry usable provenance: a spec citation pinned to the
-/// submodule SHA, a dimension, and an RFC 2119 level.
+/// submodule SHA. The `normative_level` and `expectation` vocabularies are now
+/// enforced structurally — an unknown value fails deserialization by naming
+/// itself — so the only cross-field invariant left to assert is that a pinned
+/// baseline never masquerades as a MUST-level spec expectation.
 #[test]
 fn every_row_carries_provenance() {
     let fx = load();
@@ -221,25 +225,11 @@ fn every_row_carries_provenance() {
             row.id,
             row.spec_citation
         );
-        assert!(
-            matches!(row.normative_level.as_str(), "must" | "should" | "n/a"),
-            "row {} has an unknown normative level {:?}",
-            row.id,
-            row.normative_level
-        );
-        assert!(
-            matches!(
-                row.expectation.as_str(),
-                "spec-mandated" | "pinned-baseline"
-            ),
-            "row {} has an unknown expectation kind {:?}",
-            row.id,
-            row.expectation
-        );
         // A pinned baseline must never masquerade as a spec expectation.
-        if row.expectation == "pinned-baseline" {
+        if row.expectation == Expectation::PinnedBaseline {
             assert_ne!(
-                row.normative_level, "must",
+                row.normative_level,
+                NormativeLevel::Must,
                 "row {} pins current behaviour but claims MUST-level force",
                 row.id
             );
@@ -256,25 +246,25 @@ fn every_row_carries_provenance() {
 /// Regenerate the numbers with:
 ///   `cargo run --features dev --example generate_spec_enumeration -- --census`
 /// and read `by_status` in the generated fixture.
-const DIVERGENCE_BUDGET: &[(&str, usize)] = &[
+const DIVERGENCE_BUDGET: &[(Status, usize)] = &[
     // Spec-forbidden strings ferro parses and renders anyway.
-    ("false-acceptance", 6),
+    (Status::FalseAcceptance, 6),
     // Spec names a canonical replacement; ferro accepts the bad string and
     // renders something else. These are the genuine violations.
-    ("repair-diverges", 4),
+    (Status::RepairDiverges, 4),
     // Spec names a canonical replacement; ferro rejects the bad string instead
     // of repairing it. Spec-conformant — rejection is always permitted.
-    ("rejected-not-repaired", 13),
+    (Status::RejectedNotRepaired, 13),
     // Repairs that need real reference bases; not assertable hermetically.
-    ("requires-reference", 10),
+    (Status::RequiresReference, 10),
     // MUST-level output invariants violated by a string ferro emits.
-    ("invariant-violation-must", 0),
+    (Status::InvariantViolationMust, 0),
     // SHOULD-level (advisory) output invariants. Never a hard failure.
-    ("invariant-violation-should", 2),
+    (Status::InvariantViolationShould, 2),
     // syntax.yaml examples that do not parse into their declared axis.
-    ("form-axis-diverges", 3),
+    (Status::FormAxisDiverges, 3),
     // Projections whose rendered form differs from the one the spec states.
-    ("projection-diverges", 0),
+    (Status::ProjectionDiverges, 0),
 ];
 
 /// Does a projected string match the form the spec states? Mirrors
@@ -297,7 +287,7 @@ fn divergence_budget_is_unchanged() {
     }
     let mut mismatches = Vec::new();
     for (status, budget) in DIVERGENCE_BUDGET {
-        let actual = counts.get(status).copied().unwrap_or(0);
+        let actual = counts.get(status.as_str()).copied().unwrap_or(0);
         if actual != *budget {
             mismatches.push(format!("  {status}: budget {budget}, actual {actual}"));
         }
@@ -320,37 +310,37 @@ fn divergence_budget_is_unchanged() {
 /// silent pass. Regenerate the roster of observed statuses with:
 ///   `cargo run --features dev --example generate_spec_enumeration -- --census`
 /// and read `by_status` in the generated fixture.
-const KNOWN_PASSING_STATUSES: &[&str] = &[
+const KNOWN_PASSING_STATUSES: &[Status] = &[
     // Spec-forbidden string that ferro rejected outright (parse error) — the
     // conformant counterpart of the budgeted `false-acceptance`.
-    "correctly-rejected",
+    Status::CorrectlyRejected,
     // Bad string repaired to the canonical form the spec names — the ideal
     // outcome of a repair.
-    "repaired",
+    Status::Repaired,
     // Grammar example that parses into the coordinate axis the spec declares.
-    "form-axis-ok",
+    Status::FormAxisOk,
     // Grammar example whose axis the spec does not state; ferro's parsed axis is
     // pinned as a baseline (not a spec matter). Emittable but currently 0 rows.
-    "form-axis-pinned",
+    Status::FormAxisPinned,
     // Projection that matches the form the spec states — the conformant
     // counterpart of the budgeted `projection-diverges`.
-    "preserved",
+    Status::Preserved,
     // Projection with no spec-stated expectation, pinned as a baseline: ferro
     // rendered a form, declined/unavailable, or errored. None is a spec
     // divergence — the spec mandates no expectation for these.
-    "projection-pinned",
-    "projection-unavailable-pinned",
-    "projection-error-pinned",
+    Status::ProjectionPinned,
+    Status::ProjectionUnavailablePinned,
+    Status::ProjectionErrorPinned,
     // Error-mode outcome pinned as ferro policy: the spec says nothing about
     // ferro's error modes, so a per-mode divergence is never a spec expectation.
-    "mode-divergence-pinned",
+    Status::ModeDivergencePinned,
 ];
 
 /// A status is accounted for if it is either budgeted (a tracked divergence in
 /// `DIVERGENCE_BUDGET`) or allowlisted (a known passing outcome in
 /// `KNOWN_PASSING_STATUSES`).
-fn status_is_accounted_for(status: &str) -> bool {
-    DIVERGENCE_BUDGET.iter().any(|(s, _)| *s == status) || KNOWN_PASSING_STATUSES.contains(&status)
+fn status_is_accounted_for(status: &Status) -> bool {
+    DIVERGENCE_BUDGET.iter().any(|(s, _)| s == status) || KNOWN_PASSING_STATUSES.contains(status)
 }
 
 /// Returns the distinct observed statuses that are neither budgeted (a tracked
@@ -359,8 +349,8 @@ fn status_is_accounted_for(status: &str) -> bool {
 /// status is a new, unreviewed category — `divergence_budget_is_unchanged` is
 /// blind to it, so this is what `every_observed_status_is_accounted_for` gates
 /// on.
-fn unaccounted_statuses<'a>(statuses: impl IntoIterator<Item = &'a str>) -> Vec<&'a str> {
-    let mut unknown: Vec<&str> = statuses
+fn unaccounted_statuses<'a>(statuses: impl IntoIterator<Item = &'a Status>) -> Vec<&'a Status> {
+    let mut unknown: Vec<&Status> = statuses
         .into_iter()
         .filter(|status| !status_is_accounted_for(status))
         .collect();
@@ -375,8 +365,12 @@ fn unaccounted_statuses_flags_a_new_status() {
     // allowlisted (e.g. a future `projection panicked` defect indicator) must
     // be surfaced by name so it becomes a deliberate decision, not a silent
     // pass. This holds independent of the allowlist's contents.
-    let observed = ["false-acceptance", "projection panicked"];
-    assert_eq!(unaccounted_statuses(observed), vec!["projection panicked"]);
+    let observed = [
+        Status::FalseAcceptance,
+        Status::from_wire("projection panicked"),
+    ];
+    let expected = Status::Unknown("projection panicked".to_string());
+    assert_eq!(unaccounted_statuses(&observed), vec![&expected]);
 }
 
 #[test]
@@ -385,10 +379,13 @@ fn budget_and_allowlist_are_disjoint() {
     // conformant outcomes: the two carve the status vocabulary into disjoint
     // halves. A status in both would blur that intent (and be double-classified),
     // so guard the split explicitly.
-    let overlap: Vec<&str> = KNOWN_PASSING_STATUSES
+    let overlap: Vec<&Status> = KNOWN_PASSING_STATUSES
         .iter()
-        .copied()
-        .filter(|s| DIVERGENCE_BUDGET.iter().any(|(b, _)| b == s))
+        .filter(|passing| {
+            DIVERGENCE_BUDGET
+                .iter()
+                .any(|(budgeted, _)| budgeted == *passing)
+        })
         .collect();
     assert!(
         overlap.is_empty(),
@@ -399,7 +396,7 @@ fn budget_and_allowlist_are_disjoint() {
 #[test]
 fn every_observed_status_is_accounted_for() {
     let fx = load();
-    let unknown = unaccounted_statuses(fx.rows.iter().map(|row| row.status.as_str()));
+    let unknown = unaccounted_statuses(fx.rows.iter().map(|row| &row.status));
     assert!(
         unknown.is_empty(),
         "the enumeration emitted status(es) that are neither in DIVERGENCE_BUDGET \
@@ -422,7 +419,7 @@ fn invariant_catalog_has_no_false_positives_on_blessed_output() {
     let offenders: Vec<&Row> = fx
         .rows
         .iter()
-        .filter(|r| r.status == "invariant-violation-must")
+        .filter(|r| r.status == Status::InvariantViolationMust)
         .filter(|r| {
             // The generator records the source row's pinned status in `note`;
             // a blessed output is one whose source row is `preserved`.
@@ -441,7 +438,8 @@ fn invariant_catalog_has_no_false_positives_on_blessed_output() {
     for row in fx.rows.iter().filter(|r| r.dimension == "output-invariant") {
         if row.id.contains("/A1-") || row.id.contains("/A2-") {
             assert_eq!(
-                row.normative_level, "should",
+                row.normative_level,
+                NormativeLevel::Should,
                 "advisory rule {} must never be MUST-level",
                 row.id
             );
@@ -460,14 +458,19 @@ fn passing_spec_mandated_musts_stay_passing() {
     let mut checked = 0usize;
 
     for row in &fx.rows {
-        if row.expectation != "spec-mandated" || row.normative_level != "must" {
+        if row.expectation != Expectation::SpecMandated
+            || row.normative_level != NormativeLevel::Must
+        {
             continue;
         }
         let passing = matches!(
-            row.status.as_str(),
-            "correctly-rejected" | "repaired" | "rejected-not-repaired" | "form-axis-ok"
+            row.status,
+            Status::CorrectlyRejected
+                | Status::Repaired
+                | Status::RejectedNotRepaired
+                | Status::FormAxisOk
                 // A projection that already matches the form the spec states.
-                | "preserved"
+                | Status::Preserved
         );
         if !passing {
             continue;
@@ -476,16 +479,16 @@ fn passing_spec_mandated_musts_stay_passing() {
             continue;
         };
         checked += 1;
-        let ok = match row.status.as_str() {
-            "correctly-rejected" | "rejected-not-repaired" => {
+        let ok = match row.status {
+            Status::CorrectlyRejected | Status::RejectedNotRepaired => {
                 observed.starts_with("parse error") || observed.starts_with("normalize error")
             }
-            "repaired" => Some(&observed) == row.expected.as_ref(),
-            "form-axis-ok" => Some(&observed) == row.expected.as_ref(),
+            Status::Repaired => Some(&observed) == row.expected.as_ref(),
+            Status::FormAxisOk => Some(&observed) == row.expected.as_ref(),
             // The spec writes a projected form with or without its accession;
             // an accession-less statement is compared against the coordinate
             // part only, mirroring the generator (see `projection_matches`).
-            "preserved" => row
+            Status::Preserved => row
                 .expected
                 .as_ref()
                 .is_some_and(|e| projection_matches(&observed, e)),


### PR DESCRIPTION
Closes #1109.

Stacked on #1108 — this branches off `test/issue-1107-divergence-budget-allowlist` and targets it, so the diff here is only the enum conversion. Retarget to `main` once #1108 merges.

## What

The spec-enumeration `Row` classification fields were stringly-typed: the generator (`examples/generate_spec_enumeration.rs`) emitted ~17 status literals across ~10 sites, and the driver (`tests/it/spec_enumeration_tests.rs`) consumed them as `&str`, so a typo or drift between the two was caught only at runtime.

This introduces a shared `conformance::spec_enumeration` module with three typed vocabularies and uses them in both the generator's `Row` and the driver.

- **`Status`** — 17 variants plus an `Unknown(String)` fallback. A new status the generator starts emitting deserializes into `Unknown`, so the #1107 `every_observed_status_is_accounted_for` guard still names the offender rather than degrading into an opaque serde "unknown variant" error (the behaviour the issue explicitly asked to preserve). Custom string `Serialize`/`Deserialize` keeps the kebab-case wire form, so the generated fixture is byte-for-byte unchanged.
- **`Expectation`** (`spec-mandated` | `pinned-baseline`) and **`NormativeLevel`** (`must` | `should` | `n/a`) — derived serde. These small closed vocabularies now reject an unknown value at deserialize time (naming it), which replaces the ad-hoc `matches!` guards in `every_row_carries_provenance`.

`DIVERGENCE_BUDGET` and `KNOWN_PASSING_STATUSES` become `&[(Status, usize)]` and `&[Status]`. The runtime accounted-for guard is kept: the generator and driver stay decoupled through the JSON fixture, so it remains valuable even with the enum.

Also applied to the two override structs' `normative_level`, `RowOverride.status`, and the invariants `Violation.level`, so a new value is a deliberate variant add at the source.

## Deliberately deferred: `error_mode`

Audited and left as a string. The enumeration's `error_mode` carries a `"default"` (not-varied) sentinel the runtime `error_handling::ErrorMode` (Strict/Lenient/Silent) deliberately lacks, and it also threads through the dedup key tuple. Modelling it would either pollute the runtime type with a non-runtime concept or introduce a second confusingly-named `ErrorMode`, for little gain. `dimension`/`operation` are large open vocabularies with no runtime guard depending on them and are likewise left as strings.

## Verification

- New unit tests: known-variant roundtrip, `Unknown` name-preservation, strict-enum reject-unknown.
- Full suite: 8205 passed, 0 failed. `cargo fmt --check` clean; `clippy --all-targets -D warnings` clean.
- Confirmed the generated `hgvs_spec_enumeration.json` is byte-identical to the pre-change output (diffed new-code vs old-code generation), so the CI `--check` up-to-date gate passes with no fixture churn.

## Reading order

1. `src/conformance/spec_enumeration.rs` (new — the three enums + tests).
2. `examples/generate_spec_enumeration.rs` (generator now constructs variants).
3. `tests/it/spec_enumeration_tests.rs` (driver deserializes + budget/allowlist/guard).