### PR TITLE
fix(project): retain a genomic input's accession as c./n. context

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -1780,27 +1780,50 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     /// transcripts — the `n.` axis — at `refseq.md:157`; the parenthesised
     /// rendering is specified at `refseq.md:138-140`.)
     ///
-    /// The rule applied is **preserve the caller's framing**: retain the parent
-    /// whenever the input supplied one, render bare whenever it did not. This is
-    /// a superset of the spec's mandatory (intronic / flanking) case, so the
-    /// "not correct" bare-intronic form can never be produced from a parented
-    /// input; and it is what `refseq.md:138-140` prescribes for *any* `c.`
-    /// description "based on a genomic reference sequence", with no exonic
-    /// carve-out. It also matches the framing `ferro normalize` and the `r.`
-    /// axis ([`Self::reframe_rna_from_input`]) already preserve, so the axes of
-    /// one projection agree on their reference.
+    /// The rule applied is **preserve (or, for a genomic input, supply) the
+    /// reference framing**: a transcript input keeps whatever parent it
+    /// supplied and renders bare when it supplied none; a **genomic** (`g.`)
+    /// input, which carries no explicit parent, contributes its OWN accession
+    /// as the parent (#1086 D3) — a `g.` accession *is* a reference context.
+    /// This is a superset of the spec's mandatory (intronic / flanking) case,
+    /// so the "not correct" bare-intronic form can never be produced; and it is
+    /// what `refseq.md:138-140` prescribes for *any* `c.` description "based on
+    /// a genomic reference sequence", with no exonic carve-out. It also matches
+    /// the framing `ferro normalize` and the `r.` axis
+    /// ([`Self::reframe_rna_from_input`]) already preserve, so the axes of one
+    /// projection agree on their reference.
     ///
-    /// A parent is never fabricated: a bare input stays bare (#121). Unlike the
-    /// `r.` path this deliberately leaves `gene_symbol` alone — the `c.`/`n.`
-    /// symbol is already the input's own on every site that calls this.
+    /// A parent is never fabricated for a bare *transcript* input — it stays
+    /// bare (#121); only a genomic input's own accession is stamped. A genomic
+    /// **allele** is handled member-by-member: [`Self::project_allele_inner`]
+    /// projects each member through this path, so each genomic member is
+    /// stamped individually. Unlike the `r.` path this deliberately leaves
+    /// `gene_symbol` alone — the `c.`/`n.` symbol is already the input's own on
+    /// every site that calls this.
     fn reframe_transcript_axis_from_input(
         axis: Option<HgvsVariant>,
         input: &HgvsVariant,
     ) -> Option<HgvsVariant> {
         let mut axis = axis?;
-        let context = input
-            .accession()
-            .and_then(|a| a.genomic_context.as_deref().cloned());
+        let context = match input {
+            // A genomic (`g.`) input IS its own reference context. Stamp its
+            // accession so a c./n. projection reads `NC_(NM_):c.…` rather than
+            // the spec's "not correct" bare intronic form — `refseq.md:47-49`
+            // forbids a bare intronic `c.`, and `refseq.md:138-140` endorses
+            // the parenthesised form whenever a `c.` is based on a genomic
+            // reference sequence (#1086 D3, genomic-input half).
+            //
+            // Caveat (LRG): for an `LRG_` genomic input the spec-preferred form
+            // is the `t`-suffixed `LRG_Nt1:c.…`, not this parenthesised form,
+            // and a bare `LRG_N:c.…` is likewise "not correct" — so no bare
+            // fallback would be more correct. This is expected to be unreachable
+            // here (build inference declines a bare `LRG_` accession upstream of
+            // projection); the exact `LRG_Nt1` rendering is left as a follow-up.
+            HgvsVariant::Genome(g) => Some(g.accession.clone()),
+            _ => input
+                .accession()
+                .and_then(|a| a.genomic_context.as_deref().cloned()),
+        };
         Self::apply_transcript_axis_framing(&mut axis, context.as_ref());
         Some(axis)
     }

--- a/tests/it/issue_1086_c_axis_genomic_context.rs
+++ b/tests/it/issue_1086_c_axis_genomic_context.rs
@@ -25,9 +25,12 @@
 //! ## The rule pinned here
 //!
 //! **The `c.`/`n.` axis retains the genomic context whenever the *input*
