### PR TITLE
fix(normalize): maximize the repeat tract instead of taking the first literal hit

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -1708,11 +1708,33 @@ pub fn normalize_repeat(
     // (`unit_len^2` probes). An explicit range is spelled unit-aligned by the
     // caller, so it keeps the literal unit (no search) — only length>=2 units on a
     // single anchor can be off-phase.
+    //
+    // The search is a MAXIMIZATION, not a fallback (it used to run only when the
+    // literal lookup returned `None`). A literal match that succeeds can still be
+    // the *shorter* phase: for `…ACTGAAGTGTTACTTT…` anchored at the tract's last
+    // base, literal `TG` tiles 1 copy while the `GT` rotation tiles 2 copies
+    // across the same anchor. Taking the literal hit unconditionally made
+    // normalization non-idempotent — pass 1 emitted a window covering only the
+    // short tract, and pass 2 read that as an explicit range, re-discovered the
+    // real (longer) tract and absorbed the extra copies into the count, so window
+    // AND count both grew (`r.-124ug[14]` → `r.-125_-124gu[14]` →
+    // `r.-127_-124gu[15]`). Seed `best` with the literal result and let a strictly
+    // longer spanning rotation displace it; ties keep the literal, so the only
+    // behavior change is preferring a genuinely larger tract.
     let mut working_unit = canonical_unit.to_vec();
-    let tract = match count_tandem_repeats(ref_seq, pos, &working_unit) {
-        Some(t) => Some(t),
-        None if end_pos == pos && working_unit.len() >= 2 => {
-            let mut best: Option<(u64, usize, usize, Vec<u8>)> = None;
+    let literal_tract = count_tandem_repeats(ref_seq, pos, &working_unit);
+    let tract = match literal_tract {
+        _ if end_pos == pos && working_unit.len() >= 2 => {
+            // Hold the literal seed to the SAME span test the rotations below
+            // must pass. `count_tandem_repeats` can return a tract lying entirely
+            // 5' of the anchor — e.g. `ref="ACACTT", pos=4, unit="AC"` back-scans
+            // to `start=0` and counts forward to `end=4`, so `pos < e` is false.
+            // Seeding `best` with such a tract would let a non-spanning literal
+            // out-count, and thereby suppress, a rotation that genuinely spans the
+            // anchor.
+            let mut best: Option<(u64, usize, usize, Vec<u8>)> = literal_tract
+                .filter(|&(_, s, e)| s <= pos && pos < e)
+                .map(|(c, s, e)| (c, s, e, canonical_unit.to_vec()));
             for a in 0..canonical_unit.len() {
                 let Some(anchor) = pos.checked_sub(a) else {
                     continue;
@@ -1737,7 +1759,9 @@ pub fn normalize_repeat(
                 None => None,
             }
         }
-        None => None,
+        // Explicit range, or a 1-base unit: the caller spelled it unit-aligned,
+        // so the literal lookup stands as-is.
+        other => other,
     };
     let Some((ref_count, mut ref_start, mut ref_end)) = tract else {
         return RepeatNormResult::Unchanged;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -306,6 +306,7 @@ mod reject_single_position_insertion;
 mod reject_u_in_dna;
 mod repeat_count_trans;
 mod repeat_deln_uncertain_range;
+mod repeat_tract_maximization;
 mod rna_coding_consistency;
 mod rna_spl_marker;
 mod service_tools_tests;

--- a/tests/it/repeat_tract_maximization.rs
+++ b/tests/it/repeat_tract_maximization.rs
@@ -1,0 +1,99 @@
+//! A single-position repeat anchor must find the *maximal* tandem tract, not
+//! whichever phase the literal unit happens to match first.
+//!
+//! `normalize_repeat` tries `count_tandem_repeats` with the caller-spelled unit
+//! and only falls back to the rotation/offset search when that returns `None`.
+//! So when the literal unit matches a SHORT tract while a rotation of it matches
+//! a LONGER tract covering the same anchor, the short one wins and the longer
+//! one is never considered — the search is a fallback rather than a
+//! maximization.
+//!
+//! That makes normalization non-idempotent: pass 1 emits a window covering only
+//! the short tract, which pass 2 reads as an explicit *range*, discovers the
+//! real (longer) tract around it, and absorbs the extra reference copies into
+//! the count. Window and count both grow.
+//!
+//! Found by the projector-path idempotency oracle on a real spec input,
+//! `NM_004006.3:r.-124ug[14]`, whose reference reads `…ACTGAAGTGTTACTTT…`:
+//! literal `TG` matches 1 copy at one offset while `GT` matches 2 copies
+//! spanning the same anchor.
+//!
+//! ```text
+//! r.-124ug[14]      -> r.-125_-124gu[14]    (1-copy TG tract)
+//! r.-125_-124gu[14] -> r.-127_-124gu[15]    (2-copy GT tract + absorption)
+//! ```
+//!
+//! The core below reproduces that shape on the genomic axis: `GTGT` at
+//! g.259..262 is 2 copies of `GT`, and the anchor g.262 is the tract's last
+//! base, where literal `TG` tiles only 1 copy.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// `AA` + `GTGT` (g.259..262) + `TA` — the `GT` tract is 2 copies, cleanly
+/// bounded (`A` before, `T` after breaks the `GT` phase on both sides).
+const CORE: &str = "AAGTGTTA";
+
+fn norm(input: &str, dir: ShuffleDirection) -> String {
+    Normalizer::with_config(
+        SyntheticBuilder::genomic(CORE).build(),
+        NormalizeConfig::default().with_direction(dir),
+    )
+    .normalize(&parse_hgvs(input).expect("parse"))
+    .expect("normalize")
+    .to_string()
+}
+
+/// The one canonical form every spelling and direction must reach.
+///
+/// The maximal tract is the 2-copy `GT` at g.259..262. Neither direction can
+/// slide it — the flanking `A` (g.258) and `T` (g.263) break the `GT` phase on
+/// both sides — so the window is identical under 3' and 5', and the count is the
+/// requested 6. Asserting this value, and not merely that the spellings agree,
+/// is what distinguishes "both found the maximal tract" from "both found the
+/// same NON-maximal tract" (the pre-fix 1-copy `TG` window would satisfy a bare
+/// equality check).
+const CANONICAL: &str = "NC_TEST.1:g.259_262GT[6]";
+
+/// An expansion spelled on a single anchor whose literal unit tiles the shorter
+/// phase must still be a fixed point — and must land on the maximal tract.
+#[test]
+fn single_anchor_repeat_expansion_is_idempotent_three_prime() {
+    let once = norm("NC_TEST.1:g.262TG[6]", ShuffleDirection::ThreePrime);
+    assert_eq!(once, CANONICAL, "must maximize to the 2-copy GT tract");
+    let twice = norm(&once, ShuffleDirection::ThreePrime);
+    assert_eq!(
+        once, twice,
+        "NOT IDEMPOTENT\n  once ={once}\n  twice={twice}"
+    );
+}
+
+#[test]
+fn single_anchor_repeat_expansion_is_idempotent_five_prime() {
+    let once = norm("NC_TEST.1:g.262TG[6]", ShuffleDirection::FivePrime);
+    assert_eq!(
+        once, CANONICAL,
+        "the tract cannot slide 5' (g.258 is `A`), so 5' matches 3'"
+    );
+    let twice = norm(&once, ShuffleDirection::FivePrime);
+    assert_eq!(
+        once, twice,
+        "NOT IDEMPOTENT\n  once ={once}\n  twice={twice}"
+    );
+}
+
+/// The anchored and range spellings of the same tract must agree, which is the
+/// property whose violation produced the drift: the single anchor found 1 copy
+/// where the explicit range found 2.
+#[test]
+fn anchored_and_range_spellings_agree_on_the_maximal_tract() {
+    let anchored = norm("NC_TEST.1:g.262TG[6]", ShuffleDirection::ThreePrime);
+    let ranged = norm("NC_TEST.1:g.259_262GT[6]", ShuffleDirection::ThreePrime);
+    assert_eq!(anchored, CANONICAL, "anchored spelling");
+    assert_eq!(ranged, CANONICAL, "ranged spelling");
+    assert_eq!(
+        anchored, ranged,
+        "a single anchor and an explicit range over the same tract must \
+         normalize identically\n  anchored={anchored}\n  ranged  ={ranged}"
+    );
+}


### PR DESCRIPTION
## Summary

`normalize_repeat` ran its rotation/offset tract search **only when the literal unit lookup returned `None`** — a *fallback* rather than a *maximization*. But a literal match that succeeds can still be the **shorter** phase, and taking it unconditionally made normalization non-idempotent.

## The defect

Reference `…ACTGAAGTGTTACTTT…`, anchored at the tract's last base:

| candidate | tiles |
|---|---|
| literal `TG` | **1** copy |
| `GT` rotation (same anchor) | **2** copies |

The literal hit won, so the search that would have found the 2-copy tract never ran. Pass 1 emitted a window covering only the 1-copy tract; pass 2 read that window as an explicit **range**, re-discovered the real 2-copy tract around it, and the flank-absorption branch folded the extra reference copy into the count — so window *and* count both grew:

```
NM_004006.3:r.-124ug[14]  ->  r.-125_-124gu[14]  ->  r.-127_-124gu[15]
```

## Fix

Seed `best` with the literal result and let a strictly longer *spanning* rotation displace it. Ties keep the literal, so the only behavior change is preferring a genuinely larger tract. An explicit range, or a 1-base unit, still takes the literal lookup untouched.

## How it was found

By the projector-path idempotency oracle (#1174), on a real spec-enumeration input. **The failure was invisible while the oracle only wrapped `normalize()`** — this input reaches normalization through `VariantProjector`. That PR is stacked on this one and goes green once this lands.

Worth noting for the record: my first hypothesis was that this was an `r.`-axis / negative-5'UTR-coordinate mapping bug. It is not — the coordinate axis is incidental. Instrumenting the tract discovery showed a plain phase-selection defect that reproduces on the genomic axis with no UTR or projection involved.

## Tests

Reproduced synthetically before fixing (verified RED → GREEN):

- `AAGTGTTA` with `g.262TG[6]` — the same 1-copy-literal / 2-copy-rotation shape — asserted idempotent in **both** directions.
- An anchored-vs-range agreement test, since *the two spellings disagreeing about the tract* is the underlying defect, not just the drift it produced.

## Verification

- Full suite green (8526).
- The previously-failing `enumeration_replays_recorded_behavior` passes under `FERRO_ASSERT_IDEMPOTENT=1` with #1174's oracle commit applied — confirmed directly by temporarily cherry-picking it onto this branch.
- `clippy --all-targets -D warnings` clean; `cargo fmt` applied.
- The #852/#866 rotation-and-phase tests that share this path all still pass.
