### PR TITLE
fix(normalize): scope the protein coalesce to-Ter decline to the affected run

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1234,6 +1234,23 @@ fn build_naedit<P>(
 /// allele fell through to the bracket form `protein/substitution.md:23` calls
 /// "not correct".
 ///
+/// A to-`Ter` (nonsense) member **bounds** coalescing rather than vetoing the
+/// whole allele (#1125): only a run lying **entirely 5′ of the earliest `Ter`**
+/// may merge. A run that contains that `Ter`, or that sits wholly downstream of
+/// it, is left as authored — but an unrelated upstream run still collapses, e.g.
+/// `p.[Cys100Ser;Asp101Gly;Arg200Ter]` → `p.[Cys100_Asp101delinsSerGly;Arg200Ter]`.
+///
+/// The `Ter`-containing run is declined **conservatively**, not because every
+/// such merge is spec-invalid. The spec forbids two specific shapes: residues
+/// listed *after* a stop (`protein/delins.md:45` — not `delinsSerSerTerAlaAsp`)
+/// and an *immediate* stop written as a delins (`protein/substitution.md:20` —
+/// not `p.Cys5_Ser6delinsTerGluAsp`, but `p.Tyr4Ter`). A run whose to-`Ter`
+/// member is **last** would merge to a *trailing*-`Ter` delins, which the spec
+/// endorses (`protein/delins.md:47`: `p.(Pro578_Lys579delinsLeuTer)`); declining
+/// it is a known completeness gap inherited from #1095, tracked separately.
+/// Collapsing a nonsense change toward `p.<ref><pos>Ter` is likewise a separate
+/// rule.
+///
 /// Returns `Some` only when at least one run of ≥2 adjacent members is merged;
 /// a fully-merged allele collapses to a bare [`HgvsVariant::Protein`], a
 /// partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
@@ -1242,8 +1259,7 @@ fn build_naedit<P>(
 ///   - any member is not a single-residue protein substitution or deletion
 ///     (other edit kinds — dup / ins / inv / fs / ext / multi-residue — are
 ///     out of scope for this narrow rule),
-///   - any substitution member changes the residue to `Ter` (a `delins…Ter…`
-///     run would list residues after the stop — spec-invalid),
+///   - every run is at or after a to-`Ter` member (see above),
 ///   - two members share a residue position (a `n,n` pair is the contradictory
 ///     same-residue case, not a delins), or
 ///   - a run would mix predicted `( )` and certain members (ambiguous).
@@ -1319,14 +1335,6 @@ pub(crate) fn coalesce_protein_adjacent_changes(
             Mu::Uncertain(ProteinEdit::Deletion { .. }) => (None, true),
             _ => return None,
         };
-        // A to-`Ter` (nonsense) substitution is out of scope: the spec forbids
-        // listing residues after the stop, so a `delins…Ter…` run would be
-        // unparseable and spec-invalid (protein/substitution.md:20,
-        // protein/delins.md:45). Leave such an allele untouched — collapsing a
-        // nonsense change toward `p.<ref><pos>Ter` is a separate rule.
-        if alternative == Some(AminoAcid::Ter) {
-            return None;
-        }
         members.push(Member {
             pos: s.number,
             reference: s.aa,
@@ -1348,6 +1356,16 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         return None;
     }
 
+    // The earliest residue changed to `Ter` (a nonsense substitution), if any.
+    // Only a run lying *entirely* 5′ of this position may coalesce; every other
+    // run is left as authored (see the to-`Ter` paragraph on this function).
+    // Members are already in ascending residue order, so the first to-`Ter`
+    // member is the earliest.
+    let first_ter_pos = members
+        .iter()
+        .find(|m| m.alternative == Some(AminoAcid::Ter))
+        .map(|m| m.pos);
+
     let mut merged: Vec<HgvsVariant> = Vec::new();
     let mut changed = false;
     let mut i = 0;
@@ -1356,7 +1374,12 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         while j + 1 < members.len() && members[j + 1].pos == members[j].pos + 1 {
             j += 1;
         }
-        if j > i {
+        // A run that reaches the earliest stop — whether it contains that
+        // `Ter` or sits wholly downstream of it — stays as authored. Only the
+        // run itself is declined, so a coalescible run 5′ of the stop is
+        // unaffected (#1125).
+        let run_precedes_any_ter = first_ter_pos.is_none_or(|ter| members[j].pos < ter);
+        if j > i && run_precedes_any_ter {
             // A run of ≥2 strictly-adjacent members → one edit spanning
             // residues `i..=j`. The inserted sequence is each member's
             // alternative in order, with deletions contributing nothing.
@@ -1398,10 +1421,13 @@ pub(crate) fn coalesce_protein_adjacent_changes(
             }));
             changed = true;
         } else {
-            // A lone member (substitution or deletion) keeps its original
-            // variant verbatim, indexed through `source` since `members` is in
-            // residue order, not input order.
-            merged.push(allele.variants[members[i].source].clone());
+            // A lone member (substitution or deletion) — or every member of a
+            // declined run — keeps its original variant verbatim, indexed
+            // through `source` since `members` is in residue order, not input
+            // order.
+            for m in &members[i..=j] {
+                merged.push(allele.variants[m.source].clone());
+            }
         }
         i = j + 1;
     }

--- a/tests/it/issue_1116_protein_coalesce_order_independence.rs
+++ b/tests/it/issue_1116_protein_coalesce_order_independence.rs
@@ -169,9 +169,11 @@ fn duplicate_residue_positions_never_coalesce() {
     }
 }
 
