### PR TITLE
fix(normalize): sort protein cis members before the delins coalesce

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1213,6 +1213,17 @@ fn build_naedit<P>(
 /// spec pins that exact non-example (`protein/delins.md:63`: `p.[Ser44Arg;Trp46Arg]`
 /// is *not* described as `p.Ser44_Trp46delinsArgLeuArg`).
 ///
+/// Member **input order** does not affect the result (#1116): the members are
+/// sorted into ascending residue order before runs are detected, so every
+/// permutation of one member set coalesces identically. Reordering is
+/// meaning-preserving here because every member has already been established to
+/// be a plain single-residue substitution on one shared accession — and the
+/// post-normalize display sort (#1098/#1101) puts cis members into exactly that
+/// residue order anyway, so an allele that does *not* coalesce still renders
+/// ascending. This is the protein-axis counterpart of #1103's sort-before-merge
+/// on the nucleotide axis; without it a descending-order allele fell through to
+/// the bracket form `protein/substitution.md:23` calls "not correct".
+///
 /// Returns `Some` only when at least one run of ≥2 adjacent substitutions is
 /// merged; a fully-merged allele collapses to a bare [`HgvsVariant::Protein`],
 /// a partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
@@ -1220,9 +1231,8 @@ fn build_naedit<P>(
 ///   - the phase is not cis (trans / unknown / mosaic / … are independent),
 ///   - any member is not a single-residue protein substitution (mixed edit
 ///     kinds are out of scope for this narrow rule),
-///   - members are not in ascending, duplicate-free residue order (a `n,n`
-///     pair is the contradictory same-residue case, not a delins; an
-///     out-of-order allele is left as the author wrote it), or
+///   - two members share a residue position (a `n,n` pair is the contradictory
+///     same-residue case, not a delins), or
 ///   - a run would mix predicted `( )` and certain members (ambiguous).
 pub(crate) fn coalesce_protein_adjacent_substitutions(
     allele: &crate::hgvs::variant::AlleleVariant,
@@ -1236,12 +1246,15 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
         return None;
     }
 
-    /// One member reduced to a single-residue substitution.
+    /// One member reduced to a single-residue substitution. `source` is the
+    /// member's index in `allele.variants`, kept so a substitution that ends up
+    /// in no run is re-emitted verbatim even after the residue-order sort.
     struct Sub {
         pos: u64,
         reference: AminoAcid,
         alternative: AminoAcid,
         predicted: bool,
+        source: usize,
     }
 
     let first = match &allele.variants[0] {
@@ -1252,7 +1265,7 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
     let gene_symbol = first.gene_symbol.clone();
 
     let mut subs: Vec<Sub> = Vec::with_capacity(allele.variants.len());
-    for v in &allele.variants {
+    for (source, v) in allele.variants.iter().enumerate() {
         let HgvsVariant::Protein(pv) = v else {
             return None;
         };
@@ -1291,13 +1304,19 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
             reference: s.aa,
             alternative,
             predicted,
+            source,
         });
     }
 
-    // Require ascending, duplicate-free residue order. A descending or
-    // duplicate (`n,n`) allele is out of scope — do not reorder the author's
-    // description, and the same-residue pair is a contradiction, not a delins.
-    if subs.windows(2).any(|w| w[1].pos <= w[0].pos) {
+    // Sort into ascending residue order so run detection — and therefore the
+    // coalesced `delins` payload — is independent of the author's member order
+    // (#1116). The sort is stable, so members sharing a residue stay adjacent
+    // in input order and are caught by the duplicate check below.
+    subs.sort_by_key(|s| s.pos);
+
+    // Two members at the same residue are a contradiction, not a delins: the
+    // allele states two different changes to one amino acid. Leave it untouched.
+    if subs.windows(2).any(|w| w[1].pos == w[0].pos) {
         return None;
     }
 
@@ -1336,8 +1355,10 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
             }));
             changed = true;
         } else {
-            // A lone substitution keeps its original member verbatim.
-            merged.push(allele.variants[i].clone());
+            // A lone substitution keeps its original member verbatim (indexed
+            // through `source`, since `subs` is in residue order, not input
+            // order).
+            merged.push(allele.variants[subs[i].source].clone());
         }
         i = j + 1;
     }

--- a/tests/it/allele_grammar_corners.rs
+++ b/tests/it/allele_grammar_corners.rs
@@ -287,24 +287,22 @@ fn protein_to_ter_run_is_not_coalesced() {
     );
 }
 
-/// Members authored in descending residue order are reordered to ascending
-/// residue order by #1098's cis-member sort.
+/// Members authored in descending residue order coalesce to the same delins as
+/// the ascending order.
 ///
