### PR TITLE
fix(project): read r.-axis inputs as CDS-relative, not transcript-relative

### DIFF
--- a/src/project/projector.rs
+++ b/src/project/projector.rs
@@ -2426,7 +2426,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         p: crate::hgvs::location::CdsPos,
         is_coding: bool,
         is_cds_input: bool,
-        input_is_transcript_coord: bool,
+        input_base_is_tx_relative: bool,
         build_hint: Option<&'static str>,
     ) -> Result<u64, FerroError> {
         use crate::hgvs::location::CdsPos;
@@ -2447,7 +2447,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             // position — feeding it to `cds_pos_from_tx_pos` would renumber it as a
             // transcript base. Leave such positions untouched so the downstream
             // CDS-aware mapping interprets the `*N` directly.
-            if !(input_is_transcript_coord && is_coding) || p.utr3 {
+            if !(input_base_is_tx_relative && is_coding) || p.utr3 {
                 return Ok(p);
             }
             if p.base < 1 {
@@ -2628,12 +2628,21 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         //    route through `data::mapping::CoordinateMapper::cds_to_genome`
         //    (which also handles intronic offsets and the `utr3` flag); the
         //    non-coding path uses `CdotTranscript::tx_to_genome` directly.
-        // `input_is_transcript_coord` distinguishes `n.`/`r.` inputs (whose
-        // `base` is a 1-based *transcript* position) from `c.` inputs (CDS
-        // coordinates). For a coding transcript an `n.`/`r.` base must be
-        // converted to a CDS coordinate before the CDS-aware genome mapping runs
-        // (#693) — without it, `n.204` is mapped as if it were `c.204`.
-        let (accession, gene_symbol, edit_mu, start_cds, end_cds, input_is_transcript_coord) =
+        // `input_base_is_tx_relative` marks the inputs whose `base` is a 1-based
+        // *transcript* position, which must be converted to a CDS coordinate
+        // before the CDS-aware genome mapping runs (#693) — without it, `n.204`
+        // is mapped as if it were `c.204`.
+        //
+        // That is `n.` only. A `c.` input is already CDS-relative, and so is an
+        // `r.` input: on a coding transcript the `r.` axis IS the `c.` axis
+        // (`r.N` describes the same base as `c.N`; HGVS
+        // `background/numbering.md` L58/L61, pinned by #469). Marking `r.` as
+        // tx-relative applied the CDS offset to a coordinate that never carried
+        // it, silently landing the genomic result `cds_start` bases away — which
+        // on a transcript with large introns is hundreds of kb (#1177). On a
+        // non-coding transcript `r.` and `n.` do coincide, but `to_cds_frame`
+        // self-gates on `is_coding`, so no conversion runs there either way.
+        let (accession, gene_symbol, edit_mu, start_cds, end_cds, input_base_is_tx_relative) =
             match variant {
                 HgvsVariant::Cds(v) => {
                     let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "c.", "start")?;
@@ -2668,7 +2677,10 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                 HgvsVariant::Rna(v) => {
                     let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "r.", "start")?;
                     let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "r.", "end")?;
-                    // RnaPos shape mirrors CdsPos exactly.
+                    // RnaPos mirrors CdsPos in both shape AND numbering: on a
+                    // coding transcript `r.` is the `c.` axis, so this reshape is
+                    // the whole conversion and the position must NOT be rebased
+                    // again (`false` below, #1177).
                     let to_cds = |p: crate::hgvs::location::RnaPos| CdsPos {
                         base: p.base,
                         offset: p.offset,
@@ -2681,7 +2693,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
                         v.loc_edit.edit.clone(),
                         to_cds(s),
                         to_cds(e),
-                        true,
+                        false,
                     )
                 }
                 _ => unreachable!("variant kind already filtered above"),
@@ -2805,7 +2817,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             start_cds,
             is_coding,
             is_cds_input,
-            input_is_transcript_coord,
+            input_base_is_tx_relative,
             build_hint,
         )?;
         let end_g = self.map_cnr_position_to_genome(
@@ -2814,7 +2826,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
             end_cds,
             is_coding,
             is_cds_input,
-            input_is_transcript_coord,
+            input_base_is_tx_relative,
             build_hint,
         )?;
 
@@ -4187,51 +4199,56 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
     ) -> Result<VariantProjection, FerroError> {
         use crate::reference::Strand as RefStrand;
 
-        // Pull the common pieces (accession, gene_symbol, edit, raw start/end
-        // as a transcript TxPos) out of the n. / r. input. RNA positions share
-        // the same `base`/`offset`/`utr3` shape as transcript positions, so we
-        // normalize both to `TxPos`. RNA edits carry `Base::U`; the protein
+        // Pull the common pieces (accession, gene_symbol, edit, raw start/end)
+        // out of the n. / r. input. `RnaPos` and `TxPos` share a
+        // `base`/`offset`/`utr3`↔`downstream` *shape*, so both reshape into
+        // `TxPos` — but they do NOT share an *origin*, so for an `r.` input the
+        // reshaped value is still CDS-relative and gets rebased below
+        // (`input_is_rna`, #1177). RNA edits carry `Base::U`; the protein
         // machinery reads the transcript's DNA CDS, so we translate U→T below.
-        let (accession, gene_symbol, edit_mu, axis_label, start_tx, end_tx) = match normalized {
-            HgvsVariant::Tx(v) => {
-                let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "n.", "start")?;
-                let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "n.", "end")?;
-                (
-                    v.accession.clone(),
-                    v.gene_symbol.clone(),
-                    v.loc_edit.edit.clone(),
-                    "n.",
-                    s,
-                    e,
-                )
-            }
-            HgvsVariant::Rna(v) => {
-                let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "r.", "start")?;
-                let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "r.", "end")?;
-                // RnaPos shape mirrors TxPos: base / offset / utr3↔downstream.
-                let to_tx = |p: crate::hgvs::location::RnaPos| TxPos {
-                    base: p.base,
-                    offset: p.offset,
-                    downstream: p.utr3,
-                };
-                (
-                    v.accession.clone(),
-                    v.gene_symbol.clone(),
-                    v.loc_edit.edit.clone(),
-                    "r.",
-                    to_tx(s),
-                    to_tx(e),
-                )
-            }
-            _ => {
-                return Err(FerroError::UnsupportedProjection {
-                    reason: format!(
-                        "project_noncoding_direct only accepts n./r. inputs, got {}",
-                        normalized.variant_type()
-                    ),
-                })
-            }
-        };
+        let (accession, gene_symbol, edit_mu, axis_label, raw_start, raw_end, input_is_rna) =
+            match normalized {
+                HgvsVariant::Tx(v) => {
+                    let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "n.", "start")?;
+                    let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "n.", "end")?;
+                    (
+                        v.accession.clone(),
+                        v.gene_symbol.clone(),
+                        v.loc_edit.edit.clone(),
+                        "n.",
+                        s,
+                        e,
+                        false,
+                    )
+                }
+                HgvsVariant::Rna(v) => {
+                    let s = resolve_uncertain_boundary(&v.loc_edit.location.start, "r.", "start")?;
+                    let e = resolve_uncertain_boundary(&v.loc_edit.location.end, "r.", "end")?;
+                    // Shape-only reshape; the numbering is still CDS-relative.
+                    let to_tx = |p: crate::hgvs::location::RnaPos| TxPos {
+                        base: p.base,
+                        offset: p.offset,
+                        downstream: p.utr3,
+                    };
+                    (
+                        v.accession.clone(),
+                        v.gene_symbol.clone(),
+                        v.loc_edit.edit.clone(),
+                        "r.",
+                        to_tx(s),
+                        to_tx(e),
+                        true,
+                    )
+                }
+                _ => {
+                    return Err(FerroError::UnsupportedProjection {
+                        reason: format!(
+                            "project_noncoding_direct only accepts n./r. inputs, got {}",
+                            normalized.variant_type()
+                        ),
+                    })
+                }
+            };
 
         // Mirror the genome path's transcript_id-mismatch guard: an n./r. input
         // must be projected against its own transcript.