-/// A to-`Ter` member keeps the whole allele out of scope (the spec forbids
+/// A run containing a to-`Ter` member never coalesces (the spec forbids
 /// listing residues after the stop, `protein/substitution.md:20` /
-/// `protein/delins.md:45`), in either input order.
+/// `protein/delins.md:45`), in either input order. The decline is scoped to
+/// the run, not the allele — see `issue_1125_ter_scoped_coalesce` for a run
+/// that is 5′ of an unrelated `Ter` and does coalesce.
 #[test]
 fn a_to_ter_run_never_coalesces_in_either_order() {
     all_permutations_normalize_to(

--- a/tests/it/issue_1125_ter_scoped_coalesce.rs
+++ b/tests/it/issue_1125_ter_scoped_coalesce.rs
@@ -1,0 +1,179 @@
+//! Scope the protein cis-allele coalesce's to-`Ter` decline to the affected
+//! run(s) instead of the whole allele — #1125.
+//!
+//! # Spec
+//!
+//! `protein/substitution.md:23` / `protein/delins.md:18`:
+//!
+//! > changes involving **two or more consecutive amino acids** are described
+//! > as a deletion/insertion variant (delins).
+//!
+//! The countervailing rules are about a translation stop: residues may not be
+//! listed *after* one (`protein/delins.md:45` — not `delinsSerSerTerAlaAsp`),
+//! and an *immediate* stop is a nonsense substitution, not a delins
+//! (`protein/substitution.md:20` — not `p.Cys5_Ser6delinsTerGluAsp`). A run
+//! carrying a to-`Ter` member is declined conservatively on that basis.
+//!
+//! Either way the constraint is about the **run**, not the allele: a run lying
+//! entirely 5′ of the earliest `Ter` is unaffected by the stop and still owes
+//! the spec its `delins`. That is what this suite pins.
+//!
+//! Known gap (pre-existing, tracked separately): a run whose to-`Ter` member is
+//! **last** would merge to a *trailing*-`Ter` delins, a form the spec endorses
+//! (`protein/delins.md:47`: `p.(Pro578_Lys579delinsLeuTer)`). It is still
+//! declined here; the tests below pin the current conservative behavior.
+//!
+//! Every rewrite here is reference-independent (all residues are named in the
+//! AST), so an empty `MockProvider` exercises them.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Pin the canonical form ferro's normalizer produces for `input`, and require
+/// that form to be a normalization fixed point (idempotent). The idempotency
+/// leg matters here because a partially-coalesced allele is re-parsed as a
+/// bracket whose surviving `Ter` member must not then block a second pass.
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// Every permutation of `items` via Heap's algorithm.
+fn permutations<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+    let mut result = Vec::new();
+    let mut arr = items.to_vec();
+    let n = arr.len();
+    let mut c = vec![0usize; n];
+    result.push(arr.clone());
+    let mut i = 0;
+    while i < n {
+        if c[i] < i {
+            if i % 2 == 0 {
+                arr.swap(0, i);
+            } else {
+                arr.swap(c[i], i);
+            }
+            result.push(arr.clone());
+            c[i] += 1;
+            i = 0;
+        } else {
+            c[i] = 0;
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Assert EVERY permutation of `members` (joined into `NP_003997.1:p.[…]`)
+/// canonicalizes to `expected`, so the `Ter` scoping is independent of where
+/// the nonsense member was authored (#1116's order-independence contract).
+fn all_orders_canonicalize_to(members: &[&str], expected: &str) {
+    for perm in permutations(members) {
+        let input = format!("NP_003997.1:p.[{}]", perm.join(";"));
+        canonicalizes_to(&input, expected);
+    }
+}
+
+/// Control: with no `Ter` anywhere, the adjacent run coalesces (the behavior
+/// #1125's upstream run is being denied).
+#[test]
+fn adjacent_run_without_ter_coalesces() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100Ser;Asp101Gly]",
+        "NP_003997.1:p.Cys100_Asp101delinsSerGly",
+    );
+}
+
+/// The #1125 repro: a lone downstream nonsense member must not block an
+/// adjacent run that lies entirely 5′ of it. The run coalesces; the `Ter`
+/// re-emits verbatim alongside it.
+#[test]
+fn downstream_ter_does_not_block_an_upstream_run() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg200Ter"],
+        "NP_003997.1:p.[Cys100_Asp101delinsSerGly;Arg200Ter]",
+    );
+}
+
+/// A run that *contains* the nonsense member still declines — the conservative
+/// pre-existing behavior this PR does not change (see the module header's known
+/// gap note for the trailing-`Ter` form the spec would allow).
+#[test]
+fn a_run_containing_the_ter_still_declines() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Ter"],
+        "NP_003997.1:p.[Cys100Ser;Asp101Ter]",
+    );
+}
+
+/// A run whose members sit at/after the earliest `Ter` also declines — the
+/// residues it would describe are downstream of a stop, so coalescing them
+/// into a new `delins` is out of scope for this narrow rule.
+#[test]
+fn a_run_downstream_of_the_ter_declines() {
+    all_orders_canonicalize_to(
+        &["Arg100Ter", "Cys200Ser", "Asp201Gly"],
+        "NP_003997.1:p.[Arg100Ter;Cys200Ser;Asp201Gly]",
+    );
+}
+
+/// With two nonsense members, the EARLIEST one governs: a run between them is
+/// downstream of a stop and declines, while a run 5′ of both coalesces.
+#[test]
+fn the_earliest_ter_governs_when_several_are_present() {
+    all_orders_canonicalize_to(
+        &[
+            "Cys50Ser",
+            "Asp51Gly",
+            "Arg100Ter",
+            "Gly150Ala",
+            "Ala151Val",
+            "Trp200Ter",
+        ],
+        "NP_003997.1:p.[Cys50_Asp51delinsSerGly;Arg100Ter;Gly150Ala;Ala151Val;Trp200Ter]",
+    );
+}
+
+/// A `Ter` strictly adjacent to a run is *part of* that run (adjacency is what
+/// defines a run), so the run contains the stop and takes the same conservative
+/// decline — the scoping does not let an adjacent stop be merged in.
+#[test]
+fn a_ter_adjacent_to_a_run_joins_it_and_declines() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg102Ter"],
+        "NP_003997.1:p.[Cys100Ser;Asp101Gly;Arg102Ter]",
+    );
+}
+
+/// Tightest coalescible boundary: one unchanged residue separates the run from
+/// the `Ter`, so the run is a separate run AND ends strictly before the stop.
+#[test]
+fn a_run_ending_just_before_the_ter_coalesces() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg103Ter"],
+        "NP_003997.1:p.[Cys100_Asp101delinsSerGly;Arg103Ter]",
+    );
+}
+
+/// A deletion sibling downstream of a coalescible run is unaffected by the
+/// scoping: the run merges, the `Ter` and the separated `del` re-emit verbatim.
+#[test]
+fn scoping_preserves_unrelated_lone_members() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg200Ter", "Gly300del"],
+        "NP_003997.1:p.[Cys100_Asp101delinsSerGly;Arg200Ter;Gly300del]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -111,6 +111,7 @@ mod issue_1114_star_ter_strict;
 mod issue_1116_protein_coalesce_order_independence;
 mod issue_1119_protein_delins_canonical;
 mod issue_1120_cis_coalesce_sub_del;
