### PR TITLE
test(audit): scan corrections.rs and ignore #[cfg(test)] in the emission-site check

### DIFF
--- a/tests/it/error_code_audit.rs
+++ b/tests/it/error_code_audit.rs
@@ -55,6 +55,10 @@ fn fixture_path() -> PathBuf {
 /// `NormalizationWarning::*`, and any future emission site.
 const EMISSION_SCAN_PATHS: &[&str] = &[
     "src/error_handling/preprocessor.rs",
+    // The deprecated-form correction functions (`correct_deprecated_protein_forms`
+    // etc.) construct the `ErrorType::*` values the preprocessor emits; this is
+    // their real production emission site (#1123).
+    "src/error_handling/corrections.rs",
     "src/hgvs",
     "src/normalize/mod.rs",
     "src/normalize/overlap.rs",
@@ -97,6 +101,202 @@ fn emitted_error_type_variants() -> BTreeSet<String> {
     found
 }
 
+/// Remove `#[cfg(test)] mod … { … }` blocks from Rust source so `ErrorType::*`
+/// references inside unit-test modules are not counted as production emission
+/// sites (#1123). Only `mod` blocks are stripped; a non-`mod` `#[cfg(test)]`
+/// item (e.g. `#[cfg(test)] use …;`) is left untouched (there are none in the
+/// scanned tree, and skipping them avoids over-stripping).
+///
+/// The closing brace is found by a brace-matcher that skips over string, char,
+/// raw-string, and comment content, so braces inside literals/comments (e.g.
+/// format strings like `"{x}"`, or `r#"…{…"#`) do not unbalance the count.
+fn strip_cfg_test_modules(text: &str) -> String {
+    const ATTR: &str = "#[cfg(test)]";
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut copied = 0usize; // next byte index not yet copied to `out`
+    let mut search = 0usize; // where to look for the next attribute
+    while let Some(rel) = text[search..].find(ATTR) {
+        let attr = search + rel;
+        let after = attr + ATTR.len();
+        // The attribute must be the first non-whitespace on its line. A real
+        // `#[cfg(test)]` is emitted at line start (rustfmt), whereas a mention
+        // embedded in a doc comment (`/// … #[cfg(test)] …`) or a string is
+        // preceded by other text on the line. Without this guard the raw-text
+        // search below could read such a mention as a module attribute and,
+        // finding `mod ` before the next `;`, strip real production code after
+        // it (a false FAIL). The brace-matcher is already literal/comment-aware;
+        // this guards the search that *locates* the block.
+        let line_start = text[..attr].rfind('\n').map_or(0, |n| n + 1);
+        if text[line_start..attr]
+            .bytes()
+            .any(|c| c != b' ' && c != b'\t')
+        {
+            search = after;
+            continue;
+        }
+        // Find the first `{` and first `;` after the attribute. A `{` reached
+        // before any `;`, with `mod ` in between, marks a test-module block.
+        let brace = text[after..].find('{').map(|b| after + b);
+        let semi = text[after..].find(';').map(|s| after + s);
+        let is_mod_block = matches!((brace, semi),
+            (Some(b), s) if s.is_none_or(|s| b < s) && text[after..b].contains("mod "));
+        if !is_mod_block {
+            search = after;
+            continue;
+        }
+        let open = brace.unwrap();
+        let end = match_block_end(bytes, open);
+        out.push_str(&text[copied..attr]);
+        copied = end;
+        search = end;
+    }
+    out.push_str(&text[copied..]);
+    out
+}
+
+/// Given `bytes[open] == b'{'`, return the index just past its matching `}`,
+/// skipping string / char / raw-string literals and `//` / `/* */` comments so
+/// braces inside them are not counted. Best-effort lexing sufficient for the
+/// well-formed Rust sources scanned here.
+fn match_block_end(bytes: &[u8], open: usize) -> usize {
+    let mut depth = 0usize;
+    let mut i = open;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return i + 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                // Rust block comments nest (`/* /* */ */`). Track depth so an
+                // inner `/* … */` does not end the outer comment early and leak
+                // its (possibly brace-bearing) tail into the brace count.
+                let mut comment_depth = 1usize;
+                i += 2;
+                while i + 1 < bytes.len() && comment_depth > 0 {
+                    if bytes[i] == b'/' && bytes[i + 1] == b'*' {
+                        comment_depth += 1;
+                        i += 2;
+                    } else if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        comment_depth -= 1;
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                continue;
+            }
+            b'"' => {
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2,
+                        b'"' => {
+                            i += 1;
+                            break;
+                        }
+                        _ => i += 1,
+                    }
+                }
+                continue;
+            }
+            b'\'' => {
+                // Char literal (with escapes) or a lifetime (`'a`, no closer).
+                // Scan a short window for a closing quote; if none, advance one.
+                // 6 bytes covers every char literal up to `'\xNN'`; the only
+                // longer form, a `'\u{…}'` escape, carries a *balanced* `{…}`
+                // pair, so overshooting it cannot unbalance the brace count.
+                let mut j = i + 1;
+                let mut closed = false;
+                let mut steps = 0;
+                while j < bytes.len() && steps < 6 {
+                    match bytes[j] {
+                        b'\\' => {
+                            j += 2;
+                            steps += 2;
+                        }
+                        b'\'' => {
+                            closed = true;
+                            j += 1;
+                            break;
+                        }
+                        _ => {
+                            j += 1;
+                            steps += 1;
+                        }
+                    }
+                }
+                i = if closed { j } else { i + 1 };
+                continue;
+            }
+            b'r' | b'b' => {
+                // Possible raw string: r"…", r#…"…"…#, br"…", br#…"…"…#. Only
+                // when `r`/`b` does not continue an identifier.
+                let prev_ident =
+                    i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_');
+                if !prev_ident {
+                    if let Some(next) = raw_string_end(bytes, i) {
+                        i = next;
+                        continue;
+                    }
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// If a raw string literal starts at `start` (`r`/`br` then `#`* then `"`),
+/// return the index just past its closing `"#*`; otherwise `None`.
+fn raw_string_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut j = start;
+    if bytes[j] == b'b' {
+        j += 1;
+    }
+    if j >= bytes.len() || bytes[j] != b'r' {
+        return None;
+    }
+    j += 1;
+    let hashes = j;
+    while j < bytes.len() && bytes[j] == b'#' {
+        j += 1;
+    }
+    if j >= bytes.len() || bytes[j] != b'"' {
+        return None;
+    }
+    let n = j - hashes;
+    j += 1;
+    while j < bytes.len() {
+        if bytes[j] == b'"' {
+            let mut k = j + 1;
+            let mut cnt = 0;
+            while k < bytes.len() && cnt < n && bytes[k] == b'#' {
+                k += 1;
+                cnt += 1;
+            }
+            if cnt == n {
+                return Some(k);
+            }
+        }
+        j += 1;
+    }
+    Some(bytes.len())
+}
+
 fn scan_for_variants(path: &std::path::Path, out: &mut BTreeSet<String>) {
     if !path.exists() {
         return;
@@ -104,8 +304,13 @@ fn scan_for_variants(path: &std::path::Path, out: &mut BTreeSet<String>) {
     if path.is_file() {
         if path.extension().and_then(|e| e.to_str()) == Some("rs") {
             if let Ok(text) = std::fs::read_to_string(path) {
-                extract_error_type_variants(&text, out);
-                extract_normalization_warning_variants(&text, out);
+                // Strip `#[cfg(test)]` modules so `ErrorType::*` references
+                // inside unit tests do not count as production emission sites
+                // (#1123). Otherwise a test-only reference masks a deleted
+                // production emitter and the emission-site audit passes falsely.
+                let production = strip_cfg_test_modules(&text);
+                extract_error_type_variants(&production, out);
+                extract_normalization_warning_variants(&production, out);
             }
         }
         return;
@@ -366,5 +571,162 @@ fn audit_registered_warning_rows_have_no_emission_site() {
          test/import — in which case extend EMISSION_SCAN_PATHS' exclusions \
          instead.\n  {:?}",
         should_upgrade
+    );
+}
+
+/// A variant referenced only inside a `#[cfg(test)]` module must NOT count as a
+/// production emission site (#1123). Otherwise a test-only reference can mask a
+/// deleted production emitter, defeating `audit_enforced_warning_rows_have_emission_sites`.
+#[test]
+fn emission_scan_excludes_cfg_test_module_refs() {
+    let src = r#"
+        fn emit() {
+            let _ = ErrorType::RealEmitter;
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn t() {
+                let _ = ErrorType::TestOnly;
+            }
+        }
+    "#;
+    let mut found = BTreeSet::new();
+    extract_error_type_variants(&strip_cfg_test_modules(src), &mut found);
+    assert!(
+        found.contains("RealEmitter"),
+        "production ErrorType reference must be kept: {found:?}",
+    );
+    assert!(
+        !found.contains("TestOnly"),
+        "ErrorType reference inside a #[cfg(test)] module must be excluded: {found:?}",
+    );
+}
+
+/// The `#[cfg(test)]` stripper must skip braces inside string/raw-string/
+/// comment content so an unbalanced-looking brace in a literal does not end the
+/// block early and leak a test-only reference (#1123).
+#[test]
+fn strip_handles_braces_in_strings_raw_strings_and_comments() {
+    let src = r####"
+        fn emit() { let _ = ErrorType::Real; }
+
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let _a = "unbalanced { brace only in string";
+                let _b = r#"raw string with } and { braces"#;
+                // a line comment with a } brace
+                let _ = ErrorType::TestOnly;
+            }
+        }
+    "####;
+    let mut found = BTreeSet::new();
+    extract_error_type_variants(&strip_cfg_test_modules(src), &mut found);
+    assert!(found.contains("Real"), "production ref kept: {found:?}");
+    assert!(
+        !found.contains("TestOnly"),
+        "test-module ref excluded despite braces in literals/comments: {found:?}",
+    );
+}
+
+/// The stripper must end a `#[cfg(test)]` block at exactly its closing brace, so
+/// production code AFTER the module still counts. Placing a production reference
+/// after the test module pins the block-end index — a matcher that over-consumes
+/// (e.g. a literal/comment brace miscount) would drop `AfterMod` and produce a
+/// spurious audit failure (#1123).
+#[test]
+fn strip_keeps_production_ref_after_cfg_test_module() {
+    let src = r####"
+        fn emit() { let _ = ErrorType::Before; }
+
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                let _a = "trailing brace in string }";
+                let _b = r#"and a raw one }"#;
+                /* block comment with a } brace */
+                let _ = ErrorType::TestOnly;
+            }
+        }
+
+        fn emit_more() { let _ = ErrorType::AfterMod; }
+    "####;
+    let mut found = BTreeSet::new();
+    extract_error_type_variants(&strip_cfg_test_modules(src), &mut found);
+    assert!(
+        found.contains("Before"),
+        "ref before the module kept: {found:?}"
+    );
+    assert!(
+        found.contains("AfterMod"),
+        "ref AFTER the module must survive — the block must end at its own brace: {found:?}",
+    );
+    assert!(
+        !found.contains("TestOnly"),
+        "test-module ref excluded: {found:?}"
+    );
+}
+
+/// A `#[cfg(test)]` mention inside a doc comment or string is not a module
+/// attribute. The raw-text search must not treat it as one and strip the
+/// production item that follows (#1123). Both mentions here are load-bearing:
+/// each is followed by `mod ` and a `{` before the next `;`, so without the
+/// line-start guard the raw-text search would classify it as a module block and
+/// strip the real code after it.
+#[test]
+fn strip_ignores_cfg_test_mention_in_non_attribute_position() {
+    let src = r#"
+        /// Mirrors the pattern used by #[cfg(test)] mod tests { below.
+        fn documented() { let _ = ErrorType::Documented; }
+
+        fn note() {
+            let _msg = "guard #[cfg(test)] mod names { in a message";
+            let _ = ErrorType::Noted;
+        }
+    "#;
+    let mut found = BTreeSet::new();
+    extract_error_type_variants(&strip_cfg_test_modules(src), &mut found);
+    assert!(
+        found.contains("Documented") && found.contains("Noted"),
+        "a #[cfg(test)] mention in a comment/string must not strip real code: {found:?}",
+    );
+}
+
+/// Rust block comments nest; the brace-matcher must too. An inner `/* … */`
+/// whose tail carries an unbalanced brace must not end the outer comment early
+/// and corrupt the depth count, which could leak a test ref (false PASS) or drop
+/// production code after the module (false FAIL) (#1123).
+#[test]
+fn strip_handles_nested_block_comments() {
+    let src = r####"
+        fn emit() { let _ = ErrorType::Real; }
+
+        #[cfg(test)]
+        mod tests {
+            fn t() {
+                /* outer /* inner } */ still in outer { */
+                let _ = ErrorType::TestOnly;
+            }
+        }
+
+        fn after() { let _ = ErrorType::AfterMod; }
+    "####;
+    let mut found = BTreeSet::new();
+    extract_error_type_variants(&strip_cfg_test_modules(src), &mut found);
+    assert!(
+        found.contains("Real"),
+        "production ref before kept: {found:?}"
+    );
+    assert!(
+        found.contains("AfterMod"),
+        "production ref after module kept: {found:?}"
+    );
+    assert!(
+        !found.contains("TestOnly"),
+        "test-module ref excluded despite nested block comments: {found:?}",
     );
 }


### PR DESCRIPTION
## Summary

`error_code_audit::audit_enforced_warning_rows_have_emission_sites` claims to verify every `enforced` W-code has a **production** emission site — catching *"an emission site was deleted but the audit row was not updated."* It gave a **false pass** for the four deprecated-form codes **W3007 / W3008 / W3009 / W3010**:

1. Their real emitter — `correct_deprecated_protein_forms` in `src/error_handling/corrections.rs` — was **not** in `EMISSION_SCAN_PATHS`.
2. The scanner read whole `.rs` files **including `#[cfg(test)]` modules**, so those four codes passed only because of `ErrorType::*` references inside `preprocessor.rs`'s test module.

Delete the real emitter and leave the tests, and the audit stays green. An analysis confirmed these four are the *only* variants in the scanned paths whose `ErrorType::` references live exclusively inside `#[cfg(test)]` blocks, and all four are genuinely emitted in `corrections.rs`.

## Change (test-only)

- Add `src/error_handling/corrections.rs` to `EMISSION_SCAN_PATHS` — the actual emitter.
- Strip `#[cfg(test)] mod … { … }` blocks before matching `ErrorType::<Variant>`, via a brace-matcher (`match_block_end`) that skips string / raw-string / char literals and `//` / `/* */` comments so braces inside literals (e.g. `"{x}"`, `r#"…{…"#`) don't unbalance the count.

With both, the four codes are detected via their genuine `corrections.rs` emission (the `enforced` rows stay green), and the audit now correctly fails if a production emitter is ever removed — even with test references still present.

## Tests

New unit tests for the stripper: a test-module `ErrorType::` reference is excluded while a production one is kept, including when the module body contains unbalanced-looking braces inside strings, raw strings, and comments. All existing audit tests remain green (the four `enforced` deprecated-form rows now verified against `corrections.rs`, not test code).

No production code changes. Full suite green (8258 tests), clippy clean, fmt clean.

Closes #1123