@@ -4251,7 +4268,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // it up front to match the coding-path contract. (Transcript positions
         // cannot carry chromosome-arm markers — only `CdsPos` has a `special`
         // field — so there is no pter/qter/cen case to handle here.)
-        if start_tx.base == 0 || end_tx.base == 0 {
+        if raw_start.base == 0 || raw_end.base == 0 {
             return Err(FerroError::UnsupportedProjection {
                 reason: format!(
                     "cannot resolve `?` position sentinel on direct {axis_label}→p. projection"
@@ -4268,7 +4285,7 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // `downstream` into `CdsPos.utr3` (which `cds_to_genome` honors), but the
         // direct path has no exon-aware 3'UTR translation, so reject these up
         // front rather than mis-project them.
-        if start_tx.downstream || end_tx.downstream {
+        if raw_start.downstream || raw_end.downstream {
             return Err(FerroError::UnsupportedProjection {
                 reason: format!(
                     "cannot project 3'-downstream (`*N`) positions on direct {axis_label}→p. \
@@ -4309,6 +4326,39 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // one, else the metadata gene symbol; mirrors the coding path.
         let gene_symbol = gene_symbol.or(gene_symbol_meta);
 
+        // #1177: rebase an `r.` input onto the transcript axis. On a CODING
+        // transcript `r.` is CDS-relative — the same axis as `c.`, so `r.N`
+        // describes the same base as `c.N` (HGVS `background/numbering.md`
+        // L58/L61, pinned by #469) — whereas everything below this point works in
+        // 1-based transcript coordinates. Reshaping `RnaPos` into `TxPos` above
+        // matched the struct but not the origin, so without this step the CDS
+        // offset was applied to a coordinate that never carried it: every `r.`
+        // input came out shifted by `cds_start`, silently, on the c./n./r. axes
+        // and on the derived protein gate.
+        //
+        // On a NON-CODING transcript there is no CDS for `r.` to be relative to,
+        // so the two axes genuinely coincide and the reshape alone is already
+        // correct — hence the `is_coding` gate (and `cds_to_tx` would error
+        // there anyway, having no CDS bounds to work from).
+        let (start_tx, end_tx) = if input_is_rna && is_coding {
+            let mapper = crate::convert::mapper::CoordinateMapper::new(&tx);
+            // Re-label rather than convert: these values are already CDS-relative,
+            // and `cds_to_tx` is the exon-aware inverse of the `tx_to_cds` applied
+            // below. `utr3` is known false — the `*N` guard above rejected it.
+            let to_cds = |p: TxPos| CdsPos {
+                base: p.base,
+                offset: p.offset,
+                utr3: p.downstream,
+                special: None,
+            };
+            (
+                mapper.cds_to_tx(&to_cds(raw_start))?,
+                mapper.cds_to_tx(&to_cds(raw_end))?,
+            )
+        } else {
+            (raw_start, raw_end)
+        };
+
         let edit = edit_mu
             .inner()
             .cloned()
@@ -4326,12 +4376,12 @@ impl<P: ReferenceProvider + Clone> VariantProjector<P> {
         // For an `n.` input that IS the input; for an `r.` input the input is an
         // RNA description (`r.` prefix, lowercase RNA alphabet with `u`), and
         // returning it verbatim reports the wrong coordinate system on the `n.`
-        // axis. Numbering is shared between the two — `RnaPos` and `TxPos` have
-        // the same base/offset/downstream shape, which is exactly how
-        // `start_tx`/`end_tx` were derived above — so re-expressing an `r.` input
-        // as `n.` is a prefix + alphabet change only (`c_edit`'s U→T mapping).
-        // The edit's certainty is carried through so a predicted `r.(11u>g)`
-        // stays predicted on the `n.` axis.
+        // axis. Re-expressing it is a prefix + alphabet change (`c_edit`'s U→T
+        // mapping) **plus** a change of origin on a coding transcript, where `r.`
+        // is CDS-relative and `n.` is transcript-relative; `start_tx`/`end_tx`
+        // above already carry that rebase (#1177), so use them rather than the
+        // input's own positions. The edit's certainty is carried through so a
+        // predicted `r.(11u>g)` stays predicted on the `n.` axis.
         let noncoding_axis = match normalized {
             HgvsVariant::Rna(_) => HgvsVariant::Tx(TxVariant {
                 accession: accession.clone(),

--- a/tests/it/issue_1086_cross_axis_projection.rs
+++ b/tests/it/issue_1086_cross_axis_projection.rs
@@ -230,6 +230,17 @@ fn exonic_edit_still_projects_to_rna_axis() {
 /// `LRG_199t1:r.11u>g` (the spec's own example, `background/refseq.md`) must
 /// yield a real `n.` description on the non-coding axis. Before the fix the
 /// field held the `r.` input verbatim.
+///
+/// **Coordinates re-blessed by #1177.** This test previously expected
+/// `n.11T>G` / `c.-234T>G`, which pinned a defect: `LRG_199t1` is *coding*
+/// (`NM_004006.2`, `cds_start = 245`), and on a coding transcript the `r.` axis
+/// is CDS-relative, so `r.11` describes the same base as `c.11` — not `n.11`
+/// (`background/numbering.md`: "nucleotide `r.123` relates to `c.123` or
+/// `n.123`", and "in a coding RNA reference sequence, nucleotide numbering …
+/// follow[s] that of a coding DNA reference sequence"). #1086 correctly fixed
+/// the *shape* of this field (it had held the `r.` input verbatim) but carried
+/// the input's number across unchanged, so the value stayed off by `cds_start`.
+/// The spec-correct pair is `n.255T>G` (`245 + 11 - 1`) and `c.11T>G`.
 #[test]
 fn rna_input_noncoding_axis_is_an_n_description() {
     let Some(vp) = manifest_projector() else {
@@ -242,11 +253,11 @@ fn rna_input_noncoding_axis_is_an_n_description() {
         matches!(noncoding, ferro_hgvs::HgvsVariant::Tx(_)),
         "noncoding axis must hold an n. (Tx) variant, got {noncoding}",
     );
-    assert_eq!(noncoding.to_string(), "LRG_199t1:n.11T>G");
-    // The c. axis already handled this input and must stay correct.
+    assert_eq!(noncoding.to_string(), "LRG_199t1:n.255T>G");
+    // The c. axis must agree with the r. input it was derived from: r.11 is c.11.
     assert_eq!(
         proj.coding.expect("coding axis").to_string(),
-        "LRG_199t1:c.-234T>G",
+        "LRG_199t1:c.11T>G",
     );
 }
 

--- a/tests/it/issue_1177_rna_axis_cds_relative.rs
+++ b/tests/it/issue_1177_rna_axis_cds_relative.rs
@@ -1,0 +1,221 @@
+//! Issue #1177 — an `r.` input's position must be read as **CDS-relative**.
+//!
+//! On a coding transcript the `r.` axis is CDS-relative — the same axis as
+//! `c.`, so `r.N` describes the same base as `c.N` (HGVS
+//! `background/numbering.md` L58/L61; pinned for the normalizer by #469 and
+//! `issue_291_rna_axis_convention.rs`). `VariantProjection::rna` already
+//! documents its own output that way ("CDS-relative numbering (matches `c.`)").
+//!
+//! The projector's *input* handling disagreed: it copied `RnaPos.base` straight
+//! into a transcript-relative position, on the premise that the two share a
+//! `base`/`offset`/`utr3` struct shape. They share a shape but not an *origin*,
+//! so every `r.` input on a coding transcript was silently mis-projected by
+//! `cds_start` — no error, no warning. On the genomic axis of a real transcript
+//! with large introns that put the result hundreds of kb from the truth.
+//!
+//! The invariant these tests pin is **cross-axis agreement**: three spellings of
+//! the same physical base — `c.N`, `n.(cds_start + N - 1)` and `r.N` — must
+//! project to identical results on every axis. That invariant was entirely
+//! absent, which is why the defect survived; it is not expressible as a
+//! single-axis expectation, and the `FERRO_ASSERT_IDEMPOTENT` oracle cannot see
+//! it either (it checks `norm(norm(x)) == norm(x)`, not cross-axis agreement).
+
+use ferro_hgvs::data::cdot::CdotMapper;
+use ferro_hgvs::data::projection::Projector;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand as TxStrand, Transcript};
+use ferro_hgvs::{parse_hgvs, VariantProjection, VariantProjector};
+
+/// 5'UTR length, and therefore the 1-based transcript position of `c.1`.
+///
+/// Deliberately non-trivial: with `cds_start = 1` the CDS-relative and
+/// transcript-relative axes coincide and the bug is invisible.
+const CDS_START: i64 = 21;
+
+/// 20-base 5'UTR, then a 30-base CDS (`ATG` + 8 codons + `TAA`), then a 10-base
+/// 3'UTR — 60 bases total.
+///
+/// | tx    | region | notes                          |
+/// |-------|--------|--------------------------------|
+/// | 1..20 | 5'UTR  | `tx 11` = `G` = `c.-10` = `r.-10` |
+/// | 21..50| CDS    | `tx 21` = `A` of `ATG` = `c.1`; `tx 25` = `G` = `c.5` = `r.5` |
+/// | 51..60| 3'UTR  |                                |
+const TX_SEQUENCE: &str = concat!(
+    "CTGACTGACTGACTGACTGA",     // 1..20   5'UTR
+    "ATG",                      // 21..23  c.1..c.3
+    "CGCGCGCGCGCGCGCGCGCGCGCG", // 24..47  c.4..c.27
+    "TAA",                      // 48..50  c.28..c.30 (stop)
+    "GTCAGTCAGT",               // 51..60  3'UTR
+);
+
+fn projector() -> VariantProjector<MockProvider> {
+    let mut provider = MockProvider::new();
+    let tx = Transcript::new(
+        "NM_TEST.1".to_string(),
+        Some("MYGENE".to_string()),
+        TxStrand::Plus,
+        TX_SEQUENCE.to_string(),
+        Some(CDS_START as u64),
+        Some(50),
+        vec![Exon::with_genomic(1, 1, 60, 1000, 1059)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1059),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    )
+    .with_protein_id(Some("NP_TEST.1".to_string()));
+    provider.add_transcript(tx);
+    let prefix = "N".repeat(999);
+    let suffix = "N".repeat(100);
+    provider.add_genomic_sequence("chr1", format!("{prefix}{TX_SEQUENCE}{suffix}"));
+    let cdot = CdotMapper::from_transcripts(provider.all_transcripts());
+    VariantProjector::new(Projector::new(cdot), provider)
+}
+
+/// Every axis of a projection, rendered for comparison.
+fn axes(p: &VariantProjection) -> Vec<(&'static str, Option<String>)> {
+    vec![
+        ("g", p.genomic.as_ref().map(ToString::to_string)),
+        ("c", p.coding.as_ref().map(ToString::to_string)),
+        ("n", p.noncoding.as_ref().map(ToString::to_string)),
+        ("r", p.rna.as_ref().map(ToString::to_string)),
+        ("p", p.protein.as_ref().map(ToString::to_string)),
+    ]
+}
+
+fn project(input: &str) -> VariantProjection {
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    projector()
+        .project_variant(&variant, "NM_TEST.1")
+        .unwrap_or_else(|e| panic!("project {input} must not error: {e}"))
+}
+
+/// Assert that three spellings of one base agree on every axis.
+///
+/// `c.` is the reference spelling: it is the axis the projector has always read
+/// correctly, so a disagreement localises the fault to the other input.
+fn assert_axes_agree(coding: &str, noncoding: &str, rna: &str) {
+    let expected = axes(&project(coding));
+    for other in [noncoding, rna] {
+        assert_eq!(
+            axes(&project(other)),
+            expected,
+            "`{other}` and `{coding}` describe the same base, so every projected axis must \
+             match; a mismatch means the input's coordinate axis was misread",
+        );
+    }
+}
+
+/// A positive, in-CDS `r.` coordinate. `r.5` is `c.5` is `n.25`
+/// (`CDS_START + 5 - 1`).
+///
+/// Pre-fix this reported `c.-16` for the `r.` input (`5 - 21`), i.e. an
+/// ordinary in-CDS RNA description was relocated into the 5'UTR.
+#[test]
+fn in_cds_r_position_agrees_with_c_and_n() {
+    assert_axes_agree("NM_TEST.1:c.5G>A", "NM_TEST.1:n.25G>A", "NM_TEST.1:r.5g>a");
+}
+
+/// A negative 5'UTR `r.` coordinate. `r.-10` is `c.-10` is `n.11`
+/// (`CDS_START - 10`) — note HGVS `c.`/`r.` numbering has no zero, so the
+/// mapping is `cds_start + N` for negative `N`, not `cds_start + N - 1`.
+#[test]
+fn five_prime_utr_r_position_agrees_with_c_and_n() {
+    assert_axes_agree(
+        "NM_TEST.1:c.-10G>A",
+        "NM_TEST.1:n.11G>A",
+        "NM_TEST.1:r.-10g>a",
+    );
+}
+
+/// The same invariant on the **genomic** axis, which a bare `NM_` input cannot
+/// reach (no genome alignment, so `genomic` is `None`). Supplying an explicit
+/// genomic context routes the projection through the genome pivot
+/// (`map_cnr_position_to_genome`) — a second, independent place where the input
+/// axis is interpreted.
+///
+/// This matters most in practice: on a real transcript with large introns a
+/// `cds_start`-sized error in transcript space lands the genomic coordinate
+/// hundreds of kb away from the truth.
+#[test]
+fn genomic_axis_of_r_position_agrees_with_c_and_n() {
+    assert_axes_agree(
+        "chr1(NM_TEST.1):c.5G>A",
+        "chr1(NM_TEST.1):n.25G>A",
+        "chr1(NM_TEST.1):r.5g>a",
+    );
+}
+
+/// The `r.` axis of an `r.` input must be a fixed point: re-projecting an
+/// already-`r.` description must not move it.
+///
+/// This is the property whose failure originally exposed the bug — re-feeding
+/// the `r.` output walked by exactly `-cds_start` per pass, forever.
+#[test]
+fn r_axis_projection_is_a_fixed_point() {
+    let first = project("NM_TEST.1:r.5g>a")
+        .rna
+        .expect("an r. input must have an r. axis")
+        .to_string();
+    // Pin the position, not just the stability. A fixed-point assertion alone is
+    // satisfied by any bug that shifts once and then stays put, which is exactly
+    // the shape of a constant `cds_start` offset applied at a single conversion
+    // site. The position must come back as `5` — the r. axis of an r. input is
+    // the same base — while the `( )` is expected: the r. axis is *predicted*
+    // from the c. form (`predict_rna`), and HGVS parenthesises a predicted RNA
+    // consequence.
+    assert_eq!(
+        first, "NM_TEST.1:r.(5g>a)",
+        "the r. axis of an r. input must reproduce the input's position, as a predicted form",
+    );
+    let second = project(&first)
+        .rna
+        .expect("an r. input must have an r. axis")
+        .to_string();
+    assert_eq!(
+        second, first,
+        "projecting an r. description onto the r. axis must be idempotent; drift means the \
+         input's coordinate axis is re-interpreted on each pass",
+    );
+}
+
+/// Guardrail: on a **non-coding** transcript `r.` and `n.` genuinely are the
+/// same axis (there is no CDS to be relative to), so the verbatim copy is
+/// correct there and must stay untouched by the fix.
+#[test]
+fn noncoding_transcript_r_position_is_transcript_relative() {
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NR_TEST.1".to_string(),
+        Some("MYGENE".to_string()),
+        TxStrand::Plus,
+        TX_SEQUENCE.to_string(),
+        None,
+        None,
+        vec![Exon::with_genomic(1, 1, 60, 1000, 1059)],
+        Some("chr1".to_string()),
+        Some(1000),
+        Some(1059),
+        Default::default(),
+        ManeStatus::default(),
+        None,
+        None,
+    ));
+    let prefix = "N".repeat(999);
+    provider.add_genomic_sequence("chr1", format!("{prefix}{TX_SEQUENCE}{}", "N".repeat(100)));
+    let cdot = CdotMapper::from_transcripts(provider.all_transcripts());
+    let vp = VariantProjector::new(Projector::new(cdot), provider);
+
+    let rna = parse_hgvs("NR_TEST.1:r.25g>a").expect("parse");
+    let tx = parse_hgvs("NR_TEST.1:n.25G>A").expect("parse");
+    let from_rna = vp.project_variant(&rna, "NR_TEST.1").expect("project r.");
+    let from_tx = vp.project_variant(&tx, "NR_TEST.1").expect("project n.");
+    assert_eq!(
+        axes(&from_rna),
+        axes(&from_tx),
+        "with no CDS, r.25 and n.25 are the same position and must project identically",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -130,6 +130,7 @@ mod issue_1157_delins_reduction_shift;
 mod issue_1157_five_prime_insertion_rotation;
 mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
+mod issue_1177_rna_axis_cds_relative;
 mod issue_1183_rna_axis_ins_expansion;
 mod issue_1192_rna_codon_frame_gate;
 mod issue_129_mt_circular_wraparound;


### PR DESCRIPTION
Closes #1177

## What was wrong

On a coding transcript the `r.` axis is **CDS-relative** — the same axis as `c.`, so `r.N` describes the same base as `c.N` (HGVS `background/numbering.md` L58/L61, pinned by #469 and `tests/it/issue_291_rna_axis_convention.rs`). Two projector sites read an `r.` **input** as *transcript*-relative, applying the CDS-start offset to a coordinate that never carried it.

Every `r.` input on a coding transcript came out shifted by `cds_start` — **silently**: no error, no warning, plausible-looking output.

```
ferro project 'NM_004006.3:r.100u>c' --axis c   ->  c.-138T>C     WRONG (100 - 238); should be c.100T>C
ferro project 'NM_004006.3:c.100T>C' --axis c   ->  c.100T>C      ok
ferro project 'NM_004006.3:n.337T>C' --axis c   ->  c.100T>C      ok   (tx 337 is the same base)
ferro project 'NM_004006.3:c.100T>C' --axis r   ->  r.(100u>c)    ok   <-- the writer already said r.100 == c.100
```

An ordinary in-CDS RNA description was relocated into the 5'UTR. On the genomic axis it is far worse, because a 237-base error in transcript space crosses DMD's large introns:

```
NC_000023.11(NM_004006.3):r.100u>c  --axis g  ->  g.33211450A>G   WRONG   (== genomic_end - 99, the naive tx reading)
NC_000023.11(NM_004006.3):c.100T>C  --axis g  ->  g.32849814A>G   ok
NC_000023.11(NM_004006.3):n.337T>C  --axis g  ->  g.32849814A>G   ok
```

~361 kb apart. So ferro's `r.` *writer* was spec-correct and its `r.` *reader* was not — the two disagreed about the axis origin. This affected the shipped `ferro project` CLI, the Python binding, and `conformance::spec_projection::project_all_axes`.

It is not UTR-specific and not sign-specific: the shift is always exactly `cds_start`, confirmed on a second transcript (`NM_004006.2`, `cds_start = 245`, gives `r.-124u>c -> c.-369T>G`).

## The fix

Both sites are in `src/project/projector.rs`:

1. **`project_noncoding_direct`** — the `RnaPos → TxPos` reshape is kept (it *is* shape-only), but an `r.` input is now **rebased** onto the transcript axis via the exon-aware `CoordinateMapper::cds_to_tx`, gated on `is_coding`. The `?`-sentinel and `*N` guards now read the pre-rebase values, which is correct: both test axis-agnostic properties (`base == 0`, the `downstream` flag).
2. **`map_cnr_position_to_genome`** — an `Rna` input no longer claims a tx-relative base, so `to_cds_frame` stops applying a second CDS conversion. The flag is renamed `input_is_transcript_coord` → **`input_base_is_tx_relative`**, which names the actual invariant: only `n.` has a tx-relative `base`.

The two false-premise comments are corrected. They asserted that because `RnaPos` and `TxPos` share a `base`/`offset`/`utr3` struct *shape*, re-expressing one as the other is "a prefix + alphabet change only" — sharing a shape is not sharing an **origin**.

**Non-coding transcripts are unaffected.** With no CDS the two axes genuinely coincide, so the reshape alone is already correct there, and `to_cds_frame` self-gates on `is_coding`.

## Tests

`tests/it/issue_1177_rna_axis_cds_relative.rs` pins the invariant that was **missing entirely**, which is why this survived: `c.N`, `n.(cds_start + N - 1)` and `r.N` must project **identically on every axis**. Covered: an in-CDS coordinate, a 5'UTR coordinate, the genome-pivot path (site 2), an `r.`-axis fixed-point check, and a non-coding guardrail.

Two things worth noting for review:

- It is **hermetic**, so it runs in normal PR CI. The closest existing test (#1086) is manifest-gated and skips in PR CI, which is part of why the defect went unnoticed.
- The **non-coding guardrail passes pre-fix**. That is what demonstrates the fix is correctly scoped to coding transcripts rather than blanket-shifting every `r.` input.

Neither the `FERRO_ASSERT_IDEMPOTENT` oracle (it checks `norm(norm(x)) == norm(x)`, not cross-axis agreement) nor the idempotency proptest (its coordinate-system strategy cannot generate `n.`/`r.` at all) can see this class of bug.

## Re-blessed expectation — please review this specifically

`issue_1086_cross_axis_projection::rna_input_noncoding_axis_is_an_n_description` expected `n.11T>G` / `c.-234T>G` for `LRG_199t1:r.11u>g`. **Those numbers pinned this defect.** `LRG_199t1` is coding (`NM_004006.2`, `cds_start = 245`), so `r.11` is `c.11`, and the spec-correct pair is `n.255T>G` (`245 + 11 - 1`) and `c.11T>G`.

#1086 correctly fixed that field's *shape* — it had held the `r.` input verbatim — but carried the input's number across unchanged, so the value stayed off by `cds_start`. Spec basis (`background/numbering.md`):

> nucleotide numbering for an RNA reference sequence follows that of the associated coding or non-coding DNA reference sequence; nucleotide `r.123` relates to `c.123` or `n.123`
> in a **coding** RNA reference sequence, nucleotide numbering is based on the annotated protein isoform … following that of a coding DNA reference sequence

## Generated-fixture delta, measured in isolation

Diffing the enumeration against `main`'s copy is misleading: it is generated from `hgvs_spec_normalization.json`, which is *also* gitignored, so a cross-worktree comparison diffs two independently-generated fixtures (that showed a phantom "9 rows removed"). Toggling only the `src/` change in one worktree and regenerating both fixtures each time gives the true delta:

- `hgvs_spec_normalization.json` — **byte-identical**. This does not touch normalization.
- `hgvs_spec_enumeration.json` — 2189 rows before and after, **0 added, 0 removed, 399 changed**, and **every changed row has an `r.` input** (zero collateral on `c.`/`n.`/`g.`/`p.` inputs).

Status transitions: 362 value corrections, **34 `projection-unavailable-pinned` → `projection-pinned`** (axes the wrong coordinate had suppressed — e.g. a protein consequence lost because the mis-shifted coordinate landed in the UTR), and 3 the other way. All 3 of those verified against the real prepared reference:

- `NC_000023.11(NM_004006.2):r.778_831del` (p. and r. axes) — the corrected coordinate normalizes 3' to `c.780_831+2del`, i.e. into the intron, and the `r.` axis declines intronic positions (#1086 D5). The `c.` spelling of the same variant now behaves **identically** — which is precisely the invariant. The old "available" answers were computed from the wrong, comfortably-exonic coordinate.
- `NM_004006.3:r.124_500delins[AB053210.2:r.1289-365_1289-73inv]` (p. axis) — the old `p.(Met1?)` was start-loss, reachable only because the mis-shifted range `c.-114_262` spanned the CDS start. `c.124` is well past `c.3`, so start-loss is simply wrong; declining is honest (the inserted sequence is an unresolvable external accession).

One row's spec example is a nice independent check: `project-c/LRG_199t1:r.186_187ins186+1_186+4` now renders `c.186_187ins186+1_186+4`, matching the spec's own string at `numbering.md` L63 (it was `c.-59_-58ins186+1_186+4`).

## Verification

- Full suite with the real manifest and `FERRO_ASSERT_IDEMPOTENT=1`: **8527 passed, 1 failed**.
- The one failure is `mutalyzer_normalize_tests::axis_errors`, which fails **identically on clean `main`** with the manifest set (same two rows, `NM_000143.3:c.45del4` / `c.45dup4`). It is the pre-existing failure that **#1173** fixes — verified on `main` at `be47233`, not a regression from this PR.
- `cargo clippy --features dev --all-targets -- -D warnings` clean; `cargo fmt --all` clean.

Also confirmed end-to-end: the non-converging round-trip that first exposed this now terminates.

```
r.-124ug[14] -> r.(-125_-124gu[14]) -> r.(-127_-124gu[15]) -> r.(-127_-124gu[15])   fixed point
```

The `-238`-per-pass walk is gone. The remaining two-step settle is exactly the *separate* tract-maximization defect that **#1176** fixes (its recorded signature is `once: r.-125_-124gu[14]`, `twice: r.-127_-124gu[15]`); expect convergence at pass 2 once #1176 lands. Independent bug, independent PR — no dependency between them, and this PR is based on `main`.
