### PR TITLE
fix(reference): enforce the canonical-overrides schema version at load

### DIFF
--- a/src/reference/authoritative.rs
+++ b/src/reference/authoritative.rs
@@ -23,6 +23,9 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::error::FerroError;
 
 /// The authoritative facts about a transcript at an exact accession version,
 /// taken from its canonical RefSeq (GenBank) record.
@@ -275,6 +278,40 @@ impl CanonicalOverrides {
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }
+
+    /// Load from a JSON file, enforcing the schema-version handshake (#1001
+    /// follow-up).
+    ///
+    /// Mirrors [`crate::reference::derived_placement::DerivedPlacements::from_json_path`]
+    /// and
+    /// [`crate::reference::derived_tx_structure::DerivedTxStructures::from_json_path`]:
+    /// an absent `schema_version` (a pre-versioning on-disk file) deserializes
+    /// to `0` and is accepted as legacy; a version newer than
+    /// [`CANONICAL_OVERRIDES_SCHEMA_VERSION`] is a hard error rather than a
+    /// silently-dropped artifact.
+    /// Read and parse failures name the offending file: this is now a hard
+    /// error at provider construction, and the bare `io`/`serde` message alone
+    /// ("No such file or directory", "expected value at line 1 column 3") does
+    /// not say which artifact to fix.
+    pub fn from_json_path<P: AsRef<Path>>(path: P) -> Result<Self, FerroError> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path).map_err(|e| FerroError::Io {
+            msg: format!("Failed to read canonical overrides {}: {e}", path.display()),
+        })?;
+        let parsed: Self = serde_json::from_str(&content).map_err(|e| FerroError::Json {
+            msg: format!(
+                "Failed to parse canonical overrides {}: {e}",
+                path.display()
+            ),
+        })?;
+        crate::reference::check_artifact_schema_version(
+            "canonical_overrides",
+            parsed.schema_version,
+            CANONICAL_OVERRIDES_SCHEMA_VERSION,
+            path,
+        )?;
+        Ok(parsed)
+    }
 }
 
 /// Build a [`CanonicalOverrides`] for `accessions` by fetching and parsing each
