### PR TITLE
fix(normalize): make the #418 CDS-start boundary clamp a stable fixed point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,15 @@ jobs:
         run: cargo run --features dev --example generate_spec_enumeration
       - name: Run Rust tests
         run: cargo nextest run --features dev
+      - name: Run Rust tests with normalization idempotency self-check
+        # Re-run the suite with the opt-in boundary-level idempotency oracle
+        # enabled (`FERRO_ASSERT_IDEMPOTENT`), turning every reference-backed
+        # test into an assertion that `norm(norm(x)) == norm(x)`. The gate is
+        # `#[cfg(debug_assertions)]`, which is on in the test profile even with
+        # `CARGO_PROFILE_TEST_DEBUG=0` (that strips debuginfo, not assertions).
+        # Reuses the binaries built by the step above, so this is only re-run
+        # cost, no recompile. See src/normalize/mod.rs::normalize.
+        run: FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
       - name: Verify conformance summary docs are up to date
         run: cargo run --features dev --example generate_conformance_summary -- --check
       - name: Tool-support tables up to date

--- a/.github/workflows/nightly-mutalyzer.yml
+++ b/.github/workflows/nightly-mutalyzer.yml
@@ -126,6 +126,14 @@ jobs:
         continue-on-error: true
         env:
           FERRO_MANIFEST: ${{ github.workspace }}/benchmark-output/manifest.json
+          # This is the only job that provisions a manifest, so it is the only
+          # place the idempotency oracle sees the reference-backed corpora at
+          # all (PR CI's copy of this gate runs manifest-free — see the
+          # "reference-aware tests are skipped without a manifest" annotation
+          # in ci.yml). The corpus runner wraps normalization in
+          # `catch_panics`, so an oracle panic surfaces as that case FAILing
+          # its axis tally and landing in the xfail report, not as a lost run.
+          FERRO_ASSERT_IDEMPOTENT: "1"
         run: |
           cargo nextest run --features dev \
             -E 'test(/mutalyzer_normalize_tests::/) | test(/biocommons_normalize_tests::/) | test(/hgvs_rs_projection_tests::/)'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,23 @@ cargo test --features dev            # Alternative
 cargo nextest run -E 'test(parse)'   # Run specific tests by name pattern
 ```
 
+#### Normalization idempotency oracle
+
+`FERRO_ASSERT_IDEMPOTENT=1` turns every `Normalizer::normalize` call into an
+assertion that `norm(norm(x)) == norm(x)`, so any test that normalizes becomes an
+idempotency check:
+
+```bash
+FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev
+```
+
+It is compiled out in release builds (`#[cfg(debug_assertions)]`) and read once
+into a `OnceLock`, so a disabled run pays only one atomic load. CI runs the suite
+a second time with it set; the nightly reference-aware job sets it too, which is
+where the manifest-backed conformance corpora are actually covered. Coverage is
+limited to `normalize()` — `VariantProjector` calls `normalize_core_checked`
+directly and is not checked.
+
 ### Generated spec fixture (not committed)
 
 `tests/fixtures/grammar/hgvs_spec_normalization.json` is a **generated build artifact** — it is `.gitignore`d, not committed. It is produced by the `generate_spec_fixture` example from the HGVS spec submodule, the parser's behavior, and the curated `tests/fixtures/grammar/hgvs_spec_normalization_overrides.json`. (Committing it made every parser PR a merge-conflict magnet, since each PR regenerated the whole file.)

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3248,7 +3248,24 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // (start == end) Insertion shape that only arises from
         // left-saturation, and fire the clamp the same way the
         // non-degenerate case does.
-        let cds_start_left_saturated = matches!(edit, NaEdit::Insertion { .. })
+        //
+        // The degenerate shape is keyed on `new_edit` (the OUTPUT), not
+        // just `edit` (the INPUT): a `delins` input at `cds_start` whose
+        // shared-affix trim reduces it to an insertion (e.g. `c.1delinsACA`
+        // -> trim prefix `A` -> `insCA`) recurses through the SAME
+        // insertion 5'-shuffle and produces the SAME degenerate saturated
+        // `new_edit`, but arrives here with `edit == Delins`. Keying only on
+        // the input `edit` missed that path, so the clamp fired for the
+        // insertion spelling (`c.1_2insCA` -> `c.1delinsACA`) but not the
+        // delins spelling, which then leaked the degenerate `c.1insCA` —
+        // making the blessed `c.1delinsACA` a non-fixed-point (the
+        // `NaEdit::Delins` restore arm below already handles it once
+        // reached). Adding the `new_edit` disjunct makes the gate fire for
+        // both spellings, so they converge on the same fixed point. Issue
+        // #1157 follow-up (idempotency campaign). Keeping the `edit`
+        // disjunct too is strictly additive over prior behavior.
+        let cds_start_left_saturated = (matches!(edit, NaEdit::Insertion { .. })
+            || matches!(new_edit, NaEdit::Insertion { .. }))
             && new_tx_start == cds_start
             && new_tx_end == cds_start;
         if matches!(start_axis, boundary::AxisRegion::Cds)

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -1124,6 +1124,23 @@ fn sort_cis_members_by_genomic_order(members: &mut [HgvsVariant]) {
     }
 }
 
