### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.10.0...v0.10.1) - 2026-07-23
+
+### Fixed
+
+- *(lenient)* stop the one-letter AA expansion at the next member's accession ([#1150](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1150))
+- *(render)* apply the protein render style to an allele's members ([#1149](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1149))
+- *(parser)* accept a specification on custom and assembly references ([#1148](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1148))
+- *(hgvs)* single-source the gene-symbol selector's Display rule ([#1141](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1141))
+- *(render)* drop the gene-symbol selector on every protein allele ([#1144](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1144))
+- *(project)* name the codons an all-silent change rewrote ([#1140](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1140))
+- *(normalize)* describe a self-cancelling del+ins merge as an identity ([#1136](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1136))
+
+### Other
+
+- *(hgvs)* pin that an assembly reference keeps its gene-symbol selector ([#1147](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1147))
+
 ## [0.10.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.9.1...v0.10.0) - 2026-07-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.10.0 -> 0.10.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.10.0...v0.10.1) - 2026-07-23

### Fixed

- *(lenient)* stop the one-letter AA expansion at the next member's accession ([#1150](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1150))
- *(render)* apply the protein render style to an allele's members ([#1149](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1149))
- *(parser)* accept a specification on custom and assembly references ([#1148](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1148))
- *(hgvs)* single-source the gene-symbol selector's Display rule ([#1141](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1141))
- *(render)* drop the gene-symbol selector on every protein allele ([#1144](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1144))
- *(project)* name the codons an all-silent change rewrote ([#1140](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1140))
- *(normalize)* describe a self-cancelling del+ins merge as an identity ([#1136](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1136))

### Other

- *(hgvs)* pin that an assembly reference keeps its gene-symbol selector ([#1147](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1147))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).