### PR TITLE
fix(normalize): canonicalize protein delins to its minimal form (reference-free)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4232,8 +4232,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     ///
     /// Returns `Some((edit, interval))` when the rewrite applied;
     /// `None` to fall back to the input delins (used for genuine
-    /// delins with no shared affix, uncertain endpoints, or
-    /// missing provider data).
+    /// delins with no shared affix, uncertain endpoints, or a
+    /// ≥3-residue range with no provider data — the ≤2-residue
+    /// cases are trimmed reference-free from the named endpoints).
     ///
     /// Branches (per HGVS Prioritization `general.md:56-57`):
     /// - residual empty + del empty → identity `p.<X>_<Y>=`
@@ -4269,17 +4270,31 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if start_pos.number == 0 {
             return None;
         }
-        if !self.provider.has_protein_data() {
-            return None;
-        }
-
-        let accession = variant.accession.transcript_accession();
         let expected_len = (end_pos.number - start_pos.number + 1) as usize;
-        let ref_aas =
-            self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)?;
-        if ref_aas.len() != expected_len {
-            return None;
-        }
+
+        // Obtain the deleted reference residues. Prefer the provider's protein
+        // sequence (works for any range length); without it, fall back to the
+        // residues NAMED in the `delins` location endpoints. That fallback is
+        // valid only when *every* deleted residue is named — i.e. the range
+        // spans ≤ 2 residues (start and/or end). A ≥ 3-residue range has
+        // unnamed interior residues and cannot be trimmed reference-free
+        // (#1119). This mirrors the nucleotide axis's reference-driven
+        // `canonicalize_delins`, restricted here to the AST-derivable cases.
+        let ref_aas: Vec<AminoAcid> = if self.provider.has_protein_data() {
+            let accession = variant.accession.transcript_accession();
+            let aas =
+                self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)?;
+            if aas.len() != expected_len {
+                return None;
+            }
+            aas
+        } else {
+            match expected_len {
+                1 => vec![start_pos.aa],
+                2 => vec![start_pos.aa, end_pos.aa],
+                _ => return None,
+            }
+        };
 
         // Affix-trim: longest common prefix then longest common suffix.
         let mut lcp = 0usize;
@@ -4309,12 +4324,14 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Vec::new()
         };
 
-        // No progress — caller falls back to the unchanged delins.
-        // Do NOT route through an ins→dup search here: the deleted
-        // window is still non-empty, so any tandem-match rewrite
-        // would emit a bare `dup` that silently drops the deletion
-        // side of the edit and returns a non-equivalent variant.
-        if lcp == 0 && lcs == 0 {
+        // No affix trimmed. A 1→1 delins is still a substitution (sub > delins
+        // priority, `delins.md`) even with no shared affix, so let that single
+        // case fall through to the reduction below; otherwise there is no
+        // rewrite to make. Do NOT route the non-1→1 case through an ins→dup
+        // search here: the deleted window is still non-empty, so any
+        // tandem-match rewrite would emit a bare `dup` that silently drops the
+        // deletion side of the edit and returns a non-equivalent variant.
+        if lcp == 0 && lcs == 0 && !(residual_del.len() == 1 && residual_seq.0.len() == 1) {
             return None;
         }
 
@@ -4346,6 +4363,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ));
         }
         if residual_del.is_empty() {
+            // Trimmed to a pure insertion. The ins→dup search and the flanking
+            // residue lookups below both need the protein sequence, so without
+            // it (the reference-free ≤2-residue path) bail and keep the input
+            // delins rather than emit an insertion we cannot dup-canonicalize
+            // (#1119).
+            if !self.provider.has_protein_data() {
+                return None;
+            }
+            let accession = variant.accession.transcript_accession();
             // Zero-width del + non-empty ins → route through the
             // existing ins→dup helper anchored at the flanking
             // positions of the trimmed range.

--- a/tests/it/issue_1119_protein_delins_canonical.rs
+++ b/tests/it/issue_1119_protein_delins_canonical.rs
@@ -1,0 +1,129 @@
+//! Reference-free canonicalization of a protein `delins` to its minimal form
+//! (#1119). A `delins` that is structurally a smaller edit is rewritten per the
+//! HGVS minimal-form / edit-priority rule (`protein/delins.md`), even when no
+//! protein reference sequence is available — for the cases derivable from the
+//! AST alone.
+//!
+//! # Scope
+//!
+//! Without a protein sequence, the deleted residues are known only where the
+//! `delins` **location names them** — its start and end residues. That covers a
+//! range spanning **≤ 2 residues** (every deleted residue is a named endpoint):
+//!
+//! - a 1-residue `delins` with a 1-residue insert is a **substitution**
+//!   (`p.Val559delinsGly` → `p.Val559Gly`), regardless of shared affix
+//!   (`delins.md`: sub > delins);
+//! - a 2-residue `delins` whose inserted sequence shares a boundary residue
+//!   with a named endpoint trims to a substitution or a pure deletion.
+//!
+//! A range spanning ≥ 3 residues has unnamed interior residues, so it cannot be
+//! trimmed without the protein sequence and is left unchanged (the
+//! reference-gated path in `try_protein_delins_canonicalize` handles it when a
+//! protein-backed provider is present).
+//!
+//! These rewrites use an empty `MockProvider` (no protein data) to prove the
+//! reference-free path.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    // The canonical form must be a normalization fixed point: re-normalizing it
+    // (reference-free) reproduces it exactly. This guards against a rewrite that
+    // is not idempotent — e.g. one that keeps trimming or oscillates — across
+    // every case the suite pins.
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// A 1→1 delins is a substitution even with no shared affix.
+#[test]
+fn single_residue_delins_becomes_substitution() {
+    canonicalizes_to("NP_003997.1:p.Val559delinsGly", "NP_003997.1:p.Val559Gly");
+}
+
+/// A predicted `( )` delins is canonicalized inside its wrapper on the
+/// reference-free path too: the minimized edit stays predicted, so the wrapper
+/// is preserved rather than dropped or duplicated.
+#[test]
+fn predicted_delins_canonicalizes_inside_parens_reference_free() {
+    canonicalizes_to(
+        "NP_003997.1:p.(Val559delinsGly)",
+        "NP_003997.1:p.(Val559Gly)",
+    );
+}
+
+/// A 2-residue delins whose trailing inserted residue matches the named end
+/// residue trims to a pure deletion of the remaining named residue.
+#[test]
+fn two_residue_delins_trailing_match_becomes_deletion() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsGlu",
+        "NP_003997.1:p.Val559del",
+    );
+}
+
+/// A 2-residue delins whose trailing inserted residue matches the named end
+/// residue trims to a substitution at the remaining named residue.
+#[test]
+fn two_residue_delins_trailing_match_becomes_substitution() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsSerGlu",
+        "NP_003997.1:p.Val559Ser",
+    );
+}
+
+/// A 2-residue delins whose leading inserted residue matches the named start
+/// residue trims to a substitution at the remaining named residue.
+#[test]
+fn two_residue_delins_leading_match_becomes_substitution() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsValSer",
+        "NP_003997.1:p.Glu560Ser",
+    );
+}
+
+/// A 2-residue delins whose only inserted residue matches the named start
+/// residue trims the leading match away, leaving a pure deletion of the
+/// remaining named residue (the leading-trim counterpart of the trailing-trim
+/// deletion above).
+#[test]
+fn two_residue_delins_leading_match_becomes_deletion() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsVal",
+        "NP_003997.1:p.Glu560del",
+    );
+}
+
+/// A 2-residue delins with no shared boundary residue cannot be reduced
+/// (reference-free) and is left unchanged.
+#[test]
+fn two_residue_delins_no_affix_is_unchanged() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsSerTrp",
+        "NP_003997.1:p.Val559_Glu560delinsSerTrp",
+    );
+}
+
+/// A ≥3-residue delins has unnamed interior residues, so without a protein
+/// sequence it is left unchanged even when a boundary residue matches.
+#[test]
+fn three_residue_delins_is_unchanged_without_reference() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Trp561delinsAlaGlyTrp",
+        "NP_003997.1:p.Val559_Trp561delinsAlaGlyTrp",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -108,6 +108,7 @@ mod issue_1103_cis_merge_order_independence;
 mod issue_1111_rna_noncoding_reframe;
 mod issue_1114_star_ter_strict;
 mod issue_1116_protein_coalesce_order_independence;
