### PR TITLE
test(normalize): make the direction-invariance test and proptest flanks honest

### DIFF
--- a/tests/it/issue_340_homopolymer_shift.rs
+++ b/tests/it/issue_340_homopolymer_shift.rs
@@ -219,34 +219,146 @@ fn delins_to_dup_canonicalizes_multibase_dup_on_genome() {
     );
 }
 
+/// Normalize `input` against `provider` in `dir`, rendered.
+fn norm_with(provider: MockProvider, input: &str, dir: ShuffleDirection) -> String {
+    let normalizer =
+        Normalizer::with_config(provider, NormalizeConfig::default().with_direction(dir));
+    let variant = parse_hgvs(input).expect("parse");
+    format!("{}", normalizer.normalize(&variant).expect("normalize"))
+}
+
+/// #357: `insertion_to_repeat` on an **unambiguously-phased** tract is
+/// direction-invariant.
+///
+/// 2-copy insertion `AA` extends the n.4-n.6 `AAA` tract to 5 copies. The
+/// canonical repeat form covers the full tract, and for a homopolymer the
+/// 3'-most and 5'-most phases are the same window, so both directions must
+/// render identically.
+///
+/// Scope, stated precisely because the original name (`..._is_direction_invariant_...`)
+/// over-promised: this pins invariance ONLY where the tract's phase is
+/// unambiguous. It is not a general direction-invariance guarantee — a tract
+/// whose flanking base continues the unit's rotation phases to the
+/// direction-appropriate end, which the companion test below pins. Before that
+/// companion existed, a homopolymer was the only case under test, so this test
+/// would have kept passing even if multi-base-unit direction handling broke
+/// entirely.
 #[test]
