### PR TITLE
fix: compare resulting sequence in EquivalenceChecker for complex indels (#1158)

### DIFF
--- a/python/ferro_hgvs/__init__.pyi
+++ b/python/ferro_hgvs/__init__.pyi
@@ -802,6 +802,7 @@ class EquivalenceLevel(IntEnum):
     NormalizedMatch = 1
     AccessionVersionDifference = 2
     NotEquivalent = 3
+    SequenceMatch = 4
 
     def is_equivalent(self) -> bool:
         """Returns true if the variants are considered equivalent."""

--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -1,9 +1,17 @@
 //! Equivalence checker implementation.
 
 use crate::error::FerroError;
-use crate::hgvs::variant::HgvsVariant;
+use crate::hgvs::variant::{AllelePhase, HgvsVariant};
 use crate::normalize::{NormalizeConfig, Normalizer};
 use crate::reference::ReferenceProvider;
+use crate::spdi::{hgvs_to_spdi, SpdiVariant};
+
+/// Largest reference window (in bases) the sequence-level equivalence rung will
+/// reconstruct. Two variants whose edited spans are farther apart than this
+/// cannot describe the same local edit, so declining beyond the cap only ever
+/// leaves the pre-existing `NotEquivalent` verdict in place while bounding the
+/// cost of a reference fetch.
+const MAX_SEQUENCE_COMPARE_WINDOW: u64 = 100_000;
 
 /// Level of equivalence between two variants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -12,6 +20,11 @@ pub enum EquivalenceLevel {
     Identical,
     /// Equivalent after normalization (e.g., shifted to same position).
     NormalizedMatch,
+    /// Equivalent by resulting reference sequence: the two variants normalize
+    /// to different HGVS strings but, when applied to the reference, produce the
+    /// same edited sequence (e.g. a length-changing `delins` vs a decomposed
+    /// cis allele of the same edit). See issue #1158.
+    SequenceMatch,
     /// Same variant but different accession versions (e.g., NM_000088.3 vs NM_000088.4).
     AccessionVersionDifference,
     /// Not equivalent - represent different changes.
@@ -29,6 +42,7 @@ impl EquivalenceLevel {
         match self {
             EquivalenceLevel::Identical => "Identical representation",
             EquivalenceLevel::NormalizedMatch => "Equivalent after normalization",
+            EquivalenceLevel::SequenceMatch => "Equivalent by resulting sequence",
             EquivalenceLevel::AccessionVersionDifference => {
                 "Same variant, different accession versions"
             }
@@ -197,6 +211,21 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
                 return Ok(result.with_note("Equivalent after normalization, different versions"));
             }
 
+            // Sequence-level equivalence (issue #1158): two variants may
+            // normalize to different HGVS strings yet produce the same edited
+            // reference sequence — e.g. a length-changing `delins` vs a
+            // decomposed cis allele of the same edit, which ferro deliberately
+            // keeps in distinct canonical forms. Reconstruct each edited window
+            // from SPDI triples and compare. This is best-effort: any variant
+            // that cannot be projected (unsupported edit, missing reference,
+            // mixed accessions, or a multi-molecule allele) simply declines, so
+            // the rung only ever upgrades a `NotEquivalent` verdict.
+            if self.same_resulting_sequence(&norm1, &norm2) {
+                return Ok(EquivalenceResult::new(EquivalenceLevel::SequenceMatch)
+                    .with_normalized(norm_str1, norm_str2)
+                    .with_note("Variants produce the same resulting sequence"));
+            }
+
             Ok(EquivalenceResult::new(EquivalenceLevel::NotEquivalent)
                 .with_normalized(norm_str1, norm_str2)
                 .with_note("Variants do not normalize to the same form"))
@@ -255,6 +284,113 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
         }
 
         None
+    }
+
+    /// Decide whether two variants, applied to their (shared) reference, produce
+    /// the same edited sequence.
+    ///
+    /// Best-effort and side-effect free: returns `false` (declines) for any
+    /// variant that cannot be projected to SPDI triples on a single shared
+    /// accession, or when the reference window needed to compare them exceeds
+    /// [`MAX_SEQUENCE_COMPARE_WINDOW`]. Callers use this only to *upgrade* a
+    /// `NotEquivalent` verdict, so a decline is always safe.
+    fn same_resulting_sequence(&self, v1: &HgvsVariant, v2: &HgvsVariant) -> bool {
+        let (acc1, triples1) = match self.edit_triples(v1) {
+            Some(t) => t,
+            None => return false,
+        };
+        let (acc2, triples2) = match self.edit_triples(v2) {
+            Some(t) => t,
+            None => return false,
+        };
+        // A resulting sequence is only comparable on the same reference.
+        if acc1 != acc2 {
+            return false;
+        }
+
+        // The union window covering every edit of both variants. SPDI positions
+        // are 0-based interbase; a triple spans `[position, position + del_len)`.
+        let all = triples1.iter().chain(triples2.iter());
+        let (mut win_start, mut win_end) = (u64::MAX, u64::MIN);
+        for t in all {
+            win_start = win_start.min(t.position);
+            win_end = win_end.max(t.position + t.deletion.len() as u64);
+        }
+        if win_start > win_end || win_end - win_start > MAX_SEQUENCE_COMPARE_WINDOW {
+            return false;
+        }
+
+        let reference = match self.fetch_window(&acc1, win_start, win_end) {
+            Some(r) => r,
+            None => return false,
+        };
+
+        match (
+            apply_triples(&reference, win_start, &triples1),
+            apply_triples(&reference, win_start, &triples2),
+        ) {
+            // Case-insensitive, like the deletion check in `apply_triples`:
+            // reference FASTAs are often soft-masked (repeats lower-cased), so
+            // case carries no biological meaning here and must not split two
+            // otherwise-identical resulting sequences.
+            (Some(a), Some(b)) => a.eq_ignore_ascii_case(&b),
+            _ => false,
+        }
+    }
+
+    /// Project a variant to the SPDI primitive edits that make up its resulting
+    /// sequence, together with the single accession they act on.
+    ///
+    /// Returns `None` when a single resulting sequence is undefined or cannot be
+    /// derived: multi-molecule alleles (trans / mosaic / chimeric / and-or /
+    /// products / unknown phase), null/unknown alleles, edits SPDI cannot
+    /// represent, or members that span more than one accession.
+    fn edit_triples(&self, v: &HgvsVariant) -> Option<(String, Vec<SpdiVariant>)> {
+        let members: Vec<&HgvsVariant> = match v {
+            HgvsVariant::Allele(allele) => {
+                // A single resulting sequence is only well-defined for a cis
+                // allele — all edits applied to the same molecule.
+                if allele.phase != AllelePhase::Cis {
+                    return None;
+                }
+                allele.variants.iter().collect()
+            }
+            HgvsVariant::NullAllele | HgvsVariant::UnknownAllele => return None,
+            single => vec![single],
+        };
+        if members.is_empty() {
+            return None;
+        }
+
+        let mut accession: Option<String> = None;
+        let mut triples = Vec::with_capacity(members.len());
+        for member in members {
+            let spdi = hgvs_to_spdi(member, self.normalizer.provider()).ok()?;
+            match &accession {
+                None => accession = Some(spdi.sequence.clone()),
+                Some(acc) if *acc != spdi.sequence => return None,
+                Some(_) => {}
+            }
+            triples.push(spdi);
+        }
+        accession.map(|acc| (acc, triples))
+    }
+
+    /// Fetch reference bases for the 0-based half-open interval
+    /// `[start, end)` on `accession`, trying the genomic provider first and
+    /// falling back to the transcript-sequence provider (mirroring the SPDI
+    /// converter's own fetch). Returns `None` on any provider error or short
+    /// read.
+    fn fetch_window(&self, accession: &str, start: u64, end: u64) -> Option<String> {
+        let provider = self.normalizer.provider();
+        let bases = provider
+            .get_genomic_sequence(accession, start, end)
+            .or_else(|_| provider.get_sequence(accession, start, end))
+            .ok()?;
+        if bases.len() as u64 != end - start {
+            return None;
+        }
+        Some(bases)
     }
 
     /// Check if multiple variants are all equivalent to each other.
