### PR TITLE
test(normalize): fuzz the n./r. axes and inv/con edits for idempotency

### DIFF
--- a/tests/it/cds_utr3_crossing_shift_idempotency.rs
+++ b/tests/it/cds_utr3_crossing_shift_idempotency.rs
@@ -1,0 +1,288 @@
+//! Regression pins for `c.`-axis 3'-shifts that cross `cds_end` into the 3'UTR
+//! (`*N`) — a family that needed **two** normalization passes to settle and now
+//! settles in one.
+//!
+//! Found by the extended `normalize_idempotency_proptest` generator (the
+//! `n.`/`r.` axis + `inv`/`con` edit-kind extension). The `dup`/`delins`/`con`
+//! finding was filed as #1185 and fixed by PR #1189 (complete the shift in one
+//! pass) together with the #1192 codon-frame gate. Every case below is now
+//! idempotent on the first pass and is pinned here as a regression over a
+//! **hand-built** transcript, complementing the random synthetic fuzz that
+//! found them.
+//!
+//! The `ins` sibling — an insertion resting at `cds_end` that the #387 clamp
+//! rewrote instead of letting it shift on — was #1209, fixed by PR #1211. It is
+//! pinned in its own module, `issue_1209_cds_end_insertion_shift`, rather than
+//! duplicated here. With both fixed, the `c.`-with-3'UTR systems are fuzzed
+//! directly as `Sys::CdsUtr3Plus` / `Sys::CdsUtr3Minus` in
+//! `tests/it/normalize_idempotency_proptest.rs`, so this module is now a
+//! deterministic backstop rather than a stand-in for missing fuzz coverage.
+//!
+//! ## Why these cases were real bugs and not fixture artifacts
+//!
+//! [`rna_axis_shifts_across_cds_end_in_one_pass`] is the control. It runs the
+//! **same edit over the byte-identical transcript**, differing only in the axis
+//! it is spelled on (`r.` instead of `c.`). On a coding transcript `r.` *is*
+//! the CDS-relative axis — the same axis as `c.` (HGVS
+//! `background/numbering.md` L58/L61, issue #469, pinned by
+//! `issue_291_rna_axis_convention`) — so both spellings name the same bases and
+//! must shift identically. `r.` settled in one pass while `c.` did not, which
+//! localised the defect to the `c.` code path rather than to the reference
+//! bases or to 3'-shifting across `cds_end` in general. Both spellings now
+//! agree, and that agreement is what these tests assert.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+/// A plain coding transcript with a 5'UTR, a short CDS, and a 3'UTR — built by
+/// hand rather than via `SyntheticBuilder` so no property of the synthetic
+/// padding can be blamed for the outcome.
+///
+/// | tx range   | bases                                      | region        |
+/// |------------|--------------------------------------------|---------------|
+/// | 1..=40     | `C` * 40                                   | 5'UTR         |
+/// | 41..=49    | `GGAAAAAAC`                                | CDS c.1..c.9  |
+/// | 50..=89    | `AC` * 20                                  | 3'UTR `*1..`  |
+///
+/// The CDS *ends* with `AC` (`c.8_9`) and the 3'UTR *begins* with `AC`, so a
+/// deletion of that `AC` has an `AC` tandem to 3'-shift along — a shift that
+/// necessarily crosses `cds_end` and must be rendered with `*N` positions.
+fn transcript_with_utr3_ac_tandem(strand: Strand) -> MockProvider {
+    let provider = coding_transcript("GGAAAAAAC", &"AC".repeat(20), strand);
+    // c.8_9 is the `AC` at the end of the CDS, and the 3'UTR continues it.
+    assert_eq!(&"GGAAAAAAC"[7..9], "AC", "c.8_9 must be 'AC'");
+    provider
+}
+
+/// Same shape, but the 3'UTR is a period-4 `ACGT` tandem, so an `AC` repeat
+/// running out of the CDS *terminates* two bases into the UTR (`*3` is `G`)
+/// instead of continuing to the transcript end. That bounded-tract layout is
+/// what exposes the `dup` symptom.
+fn transcript_with_utr3_acgt_padding(strand: Strand) -> MockProvider {
+    coding_transcript("GAAAAAACAC", &"ACGT".repeat(10), strand)
+}
+
+/// Build a coding transcript as `C * 40` (5'UTR) ++ `cds` ++ `utr3`.
+fn coding_transcript(cds: &str, utr3: &str, strand: Strand) -> MockProvider {
+    const UTR5_LEN: usize = 40;
+    let sequence = format!("{}{cds}{utr3}", "C".repeat(UTR5_LEN));
+    let cds_start = (UTR5_LEN + 1) as u64;
+    let cds_end = (UTR5_LEN + cds.len()) as u64;
+    let tx_len = sequence.len() as u64;
+
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_UTR3.1".to_string(),
+        Some("UTR3_TEST".to_string()),
+        strand,
+        sequence,
+        Some(cds_start),
+        Some(cds_end),
+        vec![Exon::new(1, 1, tx_len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Normalize `input` twice and return `(once, twice)` as rendered strings.
+fn normalize_twice(provider: MockProvider, input: &str) -> (String, String) {
+    let normalizer = Normalizer::new(provider);
+    let variant: HgvsVariant = parse_hgvs(input).expect("parse failed");
+    let once = normalizer
+        .normalize(&variant)
+        .expect("first normalize failed");
+    let twice = normalizer.normalize(&once).expect("re-normalize failed");
+    (once.to_string(), twice.to_string())
+}
+
+/// A `delins` that reduces to a deletion whose 3'-shift crosses `cds_end`
+/// completes that shift on the **first** pass.
+///
+/// `c.7_9delinsA`: ref `c.7_9` = `AAC`, alt `A`; the shared `A` prefix trims it
+/// to a deletion of `AC` at `c.8_9`, which 3'-shifts along the `AC` tandem
+/// running from `c.8` into the 3'UTR. The one-pass answer is the fully shifted
+/// `c.*39_*40del`. Before #1189 pass 1 stopped at the unshifted `c.8_9del`.
+#[test]
+fn delins_reducing_to_deletion_shifts_across_cds_end_in_one_pass() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.7_9delinsA",
+    );
+    assert_eq!(
+        once, "NM_UTR3.1:c.*39_*40del",
+        "pass 1 shifts all the way past cds_end"
+    );
+    assert_eq!(twice, once, "and is a fixed point");
+}
+
+/// The intermediate spelling pass 1 used to stop at is itself normalized to the
+/// same fully shifted form — so the two spellings are confluent, not merely
+/// each idempotent.
+#[test]
+fn unshifted_deletion_at_cds_end_shifts_to_the_same_fixed_point() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.8_9del",
+    );
+    assert_eq!(once, "NM_UTR3.1:c.*39_*40del");
+    assert_eq!(
+        twice, "NM_UTR3.1:c.*39_*40del",
+        "and it is stable from there"
+    );
+}
+
+/// A `dup` whose 3'-shift crosses `cds_end` used to diverge across passes in
+/// *edit kind*, not merely position: `dup` -> `ins` -> repeat. It now reaches
+/// the repeat spelling directly.
+///
+/// CDS `GAAAAAACAC` (`c.1..c.10`) followed by an `ACGT…` 3'UTR puts an `AC[3]`
+/// tandem at `c.7..*2`, bounded by the `G` at `*3`. Duplicating `c.7_10`
+/// (`ACAC`) 3'-shifts within that tandem, and the shift crosses `cds_end`.
+#[test]
+fn duplication_crossing_cds_end_settles_in_one_pass() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_acgt_padding(Strand::Plus),
+        "NM_UTR3.1:c.7_10dup",
+    );
+    assert_eq!(
+        once, "NM_UTR3.1:c.7_*2AC[5]",
+        "pass 1 spells the shifted duplication as the repeat directly, rather \
+         than parking an insertion in the 3'UTR for a second pass to re-spell"
+    );
+    assert_eq!(twice, once, "and is a fixed point");
+
+    // Cross-axis oracle: `r.` reaches the same answer through `normalize_rna`
+    // rather than `normalize_cds`, so this is corroboration by a different code
+    // path over the byte-identical transcript — not another self-consistency
+    // check on the same one.
+    let (r_once, r_twice) = normalize_twice(
+        transcript_with_utr3_acgt_padding(Strand::Plus),
+        "NM_UTR3.1:r.7_10dup",
+    );
+    assert_eq!(r_once, "NM_UTR3.1:r.7_*2ac[5]");
+    assert_eq!(r_twice, r_once, "the r. spelling is a fixed point too");
+    assert_eq!(
+        once.split_once("c.").expect("c. prefix").1.to_lowercase(),
+        r_once.split_once("r.").expect("r. prefix").1,
+        "the c. and r. spellings of one axis must name the same edit"
+    );
+}
+
+/// `con` canonicalizes to a `delins`, so it inherits the fix along with it.
+#[test]
+fn conversion_crossing_cds_end_settles_in_one_pass() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.7_9con7_7",
+    );
+    assert_eq!(
+        once, "NM_UTR3.1:c.*39_*40del",
+        "con reduces to the same fully shifted deletion as the delins spelling"
+    );
+    assert_eq!(twice, once, "and is a fixed point");
+}
+
+/// Fixed on the minus strand too, so the repair is not strand-specific.
+#[test]
+fn delins_reducing_to_deletion_settles_in_one_pass_on_minus_strand() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Minus),
+        "NM_UTR3.1:c.7_9delinsA",
+    );
+    assert_eq!(once, "NM_UTR3.1:c.*39_*40del");
+    assert_eq!(twice, once, "and is a fixed point");
+}
+
+// ---------------------------------------------------------------------------
+// Controls. These passed even while the cases above were broken, and MUST keep
+// passing: they are what established that the defect was a `c.`-axis code-path
+// bug rather than a property of the reference sequence or of 3'-shifting across
+// `cds_end` in general. They now also pin the agreement between axes.
+// ---------------------------------------------------------------------------
+
+/// **The control that ruled out a fixture artifact.** `r.` on a coding
+/// transcript is the CDS-relative axis — the same axis as `c.` (#469) — so
+/// `r.7_9delinsa` names exactly the bases `c.7_9delinsA` names, over the
+/// byte-identical transcript. It shifts across `cds_end` and settles in ONE
+/// pass, which the `c.` spelling of the same edit now does too (see
+/// [`delins_reducing_to_deletion_shifts_across_cds_end_in_one_pass`], whose
+/// answer is this one re-spelled on the `c.` axis).
+#[test]
+fn rna_axis_shifts_across_cds_end_in_one_pass() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:r.7_9delinsa",
+    );
+    assert_eq!(
+        once, "NM_UTR3.1:r.*39_*40del",
+        "the r. axis completes the cross-cds_end shift on the first pass"
+    );
+    assert_eq!(once, twice, "and is idempotent");
+}
+
+/// A plain `del` on the `c.` axis crosses `cds_end` in one pass, so the bug is
+/// not "the `c.` axis cannot shift into the 3'UTR".
+#[test]
+fn plain_deletion_crosses_cds_end_in_one_pass() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.*1_*2del",
+    );
+    assert_eq!(once, "NM_UTR3.1:c.*39_*40del");
+    assert_eq!(once, twice);
+}
+
+/// The same `delins` reduction is idempotent when the shift target stays
+/// **inside** the CDS, so the trigger is specifically crossing `cds_end`.
+/// `c.3_5delinsA` reduces to a deletion of `AA` that shifts along the interior
+/// `A`-run (`c.3..c.8`) and lands at `c.7_8`, still inside the CDS.
+#[test]
+fn delins_reduction_is_idempotent_when_shift_stays_inside_cds() {
+    let (once, twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.3_5delinsA",
+    );
+    assert_eq!(once, "NM_UTR3.1:c.7_8del");
+    assert_eq!(once, twice);
+
+    // Cross-axis oracle, as above: the `r.` spelling of the same edit resolves
+    // through `normalize_rna` and must land on the same two bases.
+    let (r_once, r_twice) = normalize_twice(
+        transcript_with_utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:r.3_5delinsa",
+    );
+    assert_eq!(r_once, "NM_UTR3.1:r.7_8del");
+    assert_eq!(r_twice, r_once, "the r. spelling is a fixed point too");
+    assert_eq!(
+        once.split_once("c.").expect("c. prefix").1.to_lowercase(),
+        r_once.split_once("r.").expect("r. prefix").1,
+        "an interior shift must agree across the two spellings too"
+    );
+}
+
+/// The genomic axis over the same sequence is idempotent, so the bug is not in
+/// the shuffle itself.
+#[test]
+fn genomic_axis_shifts_in_one_pass() {
+    let mut provider = MockProvider::new();
+    // Same layout as the transcript, addressed as a contig: the "CDS" bases sit
+    // at g.41..=49 and the `AC` tandem continues from g.48.
+    provider.add_genomic_sequence(
+        "NC_UTR3.1",
+        format!("{}{}{}", "C".repeat(40), "GGAAAAAAC", "AC".repeat(20)),
+    );
+    let (once, twice) = normalize_twice(provider, "NC_UTR3.1:g.47_49delinsA");
+    // The `AC` tandem runs g.48..g.89 (the contig ends at g.89), so the
+    // reduced `AC` deletion 3'-shifts to the final copy.
+    assert_eq!(
+        once, "NC_UTR3.1:g.88_89del",
+        "the genomic axis shifts to the end of the tandem in one pass"
+    );
+    assert_eq!(twice, once, "and is idempotent over the same bases");
+}