+mod issue_1125_ter_scoped_coalesce;
 mod issue_1126_reference_free_delins_to_ins;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
## Summary

`coalesce_protein_adjacent_changes` declined the **entire** cis protein allele as soon as **any** member was a to-`Ter` (nonsense) substitution. An adjacent run lying entirely 5′ of an unrelated downstream stop was therefore left as a bracket instead of collapsing to the spec-preferred `delins`.

| input | before | after |
|-------|--------|-------|
| `NP_003997.1:p.[Cys100Ser;Asp101Gly;Arg200Ter]` | unchanged | `NP_003997.1:p.[Cys100_Asp101delinsSerGly;Arg200Ter]` |
| `NP_003997.1:p.[Cys100Ser;Asp101Ter]` | unchanged | unchanged (run contains the stop) |
| `NP_003997.1:p.[Arg100Ter;Cys200Ser;Asp201Gly]` | unchanged | unchanged (run is downstream of the stop) |

## Why

The old guard was coarser than the rule it enforces. Nothing may be described at or after a translation stop (`protein/substitution.md:20`, `protein/delins.md:45`) — that constrains the *run* being merged, not every other run in the allele. Meanwhile `protein/substitution.md:23` / `protein/delins.md:18` require two or more consecutive changed amino acids to be described as a `delins`, so an untouched upstream run is a canonicalization the spec asks for.