@@ -337,6 +473,40 @@ impl<P: ReferenceProvider> EquivalenceChecker<P> {
 
         Ok(groups)
     }
+}
+
+/// Apply SPDI triples to `reference` — the bases spanning the interbase
+/// interval that begins at `win_start` — and return the edited sequence.
+///
+/// Triples are applied from the 3' end (descending position) so that an earlier
+/// splice never shifts the coordinates of a later one. Each triple's stated
+/// deleted bases are validated against the actual reference bases at that span;
+/// if they disagree (a ref-mismatched input — e.g. `c.5A>G` where the reference
+/// base is not `A`), we cannot faithfully reconstruct the edit, so we decline
+/// (`None`) rather than assert a sequence equivalence we cannot trust. Also
+/// returns `None` if any triple falls outside the window (a defensive guard;
+/// callers build the window to cover every triple).
+fn apply_triples(reference: &str, win_start: u64, triples: &[SpdiVariant]) -> Option<String> {
+    let ref_bytes = reference.as_bytes();
+    let mut bytes = ref_bytes.to_vec();
+    let mut ordered: Vec<&SpdiVariant> = triples.iter().collect();
+    ordered.sort_by_key(|t| std::cmp::Reverse(t.position));
+    for t in ordered {
+        let rel = t.position.checked_sub(win_start)? as usize;
+        let end = rel.checked_add(t.deletion.len())?;
+        if end > ref_bytes.len() {
+            return None;
+        }
+        // Validate the stated deletion against the original reference span.
+        // (Checked against `ref_bytes`, not the mutated `bytes`: descending
+        // order means every already-applied splice sits strictly 3' of `rel`,
+        // so this span is untouched either way.)
+        if !ref_bytes[rel..end].eq_ignore_ascii_case(t.deletion.as_bytes()) {
+            return None;
+        }
+        bytes.splice(rel..end, t.insertion.bytes());
+    }
+    String::from_utf8(bytes).ok()
 }
 
 /// Extract the variant part from an HGVS string (everything after the colon).
