### PR TITLE
fix(render): apply the protein render style to an allele's members

### DIFF
--- a/src/hgvs/variant.rs
+++ b/src/hgvs/variant.rs
@@ -1756,8 +1756,17 @@ fn write_bare_edit(f: &mut fmt::Formatter<'_>, variant: &HgvsVariant) -> fmt::Re
     }
 }
 
-impl fmt::Display for AlleleVariant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl AlleleVariant {
+    /// The single implementation of allele rendering, parameterized by protein
+    /// render style. `Display` delegates with `None`; `to_styled_string`
+    /// delegates with `Some(style)` so a caller's amino-acid preferences reach
+    /// the members — the members are what carry the amino acids, so rendering
+    /// them unstyled silently ignored the request.
+    fn fmt_with_style(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        style: Option<crate::hgvs::location::ProteinRenderStyle>,
+    ) -> fmt::Result {
         // Per HGVS spec, `[var]` denotes a multi-variant allele; a singleton
         // is just the inner variant. (Mosaic/chimeric already emit bare via
         // their separator-only loops; this unifies cis/trans/unknown.)
@@ -1767,7 +1776,7 @@ impl fmt::Display for AlleleVariant {
         // also guards `allele.uncertain` before collapsing a cis allele to a
         // singleton, keeping this invariant intact through the normalize path.
         if self.variants.len() == 1 {
-            return self.variants[0].fmt(f);
+            return fmt_member_full(f, &self.variants[0], style);
         }
         match self.phase {
             AllelePhase::Cis => {
@@ -1782,7 +1791,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, ";")?;
                         }
-                        v.fmt_loc_edit(f)?;
+                        fmt_member_loc_edit(f, v, style)?;
                     }
                     write!(f, "{}]", rp)
                 } else {
@@ -1792,7 +1801,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, ";")?;
                         }
-                        write!(f, "{}", v)?;
+                        fmt_member_full(f, v, style)?;
                     }
                     write!(f, "{}]", rp)
                 }
@@ -1811,7 +1820,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, ",")?;
                         }
-                        v.fmt_loc_edit(f)?;
+                        fmt_member_loc_edit(f, v, style)?;
                     }
                     write!(f, "{}]", rp)
                 } else {
@@ -1820,7 +1829,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, ",")?;
                         }
-                        write!(f, "{}", v)?;
+                        fmt_member_full(f, v, style)?;
                     }
                     write!(f, "{}]", rp)
                 }
@@ -1867,7 +1876,7 @@ impl fmt::Display for AlleleVariant {
                     // group has no nested-cis members, so it is disjoint from
                     // the `has_nested_group` arm above.
                     write_compact_prefix(f, &self.variants[0])?;
-                    self.variants[0].fmt_loc_edit(f)?;
+                    fmt_member_loc_edit(f, &self.variants[0], style)?;
                     for v in &self.variants[1..] {
                         write!(f, ";")?;
                         // `repeat_count_of` cannot be `None` here: every member
@@ -1892,7 +1901,7 @@ impl fmt::Display for AlleleVariant {
                             write!(f, ";")?;
                         }
                         write!(f, "[")?;
-                        v.fmt_loc_edit(f)?;
+                        fmt_member_loc_edit(f, v, style)?;
                         write!(f, "]")?;
                     }
                     Ok(())
@@ -1918,7 +1927,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, "(;)")?;
                         }
-                        v.fmt_loc_edit(f)?;
+                        fmt_member_loc_edit(f, v, style)?;
                     }
                     Ok(())
                 } else {
@@ -1928,7 +1937,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, "(;)")?;
                         }
-                        write!(f, "{}", v)?;
+                        fmt_member_full(f, v, style)?;
                     }
                     write!(f, "]")
                 }
@@ -1948,7 +1957,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, "^")?;
                         }
-                        v.fmt_loc_edit(f)?;
+                        fmt_member_loc_edit(f, v, style)?;
                     }
                     write!(f, ")")
                 } else if self.uncertain {
@@ -1959,7 +1968,7 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, "^")?;
                         }
