### PR TITLE
fix(normalize): 5' boundary + repeat/dup canonicalization; enable the general 5' idempotency proptest

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3249,111 +3249,62 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // left-saturation, and fire the clamp the same way the
         // non-degenerate case does.
         //
-        // The degenerate shape is keyed on `new_edit` (the OUTPUT), not
-        // just `edit` (the INPUT): a `delins` input at `cds_start` whose
-        // shared-affix trim reduces it to an insertion (e.g. `c.1delinsACA`
-        // -> trim prefix `A` -> `insCA`) recurses through the SAME
-        // insertion 5'-shuffle and produces the SAME degenerate saturated
-        // `new_edit`, but arrives here with `edit == Delins`. Keying only on
-        // the input `edit` missed that path, so the clamp fired for the
-        // insertion spelling (`c.1_2insCA` -> `c.1delinsACA`) but not the
-        // delins spelling, which then leaked the degenerate `c.1insCA` —
-        // making the blessed `c.1delinsACA` a non-fixed-point (the
-        // `NaEdit::Delins` restore arm below already handles it once
-        // reached). Adding the `new_edit` disjunct makes the gate fire for
-        // both spellings, so they converge on the same fixed point. Issue
-        // #1157 follow-up (idempotency campaign). Keeping the `edit`
-        // disjunct too is strictly additive over prior behavior.
-        let cds_start_left_saturated = (matches!(edit, NaEdit::Insertion { .. })
-            || matches!(new_edit, NaEdit::Insertion { .. }))
-            && new_tx_start == cds_start
-            && new_tx_end == cds_start;
+        // Rewrite via an exact coordinate identity keyed on the POST-shuffle
+        // edit (`new_edit`), not the input `edit`. After shuffling, an
+        // insertion of the (rotated) sequence `A'` that has come to rest
+        // immediately 5' of `cds_start` occupies flanks
+        // `(cds_start-1, cds_start)` [`c.-1_1`] when a 5'UTR exists, or the
+        // degenerate `(cds_start, cds_start)` when it does not (the 0-based-0
+        // shuffle result clamps back to HGVS 1). "Insert `A'` between
+        // `cds_start-1` and `cds_start`" is *identically* "delete
+        // `ref[cds_start]`, insert `A' ++ ref[cds_start]`" — moving the delete
+        // boundary one base, exact for ANY `A'`, no equivalence check needed.
+        //
+        // Keying on `new_edit` unifies three inputs that all reach here as the
+        // same shuffled `A'`: a directly-written insertion, a codon-gated
+        // `dup` (routed through the shuffle in `normalize_na_edit`), and any
+        // start position — so every spelling of one haplotype collapses to a
+        // single minimal, idempotent `c.<cds_start>delins<A' ++ ref[cds_start]>`
+        // (confluence; supersedes the earlier width-varying `k`-widened form).
+        let insertion_rests_at_cds_start = matches!(new_edit, NaEdit::Insertion { .. })
+            && new_tx_end == cds_start
+            && (new_tx_start == cds_start || new_tx_start + 1 == cds_start);
         if matches!(start_axis, boundary::AxisRegion::Cds)
-            && (new_tx_start < cds_start || cds_start_left_saturated)
             && !spanning_dup_exception
