### PR TITLE
fix(normalize): handle an inv suffix on a cross-reference insertion range

### DIFF
--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -2463,6 +2463,12 @@ struct CrossReferenceParse {
     start: u64,
     /// One-based end position (equal to `start` for a single-position payload).
     end: u64,
+    /// Whether the payload range carried a trailing `inv`, meaning the fetched
+    /// bases are inserted reverse-complemented. Only ever set for a two-part
+    /// `A_Binv` range — a single position has no orientation to invert, matching
+    /// the same-reference parse paths, which likewise build an
+    /// `InsertedPart::PositionRangeInv` only from a range. #1184.
+    inv: bool,
     /// Whether the positions index the transcript (`c.`/`n.`/`r.`) rather than a
     /// genomic / absolute frame (`g./m./o.`). When set, a genomic-context
     /// compound accession (`NG_(NM_)`) must be reduced to its transcript before
@@ -2477,12 +2483,13 @@ struct CrossReferenceParse {
 /// `"NC_000022.10:g.42536337_42536382"`) into its components for
 /// provider lookup. Returns a `CrossReferenceParse` (the inner accession,
 /// the `InsCoordKind` used to fetch its bases, the one-based `start`/`end`,
-/// and the `transcript_relative` flag) on success.
+/// the `transcript_relative` flag, and the `inv` orientation) on success.
 ///
 /// Two payload forms are accepted:
 ///   - **Axis-qualified** (`<ACC>:<axis>.<range>`): supports g./m./o./c./n./r.
 ///     axes with simple positive-integer positions or ranges (no offsets,
-///     no `*N`, no `?`, no `pter`/`qter` markers).
+///     no `*N`, no `?`, no `pter`/`qter` markers). A range may carry a trailing
+///     `inv` (`A_Binv`), which inverts the fetched bases (#1184).
 ///   - **Axis-less native-frame** (`<ACC>:<range>`, #759): the bare positions
 ///     index the accession's *native frame* — the axis an explicit
 ///     description would default to for that accession
@@ -2558,10 +2565,24 @@ fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
         let (kind, transcript_relative) = axisless_native_frame(acc_part)?;
         (kind, transcript_relative, after_colon)
     };
+    // A trailing `inv` inverts the payload (`A_Binv`). Strip it up front so the
+    // position parse below still sees a bare range, and record the orientation
+    // for `resolve_cross_reference_bases` to apply. `strip_suffix` anchors to the
+    // end, so an embedded `inv` (`1inv_3`) is left alone and still rejected by
+    // the digits-only checks. #1184.
+    let (range_str, inv) = match range_str.strip_suffix("inv") {
+        Some(stripped) => (stripped, true),
+        None => (range_str, false),
+    };
     // A payload may name a range (`A_B`) or a single position (`A`, a one-base
     // copy with start == end).
     let (start_str, end_str) = match range_str.split_once('_') {
         Some((s, e)) => (s, e),
+        // A single position has no orientation, so `Ainv` is not a meaningful
+        // shape — and it is unrepresentable in the same-reference form, where
+        // both parse paths build a `PositionRangeInv` only from a two-part
+        // range. Keep it out of scope rather than complement one base. #1184.
+        None if inv => return None,
         None => (range_str, range_str),
     };
     if start_str.is_empty() || end_str.is_empty() {
@@ -2569,7 +2590,8 @@ fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
     }
     // Reject any decoration: offsets (`+`/`-`), UTR markers (`*`),
     // unknown markers (`?`), pter/qter/cen. Only positive-integer
-    // ranges in scope per the issue's acceptance criteria.
+    // ranges in scope per the issue's acceptance criteria — the one
+    // permitted suffix, a trailing `inv`, is already stripped above.
     if !start_str.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
@@ -2584,6 +2606,7 @@ fn parse_cross_reference(reference: &str) -> Option<CrossReferenceParse> {
         start,
         end,
         transcript_relative,
+        inv,
     })
 }
 