-                        write!(f, "{}", v)?;
+                        fmt_member_full(f, v, style)?;
                     }
                     write!(f, ")")
                 } else if andor_alleles_share_accession(&self.variants) {
@@ -1991,12 +2000,44 @@ impl fmt::Display for AlleleVariant {
                         if i > 0 {
                             write!(f, "^")?;
                         }
-                        write!(f, "{}", v)?;
+                        fmt_member_full(f, v, style)?;
                     }
                     Ok(())
                 }
             }
         }
+    }
+}
+
+impl fmt::Display for AlleleVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_with_style(f, None)
+    }
+}
+
+/// Render an allele member's position+edit, honouring `style` on the `p.` axis.
+fn fmt_member_loc_edit(
+    f: &mut fmt::Formatter<'_>,
+    v: &HgvsVariant,
+    style: Option<crate::hgvs::location::ProteinRenderStyle>,
+) -> fmt::Result {
+    match (v, style) {
+        (HgvsVariant::Protein(p), Some(s)) => p.fmt_loc_edit_styled(f, s),
+        _ => v.fmt_loc_edit(f),
+    }
+}
+
+/// Render a full allele member (accession included), honouring `style` on the
+/// `p.` axis and recursing so a nested allele keeps it too.
+fn fmt_member_full(
+    f: &mut fmt::Formatter<'_>,
+    v: &HgvsVariant,
+    style: Option<crate::hgvs::location::ProteinRenderStyle>,
+) -> fmt::Result {
+    match (v, style) {
+        (HgvsVariant::Protein(p), Some(s)) => p.fmt_styled(f, s),
+        (HgvsVariant::Allele(a), _) => a.fmt_with_style(f, style),
+        _ => write!(f, "{}", v),
     }
 }
 
@@ -2279,16 +2320,28 @@ impl HgvsVariant {
     /// are affected; every other coordinate system renders identically to
     /// [`Display`](Self) (the style has no meaning there).
     ///
-    /// Styles only a single `HgvsVariant::Protein`; compound/allele forms
-    /// fall through to `to_string()` unstyled. That is acceptable — the
-    /// projector's `.protein` field is always a single
-    /// `HgvsVariant::Protein(ProteinVariant)`, never an allele, so `p_name`
-    /// styling is unaffected.
+    /// Styles a single `HgvsVariant::Protein` **and** an allele of protein
+    /// members; every other coordinate system renders identically to `Display`,
+    /// since the style has no meaning off the `p.` axis.
+    ///
+    /// The allele arm is not an edge case. This method used to excuse skipping
+    /// it on the grounds that "the projector's `.protein` field is always a
+    /// single `HgvsVariant::Protein`, never an allele" — no longer true:
+    /// separated residues render as a cis allele (#1095 for changed residues,
+    /// #1099 for silent ones), so a `.protein` is routinely bracketed and the
+    /// caller's amino-acid preferences were silently dropped for it.
     pub fn to_styled_string(&self, style: crate::hgvs::location::ProteinRenderStyle) -> String {
-        match self {
-            HgvsVariant::Protein(v) => v.to_styled_string(style),
-            other => other.to_string(),
+        struct Styled<'a>(&'a HgvsVariant, crate::hgvs::location::ProteinRenderStyle);
+        impl fmt::Display for Styled<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match self.0 {
+                    HgvsVariant::Protein(v) => v.fmt_styled(f, self.1),
+                    HgvsVariant::Allele(a) => a.fmt_with_style(f, Some(self.1)),
+                    other => write!(f, "{}", other),
+                }
+            }
         }
+        format!("{}", Styled(self, style))
     }
 
     /// Format just the position+edit portion (without accession and coordinate prefix).

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -283,6 +283,7 @@ mod protein_frameshift_legacy_stop_modes;
 mod protein_insertion_special;
 mod protein_no_protein_roundtrip;
 mod protein_predicted_trans;
+mod protein_render_policy;
 mod protein_silent_eq;
 mod protein_stop_codon_canonicalization;
 mod protein_substitution_alternatives;

