### PR TITLE
perf(io): buffer serde_json reads from files

### DIFF
--- a/src/benchmark/biocommons.rs
+++ b/src/benchmark/biocommons.rs
@@ -1446,8 +1446,8 @@ pub fn load_sequences_to_seqrepo(
                     e
                 ),
             })?;
-            let metadata: SupplementalMetadata =
-                serde_json::from_reader(file).map_err(|e| FerroError::Json {
+            let metadata: SupplementalMetadata = serde_json::from_reader(BufReader::new(file))
+                .map_err(|e| FerroError::Json {
                     msg: format!(
                         "Failed to parse {}: {}",
                         supplemental_metadata_path.display(),
@@ -2531,15 +2531,14 @@ pub fn run_biocommons_normalizer_parallel(
             )?;
 
             // Parse results
-            let output_data: serde_json::Value =
-                serde_json::from_reader(std::fs::File::open(output_temp.path()).map_err(|e| {
-                    FerroError::Io {
-                        msg: format!("Failed to read output: {}", e),
-                    }
-                })?)
-                .map_err(|e| FerroError::Io {
-                    msg: format!("Failed to parse JSON: {}", e),
-                })?;
+            let output_data: serde_json::Value = serde_json::from_reader(BufReader::new(
+                std::fs::File::open(output_temp.path()).map_err(|e| FerroError::Io {
+                    msg: format!("Failed to read output: {}", e),
+                })?,
+            ))
+            .map_err(|e| FerroError::Io {
+                msg: format!("Failed to parse JSON: {}", e),
+            })?;
 
             // Extract results
             let results_array =

--- a/src/benchmark/cache.rs
+++ b/src/benchmark/cache.rs
@@ -184,7 +184,7 @@ pub fn populate_mutalyzer_cache<P: AsRef<Path>>(
         let file = File::open(&manifest_path).map_err(|e| FerroError::Io {
             msg: format!("Failed to open manifest: {}", e),
         })?;
-        serde_json::from_reader(file).map_err(|e| FerroError::Json {
+        serde_json::from_reader(BufReader::new(file)).map_err(|e| FerroError::Json {
             msg: format!("Failed to parse manifest: {}", e),
         })?
     };
@@ -238,8 +238,8 @@ pub fn populate_mutalyzer_cache<P: AsRef<Path>>(
             let file = File::open(&metadata_path).map_err(|e| FerroError::Io {
                 msg: format!("Failed to open {}: {}", metadata_path.display(), e),
             })?;
-            let metadata: SupplementalMetadata =
-                serde_json::from_reader(file).map_err(|e| FerroError::Json {
+            let metadata: SupplementalMetadata = serde_json::from_reader(BufReader::new(file))
+                .map_err(|e| FerroError::Json {
                     msg: format!("Failed to parse {}: {}", metadata_path.display(), e),
                 })?;
             for (acc, info) in metadata.transcripts {
@@ -2001,7 +2001,7 @@ pub fn fetch_fasta_to_file(
         let file = File::open(&metadata_path).map_err(|e| FerroError::Io {
             msg: format!("Failed to open {}: {}", metadata_path.display(), e),
         })?;
-        serde_json::from_reader(file).unwrap_or_else(|_| SupplementalMetadata {
+        serde_json::from_reader(BufReader::new(file)).unwrap_or_else(|_| SupplementalMetadata {
             generated_at: chrono::Utc::now().to_rfc3339(),
             transcripts: std::collections::HashMap::new(),
         })

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -598,8 +598,10 @@ fn run_populate_cache(
                         msg: format!("Failed to open manifest: {}", e),
                     }
                 })?;
-                serde_json::from_reader(file).map_err(|e| ferro_hgvs::FerroError::Json {
-                    msg: format!("Failed to parse manifest: {}", e),
+                serde_json::from_reader(std::io::BufReader::new(file)).map_err(|e| {
+                    ferro_hgvs::FerroError::Json {
+                        msg: format!("Failed to parse manifest: {}", e),
+                    }
                 })?
             };
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -178,7 +178,7 @@ pub fn cdot_cache_load_source(
         msg: format!("Failed to open manifest {}: {}", manifest_path.display(), e),
     })?;
     let manifest: serde_json::Value =
-        serde_json::from_reader(file).map_err(|e| FerroError::Io {
+        serde_json::from_reader(BufReader::new(file)).map_err(|e| FerroError::Io {
             msg: format!(
                 "Failed to parse manifest {}: {}",
                 manifest_path.display(),

--- a/src/reference/multi_fasta.rs
+++ b/src/reference/multi_fasta.rs
@@ -638,8 +638,11 @@ impl MultiFastaProvider {
             msg: format!("Failed to open manifest: {}", e),
         })?;
 
+        // `serde_json::from_reader` on an unbuffered `File` issues one read
+        // syscall per byte; buffering the reader is worth ~26 ms of startup on
+        // a 65 KB manifest alone (measured 25.6 ms -> 0.3 ms).
         let manifest: serde_json::Value =
-            serde_json::from_reader(file).map_err(|e| FerroError::Io {
+            serde_json::from_reader(BufReader::new(file)).map_err(|e| FerroError::Io {
                 msg: format!("Failed to parse manifest: {}", e),
             })?;
 


### PR DESCRIPTION
`serde_json::from_reader` on an unbuffered `File` reads through `io::Read::bytes()`, issuing one `read()` syscall per byte. Eight call sites passed a bare `File`; every other reader in the tree was already wrapped.

## Measured

Warm page cache, release build, against a real prepared reference. The parsed value is identical in both cases (asserted in the harness).

| file | before | after | |
|---|---|---|---|
| `manifest.json` (65 KB) | 25.6 ms | 0.3 ms | 85× |
| `patterns_transcripts.metadata.json` (24.3 MB) | 12.2 s | 0.33 s | 37× |

The manifest read sits on the `ferro normalize --reference` startup path (`MultiFastaProvider::from_manifest_inner`), so this is ~26 ms off every invocation. The 24.3 MB read is the benchmark cache's supplemental-CDS load, where the unbuffered form cost over twelve seconds — that one is a live stall, not a micro-optimization.

## Sites fixed

- `src/reference/multi_fasta.rs` — manifest (startup path)
- `src/commands/mod.rs` — manifest
- `src/benchmark/cache.rs` ×3 — manifest, supplemental metadata (the 12 s one), supplemental metadata again
- `src/benchmark/biocommons.rs` ×2 — supplemental metadata, tool output
- `src/bin/benchmark.rs` — manifest

## Behavior

None. `BufReader` changes neither the parsed value nor the error type. No public API change.

## Follow-up, deliberately not in this PR

The write side has the same defect: `serde_json::to_writer_pretty` on a bare `File` measured at **18.1 s vs 78 ms buffered (231×)** for the same 24.3 MB file, across roughly eleven sites in `benchmark/`, `prepare/manifest.rs`, and `prepare/mod.rs`. That fix needs an explicit `flush()` at each site, because `BufWriter` swallows write errors when it flushes on drop — so it is a genuinely different change with real error-handling review, rather than the one-line-each substitution here.

## Testing

`cargo nextest run --features dev`: 8,523 passed, 0 failed. `cargo clippy --all-targets -- -D warnings` clean on both `--features dev` and `--features benchmark`.