### PR TITLE
fix(normalize): describe a self-cancelling del+ins merge as an identity

### DIFF
--- a/src/normalize/merge.rs
+++ b/src/normalize/merge.rs
@@ -1168,8 +1168,27 @@ fn build_naedit<P>(
             merged.end + 1,
             "invariant: insertion anchor span = 1 nt"
         );
-        NaEdit::Insertion {
-            sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
+        if merged.alt.is_empty() {
+            // The members cancelled out: an insertion anchor with nothing left
+            // to insert (e.g. `g.[100del;100_101insA]` over a homopolymer,
+            // where the deletion 3'-shifts onto the insertion point). Emitting
+            // `NaEdit::Insertion` here would build an edit with an empty
+            // sequence — not a valid HGVS description (it renders as `ins`
+            // with no bases), and it later divides by zero when
+            // `normalize_na_edit` rotates the inserted sequence through a
+            // repeat. The sequence is unchanged across the anchor, so describe
+            // it as an identity (`DNA/other.md`, `c.123_145=`).
+            //
+            // Mirrors the protein coalescer below, which likewise refuses to
+            // emit an empty `delins` when every member of a run is a deletion.
+            NaEdit::Identity {
+                sequence: None,
+                whole_entity: false,
+            }
+        } else {
+            NaEdit::Insertion {
+                sequence: InsertedSequence::Literal(Sequence::new(merged.alt)),
+            }
         }
     } else if merged.alt.is_empty() {
         NaEdit::Deletion {
@@ -1540,6 +1559,50 @@ mod tests {
     use crate::hgvs::parser::parse_hgvs;
     use crate::hgvs::variant::Accession;
     use crate::reference::MockProvider;
+
+    /// #1135: an insertion-shaped anchor with nothing left to insert (a
+    /// cancelling del+ins after 3'-shifting) must not become an `Insertion`
+    /// carrying an empty sequence — that is not valid HGVS and made
+    /// `normalize_na_edit` divide by zero rotating the empty sequence.
+    ///
+    /// Pinned on `build_naedit` with the anchor state directly: reaching it
+    /// through `merge_consecutive_edits` requires the normalizer to have
+    /// shifted the pair together first, so a merge-level test exercises the
+    /// `Delins` branch instead and would not cover this.
+    #[test]
+    fn empty_insertion_anchor_builds_an_identity() {
+        // Insertion-shaped anchor (`start == end + 1`) with an empty payload.
+        let anchor = Anchor {
+            region: Region::Genome,
+            start: 1010,
+            end: 1009,
+            alt: Vec::new(),
+        };
+        let (interval, edit) = build_naedit(anchor, |_, p| GenomePos::new(p as u64));
+
+        match edit {
+            NaEdit::Identity { .. } => {}
+            other => panic!("expected NaEdit::Identity, got {other:?}"),
+        }
+        assert_eq!(interval.to_string(), "1009_1010");
+    }
+
+    /// The non-empty sibling still builds a real insertion — the guard must not
+    /// swallow a payload-carrying anchor.
+    #[test]
+    fn non_empty_insertion_anchor_still_builds_an_insertion() {
+        let anchor = Anchor {
+            region: Region::Genome,
+            start: 1010,
+            end: 1009,
+            alt: vec![Base::A],
+        };
+        let (_, edit) = build_naedit(anchor, |_, p| GenomePos::new(p as u64));
+        match edit {
+            NaEdit::Insertion { .. } => {}
+            other => panic!("expected NaEdit::Insertion, got {other:?}"),
+        }
+    }
 
     #[test]
     fn empty_input_returns_empty() {

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7418,7 +7418,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     // rotates. For example, shifting "GGC" by 1 position gives "GCG".
                     let shift_amount =
                         (result.start as usize).saturating_sub(shuffle_start as usize);
-                    let rotation = shift_amount % seq_bytes.len();
+                    // Defence in depth. `build_naedit` no longer merges a
+                    // cancelling del+ins into an empty insertion (#1135), which
+                    // was the reachable producer here — but the *type* still
+                    // permits one (the parser accepts a bare `ins`), so a
+                    // future path must not be able to turn that into a process
+                    // abort. Nothing to rotate means no rotation.
+                    let rotation = if seq_bytes.is_empty() {
+                        0
+                    } else {
+                        shift_amount % seq_bytes.len()
+                    };
                     let rotated_seq: Vec<u8> = if rotation > 0 {
                         seq_bytes[rotation..]
                             .iter()

--- a/tests/it/issue_1135_self_cancelling_merge.rs
+++ b/tests/it/issue_1135_self_cancelling_merge.rs
@@ -1,0 +1,86 @@
+//! Issue #1135: merging a self-cancelling del+ins cis allele must not panic.
+//!
+//! `build_naedit` chose the insertion branch on the anchor *shape*
+//! (`start == end + 1`) without checking whether anything was left to insert.
+//! When a deletion 3'-shifts onto an adjacent insertion of the same base — the
+//! two cancel — `merged.alt` is empty while the anchor keeps insertion shape,
+//! so an `NaEdit::Insertion` was built with an **empty** sequence. That is not
+//! a valid HGVS edit, and `normalize_na_edit` then divided by zero rotating the
+//! (empty) inserted sequence through the repeat:
+//! `attempt to calculate the remainder with a divisor of zero`.
+//!
+//! These run without a prepared reference so they gate every PR, not just the
+//! nightly manifest job. Expected strings are pinned exactly rather than
+//! pattern-matched: the identity's span comes from the merged anchor
+//! arithmetic, so a change there has to fail loudly instead of sliding past a
+//! suffix check.
+
+use ferro_hgvs::reference::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// A contig carrying an `AAAAA` homopolymer at `g.1004..1008`, long enough for
+/// a deletion to 3'-shift across it onto an insertion anchor.
+fn homopolymer_normalizer() -> Normalizer<MockProvider> {
+    let mut provider = MockProvider::new();
+    provider.add_genomic_sequence(
+        "NC_000001.11",
+        format!("{}ATGAAAAAGCCTAA{}", "N".repeat(1000), "N".repeat(100)),
+    );
+    Normalizer::new(provider)
+}
+
+/// The reported input and two neighbouring spellings: a deletion and an
+/// insertion of the same base inside one homopolymer cancel out, leaving the
+/// sequence unchanged across the merged anchor.
+#[test]
+fn self_cancelling_del_ins_allele_normalizes_to_an_identity() {
+    let normalizer = homopolymer_normalizer();
+    for (input, expected) in [
+        (
+            "NC_000001.11:g.[1004del;1008_1009insA]",
+            "NC_000001.11:g.1009_1010=",
+        ),
+        (
+            "NC_000001.11:g.[1004del;1004_1005insA]",
+            "NC_000001.11:g.1005_1006=",
+        ),
+        (
+            "NC_000001.11:g.[1005del;1008_1009insA]",
+            "NC_000001.11:g.1009_1010=",
+        ),
+    ] {
+        let variant = parse_hgvs(input).unwrap();
+        let normalized = normalizer
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("{input} failed to normalize: {e}"));
+        let rendered = normalized.to_string();
+
+        assert_eq!(rendered, expected, "{input} normalized unexpectedly");
+
+        // Whatever we emit has to be real HGVS, and stable under a second pass.
+        parse_hgvs(&rendered)
+            .unwrap_or_else(|e| panic!("{input} -> {rendered} does not re-parse: {e}"));
+        assert_eq!(
+            normalizer.normalize(&normalized).unwrap().to_string(),
+            rendered,
+            "{input} is not idempotent"
+        );
+    }
+}
+
+/// Guard against the fix over-triggering: a del+ins pair that does **not**
+/// cancel must still merge into a real edit, not collapse to an identity.
+#[test]
+fn non_cancelling_del_ins_allele_still_merges() {
+    let normalizer = homopolymer_normalizer();
+    let input = "NC_000001.11:g.[1004del;1008_1009insGG]";
+    let variant = parse_hgvs(input).unwrap();
+    let rendered = normalizer.normalize(&variant).unwrap().to_string();
+
+    assert_eq!(
+        rendered, "NC_000001.11:g.[1008del;1009G[3]]",
+        "{input} changes the sequence and must not collapse to an identity"
+    );
+    parse_hgvs(&rendered)
+        .unwrap_or_else(|e| panic!("{input} -> {rendered} does not re-parse: {e}"));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -116,6 +116,7 @@ mod issue_1126_reference_free_delins_to_ins;
 mod issue_1129_trailing_ter_delins;
 mod issue_1130_scoped_coalesce_declines;
 mod issue_1131_provider_accession_fallback;
+mod issue_1135_self_cancelling_merge;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Closes #1135.

`ferro normalize` aborted the process (exit 101) on a valid cis allele whose members cancel out.

## The bug

`build_naedit` (`src/normalize/merge.rs`) picked the insertion branch on the anchor *shape* — `start == end + 1` — without checking whether anything remained to insert:

```rust
let edit = if merged.start > merged.end {
    NaEdit::Insertion { sequence: InsertedSequence::Literal(Sequence::new(merged.alt)) }
} else if merged.alt.is_empty() {
    NaEdit::Deletion { .. }
} else {
    NaEdit::Delins { .. }
};
```

When a deletion 3'-shifts onto an adjacent insertion of the same base, the two cancel: `merged.alt` is empty while the anchor keeps insertion shape. The result was an `NaEdit::Insertion` carrying an **empty** sequence — not a valid HGVS edit, since it renders as `ins` with nothing after it.

The panic was the downstream symptom. `normalize_na_edit` rotates the inserted sequence when shifting an insertion through a repeat, and divided by zero:

```
$ ferro normalize --reference <ref> 'NM_004006.3:c.[179del;183_184insA]'
thread 'main' panicked at src/normalize/mod.rs: attempt to calculate the remainder with a divisor of zero
```

Both members normalize fine in isolation (`c.179del` → `c.183del`, `c.183_184insA` → `c.183dup`); only the cis combination failed. DMD `c.179`–`c.183` is an `AAAAA` homopolymer, so the deletion shifts onto the insertion anchor. **Not a regression** — v0.9.1 panics identically.

I confirmed the mechanism by instrumentation rather than inference: `build_naedit` fires with `start=1010 end=1009` and an empty `alt` on the reduced fixture. The backtrace alone does not show it — the merge has already returned by the time `normalize_na_edit` panics.

## The fix

A cancelling pair leaves the sequence unchanged across the anchor, so the merge now emits an identity (`NaEdit::Identity`, e.g. `g.1009_1010=` — cf. `DNA/other.md`'s `c.123_145=`) rather than an empty insertion.

This mirrors the protein coalescer a few lines below, which already declines the analogous shape: *"Every member in the run is a deletion, so there is nothing to insert: emit a pure range deletion, not an (invalid) empty `delins`."* The nucleotide path simply lacked the equivalent guard.

The rotation site is additionally guarded (`seq_bytes.is_empty()` → no rotation) as defence in depth, so that a future producer of an empty inserted sequence causes a description bug rather than a process abort.

## Tests

`tests/it/issue_1135_self_cancelling_merge.rs`, **reference-free** so it gates every PR rather than only the nightly manifest job:

- `self_cancelling_del_ins_allele_does_not_panic` — the reported input plus two neighbouring spellings; asserts each normalizes to an identity, never renders a bare `ins`, and **re-parses**.
- `non_cancelling_del_ins_allele_still_merges` — guards against the fix over-triggering: `g.[1004del;1008_1009insGG]` changes the sequence and must not collapse to an identity.

Verified failing before the fix (same divide-by-zero) and passing after.

`cargo nextest run --features dev`: **8334 passed, 0 failed**, 145 skipped. `cargo fmt --check` and `cargo clippy --features dev --all-targets -- -D warnings` clean.

## Reviewer note

The identity's *span* is the merged anchor interval, which for `g.[1004del;1008_1009insA]` lands on `g.1009_1010=`. The description is truthful — that sequence is unchanged — but I have not tried to establish that this is the most natural span to report for a cancelling pair, and the anchor arithmetic that produces it is untouched by this PR. Worth a second opinion; if a different span is preferred it is a follow-up, since the panic fix stands either way.
