### PR TITLE
fix(parser): accept the '*' stop-codon glyph in strict mode

### DIFF
--- a/src/error_handling/codes.rs
+++ b/src/error_handling/codes.rs
@@ -77,6 +77,14 @@ impl ModeBehavior {
         )
     }
 
+    /// Accept as-is in every mode with no warning or correction — for a
+    /// spec-valid input form that the parser handles natively (e.g. a glyph
+    /// canonicalized on display). The code is retained for documentation but is
+    /// never emitted.
+    pub const fn accepted() -> Self {
+        Self::new(ModeAction::Accept, ModeAction::Accept, ModeAction::Accept)
+    }
+
     /// Reject in strict, warn in lenient, warn in silent (always warn if not rejected).
     pub const fn always_warn_if_not_rejected() -> Self {
         Self::new(

--- a/src/error_handling/corrections.rs
+++ b/src/error_handling/corrections.rs
@@ -342,20 +342,21 @@ pub fn correct_protein_arrow(input: &str) -> (Cow<'_, str>, Vec<DetectedCorrecti
     (Cow::Borrowed(input), corrections)
 }
 
-/// Correct deprecated stop-codon and frameshift forms in protein descriptions.
+/// Correct deprecated `X` stop-codon and frameshift forms in protein
+/// descriptions.
 ///
-/// Detects four deprecated forms within `p.` segments of the input and rewrites
-/// them to their canonical `Ter`-based equivalents:
+/// Detects the two deprecated `X` forms within `p.` segments of the input and
+/// rewrites them to their canonical `Ter`-based equivalents:
 ///
 /// - `fsXN` (digits) or `fsX?` (uncertain) → `fsTerN` / `fsTer?` — emits
 ///   `DeprecatedFrameshiftX` (W3010).
-/// - `fs*N` (digits) or `fs*?` (uncertain) → `fsTerN` / `fsTer?` — emits
-///   `DeprecatedFrameshiftStar` (W3009).
 /// - position-then-`X` at edit boundary → `Ter` — emits `DeprecatedStopCodonX` (W3008).
 ///   Distinguished from `Xaa` by requiring `X` not followed by a letter.
-/// - position-then-`*` at edit boundary → `Ter` — emits `DeprecatedStopCodonStar` (W3007).
-///   Distinguished from `fs*N` (already handled), from `c.*N` UTR positions
-///   (digits do NOT precede `*` there), and from `delext*N` (preceding `t` is `t`).
+///
+/// The `*` spellings (`p.Arg97*`, `p.Arg97fs*23`) are **not** handled here:
+/// `*` is a spec-sanctioned stop-codon glyph co-equal with `Ter`
+/// (`checklist.md:63`), so it is left untouched for the core parser to accept
+/// natively and `Display`-canonicalize to `Ter` (#1114).
 ///
 /// The function preserves byte offsets relative to the *original* input by tracking
 /// the input cursor, even when replacements change the output length. Only operates
@@ -375,21 +376,27 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (Cow<'_, str>, Vec<Detec
     while i < bytes.len() {
         let c = bytes[i];
 
-        // Detect "fs*N", "fsXN", "fs*?", or "fsX?" (frameshift termination
-        // notation, both known-position and uncertain-position forms).
-        // Must begin at a literal "fs" boundary; the byte before the `f` is not
-        // a lowercase letter (so we don't catch e.g. "ffs" — though that's
-        // implausible in HGVS).
+        // Detect "fsXN" or "fsX?" (deprecated frameshift termination notation,
+        // both known-position and uncertain-position forms). Must begin at a
+        // literal "fs" boundary; the byte before the `f` is not a lowercase
+        // letter (so we don't catch e.g. "ffs" — though that's implausible in
+        // HGVS).
+        //
+        // Only `X` is handled here. The `*` spelling (`fs*N` / `fs*?`) is a
+        // spec-sanctioned equivalent of `fsTerN` (`checklist.md:63` "`Ter` or
+        // `*` should be used ... the `X` should not be used"; `frameshift.md`
+        // lists `p.Arg97Profs*23` as valid), so it is left untouched for the
+        // core parser to accept natively as `Ter` rather than flagged as a
+        // deprecated form (#1114).
         if c == b'f'
             && i + 1 < bytes.len()
             && bytes[i + 1] == b's'
             && i + 2 < bytes.len()
-            && (bytes[i + 2] == b'*' || bytes[i + 2] == b'X')
+            && bytes[i + 2] == b'X'
             && i + 3 < bytes.len()
             && (bytes[i + 3].is_ascii_digit() || bytes[i + 3] == b'?')
             && in_protein_segment(input, i + 2)
         {
-            let star_or_x = bytes[i + 2];
             // Walk the trailing token: either a digit run ("23") or a single
             // "?" (uncertain termination position, VEP notation).
             let trail_start = i + 3;
@@ -402,15 +409,10 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (Cow<'_, str>, Vec<Detec
                 }
                 (input[trail_start..digits_end].to_string(), digits_end)
             };
-            let original = &input[i + 2..trail_end]; // "*23", "X23", "*?", or "X?"
+            let original = &input[i + 2..trail_end]; // "X23" or "X?"
             let corrected = format!("Ter{}", corrected_trail);
-            let error_type = if star_or_x == b'*' {
-                ErrorType::DeprecatedFrameshiftStar
-            } else {
-                ErrorType::DeprecatedFrameshiftX
-            };
             corrections.push(DetectedCorrection::new(
-                error_type,
+                ErrorType::DeprecatedFrameshiftX,
                 original.to_string(),
                 corrected.clone(),
                 i + 2,
@@ -423,32 +425,28 @@ pub fn correct_deprecated_protein_forms(input: &str) -> (Cow<'_, str>, Vec<Detec
             continue;
         }
 
-        // Detect a stop-codon `*` or `X` immediately following a digit at the
-        // edit boundary. The `*` or `X` must:
+        // Detect a deprecated stop-codon `X` immediately following a digit at
+        // the edit boundary. The `X` must:
         // - be preceded by an ASCII digit (the position number),
-        // - not be followed by a digit (else it's a position offset like c.*5),
-        // - for `X`, not be followed by an ASCII letter (else it's `Xaa`),
-        // - not be part of a `fs*N` / `fsXN` run (handled above).
+        // - not be followed by a digit (else it's a position offset),
+        // - not be followed by an ASCII letter (else it's `Xaa` / `Xxx`),
+        // - not be part of an `fsXN` run (handled above).
         //
         // We also gate on protein context: only when, looking back, we find
         // `p.` before a top-level boundary (`:` or `[` or start) without an
         // intervening boundary that would put us back outside protein context.
-        if (c == b'*' || c == b'X') && i > 0 && bytes[i - 1].is_ascii_digit() {
+        //
+        // The `*` spelling is intentionally NOT handled here: it is a
+        // spec-sanctioned equivalent of `Ter` (`checklist.md:63`), so a
+        // stop-codon `*` is left for the core parser to accept natively rather
+        // than flagged as a deprecated form (#1114).
+        if c == b'X' && i > 0 && bytes[i - 1].is_ascii_digit() {
             let next_is_digit = i + 1 < bytes.len() && bytes[i + 1].is_ascii_digit();
             let next_is_alpha = i + 1 < bytes.len() && bytes[i + 1].is_ascii_alphabetic();
-            // For `X`, also reject when followed by an ASCII letter (Xaa, Xxx).
-            let invalid_for_x = c == b'X' && next_is_alpha;
-            // For `*`, `c.*5` UTR position has `*` BEFORE digits, not after, so
-            // we don't need to filter that here; but `*N` followed by another
-            // digit is rare in protein context — still, safer to skip.
-            if !next_is_digit && !invalid_for_x && in_protein_segment(input, i) {
-                let error_type = if c == b'*' {
-                    ErrorType::DeprecatedStopCodonStar
-                } else {
-                    ErrorType::DeprecatedStopCodonX
-                };
+            // Reject when followed by an ASCII letter (Xaa, Xxx).
+            if !next_is_digit && !next_is_alpha && in_protein_segment(input, i) {
                 corrections.push(DetectedCorrection::new(
-                    error_type,
+                    ErrorType::DeprecatedStopCodonX,
                     (c as char).to_string(),
                     "Ter".to_string(),
                     i,
@@ -4942,16 +4940,14 @@ mod tests {
     // ----------------------------------------------------------------------
 
     #[test]
-    fn test_deprecated_stop_star_substitution() {
+    fn test_star_stop_substitution_not_corrected() {
+        // `*` is a spec-valid stop-codon glyph (`checklist.md:63`: "`Ter` or
+        // `*` should be used ... the `X` should not be used"), so the
+        // deprecated-form corrector must leave it untouched — the core parser
+        // accepts it natively as `Ter` (#1114). Only `X` is deprecated.
         let (corrected, corrections) = correct_deprecated_protein_forms("NP_000079.2:p.Arg97*");
-        assert_eq!(corrected, "NP_000079.2:p.Arg97Ter");
-        assert_eq!(corrections.len(), 1);
-        assert_eq!(
-            corrections[0].error_type,
-            ErrorType::DeprecatedStopCodonStar
-        );
-        assert_eq!(corrections[0].original, "*");
-        assert_eq!(corrections[0].corrected, "Ter");
+        assert_eq!(corrected, "NP_000079.2:p.Arg97*");
+        assert!(corrections.is_empty());
     }
 
     #[test]
@@ -4963,16 +4959,13 @@ mod tests {
     }
 
     #[test]
-    fn test_deprecated_frameshift_star() {
+    fn test_frameshift_star_not_corrected() {
+        // The `fs*N` frameshift-termination glyph is spec-valid
+        // (`frameshift.md` lists `p.Arg97Profs*23`), so the corrector leaves
+        // it untouched for the core parser to accept natively (#1114).
         let (corrected, corrections) = correct_deprecated_protein_forms("NP_000079.2:p.Arg97fs*23");
-        assert_eq!(corrected, "NP_000079.2:p.Arg97fsTer23");
-        assert_eq!(corrections.len(), 1);
-        assert_eq!(
-            corrections[0].error_type,
-            ErrorType::DeprecatedFrameshiftStar
-        );
-        assert_eq!(corrections[0].original, "*23");
-        assert_eq!(corrections[0].corrected, "Ter23");
+        assert_eq!(corrected, "NP_000079.2:p.Arg97fs*23");
+        assert!(corrections.is_empty());
     }
 
     #[test]
@@ -4985,15 +4978,12 @@ mod tests {
 
     #[test]
     fn test_deprecated_frameshift_with_new_aa() {
-        // p.Arg97ProfsTer23 with deprecated Star or X.
+        // The spec-valid `*` glyph is left untouched (#1114); only the
+        // deprecated `X` glyph is corrected to `Ter`.
         let (corrected, corrections) =
             correct_deprecated_protein_forms("NP_000079.2:p.Arg97Profs*23");
-        assert_eq!(corrected, "NP_000079.2:p.Arg97ProfsTer23");
-        assert_eq!(corrections.len(), 1);
-        assert_eq!(
-            corrections[0].error_type,
-            ErrorType::DeprecatedFrameshiftStar
-        );
+        assert_eq!(corrected, "NP_000079.2:p.Arg97Profs*23");
+        assert!(corrections.is_empty());
 
         let (corrected, corrections) =
             correct_deprecated_protein_forms("NP_000079.2:p.Arg97ProfsX23");
@@ -5219,17 +5209,14 @@ mod tests {
 
     #[test]
     fn test_deprecated_multiple_in_compound_allele() {
-        // Compound protein allele with two deprecated forms should emit two
-        // corrections in order.
+        // Compound protein allele mixing the spec-valid `*` with the
+        // deprecated `X`: only the `X` member is corrected (#1114). The `*`
+        // is preserved for native parsing.
         let (corrected, corrections) =
             correct_deprecated_protein_forms("NP_000079.2:p.[Arg97*;Arg100X]");
-        assert_eq!(corrected, "NP_000079.2:p.[Arg97Ter;Arg100Ter]");
-        assert_eq!(corrections.len(), 2);
-        assert_eq!(
-            corrections[0].error_type,
-            ErrorType::DeprecatedStopCodonStar
-        );
-        assert_eq!(corrections[1].error_type, ErrorType::DeprecatedStopCodonX);
+        assert_eq!(corrected, "NP_000079.2:p.[Arg97*;Arg100Ter]");
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].error_type, ErrorType::DeprecatedStopCodonX);
     }
 
     #[test]
@@ -5250,8 +5237,9 @@ mod tests {
 
     #[test]
     fn test_deprecated_predicted_paren_form() {
-        // Predicted protein consequences in parentheses still match.
-        let (corrected, corrections) = correct_deprecated_protein_forms("NP_000079.2:p.(Arg97*)");
+        // Predicted protein consequences in parentheses still match (uses the
+        // deprecated `X` glyph, since `*` is no longer corrected — #1114).
+        let (corrected, corrections) = correct_deprecated_protein_forms("NP_000079.2:p.(Arg97X)");
         assert_eq!(corrected, "NP_000079.2:p.(Arg97Ter)");
         assert_eq!(corrections.len(), 1);
     }
@@ -5260,12 +5248,14 @@ mod tests {
     fn test_deprecated_byte_offsets_track_original_input() {
         // The DetectedCorrection's start/end refer to the ORIGINAL input bytes,
         // not the rewritten output, so downstream span reporting is accurate.
-        let input = "NP_000079.2:p.Arg97fs*23";
+        // Uses the deprecated `X` glyph, since `*` is no longer corrected
+        // (#1114).
+        let input = "NP_000079.2:p.Arg97fsX23";
         let (_, corrections) = correct_deprecated_protein_forms(input);
         assert_eq!(corrections.len(), 1);
-        // "*23" begins at byte index of the '*' in the input.
-        let star_pos = input.find('*').unwrap();
-        assert_eq!(corrections[0].start, star_pos);
+        // "X23" begins at byte index of the 'X' in the input.
+        let x_pos = input.find('X').unwrap();
+        assert_eq!(corrections[0].start, x_pos);
         assert_eq!(corrections[0].end, input.len()); // up through "23"
     }
 
@@ -5274,8 +5264,9 @@ mod tests {
         // Non-ASCII bytes elsewhere in the input must pass through unchanged
         // (the byte-walking loop must not split multi-byte UTF-8 into stray
         // Latin-1 codepoints). Input is not valid HGVS but the corrector
-        // should be UTF-8 correct regardless.
-        let input = "NP_000079.2:p.Arg97* αβ";
+        // should be UTF-8 correct regardless. Uses the deprecated `X` glyph,
+        // since `*` is no longer corrected (#1114).
+        let input = "NP_000079.2:p.Arg97X αβ";
         let (corrected, corrections) = correct_deprecated_protein_forms(input);
         assert_eq!(corrections.len(), 1);
         assert_eq!(corrected, "NP_000079.2:p.Arg97Ter αβ");

--- a/src/error_handling/preprocessor.rs
+++ b/src/error_handling/preprocessor.rs
@@ -476,12 +476,15 @@ impl InputPreprocessor {
             }
         }
 
-        // Phase 6b: Rewrite deprecated stop-codon and frameshift forms in protein
-        // descriptions (SVA-003..SVA-006, issue #125):
-        //   p.Arg97*       → p.Arg97Ter         (W3007 DeprecatedStopCodonStar)
+        // Phase 6b: Rewrite deprecated `X` stop-codon and frameshift forms in
+        // protein descriptions (SVA-004/SVA-005, issue #125):
         //   p.Arg97X       → p.Arg97Ter         (W3008 DeprecatedStopCodonX)
-        //   p.Arg97fs*23   → p.Arg97fsTer23     (W3009 DeprecatedFrameshiftStar)
         //   p.Arg97fsX23   → p.Arg97fsTer23     (W3010 DeprecatedFrameshiftX)
+        //
+        // The `*` spellings (`p.Arg97*`, `p.Arg97fs*23`) are NOT rewritten
+        // here: `*` is a spec-sanctioned stop-codon glyph co-equal with `Ter`
+        // (`checklist.md:63`), so it is left for the core parser to accept
+        // natively and `Display`-canonicalize to `Ter` (#1114).
         //
         // Must run BEFORE Phase 6c (single-letter expansion): otherwise the
         // `X` in `p.Arg97X` would be expanded to `Xaa` ("any amino acid") and
@@ -489,7 +492,7 @@ impl InputPreprocessor {
         //
         // Each detection's action is resolved independently and applied
         // per-correction, so mixing `Accept` with `WarnCorrect`/`SilentCorrect`
-        // overrides across the four W-codes yields a partial rewrite —
+        // overrides across the `X` W-codes yields a partial rewrite —
         // Accept-marked tokens are preserved even when sibling detections in
         // the same input are rewritten.
         let (corrected_full, corrections) = correct_deprecated_protein_forms(&current);
@@ -513,7 +516,8 @@ impl InputPreprocessor {
                                 .with_suggestion(corrected_full.clone())
                                 .with_hint(
                                     "HGVS uses 'Ter' (or 'fsTerN') for translation termination; \
-                                    'X' and '*' are deprecated alternatives.",
+                                    'X' is a deprecated alternative. ('*' is a spec-valid glyph \
+                                    co-equal with 'Ter' and is accepted as-is.)",
                                 ),
                         ),
                     );
@@ -1630,11 +1634,14 @@ mod tests {
     // ----------------------------------------------------------------------
 
     #[test]
-    fn test_preprocessor_strict_rejects_deprecated_stop_star() {
+    fn test_preprocessor_strict_accepts_star_stop() {
+        // Strict mode accepts the spec-valid `*` glyph (#1114), preserving it
+        // verbatim for native parsing rather than rejecting it.
         let preprocessor = InputPreprocessor::strict();
         let result = preprocessor.preprocess("NP_000079.2:p.Arg97*");
-        assert!(!result.success);
-        assert!(result.error.is_some());
+        assert!(result.success);
+        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97*");
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
@@ -1645,10 +1652,13 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocessor_strict_rejects_deprecated_frameshift_star() {
+    fn test_preprocessor_strict_accepts_frameshift_star() {
+        // Strict mode accepts the spec-valid `fs*N` glyph (#1114).
         let preprocessor = InputPreprocessor::strict();
         let result = preprocessor.preprocess("NP_000079.2:p.Arg97fs*23");
-        assert!(!result.success);
+        assert!(result.success);
+        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97fs*23");
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
@@ -1659,16 +1669,15 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocessor_lenient_corrects_deprecated_stop_star() {
+    fn test_preprocessor_accepts_star_stop_uncorrected() {
+        // `*` is a spec-valid stop-codon glyph (#1114): the preprocessor
+        // preserves it verbatim (no correction, no warning) and the core
+        // parser canonicalizes it to `Ter` downstream.
         let preprocessor = InputPreprocessor::lenient();
         let result = preprocessor.preprocess("NP_000079.2:p.Arg97*");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97Ter");
-        assert_eq!(result.warnings.len(), 1);
-        assert_eq!(
-            result.warnings[0].error_type,
-            ErrorType::DeprecatedStopCodonStar
-        );
+        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97*");
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
@@ -1685,16 +1694,15 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocessor_lenient_corrects_deprecated_frameshift_star() {
+    fn test_preprocessor_accepts_frameshift_star_uncorrected() {
+        // `fs*N` is a spec-valid frameshift-termination glyph (#1114): the
+        // preprocessor preserves it verbatim (no correction, no warning); the
+        // core parser canonicalizes it to `fsTer` downstream.
         let preprocessor = InputPreprocessor::lenient();
         let result = preprocessor.preprocess("NP_000079.2:p.Arg97fs*23");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97fsTer23");
-        assert_eq!(result.warnings.len(), 1);
-        assert_eq!(
-            result.warnings[0].error_type,
-            ErrorType::DeprecatedFrameshiftStar
-        );
+        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97fs*23");
+        assert!(result.warnings.is_empty());
     }
 
     #[test]
@@ -1713,12 +1721,8 @@ mod tests {
     #[test]
     fn test_preprocessor_silent_corrects_deprecated_without_warnings() {
         let preprocessor = InputPreprocessor::silent();
-        for input in [
-            "NP_000079.2:p.Arg97*",
-            "NP_000079.2:p.Arg97X",
-            "NP_000079.2:p.Arg97fs*23",
-            "NP_000079.2:p.Arg97fsX23",
-        ] {
+        // Deprecated `X` glyphs are corrected to `Ter` silently.
+        for input in ["NP_000079.2:p.Arg97X", "NP_000079.2:p.Arg97fsX23"] {
             let result = preprocessor.preprocess(input);
             assert!(result.success, "expected success for {}", input);
             assert!(!result.has_warnings(), "expected no warnings for {}", input);
@@ -1726,6 +1730,18 @@ mod tests {
                 result.preprocessed.contains("Ter"),
                 "expected Ter in {}",
                 result.preprocessed
+            );
+        }
+        // Spec-valid `*` glyphs are accepted unchanged — no correction, no
+        // warning; the core parser canonicalizes them to `Ter` (#1114).
+        for input in ["NP_000079.2:p.Arg97*", "NP_000079.2:p.Arg97fs*23"] {
+            let result = preprocessor.preprocess(input);
+            assert!(result.success, "expected success for {}", input);
+            assert!(!result.has_warnings(), "expected no warnings for {}", input);
+            assert_eq!(
+                result.preprocessed, input,
+                "`*` glyph must be preserved for {}",
+                input
             );
         }
     }
@@ -1757,18 +1773,16 @@ mod tests {
     }
 
     #[test]
-    fn test_preprocessor_lenient_compound_protein_allele_two_warnings() {
+    fn test_preprocessor_lenient_compound_protein_allele_one_warning() {
         let preprocessor = InputPreprocessor::lenient();
         let result = preprocessor.preprocess("NP_000079.2:p.[Arg97*;Arg100X]");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.[Arg97Ter;Arg100Ter]");
-        assert_eq!(result.warnings.len(), 2);
+        // Only the deprecated `X` member is corrected; the spec-valid `*` is
+        // preserved for native parsing (#1114).
+        assert_eq!(result.preprocessed, "NP_000079.2:p.[Arg97*;Arg100Ter]");
+        assert_eq!(result.warnings.len(), 1);
         assert_eq!(
             result.warnings[0].error_type,
-            ErrorType::DeprecatedStopCodonStar
-        );
-        assert_eq!(
-            result.warnings[1].error_type,
             ErrorType::DeprecatedStopCodonX
         );
     }
@@ -1776,36 +1790,52 @@ mod tests {
     #[test]
     fn test_preprocessor_lenient_idempotent_on_corrected_output() {
         // Re-running the preprocessor on its own output yields no further
-        // deprecated-form warnings.
+        // deprecated-form warnings (uses the deprecated `X` glyph, which IS
+        // corrected — `*` is no longer a correctable form, #1114).
         let preprocessor = InputPreprocessor::lenient();
-        let first = preprocessor.preprocess("NP_000079.2:p.Arg97fs*23");
+        let first = preprocessor.preprocess("NP_000079.2:p.Arg97fsX23");
+        assert_eq!(first.preprocessed, "NP_000079.2:p.Arg97fsTer23");
         let second = preprocessor.preprocess(&first.preprocessed);
         assert_eq!(second.preprocessed, first.preprocessed);
         assert!(!second.has_warnings());
     }
 
     #[test]
-    fn test_preprocessor_override_accept_keeps_deprecated_form() {
-        // When the override is Accept, the deprecated form passes through
-        // unchanged with no warning.
+    fn test_preprocessor_override_accept_x_falls_through_to_xaa() {
+        // When DeprecatedStopCodonX is Accept-overridden, the `X` is not
+        // treated as a stop codon and emits no warning; it then falls through
+        // to single-letter expansion (Phase 6c) and becomes the canonical
+        // `Xaa` ("any amino acid"). (This test used `*` before #1114; `*` is
+        // no longer a detected form, so it exercises the `X` code instead.)
         let config = ErrorConfig::lenient()
-            .with_override(ErrorType::DeprecatedStopCodonStar, ErrorOverride::Accept);
+            .with_override(ErrorType::DeprecatedStopCodonX, ErrorOverride::Accept);
         let preprocessor = InputPreprocessor::new(config);
-        let result = preprocessor.preprocess("NP_000079.2:p.Arg97*");
+        let result = preprocessor.preprocess("NP_000079.2:p.Arg97X");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97*");
-        assert!(!result.has_warnings());
+        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97Xaa");
+        // The stop-codon-X detection was Accepted (no W3008 warning); the only
+        // warning is the downstream single-letter `X` → `Xaa` expansion.
+        assert!(result
+            .warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::DeprecatedStopCodonX));
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::SingleLetterAminoAcid));
     }
 
     #[test]
     fn test_preprocessor_override_silent_in_strict_mode() {
-        // SilentCorrect override in strict mode rewrites without warning.
+        // SilentCorrect override in strict mode rewrites without warning. Uses
+        // the deprecated `X` glyph (W3010), since `*` is no longer a
+        // correctable form (#1114).
         let config = ErrorConfig::strict().with_override(
-            ErrorType::DeprecatedFrameshiftStar,
+            ErrorType::DeprecatedFrameshiftX,
             ErrorOverride::SilentCorrect,
         );
         let preprocessor = InputPreprocessor::new(config);
-        let result = preprocessor.preprocess("NP_000079.2:p.Arg97fs*23");
+        let result = preprocessor.preprocess("NP_000079.2:p.Arg97fsX23");
         assert!(result.success);
         assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97fsTer23");
         assert!(!result.has_warnings());
@@ -1824,22 +1854,38 @@ mod tests {
 
     #[test]
     fn test_preprocessor_partial_accept_only_rewrites_non_accept_codes() {
-        // With DeprecatedStopCodonStar = Accept and DeprecatedStopCodonX left
-        // at the lenient default (WarnCorrect), the `*` must remain literal
-        // while the `X` is rewritten to `Ter`. Per-correction action
-        // resolution — without it, the Accept override is silently ignored
-        // when any sibling detection is non-Accept.
+        // Per-correction action resolution: with DeprecatedStopCodonX = Accept
+        // and DeprecatedFrameshiftX left at the lenient default (WarnCorrect),
+        // the Accept applies only to the stop `X` (which is not corrected to
+        // `Ter` and instead falls through to `Xaa` expansion) while the
+        // frameshift `X` is still rewritten to `Ter` with its warning. Without
+        // per-correction resolution, the Accept override would be silently
+        // ignored when a sibling detection is non-Accept. (Uses the two `X`
+        // codes since `*` is no longer a detected form — #1114.)
         let config = ErrorConfig::lenient()
-            .with_override(ErrorType::DeprecatedStopCodonStar, ErrorOverride::Accept);
+            .with_override(ErrorType::DeprecatedStopCodonX, ErrorOverride::Accept);
         let preprocessor = InputPreprocessor::new(config);
-        let result = preprocessor.preprocess("NP_000079.2:p.[Arg97*;Arg100X]");
+        let result = preprocessor.preprocess("NP_000079.2:p.[Arg97X;Arg100fsX23]");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.[Arg97*;Arg100Ter]");
-        assert_eq!(result.warnings.len(), 1);
         assert_eq!(
-            result.warnings[0].error_type,
-            ErrorType::DeprecatedStopCodonX
+            result.preprocessed,
+            "NP_000079.2:p.[Arg97Xaa;Arg100fsTer23]"
         );
+        // Stop-X was Accepted (no W3008) → falls through to `Xaa`
+        // (SingleLetterAminoAcid); the sibling frameshift-X was still corrected
+        // to `fsTer23` (W3010). The Accept override applied per-correction.
+        assert!(result
+            .warnings
+            .iter()
+            .all(|w| w.error_type != ErrorType::DeprecatedStopCodonX));
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::DeprecatedFrameshiftX));
+        assert!(result
+            .warnings
+            .iter()
+            .any(|w| w.error_type == ErrorType::SingleLetterAminoAcid));
     }
 
     // ===== Issue #115: deprecated multi-base substitution (W3003) =====

--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -781,14 +781,18 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
         CodeInfo {
             code: "W3007",
             name: "DeprecatedStopCodonStar",
-            summary: "Deprecated '*' for stop codon in protein substitution.",
-            explanation: "The HGVS checklist permits both 'Ter' and '*' to indicate a \
-                translation stop codon, but the three-letter 'Ter' is the preferred form. \
-                In lenient/silent modes 'p.Arg97*' is rewritten to 'p.Arg97Ter'.",
+            summary: "'*' stop-codon glyph (spec-valid; retained but no longer emitted).",
+            explanation: "Per the HGVS checklist ('Ter' or '*' should be used for a \
+                translation stop codon; 'X' should not), '*' is a spec-valid glyph \
+                co-equal with 'Ter' — not a deprecated form. The parser accepts '*' \
+                natively in every mode (e.g. 'p.Arg97*') and canonicalizes it to the \
+                preferred three-letter 'Ter' on display, so no correction or warning is \
+                produced. This code is retained (python-exposed, stable discriminant) but \
+                is never emitted (#1114).",
             category: CodeCategory::Format,
-            bad_examples: &["NP_000079.2:p.Arg97*", "NP_000079.2:p.Trp10*"],
+            bad_examples: &[],
             good_examples: &["NP_000079.2:p.Arg97Ter", "NP_000079.2:p.Trp10Ter"],
-            mode_behavior: Some(ModeBehavior::standard_correctable()),
+            mode_behavior: Some(ModeBehavior::accepted()),
             hgvs_spec_url: Some("https://hgvs-nomenclature.org/stable/recommendations/checklist/"),
             related_codes: &["W3008", "W3009", "W3010"],
         },
@@ -820,17 +824,22 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
         CodeInfo {
             code: "W3009",
             name: "DeprecatedFrameshiftStar",
-            summary: "Deprecated 'fs*N' frameshift termination notation.",
-            explanation: "The canonical HGVS frameshift form uses 'fsTerN', e.g. \
-                'p.Arg123LysfsTer34'. The 'fs*N' alternative is permitted but discouraged. \
-                In lenient/silent modes 'p.Arg97fs*23' is rewritten to 'p.Arg97fsTer23'.",
+            summary: "'fs*N' frameshift-termination glyph (spec-valid; retained but no longer \
+                emitted).",
+            explanation: "Per HGVS (the checklist's 'Ter' or '*' guidance, and \
+                'protein/frameshift.md', which lists 'p.Arg97Profs*23' as a valid example), \
+                'fs*N' is a spec-valid frameshift-termination glyph — not a deprecated form. \
+                The parser accepts it natively in every mode (e.g. 'p.Arg97fs*23') and \
+                canonicalizes it to the preferred 'fsTerN' on display, so no correction or \
+                warning is produced. This code is retained (python-exposed, stable \
+                discriminant) but is never emitted (#1114).",
             category: CodeCategory::Format,
-            bad_examples: &["NP_000079.2:p.Arg97fs*23", "NP_000079.2:p.Ser539Alafs*110"],
+            bad_examples: &[],
             good_examples: &[
                 "NP_000079.2:p.Arg97fsTer23",
                 "NP_000079.2:p.Ser539AlafsTer110",
             ],
-            mode_behavior: Some(ModeBehavior::standard_correctable()),
+            mode_behavior: Some(ModeBehavior::accepted()),
             hgvs_spec_url: Some(
                 "https://hgvs-nomenclature.org/stable/recommendations/protein/variant/frameshift/",
             ),

--- a/src/error_handling/types.rs
+++ b/src/error_handling/types.rs
@@ -126,11 +126,16 @@ pub enum ErrorType {
     /// This format was used in older databases but is not valid per current HGVS spec.
     OldAlleleFormat,
 
-    /// Deprecated `*` for stop codon in protein substitution position.
+    /// `*` for stop codon in protein substitution position.
     ///
-    /// Per HGVS checklist (`recommendations/checklist.md`), `Ter` and `*` may
-    /// both indicate a translation stop codon, but the three-letter `Ter` is
-    /// preferred. Example: `p.Arg97*` (corrected to `p.Arg97Ter`).
+    /// **Retained for compatibility but no longer emitted (#1114).** Per HGVS
+    /// checklist (`recommendations/checklist.md:63`, "`Ter` or `*` should be
+    /// used ... the `X` should not be used"), `*` is a spec-valid stop-codon
+    /// glyph co-equal with `Ter` — not a deprecated form. The core parser
+    /// accepts `*` natively (e.g. `p.Arg97*`) and `Display` canonicalizes it
+    /// to the preferred three-letter `Ter`, so no correction/warning is
+    /// produced. This variant is kept (it is python-exposed with a stable
+    /// discriminant) but is never raised.
     DeprecatedStopCodonStar,
 
     /// Deprecated `X` for stop codon in protein substitution position.
@@ -142,12 +147,16 @@ pub enum ErrorType {
     /// Corrected to `p.Arg97Ter`.
     DeprecatedStopCodonX,
 
-    /// Deprecated `fs*N` frameshift termination notation.
+    /// `fs*N` frameshift termination notation.
     ///
-    /// Per HGVS frameshift recommendation (`recommendations/protein/frameshift.md`),
-    /// the canonical form is `fsTerN` (e.g. `p.Arg123LysfsTer34`). The `fs*N`
-    /// form is permitted as an alternative but `fsTerN` is preferred.
-    /// Example: `p.Arg97fs*23` (corrected to `p.Arg97fsTer23`).
+    /// **Retained for compatibility but no longer emitted (#1114).** Per HGVS
+    /// (`recommendations/checklist.md:63` and `protein/frameshift.md`, which
+    /// lists `p.Arg97Profs*23` as a valid example), `fs*N` is a spec-valid
+    /// frameshift-termination glyph — not a deprecated form. The core parser
+    /// accepts it natively (e.g. `p.Arg97fs*23`) and `Display` canonicalizes
+    /// it to the preferred `fsTerN`, so no correction/warning is produced.
+    /// This variant is kept (python-exposed with a stable discriminant) but
+    /// is never raised.
     DeprecatedFrameshiftStar,
 
     /// Deprecated `fsXN` frameshift termination notation.
@@ -593,10 +602,12 @@ impl ErrorType {
             ErrorType::TrailingAnnotation => "trailing protein annotation",
             ErrorType::MissingCoordinatePrefix => "missing coordinate type prefix",
             ErrorType::OldAlleleFormat => "old/deprecated allele format",
-            ErrorType::DeprecatedStopCodonStar => "deprecated '*' for stop codon (use 'Ter')",
+            ErrorType::DeprecatedStopCodonStar => {
+                "spec-valid '*' stop-codon glyph, canonicalized to 'Ter' (retained, not emitted)"
+            }
             ErrorType::DeprecatedStopCodonX => "deprecated 'X' for stop codon (use 'Ter')",
             ErrorType::DeprecatedFrameshiftStar => {
-                "deprecated 'fs*N' frameshift notation (use 'fsTerN')"
+                "spec-valid 'fs*N' frameshift glyph, canonicalized to 'fsTerN' (retained, not emitted)"
             }
             ErrorType::DeprecatedFrameshiftX => {
                 "deprecated 'fsXN' frameshift notation (use 'fsTerN')"
@@ -681,9 +692,12 @@ impl ErrorType {
             ErrorType::OldAlleleFormat => true,
             // RefSeqMismatch can be "corrected" by using the actual reference
             ErrorType::RefSeqMismatch => true,
-            ErrorType::DeprecatedStopCodonStar => true,
+            // The `*` glyphs are spec-valid and accepted natively (never
+            // corrected), so they are not correctable (#1114); only the `X`
+            // forms are rewritten.
+            ErrorType::DeprecatedStopCodonStar => false,
             ErrorType::DeprecatedStopCodonX => true,
-            ErrorType::DeprecatedFrameshiftStar => true,
+            ErrorType::DeprecatedFrameshiftStar => false,
             ErrorType::DeprecatedFrameshiftX => true,
             // Lenient mode warns without rewriting (warn_accept); strict rejects.
             ErrorType::DelSizeSuffix => false,

--- a/tests/fixtures/error_code_audit.json
+++ b/tests/fixtures/error_code_audit.json
@@ -307,12 +307,12 @@
     },
     {
       "code": "W3007",
-      "description": "DeprecatedStopCodonStar — 'p.Arg97*' rewritten to 'p.Arg97Ter' (Ter is the preferred stop-codon form).",
-      "spec_section": "recommendations/checklist.md (HGVS checklist: 'Ter' is the preferred form for the translation stop codon; '*' is permitted but discouraged)",
+      "description": "DeprecatedStopCodonStar — retained for compatibility but no longer emitted: '*' is a spec-valid stop-codon glyph, accepted natively and canonicalized to 'Ter' by the parser (#1114).",
+      "spec_section": "recommendations/checklist.md:63 ('Ter or * should be used to indicate a translation stop codon; the X should not be used') — '*' is co-equal with 'Ter', not deprecated",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/checklist/",
-      "status": "enforced",
-      "spec_section_notes": "correct_deprecated_protein_forms in src/error_handling/corrections.rs returns ErrorType::DeprecatedStopCodonStar; emitted by preprocessor Phase 6b (deprecated-form rewrites) in lenient/silent modes. Strict mode rejects the input. Closes #125.",
-      "follow_up_issues": [125]
+      "status": "registered",
+      "spec_section_notes": "The '*' stop-codon glyph is spec-sanctioned (checklist.md:63), so correct_deprecated_protein_forms no longer detects it — the core parser accepts '*' natively as Ter and Display canonicalizes it. The ErrorType variant is retained (python-exposed) but never emitted. Reclassified from `enforced` to `registered` in #1114 (originally #125).",
+      "follow_up_issues": [125, 1114]
     },
     {
       "code": "W3008",
@@ -325,12 +325,12 @@
     },
     {
       "code": "W3009",
-      "description": "DeprecatedFrameshiftStar — 'p.Arg97fs*23' rewritten to 'p.Arg97fsTer23'.",
-      "spec_section": "recommendations/protein/variant/frameshift.md (canonical 'fsTerN'; 'fs*N' is permitted but discouraged)",
+      "description": "DeprecatedFrameshiftStar — retained for compatibility but no longer emitted: 'fs*N' is a spec-valid frameshift-termination glyph, accepted natively and canonicalized to 'fsTerN' by the parser (#1114).",
+      "spec_section": "recommendations/checklist.md:63 ('Ter or * should be used ... the X should not be used'); recommendations/protein/frameshift.md lists 'p.Arg97Profs*23' as a valid example — 'fs*N' is not deprecated",
       "spec_url": "https://hgvs-nomenclature.org/stable/recommendations/protein/variant/frameshift/",
-      "status": "enforced",
-      "spec_section_notes": "correct_deprecated_protein_forms in src/error_handling/corrections.rs returns ErrorType::DeprecatedFrameshiftStar; emitted by preprocessor Phase 6b (deprecated-form rewrites) in lenient/silent modes. Strict mode rejects the input. Closes #125.",
-      "follow_up_issues": [125]
+      "status": "registered",
+      "spec_section_notes": "The 'fs*N' glyph is spec-sanctioned, so correct_deprecated_protein_forms no longer detects it — the core parser accepts 'fs*N' natively as fsTerN and Display canonicalizes it. The ErrorType variant is retained (python-exposed) but never emitted. Reclassified from `enforced` to `registered` in #1114 (originally #125).",
+      "follow_up_issues": [125, 1114]
     },
     {
       "code": "W3010",

--- a/tests/it/error_mode_tests.rs
+++ b/tests/it/error_mode_tests.rs
@@ -1085,33 +1085,44 @@ mod deprecated_stop_codon_and_frameshift_forms {
         assert_eq!(parsed.to_string(), expected);
     }
 
-    // --- W3007: deprecated `*` for stop in protein substitution (SVA-003) ---
-
-    #[test]
-    fn lenient_corrects_w3007_star_for_stop() {
-        assert_corrects_with_warning(
-            "NP_000079.2:p.Arg97*",
-            "NP_000079.2:p.Arg97Ter",
-            ErrorType::DeprecatedStopCodonStar,
-        );
+    /// Assert a `*` stop glyph is accepted in every mode: the preprocessor
+    /// preserves it verbatim (no correction, no warning) and the full parser
+    /// canonicalizes it to the spec-preferred three-letter `Ter` (#1114).
+    fn assert_star_accepted_as_ter(input: &str, expected_display: &str) {
+        for config in [
+            ErrorConfig::strict(),
+            ErrorConfig::lenient(),
+            ErrorConfig::silent(),
+        ] {
+            let preprocessor = config.preprocessor();
+            let result = preprocessor.preprocess(input);
+            assert!(
+                result.success,
+                "{input:?} must be accepted: {:?}",
+                result.error
+            );
+            assert_eq!(
+                result.preprocessed, input,
+                "`*` must be preserved for {input:?}",
+            );
+            assert!(
+                result.warnings.is_empty(),
+                "{input:?} must not warn; got {:?}",
+                result.warnings,
+            );
+        }
+        let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("{input:?} must parse: {e}"));
+        assert_eq!(parsed.to_string(), expected_display);
     }
 
-    #[test]
-    fn strict_rejects_w3007_star_for_stop() {
-        let config = ErrorConfig::strict();
-        let preprocessor = config.preprocessor();
-        let result = preprocessor.preprocess("NP_000079.2:p.Arg97*");
-        assert!(!result.success);
-    }
+    // --- `*` for stop in protein substitution: spec-valid per checklist.md:63
+    // ("`Ter` or `*` should be used ... the `X` should not be used"). Accepted
+    // in every mode and canonicalized to `Ter`; NOT a deprecated form (#1114).
+    // Only `X` (W3008, below) is deprecated. ---
 
     #[test]
-    fn silent_corrects_w3007_no_warning() {
-        let config = ErrorConfig::silent();
-        let preprocessor = config.preprocessor();
-        let result = preprocessor.preprocess("NP_000079.2:p.Arg97*");
-        assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.Arg97Ter");
-        assert!(result.warnings.is_empty());
+    fn star_for_stop_accepted_as_ter_all_modes() {
+        assert_star_accepted_as_ter("NP_000079.2:p.Arg97*", "NP_000079.2:p.Arg97Ter");
     }
 
     // --- W3008: deprecated `X` for stop in protein substitution (SVA-004) ---
@@ -1154,32 +1165,21 @@ mod deprecated_stop_codon_and_frameshift_forms {
         assert!(result.warnings.is_empty());
     }
 
-    // --- W3009: deprecated `fs*N` frameshift termination (SVA-006) ---
+    // --- `fs*N` frameshift termination: spec-valid (`frameshift.md` lists
+    // `p.Arg97Profs*23`). Accepted in every mode and canonicalized to `fsTer`;
+    // NOT a deprecated form (#1114). Only `fsXN` (W3010, below) is deprecated. ---
 
     #[test]
-    fn lenient_corrects_w3009_fs_star_n() {
-        assert_corrects_with_warning(
-            "NP_000079.2:p.Arg97fs*23",
-            "NP_000079.2:p.Arg97fsTer23",
-            ErrorType::DeprecatedFrameshiftStar,
-        );
+    fn fs_star_n_accepted_as_ter_all_modes() {
+        assert_star_accepted_as_ter("NP_000079.2:p.Arg97fs*23", "NP_000079.2:p.Arg97fsTer23");
     }
 
     #[test]
-    fn lenient_corrects_w3009_with_new_aa() {
-        assert_corrects_with_warning(
+    fn fs_star_with_new_aa_accepted_as_ter_all_modes() {
+        assert_star_accepted_as_ter(
             "NP_000079.2:p.Arg97Profs*23",
             "NP_000079.2:p.Arg97ProfsTer23",
-            ErrorType::DeprecatedFrameshiftStar,
         );
-    }
-
-    #[test]
-    fn strict_rejects_w3009_fs_star_n() {
-        let config = ErrorConfig::strict();
-        let preprocessor = config.preprocessor();
-        let result = preprocessor.preprocess("NP_000079.2:p.Arg97fs*23");
-        assert!(!result.success);
     }
 
     // --- W3010: deprecated `fsXN` frameshift termination (SVA-005) ---
@@ -1229,13 +1229,20 @@ mod deprecated_stop_codon_and_frameshift_forms {
     }
 
     #[test]
-    fn lenient_compound_protein_allele_emits_two_warnings() {
+    fn lenient_compound_protein_allele_emits_one_warning() {
+        // A compound allele mixing the spec-valid `*` with the deprecated `X`:
+        // only the `X` member is corrected (one W3008 warning); the `*` is
+        // preserved for native parsing (#1114).
         let config = ErrorConfig::lenient();
         let preprocessor = config.preprocessor();
         let result = preprocessor.preprocess("NP_000079.2:p.[Arg97*;Arg100X]");
         assert!(result.success);
-        assert_eq!(result.preprocessed, "NP_000079.2:p.[Arg97Ter;Arg100Ter]");
-        assert_eq!(result.warnings.len(), 2);
+        assert_eq!(result.preprocessed, "NP_000079.2:p.[Arg97*;Arg100Ter]");
+        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(
+            result.warnings[0].error_type,
+            ferro_hgvs::error_handling::ErrorType::DeprecatedStopCodonX
+        );
     }
 
     #[test]

--- a/tests/it/issue_1114_star_ter_strict.rs
+++ b/tests/it/issue_1114_star_ter_strict.rs
@@ -1,0 +1,107 @@
+//! `*` (asterisk) is a spec-sanctioned stop-codon spelling and must be
+//! accepted in strict mode — not rejected as a deprecated form (#1114).
+//!
+//! # Spec
+//!
+//! `recommendations/checklist.md:63`:
+//!
+//! > **`Ter` or `*` should be used** to indicate a translation stop codon;
+//! > the `X` should not be used.
+//!
+//! `recommendations/general.md:54` ("the `*` can be used to indicate the
+//! translation stop codon in both one- and three-letter amino acid code
+//! descriptions") and `protein/frameshift.md` (which lists `p.Arg97Profs*23`
+//! and `p.Gln151Thrfs*9` as valid examples) confirm `*` is co-equal with
+//! `Ter`. Only `X` is deprecated.
+//!
+//! # Behavior
+//!
+//! ferro previously classified `*` as `DeprecatedStopCodonStar` (W3007) /
+//! `DeprecatedFrameshiftStar` (W3009) and rejected it in strict mode (the
+//! deprecated-form preprocessor pass turned `success = false`). This
+//! reclassifies `*` as a valid `Ter` spelling: it parses to the `Ter` AST in
+//! every mode (the core parser already accepts it) and Display canonicalizes
+//! to the spec-preferred three-letter `Ter`. It is therefore *not* a
+//! correction — no W3007/W3009 warning is emitted. The genuinely-deprecated
+//! `X` spelling stays rejected.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
+
+/// (input, expected canonical display) — spec-valid `*` stop spellings across
+/// the nonsense-substitution (W3007) and frameshift-termination (W3009) slots.
+const STAR_STOP_FORMS: &[(&str, &str)] = &[
+    ("NP_003997.1:p.Trp26*", "NP_003997.1:p.Trp26Ter"),
+    (
+        "NP_003997.1:p.Arg97Profs*23",
+        "NP_003997.1:p.Arg97ProfsTer23",
+    ),
+    (
+        "NP_003997.1:p.Gln151Thrfs*9",
+        "NP_003997.1:p.Gln151ThrfsTer9",
+    ),
+    // Extension: the `*` new-stop glyph is accepted and canonicalizes to `Ter`.
+    (
+        "NP_003997.1:p.Ter327Glnext*?",
+        "NP_003997.1:p.Ter327GlnextTer?",
+    ),
+];
+
+/// Strict mode accepts every `*` stop spelling and canonicalizes it to `Ter`.
+#[test]
+fn strict_accepts_star_stop_codon_as_ter() {
+    for (input, expected) in STAR_STOP_FORMS {
+        let parsed = parse_hgvs_with_config(input, ErrorConfig::strict())
+            .unwrap_or_else(|e| panic!("strict must accept spec-valid {input:?}: {e}"));
+        assert_eq!(parsed.result.to_string(), *expected, "input {input:?}");
+    }
+}
+
+/// `*` is valid, not a deprecated form, so strict-accepting it emits no
+/// W3007/W3009 deprecation warning.
+#[test]
+fn star_stop_codon_is_not_a_correction() {
+    for (input, _) in STAR_STOP_FORMS {
+        let parsed = parse_hgvs_with_config(input, ErrorConfig::strict())
+            .unwrap_or_else(|e| panic!("strict must accept {input:?}: {e}"));
+        assert!(
+            parsed.warnings.is_empty(),
+            "{input:?} is a valid `*` spelling; expected no warnings, got {:?}",
+            parsed.warnings,
+        );
+    }
+}
+
+/// The genuinely-deprecated `X` stop spelling (checklist.md:63 "the `X`
+/// should not be used") stays rejected in strict — the reclassification is
+/// `*`-only, leaving `X` (W3008 / W3010) unchanged.
+#[test]
+fn strict_still_rejects_deprecated_x_stop() {
+    // Strict rejects the deprecated `X` stop (W3008) and frameshift (W3010)
+    // forms. Assert the rejection is specifically the deprecated-`X` diagnostic
+    // — not an unrelated parse failure — so this can't silently pass on the
+    // wrong error. (Strict surfaces the diagnostic message; the W-code itself is
+    // carried on the warning in lenient/silent, exercised elsewhere.)
+    for input in ["NP_003997.1:p.Trp26X", "NP_003997.1:p.Arg97ProfsX23"] {
+        let err = parse_hgvs_with_config(input, ErrorConfig::strict())
+            .expect_err(&format!(
+                "strict must still reject deprecated `X` form {input:?}"
+            ))
+            .to_string();
+        assert!(
+            err.contains("Deprecated protein notation 'X"),
+            "strict rejection of {input:?} must cite the deprecated `X` notation; got: {err}",
+        );
+    }
+}
+
+/// The 3'UTR `*` (`c.*10`) is a *coordinate* marker, a wholly separate meaning
+/// from the protein stop-codon `*`. Accepting the stop-codon `*` must not
+/// conflate the two: a UTR `*` still parses (in strict) and is preserved
+/// verbatim, not rewritten to `Ter`.
+#[test]
+fn utr_star_coordinate_is_not_conflated_with_stop_codon() {
+    let parsed = parse_hgvs_with_config("NM_004006.2:c.*10A>G", ErrorConfig::strict())
+        .expect("strict must accept a 3'UTR `*` coordinate");
+    assert_eq!(parsed.result.to_string(), "NM_004006.2:c.*10A>G");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -106,6 +106,7 @@ mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;
 mod issue_1103_cis_merge_order_independence;
 mod issue_1111_rna_noncoding_reframe;
+mod issue_1114_star_ter_strict;
 mod issue_1116_protein_coalesce_order_independence;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;

--- a/tests/it/protein_frameshift_legacy_stop_modes.rs
+++ b/tests/it/protein_frameshift_legacy_stop_modes.rs
@@ -9,21 +9,21 @@
 //! not be used."*
 //!
 //! ferro's mode-aware error handling distinguishes these correctly:
-//! - `Ter` and `*` (with digits OR `?`) are parser-native and round-trip
-//!   silently in every mode.
+//! - `Ter` and `*` (with digits OR `?`) are parser-native and accepted in
+//!   every mode, canonicalizing to the spec-preferred three-letter `Ter` on
+//!   Display with no warning. `*` is a valid glyph, not a deprecated form
+//!   (#1114).
 //! - `X` (with digits OR `?`) triggers **W3010 DeprecatedFrameshiftX**:
 //!   strict rejects, lenient rewrites → `Ter` + warning, silent rewrites
 //!   silently.
-//! - `*` ALSO triggers **W3009 DeprecatedFrameshiftStar** at the
-//!   preprocessor level (ferro is stricter than the spec here, treating
-//!   `*` as deprecated and canonicalizing to `Ter`). Same mode mapping.
 //!
-//! This file pins all four lanes — `fsXN`, `fsX?`, `fs*N`, `fs*?` — in
-//! both lenient (warn-and-correct) and strict (reject) modes, plus the
-//! canonical `fsTerN` / `fsTer?` round-trip. Closes the gap surfaced
-//! while investigating #81 D1: previously `fsX?` was rejected outright
-//! by the parser (corrector required digits after `X`), inconsistent
-//! with the digit-bearing `fsXN` lenient path.
+//! This file pins the `fsXN` / `fsX?` deprecated lanes (lenient warn-and-
+//! correct, strict reject), the spec-valid `fs*N` / `fs*?` lanes (accepted
+//! in every mode, canonicalized to `Ter`, no warning), and the canonical
+//! `fsTerN` / `fsTer?` round-trip. Closes the gap surfaced while
+//! investigating #81 D1: previously `fsX?` was rejected outright by the
+//! parser (corrector required digits after `X`), inconsistent with the
+//! digit-bearing `fsXN` lenient path.
 
 use ferro_hgvs::error_handling::{ErrorConfig, ErrorType};
 use ferro_hgvs::hgvs::parser::parse_hgvs_with_config;
@@ -32,6 +32,10 @@ const ACC: &str = "NP_000079.2";
 
 fn lenient() -> ErrorConfig {
     ErrorConfig::lenient()
+}
+
+fn silent() -> ErrorConfig {
+    ErrorConfig::silent()
 }
 
 fn strict() -> ErrorConfig {
@@ -130,38 +134,47 @@ fn strict_rejects_fs_x_question_per_checklist_63() {
 }
 
 // =====================================================================
-// W3009 — fs* (one-letter Star spelling, spec-valid but ferro deprecates)
+// fs* — one-letter Star spelling: spec-valid (checklist.md:63), parser-
+// native. Accepted in every mode, canonicalized to `Ter`, no W3009.
 // =====================================================================
 
+/// `*` is a valid frameshift-stop glyph: accepted in ALL modes (strict,
+/// lenient, silent), canonicalized to the three-letter `Ter` on Display, with
+/// no warning at all — it is not a correction, it is native acceptance (#1114).
+fn star_accepted_as_ter(input: &str, expected_display: &str) {
+    for config in [strict(), lenient(), silent()] {
+        let result = parse_hgvs_with_config(input, config)
+            .unwrap_or_else(|e| panic!("must accept {input:?}: {e}"));
+        assert_eq!(
+            result.result.to_string(),
+            expected_display,
+            "Display mismatch for {input:?}",
+        );
+        assert!(
+            result.warnings.is_empty(),
+            "{input:?} must be accepted natively with no warning (not corrected); \
+             got {:?}",
+            result.warnings,
+        );
+    }
+}
+
 #[test]
-fn lenient_rewrites_fs_star_n_with_digits() {
-    lenient_rewrites_to(
+fn fs_star_n_with_digits_accepted_as_ter() {
+    star_accepted_as_ter(
         &format!("{ACC}:p.Arg97fs*23"),
         &format!("{ACC}:p.Arg97fsTer23"),
-        ErrorType::DeprecatedFrameshiftStar,
     );
 }
 
 #[test]
-fn lenient_rewrites_fs_star_question_uncertain() {
-    // `fs*?` goes through the corrector (same mode mapping as `fs*N`); the
-    // deprecated `*?` rewrites to the canonical unknown-stop marker `fsTer?`
-    // (preserved, no longer collapsed to bare `fs`).
-    lenient_rewrites_to(
+fn fs_star_question_uncertain_accepted_as_ter() {
+    // `fs*?` (uncertain stop position) is parser-native; it canonicalizes to
+    // the unknown-stop marker `fsTer?`.
+    star_accepted_as_ter(
         &format!("{ACC}:p.Arg97fs*?"),
         &format!("{ACC}:p.Arg97fsTer?"),
-        ErrorType::DeprecatedFrameshiftStar,
     );
-}
-
-#[test]
-fn strict_rejects_fs_star_n() {
-    strict_rejects(&format!("{ACC}:p.Arg97fs*23"), "Deprecated");
-}
-
-#[test]
-fn strict_rejects_fs_star_question() {
-    strict_rejects(&format!("{ACC}:p.Arg97fs*?"), "Deprecated");
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary

In strict parse mode ferro rejected the `*` (asterisk) spelling of the translation-termination codon, even though the HGVS spec sanctions `*` as a co-equal spelling of `Ter`. The equivalent `Ter` spelling parsed fine, and lenient mode already accepted `*` (repairing it to `Ter`) — so strict mode was turning away spec-valid syntax. This is a **false rejection of a legal description**.

```
ferro parse "NP_003997.1:p.Arg97Profs*23"   # was: ERROR   → now: p.Arg97ProfsTer23
ferro parse "NP_003997.1:p.Gln151Thrfs*9"    # was: ERROR   → now: p.Gln151ThrfsTer9
ferro parse "NP_003997.1:p.Trp26*"           # was: ERROR   → now: p.Trp26Ter
```

The rejection was **not** specific to the frameshift slot — a plain nonsense substitution (`p.Trp26*`) was rejected too.

## Spec basis — `*` is valid, not deprecated

- `checklist.md:63` — "**`Ter` or `*` should be used** to indicate a translation stop codon; the `X` should not be used."
- `general.md:54,77` — "the `*` can be used to indicate the translation stop codon"; examples `c.*32G>A`, `p.Trp41*`.
- `protein/frameshift.md` — lists `p.Arg97Profs*23` and `p.Gln151Thrfs*9` as valid examples.

No bare `*`-for-`Ter` form is tagged `<code class="invalid">` anywhere in the protein pages. The genuinely-deprecated single-letter stop symbol is `X` (`substitution.md:104`), which this PR leaves rejected.

## Root cause & fix

The core parser already accepts `*` natively (it maps to the `Ter` AST, and `Display` canonicalizes to the preferred three-letter `Ter`). The strict rejection came solely from the deprecated-form preprocessor pass (`correct_deprecated_protein_forms`), which mis-classified `*` as `DeprecatedStopCodonStar` (W3007) / `DeprecatedFrameshiftStar` (W3009).

This PR narrows that pass to the genuinely-deprecated `X` spellings (W3008 / W3010), so `*` passes through untouched and is accepted in **every** mode with no warning, canonicalizing to `Ter` on output. `X` stays rejected in strict / repaired in lenient.

The `W3007` / `W3009` `ErrorType` variants are retained (they are python-exposed with stable discriminants) but are no longer emitted; their `error_code_audit.json` rows move from `enforced` to `registered`.

## Tests

- New `tests/it/issue_1114_star_ter_strict.rs`: strict accepts every `*` stop spelling and canonicalizes to `Ter` (no warning); `X` stays rejected.
- Updated the deprecated-form unit/integration tests (`corrections.rs`, `preprocessor.rs`, `error_mode_tests.rs`, `protein_frameshift_legacy_stop_modes.rs`) to the new behavior — `*` accepted, `X` still corrected/rejected — including the documented `X`→`Xaa` single-letter-expansion interaction under an Accept override.

Full suite green (8239 tests), clippy clean, `generate_spec_fixture --check` passes.

Closes #1114