+/// Whether the opt-in normalization idempotency self-check is active.
+///
+/// Enabled when the `FERRO_ASSERT_IDEMPOTENT` environment variable is set to
+/// anything other than `0`/empty. Read once and cached, so the per-`normalize`
+/// cost when disabled is a single relaxed atomic load. Only compiled in debug
+/// builds; see the call site in [`Normalizer::normalize`].
+#[cfg(debug_assertions)]
+fn idempotency_self_check_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("FERRO_ASSERT_IDEMPOTENT")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl<P: ReferenceProvider> Normalizer<P> {
     /// Create a new normalizer with the given reference provider
     pub fn new(provider: P) -> Self {
@@ -1157,7 +1174,39 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // normalization AND the strict-mode rejection ladder live in
         // `normalize_core_checked`, so a strict config rejects identically
         // whether a variant is normalized directly or through the projector.
-        Ok(self.normalize_core_checked(variant)?.0)
+        let normalized = self.normalize_core_checked(variant)?.0;
+
+        // Opt-in idempotency self-check (issue #1157 follow-up): a normalizer
+        // must satisfy `norm(norm(x)) == norm(x)`. When enabled it re-normalizes
+        // the output and panics on any drift, so every test that reaches THIS
+        // method becomes an idempotency oracle for the cost of one gated check
+        // — including the `axis_normalized` conformance corpora, which call
+        // `normalize()` directly. Coverage stops at this entry point:
+        // `VariantProjector` deliberately calls `normalize_core_checked`
+        // instead (see projector.rs), so the projection-driven axes
+        // (genomic/coding/protein) are NOT checked. The second pass goes through
+        // `normalize_core_checked` — the same computation this method performs —
+        // NOT the public `normalize`, so there is no re-entrancy (internal
+        // normalization recurses via `normalize_core`, never through this
+        // method) and no guard is needed. Compiled out entirely in release
+        // (`debug_assertions`), so production is untouched and zero-cost.
+        #[cfg(debug_assertions)]
+        if idempotency_self_check_enabled() {
+            match self.normalize_core_checked(&normalized) {
+                Ok((again, _)) => assert_eq!(
+                    normalized.to_string(),
+                    again.to_string(),
+                    "FERRO_ASSERT_IDEMPOTENT: normalize is not idempotent\n  \
+                     input: {variant}\n  once:  {normalized}\n  twice: {again}",
+                ),
+                Err(e) => panic!(
+                    "FERRO_ASSERT_IDEMPOTENT: normalized output failed to re-normalize\n  \
+                     input: {variant}\n  once:  {normalized}\n  error: {e}",
+                ),
+            }
+        }
+
+        Ok(normalized)
     }
 
     /// Normalize a variant, apply the strict-mode rejection ladder, and return

--- a/tests/it/issue_418_no_utr5_boundary.rs
+++ b/tests/it/issue_418_no_utr5_boundary.rs
@@ -184,3 +184,53 @@ fn delins_cds_interior_no_utr5_unaffected() {
         "NM_TEST418.1:c.10delinsCA",
     );
 }
