### PR TITLE
fix(parser): reject an insertion with no inserted sequence (bare `ins`)

### DIFF
--- a/src/error_handling/registry.rs
+++ b/src/error_handling/registry.rs
@@ -582,8 +582,8 @@ fn build_registry() -> HashMap<&'static str, CodeInfo> {
             explanation: "Edit type keywords should be lowercase (del, ins, dup, etc.). \
                 Mixed case like 'Del' or 'INS' is auto-corrected in lenient/silent modes.",
             category: CodeCategory::Case,
-            bad_examples: &["c.100Del", "c.100_101INS"],
-            good_examples: &["c.100del", "c.100_101ins"],
+            bad_examples: &["c.100Del", "c.100_101INSA"],
+            good_examples: &["c.100del", "c.100_101insA"],
             mode_behavior: Some(ModeBehavior::standard_correctable()),
             hgvs_spec_url: None,
             related_codes: &[],

--- a/src/hgvs/parser/edit.rs
+++ b/src/hgvs/parser/edit.rs
@@ -287,9 +287,21 @@ fn parse_deletion(input: &str) -> IResult<&str, NaEdit> {
 
 /// Parse an insertion (e.g., insA, insATG, ins10, ins(10), ins(10_20), insA[10], ins[A[10];T])
 fn parse_insertion(input: &str, allow_special_positions: bool) -> IResult<&str, NaEdit> {
-    let (input, _) = tag("ins").parse(input)?;
-    let (input, sequence) = parse_inserted_sequence(input, allow_special_positions)?;
-    Ok((input, NaEdit::Insertion { sequence }))
+    let (rest, _) = tag("ins").parse(input)?;
+    let (rest, sequence) = parse_inserted_sequence(rest, allow_special_positions)?;
+    // An insertion is defined by what it inserts (`DNA/insertion.md:22`); the
+    // spec offers no production for a bare `ins` (#1137). Reject an empty
+    // inserted sequence rather than mint a `NaEdit::Insertion { sequence: Empty }`
+    // that asserts no change. `delins` with an empty insert is a distinct case
+    // (it collapses to `del`, handled by the preprocessor) and is unaffected —
+    // this guard only fires on the `ins` edit itself.
+    if sequence.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+    Ok((rest, NaEdit::Insertion { sequence }))
 }
 
 /// Parse an inserted sequence in any format

--- a/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
+++ b/tests/fixtures/bulk/clinvar_hgvs_unique_failure_expectations.json
@@ -339,6 +339,11 @@
       "category": "rejected_by_design",
       "reason": "Insertion anchored on two positions that are not flanking (adjacent). HGVS DNA/insertion.md:15 requires the `positions flanking` to be `123_124`, not `123_125`, and line 16 requires them listed 5' to 3'; syntax.yaml `dna.ins` restates it as `range` must be specified using adjacent positions. Sibling rule to `[single_position_insertion]`, and rejected for the same reason: the intended flanking pair is not recoverable, so no repair is derivable. A wide anchor is a deletion-insertion (`delins`), not an insertion.",
       "tracking": "#1079"
+    },
+    "[insertion_without_inserted_sequence]": {
+      "category": "rejected_by_design",
+      "reason": "Bare `ins` with no inserted sequence. An insertion is defined by what it inserts (HGVS DNA/insertion.md:22); every form the spec offers supplies a payload (literal bases, a same-reference range, or another reference) and syntax.yaml `dna.ins` has no production for a payload-less `ins`. A bare `ins` asserts no change and has no derivable repair, so it is rejected in every error mode.",
+      "tracking": "#1137"
     }
   },
   "expected_failures": {
@@ -552,6 +557,7 @@
     "NM_003977.2:c.878_879AG>GT": "[multibase_substitution]",
     "NC_000011.10:g.5238138_5153222insTATTT": "[non_flanking_insertion_anchor]",
     "NM_000061.3:c.418_424insSVA": "[non_flanking_insertion_anchor]",
-    "NM_000548.3:c.[4621_4629del9;4621_4634ins14]": "[non_flanking_insertion_anchor]"
+    "NM_000548.3:c.[4621_4629del9;4621_4634ins14]": "[non_flanking_insertion_anchor]",
+    "NM_001134407.3:c.(414+1_415-1)_(1007+1_1008-1)ins": "[insertion_without_inserted_sequence]"
   }
 }

