### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.10.1...v0.11.0) - 2026-07-27
+
+### Added
+
+- *(error-handling)* diagnose a bare `ins` as W3027 InsertionWithoutInsertedSequence ([#1166](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1166))
+- *(prepare)* record the cdot data release per artifact ([#1164](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1164))
+- *(reference)* per-artifact schema handshake + recorded cdot data version (#1001 item 3) ([#1154](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1154))
+- *(reference)* stamp & verify a reference content identity (#1001 items 2+4) ([#1153](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1153))
+
+### Fixed
+
+- *(test)* pass the target directory to the generator-example build ([#1225](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1225))
+- *(test)* build the generator examples for the running profile ([#1224](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1224))
+- *(error-handling)* make every enforced warning code reach the error configuration ([#1220](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1220))
+- *(project)* surface the engine's own reason for an unavailable axis ([#1221](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1221))
+- *(normalize)* clamp an insertion saturated at a mitochondrial terminus ([#1222](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1222))
+- *(normalize)* clamp an insertion saturated at a contig bound on the g. axis ([#1215](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1215))
+- *(normalize)* fall back to dup, not ins, where the codon gate refuses a repeat ([#1213](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1213))
+- *(project)* refuse out-of-transcript positions and surface projection warnings ([#1193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1193))
+- *(test)* stop spec_generator_preconditions running a stale example binary ([#1219](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1219))
+- *(cli)* pass the error configuration to the normalizer ([#1191](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1191))
+- *(normalize)* answer the repeat codon gate for the tract, not the input span ([#1212](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1212))
+- *(normalize)* shift a c.-axis insertion past cds_end in one pass ([#1211](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1211))
+- *(normalize)* clamp a saturated insertion at the CDS bounds on the r. axis ([#1208](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1208))
+- *(normalize)* complete the 3'-shift across cds_end in one pass for delins and dup ([#1189](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1189))
+- *(normalize)* clamp boundary-saturated insertions at the transcript bounds ([#1203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1203))
+- *(project)* read r.-axis inputs as CDS-relative, not transcript-relative ([#1179](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1179))
+- *(normalize)* apply the codon-frame gate on the r. axis ([#1194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1194))
+- *(normalize)* run the ins[...] expansion on the r. axis ([#1188](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1188))
+- *(normalize)* handle an inv suffix on a cross-reference insertion range ([#1187](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1187))
+- *(normalize)* maximize the repeat tract instead of taking the first literal hit ([#1176](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1176))
+- *(normalize)* direction-aware copy selection in normalize_repeat; fuzz unit[N] inputs ([#1172](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1172))
+- *(normalize)* 5' boundary + repeat/dup canonicalization; enable the general 5' idempotency proptest ([#1170](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1170))
+- *(dev)* make the spec generators usable on a fresh worktree ([#1201](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1201))
+- *(normalize)* rotate the inserted sequence when 5'-shifting a multi-base insertion ([#1169](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1169))
+- *(normalize)* make the #418 CDS-start boundary clamp a stable fixed point ([#1167](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1167))
+- compare resulting sequence in EquivalenceChecker for complex indels ([#1158](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1158)) ([#1161](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1161))
+- *(reference)* enforce the canonical-overrides schema version at load ([#1155](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1155))
+- 3'-shift delins that reduces to a deletion or duplication ([#1157](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1157)) ([#1160](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1160))
+- *(parser)* reject an insertion with no inserted sequence (bare `ins`) ([#1152](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1152))
+
+### Other
+
+- *(reference)* construct the FASTA index through a single PreparedIndex type ([#1186](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1186))
+- *(reference)* stop building FASTA-index state that is immediately discarded ([#1178](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1178))
+- *(normalize)* require an explicit ErrorConfig at every entry point ([#1223](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1223))
+- *(io)* buffer serde_json reads from files ([#1171](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1171))
+- *(compliance)* pin cross-document HGVS rules (round-trip identity + contiguous changes) ([#1190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1190))
+- *(conformance)* accept the sized-suffix parse-rejection taxonomy divergence ([#1173](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1173))
+- *(normalize)* fold is_coding + cds_span into one CodonGate ([#1214](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1214))
+- shard the test suite and gate every PR on a 1M-case idempotency soak ([#1216](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1216))
+- *(normalize)* fuzz the n./r. axes and inv/con edits for idempotency ([#1180](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1180))
+- *(normalize)* extend the idempotency oracle to the projector path ([#1174](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1174))
+- *(normalize)* make the direction-invariance test and proptest flanks honest ([#1175](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1175))
+- [**breaking**] mark the remaining additive-change-prone public types non_exhaustive ([#1168](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1168))
+- [**breaking**] make the public equivalence API robust to additive changes ([#1165](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1165))
+
 ## [0.10.1](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.10.0...v0.10.1) - 2026-07-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "ferro-hgvs"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferro-hgvs"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.87"
 authors = ["ferro-hgvs contributors"]


### PR DESCRIPTION



## 🤖 New release

* `ferro-hgvs`: 0.10.1 -> 0.11.0 (⚠ API breaking changes)

### ⚠ `ferro-hgvs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DerivedPlacements.schema_version in /tmp/.tmprtcNKp/ferro-hgvs/src/reference/derived_placement.rs:444
  field DerivedTxStructures.schema_version in /tmp/.tmprtcNKp/ferro-hgvs/src/reference/derived_tx_structure.rs:101
  field ReferenceManifest.cdot_data_versions in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:169
  field ReferenceManifest.cdot_data_version in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:177
  field ReferenceManifest.reference_identity in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:182
  field ReferenceManifest.cdot_data_versions in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:169
  field ReferenceManifest.cdot_data_version in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:177
  field ReferenceManifest.reference_identity in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:182
  field ReferenceManifest.cdot_data_versions in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:169
  field ReferenceManifest.cdot_data_version in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:177
  field ReferenceManifest.reference_identity in /tmp/.tmprtcNKp/ferro-hgvs/src/prepare/manifest.rs:182

--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum SpdiParseError in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/parser.rs:15
  enum ShuffleDirection in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:15
  enum ShuffleDirection in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:15
  enum ShuffleDirection in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:15
  enum ConversionError in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/convert.rs:104
  enum ConversionError in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/convert.rs:104
  enum ConversionError in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/convert.rs:104
  enum EquivalenceLevel in /tmp/.tmprtcNKp/ferro-hgvs/src/equivalence/checker.rs:26

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant EquivalenceLevel::AccessionVersionDifference 2 -> 3 in /tmp/.tmprtcNKp/ferro-hgvs/src/equivalence/checker.rs:37
  variant EquivalenceLevel::NotEquivalent 3 -> 4 in /tmp/.tmprtcNKp/ferro-hgvs/src/equivalence/checker.rs:39
  variant FerroError::ReducedReferenceCapability 21 -> 22 in /tmp/.tmprtcNKp/ferro-hgvs/src/error.rs:536
  variant FerroError::ReducedReferenceCapability 21 -> 22 in /tmp/.tmprtcNKp/ferro-hgvs/src/error.rs:536

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field warnings of variant AxisOutcome::Rendered in /tmp/.tmprtcNKp/ferro-hgvs/src/cli/project.rs:87
  field warnings of variant AxisOutcome::Unavailable in /tmp/.tmprtcNKp/ferro-hgvs/src/cli/project.rs:96
  field warnings of variant AxisOutcome::Rendered in /tmp/.tmprtcNKp/ferro-hgvs/src/cli/project.rs:87
  field warnings of variant AxisOutcome::Unavailable in /tmp/.tmprtcNKp/ferro-hgvs/src/cli/project.rs:96

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant PyEquivalenceLevel:SequenceMatch in /tmp/.tmprtcNKp/ferro-hgvs/src/python.rs:2447
  variant ErrorType:InsertionWithoutInsertedSequence in /tmp/.tmprtcNKp/ferro-hgvs/src/error_handling/types.rs:481
  variant PyErrorType:InsertionWithoutInsertedSequence in /tmp/.tmprtcNKp/ferro-hgvs/src/python.rs:3519

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_parameter_count_changed.ron

Failed in:
  ferro_hgvs::commands::create_reference_provider now takes 2 parameters instead of 1, in /tmp/.tmprtcNKp/ferro-hgvs/src/commands/mod.rs:123
  ferro_hgvs::normalize::rules::insertion_to_repeat now takes 6 parameters instead of 4, in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/rules.rs:335
  ferro_hgvs::normalize::rules::normalize_repeat now takes 7 parameters instead of 6, in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/rules.rs:1711

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct SpdiVariant in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/mod.rs:77
  struct SpdiVariant in /tmp/.tmprtcNKp/ferro-hgvs/src/spdi/mod.rs:77
  struct NormalizeConfig in /tmp/.tmprtcNKp/ferro-hgvs/src/commands/mod.rs:92
  struct EquivalenceResult in /tmp/.tmprtcNKp/ferro-hgvs/src/equivalence/checker.rs:80
  struct NormalizeConfig in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:57
  struct NormalizeConfig in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:57
  struct NormalizeConfig in /tmp/.tmprtcNKp/ferro-hgvs/src/normalize/config.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/fulcrumgenomics/ferro-hgvs/compare/v0.10.1...v0.11.0) - 2026-07-27

### Added

- *(error-handling)* diagnose a bare `ins` as W3027 InsertionWithoutInsertedSequence ([#1166](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1166))
- *(prepare)* record the cdot data release per artifact ([#1164](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1164))
- *(reference)* per-artifact schema handshake + recorded cdot data version (#1001 item 3) ([#1154](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1154))
- *(reference)* stamp & verify a reference content identity (#1001 items 2+4) ([#1153](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1153))

### Fixed

- *(test)* pass the target directory to the generator-example build ([#1225](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1225))
- *(test)* build the generator examples for the running profile ([#1224](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1224))
- *(error-handling)* make every enforced warning code reach the error configuration ([#1220](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1220))
- *(project)* surface the engine's own reason for an unavailable axis ([#1221](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1221))
- *(normalize)* clamp an insertion saturated at a mitochondrial terminus ([#1222](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1222))
- *(normalize)* clamp an insertion saturated at a contig bound on the g. axis ([#1215](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1215))
- *(normalize)* fall back to dup, not ins, where the codon gate refuses a repeat ([#1213](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1213))
- *(project)* refuse out-of-transcript positions and surface projection warnings ([#1193](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1193))
- *(test)* stop spec_generator_preconditions running a stale example binary ([#1219](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1219))
- *(cli)* pass the error configuration to the normalizer ([#1191](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1191))
- *(normalize)* answer the repeat codon gate for the tract, not the input span ([#1212](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1212))
- *(normalize)* shift a c.-axis insertion past cds_end in one pass ([#1211](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1211))
- *(normalize)* clamp a saturated insertion at the CDS bounds on the r. axis ([#1208](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1208))
- *(normalize)* complete the 3'-shift across cds_end in one pass for delins and dup ([#1189](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1189))
- *(normalize)* clamp boundary-saturated insertions at the transcript bounds ([#1203](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1203))
- *(project)* read r.-axis inputs as CDS-relative, not transcript-relative ([#1179](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1179))
- *(normalize)* apply the codon-frame gate on the r. axis ([#1194](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1194))
- *(normalize)* run the ins[...] expansion on the r. axis ([#1188](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1188))
- *(normalize)* handle an inv suffix on a cross-reference insertion range ([#1187](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1187))
- *(normalize)* maximize the repeat tract instead of taking the first literal hit ([#1176](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1176))
- *(normalize)* direction-aware copy selection in normalize_repeat; fuzz unit[N] inputs ([#1172](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1172))
- *(normalize)* 5' boundary + repeat/dup canonicalization; enable the general 5' idempotency proptest ([#1170](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1170))
- *(dev)* make the spec generators usable on a fresh worktree ([#1201](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1201))
- *(normalize)* rotate the inserted sequence when 5'-shifting a multi-base insertion ([#1169](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1169))
- *(normalize)* make the #418 CDS-start boundary clamp a stable fixed point ([#1167](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1167))
- compare resulting sequence in EquivalenceChecker for complex indels ([#1158](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1158)) ([#1161](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1161))
- *(reference)* enforce the canonical-overrides schema version at load ([#1155](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1155))
- 3'-shift delins that reduces to a deletion or duplication ([#1157](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1157)) ([#1160](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1160))
- *(parser)* reject an insertion with no inserted sequence (bare `ins`) ([#1152](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1152))

### Other

- *(reference)* construct the FASTA index through a single PreparedIndex type ([#1186](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1186))
- *(reference)* stop building FASTA-index state that is immediately discarded ([#1178](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1178))
- *(normalize)* require an explicit ErrorConfig at every entry point ([#1223](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1223))
- *(io)* buffer serde_json reads from files ([#1171](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1171))
- *(compliance)* pin cross-document HGVS rules (round-trip identity + contiguous changes) ([#1190](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1190))
- *(conformance)* accept the sized-suffix parse-rejection taxonomy divergence ([#1173](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1173))
- *(normalize)* fold is_coding + cds_span into one CodonGate ([#1214](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1214))
- shard the test suite and gate every PR on a 1M-case idempotency soak ([#1216](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1216))
- *(normalize)* fuzz the n./r. axes and inv/con edits for idempotency ([#1180](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1180))
- *(normalize)* extend the idempotency oracle to the projector path ([#1174](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1174))
- *(normalize)* make the direction-invariance test and proptest flanks honest ([#1175](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1175))
- [**breaking**] mark the remaining additive-change-prone public types non_exhaustive ([#1168](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1168))
- [**breaking**] make the public equivalence API robust to additive changes ([#1165](https://github.com/fulcrumgenomics/ferro-hgvs/pull/1165))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).