### PR TITLE
fix: 3'-shift delins that reduces to a deletion or duplication (#1157)

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -6955,15 +6955,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         DelinsCanonical::Deletion { start: s0, end: e0 } => {
                             // c.2_5delinsAT (ref ACGT) -> c.3_4del. Range fields
                             // are the trimmed half-open 0-indexed interval.
-                            return Ok((
-                                index_to_hgvs_pos(s0),
-                                e0 as u64,
-                                NaEdit::Deletion {
-                                    sequence: None,
-                                    length: None,
-                                },
-                                warnings.clone(),
-                            ));
+                            //
+                            // Recurse into `normalize_na_edit` with the reduced
+                            // deletion so the full del pipeline (3'-shift
+                            // `shuffle()` + repeat contraction) runs — exactly as
+                            // the `Insertion` arm below already does. Returning
+                            // the trimmed deletion directly skipped the shift,
+                            // making the output non-idempotent and non-confluent
+                            // with the same edit written as a plain `del`:
+                            // `g.257_259delinsT` emitted the unshifted
+                            // `g.258_259del`, while a direct `g.258_259del`
+                            // 3'-shifts (and contracts) to `g.258_262A[3]`, so
+                            // `norm(norm(x)) != norm(x)`. Issue #1157.
+                            let new_edit = NaEdit::Deletion {
+                                sequence: None,
+                                length: None,
+                            };
+                            let (new_start, new_end, new_edit, mut child_warnings) = self
+                                .normalize_na_edit(
+                                    ref_seq,
+                                    &new_edit,
+                                    index_to_hgvs_pos(s0),
+                                    e0 as u64,
+                                    boundaries,
+                                    is_coding,
+                                )?;
+                            let mut merged = warnings.clone();
+                            merged.append(&mut child_warnings);
+                            return Ok((new_start, new_end, new_edit, merged));
                         }
                         DelinsCanonical::Insertion {
                             after_index,
@@ -7044,16 +7063,31 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             // c.5delinsGG where ref[5]=G  ->  c.5dup. Duplication
                             // is detected before trimming, so the range matches
                             // the input.
-                            return Ok((
-                                index_to_hgvs_pos(s0),
-                                e0 as u64,
-                                NaEdit::Duplication {
-                                    sequence: None,
-                                    length: None,
-                                    uncertain_extent: None,
-                                },
-                                warnings.clone(),
-                            ));
+                            //
+                            // Recurse so the reduced duplication takes the same
+                            // 3'-shift `shuffle()` a plain `dup` receives, mirror
+                            // of the Deletion/Insertion arms. Direct-return here
+                            // skipped the shift, so `g.258delinsGG` in a G-tract
+                            // emitted the unshifted `g.258dup` while a direct
+                            // `g.258dup` shifts to `g.262dup` — non-idempotent and
+                            // non-confluent. Issue #1157.
+                            let new_edit = NaEdit::Duplication {
+                                sequence: None,
+                                length: None,
+                                uncertain_extent: None,
+                            };
+                            let (new_start, new_end, new_edit, mut child_warnings) = self
+                                .normalize_na_edit(
+                                    ref_seq,
+                                    &new_edit,
+                                    index_to_hgvs_pos(s0),
+                                    e0 as u64,
+                                    boundaries,
+                                    is_coding,
+                                )?;
+                            let mut merged = warnings.clone();
+                            merged.append(&mut child_warnings);
+                            return Ok((new_start, new_end, new_edit, merged));
                         }
                         DelinsCanonical::KeepAsDelins {
                             start: s0,

--- a/tests/it/issue_1157_delins_reduction_shift.rs
+++ b/tests/it/issue_1157_delins_reduction_shift.rs
@@ -1,0 +1,162 @@
+//! Regression test for issue #1157: normalization of a `delins` that reduces
+//! to a pure deletion (or a duplication) was **not idempotent** and **not
+//! confluent** with the same edit written directly as a `del`/`dup`.
+//!
+//! Root cause: in `normalize_na_edit`, when `canonicalize_delins` trimmed a
+//! `delins` down to a `DelinsCanonical::Deletion` (or `::Duplication`), the
+//! arm returned the reduced edit **directly**, bypassing the 3'-shift
+//! `shuffle()` that every genuine `del`/`dup` input receives. The sibling
+//! `DelinsCanonical::Insertion` arm already recurses into `normalize_na_edit`
+//! for exactly this reason; the del/dup arms did not.
+//!
+//! Symptom (from the issue):
+//!   norm(g.10_20delinsTC) = g.12_20del        (unshifted — WRONG)
+//!   norm(g.12_20del)      = g.13_21del         (shifted — the true canonical)
+//!   ⇒ norm(norm(x)) != norm(x)   (idempotence violated)
+//!
+//! These tests exercise the same defect on the synthetic homopolymer/tandem
+//! fixtures where the 3'-shift target is unambiguous.
+
+use crate::common::synthetic::{normalize_to_string, SyntheticBuilder};
+
+/// Normalize `input` against a genomic provider whose core sequence is `core`
+/// (padded on both sides; the core's first base is at 1-based HGVS position
+/// `PAD_OFFSET + 1`).
+fn norm(core: &str, input: &str) -> String {
+    normalize_to_string(SyntheticBuilder::genomic(core).build(), input)
+}
+
+// --------------------------------------------------------------------------
+// delins → deletion
+// --------------------------------------------------------------------------
+
+/// Core `T AAAAA G`: a `T` at core position 1, an A-tract at core 2..=6, a `G`
+/// at core 7. `PAD_OFFSET` = 256, so core position k is HGVS position 256 + k.
+///
+/// `g.257_259delinsT` deletes ref `TAA` and inserts `T`: shared-affix trimming
+/// strips the leading `T`, leaving a pure deletion of `AA` at 258_259 — inside
+/// the A-tract 258..=262. A genuine deletion of two A's from that tract 3'-shifts
+/// and collapses to the repeat form `g.258_262A[3]`.
+const DEL_CORE: &str = "TAAAAAG";
+
+#[test]
+fn delins_reducing_to_deletion_is_three_prime_shifted() {
+    // The bug returned the unshifted `g.258_259del`; the canonical form is the
+    // 3'-shifted repeat contraction.
+    assert_eq!(
+        norm(DEL_CORE, "NC_TEST.1:g.257_259delinsT"),
+        "NC_TEST.1:g.258_262A[3]",
+    );
+}
+
+#[test]
+fn delins_reducing_to_deletion_is_idempotent() {
+    let once = norm(DEL_CORE, "NC_TEST.1:g.257_259delinsT");
+    let twice = norm(DEL_CORE, &once);
+    assert_eq!(once, twice, "norm(norm(x)) must equal norm(x)");
+}
+
+#[test]
+fn delins_reducing_to_deletion_matches_direct_deletion() {
+    // Encoding invariance: the delins spelling and the equivalent direct
+    // deletion of the same two A's must normalize to the same canonical form.
+    assert_eq!(
+        norm(DEL_CORE, "NC_TEST.1:g.257_259delinsT"),
+        norm(DEL_CORE, "NC_TEST.1:g.258_259del"),
+    );
+}
+
+// --------------------------------------------------------------------------
+// delins → duplication (sibling defect in the same function)
+// --------------------------------------------------------------------------
+
+/// Core `A GGGGG T`: a `G`-tract at core 2..=6. `g.258delinsGG` deletes ref `G`
+/// and inserts `GG` — a single-copy duplication of the reference `G` at 258.
+/// A genuine duplication inside the G-tract 3'-shifts to the tract's 3' end,
+/// `g.262dup`.
+const DUP_CORE: &str = "AGGGGGT";
+
+#[test]
+fn delins_reducing_to_duplication_is_three_prime_shifted() {
+    // The bug returned the unshifted `g.258dup`; the canonical form is `g.262dup`.
+    assert_eq!(
+        norm(DUP_CORE, "NC_TEST.1:g.258delinsGG"),
+        "NC_TEST.1:g.262dup",
+    );
+}
+
+#[test]
+fn delins_reducing_to_duplication_is_idempotent() {
+    let once = norm(DUP_CORE, "NC_TEST.1:g.258delinsGG");
+    let twice = norm(DUP_CORE, &once);
+    assert_eq!(once, twice, "norm(norm(x)) must equal norm(x)");
+}
+
+#[test]
+fn delins_reducing_to_duplication_matches_direct_duplication() {
+    assert_eq!(
+        norm(DUP_CORE, "NC_TEST.1:g.258delinsGG"),
+        norm(DUP_CORE, "NC_TEST.1:g.258dup"),
+    );
+}
+
+// --------------------------------------------------------------------------
+// Scope boundary: issue #1157 "case A" is deliberate behavior, not a bug.
+// --------------------------------------------------------------------------
+//
+// A single length-changing `delins` and a decomposed cis allele of the *same*
+// edit produce the same resulting sequence but are kept in DISTINCT canonical
+// forms: ferro does not merge non-adjacent cis-allele members across unchanged
+// reference bases into one spanning `delins` (that would be a coarser, lossy
+// description the HGVS spec does not require). "Same resulting sequence" is the
+// EquivalenceChecker's job (issue #1158), not the normalizer's.
+//
+// These are characterization tests: they lock the deliberate non-confluence so
+// a future change that accidentally collapses alleles into spanning delins (or
+// vice versa) is caught. Both forms are — and must remain — idempotent.
+//
+// Core `AGTCAGT` at HGVS 257..=263: replacing all seven bases with `GATTA`
+// (`g.257_263delinsGATTA`) yields the same sequence as
+// `g.[257A>G;258G>A;260C>T;262_263del]`.
+const CASE_A_CORE: &str = "AGTCAGT";
+const CASE_A_DELINS: &str = "NC_TEST.1:g.257_263delinsGATTA";
+const CASE_A_ALLELE: &str = "NC_TEST.1:g.[257A>G;258G>A;260C>T;262_263del]";
+
+#[test]
+fn decomposed_cis_allele_is_not_collapsed_into_a_spanning_delins() {
+    // Adjacent members 257A>G;258G>A merge to 257_258delinsGA, but the allele
+    // keeps three members: the unchanged bases at 259 and 261 are NOT absorbed
+    // into a single spanning delins over 257..=263.
+    assert_eq!(
+        norm(CASE_A_CORE, CASE_A_ALLELE),
+        "NC_TEST.1:g.[257_258delinsGA;260C>T;262_263del]",
+    );
+}
+
+#[test]
+fn single_delins_is_not_decomposed_into_an_allele() {
+    // The length-changing delins stays a single delins; it is not rewritten as
+    // the decomposed allele. Together with the test above, this pins that the
+    // two sequence-identical encodings remain distinct after normalization.
+    assert_eq!(norm(CASE_A_CORE, CASE_A_DELINS), CASE_A_DELINS);
+}
+
+#[test]
+fn sequence_identical_delins_and_allele_do_not_normalize_equal() {
+    // The scope-decision point of #1157 in one assertion: same resulting
+    // sequence, different canonical forms — by design.
+    assert_ne!(
+        norm(CASE_A_CORE, CASE_A_DELINS),
+        norm(CASE_A_CORE, CASE_A_ALLELE),
+    );
+}
+
+#[test]
+fn decomposed_cis_allele_is_idempotent() {
+    let once = norm(CASE_A_CORE, CASE_A_ALLELE);
+    assert_eq!(
+        once,
+        norm(CASE_A_CORE, &once),
+        "norm(norm(x)) must equal norm(x)"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -121,6 +121,7 @@ mod issue_1135_self_cancelling_merge;
 mod issue_1137_reject_bare_ins;
 mod issue_1139_gene_symbol_specification;
 mod issue_1146_custom_compound_accession;
+mod issue_1157_delins_reduction_shift;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
## Summary

`Normalizer::normalize` was **not idempotent** and **not encoding-invariant** for a `delins` that reduces to a pure deletion or a duplication, as reported in #1157 (case B).

When `canonicalize_delins` trims a `delins` down to a `DelinsCanonical::Deletion` or `::Duplication`, `normalize_na_edit` returned the reduced edit **directly**, bypassing the 3'-shift `shuffle()` (and repeat contraction) that every genuine `del`/`dup` input receives. The sibling `DelinsCanonical::Insertion` arm already recurses into `normalize_na_edit` for exactly this reason — the `Deletion` and `Duplication` arms did not.

Consequences (reproduced on synthetic homopolymer fixtures where the 3'-shift target is unambiguous):

- `g.257_259delinsT` (ref `TAA`, trims prefix `T` → deletion of `AA` in an A-tract) emitted the **unshifted** `g.258_259del`, whereas a direct `g.258_259del` 3'-shifts and contracts to `g.258_262A[3]`. So `norm(norm(x)) != norm(x)` and the delins spelling never compared equal to the direct-deletion spelling.
- The same defect existed for the `delins → dup` reduction: `g.258delinsGG` in a G-tract emitted the unshifted `g.258dup` while a direct `g.258dup` shifts to `g.262dup`.

## Fix

Make both reduction arms recurse through `normalize_na_edit` with the reduced edit (mirroring the `Insertion` arm), so the 3'-shift and repeat-collapse run, and collected warnings are preserved.

## Tests

New `tests/it/issue_1157_delins_reduction_shift.rs` asserts, for both the del- and dup-reduction paths:
- the reduced edit is 3'-shifted to its canonical form,
- `norm(norm(x)) == norm(x)` (idempotence),
- the delins spelling and the direct `del`/`dup` spelling of the same edit normalize identically (confluence).

All 6 fail before the fix and pass after; the full suite (8436 tests) is green, including the reference-free idempotency corpus and the pinned spec-normalization tests. `cargo fmt`/`clippy -D warnings` clean.

## Scope note (case A)

The issue also reports "case A": a single `delins` (`g.8_14delinsGATTA`) and a decomposed multi-part allele (`g.[8A>G;9G>A;11C>T;13_14del]`) — same resulting sequence — normalize to two different (but each idempotent) strings. That is **not** addressed here, and I don't believe it is a normalizer bug: ferro deliberately does not merge non-adjacent cis-allele members across unchanged reference bases into one spanning `delins` (that would be a coarser, arguably lossy description, and is not required by the spec). Declaring two encodings "the same variant" by *resulting sequence* is the job of `EquivalenceChecker`, which is fixed separately in the companion PR for #1158.

Closes #1157