--- a/tests/it/common/synthetic.rs
+++ b/tests/it/common/synthetic.rs
@@ -19,7 +19,21 @@ const TX_ACCESSION: &str = "NM_TEST.1";
 const NR_ACCESSION: &str = "NR_TEST.1";
 const TX_CONTIG: &str = "chr_synth";
 
-fn padded(core: &str) -> String {
+/// Wrap `core` in [`PAD_OFFSET`] bases of `ACGT…` padding on each side.
+///
+/// Used internally by every builder to keep the normalizer's 100bp window in
+/// bounds. It is also public so a caller can build a **transcript** out of the
+/// padded string and thereby give that transcript a real 5'UTR: passing
+/// `padded(core)` to [`SyntheticBuilder::cds`] with `cds_start = PAD_OFFSET + 1`
+/// puts core base `p` at CDS position `p`, while the CDS translation itself is
+/// non-trivial (offset by [`PAD_OFFSET`]) rather than the identity you get from
+/// `cds_start == 1`.
+///
+/// The padding is a perfect period-4 `ACGT` tandem: the base immediately 5' of
+/// the core is `T` and the base immediately 3' of it is `A`. A core whose first
+/// base is not `A` and whose last base is not `T` therefore cannot extend the
+/// pad's own rotation, which is what bounds a repeat tract to the core.
+pub fn padded(core: &str) -> String {
     format!("{}{}{}", PAD, core, PAD)
 }
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -33,6 +33,7 @@ mod bracket_cardinality_conformance;
 mod breakpoint_insertion;
 mod build_transcript_library_parity;
 mod bulk_fixture_tests;
+mod cds_utr3_crossing_shift_idempotency;
 mod civic_validation;
 mod cli_build_transcript;
 mod cli_check_transcripts_json;

--- a/tests/it/normalize_idempotency_proptest.rs
+++ b/tests/it/normalize_idempotency_proptest.rs
@@ -4,8 +4,20 @@
 //! The pre-existing idempotency coverage is reference-free (empty provider, so
 //! nothing shifts) or substitution-only (subs never shift). This fuzzes random
 //! **repeat-biased** cores (homopolymers + short tandems, where del/dup/ins
-//! actually 3'-shift) across the genomic and CDS (both strands) coordinate
-//! systems, and every edit type, asserting `norm(norm(x)) == norm(x)`.
+//! actually 3'-shift) across `g.`, `c.`, `n.`, and `r.` — the last on a coding
+//! *and* a non-coding transcript, which are two different axes — each
+//! transcript axis on both strands, and every edit kind (`del`, `dup`, `ins`,
+//! `delins`, `inv`, `con`), asserting `norm(norm(x)) == norm(x)`. `c.` likewise
+//! appears twice: once where the transcript *is* the CDS, and once on a
+//! UTR-bearing transcript, where alone a shift can cross `cds_end` into `*N`.
+//!
+//! `case_strategy_covers_every_system_and_edit_kind` is the non-vacuity guard:
+//! it samples the strategy and fails if any (coordinate system x edit kind)
+//! cell is empty, so the property above cannot quietly stop exercising an axis.
+//!
+//! Scope: **normalization only**. Nothing here goes through `VariantProjector`,
+//! which reads the `r.` axis as transcript-relative rather than CDS-relative
+//! (issue #1177) and would fail for that unrelated reason.
 //!
 //! Three properties are fuzzed:
 //!   * `norm(norm(x)) == norm(x)` (idempotency), covering the full edit/coord
@@ -37,9 +49,10 @@
 //! failing first-pass normalize is a bug in the generator or the normalizer and
 //! fails the test rather than silently shrinking the exercised set. Failure
 //! seeds are recorded by proptest under
-//! `tests/it/proptest-regressions/normalize_idempotency_proptest.txt`.
+//! `tests/proptest-regressions/normalize_idempotency_proptest.txt` (proptest
+//! anchors that directory at the crate's `tests/`, not at this module's dir).
 
-use crate::common::synthetic::{SyntheticBuilder, PAD_OFFSET};
+use crate::common::synthetic::{padded, SyntheticBuilder, PAD_OFFSET};
 use ferro_hgvs::reference::transcript::Strand;
 use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
 use proptest::prelude::*;
@@ -59,14 +72,121 @@ fn both_directions() -> impl Strategy<Value = ShuffleDirection> {
     ])
 }
 