@@ -2610,10 +2633,10 @@ fn cross_reference_shape_error(reference: &str) -> FerroError {
         variant_type: format!(
             "ins[{}] cross-reference shape not yet supported. \
              Expansion currently covers g./m./o./c./n./r. axes with simple \
-             positive-integer positions or ranges. Out-of-scope: p. (protein — \
-             structurally invalid as DNA-insertion payload), offsets (+/-), UTR \
-             markers (*N), unknown markers (?), and pter/qter/cen \
-             decorations",
+             positive-integer positions or ranges, optionally with a trailing \
+             `inv` on a range. Out-of-scope: p. (protein — structurally invalid \
+             as DNA-insertion payload), offsets (+/-), UTR markers (*N), \
+             unknown markers (?), and pter/qter/cen decorations",
             reference,
         ),
     }
@@ -2629,6 +2652,7 @@ fn resolve_cross_reference_bases<P: ReferenceProvider>(
         start,
         end,
         transcript_relative,
+        inv,
     } = parse_cross_reference(reference).ok_or_else(|| cross_reference_shape_error(reference))?;
     // A transcript-relative payload (`c.`, `n.`, or `r.`) indexes the transcript, so a
     // genomic-context compound accession (`NG_(NM_)`) must be reduced to its
@@ -2641,7 +2665,17 @@ fn resolve_cross_reference_bases<P: ReferenceProvider>(
     } else {
         accession
     };
-    fetch_position_range_bases(&accession, start, end, kind, provider)
+    let bases = fetch_position_range_bases(&accession, start, end, kind, provider)?;
+    // A trailing `inv` on the payload range inserts the segment
+    // reverse-complemented, exactly as the same-reference
+    // `InsertedPart::PositionRangeInv` / `InsertedSequence::PositionRangeInv`
+    // arms do. Applied after the fetch so the axis-specific position
+    // translation is unaffected by the orientation. #1184.
+    if inv {
+        Ok(crate::sequence::reverse_complement(&bases))
+    } else {
+        Ok(bases)
+    }
 }
 
 /// Resolve the `(InsCoordKind, transcript_relative)` an axis-less cross-reference
