### PR TITLE
fix(normalize): coalesce a protein cis run whose to-Ter member is last

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1235,21 +1235,25 @@ fn build_naedit<P>(
 /// "not correct".
 ///
 /// A to-`Ter` (nonsense) member **bounds** coalescing rather than vetoing the
-/// whole allele (#1125): only a run lying **entirely 5′ of the earliest `Ter`**
-/// may merge. A run that contains that `Ter`, or that sits wholly downstream of
-/// it, is left as authored — but an unrelated upstream run still collapses, e.g.
+/// whole allele (#1125): a run merges only when it **ends at or before the
+/// earliest `Ter`**. An unrelated upstream run still collapses, e.g.
 /// `p.[Cys100Ser;Asp101Gly;Arg200Ter]` → `p.[Cys100_Asp101delinsSerGly;Arg200Ter]`.
 ///
-/// The `Ter`-containing run is declined **conservatively**, not because every
-/// such merge is spec-invalid. The spec forbids two specific shapes: residues
-/// listed *after* a stop (`protein/delins.md:45` — not `delinsSerSerTerAlaAsp`)
-/// and an *immediate* stop written as a delins (`protein/substitution.md:20` —
-/// not `p.Cys5_Ser6delinsTerGluAsp`, but `p.Tyr4Ter`). A run whose to-`Ter`
-/// member is **last** would merge to a *trailing*-`Ter` delins, which the spec
-/// endorses (`protein/delins.md:47`: `p.(Pro578_Lys579delinsLeuTer)`); declining
-/// it is a known completeness gap inherited from #1095, tracked separately.
-/// Collapsing a nonsense change toward `p.<ref><pos>Ter` is likewise a separate
-/// rule.
+/// A run that ends *exactly* at that `Ter` merges too (#1129): its insert then
+/// carries the stop in final position, which the spec endorses
+/// (`protein/delins.md:47`: `p.(Pro578_Lys579delinsLeuTer)`), so
+/// `p.[Cys100Ser;Asp101Ter]` → `p.Cys100_Asp101delinsSerTer`. Only the two
+/// shapes the spec actually forbids stay declined, and one comparison covers
+/// both since `first_ter_pos` is the earliest stop:
+///   - a run whose **first** member is the `Ter` — an *immediate* stop, which
+///     must be a nonsense substitution (`protein/substitution.md:20`: not
+///     `p.Cys5_Ser6delinsTerGluAsp`, but `p.Tyr4Ter`);
+///   - a run carrying the `Ter` **interior** — residues after the stop
+///     (`protein/delins.md:45`: not `delinsSerSerTerAlaAsp`).
+///
+/// A run sitting wholly downstream of an earlier stop is likewise left as
+/// authored. Collapsing a nonsense change toward `p.<ref><pos>Ter` is a
+/// separate rule.
 ///
 /// Returns `Some` only when at least one run of ≥2 adjacent members is merged;
 /// a fully-merged allele collapses to a bare [`HgvsVariant::Protein`], a
@@ -1357,7 +1361,7 @@ pub(crate) fn coalesce_protein_adjacent_changes(
     }
 
     // The earliest residue changed to `Ter` (a nonsense substitution), if any.
-    // Only a run lying *entirely* 5′ of this position may coalesce; every other
+    // Only a run ending at or before this position may coalesce; every other
     // run is left as authored (see the to-`Ter` paragraph on this function).
     // Members are already in ascending residue order, so the first to-`Ter`
     // member is the earliest.
@@ -1374,12 +1378,22 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         while j + 1 < members.len() && members[j + 1].pos == members[j].pos + 1 {
             j += 1;
         }
-        // A run that reaches the earliest stop — whether it contains that
-        // `Ter` or sits wholly downstream of it — stays as authored. Only the
-        // run itself is declined, so a coalescible run 5′ of the stop is
-        // unaffected (#1125).
-        let run_precedes_any_ter = first_ter_pos.is_none_or(|ter| members[j].pos < ter);
-        if j > i && run_precedes_any_ter {
+        // A run may merge when it ends at or before the earliest stop.
+        //
+        // `<` is the #1125 case: the run lies wholly 5′ of the stop, which does
+        // not constrain it. `==` is the #1129 case: the earliest `Ter` is the
+        // run's own **last** member, so the merged insert carries the `Ter` in
+        // final position — the spec's `p.(Pro578_Lys579delinsLeuTer)` form
+        // (`protein/delins.md:47`).
+        //
+        // `>` covers both forbidden shapes at once, because `first_ter_pos` is
+        // the *earliest* stop and run positions strictly ascend: a run reaching
+        // past it either starts at that `Ter` (an immediate stop, which must be
+        // a nonsense substitution — `protein/substitution.md:20`) or carries it
+        // interior (residues after the stop — `protein/delins.md:45`), or else
+        // sits wholly downstream of an earlier stop, which stays out of scope.
+        let run_ends_at_or_before_any_ter = first_ter_pos.is_none_or(|ter| members[j].pos <= ter);
+        if j > i && run_ends_at_or_before_any_ter {
             // A run of ≥2 strictly-adjacent members → one edit spanning
             // residues `i..=j`. The inserted sequence is each member's
             // alternative in order, with deletions contributing nothing.

--- a/tests/it/issue_1125_ter_scoped_coalesce.rs
+++ b/tests/it/issue_1125_ter_scoped_coalesce.rs
@@ -18,10 +18,11 @@
 //! entirely 5′ of the earliest `Ter` is unaffected by the stop and still owes
 //! the spec its `delins`. That is what this suite pins.
 //!
-//! Known gap (pre-existing, tracked separately): a run whose to-`Ter` member is
-//! **last** would merge to a *trailing*-`Ter` delins, a form the spec endorses
-//! (`protein/delins.md:47`: `p.(Pro578_Lys579delinsLeuTer)`). It is still
-//! declined here; the tests below pin the current conservative behavior.
+//! A run whose to-`Ter` member is **last** does merge, to the trailing-`Ter`
+//! delins the spec endorses (`protein/delins.md:47`) — see
+//! `issue_1129_trailing_ter_delins` for that rule and the two `Ter` shapes that
+//! still decline. This file stays on the *scoping* question: which runs a `Ter`
+//! elsewhere in the allele may and may not hold back.
 //!
 //! Every rewrite here is reference-independent (all residues are named in the
 //! AST), so an empty `MockProvider` exercises them.
@@ -108,18 +109,7 @@ fn downstream_ter_does_not_block_an_upstream_run() {
     );
 }
 
-/// A run that *contains* the nonsense member still declines — the conservative
-/// pre-existing behavior this PR does not change (see the module header's known
-/// gap note for the trailing-`Ter` form the spec would allow).
-#[test]
-fn a_run_containing_the_ter_still_declines() {
-    all_orders_canonicalize_to(
-        &["Cys100Ser", "Asp101Ter"],
-        "NP_003997.1:p.[Cys100Ser;Asp101Ter]",
-    );
-}
-
-/// A run whose members sit at/after the earliest `Ter` also declines — the
+/// A run whose members sit after the earliest `Ter` declines — the
 /// residues it would describe are downstream of a stop, so coalescing them
 /// into a new `delins` is out of scope for this narrow rule.
 #[test]
@@ -147,14 +137,16 @@ fn the_earliest_ter_governs_when_several_are_present() {
     );
 }
 
-/// A `Ter` strictly adjacent to a run is *part of* that run (adjacency is what
-/// defines a run), so the run contains the stop and takes the same conservative
-/// decline — the scoping does not let an adjacent stop be merged in.
+/// A run that must decline does not drag down an unrelated upstream run: the
+/// `Ter` here **leads** its own run (`Arg100Ter;Gly101Ala`), so that run stays
+/// as authored per `protein/substitution.md:20`, while the run at `50/51` — 5′
+/// of the stop — still collapses. This is the scoping property in its sharpest
+/// form: two runs, one declining, one merging, in a single allele.
 #[test]
-fn a_ter_adjacent_to_a_run_joins_it_and_declines() {
+fn a_declining_run_does_not_block_an_upstream_run() {
     all_orders_canonicalize_to(
-        &["Cys100Ser", "Asp101Gly", "Arg102Ter"],
-        "NP_003997.1:p.[Cys100Ser;Asp101Gly;Arg102Ter]",
+        &["Cys50Ser", "Asp51Gly", "Arg100Ter", "Gly101Ala"],
+        "NP_003997.1:p.[Cys50_Asp51delinsSerGly;Arg100Ter;Gly101Ala]",
     );
 }
 

--- a/tests/it/issue_1129_trailing_ter_delins.rs
+++ b/tests/it/issue_1129_trailing_ter_delins.rs
@@ -1,0 +1,175 @@
+//! A protein cis-allele run whose to-`Ter` (nonsense) member is **last**
+//! coalesces to a trailing-`Ter` `delins` — #1129, narrowing the conservative
+//! decline #1095 introduced and #1125 scoped to the run.
+//!
+//! # Spec
+//!
+//! `protein/substitution.md:23` / `protein/delins.md:18` require two or more
+//! consecutive changed amino acids to be described as a `delins`, and pin the
+//! bracket form as wrong:
+//!
+//! > the description `p.Arg76_Cys77delinsSerTrp` is correct, the description
+//! > `p.[Arg76Ser;Cys77Trp]` is not correct.
+//!
+//! A trailing `Ter` in the inserted peptide is explicitly endorsed —
+//! `protein/delins.md:47`:
+//!
+//! > **`p.(Pro578_Lys579delinsLeuTer)`** — a deletion of amino acids `Pro578`
+//! > and `Lys579` replaced by `LeuTer` (alternatively `Leu*`).
+//!
+//! and `protein/delins.md:43` gives the single-residue form
+//! (`NP_004371.2:p.(Asn47delinsSerSerTer)`).
+//!
+//! Only two `Ter` shapes stay forbidden, and both still decline here:
+//!
+//! - residues listed **after** the stop — `protein/delins.md:45`: "the
+//!   deletion-insertion is not described as `delinsSerSerTerAlaAsp`, amino acids
+//!   after the translation termination codon are **not** listed". So a run whose
+//!   `Ter` member is interior must not merge.
+//! - an **immediate** stop — `protein/substitution.md:20`: "not
+//!   `p.Cys5_Ser6delinsTerGluAsp` but `p.Tyr4Ter`". So a run whose *first*
+//!   member is the `Ter` must not merge either.
+//!
+//! These rewrites are reference-independent (all residues are named in the
+//! AST), so an empty `MockProvider` exercises them.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Pin the canonical form of `input` and require it to be a normalization fixed
+/// point. Idempotency is load-bearing here: the merged `delins…Ter` must not be
+/// re-trimmed or re-expanded on a second pass.
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+/// Every permutation of `items` via Heap's algorithm.
+fn permutations<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+    let mut result = Vec::new();
+    let mut arr = items.to_vec();
+    let n = arr.len();
+    let mut c = vec![0usize; n];
+    result.push(arr.clone());
+    let mut i = 0;
+    while i < n {
+        if c[i] < i {
+            if i % 2 == 0 {
+                arr.swap(0, i);
+            } else {
+                arr.swap(c[i], i);
+            }
+            result.push(arr.clone());
+            c[i] += 1;
+            i = 0;
+        } else {
+            c[i] = 0;
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Assert EVERY permutation of `members` (joined into `NP_003997.1:p.[…]`)
+/// canonicalizes to `expected` — the `Ter`'s position in the *run* decides, not
+/// its position in the author's input (#1116's order-independence contract).
+fn all_orders_canonicalize_to(members: &[&str], expected: &str) {
+    for perm in permutations(members) {
+        let input = format!("NP_003997.1:p.[{}]", perm.join(";"));
+        canonicalizes_to(&input, expected);
+    }
+}
+
+/// The #1129 repro: a two-member run whose second member is the nonsense
+/// substitution merges to the spec's `delins…Ter` form.
+#[test]
+fn a_run_ending_in_ter_coalesces_to_a_trailing_ter_delins() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Ter"],
+        "NP_003997.1:p.Cys100_Asp101delinsSerTer",
+    );
+}
+
+/// A longer run ending in `Ter` merges the same way — every preceding residue
+/// contributes to the insert, which terminates at the stop.
+#[test]
+fn a_longer_run_ending_in_ter_coalesces() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg102Ter"],
+        "NP_003997.1:p.Cys100_Arg102delinsSerGlyTer",
+    );
+}
+
+/// A deletion member inside a run ending in `Ter` contributes nothing to the
+/// insert, exactly as in #1120's mixed sub/del runs.
+#[test]
+fn a_del_member_inside_a_run_ending_in_ter_contributes_nothing() {
+    all_orders_canonicalize_to(
+        &["Cys100del", "Asp101Ter"],
+        "NP_003997.1:p.Cys100_Asp101delinsTer",
+    );
+}
+
+/// Predicted `( )` members stay predicted through the merge.
+#[test]
+fn a_predicted_run_ending_in_ter_coalesces_predicted() {
+    all_orders_canonicalize_to(
+        &["(Cys100Ser)", "(Asp101Ter)"],
+        "NP_003997.1:p.(Cys100_Asp101delinsSerTer)",
+    );
+}
+
+/// An **immediate** stop must stay a nonsense substitution: a run whose FIRST
+/// member is the `Ter` would merge to `delinsTer…`, which
+/// `protein/substitution.md:20` forbids.
+#[test]
+fn a_run_starting_with_ter_still_declines() {
+    all_orders_canonicalize_to(
+        &["Arg76Ter", "Cys77Trp"],
+        "NP_003997.1:p.[Arg76Ter;Cys77Trp]",
+    );
+}
+
+/// An **interior** `Ter` would list residues after the stop
+/// (`protein/delins.md:45`), so the run still declines.
+#[test]
+fn a_run_with_an_interior_ter_still_declines() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Ter", "Arg102Trp"],
+        "NP_003997.1:p.[Cys100Ser;Asp101Ter;Arg102Trp]",
+    );
+}
+
+/// #1125's scoping is preserved: a run 5′ of an unrelated downstream `Ter`
+/// still coalesces, and that lone `Ter` re-emits verbatim.
+#[test]
+fn an_unrelated_downstream_ter_still_does_not_block_an_upstream_run() {
+    all_orders_canonicalize_to(
+        &["Cys100Ser", "Asp101Gly", "Arg200Ter"],
+        "NP_003997.1:p.[Cys100_Asp101delinsSerGly;Arg200Ter]",
+    );
+}
+
+/// A run 3′ of an earlier stop still declines even though it ends in its own
+/// `Ter` — the residues it describes are already downstream of a translation
+/// termination, which stays out of scope for this narrow rule (#1125).
+#[test]
+fn a_run_ending_in_ter_but_downstream_of_an_earlier_ter_declines() {
+    all_orders_canonicalize_to(
+        &["Arg50Ter", "Cys100Ser", "Asp101Ter"],
+        "NP_003997.1:p.[Arg50Ter;Cys100Ser;Asp101Ter]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -113,6 +113,7 @@ mod issue_1119_protein_delins_canonical;
 mod issue_1120_cis_coalesce_sub_del;
 mod issue_1125_ter_scoped_coalesce;
 mod issue_1126_reference_free_delins_to_ins;
+mod issue_1129_trailing_ter_delins;
 mod issue_1131_provider_accession_fallback;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
## Summary

The protein cis-allele coalesce declined **any** adjacent run containing a to-`Ter` (nonsense) substitution. That guard is broader than the spec: a run whose `Ter` member is **last** merges to a *trailing*-`Ter` `delins`, a form the spec endorses directly.

| input | before | after |
|-------|--------|-------|
| `NP_003997.1:p.[Cys100Ser;Asp101Ter]` | unchanged | `NP_003997.1:p.Cys100_Asp101delinsSerTer` |
| `NP_003997.1:p.[Cys100Ser;Asp101Gly;Arg102Ter]` | unchanged | `NP_003997.1:p.Cys100_Arg102delinsSerGlyTer` |
| `NP_003997.1:p.[Cys100del;Asp101Ter]` | unchanged | `NP_003997.1:p.Cys100_Asp101delinsTer` |
| `NP_003997.1:p.[Arg76Ter;Cys77Trp]` | unchanged | unchanged — immediate stop |
| `NP_003997.1:p.[Cys100Ser;Asp101Ter;Arg102Trp]` | unchanged | unchanged — interior `Ter` |

## Why

`protein/delins.md:47` gives the trailing-`Ter` form outright:

> **`p.(Pro578_Lys579delinsLeuTer)`** — a deletion of amino acids `Pro578` and `Lys579` replaced by `LeuTer` (alternatively `Leu*`).

with `protein/delins.md:43` the single-residue version (`NP_004371.2:p.(Asn47delinsSerSerTer)`). Meanwhile `protein/substitution.md:23` / `protein/delins.md:18` require two or more consecutive changed amino acids to be a `delins` and pin `p.[Arg76Ser;Cys77Trp]` as "not correct" — so `p.[Cys100Ser;Asp101Ter]` was being left in exactly the shape the spec rejects.

Only two `Ter` shapes are genuinely forbidden:

- **an immediate stop** — `protein/substitution.md:20`: not `p.Cys5_Ser6delinsTerGluAsp`, but `p.Tyr4Ter`. A run whose *first* member is the `Ter` must stay a nonsense substitution.
- **residues after the stop** — `protein/delins.md:45`: "the deletion-insertion is not described as `delinsSerSerTerAlaAsp`, amino acids after the translation termination codon are **not** listed". A run carrying the `Ter` *interior* must not merge.

## Change

The run gate relaxes from "ends **strictly before** the earliest `Ter`" to "ends **at or before**" it — a single comparison, because `first_ter_pos` is the *earliest* stop and run positions strictly ascend:

- `<` is #1125's case: the run is wholly 5′ of the stop, unconstrained by it.
- `==` is this PR's case: the earliest `Ter` is the run's own last member, so the insert carries the stop in final position.
- `>` covers **both** forbidden shapes at once — the run either starts at that `Ter` (immediate stop) or carries it interior (residues after the stop) — plus #1125's out-of-scope case of a run sitting wholly downstream of an earlier stop.

No new state, no second scan; the `first_ter_pos` computed for #1125 is sufficient.

## Tests

New `tests/it/issue_1129_trailing_ter_delins.rs` — every case run over **all permutations** of its members and asserted to be an idempotent fixed point:

- a two-member run ending in `Ter` → `delinsSerTer`;
- a three-member run ending in `Ter`;
- a `del` member inside such a run contributes nothing to the insert (#1120's mixed runs);
- predicted `( )` members stay predicted through the merge;
- a run **starting** with `Ter` still declines (immediate stop);
- a run with an **interior** `Ter` still declines (residues after the stop);
- #1125's scoping preserved — an unrelated downstream `Ter` still does not block an upstream run;
- a run ending in its own `Ter` but downstream of an *earlier* stop still declines.

Two `issue_1125_ter_scoped_coalesce` cases pinned the old conservative decline and are re-blessed: one is superseded by this suite's repro, the other is replaced by a sharper scoping test — two runs in one allele, one declining (`Ter`-led) and one merging. The `Ter`-first expectations in `allele_grammar_corners`, `issue_1116` and `issue_1120` are untouched and still pass.

Full suite green (8315 passed), `clippy --all-features --all-targets -D warnings` clean, `fmt --check` clean.

## Notes

Output was valid HGVS before and after — this closes a canonicalization completeness gap. Found by the HGVS spec audit while dual-reviewing #1127.

Closes #1129