+            && (insertion_rests_at_cds_start || new_tx_start < cds_start)
         {
-            match edit {
-                NaEdit::Insertion {
-                    sequence: InsertedSequence::Literal(in_lit),
-                } => {
-                    let alt_bytes: Vec<u8> = in_lit.bases().iter().map(|b| *b as u8).collect();
-                    let x = (tx_start.saturating_sub(cds_start) + 1) as usize;
+            if matches!(edit, NaEdit::Delins { .. }) {
+                // A Delins input whose canonicalisation pushed the residual
+                // past the boundary restores to its own form (#383): the
+                // shared-affix trim is what drove it past `cds_start`.
+                new_edit = edit.clone();
+                new_tx_start = tx_start;
+                new_tx_end = tx_end;
+            } else if insertion_rests_at_cds_start {
+                if let NaEdit::Insertion {
+                    sequence: InsertedSequence::Literal(a_prime),
+                } = &new_edit
+                {
                     let cds_start_0b = (cds_start as usize).saturating_sub(1);
-                    let prefix_end = cds_start_0b + x;
-                    // k = max(1, x - L). For x <= L+1 this is 1 (the
-                    // original 1-base-anchor formula); for the long-
-                    // shift homopolymer case (x > L+1) this widens the
-                    // delete window enough to give us a non-negative
-                    // alt_take.
-                    let k = x.saturating_sub(alt_bytes.len()).max(1);
-                    let alt_take = (alt_bytes.len() + k).saturating_sub(x);
-                    let delete_end_0b = cds_start_0b + k;
-                    if x >= 1
-                        && prefix_end <= seq.len()
-                        && delete_end_0b <= seq.len()
-                        && alt_take <= alt_bytes.len()
-                    {
-                        let prefix = &seq[cds_start_0b..prefix_end];
-                        let alt_part = &alt_bytes[..alt_take];
-                        let mut new_alt: Vec<u8> = prefix.to_vec();
-                        new_alt.extend_from_slice(alt_part);
-                        // Equivalence check: the clamped delins
-                        //   delete ref[cds_start_0b..cds_start_0b+k]
-                        //   insert new_alt (length L+k)
-                        // must yield the same final sequence as the
-                        // input
-                        //   insert alt at tx_start (length L)
-                        //   = between bytes tx_start_0b and
-                        //     tx_start_0b+1 (tx_start_0b = cds_start_0b+x-1).
-                        // After cancelling the shared prefix at
-                        // `cds_start_0b` and the shared suffix from
-                        // `cds_start_0b+x` onward, equivalence reduces
-                        // to:
-                        //   alt[..alt_take] ++ ref[cds_start_0b+k..
-                        //                          cds_start_0b+x]
-                        //       == alt
-                        // i.e. the last (x - k) bytes of `alt` must
-                        // equal the corresponding ref window. For the
-                        // x <= L+1 case (k = 1) this collapses to the
-                        // pre-existing single-base-anchor formula and
-                        // always holds because the canonicalisation
-                        // shifted past that ref window in the first
-                        // place. For x > L+1 (k = x - L) the check
-                        // accepts homopolymer / tandem-repeat cases
-                        // and rejects anything else, so we never emit
-                        // a delins that disagrees with the input.
-                        let ref_tail = &seq[delete_end_0b..prefix_end];
-                        let alt_tail_start = alt_take;
-                        let equivalent = ref_tail.len() == alt_bytes.len() - alt_tail_start
-                            && ref_tail == &alt_bytes[alt_tail_start..];
-                        if equivalent {
-                            let bases: Vec<Base> = new_alt
-                                .iter()
-                                .filter_map(|b| Base::from_char(*b as char))
-                                .collect();
-                            if bases.len() == new_alt.len() {
-                                new_edit = NaEdit::Delins {
-                                    sequence: InsertedSequence::Literal(Sequence::new(bases)),
-                                    deleted: None,
-                                    deleted_length: None,
-                                    substitution_reference: None,
-                                };
-                                new_tx_start = cds_start;
-                                new_tx_end = cds_start + (k as u64) - 1;
-                            }
+                    if cds_start_0b < seq.len() {
+                        let mut new_alt: Vec<u8> =
+                            a_prime.bases().iter().map(|b| *b as u8).collect();
+                        new_alt.push(seq[cds_start_0b]);
+                        let bases: Vec<Base> = new_alt
+                            .iter()
+                            .filter_map(|b| Base::from_char(*b as char))
+                            .collect();
+                        if bases.len() == new_alt.len() {
+                            new_edit = NaEdit::Delins {
+                                sequence: InsertedSequence::Literal(Sequence::new(bases)),
+                                deleted: None,
+                                deleted_length: None,
+                                substitution_reference: None,
+                            };
+                            new_tx_start = cds_start;
+                            new_tx_end = cds_start;
                         }
                     }
-                }
-                NaEdit::Delins { .. } => {
-                    new_edit = edit.clone();
-                    new_tx_start = tx_start;
-                    new_tx_end = tx_end;
-                }
-                _ => {
-                    // Other edit types (Deletion, Duplication directly
-                    // as input, Inversion, …) do not currently produce
-                    // 5'UTR-resident rewrites from CDS-interior inputs
-                    // in this canonicalisation path.
                 }
             }
         }
@@ -3406,64 +3357,52 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // `Duplication` whose end reaches CDS — but both have the same
         // intent: preserve spanning duplications, clamp everything
         // else.
+        //
+        // Rewrite via the mirror of the CDS-start identity, keyed on the
+        // POST-shuffle `new_edit`. After shuffling, an insertion of the
+        // (rotated) sequence `A'` resting immediately 3' of `cds_end` occupies
+        // flanks `(cds_end, cds_end+1)` [`c.<cds_end>_*1`]. "Insert `A'` between
+        // `cds_end` and `cds_end+1`" is *identically* "delete `ref[cds_end]`,
+        // insert `ref[cds_end] ++ A'`" — exact for ANY `A'`. This keeps a
+        // CDS-interior edit on the CDS axis instead of drifting onto the 3'UTR
+        // (`c.*1`) axis, and (keyed on `new_edit`) unifies dup- and
+        // insertion-spelled inputs and every start position into one minimal,
+        // idempotent `c.<cds_end>delins<ref[cds_end] ++ A'>` (confluence;
+        // resolves the #387 CDS-end saturation latent). Spanning *duplications*
+        // (`new_edit` = Duplication, e.g. `c.9171_*1dup`) are the spec-canonical
+        // form and are NOT clamped.
         if let Some(cds_end_tx) = transcript.cds_end {
-            if matches!(start_axis, boundary::AxisRegion::Cds)
-                && new_tx_end > cds_end_tx
-                && matches!(new_edit, NaEdit::Insertion { .. })
-            {
-                match edit {
-                    NaEdit::Insertion {
-                        sequence: InsertedSequence::Literal(in_lit),
-                    } => {
-                        let alt_bytes: Vec<u8> = in_lit.bases().iter().map(|b| *b as u8).collect();
-                        // Y_c = cds_end_c. - X = cds_end_tx - tx_start
-                        // (both 1-based tx; the cds_start offsets cancel
-                        // because the input start in c.-axis 1-based is
-                        // `tx_start - cds_start + 1`).
-                        let y_c = cds_end_tx.saturating_sub(tx_start);
-                        // y_c >= 1 here (else `new_tx_end > cds_end_tx`
-                        // could not have fired for an Insertion that
-                        // started strictly inside CDS proper). Bound the
-                        // alt-tail offset on the alt length too, so a
-                        // pathological state (`y_c > |alt| + 1`) leaves
-                        // the result untouched rather than panicking.
-                        let alt_take_start = y_c.saturating_sub(1) as usize;
-                        let suffix_start = (tx_end as usize).saturating_sub(1);
-                        let suffix_end = cds_end_tx as usize;
-                        if y_c >= 1
-                            && alt_take_start <= alt_bytes.len()
-                            && suffix_start <= suffix_end
-                            && suffix_end <= seq.len()
-                        {
-                            let alt_part = &alt_bytes[alt_take_start..];
-                            let suffix = &seq[suffix_start..suffix_end];
-                            let mut new_alt: Vec<u8> = alt_part.to_vec();
-                            new_alt.extend_from_slice(suffix);
-                            let bases: Vec<Base> = new_alt
-                                .iter()
-                                .filter_map(|b| Base::from_char(*b as char))
-                                .collect();
-                            if bases.len() == new_alt.len() {
-                                new_edit = NaEdit::Delins {
-                                    sequence: InsertedSequence::Literal(Sequence::new(bases)),
-                                    deleted: None,
-                                    deleted_length: None,
-                                    substitution_reference: None,
-                                };
-                                new_tx_start = cds_end_tx;
-                                new_tx_end = cds_end_tx;
-                            }
+            let insertion_rests_at_cds_end = matches!(new_edit, NaEdit::Insertion { .. })
+                && new_tx_start == cds_end_tx
+                && (new_tx_end == cds_end_tx || new_tx_end == cds_end_tx + 1);
+            if matches!(start_axis, boundary::AxisRegion::Cds) && insertion_rests_at_cds_end {
+                if matches!(edit, NaEdit::Delins { .. }) {
+                    // Delins input restores to its own form (mirror #383/#387).
+                    new_edit = edit.clone();
+                    new_tx_start = tx_start;
+                    new_tx_end = tx_end;
+                } else if let NaEdit::Insertion {
+                    sequence: InsertedSequence::Literal(a_prime),
+                } = &new_edit
+                {
+                    let cds_end_0b = (cds_end_tx as usize).saturating_sub(1);
+                    if cds_end_0b < seq.len() {
+                        let mut new_alt: Vec<u8> = vec![seq[cds_end_0b]];
+                        new_alt.extend(a_prime.bases().iter().map(|b| *b as u8));
+                        let bases: Vec<Base> = new_alt
+                            .iter()
+                            .filter_map(|b| Base::from_char(*b as char))
+                            .collect();
+                        if bases.len() == new_alt.len() {
+                            new_edit = NaEdit::Delins {
+                                sequence: InsertedSequence::Literal(Sequence::new(bases)),
+                                deleted: None,
+                                deleted_length: None,
+                                substitution_reference: None,
+                            };
+                            new_tx_start = cds_end_tx;
+                            new_tx_end = cds_end_tx;
                         }
-                    }
-                    NaEdit::Delins { .. } => {
-                        new_edit = edit.clone();
-                        new_tx_start = tx_start;
-                        new_tx_end = tx_end;
-                    }
-                    _ => {
-                        // Other edit types do not currently produce
-                        // 3'UTR-resident rewrites from CDS-interior
-                        // inputs in this canonicalisation path.
                     }
                 }
             }
@@ -7777,7 +7716,26 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 let ins_edit = NaEdit::Insertion {
                                     sequence: InsertedSequence::Literal(Sequence::new(bases)),
                                 };
-                                return Ok((ins_start, ins_end, ins_edit, warnings));
+                                // The rule layer anchors the gated insertion at
+                                // the tract's 3' flank regardless of shuffle
+                                // direction. Re-enter `normalize_na_edit` on the
+                                // derived insertion so it shuffles to the
+                                // direction-appropriate boundary and reaches the
+                                // same CDS-start/-end boundary clamps a directly
+                                // written insertion does — otherwise a
+                                // `dup`-spelled homopolymer edit and its
+                                // insertion-spelled twin normalize to different
+                                // (and, at a coding boundary, invalid) forms.
+                                // Terminates: the derived edit is an Insertion,
+                                // which never re-enters this Duplication arm.
+                                let (rec_start, rec_end, rec_edit, mut rec_warnings) = self
+                                    .normalize_na_edit(
+                                        ref_seq, &ins_edit, ins_start, ins_end, boundaries,
+                                        is_coding,
+                                    )?;
+                                let mut merged = warnings;
+                                merged.append(&mut rec_warnings);
+                                return Ok((rec_start, rec_end, rec_edit, merged));
                             }
                             // Defensive fallback: rule layer returned a base
                             // byte that doesn't fit the Base alphabet (e.g.

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7576,16 +7576,33 @@ impl<P: ReferenceProvider> Normalizer<P> {
                             }
                         };
                         let dup_len = rotated_seq.len() as u64;
+                        // 3'-side anchor is derived from `pos_idx` (the 0-based
+                        // matched-tract start `ref[pos_idx..pos_idx+L]`), NOT from
+                        // `new_start`: when a 5'-shuffled insertion comes to rest
+                        // at the transcript start (`result.start == 0`), the
+                        // insertion coordinate adjust-back `saturating_sub(1)`
+                        // collapses `new_start` to c.1, breaking the usual
+                        // `new_start == pos_idx + 1` relation and mislabelling the
+                        // dup one position 3' (e.g. `c.2_3insGA` in `G[A..]` →
+                        // `c.2_3dup` = a different haplotype instead of the correct
+                        // `c.1_2dup`). `pos_idx` is unaffected by that clamp, and
+                        // `index_to_hgvs_pos(pos_idx) == new_start + 1` whenever no
+                        // saturation occurred, so this is identical off-boundary.
+                        let three_prime_anchor = index_to_hgvs_pos(pos_idx);
                         let (dup_start, dup_end) = if prefer_three_prime {
-                            if dup_len == 1 {
-                                (new_start + 1, new_start + 1)
-                            } else {
-                                (new_start + 1, new_start + dup_len)
-                            }
+                            (three_prime_anchor, three_prime_anchor + dup_len - 1)
                         } else if dup_len == 1 {
                             (new_start, new_start)
                         } else {
-                            (new_start - dup_len + 1, new_start)
+                            // `saturating_sub` for parity with the 3' arm above: that
+                            // arm switched off `new_start` precisely because the
+                            // insertion adjust-back clamp can collapse it to c.1. A
+                            // 5'-side match needs a tract 5' of the insertion point,
+                            // which cannot exist at the transcript start, so this is
+                            // believed unreachable — but plain `-` on `u64` would
+                            // panic in debug / wrap in release if it ever were, and
+                            // the rest of this path guards the same way.
+                            (new_start.saturating_sub(dup_len - 1).max(1), new_start)
                         };
                         (
                             dup_start,

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7194,6 +7194,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     &repeat_unit,
                     *specified_count,
                     is_coding,
+                    self.config.shuffle_direction,
                 ) {
                     rules::RepeatNormResult::Deletion {
                         start: del_start,
@@ -7365,6 +7366,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 original_pos_idx,
                                 &seq_bytes,
                                 is_coding,
+                                self.config.shuffle_direction,
                             )
                         {
                             use crate::hgvs::edit::Base;

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -302,12 +302,16 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 ///
 /// Unlike `insertion_to_duplication` (which picks an explicit
 /// direction-aligned slot), `insertion_to_repeat` returns the canonical
-/// `unit[N+k]` window spanning the full reference tract, anchored at
-/// `ref_start`. The returned window covers the entire tract regardless
-/// of where shuffle would have placed the original insertion, so the
-/// output is invariant under `ShuffleDirection`. A direction-parameter
-/// audit was performed in #357 and locked in by
-/// `insertion_to_repeat_output_is_direction_invariant_on_n_axis`.
+/// `unit[N+k]` window spanning the full reference tract. The window covers the
+/// entire tract regardless of where shuffle would have placed the original
+/// insertion; only the tract's *phase* is direction-dependent, delegated to
+/// [`normalize_repeat`] (see below). For a homopolymer or a tract bounded by
+/// non-unit bases the 3'- and 5'-most phases coincide, so the displayed range is
+/// still direction-invariant there (#357,
+/// `insertion_to_repeat_output_is_direction_invariant_on_n_axis`); an ambiguous
+/// alternating tract, by contrast, is phased to the direction-appropriate end of
+/// the tract (#8), which is what makes the emitted repeat a fixed point under
+/// re-normalization.
 ///
 /// This function owns only the insertion-specific work: rotation-aware
 /// discovery of the adjacent tandem tract (`find_tandem_extent`) and the #882
@@ -324,6 +328,7 @@ pub fn insertion_to_repeat(
     pos: u64,
     inserted_seq: &[u8],
     is_coding: bool,
+    direction: crate::normalize::config::ShuffleDirection,
 ) -> Option<(u8, u64, u64, u64, Vec<u8>)> {
     if inserted_seq.is_empty() {
         return None;
@@ -366,34 +371,42 @@ pub fn insertion_to_repeat(
     // expand it by the inserted copies. Because `find_tandem_extent` and
     // `count_tandem_repeats` walk the tract identically, `normalize_repeat`
     // re-discovers the same tract, absorbs no flanks, and applies the SAME
-    // `three_prime_align_tract` + codon gate — so the emitted window/unit/count
-    // equal today's inline computation. `added_copies >= 2` ⇒ the target is
+    // direction-aware phase alignment + codon gate — so the emitted
+    // window/unit/count agree with `normalize_repeat` on the same reference tract
+    // in the same direction. `added_copies >= 2` ⇒ the target is
     // `>= ref_count + 2`, so only `Repeat` (or the codon-gated `Insertion` → None)
     // is reachable; `Deletion`/`Duplication`/`Unchanged` cannot occur.
     let target = ref_count + added_copies;
     let end_pos_incl = ref_end_excl - 1;
-    let (start_idx, emitted_end_hgvs, rotated_unit, total_count) =
-        match normalize_repeat(ref_seq, ref_start, end_pos_incl, &unit, target, is_coding) {
-            RepeatNormResult::Repeat {
-                start,
-                end,
-                sequence,
-                count,
-            } => (hgvs_pos_to_index(start), end, sequence, count),
-            // Codon gate (c. + non-codon unit) reroutes the expansion to `Insertion`;
-            // the caller then emits the literal `ins` form. Matches the pre-#866 gate.
-            RepeatNormResult::Insertion { .. } => return None,
-            // `added_copies >= 2` ⇒ `target = ref_count + added_copies >= ref_count + 2`,
-            // so a contraction / one-copy-expansion / identity result cannot arise here.
-            // Assert it loudly rather than silently returning `None`, so a future change
-            // that relaxes the `added_copies >= 2` guard is caught at test time.
-            RepeatNormResult::Deletion { .. }
-            | RepeatNormResult::Duplication { .. }
-            | RepeatNormResult::Unchanged => unreachable!(
-                "insertion_to_repeat delegates with added_copies >= 2, so target >= \
+    let (start_idx, emitted_end_hgvs, rotated_unit, total_count) = match normalize_repeat(
+        ref_seq,
+        ref_start,
+        end_pos_incl,
+        &unit,
+        target,
+        is_coding,
+        direction,
+    ) {
+        RepeatNormResult::Repeat {
+            start,
+            end,
+            sequence,
+            count,
+        } => (hgvs_pos_to_index(start), end, sequence, count),
+        // Codon gate (c. + non-codon unit) reroutes the expansion to `Insertion`;
+        // the caller then emits the literal `ins` form. Matches the pre-#866 gate.
+        RepeatNormResult::Insertion { .. } => return None,
+        // `added_copies >= 2` ⇒ `target = ref_count + added_copies >= ref_count + 2`,
+        // so a contraction / one-copy-expansion / identity result cannot arise here.
+        // Assert it loudly rather than silently returning `None`, so a future change
+        // that relaxes the `added_copies >= 2` guard is caught at test time.
+        RepeatNormResult::Deletion { .. }
+        | RepeatNormResult::Duplication { .. }
+        | RepeatNormResult::Unchanged => unreachable!(
+            "insertion_to_repeat delegates with added_copies >= 2, so target >= \
                  ref_count + 2; only Repeat or the codon-gated Insertion are reachable"
-            ),
-        };
+        ),
+    };
     // `emitted_end_hgvs` is a 1-based INCLUSIVE HGVS position, numerically equal to
     // the 0-based EXCLUSIVE aligned end; recover the exclusive end for the #882 gate
     // with no double correction.
@@ -575,7 +588,22 @@ pub(crate) fn insertion_to_duplication(
             unit = aligned_unit;
             aligned_end - unit.len()
         }
-        ShuffleDirection::FivePrime => ref_start,
+        ShuffleDirection::FivePrime => {
+            // Mirror of the 3' branch: push to the *true* 5'-most slot, crossing
+            // any off-phase tract extension. `ref_start` only 5'-aligns within the
+            // abutting rotation's phase; when the run continues one base further 5'
+            // in the opposite phase (e.g. inserting `TG` at the 3' edge of a
+            // `GTGTGTG` run — the abutting `TG` tract starts one base short of the
+            // run's true 5' end), stopping there under-shifts by one and is not a
+            // fixed point (the emitted `dup` re-shuffles one base further 5').
+            // `five_prime_align_tract` walks the remaining 5' flank while
+            // `ref[start-1] == rotated.last()` — the mirror duplication slide rule
+            // — rotating the unit to the run's 5' phase (#8's dup-path sibling).
+            let (aligned_start, _, aligned_unit) =
+                five_prime_align_tract(ref_seq, ref_start, tract_end_idx, &unit);
+            unit = aligned_unit;
+            aligned_start
+        }
     };
     let dup_end_idx = dup_start_idx + unit.len() - 1;
 
@@ -1582,6 +1610,39 @@ fn three_prime_align_tract(
     (start, end, rotated)
 }
 
+/// 5' mirror of [`three_prime_align_tract`] for `ShuffleDirection::FivePrime`.
+///
+/// While the base immediately 5' of the tract equals the rotating unit's *tail*,
+/// the window slides one base 5' and the unit rotates right by one — the
+/// direction-mirrored re-phasing that preserves the copy count. Returns the
+/// rotated `(start, end_exclusive, rotated_unit)`.
+///
+/// This is what keeps a `FivePrime` repeat idempotent AND confluent over an
+/// ambiguous alternating tract: `AG[4]` anchored at the tract's 3' phase and
+/// `GA[4]` anchored at its 5' phase both re-anchor to the single 5'-most form
+/// (#8, the tandem-repeat mirror of the #403 direction tie-break). `ThreePrime`
+/// keeps [`three_prime_align_tract`], so 3' output is unchanged.
+fn five_prime_align_tract(
+    ref_seq: &[u8],
+    ref_start: usize,
+    ref_end: usize,
+    unit: &[u8],
+) -> (usize, usize, Vec<u8>) {
+    let mut start = ref_start;
+    let mut end = ref_end;
+    let mut rotated = unit.to_vec();
+    while start > 0
+        && rotated
+            .last()
+            .is_some_and(|&tail| ref_seq[start - 1] == tail)
+    {
+        rotated.rotate_right(1);
+        start -= 1;
+        end -= 1;
+    }
+    (start, end, rotated)
+}
+
 /// Normalize a repeat variant
 ///
 /// Given a repeat notation like CAT[1], determines the appropriate
@@ -1613,6 +1674,7 @@ pub fn normalize_repeat(
     repeat_unit: &[u8],
     specified_count: u64,
     is_coding: bool,
+    direction: crate::normalize::config::ShuffleDirection,
 ) -> RepeatNormResult {
     // Match `count_tandem_repeats`'s pre-refactor contract: an empty unit
     // is meaningless and falls through to `Unchanged`. Without this guard,
@@ -1702,13 +1764,22 @@ pub fn normalize_repeat(
         specified_count += absorbed;
     }
 
-    // 3'-rule unit rotation (repeated.md L44: "applying the 3'rule, the repeat
-    // has to be described as an AGC repeat") via the shared helper, so
-    // `insertion_to_repeat` reaches the identical 3'-most phase (idempotency;
-    // #852). `ref_end` stays exclusive (the later `index_to_hgvs_pos(ref_end - 1)`
-    // is unchanged).
-    let (ns, ne, rotated_unit) =
-        three_prime_align_tract(ref_seq, ref_start, ref_end, canonical_unit);
+    // Direction-aware unit rotation. For `ThreePrime`, repeated.md L44 ("applying
+    // the 3'rule, the repeat has to be described as an AGC repeat") — slide to the
+    // 3'-most phase via the shared helper, so `insertion_to_repeat` reaches the
+    // identical phase (idempotency; #852). For `FivePrime`, slide to the mirror
+    // 5'-most phase so a `dup`→`unit[N]` emission (which the shuffle stage already
+    // 5'-anchors) is a fixed point rather than drifting 3' (#8). `ref_end` stays
+    // exclusive (the later `index_to_hgvs_pos(ref_end - 1)` is unchanged).
+    use crate::normalize::config::ShuffleDirection;
+    let (ns, ne, rotated_unit) = match direction {
+        ShuffleDirection::ThreePrime => {
+            three_prime_align_tract(ref_seq, ref_start, ref_end, canonical_unit)
+        }
+        ShuffleDirection::FivePrime => {
+            five_prime_align_tract(ref_seq, ref_start, ref_end, canonical_unit)
+        }
+    };
     ref_start = ns;
     ref_end = ne;
     let canonical_unit: &[u8] = &rotated_unit;
@@ -2896,7 +2967,8 @@ mod tests {
         // 2-copy reference window. Hand-verified: unit GT, count 5, 1-based 3_6.
         let r = b"CTGTGTT";
         let (base, count, start, end, unit) =
-            insertion_to_repeat(r, 4, b"TGTGTG", false).expect("repeat");
+            insertion_to_repeat(r, 4, b"TGTGTG", false, ShuffleDirection::ThreePrime)
+                .expect("repeat");
         assert_eq!(base, b'G');
         assert_eq!(count, 5);
         assert_eq!((start, end), (3, 6));
@@ -2911,7 +2983,7 @@ mod tests {
         // the rotation retry `normalize_repeat` bails to `Unchanged`. It must
         // instead find the GT tract and emit the entire-range 3'-form.
         let r = b"CTGTGTT";
-        let got = normalize_repeat(r, 2, 2, b"TG", 5, false);
+        let got = normalize_repeat(r, 2, 2, b"TG", 5, false, ShuffleDirection::ThreePrime);
         assert_eq!(
             got,
             RepeatNormResult::Repeat {
@@ -2930,7 +3002,7 @@ mod tests {
         // the last base (idx 4) — a boundary-anchored count undercounts, so the
         // offset search must recover the full 2-copy tract (the `c.3GC[5]` shape).
         let r = b"TGCGCA";
-        let got = normalize_repeat(r, 4, 4, b"GC", 5, false);
+        let got = normalize_repeat(r, 4, 4, b"GC", 5, false, ShuffleDirection::ThreePrime);
         assert_eq!(
             got,
             RepeatNormResult::Repeat {
@@ -2947,7 +3019,7 @@ mod tests {
         // The already-phase-aligned unit takes the direct path and yields the same
         // result (phase-independence / idempotency).
         let r = b"CTGTGTT";
-        let got = normalize_repeat(r, 2, 2, b"GT", 5, false);
+        let got = normalize_repeat(r, 2, 2, b"GT", 5, false, ShuffleDirection::ThreePrime);
         assert_eq!(
             got,
             RepeatNormResult::Repeat {
@@ -3040,10 +3112,23 @@ mod tests {
             },
         ];
         for c in cases {
-            let (_b, _c, ins_start, ins_end, ins_unit) =
-                insertion_to_repeat(c.ref_seq, c.ins_pos, c.ins_seq, false)
-                    .unwrap_or_else(|| panic!("insertion_to_repeat None for {:?}", c.ref_seq));
-            match normalize_repeat(c.ref_seq, c.nr_pos, c.nr_end, c.nr_unit, c.nr_count, false) {
+            let (_b, _c, ins_start, ins_end, ins_unit) = insertion_to_repeat(
+                c.ref_seq,
+                c.ins_pos,
+                c.ins_seq,
+                false,
+                ShuffleDirection::ThreePrime,
+            )
+            .unwrap_or_else(|| panic!("insertion_to_repeat None for {:?}", c.ref_seq));
+            match normalize_repeat(
+                c.ref_seq,
+                c.nr_pos,
+                c.nr_end,
+                c.nr_unit,
+                c.nr_count,
+                false,
+                ShuffleDirection::ThreePrime,
+            ) {
                 RepeatNormResult::Repeat {
                     start,
                     end,
@@ -3067,10 +3152,18 @@ mod tests {
         // `normalize_repeat` routes the expansion to `Insertion`. Kept out of the shared
         // loop above (which unwraps a `Repeat`) since this case is intentionally None.
         assert!(
-            insertion_to_repeat(b"CAAAAAC", 5, b"AA", true).is_none(),
+            insertion_to_repeat(b"CAAAAAC", 5, b"AA", true, ShuffleDirection::ThreePrime).is_none(),
             "coding non-codon-aligned expansion must not be repeat notation"
         );
-        match normalize_repeat(b"CAAAAAC", 1, 5, b"A", 7, true) {
+        match normalize_repeat(
+            b"CAAAAAC",
+            1,
+            5,
+            b"A",
+            7,
+            true,
+            ShuffleDirection::ThreePrime,
+        ) {
             RepeatNormResult::Insertion {
                 start,
                 end,
@@ -3499,7 +3592,7 @@ mod tests {
         // insertion point. pos=7 means insert between index 7 and 8 — i.e.,
         // immediately after the last A in the homopolymer. Inserting AA here
         // should become A[7] (5 ref + 2 inserted).
-        let result = insertion_to_repeat(ref_seq, 7, b"AA", false);
+        let result = insertion_to_repeat(ref_seq, 7, b"AA", false, ShuffleDirection::ThreePrime);
         assert!(result.is_some());
         let (base, count, start, end, _unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -3508,15 +3601,15 @@ mod tests {
         assert_eq!(end, 8); // 1-indexed end of A region in reference (per HGVS, positions refer to reference tract)
 
         // Single-copy inserts (added_copies < 2) are duplications, not repeats.
-        let result = insertion_to_repeat(ref_seq, 7, b"A", false);
+        let result = insertion_to_repeat(ref_seq, 7, b"A", false, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Inserting T (non-matching) should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"T", false);
+        let result = insertion_to_repeat(ref_seq, 7, b"T", false, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Inserting mixed bases should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"AT", false);
+        let result = insertion_to_repeat(ref_seq, 7, b"AT", false, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Multi-base tandem unit: insert ACAC into ACAC tract → AC[4].
@@ -3524,7 +3617,7 @@ mod tests {
         // (pos=3, between A at index 3 and base at index 4). Expected:
         // 2 ref AC units + 2 inserted AC units = AC[4] at ref indices 0..3.
         let ref_ac = b"ACACGGG";
-        let result = insertion_to_repeat(ref_ac, 3, b"ACAC", false);
+        let result = insertion_to_repeat(ref_ac, 3, b"ACAC", false, ShuffleDirection::ThreePrime);
         assert!(result.is_some());
         let (base, count, start, end, unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -3648,7 +3741,15 @@ mod tests {
         // Specifying CAT[1]: ref_count=4, specified=1, k=3 >= 2, post=1 >= 1 → B2 → Repeat
         let ref_seq = b"GGGCATCATCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 1, false);
+        let result = normalize_repeat(
+            ref_seq,
+            3,
+            3,
+            b"CAT",
+            1,
+            false,
+            ShuffleDirection::ThreePrime,
+        );
         match result {
             RepeatNormResult::Repeat {
                 sequence, count, ..
@@ -3666,7 +3767,15 @@ mod tests {
         // Specifying CAT[3] (ref is 2, so 2+1=3) should become duplication
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 3, false);
+        let result = normalize_repeat(
+            ref_seq,
+            3,
+            3,
+            b"CAT",
+            3,
+            false,
+            ShuffleDirection::ThreePrime,
+        );
         match result {
             RepeatNormResult::Duplication {
                 start,
@@ -3686,7 +3795,15 @@ mod tests {
         // Specifying CAT[5] (ref is 2, 5 > 2+1) should stay as repeat
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 5, false);
+        let result = normalize_repeat(
+            ref_seq,
+            3,
+            3,
+            b"CAT",
+            5,
+            false,
+            ShuffleDirection::ThreePrime,
+        );
         match result {
             RepeatNormResult::Repeat {
                 count, sequence, ..
@@ -3704,7 +3821,15 @@ mod tests {
         // Specifying CAT[2] (same as ref) should be unchanged
         let ref_seq = b"GGGCATCATGGG";
 
-        let result = normalize_repeat(ref_seq, 3, 3, b"CAT", 2, false);
+        let result = normalize_repeat(
+            ref_seq,
+            3,
+            3,
+            b"CAT",
+            2,
+            false,
+            ShuffleDirection::ThreePrime,
+        );
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -3718,7 +3843,7 @@ mod tests {
         // canonical_unit.len()` unless we guard up front. This test pins the
         // pre-refactor contract.
         let ref_seq = b"GGGCATCATGGG";
-        let result = normalize_repeat(ref_seq, 3, 3, b"", 1, false);
+        let result = normalize_repeat(ref_seq, 3, 3, b"", 1, false, ShuffleDirection::ThreePrime);
         assert!(matches!(result, RepeatNormResult::Unchanged));
     }
 
@@ -3730,7 +3855,15 @@ mod tests {
         // this would fall to a 1-unit (ATAT) reduction → deletion (k<2).
         let ref_seq = b"GGGATATATATGGG"; // AT-tract at indices 3..11 (4 AT)
 
-        let result = normalize_repeat(ref_seq, 3, 3, b"ATAT", 1, false);
+        let result = normalize_repeat(
+            ref_seq,
+            3,
+            3,
+            b"ATAT",
+            1,
+            false,
+            ShuffleDirection::ThreePrime,
+        );
         match result {
             RepeatNormResult::Repeat {
                 start,
@@ -4114,7 +4247,7 @@ mod tests {
         // emit A[7], but unit_len=1 is not a multiple of 3 in c. context,
         // so the gate returns None.
         let ref_seq = b"CAAAAAC";
-        let result = insertion_to_repeat(ref_seq, 5, b"AA", true);
+        let result = insertion_to_repeat(ref_seq, 5, b"AA", true, ShuffleDirection::ThreePrime);
         assert!(
             result.is_none(),
             "is_coding=true + unit_len=1 must return None"
@@ -4126,7 +4259,7 @@ mod tests {
         // Reference: AT[3] tandem flanked by Cs. Insert ATAT → unit_len=2,
         // gate blocks in coding context.
         let ref_seq = b"CATATATC";
-        let result = insertion_to_repeat(ref_seq, 6, b"ATAT", true);
+        let result = insertion_to_repeat(ref_seq, 6, b"ATAT", true, ShuffleDirection::ThreePrime);
         assert!(
             result.is_none(),
             "is_coding=true + unit_len=2 must return None"
@@ -4138,7 +4271,7 @@ mod tests {
         // Reference: CAG[3] tandem. Insert CAGCAG → unit_len=3, codon-aligned,
         // gate passes; result is Some(...) carrying CAG[5].
         let ref_seq = b"CCAGCAGCAGT";
-        let result = insertion_to_repeat(ref_seq, 9, b"CAGCAG", true);
+        let result = insertion_to_repeat(ref_seq, 9, b"CAGCAG", true, ShuffleDirection::ThreePrime);
         assert!(
             result.is_some(),
             "is_coding=true + unit_len=3 must allow rewrite"
@@ -4153,7 +4286,7 @@ mod tests {
         // Same A-homopolymer case as the blocking test, but is_coding=false
         // → gate is a no-op, repeat rewrite proceeds.
         let ref_seq = b"CAAAAAC";
-        let result = insertion_to_repeat(ref_seq, 5, b"AA", false);
+        let result = insertion_to_repeat(ref_seq, 5, b"AA", false, ShuffleDirection::ThreePrime);
         assert!(result.is_some(), "is_coding=false must not gate");
     }
 
@@ -4215,7 +4348,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_routes_contraction_to_deletion() {
         // 5-A tract, specified A[3] in coding → must NOT emit Repeat; emits Deletion.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, 1, b"A", 3, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 3, true, ShuffleDirection::ThreePrime);
         match result {
             RepeatNormResult::Deletion { .. } => {}
             other => panic!("expected Deletion under gate, got {:?}", other),
@@ -4226,7 +4359,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_routes_expansion_to_insertion() {
         // 5-A tract, specified A[8] in coding → must NOT emit Repeat; emits Insertion.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, 1, b"A", 8, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 8, true, ShuffleDirection::ThreePrime);
         match result {
             RepeatNormResult::Insertion { sequence, .. } => {
                 assert_eq!(sequence, b"AAA", "3 extra A's");
@@ -4239,7 +4372,7 @@ mod tests {
     fn test_normalize_repeat_codon_frame_gate_passes_through_dup_branch() {
         // 5-A tract, specified A[6] in coding → +1 copy = dup, gate doesn't change this.
         let ref_seq = b"CAAAAAC";
-        let result = normalize_repeat(ref_seq, 1, 1, b"A", 6, true);
+        let result = normalize_repeat(ref_seq, 1, 1, b"A", 6, true, ShuffleDirection::ThreePrime);
         match result {
             RepeatNormResult::Duplication { .. } => {}
             other => panic!("expected Duplication, got {:?}", other),
@@ -5047,12 +5180,57 @@ mod tests {
         assert_eq!(got.end, 8);
     }
 
+    /// Regression for the `FivePrime` branch of `insertion_to_duplication`: the
+    /// odd-length off-phase partial flank that `five_prime_align_tract` exists to
+    /// cross.
+    ///
+    /// In `ACTGTGTGTGTAC` the alternating run spans indices 2..=10
+    /// (`T G T G T G T G T`). The `GT` tract abutting the cut starts at index 3,
+    /// but the run continues ONE base further 5' in the *opposite* phase — the
+    /// stray `T` at index 2. Stopping at `ref_start` would emit HGVS 4_5, which
+    /// is not a fixed point (the dup re-shuffles one base further 5' on the next
+    /// pass). The aligner must rotate `GT` → `TG` and land on 3_4.
+    #[test]
+    fn insertion_to_duplication_five_prime_crosses_off_phase_partial_flank() {
+        let r = b"ACTGTGTGTGTAC";
+        let got = insertion_to_duplication(r, 10, b"GT", ShuffleDirection::FivePrime)
+            .expect("5' insGT inside the GT run must convert to a dup");
+        assert_eq!(
+            got.unit, b"TG",
+            "unit rotates right as the window slides one base 5'"
+        );
+        assert_eq!(
+            (got.start, got.end),
+            (3, 4),
+            "the 5'-most slot lies across the off-phase T at index 2"
+        );
+
+        // The emitted dup must describe the SAME haplotype as the input insertion.
+        let inserted = {
+            let mut s = r.to_vec();
+            s.splice(11..11, b"GT".iter().copied());
+            s
+        };
+        let duplicated = {
+            let (s, e) = (got.start as usize - 1, got.end as usize); // 1-based incl → 0-based excl
+            let mut v = r.to_vec();
+            let copy = r[s..e].to_vec();
+            v.splice(e..e, copy);
+            v
+        };
+        assert_eq!(
+            String::from_utf8_lossy(&inserted),
+            String::from_utf8_lossy(&duplicated),
+            "dup and insertion spellings must reconstruct byte-identical sequences"
+        );
+    }
+
     #[test]
     fn insertion_to_repeat_rejects_out_of_phase_882() {
         // TGCGCA: insGCGC at the G|C cut (pos=1) is out of phase with the GC
         // tract; today it wrongly becomes GC[4]. Must be None now.
         let r = b"TGCGCA";
-        assert!(insertion_to_repeat(r, 1, b"GCGC", false).is_none());
+        assert!(insertion_to_repeat(r, 1, b"GCGC", false, ShuffleDirection::ThreePrime).is_none());
     }
 
     #[test]
@@ -5060,7 +5238,8 @@ mod tests {
         // In-phase rotation insCGCG reaches the same GC[4] window and is preserved.
         let r = b"TGCGCA";
         let (_b, count, start, end, unit) =
-            insertion_to_repeat(r, 1, b"CGCG", false).expect("in-phase should convert");
+            insertion_to_repeat(r, 1, b"CGCG", false, ShuffleDirection::ThreePrime)
+                .expect("in-phase should convert");
         assert_eq!(count, 4);
         assert_eq!((start, end), (2, 5));
         assert_eq!(unit, b"GC");

--- a/tests/it/five_prime_boundary_delins_unification.rs
+++ b/tests/it/five_prime_boundary_delins_unification.rs
@@ -1,0 +1,178 @@
+//! Regression tests for the 5'/3' homopolymer-boundary insertion/dup → delins
+//! unification (idempotency-campaign follow-up to PR #1169; resolves the #387
+//! CDS-end saturation latent and the dup-path non-confluence).
+//!
+//! At a CDS-interior homopolymer that saturates against a coding boundary, every
+//! spelling of the same haplotype — whether written as a dup or a direct
+//! insertion, at any start position — must normalize to ONE valid, idempotent
+//! `c.<cds_boundary>delins…` form. ferro's design forbids re-axing a CDS-interior
+//! edit onto the 3'UTR (`c.*N`) axis (see the CDS-start/-end clamps in
+//! `src/normalize/mod.rs`), so the canonical boundary form is the delins, not a
+//! `c.<cds_end>_*1ins…` spanning insertion. Spanning *duplications*
+//! (`c.7_*1dup`) remain the spec-canonical form and are preserved.
+//!
+//! Before this fix the dup path returned the 3'-anchored `c.7_*1insAA` verbatim
+//! (bypassing both boundary clamps), the direct-insertion path was non-confluent
+//! (`c.1delinsAAA` / `c.1_3delinsAAAAA` / `c.1_4delinsAAAAAA`), and every 5' form
+//! re-normalized to the INVALID single-position `c.1insAA` (which ferro's own
+//! parser rejects).
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Normalize `input` against a plus-strand CDS whose transcript is `core`, with
+/// the CDS spanning `cds_start..=cds_end` (1-based), in shuffle `dir`.
+fn norm(core: &str, cds_start: u64, cds_end: u64, input: &str, dir: ShuffleDirection) -> String {
+    let normalizer = Normalizer::with_config(
+        SyntheticBuilder::cds(core, cds_start, cds_end, Strand::Plus).build(),
+        NormalizeConfig::default().with_direction(dir),
+    );
+    normalizer
+        .normalize(&parse_hgvs(input).expect("parse input"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// Assert `s` is valid HGVS that ferro can re-parse (guards against emitting the
+/// invalid single-position `c.1insAA`).
+fn assert_reparses(s: &str) {
+    parse_hgvs(s).unwrap_or_else(|e| panic!("normalizer emitted un-parseable HGVS {s:?}: {e}"));
+}
+
+const A7: &str = "AAAAAAA"; // 7-A CDS, cds 1..=7, no UTR either side.
+
+// ---- 5' direction: all spellings converge to c.1delinsAAA -------------------
+
+#[test]
+fn five_prime_boundary_dup_becomes_start_delins() {
+    for input in ["c.1_2dup", "c.3_4dup", "c.6_7dup"] {
+        let out = norm(
+            A7,
+            1,
+            7,
+            &format!("NM_TEST.1:{input}"),
+            ShuffleDirection::FivePrime,
+        );
+        assert_eq!(out, "NM_TEST.1:c.1delinsAAA", "5' {input}");
+    }
+}
+
+#[test]
+fn five_prime_boundary_insertion_becomes_start_delins() {
+    for input in ["c.1_2insAA", "c.3_4insAA", "c.5_6insAA", "c.6_7insAA"] {
+        let out = norm(
+            A7,
+            1,
+            7,
+            &format!("NM_TEST.1:{input}"),
+            ShuffleDirection::FivePrime,
+        );
+        assert_eq!(out, "NM_TEST.1:c.1delinsAAA", "5' {input}");
+    }
+}
+
+#[test]
+fn five_prime_boundary_delins_is_idempotent() {
+    let once = norm(
+        A7,
+        1,
+        7,
+        "NM_TEST.1:c.1delinsAAA",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(
+        once, "NM_TEST.1:c.1delinsAAA",
+        "c.1delinsAAA must be a 5' fixed point"
+    );
+}
+
+#[test]
+fn five_prime_boundary_output_always_reparses() {
+    for input in ["c.1_2dup", "c.6_7dup", "c.1_2insAA", "c.6_7insAA"] {
+        let out = norm(
+            A7,
+            1,
+            7,
+            &format!("NM_TEST.1:{input}"),
+            ShuffleDirection::FivePrime,
+        );
+        assert_reparses(&out);
+    }
+}
+
+// ---- 3' direction: all spellings converge to c.7delinsAAA -------------------
+
+#[test]
+fn three_prime_boundary_dup_becomes_end_delins() {
+    for input in ["c.1_2dup", "c.3_4dup", "c.6_7dup"] {
+        let out = norm(
+            A7,
+            1,
+            7,
+            &format!("NM_TEST.1:{input}"),
+            ShuffleDirection::ThreePrime,
+        );
+        assert_eq!(out, "NM_TEST.1:c.7delinsAAA", "3' {input}");
+    }
+}
+
+#[test]
+fn three_prime_boundary_insertion_becomes_end_delins() {
+    for input in ["c.1_2insAA", "c.3_4insAA", "c.5_6insAA", "c.6_7insAA"] {
+        let out = norm(
+            A7,
+            1,
+            7,
+            &format!("NM_TEST.1:{input}"),
+            ShuffleDirection::ThreePrime,
+        );
+        assert_eq!(out, "NM_TEST.1:c.7delinsAAA", "3' {input}");
+    }
+}
+
+#[test]
+fn three_prime_boundary_delins_is_idempotent() {
+    let once = norm(
+        A7,
+        1,
+        7,
+        "NM_TEST.1:c.7delinsAAA",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(
+        once, "NM_TEST.1:c.7delinsAAA",
+        "c.7delinsAAA must be a 3' fixed point"
+    );
+}
+
+// ---- WITH a real 3'UTR: spanning dups preserved, not over-clamped -----------
+
+/// `AAAAAAAGCG`: A-run CDS c.1..=7, 3'UTR = `GCG` (so c.*1 = 'G' EXISTS).
+/// A homopolymer insertion at the boundary still clamps to the CDS-end delins
+/// (CDS-interior edit stays on the CDS axis)…
+#[test]
+fn with_3utr_homopolymer_insertion_clamps_to_end_delins() {
+    let out = norm(
+        "AAAAAAAGCG",
+        1,
+        7,
+        "NM_TEST.1:c.6_7insAA",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(out, "NM_TEST.1:c.7delinsAAA");
+}
+
+/// …but a genuine boundary-spanning *duplication* (`AG` = dup of c.7_*1) is the
+/// spec-canonical form and must be PRESERVED, never clamped to a delins.
+#[test]
+fn with_3utr_spanning_duplication_is_preserved() {
+    let out = norm(
+        "AAAAAAAGCG",
+        1,
+        7,
+        "NM_TEST.1:c.6_7insAG",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(out, "NM_TEST.1:c.7_*1dup");
+}

--- a/tests/it/five_prime_insertion_dup_boundary_anchor.rs
+++ b/tests/it/five_prime_insertion_dup_boundary_anchor.rs
@@ -26,6 +26,16 @@ fn norm(core: &str, input: &str, dir: ShuffleDirection) -> String {
     .to_string()
 }
 
+fn norm_genomic(core: &str, input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::genomic(core).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
 /// `G` then a 6-A run: `c.2_3insGA` is the same haplotype as duplicating the
 /// leading `GA` (`c.1_2`), not the interior `AA` (`c.2_3`). Both directions must
 /// agree on `c.1_2dup`.
@@ -66,6 +76,53 @@ fn five_prime_boundary_dup_is_idempotent() {
         norm("GAAAAAAC", &once, ShuffleDirection::FivePrime),
         once,
         "norm(norm(x)) must equal norm(x)"
+    );
+}
+
+/// 5' single-copy dup into a dinucleotide tract whose run continues one base
+/// further 5' in the *opposite* phase than the abutting-unit anchor. Inserting
+/// `TG` at the 3' edge of an odd-length `GTGTGTGTG` run: `find_tandem_extent`
+/// anchors on the abutting `TG` phase (one base short of the run's true 5' end),
+/// so the naive `ref_start` slot emits `g.259_260dup` — but the run's 5'-most
+/// phase is `GT` one base further 5'. Without the mirror `five_prime_align_tract`
+/// (the sibling of the 3' branch's `three_prime_align_tract`), the emitted dup
+/// under-shifts by one and re-shuffles on the second pass (`g.259_260dup` →
+/// `g.258_259dup`), breaking idempotency. The fix pushes to the true 5'-most
+/// slot: `g.258_259dup`, a fixed point. Regression for the ins→dup sibling of #8.
+#[test]
+fn five_prime_dinucleotide_dup_crosses_off_phase_extension_and_is_idempotent() {
+    // core: A | GTGTGTGTG (odd 9-base GT run, g.258..266) | C
+    let core = "AGTGTGTGTGC";
+    let once = norm_genomic(
+        core,
+        "NC_TEST.1:g.266_267insTG",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(
+        once, "NC_TEST.1:g.258_259dup",
+        "must reach the true 5'-most GT slot"
+    );
+    assert_eq!(
+        norm_genomic(core, &once, ShuffleDirection::FivePrime),
+        once,
+        "5' ins→dup over a dinucleotide tract must be a fixed point"
+    );
+}
+
+/// 3' is unaffected: it phases to the 3'-most slot and is idempotent.
+#[test]
+fn three_prime_dinucleotide_dup_unchanged_and_idempotent() {
+    let core = "AGTGTGTGTGC";
+    let once = norm_genomic(
+        core,
+        "NC_TEST.1:g.266_267insTG",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(once, "NC_TEST.1:g.265_266dup");
+    assert_eq!(
+        norm_genomic(core, &once, ShuffleDirection::ThreePrime),
+        once,
+        "3' must remain idempotent"
     );
 }
 

--- a/tests/it/five_prime_insertion_dup_boundary_anchor.rs
+++ b/tests/it/five_prime_insertion_dup_boundary_anchor.rs
@@ -1,0 +1,87 @@
+//! Regression tests for the 5'-direction insertion→duplication anchor at the
+//! transcript-start boundary (idempotency-campaign follow-up to PR #1169/#1170).
+//!
+//! When a 5'-shuffled insertion (or a delins that reduces to one) comes to rest
+//! at the transcript start (`result.start == 0`, i.e. inserting immediately
+//! before c.1) and its rotated sequence duplicates the following reference
+//! tract, the emitted `dup` must be anchored on that tract. The 3'-side dup
+//! anchor previously used `new_start`, which the insertion coordinate
+//! adjust-back (`saturating_sub(1)`) collapses to c.1 at the boundary — so the
+//! dup was mislabelled one position 3', producing a DIFFERENT haplotype
+//! (`c.2_3insGA` in `G` + A-run → `c.2_3dup` (unit `AA`) instead of the correct
+//! `c.1_2dup` (unit `GA`)). 3' was already correct; the fix derives the anchor
+//! from the matched-tract position `pos_idx` so both directions agree.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+fn norm(core: &str, input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Plus).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
+/// `G` then a 6-A run: `c.2_3insGA` is the same haplotype as duplicating the
+/// leading `GA` (`c.1_2`), not the interior `AA` (`c.2_3`). Both directions must
+/// agree on `c.1_2dup`.
+#[test]
+fn five_prime_boundary_insertion_dups_matched_tract_not_offset() {
+    assert_eq!(
+        norm(
+            "GAAAAAAC",
+            "NM_TEST.1:c.2_3insGA",
+            ShuffleDirection::FivePrime
+        ),
+        "NM_TEST.1:c.1_2dup",
+    );
+}
+
+#[test]
+fn three_prime_agrees_on_same_boundary_dup() {
+    assert_eq!(
+        norm(
+            "GAAAAAAC",
+            "NM_TEST.1:c.2_3insGA",
+            ShuffleDirection::ThreePrime
+        ),
+        "NM_TEST.1:c.1_2dup",
+    );
+}
+
+/// The resulting `c.1_2dup` must be a 5' fixed point (it previously drifted to
+/// the wrong-haplotype `c.2_3dup`).
+#[test]
+fn five_prime_boundary_dup_is_idempotent() {
+    let once = norm(
+        "GAAAAAAC",
+        "NM_TEST.1:c.2_3insGA",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(
+        norm("GAAAAAAC", &once, ShuffleDirection::FivePrime),
+        once,
+        "norm(norm(x)) must equal norm(x)"
+    );
+}
+
+/// A delins that canonicalizes to the same boundary insertion takes the same
+/// path: `c.1delinsGCG` in `GCC…` is `c.1_2dup` (dup of leading `GC`), idempotent.
+#[test]
+fn five_prime_boundary_delins_reduces_to_matched_tract_dup() {
+    let out = norm(
+        "GCCTGTGTGTGC",
+        "NM_TEST.1:c.1delinsGCG",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(out, "NM_TEST.1:c.1_2dup");
+    assert_eq!(
+        norm("GCCTGTGTGTGC", &out, ShuffleDirection::FivePrime),
+        out,
+        "delins-derived boundary dup must be idempotent"
+    );
+}

--- a/tests/it/five_prime_tandem_repeat_dup_rotation.rs
+++ b/tests/it/five_prime_tandem_repeat_dup_rotation.rs
@@ -1,0 +1,80 @@
+//! Regression tests for the 5'-direction tandem-repeat `dup` idempotency
+//! (idempotency-campaign follow-up to PR #1169/#1170).
+//!
+//! A duplication over an ambiguous alternating tandem tract routes to `unit[N]`
+//! repeat notation. The `dup`→`unit[N]` emission is anchored at the shuffle
+//! stage's direction-appropriate position (5'-most under `FivePrime`), but the
+//! repeat *re-normalization* (`normalize_repeat`) previously always applied the
+//! 3' phase alignment (`three_prime_align_tract`) regardless of direction — so a
+//! `FivePrime` `GA[4]` anchored at the tract's 5' phase drifted one base 3' to
+//! `AG[4]` and rotated its unit on the second pass, breaking idempotency.
+//!
+//! The fix makes `normalize_repeat` direction-aware: `FivePrime` uses the mirror
+//! `five_prime_align_tract`, so the 5'-most repeat is a fixed point AND both
+//! spellings of the haplotype converge to it. `ThreePrime` is unchanged.
+//!
+//! Reference core `GGAGAGGGC` places an ambiguous `GAGAG` tract at g.258..262
+//! (as `GA` it is 2 clean copies at g.258; as `AG` it is 2 clean copies at
+//! g.259). `g.258_261dup` extends it to 4 copies either way — the same
+//! haplotype, so the two representations `g.258_261GA[4]` and `g.259_262AG[4]`
+//! describe identical sequence and differ only in canonical anchor/phase.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+const CORE: &str = "GGAGAGGGC";
+
+fn norm(input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::genomic(CORE).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
+/// 5' normalizes the dup to the 5'-most repeat phase `GA[4]` at g.258.
+#[test]
+fn five_prime_tandem_dup_anchors_at_five_prime_phase() {
+    assert_eq!(
+        norm("NC_TEST.1:g.258_261dup", ShuffleDirection::FivePrime),
+        "NC_TEST.1:g.258_261GA[4]",
+    );
+}
+
+/// That 5' repeat is a fixed point — it previously drifted to `g.259_262AG[4]`.
+#[test]
+fn five_prime_tandem_dup_is_idempotent() {
+    let once = norm("NC_TEST.1:g.258_261dup", ShuffleDirection::FivePrime);
+    assert_eq!(
+        norm(&once, ShuffleDirection::FivePrime),
+        once,
+        "norm(norm(x)) must equal norm(x)"
+    );
+}
+
+/// Both spellings of the one haplotype converge to the 5'-most `GA[4]` under 5'
+/// (idempotency alone would not catch a per-spelling fixed point).
+#[test]
+fn five_prime_tandem_repeat_spellings_are_confluent() {
+    for input in ["NC_TEST.1:g.258_261GA[4]", "NC_TEST.1:g.259_262AG[4]"] {
+        assert_eq!(
+            norm(input, ShuffleDirection::FivePrime),
+            "NC_TEST.1:g.258_261GA[4]",
+            "5' confluence for {input}",
+        );
+    }
+}
+
+/// 3' is unchanged: it phases to the 3'-most `AG[4]` at g.259 and is idempotent.
+#[test]
+fn three_prime_tandem_dup_unchanged_and_idempotent() {
+    let once = norm("NC_TEST.1:g.258_261dup", ShuffleDirection::ThreePrime);
+    assert_eq!(once, "NC_TEST.1:g.259_262AG[4]");
+    assert_eq!(
+        norm(&once, ShuffleDirection::ThreePrime),
+        once,
+        "3' must remain idempotent"
+    );
+}

--- a/tests/it/issue_383_canon_cds_start_clamp.rs
+++ b/tests/it/issue_383_canon_cds_start_clamp.rs
@@ -234,23 +234,26 @@ fn five_prime_insertion_long_homopolymer_shift_clamps_at_cds_start() {
     // `c.-1_1insAA` — strictly inside 5'UTR even though the input was
     // CDS-interior.
     //
-    // Spec-canonical clamp for the homopolymer case is a delins anchored
-    // at c.1 that absorbs the boundary positions: `c.1_3delinsAAAAA`
-    // (= delete c.1..c.3 = "AAA", insert 5 A's). Applying this to the
-    // ref `GGG | AAAAAAAAAAAAAAAAAAAA | G...` yields `GGG + AAAAA +
-    // ref[c.4..]` = `GGG + 22*A + G...`, the same total as the input
-    // `c.5_6insAA` (insert 2 A's into the 20-A tract).
+    // Clamp form is the MINIMAL, single-base-anchored delins at c.1:
+    // `c.1delinsAAA` (= delete c.1 = "A", insert 3 A's = net +2). Applying
+    // this to the ref `GGG | AAAAAAAAAAAAAAAAAAAA | G...` yields
+    // `GGG + AAA + ref[c.2..]` = `GGG + 22*A + G...`, the same total as the
+    // input `c.5_6insAA` (insert 2 A's into the 20-A tract).
     //
-    // The exact form here is the *implementation's* spec-canonical
-    // emission; assert it precisely so any future regression to
-    // c.-N_… or to a different delete window is caught immediately.
+    // (Re-blessed from the earlier width-varying `c.1_3delinsAAAAA`: the
+    // boundary clamp now rewrites via the exact coordinate identity
+    // `delete ref[cds_start], insert A' ++ ref[cds_start]` keyed on the
+    // shuffled `A'`, so every start position of the same haplotype collapses
+    // to ONE minimal, idempotent form — confluence. The `k`-widened form was
+    // equivalent but non-confluent, e.g. `c.6_7insAA` gave a different
+    // `c.1_4delinsAAAAAA`.)
     assert_eq!(
         normalize_with_provider(
             provider_homopolymer(),
             ShuffleDirection::FivePrime,
             "NM_TEST383HP.1:c.5_6insAA",
         ),
-        "NM_TEST383HP.1:c.1_3delinsAAAAA",
+        "NM_TEST383HP.1:c.1delinsAAA",
     );
 }
 
@@ -261,15 +264,16 @@ fn five_prime_insertion_far_interior_homopolymer_shift_clamps() {
     // and alt.len() = 3, so x = 20 >> alt.len() + 1 = 4 — the buggy
     // branch was silently no-op'ing on inputs of this shape.
     //
-    // Clamp form: delete c.1..c.{x-L} = c.1..c.17 (17 A's), insert
-    // x A's = 20 A's. Equivalent to extending the 20-A tract by 3
-    // bases (the alt length).
+    // Minimal single-base-anchored clamp form: delete c.1 = "A", insert
+    // 4 A's (net +3), extending the 20-A tract by the alt length. Re-blessed
+    // from the earlier width-varying `c.1_17delinsAAAAAAAAAAAAAAAAAAAA` for
+    // confluence (see the sibling long-homopolymer test).
     assert_eq!(
         normalize_with_provider(
             provider_homopolymer(),
             ShuffleDirection::FivePrime,
             "NM_TEST383HP.1:c.20_21insAAA",
         ),
-        "NM_TEST383HP.1:c.1_17delinsAAAAAAAAAAAAAAAAAAAA",
+        "NM_TEST383HP.1:c.1delinsAAAA",
     );
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -13,6 +13,7 @@
 
 mod common;
 mod five_prime_boundary_delins_unification;
+mod five_prime_insertion_dup_boundary_anchor;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -12,6 +12,7 @@
 //! (`it::<module>::<test>`); filters by test name are unaffected.
 
 mod common;
+mod five_prime_boundary_delins_unification;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -14,6 +14,7 @@
 mod common;
 mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
+mod five_prime_tandem_repeat_dup_rotation;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/normalize_idempotency_proptest.rs
+++ b/tests/it/normalize_idempotency_proptest.rs
@@ -7,11 +7,25 @@
 //! actually 3'-shift) across the genomic and CDS (both strands) coordinate
 //! systems, and every edit type, asserting `norm(norm(x)) == norm(x)`.
 //!
-//! Direction: this test covers the **3' (default, HGVS-canonical) direction**
-//! only. The 5' direction is a separate, systemically under-baked mode with
-//! multiple independent non-idempotency / non-confluence bugs in the shuffle +
-//! boundary-clamp interaction; it is being reworked as its own dedicated effort
-//! and is intentionally out of scope here (see the campaign handoff).
+//! Two properties are fuzzed:
+//!   * `norm(norm(x)) == norm(x)` (idempotency), covering the full edit/coord
+//!     matrix in the **3' (default, HGVS-canonical)** direction;
+//!   * multiple spellings of ONE homopolymer-boundary haplotype normalize to ONE
+//!     form (confluence), in **both** directions. Idempotency is necessary but
+//!     NOT sufficient — a mode can be idempotent yet non-confluent (each spelling
+//!     its own fixed point), which the confluence property catches. The 5'
+//!     boundary/homopolymer shuffle was reworked to a coordinate-identity clamp
+//!     keyed on the post-shuffle edit (see `src/normalize/mod.rs` CDS-start/-end
+//!     clamps + the dup-routing recursion in `normalize_na_edit`) so those
+//!     spellings now converge.
+//!
+//! Scope note: a *general* 5' idempotency fuzz is intentionally NOT run here yet.
+//! The 5' direction still has separate, pre-existing bugs outside the boundary
+//! rework — a `convert-to-dup` step that selects the wrong tract for
+//! heterogeneous content, and a tandem-repeat `dup` whose repeat unit rotates on
+//! re-normalization — each tracked as its own follow-up. The confluence property
+//! plus the explicit `five_prime_boundary_delins_unification` regression tests
+//! cover the 5' classes this change actually fixes.
 //!
 //! Cases are generated **valid by construction** (edit endpoints derived from
 //! the core length), so there is no skip path at all: an unparseable render or a
@@ -22,9 +36,23 @@
 
 use crate::common::synthetic::{SyntheticBuilder, PAD_OFFSET};
 use ferro_hgvs::reference::transcript::Strand;
-use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
 use proptest::prelude::*;
-use proptest::test_runner::Config as ProptestConfig;
+use proptest::test_runner::{Config as ProptestConfig, TestCaseError};
+
+fn normalizer_for(core: &str, sys: Sys, dir: ShuffleDirection) -> Normalizer<MockProvider> {
+    Normalizer::with_config(
+        provider_for(core, sys),
+        NormalizeConfig::default().with_direction(dir),
+    )
+}
+
+fn both_directions() -> impl Strategy<Value = ShuffleDirection> {
+    prop::sample::select(vec![
+        ShuffleDirection::ThreePrime,
+        ShuffleDirection::FivePrime,
+    ])
+}
 
 /// Coordinate system under test. All use `cds_start == 1` / `cds_end == len`
 /// for the CDS cases so `c.k` maps directly to core position `k` and both
@@ -73,7 +101,7 @@ fn core_strategy() -> impl Strategy<Value = String> {
 }
 
 fn case_strategy() -> impl Strategy<Value = Case> {
-    core_strategy().prop_flat_map(|core| {
+    core_strategy().prop_flat_map(move |core| {
         let len = core.len();
         let sys = prop::sample::select(vec![Sys::Genomic, Sys::CdsPlus, Sys::CdsMinus]);
         // kind: 0=del 1=dup 2=ins 3=delins
@@ -127,40 +155,147 @@ fn provider_for(core: &str, sys: Sys) -> MockProvider {
     }
 }
 
+/// `norm(norm(x)) == norm(x)` for one case in one direction, and the normalized
+/// output must always re-parse — a normalizer that emits invalid HGVS (e.g. a
+/// degenerate single-position `c.1insAA`) fails the re-parse step.
+///
+/// The render and first normalize fail LOUDLY, not by silent skip: cases are
+/// valid by construction and the provider supplies the very core the coordinates
+/// were derived from, so a parse/normalize error is a generator or normalizer
+/// bug — and a skip branch here would let the whole property go vacuous unnoticed
+/// (measured: 0 parse errors, 0 first-pass normalize errors over 4000 cases).
+fn check_idempotent(case: &Case, dir: ShuffleDirection) -> Result<(), TestCaseError> {
+    let norm = normalizer_for(&case.core, case.sys, dir);
+    let v = parse_hgvs(&case.hgvs)
+        .unwrap_or_else(|e| panic!("generator produced unparseable HGVS {}: {e}", case.hgvs));
+    let n1 = norm
+        .normalize(&v)
+        .unwrap_or_else(|e| panic!("first normalize failed: {}: {e}", case.hgvs));
+    let f1 = n1.to_string();
+    // The normalized output MUST re-parse and re-normalize cleanly; an error
+    // here (parse or normalize) is a bug.
+    let reparsed = parse_hgvs(&f1).unwrap_or_else(|e| {
+        panic!(
+            "normalized output does not re-parse: {} -> {f1}: {e}\n  (dir={dir:?}, core={})",
+            case.hgvs, case.core
+        )
+    });
+    let n2 = norm
+        .normalize(&reparsed)
+        .unwrap_or_else(|e| panic!("re-normalize failed: {} -> {f1}: {e}", case.hgvs));
+    prop_assert_eq!(
+        &f1,
+        &n2.to_string(),
+        "NOT IDEMPOTENT\n  core={} sys={:?} dir={:?}\n  input={}\n  once ={}\n  twice={}",
+        case.core,
+        case.sys,
+        dir,
+        case.hgvs,
+        f1,
+        n2
+    );
+    Ok(())
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(4000))]
 
-    /// `norm(norm(x)) == norm(x)` for every reference-backed synthetic case in
-    /// the default 3' direction.
+    /// 3' (default, HGVS-canonical) direction, fully general edit content.
+    /// (5' general idempotency is deferred — see the module-level scope note.)
     #[test]
     fn normalization_is_idempotent_three_prime(case in case_strategy()) {
-        let norm = Normalizer::new(provider_for(&case.core, case.sys));
-        // Both of these are generator/normalizer bugs, not "cases not under
-        // test", so they fail loudly rather than silently skipping — a skip
-        // branch here would let the whole property go vacuous unnoticed. The
-        // renders are valid by construction and the provider supplies the very
-        // core the coordinates were derived from, so neither fires today
-        // (measured: 0 parse errors, 0 first-pass normalize errors over 4000
-        // cases). Should a future change reintroduce either, that is the signal.
-        let v = parse_hgvs(&case.hgvs)
-            .unwrap_or_else(|e| panic!("generator produced unparseable HGVS {}: {e}", case.hgvs));
-        let n1 = norm
-            .normalize(&v)
-            .unwrap_or_else(|e| panic!("first normalize failed: {}: {e}", case.hgvs));
-        let f1 = n1.to_string();
-        // The normalized output MUST re-normalize cleanly; an error here is a bug.
-        let n2 = norm
-            .normalize(&n1)
-            .unwrap_or_else(|e| panic!("re-normalize failed: {} -> {f1}: {e}", case.hgvs));
+        check_idempotent(&case, ShuffleDirection::ThreePrime)?;
+    }
+}
+
+/// A homopolymer confluence case: a run of `base` of length `run_len`, embedded
+/// in the CDS, with two distinct HGVS spellings of the SAME haplotype (inserting
+/// `unit_len` more copies of `base` into the run at two different positions).
+/// Both spellings describe an identical resulting sequence, so a confluent
+/// normalizer must map them to the same normal form.
+#[derive(Debug, Clone)]
+struct ConfluenceCase {
+    core: String,
+    sys: Sys,
+    a: String,
+    b: String,
+}
+
+/// Build a pure-homopolymer or boundary-adjacent run and two equivalent
+/// insertion spellings within it. Using `cds_start == 1`/`cds_end == len`
+/// exercises the CDS-start and CDS-end boundary clamps (the confluence-critical
+/// region), where all spellings must collapse to one `c.<boundary>delins…`.
+fn confluence_case_strategy() -> impl Strategy<Value = ConfluenceCase> {
+    (
+        prop::sample::select(vec!['A', 'C', 'G', 'T']),
+        4usize..=12, // run length
+        1usize..=3,  // number of extra copies inserted
+        prop::sample::select(vec![Sys::CdsPlus, Sys::CdsMinus]),
+    )
+        .prop_flat_map(|(base, run_len, extra, sys)| {
+            // The whole CDS is the homopolymer run, so c.k maps to core k and
+            // both transcript boundaries participate.
+            let core: String = std::iter::repeat_n(base, run_len).collect();
+            let unit: String = std::iter::repeat_n(base, extra).collect();
+            // Insertion sits between positions p and p+1 (1-based), p in 1..run_len.
+            // Any two distinct p give the same haplotype (run grows by `extra`).
+            let core_c = core.clone();
+            let unit_c = unit.clone();
+            // `p2` is drawn as a non-zero offset from `p1` modulo the position
+            // count, so the two spellings are always DISTINCT. Sampling both
+            // independently would let `p1 == p2` through, and comparing a
+            // normalized form against itself is trivially equal — a silent
+            // weakening of the confluence property on those cases.
+            let slots = run_len - 1; // positions are 1..run_len
+            (1usize..run_len, 1usize..slots).prop_map(move |(p1, offset)| {
+                let p2 = 1 + ((p1 - 1 + offset) % slots);
+                let acc = "NM_TEST.1";
+                let spell = |p: usize| format!("{acc}:c.{}_{}ins{}", p, p + 1, unit_c);
+                ConfluenceCase {
+                    core: core_c.clone(),
+                    sys,
+                    a: spell(p1),
+                    b: spell(p2),
+                }
+            })
+        })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(4000))]
+
+    /// Two spellings of one haplotype (insert the same unit at two positions in
+    /// a homopolymer run) must normalize to the SAME form, in both directions.
+    /// This catches non-confluence that idempotency alone cannot: before the
+    /// boundary-clamp rework the 5' direction mapped `c.1_2insAA`,
+    /// `c.5_6insAA`, … to distinct (each individually idempotent)
+    /// `c.1delinsAAA` / `c.1_3delinsAAAAA` / … forms.
+    #[test]
+    fn normalization_is_confluent(case in confluence_case_strategy(), dir in both_directions()) {
+        let norm = normalizer_for(&case.core, case.sys, dir);
+        // No skip branches: the generator only emits well-formed spellings, so a
+        // parse or normalize failure is a BUG, not a case to pass over. Returning
+        // `Ok(())` here would let the whole property go vacuous unnoticed — the
+        // exact hazard `check_idempotent` documents and avoids.
+        let va = parse_hgvs(&case.a)
+            .unwrap_or_else(|e| panic!("generator produced unparseable HGVS {}: {e}", case.a));
+        let vb = parse_hgvs(&case.b)
+            .unwrap_or_else(|e| panic!("generator produced unparseable HGVS {}: {e}", case.b));
+        let na = norm
+            .normalize(&va)
+            .unwrap_or_else(|e| panic!("normalize failed: {}: {e}", case.a));
+        let nb = norm
+            .normalize(&vb)
+            .unwrap_or_else(|e| panic!("normalize failed: {}: {e}", case.b));
         prop_assert_eq!(
-            &f1,
-            &n2.to_string(),
-            "NOT IDEMPOTENT\n  core={} sys={:?}\n  input={}\n  once ={}\n  twice={}",
+            na.to_string(),
+            nb.to_string(),
+            "NOT CONFLUENT\n  core={} sys={:?} dir={:?}\n  a={} b={}",
             case.core,
             case.sys,
-            case.hgvs,
-            f1,
-            n2
+            dir,
+            case.a,
+            case.b
         );
     }
 }

--- a/tests/it/normalize_idempotency_proptest.rs
+++ b/tests/it/normalize_idempotency_proptest.rs
@@ -7,9 +7,12 @@
 //! actually 3'-shift) across the genomic and CDS (both strands) coordinate
 //! systems, and every edit type, asserting `norm(norm(x)) == norm(x)`.
 //!
-//! Two properties are fuzzed:
+//! Three properties are fuzzed:
 //!   * `norm(norm(x)) == norm(x)` (idempotency), covering the full edit/coord
 //!     matrix in the **3' (default, HGVS-canonical)** direction;
+//!   * the same idempotency property in the **5'** direction — the mirror of the
+//!     3' property, enabled once the campaign's pre-existing 5' bugs were fixed
+//!     (see the 5' scope note below);
 //!   * multiple spellings of ONE homopolymer-boundary haplotype normalize to ONE
 //!     form (confluence), in **both** directions. Idempotency is necessary but
 //!     NOT sufficient — a mode can be idempotent yet non-confluent (each spelling
@@ -19,13 +22,15 @@
 //!     clamps + the dup-routing recursion in `normalize_na_edit`) so those
 //!     spellings now converge.
 //!
-//! Scope note: a *general* 5' idempotency fuzz is intentionally NOT run here yet.
-//! The 5' direction still has separate, pre-existing bugs outside the boundary
-//! rework — a `convert-to-dup` step that selects the wrong tract for
-//! heterogeneous content, and a tandem-repeat `dup` whose repeat unit rotates on
-//! re-normalization — each tracked as its own follow-up. The confluence property
-//! plus the explicit `five_prime_boundary_delins_unification` regression tests
-//! cover the 5' classes this change actually fixes.
+//! 5' scope note: the general 5' idempotency fuzz is now enabled. Reaching green
+//! required fixing three separate pre-existing 5' bugs the fuzzer surfaced, all
+//! outside the boundary rework: the boundary dup/insertion→delins family, an
+//! insertion→dup step that selected the wrong tract for heterogeneous content
+//! (#7), a tandem-repeat `dup` whose `unit[N]` phase rotated on re-normalization
+//! (#8, `normalize_repeat` now direction-aware), and the ins→dup sibling of #8 —
+//! a single-copy dup over a dinucleotide tract that under-shifted by one when the
+//! run continued off-phase 5' (fixed by mirroring the 3' branch's tract
+//! alignment). Each has an explicit regression test alongside this fuzz.
 //!
 //! Cases are generated **valid by construction** (edit endpoints derived from
 //! the core length), so there is no skip path at all: an unparseable render or a
@@ -201,10 +206,18 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(4000))]
 
     /// 3' (default, HGVS-canonical) direction, fully general edit content.
-    /// (5' general idempotency is deferred — see the module-level scope note.)
     #[test]
     fn normalization_is_idempotent_three_prime(case in case_strategy()) {
         check_idempotent(&case, ShuffleDirection::ThreePrime)?;
+    }
+
+    /// 5' direction, fully general edit content — the mirror of the 3' property.
+    /// Enabled once the three pre-existing 5' bugs the campaign chased down
+    /// (boundary dup/insertion→delins, insertion→dup tract selection, and the
+    /// tandem-repeat `dup` unit rotation) were fixed.
+    #[test]
+    fn normalization_is_idempotent_five_prime(case in case_strategy()) {
+        check_idempotent(&case, ShuffleDirection::FivePrime)?;
     }
 }
 

--- a/tests/it/normalize_tests.rs
+++ b/tests/it/normalize_tests.rs
@@ -2863,6 +2863,7 @@ mod insertion_rotation_tests {
 #[cfg(test)]
 mod repeat_position_tests {
     use ferro_hgvs::normalize::rules::{count_tandem_repeats, normalize_repeat, RepeatNormResult};
+    use ferro_hgvs::ShuffleDirection;
 
     /// Test what happens when the repeat unit doesn't match at the specified position
     /// but exists nearby. This simulates c.4261_4262CA[1] where:
@@ -2895,7 +2896,7 @@ mod repeat_position_tests {
         );
 
         // Test normalize_repeat - should return Unchanged
-        let result = normalize_repeat(ref_seq, 6, 6, b"CA", 1, false);
+        let result = normalize_repeat(ref_seq, 6, 6, b"CA", 1, false, ShuffleDirection::ThreePrime);
         assert!(
             matches!(result, RepeatNormResult::Unchanged),
             "Should return Unchanged when repeat unit not found at position. Got {:?}",
@@ -2919,7 +2920,7 @@ mod repeat_position_tests {
         );
 
         // normalize_repeat with count=1 should produce deletion
-        let result = normalize_repeat(ref_seq, 0, 0, b"CA", 1, false);
+        let result = normalize_repeat(ref_seq, 0, 0, b"CA", 1, false, ShuffleDirection::ThreePrime);
         match result {
             RepeatNormResult::Deletion { start, end } => {
                 // Should delete one copy (2 bases) from the 3' end

--- a/tests/proptest-regressions/normalize_idempotency_proptest.txt
+++ b/tests/proptest-regressions/normalize_idempotency_proptest.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc bf332dd0e9d843159242ec546b6e1eb7518b888030fe9438d344dd93044a7394 # shrinks to case = Case { core: "GTGTGTGTGTGCTCC", sys: Genomic, hgvs: "NC_TEST.1:g.267_268insTG" }


### PR DESCRIPTION
## Summary

Follow-up to the #1157 idempotency campaign (after #1169). Fixes the remaining 5' normalization bugs where the same haplotype normalized to different forms — or, under 5', to an **invalid** `c.1insAA` — depending on how it was spelled (`dup` vs insertion) and where it started. With these, the **general 5' idempotency property is green** and is now enforced by a proptest.

## Changes

**1. Boundary dup/insertion → delins identity.** Both the CDS-start and CDS-end boundary clamps are rewritten to an exact coordinate identity, keyed on the **post-shuffle** edit (`new_edit`) rather than the input `edit`:

- insert `A'` just 5' of `cds_start`  ≡  delete `ref[cds_start]`, insert `A' ++ ref[cds_start]`
- insert `A'` just 3' of `cds_end`    ≡  delete `ref[cds_end]`, insert `ref[cds_end] ++ A'`

Both are exact for **any** `A'` (they just move the delete boundary one base), so no equivalence check is needed. Reading `A'` from `new_edit` unifies three inputs that all reach the clamp as the same shuffled sequence — a directly-written insertion, a codon-gated `dup` (now routed through the shuffle by recursing the derived insertion in `normalize_na_edit`), and any start position — so every spelling of one haplotype collapses to a single minimal `c.<boundary>delins`. This also closes the CDS-end saturation gap (the previous `y_c` formula overflowed for far-from-boundary inserts and left an invalid `c.<cds_end>_*1ins…` on the 3'UTR axis) and reproduces the biocommons `NM_212556.2:c.1400_1401insAC → c.1401delinsACA` form exactly. Spanning *duplications* (`c.7_*1dup`) remain the spec-canonical form and are not clamped.

**2. 5' boundary insertion→dup anchor off-by-one.** When a 5'-shuffled insertion (or a delins that reduces to one) came to rest at the transcript start and its rotated sequence duplicated the following tract, the 3'-side dup anchor used `new_start` — which the insertion coordinate adjust-back collapses to c.1 at the boundary — mislabelling the dup one position 3' and emitting a *different haplotype* (`c.2_3insGA` → `c.2_3dup` instead of the correct `c.1_2dup`). The anchor now derives from the matched-tract position `pos_idx`, identical off-boundary.

**3. Direction-aware phase alignment for repeat notation.** `normalize_repeat` always applied the 3' phase alignment regardless of shuffle direction, so under 5' a duplication over an ambiguous alternating tandem tract was not idempotent: `g.258_261dup` emitted the 5'-most `GA[4]`@258 (the dup path 5'-anchors first), but re-normalizing that repeat drifted it 3' to `AG[4]`@259 and rotated the unit — the two steps disagreed on the canonical anchor/phase for one haplotype. `normalize_repeat` (and its delegate `insertion_to_repeat`) now take the direction and, under 5', slide to the mirror 5'-most phase via a new `five_prime_align_tract`. Both spellings converge to the 5'-most form and it is a fixed point. **`ThreePrime` output is byte-identical**, so the biocommons/mutalyzer 3' conformance corpora and all existing repeat tests are unchanged.

**4. ins→dup off-phase extension (the dup-path sibling of 3).** The same flaw existed in `insertion_to_duplication`: its 5' branch used the raw `find_tandem_extent` `ref_start`, which anchors on the abutting rotation's phase and stops one base short when the run continues 5' in the *opposite* phase (e.g. inserting `TG` at the 3' edge of a `GTGTGTG` run). The emitted dup under-shifted by one and re-shuffled on the second pass. The 5' branch now mirrors what the 3' branch already did with `three_prime_align_tract`, so the dup anchors on the run's true 5'-most slot. Surfaced by the newly-enabled 5' fuzz, not by hand.

## Tests

- New regression tests: `five_prime_boundary_delins_unification` (dup/insertion → delins convergence, spanning-dup preservation, always-reparses), `five_prime_insertion_dup_boundary_anchor` (matched-tract dup + idempotency, insertion and delins paths, plus the off-phase dinucleotide case), and `five_prime_tandem_repeat_dup_rotation` (5' repeat phase: idempotency **and** confluence; 3' unchanged).
- New **confluence** property in the idempotency proptest (both directions): two spellings of one haplotype must normalize identically — idempotency alone cannot catch non-confluence (each spelling is its own fixed point).
- **The general 5' idempotency proptest is enabled** — the mirror of the existing 3' property over the full edit/coordinate matrix. Green at 300k cases locally. The minimized seed for the bug in (4) is committed under `tests/proptest-regressions/` so it re-runs ahead of novel cases.
- The homopolymer boundary assertions in the CDS-start clamp test are re-blessed from the earlier width-varying `k`-widened delins (e.g. `c.1_3delinsAAAAA`) to the minimal confluent form (`c.1delinsAAA`); heterogeneous cases are unchanged.

## Verification

- Full suite green (8544 tests), and green again under the `FERRO_ASSERT_IDEMPOTENT=1` oracle, which turns every `normalize()` in the suite into a `norm(norm(x)) == norm(x)` assertion.
- Reference-backed conformance run locally against a prepared reference (these skip without `FERRO_MANIFEST` in standard CI): the normalization axes pass, including `axis_normalized_idempotent` and `axis_genomic_idempotent`. The one `axis_errors` divergence (`c.45del4` / `c.45dup4`, sized-suffix-on-single-anchor rejected at **parse** time) reproduces identically on this PR's merge-base and is unrelated — this PR does not touch the parser.

## Scope

This closes out the 5' half of the #1157 campaign: the general 5' idempotency fuzz that was deferred in earlier PRs is now enabled and green. All behavior changes outside the boundary-clamp rework are gated on `ShuffleDirection::FivePrime`; the 3' default is unchanged.
