### PR TITLE
fix(normalize): scope the remaining protein coalesce declines to the affected members

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1255,18 +1255,31 @@ fn build_naedit<P>(
 /// authored. Collapsing a nonsense change toward `p.<ref><pos>Ter` is a
 /// separate rule.
 ///
+/// Every other restriction is likewise scoped to the member or run it concerns,
+/// so one out-of-scope member never leaves a well-formed run elsewhere in the
+/// allele as the bracket `protein/substitution.md:23` calls "not correct"
+/// (#1130). A member is barred from merging — and re-emitted verbatim — when:
+///   - its edit is not a single-residue substitution or deletion (`dup` / `ins`
+///     / `fs` / `ext` / multi-residue are out of scope for this narrow rule);
+///     such a member is **opaque**, and it also bars any member it overlaps;
+///   - it overlaps another member — two edits at one residue are the
+///     contradictory same-residue case, not a delins.
+///
+/// A run additionally **splits** at any predicted `( )` ↔ certain boundary, so a
+/// mixed stretch never fabricates a certainty its members do not jointly assert,
+/// while each same-certainty stretch of ≥2 still merges.
+///
 /// Returns `Some` only when at least one run of ≥2 adjacent members is merged;
 /// a fully-merged allele collapses to a bare [`HgvsVariant::Protein`], a
 /// partial merge to a smaller [`HgvsVariant::Allele`]. Returns `None` — leave
-/// the allele untouched — when it is conservatively out of scope:
+/// the allele untouched — when no run merges, or when the allele as a whole is
+/// out of scope:
 ///   - the phase is not cis (trans / unknown / mosaic / … are independent),
-///   - any member is not a single-residue protein substitution or deletion
-///     (other edit kinds — dup / ins / inv / fs / ext / multi-residue — are
-///     out of scope for this narrow rule),
-///   - every run is at or after a to-`Ter` member (see above),
-///   - two members share a residue position (a `n,n` pair is the contradictory
-///     same-residue case, not a delins), or
-///   - a run would mix predicted `( )` and certain members (ambiguous).
+///   - a member is not a protein variant, or does not share the first member's
+///     accession and gene symbol, or
+///   - a member has an uncertain or range endpoint, leaving it unplaceable —
+///     without a total order over the members, run detection is unsound, so
+///     this one really does decline the whole allele.
 pub(crate) fn coalesce_protein_adjacent_changes(
     allele: &crate::hgvs::variant::AlleleVariant,
 ) -> Option<HgvsVariant> {
@@ -1279,17 +1292,36 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         return None;
     }
 
-    /// One member reduced to a single-residue edit: a substitution
-    /// (`alternative = Some(aa)`, contributes that residue to the merged
-    /// insert) or a deletion (`alternative = None`, contributes nothing).
-    /// `source` is the member's index in `allele.variants`, kept so a member
-    /// that ends up in no run is re-emitted verbatim even after the
-    /// residue-order sort (#1116).
+    /// What a member contributes to a merged run.
+    enum Change {
+        /// A single-residue substitution; contributes `aa` to the insert.
+        Substitution(AminoAcid),
+        /// A single-residue deletion; contributes nothing to the insert.
+        Deletion,
+        /// Any other member — a `dup` / `ins` / `fs` / `ext` / multi-residue
+        /// edit, i.e. an edit kind this narrow rule does not merge. It is
+        /// ordered with the rest and re-emitted verbatim, but never joins a run
+        /// (#1130).
+        Opaque,
+    }
+
+    /// One member of the allele, reduced to what run detection needs.
+    ///
+    /// `lo`/`hi` are the member's occupied residue span (1-based, inclusive);
+    /// a single-residue member has `lo == hi`. `source` is the member's index
+    /// in `allele.variants`, kept so a member that ends up in no run is
+    /// re-emitted verbatim even after the residue-order sort (#1116).
     struct Member {
-        pos: u64,
+        lo: u64,
+        hi: u64,
         reference: AminoAcid,
-        alternative: Option<AminoAcid>,
+        change: Change,
         predicted: bool,
+        /// Set when this member overlaps another: a second edit at one residue
+        /// (contradictory), or a residue covered by an opaque member's span.
+        /// Blocked members are emitted verbatim and break any run through them
+        /// (#1130).
+        blocked: bool,
         source: usize,
     }
 
@@ -1312,52 +1344,70 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         if pv.accession != accession || pv.gene_symbol != gene_symbol {
             return None;
         }
-        // Exactly one certain residue (a point, start == end, both certain).
+        // Both endpoints must be certain single points so the member can be
+        // ordered and its span known. An uncertain or range endpoint leaves the
+        // member unplaceable, and run detection would be unsound without a
+        // total order — so that one really does decline the whole allele.
         let (Some(Mu::Certain(s)), Some(Mu::Certain(e))) = (
             pv.loc_edit.location.start.as_single(),
             pv.loc_edit.location.end.as_single(),
         ) else {
             return None;
         };
-        if s != e {
+        if e.number < s.number {
             return None;
         }
-        let (alternative, predicted) = match &pv.loc_edit.edit {
-            Mu::Certain(ProteinEdit::Substitution { alternative, .. }) => {
-                (Some(*alternative), false)
+        let single_residue = s == e;
+        let (change, predicted) = match &pv.loc_edit.edit {
+            Mu::Certain(ProteinEdit::Substitution { alternative, .. }) if single_residue => {
+                (Change::Substitution(*alternative), false)
             }
-            Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) => {
-                (Some(*alternative), true)
+            Mu::Uncertain(ProteinEdit::Substitution { alternative, .. }) if single_residue => {
+                (Change::Substitution(*alternative), true)
             }
             // A single-residue deletion contributes no residue to the merged
-            // insert. `start == end` was already enforced above, so this is a
-            // one-residue `del` (a multi-residue `del` range has `s != e` and
-            // bails). A deletion carrying an explicit deleted-sequence or count
+            // insert. A deletion carrying an explicit deleted-sequence or count
             // annotation still describes a single residue here, so it merges
-            // the same way.
-            Mu::Certain(ProteinEdit::Deletion { .. }) => (None, false),
-            Mu::Uncertain(ProteinEdit::Deletion { .. }) => (None, true),
-            _ => return None,
+            // the same way; a multi-residue `del` range falls through to
+            // `Opaque` below.
+            Mu::Certain(ProteinEdit::Deletion { .. }) if single_residue => {
+                (Change::Deletion, false)
+            }
+            Mu::Uncertain(ProteinEdit::Deletion { .. }) if single_residue => {
+                (Change::Deletion, true)
+            }
+            // Every other edit kind is out of scope for this narrow rule, but
+            // only for itself — it no longer vetoes the allele (#1130).
+            other => (Change::Opaque, matches!(other, Mu::Uncertain(_))),
         };
         members.push(Member {
-            pos: s.number,
+            lo: s.number,
+            hi: e.number,
             reference: s.aa,
-            alternative,
+            change,
             predicted,
+            blocked: false,
             source,
         });
     }
 
     // Sort into ascending residue order so run detection — and therefore the
     // coalesced payload — is independent of the author's member order (#1116).
-    // The sort is stable, so members sharing a residue stay adjacent and are
-    // caught by the duplicate check below.
-    members.sort_by_key(|m| m.pos);
+    // The sort is stable, so members sharing a start stay in input order.
+    members.sort_by_key(|m| (m.lo, m.hi));
 
-    // Two members at the same residue are a contradiction, not a delins: the
-    // allele states two different changes to one amino acid. Leave it untouched.
-    if members.windows(2).any(|w| w[1].pos == w[0].pos) {
-        return None;
+    // Mark every member that overlaps another. Two edits at one residue are a
+    // contradiction rather than a delins, and a residue covered by an opaque
+    // member's span cannot also be merged into a run — so both members of any
+    // overlapping pair are emitted verbatim, and neither can join a run
+    // (#1130). Quadratic in the member count, which is tiny for an allele.
+    for i in 0..members.len() {
+        for j in (i + 1)..members.len() {
+            if members[i].hi >= members[j].lo {
+                members[i].blocked = true;
+                members[j].blocked = true;
+            }
+        }
     }
 
     // The earliest residue changed to `Ter` (a nonsense substitution), if any.
@@ -1367,16 +1417,34 @@ pub(crate) fn coalesce_protein_adjacent_changes(
     // member is the earliest.
     let first_ter_pos = members
         .iter()
-        .find(|m| m.alternative == Some(AminoAcid::Ter))
-        .map(|m| m.pos);
+        .find(|m| matches!(m.change, Change::Substitution(AminoAcid::Ter)))
+        .map(|m| m.lo);
+
+    /// Whether `m` may take part in a merged run at all: it must be one of the
+    /// two mergeable single-residue edit kinds and must not overlap another
+    /// member (#1130).
+    fn is_runnable(m: &Member) -> bool {
+        !m.blocked && !matches!(m.change, Change::Opaque)
+    }
 
     let mut merged: Vec<HgvsVariant> = Vec::new();
     let mut changed = false;
     let mut i = 0;
     while i < members.len() {
+        // Grow the longest run of strictly-adjacent runnable members that also
+        // agree on certainty. Splitting at a predicted/certain boundary keeps a
+        // mixed stretch from fabricating a certainty its members do not jointly
+        // assert, while still letting each same-certainty stretch of ≥2 merge
+        // (#1130); before, the mixed case declined the whole allele.
         let mut j = i;
-        while j + 1 < members.len() && members[j + 1].pos == members[j].pos + 1 {
-            j += 1;
+        if is_runnable(&members[i]) {
+            while j + 1 < members.len()
+                && is_runnable(&members[j + 1])
+                && members[j + 1].lo == members[j].lo + 1
+                && members[j + 1].predicted == members[j].predicted
+            {
+                j += 1;
+            }
         }
         // A run may merge when it ends at or before the earliest stop.
         //
@@ -1392,23 +1460,25 @@ pub(crate) fn coalesce_protein_adjacent_changes(
         // a nonsense substitution — `protein/substitution.md:20`) or carries it
         // interior (residues after the stop — `protein/delins.md:45`), or else
         // sits wholly downstream of an earlier stop, which stays out of scope.
-        let run_ends_at_or_before_any_ter = first_ter_pos.is_none_or(|ter| members[j].pos <= ter);
+        let run_ends_at_or_before_any_ter = first_ter_pos.is_none_or(|ter| members[j].lo <= ter);
         if j > i && run_ends_at_or_before_any_ter {
             // A run of ≥2 strictly-adjacent members → one edit spanning
             // residues `i..=j`. The inserted sequence is each member's
             // alternative in order, with deletions contributing nothing.
-            let all_predicted = members[i..=j].iter().all(|m| m.predicted);
-            let any_predicted = members[i..=j].iter().any(|m| m.predicted);
-            if any_predicted && !all_predicted {
-                return None;
-            }
+            // Certainty is uniform across the run by construction (the walk
+            // above splits on it), so the whole run is predicted iff its first
+            // member is.
+            let all_predicted = members[i].predicted;
             let loc = ProtInterval::new(
-                ProtPos::new(members[i].reference, members[i].pos),
-                ProtPos::new(members[j].reference, members[j].pos),
+                ProtPos::new(members[i].reference, members[i].lo),
+                ProtPos::new(members[j].reference, members[j].lo),
             );
             let inserted: Vec<AminoAcid> = members[i..=j]
                 .iter()
-                .filter_map(|m| m.alternative)
+                .filter_map(|m| match m.change {
+                    Change::Substitution(aa) => Some(aa),
+                    Change::Deletion | Change::Opaque => None,
+                })
                 .collect();
             let edit = if inserted.is_empty() {
                 // Every member in the run is a deletion, so there is nothing to

--- a/tests/it/issue_1130_scoped_coalesce_declines.rs
+++ b/tests/it/issue_1130_scoped_coalesce_declines.rs
@@ -1,0 +1,183 @@
+//! Scope the protein cis-allele coalesce's three remaining declines to the
+//! affected members/run instead of vetoing the whole allele — #1130, completing
+//! what #1125 did for the to-`Ter` decline.
+//!
+//! # Spec
+//!
+//! `protein/substitution.md:23` / `protein/delins.md:18`:
+//!
+//! > changes involving **two or more consecutive amino acids** are described as
+//! > a deletion/insertion variant (delins) […] the description
+//! > `p.Arg76_Cys77delinsSerTrp` is correct, the description
+//! > `p.[Arg76Ser;Cys77Trp]` is not correct.
+//!
+//! That obligation attaches to a **run** of consecutive changed residues. An
+//! unrelated member elsewhere in the allele — an edit kind this narrow rule does
+//! not merge, a second edit at one residue, or a `( )` predicted member — is a
+//! reason to leave *that* member alone, not to leave a well-formed run of
+//! consecutive changes in the bracket shape the spec calls "not correct".
+//!
+//! The three declines and what now happens instead:
+//!
+//! | decline | before | now |
+//! |---------|--------|-----|
+//! | member is not a single-residue sub/del | whole allele | that member is opaque: emitted verbatim, never merged, and it blocks any member it overlaps |
+//! | two members occupy one residue | whole allele | those members are emitted verbatim; every other run merges |
+//! | a run mixes predicted `( )` and certain members | whole allele | the run splits at each certainty boundary; each same-certainty sub-run of ≥2 merges |
+//!
+//! These rewrites are reference-independent (all residues are named in the
+//! AST), so an empty `MockProvider` exercises them.
+
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Pin the canonical form of `input` and require it to be a normalization fixed
+/// point. Idempotency matters here because a partially-coalesced allele is
+/// re-parsed as a bracket whose surviving blocked members must not then change
+/// the outcome of a second pass.
+fn canonicalizes_to(input: &str, expected: &str) {
+    let parsed = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?}: {e}"));
+    let normalized = Normalizer::new(MockProvider::new())
+        .normalize(&parsed)
+        .unwrap_or_else(|e| panic!("normalize {input:?}: {e}"));
+    assert_eq!(normalized.to_string(), expected, "for {input:?}");
+
+    let reparsed =
+        parse_hgvs(expected).unwrap_or_else(|e| panic!("parse expected {expected:?}: {e}"));
+    let renormalized = Normalizer::new(MockProvider::new())
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize {expected:?}: {e}"));
+    assert_eq!(
+        renormalized.to_string(),
+        expected,
+        "canonical form {expected:?} is not a normalization fixed point",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decline 1: a member whose edit kind this rule does not merge
+// ---------------------------------------------------------------------------
+
+/// A single-residue `dup` is out of scope for the coalesce, but it must not
+/// hold back an unrelated adjacent run.
+#[test]
+fn an_unmergeable_edit_kind_no_longer_blocks_an_unrelated_run() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100Ser;Asp101dup;Gly200Ala;Ala201Val]",
+        "NP_003997.1:p.[Cys100Ser;Asp101dup;Gly200_Ala201delinsAlaVal]",
+    );
+}
+
+/// A **multi-residue** member is opaque the same way — it occupies its whole
+/// span, and a run clear of that span still merges.
+#[test]
+fn a_multi_residue_member_no_longer_blocks_an_unrelated_run() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100_Asp105del;Gly200Ala;Ala201Val]",
+        "NP_003997.1:p.[Cys100_Asp105del;Gly200_Ala201delinsAlaVal]",
+    );
+}
+
+/// An opaque member breaks adjacency at the residues it occupies: a sub at 106
+/// overlaps the `100_106del` span, so it is emitted verbatim and cannot pair
+/// with the sub at 107.
+#[test]
+fn an_opaque_member_blocks_a_run_it_overlaps() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100_Gly106del;Gly106Ala;Ala107Val]",
+        "NP_003997.1:p.[Cys100_Gly106del;Gly106Ala;Ala107Val]",
+    );
+}
+
+/// The opaque member itself is never merged into an adjacent run — a `dup` at
+/// 101 sits between subs at 100 and 102, and none of the three coalesce.
+#[test]
+fn an_opaque_member_is_never_merged_into_a_run() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100Ser;Asp101dup;Gly102Ala]",
+        "NP_003997.1:p.[Cys100Ser;Asp101dup;Gly102Ala]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decline 2: two members at one residue
+// ---------------------------------------------------------------------------
+
+/// Two edits at one residue are a contradiction, not a delins — but they must
+/// not hold back an unrelated adjacent run.
+#[test]
+fn a_duplicate_residue_no_longer_blocks_an_unrelated_run() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser;Gly200Ala;Ala201Val]",
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser;Gly200_Ala201delinsAlaVal]",
+    );
+}
+
+/// The contradictory pair itself is still never coalesced (#1116).
+#[test]
+fn a_duplicate_residue_pair_is_still_never_coalesced() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser]",
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser]",
+    );
+}
+
+/// A residue carrying two edits also breaks a run through it: the subs at 100
+/// and 102 are each adjacent to 101, but 101 is contradictory, so nothing
+/// merges.
+#[test]
+fn a_duplicate_residue_breaks_a_run_through_it() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100Ser;Asp101Gly;Asp101Trp;Arg102Ala]",
+        "NP_003997.1:p.[Cys100Ser;Asp101Gly;Asp101Trp;Arg102Ala]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decline 3: a run mixing predicted `( )` and certain members
+// ---------------------------------------------------------------------------
+
+/// A mixed predicted/certain run is still not merged (merging would fabricate a
+/// certainty the members do not jointly assert), but it no longer vetoes an
+/// unrelated run elsewhere in the allele.
+#[test]
+fn a_mixed_certainty_run_no_longer_blocks_an_unrelated_run() {
+    canonicalizes_to(
+        "NP_003997.1:p.[(Cys100Ser);Asp101Gly;Gly200Ala;Ala201Val]",
+        "NP_003997.1:p.[(Cys100Ser);Asp101Gly;Gly200_Ala201delinsAlaVal]",
+    );
+}
+
+/// A mixed run splits at the certainty boundary: each same-certainty stretch of
+/// ≥2 members merges on its own, so a `[certain, certain, predicted, predicted]`
+/// run becomes two delins rather than staying a four-member bracket.
+#[test]
+fn a_mixed_certainty_run_splits_at_the_boundary() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Cys100Ser;Asp101Gly;(Gly102Ala);(Ala103Val)]",
+        "NP_003997.1:p.[Cys100_Asp101delinsSerGly;(Gly102_Ala103delinsAlaVal)]",
+    );
+}
+
+/// A two-member mixed run has no same-certainty stretch of ≥2, so neither
+/// member merges — the #1116 expectation, unchanged.
+#[test]
+fn a_two_member_mixed_certainty_run_is_still_not_coalesced() {
+    canonicalizes_to(
+        "NP_003997.1:p.[(Arg76Ser);Cys77Trp]",
+        "NP_003997.1:p.[(Arg76Ser);Cys77Trp]",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Combined
+// ---------------------------------------------------------------------------
+
+/// All three blocked shapes in one allele, plus a to-`Ter` member (#1125), must
+/// still leave the one clean run free to coalesce.
+#[test]
+fn every_decline_at_once_still_lets_a_clean_run_coalesce() {
+    canonicalizes_to(
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser;(Cys100Ser);Asp101Gly;Trp150dup;Gly200Ala;Ala201Val;Arg300Ter]",
+        "NP_003997.1:p.[Arg76Cys;Arg76Ser;(Cys100Ser);Asp101Gly;Trp150dup;Gly200_Ala201delinsAlaVal;Arg300Ter]",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -114,6 +114,7 @@ mod issue_1120_cis_coalesce_sub_del;
 mod issue_1125_ter_scoped_coalesce;
 mod issue_1126_reference_free_delins_to_ins;
 mod issue_1129_trailing_ter_delins;
+mod issue_1130_scoped_coalesce_declines;
 mod issue_1131_provider_accession_fallback;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;


### PR DESCRIPTION
## Summary

#1125 scoped the protein cis-allele coalesce's to-`Ter` decline from the whole allele down to the affected run. Its **three other** declines still returned `None` for the entire allele, so one out-of-scope member left a well-formed run of consecutive changes elsewhere in the allele in exactly the bracket shape `protein/substitution.md:23` calls "not correct".

| decline | input | before | after |
|---------|-------|--------|-------|
| unmergeable edit kind | `p.[Cys100Ser;Asp101dup;Gly200Ala;Ala201Val]` | unchanged | `p.[Cys100Ser;Asp101dup;Gly200_Ala201delinsAlaVal]` |
| multi-residue member | `p.[Cys100_Asp105del;Gly200Ala;Ala201Val]` | unchanged | `p.[Cys100_Asp105del;Gly200_Ala201delinsAlaVal]` |
| two edits at one residue | `p.[Arg76Cys;Arg76Ser;Gly200Ala;Ala201Val]` | unchanged | `p.[Arg76Cys;Arg76Ser;Gly200_Ala201delinsAlaVal]` |
| predicted/certain mix | `p.[(Cys100Ser);Asp101Gly;Gly200Ala;Ala201Val]` | unchanged | `p.[(Cys100Ser);Asp101Gly;Gly200_Ala201delinsAlaVal]` |
| predicted/certain mix | `p.[Cys100Ser;Asp101Gly;(Gly102Ala);(Ala103Val)]` | unchanged | `p.[Cys100_Asp101delinsSerGly;(Gly102_Ala103delinsAlaVal)]` |

(All accessions `NP_003997.1`, elided for width.)

## Change

Each restriction now applies to the member or run it concerns.

**Opaque members.** A member whose edit is not a single-residue substitution or deletion becomes `Change::Opaque` rather than bailing: it is ordered with the rest, re-emitted verbatim, and never merged. Multi-residue members are folded in the same way, so the old `s != e` bail is gone too.

**Span-based blocking.** Members now carry their occupied span (`lo`/`hi`) instead of a single position, and any two members that overlap are marked `blocked` — emitted verbatim, barred from any run. This *generalizes* the old same-residue check (it also catches a single-residue edit falling inside a multi-residue member's span, e.g. `p.[Cys100_Gly106del;Gly106Ala;Ala107Val]`) while confining it to the members actually involved.

**Certainty-split runs.** The run walk now stops at a predicted `( )` ↔ certain boundary instead of building a maximal run and then declining it. A mixed stretch therefore never fabricates a certainty its members do not jointly assert, and each same-certainty stretch of ≥2 still merges. As a side effect the post-hoc `any_predicted && !all_predicted` check disappears — certainty is uniform across a run by construction.

**One whole-allele decline remains, now documented as deliberate:** a member with an uncertain or range endpoint is unplaceable, and run detection is unsound without a total order over the members.

## Tests

New `tests/it/issue_1130_scoped_coalesce_declines.rs`, three sections mirroring the three declines plus a combined case, each asserting an idempotent fixed point:

- an unmergeable edit kind, and a multi-residue member, no longer block an unrelated run;
- an opaque member **blocks a run it overlaps**, and is never merged into an adjacent run;
- a duplicate residue no longer blocks an unrelated run, is still never coalesced itself, and **breaks a run through it**;
- a mixed-certainty run no longer blocks an unrelated run, splits at the boundary, and a two-member mixed run still does not merge (the #1116 expectation);
- all three blocked shapes plus a to-`Ter` member in one allele still leave the single clean run free to coalesce.

**No existing expectation moved** — full suite green at 8326 passed with no re-blessing, which is the signal that the change only lets *more* alleles coalesce, never fewer. `clippy --all-features --all-targets -D warnings` clean, `fmt --check` clean.

## Notes

Output was valid HGVS before and after — this closes canonicalization completeness gaps. Found by the sibling-pattern pass while dual-reviewing #1127.

Closes #1130