### PR TITLE
test(hgvs): pin that an assembly reference keeps its gene-symbol selector

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -503,7 +503,7 @@ impl Accession {
     /// and unclassifiable custom references. The value always remains on the
     /// struct for programmatic access, independent of Display.
     ///
-    /// **Assembly references keep their selector, by design.** An
+    /// **Assembly references keep their selector, by design** (#1145). An
     /// assembly/chromosome reference ([`Self::is_assembly_ref`], e.g.
     /// `GRCh38(chr1)`) renders its parenthesised group from the
     /// `assembly`/`chromosome` fields, and that group is part of the *reference
@@ -512,7 +512,9 @@ impl Accession {
     /// `<identifier>(<selector>)`: one specification, the structural analogue of
     /// the preserved `NC_000023.10(DMD):c.…`, and **not** a stacked
     /// `(...)(...)`. Testing `genomic_context` rather than the rendered parens is
-    /// what keeps the two apart.
+    /// what keeps the two apart. (The form itself is a ferro extension for
+    /// tolerated legacy input; the spec declines genome-build references outright
+    /// — `refseq.md:222-231`.)
     pub(crate) fn admits_gene_selector(&self) -> bool {
         !self.is_transcript_reference() && self.genomic_context.is_none()
     }

--- a/tests/it/gene_selector_roundtrip.rs
+++ b/tests/it/gene_selector_roundtrip.rs
@@ -372,6 +372,54 @@ fn display_drops_gene_selector_with_compound_ref_whose_inner_is_not_a_transcript
     );
 }
 
+// =============================================================================
+// Assembly/chromosome references (#1145). `GRCh38(chr1)` renders its
+// parenthesised group from the `assembly`/`chromosome` fields: that group is
+// part of the reference *identifier* (an assembly alone names no sequence), not
+// a `refseq.md:38` specification. So a following `(GENE)` is the reference's
+// FIRST specification — the structural analogue of the preserved
+// `NC_000023.10(DMD):c.…` — and must be kept, not treated as a stacked group.
+// These pin that distinction so the #1139 drop is never widened to swallow it.
+// =============================================================================
+
+#[test]
+fn assembly_ref_keeps_its_gene_selector() {
+    let input = "GRCh38(chr1)(BRCA1):g.100A>G";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(gene_symbol_of(&v), Some("BRCA1"));
+    assert_eq!(
+        v.to_string(),
+        input,
+        "the assembly group is the identifier, so (BRCA1) is the sole specification and is preserved",
+    );
+}
+
+#[test]
+fn assembly_ref_gene_selector_survives_reparse() {
+    // Idempotency: the preserved form must be a fixed point, exactly as the
+    // dropped compound form is. Assert the concrete string at *both* steps, not
+    // just `once == twice` — the latter also holds if both renders wrongly
+    // dropped the selector, so it would not catch the regression this pins.
+    const EXPECTED: &str = "GRCh38(chr1)(BRCA1):g.100A>G";
+    let once = parse_hgvs(EXPECTED).unwrap().to_string();
+    assert_eq!(once, EXPECTED, "first render must keep the selector");
+    let reparsed = parse_hgvs(&once).unwrap();
+    assert_eq!(
+        gene_symbol_of(&reparsed),
+        Some("BRCA1"),
+        "reparse must re-observe the selector, not silently drop it",
+    );
+    assert_eq!(reparsed.to_string(), EXPECTED, "second render must match");
+}
+
+#[test]
+fn assembly_ref_without_selector_unchanged() {
+    let input = "GRCh38(chr1):g.100A>G";
+    let v = parse_hgvs(input).unwrap();
+    assert_eq!(gene_symbol_of(&v), None);
+    assert_eq!(v.to_string(), input);
+}
+
 #[test]
 fn compound_ref_with_nontranscript_inner_display_is_idempotent() {
     // The dropped form must be a fixed point — re-parsing the rendered string


### PR DESCRIPTION
Stacked on #1141 — it needs `Accession::admits_gene_selector`, which that PR introduces. GitHub will retarget this to `main` when #1141 merges.

## Outcome: no code change, the premise was wrong

#1145 asked whether `GRCh38(chr1)(BRCA1):g.100A>G` — which still renders two parenthesised groups after #1139 — is a stacked specification that `admits_gene_selector` should also suppress via a one-line `&& !self.is_assembly_ref()`.

It is not, and that change would be a bug.

An assembly reference renders its group from the `assembly`/`chromosome` fields, and that group is part of the reference **identifier** — an assembly alone names no sequence, only assembly+chromosome does — not a specification in the sense of `refseq.md:38` ("specifications to a specific annotated segment of a reference sequence can be given in parentheses directly after the reference sequence").

The parse confirms the model:

```
GRCh38(chr1)(BRCA1):g.100A>G
   assembly=Some("GRCh38") chromosome=Some("chr1") genomic_context=None gene=Some("BRCA1")
```

One identifier, one specification. That is the structural analogue of `NC_000023.10(DMD):c.…`, which #1051 deliberately preserves as the gene-stands-in-for-a-transcript form. Suppressing it would strip a selector ferro cannot safely drop.

Keying the predicate on `genomic_context` rather than on the rendered parentheses is precisely what keeps the two shapes apart, so `admits_gene_selector` is already correct.

For the record, the spec declines genome-build references outright (`refseq.md:222-231`: *"A genome build is not a real reference sequence"*, *"The preferred genomic reference sequence is a `NC_` file"*). The form exists in ferro only to tolerate legacy input.

## What this PR does

- Three regression tests in `tests/it/gene_selector_roundtrip.rs` pinning the distinction, so it is not later "fixed" away: the selector is preserved, the preserved form is idempotent under reparse, and the selectorless form is unchanged.
- Replaces the hedging "narrowing it is tracked separately" note on `admits_gene_selector` with the actual reasoning and its citation.

These tests pass on arrival — they characterize already-correct behavior rather than driving a fix. Stating that plainly because it is the opposite of the usual red-green expectation for a `Closes #…` PR.

## Related defect found, not fixed here

The probe turned up a genuine modelling bug in the same neighborhood, which belongs to #1146 rather than here:

```
GRCh38(chr1)(NM_004006.2):c.100A>G
   assembly=Some("GRCh38") chromosome=Some("chr1") genomic_context=None gene=Some("NM_004006.2")
```

A transcript specification on an assembly reference lands in `gene_symbol`. Same root cause as #1146 — the parser's compound `outer(inner)` branch is only reachable for RefSeq-shaped outer accessions.

## Verification

- `cargo nextest run --features dev` — 8351 passed, 0 failed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo fmt` — clean

Closes #1145


> [!IMPORTANT]
> **CI does not run on this PR yet.** `.github/workflows/ci.yml` triggers on `pull_request: branches: [main]`, and this PR targets the #1141 branch, so only the CodeRabbit integration reports — the 8 real jobs (Build, Clippy ×2, Format, Test, Python Lint, Python Wheel Test, abi3) are not scheduled. They will run automatically once #1141 merges and GitHub retargets this to `main`. Until then the verification above is **local only**. Do not read the short check list as a green build.