--- a/tests/it/issue_1137_reject_bare_ins.rs
+++ b/tests/it/issue_1137_reject_bare_ins.rs
@@ -1,0 +1,102 @@
+//! Issue #1137: the parser must reject an insertion with no inserted sequence.
+//!
+//! An insertion is defined by what it inserts (`DNA/insertion.md:22`): every
+//! form the spec offers supplies a payload — literal bases (`insAGC`), a
+//! same-reference range (`ins858_895`), or another reference. There is no
+//! production for a bare `ins` in `syntax.yaml`'s `dna.ins`. Before this fix
+//! the parser accepted `…ins` and round-tripped it unchanged, minting a
+//! `NaEdit::Insertion { sequence: Empty }` — a semantically empty edit that
+//! asserts no change and forces downstream code to defend against it (see the
+//! internally-constructed empty-insertion guard from #1136).
+//!
+//! A bare `ins` has no repair (the bases are simply absent), so it is rejected
+//! in every error mode — standard, lenient, and strict — at parse time. These
+//! tests need no prepared reference, so they gate every PR.
+
+use ferro_hgvs::error_handling::ErrorConfig;
+use ferro_hgvs::hgvs::parser::{parse_hgvs_lenient, parse_hgvs_with_config};
+use ferro_hgvs::parse_hgvs;
+
+/// Bare-`ins` inputs across coordinate systems, each a two-position anchor with
+/// the payload omitted.
+const BARE_INS: &[&str] = &[
+    "NC_000001.11:g.100_101ins",
+    "NM_004006.3:c.179_180ins",
+    "NM_000088.3:n.100_101ins",
+    "NM_004006.2:r.100_101ins",
+    "NC_012920.1:m.100_101ins",
+];
+
+/// The default (standard) parse path must reject a bare `ins`.
+#[test]
+fn standard_parse_rejects_bare_ins() {
+    for input in BARE_INS {
+        assert!(
+            parse_hgvs(input).is_err(),
+            "expected a bare `ins` to be rejected in standard mode: {input:?}"
+        );
+    }
+}
+
+/// Lenient mode has no repair for a missing inserted sequence, so it rejects
+/// rather than round-tripping the empty edit.
+#[test]
+fn lenient_parse_rejects_bare_ins() {
+    for input in BARE_INS {
+        assert!(
+            parse_hgvs_lenient(input).is_err(),
+            "expected a bare `ins` to be rejected in lenient mode: {input:?}"
+        );
+    }
+}
+
+/// Strict mode rejects a bare `ins`.
+#[test]
+fn strict_parse_rejects_bare_ins() {
+    for input in BARE_INS {
+        assert!(
+            parse_hgvs_with_config(input, ErrorConfig::strict()).is_err(),
+            "expected a bare `ins` to be rejected in strict mode: {input:?}"
+        );
+    }
+}
+
+/// Regression guard: insertions that DO carry a payload still parse. The fix
+/// keys on the resulting empty sequence, so every legitimate inserted-sequence
+/// form must be unaffected.
+#[test]
+fn insertions_with_a_payload_still_parse() {
+    for input in [
+        "NC_000001.11:g.100_101insA",
+        "NC_000001.11:g.100_101insATG",
+        "NC_000001.11:g.100_101ins10",
+        "NC_000001.11:g.100_101ins[A[10];T]",
+        "NM_000088.3:c.100_101insA",
+        "NC_000001.11:g.849_850ins858_895",
+    ] {
+        assert!(
+            parse_hgvs(input).is_ok(),
+            "a payloaded insertion must still parse: {input:?}"
+        );
+    }
+}
+
+/// Regression guard: a `delins` with no inserted sequence is a distinct case
+/// (it collapses to a plain `del`, handled elsewhere as W3012) and must not be
+/// swept up by the bare-`ins` rejection. A plain `del` is likewise unaffected.
+#[test]
+fn del_and_bare_delins_are_unaffected() {
+    // A bare `delins` still parses — the bare-`ins` rejection lives in
+    // `parse_insertion`, which `delins` never reaches. The standard path parses
+    // it as-is; lenient rewrites it to the equivalent plain `del` (W3012).
+    let standard = parse_hgvs("NC_000001.11:g.100_101delins")
+        .expect("a bare `delins` must still parse in standard mode");
+    assert_eq!(standard.to_string(), "NC_000001.11:g.100_101delins");
+
+    let lenient = parse_hgvs_lenient("NC_000001.11:g.100_101delins")
+        .expect("a bare `delins` must still parse in lenient mode");
+    assert_eq!(lenient.result.to_string(), "NC_000001.11:g.100_101del");
+
+    // A plain deletion is valid and stays valid.
+    assert!(parse_hgvs("NC_000001.11:g.100_101del").is_ok());
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -118,6 +118,7 @@ mod issue_1129_trailing_ter_delins;
 mod issue_1130_scoped_coalesce_declines;
 mod issue_1131_provider_accession_fallback;
 mod issue_1135_self_cancelling_merge;
+mod issue_1137_reject_bare_ins;
 mod issue_1139_gene_symbol_specification;
 mod issue_1146_custom_compound_accession;
 mod issue_129_mt_circular_wraparound;


### PR DESCRIPTION
## Summary

The parser accepted a bare `ins` (an insertion with no inserted sequence) and round-tripped it unchanged:

```
$ ferro parse 'NC_000001.11:g.100_101ins'
NC_000001.11:g.100_101ins        # before: accepted
ERROR: ... Failed to parse       # after:  rejected
```

This minted a `NaEdit::Insertion { sequence: Empty }` — a semantically empty edit that asserts no change. An insertion is defined by what it inserts (`DNA/insertion.md:22`): every form the spec offers supplies a payload — literal bases (`insAGC`), a same-reference range (`ins858_895`), or another reference — and `syntax.yaml`'s `dna.ins` has no production for a payload-less `ins`.

## The fix

`parse_insertion` now rejects an empty inserted sequence at parse time, keying on `InsertedSequence::is_empty()` (which covers `Empty`, empty-literal, and empty-named). Because the check is at the nom parser level, a bare `ins` is rejected in **every error mode** — standard, lenient, and strict. There is no repair (the bases are simply absent), so rejection is correct in all modes. This removes the shape from the parse-reachable states.

`delins` with an empty insert is a distinct case — it collapses to a plain `del` (handled by the preprocessor as W3012) and does not go through `parse_insertion`, so it is unaffected. `dup`, `dupins`, and payloaded insertions are likewise untouched.

## Ripple fixes

- **W1004 registry examples.** The `MixedCaseEditType` entry used `c.100_101ins` as its "good example" — now itself invalid — so both examples get a payload (`c.100_101insA` / `c.100_101INSA`). These are documentation-only and not test-parsed; the mixed-case correction is exercised separately with payloaded forms.
- **Bulk failure-expectations snapshot.** The ClinVar bulk fixture contained one real-world bare-`ins` input, `NM_001134407.3:c.(414+1_415-1)_(1007+1_1008-1)ins`, which now correctly fails. It is recorded under a curated `rejected_by_design` kind (`[insertion_without_inserted_sequence]`) rather than the auto-blesser's `needs_triage` kind (which would fail the build).

## Tests

New `tests/it/issue_1137_reject_bare_ins.rs` (TDD, written failing first):

- bare `ins` rejected across g/c/n/r/m in standard, lenient, and strict modes;
- regression guards that payloaded insertions (`insA`, `insATG`, `ins10`, `ins[A[10];T]`, `ins858_895`) and a plain `del` still parse.

Full suite green (8435/8435), targeted sweep 849/849, `cargo fmt` + `clippy --all-targets -D warnings` clean. Regenerating the spec fixture leaves its status counts unchanged (no bare-`ins` rows exist in the harvested spec).

## Follow-up

As noted in the issue, this makes the empty-insertion shape unreachable *via parsing*, which would let #1136's defensive rotation guard be retired. That guard defends the internally-constructed cis-merge path and is left in place here; retiring it warrants separate analysis.

Closes #1137