-fn insertion_to_repeat_output_is_direction_invariant_on_n_axis() {
-    // 2-copy insertion `AA` extends the n.4-n.6 AAA tract to 5 copies.
-    // The canonical repeat form covers the full tract; output must be
-    // identical under both shuffle directions. If `insertion_to_repeat`
-    // ever becomes direction-dependent in a way that affects the
-    // displayed range, this test will start failing and trigger a
-    // semantic decision per #357.
+fn insertion_to_repeat_is_direction_invariant_for_unambiguous_tract_on_n_axis() {
     let input = "NR_REPAUDIT.1:n.6_7insAA";
-    let five_prime = {
-        let normalizer = Normalizer::with_config(
-            provider_with_aaa_tract_noncoding(),
-            NormalizeConfig::default().with_direction(ShuffleDirection::FivePrime),
-        );
-        let variant = parse_hgvs(input).expect("parse");
-        format!("{}", normalizer.normalize(&variant).expect("normalize"))
-    };
-    let three_prime = {
-        let normalizer = Normalizer::with_config(
-            provider_with_aaa_tract_noncoding(),
-            NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
-        );
-        let variant = parse_hgvs(input).expect("parse");
-        format!("{}", normalizer.normalize(&variant).expect("normalize"))
-    };
+    let five_prime = norm_with(
+        provider_with_aaa_tract_noncoding(),
+        input,
+        ShuffleDirection::FivePrime,
+    );
+    let three_prime = norm_with(
+        provider_with_aaa_tract_noncoding(),
+        input,
+        ShuffleDirection::ThreePrime,
+    );
+    // Assert the canonical value on each direction independently, not merely that
+    // the two agree: two identically-wrong renderings would satisfy a mutual-
+    // equality check. The window names the REFERENCE tract (n.4-n.6, 3 copies of
+    // `A`), and the count is the post-edit total (3 ref + 2 inserted = 5).
+    const CANONICAL: &str = "NR_REPAUDIT.1:n.4_6A[5]";
+    assert_eq!(three_prime, CANONICAL, "3' canonical form");
+    assert_eq!(five_prime, CANONICAL, "5' canonical form");
     assert_eq!(
         five_prime, three_prime,
-        "insertion_to_repeat output should be direction-invariant for multi-copy \
-         inserts on the n. axis: 5prime={five_prime} 3prime={three_prime}",
+        "a homopolymer tract has one phase, so insertion_to_repeat must render \
+         identically in both directions: 5prime={five_prime} 3prime={three_prime}",
     );
+}
+
+/// An `n.` transcript whose n.3-n.11 is the odd alternating run `GAGAGAGAG`.
+///
+/// Odd length is what makes the phase ambiguous: read as `GA` the run starts at
+/// n.3, read as `AG` it starts at n.4, and each flanking base continues the
+/// other reading's rotation. That is the shape a homopolymer fixture cannot
+/// express, and the one where direction actually decides the window.
+fn provider_with_ambiguous_ag_tract_noncoding() -> MockProvider {
+    let mut provider = MockProvider::new();
+    //                       1234567890123
+    let sequence = "CCGAGAGAGAGCC".to_string();
+    //                ^^^^^^^^^ n.3-n.11 = GAGAGAGAG
+    let len = sequence.len() as u64;
+    let transcript = Transcript::new(
+        "NR_REPAUDIT.1".to_string(),
+        Some("REPAUDIT".to_string()),
+        Strand::Plus,
+        sequence,
+        None,
+        None,
+        vec![Exon::new(1, 1, len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    );
+    provider.add_transcript(transcript);
+    provider
+}
+
+/// #357 companion: on an **ambiguously-phased** tract the repeat form phases to
+/// the direction-canonical end, so the two directions deliberately differ.
+///
+/// This is the case the homopolymer test above cannot reach. Inserting `AGAG`
+/// against the odd `GAGAGAGAG` run yields one haplotype with two equally-valid
+/// spellings; 3' names the 3'-most phase (`AG[6]` at n.4) and 5' the 5'-most
+/// (`GA[6]` at n.3). Asserting the *difference* is what keeps a future change
+/// from silently collapsing 5' back onto the 3' phase — the defect class fixed
+/// in the repeat/dup direction-awareness work.
+#[test]
+fn insertion_to_repeat_phases_to_direction_canonical_end_for_ambiguous_tract() {
+    let input = "NR_REPAUDIT.1:n.11_12insAGAG";
+    let three_prime = norm_with(
+        provider_with_ambiguous_ag_tract_noncoding(),
+        input,
+        ShuffleDirection::ThreePrime,
+    );
+    let five_prime = norm_with(
+        provider_with_ambiguous_ag_tract_noncoding(),
+        input,
+        ShuffleDirection::FivePrime,
+    );
+    assert_eq!(three_prime, "NR_REPAUDIT.1:n.4_11AG[6]", "3'-most phase");
+    assert_eq!(five_prime, "NR_REPAUDIT.1:n.3_10GA[6]", "5'-most phase");
+    assert_ne!(
+        three_prime, five_prime,
+        "an ambiguous tract must phase to the direction-canonical end",
+    );
+}
+
+/// Both directions stay confluent on the ambiguous tract: other spellings of the
+/// same haplotype (a 5'-side insertion, and the equivalent `dup`) reach the same
+/// direction-canonical form as the 3'-side insertion above.
+#[test]
+fn ambiguous_tract_spellings_are_confluent_within_each_direction() {
+    for input in [
+        "NR_REPAUDIT.1:n.2_3insGAGA",
+        "NR_REPAUDIT.1:n.3_6dup",
+        "NR_REPAUDIT.1:n.11_12insAGAG",
+    ] {
+        assert_eq!(
+            norm_with(
+                provider_with_ambiguous_ag_tract_noncoding(),
+                input,
+                ShuffleDirection::ThreePrime
+            ),
+            "NR_REPAUDIT.1:n.4_11AG[6]",
+            "3' confluence for {input}",
+        );
+        assert_eq!(
+            norm_with(
+                provider_with_ambiguous_ag_tract_noncoding(),
+                input,
+                ShuffleDirection::FivePrime
+            ),
+            "NR_REPAUDIT.1:n.3_10GA[6]",
+            "5' confluence for {input}",
+        );
+    }
 }

--- a/tests/it/normalize_idempotency_proptest.rs
+++ b/tests/it/normalize_idempotency_proptest.rs
@@ -85,15 +85,32 @@ fn dna(n: std::ops::RangeInclusive<usize>) -> impl Strategy<Value = String> {
 /// homopolymers and short tandems dominate. Length (of the body) clamped to
 /// 6..=40.
 ///
-/// The body is wrapped in fixed `G…C` breaker flanks. `SyntheticBuilder` pads
+/// The body is wrapped in homopolymer breaker flanks. `SyntheticBuilder` pads
 /// the genomic contig with a perfect `ACGT…` tandem, and its base immediately
-/// 5' of the core is `T`, immediately 3' is `A`. A body that starts with `A` or
-/// ends with `T` (common for `ACG`-ish cores) would *continue* that pad tandem,
-/// creating a 256bp+ repeat an edit can 3'-shift into — but only ~100bp per pass
-/// (the normalizer window), which is a window-limited-tandem artifact of the
-/// harness, not a shuffle-logic bug. `G` (!= `A`, and `T`+`G` is no run) and `C`
-/// (!= `T`, and `C`+`A` is no run) break the pad period on both sides, so all
-/// shuffling stays inside the <=42bp core, well within the window.
+/// 5' of the core is `T`, immediately 3' is `A`. Without a breaker, a tract at
+/// the core's edge *continues* that pad tandem, creating a 256bp+ repeat an edit
+/// can shift into — but only ~100bp per pass (the normalizer window), which is a
+/// window-limited-tandem artifact of the harness, not a shuffle-logic bug.
+///
+/// The flanks are `CCCC…` / `…GGGG` (was a single `G`…`C`). The single-base
+/// version only broke a *homopolymer* run against the pad (`T`+`G` is no run,
+/// `C`+`A` is no run) and did NOT stop a **rotational** multi-base unit from
+/// cycling straight through it: a body ending `…CAG` plus the old `C` flank
+/// gives `…CAGC`, and the pad's leading `A` continues the `CAG` cycle. A
+/// debugging session lost real time to exactly that — a "3' non-idempotency"
+/// that turned out to be the normalizer correctly following a tract which had
+/// genuinely leaked into the padding.
+///
+/// A 4-base homopolymer flank closes it: for a phase walk to cross `GGGG` with a
+/// unit of length <= 3, every rotation it visits there must be `G`, i.e. the
+/// minimal unit is the homopolymer `G` — which then stops at the pad's leading
+/// `A`. Symmetrically `CCCC` stops against the pad's trailing `T`. So no tract
+/// of any unit length this strategy can build reaches the padding, and a failure
+/// reported against a generated core is always about the normalizer.
+///
+/// (`repeat_case_strategy` below needs the same property and gets it a different
+/// way — it knows its tract's unit, so it derives the breaker from that unit
+/// directly rather than relying on a fixed flank.)
 fn core_strategy() -> impl Strategy<Value = String> {
     prop::collection::vec((dna(1..=3), 1usize..=5), 2..=5)
         .prop_map(|runs| {
@@ -102,7 +119,7 @@ fn core_strategy() -> impl Strategy<Value = String> {
                 .collect::<String>()
         })
         .prop_filter("body length 6..=40", |s| s.len() >= 6 && s.len() <= 40)
-        .prop_map(|body| format!("G{body}C"))
+        .prop_map(|body| format!("CCCC{body}GGGG"))
 }
 
 /// A core carrying ONE cleanly-bounded tandem tract, plus a `unit[N]` input
@@ -295,6 +312,33 @@ proptest! {
     fn repeat_input_is_idempotent(case in repeat_case_strategy(), dir in both_directions()) {
         check_idempotent(&case, dir)?;
     }
+}
+
+/// Explicit pin for the #1169 multi-base 5'-shift rotation bug (`insCA` emitted
+/// unrotated at the shifted position — a *different haplotype*, not merely a
+/// non-canonical spelling).
+///
+/// Its only coverage was the `bf332dd0…` seed in
+/// `tests/proptest-regressions/normalize_idempotency_proptest.txt`, recorded as
+/// `core: "GTGTGTGTGTGCTCC"`. **Seeds are replayed through the *current*
+/// strategy, not stored cases** — and this PR rewrites `core_strategy`'s flanks
+/// to `CCCC…GGGG`, so no core it can now generate equals that string. The seed
+/// therefore silently stops reproducing this case. Pinning it as a concrete test
+/// makes the coverage immune to any future strategy change.
+///
+/// The odd 11-base `GTGTGTGTGTG` run is the ambiguous-phase shape that made the
+/// rotation matter: inserting `TG` has two equally-valid spellings, and the 5'
+/// path must rotate the inserted bases as it slides rather than carry them
+/// verbatim.
+#[test]
+fn issue_1169_multibase_five_prime_rotation_is_idempotent() {
+    let case = Case {
+        core: "GTGTGTGTGTGCTCC".to_string(),
+        sys: Sys::Genomic,
+        hgvs: "NC_TEST.1:g.267_268insTG".to_string(),
+    };
+    check_idempotent(&case, ShuffleDirection::FivePrime)
+        .expect("#1169 regression: 5' multi-base insertion rotation must be a fixed point");
 }
 
 /// A homopolymer confluence case: a run of `base` of length `run_len`, embedded


### PR DESCRIPTION
> **Stacked on #1172** (which is itself stacked on #1170) — base is `fix/repeat-input-idempotency`. Both changes assert behavior those PRs introduce. This PR's own diff is the last two commits.
>
> ⚠️ **CI does not run on this PR.** `.github/workflows/ci.yml` triggers on `pull_request: branches: [main]` only, so a PR targeting a non-`main` base gets no jobs — the empty check list means *"not run"*, not *"passed"*. Verified locally: full suite green (8555), green again under `FERRO_ASSERT_IDEMPOTENT=1`, `clippy --all-targets -D warnings` clean, all four proptest properties green at 20k cases.

Two test-honesty fixes in the normalization suite. No production code changes.

## 1. The #357 direction-invariance test was weaker than its name

`insertion_to_repeat_output_is_direction_invariant_on_n_axis` passed only because its fixture is a **homopolymer** (`AAA`, unit `A`), where the 3'-most and 5'-most phases are the same window by construction. Once the repeat phase became direction-aware (#1170/#1172), the test stopped pinning what its name claimed: multi-base-unit direction handling could break entirely and it would keep passing.

- **Renamed** to `insertion_to_repeat_is_direction_invariant_for_unambiguous_tract_on_n_axis`, with the scope stated in the docstring.
- **Added the case it cannot reach**: a fixture whose n.3-n.11 is the odd alternating run `GAGAGAGAG`, where each flanking base continues the *other* reading's rotation, so the phase is genuinely ambiguous.

```
n.11_12insAGAG   ->   3': n.4_11AG[6]      5': n.3_10GA[6]
```

The new test asserts both forms **and that they differ**, so a future change cannot silently collapse 5' back onto the 3' phase. A second test pins confluence within each direction (a 5'-side insertion and the equivalent `dup` reach the same form).

Both new tests were **verified to fail on `main`** — which returns the 3' phase `n.4_11AG[6]` for 5' as well — so they are guards, not tautologies.

## 2. Proptest core flanks did not stop rotational units leaking into the padding

`core_strategy` wrapped each generated body in single `G`…`C` breaker flanks, chosen so a core would not continue the `ACGT…` padding's tandem. That works for a **homopolymer** run (`T`+`G` is no run, `C`+`A` is no run) but does **not** stop a **rotational** multi-base unit from cycling straight through it: a body ending `…CAG` plus the `C` flank gives `…CAGC`, and the pad's leading `A` continues the `CAG` cycle into 256bp of padding.

This is not hypothetical — it cost real debugging time during this campaign. An apparent "3' non-idempotency" on a hand-built `GCAGCAGCAGCAGC` core turned out to be the normalizer correctly following a tract that had genuinely leaked into the padding. A *generated* core can reach the same shape, so a real proptest failure could be dismissed (or chased) on the same false premise.

Widened to `CCCC`…`GGGG`. For a phase walk to cross `GGGG` with a unit of length ≤ 3, every rotation it visits there must be `G` — i.e. the minimal unit is the homopolymer `G`, which then stops at the pad's leading `A`. Symmetrically `CCCC` stops against the pad's trailing `T`. So no tract this strategy can build reaches the padding, and **a failure reported against a generated core is always about the normalizer**.

(`repeat_case_strategy` needs the same property and already gets it a different way — it knows its tract's unit, so it derives the breaker from that unit directly.)

All four proptest properties stay green at 20k cases with the wider flanks.
