### PR TITLE
refactor!: make the public equivalence API robust to additive changes

### DIFF
--- a/src/equivalence/checker.rs
+++ b/src/equivalence/checker.rs
@@ -14,7 +14,15 @@ use crate::spdi::{hgvs_to_spdi, SpdiVariant};
 const MAX_SEQUENCE_COMPARE_WINDOW: u64 = 100_000;
 
 /// Level of equivalence between two variants.
+///
+/// This enum is open-ended: the checker gains rungs as new classes of
+/// equivalence become decidable (`SequenceMatch` was added in #1158 for two
+/// encodings that produce the same edited sequence). Marked `#[non_exhaustive]`
+/// so downstream callers must include a wildcard arm when matching — adding a
+/// rung is therefore not a breaking change. Mirrors the same attribute on
+/// [`EquivalenceResult`] and on the error/projection API (#1033).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum EquivalenceLevel {
     /// Exactly identical (same string representation).
     Identical,
@@ -58,7 +66,17 @@ impl std::fmt::Display for EquivalenceLevel {
 }
 
 /// Result of an equivalence check with additional details.
+///
+/// Marked `#[non_exhaustive]` so a future detail field is not a breaking
+/// change. Construct it with [`EquivalenceResult::new`] plus the `with_*`
+/// builders rather than a struct literal; the fields stay `pub`, so anything
+/// the builders do not cover (setting only one of the two normalized forms,
+/// which [`EquivalenceResult::with_normalized`] sets as a pair) is still
+/// reachable by assigning to the field directly. Mirrors the same attribute on
+/// [`EquivalenceLevel`] and
+/// `NormalizeResult` (#1033).
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EquivalenceResult {
     /// The determined equivalence level.
     pub level: EquivalenceLevel,

--- a/src/equivalence/mod.rs
+++ b/src/equivalence/mod.rs
@@ -27,8 +27,15 @@
 //!
 //! - **Identical**: Same string representation
 //! - **NormalizedMatch**: Same after normalization (e.g., different positions in repeat region)
+//! - **SequenceMatch**: Different normalized strings, same resulting sequence when
+//!   applied to the reference (e.g. a length-changing `delins` vs a decomposed
+//!   cis allele of the same edit)
 //! - **AccessionVersionDifference**: Same variant, different accession versions
 //! - **NotEquivalent**: Represent different changes
+//!
+//! The list is open-ended — [`EquivalenceLevel`] is `#[non_exhaustive]`, so
+//! recognizing a new class of equivalence adds a level without breaking
+//! downstream matches.
 //!
 //! # References
 //!


### PR DESCRIPTION
## Summary

`EquivalenceLevel` gained a `SequenceMatch` rung in #1158. Because the enum was exhaustive, that addition was a **breaking change** for any downstream crate matching on it — the same hazard #1033 removed from the error and projection APIs. It is not a one-off: the checker gains a rung whenever a new class of equivalence becomes decidable, so the next one breaks downstream again.

Mark `EquivalenceLevel` and `EquivalenceResult` `#[non_exhaustive]`.

## Why this costs nothing in-crate

`non_exhaustive` has no effect within the defining crate, and both exhaustive matches on the enum — `description()` and the PyO3 `From<EquivalenceLevel>` impl — live here. The **doctests are the one place the attribute does bite**, since rustdoc compiles them as an external crate; all four equivalence doctests already use `matches!` or `is_equivalent()`, and `cargo test --doc equivalence` passes.

`EquivalenceResult` keeps its `pub` fields, so nothing becomes unsettable: `new()` plus the `with_*` builders cover the common path, and direct field assignment still reaches what they do not (setting only one of the two normalized forms — `with_normalized` sets them as a pair). This mirrors `NormalizeResult`, which #1033 marked for the same reason.

Also records `SequenceMatch` in the module-level list of equivalence levels, which #1158 left unlisted.

## Testing

The property is compile-time and only observable from *outside* the crate, so there is nothing to unit-test in-crate — same as #1033, which added no tests. Verified nothing regressed:

- `cargo test --features dev` — clean; `cargo test --doc equivalence` — 4 passed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo check --features python` — clean (the PyO3 `From` impl still compiles)
- `cargo fmt --check` — clean

## Semver

Deliberately **breaking** for downstream crates that match on `EquivalenceLevel` without a wildcard, done now at 0.x precisely so the *next* rung isn't. The commit is typed `refactor!` with a `BREAKING CHANGE:` footer, and this PR title carries the `!` too — release-plz reads the squashed commit, which takes the PR title, so the marker must be in both to produce the right bump (`refactor:` alone would cut a patch for a match-breaking change).

## Review note

Reviewed by an independent reviewer that had no context on the authoring rationale. It confirmed the "no in-crate effect" claim (two in-crate exhaustive matches, zero external struct literals, doctests safe) and caught three doc inaccuracies now fixed: a claim that the struct had "grown a field per rung" (it has not — the fields are unchanged since the initial commit), an incomplete description of the construction path, and the missing `SequenceMatch` module-doc entry.

It also flagged that other public types have the same additive-change exposure and remain unmarked — `NormalizeConfig`, `ShuffleDirection`, `SpdiParseError`, `ConversionError`, `SpdiVariant`. That is out of scope here (this PR is the equivalence API); it is worth a separate pass so the #1033 → #1165 hardening does not stay patchy.