-/// KNOWN LIMITATION (protein axis): the descending input reorders to the bracket
-/// `p.[Arg76Ser;Cys77Trp]` but is *not* re-merged into the delins
-/// `protein/substitution.md:23` requires (`p.Arg76_Cys77delinsSerTrp`). #1103/#1106
-/// makes the *nucleotide* merge input-order-independent by sorting before the
-/// `merge_consecutive_edits` pipeline, but the protein delins-canonicalization
-/// (`coalesce_protein_adjacent_substitutions`) is a separate pass that still runs
-/// before the sort, so this protein order-dependence persists after #1106 — a
-/// candidate follow-up (re-run the protein coalesce after the sort). The sort is
-/// nonetheless the machinery that makes the ascending delins reachable at all.
+/// #1116 sorts members into ascending residue order inside the protein
+/// delins-canonicalization (`coalesce_protein_adjacent_substitutions`), which
+/// used to decline outright on non-ascending members. Before it, the descending
+/// input only picked up #1098/#1101's post-normalize display sort and came out
+/// as the bracket `p.[Arg76Ser;Cys77Trp]` — a form `protein/substitution.md:23`
+/// explicitly calls "not correct". This is the protein-axis counterpart of
+/// #1103/#1106, which does the same for the nucleotide merge.
 #[test]