-/// Coordinate system under test. All use `cds_start == 1` / `cds_end == len`
-/// for the CDS cases so `c.k` maps directly to core position `k` and both
-/// transcript boundaries are exercised.
+/// Coordinate system under test.
+///
+/// Every variant is arranged so that **core position `p` is rendered as
+/// position `p`** on its own axis (genomic positions additionally carry
+/// [`PAD_OFFSET`]), which is what lets one generator emit valid coordinates for
+/// all of them from a single core length.
+///
+/// The `r.` axis appears twice on purpose, because its meaning depends on the
+/// transcript it sits on (HGVS `background/numbering.md` L58/L61, issue #469,
+/// pinned by `issue_291_rna_axis_convention`):
+///
+/// - on a **coding** transcript `r.` is **CDS-relative** — literally the same
+///   axis as `c.`, so `r.N` and `c.N` name the same base;
+/// - on a **non-coding** transcript there is no CDS, so `r.` coincides with
+///   `n.` (transcript-relative).
+///
+/// The `r.` systems therefore share fixtures with their same-axis twins:
+/// [`Sys::RnaNoncodingPlus`] uses the very `NR_TEST.1` provider
+/// [`Sys::NoncodingPlus`] uses, and [`Sys::RnaCodingPlus`] uses a coding
+/// `NM_TEST.1` provider whose `c.` spelling would be the same axis.
 #[derive(Debug, Clone, Copy)]
 enum Sys {
+    /// `g.` on the padded contig `NC_TEST.1`.
     Genomic,
+    /// `c.` on `NM_TEST.1` where the transcript *is* the CDS
+    /// (`cds_start == 1`), so the CDS translation is the identity and both
+    /// transcript boundaries are exercised.
     CdsPlus,
+    /// Minus-strand twin of [`Sys::CdsPlus`].
     CdsMinus,
+    /// `n.` on the non-coding `NR_TEST.1` — transcript-relative.
+    NoncodingPlus,
+    /// Minus-strand twin of [`Sys::NoncodingPlus`].
+    NoncodingMinus,
+    /// `r.` on a **coding** `NM_TEST.1` that carries a real
+    /// [`PAD_OFFSET`]-base 5'UTR *and* 3'UTR, so `cds_start == PAD_OFFSET + 1`:
+    /// CDS-relative, the same axis as `c.`. The 5'UTR is what gives this teeth
+    /// — with `cds_start == 1` the CDS-relative and transcript-relative
+    /// readings coincide and the axis would go untested — and the 3'UTR lets
+    /// a 3'-shift cross `cds_end` into `*N`, which does happen here and is
+    /// idempotent on this axis.
+    RnaCodingPlus,
+    /// Minus-strand twin of [`Sys::RnaCodingPlus`].
+    RnaCodingMinus,
+    /// `r.` on the **non-coding** `NR_TEST.1`: no CDS, so transcript-relative,
+    /// coinciding with [`Sys::NoncodingPlus`].
+    RnaNoncodingPlus,
+    /// Minus-strand twin of [`Sys::RnaNoncodingPlus`].
+    RnaNoncodingMinus,
+    /// `c.` on the same 5'UTR- *and* 3'UTR-bearing `NM_TEST.1` fixture
+    /// [`Sys::RnaCodingPlus`] uses — the `c.` spelling of that identical axis.
+    ///
+    /// Distinct from [`Sys::CdsPlus`], where `cds_start == 1` leaves no UTR on
+    /// either side: only here can a 3'-shift run off `cds_end` into `*N`. That
+    /// shape was non-idempotent until #1185/#1192 (fixed by #1189) and #1209
+    /// (fixed by #1211), which is why these two systems were held out until now.
+    CdsUtr3Plus,
+    /// Minus-strand twin of [`Sys::CdsUtr3Plus`].
+    CdsUtr3Minus,
+}
+
+/// Every coordinate system the generator draws from. Also drives the
+/// non-vacuity histogram in
+/// `case_strategy_covers_every_system_and_edit_kind`, so a system added here
+/// without the generator actually emitting it fails that test.
+///
+/// `CdsUtr3*` — `c.` on a transcript with a 3'UTR — was held out of this list
+/// while a 3'-shift crossing `cds_end` into `*N` was non-idempotent there. Two
+/// distinct defects caused that, both now fixed: the `dup`/`delins`/`con`
+/// family (#1185, fixed by #1189) and an insertion resting at `cds_end` that
+/// the #387 clamp rewrote instead of letting it shift on (#1209, fixed by
+/// #1211). Neither was a harness artifact — `r.` performed the identical shift
+/// over the byte-identical reference in one pass throughout, which is what
+/// localised both to the `c.` path. Minimal repros stay pinned in
+/// `tests/it/cds_utr3_crossing_shift_idempotency.rs` and
+/// `tests/it/issue_1209_cds_end_insertion_shift.rs`.
+const ALL_SYSTEMS: [Sys; 11] = [
+    Sys::Genomic,
+    Sys::CdsPlus,
+    Sys::CdsMinus,
+    Sys::NoncodingPlus,
+    Sys::NoncodingMinus,
+    Sys::RnaCodingPlus,
+    Sys::RnaCodingMinus,
+    Sys::RnaNoncodingPlus,
+    Sys::RnaNoncodingMinus,
+    Sys::CdsUtr3Plus,
+    Sys::CdsUtr3Minus,
+];
+
+impl Sys {
+    /// Accession and axis prefix this system renders under.
+    fn accession_and_prefix(self) -> (&'static str, &'static str) {
+        match self {
+            Sys::Genomic => ("NC_TEST.1", "g."),
+            Sys::CdsPlus | Sys::CdsMinus | Sys::CdsUtr3Plus | Sys::CdsUtr3Minus => {
+                ("NM_TEST.1", "c.")
+            }
+            Sys::RnaCodingPlus | Sys::RnaCodingMinus => ("NM_TEST.1", "r."),
+            Sys::NoncodingPlus | Sys::NoncodingMinus => ("NR_TEST.1", "n."),
+            Sys::RnaNoncodingPlus | Sys::RnaNoncodingMinus => ("NR_TEST.1", "r."),
+        }
+    }
+
+    /// True for the `r.` axes, whose literal base sequences must be written in
+    /// the RNA alphabet (`acgu`) rather than DNA.
+    fn is_rna(self) -> bool {
+        matches!(
+            self,
+            Sys::RnaCodingPlus
+                | Sys::RnaCodingMinus
+                | Sys::RnaNoncodingPlus
+                | Sys::RnaNoncodingMinus
+        )
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +231,13 @@ fn dna(n: std::ops::RangeInclusive<usize>) -> impl Strategy<Value = String> {
 /// (`repeat_case_strategy` below needs the same property and gets it a different
 /// way — it knows its tract's unit, so it derives the breaker from that unit
 /// directly rather than relying on a fixed flank.)
+///
+/// Provenance, since the narrower single-base `G`/`C` flanks this replaced are
+/// referenced elsewhere: those let a 2-base rotation continue a few periods into
+/// the pad, and that leak is what originally surfaced the `cds_end`-crossing
+/// non-idempotency. That case is now pinned explicitly by
+/// `tests/it/cds_utr3_crossing_shift_idempotency.rs`, so widening the flanks
+/// does not lose it.
 fn core_strategy() -> impl Strategy<Value = String> {
     prop::collection::vec((dna(1..=3), 1usize..=5), 2..=5)
         .prop_map(|runs| {
@@ -189,49 +316,104 @@ fn repeat_case_strategy() -> impl Strategy<Value = Case> {
         })
 }
 
+/// Re-express a DNA literal in the RNA alphabet used by the `r.` axis
+/// (lowercase, `t` -> `u`). Feeding real `u` bases through the `r.` cases also
+/// exercises the U->T rewrite normalization applies before comparing an `r.`
+/// edit against the DNA-stored transcript (#736).
+fn to_rna(dna: &str) -> String {
+    dna.chars()
+        .map(|c| match c {
+            'T' | 't' => 'u',
+            other => other.to_ascii_lowercase(),
+        })
+        .collect()
+}
+
 fn case_strategy() -> impl Strategy<Value = Case> {
     core_strategy().prop_flat_map(move |core| {
         let len = core.len();
-        let sys = prop::sample::select(vec![Sys::Genomic, Sys::CdsPlus, Sys::CdsMinus]);
-        // kind: 0=del 1=dup 2=ins 3=delins
-        (sys, 0u8..=3, 1usize..=len, 0usize..=3, dna(1..=3)).prop_map(
-            move |(sys, kind, start, span, ins)| {
-                let end = (start + span).min(len);
-                let (s, e) = (start.min(end), start.max(end));
-                let render_pos = |p: usize| -> u64 {
-                    match sys {
-                        Sys::Genomic => (PAD_OFFSET as usize + p) as u64,
-                        _ => p as u64, // cds_start == 1 => c.p maps to core p
-                    }
-                };
-                let (prefix, acc) = match sys {
-                    Sys::Genomic => ("g.", "NC_TEST.1"),
-                    _ => ("c.", "NM_TEST.1"),
-                };
-                let range = |s: usize, e: usize| {
-                    if s == e {
-                        format!("{}", render_pos(s))
-                    } else {
-                        format!("{}_{}", render_pos(s), render_pos(e))
-                    }
-                };
-                let body = match kind {
-                    0 => format!("{}del", range(s, e)),
-                    1 => format!("{}dup", range(s, e)),
-                    2 => {
-                        // insertion sits between p and p+1; keep p in 1..len
-                        let p = s.min(len - 1);
-                        format!("{}_{}ins{}", render_pos(p), render_pos(p + 1), ins)
-                    }
-                    _ => format!("{}delins{}", range(s, e), ins),
-                };
-                Case {
-                    core: core.clone(),
-                    sys,
-                    hgvs: format!("{acc}:{prefix}{body}"),
-                }
-            },
+        let sys = prop::sample::select(ALL_SYSTEMS.to_vec());
+        // kind: 0=del 1=dup 2=ins 3=delins 4=inv 5=con
+        (
+            sys,
+            0u8..=5,
+            1usize..=len,
+            0usize..=3,
+            dna(1..=3),
+            // `con` donor interval, drawn from the same core so the donated
+            // bases are as short as an `ins` payload (1..=3) and the resulting
+            // delins cannot 3'-shift any further than the `ins`/`delins` cases
+            // already can.
+            1usize..=len,
+            0usize..=2,
         )
+            .prop_map(
+                move |(sys, kind, start, span, ins, donor_start, donor_span)| {
+                    let end = (start + span).min(len);
+                    let (s, e) = (start.min(end), start.max(end));
+                    // Every axis renders core position `p` as `p`; only the
+                    // genomic contig carries the padding offset. For the
+                    // 5'UTR-bearing coding fixture this holds because
+                    // `cds_start == PAD_OFFSET + 1`, so `c.p`/`r.p` translate
+                    // to transcript `PAD_OFFSET + p` = core position `p`.
+                    let render_pos = |p: usize| -> u64 {
+                        match sys {
+                            Sys::Genomic => (PAD_OFFSET as usize + p) as u64,
+                            _ => p as u64,
+                        }
+                    };
+                    let (acc, prefix) = sys.accession_and_prefix();
+                    let bases = if sys.is_rna() {
+                        to_rna(&ins)
+                    } else {
+                        ins.clone()
+                    };
+                    let range = |s: usize, e: usize| {
+                        if s == e {
+                            format!("{}", render_pos(s))
+                        } else {
+                            format!("{}_{}", render_pos(s), render_pos(e))
+                        }
+                    };
+                    let body = match kind {
+                        0 => format!("{}del", range(s, e)),
+                        1 => format!("{}dup", range(s, e)),
+                        2 => {
+                            // insertion sits between p and p+1; keep p in 1..len
+                            let p = s.min(len - 1);
+                            format!("{}_{}ins{}", render_pos(p), render_pos(p + 1), bases)
+                        }
+                        3 => format!("{}delins{}", range(s, e), bases),
+                        4 => {
+                            // "an inversion covers more than one nucleotide by
+                            // definition" (HGVS DNA/inversion.md:16) and the
+                            // parser enforces it, so widen a degenerate
+                            // interval to two bases instead of emitting an
+                            // input the generator knows is invalid.
+                            let (s, e) = match (s, e) {
+                                (s, e) if e > s => (s, e),
+                                (s, _) if s < len => (s, s + 1),
+                                (s, _) => (s - 1, s),
+                            };
+                            format!("{}inv", range(s, e))
+                        }
+                        _ => {
+                            // Always render the donor as an explicit `S_E`
+                            // pair, even when `S == E`: a bare `conN` parses
+                            // as an opaque cross-reference (`delins[N]`)
+                            // rather than a same-reference position range.
+                            let ds = donor_start;
+                            let de = (ds + donor_span).min(len);
+                            format!("{}con{}_{}", range(s, e), render_pos(ds), render_pos(de))
+                        }
+                    };
+                    Case {
+                        core: core.clone(),
+                        sys,
+                        hgvs: format!("{acc}:{prefix}{body}"),
+                    }
+                },
+            )
     })
 }
 
@@ -241,7 +423,100 @@ fn provider_for(core: &str, sys: Sys) -> MockProvider {
         Sys::Genomic => SyntheticBuilder::genomic(core).build(),
         Sys::CdsPlus => SyntheticBuilder::cds(core, 1, len, Strand::Plus).build(),
         Sys::CdsMinus => SyntheticBuilder::cds(core, 1, len, Strand::Minus).build(),
+        // A coding transcript of `PAD + core + PAD` whose CDS covers exactly
+        // the core, giving it both a 5'UTR and a 3'UTR.
+        // `cds_start == PAD_OFFSET + 1` makes the CDS translation a real offset
+        // (unlike `CdsPlus`/`CdsMinus`, where it is the identity), which is what
+        // makes "`r.` is CDS-relative" an observable claim; the padding doubles
+        // as the repeat-tract breaker on both sides.
+        // `CdsUtr3*` is the `c.` spelling of that same axis over the same
+        // fixture, so it shares the provider outright.
+        Sys::RnaCodingPlus | Sys::CdsUtr3Plus => SyntheticBuilder::cds(
+            &padded(core),
+            PAD_OFFSET + 1,
+            PAD_OFFSET + len,
+            Strand::Plus,
+        )
+        .build(),
+        Sys::RnaCodingMinus | Sys::CdsUtr3Minus => SyntheticBuilder::cds(
+            &padded(core),
+            PAD_OFFSET + 1,
+            PAD_OFFSET + len,
+            Strand::Minus,
+        )
+        .build(),
+        // `n.` and `r.` on a non-coding transcript are likewise the same axis
+        // (no CDS to be relative to), so they share the `NR_TEST.1` fixture.
+        Sys::NoncodingPlus | Sys::RnaNoncodingPlus => {
+            SyntheticBuilder::noncoding(core, Strand::Plus).build()
+        }
+        Sys::NoncodingMinus | Sys::RnaNoncodingMinus => {
+            SyntheticBuilder::noncoding(core, Strand::Minus).build()
+        }
     }
+}
+
+/// Edit-kind label recovered from a *rendered* case, so the histogram below
+/// observes what the generator actually emitted rather than a self-reported
+/// tag. Order matters: `delins` contains both `del` and `ins`.
+fn edit_kind_label(hgvs: &str) -> &'static str {
+    for kind in ["delins", "del", "dup", "inv", "con", "ins"] {
+        if hgvs.contains(kind) {
+            return kind;
+        }
+    }
+    "?"
+}
+
+/// Non-vacuity guard for [`case_strategy`].
+///
+/// A passing idempotency property proves nothing about a coordinate system or
+/// edit kind the strategy never emits, and a `prop_filter` or a mis-ordered
+/// `match` arm can silently drop a whole bucket without any test going red.
+/// This samples the strategy directly and asserts every
+/// (coordinate system x edit kind) cell is actually populated.
+#[test]
+fn case_strategy_covers_every_system_and_edit_kind() {
+    use proptest::strategy::{Strategy as _, ValueTree as _};
+    use proptest::test_runner::TestRunner;
+    use std::collections::BTreeMap;
+
+    const SAMPLES: usize = 4000;
+    const KINDS: [&str; 6] = ["del", "dup", "ins", "delins", "inv", "con"];
+    // Derived from the enum rather than spelled out, so adding a `Sys` variant
+    // to `ALL_SYSTEMS` without teaching the generator to emit it fails here.
+    let systems: Vec<String> = ALL_SYSTEMS.iter().map(|s| format!("{s:?}")).collect();
+
+    let strategy = case_strategy();
+    let mut runner = TestRunner::deterministic();
+    let mut histogram: BTreeMap<(String, &'static str), usize> = BTreeMap::new();
+    for _ in 0..SAMPLES {
+        let case = strategy
+            .new_tree(&mut runner)
+            .expect("case_strategy must always produce a value")
+            .current();
+        *histogram
+            .entry((format!("{:?}", case.sys), edit_kind_label(&case.hgvs)))
+            .or_default() += 1;
+    }
+
+    let mut report = String::new();
+    let mut missing = Vec::new();
+    for sys in &systems {
+        for kind in KINDS {
+            let n = histogram.get(&(sys.clone(), kind)).copied().unwrap_or(0);
+            report.push_str(&format!("  {sys:16} {kind:8} {n:5}\n"));
+            if n == 0 {
+                missing.push(format!("{sys}/{kind}"));
+            }
+        }
+    }
+    println!("case_strategy coverage over {SAMPLES} samples:\n{report}");
+    assert!(
+        missing.is_empty(),
+        "case_strategy never generated these (system, edit kind) cells: {missing:?}\n\
+         full histogram over {SAMPLES} samples:\n{report}"
+    );
 }
 
 /// `norm(norm(x)) == norm(x)` for one case in one direction, and the normalized
@@ -287,7 +562,25 @@ fn check_idempotent(case: &Case, dir: ShuffleDirection) -> Result<(), TestCaseEr
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(4000))]
+    // 12k cases rather than 4k: the case space is 11 coordinate systems x 6 edit
+    // kinds = 66 cells (it was 3 x 4 = 12), so 4k would leave only ~61 cases per
+    // cell. 12k restores ~182 per cell and still runs in ~1s.
+    //
+    // `max_local_rejects` is raised off its 65_536 default because
+    // `core_strategy`'s `body length 6..=40` filter rejects a steady ~6.7% of
+    // draws, so the *absolute* default cap is reached partway through any run
+    // over ~900k cases and aborts it with "Too many local rejects" — which looks
+    // like a failure but is purely the harness's own quota. 1M rejects covers
+    // ~14M cases while still aborting promptly if the generator ever degenerates
+    // into rejecting nearly everything. Both values are overridden by
+    // `PROPTEST_CASES` / `PROPTEST_MAX_LOCAL_REJECTS` (the `proptest!` macro
+    // re-applies the env vars over this config), so a soak is just
+    // `PROPTEST_CASES=1000000 cargo nextest run …`. 1M cases verified clean.
+    #![proptest_config(ProptestConfig {
+        cases: 12_000,
+        max_local_rejects: 1_000_000,
+        ..ProptestConfig::default()
+    })]
 
     /// 3' (default, HGVS-canonical) direction, fully general edit content.
     #[test]