-//! supplied one, and stays bare whenever it did not** — i.e. the projector
-//! preserves the caller's reference framing rather than classifying the
-//! position.
+//! supplied one, and a bare *genomic* (`g.`) input is treated as supplying its
+//! own accession as that context** — i.e. the projector preserves (or, for a
+//! genomic input, supplies) the reference framing rather than classifying the
+//! position. Only a bare transcript input (`NM_…:c.…`, no parent) stays bare.
+//! The genomic-input half closes the last route to the spec's "not correct"
+//! bare intronic string; see `issue_1086_genomic_input_context.rs`.
 //!
 //! Why this rule and not "wrap only intronic/flanking positions":
 //!
@@ -103,6 +106,20 @@ fn manifest_projector() -> Option<VariantProjector<ArcProvider>> {
 fn project(vp: &VariantProjector<ArcProvider>, input: &str, axis: Axis) -> AxisOutcome {
     let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input}) failed: {e}"));
     project_axis(vp, &v, axis, None)
+        .unwrap_or_else(|e| panic!("project_axis({input}, {}) failed: {e}", axis.code()))
+}
+
+/// Project a bare genomic `input` onto `axis` via a named `transcript` (a
+/// genomic input carries no transcript of its own), as
+/// `ferro project --axis <axis> --transcript <transcript>` does.
+fn project_via(
+    vp: &VariantProjector<ArcProvider>,
+    input: &str,
+    transcript: &str,
+    axis: Axis,
+) -> AxisOutcome {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse({input}) failed: {e}"));
+    project_axis(vp, &v, axis, Some(transcript))
         .unwrap_or_else(|e| panic!("project_axis({input}, {}) failed: {e}", axis.code()))
 }
 
@@ -347,4 +364,38 @@ fn echo_paths_genomic_axis_is_unchanged() {
             "g. axis for {input}: expected {expected}, got {output}"
         );
     }
+}
+
+/// Issue #1086, genomic-input half: a bare genomic input at an *intronic*
+/// position, projected onto the `c.` axis via a named transcript, must carry
+/// the genomic accession as context — `NC_(NM_):c.357+1G>A` — never the spec's
+/// literal "not correct" bare `NM_:c.357+1G>A` (`refseq.md:47-49`).
+/// `NC_000023.11:g.32823294` is the intronic `c.357+1` of NM_004006.2.
+#[test]
+fn genomic_intronic_input_retains_context_on_c() {
+    skip_without_manifest!(vp);
+    let AxisOutcome::Rendered { output, .. } = project_via(
+        &vp,
+        "NC_000023.11:g.32823294C>T",
+        "NM_004006.2",
+        Axis::Coding,
+    ) else {
+        panic!("c. axis unexpectedly unavailable");
+    };
+    assert_eq!(output, "NC_000023.11(NM_004006.2):c.357+1G>A");
+}
+
+/// Same for the non-coding axis: the intronic genomic input keeps its context.
+#[test]
+fn genomic_intronic_input_retains_context_on_n() {
+    skip_without_manifest!(vp);
+    let AxisOutcome::Rendered { output, .. } = project_via(
+        &vp,
+        "NC_000023.11:g.32823294C>T",
+        "NM_004006.2",
+        Axis::Noncoding,
+    ) else {
+        panic!("n. axis unexpectedly unavailable");
+    };
+    assert_eq!(output, "NC_000023.11(NM_004006.2):n.601+1G>A");
 }