@@ -442,6 +479,54 @@ ORIGIN
         let ov = CanonicalOverrides::from_json(r#"{"records":{}}"#).unwrap();
         assert_eq!(ov.schema_version, 0);
         assert!(ov.is_empty());
+    }
+
+    #[test]
+    fn legacy_overrides_file_without_schema_version_loads_via_path() {
+        // Mirrors DerivedPlacements::from_json_path /
+        // DerivedTxStructures::from_json_path: a pre-versioning on-disk file (no
+        // `schema_version` key at all) must still load, not be rejected.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("overrides.json");
+        std::fs::write(&p, br#"{"records":{}}"#).unwrap();
+        let loaded =
+            CanonicalOverrides::from_json_path(&p).expect("legacy overrides file must load");
+        assert_eq!(loaded.schema_version, 0, "absent version reads as 0");
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn current_schema_version_overrides_file_loads_via_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("overrides.json");
+        std::fs::write(
+            &p,
+            format!(
+                r#"{{"schema_version":{},"records":{{}}}}"#,
+                CANONICAL_OVERRIDES_SCHEMA_VERSION
+            ),
+        )
+        .unwrap();
+        assert!(CanonicalOverrides::from_json_path(&p).is_ok());
+    }
+
+    #[test]
+    fn newer_schema_version_overrides_file_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("overrides.json");
+        std::fs::write(
+            &p,
+            format!(
+                r#"{{"schema_version":{},"records":{{}}}}"#,
+                CANONICAL_OVERRIDES_SCHEMA_VERSION + 1
+            ),
+        )
+        .unwrap();
+        let err = CanonicalOverrides::from_json_path(&p).unwrap_err();
+        assert!(
+            format!("{err}").contains("newer than this build"),
+            "expected an actionable version error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -1182,21 +1182,14 @@ impl MultiFastaProvider {
         // derived old version is applied to the injected record.
         if let Some(overrides_ref) = manifest.get("canonical_overrides").and_then(|v| v.as_str()) {
             let path = resolve_path(overrides_ref);
-            match std::fs::read_to_string(&path) {
-                Ok(text) => match CanonicalOverrides::from_json(&text) {
-                    Ok(ov) => {
-                        eprintln!("Loaded {} canonical override records", ov.len());
-                        provider.canonical_overrides = ov;
-                        provider.reconcile_cdot_with_overrides();
-                    }
-                    Err(e) => eprintln!("Warning: Failed to parse canonical overrides: {}", e),
-                },
-                Err(e) => eprintln!(
-                    "Warning: Failed to read canonical overrides {}: {}",
-                    path.display(),
-                    e
-                ),
-            }
+            // A wired canonical_overrides entry is a promise that these
+            // corrections apply; a read/parse/schema failure here must be a
+            // hard error (not a warning), else the provider would silently
+            // serve un-corrected CDS/protein metadata (#1001 follow-up).
+            let ov = CanonicalOverrides::from_json_path(&path)?;
+            eprintln!("Loaded {} canonical override records", ov.len());
+            provider.canonical_overrides = ov;
+            provider.reconcile_cdot_with_overrides();
         }
 
         Ok(provider)
@@ -7391,5 +7384,83 @@ NC_000001.11\tRefSeq\tmatch\t9000\t9099\t100\t+\t.\tID=a1;Target=NG_008000.1 1 1
             serde_json::from_slice(&std::fs::read(dir.path().join("manifest.json")).unwrap())
                 .unwrap();
         assert!(verify_reference_identity(&v, dir.path()).is_err());
+    }
+
+    // --- canonical-overrides schema version enforced at load (follow-up to #1001) ---
+
+    /// A wired-but-unusable `canonical_overrides` artifact must now fail
+    /// provider construction outright, rather than being warned-and-dropped so
+    /// the provider silently serves un-corrected CDS/protein metadata.
+    #[test]
+    fn from_manifest_fails_on_a_newer_schema_canonical_overrides() {
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        fs::write(d.join("tx.fna"), ">NM_000088.4\nAAAA\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000088.4\t4\t13\t4\t5\n").unwrap();
+        fs::write(
+            d.join("overrides.json"),
+            format!(
+                r#"{{"schema_version":{},"records":{{}}}}"#,
+                crate::reference::authoritative::CANONICAL_OVERRIDES_SCHEMA_VERSION + 1
+            ),
+        )
+        .unwrap();
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "canonical_overrides": "overrides.json",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        match MultiFastaProvider::from_manifest(d.join("manifest.json")) {
+            Ok(_) => panic!("expected a schema-version load failure"),
+            Err(err) => assert!(
+                format!("{err}").contains("newer than this build"),
+                "expected a schema-version load failure, got: {err}"
+            ),
+        }
+    }
+
+    /// A corrupt (unparseable) `canonical_overrides` artifact must likewise fail
+    /// provider construction rather than being warned-and-dropped.
+    #[test]
+    fn from_manifest_fails_on_a_corrupt_canonical_overrides() {
+        use std::fs;
+
+        let dir = tempdir().unwrap();
+        let d = dir.path();
+
+        fs::write(d.join("tx.fna"), ">NM_000088.4\nAAAA\n").unwrap();
+        fs::write(d.join("tx.fna.fai"), "NM_000088.4\t4\t13\t4\t5\n").unwrap();
+        fs::write(d.join("overrides.json"), b"{ not valid json").unwrap();
+        fs::write(
+            d.join("manifest.json"),
+            r#"{
+                "prepared_at": "test",
+                "transcript_fastas": ["tx.fna"],
+                "canonical_overrides": "overrides.json",
+                "transcript_count": 1,
+                "available_prefixes": []
+            }"#,
+        )
+        .unwrap();
+
+        let err = MultiFastaProvider::from_manifest(d.join("manifest.json"))
+            .err()
+            .expect("a corrupt canonical_overrides artifact must fail provider construction");
+        // The failure is fatal now, so it must name the file to fix — a bare
+        // serde message ("expected value at line 1 column 3") would not.
+        assert!(
+            format!("{err}").contains("overrides.json"),
+            "the error must name the offending artifact, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
> **Stacked on #1154** (which is itself stacked on #1153). Base branch is `feat/issue-1001-artifact-handshake`, not `main`. This PR's diff is the single commit on top of #1154 — it reuses the `check_artifact_schema_version` helper that PR introduces.

## Summary

Closes the last artifact in the same class #1001 addressed. `CanonicalOverrides` already had a `schema_version` field and a hand-written `Default`, but **nothing checked the version at load** — the one ferro-authored JSON artifact left without a handshake after #1154.

## Why the check alone wasn't enough

Adding the gate naively would have been **inert**. The single runtime load site (`src/reference/multi_fasta.rs`) swallowed every failure:

```rust
Ok(text) => match CanonicalOverrides::from_json(&text) {
    Ok(ov) => { /* apply */ }
    Err(e) => eprintln!("Warning: Failed to parse canonical overrides: {}", e),
},
Err(e) => eprintln!("Warning: Failed to read canonical overrides {}: {}", ...),
```

So a corrupt or newer-schema overrides file was dropped with a warning and the provider carried on with **empty** overrides — serving un-corrected CDS/protein metadata. That is exactly the silent-wrong-output failure mode #1001 set out to eliminate, and it would have swallowed the new schema rejection too.

## What changed

- **`CanonicalOverrides::from_json_path`** — mirrors the convention its siblings already use (`DerivedTxStructures::from_json_path`, `DerivedPlacements::from_json_path`): read → deserialize → `check_artifact_schema_version("canonical_overrides", …)`. Same semantics as the siblings: an overrides file with **no** `schema_version` key deserializes to `0` and is **accepted as legacy**; a version **newer** than this build supports is hard-rejected. `from_json(&str)` is unchanged for its existing callers.
- **The load site now propagates.** A wired `canonical_overrides` entry is a promise that those corrections apply, so a read/parse/schema failure is now a hard `FerroError` out of `from_manifest_inner` rather than a warning. This is consistent with the surrounding design: #1153's `ensure_stamped_artifacts_readable` already hard-errors on a *missing* wired `canonical_overrides`, so tolerating an unusable one was the odd case out.

## Testing

Full suite **8468 passed / 0 failed** (145 manifest-gated skips) — **no existing test needed changing**, i.e. nothing depended on the previous silent-tolerance behavior. New coverage: legacy (no version key) accepted, current version accepted, `CURRENT + 1` rejected with "newer than this build", and a load-site test that a provider whose manifest wires an unusable overrides file now fails to construct instead of silently proceeding with empty overrides. Live parity still reproduces the pinned reference identity `aa8b3246d83055cc`; `cargo fmt` + `clippy --all-targets -D warnings` clean.