### PR TITLE
fix(parser): accept a specification on custom and assembly references

### DIFF
--- a/src/hgvs/parser/accession.rs
+++ b/src/hgvs/parser/accession.rs
@@ -48,7 +48,15 @@ fn is_valid_compound_outer(outer: &Accession) -> bool {
     // bare `LRG_<N>` as genomic (`g`). Also accept the RefSeq genomic prefixes it does not
     // classify — `AC_` (alternate-assembly) and `NZ_` (WGS) — so a valid genomic outer is
     // never falsely rejected.
-    outer.inferred_variant_type() == Some("g") || matches!(&*outer.prefix, "AC" | "NZ")
+    if outer.inferred_variant_type() == Some("g") || matches!(&*outer.prefix, "AC" | "NZ") {
+        return true;
+    }
+    // An assembly/chromosome reference (`GRCh38(chr1)`) names a genomic sequence, and a
+    // custom (SAM-refname) accession is unclassifiable — ferro cannot call either pairing
+    // backwards, and rejecting them would leave a custom or assembly reference unable to
+    // carry a specification at all (#1146). Only a *known* transcript/protein outer
+    // (`NM_`, `ENST`, `NP_`, `LRG_<N>t<M>`, …) is a genuine backwards pairing (#963).
+    outer.is_assembly_ref() || outer.inferred_variant_type().is_none()
 }
 
 /// Dispatch an accession parse on the first byte(s), avoiding trying all alternatives.