--- a/tests/proptest-regressions/normalize_idempotency_proptest.txt
+++ b/tests/proptest-regressions/normalize_idempotency_proptest.txt
@@ -6,3 +6,7 @@
 # everyone who runs the test benefits from these saved cases.
 cc bf332dd0e9d843159242ec546b6e1eb7518b888030fe9438d344dd93044a7394 # shrinks to case = Case { core: "GTGTGTGTGTGCTCC", sys: Genomic, hgvs: "NC_TEST.1:g.267_268insTG" }
 cc ddec17ccae74300ac0056191f141ead3b469a70af2b335c064a8300fd22ad3fc # shrinks to case = Case { core: "CCCAAACCC", sys: CdsPlus, hgvs: "NM_TEST.1:c.4A[5]" }, dir = FivePrime
+cc ce2247887cce1fd6f6e7f2854dccbb108e64e6aac1a4ae826d5403a5c2853f0e # shrinks to case = Case { core: "CCCCAAAAAAAGGGG", sys: NoncodingPlus, hgvs: "NR_TEST.1:n.1_2insGC" }
+cc 87f7c72196c50a21cb8322872c481d0e71cd9867a62d343a467e434d803c89eb # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.1_2dup" }
+cc 963ed918c565168dda03912561f65f99d0a3a5398c144fdd1dd0157e4c5563ae # shrinks to case = Case { core: "CCCCAAAAAAGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.11_12dup" }
+cc 8d1ceaa8eae1c6162271d431b2cb4395e0359a560661739dc5402acd0d9bdf33 # shrinks to case = Case { core: "CCCCAACACACGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15delinsgaa" }


