### PR TITLE
fix(normalize): coalesce mixed sub+del protein cis runs into one delins

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1195,13 +1195,22 @@ fn build_naedit<P>(
     )
 }
 
-/// Coalesce runs of consecutive-residue substitutions in a **cis protein
-/// allele** into a single delins, per `protein/substitution.md:23`:
+/// Coalesce runs of consecutive-residue changes in a **cis protein allele**
+/// into a single delins (or a pure range deletion), per
+/// `protein/substitution.md:23` / `protein/delins.md:18`:
 ///
 /// > changes involving two or more consecutive amino acids are described as a
 /// > deletion/insertion variant (delins) […] the description
 /// > `p.Arg76_Cys77delinsSerTrp` is correct, the description
 /// > `p.[Arg76Ser;Cys77Trp]` is not correct.
+///
+/// "changes" is general: each member may be a single-residue **substitution**
+/// (contributing its alternative residue to the merged insert) or a
+/// single-residue **deletion** (contributing nothing) — e.g.
+/// `p.[Arg76Ser;Cys77del]` → `p.Arg76_Cys77delinsSer`, and `delins.md:41`'s
+/// `p.Cys28_Lys29delinsTrp` (del+sub). A run whose members are *all* deletions
+/// has an empty insert, so it collapses to a pure range deletion
+/// (`p.Arg76_Cys77del`) rather than an invalid empty `delins`.
 ///
 /// This is the protein-axis counterpart of the nucleotide adjacency merge that
 /// [`merge_consecutive_edits`] performs — the nucleotide path is positional on
