### PR TITLE
fix(normalize): fall back to named endpoints when a provider lacks the accession

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -4275,27 +4275,37 @@ impl<P: ReferenceProvider> Normalizer<P> {
         let expected_len = (end_pos.number - start_pos.number + 1) as usize;
 
         // Obtain the deleted reference residues. Prefer the provider's protein
-        // sequence (works for any range length); without it, fall back to the
+        // sequence (works for any range length); failing that, fall back to the
         // residues NAMED in the `delins` location endpoints. That fallback is
         // valid only when *every* deleted residue is named — i.e. the range
         // spans ≤ 2 residues (start and/or end). A ≥ 3-residue range has
         // unnamed interior residues and cannot be trimmed reference-free
         // (#1119). This mirrors the nucleotide axis's reference-driven
         // `canonicalize_delins`, restricted here to the AST-derivable cases.
-        let ref_aas: Vec<AminoAcid> = if self.provider.has_protein_data() {
+        //
+        // `has_protein_data()` is a **provider-wide** flag, so a provider that
+        // carries proteins for other accessions still fails to fetch the one at
+        // hand. That is "no reference for this accession", not "cannot
+        // canonicalize": take the same named-endpoint fallback rather than
+        // declining outright (#1131).
+        let fetched: Option<Vec<AminoAcid>> = if self.provider.has_protein_data() {
             let accession = variant.accession.transcript_accession();
-            let aas =
-                self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)?;
-            if aas.len() != expected_len {
-                return None;
-            }
-            aas
+            self.fetch_protein_window(&accession, start_pos.number - 1, end_pos.number)
+                .filter(|aas| aas.len() == expected_len)
         } else {
-            match expected_len {
+            None
+        };
+        // Whether `ref_aas` came from the reference. Gates the branches below
+        // that need more of the protein than the location names — the ins→dup
+        // search and its flanking-residue lookups.
+        let reference_backed = fetched.is_some();
+        let ref_aas: Vec<AminoAcid> = match fetched {
+            Some(aas) => aas,
+            None => match expected_len {
                 1 => vec![start_pos.aa],
                 2 => vec![start_pos.aa, end_pos.aa],
                 _ => return None,
-            }
+            },
         };
 
         // Affix-trim: longest common prefix then longest common suffix.
@@ -4381,10 +4391,13 @@ impl<P: ReferenceProvider> Normalizer<P> {
             // residue is only knowable from the reference — so keep the input
             // delins (#1119's conservative default).
             //
-            // The ins→dup refinement stays reference-gated: a protein-backed
-            // provider may reduce this same insertion further to a `dup`, which
-            // only the reference can establish.
-            if !self.provider.has_protein_data() {
+            // The ins→dup refinement stays reference-gated: when the reference
+            // really backed `ref_aas`, it may reduce this same insertion further
+            // to a `dup`, which only the reference can establish. Gate on
+            // `reference_backed`, not the provider-wide capability flag — for an
+            // accession the provider lacks, the reference path can only bail
+            // (#1131).
+            if !reference_backed {
                 if lcp == 0 || lcp >= ref_aas.len() {
                     return None;
                 }

--- a/tests/it/issue_1131_provider_accession_fallback.rs
+++ b/tests/it/issue_1131_provider_accession_fallback.rs
@@ -1,0 +1,140 @@
+//! A provider that carries protein data for *some* accessions must not block
+//! the AST-derivable `delins` minimization for an accession it does **not**
+//! carry — #1131.
+//!
+//! # Scope
+//!
+//! `try_protein_delins_canonicalize` picks between its reference-backed and
+//! reference-free paths on `ReferenceProvider::has_protein_data()`, which is a
+//! **provider-wide** capability flag. The reference-backed branch then bails out
+//! of the whole function when the fetch fails for the **specific** accession at
+//! hand — so the reference-free minimizations of #1119 and #1126 never ran for
+//! an accession a real provider does not carry, even though they need no
+//! reference at all.
+//!
+//! A failed fetch means "no reference for this accession", not "cannot
+//! canonicalize": fall back to the residues the `delins` location names, exactly
+//! as the no-provider path does. The reference is still required for a range
+//! spanning ≥ 3 residues (unnamed interior residues) and for the ins→dup
+//! refinement, both of which keep declining.
+//!
+//! Each test builds a provider whose protein set is non-empty (so
+//! `has_protein_data()` is true) but does not contain `NP_003997.1`.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// The accession every case below is written against — deliberately absent from
+/// the providers built here.
+const MISSING: &str = "NP_003997.1";
+
+/// A provider with protein data for an unrelated accession, so
+/// `has_protein_data()` is true while `MISSING` cannot be fetched.
+fn provider_without_the_accession() -> MockProvider {
+    let mut provider = MockProvider::new();
+    provider.add_protein("NP_999999.9", "MAAAAKGSTVE");
+    provider
+}
+
+/// A protein sequence for `MISSING` positioned so that residue 559 is `V` and
+/// residue 560 is `E` (1-based), matching the endpoints the inputs below name.
+fn sequence_for_the_accession() -> String {
+    let mut seq = String::from("M");
+    seq.push_str(&"A".repeat(556)); // residues 2..=557
+    seq.push_str("SVE"); // residues 558, 559, 560
+    seq.push_str(&"A".repeat(10));
+    seq
+}
+
+/// Normalize `input` with `provider` and assert the rendered result, then
+/// require that result to be a fixed point under the same provider.
+fn canonicalizes_with(provider: MockProvider, input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(provider.clone())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(provider)
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// #1119's single-residue `delins` → substitution reduction must still apply
+/// when the provider has protein data for a different accession.
+#[test]
+fn single_residue_delins_reduces_for_an_accession_the_provider_lacks() {
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &format!("{MISSING}:p.Val559delinsGly"),
+        &format!("{MISSING}:p.Val559Gly"),
+    );
+}
+
+/// #1119's two-residue affix trim → substitution.
+#[test]
+fn two_residue_delins_trims_for_an_accession_the_provider_lacks() {
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &format!("{MISSING}:p.Val559_Glu560delinsSerGlu"),
+        &format!("{MISSING}:p.Val559Ser"),
+    );
+}
+
+/// #1119's affix trim that leaves a pure deletion.
+#[test]
+fn two_residue_delins_becomes_deletion_for_an_accession_the_provider_lacks() {
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &format!("{MISSING}:p.Val559_Glu560delinsVal"),
+        &format!("{MISSING}:p.Glu560del"),
+    );
+}
+
+/// #1126's named-flank pure insertion.
+#[test]
+fn named_flank_insertion_trims_for_an_accession_the_provider_lacks() {
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &format!("{MISSING}:p.Val559_Glu560delinsValSerGlu"),
+        &format!("{MISSING}:p.Val559_Glu560insSer"),
+    );
+}
+
+/// A ≥3-residue range has unnamed interior residues, so the fallback must NOT
+/// fabricate them — it still declines, exactly as the no-provider path does.
+#[test]
+fn three_residue_delins_still_declines_for_an_accession_the_provider_lacks() {
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &format!("{MISSING}:p.Val559_Trp561delinsAlaGlyTrp"),
+        &format!("{MISSING}:p.Val559_Trp561delinsAlaGlyTrp"),
+    );
+}
+
+/// The fallback must not shadow a **successful** reference fetch: with the
+/// accession present, the ins→dup refinement the reference enables still wins
+/// over the plain `ins` the AST alone would produce.
+#[test]
+fn a_present_accession_still_takes_the_reference_backed_path() {
+    let input = format!("{MISSING}:p.Val559_Glu560delinsValValGlu");
+
+    // Reference-free (the AST-only result): a plain insertion.
+    canonicalizes_with(
+        provider_without_the_accession(),
+        &input,
+        &format!("{MISSING}:p.Val559_Glu560insVal"),
+    );
+
+    // With the protein sequence, the inserted `Val` is recognized as a tandem
+    // duplication of `Val559` — a reduction only the reference can establish.
+    let mut with_protein = MockProvider::new();
+    with_protein.add_protein(MISSING, sequence_for_the_accession());
+    canonicalizes_with(with_protein, &input, &format!("{MISSING}:p.Val559dup"));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -112,6 +112,7 @@ mod issue_1116_protein_coalesce_order_independence;
 mod issue_1119_protein_delins_canonical;
 mod issue_1120_cis_coalesce_sub_del;
 mod issue_1126_reference_free_delins_to_ins;
+mod issue_1131_provider_accession_fallback;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Summary

`try_protein_delins_canonicalize` chose between its reference-backed and reference-free paths on `ReferenceProvider::has_protein_data()` — a **provider-wide** capability flag — but the reference-backed branch then bailed out of the whole function when the fetch failed for the **specific** accession at hand. A provider carrying proteins for other accessions therefore silently disabled the AST-derivable minimizations of #1119 and #1126, which need no reference at all.

| input | before | after |
|-------|--------|-------|
| `NP_003997.1:p.Val559delinsGly` | unchanged | `NP_003997.1:p.Val559Gly` (#1119) |
| `NP_003997.1:p.Val559_Glu560delinsSerGlu` | unchanged | `NP_003997.1:p.Val559Ser` (#1119) |
| `NP_003997.1:p.Val559_Glu560delinsVal` | unchanged | `NP_003997.1:p.Glu560del` (#1119) |
| `NP_003997.1:p.Val559_Glu560delinsValSerGlu` | unchanged | `NP_003997.1:p.Val559_Glu560insSer` (#1126) |
| `NP_003997.1:p.Val559_Trp561delinsAlaGlyTrp` | unchanged | unchanged (≥3 residues — still needs the reference) |

This is reachable in practice, not just in tests: it reproduces through `ferro normalize` with no `--reference`, whose default `MockProvider::with_test_data()` has protein data but not `NP_003997.1`, and through any prepared reference whose protein set does not cover the queried `NP_` (e.g. one built without `ferro prepare --proteins`).

## Change

A failed fetch means "no reference for this accession", not "cannot canonicalize":

- keep the fetch result as an `Option` and fall back to the residues the `delins` location names — the same `expected_len <= 2` fallback the no-provider path already uses — instead of `?`-returning `None`;
- treat a fetched window whose length disagrees with the range the same way (it was a hard `return None`);
- introduce `reference_backed` (did the reference actually supply `ref_aas`?) and gate the pure-insertion branch's ins→dup search on **that**, not on the provider-wide flag. For an accession the provider lacks, the ins→dup path can only bail, so gating on the flag just suppressed the plain `ins`.

A range spanning ≥3 residues still declines — its interior residues are unnamed and genuinely need the reference — and a **successful** fetch still wins, so reference-backed behavior (including the dup canonicalization) is untouched.

## Tests

New `tests/it/issue_1131_provider_accession_fallback.rs`. Every case builds a provider whose protein set is non-empty (so `has_protein_data()` is true) but does not contain `NP_003997.1`, and asserts an idempotent fixed point:

- #1119's three reductions (`delins`→sub, affix-trim→sub, affix-trim→del) now apply;
- #1126's named-flank pure insertion now applies;
- a ≥3-residue `delins` still declines — the fallback must not fabricate unnamed interior residues;
- **the fallback does not shadow a successful fetch**: `p.Val559_Glu560delinsValValGlu` gives the plain `p.Val559_Glu560insVal` for an accession the provider lacks, but `p.Val559dup` when the protein sequence is present — the ins→dup reduction only the reference can establish.

Full suite green (8306 passed), `clippy --all-features --all-targets -D warnings` clean, `fmt --check` clean.

## Notes

Output was valid HGVS before and after — this closes a canonicalization completeness gap, not a correctness bug. Found while dual-reviewing #1127/#1128.

Closes #1131
