### PR TITLE
fix(render): drop the gene-symbol selector on every protein allele

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -445,11 +445,19 @@ impl Accession {
     /// reference needs no such specification at all (bare `NM_…:c.…` is the
     /// canonical form). So when the reference is itself a transcript, the
     /// gene-symbol selector is disallowed and Display drops it. Genomic
-    /// (`NC`/`NG`/`NT`/`NW`/`ENSG`/bare `LRG_<N>`), mitochondrial, protein, and
+    /// (`NC`/`NG`/`NT`/`NW`/`ENSG`/bare `LRG_<N>`), mitochondrial, and
     /// unclassifiable (custom) references are **not** transcript references:
     /// there the selector is either the spec-sanctioned exception (a gene with
     /// no transcript, e.g. mitochondrial) or a value ferro cannot safely drop,
     /// so Display preserves it.
+    ///
+    /// **This predicate answers only the transcript-vs-not question.** It is not
+    /// the whole selector policy: the `p.` axis takes no gene-symbol selector on
+    /// **any** accession (#310/#1142), which the render sites enforce by
+    /// coordinate type rather than by reference class. The two rules can
+    /// disagree — a mitochondrial `m.` description keeps its selector while a
+    /// mitochondrial *protein* (`YP_…:p.…`) does not — so do not read a `false`
+    /// here as "the selector is emitted".
     ///
     /// The check is on `self` only — a compound reference such as
     /// `NC_(NM_)(GENE)` stores the transcript (`NM`) as `self` with the genomic
@@ -1418,8 +1426,14 @@ fn write_compact_prefix(f: &mut fmt::Formatter<'_>, first: &HgvsVariant) -> fmt:
     write!(f, "{}", accession)?;
     if let Some(gene) = first.gene_symbol() {
         // Same reference-type gate as `write_accession_with_optional_gene`
-        // (#1051): a transcript reference takes no gene-symbol selector.
-        if !accession.is_transcript_reference() {
+        // (#1051): a transcript reference takes no gene-symbol selector. The
+        // `p.` axis takes none either, on any accession (#310/#1142) — keyed on
+        // the rendered coordinate type rather than the accession prefix so it
+        // covers `NP`/`XP`/`YP`/`ENSP`/`LRG_<n>p<m>`/UniProt and unclassifiable
+        // protein references alike. Without this, a protein *allele* emitted a
+        // selector its single-variant sibling has always dropped, because
+        // `ProteinVariant`'s own Display never reaches this function.
+        if !accession.is_transcript_reference() && first.variant_type() != "p" {
             write!(f, "({})", gene)?;
         }
     }

--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -13110,7 +13110,7 @@ mod tests {
         // NOT merged into a single delins (delins.md:21).
         assert_eq!(
             format!("{}", proj.protein.expect("protein expected")),
-            "NP_SEP.1(SEPGENE):p.[(Asp2del);(Cys4del)]"
+            "NP_SEP.1:p.[(Asp2del);(Cys4del)]"
         );
     }
 
@@ -13489,10 +13489,7 @@ mod tests {
         // Separated subs stay an Allele; the Allele Display hoists the shared gene
         // symbol (unchanged pre-existing behavior). The point of this guard is that
         // they are NOT merged into a single delins.
-        assert_eq!(
-            format!("{protein}"),
-            "NP_SEP.1(SEPGENE):p.[(Asp2Tyr);(Cys4Tyr)]"
-        );
+        assert_eq!(format!("{protein}"), "NP_SEP.1:p.[(Asp2Tyr);(Cys4Tyr)]");
     }
 
     #[test]

--- a/src/project/protein/identity.rs
+++ b/src/project/protein/identity.rs
@@ -359,9 +359,6 @@ mod tests {
             &parse_accession("NP_000001.1"),
             &Some("GENE1".to_string()),
         );
-        assert_eq!(
-            bracketed.to_string(),
-            "NP_000001.1(GENE1):p.[(Leu2=);(Ala5=)]"
-        );
+        assert_eq!(bracketed.to_string(), "NP_000001.1:p.[(Leu2=);(Ala5=)]");
     }
 }

--- a/tests/it/gene_selector_display_preserve.rs
+++ b/tests/it/gene_selector_display_preserve.rs
@@ -17,6 +17,13 @@
 //! 3. **Never synthesizes** it — a bare input stays bare, and normalization
 //!    does not invent a selector from transcript metadata.
 //!
+//! A **second, orthogonal rule** applies on the protein axis: `p.` carries no
+//! gene-symbol selector on **any** accession (#310/#1142), enforced by
+//! coordinate type rather than reference class. The two rules can disagree, and
+//! both are tested here — `NC_012920.1(MT-TL1):m.[…]` keeps its selector under
+//! the mitochondrial exception while `YP_003024026.1(MT-ND1):p.[…]` drops its
+//! own, because the axis rule wins on `p.`.
+//!
 //! The value always remains on the struct for programmatic access regardless
 //! of whether Display emits it (`variant.<X>.gene_symbol`). This file targets
 //! the *formatter* per-kind; end-to-end round-trip identity lives in
@@ -495,4 +502,177 @@ fn hyphenated_selector_preserved_on_mitochondrial_reference() {
     assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):m.3243A>G", "MT-TL1");
     assert_display_preserves_gene_selector("NC_012920.1(MT-ND1):m.3460G>A", "MT-ND1");
     assert_display_preserves_gene_selector("NC_012920.1(MT-TL1):n.14A>G", "MT-TL1");
+}
+
+// =============================================================================
+// Drop: the `p.` axis takes no gene-symbol selector in ANY shape (#1142).
+//
+// `refseq.md:41` — "Gene symbols should **not** be used as specification" —
+// with the exception at `:42` scoped to "genes annotated on a genomic reference
+// for which no transcript reference sequence is available". A protein accession
+// is not a genomic reference, so no protein form may carry one.
+//
+// The single-variant case is covered above (`..._refseq_np_protein`). It is
+// enforced by `ProteinVariant`'s own Display, which never reads `gene_symbol`,
+// so it never reached the allele path — an allele renders through
+// `write_compact_prefix`, whose only gate was "is this a transcript reference?".
+// =============================================================================
+
+/// The gene symbol of a variant, reaching into an allele's first member.
+///
+/// `gene_symbol_of` reads the field off a single variant and an `Allele` carries
+/// none — the symbol lives on each member — so allele cases need this instead.
+fn member_gene_symbol(variant: &HgvsVariant) -> Option<&str> {
+    match variant {
+        HgvsVariant::Allele(a) => a.variants.first().and_then(member_gene_symbol),
+        other => gene_symbol_of(other),
+    }
+}
+
+/// Assert `input` parses, **retains** `gene` on the member, and Displays as
+/// `expected` without it.
+///
+/// Both halves matter: this file's contract is that the parser always captures
+/// the selector for programmatic access and only `Display` omits it. Asserting
+/// the rendering alone would pass equally if the parser had silently dropped the
+/// value, which would be a different (and worse) bug.
+fn assert_selector_dropped(input: &str, gene: &str, expected: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} should parse: {e}"));
+    assert_eq!(
+        member_gene_symbol(&v),
+        Some(gene),
+        "parse must still capture gene_symbol={gene:?} for {input}"
+    );
+    assert_eq!(
+        v.to_string(),
+        expected,
+        "Display should drop the gene-symbol selector for {input}"
+    );
+}
+
+#[test]
+fn display_drops_gene_selector_protein_cis_allele() {
+    // The shape #1099's projector emits for an all-silent cis allele whose
+    // rewritten codons are separated.
+    assert_selector_dropped(
+        "NP_003997.2(DMD):p.[(Phe41=);(Gly47=)]",
+        "DMD",
+        "NP_003997.2:p.[(Phe41=);(Gly47=)]",
+    );
+    assert_selector_dropped(
+        "NP_003997.2(DMD):p.[(Phe41Cys);(Gly47Arg)]",
+        "DMD",
+        "NP_003997.2:p.[(Phe41Cys);(Gly47Arg)]",
+    );
+}
+
+#[test]
+fn display_drops_gene_selector_protein_trans_allele() {
+    assert_selector_dropped(
+        "NP_003997.2(DMD):p.[(Phe41Cys)];[(Gly47Arg)]",
+        "DMD",
+        "NP_003997.2:p.[(Phe41Cys)];[(Gly47Arg)]",
+    );
+}
+
+#[test]
+fn display_drops_gene_selector_protein_unknown_phase_allele() {
+    assert_selector_dropped(
+        "NP_003997.2(DMD):p.(Phe41Cys)(;)(Gly47Arg)",
+        "DMD",
+        "NP_003997.2:p.(Phe41Cys)(;)(Gly47Arg)",
+    );
+}
+
+/// Every protein accession class, not just `NP_`.
+///
+/// The obvious gate — "does the accession prefix infer to `p`?" — is incomplete:
+/// `XP_` and `YP_` are not in `Accession::inferred_variant_type`'s match, so
+/// they would keep the selector. `YP_` matters especially: it is the accession
+/// class the spec's own mitochondrial passage uses (`refseq.md:291` gives
+/// `YP_003024026.1:p.(Ala52Thr)` as the correct form). Gating on the rendered
+/// *coordinate type* rather than the accession prefix covers all of them.
+#[test]
+fn display_drops_gene_selector_on_every_protein_accession_class() {
+    assert_selector_dropped(
+        "XP_003997.2(DMD):p.[(Phe41Cys);(Gly300Arg)]",
+        "DMD",
+        "XP_003997.2:p.[(Phe41Cys);(Gly300Arg)]",
+    );
+    assert_selector_dropped(
+        "YP_003024026.1(MT-ND1):p.[(Ala52Thr);(Gly300Arg)]",
+        "MT-ND1",
+        "YP_003024026.1:p.[(Ala52Thr);(Gly300Arg)]",
+    );
+    // The classes the prefix-based predicate does cover, asserted so the gate
+    // cannot regress to one that only handles RefSeq.
+    assert_selector_dropped(
+        "ENSP00000369497.3(BRCA2):p.[(Phe41Cys);(Gly47Arg)]",
+        "BRCA2",
+        "ENSP00000369497.3:p.[(Phe41Cys);(Gly47Arg)]",
+    );
+    assert_selector_dropped(
+        "LRG_199p1(BRCA1):p.[(Phe41Cys);(Gly47Arg)]",
+        "BRCA1",
+        "LRG_199p1:p.[(Phe41Cys);(Gly47Arg)]",
+    );
+    // UniProt: a single-letter prefix, and no RefSeq-shaped accession at all.
+    assert_selector_dropped(
+        "P38398(BRCA1):p.[(Phe41Cys);(Gly47Arg)]",
+        "BRCA1",
+        "P38398:p.[(Phe41Cys);(Gly47Arg)]",
+    );
+}
+
+// =============================================================================
+// Guards: what the #1142 gate must NOT touch.
+// =============================================================================
+
+/// A parenthesised **accession** is a spec-sanctioned specification, not a gene
+/// symbol, and must survive on the protein axis.
+///
+/// `refseq.md:40` — "accepted specifications include transcripts
+/// (`NM_004006.2`) and proteins (`NP_003997.1`)" — and `:190`, "when, based on
+/// a genomic reference sequence, variants are reported using a `p.` prefix, the
+/// reference protein isoform used should be indicated". This parenthetical is
+/// the accession's own `genomic_context`, a different field from the gene-symbol
+/// selector, so narrowing the selector must leave it alone.
+#[test]
+fn display_preserves_a_protein_accession_specification() {
+    let v = parse_hgvs("NG_012232.1(NP_003997.1):p.(Val25Gly)").unwrap();
+    assert_eq!(v.to_string(), "NG_012232.1(NP_003997.1):p.(Val25Gly)");
+}
+
+/// Assert an allele retains `gene` on its member AND renders it, naming the
+/// expected string explicitly rather than comparing against the input.
+fn assert_allele_selector_preserved(input: &str, gene: &str, expected: &str) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    assert_eq!(
+        member_gene_symbol(&v),
+        Some(gene),
+        "parse must capture gene_symbol={gene:?} for {input}"
+    );
+    assert_eq!(v.to_string(), expected, "Display must preserve {input}");
+}
+
+/// The mitochondrial exception still holds for an *allele*, not just a single
+/// variant — the gate is on the `p.` axis, not on alleles generally.
+#[test]
+fn display_preserves_mitochondrial_gene_selector_on_an_allele() {
+    assert_allele_selector_preserved(
+        "NC_012920.1(MT-TL1):m.[3243A>G;3244G>A]",
+        "MT-TL1",
+        "NC_012920.1(MT-TL1):m.[3243A>G;3244G>A]",
+    );
+}
+
+/// A genomic allele keeps its selector: the gene stands in for a transcript
+/// there, and `g.` is not the axis #1142 narrows.
+#[test]
+fn display_preserves_genomic_gene_selector_on_an_allele() {
+    assert_allele_selector_preserved(
+        "NC_000013.11(FLT3):g.[12345A>G;12400C>T]",
+        "FLT3",
+        "NC_000013.11(FLT3):g.[12345A>G;12400C>T]",
+    );
 }

