### PR TITLE
fix(normalize): minimize a named-flank pure insertion reference-free

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4242,7 +4242,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// - residual single AA, del single AA → substitution
     /// - residual non-empty, del empty → route through
     ///   `try_protein_ins_to_dup` (anchored at the flanking
-    ///   positions of the trimmed range)
+    ///   positions of the trimmed range); reference-free, emit the
+    ///   plain `<X>_<Y>ins<residual>` when both flanking residues are
+    ///   named by the input's endpoints (#1126)
     /// - otherwise → smaller delins (caller falls back; the helper
     ///   returns `None` for the no-progress case)
     fn try_protein_delins_canonicalize(
@@ -4363,13 +4365,37 @@ impl<P: ReferenceProvider> Normalizer<P> {
             ));
         }
         if residual_del.is_empty() {
-            // Trimmed to a pure insertion. The ins→dup search and the flanking
-            // residue lookups below both need the protein sequence, so without
-            // it (the reference-free ≤2-residue path) bail and keep the input
-            // delins rather than emit an insertion we cannot dup-canonicalize
-            // (#1119).
+            // Trimmed to a pure insertion. The ins→dup search below needs the
+            // protein sequence; without it, emit the minimal insertion when —
+            // and only when — the AST names the residue on BOTH sides of the
+            // insertion point (#1126).
+            //
+            // `ref_aas[k]` is the residue at 1-based position
+            // `start_pos.number + k`, so the insertion point's flanks —
+            // `new_start - 1` and `new_start`, i.e. `start_pos.number + lcp - 1`
+            // and `start_pos.number + lcp` — are `ref_aas[lcp - 1]` and
+            // `ref_aas[lcp]`. Both are in range exactly when
+            // `1 <= lcp < ref_aas.len()`: a leading trim that consumed nothing
+            // puts the point 5′ of the named window, one that consumed all of it
+            // puts the point 3′ of it, and in either case the missing flank
+            // residue is only knowable from the reference — so keep the input
+            // delins (#1119's conservative default).
+            //
+            // The ins→dup refinement stays reference-gated: a protein-backed
+            // provider may reduce this same insertion further to a `dup`, which
+            // only the reference can establish.
             if !self.provider.has_protein_data() {
-                return None;
+                if lcp == 0 || lcp >= ref_aas.len() {
+                    return None;
+                }
+                let ins_start = ProtPos::new(ref_aas[lcp - 1], new_start - 1);
+                let ins_end = ProtPos::new(ref_aas[lcp], new_start);
+                return Some((
+                    ProteinEdit::Insertion {
+                        sequence: ProteinInsSeq::Literal(residual_seq),
+                    },
+                    Interval::new(ins_start, ins_end),
+                ));
             }
             let accession = variant.accession.transcript_accession();
             // Zero-width del + non-empty ins → route through the

--- a/tests/it/issue_1126_reference_free_delins_to_ins.rs
+++ b/tests/it/issue_1126_reference_free_delins_to_ins.rs
@@ -1,0 +1,114 @@
+//! Reference-free minimization of a protein `delins` whose affix-trim leaves a
+//! **pure insertion between two named endpoints** — #1126, extending #1119.
+//!
+//! # Scope
+//!
+//! `try_protein_delins_canonicalize` trims a ≤2-residue `delins` against the
+//! residues its own location names. When the trim consumes the whole deleted
+//! window the residual is a pure insertion, which previously required a
+//! protein-backed provider (the ins→dup search needs the reference). But when
+//! the trim leaves a named residue on *both* sides of the insertion point, the
+//! minimal form is derivable from the AST alone:
+//!
+//! `p.Val559_Glu560delinsValSerGlu` — leading `Val` matches `Val559`, trailing
+//! `Glu` matches `Glu560` — is `p.Val559_Glu560insSer`.
+//!
+//! The ins→dup refinement stays reference-gated: with a protein-backed provider
+//! the same input may reduce further to a `dup`, which only the reference can
+//! establish. Reference-free we emit the minimal `ins`.
+//!
+//! When either flank is **unnamed** — the trim ran off the start of the named
+//! window, or consumed it entirely — the insertion point cannot be anchored
+//! without the reference, and the input `delins` is kept.
+//!
+//! These rewrites use an empty `MockProvider` (no protein data) to prove the
+//! reference-free path.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Pin the canonical reference-free form of `input`, and require that form to
+/// be a normalization fixed point (idempotent) — a `delins`→`ins` rewrite must
+/// not then be re-trimmed or oscillate on a second pass.
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// The #1126 repro: both flanks are named, so the residual single-residue
+/// insertion is expressible without a reference.
+#[test]
+fn both_flanks_named_trims_to_insertion() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsValSerGlu",
+        "NP_003997.1:p.Val559_Glu560insSer",
+    );
+}
+
+/// A multi-residue residual insertion trims the same way — the whole residual
+/// becomes the inserted sequence.
+#[test]
+fn multi_residue_residual_trims_to_insertion() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsValSerTrpGlu",
+        "NP_003997.1:p.Val559_Glu560insSerTrp",
+    );
+}
+
+/// The predicted `( )` wrapper survives the rewrite.
+#[test]
+fn predicted_delins_trims_to_predicted_insertion() {
+    canonicalizes_to(
+        "NP_003997.1:p.(Val559_Glu560delinsValSerGlu)",
+        "NP_003997.1:p.(Val559_Glu560insSer)",
+    );
+}
+
+/// No leading match: the trim comes entirely off the trailing end, so the
+/// insertion point sits 5′ of the named window and its left flank residue is
+/// unknown. Reference-free this cannot be anchored — keep the input.
+#[test]
+fn unnamed_left_flank_keeps_the_delins() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Glu560delinsSerValGlu",
+        "NP_003997.1:p.Val559_Glu560delinsSerValGlu",
+    );
+}
+
+/// The leading match consumes the ENTIRE named window, so the insertion point
+/// sits 3′ of it and its right flank residue is unknown — keep the input.
+#[test]
+fn unnamed_right_flank_keeps_the_delins() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559_Val560delinsValValVal",
+        "NP_003997.1:p.Val559_Val560delinsValValVal",
+    );
+}
+
+/// A 1-residue `delins` can never leave a pure insertion between two *named*
+/// flanks — one side is always outside the single named residue — so both
+/// trim directions keep the input.
+#[test]
+fn single_residue_delins_keeps_the_delins_in_both_trim_directions() {
+    canonicalizes_to(
+        "NP_003997.1:p.Val559delinsValSer",
+        "NP_003997.1:p.Val559delinsValSer",
+    );
+    canonicalizes_to(
+        "NP_003997.1:p.Val559delinsSerVal",
+        "NP_003997.1:p.Val559delinsSerVal",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -111,6 +111,7 @@ mod issue_1114_star_ter_strict;
 mod issue_1116_protein_coalesce_order_independence;
 mod issue_1119_protein_delins_canonical;
 mod issue_1120_cis_coalesce_sub_del;
+mod issue_1126_reference_free_delins_to_ins;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Summary

The reference-free branch of `try_protein_delins_canonicalize` minimizes a ≤2-residue `delins` by trimming it against the residues its own location names. When that trim consumed the whole deleted window the residual was a **pure insertion**, which the code routed through the ins→dup search — and that search needs a protein reference, so reference-free it bailed and kept the input `delins`.

| input | before | after |
|-------|--------|-------|
| `NP_003997.1:p.Val559_Glu560delinsValSerGlu` | unchanged | `NP_003997.1:p.Val559_Glu560insSer` |
| `NP_003997.1:p.Val559_Glu560delinsValSerTrpGlu` | unchanged | `NP_003997.1:p.Val559_Glu560insSerTrp` |
| `NP_003997.1:p.Val559_Glu560delinsSerValGlu` | unchanged | unchanged (left flank unnamed) |

For the repro the leading `Val` matches `Val559` and the trailing `Glu` matches `Glu560`, so both anchors of the residual `Ser` insertion are named in the AST — the minimal form is derivable with no reference at all.

## Change

In the pure-insertion branch, when the provider has no protein data, emit `p.<X>_<Y>ins<residual>` when the trim leaves a **named residue on both sides** of the insertion point.

`ref_aas[k]` is the residue at 1-based `start_pos.number + k`, so the flanks — `new_start - 1` and `new_start` — are `ref_aas[lcp - 1]` and `ref_aas[lcp]`. Both are in range exactly when `1 <= lcp < ref_aas.len()`:

- `lcp == 0` — the trim came entirely off the trailing end, putting the insertion point 5′ of the named window (left flank unknown);
- `lcp == ref_aas.len()` — the leading match consumed the whole window, putting the point 3′ of it (right flank unknown).

Either way the missing flank residue is knowable only from the reference, so #1119's conservative default holds and the input `delins` is kept.

The ins→dup refinement stays reference-gated: with a protein-backed provider the same insertion may reduce further to a `dup`, which only the reference can establish. Nothing on the reference-backed path changes.

## Tests

New `tests/it/issue_1126_reference_free_delins_to_ins.rs` (empty `MockProvider`, every case asserting an idempotent fixed point):

- the repro — both flanks named → `ins`;
- multi-residue residual insertion;
- the predicted `( )` wrapper survives the rewrite;
- unnamed **left** flank keeps the `delins`;
- unnamed **right** flank keeps the `delins`;
- a 1-residue `delins` can never leave a pure insertion between two named flanks — both trim directions keep the input.

The #1119 suite is unchanged and still green. Full suite green (8300 passed), `clippy -D warnings` clean.

## Notes

Output was valid HGVS before and after — this closes a canonicalization completeness gap on the no-provider path, not a correctness bug.

Closes #1126