### PR DESCRIPTION
Widens the normalization idempotency proptest from 3 coordinate systems to 11, and from 4 edit kinds to 6. Test-only — no production code changes.

## Why

The fuzz could only generate `g.` and `c.` (both strands, `cds_start == 1`) with `del`/`dup`/`ins`/`delins`. Everything else was unfuzzed, which is how a repeat-notation bug reached `main` earlier in this campaign: it lived on an axis the strategy could not produce.

## What changed

- **`n.`** on a non-coding `NR_` transcript.
- **`r.` twice**, because it is genuinely two different axes: on a coding transcript it is CDS-relative — the same axis as `c.` (#469) — and on a non-coding transcript it coincides with `n.`.
- **`c.` twice**: the existing `cds_start == 1` fixture, plus `CdsUtr3*` on a UTR-bearing transcript, where alone a 3'-shift can cross `cds_end` into `*N`.
- **`inv`** (widened to the ≥2 nucleotides the spec requires; a 1-base `inv` is a parse error) and **`con`** (donor always an explicit `S_E` pair, since a bare `conN` parses as an opaque cross-reference).

One deliberate fixture choice worth noting: the coding `r.`/`CdsUtr3` transcript carries a **real 256-base 5'UTR** (`cds_start == PAD_OFFSET + 1`). With `cds_start == 1` the CDS-relative and transcript-relative readings coincide, so the axis would be *vacuously* covered — present in the strategy, but incapable of distinguishing right from wrong.

## Non-vacuity guard

`case_strategy_covers_every_system_and_edit_kind` is the load-bearing addition. A passing property test proves nothing about a cell the strategy never emits, so this samples the strategy and fails if any (system × edit kind) cell is empty. It derives the expected system list from `ALL_SYSTEMS` and recovers the edit kind by parsing the *rendered* HGVS rather than trusting a self-reported tag, so adding a variant the generator does not emit fails here rather than passing silently.

It was written first and watched fail: on the unmodified generator, 12 cells were empty across 4000 samples. After the change all 66 are populated.

## What the fuzz found

This is the point of the PR, so it is worth being concrete. The widened strategy surfaced four idempotency defects. **All four are now fixed on `main`**, each by its own PR, and this branch is the last piece.

| found | axis / shape | fixed by |
|---|---|---|
| #1185 | `c.` `dup`/`delins`/`con` whose 3'-shift crosses `cds_end` into `*N` | #1189 |
| #1202 | `n.`/`r.` insertion saturating the transcript bounds | #1203 |
| #1207 | `r.` `dup` saturating a CDS boundary (a #1192 regression) | #1208 |
| #1209 | `c.` insertion resting at `cds_end`, clamped instead of shifting into the 3'UTR | #1211 |
| #1210 | `r.` repeat gate answered for the input span, not the emitted tract | #1212 |

Four failure seeds are committed to `tests/proptest-regressions/normalize_idempotency_proptest.txt` (#1202, both #1207 cases, and #1210). They replay through the *current* strategy, and this is the PR that widens that strategy to `n.`/`r.`, so they must travel with it. Now that the underlying bugs are fixed they act as regression guards — the convention the file's own header describes and which #1170 and #1172 each followed.

## Two things a reviewer should know

**1. `tests/it/cds_utr3_crossing_shift_idempotency.rs` is now a set of one-pass regressions.** It began as characterization tests for the *unfixed* #1185; with #1189 merged those cases are flipped to assert the correct one-pass answers and survive as deterministic pins over a hand-built transcript:

```
c.7_9delinsA -> c.*39_*40del    (fixed point)
c.7_10dup    -> c.7_*2AC[5]     (fixed point)
c.7_9con7_7  -> c.*39_*40del    (fixed point)
```

Its `FERRO_ASSERT_IDEMPOTENT` skip helper is gone — nothing in the file is non-idempotent any more, so every test runs under the oracle instead of opting out of it. The #1209 case is **not** duplicated here; #1211 ships a dedicated `issue_1209_cds_end_insertion_shift` module using the same fixture, and maintaining two copies of one case would only invite drift.

The padding artifact that produced a retracted finding earlier in this campaign was ruled out, not assumed: every repro is a hand-rolled transcript with no `SyntheticBuilder`. The decisive control throughout is that `r.` and `c.` share the byte-identical fixture yet the `r.` spelling settled in one pass — which is what localised each defect to the `c.` path rather than to the reference bases.

**2. `c.`-with-3'UTR is now IN the fuzz.** These two systems were held out while the axis was non-idempotent; both blockers (#1209, #1210) are fixed, so `CdsUtr3Plus`/`CdsUtr3Minus` join `ALL_SYSTEMS` here. The hold-out was never a weakened fixture — `RnaCoding*` always fuzzed that same 3'UTR-bearing transcript — but the `c.` spelling of that axis is a distinct code path, and it is now covered directly rather than by proxy.

## Also

- `common::synthetic::padded` made `pub` so a caller can build a transcript from the padded string with real UTRs.
- Corrected `core_strategy`'s flank-breaker comment: the `G`/`C` flanks bound a *homopolymer* but do **not** stop a 2-base rotation — a body ending `…A` gives suffix `…AC` and the pad resumes `AC`. That layout is what surfaced #1185.
- Case count 4k → 12k (the space grew from 12 cells to 66), and `max_local_rejects` lifted off its absolute 65,536 default. That default, against `core_strategy`'s pre-existing ~6.7% body-length reject rate, aborts any soak past ~900k cases — a first 1M run reported `FAIL` after 910,533 *successes*, which was a reject-cap abort and not an idempotency failure. Both still env-overridable.

## Verification

Rebased onto `main` at `f9ae3be` (#1212).

- Full suite: **8646 passed, 0 failed, 145 skipped**, and identical under `FERRO_ASSERT_IDEMPOTENT=1`.
- **1M-case soak clean** on all six properties (445s), including `normalization_is_idempotent_three_prime` — the property that failed at 150,830 cases before #1212, and the first 1M run to include the `CdsUtr3*` systems.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- With `FERRO_MANIFEST` set, `mutalyzer_normalize_tests::axis_errors` fails — verified to fail *identically* on the unmodified baseline (same two rows, `NM_000143.3:c.45del4` / `c.45dup4`). Pre-existing; it is what #1173 addresses.

## Note on where this coverage actually pays off

Worth stating plainly for whoever maintains this next: **PR CI's 12k-case run did not find any of the five defects above.** #1210 first reproduced at ~150k cases. The 12k setting is a smoke test; the soak is the detector, and it currently runs only by hand. Automating a nightly soak — and trimming what PR CI spends on random cases — is tracked separately from this PR.
