### PR TITLE
fix(project): name the codons an all-silent change rewrote

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -16,9 +16,10 @@ use crate::project::accession::parse_accession;
 use crate::project::edit::transform_edit_for_strand;
 use crate::project::protein::{
     build_initiator_unknown, build_whole_protein_unknown, cds_has_recognized_start,
-    cds_has_valid_start, combined_cis_residue_changes, edit_reaches_initiation_codon,
-    edit_spans_cds_into_3utr, predict_indel_protein, predict_stop_region_extension,
-    predict_substitution_protein, read_cds_start_codon, try_project_cis_combined_inframe,
+    cds_has_valid_start, codon_residues, combined_cis_residue_changes,
+    edit_reaches_initiation_codon, edit_spans_cds_into_3utr, group_consecutive_by,
+    predict_indel_protein, predict_stop_region_extension, predict_substitution_protein,
+    read_cds_start_codon, render_silent_identity, try_project_cis_combined_inframe,
     whole_exon_deletion_span, CisCombined, RefProteinBundle,
 };
 use crate::project::result::VariantProjection;
@@ -373,15 +374,11 @@ fn render_cis_substitution_groups(
 
 /// Group changed residues (distinct, ascending) into runs of consecutive
 /// positions. Residues separated by an unchanged residue land in different runs.
+///
+/// Shares [`group_consecutive_by`] with the identity renderer so changed and
+/// unchanged residues are grouped by one rule (#1099).
 fn group_consecutive_residues(spans: Vec<SubSpan>) -> Vec<Vec<SubSpan>> {
-    let mut groups: Vec<Vec<SubSpan>> = Vec::new();
-    for s in spans {
-        match groups.last_mut() {
-            Some(g) if s.pos == g.last().expect("non-empty group").pos + 1 => g.push(s),
-            _ => groups.push(vec![s]),
-        }
-    }
-    groups
+    group_consecutive_by(spans, |s| s.pos)
 }
 
 /// Combine the per-member protein consequences of an **in-cis** allele into a
@@ -518,10 +515,7 @@ fn combine_cis_substitutions_by_codon(
     members: &[(i64, crate::hgvs::edit::Base)],
     protein_accession: &str,
 ) -> Option<HgvsVariant> {
-    use crate::hgvs::edit::ProteinEdit;
-    use crate::hgvs::interval::ProtInterval;
-    use crate::hgvs::location::{AminoAcid, ProtPos};
-    use crate::hgvs::variant::{LocEdit, ProteinVariant};
+    use crate::hgvs::location::AminoAcid;
     use crate::project::protein::{apply_substitution, read_ref_codon, translate};
     use std::collections::BTreeMap;
 
@@ -554,10 +548,15 @@ fn combine_cis_substitutions_by_codon(
     let gene_symbol = transcript.gene_symbol.clone();
 
     // Per codon: apply all member base changes to the reference codon, translate
-    // once, and keep the residues whose amino acid actually changes. Track the
-    // first affected residue so an all-synonymous result still names a position.
+    // once, and keep the residues whose amino acid actually changes. Also record
+    // the codons whose reference triplet the members actually rewrote, which is
+    // what an all-synonymous result is described by (#1099). That set is derived
+    // by comparing triplets — the same rule `rewritten_codons` applies to a whole
+    // mutated CDS, applied one codon at a time here because this path never
+    // builds one — and NOT from `by_codon` membership, which is member-derived:
+    // a member whose alternative base equals the reference rewrites nothing.
     let mut changed: Vec<SubSpan> = Vec::new();
-    let mut first_affected: Option<(u64, AminoAcid)> = None;
+    let mut rewritten: Vec<(u64, AminoAcid)> = Vec::new();
     for (codon_index, subs) in &by_codon {
         let codon_first_cds_pos = codon_index * 3 + 1;
         let (ref_codon, _frame) = read_ref_codon(transcript, codon_first_cds_pos).ok()?;
@@ -584,8 +583,8 @@ fn combine_cis_substitutions_by_codon(
         if ref_aa == AminoAcid::Ter && alt_aa != AminoAcid::Ter {
             return None;
         }
-        if first_affected.is_none() {
-            first_affected = Some((pos, ref_aa));
+        if alt_codon != ref_codon {
+            rewritten.push((pos, ref_aa));
         }
         if ref_aa != alt_aa {
             changed.push(SubSpan {
@@ -596,21 +595,22 @@ fn combine_cis_substitutions_by_codon(
         }
     }
 
-    // No residue changed: the combined product is synonymous → p.(RefNNN=) at the
-    // first affected residue (substitution.md: silent changes are `p.Cys123=`).
+    // No residue changed: the combined product is synonymous, so name every codon
+    // the members rewrote — `p.(Leu2=)`, the range `p.(Leu2_Arg3=)`, or the
+    // bracket `p.[(Leu2=);(Ala5=)]` when an untouched codon separates them
+    // (#1099). The shared renderer keeps this in step with the residue-level
+    // combiner, which reaches the same shapes from a whole mutated CDS.
     if changed.is_empty() {
-        let (pos, ref_aa) = first_affected?;
-        return Some(HgvsVariant::Protein(ProteinVariant {
-            accession,
-            gene_symbol,
-            loc_edit: LocEdit::new_predicted(
-                ProtInterval::point(ProtPos::new(ref_aa, pos)),
-                ProteinEdit::Identity {
-                    predicted: false,
-                    whole_protein: false,
-                },
-            ),
-        }));
+        // No translated protein is in scope on this path: it reads one
+        // reference codon at a time. The whole-molecule anchor is unreachable
+        // here anyway — an empty set needs every member to leave its triplet
+        // byte-identical, which `cis_substitution_members` does not produce.
+        return Some(render_silent_identity(
+            rewritten,
+            None,
+            &accession,
+            &gene_symbol,
+        ));
     }
 
     let groups = group_consecutive_residues(changed);
@@ -638,8 +638,10 @@ fn combine_cis_substitutions_by_codon(
 /// The changed residues come from [`combined_cis_residue_changes`] (a
 /// residue-wise diff of the combined product against the reference protein) and
 /// are rendered by the shared [`render_cis_substitution_groups`]: one changed
-/// residue → a substitution, a contiguous run → one delins, no change → the
-/// silent `p.(Xxx{N}=)` at the first affected residue.
+/// residue → a substitution, a contiguous run → one delins. When nothing
+/// changed, the same diff's rewritten codons are rendered by
+/// [`render_silent_identity`] — `p.(Leu2=)`, `p.(Leu2_Arg3=)` or
+/// `p.[(Leu2=);(Ala5=)]` (#1099).
 ///
 /// Returns `None` — the caller keeps its existing (bracketed / per-member)
 /// behavior — when the combined product is not a length-preserving residue-wise
@@ -653,35 +655,26 @@ fn combine_cis_members_by_residue(
     members: &[(i64, i64, &NaEdit)],
     protein_accession: &str,
 ) -> Option<HgvsVariant> {
-    use crate::hgvs::edit::ProteinEdit;
-    use crate::hgvs::interval::ProtInterval;
-    use crate::hgvs::location::ProtPos;
-    use crate::hgvs::variant::{LocEdit, ProteinVariant};
-
-    let changed = combined_cis_residue_changes(transcript, bundle, members)?;
+    let diff = combined_cis_residue_changes(transcript, bundle, members)?;
     let accession = parse_accession(protein_accession);
     let gene_symbol = transcript.gene_symbol.clone();
 
-    // Nothing changed: the combined product is silent → `p.(Xxx{N}=)` at the
-    // 5'-most residue any member touches (substitution.md: `p.Cys123=`).
-    if changed.is_empty() {
-        let lo_min = members.iter().map(|(lo, _, _)| *lo).min()?;
-        let pos = ((lo_min - 1) / 3 + 1) as u64;
-        let ref_aa = *bundle.ref_protein.get((pos - 1) as usize)?;
-        return Some(HgvsVariant::Protein(ProteinVariant {
-            accession,
-            gene_symbol,
-            loc_edit: LocEdit::new_predicted(
-                ProtInterval::point(ProtPos::new(ref_aa, pos)),
-                ProteinEdit::Identity {
-                    predicted: false,
-                    whole_protein: false,
-                },
-            ),
-        }));
+    // Nothing changed: the combined product is silent, so describe the codons the
+    // members rewrote — grouped into runs, never the 5'-most member's residue
+    // alone, and never `p.(=)` while a codon can be named (#1099).
+    if diff.changed.is_empty() {
+        let residues = codon_residues(&diff.rewritten_codons, &bundle.ref_protein_with_stop)?;
+        let initiator = bundle.ref_protein_with_stop.first().copied();
+        return Some(render_silent_identity(
+            residues,
+            initiator,
+            &accession,
+            &gene_symbol,
+        ));
     }
 
-    let spans: Vec<SubSpan> = changed
+    let spans: Vec<SubSpan> = diff
+        .changed
         .into_iter()
         .map(|(pos, ref_aa, alt_aa)| SubSpan {
             pos,
@@ -12755,6 +12748,40 @@ mod tests {
         assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2=)"));
     }
 
+    /// #1099 (unit): consecutive silent codons on the CODON-LEVEL path render as
+    /// one range identity. CDS `ATGCGACGCTAA`; `c.6A>G` (`CGA`→`CGG`, Arg) and
+    /// `c.9C>T` (`CGC`→`CGT`, Arg) rewrite codons 2 and 3, both silent.
+    #[test]
+    fn combine_by_codon_consecutive_silent_codons_form_a_range() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str("ATGCGACGCTAA", &[(6, Base::G), (9, Base::T)]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2_Arg3=)"));
+    }
+
+    /// #1099 (unit): silent codons separated by an untouched codon stay
+    /// individual and are bracketed, on the codon-level path as on the
+    /// residue-level one. CDS `ATGCGATGGCGCTAA` (Met-Arg-Trp-Arg-Ter): `c.6A>G`
+    /// rewrites codon 2 and `c.12C>T` rewrites codon 4; codon 3 (`TGG`, Trp) is
+    /// untouched.
+    #[test]
+    fn combine_by_codon_separated_silent_codons_are_bracketed() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str("ATGCGATGGCGCTAA", &[(6, Base::G), (12, Base::T)]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.[(Arg2=);(Arg4=)]"));
+    }
+
+    /// #1099 (unit): a member whose alternative base equals the reference
+    /// rewrites no triplet, so it contributes no codon. This is the codon-level
+    /// twin of `combine_by_residue_ignores_a_member_that_rewrites_nothing`, and
+    /// the direct test of the `alt_codon != ref_codon` derivation: keying off
+    /// `by_codon` membership instead would wrongly name codon 3.
+    #[test]
+    fn combine_by_codon_ignores_a_member_that_rewrites_nothing() {
+        use crate::hgvs::edit::Base;
+        let s = combine_by_codon_str("ATGCGACGCTAA", &[(6, Base::G), (9, Base::C)]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2=)"));
+    }
+
     /// #1076 (unit): substitutions in ADJACENT codons combine to one delins, not a
     /// bracketed list (delins.md). codon 2 `GAT`→`TAT` (Asp2Tyr), codon 3
     /// `TAT`→`TGT` (Tyr3Cys); `c.4G>T` + `c.8A>G` → `p.(Asp2_Tyr3delinsTyrCys)`.
@@ -12848,13 +12875,26 @@ mod tests {
         assert_eq!(s.as_deref(), Some("NP_X.1:p.(Trp3Cys)"));
     }
 
-    /// #1079 (unit): an all-silent combination is `p.(Xxx{N}=)` at the 5'-most
-    /// residue any member touches (substitution.md `p.Cys123=`), not a bracketed
-    /// pair of `(=)` members (alleles.md). CDS `ATGCGACGCTAA`: `c.6A>G`
-    /// (`CGA`→`CGG`, Arg) and `c.9C>T` (`CGC`→`CGT`, Arg) are both silent.
+    /// #1099 (unit): an all-silent combination names **every** codon it rewrote,
+    /// grouped into runs — not the 5'-most touched residue alone, which is what
+    /// #1079 originally emitted and what this issue was filed on. CDS
+    /// `ATGCGACGCTAA`: `c.6A>G` (`CGA`→`CGG`, Arg) rewrites codon 2 and `c.9C>T`
+    /// (`CGC`→`CGT`, Arg) rewrites codon 3; both are silent and consecutive, so
+    /// they render as one range identity (`DNA/other.md:29-37`).
     #[test]
-    fn combine_by_residue_all_silent_is_identity_at_first_residue() {
+    fn combine_by_residue_all_silent_names_every_rewritten_codon() {
         let s = combine_by_residue_str("ATGCGACGCTAA", &[(6, 6, "G"), (9, 9, "T")]);
+        assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2_Arg3=)"));
+    }
+
+    /// #1099 (unit): a member whose alternative base equals the reference
+    /// rewrites no triplet, so it contributes no codon — the discriminator
+    /// against deriving the affected set from member spans or `by_codon`
+    /// membership. Same CDS as above; `c.9C>C` leaves codon 3 byte-identical, so
+    /// only codon 2 is named.
+    #[test]
+    fn combine_by_residue_ignores_a_member_that_rewrites_nothing() {
+        let s = combine_by_residue_str("ATGCGACGCTAA", &[(6, 6, "G"), (9, 9, "C")]);
         assert_eq!(s.as_deref(), Some("NP_X.1:p.(Arg2=)"));
     }
 

--- a/src/project/protein/identity.rs
+++ b/src/project/protein/identity.rs
@@ -1,0 +1,367 @@
+//! Describing an all-silent change by the codons it rewrote (#1099).
+//!
+//! When a change leaves the protein identical to the reference, the description
+//! must still say *what was interrogated*: `=` means a sequence "was tested but
+//! found unchanged" (`general.md:91`), and a description "should include the
+//! position(s) screened" (`SVD-WG001:17`). The spec's preferred form for a
+//! predicted silent change is residue-scoped — `p.(Leu54=)`, not `p.Leu54Leu`
+//! (`checklist.md:64`), and `SVD-WG001:54-55` localises `p.(Phe41=)` from the
+//! DNA variant `c.123C>T`.
+//!
+//! # The rule
+//!
+//! Describe **the codons whose reference triplet was rewritten**, grouped the way
+//! changed residues already are (`DNA/other.md:29-37`, which states this exact
+//! three-tier structure one axis over):
+//!
+//! | rewritten codons | output |
+//! |---|---|
+//! | zero | `p.(=)` |
+//! | one | `p.(Phe41=)` |
+//! | one consecutive run | `p.(Phe41_Ser42=)` |
+//! | separated runs | `p.[(Phe41=);(Gly47=)]` |
+//!
+//! The whole-molecule `p.(=)` is legal (`uncertain.md:212-213`) but least
+//! informative, so it is kept for the case where it is also *accurate*: nothing
+//! in the CDS was rewritten at all. One site emits it for a second reason — the
+//! indel identity path has no fallback (declining there makes the projection
+//! emit no `p.` at all), so it also renders `p.(=)` when the affected set cannot
+//! be derived. Every other site declines instead.
+//!
+//! # Why triplets and never member spans
+//!
+//! The affected set is derived by comparing the mutated CDS against the reference
+//! CDS triplet-by-triplet. Member spans are **not** usable, for two reasons:
+//!
+//! * **3'-shift.** `g.[4_6del;15_16insGCA]` normalizes to `c.[6_8del;16_18dup]`;
+//!   the deletion of codon 2 becomes a span straddling codons 2 *and* 3, which
+//!   would invent an `Ala3=`. Triplet comparison is shift-invariant — the two
+//!   spellings splice byte-identical mutated CDSs.
+//! * **Insertions have no codon.** A cis member's insertion span is collapsed to
+//!   its anchor, so the inserted codon lands *between* residues.
+//!
+//! # Accepted limitation
+//!
+//! A codon interior to a rewritten span whose triplet is coincidentally unchanged
+//! is not named: codons 41–43 with 42 unchanged give `p.[(Phe41=);(Cys43=)]`,
+//! which is true but less complete than `p.(Phe41_Cys43=)`. Closing it needs
+//! span-derived reasoning, which is exactly what the two bullets above forbid.
+
+use crate::hgvs::edit::ProteinEdit;
+use crate::hgvs::interval::ProtInterval;
+use crate::hgvs::location::{AminoAcid, ProtPos};
+use crate::hgvs::variant::{
+    Accession, AllelePhase, AlleleVariant, HgvsVariant, LocEdit, ProteinVariant,
+};
+
+/// The 1-based codon positions whose reference triplet `mut_cds` rewrote.
+///
+/// Returns them ascending and distinct. Returns empty when nothing was rewritten
+/// (the caller then describes whole-molecule identity) and, defensively, when the
+/// two CDSs differ in length: this is the *silent* path, where a length change
+/// cannot leave the protein identical, and a per-triplet comparison across a
+/// length change would compare shifted frames.
+///
+/// A trailing partial codon (a CDS whose length is not a multiple of three) is
+/// ignored — it translates to nothing, so it has no residue to name.
+pub(crate) fn rewritten_codons(ref_cds: &str, mut_cds: &str) -> Vec<u64> {
+    if ref_cds.len() != mut_cds.len() {
+        return Vec::new();
+    }
+    ref_cds
+        .as_bytes()
+        .chunks_exact(3)
+        .zip(mut_cds.as_bytes().chunks_exact(3))
+        .enumerate()
+        .filter(|(_, (ref_codon, mut_codon))| ref_codon != mut_codon)
+        .map(|(i, _)| (i + 1) as u64)
+        .collect()
+}
+
+/// Pair each rewritten codon with its reference amino acid.
+///
+/// `ref_residues` is indexed by codon position (1-based), so pass the translation
+/// that **includes the terminator** where one is available: a silent change in the
+/// stop codon rewrites a real triplet and is named `p.(Ter66=)`, and a translation
+/// without the stop has no residue for it.
+///
+/// Returns `None` if any position has no reference residue — a codon past the end
+/// of the translated protein, which happens when the annotated CDS runs past its
+/// first stop. The caller decides what an underivable set means: sites that can
+/// fall back decline, and the whole-molecule identity site keeps `p.(=)`.
+pub(crate) fn codon_residues(
+    codons: &[u64],
+    ref_residues: &[AminoAcid],
+) -> Option<Vec<(u64, AminoAcid)>> {
+    codons
+        .iter()
+        .map(|&pos| {
+            let aa = *ref_residues.get(usize::try_from(pos).ok()?.checked_sub(1)?)?;
+            Some((pos, aa))
+        })
+        .collect()
+}
+
+/// Group items carrying ascending, distinct 1-based positions into runs of
+/// consecutive positions. Items separated by an unused position land in
+/// different runs.
+pub(crate) fn group_consecutive_by<T>(items: Vec<T>, position: impl Fn(&T) -> u64) -> Vec<Vec<T>> {
+    let mut groups: Vec<Vec<T>> = Vec::new();
+    for item in items {
+        match groups.last_mut() {
+            Some(g) if position(&item) == position(g.last().expect("non-empty group")) + 1 => {
+                g.push(item)
+            }
+            _ => groups.push(vec![item]),
+        }
+    }
+    groups
+}
+
+/// Render the rewritten codons of an all-silent change as a protein consequence.
+///
+/// `residues` are the `(1-based position, reference amino acid)` pairs of the
+/// rewritten codons, ascending and distinct — see [`rewritten_codons`] for how
+/// the set must be derived. Empty renders the whole-molecule `p.(=)`; one run
+/// renders a single residue or a range identity; separated runs are bracketed
+/// into a cis allele, mirroring how `render_cis_substitution_groups` renders
+/// separated *changed* residues.
+///
+/// `initiator` is the reference's residue 1, used only to anchor the
+/// whole-molecule form. `Display` drops that position, but the variant is
+/// serialized structurally through the Python API, so it must carry the
+/// reference's own residue rather than a presumed `Met`: `RefProteinBundle`
+/// forces `Met` only on a recognized initiator, leaving a drifted `cds_start`
+/// untouched (#625). Pass `None` where no translated protein is in scope.
+///
+/// This is the one renderer for every site that can produce a silent
+/// consequence, so the codon-level and residue-level combiners cannot drift.
+pub(crate) fn render_silent_identity(
+    residues: Vec<(u64, AminoAcid)>,
+    initiator: Option<AminoAcid>,
+    accession: &Accession,
+    gene_symbol: &Option<String>,
+) -> HgvsVariant {
+    if residues.is_empty() {
+        return HgvsVariant::Protein(ProteinVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit: LocEdit::new_predicted(
+                ProtInterval::point(ProtPos::new(initiator.unwrap_or(AminoAcid::Met), 1)),
+                ProteinEdit::Identity {
+                    predicted: false,
+                    whole_protein: true,
+                },
+            ),
+        });
+    }
+
+    let render_group = |g: &[(u64, AminoAcid)]| -> ProteinVariant {
+        let (first_pos, first_aa) = g[0];
+        let (last_pos, last_aa) = g[g.len() - 1];
+        let location = if g.len() == 1 {
+            ProtInterval::point(ProtPos::new(first_aa, first_pos))
+        } else {
+            ProtInterval::new(
+                ProtPos::new(first_aa, first_pos),
+                ProtPos::new(last_aa, last_pos),
+            )
+        };
+        ProteinVariant {
+            accession: accession.clone(),
+            gene_symbol: gene_symbol.clone(),
+            loc_edit: LocEdit::new_predicted(
+                location,
+                ProteinEdit::Identity {
+                    predicted: false,
+                    whole_protein: false,
+                },
+            ),
+        }
+    };
+
+    let groups = group_consecutive_by(residues, |(pos, _)| *pos);
+    if groups.len() == 1 {
+        HgvsVariant::Protein(render_group(&groups[0]))
+    } else {
+        let variants: Vec<HgvsVariant> = groups
+            .iter()
+            .map(|g| HgvsVariant::Protein(render_group(g)))
+            .collect();
+        HgvsVariant::Allele(AlleleVariant::new(variants, AllelePhase::Cis))
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::project::accession::parse_accession;
+
+    fn render(codons: &[u64], residues: &[AminoAcid]) -> String {
+        let pairs = codon_residues(codons, residues).expect("residues cover every codon");
+        render_silent_identity(pairs, None, &parse_accession("NP_000001.1"), &None).to_string()
+    }
+
+    /// Met-Leu-Arg-Leu-Ala-Ter, the shape the integration fixtures use.
+    fn protein() -> Vec<AminoAcid> {
+        vec![
+            AminoAcid::Met,
+            AminoAcid::Leu,
+            AminoAcid::Arg,
+            AminoAcid::Leu,
+            AminoAcid::Ala,
+            AminoAcid::Ter,
+        ]
+    }
+
+    #[test]
+    fn a_rewritten_triplet_is_reported_by_codon_position() {
+        // Codon 2 CTG -> CTA and codon 4 CTC -> CTT; codon 3 untouched.
+        assert_eq!(
+            rewritten_codons("ATGCTGCGTCTCGCCTAA", "ATGCTACGTCTTGCCTAA"),
+            vec![2, 4]
+        );
+    }
+
+    #[test]
+    fn an_unchanged_cds_rewrites_nothing() {
+        assert!(rewritten_codons("ATGCTGCGTTAA", "ATGCTGCGTTAA").is_empty());
+    }
+
+    /// A span that straddles a codon boundary names only the codons it actually
+    /// rewrote — the discriminator against deriving the set from member spans.
+    ///
+    /// Both spellings below splice the same mutated CDS, one within codon 2 and
+    /// one straddling codons 2 and 3. A span-derived implementation would name
+    /// `{2, 3}` for the straddling spelling and `{2}` for the other; the triplet
+    /// rule names `{2}` for both, because codon 3 is `GCC` either way.
+    #[test]
+    fn a_straddling_span_names_only_the_codons_it_rewrote() {
+        let reference = "ATGGCAGCCTAA"; // Met-Ala-Ala-Ter
+        let within_codon_two = format!("{}GCC{}", &reference[..3], &reference[6..]); // c.4_6delinsGCC
+        let straddling = format!("{}CG{}", &reference[..5], &reference[7..]); // c.6_7delinsCG
+        assert_eq!(within_codon_two, straddling, "same mutated CDS either way");
+        assert_eq!(rewritten_codons(reference, &within_codon_two), vec![2]);
+        assert_eq!(rewritten_codons(reference, &straddling), vec![2]);
+    }
+
+    #[test]
+    fn a_length_change_derives_no_codons() {
+        assert!(rewritten_codons("ATGCTGCGTTAA", "ATGCTGTAA").is_empty());
+    }
+
+    #[test]
+    fn a_trailing_partial_codon_is_ignored() {
+        // Both CDSs carry a dangling 2-base tail that translates to nothing.
+        assert_eq!(rewritten_codons("ATGCTGCG", "ATGCTACG"), vec![2]);
+    }
+
+    #[test]
+    fn no_rewritten_codons_render_whole_molecule_identity() {
+        assert_eq!(render(&[], &protein()), "NP_000001.1:p.(=)");
+    }
+
+    #[test]
+    fn one_rewritten_codon_renders_a_single_residue() {
+        assert_eq!(render(&[2], &protein()), "NP_000001.1:p.(Leu2=)");
+    }
+
+    #[test]
+    fn a_consecutive_run_renders_as_a_range() {
+        assert_eq!(render(&[2, 3], &protein()), "NP_000001.1:p.(Leu2_Arg3=)");
+        assert_eq!(render(&[2, 3, 4], &protein()), "NP_000001.1:p.(Leu2_Leu4=)");
+    }
+
+    #[test]
+    fn separated_runs_render_as_a_cis_bracket() {
+        assert_eq!(
+            render(&[2, 5], &protein()),
+            "NP_000001.1:p.[(Leu2=);(Ala5=)]"
+        );
+        assert_eq!(
+            render(&[2, 3, 5], &protein()),
+            "NP_000001.1:p.[(Leu2_Arg3=);(Ala5=)]"
+        );
+    }
+
+    #[test]
+    fn a_silent_change_in_the_stop_codon_names_the_terminator() {
+        assert_eq!(render(&[6], &protein()), "NP_000001.1:p.(Ter6=)");
+    }
+
+    #[test]
+    fn a_codon_past_the_translated_protein_has_no_residue() {
+        assert!(codon_residues(&[2, 9], &protein()).is_none());
+    }
+
+    /// The gene symbol is carried onto every rendered variant. Whether it is
+    /// *emitted* is the renderer's caller's business: a single protein variant
+    /// suppresses it (#310 — the p. grammar has no selector production) while an
+    /// allele emits it, exactly as the changed-residue sibling renderer behaves.
+    /// The whole-molecule form anchors on the REFERENCE's residue 1, not a
+    /// presumed `Met`. `Display` drops the position, but the variant is
+    /// serialized structurally through the Python API, and a transcript whose
+    /// `cds_start` drifted off a recognized initiator keeps its own residue 1
+    /// (#625) — so a fabricated `Met` would be a silent output divergence.
+    #[test]
+    fn whole_molecule_identity_anchors_on_the_reference_initiator() {
+        let anchored = render_silent_identity(
+            Vec::new(),
+            Some(AminoAcid::Ser),
+            &parse_accession("NP_000001.1"),
+            &None,
+        );
+        assert_eq!(anchored.to_string(), "NP_000001.1:p.(=)");
+        let HgvsVariant::Protein(pv) = &anchored else {
+            panic!("expected a protein variant");
+        };
+        let start = pv
+            .loc_edit
+            .location
+            .start
+            .inner()
+            .expect("certain position");
+        assert_eq!(start.aa, AminoAcid::Ser, "anchored on a presumed Met");
+
+        // With no protein in scope the presumed initiator is the fallback.
+        let unanchored =
+            render_silent_identity(Vec::new(), None, &parse_accession("NP_000001.1"), &None);
+        let HgvsVariant::Protein(pv) = &unanchored else {
+            panic!("expected a protein variant");
+        };
+        assert_eq!(
+            pv.loc_edit
+                .location
+                .start
+                .inner()
+                .expect("certain position")
+                .aa,
+            AminoAcid::Met
+        );
+    }
+
+    #[test]
+    fn the_gene_symbol_is_carried_onto_every_rendered_variant() {
+        let single = render_silent_identity(
+            codon_residues(&[2, 3], &protein()).expect("covered"),
+            None,
+            &parse_accession("NP_000001.1"),
+            &Some("GENE1".to_string()),
+        );
+        assert_eq!(single.gene_symbol(), Some("GENE1"));
+        assert_eq!(single.to_string(), "NP_000001.1:p.(Leu2_Arg3=)");
+
+        let bracketed = render_silent_identity(
+            codon_residues(&[2, 5], &protein()).expect("covered"),
+            None,
+            &parse_accession("NP_000001.1"),
+            &Some("GENE1".to_string()),
+        );
+        assert_eq!(
+            bracketed.to_string(),
+            "NP_000001.1(GENE1):p.[(Leu2=);(Ala5=)]"
+        );
+    }
+}

--- a/src/project/protein/indel.rs
+++ b/src/project/protein/indel.rs
@@ -17,6 +17,7 @@ use super::helpers::{
     mut_cds_with_3utr, net_length_change, translate_full_cds, translate_full_cds_with_stop,
     translate_mutated_cds, translate_mutated_cds_inframe, RefProteinBundle,
 };
+use super::identity::{codon_residues, render_silent_identity, rewritten_codons};
 
 // ── Main entry point ──────────────────────────────────────────────────────────
 
@@ -165,6 +166,11 @@ pub(crate) fn predict_indel_protein(
             net,
             ref_protein,
             &alt_protein,
+            IdentityContext {
+                ref_cds,
+                mut_cds: &mut_cds,
+                ref_residues: ref_protein_with_stop,
+            },
             protein_accession,
         )
     }
@@ -182,11 +188,13 @@ fn build_inframe_variant(
     net: i64, // net nucleotide change (negative = deletion, positive = insertion)
     ref_protein: &[AminoAcid],
     alt_protein: &[AminoAcid],
+    identity: IdentityContext<'_>,
     protein_accession: &str,
 ) -> Result<HgvsVariant, FerroError> {
-    // Check identity first: if the proteins are identical, emit p.(=).
+    // Check identity first: if the proteins are identical, describe the codons
+    // the edit rewrote (#1099).
     if ref_protein == alt_protein {
-        return build_identity_variant(ref_protein, protein_accession, transcript);
+        return build_identity_variant(identity, protein_accession, transcript);
     }
 
     // Did the edit introduce a premature termination codon? An in-frame edit
@@ -216,6 +224,7 @@ fn build_inframe_variant(
                 ref_protein,
                 alt_protein,
                 cds_start,
+                identity,
                 protein_accession,
                 transcript,
             )
@@ -230,7 +239,13 @@ fn build_inframe_variant(
             // Net < 0 always for deletion.
             if frame_at_start == 0 && net % 3 == 0 {
                 // Codon-aligned deletion: whole codons removed.
-                build_inframe_deletion(ref_protein, alt_protein, protein_accession, transcript)
+                build_inframe_deletion(
+                    ref_protein,
+                    alt_protein,
+                    identity,
+                    protein_accession,
+                    transcript,
+                )
             } else {
                 // Straddles a codon boundary: effectively a delins at the AA level.
                 delins(cds_pos_start)
@@ -293,33 +308,67 @@ fn build_inframe_variant(
     }
 }
 
-/// Identity: proteins are identical after the edit (e.g. synonymous codon change).
+/// Identity: the protein is unchanged after the edit (e.g. a synonymous codon
+/// change, or a delins that rewrites codons without changing what they encode).
+///
+/// Described by the codons the edit rewrote rather than the whole-molecule
+/// `p.(=)`, which claims nothing about *what was interrogated* (#1099; see
+/// [`super::identity`] for the rule and its citations).
+///
+/// The affected codons are derived from `identity`'s CDS pair — **not** from the
+/// edit's span, which would name codons a 3'-shifted spelling only appears to
+/// touch. This site has no fallback: declining here makes `predict_indel_protein`
+/// return `Err`, which the caller swallows to `None`, so the projection would
+/// emit no `p.` at all. When the set cannot be derived — zero rewritten codons,
+/// or a codon with no reference residue — it therefore keeps the
+/// accurate-but-unspecific `p.(=)` rather than declining.
 fn build_identity_variant(
-    ref_protein: &[AminoAcid],
+    identity: IdentityContext<'_>,
     protein_accession: &str,
     transcript: &Transcript,
 ) -> Result<HgvsVariant, FerroError> {
-    // Use the whole-protein identity representation.
     let accession = parse_accession(protein_accession);
-    // Point at Met1 for simplicity.
-    let ref_aa = ref_protein.first().copied().unwrap_or(AminoAcid::Met);
-    let loc = ProtInterval::point(ProtPos::new(ref_aa, 1));
-    let edit = crate::hgvs::edit::ProteinEdit::Identity {
-        predicted: false,
-        whole_protein: true,
-    };
-    let variant = ProteinVariant {
-        accession,
-        gene_symbol: transcript.gene_symbol.clone(),
-        loc_edit: LocEdit::new_predicted(loc, edit),
-    };
-    Ok(HgvsVariant::Protein(variant))
+    let gene_symbol = transcript.gene_symbol.clone();
+    let codons = rewritten_codons(identity.ref_cds, identity.mut_cds);
+    // `None` (a codon past the translated protein) and an empty set both render
+    // the whole-molecule identity — the one output that is always safe here. A
+    // partially derivable set is discarded whole rather than named in part:
+    // naming a subset would assert that the unnamed codons were NOT rewritten,
+    // which is exactly the over-claim `p.(=)` at least makes honestly.
+    let residues = codon_residues(&codons, identity.ref_residues).unwrap_or_default();
+    let initiator = identity.ref_residues.first().copied();
+    Ok(render_silent_identity(
+        residues,
+        initiator,
+        &accession,
+        &gene_symbol,
+    ))
+}
+
+/// What an identity consequence is derived from: the reference and mutated CDS,
+/// whose triplet-wise difference is the set of codons the edit rewrote, plus the
+/// reference residues those codons are named with (#1099).
+///
+/// Passed as a unit because the three are only meaningful together, and threaded
+/// through [`build_inframe_variant`] because the identity branch lives there
+/// while the data is only in scope at its callers.
+#[derive(Clone, Copy)]
+pub(crate) struct IdentityContext<'a> {
+    /// The transcript's reference CDS.
+    pub ref_cds: &'a str,
+    /// The same CDS with the edit (or every cis member) applied.
+    pub mut_cds: &'a str,
+    /// The reference translation **including the terminator**, indexed by codon
+    /// position, so a silent change in the stop codon is named `p.(Ter66=)`
+    /// rather than dropped.
+    pub ref_residues: &'a [AminoAcid],
 }
 
 /// Codon-aligned in-frame deletion: `p.(Xxx{N}del)` or `p.(Xxx{N}_Yyy{M}del)`.
 fn build_inframe_deletion(
     ref_protein: &[AminoAcid],
     alt_protein: &[AminoAcid],
+    identity: IdentityContext<'_>,
     protein_accession: &str,
     transcript: &Transcript,
 ) -> Result<HgvsVariant, FerroError> {
@@ -334,7 +383,7 @@ fn build_inframe_deletion(
         // "deletion" didn't shorten the protein (e.g. a stop-disrupting deletion whose
         // extension detection missed an edge case). Avoid the underflow in the
         // last_deleted computation by short-circuiting to an identity variant.
-        return build_identity_variant(ref_protein, protein_accession, transcript);
+        return build_identity_variant(identity, protein_accession, transcript);
     }
 
     let last_deleted = first_diff + n_deleted - 1;
@@ -611,6 +660,7 @@ fn build_inframe_delins(
     ref_protein: &[AminoAcid],
     alt_protein: &[AminoAcid],
     cds_pos_start: i64,
+    identity: IdentityContext<'_>,
     protein_accession: &str,
     transcript: &Transcript,
 ) -> Result<HgvsVariant, FerroError> {
@@ -629,7 +679,7 @@ fn build_inframe_delins(
     // If the alt protein is empty or only differs at the last AA:
     if first_diff >= ref_len && first_diff >= alt_len {
         // No difference at the amino acid level.
-        return build_identity_variant(ref_protein, protein_accession, transcript);
+        return build_identity_variant(identity, protein_accession, transcript);
     }
 
     // Pure-deletion guard (#847): when the last differing ref index falls
@@ -763,7 +813,13 @@ fn build_inframe_delins(
     // codon-aligned-deletion builder, which recomputes the deleted range from
     // `first_diff` and `ref_len - alt_len` (point when one residue, else range).
     if inserted.is_empty() && alt_len < ref_len {
-        return build_inframe_deletion(ref_protein, alt_protein, protein_accession, transcript);
+        return build_inframe_deletion(
+            ref_protein,
+            alt_protein,
+            identity,
+            protein_accession,
+            transcript,
+        );
     }
 
     // One amino acid replaced by one (non-stop) amino acid is, by definition, a
@@ -1476,6 +1532,11 @@ pub(crate) fn try_project_cis_combined_inframe(
         net,
         &ref_bundle.ref_protein,
         &alt_protein,
+        IdentityContext {
+            ref_cds: &ref_bundle.ref_cds,
+            mut_cds: &mut_cds,
+            ref_residues: &ref_bundle.ref_protein_with_stop,
+        },
         protein_accession,
     )?;
     Ok(CisCombined::InFrame(Box::new(pv)))
@@ -1500,10 +1561,12 @@ pub(crate) fn try_project_cis_combined_inframe(
 /// `members` are the pre-classified `SimpleExonic` members as `(lo, hi, edit)`
 /// with insertion spans already collapsed to `hi == lo`, in any order.
 ///
-/// Returns the changed residues as `(1-based position, reference AA,
-/// alternative AA)` in ascending order — empty when the combined product is
-/// silent. Returns `None` (caller keeps its existing behavior) when the combined
-/// product cannot be compared residue-for-residue against the reference:
+/// Returns a [`CisResidueDiff`]: the changed residues in ascending order — empty
+/// when the combined product is silent — alongside the codons whose reference
+/// triplet the members rewrote, which is what an all-silent combination is
+/// described by (#1099). Returns `None` (caller keeps its existing behavior)
+/// when the combined product cannot be compared residue-for-residue against the
+/// reference:
 ///
 /// - fewer than two members, an out-of-bounds or overlapping span (overlapping
 ///   members are contradictory in cis), or an unreadable CDS;
@@ -1516,7 +1579,7 @@ pub(crate) fn combined_cis_residue_changes(
     transcript: &Transcript,
     ref_bundle: &RefProteinBundle,
     members: &[(i64, i64, &NaEdit)],
-) -> Option<Vec<(u64, AminoAcid, AminoAcid)>> {
+) -> Option<CisResidueDiff> {
     if members.len() < 2 {
         return None;
     }
@@ -1560,8 +1623,8 @@ pub(crate) fn combined_cis_residue_changes(
         return None; // premature stop or stop-loss: needs its own spec form
     }
 
-    Some(
-        ref_bundle
+    Some(CisResidueDiff {
+        changed: ref_bundle
             .ref_protein
             .iter()
             .zip(alt_protein.iter())
@@ -1569,7 +1632,25 @@ pub(crate) fn combined_cis_residue_changes(
             .filter(|(_, (ref_aa, alt_aa))| ref_aa != alt_aa)
             .map(|(i, (ref_aa, alt_aa))| ((i + 1) as u64, *ref_aa, *alt_aa))
             .collect(),
-    )
+        rewritten_codons: rewritten_codons(&ref_bundle.ref_cds, &mut_cds),
+    })
+}
+
+/// The residue-level effect of applying a cis compound's members together.
+///
+/// Carries both halves of the comparison because they answer different
+/// questions: `changed` drives the description of what the change *did*, while
+/// `rewritten_codons` records what it *interrogated* — the set an all-silent
+/// combination is described by, and the same set the protein-consequence
+/// predicate will expose (#1099).
+pub(crate) struct CisResidueDiff {
+    /// Residues whose amino acid changed, as `(1-based position, reference AA,
+    /// alternative AA)` in ascending order. Empty when the combination is silent.
+    pub changed: Vec<(u64, AminoAcid, AminoAcid)>,
+    /// The 1-based codon positions whose reference triplet was rewritten,
+    /// ascending. Derived by triplet comparison, never from member spans — see
+    /// [`super::identity::rewritten_codons`].
+    pub rewritten_codons: Vec<u64>,
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -1579,6 +1660,18 @@ mod tests {
     use super::*;
     use crate::reference::transcript::{Exon, ManeStatus, Strand};
     use std::sync::OnceLock;
+
+    /// An identity context for a CDS the edit did not rewrite, for the builders
+    /// whose *position* logic is under test: their defensive identity
+    /// short-circuits then describe whole-molecule identity, as they did before
+    /// the affected-codon derivation existed (#1099).
+    fn unchanged_cds() -> IdentityContext<'static> {
+        IdentityContext {
+            ref_cds: "",
+            mut_cds: "",
+            ref_residues: &[],
+        }
+    }
 
     fn tx(seq: &str, cds_start: u64, cds_end: u64) -> Transcript {
         Transcript {
@@ -1623,7 +1716,15 @@ mod tests {
         let t = tx("ATGGCTGGTTAA", 1, 12); // sequence unused by the position logic
         let ref_protein = [Met, Ala, Gly];
         let alt_protein = [Met, Ala, Ile, Gly]; // Ile inserted between Ala(2) and Gly(3)
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 5, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            5,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Ala2_Gly3insIle)");
     }
 
@@ -1635,7 +1736,15 @@ mod tests {
         let t = tx("ATGCGCGGTTAA", 1, 12);
         let ref_protein = [Met, Arg, Gly];
         let alt_protein = [Met, Val, Gly]; // Arg2 → Val (1 AA → 1 AA)
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 4, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            4,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Arg2Val)");
     }
 
@@ -1649,7 +1758,15 @@ mod tests {
         let t = tx("ATGTGCCGCTAA", 1, 12);
         let ref_protein = [Met, Cys, Arg];
         let alt_protein = [Met, Cys, Cys, Arg]; // extra Cys inserted after Cys2
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 6, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            6,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Cys2dup)");
     }
 
@@ -1662,7 +1779,15 @@ mod tests {
         let t = tx("ATGGCAGCAGGTTAA", 1, 15);
         let ref_protein = [Met, Ala, Ala, Gly]; // Ala at positions 2 and 3
         let alt_protein = [Met, Ala, Ala, Ala, Gly]; // one extra Ala in the run
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 5, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            5,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Ala3dup)");
     }
 
@@ -1673,7 +1798,15 @@ mod tests {
         let t = tx("ATGGGCTCCCACTAA", 1, 15);
         let ref_protein = [Met, Gly, Ser, His];
         let alt_protein = [Met, Gly, Ser, Gly, Ser, His]; // GlySer copied in tandem
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 8, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            8,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Gly2_Ser3dup)");
     }
 
@@ -1685,7 +1818,15 @@ mod tests {
         let t = tx("ATGGCTGGTTAA", 1, 12);
         let ref_protein = [Met, Ala, Gly];
         let alt_protein = [Met, Ala, Ile, Gly]; // Ile ≠ Ala(2) → genuine insertion
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 5, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            5,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Ala2_Gly3insIle)");
     }
 
@@ -1717,7 +1858,15 @@ mod tests {
         let t = tx("ATGGCTCTTCTTGGTTAA", 1, 18); // sequence unused by the position logic
         let ref_protein = [Met, Ala, Leu, Leu, Gly];
         let alt_protein = [Met, Ala, Leu, Gly]; // one Leu removed from the Leu-Leu run
-        let v = build_inframe_delins(&ref_protein, &alt_protein, 8, "NP_TEST.1", &t).unwrap();
+        let v = build_inframe_delins(
+            &ref_protein,
+            &alt_protein,
+            8,
+            unchanged_cds(),
+            "NP_TEST.1",
+            &t,
+        )
+        .unwrap();
         assert_eq!(prot_str(&v), "NP_TEST.1:p.(Leu4del)");
     }
 
@@ -2108,6 +2257,33 @@ mod tests {
         assert_eq!(prot_str(&result), "NP_TEST.1:p.(Arg2Ala)");
     }
 
+    /// #1099: a real synonymous `delins` routed through `predict_indel_protein`
+    /// names the codons it rewrote instead of claiming whole-molecule identity.
+    ///
+    /// This exercises the derivation itself — a mutated CDS spliced by the edit
+    /// and diffed against the reference triplet-by-triplet — rather than the
+    /// zero-diff defensive fallback below, which hands the builders a synthetic
+    /// empty CDS pair. CDS `ATGCTGCGTTAA` (Met-Leu-Arg-Ter); `c.6delinsA`
+    /// rewrites codon 2 `CTG`→`CTA` (still Leu) and leaves codon 3 `CGT`
+    /// untouched, so exactly one codon is named.
+    #[test]
+    fn synonymous_delins_names_its_codon_not_whole_protein_identity() {
+        let t = tx("ATGCTGCGTTAA", 1, 12);
+        let edit = NaEdit::Delins {
+            sequence: InsertedSequence::Literal(Sequence::new(vec![crate::hgvs::edit::Base::A])),
+            deleted: None,
+            deleted_length: None,
+            substitution_reference: None,
+        };
+        let result = predict_indel(&t, 6, 6, &edit, "NP_TEST.1").expect("predicted");
+        let s = prot_str(&result);
+        assert_eq!(s, "NP_TEST.1:p.(Leu2=)");
+        assert!(
+            !s.contains("p.(=)"),
+            "a targeted synonymous edit must not claim whole-molecule identity: {s}"
+        );
+    }
+
     // ─── Regression tests for CodeRabbit-flagged edge cases ───────────────────
 
     #[test]
@@ -2121,7 +2297,8 @@ mod tests {
         let ref_protein = [AminoAcid::Met, AminoAcid::Arg];
         let alt_protein = [AminoAcid::Met, AminoAcid::Arg];
         let result =
-            build_inframe_deletion(&ref_protein, &alt_protein, "NP_TEST.1", &t).expect("no panic");
+            build_inframe_deletion(&ref_protein, &alt_protein, unchanged_cds(), "NP_TEST.1", &t)
+                .expect("no panic");
         let s = prot_str(&result);
         // Identity variant -- whole-protein "=" representation.
         assert!(s.contains("(="), "expected identity '(=' in '{}'", s);

--- a/src/project/protein/mod.rs
+++ b/src/project/protein/mod.rs
@@ -8,9 +8,11 @@
 //!
 //! * [`substitution`] — substitution (missense / synonymous / nonsense) prediction.
 //! * [`indel`]         — deletion / insertion / duplication / delins / inversion prediction.
+//! * [`identity`]      — describing an all-silent change by the codons it rewrote.
 //! * [`helpers`]       — shared pure helpers (CDS building, translation, diff-finding).
 
 mod helpers;
+mod identity;
 mod indel;
 mod substitution;
 
@@ -20,6 +22,10 @@ pub(crate) use helpers::{
     cds_has_valid_start, edit_reaches_initiation_codon, edit_spans_cds_into_3utr,
     read_cds_start_codon, whole_exon_deletion_span, RefProteinBundle,
 };
+// The one place an all-silent change is turned into a description (#1099), so
+// the codon-level and residue-level cis combiners in `projector.rs` and the
+// indel path cannot drift apart in how they name the codons they rewrote.
+pub(crate) use identity::{codon_residues, group_consecutive_by, render_silent_identity};
 pub(crate) use indel::{
     combined_cis_residue_changes, predict_indel_protein, predict_stop_region_extension,
     try_project_cis_combined_inframe, CisCombined,

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -1811,7 +1811,7 @@
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS §Synonymous (residue-level p.(Xaa=))",
-        "note": "For a single synonymous substitution the spec's predicted-consequence form is the residue-level p.(Asp92=) (substitution.md L24/L41-43 p.(Lys874=); SVD-WG001 p.(Phe41=)); p.(=) is reserved for 'the entire coding region was analysed'. ferro's residue-level p.(Asp92=) is spec-preferred vs mutalyzer's whole-protein p.(=). (Bare NP_ framing also differs.)"
+        "note": "For a single synonymous substitution the spec's PREFERRED predicted-consequence form is the residue-level p.(Asp92=) (checklist.md:64 'predicted silent protein level variants are described as p.(Leu54=)'; substitution.md L24/L41-43 p.(Lys874=); SVD-WG001:17 'should include the position(s) screened', :54-55 p.(Phe41=)). Mutalyzer's p.(=) is LEGAL, not a violation: uncertain.md:212-213 licenses the parenthesised whole-molecule form, and the 'entire coding region was analysed' reservation applies to the BARE p.= (substitution.md:43). It is simply less specific, naming no position. ferro's residue-level p.(Asp92=) is spec-preferred. (Bare NP_ framing also differs.)"
       }
     },
     {
@@ -1825,7 +1825,7 @@
       "spec_citation": {
         "axis": "protein_description",
         "section": "HGVS protein reference (bare NP)",
-        "note": "WT1 (NM_024426.4) is a legitimate CUG-initiation transcript; ferro translates downstream variants on it after #780. The synonymous change at codon 369 is described residue-specifically as p.(Arg369=) per HGVS substitution.md (silent change, e.g. p.(Lys874=)); mutalyzer's bare p.(=) (whole-protein-unchanged) is non-standard for a single synonymous codon. The reference is the bare NP_ (HGVS general.md §147/§148); mutalyzer's NM_x(NP_y):p. wrapper is non-standard. ferro's value is spec-correct on both.",
+        "note": "WT1 (NM_024426.4) is a legitimate CUG-initiation transcript; ferro translates downstream variants on it after #780. The synonymous change at codon 369 is described residue-specifically as p.(Arg369=) per HGVS substitution.md (silent change, e.g. p.(Lys874=)); mutalyzer's p.(=) is legal but less specific, naming no position (uncertain.md:212-213 licenses the parenthesised form; only the bare p.= carries the 'entire coding region was analysed' reservation, substitution.md:43). The reference is the bare NP_ (HGVS general.md §147/§148); mutalyzer's NM_x(NP_y):p. wrapper is non-standard. ferro's value is spec-correct on both.",
         "cluster": "bare-np-protein"
       }
     },

--- a/tests/it/issue_1099_all_silent_protein.rs
+++ b/tests/it/issue_1099_all_silent_protein.rs
@@ -1,0 +1,275 @@
+//! Issue #1099: an all-silent change must name the codons it interrogated.
+//!
+//! When a change leaves the protein identical to the reference, ferro collapsed
+//! the consequence to a single arbitrary residue's `=` — dropping every other
+//! silent codon — and a silent `delins` escaped to the whole-molecule `p.(=)`.
+//!
+//! The rule (see the issue's verdict comment): describe the codons whose
+//! reference triplet was rewritten, grouped the way changed residues already
+//! are — one codon → `p.(Xxx=)`, a consecutive run → a range identity, and
+//! separated runs → a cis bracket. `p.(=)` is reserved for the case where
+//! nothing in the CDS was rewritten at all, because only then does it not
+//! over-claim the scope of what was analysed (`general.md:91`,
+//! `SVD-WG001:17`, `checklist.md:64`).
+
+use ferro_hgvs::data::{CdotMapper, CdotTranscript, Projector};
+use ferro_hgvs::project::VariantProjector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::reference::Strand;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+/// Build a single-exon plus-strand coding transcript on contig `REF` whose CDS
+/// is `cds`, placed so that `g.N == c.N`.
+fn projector_for(cds: &str) -> VariantProjector<MockProvider> {
+    let len = cds.len() as u64;
+    let mut cdot = CdotMapper::new();
+    cdot.add_transcript(
+        "tx".to_string(),
+        CdotTranscript {
+            cds_start_incomplete: false,
+            gene_name: Some("GENE1099".to_string()),
+            contig: "REF".to_string(),
+            strand: Strand::Plus,
+            exons: vec![[1, len + 1, 0, len]],
+            cds_start: Some(0),
+            cds_end: Some(len),
+            gene_id: None,
+            protein: Some("txp".to_string()),
+            exon_cigars: Vec::new(),
+        },
+    );
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "tx".to_string(),
+        Some("GENE1099".to_string()),
+        TxStrand::Plus,
+        cds.to_string(),
+        Some(1),
+        Some(len),
+        vec![Exon::new(1, 1, len)],
+        Some("REF".to_string()),
+        Some(1),
+        Some(len),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    provider.add_genomic_sequence("REF", format!("{cds}NN"));
+
+    VariantProjector::new(Projector::new(cdot), provider)
+}
+
+/// The issue's own transcript: Met-Leu-Arg-Trp-Ala-Stop.
+/// Codon 2 `CTG`, codon 3 `CGT`, codon 5 `GCC` all have synonymous third-base
+/// alternatives; codon 4 `TGG` (Trp) has none, which is why the separated-run
+/// case below skips to codon 5.
+const ISSUE_CDS: &str = "ATGCTGCGTTGGGCCTAA";
+
+/// Met-Leu-Arg-Leu-Ala-Stop — four consecutive degenerate codons, so a run of
+/// three silent codons is constructible (the issue's CDS cannot express one,
+/// because `TGG` blocks codon 4).
+const RUN_CDS: &str = "ATGCTGCGTCTCGCCTAA";
+
+fn protein_of(projector: &VariantProjector<MockProvider>, input: &str) -> String {
+    projector
+        .project(input, "tx")
+        .unwrap_or_else(|e| panic!("{input} failed to project: {e}"))
+        .protein
+        .unwrap_or_else(|| panic!("{input} produced no protein consequence"))
+        .to_string()
+}
+
+/// Every all-silent cis allele names each codon it rewrote, grouped into runs.
+/// The first row is the input the issue was filed on.
+#[test]
+fn all_silent_cis_allele_names_every_rewritten_codon() {
+    let vp = projector_for(ISSUE_CDS);
+    for (input, expected) in [
+        // Issue headline: three members, two codons (2 and 3), consecutive.
+        ("REF:g.[4C>T;6G>A;9T>C]", "txp:p.(Leu2_Arg3=)"),
+        // Two members, one per codon — the case the issue called "fine" and
+        // which regressed to a single residue under #1083.
+        ("REF:g.[6G>A;9T>C]", "txp:p.(Leu2_Arg3=)"),
+        ("REF:g.[4C>T;9T>C]", "txp:p.(Leu2_Arg3=)"),
+    ] {
+        assert_eq!(protein_of(&vp, input), expected, "input: {input}");
+    }
+}
+
+/// A run of three consecutive silent codons renders as one range identity —
+/// not the two endpoints, and not a three-member bracket.
+#[test]
+fn three_consecutive_silent_codons_render_as_one_range() {
+    let vp = projector_for(RUN_CDS);
+    assert_eq!(
+        protein_of(&vp, "REF:g.[6G>A;9T>C;12C>A]"),
+        "txp:p.(Leu2_Leu4=)"
+    );
+}
+
+/// Silent codons separated by an untouched codon stay individual, bracketed —
+/// the same rule `delins.md` applies to separated *changed* residues.
+///
+/// The `(GENE1099)` selector is not part of what this fix decides: a protein
+/// *allele* renders its gene symbol while a single protein variant suppresses it
+/// (#310, "no parenthesized selector position" in the p. grammar), so the
+/// bracket here matches what the sibling renderer already emits for separated
+/// changed residues (`txp(GENE1099):p.[(Leu2Gln);(Ala5Asp)]`, measured). The
+/// asymmetry is pre-existing and out of scope; see
+/// `gene_symbol_rendering_matches_the_changed_residue_sibling` below, which
+/// pins both halves so this fix cannot be blamed for either.
+#[test]
+fn separated_silent_codons_render_as_a_bracket() {
+    let vp = projector_for(ISSUE_CDS);
+    assert_eq!(
+        protein_of(&vp, "REF:g.[6G>A;15C>A]"),
+        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+    );
+}
+
+/// The **codon-level** combiner groups separated codons too.
+///
+/// Two members sharing a codon route the allele to
+/// `combine_cis_substitutions_by_codon` rather than
+/// `combine_cis_members_by_residue` — a separate implementation that derives its
+/// codon set one reference codon at a time instead of from a whole mutated CDS.
+/// Every other bracket assertion here goes through the residue-level site, so
+/// without this case a grouping regression in the codon-level path would ship
+/// green. `c.4C>T` and `c.6G>A` share codon 2; `c.15C>A` rewrites codon 5.
+#[test]
+fn the_codon_level_combiner_also_brackets_separated_codons() {
+    let vp = projector_for(ISSUE_CDS);
+    assert_eq!(
+        protein_of(&vp, "REF:g.[4C>T;6G>A;15C>A]"),
+        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+    );
+}
+
+/// Silent and changed residues render their gene symbol the same way, so the
+/// identity renderer cannot drift from the substitution renderer it mirrors.
+///
+/// Single protein variants suppress the symbol on both sides; bracketed alleles
+/// carry it on both sides. (Whether an allele *should* emit a selector the p.
+/// grammar has no production for is #310's question, not this fix's.)
+#[test]
+fn gene_symbol_rendering_matches_the_changed_residue_sibling() {
+    let vp = projector_for(ISSUE_CDS);
+    // Separated: bracket, symbol on both.
+    assert_eq!(
+        protein_of(&vp, "REF:g.[6G>A;15C>A]"),
+        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+    );
+    assert_eq!(
+        protein_of(&vp, "REF:g.[5T>A;14C>A]"),
+        "txp(GENE1099):p.[(Leu2Gln);(Ala5Asp)]"
+    );
+    // Consecutive: single variant, symbol suppressed on both.
+    assert_eq!(protein_of(&vp, "REF:g.[6G>A;9T>C]"), "txp:p.(Leu2_Arg3=)");
+    assert_eq!(
+        protein_of(&vp, "REF:g.[5T>A;8G>A]"),
+        "txp:p.(Leu2_Arg3delinsGlnHis)"
+    );
+}
+
+/// Members inside one codon still collapse to that single residue — the fix
+/// must not turn a one-codon allele into a bracket or a range.
+#[test]
+fn all_silent_members_in_one_codon_stay_a_single_residue() {
+    let vp = projector_for(ISSUE_CDS);
+    assert_eq!(protein_of(&vp, "REF:g.[4C>T;6G>A]"), "txp:p.(Leu2=)");
+}
+
+/// A single silent substitution is unchanged by this fix.
+#[test]
+fn single_silent_substitution_is_unchanged() {
+    let vp = projector_for(ISSUE_CDS);
+    assert_eq!(protein_of(&vp, "REF:g.9T>C"), "txp:p.(Arg3=)");
+    assert_eq!(protein_of(&vp, "REF:g.6G>A"), "txp:p.(Leu2=)");
+}
+
+/// A silent `delins` spanning two codons must name them, not emit the
+/// whole-molecule `p.(=)`. This is reachable from a **single variant** — no
+/// allele involved — and is the half of the defect the issue does not report.
+#[test]
+fn silent_delins_names_its_codons_instead_of_whole_protein_identity() {
+    let vp = projector_for(ISSUE_CDS);
+    // c.6_9 -> ACGC: codon 2 CTG->CTA (Leu), codon 3 CGT->CGC (Arg). Both
+    // triplets rewritten, both silent.
+    let rendered = protein_of(&vp, "REF:g.6_9delinsACGC");
+    assert_eq!(rendered, "txp:p.(Leu2_Arg3=)");
+    assert!(
+        rendered != "txp:p.(=)",
+        "a targeted delins must not claim whole-protein identity"
+    );
+}
+
+/// ACCEPTED LIMITATION, pinned so it stays deliberate: a codon *interior* to a
+/// rewritten span whose triplet is coincidentally unchanged is not named, so the
+/// run is reported as two separated codons rather than one range.
+///
+/// `c.4_12delinsCTACGTCTT` rewrites codon 2 (`CTG`→`CTA`, Leu) and codon 4
+/// (`CTC`→`CTT`, Leu) but leaves codon 3's `CGT` byte-identical. The output
+/// `p.[(Leu2=);(Leu4=)]` is true but less complete than `p.(Leu2_Leu4=)`.
+/// Closing the gap would require deriving the set from the edit's *span*, which
+/// is exactly what a 3'-shifted spelling makes unsound — so the limitation is
+/// the price of the shift-invariance the rest of these tests depend on.
+#[test]
+fn an_unchanged_interior_codon_is_not_named() {
+    let vp = projector_for(RUN_CDS);
+    assert_eq!(
+        protein_of(&vp, "REF:g.4_12delinsCTACGTCTT"),
+        "txp(GENE1099):p.[(Leu2=);(Leu4=)]"
+    );
+}
+
+/// Order and grouping of members must not affect the result — the defect the
+/// issue describes is precisely that they did.
+#[test]
+fn output_is_independent_of_member_order() {
+    let vp = projector_for(ISSUE_CDS);
+    let forward = protein_of(&vp, "REF:g.[6G>A;9T>C]");
+    let reverse = protein_of(&vp, "REF:g.[9T>C;6G>A]");
+    assert_eq!(forward, reverse);
+}
+
+/// Every emitted shape survives `ferro normalize` byte-for-byte.
+///
+/// The two new shapes — a range identity and a bracketed cis allele of
+/// identities — are protein cis runs flowing through the same merge machinery
+/// that coalesces `p.[(Arg76Ser);(Cys77Trp)]` into a delins (#1127/#1128/#1133/
+/// #1134). An `=` is not a change, so nothing may be coalesced here; this pins
+/// that the coalescer leaves them alone rather than inventing a delins whose
+/// inserted residues equal the reference (which `protein/delins.md:55` marks
+/// invalid, "effectively is no change").
+#[test]
+fn emitted_identities_survive_normalization_unchanged() {
+    let normalizer = Normalizer::new(MockProvider::new());
+    for rendered in [
+        "txp:p.(Leu2=)",
+        "txp:p.(Leu2_Arg3=)",
+        "txp:p.(Leu2_Leu4=)",
+        "txp:p.[(Leu2=);(Ala5=)]",
+        "txp:p.(=)",
+    ] {
+        let parsed =
+            parse_hgvs(rendered).unwrap_or_else(|e| panic!("{rendered} does not parse: {e}"));
+        let normalized = normalizer
+            .normalize(&parsed)
+            .unwrap_or_else(|e| panic!("{rendered} does not normalize: {e}"));
+        assert_eq!(normalized.to_string(), rendered, "normalization moved it");
+    }
+}
+
+/// Emitted consequences have to be real HGVS.
+#[test]
+fn emitted_identities_reparse() {
+    let vp = projector_for(ISSUE_CDS);
+    for input in ["REF:g.[4C>T;6G>A;9T>C]", "REF:g.[6G>A;15C>A]", "REF:g.9T>C"] {
+        let rendered = protein_of(&vp, input);
+        ferro_hgvs::parse_hgvs(&rendered)
+            .unwrap_or_else(|e| panic!("{input} -> {rendered} does not re-parse: {e}"));
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -105,6 +105,7 @@ mod issue_1086_cross_axis_projection;
 mod issue_1086_genomic_input_context;
 mod issue_1092_stated_substitution_reference;
 mod issue_1097_range_sub_refseq_reject;
+mod issue_1099_all_silent_protein;
 mod issue_1103_cis_merge_order_independence;
 mod issue_1111_rna_noncoding_reframe;
 mod issue_1114_star_ter_strict;


### PR DESCRIPTION
Closes #1099

## The problem

When a change leaves the protein identical to the reference, ferro had **five** ways of saying so, selected by how the input happened to be spelled rather than by the biology. Measured on the real prepared reference (`NM_004006.3`, DMD):

| input | before | after |
|---|---|---|
| `c.123C>T` | `p.(Phe41=)` | unchanged |
| `c.[123C>T;126T>C]` | `p.(Phe41=)` — `Ser42` dropped | **`p.(Phe41_Ser42=)`** |
| `c.[123C>T;126T>C;129C>T]` | `p.(Phe41=)` — two dropped | **`p.(Phe41_Asp43=)`** |
| `c.[123C>T;141G>A]` | `p.(Phe41=)` — `Gly47` dropped | **`p.[(Phe41=);(Gly47=)]`** |
| `c.123_125delinsTTC` | `p.(=)` | **`p.(Phe41_Ser42=)`** |
| `c.[123C>T;124A>T;125G>C]` | `p.(=)` | **`p.(Phe41_Ser42=)`** |
| `c.[122T>G;141G>A]` (mixed) | `p.(Phe41Cys)` | unchanged (out of scope) |

A consumer asking "is the protein unchanged?" had to match five shapes plus an absence. **That inconsistency — not any single output being illegal — is the defect.** Part of it is also a regression: `combine_cis_members_by_residue` did not exist at v0.9.1, and the `changed.is_empty()` early return it introduced short-circuits the multi-run decline, so separated silent codons collapsed to one residue.

The silent-`delins` half is reachable from a **single variant**, with no allele involved, and is not reported in the issue.

## The rule

> Describe **the codons whose reference triplet was rewritten** — never the whole-molecule `p.(=)` while a codon can be named, never an arbitrary subset.

Grouped the way changed residues already are:

| rewritten codons | output |
|---|---|
| zero | `p.(=)` |
| one | `p.(Phe41=)` |
| one consecutive run | `p.(Phe41_Ser42=)` |
| separated runs | `p.[(Phe41=);(Gly47=)]` |

`DNA/other.md:29-37` states exactly this three-tier structure in the normative recommendations one axis over (`c.123=` / `c.123_145=` / `c.[123=;456=;789=]`); protein-axis range identity is sanctioned at `protein/alleles.md:61`, and separated runs staying individual at `protein/delins.md:62-64`. `substitution.md:22-23` (consecutive *changes* → delins) does not bite: an `=` is not a change, and the delins it would demand is itself marked invalid at `protein/delins.md:55` because replacing a residue with itself "effectively is no change".

### This is a preference and consistency fix, not a conformance repair

`p.(=)` is **legal**: `uncertain.md:212-213` licenses the parenthesised whole-molecule form. The "entire coding region was analysed" reservation attaches to the **bare** `p.=` (`substitution.md:43`). The change is justified on the spec's stated *preference* — `checklist.md:64` ("predicted **silent** protein level variants are described as **p.(Leu54=)**"), `SVD-WG001:17` ("should include the position(s) screened"), and `SVD-WG001:54-55`, which localises `p.(Phe41=)` from the DNA variant `c.123C>T`.

Accordingly this PR also **corrects two blessed `spec_citation` notes** in `cases.json` that called Mutalyzer's `p.(=)` "non-standard" and claimed `p.(=)` is reserved for the whole coding region. Both were wrong; left alone they would have propagated the error into any future re-blessing.

**Documented divergence:** `general.md:13`/`:155-160` say protein descriptions should be derived by comparing proteins and that "knowledge on the underlying change on the DNA level should not be used". This rule does the opposite — deliberately. For an all-silent change the protein diff is empty by construction, so the spec's default rule is degenerate, and `SVD-WG001:54-55` itself localises the residue from the DNA variant.

## Why triplets, never member spans

The affected set is derived by comparing the mutated CDS against the reference CDS triplet-by-triplet. Member spans are unusable:

- **3'-shift.** `g.[4_6del;15_16insGCA]` normalizes to `c.[6_8del;16_18dup]` — the deletion of codon 2 becomes a span straddling codons 2 **and** 3, inventing an `Ala3=`. Triplet comparison is shift-invariant.
- **Insertions have no codon.** A cis member's insertion span collapses to its anchor, so the inserted codon lands *between* residues.

`a_straddling_span_names_only_the_codons_it_rewrote` pins this directly: two spellings that splice the same mutated CDS — one inside a codon, one straddling two — both name `{2}`, where a span-derived implementation would name `{2, 3}` for the straddling one.

## Structure

A new `src/project/protein/identity.rs` carries the rule, its citations, and the one renderer. Three sites feed it:

- `combine_cis_members_by_residue` (residue-level cis) — from the diff's rewritten codons
- `combine_cis_substitutions_by_codon` (codon-level cis) — `alt_codon != ref_codon` per codon, deliberately **not** `by_codon` membership, which is member-derived: a member whose alternative equals the reference rewrites nothing
- `build_identity_variant` (indel path) — a new `IdentityContext { ref_cds, mut_cds, ref_residues }` threaded through `build_inframe_variant`

One renderer means the three cannot drift, which was the review's stated risk. `combined_cis_residue_changes` now returns `CisResidueDiff { changed, rewritten_codons }` — the affected set is **returned rather than discarded**, since the follow-up protein-consequence predicate exposes the same set and reconstructing it later would be far more expensive.

**Per-site decline semantics differ and are load-bearing.** The two cis sites may return `None`, and control reaches the pre-existing all-or-nothing fallback. The identity site has **no fallback**: declining there makes `predict_indel_protein` return `Err`, which `predict_protein_consequence` swallows to `None`, so the projection would emit no `p.` at all — turning a wrong-but-present answer into an absence. It therefore keeps `p.(=)` when the set cannot be derived.

## Accepted limitation

A codon *interior* to a rewritten span whose triplet is coincidentally unchanged is not named: codons 2–4 with 3 unchanged give `p.[(Leu2=);(Leu4=)]`, true but less complete than `p.(Leu2_Leu4=)`. Closing it needs span-derived reasoning, which is exactly what the two bullets above forbid. Pinned by `an_unchanged_interior_codon_is_not_named` so it stays deliberate.

## Two findings that corrected the design

1. **The gene symbol was never lost on the cis path.** The "cis drops `(DMD)`, trans keeps it" observation is entirely `Display`: `ProteinVariant` deliberately never emits the selector (#310 — the p. grammar has no such production), while `AlleleVariant` does. The data carries it on both paths. So there was nothing to restore, and the new bracket matches what the changed-residue renderer already emits — `gene_symbol_rendering_matches_the_changed_residue_sibling` pins both halves side by side. Whether an allele *should* emit a selector the p. grammar lacks is #310's question, and is left alone here.
2. **The conformance ledgers did not move.** `axis_protein_description`, `axis_coding_protein_descriptions`, `gate_protein_snapshot` and `axis_normalized` all pass unchanged against the real prepared reference, so no re-blessing was needed.

## Testing

- 11 integration tests in `tests/it/issue_1099_all_silent_protein.rs` and 12 unit tests in the new module, all written **before** the implementation (4 failing / 4 passing at baseline).
- Discriminators, not just examples: a 3-codon run (distinguishes "range" from "list the endpoints"), the straddling-span case, a member that rewrites nothing, order-independence, and a normalize round-trip guarding the freshly-churned protein coalescer (#1127/#1128/#1133/#1134) against inventing a delins whose inserted residues equal the reference.
- Two fixtures: the issue's own CDS, plus a second one because codon 4 of the issue's transcript is `TGG` (Trp), which has no synonym and so cannot express a 3-codon run.
- Full suite green (8356 tests); `clippy --all-features --all-targets -D warnings` clean; real-reference DMD output verified row-for-row against the table above.

## Follow-ups (not in this PR)

- **Protein-consequence predicate** — tri-state `#[non_exhaustive]` enum (`Unchanged` / `Changed` / `NotPredictable`) plus the affected residue set, across Rust, Python and CLI `--format json`. The reporter's actual acceptance condition, and the only way to answer "is the protein unchanged?" without string-matching. This PR already returns the set it needs.
- **Mixed alleles** still drop silent members (`c.[122T>G;141G>A]` → `p.(Phe41Cys)`, losing `Gly47=`) — also an unreported v0.9.1 regression. Changing two things at once would make the ledger movement unreadable.
- **The `Display` selector asymmetry** between a single protein variant and a protein allele (#310).