@@ -2853,7 +2887,8 @@ pub(crate) fn expand_complex_parts<P: ReferenceProvider>(
 ///     decoration, etc.): error carries `"cross-reference"` and
 ///     describes the supported axis set. Simple positive-integer
 ///     ranges on g./m./o./c./n. (#422) and r. (#773) are now
-///     expanded and no longer surface as errors.
+///     expanded and no longer surface as errors, as is such a range
+///     carrying a trailing `inv` (#1184).
 /// - `Err(FerroError::...)` — genuine provider lookup failure
 ///   (`ReferenceNotFound`, `InvalidCoordinates`, etc.).
 pub fn expand_inserted_sequence<P: ReferenceProvider>(
@@ -4979,6 +5014,89 @@ mod tests {
         let bases = resolve_cross_reference_bases("NG_999999.9(NM_001234.1):r.2", &provider)
             .expect("genomic-context compound r. cross-reference should resolve");
         assert_eq!(bases, "T");
+    }
+
+    #[test]
+    fn resolve_cross_reference_inv_suffix_reverse_complements_the_payload() {
+        // #1184: a trailing `inv` on a cross-reference range inverts the fetched
+        // bases, mirroring the same-reference `PositionRangeInv` arm. `NM_000088.3`
+        // has cds_start=1 over "ATGCCCAAG…", so c.1_3 == "ATG" and c.1_3inv is its
+        // reverse complement "CAT".
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        let forward = resolve_cross_reference_bases("NM_000088.3:c.1_3", &provider)
+            .expect("forward c. cross-reference should resolve");
+        assert_eq!(forward, "ATG");
+        let inverted = resolve_cross_reference_bases("NM_000088.3:c.1_3inv", &provider)
+            .expect("inv-suffixed c. cross-reference should resolve");
+        assert_eq!(inverted, "CAT");
+        assert_eq!(
+            inverted,
+            crate::sequence::reverse_complement(&forward),
+            "inv payload must be the reverse complement of the forward payload"
+        );
+    }
+
+    #[test]
+    fn resolve_cross_reference_inv_suffix_applies_on_every_axis() {
+        // The suffix is stripped before axis-specific position translation, so it
+        // composes with each axis's frame rather than replacing it. NR_000123.1 is
+        // "ACGTACGTACGT" (non-coding: n./r. are transcript-relative), so 1_5 is
+        // "ACGTA" — deliberately NOT a palindrome, so this would fail if the
+        // suffix were stripped without inverting.
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        for reference in [
+            "NR_000123.1:n.1_5inv",
+            "NR_000123.1:r.1_5inv",
+            // Axis-less native frame (#759) — non-coding accession resolves to n.
+            "NR_000123.1:1_5inv",
+        ] {
+            let bases = resolve_cross_reference_bases(reference, &provider)
+                .unwrap_or_else(|e| panic!("{reference} should resolve, got {e:?}"));
+            assert_eq!(bases, "TACGT", "{reference} must reverse-complement ACGTA");
+        }
+    }
+
+    #[test]
+    fn resolve_cross_reference_inv_requires_a_two_part_range() {
+        // Both same-reference parse paths (`parse_external_ref_part`,
+        // `parse_simple_count`) only ever build a `PositionRangeInv` from an
+        // `A_Binv` range — a bare `Ainv` is a parse error there. The
+        // cross-reference form mirrors that: a single position with an `inv`
+        // suffix stays an out-of-scope shape rather than silently complementing
+        // one base.
+        let provider = crate::reference::mock::MockProvider::with_test_data();
+        assert!(parse_cross_reference("NM_000088.3:c.2inv").is_none());
+        let err = resolve_cross_reference_bases("NM_000088.3:c.2inv", &provider)
+            .expect_err("single-position inv must stay unsupported");
+        assert!(
+            matches!(err, FerroError::UnsupportedVariant { .. }),
+            "expected the shape error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_cross_reference_inv_does_not_loosen_decoration_rejection() {
+        // Stripping `inv` must not become a general-purpose suffix strip: the
+        // decorations that were out of scope before are still out of scope with
+        // an `inv` on the end, and a lone/embedded `inv` is not a range.
+        for reference in [
+            // pter/qter keep their own rejection (these appear in the spec corpus).
+            "NC_000014.9:g.29745314_qterinv",
+            "NC_000011.10:g.pter_15825266inv",
+            // Offsets and UTR markers stay rejected.
+            "NM_000088.3:c.244-8_249inv",
+            "NM_000088.3:c.100_*200inv",
+            // Not a range / not a position at all.
+            "NM_000088.3:c.inv",
+            "NM_000088.3:c.1_inv",
+            // `inv` must be a *trailing* suffix, not matched mid-string.
+            "NM_000088.3:c.1inv_3",
+        ] {
+            assert!(
+                parse_cross_reference(reference).is_none(),
+                "{reference} must remain an out-of-scope cross-reference shape"
+            );
+        }
     }
 
     #[test]

--- a/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
+++ b/tests/fixtures/mutalyzer-normalize/mock-pin/normalized.txt
@@ -210,7 +210,7 @@ NM_003002.2:c.pterdel	NM_003002.2:c.pterdel
 NM_003002.2:c.qterdel	NM_003002.2:c.qterdel
 LRG_24:g.5525_5532delinsNM_003002.2:c.pter_-51	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.pter_-51'
 LRG_24:g.5525_5532delinsNM_003002.2:c.*835_qter	parse error: Parse error at position 26: Unexpected trailing characters: '_003002.2:c.*835_qter'
-LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n./r. axes with simple positive-integer positions or ranges. Out-of-scope: p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations
+LRG_24t1:c.126_133delins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter]	normalize error: Unsupported variant type: ins[NM_003002.2:c.pter_-51;NM_003002.2:c.*835_qter] cross-reference shape not yet supported. Expansion currently covers g./m./o./c./n./r. axes with simple positive-integer positions or ranges, optionally with a trailing `inv` on a range. Out-of-scope: p. (protein — structurally invalid as DNA-insertion payload), offsets (+/-), UTR markers (*N), unknown markers (?), and pter/qter/cen decorations
 LRG_24t1:c.pter_qterdelinspter_qter	parse error: Parse error at position 26: Unexpected trailing characters: 'pter_qter'
 LRG_24t1:c.pter_qterdelins[pter_qter;NM_003002.2:c.*835_qter]	parse error: Parse error at position 23: Unexpected trailing characters: 'ins[pter_qter;NM_003002.2:c.*835_qter]'
 NG_012337.1(NM_003002.2):c.[274=;275del]	NG_012337.1(NM_003002.2):c.[274=;275del]

--- a/tests/it/issue_422_cross_reference_ins.rs
+++ b/tests/it/issue_422_cross_reference_ins.rs
@@ -340,3 +340,103 @@ fn unsupported_cross_reference_after_repeat_part_still_defers() {
         result.ok(),
     );
 }
+
+// =============================================================================
+// Issue #1184 — a trailing `inv` on a cross-reference range.
+//
+// `parse_external_ref_part` slurps the whole payload (including a trailing
+// `inv`) into an opaque `ExternalRef`, so the suffix used to reach
+// `parse_cross_reference` glued to the end position and fail its digits-only
+// test — rejecting `[ACC:g.A_Binv]` as an unsupported shape even though the
+// identical range without `inv` expanded fine. These pin the end-to-end
+// behavior through BOTH entry points (bare `Reference` and bracketed
+// `ExternalRef`), which matters because the `detect_deferred_part` pre-scan
+// gates on `parse_cross_reference` independently of the expansion itself.
+//
+// `NC_000011.10` is `"GGGGTTTTAAAACCCC"` repeated, so `g.1_6` is `GGGGTT` —
+// deliberately not a palindrome, so a bug that stripped the suffix without
+// inverting would fail these rather than pass by coincidence.
+// =============================================================================
+
+/// Provider for the `inv` tests. The outer accession's replaced range
+/// (`g.10_15` == `CTATAG`) is chosen so that **no** position matches either
+/// payload — forward `GGGGTT` or inverted `AACCCC` — and both are the same
+/// length as the range. Otherwise the normalizer's canonical split factors the
+/// coincidental matches out into an allele (e.g.
+/// `g.[10C>G;12_15delinsGGTT]`), which would hide the inserted literal this
+/// test is about.
+fn inv_payload_provider() -> MockProvider {
+    let mut p = MockProvider::new();
+    p.add_genomic_sequence(
+        "NC_000022.10",
+        format!("{}CTATAG{}", "G".repeat(9), "A".repeat(10)),
+    );
+    p.add_genomic_sequence("NC_000011.10", "GGGGTTTTAAAACCCC".repeat(10));
+    p
+}
+
+/// The forward control and the inverted form differ, and the inverted form is
+/// exactly the reverse complement of the forward one.
+#[test]
+fn cross_reference_inv_suffix_inserts_the_reverse_complement() {
+    let forward = normalize(
+        "NC_000022.10:g.10_15delins[NC_000011.10:g.1_6]",
+        inv_payload_provider(),
+    )
+    .expect("forward cross-reference must expand");
+    assert_eq!(
+        forward, "NC_000022.10:g.10_15delinsGGGGTT",
+        "forward payload must be the literal GGGGTT",
+    );
+
+    let inverted = normalize(
+        "NC_000022.10:g.10_15delins[NC_000011.10:g.1_6inv]",
+        inv_payload_provider(),
+    )
+    .expect("inv-suffixed cross-reference must expand (#1184)");
+    assert_eq!(
+        inverted, "NC_000022.10:g.10_15delinsAACCCC",
+        "inv payload must be the reverse complement of GGGGTT",
+    );
+    assert_ne!(
+        forward, inverted,
+        "inv must change the inserted sequence, not be silently ignored",
+    );
+}
+
+/// The bracketed `Complex` path (`ins[<literal>;<cross-ref>inv]`) resolves
+/// through `append_part_bases`' `ExternalRef` arm — a separate call site from
+/// the bare-`Reference` path above, so it needs its own pin.
+#[test]
+fn cross_reference_inv_suffix_expands_inside_a_complex_bracket() {
+    let out = normalize(
+        "NC_000022.10:g.10_15delins[A;NC_000011.10:g.1_6inv]",
+        inv_payload_provider(),
+    )
+    .expect("inv-suffixed cross-reference in a Complex bracket must expand (#1184)");
+    // Pin the whole description, not just the `delins…` tail: the replaced range
+    // (`g.10_15` == `CTATAG`) shares no base with the payload, so the canonical
+    // split cannot trim either endpoint and the anchor must stay `10_15`. The
+    // payload is the literal `A` followed by the reverse complement `AACCCC`,
+    // and the flattening leaves no bracket behind.
+    assert_eq!(
+        out, "NC_000022.10:g.10_15delinsAAACCCC",
+        "literal `A` then the reverse complement `AACCCC`, at the unshifted anchor",
+    );
+}
+
+/// A single position carries no orientation, and the same-reference form cannot
+/// express one either (both parse paths build a `PositionRangeInv` only from a
+/// two-part range). `Ainv` must therefore stay an out-of-scope shape rather
+/// than quietly complement one base.
+#[test]
+fn cross_reference_inv_on_a_single_position_is_still_unsupported() {
+    let result = normalize(
+        "NC_000022.10:g.10_15delins[NC_000011.10:g.5inv]",
+        inv_payload_provider(),
+    );
+    assert!(
+        matches!(result, Err(FerroError::UnsupportedVariant { .. })),
+        "single-position inv must stay unsupported; got {result:?}",
+    );
+}


### PR DESCRIPTION
A cross-reference insertion whose range carried a trailing `inv` (`delins[NM_003002.4:c.10_20inv]`) was rejected as an unsupported shape, even though the identical range *without* the suffix expanded fine. Same accession, same range — only the suffix differed.

## Cause

`parse_external_ref_part` (`src/hgvs/parser/edit.rs`) slurps everything up to `;`/`]` into an opaque `ExternalRef`, trailing `inv` included. `parse_cross_reference` then split `10_20inv` into `end_str = "20inv"`, which failed its digits-only test and fell through to `cross_reference_shape_error`.

## Fix

Strip a trailing `inv` before the position parse and reverse-complement the fetched bases — mirroring the same-reference `InsertedPart::PositionRangeInv` / `InsertedSequence::PositionRangeInv` arms in the same file, which already do exactly this. The inversion is applied *after* the fetch, so it composes with each axis's position translation rather than replacing it.

Three deliberate scope decisions:

- **`inv` is accepted only on a two-part `A_Binv` range.** A single position has no orientation, and it is unrepresentable in the same-reference form — both parse paths there (`parse_external_ref_part`, `parse_simple_count`) build a `PositionRangeInv` only from a range, so a bare `Ainv` is a parse error. It therefore stays out of scope here rather than silently complementing one base.
- **Stripping is anchored to the end** (`strip_suffix`), so this is not a general-purpose suffix strip. Every decoration that was out of scope before still is with an `inv` appended (offsets, `*N`, `?`, `pter`/`qter`/`cen`), and an embedded `inv` such as `1inv_3` is still caught by the digits-only checks. There is a test pinning each of these.
- **The shape-error message now names the newly covered form**, so it stays accurate about what is and isn't supported.

## Tests

Unit tests on the resolver (`src/normalize/rules.rs`) cover the reverse complement, composition with every axis (`c.`/`n.`/`r.`/axis-less native frame), the single-position rejection, and the seven decorations that must stay rejected.

End-to-end tests (`tests/it/issue_422_cross_reference_ins.rs`) exercise the full normalize path through **both** entry points — the bare `Reference` and the bracketed `ExternalRef` inside a `Complex` — which matters because the `detect_deferred_part` pre-scan gates on `parse_cross_reference` independently of the expansion itself.

Those tests use a dedicated provider whose replaced range shares no position with either payload. The obvious fixture choice (the existing cyclic `ACGT` contig) is self-reverse-complementary, so tests written against it pass whether or not the bases are actually inverted; and coincidental matches make the normalizer's canonical split factor the result into an allele, hiding the inserted literal. The payloads are `GGGGTT` / `AACCCC` for the same reason — not palindromes.

## Verification

- 8530/8530 tests pass; `clippy --all-features --all-targets -D warnings` clean.
- The idempotency oracle (`FERRO_ASSERT_IDEMPOTENT=1`) passes over the 984 normalize/cross-reference tests.
- Against the real prepared reference, the issue's repro now yields `NM_004006.3:c.126_500delinsCCTCCAGAG`, and that output parses back cleanly. Checked by hand rather than taken on trust: the forward payload is `CTCTGGAGGCT`, whose reverse complement is `AGCCTCCAGAG`; trimming the outer `AG` gives exactly the observed result.

## Baseline churn

One line, in `mock-pin/normalized.txt` — the updated shape-error message text. That row's payload is `pter`/`qter`-decorated, so it still errors; only the wording moved. The generated `hgvs_spec_normalization.json` (gitignored) was regenerated and shows no status changes: the `inv`-bearing rows that reach the resolver are all `qter`-decorated and stay rejected.

Closes #1184