--- a/tests/it/protein_render_policy.rs
+++ b/tests/it/protein_render_policy.rs
@@ -1,0 +1,135 @@
+//! The protein render style must reach an allele's members.
+//!
+//! Two rules govern how a `p.` description is written, and both were originally
+//! implemented only on the single-variant path — an allele of protein members
+//! reaches a different renderer and silently diverged from each:
+//!
+//! 1. **No gene-symbol selector** (`refseq.md:41`). Fixed for alleles by #1142
+//!    and single-sourced by #1141's `gene_selector_visible`, which composes the
+//!    accession-level and axis-level halves. Pinned here across the *styled*
+//!    path too, which reaches alleles for the first time now that they are
+//!    styled at all.
+//! 2. **The amino-acid render style** — what this file's remaining tests fix.
+//!    `to_styled_string` applied a caller's one-letter/three-letter and
+//!    `Ter`/`*` preferences to a single protein variant but sent an allele to
+//!    unstyled `Display`, so a bracketed consequence ignored the request. The
+//!    justification was that "the projector's `.protein` field is always a
+//!    single `HgvsVariant::Protein`, never an allele" — untrue since separated
+//!    residues began rendering as a cis allele (#1095 for changed residues,
+//!    #1099 for silent ones), which the projector emits routinely.
+
+use ferro_hgvs::{parse_hgvs, AaCode, ProteinRenderStyle, TerStyle};
+
+fn one_letter() -> ProteinRenderStyle {
+    ProteinRenderStyle {
+        aa_code: AaCode::One,
+        stop: TerStyle::Ter,
+    }
+}
+
+fn styled(input: &str) -> String {
+    parse_hgvs(input)
+        .unwrap_or_else(|e| panic!("{input} should parse: {e}"))
+        .to_styled_string(one_letter())
+}
+
+/// The baseline that already worked: a single protein variant honours the style.
+#[test]
+fn a_single_protein_variant_honours_the_render_style() {
+    assert_eq!(styled("NP_003997.2:p.(Phe41Cys)"), "NP_003997.2:p.(F41C)");
+}
+
+/// An allele must honour it too — the members are the things carrying the
+/// amino acids, so falling through to unstyled `Display` ignores the request.
+#[test]
+fn a_protein_cis_allele_honours_the_render_style() {
+    assert_eq!(
+        styled("NP_003997.2:p.[(Phe41Cys);(Gly47Arg)]"),
+        "NP_003997.2:p.[(F41C);(G47R)]"
+    );
+}
+
+#[test]
+fn a_protein_trans_allele_honours_the_render_style() {
+    assert_eq!(
+        styled("NP_003997.2:p.[(Phe41Cys)];[(Gly47Arg)]"),
+        "NP_003997.2:p.[(F41C)];[(G47R)]"
+    );
+}
+
+/// The remaining parseable phases, so the style reaches every renderer arm and
+/// not just the two common ones. `(;)` exercises the unknown-phase compact
+/// path; `^` renders *expanded*, so it exercises the full-member arm (accession
+/// included) rather than the loc-edit-only one.
+#[test]
+fn the_remaining_allele_phases_honour_the_render_style() {
+    assert_eq!(
+        styled("NP_003997.2:p.(Phe41Cys)(;)(Gly47Arg)"),
+        "NP_003997.2:p.(F41C)(;)(G47R)"
+    );
+    assert_eq!(
+        styled("NP_003997.2:p.(Phe41Cys)^(Gly47Arg)"),
+        "NP_003997.2:p.(F41C)^NP_003997.2:p.(G47R)"
+    );
+}
+
+/// The identity shapes #1099 emits are protein alleles too.
+#[test]
+fn a_silent_protein_allele_honours_the_render_style() {
+    assert_eq!(
+        styled("NP_003997.2:p.[(Phe41=);(Gly47=)]"),
+        "NP_003997.2:p.[(F41=);(G47=)]"
+    );
+}
+
+/// `Ter` styling reaches allele members as well.
+#[test]
+fn ter_style_reaches_allele_members() {
+    let star = ProteinRenderStyle {
+        aa_code: AaCode::Three,
+        stop: TerStyle::Star,
+    };
+    let v = parse_hgvs("NP_003997.2:p.[(Phe41Ter);(Gly47Arg)]").expect("parses");
+    assert_eq!(
+        v.to_styled_string(star),
+        "NP_003997.2:p.[(Phe41*);(Gly47Arg)]"
+    );
+}
+
+/// A non-protein allele is unaffected: the style has no meaning off the `p.`
+/// axis, so rendering must be byte-identical to `Display`.
+#[test]
+fn a_non_protein_allele_is_unchanged_by_the_style() {
+    for input in [
+        "NC_000013.11(FLT3):g.[12345A>G;12400C>T]",
+        "NM_000088.3:c.[100A>G;200C>T]",
+    ] {
+        let v = parse_hgvs(input).expect("parses");
+        assert_eq!(v.to_styled_string(one_letter()), v.to_string(), "{input}");
+    }
+}
+
+/// The gene-symbol rule holds on every protein rendering path, styled included
+/// — one predicate decides it, so the styled renderer cannot reintroduce the
+/// selector that #1142 removed from the plain one.
+#[test]
+fn no_protein_rendering_path_emits_a_gene_symbol_selector() {
+    for input in [
+        "NP_003997.2(DMD):p.(Phe41Cys)",
+        "NP_003997.2(DMD):p.[(Phe41Cys);(Gly47Arg)]",
+        "NP_003997.2(DMD):p.[(Phe41Cys)];[(Gly47Arg)]",
+        // The unknown-phase and product phases reach the styled renderer via
+        // different arms (compact and expanded); both must still suppress.
+        "NP_003997.2(DMD):p.(Phe41Cys)(;)(Gly47Arg)",
+        "NP_003997.2(DMD):p.(Phe41Cys)^(Gly47Arg)",
+        "YP_003024026.1(MT-ND1):p.[(Ala52Thr);(Gly300Arg)]",
+    ] {
+        let v = parse_hgvs(input).unwrap_or_else(|e| panic!("{input} should parse: {e}"));
+        for rendered in [v.to_string(), v.to_styled_string(one_letter())] {
+            assert!(
+                !rendered.contains("(DMD)") && !rendered.contains("(MT-ND1)"),
+                "{input} rendered a gene-symbol selector: {rendered}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
**Scope reduced during review.** This PR originally also unified the gene-symbol selector predicate. #1141 landed that on `main` first (`gene_selector_visible(accession, variant_type) = accession.admits_gene_selector() && variant_type != "p"`), so that half was dropped rather than duplicated — what remains is the render-style bug, which `main` still has.

## The bug

`to_styled_string` applied a caller's amino-acid preferences to a single protein variant but sent an allele to unstyled `Display`:

```
NP_003997.2:p.(Phe41Cys)              ->  NP_003997.2:p.(F41C)                    ✓
NP_003997.2:p.[(Phe41Cys);(Gly47Arg)] ->  NP_003997.2:p.[(Phe41Cys);(Gly47Arg)]   ✗ style ignored
```

The method's own doc excused it:

> Styles only a single `HgvsVariant::Protein`; compound/allele forms fall through to `to_string()` unstyled. That is acceptable — the projector's `.protein` field is always a single `HgvsVariant::Protein(ProteinVariant)`, never an allele, so `p_name` styling is unaffected.

**That premise expired.** Separated residues render as a cis allele — #1095 for changed residues, #1099 for silent ones — so a projected `.protein` is routinely bracketed. Python's `p_name` styling (`python.rs`, `to_styled_string` per variant) has therefore been silently not applying to a common shape.

## The fix

Parameterize rather than duplicate. The allele renderer is ~240 lines across seven phases; copying it for styling would be the wrong trade. Instead `fmt_with_style(f, Option<ProteinRenderStyle>)` becomes the single implementation, `Display` delegates with `None`, `to_styled_string` with `Some(style)`. Two helpers route each member — `fmt_member_loc_edit` for the compact form, `fmt_member_full` for the expanded one — and `fmt_member_full` recurses so a nested allele keeps the style.

Non-protein members are untouched: the style has no meaning off the `p.` axis, and a guard test pins that a genomic and a coding allele render byte-identically to `Display`.

## Testing

Test-first: four failing cases — cis, trans, the silent-identity shape #1099 emits, and `Ter`/`*` styling reaching members — plus three that had to pass from the start: the single-variant baseline, the non-protein guard, and an invariant that no protein rendering path emits a gene-symbol selector.

That last one is worth keeping despite the dropped refactor: the styled path reaches alleles for the first time here, so it is newly able to violate #1141's rule. It asserts `gene_selector_visible` still decides the outcome on both the plain and styled paths.

Full suite green (8396); `clippy --all-features --all-targets -D warnings` and `fmt --check` clean.
