### PR TITLE
fix(normalize): direction-aware copy selection in normalize_repeat; fuzz unit[N] inputs

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1803,9 +1803,17 @@ pub fn normalize_repeat(
         } else {
             // 1-unit reduction, full tract removal, or codon-frame-gated → deletion
             // (HGVS prioritization: deletion outranks unranked repeat[0])
+            //
+            // Removing any `k` copies of a pure tandem unit yields the same
+            // haplotype, so the direction rule picks which copies are named: the
+            // 3'-most under `ThreePrime`, the 5'-most under `FivePrime`. Naming
+            // the 3'-most copies unconditionally made the emitted `del` a
+            // non-fixed-point under 5' (it re-shuffled to the 5'-most slot).
             let del_len = (k as usize) * unit_len as usize;
-            let del_end_idx = ref_end - 1;
-            let del_start_idx = ref_end - del_len;
+            let (del_start_idx, del_end_idx) = match direction {
+                ShuffleDirection::ThreePrime => (ref_end - del_len, ref_end - 1),
+                ShuffleDirection::FivePrime => (ref_start, ref_start + del_len - 1),
+            };
             RepeatNormResult::Deletion {
                 start: index_to_hgvs_pos(del_start_idx),
                 end: index_to_hgvs_pos(del_end_idx),
@@ -1814,10 +1822,17 @@ pub fn normalize_repeat(
     } else if specified_count == ref_count + 1 {
         // Convert to duplication - we're adding exactly one copy.
         // dup is always permitted; the spec exception only forbids `[N]`.
-        // The duplicated region is the last copy in the reference.
-        // ref_end is exclusive, so last position is ref_end - 1
-        let dup_end_idx = ref_end - 1;
-        let dup_start_idx = ref_end - canonical_unit.len();
+        //
+        // Duplicating any one copy of a pure tandem unit yields the same
+        // haplotype, so the direction rule picks which copy is named: the last
+        // (3'-most) under `ThreePrime`, the first (5'-most) under `FivePrime`.
+        // Naming the last copy unconditionally made the emitted `dup` a
+        // non-fixed-point under 5' (it re-shuffled to the 5'-most slot).
+        // `ref_end` is exclusive, so the tract's last position is `ref_end - 1`.
+        let (dup_start_idx, dup_end_idx) = match direction {
+            ShuffleDirection::ThreePrime => (ref_end - canonical_unit.len(), ref_end - 1),
+            ShuffleDirection::FivePrime => (ref_start, ref_start + canonical_unit.len() - 1),
+        };
         RepeatNormResult::Duplication {
             start: index_to_hgvs_pos(dup_start_idx),
             end: index_to_hgvs_pos(dup_end_idx),
@@ -1829,14 +1844,27 @@ pub fn normalize_repeat(
     } else if codon_blocks_repeat {
         // Expansion of >=2 copies in c. with non-codon-aligned unit: spec
         // mandates `ins<literal>` form (e.g., c.1741_1742insTATATATA), not
-        // `[N]`. Insertion point is between the last base of the reference
-        // tract (ref_end - 1, 0-based) and the next base (ref_end).
+        // `[N]`.
+        //
+        // Adding the copies at either end of a pure tandem tract yields the same
+        // haplotype, so the direction rule picks the flank the insertion is named
+        // against: the 3' flank (between `ref_end - 1` and `ref_end`) under
+        // `ThreePrime`, the 5' flank (between `ref_start - 1` and `ref_start`)
+        // under `FivePrime`. Naming the 3' flank unconditionally made the emitted
+        // `ins` a non-fixed-point under 5' (it re-shuffled to the 5' flank).
+        //
+        // A tract flush against the sequence start (`ref_start == 0`) has no 5'
+        // flank base to name, so it keeps the 3' flank; that is the transcript-
+        // start boundary case the CDS-start clamp in `normalize_na_edit` owns.
         let added_copies = specified_count - ref_count;
         let mut inserted = Vec::with_capacity((added_copies as usize) * canonical_unit.len());
         for _ in 0..added_copies {
             inserted.extend_from_slice(canonical_unit);
         }
-        let flank_left = index_to_hgvs_pos(ref_end - 1);
+        let flank_left = match direction {
+            ShuffleDirection::FivePrime if ref_start > 0 => index_to_hgvs_pos(ref_start - 1),
+            _ => index_to_hgvs_pos(ref_end - 1),
+        };
         let flank_right = flank_left + 1;
         RepeatNormResult::Insertion {
             start: flank_left,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -15,6 +15,7 @@ mod common;
 mod five_prime_boundary_delins_unification;
 mod five_prime_insertion_dup_boundary_anchor;
 mod five_prime_tandem_repeat_dup_rotation;
+mod repeat_input_idempotency;
 
 mod allele_grammar_corners;
 mod allele_trans_phase;

--- a/tests/it/normalize_idempotency_proptest.rs
+++ b/tests/it/normalize_idempotency_proptest.rs
@@ -105,6 +105,73 @@ fn core_strategy() -> impl Strategy<Value = String> {
         .prop_map(|body| format!("G{body}C"))
 }
 
+/// A core carrying ONE cleanly-bounded tandem tract, plus a `unit[N]` input
+/// spelled against it — the input class `case_strategy` cannot reach (it only
+/// emits `del`/`dup`/`ins`/`delins`), which is how the 5' repeat del/dup
+/// non-idempotency hid.
+///
+/// The tract is `unit` repeated `ref_copies` times, flanked on both sides by a
+/// run of a single **breaker** base chosen so it can continue the unit's
+/// rotation on neither side: `breaker != unit.first()` blocks the 3' phase walk
+/// (`three_prime_align_tract` slides while `ref[end] == rotated[0]`) and
+/// `breaker != unit.last()` blocks the 5' one (`five_prime_align_tract` slides
+/// while `ref[start-1] == rotated.last()`). A 1-3bp unit constrains at most 2 of
+/// the 4 bases, so a breaker always exists.
+///
+/// This matters more than the usual "break the pad run" guard: `SyntheticBuilder`
+/// pads with `ACGT…`, and a *rotational* (multi-base) unit can keep cycling into
+/// that pad even where a homopolymer run would stop — e.g. a core ending `…CAGC`
+/// continues the `CAG` cycle into the pad's leading `A`. Flanking by unit-derived
+/// exclusion is what keeps the tract's extent equal to what the test intends.
+fn repeat_case_strategy() -> impl Strategy<Value = Case> {
+    const FLANK: usize = 3;
+    (dna(1..=3), 2usize..=6)
+        .prop_flat_map(|(unit, ref_copies)| {
+            let ub = unit.as_bytes();
+            let (first, last) = (ub[0] as char, ub[ub.len() - 1] as char);
+            let breakers: Vec<char> = ['A', 'C', 'G', 'T']
+                .into_iter()
+                .filter(|&b| b != first && b != last)
+                .collect();
+            (
+                Just(unit),
+                Just(ref_copies),
+                prop::sample::select(breakers),
+                prop::sample::select(vec![Sys::Genomic, Sys::CdsPlus, Sys::CdsMinus]),
+            )
+        })
+        .prop_flat_map(|(unit, ref_copies, breaker, sys)| {
+            // count 0..=ref_copies+3 spans every normalize_repeat arm:
+            // contraction to zero / with survivors, identity, +1 (dup), expansion.
+            (
+                Just(unit),
+                Just(ref_copies),
+                Just(breaker),
+                Just(sys),
+                0u64..=(ref_copies as u64 + 3),
+            )
+        })
+        .prop_map(|(unit, ref_copies, breaker, sys, count)| {
+            let flank: String = std::iter::repeat_n(breaker, FLANK).collect();
+            let core = format!("{flank}{}{flank}", unit.repeat(ref_copies));
+            // 1-based position of the tract's first base within the core.
+            let tract_start_in_core = FLANK + 1;
+            let (prefix, acc) = match sys {
+                Sys::Genomic => ("g.", "NC_TEST.1"),
+                _ => ("c.", "NM_TEST.1"),
+            };
+            let pos = match sys {
+                Sys::Genomic => PAD_OFFSET as usize + tract_start_in_core,
+                _ => tract_start_in_core, // cds_start == 1 => c.p maps to core p
+            };
+            Case {
+                core,
+                sys,
+                hgvs: format!("{acc}:{prefix}{pos}{unit}[{count}]"),
+            }
+        })
+}
+
 fn case_strategy() -> impl Strategy<Value = Case> {
     core_strategy().prop_flat_map(move |core| {
         let len = core.len();
@@ -218,6 +285,15 @@ proptest! {
     #[test]
     fn normalization_is_idempotent_five_prime(case in case_strategy()) {
         check_idempotent(&case, ShuffleDirection::FivePrime)?;
+    }
+
+    /// Repeat-notation (`unit[N]`) **inputs**, both directions. `case_strategy`
+    /// never emits these, so `normalize_repeat`'s own result arms were only ever
+    /// reached as an *output* of a del/dup/ins — never re-entered as an input.
+    /// That gap hid the 5' del/dup arms naming the 3'-most copy (non-idempotent).
+    #[test]
+    fn repeat_input_is_idempotent(case in repeat_case_strategy(), dir in both_directions()) {
+        check_idempotent(&case, dir)?;
     }
 }
 

--- a/tests/it/repeat_input_idempotency.rs
+++ b/tests/it/repeat_input_idempotency.rs
@@ -1,0 +1,171 @@
+//! Idempotency of **repeat-notation (`unit[N]`) inputs**.
+//!
+//! The idempotency proptest generates only `del`/`dup`/`ins`/`delins` inputs, so
+//! `unit[N]` spelled *as input* was never fuzzed. `normalize_repeat` must be a
+//! fixed point for these too: `norm(norm(x)) == norm(x)`.
+//!
+//! Core `TCAGCAGCAGCAGTT` places exactly 4 clean copies of `CAG` at g.258..269,
+//! bounded by `T` on both sides so neither the 5' nor the 3' phase walk can leak
+//! into the `ACGT…` padding (a `G`-prefixed or `C`-suffixed core would continue
+//! the CAG rotation into the pad and measure a harness artifact instead).
+//!
+//! Three count regimes exercise three of the `normalize_repeat` result arms:
+//!   * `[5]` = ref_count + 1  -> Duplication arm
+//!   * `[3]` = ref_count - 1  -> Deletion arm
+//!   * `[2]` = ref_count - 2  -> Repeat (contraction-with-survivors, B2) arm
+//!
+//! The fourth — the codon-gated `Insertion` arm, reachable only in `c.` context
+//! with a non-codon-aligned unit — is covered separately at the bottom of the
+//! file, on its own CDS fixture.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// 4 clean copies of `CAG` at g.258..269, `T`-bounded on both flanks.
+const CORE: &str = "TCAGCAGCAGCAGTT";
+
+fn norm(input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::genomic(CORE).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
+fn norm_cds(core: &str, input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::cds(core, 1, core.len() as u64, Strand::Plus).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
+/// `norm(x) == expected` AND `norm(norm(x)) == norm(x)`.
+///
+/// Pinning the exact canonical form matters as much as the fixed point: a
+/// normalizer that returned its input untouched would satisfy idempotency alone,
+/// so a fixed-point-only assertion cannot tell a working direction rule from a
+/// no-op. `expected` also encodes *which* copy each direction names, which is the
+/// behavior this PR changes.
+fn assert_normalizes_to(input: &str, dir: ShuffleDirection, expected: &str) {
+    let once = norm(input, dir);
+    assert_eq!(
+        once, expected,
+        "WRONG CANONICAL FORM ({dir:?})\n  input   ={input}\n  got     ={once}\n  expected={expected}"
+    );
+    let twice = norm(&once, dir);
+    assert_eq!(
+        once, twice,
+        "NOT IDEMPOTENT ({dir:?})\n  input={input}\n  once ={once}\n  twice={twice}"
+    );
+}
+
+// The tract is 4 copies of `CAG` at g.258..269 — copies at 258_260, 261_263,
+// 264_266, 267_269. Every expectation below follows from that layout plus the
+// direction rule: `ThreePrime` names the 3'-most copy/copies, `FivePrime` the
+// 5'-most. The `[2]` (contraction-with-survivors) case is the exception — the
+// B2 `Repeat` arm emits a window spanning the WHOLE tract, so it is
+// direction-invariant by construction and both directions agree.
+
+#[test]
+fn three_prime_repeat_expansion_names_the_last_copy() {
+    // +1 copy -> Duplication arm; 3' names the 3'-most copy.
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[5]",
+        ShuffleDirection::ThreePrime,
+        "NC_TEST.1:g.267_269dup",
+    );
+}
+
+#[test]
+fn three_prime_repeat_single_contraction_names_the_last_copy() {
+    // -1 copy -> Deletion arm; 3' names the 3'-most copy.
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[3]",
+        ShuffleDirection::ThreePrime,
+        "NC_TEST.1:g.267_269del",
+    );
+}
+
+#[test]
+fn three_prime_repeat_double_contraction_spans_the_whole_tract() {
+    // -2 copies with survivors -> B2 Repeat arm; window covers the full tract.
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[2]",
+        ShuffleDirection::ThreePrime,
+        "NC_TEST.1:g.258_269CAG[2]",
+    );
+}
+
+#[test]
+fn five_prime_repeat_expansion_names_the_first_copy() {
+    // Same haplotype as the 3' case, but 5' names the 5'-most copy.
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[5]",
+        ShuffleDirection::FivePrime,
+        "NC_TEST.1:g.258_260dup",
+    );
+}
+
+#[test]
+fn five_prime_repeat_single_contraction_names_the_first_copy() {
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[3]",
+        ShuffleDirection::FivePrime,
+        "NC_TEST.1:g.258_260del",
+    );
+}
+
+#[test]
+fn five_prime_repeat_double_contraction_spans_the_whole_tract() {
+    // Direction-invariant: identical to the 3' expectation above.
+    assert_normalizes_to(
+        "NC_TEST.1:g.258CAG[2]",
+        ShuffleDirection::FivePrime,
+        "NC_TEST.1:g.258_269CAG[2]",
+    );
+}
+
+/// The codon-frame gate (`repeated.md`: `c.` repeat notation requires
+/// `unit_len % 3 == 0`) routes a >=2-copy expansion of a non-codon-aligned unit
+/// to a literal `ins`. That insertion point was named against the tract's **3'**
+/// flank regardless of direction, so under 5' it re-shuffled to the 5' flank
+/// (`c.6_7insAA` -> `c.3_4insAA`). Found by the repeat-input fuzz.
+///
+/// Core `CCCAAACCC`: an `AAA` tract at c.4..6 (unit `A`, len 1, gate blocks),
+/// expanded to 5 copies = +2 copies.
+#[test]
+fn five_prime_codon_gated_repeat_expansion_is_idempotent() {
+    let once = norm_cds(
+        "CCCAAACCC",
+        "NM_TEST.1:c.4A[5]",
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(once, "NM_TEST.1:c.3_4insAA", "must name the 5' flank");
+    assert_eq!(
+        norm_cds("CCCAAACCC", &once, ShuffleDirection::FivePrime),
+        once,
+        "codon-gated 5' repeat expansion must be a fixed point"
+    );
+}
+
+/// 3' is unchanged: it names the tract's 3' flank and is idempotent.
+#[test]
+fn three_prime_codon_gated_repeat_expansion_unchanged() {
+    let once = norm_cds(
+        "CCCAAACCC",
+        "NM_TEST.1:c.4A[5]",
+        ShuffleDirection::ThreePrime,
+    );
+    assert_eq!(once, "NM_TEST.1:c.6_7insAA");
+    assert_eq!(
+        norm_cds("CCCAAACCC", &once, ShuffleDirection::ThreePrime),
+        once,
+        "3' must remain idempotent"
+    );
+}

--- a/tests/proptest-regressions/normalize_idempotency_proptest.txt
+++ b/tests/proptest-regressions/normalize_idempotency_proptest.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc bf332dd0e9d843159242ec546b6e1eb7518b888030fe9438d344dd93044a7394 # shrinks to case = Case { core: "GTGTGTGTGTGCTCC", sys: Genomic, hgvs: "NC_TEST.1:g.267_268insTG" }
+cc ddec17ccae74300ac0056191f141ead3b469a70af2b335c064a8300fd22ad3fc # shrinks to case = Case { core: "CCCAAACCC", sys: CdsPlus, hgvs: "NM_TEST.1:c.4A[5]" }, dir = FivePrime


### PR DESCRIPTION
> **Stacked on #1170** — base is `fix/five-prime-shuffle-idempotency`, not `main`. The fix needs the `direction` parameter #1170 threads into `normalize_repeat`. Review #1170 first; this PR's own diff is the last two commits. Rebase onto `main` once #1170 merges.
>
> ⚠️ **CI does not run on this PR.** `.github/workflows/ci.yml` triggers on `pull_request: branches: [main]` only, so a PR targeting a non-`main` base gets no jobs — the empty check list here means *"not run"*, not *"passed"*. Verified locally instead: full suite green (8553), green again under `FERRO_ASSERT_IDEMPOTENT=1`, `clippy --all-targets -D warnings` clean, fuzz green at 100k. CI will run for real once this is retargeted/rebased onto `main` after #1170 merges.

## Summary

`normalize_repeat` has four result arms that name a *specific* window inside a tandem tract. Three of them named the **3'-most** copy (or the tract's 3' flank) unconditionally, ignoring shuffle direction — so under `FivePrime` the emitted `del`/`dup`/`ins` was not a fixed point: it re-shuffled to the 5'-most slot on the next pass.

This is the same class of defect #1170 fixed for the *phase alignment*, in the arms that PR deliberately left alone.

## The gap that hid it

`normalize_idempotency_proptest::case_strategy` generates only `del` / `dup` / `ins` / `delins` inputs — it **never generates `unit[N]` repeat inputs**. So `normalize_repeat`'s arms were only ever reached as the *output* of some other edit, never re-entered as an input, and the whole-suite `FERRO_ASSERT_IDEMPOTENT=1` oracle had no test feeding one.

## Changes

**1. Three `normalize_repeat` arms become direction-aware.** Removing, duplicating, or appending copies of a pure tandem unit yields the same haplotype either way, so the direction rule picks *which* copy is named — 3'-most under `ThreePrime`, 5'-most under `FivePrime`:

| arm | repro (5') | before | after (fixed point) |
|---|---|---|---|
| Duplication | `g.258CAG[5]`, core `TCAGCAGCAGCAGTT` | `g.267_269dup` → drifted | `g.258_260dup` |
| Deletion | `g.258CAG[3]`, same core | `g.267_269del` → drifted | `g.258_260del` |
| Insertion (codon-gated) | `c.4A[5]`, core `CCCAAACCC` | `c.6_7insAA` → drifted | `c.3_4insAA` |

The fourth arm (`Repeat`, contraction-with-survivors) already spans the whole tract and needed no change. **`ThreePrime` output is byte-identical** — every 3' assertion, the biocommons/mutalyzer conformance corpora, and the existing repeat tests are unchanged.

Edge case: a tract flush against the sequence start (`ref_start == 0`) has no 5' flank base to name, so the `Insertion` arm keeps the 3' flank there — that is the transcript-start boundary case the CDS-start clamp in `normalize_na_edit` already owns.

**2. Fuzz repeat-notation inputs (`repeat_case_strategy`).** Closes the generator gap above: builds a core with one cleanly-bounded tandem tract and spells a `unit[N]` input against it, across genomic and CDS (both strands), with counts spanning every arm (contraction to zero, contraction with survivors, identity, +1, expansion).

The tract is flanked by a **breaker base chosen from the unit** — `breaker != unit.first()` blocks the 3' phase walk, `breaker != unit.last()` blocks the 5' one. This is stricter than the existing "break the pad run" guard for a reason: `SyntheticBuilder` pads with `ACGT…`, and a *rotational* multi-base unit keeps cycling into that pad where a homopolymer run would stop (a core ending `…CAGC` continues the `CAG` cycle into the pad's leading `A`). Without unit-derived flanking, such a test measures a harness artifact rather than the normalizer — which is exactly what an early draft of this investigation did, and why one suspected 3' defect turned out not to exist.

This new property is what found the codon-gated `Insertion` arm; the first two were found by hand.

## Tests

- `repeat_input_idempotency` — 8 targeted regressions: each arm, both directions, plus the codon-gated CDS case. Verified to fail without the fix and pass with it.
- `repeat_input_is_idempotent` — the new fuzz property, both directions. Green at 100k cases.

## Verification

- Full suite green (8553), and green again under `FERRO_ASSERT_IDEMPOTENT=1`.
- `clippy --all-targets -D warnings` clean; `cargo fmt` applied.
- Reference-backed conformance run locally against a prepared reference (skipped in standard CI without `FERRO_MANIFEST`).