## Change

Bound coalescing by the earliest to-`Ter` residue position instead of vetoing the allele:

- a run merges only when it ends **strictly before** that position;
- a run that **contains** the stop (its merged insert would read `…Ter…`) or that sits **wholly downstream** of it re-emits its members verbatim;
- with no to-`Ter` member anywhere, behavior is unchanged.

Because `members` is already sorted into ascending residue order (#1116), the first to-`Ter` member is the earliest, and the decline stays independent of the author's member order.

The `else` arm now re-emits every member of a declined run (not just the first), indexed through `source` so a declined multi-member run round-trips exactly as authored.

## Tests

New `tests/it/issue_1125_ter_scoped_coalesce.rs` (all permutations of each member set, each asserting an idempotent fixed point):

- the repro — a downstream `Ter` no longer blocks an upstream run;
- a run **containing** the `Ter` still declines;
- a run **downstream** of the `Ter` declines;
- with several `Ter` members, the **earliest** governs;
- a `Ter` strictly adjacent to a run joins that run and declines it;
- tightest coalescible boundary — one unchanged residue between run and stop;
- unrelated lone members (including a `del`) survive the partial coalesce.

Existing declines (`allele_grammar_corners`, `issue_1116`, `issue_1120`) are unaffected; the `issue_1116` doc comment is updated to say the decline is scoped to the run, not the allele. Full suite green (8302 passed), `clippy -D warnings` clean.

## Notes

Output was valid HGVS before and after — this closes a canonicalization completeness gap, not a correctness bug. Collapsing a nonsense change toward `p.<ref><pos>Ter` remains a separate rule.

Closes #1125