-fn protein_descending_order_members_reorder_to_residue_order() {
+fn protein_descending_order_members_coalesce_to_the_same_delins() {
     pin_canonicalizes_to(
         "NP_003997.1:p.[Cys77Trp;Arg76Ser]",
-        "NP_003997.1:p.[Arg76Ser;Cys77Trp]",
-        "#1098 orders cis members; protein delins-canonicalization does not re-run after the sort",
+        "NP_003997.1:p.Arg76_Cys77delinsSerTrp",
+        "protein/substitution.md:23 — #1116 sorts members before the protein coalesce",
     );
 }
 

--- a/tests/it/issue_1116_protein_coalesce_order_independence.rs
+++ b/tests/it/issue_1116_protein_coalesce_order_independence.rs
@@ -1,0 +1,197 @@
+//! Issue #1116: protein cis-allele member order must not leak into the
+//! consecutive-residue delins coalescing.
+//!
+//! #1103/#1106 make the **nucleotide** merge input-order-independent by sorting
+//! cis members into a canonical merge order before `merge_consecutive_edits`.
+//! The **protein** axis is canonicalized by a separate pass,
+//! `coalesce_protein_adjacent_substitutions`, which runs *before* that sort and
+//! declined outright on non-ascending members. A descending-order protein allele
+//! therefore only got the #1098/#1101 post-normalize display sort applied and
+//! came out as the bracket form `protein/substitution.md:23` explicitly calls
+//! "not correct":
+//!
+//! > […] the description `p.Arg76_Cys77delinsSerTrp` is correct, the
+//! > description `p.[Arg76Ser;Cys77Trp]` is not correct.
+//!
+//! The fix sorts the members into ascending residue order inside the coalescing
+//! pass, so every permutation of one adjacent-residue substitution set yields
+//! the same canonical delins. Duplicate residue positions still decline — a
+//! `n,n` pair is a contradiction, not a delins.
+//!
+//! These cases run under `MockProvider::new()` (no reference sequence), so the
+//! only behavior being pinned is the coalescing pass' member-order handling.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Normalize `input` against a base-free `MockProvider` and return the rendered
+/// string. Panics on parse or normalize failure.
+fn normalize_to_string(input: &str) -> String {
+    let normalizer = Normalizer::new(MockProvider::new());
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse failed for `{input}`: {e}"));
+    let normalized = normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize failed for `{input}`: {e}"));
+    format!("{normalized}")
+}
+
+/// Generate every permutation of `items` via Heap's algorithm.
+fn permutations<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+    let mut result = Vec::new();
+    let mut arr = items.to_vec();
+    let n = arr.len();
+    let mut c = vec![0usize; n];
+    result.push(arr.clone());
+    let mut i = 0;
+    while i < n {
+        if c[i] < i {
+            if i % 2 == 0 {
+                arr.swap(0, i);
+            } else {
+                arr.swap(c[i], i);
+            }
+            result.push(arr.clone());
+            c[i] += 1;
+            i = 0;
+        } else {
+            c[i] = 0;
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Assert every permutation of `members` normalizes to `canonical`.
+fn all_permutations_normalize_to(accession: &str, members: &[&str], canonical: &str) {
+    for perm in permutations(members) {
+        let input = format!("{accession}:p.[{}]", perm.join(";"));
+        assert_eq!(
+            normalize_to_string(&input),
+            canonical,
+            "permutation `{input}` must normalize to the canonical `{canonical}` \
+             (member order must not leak into the protein coalescing pass)"
+        );
+    }
+    // The canonical form is a normalization fixed point (idempotent).
+    assert_eq!(
+        normalize_to_string(canonical),
+        canonical,
+        "canonical `{canonical}` must be a normalization fixed point"
+    );
+}
+
+/// The protein analogue of #1103's mergeable-trio test: every permutation of an
+/// adjacent-residue substitution pair must coalesce to the one delins
+/// `protein/substitution.md:23` requires. `p.[Arg76Ser;Cys77Trp]` and
+/// `p.Arg76_Cys77delinsSerTrp` are the spec's own correct/not-correct pair.
+#[test]
+fn both_orders_of_an_adjacent_pair_coalesce_to_one_delins() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Arg76Ser", "Cys77Trp"],
+        "NP_003997.1:p.Arg76_Cys77delinsSerTrp",
+    );
+}
+
+/// A three-residue run coalesces identically from all six input orders, and the
+/// inserted payload follows the residues' ascending order — not the input's.
+#[test]
+fn all_permutations_of_an_adjacent_run_coalesce_to_one_delins() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Arg76Ser", "Cys77Trp", "Gly78Ala"],
+        "NP_003997.1:p.Arg76_Gly78delinsSerTrpAla",
+    );
+}
+
+/// A partial allele — one adjacent run plus a separated member — coalesces only
+/// the run, and the separated member is re-emitted verbatim in residue order
+/// from every input permutation. This pins that a member which ends up in no run
+/// is looked up through its *source* index, not its post-sort position.
+#[test]
+fn a_partial_run_coalesces_identically_from_every_order() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Arg76Ser", "Cys77Trp", "Gly90Asp"],
+        "NP_003997.1:p.[Arg76_Cys77delinsSerTrp;Gly90Asp]",
+    );
+}
+
+/// The leading member of the allele is not privileged: a run that starts at the
+/// *last*-authored member coalesces the same way. (The coalesced delins takes
+/// its accession from the allele's first member; every member is required to
+/// share it, so the stamp is order-independent.)
+#[test]
+fn a_trailing_authored_run_coalesces_identically_from_every_order() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Gly90Asp", "Arg76Ser", "Cys77Trp"],
+        "NP_003997.1:p.[Arg76_Cys77delinsSerTrp;Gly90Asp]",
+    );
+}
+
+/// A gapped run is not adjacent, so it never coalesces (`protein/delins.md:63`
+/// pins `p.[Ser44Arg;Trp46Arg]` as *not* describable as a single delins). Both
+/// orders must still land on the same canonical bracket — the #1098/#1101
+/// display sort's job, unchanged by this fix.
+#[test]
+fn a_gapped_run_stays_a_bracket_in_both_orders() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Ser44Arg", "Trp46Arg"],
+        "NP_003997.1:p.[Ser44Arg;Trp46Arg]",
+    );
+}
+
+/// Two substitutions at the *same* residue are a contradiction, not a delins:
+/// the coalescing pass must still decline regardless of input order. Sorting is
+/// stable, so the duplicate pair reaches the decline check adjacent, exactly as
+/// before.
+#[test]
+fn duplicate_residue_positions_never_coalesce() {
+    // Both input orders decline coalescing and land on the SAME canonical
+    // bracket: both edits are retained at residue 76 and the #1098/#1101 display
+    // sort orders them deterministically (Cys before Ser), so neither the
+    // coalescing decline nor the rendering leaks input order.
+    for input in [
+        "NP_003997.1:p.[Arg76Ser;Arg76Cys]",
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser]",
+    ] {
+        let output = normalize_to_string(input);
+        assert_eq!(
+            output, "NP_003997.1:p.[Arg76Cys;Arg76Ser]",
+            "`{input}` must keep both same-residue edits as a canonical bracket, \
+             not coalesce them into a delins"
+        );
+        assert!(
+            !output.contains("delins"),
+            "`{input}` must not coalesce two edits at one residue; got `{output}`"
+        );
+    }
+}
+
+/// A to-`Ter` member keeps the whole allele out of scope (the spec forbids
+/// listing residues after the stop, `protein/substitution.md:20` /
+/// `protein/delins.md:45`), in either input order.
+#[test]
+fn a_to_ter_run_never_coalesces_in_either_order() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["Arg76Ter", "Cys77Trp"],
+        "NP_003997.1:p.[Arg76Ter;Cys77Trp]",
+    );
+}
+
+/// An adjacent run that mixes a predicted `( )` member with a certain one is
+/// ambiguous and must decline coalescing (merging would fabricate a
+/// certainty the members do not jointly assert). With run membership now keyed
+/// off sorted residue position, that decline must hold in either input order —
+/// this is the one decline branch the permutation suite otherwise leaves
+/// untouched.
+#[test]
+fn a_mixed_predicted_and_certain_run_never_coalesces_in_either_order() {
+    all_permutations_normalize_to(
+        "NP_003997.1",
+        &["(Arg76Ser)", "Cys77Trp"],
+        "NP_003997.1:p.[(Arg76Ser);Cys77Trp]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -106,6 +106,7 @@ mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;
 mod issue_1103_cis_merge_order_independence;
 mod issue_1111_rna_noncoding_reframe;
+mod issue_1116_protein_coalesce_order_independence;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Summary

Follow-up to #1103 / #1106, which fix input-order dependence on the **nucleotide** axis by sorting cis members into a canonical merge order before `merge_consecutive_edits`. The **protein** axis is canonicalized by a separate pass — `coalesce_protein_adjacent_substitutions` — which declined outright on non-ascending members:

```rust
// Require ascending, duplicate-free residue order. ...
if subs.windows(2).any(|w| w[1].pos <= w[0].pos) {
    return None;
}
```

So the two permutations of one adjacent-residue substitution pair normalized to two different strings, one of them a form `protein/substitution.md:23` explicitly calls incorrect:

| input | before | after |
| --- | --- | --- |
| `NP_003997.1:p.[Arg76Ser;Cys77Trp]` | `NP_003997.1:p.Arg76_Cys77delinsSerTrp` | unchanged |
| `NP_003997.1:p.[Cys77Trp;Arg76Ser]` | `NP_003997.1:p.[Arg76Ser;Cys77Trp]` ❌ | `NP_003997.1:p.Arg76_Cys77delinsSerTrp` ✅ |

> changes involving two or more consecutive amino acids are described as a deletion/insertion variant (delins) […] the description `p.Arg76_Cys77delinsSerTrp` is correct, the description `p.[Arg76Ser;Cys77Trp]` is not correct.

This is the known limitation #1106 documents on `allele_grammar_corners::protein_descending_order_members_reorder_to_residue_order`; that test now pins the delins instead.

## Fix

Sort the collected members into ascending residue order before run detection, so every permutation of one member set coalesces identically.

Reordering is meaning-preserving at that point in the pass: it has already established that every member is a plain single-residue substitution on one shared accession (mixed accessions, mixed edit kinds, non-point locations, and uncertain-position members all bail earlier), and the post-normalize display sort (#1098/#1101) canonicalizes protein cis members into exactly that residue order anyway — so an allele that does *not* coalesce already rendered ascending. The delins is stamped with the allele-first member's accession/gene symbol, which every member is required to match, so the stamp is order-independent too.

Two details worth a reviewer's eye:

- **The duplicate check survives.** The old guard rejected `w[1].pos <= w[0].pos`, conflating "descending" with "same residue". Only the latter is a real out-of-scope case (`p.[Asp2His;Asp2Glu]` — one residue cannot be two things in cis). The sort is *stable*, so same-residue members stay adjacent in input order and the narrowed `w[1].pos == w[0].pos` check catches them exactly as before.
- **Non-run members are re-emitted by source index.** A member that lands in no run is cloned from `allele.variants`; `subs` is now in residue order, not input order, so each `Sub` records its `source` index and the lone-substitution branch indexes through it.

The gapped-run (`protein/delins.md:63`), to-`Ter` (`protein/substitution.md:20`, `protein/delins.md:45`), `trans`, and predicted/certain-mixing guards are untouched.

## Tests

New `issue_1116_protein_coalesce_order_independence` — the protein analogue of #1106's `issue_1103_cis_merge_order_independence`, asserting over **every permutation** (Heap's algorithm, base-free `MockProvider`) that:

- an adjacent pair and an adjacent three-residue run each coalesce to one canonical delins, with the inserted payload in residue order;
- a partial run (`{Arg76Ser, Cys77Trp, Gly90Asp}`) coalesces only the run and re-emits the separated member verbatim — this is what pins the `source`-index lookup;
- the same set authored with the run *last* behaves identically;
- a gapped run stays a bracket, a to-`Ter` run never coalesces, and duplicate residue positions never coalesce, in every order.

`allele_grammar_corners::protein_descending_order_members_reorder_to_residue_order` → `…_coalesce_to_the_same_delins`, expectation flipped from the bracket to the delins.

Full suite green (8262/8262), `clippy --all-targets -D warnings` clean.

Conformance against the prepared reference is unchanged: `axis_normalized` / `axis_protein_description` / `axis_coding_protein_descriptions` pass, and `axis_errors` shows only the 2 pre-existing FAILs (`NM_000143.3:c.45del4`, `c.45dup4` — length-mismatch tag divergence), verified identical by running the same axes on the unmodified base.

## Notes for the reviewer

This is a follow-up to #1106 but is **not stacked on it** — it is based on `main` and the source change is confined to the protein pass, so it merges independently and in either order. The one point of contact is the shared test function `allele_grammar_corners::protein_descending_order_members_*`, whose doc comment #1106 also edits; whichever of the two merges second resolves that hunk by keeping this PR's version (the delins expectation).

Closes #1116