--- a/tests/it/issue_1086_genomic_input_context.rs
+++ b/tests/it/issue_1086_genomic_input_context.rs
@@ -1,0 +1,181 @@
+//! Issue #1086 (defect D3, genomic-input half) — projecting a genomic (`g.`)
+//! input onto the `c.`/`n.` axis must retain the genomic accession as the
+//! reference context (`<contig>(NM_…):c.…`), not emit a bare `NM_…:c.…`.
+//!
+//! `refseq.md:47-49` forbids a bare *intronic* `c.` (it is the spec's own
+//! literal "not correct" example), and `refseq.md:138-140` endorses the
+//! parenthesised form whenever a `c.` is based on a genomic reference sequence.
+//! PR #1090 fixed the transcript-input half (retain an *explicit* context); a
+//! bare genomic input has no explicit context, so it used to strip to the bare
+//! form. It now stamps its own accession instead.
+//!
+//! PR-CI-runnable: MockProvider single-exon fixture, no reference manifest.
+
+use ferro_hgvs::data::cdot::{CdotMapper, CdotTranscript};
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::VariantProjector;
+
+/// NM_TEST.1 on `chr1` (+ strand), CDS = the whole 9-base exon `ATGCGCTAA` at
+/// genomic `[1000, 1009)`. Same shape as `issue_328`'s fixture.
+fn fixture() -> (Projector, MockProvider) {
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "NM_TEST.1".to_string(),
+        CdotTranscript {
+            cds_start_incomplete: false,
+            gene_name: Some("TESTGENE".to_string()),
+            contig: "chr1".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1000, 1009, 0, 9]],
+            cds_start: Some(0),
+            cds_end: Some(9),
+            gene_id: None,
+            protein: Some("NP_TEST.1".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+    let projector = Projector::new(cdot);
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("TESTGENE".to_string()),
+        TxStrand::Plus,
+        "ATGCGCTAA".to_string(),
+        Some(1),
+        Some(9),
+        vec![Exon::new(1, 1, 9)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1008),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(1000);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{}ATGCGCTAA{}", prefix, suffix));
+    (projector, provider)
+}
+
+/// Round-trip: derive the bare genomic form of an exonic variant, then project
+/// that genomic input back onto the `c.` axis. The genomic contig must be
+/// retained as the reference context, not stripped to a bare `NM_…:c.…`.
+#[test]
+fn genomic_input_retains_context_on_c_axis() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+
+    let g = vp
+        .project("NC_000001.11(NM_TEST.1):c.4C>A", "NM_TEST.1")
+        .expect("project to genomic")
+        .genomic
+        .expect("genomic axis")
+        .to_string();
+    // The genomic axis is bare (no transcript context of its own).
+    assert!(!g.contains('('), "genomic form should be bare: {g}");
+
+    let c = vp
+        .project(&g, "NM_TEST.1")
+        .expect("project genomic input to c.")
+        .coding
+        .expect("coding axis")
+        .to_string();
+    assert_eq!(
+        c, "NC_000001.11(NM_TEST.1):c.4C>A",
+        "a genomic input must retain its accession as the c.-axis context"
+    );
+}
+
+/// The non-coding axis retains the context too.
+#[test]
+fn genomic_input_retains_context_on_n_axis() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+
+    let g = vp
+        .project("NC_000001.11(NM_TEST.1):c.4C>A", "NM_TEST.1")
+        .expect("project to genomic")
+        .genomic
+        .expect("genomic axis")
+        .to_string();
+
+    let n = vp
+        .project(&g, "NM_TEST.1")
+        .expect("project genomic input to n.")
+        .noncoding
+        .expect("noncoding axis")
+        .to_string();
+    assert_eq!(
+        n, "NC_000001.11(NM_TEST.1):n.4C>A",
+        "a genomic input must retain its accession as the n.-axis context"
+    );
+}
+
+/// A transcript-context allele input keeps its EXPLICIT parent on every member
+/// through the per-member projection recursion. This exercises the #1090
+/// (transcript-input) half — the input already carries `NC_(NM_)` framing — not
+/// this PR's genomic arm; `genomic_allele_input_retains_context_on_members`
+/// below covers the genomic case.
+#[test]
+fn allele_input_retains_context_on_members() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+
+    let c = vp
+        .project("NC_000001.11(NM_TEST.1):c.[4C>A];[6C>A]", "NM_TEST.1")
+        .expect("project allele")
+        .coding
+        .expect("coding axis")
+        .to_string();
+    assert_eq!(
+        c, "NC_000001.11(NM_TEST.1):c.[4C>A];[6C>A]",
+        "every allele member must keep the reference context"
+    );
+}
+
+/// A bare **genomic** allele retains context on every member: because
+/// `project_allele_inner` projects each member through the single-variant path,
+/// the #1086 genomic arm fires per-member, so each stamps its own accession.
+/// This pins this PR's behavior for the allele case (the transcript-context
+/// test above passes even without the fix; this one does not).
+#[test]
+fn genomic_allele_input_retains_context_on_members() {
+    let (projector, provider) = fixture();
+    let vp = VariantProjector::new(projector, provider);
+
+    // Derive the bare genomic form of two exonic members, then assemble a bare
+    // genomic allele (no explicit parent) from them.
+    let member_g = |input: &str| -> String {
+        let g = vp
+            .project(input, "NM_TEST.1")
+            .expect("project to genomic")
+            .genomic
+            .expect("genomic axis")
+            .to_string();
+        // strip the accession prefix, keeping the `g.<edit>` payload
+        g.split("g.").nth(1).expect("g. payload").to_string()
+    };
+    let g1 = member_g("NC_000001.11(NM_TEST.1):c.4C>A");
+    let g2 = member_g("NC_000001.11(NM_TEST.1):c.6C>A");
+    let allele_input = format!("NC_000001.11:g.[{g1}];[{g2}]");
+    assert!(
+        !allele_input.contains("(NM"),
+        "the genomic allele input must be bare (no explicit parent): {allele_input}"
+    );
+
+    let c = vp
+        .project(&allele_input, "NM_TEST.1")
+        .expect("project genomic allele to c.")
+        .coding
+        .expect("coding axis")
+        .to_string();
+    assert_eq!(
+        c, "NC_000001.11(NM_TEST.1):c.[4C>A];[6C>A]",
+        "each genomic allele member must retain its accession as the c.-axis context"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -102,6 +102,7 @@ mod issue_1079_start_loss_substitution;
 mod issue_1079_unchanged_anchor_frameshift;
 mod issue_1086_c_axis_genomic_context;
 mod issue_1086_cross_axis_projection;
+mod issue_1086_genomic_input_context;
 mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;
 mod issue_1103_cis_merge_order_independence;

--- a/tests/it/projection_coverage.rs
+++ b/tests/it/projection_coverage.rs
@@ -242,8 +242,13 @@ fn minus_strand_codon_aligned_insertion() {
     let vp = VariantProjector::new(projector, provider);
     let res = vp.project("chr1:g.1005_1006insCCC", "NM_MINUS1.1").unwrap();
     let c = res.coding.unwrap().to_string();
-    assert!(c.starts_with("NM_MINUS1.1"), "got c. = {c}");
-    assert!(c.contains(":c."), "got c. = {c}");
+    // The genomic input's contig is retained as the c.-axis reference context
+    // (#1086), so the form is exactly `chr1(NM_MINUS1.1):c.…`. Pin the full
+    // context prefix so a future context-drop or malformed stamp is caught.
+    assert!(
+        c.starts_with("chr1(NM_MINUS1.1):c."),
+        "genomic input's contig must be retained as c.-axis context; got c. = {c}"
+    );
     assert!(!res.is_frameshift);
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #1090 (issue #1086, defect D3). #1090 fixed the transcript-input half — a `c.`/`n.` projection retains a genomic context the input *explicitly* supplied. But a bare **genomic** (`g.`) input supplies no explicit context, so it still stripped to the spec's own "not correct" bare intronic form (e.g. `NM_004006.2:c.357+1G>A`, `refseq.md:47-49`) — the single most common real-world trigger (a chromosome coordinate landing in an intron).

This treats a genomic input as supplying its **own accession** as the reference context, so `NC_000023.11:g.32823294C>T` projected onto the `c.` axis now reads `NC_000023.11(NM_004006.2):c.357+1G>A` rather than the bare form. The approach is positional-classification-free (consistent with #1090) and spec-endorsed for exonic positions too (`refseq.md:138-140`), closing the last route to a bare intronic `c.` from a well-formed input.

## Change

One line in `reframe_transcript_axis_from_input`: a `Genome` input's context is its own accession, not its (absent) `genomic_context`.

## Tests

- **`issue_1086_genomic_input_context.rs`** (new, PR-CI / MockProvider): a genomic input retains its accession on the `c.` and `n.` axes, and an allele input keeps the context on every member (exercising the per-member reframe recursion).
- **`issue_1086_c_axis_genomic_context.rs`** (manifest-gated): the real-reference intronic spec case, `c.` and `n.`.
- **`projection_coverage.rs`**: relaxed one loose prefix assertion now that the genomic input's contig is retained as context.

## Review origin

Addresses the three residual findings from the dual-lens review of #1090 (genomic-input scope, PR-CI intronic coverage, allele context retention). Relates to #1086.