@@ -69,7 +77,7 @@ fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
         b'N' | b'X' => {
             // Check for underscore pattern (standard accession)
             if bytes.len() > 2 && bytes[2] == b'_' {
-                if let Ok(result) = parse_standard_accession(input) {
+                if let Ok(result) = parse_standard_accession(input, ALLOW_COMPOUND) {
                     return Ok(result);
                 }
             }
@@ -79,7 +87,7 @@ fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
         // Ensembl accessions: ENST, ENSG, ENSP, ENSE, ENSR
         b'E' => {
             if bytes.len() >= 4 && bytes[1] == b'N' && bytes[2] == b'S' {
-                if let Ok(result) = parse_ensembl_accession(input) {
+                if let Ok(result) = parse_ensembl_accession(input, ALLOW_COMPOUND) {
                     return Ok(result);
                 }
             }
@@ -106,7 +114,7 @@ fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
         // LRG accessions: LRG_XXX
         b'L' => {
             if bytes.len() >= 4 && bytes[1] == b'R' && bytes[2] == b'G' && bytes[3] == b'_' {
-                if let Ok(result) = parse_standard_accession(input) {
+                if let Ok(result) = parse_standard_accession(input, ALLOW_COMPOUND) {
                     return Ok(result);
                 }
             }
@@ -122,7 +130,7 @@ fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
             }
             // Try standard accession for other letter prefixes (like AC_)
             if bytes.len() > 2 && bytes[2] == b'_' {
-                if let Ok(result) = parse_standard_accession(input) {
+                if let Ok(result) = parse_standard_accession(input, ALLOW_COMPOUND) {
                     return Ok(result);
                 }
             }
@@ -141,6 +149,27 @@ fn parse_accession_dispatch(input: &str) -> IResult<&str, Accession> {
 /// Per SAM spec v1, reference names may contain printable ASCII `[!-~]` except:
 /// `\ , " ' ( ) [ ] { } < >`
 /// Additionally, they cannot start with `*` or `=` (handled separately).
+/// A version suffix is a non-empty all-digit run that is **canonical** and fits
+/// `u32`.
+///
+/// Both conditions are part of the definition, not implementation details:
+/// `Accession::version` is a `u32`, so anything it cannot represent *exactly*
+/// is dropped from `Display` and silently renames the reference —
+/// `MYTX.4294967296` → `MYTX` on overflow, `MYTX.007` → `MYTX.7` on
+/// zero-padding. Callers therefore treat `None` as "this token is not
+/// versioned" and keep the text verbatim, which is lossless.
+///
+/// Canonical means no leading zeros; a bare `0` is itself canonical.
+fn parse_version_suffix(digits: &str) -> Option<u32> {
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    if digits.len() > 1 && digits.starts_with('0') {
+        return None; // zero-padded: not representable without rewriting the text
+    }
+    digits.parse::<u32>().ok()
+}
+
 fn is_sam_refname_char(c: char) -> bool {
     // Printable ASCII range: ! (33) to ~ (126)
     let code = c as u32;
@@ -239,23 +268,34 @@ fn parse_simple_accession(input: &str) -> IResult<&str, Accession> {
         )));
     }
 
-    // Check for optional version suffix: ".N" at the end where N is digits
+    // Check for optional version suffix: ".N" at the end where N is digits.
+    //
+    // A digit run that does not fit `u32` is NOT a version: splitting it off and
+    // storing `None` would drop it from `Display`, silently rewriting
+    // `MYTX.4294967296` into `MYTX` — a different reference sequence. Keep the
+    // whole token as the name instead, so the accession round-trips verbatim.
     let (name, version) = if let Some(dot_pos) = accession_str.rfind('.') {
         let potential_version = &accession_str[dot_pos + 1..];
-        if !potential_version.is_empty() && potential_version.chars().all(|c| c.is_ascii_digit()) {
-            let version_num = potential_version.parse::<u32>().ok();
-            (&accession_str[..dot_pos], version_num)
-        } else {
-            (accession_str, None)
+        match parse_version_suffix(potential_version) {
+            Some(version_num) => (&accession_str[..dot_pos], Some(version_num)),
+            None => (accession_str, None),
         }
     } else {
         (accession_str, None)
     };
 
-    Ok((
-        &input[accession_end..],
-        Accession::with_style(name, "", version, true),
-    ))
+    let outer = Accession::with_style(name, "", version, true);
+    let remaining = &input[accession_end..];
+
+    // A custom accession can carry a specification too (#1146): the compound
+    // branch used to be reachable only for RefSeq/Ensembl/LRG outers, so
+    // `Template(Template-gene.1):c.…` — the form the projector emits — re-parsed
+    // with the transcript id sitting in `gene_symbol`.
+    if let Some(result) = try_compound_suffix(remaining, &outer) {
+        return Ok(result);
+    }
+
+    Ok((remaining, outer))
 }
 
 /// Parse a UniProt-style accession (e.g., "P54802", "Q8TAM1", "A0A024R1R8")
@@ -389,12 +429,21 @@ fn parse_assembly_accession(input: &str) -> IResult<&str, Accession> {
     let (input, chromosome) = take_while1(|c: char| c.is_ascii_alphanumeric()).parse(input)?;
     let (input, _) = tag(")").parse(input)?;
 
-    Ok((input, Accession::from_assembly(assembly, chromosome)))
+    let outer = Accession::from_assembly(assembly, chromosome);
+
+    // An assembly/chromosome reference can carry a specification too (#1146),
+    // e.g. `GRCh38(chr1)(NM_004006.2):c.…`; without this the transcript was
+    // modelled as a gene symbol (found while resolving #1145).
+    if let Some(result) = try_compound_suffix(input, &outer) {
+        return Ok(result);
+    }
+
+    Ok((input, outer))
 }
 
 /// Parse a standard RefSeq-style accession with underscore (e.g., "NM_000088.3")
 /// Also handles compound reference syntax: NC_000013.11(NM_004119.3)
-fn parse_standard_accession(input: &str) -> IResult<&str, Accession> {
+fn parse_standard_accession(input: &str, allow_compound: bool) -> IResult<&str, Accession> {
     let (input, prefix) = parse_prefix(input)?;
     let (input, _) = tag("_").parse(input)?;
     let (input, number) = parse_number(input)?;
@@ -402,23 +451,69 @@ fn parse_standard_accession(input: &str) -> IResult<&str, Accession> {
 
     let outer = Accession::with_style(prefix, number, version, false);
 
-    // Check for compound reference syntax: outer(inner)
-    // Only attempt if the next char is '(' and the content looks like an accession
-    // (starts with a letter pattern that could be a RefSeq/Ensembl/LRG accession)
-    if let Some(rest) = input.strip_prefix('(') {
-        if looks_like_accession_start(rest) {
-            if let Ok((after_inner, inner)) = parse_compound_inner(rest) {
-                // Reject nested compound refs: inner must not already have a genomic_context
-                if inner.genomic_context.is_none() {
-                    if let Some(after_close) = after_inner.strip_prefix(')') {
-                        return Ok((after_close, inner.with_genomic_context(outer)));
-                    }
-                }
-            }
+    // Compound reference syntax: outer(inner). See `try_compound_suffix`.
+    if allow_compound {
+        if let Some(result) = try_compound_suffix(input, &outer) {
+            return Ok(result);
         }
     }
 
     Ok((input, outer))
+}
+
+/// Attempt the compound-reference suffix `(inner)` at the head of `input`,
+/// given the already-parsed `outer` accession.
+///
+/// On success returns the remaining input (past the closing paren) and the
+/// compound accession — the **inner** becomes the primary accession and `outer`
+/// becomes its `genomic_context`, so `Accession::transcript_accession` resolves
+/// the inner. This is the single implementation of the rule; every accession
+/// family's parser calls it (#1146), so `NC_`, Ensembl, custom, and
+/// assembly/chromosome outers all admit a specification on the same terms.
+///
+/// Returns `None` — leaving the parens for the caller's gene-symbol selector
+/// parse — when the token is not accession-shaped, when it is already compound
+/// (nested compound refs are rejected), or when the parens are unbalanced.
+fn try_compound_suffix<'a>(input: &'a str, outer: &Accession) -> Option<(&'a str, Accession)> {
+    let rest = input.strip_prefix('(')?;
+    if !looks_like_accession_start(rest) && versioned_inner_span(rest).is_none() {
+        return None;
+    }
+    let (after_inner, inner) = parse_compound_inner(rest).ok()?;
+    // Reject nested compound refs: inner must not already have a genomic_context.
+    if inner.genomic_context.is_some() {
+        return None;
+    }
+    let after_close = after_inner.strip_prefix(')')?;
+    Some((after_close, inner.with_genomic_context(outer.clone())))
+}
+
+/// Locate a **custom** accession carrying a `.<digits>` version in the token up
+/// to the closing `)`, e.g. `MYTX.1` or `Template-gene.1`. Returns
+/// `(close_paren_index, version_dot_index)`, or `None` when the token is not
+/// accession-shaped.
+///
+/// This is the disambiguator between a compound reference's inner accession and
+/// a gene-symbol selector for accession families that no prefix whitelist can
+/// recognise (#1146). HGNC gene symbols do not carry a version suffix, so
+/// `MYREF_SEQ(GENE1)` keeps its gene-symbol reading (PR #70) while
+/// `MYREF_SEQ(MYTX.1)` is read as a specification. The version must follow at
+/// least one character, so a bare `(.1)` is not accession-shaped.
+///
+/// Returning the indices rather than a bool lets [`parse_compound_inner`] build
+/// the accession without re-scanning and without `expect`ing invariants this
+/// function already established.
+fn versioned_inner_span(input: &str) -> Option<(usize, usize)> {
+    let close = memchr(b')', input.as_bytes())?;
+    let token = &input[..close];
+    if token.is_empty() || !token.chars().all(is_sam_refname_char) {
+        return None;
+    }
+    let dot = token.rfind('.')?;
+    if dot == 0 || parse_version_suffix(&token[dot + 1..]).is_none() {
+        return None;
+    }
+    Some((close, dot))
 }
 
 /// Check if the input starts with something that looks like an accession
@@ -453,11 +548,31 @@ pub(crate) fn looks_like_accession_start(input: &str) -> bool {
 }
 
 /// Parse the inner accession of a compound reference (after the opening paren)
+/// Nesting cap for compound references (#1146/#1151). The parse cycle is
+/// `try_compound_suffix` → [`parse_compound_inner`] → an accession parser →
+/// `try_compound_suffix`, which is unbounded on input like
+/// `NC_1(NC_1(NC_1(…)))`. Callers at the top level pass `ALLOW_COMPOUND`;
+/// [`parse_compound_inner`] passes `FORBID_COMPOUND`, capping the nesting at a
+/// single level and terminating the recursion.
+///
+/// This is behavior-preserving, not a new restriction: `try_compound_suffix`
+/// already rejects an inner that is itself compound
+/// (`inner.genomic_context.is_some()`), so a nested form never parsed as a
+/// compound reference anyway — it fell back to a bare outer accession, which is
+/// exactly what the cap produces.
+const ALLOW_COMPOUND: bool = true;
+
+/// See [`ALLOW_COMPOUND`].
+const FORBID_COMPOUND: bool = false;
+
+/// Parse the inner accession of a compound reference (after the opening paren).
+/// Called only from `try_compound_suffix`; it passes [`FORBID_COMPOUND`] to its
+/// callees so the mutual recursion is capped at one level.
 fn parse_compound_inner(input: &str) -> IResult<&str, Accession> {
     let bytes = input.as_bytes();
     // Try standard 2-letter-prefix accession (NC_, NM_, NG_, etc.)
     if bytes.len() > 2 && bytes[2] == b'_' {
-        if let Ok(result) = parse_standard_accession(input) {
+        if let Ok(result) = parse_standard_accession(input, FORBID_COMPOUND) {
             return Ok(result);
         }
     }
@@ -471,15 +586,27 @@ fn parse_compound_inner(input: &str) -> IResult<&str, Accession> {
         && bytes[2] == b'G'
         && bytes[3] == b'_'
     {
-        if let Ok(result) = parse_standard_accession(input) {
+        if let Ok(result) = parse_standard_accession(input, FORBID_COMPOUND) {
             return Ok(result);
         }
     }
     // Try Ensembl
     if bytes.len() >= 4 && bytes[0] == b'E' && bytes[1] == b'N' && bytes[2] == b'S' {
-        if let Ok(result) = parse_ensembl_accession(input) {
+        if let Ok(result) = parse_ensembl_accession(input, FORBID_COMPOUND) {
             return Ok(result);
         }
+    }
+    // Custom (SAM-refname) accession carrying a version, e.g. `MYTX.1` or
+    // `Template-gene.1` (#1146). Built exactly as `parse_simple_accession`
+    // builds a versioned custom accession, so Display renders it back verbatim.
+    if let Some((close, dot)) = versioned_inner_span(input) {
+        let token = &input[..close];
+        // `versioned_inner_span` already established this fits `u32`.
+        let version = parse_version_suffix(&token[dot + 1..]);
+        return Ok((
+            &input[close..],
+            Accession::with_style(&token[..dot], "", version, true),
+        ));
     }
     Err(nom::Err::Error(nom::error::Error::new(
         input,
@@ -496,25 +623,18 @@ fn parse_compound_inner(input: &str) -> IResult<&str, Accession> {
 /// [`parse_standard_accession`]: the inner transcript becomes the primary
 /// accession and the outer gene becomes its `genomic_context`, so
 /// `Accession::transcript_accession` resolves the inner `ENST` (not the gene).
-fn parse_ensembl_accession(input: &str) -> IResult<&str, Accession> {
+fn parse_ensembl_accession(input: &str, allow_compound: bool) -> IResult<&str, Accession> {
     let (input, prefix) = parse_ensembl_prefix(input)?;
     let (input, number) = digit1.parse(input)?;
     let (input, version) = opt(preceded(tag("."), parse_version)).parse(input)?;
 
     let outer = Accession::with_style(prefix, number, version, true);
 
-    // Compound reference syntax: outer(inner), e.g. `ENSG…(ENST…)`. Only attempt
-    // when the next char is '(' and the content looks like an accession start.
-    if let Some(rest) = input.strip_prefix('(') {
-        if looks_like_accession_start(rest) {
-            if let Ok((after_inner, inner)) = parse_compound_inner(rest) {
-                // Reject nested compound refs: inner must not already be compound.
-                if inner.genomic_context.is_none() {
-                    if let Some(after_close) = after_inner.strip_prefix(')') {
-                        return Ok((after_close, inner.with_genomic_context(outer)));
-                    }
-                }
-            }
+    // Compound reference syntax: outer(inner), e.g. `ENSG…(ENST…)`. See
+    // `try_compound_suffix`.
+    if allow_compound {
+        if let Some(result) = try_compound_suffix(input, &outer) {
+            return Ok(result);
         }
     }
 

--- a/tests/it/fast_path_differential.rs
+++ b/tests/it/fast_path_differential.rs
@@ -165,7 +165,68 @@ const DIFFERENTIAL_CASES: &[&str] = &[
     "NM_000088.3:p.Arg100Gly",
     "ENST00000357033.8:p.Arg100Gly",
     "LRG_1:p.Arg100Gly",
+    // --- compound references on custom and assembly outers (#1146). The generic
+    // parser now admits a specification on every accession family, so the fast
+    // path must still agree — either by recognizing the form or (as today) by
+    // deferring. The assembly fast path requires a `:` immediately after its
+    // `(chrom)` group, so `GRCh38(chr1)(NM_…)` falls back; these pin that the
+    // fallback keeps producing an identical `HgvsVariant`. The unversioned-inner
+    // rows pin the gene-symbol reading the version suffix disambiguates. ---
+    "MYSEQ.1(MYTX.1):c.100A>G",
+    "MYSEQ.1(MYTX.1)(GENE1):c.100A>G",
+    "Template(Template-gene.1):c.5A>G",
+    "Template(Template-gene.1)(GENE1):c.5A>G",
+    "GRCh38(chr1)(NM_004006.2):c.100A>G",
+    "GRCh38(chr1)(BRCA1):g.100A>G",
+    "GRCh38(chr1):g.100A>G",
+    "MYREF_SEQ(GENE1):c.100A>G",
+    "NC_000023.10(DMD):c.100A>G",
+    "NC_000013.11(MYTX.1):c.100A>G",
+    "ENSG00000139618.15(MYTX.1):c.100A>G",
+    "AC_000001.1(NM_004006.2):c.100A>G",
+    "NZ_CP007265.1(NM_004006.2):c.100A>G",
+    "LRG_199(NM_004006.2):c.100A>G",
+    "LRG_199(MYTX.1):c.100A>G",
+    // Version-suffix edge cases, so the fast path and the generic parser agree on
+    // which digit runs are versions: `u32::MAX` is representable, one past it is
+    // not, and a zero-padded run cannot round-trip through a `u32`. All three
+    // must parse identically through both, not merely through `parse_hgvs`.
+    "MYSEQ.1(MYTX.4294967295):c.100A>G",
+    "MYSEQ.1(MYTX.4294967296):c.100A>G",
+    "MYTX.4294967296:c.100A>G",
+    "MYTX.007:c.100A>G",
+    "MYSEQ.1(MYTX.007):c.100A>G",
+    "MYTX.0:c.100A>G",
+    // both must reject (the inner-is-compound rejection, which the #1151 nesting
+    // cap preserves)
+    "NC_000013.11(NC_000013.11(NM_004119.3)):c.100A>G",
 ];
+
+/// The nested-compound form must be **rejected**, not merely agreed upon.
+///
+/// `divergence` returns `None` for `(Ok(a), Ok(b)) if a == b`, so the
+/// `DIFFERENTIAL_CASES` row alone would keep passing if both parsers started
+/// *accepting* nested compounds — the agreement it checks is orthogonal to the
+/// rejection the comment there claims. This asserts the disposition directly, so
+/// the #1151 nesting cap and the inner-is-compound rejection cannot regress into
+/// acceptance unnoticed.
+#[test]
+fn nested_compound_reference_is_rejected_by_both_parsers() {
+    for input in [
+        "NC_000013.11(NC_000013.11(NM_004119.3)):c.100A>G",
+        "MYSEQ.1(MYSEQ.1(MYTX.1)):c.100A>G",
+        "GRCh38(chr1)(GRCh38(chr1)):c.100A>G",
+    ] {
+        assert!(
+            parse_variant(input).is_err(),
+            "generic parser accepted the nested compound {input:?}"
+        );
+        assert!(
+            parse_hgvs(input).is_err(),
+            "fast path accepted the nested compound {input:?}"
+        );
+    }
+}
 
 #[test]
 fn fast_path_matches_standard_on_table() {
@@ -201,6 +262,36 @@ fn accession() -> impl Strategy<Value = &'static str> {
         Just("LRG_1t1"),
         Just("GRCh38(chr1)"),
         Just("GRCh37(chrX)"),
+        // Compound references, including the custom and assembly outers #1146
+        // made parseable, and a stacked selector the #1139 Display drops. The
+        // fast path recognizes none of these, so they exercise its `Fallback`
+        // branch against the generic parser across every generated edit shape —
+        // not just the fixed rows in `DIFFERENTIAL_CASES`.
+        Just("NC_000013.11(NM_004119.3)"),
+        Just("MYSEQ.1(MYTX.1)"),
+        Just("MYSEQ.1(MYTX.1)(GENE1)"),
+        Just("Template(Template-gene.1)"),
+        Just("GRCh38(chr1)(NM_004006.2)"),
+        Just("MYREF_SEQ(GENE1)"),
+        // Every outer dispatch path paired with a custom versioned inner, plus
+        // the `AC_`/`NZ_` outers `is_valid_compound_outer` admits explicitly.
+        Just("NC_000013.11(MYTX.1)"),
+        Just("ENSG00000139618.15(MYTX.1)"),
+        Just("AC_000001.1(NM_004006.2)"),
+        Just("NZ_CP007265.1(NM_004006.2)"),
+        Just("LRG_199(NM_004006.2)"),
+        Just("LRG_199(MYTX.1)"),
+        // The second assembly outer, so the `(chrom)` fast path is exercised on
+        // both generated assemblies rather than only `GRCh38`.
+        Just("GRCh37(chrX)(NM_004006.2)"),
+        // Transcript/protein outers, which `is_valid_compound_outer` rejects as
+        // backwards pairings (#963). Both parsers must agree on *rejecting*
+        // these, so they exercise the rejection branch across every generated
+        // edit shape — the accepting rows above never reach it.
+        Just("NM_000088.3(MYTX.1)"),
+        Just("NR_003051.3(MYTX.1)"),
+        Just("ENST00000357033.8(MYTX.1)"),
+        Just("LRG_1t1(MYTX.1)"),
     ]
 }
 

--- a/tests/it/issue_1146_custom_compound_accession.rs
+++ b/tests/it/issue_1146_custom_compound_accession.rs
@@ -1,0 +1,369 @@
+//! Issue #1146 — compound reference syntax `outer(inner)` was recognised only
+//! for RefSeq-shaped, Ensembl, and LRG **outer** accessions, and only for those
+//! same families as the **inner** token. A custom (SAM-refname) accession, or an
+//! assembly/chromosome reference, could not carry a transcript specification.
+//!
+//! Two consequences, both fixed here:
+//!
+//! 1. **Asymmetric acceptance.** `NC_000013.11(NM_004119.3)(FLT3):c.…` parsed,
+//!    but `MYSEQ.1(MYTX.1)(GENE1):c.…` and `Template(Template-gene.1)(GENE1):c.…`
+//!    failed with `Expected ':' after accession`, purely because of the prefix
+//!    whitelist in `looks_like_accession_start`.
+//!
+//! 2. **Display output was string-stable but not struct-stable.** The
+//!    spec-conformant string the projector emits for a custom reference (#1139),
+//!    `Template(Template-gene.1):c.5A>G`, re-parsed with the *transcript id* in
+//!    `gene_symbol` and `genomic_context: None` — so a consumer that re-parsed
+//!    `projection.c_name` and read `.gene_symbol` got a transcript accession. The
+//!    same held for `GRCh38(chr1)(NM_004006.2):c.…` (#1145).
+//!
+//! The disambiguator between "inner is an accession" and "inner is a gene-symbol
+//! selector" is the **version suffix**: HGNC gene symbols do not carry a
+//! `.<digits>` version, so `MYREF_SEQ(GENE1)` keeps its long-standing
+//! gene-symbol reading while `MYREF_SEQ(MYTX.1)` is read as a compound
+//! reference.
+
+use ferro_hgvs::hgvs::parser::variant::parse_variant;
+use ferro_hgvs::{parse_hgvs, HgvsVariant};
+
+/// The parsed variant's `gene_symbol`, regardless of variant kind.
+fn gene_symbol_of(variant: &HgvsVariant) -> Option<&str> {
+    match variant {
+        HgvsVariant::Genome(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Cds(v) => v.gene_symbol.as_deref(),
+        HgvsVariant::Tx(v) => v.gene_symbol.as_deref(),
+        _ => None,
+    }
+}
+
+/// `(genomic_context, transcript_accession, gene_symbol)` for an input.
+fn parts(input: &str) -> (Option<String>, String, Option<String>) {
+    let v = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input:?} failed: {e:?}"));
+    let acc = v.accession().expect("accession").clone();
+    (
+        acc.genomic_context.as_ref().map(|c| c.full()),
+        acc.transcript_accession(),
+        gene_symbol_of(&v).map(str::to_string),
+    )
+}
+
+// =============================================================================
+// (1) A custom outer accession accepts a versioned inner as a specification.
+// =============================================================================
+
+#[test]
+fn custom_outer_with_versioned_inner_is_a_compound_reference() {
+    let (context, transcript, gene) = parts("MYSEQ.1(MYTX.1):c.100A>G");
+    assert_eq!(context.as_deref(), Some("MYSEQ.1"));
+    assert_eq!(transcript, "MYTX.1");
+    assert_eq!(
+        gene, None,
+        "the inner token is an accession, not a selector"
+    );
+}
+
+#[test]
+fn custom_outer_with_versioned_inner_and_selector_parses() {
+    // Previously `Expected ':' after accession`.
+    let (context, transcript, gene) = parts("MYSEQ.1(MYTX.1)(GENE1):c.100A>G");
+    assert_eq!(context.as_deref(), Some("MYSEQ.1"));
+    assert_eq!(transcript, "MYTX.1");
+    assert_eq!(gene.as_deref(), Some("GENE1"));
+}
+
+#[test]
+fn projector_style_custom_reference_parses_as_compound() {
+    // The exact shape `VariantProjector` emits for a custom reference (#1139).
+    let (context, transcript, gene) = parts("Template(Template-gene.1):c.5A>G");
+    assert_eq!(context.as_deref(), Some("Template"));
+    assert_eq!(
+        transcript, "Template-gene.1",
+        "the transcript id must land in the accession, not in gene_symbol",
+    );
+    assert_eq!(gene, None);
+}
+
+#[test]
+fn projector_style_custom_reference_with_stacked_selector_parses() {
+    // The pre-#1139 malformed output must now parse (and, per #1139, Display
+    // drops the stacked selector rather than reproducing it).
+    let (context, transcript, gene) = parts("Template(Template-gene.1)(GENE1):c.5A>G");
+    assert_eq!(context.as_deref(), Some("Template"));
+    assert_eq!(transcript, "Template-gene.1");
+    assert_eq!(gene.as_deref(), Some("GENE1"));
+}
+
+// =============================================================================
+// (2) An assembly/chromosome outer reference accepts a specification too (the
+// #1145 probe: the transcript used to land in `gene_symbol`).
+// =============================================================================
+
+#[test]
+fn assembly_outer_with_transcript_inner_is_a_compound_reference() {
+    let (context, transcript, gene) = parts("GRCh38(chr1)(NM_004006.2):c.100A>G");
+    assert_eq!(context.as_deref(), Some("GRCh38(chr1)"));
+    assert_eq!(transcript, "NM_004006.2");
+    assert_eq!(
+        gene, None,
+        "a transcript specification must not be modelled as a gene symbol",
+    );
+}
+
+// =============================================================================
+// (3) Every outer dispatch path admits a custom versioned inner, not just the
+// custom/assembly ones — the shared `try_compound_suffix` is reached from the
+// standard and Ensembl parsers too.
+// =============================================================================
+
+#[test]
+fn refseq_outer_with_custom_versioned_inner_is_a_compound_reference() {
+    let (context, transcript, gene) = parts("NC_000013.11(MYTX.1):c.100A>G");
+    assert_eq!(context.as_deref(), Some("NC_000013.11"));
+    assert_eq!(transcript, "MYTX.1");
+    assert_eq!(gene, None);
+}
+
+#[test]
+fn ensembl_outer_with_custom_versioned_inner_is_a_compound_reference() {
+    let (context, transcript, gene) = parts("ENSG00000139618.15(MYTX.1):c.100A>G");
+    assert_eq!(context.as_deref(), Some("ENSG00000139618.15"));
+    assert_eq!(transcript, "MYTX.1");
+    assert_eq!(gene, None);
+}
+
+#[test]
+fn alternate_assembly_and_wgs_outers_admit_a_specification() {
+    // `AC_` / `NZ_` are accepted by `is_valid_compound_outer`'s explicit arm,
+    // which this PR restructured into an early return — pin that the arm still
+    // fires.
+    let (context, transcript, _) = parts("AC_000001.1(NM_004006.2):c.100A>G");
+    assert_eq!(context.as_deref(), Some("AC_000001.1"));
+    assert_eq!(transcript, "NM_004006.2");
+    let (context, transcript, _) = parts("NZ_CP007265.1(NM_004006.2):c.100A>G");
+    assert_eq!(context.as_deref(), Some("NZ_CP007265.1"));
+    assert_eq!(transcript, "NM_004006.2");
+}
+
+#[test]
+fn lrg_outer_admits_a_specification_on_every_inner_family() {
+    // A bare `LRG_<N>` is a genomic reference, so it takes a specification like
+    // any other — including the custom versioned inner this PR adds. (The `ferro
+    // parse` CLI rejects these for a *downstream* reason unrelated to parsing,
+    // so assert at the parser level, not through the CLI.)
+    for (input, inner) in [
+        ("LRG_199(NM_004006.2):c.100A>G", "NM_004006.2"),
+        ("LRG_199(MYTX.1):c.100A>G", "MYTX.1"),
+        ("LRG_199(LRG_199t1):c.100A>G", "LRG_199t1"),
+    ] {
+        let (context, transcript, gene) = parts(input);
+        assert_eq!(context.as_deref(), Some("LRG_199"), "context for {input:?}");
+        assert_eq!(transcript, inner, "inner for {input:?}");
+        assert_eq!(gene, None, "gene for {input:?}");
+    }
+}
+
+// =============================================================================
+// Non-regression: an UNVERSIONED inner token is still a gene-symbol selector.
+// This is the ambiguity the version suffix resolves.
+// =============================================================================
+
+#[test]
+fn custom_outer_with_unversioned_inner_is_still_a_gene_selector() {
+    // PR #70's motivating case must not change meaning.
+    let (context, transcript, gene) = parts("MYREF_SEQ(GENE1):c.100A>G");
+    assert_eq!(context, None);
+    assert_eq!(transcript, "MYREF_SEQ");
+    assert_eq!(gene.as_deref(), Some("GENE1"));
+}
+
+#[test]
+fn assembly_ref_with_unversioned_inner_is_still_a_gene_selector() {
+    // #1145 depends on this reading.
+    let (context, transcript, gene) = parts("GRCh38(chr1)(BRCA1):g.100A>G");
+    assert_eq!(context, None);
+    assert_eq!(gene.as_deref(), Some("BRCA1"));
+    assert_eq!(transcript, "GRCh38(chr1)");
+}
+
+#[test]
+fn refseq_compound_reference_is_unchanged_by_the_refactor() {
+    // The pre-existing `NC_(NM_)` path must be untouched by extracting the rule
+    // into the shared `try_compound_suffix` and by the nesting cap.
+    let (context, transcript, gene) = parts("NC_000013.11(NM_004119.3):c.100A>G");
+    assert_eq!(context.as_deref(), Some("NC_000013.11"));
+    assert_eq!(transcript, "NM_004119.3");
+    assert_eq!(gene, None);
+}
+
+#[test]
+fn nested_compound_reference_is_still_not_a_compound() {
+    // #1151 nesting cap: a nested form never parsed as a compound reference
+    // (the inner-is-compound rejection), and still does not. Pinning it proves
+    // the cap changed no behavior.
+    assert!(
+        parse_hgvs("NC_000013.11(NC_000013.11(NM_004119.3)):c.100A>G").is_err(),
+        "a nested compound reference must not parse",
+    );
+}
+
+#[test]
+fn refseq_outer_with_unversioned_inner_is_still_a_gene_selector() {
+    let (context, transcript, gene) = parts("NC_000023.10(DMD):c.100A>G");
+    assert_eq!(context, None);
+    assert_eq!(transcript, "NC_000023.10");
+    assert_eq!(gene.as_deref(), Some("DMD"));
+}
+
+// =============================================================================
+// Display round-trips on the newly-parseable forms.
+// =============================================================================
+
+#[test]
+fn custom_compound_reference_round_trips() {
+    // Cross-check against the generic `parse_variant` — a *different* internal
+    // code path than the fast-path-fronted `parse_hgvs` under test — rather than
+    // deriving the expectation from the same function (repo test policy).
+    let input = "Template(Template-gene.1):c.5A>G";
+    let via_fast_path = parse_hgvs(input).unwrap();
+    let via_generic = parse_variant(input).expect("generic parser accepts the form");
+    assert_eq!(
+        via_fast_path, via_generic,
+        "the two parse paths must agree on the compound reference",
+    );
+    assert_eq!(via_fast_path.to_string(), input);
+    assert_eq!(via_generic.to_string(), input);
+}
+
+#[test]
+fn custom_compound_display_is_idempotent() {
+    const EXPECTED: &str = "MYSEQ.1(MYTX.1):c.100A>G";
+    let once = parse_hgvs("MYSEQ.1(MYTX.1)(GENE1):c.100A>G")
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        once, EXPECTED,
+        "#1139: the stacked selector is dropped, leaving one specification",
+    );
+
+    // Assert the reparsed *structure*, not just the string: a render that
+    // round-trips byte-identically can still re-parse into a different shape —
+    // that is precisely the bug #1146 fixes, so string equality alone would not
+    // pin it.
+    let reparsed = parse_hgvs(&once).unwrap();
+    let acc = reparsed.accession().expect("accession");
+    assert_eq!(
+        acc.genomic_context.as_ref().map(|c| c.full()).as_deref(),
+        Some("MYSEQ.1")
+    );
+    assert_eq!(acc.transcript_accession(), "MYTX.1");
+    assert_eq!(gene_symbol_of(&reparsed), None);
+    assert_eq!(reparsed.to_string(), EXPECTED, "second render must match");
+}
+
+/// An over-wide version suffix must not be silently dropped.
+///
+/// `Accession::version` is a `u32`, and the parse used to be
+/// `digits.parse::<u32>().ok()` — so a digit run that did not fit became
+/// `None`, splitting the token and rendering `MYTX.4294967296` back as `MYTX`.
+/// The string parsed "successfully" and named a *different reference sequence*,
+/// the same class of silent rewrite this file's compound handling exists to
+/// prevent. An unrepresentable run is now simply not a version.
+///
+/// The two positions resolve it differently, and both are lossless:
+///
+/// * **outer** — the whole token stays the accession name, so `version` is
+///   `None` and the digits survive in the name;
+/// * **inner** — not being version-shaped, it no longer satisfies
+///   `versioned_inner_span`, so the parens fall through to the gene-symbol
+///   reading. Structurally that is the shape #1146 complains about, but it is
+///   the better of the two available answers while `version` is a `u32`:
+///   the alternative renamed the reference. Pinned so the choice is deliberate.
+#[test]
+fn an_unrepresentable_version_is_kept_in_the_accession_name() {
+    // Outer: kept in the name, no version parsed.
+    let v = parse_hgvs("MYTX.4294967296:c.100A>G").expect("parses");
+    assert_eq!(v.to_string(), "MYTX.4294967296:c.100A>G");
+    let accession = v.accession().expect("accession");
+    assert_eq!(accession.version, None, "over-wide run stored as a version");
+    assert!(
+        accession.to_string().contains("4294967296"),
+        "digits lost from the accession name: {accession}"
+    );
+
+    // Inner: falls back to the gene-symbol reading, string intact either way.
+    for input in [
+        "MYSEQ.1(MYTX.4294967296):c.100A>G",
+        "MYSEQ.1(MYTX.99999999999999999999):c.100A>G",
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} should parse: {e}"));
+        assert_eq!(v.to_string(), input, "version dropped from {input}");
+        assert!(
+            v.accession().expect("accession").genomic_context.is_none(),
+            "{input} should not be read as a compound reference"
+        );
+    }
+}
+
+/// A representable version still parses as one, so the guard above did not
+/// simply stop recognising versions.
+///
+/// Asserted on the `version` **field**, not only the rendering: keeping the
+/// digits in the accession *name* renders byte-identically, so a string
+/// round-trip cannot tell "parsed as a version" from "kept as text" — which is
+/// the whole distinction this fix turns on.
+#[test]
+fn a_representable_version_is_still_a_version() {
+    for (input, want) in [
+        ("MYTX.5:c.100A>G", 5u32),
+        ("MYSEQ.1(MYTX.5):c.100A>G", 5),
+        // `u32::MAX` itself is representable and must still split off.
+        ("MYSEQ.1(MYTX.4294967295):c.100A>G", u32::MAX),
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} should parse: {e}"));
+        let accession = v.accession().expect("accession");
+        assert_eq!(
+            accession.version,
+            Some(want),
+            "version not parsed into the field for {input}"
+        );
+        assert_eq!(v.to_string(), input);
+    }
+}
+
+/// A zero-padded version is not a version **on a custom accession**.
+///
+/// `Accession::version` is a `u32`, which cannot represent the padding, so
+/// splitting `MYTX.007` into name + `Some(7)` re-rendered it as `MYTX.7` — a
+/// different reference sequence, the same silent rewrite as the overflow case
+/// above. Keeping the token whole is lossless.
+///
+/// A single `0` is canonical and still parses as a version.
+#[test]
+fn a_zero_padded_version_is_kept_in_a_custom_accession_name() {
+    for input in [
+        "MYTX.01:c.100A>G",
+        "MYTX.007:c.100A>G",
+        "MYSEQ.1(MYTX.007):c.100A>G",
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} should parse: {e}"));
+        assert_eq!(v.to_string(), input, "zero-padded version rewritten");
+    }
+
+    let v = parse_hgvs("MYTX.0:c.100A>G").expect("parses");
+    assert_eq!(v.accession().expect("accession").version, Some(0));
+    assert_eq!(v.to_string(), "MYTX.0:c.100A>G");
+}
+
+/// A RefSeq accession is deliberately NOT covered by that rule.
+///
+/// A RefSeq version is a number whose canonical rendering is unpadded, so
+/// `NM_000088.03` → `NM_000088.3` is a correction rather than a rewrite: the
+/// accession still names the same sequence. A custom SAM refname is an opaque
+/// identifier, where the same edit changes *which* sequence is named. Pinned so
+/// the asymmetry stays deliberate.
+#[test]
+fn a_zero_padded_refseq_version_is_still_normalized() {
+    let v = parse_hgvs("NM_000088.03:c.100A>G").expect("parses");
+    assert_eq!(v.to_string(), "NM_000088.3:c.100A>G");
+    assert_eq!(v.accession().expect("accession").version, Some(3));
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -119,6 +119,7 @@ mod issue_1130_scoped_coalesce_declines;
 mod issue_1131_provider_accession_fallback;
 mod issue_1135_self_cancelling_merge;
 mod issue_1139_gene_symbol_specification;
+mod issue_1146_custom_compound_accession;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Stacked on #1141 (so the Display assertions here reflect the #1139 selector drop). GitHub will retarget this to `main` when #1141 merges.

## Problem

Compound reference syntax `outer(inner)` was recognised only when the outer accession was RefSeq-shaped or Ensembl, and only when the inner token matched the `looks_like_accession_start` prefix whitelist (`XX_`, `ENS`, `LRG_`). Custom (SAM-refname) and assembly/chromosome references could not carry a specification at all.

**Asymmetric acceptance** — the same shape parsed or failed on prefix alone:

```
NC_000013.11(NM_004119.3)(FLT3):c.100A>G   ->  parsed
MYSEQ.1(MYTX.1)(GENE1):c.100A>G            ->  Parse error: Expected ":" after accession
Template(Template-gene.1)(GENE1):c.5A>G    ->  Parse error: Expected ":" after accession
```

**Display output was string-stable but not struct-stable.** `Template(Template-gene.1):c.5A>G` — the spec-conformant form the projector emits for a custom reference after #1139 — re-parsed as:

```
accession = Template   genomic_context = None   gene_symbol = Some("Template-gene.1")
```

The transcript id lands in the gene-symbol field. The string round-trips byte-identically so no rendering test catches it, but a consumer that re-parses `projection.c_name` and reads `.gene_symbol` gets a transcript accession. Custom references reach ferro through `convert-gff`, so this is not synthetic-only.

The same shape held for assembly references, which is how it surfaced — probing #1145 showed `GRCh38(chr1)(NM_004006.2):c.100A>G` modelling `NM_004006.2` as a gene symbol.

## Fix

Extract the compound-suffix attempt into one `try_compound_suffix` and call it from **all four** accession families — standard, Ensembl, simple, and assembly. The rule previously had two copies and two omissions; now it has one implementation.

Disambiguating an inner accession from a gene-symbol selector cannot use a prefix whitelist for custom accessions, so it keys on the **version suffix**: HGNC gene symbols carry no `.<digits>` version. That keeps every existing reading intact:

| input | inner is | unchanged? |
|---|---|---|
| `MYREF_SEQ(GENE1):c.…` | gene symbol (#70) | ✅ |
| `NC_000023.10(DMD):c.…` | gene symbol (#1051) | ✅ |
| `GRCh38(chr1)(BRCA1):g.…` | gene symbol (#1145) | ✅ |
| `MYREF_SEQ(MYTX.1):c.…` | **specification** | new |
| `GRCh38(chr1)(NM_004006.2):c.…` | **specification** | new |

`is_valid_compound_outer` is widened to match: an assembly reference names a genomic sequence and a custom accession is unclassifiable, so neither can be called a backwards pairing. Only a *known* transcript/protein outer (`NM_`, `ENST`, `NP_`, `LRG_<N>t<M>`) is still rejected — which is what #963 was actually guarding against.

## Tests (written first, watched fail)

`tests/it/issue_1146_custom_compound_accession.rs` — 10 tests. 6 failed before the fix (the new parses, the struct-shape assertions, idempotency); 4 passed before and after, pinning that the unversioned-inner gene-symbol reading does not change. Assertions are on `genomic_context` / `transcript_accession` / `gene_symbol` rather than only on Display, so they pin the struct shape that was the actual defect.

## Verification

- `cargo nextest run --features dev` — 8358 passed, 0 failed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `pytest tests/python/` — 449 passed
- **Generated spec fixture: no status transitions.** Regenerated on the base and on this branch and diffed — byte-identical, so no `parse-error → preserved` movement.
- Conformance axes against the prepared reference — 224/225; the one failure (`axis_errors`, `NM_000143.3:c.45del4` / `c.45dup4`) reproduces identically on unmodified `origin/main`.

Closes #1146


> [!IMPORTANT]
> **CI does not run on this PR yet.** `.github/workflows/ci.yml` triggers on `pull_request: branches: [main]`, and this PR targets the #1141 branch, so only the CodeRabbit integration reports — the 8 real jobs (Build, Clippy ×2, Format, Test, Python Lint, Python Wheel Test, abi3) are not scheduled. They will run automatically once #1141 merges and GitHub retargets this to `main`. Until then the verification above is **local only**. Do not read the short check list as a green build.