@@ -1217,24 +1226,28 @@ fn build_naedit<P>(
 /// sorted into ascending residue order before runs are detected, so every
 /// permutation of one member set coalesces identically. Reordering is
 /// meaning-preserving here because every member has already been established to
-/// be a plain single-residue substitution on one shared accession — and the
-/// post-normalize display sort (#1098/#1101) puts cis members into exactly that
-/// residue order anyway, so an allele that does *not* coalesce still renders
-/// ascending. This is the protein-axis counterpart of #1103's sort-before-merge
-/// on the nucleotide axis; without it a descending-order allele fell through to
-/// the bracket form `protein/substitution.md:23` calls "not correct".
+/// be a plain single-residue substitution or deletion on one shared accession —
+/// and the post-normalize display sort (#1098/#1101) puts cis members into
+/// exactly that residue order anyway, so an allele that does *not* coalesce
+/// still renders ascending. This is the protein-axis counterpart of #1103's
+/// sort-before-merge on the nucleotide axis; without it a descending-order
+/// allele fell through to the bracket form `protein/substitution.md:23` calls
+/// "not correct".
 ///
-/// Returns `Some` only when at least one run of ≥2 adjacent substitutions is
-/// merged; a fully-merged allele collapses to a bare [`HgvsVariant::Protein`],
-/// a partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
+/// Returns `Some` only when at least one run of ≥2 adjacent members is merged;
+/// a fully-merged allele collapses to a bare [`HgvsVariant::Protein`], a
+/// partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
 /// the allele untouched — when it is conservatively out of scope:
 ///   - the phase is not cis (trans / unknown / mosaic / … are independent),
-///   - any member is not a single-residue protein substitution (mixed edit
-///     kinds are out of scope for this narrow rule),
+///   - any member is not a single-residue protein substitution or deletion
+///     (other edit kinds — dup / ins / inv / fs / ext / multi-residue — are
+///     out of scope for this narrow rule),
+///   - any substitution member changes the residue to `Ter` (a `delins…Ter…`
+///     run would list residues after the stop — spec-invalid),
 ///   - two members share a residue position (a `n,n` pair is the contradictory
 ///     same-residue case, not a delins), or
 ///   - a run would mix predicted `( )` and certain members (ambiguous).
-pub(crate) fn coalesce_protein_adjacent_substitutions(
+pub(crate) fn coalesce_protein_adjacent_changes(
     allele: &crate::hgvs::variant::AlleleVariant,
 ) -> Option<HgvsVariant> {
     use crate::hgvs::edit::{AminoAcidSeq, ProteinEdit};
@@ -1246,13 +1259,16 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
         return None;
     }
 
-    /// One member reduced to a single-residue substitution. `source` is the
-    /// member's index in `allele.variants`, kept so a substitution that ends up
-    /// in no run is re-emitted verbatim even after the residue-order sort.
-    struct Sub {
+    /// One member reduced to a single-residue edit: a substitution
+    /// (`alternative = Some(aa)`, contributes that residue to the merged
+    /// insert) or a deletion (`alternative = None`, contributes nothing).
+    /// `source` is the member's index in `allele.variants`, kept so a member
+    /// that ends up in no run is re-emitted verbatim even after the
+    /// residue-order sort (#1116).
+    struct Member {
         pos: u64,
         reference: AminoAcid,
-        alternative: AminoAcid,
+        alternative: Option<AminoAcid>,
         predicted: bool,
         source: usize,
     }
@@ -1264,7 +1280,7 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
     let accession = first.accession.clone();
     let gene_symbol = first.gene_symbol.clone();
 
-    let mut subs: Vec<Sub> = Vec::with_capacity(allele.variants.len());
+    let mut members: Vec<Member> = Vec::with_capacity(allele.variants.len());
     for (source, v) in allele.variants.iter().enumerate() {
         let HgvsVariant::Protein(pv) = v else {
             return None;
@@ -1287,8 +1303,20 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
             return None;
         }
         let (alternative, predicted) = match &pv.loc_edit.edit {
-            Mu::Certain(ProteinEdit::Substitution { alternative, .. }) => (*alternative, false),
-            Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) => (*alternative, true),
+            Mu::Certain(ProteinEdit::Substitution { alternative, .. }) => {
+                (Some(*alternative), false)
+            }
+            Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) => {
+                (Some(*alternative), true)
+            }
+            // A single-residue deletion contributes no residue to the merged
+            // insert. `start == end` was already enforced above, so this is a
+            // one-residue `del` (a multi-residue `del` range has `s != e` and
+            // bails). A deletion carrying an explicit deleted-sequence or count
+            // annotation still describes a single residue here, so it merges
+            // the same way.
+            Mu::Certain(ProteinEdit::Deletion { .. }) => (None, false),
+            Mu::Uncertain(ProteinEdit::Deletion { .. }) => (None, true),
             _ => return None,
         };
         // A to-`Ter` (nonsense) substitution is out of scope: the spec forbids
@@ -1296,10 +1324,10 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
         // unparseable and spec-invalid (protein/substitution.md:20,
         // protein/delins.md:45). Leave such an allele untouched — collapsing a
         // nonsense change toward `p.<ref><pos>Ter` is a separate rule.
-        if alternative == AminoAcid::Ter {
+        if alternative == Some(AminoAcid::Ter) {
             return None;
         }
-        subs.push(Sub {
+        members.push(Member {
             pos: s.number,
             reference: s.aa,
             alternative,
@@ -1309,39 +1337,54 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
     }
 
     // Sort into ascending residue order so run detection — and therefore the
-    // coalesced `delins` payload — is independent of the author's member order
-    // (#1116). The sort is stable, so members sharing a residue stay adjacent
-    // in input order and are caught by the duplicate check below.
-    subs.sort_by_key(|s| s.pos);
+    // coalesced payload — is independent of the author's member order (#1116).
+    // The sort is stable, so members sharing a residue stay adjacent and are
+    // caught by the duplicate check below.
+    members.sort_by_key(|m| m.pos);
 
     // Two members at the same residue are a contradiction, not a delins: the
     // allele states two different changes to one amino acid. Leave it untouched.
-    if subs.windows(2).any(|w| w[1].pos == w[0].pos) {
+    if members.windows(2).any(|w| w[1].pos == w[0].pos) {
         return None;
     }
 
     let mut merged: Vec<HgvsVariant> = Vec::new();
     let mut changed = false;
     let mut i = 0;
-    while i < subs.len() {
+    while i < members.len() {
         let mut j = i;
-        while j + 1 < subs.len() && subs[j + 1].pos == subs[j].pos + 1 {
+        while j + 1 < members.len() && members[j + 1].pos == members[j].pos + 1 {
             j += 1;
         }
         if j > i {
-            // A run of ≥2 strictly-adjacent substitutions → one delins spanning
-            // residues `i..=j`, inserting each member's alternative in order.
-            let all_predicted = subs[i..=j].iter().all(|s| s.predicted);
-            let any_predicted = subs[i..=j].iter().any(|s| s.predicted);
+            // A run of ≥2 strictly-adjacent members → one edit spanning
+            // residues `i..=j`. The inserted sequence is each member's
+            // alternative in order, with deletions contributing nothing.
+            let all_predicted = members[i..=j].iter().all(|m| m.predicted);
+            let any_predicted = members[i..=j].iter().any(|m| m.predicted);
             if any_predicted && !all_predicted {
                 return None;
             }
             let loc = ProtInterval::new(
-                ProtPos::new(subs[i].reference, subs[i].pos),
-                ProtPos::new(subs[j].reference, subs[j].pos),
+                ProtPos::new(members[i].reference, members[i].pos),
+                ProtPos::new(members[j].reference, members[j].pos),
             );
-            let edit = ProteinEdit::Delins {
-                sequence: AminoAcidSeq::new(subs[i..=j].iter().map(|s| s.alternative).collect()),
+            let inserted: Vec<AminoAcid> = members[i..=j]
+                .iter()
+                .filter_map(|m| m.alternative)
+                .collect();
+            let edit = if inserted.is_empty() {
+                // Every member in the run is a deletion, so there is nothing to
+                // insert: emit a pure range deletion, not an (invalid) empty
+                // `delins`.
+                ProteinEdit::Deletion {
+                    sequence: None,
+                    count: None,
+                }
+            } else {
+                ProteinEdit::Delins {
+                    sequence: AminoAcidSeq::new(inserted),
+                }
             };
             let loc_edit = if all_predicted {
                 LocEdit::new_predicted(loc, edit)
@@ -1355,10 +1398,10 @@ pub(crate) fn coalesce_protein_adjacent_substitutions(
             }));
             changed = true;
         } else {
-            // A lone substitution keeps its original member verbatim (indexed
-            // through `source`, since `subs` is in residue order, not input
-            // order).
-            merged.push(allele.variants[subs[i].source].clone());
+            // A lone member (substitution or deletion) keeps its original
+            // variant verbatim, indexed through `source` since `members` is in
+            // residue order, not input order.
+            merged.push(allele.variants[members[i].source].clone());
         }
         i = j + 1;
     }

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1705,15 +1705,18 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok((HgvsVariant::Allele(preserved), all_warnings));
         }
 
-        // Protein-axis adjacency (protein/substitution.md:23): two or more
-        // consecutive-residue substitutions in one cis allele describe a single
-        // delins (`p.[Arg76Ser;Cys77Trp]` → `p.Arg76_Cys77delinsSerTrp`). The
-        // positional nucleotide merge below never fires on protein members, so
+        // Protein-axis adjacency (protein/substitution.md:23, delins.md:18):
+        // two or more consecutive-residue changes (substitutions and/or
+        // single-residue deletions) in one cis allele describe a single delins
+        // (`p.[Arg76Ser;Cys77Trp]` → `p.Arg76_Cys77delinsSerTrp`;
+        // `p.[Arg76Ser;Cys77del]` → `p.Arg76_Cys77delinsSer`), or a pure range
+        // deletion when every member is a deletion. The positional nucleotide
+        // merge below never fires on protein members, so
         // coalesce the protein axis here and re-dispatch the result (a bare
         // `Protein` when fully merged, else a smaller `Allele`) through the
         // normal pipeline. The helper is a no-op once no adjacent run remains,
         // so the re-dispatch cannot loop.
-        if let Some(coalesced) = merge::coalesce_protein_adjacent_substitutions(allele) {
+        if let Some(coalesced) = merge::coalesce_protein_adjacent_changes(allele) {
             let (normalized, mut warnings) = self.normalize_dispatch(&coalesced)?;
             all_warnings.append(&mut warnings);
             return Ok((normalized, all_warnings));

--- a/tests/it/issue_1120_cis_coalesce_sub_del.rs
+++ b/tests/it/issue_1120_cis_coalesce_sub_del.rs
@@ -1,0 +1,182 @@
+//! Broaden protein cis-allele coalescing to mixed edit-types: a consecutive
+//! run mixing single-residue substitutions with single-residue deletions
+//! collapses into one `delins` (or a pure range `del` when every member is a
+//! deletion) — #1120, extending #1095 (substitution-only).
+//!
+//! # Spec
+//!
+//! `protein/delins.md:18` / `protein/substitution.md:23`:
+//!
+//! > changes involving **two or more consecutive amino acids** are described
+//! > as a deletion/insertion variant (delins).
+//!
+//! "changes" is general — a substitution and a deletion are both changes.
+//! `delins.md:41` gives the mixed example directly: `p.Cys28_Lys29delinsTrp`
+//! is "a deletion of amino acids `Cys28` and `Lys29`, replaced by `Trp`" — a
+//! del+sub run collapsed to one delins.
+//!
+//! These rewrites are reference-independent (all residues are named in the
+//! AST), so an empty `MockProvider` exercises them.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Pin the canonical form ferro's normalizer produces for `input`, and require
+/// that form to be a normalization fixed point (idempotent). The idempotency
+/// leg is load-bearing: because the coalesce now sorts members before merging,
+/// re-normalizing a canonical form must not shift it again (#1120/#1116).
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// Every permutation of `members` via Heap's algorithm.
+fn permutations<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+    let mut result = Vec::new();
+    let mut arr = items.to_vec();
+    let n = arr.len();
+    let mut c = vec![0usize; n];
+    result.push(arr.clone());
+    let mut i = 0;
+    while i < n {
+        if c[i] < i {
+            if i % 2 == 0 {
+                arr.swap(0, i);
+            } else {
+                arr.swap(c[i], i);
+            }
+            result.push(arr.clone());
+            c[i] += 1;
+            i = 0;
+        } else {
+            c[i] = 0;
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Assert EVERY permutation of `members` (joined into `NP_003997.1:p.[…]`)
+/// canonicalizes to `expected` — and, via `canonicalizes_to`, that the result
+/// is an idempotent fixed point. This pins member-order independence
+/// exhaustively rather than for a single hand-picked reversed order (#1116).
+fn all_orders_canonicalize_to(members: &[&str], expected: &str) {
+    for perm in permutations(members) {
+        let input = format!("NP_003997.1:p.[{}]", perm.join(";"));
+        canonicalizes_to(&input, expected);
+    }
+}
+
+/// sub + del over adjacent residues → one delins; the deleted residue
+/// contributes nothing to the inserted sequence.
+#[test]
+fn sub_then_del_coalesces_to_delins() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser;Cys77del]",
+        "NP_003997.1:p.Arg76_Cys77delinsSer",
+    );
+}
+
+/// del + sub over adjacent residues → one delins.
+#[test]
+fn del_then_sub_coalesces_to_delins() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76del;Cys77Trp]",
+        "NP_003997.1:p.Arg76_Cys77delinsTrp",
+    );
+}
+
+/// A run whose members are ALL deletions has an empty inserted sequence, so it
+/// collapses to a pure range deletion, not an (invalid) empty `delins`.
+#[test]
+fn adjacent_dels_coalesce_to_range_deletion() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76del;Cys77del]",
+        "NP_003997.1:p.Arg76_Cys77del",
+    );
+}
+
+/// Three-member mixed run (sub, del, sub) → one delins spanning the whole run.
+#[test]
+fn three_member_mixed_run_coalesces() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser;Cys77del;Gly78Asp]",
+        "NP_003997.1:p.Arg76_Gly78delinsSerAsp",
+    );
+}
+
+/// Predicted `( )` members with a del sibling stay predicted through the merge.
+#[test]
+fn predicted_mixed_run_coalesces_to_predicted_delins() {
+    canonicalizes_to(
+        "NP_003997.1:p.[(Arg76Ser);(Cys77del)]",
+        "NP_003997.1:p.(Arg76_Cys77delinsSer)",
+    );
+}
+
+/// Non-adjacent members are never coalesced (a gap of unchanged residues keeps
+/// them separate), even when one is a deletion.
+#[test]
+fn non_adjacent_sub_and_del_are_not_coalesced() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ser;Cys90del]",
+        "NP_003997.1:p.[Arg76Ser;Cys90del]",
+    );
+}
+
+/// A to-`Ter` (nonsense) substitution still bails the whole run even with a
+/// del sibling — a `delins…Ter…` run would list residues after the stop
+/// (substitution.md:20, delins.md:45).
+#[test]
+fn to_ter_run_with_del_sibling_is_not_coalesced() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Ter;Cys77del]",
+        "NP_003997.1:p.[Arg76Ter;Cys77del]",
+    );
+}
+
+/// Member **input order** must not affect a mixed sub+del coalesce, and the
+/// result must be idempotent. Before #1116's sort-before-coalesce reached this
+/// mixed path, a descending-order allele (e.g. `del` authored before its
+/// preceding `sub`) bailed the ascending-order gate and only the display sort
+/// reordered it — so `normalize` was NOT idempotent: a second pass would then
+/// coalesce it. Sorting inside the coalesce makes every permutation land on the
+/// same delins in one pass.
+#[test]
+fn mixed_sub_del_coalesces_identically_regardless_of_member_order() {
+    // sub+del (both orders) → the same delins; the deleted residue contributes
+    // nothing to the insert.
+    all_orders_canonicalize_to(
+        &["Arg76Ser", "Cys77del"],
+        "NP_003997.1:p.Arg76_Cys77delinsSer",
+    );
+    // A pure-del run collapses to a range deletion, order-independent.
+    all_orders_canonicalize_to(&["Arg76del", "Cys77del"], "NP_003997.1:p.Arg76_Cys77del");
+    // All 6 permutations of a three-member mixed run land on one delins.
+    all_orders_canonicalize_to(
+        &["Arg76Ser", "Cys77del", "Gly78Asp"],
+        "NP_003997.1:p.Arg76_Gly78delinsSerAsp",
+    );
+    // Partial coalesce whose surviving lone member is a DELETION: the run
+    // [Arg76,Cys77] collapses while the separated `Gly90del` must re-emit
+    // verbatim as a `del` — indexed through `source`, not the post-sort
+    // position — identically from EVERY input permutation. This is the exact
+    // #1116-sort × #1120-mixed-edit seam the hand-merge introduced.
+    all_orders_canonicalize_to(
+        &["Arg76Ser", "Cys77del", "Gly90del"],
+        "NP_003997.1:p.[Arg76_Cys77delinsSer;Gly90del]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -108,6 +108,7 @@ mod issue_1103_cis_merge_order_independence;
 mod issue_1111_rna_noncoding_reframe;
 mod issue_1114_star_ter_strict;
 mod issue_1116_protein_coalesce_order_independence;
+mod issue_1120_cis_coalesce_sub_del;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Summary

`coalesce_protein_adjacent_substitutions` (#1095) folds a cis allele of consecutive single-residue **substitutions** into one `delins` (`p.[Arg76Ser;Cys77Trp]` → `p.Arg76_Cys77delinsSerTrp`), but bailed on any non-substitution member — so a mixed-edit-type run was left as a bracketed cis allele:

```
p.[Arg76Ser;Cys77del]   # before: unchanged   → after: p.Arg76_Cys77delinsSer
p.[Arg76del;Cys77Trp]   # before: unchanged   → after: p.Arg76_Cys77delinsTrp
p.[Arg76del;Cys77del]   # before: unchanged   → after: p.Arg76_Cys77del
```

## Spec basis

`protein/substitution.md:23` / `protein/delins.md:18`: *"changes involving two or more consecutive amino acids are described as a deletion/insertion variant (delins)."* "changes" is general — a substitution and a deletion are both changes. `delins.md:41` gives the mixed example directly: `p.Cys28_Lys29delinsTrp` is *"a deletion of amino acids `Cys28` and `Lys29`, replaced by `Trp`."*

## Change

Generalize the coalescer (renamed `coalesce_protein_adjacent_changes`) so a run member may be a single-residue **substitution** (contributes its alternative residue to the merged insert) or a single-residue **deletion** (contributes nothing). A run whose members are *all* deletions has an empty insert and collapses to a pure range **deletion** rather than an invalid empty `delins`.

All existing guards are preserved:
- cis-only; strictly-adjacent ascending, duplicate-free residues;
- uniform predicted-`( )` across a run;
- the to-`Ter` bail — a `delins…Ter…` run would list residues after the stop (`substitution.md:20`, `delins.md:45`), a hole a reviewer fixed in #1095.

Other member kinds (`dup` / `ins` / `inv` / `fs` / `ext` / multi-residue) remain out of scope and continue to bail. These rewrites are reference-independent (all residues are named in the AST).

## Tests

New `tests/it/issue_1120_cis_coalesce_sub_del.rs`: sub+del, del+sub, all-del→range-del, three-member mixed run, predicted-parens preservation, non-adjacent (not coalesced), and to-`Ter` bail with a del sibling.

Full suite green (8262 tests), clippy clean, `generate_spec_fixture --check` passes.

Closes #1120