@@ -425,6 +595,7 @@ mod tests {
     fn test_equivalence_level_is_equivalent() {
         assert!(EquivalenceLevel::Identical.is_equivalent());
         assert!(EquivalenceLevel::NormalizedMatch.is_equivalent());
+        assert!(EquivalenceLevel::SequenceMatch.is_equivalent());
         assert!(EquivalenceLevel::AccessionVersionDifference.is_equivalent());
         assert!(!EquivalenceLevel::NotEquivalent.is_equivalent());
     }
@@ -433,6 +604,7 @@ mod tests {
     fn test_equivalence_level_description() {
         assert!(!EquivalenceLevel::Identical.description().is_empty());
         assert!(!EquivalenceLevel::NormalizedMatch.description().is_empty());
+        assert!(!EquivalenceLevel::SequenceMatch.description().is_empty());
         assert!(!EquivalenceLevel::AccessionVersionDifference
             .description()
             .is_empty());

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1143,6 +1143,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
         &self.config
     }
 
+    /// Get a reference to the underlying reference provider.
+    pub fn provider(&self) -> &P {
+        &self.provider
+    }
+
     /// Normalize a variant
     ///
     /// In strict mode (default), rejects variants with reference mismatches.

--- a/src/python.rs
+++ b/src/python.rs
@@ -2423,6 +2423,9 @@ pub enum PyEquivalenceLevel {
     AccessionVersionDifference = 2,
     /// Not equivalent - represent different changes
     NotEquivalent = 3,
+    /// Equivalent by resulting reference sequence (different normalized strings,
+    /// same edited sequence)
+    SequenceMatch = 4,
 }
 
 impl From<EquivalenceLevel> for PyEquivalenceLevel {
@@ -2430,6 +2433,7 @@ impl From<EquivalenceLevel> for PyEquivalenceLevel {
         match level {
             EquivalenceLevel::Identical => PyEquivalenceLevel::Identical,
             EquivalenceLevel::NormalizedMatch => PyEquivalenceLevel::NormalizedMatch,
+            EquivalenceLevel::SequenceMatch => PyEquivalenceLevel::SequenceMatch,
             EquivalenceLevel::AccessionVersionDifference => {
                 PyEquivalenceLevel::AccessionVersionDifference
             }
@@ -2444,6 +2448,7 @@ impl PyEquivalenceLevel {
         match self {
             PyEquivalenceLevel::Identical => "Identical",
             PyEquivalenceLevel::NormalizedMatch => "NormalizedMatch",
+            PyEquivalenceLevel::SequenceMatch => "SequenceMatch",
             PyEquivalenceLevel::AccessionVersionDifference => "AccessionVersionDifference",
             PyEquivalenceLevel::NotEquivalent => "NotEquivalent",
         }
@@ -2459,6 +2464,7 @@ impl PyEquivalenceLevel {
         match self {
             PyEquivalenceLevel::Identical => "Identical representation",
             PyEquivalenceLevel::NormalizedMatch => "Equivalent after normalization",
+            PyEquivalenceLevel::SequenceMatch => "Equivalent by resulting sequence",
             PyEquivalenceLevel::AccessionVersionDifference => {
                 "Same variant, different accession versions"
             }

--- a/tests/it/issue_1158_equivalence_resulting_sequence.rs
+++ b/tests/it/issue_1158_equivalence_resulting_sequence.rs
@@ -1,0 +1,136 @@
+//! Regression test for issue #1158: `EquivalenceChecker::check` reported
+//! `NotEquivalent` for two variants with the **same resulting sequence** when
+//! they used different (but equivalent) HGVS encodings of a complex indel.
+//!
+//! Root cause: the checker only ever compared normalized HGVS **strings**; it
+//! never projected either variant to its resulting reference sequence. Two
+//! encodings that ferro legitimately keeps in distinct canonical forms — a
+//! single length-changing `delins` vs a decomposed cis allele of the same edit
+//! — therefore compared unequal even though they produce byte-identical
+//! sequence against the reference.
+//!
+//! Fix: a sequence-level rung (`EquivalenceLevel::SequenceMatch`) that
+//! reconstructs each variant's edited window from SPDI triples and compares the
+//! resulting sequences. It only ever upgrades a `NotEquivalent` verdict — the
+//! Identical / NormalizedMatch / AccessionVersionDifference rungs run first.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::equivalence::{EquivalenceChecker, EquivalenceLevel};
+use ferro_hgvs::parse_hgvs;
+
+fn level(core: &str, a: &str, b: &str) -> EquivalenceLevel {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic(core).build());
+    checker
+        .check(&parse_hgvs(a).unwrap(), &parse_hgvs(b).unwrap())
+        .unwrap()
+        .level
+}
+
+/// Core `AGTCAGT` at HGVS 257..=263. Replacing all seven bases with `GATTA`
+/// (`g.257_263delinsGATTA`) yields the same sequence as the decomposed cis
+/// allele `[257A>G;258G>A;260C>T;262_263del]` — but ferro keeps them in
+/// different canonical forms (the length-changing delins stays a delins; the
+/// allele normalizes to `[257_258delinsGA;260C>T;262_263del]`). Same resulting
+/// sequence, different normalized strings. This is issue #1158's case A.
+const CASE_A_CORE: &str = "AGTCAGT";
+const CASE_A_DELINS: &str = "NC_TEST.1:g.257_263delinsGATTA";
+const CASE_A_ALLELE: &str = "NC_TEST.1:g.[257A>G;258G>A;260C>T;262_263del]";
+
+#[test]
+fn delins_and_decomposed_allele_with_same_sequence_are_equivalent() {
+    assert_eq!(
+        level(CASE_A_CORE, CASE_A_DELINS, CASE_A_ALLELE),
+        EquivalenceLevel::SequenceMatch,
+    );
+}
+
+#[test]
+fn sequence_match_is_equivalent() {
+    let checker = EquivalenceChecker::new(SyntheticBuilder::genomic(CASE_A_CORE).build());
+    let result = checker
+        .check(
+            &parse_hgvs(CASE_A_DELINS).unwrap(),
+            &parse_hgvs(CASE_A_ALLELE).unwrap(),
+        )
+        .unwrap();
+    assert!(result.is_equivalent());
+    assert!(EquivalenceLevel::SequenceMatch.is_equivalent());
+}
+
+/// Case B from the issue: a `delins` that reduces to a pure deletion vs the
+/// direct deletion of the same bases. Core `TAAAAAG`: `g.257_259delinsT`
+/// (delete `TAA`, insert `T`) reduces to deleting `AA`, the same edit as
+/// `g.258_259del`.
+///
+/// The issue's requirement is that the checker report these **equivalent**; it
+/// does not fix which rung gets there, and the answer legitimately moved. Before
+/// the companion normalizer fix (#1157) the reduced deletion skipped the
+/// 3'-shift, so the two spellings normalized differently and only this PR's
+/// sequence-level rung unified them. #1157 now shifts the reduction, so they
+/// normalize identically and the earlier `NormalizedMatch` rung — which runs
+/// first by design — catches them. Assert the contract (equivalent), not the
+/// rung, so neither fix's landing order can flip this test red. Case A above
+/// stays non-confluent by design and remains the sequence rung's own coverage.
+#[test]
+fn delins_reducing_to_deletion_matches_direct_deletion() {
+    let level = level(
+        "TAAAAAG",
+        "NC_TEST.1:g.257_259delinsT",
+        "NC_TEST.1:g.258_259del",
+    );
+    assert!(
+        level.is_equivalent(),
+        "a delins reducing to a deletion must be equivalent to the direct \
+         deletion of the same bases, got {level:?}"
+    );
+}
+
+/// The rung must not over-match: two delins that differ in a single inserted
+/// base produce different sequences and must stay `NotEquivalent`.
+#[test]
+fn delins_with_different_resulting_sequence_stays_not_equivalent() {
+    assert_eq!(
+        level(
+            CASE_A_CORE,
+            "NC_TEST.1:g.257_263delinsGATTA",
+            "NC_TEST.1:g.257_263delinsGATTC",
+        ),
+        EquivalenceLevel::NotEquivalent,
+    );
+}
+
+/// A decomposed allele whose edits yield a *different* sequence than the delins
+/// must also stay `NotEquivalent` (guards the allele reconstruction path).
+#[test]
+fn decomposed_allele_with_different_sequence_stays_not_equivalent() {
+    // Same as CASE_A_ALLELE but the first substitution is 257A>C (not A>G),
+    // so the resulting first base is C, not G — a different sequence.
+    assert_eq!(
+        level(
+            CASE_A_CORE,
+            CASE_A_DELINS,
+            "NC_TEST.1:g.[257A>C;258G>A;260C>T;262_263del]",
+        ),
+        EquivalenceLevel::NotEquivalent,
+    );
+}
+
+// -- Existing behavior must be preserved (the new rung runs only after these) --
+
+#[test]
+fn identical_variants_still_identical() {
+    assert_eq!(
+        level(CASE_A_CORE, "NC_TEST.1:g.258A>G", "NC_TEST.1:g.258A>G"),
+        EquivalenceLevel::Identical,
+    );
+}
+
+#[test]
+fn substitution_written_two_ways_still_normalized_match() {
+    // A substitution written as a 1-base delins normalizes to the same string,
+    // so it is caught by the NormalizedMatch rung before sequence comparison.
+    assert_eq!(
+        level(CASE_A_CORE, "NC_TEST.1:g.257A>G", "NC_TEST.1:g.257delinsG"),
+        EquivalenceLevel::NormalizedMatch,
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -123,6 +123,7 @@ mod issue_1137_reject_bare_ins;
 mod issue_1139_gene_symbol_specification;
 mod issue_1146_custom_compound_accession;
 mod issue_1157_delins_reduction_shift;
+mod issue_1158_equivalence_resulting_sequence;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;

--- a/tests/python/test_issue_1158_equivalence_resulting_sequence.py
+++ b/tests/python/test_issue_1158_equivalence_resulting_sequence.py
@@ -1,0 +1,74 @@
+"""Issue #1158: end-to-end repro via the Python API.
+
+``EquivalenceChecker.check`` returned ``NotEquivalent`` for two variants with
+the same resulting sequence when they used different (but equivalent) HGVS
+encodings of a complex indel. A sequence-level rung now reconstructs each
+variant's edited sequence against the reference and reports ``SequenceMatch``.
+
+The reference here is fully synthetic (no real accession, coordinates, or
+reference bases): the core ``AGTCAGT`` sits at 1-based g.21..=27, padded on both
+sides so the normalizer's lookahead window stays in bounds.
+"""
+
+import json
+from pathlib import Path
+
+import ferro_hgvs
+
+PAD = "GGGGCCCCTTTTAAAACGCG"  # 20 bp of padding on each side
+CORE = "AGTCAGT"  # g.21..=27 : 21=A 22=G 23=T 24=C 25=A 26=G 27=T
+CONTIG = "TEMPLATE"
+
+
+def _reference(tmp_path: Path) -> str:
+    """Write the synthetic reference under pytest's per-test ``tmp_path``.
+
+    ``tmp_path`` (rather than ``tempfile.mktemp``, which is deprecated as
+    insecure and leaves a file behind on every run) so pytest owns creation and
+    cleanup.
+    """
+    seq = PAD + CORE + PAD
+    ref = {"transcripts": [], "genomic_sequences": {CONTIG: seq}}
+    path = tmp_path / "reference.json"
+    path.write_text(json.dumps(ref))
+    return str(path)
+
+
+def _checker(tmp_path: Path) -> "ferro_hgvs.EquivalenceChecker":
+    return ferro_hgvs.EquivalenceChecker(reference_json=_reference(tmp_path))
+
+
+def _level(checker, a: str, b: str) -> "ferro_hgvs.EquivalenceLevel":
+    return checker.check(ferro_hgvs.parse(a), ferro_hgvs.parse(b)).level
+
+
+# A single length-changing delins over g.21..=27 replacing AGTCAGT with GATTA,
+# and its decomposition as a cis allele of the same edit. Same resulting
+# sequence, different normalized strings.
+DELINS = "TEMPLATE:g.21_27delinsGATTA"
+ALLELE = "TEMPLATE:g.[21A>G;22G>A;24C>T;26_27del]"
+
+
+def test_delins_vs_decomposed_allele_is_sequence_match(tmp_path):
+    checker = _checker(tmp_path)
+    result = checker.check(ferro_hgvs.parse(DELINS), ferro_hgvs.parse(ALLELE))
+    assert result.level == ferro_hgvs.EquivalenceLevel.SequenceMatch
+    assert result.level.is_equivalent()
+
+
+def test_sanity_identical_and_normalized_still_work(tmp_path):
+    checker = _checker(tmp_path)
+    assert _level(checker, "TEMPLATE:g.24C>T", "TEMPLATE:g.24C>T") == (
+        ferro_hgvs.EquivalenceLevel.Identical
+    )
+    # substitution written as a 1-base delins normalizes to the same string
+    assert _level(checker, "TEMPLATE:g.21A>G", "TEMPLATE:g.21delinsG") == (
+        ferro_hgvs.EquivalenceLevel.NormalizedMatch
+    )
+
+
+def test_different_resulting_sequence_stays_not_equivalent(tmp_path):
+    checker = _checker(tmp_path)
+    assert _level(checker, DELINS, "TEMPLATE:g.21_27delinsGATTC") == (
+        ferro_hgvs.EquivalenceLevel.NotEquivalent
+    )


### PR DESCRIPTION
## Summary

`EquivalenceChecker::check` decided equivalence purely by comparing normalized HGVS **strings** — it never projected either variant to its resulting reference sequence. So it returned `NotEquivalent` for two variants that produce the same edited sequence but that ferro legitimately keeps in distinct canonical forms:

- a single length-changing `delins` vs a decomposed cis allele of the same edit — `g.257_263delinsGATTA` vs `g.[257A>G;258G>A;260C>T;262_263del]` (this pair stays non-confluent even with a perfect normalizer, so no amount of normalization unifies it);
- a `delins` that reduces to a plain deletion vs the direct deletion — `g.257_259delinsT` vs `g.258_259del`.

This is a silent wrong answer from the API whose entire purpose is deciding equivalence, and it defeated the intended fallback for callers who already know normalized strings differ.

## Fix

Add a sequence-level rung. After the existing string ladder (Identical → NormalizedMatch → AccessionVersionDifference) fails, project each variant to SPDI primitive edits (per-member for a cis allele), reconstruct each edited sequence over a shared reference window, and compare. A match reports a new level, `EquivalenceLevel::SequenceMatch`.

Design points:

- **Only ever upgrades a `NotEquivalent` verdict.** The rung runs last; Identical/NormalizedMatch/AccessionVersionDifference are unchanged.
- **Best-effort, declines safely.** Returns "not a sequence match" (leaving `NotEquivalent`) for multi-molecule alleles (trans/mosaic/chimeric/and-or/products/unknown), null/unknown alleles, SPDI-unrepresentable edits, mixed accessions, or a reconstruction window beyond a 100 kb cap (a cost bound; equivalent forms are always local).
- **Ref-mismatch guard.** Each edit's stated deleted bases are validated against the actual reference before reconstruction, so a ref-mismatched input (e.g. `c.5A>G` where the reference base is not `A`) is not silently treated as an equivalent no-op. This also keeps the existing grouping tests (arbitrary `c.iA>G` fixtures) correctly separated.
- A new `Normalizer::provider()` accessor exposes the reference provider for base fetches. The new level is threaded through the PyO3 bindings and the `.pyi` type stub.

## Tests

- `tests/it/issue_1158_equivalence_resulting_sequence.rs`: delins vs decomposed allele → `SequenceMatch`; delins-reducing-to-del vs direct del → `SequenceMatch`; differing-sequence delins and differing-sequence allele stay `NotEquivalent`; Identical/NormalizedMatch sanity unchanged.
- `tests/python/test_issue_1158_equivalence_resulting_sequence.py`: end-to-end via the Python API (the surface the issue was filed against), verified with a local `maturin develop` build.

All Rust tests fail before the fix and pass after; the full suite (8437 tests) is green, and the Python suite passes. `cargo fmt`/`clippy -D warnings`/`cargo check --features python`/`ruff` all clean.

## Relationship to #1157

Companion normalizer fix #1157 makes the `delins → del`/`dup` reduction idempotent. The two are independent: #1157 unifies encodings that differ only by 3'-shift, while this PR's sequence-level rung also catches genuinely non-confluent encodings (delins vs decomposed allele) that normalization is not designed to merge.

Closes #1158