### PR TITLE
refactor!: mark the remaining additive-change-prone public types non_exhaustive

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -80,7 +80,15 @@ pub struct BatchResults {
 }
 
 /// Configuration for batch normalization.
+///
+/// Marked `#[non_exhaustive]` so adding a batch knob is additive rather than
+/// breaking. Build it from [`Default`] and assign the fields you need (they
+/// stay `pub`) rather than using a struct literal. Distinct from
+/// [`crate::normalize::NormalizeConfig`], which configures the normalization
+/// itself; this one configures the batch run around it, and is marked for the
+/// same reason.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct NormalizeConfig {
     /// Reference directory (with manifest.json)
     pub reference_dir: Option<std::path::PathBuf>,

--- a/src/normalize/config.rs
+++ b/src/normalize/config.rs
@@ -4,7 +4,14 @@ use crate::error_handling::{ErrorConfig, ErrorMode, ErrorOverride, ErrorType, Re
 use serde::{Deserialize, Serialize};
 
 /// Direction for variant shuffling during normalization
+///
+/// Marked `#[non_exhaustive]` so a future shuffling direction is additive. It
+/// is carried as a `pub` field of [`crate::normalize::NormalizationInfo`]'s
+/// `ShuffleApplied` variant, which is already `#[non_exhaustive]` — without
+/// this the protection there was only half applied, since downstream still had
+/// to match the direction exhaustively.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[non_exhaustive]
 pub enum ShuffleDirection {
     /// Shuffle towards 3' end (default for HGVS)
     #[default]
@@ -35,7 +42,18 @@ impl std::str::FromStr for ShuffleDirection {
 }
 
 /// Configuration for variant normalization
+///
+/// Marked `#[non_exhaustive]` so adding a normalization knob is additive rather
+/// than breaking. Build it with [`NormalizeConfig::new`] (or the
+/// [`NormalizeConfig::strict`] / [`NormalizeConfig::lenient`] /
+/// [`NormalizeConfig::silent`] presets) plus the `with_*` builders, or from
+/// [`Default`], rather than a struct literal; the fields stay `pub`, so
+/// anything the builders do not cover is still reachable by assigning to the
+/// field directly. Mirrors the attribute on its result-side counterpart
+/// [`crate::normalize::NormalizeResult`], which #1033 marked for the same
+/// reason.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct NormalizeConfig {
     /// Direction to shuffle variants (default: 3')
     pub shuffle_direction: ShuffleDirection,

--- a/src/spdi/convert.rs
+++ b/src/spdi/convert.rs
@@ -94,7 +94,13 @@ use crate::sequence::reverse_complement;
 const MAX_REPEAT_EXPANSION_BASES: usize = 100_000;
 
 /// Error type for conversion failures.
+///
+/// Marked `#[non_exhaustive]` so a new conversion-failure case is additive
+/// rather than breaking for downstream crates matching on it — the same
+/// treatment [`crate::FerroError`] and [`crate::error::ErrorCode`] received in
+/// #1033.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ConversionError {
     /// The variant type is not supported for conversion.
     UnsupportedVariantType {

--- a/src/spdi/mod.rs
+++ b/src/spdi/mod.rs
@@ -66,7 +66,14 @@ use std::str::FromStr;
 /// | Deletion | `NC:99:ATG:` | Delete ATG starting at position 100 |
 /// | Insertion | `NC:100::ATG` | Insert ATG after position 100 |
 /// | Delins | `NC:99:ATG:TCA` | Replace ATG with TCA |
+///
+/// Marked `#[non_exhaustive]` so a future field is additive rather than
+/// breaking. Build it with [`SpdiVariant::new`] rather than a struct literal;
+/// the fields stay `pub`, so they remain readable and individually assignable.
+/// Mirrors the attribute on [`crate::project::VariantProjection`], the
+/// analogous all-`pub`-field output type #1033 marked.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SpdiVariant {
     /// Reference sequence identifier (e.g., "NC_000001.11").
     pub sequence: String,

--- a/src/spdi/parser.rs
+++ b/src/spdi/parser.rs
@@ -6,7 +6,12 @@ use super::SpdiVariant;
 use std::fmt;
 
 /// Error type for SPDI parsing failures.
+///
+/// Marked `#[non_exhaustive]` so a new parse-failure case is additive rather
+/// than breaking for downstream crates matching on it — the same treatment
+/// [`crate::FerroError`] and [`crate::error::ErrorCode`] received in #1033.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SpdiParseError {
     /// Not enough colons in the input (expected exactly 3).
     NotEnoughParts {


### PR DESCRIPTION
## Summary

#1033 hardened the error and projection API; #1165 did the equivalence API. Both left neighbours with **identical exposure** unmarked, so the next additive change to them is still a silent break for downstream crates. This finishes the pass.

| Type | Module | Why it qualifies |
|---|---|---|
| `ShuffleDirection` | `normalize` | Public enum, crate-root re-exported, and carried as a `pub` field of the already-marked `NormalizationInfo::ShuffleApplied` — so that protection was only **half applied**, since downstream still had to match the direction exhaustively. |
| `NormalizeConfig` | `normalize` | All-`pub`-field struct, crate-root re-exported, and a parameter of `EquivalenceChecker::with_config`. Its result-side counterpart `NormalizeResult` was marked by #1033. |
| `NormalizeConfig` | `commands` | The batch-run config — a *distinct* type that shares the name. Marked too, so the two don't diverge in hardening. |
| `SpdiVariant` | `spdi` | All-`pub`-field struct, crate-root re-exported, while the analogous output type `VariantProjection` is marked. |
| `SpdiParseError` | `spdi` | Public error enum downstream must match, unmarked while `FerroError` is marked. |
| `ConversionError` | `spdi` | Ditto, and crate-root re-exported. |

## Nothing becomes unconstructible

Every type keeps its `pub` fields, so nothing becomes unreadable or unsettable. `NormalizeConfig` (normalize) has `new()` / `strict()` / `lenient()` / `silent()` plus ten `with_*` builders; `SpdiVariant` has `new()`; the batch config has `Default`. Direct field assignment remains available for anything the constructors don't cover — `#[non_exhaustive]` blocks struct literals, FRU and exhaustive destructuring, not public-field access.

## Verification

`non_exhaustive` has no effect *within* the defining crate — but it **does** apply to `tests/`, `examples/`, `benches/` and doctests, which are separate crates. That is the real check here, and it passes untouched:

- `cargo build --features dev --all-targets` — clean (so no test, example or bench relied on struct-literal construction or exhaustive matching)
- `cargo test --doc` — 80 passed (rustdoc compiles doctests as an external crate)
- `cargo test --features dev` — full suite green
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo check --features python` — clean
- `cargo fmt --check` — clean

No source file outside the six type definitions changed.

## Semver

Deliberately **breaking**, done now at 0.x so the next field or variant on any of these is additive. Typed `refactor!` with a `BREAKING CHANGE:` footer, and the `!` is in this PR title too — squash-merge takes the title, and that is what release-plz reads.

## Scope

Bounded to types with the *same* exposure as those #1033 and #1165 already marked: crate-root-reachable public error enums, and config/result structs on the main API paths. Deliberately not a crate-wide sweep — internal-ish types and those already unconstructible downstream (e.g. `EquivalenceChecker`, whose only field is private) are untouched.

Found by an independent reviewer during the #1164/#1165 review sweep, which flagged that the hardening campaign was otherwise being left patchy.