### PR TITLE
fix(normalize): run the ins[...] expansion on the r. axis

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2028,8 +2028,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// [`NormalizationWarning::InsertedSequenceExpanded`] for
     /// observability, or `None` when nothing was canonicalized.
     ///
-    /// The four `normalize_<axis>` methods wrap this helper to build the
-    /// per-axis variant struct. Splitting the warning construction here
+    /// The five `normalize_<axis>` methods — genome, cds, tx, rna (#1183), and
+    /// mt — wrap this helper to build the per-axis variant struct, one
+    /// `try_expand_<axis>_ins` each. Splitting the warning construction here
     /// keeps the original `[ATC]` / `[A;100_110]` rendering accessible
     /// before the edit is mutated.
     fn try_expand_ins_edit(
@@ -2155,6 +2156,36 @@ impl<P: ReferenceProvider> Normalizer<P> {
             return Ok(None);
         };
         let new_variant = TxVariant {
+            accession: variant.accession.clone(),
+            gene_symbol: variant.gene_symbol.clone(),
+            loc_edit: LocEdit::with_uncertainty(
+                variant.loc_edit.location.clone(),
+                variant.loc_edit.edit.map_ref(|_| new_edit.clone()),
+            ),
+        };
+        Ok(Some((new_variant, warning)))
+    }
+
+    /// `normalize_rna` companion — `r.` numbering follows the associated DNA
+    /// reference, so it is CDS-relative (== `c.`) on a coding transcript and
+    /// transcript-relative (== `n.`) on a non-coding one. That split needs the
+    /// provider, so it is carried by `InsCoordKind::Rna` and resolved at fetch
+    /// time in `fetch_position_range_bases` — the same kind the `r.`
+    /// cross-reference *payload* path already uses (#773). No `U`→`T` step is
+    /// needed here: the payload resolves to DNA bases from the provider, and
+    /// `RnaVariant`'s Display renders `T`→`u` again on output. #1183.
+    fn try_expand_rna_ins(
+        &self,
+        variant: &crate::hgvs::variant::RnaVariant,
+        edit: &NaEdit,
+        accession: &str,
+    ) -> Result<Option<(crate::hgvs::variant::RnaVariant, NormalizationWarning)>, FerroError> {
+        let Some((new_edit, warning)) =
+            self.try_expand_ins_edit(edit, accession, InsCoordKind::Rna)?
+        else {
+            return Ok(None);
+        };
+        let new_variant = crate::hgvs::variant::RnaVariant {
             accession: variant.accession.clone(),
             gene_symbol: variant.gene_symbol.clone(),
             loc_edit: LocEdit::with_uncertainty(
@@ -4923,10 +4954,8 @@ impl<P: ReferenceProvider> Normalizer<P> {
         }
 
         // SVD-WG009: rewrite `con` to `delins`. Re-run on the rewritten
-        // variant so downstream passes (3' shift, ins→dup, canonical
-        // split) all see the delins form. The RNA axis does not run the
-        // issue #333 ins[...] expansion step — that is wired only into
-        // the genome/cds/tx/mt axes.
+        // variant so downstream passes (the #333 `ins[...]` expansion below,
+        // 3' shift, ins→dup, canonical split) all see the delins form.
         if let Some(new_edit) = canonicalize_conversion_to_delins(edit) {
             let new_variant = RnaVariant {
                 accession: variant.accession.clone(),
@@ -4937,6 +4966,22 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 ),
             };
             return self.normalize_rna(&new_variant);
+        }
+
+        // Issue #333 / #1183: expand bracketed / reference-range `ins[...]`
+        // payloads, mirroring the genome/cds/tx/mt axes. Runs here — after the
+        // u/T and con→delins rewrites, before the `needs_normalization` and
+        // intronic dispatches below — so the payload is already a literal by the
+        // time either the intronic (tx-delegating) or exonic path sees it, and so
+        // an out-of-scope payload is *refused* on `r.` exactly as it is on `c.`
+        // instead of passing through unvalidated.
+        let rna_accession = variant.accession.transcript_accession();
+        if let Some((new_variant, warning)) =
+            self.try_expand_rna_ins(variant, edit, &rna_accession)?
+        {
+            let (result, mut warnings) = self.normalize_rna(&new_variant)?;
+            warnings.insert(0, warning);
+            return Ok((result, warnings));
         }
 
         // Only normalize indels

--- a/tests/it/issue_1183_rna_axis_ins_expansion.rs
+++ b/tests/it/issue_1183_rna_axis_ins_expansion.rs
@@ -1,0 +1,159 @@
+//! Issue #1183 — the `r.` axis must run the #333 `ins[...]` expansion.
+//!
+//! Expansion wrappers existed for the genome/cds/tx/mt axes but not for RNA, so
+//! an `r.` input carried its `ins[...]` payload through **unexpanded and
+//! unvalidated**. Two consequences, both pinned here:
+//!
+//!   1. A resolvable payload stayed bracketed on `r.` while `c.`/`n.` flattened
+//!      it to a literal.
+//!   2. An *out-of-scope* payload — which `c.` correctly refuses — was laundered
+//!      through `r.`, so projecting onto `c.` emitted a description ferro's own
+//!      validation then rejected.
+//!
+//! `NM_000088.3` in the mock has `cds_start = 1`, so `r.N` and `c.N` address the
+//! same base. That makes the two axes directly comparable: the `r.` result must
+//! be the `c.` result re-rendered as RNA (lowercase, `u` for `T`), and any
+//! divergence is the bug. Comparing against `c.` rather than a hardcoded string
+//! is deliberate — it keeps these tests honest if the shared expansion or
+//! canonicalization behavior changes later.
+
+use ferro_hgvs::error::FerroError;
+use ferro_hgvs::reference::mock::MockProvider;
+use ferro_hgvs::{parse_hgvs, Normalizer};
+
+fn normalize(input: &str) -> Result<String, FerroError> {
+    let normalizer = Normalizer::new(MockProvider::with_test_data());
+    let variant = parse_hgvs(input)?;
+    normalizer.normalize(&variant).map(|v| format!("{}", v))
+}
+
+/// `r.4_6` is `CCC` and the payload `1_3` is `ATG` — chosen so no position of the
+/// replaced range matches the inserted sequence. Coincidental matches make the
+/// normalizer's canonical split factor the result into an allele, which would
+/// hide the inserted literal these tests are about.
+const OUTER: &str = "r.4_6";
+
+// =============================================================================
+// A resolvable payload must flatten on `r.`, exactly as it does on `c.`
+// =============================================================================
+
+/// Same-reference position-range payload (`ins[A_B]`, the #333 shape).
+#[test]
+fn rna_axis_expands_a_same_reference_position_range_payload() {
+    let out = normalize(&format!("NM_000088.3:{OUTER}delins[1_3]"))
+        .expect("r.-axis same-reference payload must normalize");
+    assert_eq!(
+        out, "NM_000088.3:r.4_6delinsaug",
+        "the payload must flatten to the literal r.1_3 == aug",
+    );
+    assert!(
+        !out.contains('['),
+        "no bracket may survive expansion; got {out}",
+    );
+}
+
+/// Cross-reference payload (`ins[ACC:axis.A_B]`, the #422/#773 shape). This is
+/// the exact form in the issue report.
+#[test]
+fn rna_axis_expands_a_cross_reference_payload() {
+    let out = normalize(&format!("NM_000088.3:{OUTER}delins[NR_000123.1:n.1_4]"))
+        .expect("r.-axis cross-reference payload must normalize");
+    // NR_000123.1 is "ACGTACGTACGT", so n.1_4 == ACGT -> rendered acgu on r.
+    // Pin the whole description like the same-reference sibling above, not just
+    // the literal: `r.4_6` is `CCC`, which shares neither its first nor its last
+    // base with `acgu`, so the canonical split cannot trim either endpoint and
+    // the anchor must stay `4_6`. A weaker `contains` would miss an anchor shift.
+    assert_eq!(
+        out, "NM_000088.3:r.4_6delinsacgu",
+        "the cross-reference must flatten to the literal acgu at the unshifted anchor",
+    );
+}
+
+/// The `r.` result must agree with the `c.` result for the same positions
+/// (`cds_start == 1`), differing only in RNA rendering. This is the property the
+/// issue is really about: `r.` must not diverge from `c.`.
+#[test]
+fn rna_axis_expansion_agrees_with_the_c_axis() {
+    for payload in ["1_3", "NR_000123.1:n.1_4"] {
+        let rna = normalize(&format!("NM_000088.3:r.4_6delins[{payload}]"))
+            .unwrap_or_else(|e| panic!("r. with [{payload}] must normalize, got {e:?}"));
+        let cds = normalize(&format!("NM_000088.3:c.4_6delins[{payload}]"))
+            .unwrap_or_else(|e| panic!("c. with [{payload}] must normalize, got {e:?}"));
+        // Re-render the c. answer as RNA: lowercase, and u for T.
+        let expected = cds.replace("c.", "r.");
+        let split = expected.split_at(expected.find("delins").unwrap_or_else(|| {
+            panic!(
+                "the c. answer for [{payload}] is expected to stay a delins; got {cds} — \
+                 if canonicalization legitimately changed shape, update this re-rendering"
+            )
+        }));
+        let (prefix, edit) = split;
+        let as_rna = format!("{prefix}{}", edit.to_lowercase().replace('t', "u"));
+        assert_eq!(
+            rna, as_rna,
+            "r. must match the c. answer re-rendered as RNA (payload [{payload}])",
+        );
+    }
+}
+
+// =============================================================================
+// An out-of-scope payload must be REFUSED on `r.`, not laundered through
+// =============================================================================
+
+/// The laundering half of the bug. `c.` refuses each of these shapes; before the
+/// fix `r.` accepted them silently, so `ferro project --axis c` emitted a `c.`
+/// string that ferro itself then failed to parse/normalize.
+#[test]
+fn rna_axis_refuses_the_payloads_the_c_axis_refuses() {
+    for payload in [
+        // p. axis — structurally invalid as a DNA-insertion payload.
+        "NP_000079.2:p.10_15",
+        // Intronic offsets and UTR markers — spec-undefined for expansion.
+        "NM_000088.3:c.244-8_249",
+        "NM_000088.3:c.100_*200",
+        // pter/qter decorations have no concrete coordinate.
+        "NC_000022.10:g.pter_100",
+    ] {
+        let on_cds = normalize(&format!("NM_000088.3:c.4_6delins[{payload}]"));
+        assert!(
+            on_cds.is_err(),
+            "premise check: c. must refuse [{payload}]; got {on_cds:?}",
+        );
+        let on_rna = normalize(&format!("NM_000088.3:r.4_6delins[{payload}]"));
+        assert!(
+            on_rna.is_err(),
+            "r. must refuse [{payload}] like c. does, not launder it through; got {on_rna:?}",
+        );
+    }
+}
+
+/// A payload naming an accession absent from the provider must surface the
+/// lookup failure on `r.` too, rather than passing the variant through.
+#[test]
+fn rna_axis_surfaces_a_missing_payload_accession() {
+    let result = normalize(&format!("NM_000088.3:{OUTER}delins[NM_999999.9:c.1_3]"));
+    assert!(
+        result.is_err(),
+        "an unresolvable payload accession must error on r.; got {result:?}",
+    );
+}
+
+// =============================================================================
+// The `con` asymmetry noted in the issue's "Related" section
+// =============================================================================
+
+/// `con` is rewritten to `delins` on `r.` already, but without the expansion
+/// step the rewritten payload stayed a bare `delins1_3` where `c.` produced the
+/// literal. Same root cause, so it is fixed by the same wrapper — this pins it.
+#[test]
+fn rna_axis_con_edit_expands_to_a_literal() {
+    let out = normalize(&format!("NM_000088.3:{OUTER}con1_3")).expect("r.-axis con must normalize");
+    assert_eq!(
+        out, "NM_000088.3:r.4_6delinsaug",
+        "con must expand to the literal, not stay a bare delins1_3",
+    );
+    assert!(
+        !out.contains("delins1_3"),
+        "the unexpanded position range must not survive; got {out}",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -130,6 +130,7 @@ mod issue_1157_delins_reduction_shift;
 mod issue_1157_five_prime_insertion_rotation;
 mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
+mod issue_1183_rna_axis_ins_expansion;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
The #333 `ins[...]` expansion had wrappers for the genome/cds/tx/mt axes but none for RNA, so an `r.` input carried its payload through unexpanded and unvalidated. The code documented the gap at `src/normalize/mod.rs:4945-4947`; #773 expanded `r.` as a *payload* axis, not as the *outer* axis, which is why it survived.

Two consequences, both fixed here:

- A resolvable payload stayed bracketed on `r.` where `c.`/`n.` flattened it to a literal.
- An out-of-scope payload — which `c.` correctly refuses — was **laundered** through `r.`, so `ferro project --axis c` emitted a `c.` description that ferro's own validation then rejected.

## Fix

Add `try_expand_rna_ins` beside its four siblings and wire it into `normalize_rna` after the u/T and `con`→`delins` rewrites, before the `needs_normalization` and intronic dispatches. That placement means the payload is already a literal whichever path follows (the intronic path delegates to the tx engines, so an unexpanded bracket there would be a second, separate problem), and an out-of-scope payload is refused up front rather than passed through.

The wrapper uses `InsCoordKind::Rna`, which carries the coding-aware split — `r.` numbering is CDS-relative on a coding transcript and transcript-relative on a non-coding one — and resolves it against the provider at fetch time via `Transcript::is_coding()`. This is the same kind the `r.` cross-reference *payload* path has used since #773, so the outer and payload axes now agree on what `r.` numbering means, and the wrapper does not hardcode a frame that would need revisiting. No `U`→`T` handling is needed: the payload resolves to DNA bases from the provider, and `RnaVariant`'s Display re-renders `T`→`u` on output.

This also closes the **`con` rendering asymmetry** flagged in the issue's "Related" section. `con` was already rewritten to `delins` on `r.`, but without the expansion step the rewritten payload stayed a bare `delins1_3` where `c.` produced the literal. Same root cause, so the same wrapper fixes it — which is why the issue's guess that fixing one closes both was right.

## Tests

`tests/it/issue_1183_rna_axis_ins_expansion.rs` covers both halves: the same-reference (`ins[A_B]`) and cross-reference (`ins[ACC:axis.A_B]`) payloads flatten, four out-of-scope payload shapes are refused, a missing payload accession surfaces its lookup error, and `con` expands to a literal.

The refusal test asserts a **premise check first** — that `c.` really does refuse each shape — so it cannot silently degrade into a tautology if the `c.` behavior ever changes.

`NM_000088.3` in the mock has `cds_start = 1`, so `r.N` and `c.N` address the same base. One test exploits that to assert `r.` equals the `c.` answer re-rendered as RNA, rather than pinning a hardcoded string — the property the issue is actually about, and one that stays meaningful if the shared expansion or canonicalization behavior changes later. The replaced range (`r.4_6` == `CCC`) and payload (`1_3` == `ATG`) are chosen so no position matches; coincidental matches make the canonical split factor the result into an allele, hiding the inserted literal.

## Verification

- 8529/8529 tests pass; `clippy --all-features --all-targets -D warnings` clean; idempotency oracle (`FERRO_ASSERT_IDEMPOTENT=1`) passes over the 1528 rna/normalize/cross-reference tests.
- The generated `hgvs_spec_normalization.json` was regenerated explicitly (it is gitignored, so a stale copy gives a false pass) and the spec/enumeration suites, including `divergence_budget_is_unchanged`, still pass. No committed baseline churn at all.
- Against the real prepared reference, the issue's two repros:

```
r.124_500delins[NM_003002.4:c.10_20]  ->  r.124_498delinscucuggagg
c.124_500delins[NM_003002.4:c.10_20]  ->  c.124_498delinsCTCTGGAGG
```

The `r.` answer now matches the `c.` answer base for base including the canonical trim to 498. And the laundering repro (`r.124_500delins[AB053210.2:r.1289-365_1289-73inv]` projected to `c.`) now refuses instead of emitting a `c.` string ferro cannot read back.

Closes #1183