+
+// --------------------------------------------------------------------------
+// Issue #1157 follow-up: the clamped delins must be a stable FIXED POINT.
+// --------------------------------------------------------------------------
+//
+// The #418 clamp turns a 5'-saturated boundary insertion into the blessed
+// `c.1delinsACA`, but feeding that delins back in used to drift to `c.1insCA`:
+// its shared-affix trim reduces it to `insCA`, which re-enters the same 5'
+// saturation but arrived with `edit == Delins`, so the saturation gate (which
+// keyed only on the INPUT edit type) missed it and leaked the degenerate
+// insertion. The saturation gate now also keys on the OUTPUT (`new_edit`) shape,
+// so both spellings converge. These lock `norm(norm(x)) == norm(x)` at the
+// blessed value.
+
+#[test]
+fn clamped_delins_at_c1_is_a_fixed_point_five_prime() {
+    // The blessed clamp output must re-normalize to itself, not drift to the
+    // degenerate `c.1insCA`.
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1delinsACA"),
+        "NM_TEST418.1:c.1delinsACA",
+    );
+    // And the insertion spelling and the delins spelling now agree (confluence).
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1_2insCA"),
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1delinsACA"),
+    );
+}
+
+#[test]
+fn clamped_two_base_delins_at_c1_is_a_fixed_point_five_prime() {
+    assert_eq!(
+        normalize_with(ShuffleDirection::FivePrime, "NM_TEST418.1:c.1delinsATCA"),
+        "NM_TEST418.1:c.1delinsATCA",
+    );
+}
+
+#[test]
+fn clamped_delins_three_prime_stays_the_insertion_and_is_idempotent() {
+    // Under 3' the same delins reduces to the (stable) insertion form — not
+    // the clamp — and that is itself a fixed point. Pins that the new gate
+    // disjunct stays OFF for 3' (where `new_tx_end != cds_start`).
+    let once = normalize_with(ShuffleDirection::ThreePrime, "NM_TEST418.1:c.1delinsACA");
+    assert_eq!(once, "NM_TEST418.1:c.1_2insCA");
+    assert_eq!(
+        normalize_with(ShuffleDirection::ThreePrime, &once),
+        once,
+        "norm(norm(x)) must equal norm(x)",
+    );
+}


### PR DESCRIPTION
## Summary

A follow-up to #1157 (delins-reducing-to-del/dup skipped the 3′-shift). That bug reached a release because the existing idempotency net is reference-free or substitution-only, so nothing that actually 3′/5′-shifts was ever exercised for `norm(norm(x)) == norm(x)`.

This PR adds a **boundary-level idempotency oracle**, uses it to sweep the whole suite, and fixes the single non-idempotency it surfaced.

## What's here (three logical commits)

1. **`test:` opt-in idempotency self-check.** A gated check at the public `Normalizer::normalize` boundary: when `FERRO_ASSERT_IDEMPOTENT` is set, it re-normalizes the output and panics on drift (with `input`/`once`/`twice`), turning every reference-backed test and conformance corpus into an idempotency assertion. The second pass goes through `normalize_core_checked` (not the public `normalize`), so there's no re-entrancy and no guard needed. Gated on `#[cfg(debug_assertions)]`, so it is **compiled out entirely in release** — production is untouched and zero-cost; the env flag is read once and cached.

2. **`fix:` #418 CDS-start boundary clamp is now a stable fixed point.** The #418 no-5′UTR clamp rewrites a 5′-saturated boundary insertion into the blessed `c.1delinsACA`, but that delins wasn't a fixed point — re-normalizing drifted to the degenerate `c.1insCA`. Root cause: the saturation detector keyed on the **input** edit type (`matches!(edit, Insertion)`), so a `delins` input whose shared-affix trim reduces it to the same degenerate saturated insertion (arriving with `edit == Delins`) was missed and leaked. Fix: also key on the **output** shape (`matches!(new_edit, Insertion)`) — the existing `NaEdit::Delins` restore arm then makes both spellings converge on `c.1delinsACA`. Strictly additive: the insertion-input path, the `c.1delinsCA` panic guard, the 3′-direction cases, and every conformance/biocommons baseline are unchanged (the only newly-affected inputs resolve to their already-blessed value). New regression tests pin the fixed point + confluence in `issue_418_no_utr5_boundary.rs`.

3. **`ci:` enforce it.** The Test job re-runs the suite with `FERRO_ASSERT_IDEMPOTENT=1` (reuses built binaries — no recompile).

## Verification

- With the oracle **on**, the full suite is green: **8498 passed, 0 failed** — the finder surfaced exactly one root cause across the whole codebase (strong evidence the normalizer is otherwise idempotency-clean).
- With the oracle **off** (default), behavior is unchanged.
- `cargo fmt` / `clippy -D warnings` clean.

## Known latent follow-up

A symmetric case likely exists at the **CDS-end** boundary on a no-3′UTR transcript (the #387 mirror gate uses a strict `new_tx_end > cds_end` position test). No current test exercises it, so it's deliberately left for the follow-up reference-backed idempotency **proptest** (Phase 2) to confirm or surface, rather than changing boundary code with no failing test.