--- a/tests/it/issue_1099_all_silent_protein.rs
+++ b/tests/it/issue_1099_all_silent_protein.rs
@@ -113,20 +113,15 @@ fn three_consecutive_silent_codons_render_as_one_range() {
 /// Silent codons separated by an untouched codon stay individual, bracketed —
 /// the same rule `delins.md` applies to separated *changed* residues.
 ///
-/// The `(GENE1099)` selector is not part of what this fix decides: a protein
-/// *allele* renders its gene symbol while a single protein variant suppresses it
-/// (#310, "no parenthesized selector position" in the p. grammar), so the
-/// bracket here matches what the sibling renderer already emits for separated
-/// changed residues (`txp(GENE1099):p.[(Leu2Gln);(Ala5Asp)]`, measured). The
-/// asymmetry is pre-existing and out of scope; see
-/// `gene_symbol_rendering_matches_the_changed_residue_sibling` below, which
-/// pins both halves so this fix cannot be blamed for either.
+/// The accession renders bare: the `p.` axis takes no gene-symbol selector in
+/// any shape (#1142), so an allele drops it exactly as a single protein variant
+/// always has.
 #[test]
 fn separated_silent_codons_render_as_a_bracket() {
     let vp = projector_for(ISSUE_CDS);
     assert_eq!(
         protein_of(&vp, "REF:g.[6G>A;15C>A]"),
-        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+        "txp:p.[(Leu2=);(Ala5=)]"
     );
 }
 
@@ -144,29 +139,30 @@ fn the_codon_level_combiner_also_brackets_separated_codons() {
     let vp = projector_for(ISSUE_CDS);
     assert_eq!(
         protein_of(&vp, "REF:g.[4C>T;6G>A;15C>A]"),
-        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+        "txp:p.[(Leu2=);(Ala5=)]"
     );
 }
 
-/// Silent and changed residues render their gene symbol the same way, so the
+/// Silent and changed residues render their accession the same way, so the
 /// identity renderer cannot drift from the substitution renderer it mirrors.
 ///
-/// Single protein variants suppress the symbol on both sides; bracketed alleles
-/// carry it on both sides. (Whether an allele *should* emit a selector the p.
-/// grammar has no production for is #310's question, not this fix's.)
+/// Both suppress the gene-symbol selector, in both the bracketed-allele and the
+/// single-variant shape — the `p.` axis takes none (#310/#1142). The transcript
+/// fixture does set a gene symbol (`GENE1099`), so these assertions would catch
+/// it leaking back into either renderer.
 #[test]
 fn gene_symbol_rendering_matches_the_changed_residue_sibling() {
     let vp = projector_for(ISSUE_CDS);
-    // Separated: bracket, symbol on both.
+    // Separated: bracket, selector suppressed on both.
     assert_eq!(
         protein_of(&vp, "REF:g.[6G>A;15C>A]"),
-        "txp(GENE1099):p.[(Leu2=);(Ala5=)]"
+        "txp:p.[(Leu2=);(Ala5=)]"
     );
     assert_eq!(
         protein_of(&vp, "REF:g.[5T>A;14C>A]"),
-        "txp(GENE1099):p.[(Leu2Gln);(Ala5Asp)]"
+        "txp:p.[(Leu2Gln);(Ala5Asp)]"
     );
-    // Consecutive: single variant, symbol suppressed on both.
+    // Consecutive: single variant, selector suppressed on both.
     assert_eq!(protein_of(&vp, "REF:g.[6G>A;9T>C]"), "txp:p.(Leu2_Arg3=)");
     assert_eq!(
         protein_of(&vp, "REF:g.[5T>A;8G>A]"),
@@ -221,7 +217,7 @@ fn an_unchanged_interior_codon_is_not_named() {
     let vp = projector_for(RUN_CDS);
     assert_eq!(
         protein_of(&vp, "REF:g.4_12delinsCTACGTCTT"),
-        "txp(GENE1099):p.[(Leu2=);(Leu4=)]"
+        "txp:p.[(Leu2=);(Leu4=)]"
     );
 }
 


### PR DESCRIPTION
Closes #1142

**Stacked on #1140** — base it there, merge it after. The fix flips four expectations in `tests/it/issue_1099_all_silent_protein.rs`, which only exist on that branch, so keeping them coherent means one change rather than a broken intermediate state on `main`.

## The problem

A protein **allele** emitted a gene-symbol selector; a single protein variant on the same accession rendered bare.

```console
$ ferro normalize 'NP_003997.2(DMD):p.(Phe41=)'
NP_003997.2(DMD):p.(Phe41=) -> NP_003997.2:p.(Phe41=)          # dropped

$ ferro normalize 'NP_003997.2(DMD):p.[(Phe41=);(Gly47=)]'
NP_003997.2(DMD):p.[(Phe41=);(Gly47=)]                          # kept
```

The projector emits it directly too, and it reached the pinned spec-conformance enumeration for a genuine spec input (`NM_000797.3:c.812_829delins908_925`, cited `DNA/delins.md:60`) as `NP_000788.2(DRD4):p.[(Arg271_Gly272delinsProAsp);(Pro276_Asp277delinsSerAsn)]`.

## Why it is wrong

`background/refseq.md:38-42` is the normative rule, and it is coordinate-type agnostic:

> - specifications to a specific annotated segment of a reference sequence can be given in parentheses directly after the reference sequence.
>     - accepted specifications include transcripts (`NM_004006.2`) and proteins (`NP_003997.1`).
>       **Gene symbols should not be used as specification.**
>       **Exception:** genes annotated on a genomic reference for which no transcript reference sequence is available, e.g., … `NC_012920.1`.

The accepted parenthetical is an **accession**; a **gene symbol** is disallowed outright, and the exception is scoped to a genomic reference with no transcript. A protein accession is neither. Consistent with that, no example anywhere in the spec puts a gene symbol before `:p.`, and `syntax.yaml`'s protein productions carry no parenthetical.

## Root cause

The policy lived in two independent places, and only one covered alleles:

| shape | render path | selector |
|---|---|---|
| single protein variant | `ProteinVariant` Display (`variant.rs:2635` — never reads `gene_symbol`) | dropped |
| protein allele — cis, trans, and unknown-phase | `write_compact_prefix` → `is_transcript_reference()`, false for a protein accession | **emitted** |
| protein allele, expanded (distinct accessions) | per-member `ProteinVariant` Display | dropped |

`#310` established the protein policy as an unconditional omission inside `ProteinVariant`, which the allele path never reaches; `#1051`'s gate then keyed on "is this a transcript reference?", and `is_transcript_reference()`'s doc explicitly lists **protein** among the references whose selector is *preserved* — justified as "the spec-sanctioned exception (a gene with no transcript, e.g. mitochondrial) or a value ferro cannot safely drop." That justification does not reach protein: the mitochondrial exception is `m.`/`n.` on `NC_012920.1`.

## The fix

Gate on the rendered **coordinate type**, not the accession prefix:

```rust
if !accession.is_transcript_reference() && first.variant_type() != "p" {
    write!(f, "({})", gene)?;
}
```

All three compact phases share `write_compact_prefix`, so one gate covers cis, trans, and unknown-phase.

**Why not `Accession::inferred_variant_type() != Some("p")`** — the first predicate I reached for, and it is incomplete. That match (`variant.rs:362-379`) covers `NP`, LRG-`p<M>`, Ensembl protein and single-letter UniProt, but **`XP` and `YP` fall through to `None`**, so both would have stayed broken. `YP_` matters most: it is the accession class the spec's own mitochondrial passage uses (`refseq.md:291` gives `YP_003024026.1:p.(Ala52Thr)` as the correct form). `variant_type()` returns `"p"` for `Protein(_)` unconditionally, so it covers every protein accession class and unclassifiable ones too, and it cannot drift from the single-variant path — both now express the same rule.

## What it deliberately does not touch

A parenthesised **accession** is `Accession::genomic_context`, printed by `Accession`'s own Display, not the gene-symbol selector. `refseq.md:40` accepts protein accessions as specifications and `:190` says the protein isoform should be indicated when a `p.` is reported against a genomic reference, so this form is legitimate and still round-trips:

```console
$ ferro normalize 'NG_012232.1(NP_003997.1):p.(Val25Gly)'
NG_012232.1(NP_003997.1):p.(Val25Gly)
```

The mitochondrial and genomic gene selectors are likewise untouched on their own axes — `NC_012920.1(MT-TL1):m.[…]` and `NC_000013.11(FLT3):g.[…]` both keep theirs, including in allele form. All three are pinned as guard tests, because the risk in narrowing a Display rule is over-applying it.

## Testing

Written test-first: four failing cases (cis / trans / unknown-phase / `XP_`+`YP_`) plus three guards that had to pass unchanged from the start. Added to `tests/it/gene_selector_display_preserve.rs`, which already owns this policy per reference kind.

Expectation updates, all in the same direction — an accession that no longer carries a selector: two `projector.rs` unit tests, one `identity.rs` unit test, and four in `issue_1099_all_silent_protein.rs` (whose doc comments explaining the old asymmetry are rewritten, not just their strings). The generated spec-enumeration fixture picks up the DRD4 row automatically.

Full suite green (8373); `clippy --all-features --all-targets -D warnings` and `fmt --check` clean. Conformance against the real prepared reference shows only the pre-existing `axis_errors` failure on `c.45del4`/`c.45dup4`, which reproduces byte-identically on an unmodified baseline.

## Related

#1143, filed while investigating this one: in lenient/silent mode the single-letter amino-acid expansion runs over the accession region of a non-first allele member and corrupts `NP_000788.2` into `AsnPro_000788.2`. Independent of this change and not addressed here.
