### PR TITLE
test(conformance): accept the sized-suffix parse-rejection taxonomy divergence

### DIFF
--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -480,10 +480,21 @@ pub enum Policy {
     /// #486 errors axis: ferro rejects an HGVS-invalid input at *parse* time
     /// with a structured parse error — single-position insertion
     /// (`EINSERTIONRANGE`, also flanked by `EOVERLAP`), malformed concatenation,
-    /// missing axis prefix, or an incomplete edit — whereas mutalyzer rejects
+    /// missing axis prefix, an incomplete edit, or a **sized suffix on a
+    /// single-position anchor** (`c.45del4` / `c.45dup4`: naming one endpoint
+    /// leaves it undefined whether the edit starts at or after the anchor, so
+    /// `checklist.md:49` / `DNA/deletion.md:117` / `DNA/duplication.md:140`
+    /// decline the shape and ferro will not guess) — whereas mutalyzer rejects
     /// the same input downstream with a semantic code (`EINTRONIC`, `ENOCDS`,
-    /// `EREPEATUNSUPPORTED`, `EVARIANTNOTSUPPORTED`). Both reject the input;
-    /// only the error taxonomy differs, so the rejection is accepted.
+    /// `EREPEATUNSUPPORTED`, `EVARIANTNOTSUPPORTED`, `ELENGTHMISMATCH`). Both
+    /// reject the input; only the error taxonomy differs, so the rejection is
+    /// accepted.
+    ///
+    /// The boundary is narrow and worth stating: the *delins* form of the same
+    /// shape (`c.45del4insATC`) DOES parse in ferro — the sized `del4` is a
+    /// deleted-length there, not a lone endpoint — and then fails the
+    /// reference-length check, so it matches `ELENGTHMISMATCH` directly and
+    /// carries no annotation.
     #[serde(rename = "ferro-policy-486-parse-time-rejection-taxonomy")]
     ParseTimeRejectionTaxonomy486,
     /// #486 errors axis: ferro does not validate that a parenthesised transcript

--- a/tests/fixtures/mutalyzer-normalize/cases.json
+++ b/tests/fixtures/mutalyzer-normalize/cases.json
@@ -1995,7 +1995,12 @@
       "errors": [
         "ELENGTHMISMATCH"
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "errors",
+        "policy": "ferro-policy-486-parse-time-rejection-taxonomy",
+        "note": "The spec forbids this FORM outright, so ferro rejects it at parse time (InvalidEdit) rather than parsing it and complaining about the length. Verified against the spec source: checklist.md:49 marks it invalid -- 'Descriptions like g.123del3 are not allowed, correct is g.123_125del' (the g.123del3 is tagged class=invalid); DNA/deletion.md repeats it under Discussion -- 'Can I use NG_012232.1:g.123del6 to describe a 6 nucleotide deletion? No, a deletion of more than one residue should mention the first and last residue deleted, separated using the range symbol'. Mutalyzer parses the shape and reports the semantic ELENGTHMISMATCH instead. BOTH REJECT the input -- ferro is the stricter of the two, not the more lenient -- and only the error taxonomy differs, which the spec does not legislate. That is why this is an accepted_divergence on taxonomy rather than a spec_citation: a spec_citation would assert mutalyzer is contrary to spec, and it is not (it rejects too). Note the delins form (NM_000143.3:c.45del4insATC) DOES parse in ferro -- the sized del4 is a deleted-length there, not a lone endpoint -- and hits the reference-length check, so it matches ELENGTHMISMATCH directly and needs no annotation."
+      }
     },
     {
       "keywords": [
@@ -2235,7 +2240,12 @@
       "errors": [
         "ELENGTHMISMATCH"
       ],
-      "to_test": true
+      "to_test": true,
+      "accepted_divergence": {
+        "axis": "errors",
+        "policy": "ferro-policy-486-parse-time-rejection-taxonomy",
+        "note": "The spec forbids this FORM outright, so ferro rejects it at parse time (InvalidEdit). Verified against the spec source, DNA/duplication.md:140 -- 'Can I use g.123dup6 to describe a 6 nucleotide duplication? No, a duplication of more than one nucleotide should give the position of the first and last nucleotide duplicated, separated using the range symbol' (the g.123dup6 is tagged class=invalid). Line 143 gives the reason ferro's diagnostic paraphrases: 'from the description g.123dup6 it is not clear whether the duplication starts AT position g.123 (so g.123_128dup) or AFTER position 123 (so g.124_129dup)' -- the shape is genuinely ambiguous, so ferro declines to guess an endpoint. Mutalyzer parses the shape and reports the semantic ELENGTHMISMATCH instead. BOTH REJECT the input -- ferro is the stricter of the two -- and only the error taxonomy differs, which the spec does not legislate. Same family as the c.45del4 row above; see it for why this is an accepted_divergence rather than a spec_citation."
+      }
     },
     {
       "keywords": [

--- a/tests/fixtures/mutalyzer-normalize/failure-patterns.md
+++ b/tests/fixtures/mutalyzer-normalize/failure-patterns.md
@@ -318,6 +318,8 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | `NG_017013.2:g.17496_17497insAGCTGCTCAGATAGCGA` | normalized | accepted_divergence | — | — |
 | `NG_029724.1(NM_004321.7):c.101del` | normalized | accepted_divergence | — | — |
 | `NM_000143.3:c.-1_1insCAT` | protein_description | accepted_divergence | — | — |
+| `NM_000143.3:c.45del4` | errors | accepted_divergence | — | — |
+| `NM_000143.3:c.45dup4` | errors | accepted_divergence | — | — |
 | `NM_002001.2:c.1_3delinsATG` | normalized | accepted_divergence | — | — |
 | `NM_003002.2:c.273del` | infos | accepted_divergence | — | — |
 | `NM_003002.2:c.[100del;200_201insNM_003002.2:274+20]` | errors | accepted_divergence | — | — |
@@ -330,7 +332,7 @@ An `<range>inv` segment in an ins/delins payload inserts the reverse complement 
 | axis | accepted_divergence | known_bug | improvement | reference_unavailable | spec_citation |
 |---|---:|---:|---:|---:|---:|
 | coding_protein_descriptions | 27 | 0 | 0 | 0 | 0 |
-| errors | 17 | 0 | 0 | 0 | 0 |
+| errors | 19 | 0 | 0 | 0 | 0 |
 | genomic | 19 | 0 | 0 | 0 | 5 |
 | infos | 8 | 0 | 0 | 0 | 1 |
 | noncoding | 0 | 0 | 0 | 0 | 8 |


### PR DESCRIPTION
## Summary

`axis_errors` (the manifest-gated mutalyzer conformance axis, nightly-only in CI) failed on two rows:

```
NM_000143.3:c.45del4
NM_000143.3:c.45dup4
```

**Both ferro and mutalyzer reject these inputs.** They disagree only on the *error taxonomy*, which is what the runner's tag matcher compares:

| | behavior |
|---|---|
| ferro | parse-time `InvalidEdit` — a deletion/duplication sized by a suffix on a single-position anchor names only one endpoint, and the spec declines to say whether the edit starts at or after the anchor (`checklist.md:49` / `DNA/deletion.md:117` / `DNA/duplication.md:140`), so ferro will not guess |
| mutalyzer | parses the shape, then reports the semantic `ELENGTHMISMATCH` |

## Why annotate rather than change the parser

This is precisely the existing `ferro-policy-486-parse-time-rejection-taxonomy` policy — *"Both reject the input; only the error taxonomy differs, so the rejection is accepted."* Loosening the parser to accept `del4` on a single anchor would contradict a deliberate, spec-cited rejection that carries its own diagnostic and hint, so the annotation is the correct disposition.

The boundary is narrow and is now recorded on the policy doc: the **delins** form (`c.45del4insATC`) DOES parse in ferro — the sized `del4` is a deleted-*length* there, not a lone endpoint — and then fails the reference-length check, so it already matches `ELENGTHMISMATCH` directly and carries no annotation.

## Result

`axis_errors`: **2 FAIL → 0 FAIL**, 17 → 19 `divergence_accepted`. The (already empty) `baseline-failures/errors.txt` is unchanged — the annotation restores agreement with it rather than widening a baseline.

## Notes

- Pre-existing: this failure reproduces on `main`; it is not a regression from any open PR.
- Conformance summary (`failure-patterns.md`) regenerated via `generate_conformance_summary`.
- Verified: full suite green (8523), `axis_errors` green against a prepared reference, clippy clean.