+mod issue_1119_protein_delins_canonical;
 mod issue_1120_cis_coalesce_sub_del;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
## Summary

ferro left a protein `delins` that is structurally a smaller edit verbatim whenever no protein reference sequence was available — `try_protein_delins_canonicalize` gated on `has_protein_data()` and bailed otherwise:

```
p.Val559delinsGly            # before: unchanged   → after: p.Val559Gly
p.Val559_Glu560delinsGlu     # before: unchanged   → after: p.Val559del
p.Val559_Glu560delinsSerGlu  # before: unchanged   → after: p.Val559Ser
p.Val559_Glu560delinsValSer  # before: unchanged   → after: p.Glu560Ser
```

The nucleotide axis already does this (`c.145_147delinsTGC` → `c.145C>T` via `canonicalize_delins`); this brings the AST-derivable protein cases in line with `protein/delins.md`'s minimal-form / edit-priority rule.

## Change

1. **Reference-free `ref_aas`.** When the provider has no protein sequence, derive the deleted reference residues from the residues *named in the `delins` location endpoints*. Valid only when every deleted residue is named — a range spanning **≤ 2 residues** (start and/or end). A ≥ 3-residue range has unnamed interior residues and is still left unchanged (the existing reference-gated path handles it when a protein-backed provider is present).
2. **1→1 delins → substitution.** A one-residue delins with a one-residue insert is a substitution (`delins.md`: sub > delins) even with no shared affix, so let that single case fall through the affix-trim's no-progress guard to the substitution reduction. (This also closes the same gap on the reference-backed path.)

A residual that trims to a pure **insertion** still needs the protein sequence (for the ins→dup search and flanking residues), so the reference-free path bails there and keeps the input delins.

## Scope / follow-up

This covers scope (a) of #1119 (reference-free, ≤ 2-residue ranges). The headline `p.(Val559_Glu562delinsGlu)` → `p.(Val559_Glu561del)` case spans > 2 residues and needs the protein sequence to name residue 561 — that reference-gated path already exists in `try_protein_delins_canonicalize` and fires when a protein-backed provider is present; wiring standalone `NP_:p.` protein-sequence resolution is the deferred capability tracked in #1119.

## Tests

New `tests/it/issue_1119_protein_delins_canonical.rs` (empty `MockProvider`, no protein data): 1→1 → sub, trailing/leading boundary trims → sub/del, no-affix 2-residue unchanged, ≥ 3-residue unchanged.

Full suite green (8261 tests), clippy clean, `generate_spec_fixture --check` passes. The protein normalization conformance axis (`axis_normalized`) passes with the prepared reference; the only conformance failure (`axis_errors`: `c.45del4`/`c.45dup4`) is pre-existing on `main` and unrelated (nucleotide size-suffix forms).

Closes #1119
