### PR TITLE
fix(normalize): complete the 3'-shift across cds_end in one pass for delins and dup

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -2635,6 +2635,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             rel_end,
             &Boundaries::new(0, ref_seq.len() as u64),
             false, // genomic context: codon-frame gate does not apply
+            None,  // codon-frame gate does not apply here
         )?;
 
         // Adjust back to genomic coordinates
@@ -3283,8 +3284,19 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(cds_end) => tx_start >= cds_start && tx_end <= cds_end,
             None => false,
         };
-        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
+        // The same bounds, un-collapsed, so a gate site deciding about a span
+        // other than the input can evaluate it there instead (#1185).
+        let cds_span = transcript.cds_end.map(|cds_end| (cds_start, cds_end));
+        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                seq,
+                edit,
+                tx_start,
+                tx_end,
+                &boundaries,
+                is_coding,
+                cds_span,
+            )?;
 
         // Substitutions are validated-then-returned-unchanged by
         // `normalize_na_edit`'s `Substitution` arm; nothing downstream (axis
@@ -3396,8 +3408,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 ShuffleDirection::ThreePrime => cheap_right,
             };
             let (left_clamp_fired, right_clamp_fired) = if direction_could_clamp {
-                let (exon_only_start, exon_only_end, _exon_only_edit, _exon_only_warnings) =
-                    self.normalize_na_edit(seq, edit, tx_start, tx_end, &exon_only, is_coding)?;
+                let (exon_only_start, exon_only_end, _exon_only_edit, _exon_only_warnings) = self
+                    .normalize_na_edit(
+                    seq, edit, tx_start, tx_end, &exon_only, is_coding, cds_span,
+                )?;
                 let exon_only_start_0 = exon_only_start.saturating_sub(1);
                 (
                     cheap_left && exon_only_start_0 < boundaries.left,
@@ -3897,8 +3911,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(s) => s.as_bytes(),
             None => return Ok((HV::Tx(self.canonicalize_tx_variant(variant)), vec![])),
         };
+        // `mut` bindings are #1202's (its transcript-bound clamp rewrites these
+        // in place); the trailing `None` is #1185's `cds_span`. `n.` has no
+        // reading frame, so there is no CDS span to re-check a shuffled tract
+        // against — unlike `r.` below, which does pass real bounds.
         let (mut new_start, mut new_end, mut new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false, None)?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
         // substitutions are validated-then-returned-unchanged by
@@ -5382,8 +5400,23 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some((cds_start, cds_end)) => tx_start >= cds_start && tx_end <= cds_end,
             None => false,
         };
-        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
+        // `mut` bindings are #1202's (its transcript-bound clamp rewrites these
+        // in place). `cds_info` (not `None`) is the #1185 companion to #1192's
+        // `is_coding`: the codon-frame gate applies on `r.` exactly as on `c.`,
+        // so the shuffled-tract re-check must be able to run here too. Passing
+        // `None` would make that verdict unconditionally "exempt" and silently
+        // re-open the divergence #1192 closed — `issue_1192`'s
+        // `rna_homopolymer_expansion_inside_cds_is_gated` fails if you try it.
+        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) = self
+            .normalize_na_edit(
+                seq,
+                edit,
+                tx_start,
+                tx_end,
+                &boundaries,
+                is_coding,
+                cds_info,
+            )?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
         // substitutions are validated-then-returned-unchanged by
@@ -5933,6 +5966,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             rel_end,
             &Boundaries::new(0, ref_seq.len() as u64),
             false,
+            None, // codon-frame gate does not apply here
         )?;
 
         let new_start = new_rel_start + window_start;
@@ -6202,6 +6236,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             false,
+            None, // codon-frame gate does not apply here
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -6385,6 +6420,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             false,
+            None, // codon-frame gate does not apply here
         )?;
 
         // Map the result positions back to the genomic-strand frame
@@ -6552,6 +6588,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             false,
+            None, // codon-frame gate does not apply here
         )?;
 
         let (new_rel_start, new_rel_end) = unflip_intronic_positions(
@@ -7001,6 +7038,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             work_rel_end,
             &work_boundaries,
             false,
+            None, // codon-frame gate does not apply here
         )?;
 
         let (new_rel_start, new_rel_end) = unflip_intronic_positions(
@@ -7037,6 +7075,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
     /// Core normalization for nucleic acid edits
     ///
     /// Returns (new_start, new_end, new_edit, warnings)
+    // Already at clippy's 7-argument limit before #1185 added `cds_span`. The
+    // right cleanup is to fold `is_coding` + `cds_span` into one `CodonGate`
+    // value — they are two views of the same question — but that is a mechanical
+    // rename across every call site in this function and is deliberately left
+    // out of a behaviour fix. Suppressed rather than papered over with a tuple.
+    #[allow(clippy::too_many_arguments)]
     fn normalize_na_edit(
         &self,
         ref_seq: &[u8],
@@ -7045,6 +7089,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
         end: u64,
         boundaries: &Boundaries,
         is_coding: bool,
+        // Transcript-frame CDS bounds (1-based, inclusive), or `None` where the
+        // codon-frame gate does not apply (genomic / `n.`). **`r.` passes real
+        // bounds**, not `None`: #1192 established that the gate applies on the
+        // `r.` axis too, since `r.` on a coding transcript IS the `c.` axis
+        // (`RNA/repeated.md` L24-27). `is_coding`
+        // is this same verdict precomputed for the INPUT span; `cds_span` lets a
+        // site that decides about a DIFFERENT span ask about that span instead
+        // (#1185). Deliberately additive: every existing site keeps reading
+        // `is_coding`, so only the one site below changes behaviour.
+        cds_span: Option<(u64, u64)>,
     ) -> Result<(u64, u64, NaEdit, Vec<NormalizationWarning>), FerroError> {
         let mut warnings = Vec::new();
 
@@ -7155,7 +7209,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         };
                         let (new_start, new_end, new_edit, mut child_warnings) = self
                             .normalize_na_edit(
-                                ref_seq, &literal, start, end, boundaries, is_coding,
+                                ref_seq, &literal, start, end, boundaries, is_coding, cds_span,
                             )?;
                         warnings.append(&mut child_warnings);
                         return Ok((new_start, new_end, new_edit, warnings));
@@ -7214,8 +7268,9 @@ impl<P: ReferenceProvider> Normalizer<P> {
                         sequence: None,
                         length: None,
                     };
-                    return self
-                        .normalize_na_edit(ref_seq, &del, start, end, boundaries, is_coding);
+                    return self.normalize_na_edit(
+                        ref_seq, &del, start, end, boundaries, is_coding, cds_span,
+                    );
                 }
 
                 // HGVS spec: delins should NOT be 3' shifted like del/dup/ins,
@@ -7300,6 +7355,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     e0 as u64,
                                     boundaries,
                                     is_coding,
+                                    cds_span,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -7360,6 +7416,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     (after_index + 1) as u64,
                                     boundaries,
                                     is_coding,
+                                    cds_span,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -7405,6 +7462,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                     e0 as u64,
                                     boundaries,
                                     is_coding,
+                                    cds_span,
                                 )?;
                             let mut merged = warnings.clone();
                             merged.append(&mut child_warnings);
@@ -7988,9 +8046,33 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 // Check if duplication should become repeat notation
                 // Use the shuffled positions (result.start, result.end) which are 0-based
                 // This applies to both single-base dups in homopolymers and multi-base tandem dups
-                if let Some(dup_result) =
-                    rules::duplication_to_repeat(ref_seq, result.start, result.end, is_coding)
-                {
+                if let Some(dup_result) = rules::duplication_to_repeat(
+                    ref_seq,
+                    result.start,
+                    result.end,
+                    // #1185: this call decides about the SHUFFLED tract
+                    // (`result.*`), so the codon-frame gate must be asked
+                    // about that tract — not about the input span, which is
+                    // what `is_coding` holds.
+                    //
+                    // A dup whose 3'-shifted tract runs out of the CDS into
+                    // the 3'UTR is exempt from the multiple-of-3 rule:
+                    // "This restriction only applies to the coding sequence,
+                    // which does not include the introns or the UTR
+                    // sequence." (DNA/repeated.md) — the added copies land
+                    // past `cds_end` and so cannot move the reading frame.
+                    // Keyed on the input span it was gated to an `ins`
+                    // literal on pass 1 and collapsed to repeat notation only
+                    // on pass 2, once the straddling tract had made the input
+                    // span itself non-coding.
+                    matches!(
+                        cds_span,
+                        Some((cds_s, cds_e))
+                            if index_to_hgvs_pos(result.start as usize) >= cds_s
+                                && index_to_hgvs_pos(result.end.saturating_sub(1) as usize)
+                                    <= cds_e
+                    ),
+                ) {
                     match dup_result {
                         rules::DupToRepeatResult::Homopolymer {
                             base,
@@ -8058,10 +8140,20 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 // (and, at a coding boundary, invalid) forms.
                                 // Terminates: the derived edit is an Insertion,
                                 // which never re-enters this Duplication arm.
+                                // `cds_span` is threaded through unchanged: the
+                                // recursion stays on the same transcript, so the
+                                // CDS bounds are identical, and the derived
+                                // insertion covers a DIFFERENT span than the
+                                // input — exactly the case `cds_span` exists for
+                                // (#1185). Passing `None` here would silently
+                                // switch the codon-frame gate off for the derived
+                                // insertion. This call site postdates #1185's
+                                // base, so it is threaded on rebase rather than
+                                // in the original commit.
                                 let (rec_start, rec_end, rec_edit, mut rec_warnings) = self
                                     .normalize_na_edit(
                                         ref_seq, &ins_edit, ins_start, ins_end, boundaries,
-                                        is_coding,
+                                        is_coding, cds_span,
                                     )?;
                                 let mut merged = warnings;
                                 merged.append(&mut rec_warnings);

--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -3210,9 +3210,27 @@ impl<P: ReferenceProvider> Normalizer<P> {
         //   - only when BOTH endpoints are CDS-resident (`start_axis` /
         //     `end_axis` == Cds) so we never reinterpret a variant that already
         //     straddles an axis (those keep the #350 bail above);
-        //   - only del/dup (the spec-clear "most-3' of the reference sequence"
-        //     shapes). Insertions keep the clamp — their re-axing into the 3'UTR
-        //     is governed by the dedicated #387 CDS-end clamp;
+        //   - only del/dup/delins (the spec-clear "most-3' of the reference
+        //     sequence" shapes). Insertions keep the clamp — their re-axing into
+        //     the 3'UTR is governed by the dedicated #387 CDS-end clamp;
+        //
+        //     `Delins` is included because gating on the input's edit-kind
+        //     *spelling* made this relaxation miss its own case (#1185). A
+        //     `delins` whose ref and alt share a prefix or suffix reduces to a
+        //     pure deletion during normalization — `c.7_9delinsA` over ref `AAC`
+        //     is a deletion of `AC` at `c.8_9` — and that deletion is exactly
+        //     the shape this relaxation exists for. Clamped, it stopped at
+        //     `cds_end` on the first pass and shifted only on a second, so
+        //     normalization was not idempotent. The `r.` spelling of the
+        //     byte-identical edit already shifted in one pass, which is what
+        //     showed the clamp (not the shuffle) was at fault.
+        //
+        //     This also relaxes the bound for a `delins` that does NOT reduce,
+        //     which is a slightly wider change than the non-idempotency strictly
+        //     required. That is deliberate and consistent: the 3' rule is stated
+        //     "for all descriptions", and the single-contiguous-sequence argument
+        //     above does not depend on the edit kind. It is also what keeps the
+        //     rule from depending on how a caller happened to spell an edit.
         //   - only the 3'-direction shuffle;
         //   - the bound is relaxed to the **exon** bound, not seq_len, so the
         //     spec's exon/exon exception stays enforced: a 3'UTR intron still
@@ -3222,7 +3240,10 @@ impl<P: ReferenceProvider> Normalizer<P> {
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && matches!(start_axis, boundary::AxisRegion::Cds)
             && matches!(end_axis, boundary::AxisRegion::Cds)
-            && matches!(edit, NaEdit::Deletion { .. } | NaEdit::Duplication { .. })
+            && matches!(
+                edit,
+                NaEdit::Deletion { .. } | NaEdit::Duplication { .. } | NaEdit::Delins { .. }
+            )
         {
             boundaries = Boundaries::new(boundaries.left, exon_only.right);
         }

--- a/tests/it/issue_1185_cds_end_3utr_shift.rs
+++ b/tests/it/issue_1185_cds_end_3utr_shift.rs
@@ -139,10 +139,18 @@ fn control_plain_deletion_crosses_cds_end_in_one_pass() {
     );
 }
 
-/// The decisive control: the SAME edit over the BYTE-IDENTICAL transcript,
-/// differing only in the axis it is spelled on. On a coding transcript `r.` is
-/// the CDS-relative axis — the same axis as `c.` (#469) — so both spellings
-/// name the same bases and must shift identically.
+/// The SAME edit over the BYTE-IDENTICAL transcript, differing only in the axis
+/// it is spelled on. On a coding transcript `r.` is the CDS-relative axis — the
+/// same axis as `c.` (#469) — so both spellings name the same bases.
+///
+/// **Scope, deliberately narrow.** This is a valid control for the *shuffle*
+/// (this test), because no repeat notation is involved. It is **not** a valid
+/// control for the codon-frame gate exercised by the `dup` tests below:
+/// `normalize_rna` passes no CDS span at all, so the gate never applies on the
+/// `r.` axis — even though `RNA/repeated.md:24-27` imposes the same
+/// multiple-of-3 restriction as the DNA page. That gap is a separate defect and
+/// is deliberately not addressed here; treating `r.` as an oracle for the gate
+/// would have "confirmed" whatever `r.` happened to do.
 #[test]
 fn control_same_edit_on_r_axis_shifts_in_one_pass() {
     assert_one_pass(
@@ -172,5 +180,67 @@ fn control_delins_reduction_staying_inside_cds_is_one_pass() {
         utr3_ac_tandem(Strand::Plus),
         "NM_UTR3.1:c.3_5delinsA",
         "NM_UTR3.1:c.7_8del",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Site 2 — the codon-frame gate must be evaluated against the tract the repeat
+// description will NAME (the shuffled tract), not the input span.
+//
+// `DNA/repeated.md`: "using a coding DNA reference sequence ("c." description),
+// a repeated sequence variant description can be used only for repeat units
+// with a length which is a multiple of 3, i.e. which can not affect the reading
+// frame. … **This restriction only applies to the coding sequence, which does
+// not include the introns or the UTR sequence.** As such,
+// `NM_024312.4:c.-6_-3G[6]` is valid as the reading frame is not affected."
+//
+// So a tract that 3'-shifts out of the CDS into the 3'UTR is exempt: the added
+// copies land past `cds_end` and cannot move the reading frame.
+// ---------------------------------------------------------------------------
+
+/// CDS `GAAAAAACAC` (`c.1..c.10`) + an `ACGT` 3'UTR puts an `AC[3]` tract at
+/// `c.7_*2`, bounded by the `G` at `*3`.
+fn utr3_acgt_bounded() -> MockProvider {
+    coding_transcript("GAAAAAACAC", &"ACGT".repeat(10), Strand::Plus)
+}
+
+/// `c.7_10dup` duplicates `ACAC`, expanding the `AC[3]` tract at `c.7_*2` to
+/// `AC[5]`. The unit is 2 nt — not a multiple of 3 — but the tract runs out of
+/// the CDS into the 3'UTR, so the codon-frame restriction does not apply and
+/// repeat notation is correct.
+///
+/// Before the fix the gate was keyed on the input span (`c.7_10`, entirely
+/// CDS-resident), so pass 1 emitted the `ins` literal `c.*2_*3insACAC` and only
+/// pass 2 — by then seeing a straddling span — collapsed it to `AC[5]`.
+#[test]
+fn dup_whose_shifted_tract_leaves_the_cds_gets_repeat_notation_in_one_pass() {
+    assert_one_pass(
+        utr3_acgt_bounded(),
+        "NM_UTR3.1:c.7_10dup",
+        "NM_UTR3.1:c.7_*2AC[5]",
+    );
+}
+
+/// The control that proves the gate was narrowed, not disabled. A non-triplet
+/// unit whose tract stays **entirely inside** the CDS must still be refused
+/// repeat notation and rendered as an `ins` literal — the spec's own remedy
+/// ("use `NM_024312.4:c.1741_1742insTATATATA` and **not** `c.1738TA[6]`").
+#[test]
+fn control_non_triplet_dup_inside_the_cds_still_renders_as_ins_literal() {
+    assert_one_pass(
+        coding_transcript("GACACACACGGGTTT", &"GGGTTT".repeat(4), Strand::Plus),
+        "NM_UTR3.1:c.2_5dup",
+        "NM_UTR3.1:c.9_10insACAC",
+    );
+}
+
+/// And a codon-aligned unit inside the CDS still gets repeat notation, so the
+/// gate is discriminating on unit length rather than blanket-refusing.
+#[test]
+fn control_codon_aligned_dup_inside_the_cds_gets_repeat_notation() {
+    assert_one_pass(
+        coding_transcript("GCAGCAGCAGTTT", &"GGGTTT".repeat(4), Strand::Plus),
+        "NM_UTR3.1:c.2_7dup",
+        "NM_UTR3.1:c.2_10CAG[5]",
     );
 }

--- a/tests/it/issue_1185_cds_end_3utr_shift.rs
+++ b/tests/it/issue_1185_cds_end_3utr_shift.rs
@@ -1,0 +1,176 @@
+//! Issue #1185 — a `delins` that reduces to a pure deletion must complete its
+//! 3'-shift across `cds_end` in a **single** normalization pass.
+//!
+//! The HGVS 3' rule is unconditional — "for all descriptions, the most 3'
+//! position possible **of the reference sequence** is arbitrarily assigned to
+//! have been changed" (`general.md`; `DNA/deletion.md` L20) — and the coding DNA
+//! reference is one contiguous string (5'UTR+CDS+3'UTR, `background/refseq.md`),
+//! so a shift from `c.<N>` into `c.*<M>` stays inside that single sequence.
+//! \#918 already relaxed the CDS↔3'UTR shuffle bound for a CDS-resident
+//! `del`/`dup` for exactly this reason.
+//!
+//! That relaxation was gated on the **input's** edit-kind spelling, so a
+//! `delins` whose alt/ref share a prefix — which reduces to a pure deletion
+//! during normalization — never received it. Its shift was clamped at
+//! `cds_end`, and the reduced deletion only shifted on a *second* pass, once it
+//! re-entered spelled as a `Deletion`. Normalization was therefore not
+//! idempotent for these inputs.
+//!
+//! The controls below are what make this a bug rather than a fixture artifact:
+//! the same edit on the `r.` axis, the already-reduced `del` spelling, the
+//! `n.` axis over the same bases, and a `delins` whose shift stays inside the
+//! CDS all settle in one pass — before and after the fix.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Length of the 5'UTR, so `c.1` is transcript base `UTR5_LEN + 1`.
+const UTR5_LEN: usize = 40;
+
+/// Build `NM_UTR3.1` as `C * 40` (5'UTR) ++ `cds` ++ `utr3`, single exon.
+///
+/// Hand-rolled rather than built with `SyntheticBuilder` so that no property of
+/// the synthetic `ACGT` padding can be blamed for the outcome — a padding
+/// artifact of exactly this shape produced a false finding once before.
+fn coding_transcript(cds: &str, utr3: &str, strand: Strand) -> MockProvider {
+    let sequence = format!("{}{cds}{utr3}", "C".repeat(UTR5_LEN));
+    let tx_len = sequence.len() as u64;
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_UTR3.1".to_string(),
+        Some("UTR3_TEST".to_string()),
+        strand,
+        sequence,
+        Some((UTR5_LEN + 1) as u64),
+        Some((UTR5_LEN + cds.len()) as u64),
+        vec![Exon::new(1, 1, tx_len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// CDS `GGAAAAAAC` (`c.1..c.9`) ending in `AC`, followed by an `AC` 3'UTR — so
+/// a deletion of that `AC` has an unbroken `AC` tandem to 3'-shift along, and
+/// the shift necessarily crosses `cds_end` and must render with `*N`.
+fn utr3_ac_tandem(strand: Strand) -> MockProvider {
+    coding_transcript("GGAAAAAAC", &"AC".repeat(20), strand)
+}
+
+/// Normalize once and twice, returning both renderings.
+fn normalize_twice(provider: MockProvider, input: &str) -> (String, String) {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse");
+    let once = normalizer.normalize(&variant).expect("first normalize");
+    let twice = normalizer.normalize(&once).expect("re-normalize");
+    (once.to_string(), twice.to_string())
+}
+
+/// Assert `input` reaches `expected` on the FIRST pass and stays there.
+fn assert_one_pass(provider: MockProvider, input: &str, expected: &str) {
+    let (once, twice) = normalize_twice(provider, input);
+    assert_eq!(
+        once, expected,
+        "{input} must reach its most-3' form in one pass",
+    );
+    assert_eq!(
+        twice, once,
+        "{input} normalized to {once}, which is not a fixed point",
+    );
+}
+
+/// `c.7_9delinsA`: ref `c.7_9` = `AAC`, alt `A`. The shared `A` prefix reduces
+/// it to a deletion of `AC` at `c.8_9`, which 3'-shifts along the `AC` tandem
+/// running out of the CDS into the 3'UTR.
+///
+/// Before the fix this stopped at `c.8_9del` and only shifted on a second pass.
+#[test]
+fn delins_reducing_to_deletion_shifts_across_cds_end_in_one_pass() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.7_9delinsA",
+        "NM_UTR3.1:c.*39_*40del",
+    );
+}
+
+/// Strand must not matter: the coding reference is read in transcript
+/// orientation either way.
+#[test]
+fn delins_reducing_to_deletion_shifts_in_one_pass_on_minus_strand() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Minus),
+        "NM_UTR3.1:c.7_9delinsA",
+        "NM_UTR3.1:c.*39_*40del",
+    );
+}
+
+// A `con` inherits this fix for free rather than needing its own test: the
+// SVD-WG009 `con` → `delins` rewrite (`src/normalize/mod.rs`, the
+// `canonicalize_conversion_to_delins` branch) recurses into `normalize_cds`, so
+// every downstream pass — including the relaxation fixed here — sees the
+// `delins` form and nothing else.
+//
+// There is deliberately no `con` case below. Reaching one would need a donor
+// range whose copied bases reduce the target to a pure deletion crossing
+// `cds_end`, which on this fixture means a `*N`-marked payload
+// (`c.7_9con*39_*41`) — and `ins[...]` expansion declines `*N` markers by
+// design ("Out-of-scope: … UTR markers (*N)"). So the `con` spelling errors on
+// the payload long before the shuffle, independently of this issue.
+
+// ---------------------------------------------------------------------------
+// Controls — these all passed BEFORE the fix. They are what localise the
+// defect to the `delins`-on-`c.` path rather than to the shuffle, the fixture,
+// or the 3'UTR rendering.
+// ---------------------------------------------------------------------------
+
+/// The already-reduced spelling. The shuffle machinery itself was never broken:
+/// fed a `Deletion` directly, it crosses `cds_end` in one pass.
+#[test]
+fn control_plain_deletion_crosses_cds_end_in_one_pass() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.8_9del",
+        "NM_UTR3.1:c.*39_*40del",
+    );
+}
+
+/// The decisive control: the SAME edit over the BYTE-IDENTICAL transcript,
+/// differing only in the axis it is spelled on. On a coding transcript `r.` is
+/// the CDS-relative axis — the same axis as `c.` (#469) — so both spellings
+/// name the same bases and must shift identically.
+#[test]
+fn control_same_edit_on_r_axis_shifts_in_one_pass() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:r.7_9delinsa",
+        "NM_UTR3.1:r.*39_*40del",
+    );
+}
+
+/// The transcript-relative axis over the same bases (`n.48_49` is `c.8_9`),
+/// where there is no CDS↔3'UTR boundary to clamp against at all.
+#[test]
+fn control_n_axis_over_the_same_bases_shifts_in_one_pass() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:n.48_49del",
+        "NM_UTR3.1:n.88_89del",
+    );
+}
+
+/// A `delins` that reduces to a deletion whose 3'-shift stays INSIDE the CDS
+/// was always one-pass — so the defect was specifically about crossing
+/// `cds_end`, not about `delins` reduction in general.
+#[test]
+fn control_delins_reduction_staying_inside_cds_is_one_pass() {
+    assert_one_pass(
+        utr3_ac_tandem(Strand::Plus),
+        "NM_UTR3.1:c.3_5delinsA",
+        "NM_UTR3.1:c.7_8del",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -132,6 +132,7 @@ mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
 mod issue_1177_rna_axis_cds_relative;
 mod issue_1183_rna_axis_ins_expansion;
+mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;
 mod issue_1202_transcript_bounds_insertion_clamp;
 mod issue_129_mt_circular_wraparound;


### PR DESCRIPTION
Closes #1185

Two commits, one per half of the issue. Both halves turned out to be the **same defect at two sites**: a decision keyed on the *input's* spelling/span rather than on the *result* it actually governs.

## Commit 1 — a reducing `delins` (and `con`)

\#918 relaxed the CDS↔3'UTR shuffle bound so a CDS-resident `del`/`dup` can complete its 3'-shift into the 3'UTR — the coding DNA reference is one contiguous string and the 3' rule is stated "for all descriptions". It was gated on the input's edit-kind spelling:

```rust
matches!(edit, NaEdit::Deletion { .. } | NaEdit::Duplication { .. })
```

A `delins` whose ref and alt share a prefix reduces to a pure deletion during normalization — `c.7_9delinsA` over ref `AAC` **is** a deletion of `AC` at `c.8_9` — which is exactly the shape the relaxation exists for, but it never received it:

```
c.7_9delinsA  ->  c.8_9del  ->  c.*39_*40del
```

`con` inherits both defect and fix, since the SVD-WG009 `con` → `delins` rewrite recurses before the shuffle runs.

## Commit 2 — a `dup` whose tract leaves the CDS

```
c.7_10dup  ->  c.*2_*3insACAC  ->  c.7_*2AC[5]
```

`duplication_to_repeat` already decides about the **shuffled** tract (it is called with `result.start`/`result.end`), but the codon-frame gate it consults was `is_coding`, precomputed from the **input** span. `c.7_10dup`'s input span is CDS-resident, so the gate fired and routed the dup to an `ins` literal; only on pass 2 — when the straddling tract made the input span itself non-coding — was repeat notation allowed.

The spec exempts the shifted tract (`DNA/repeated.md`):

> using a coding DNA reference sequence ("c." description), a repeated sequence variant description can be used only for repeat units with a length which is a multiple of 3 … **This restriction only applies to the coding sequence, which does not include the introns or the UTR sequence.** As such, `NM_024312.4:c.-6_-3G[6]` is valid as the reading frame is not affected.

The added copies land past `cds_end`, so they cannot move the reading frame. `c.7_*2AC[5]` is correct in one pass even though the `AC` unit is 2 nt. (The spec gives several more `c.`-axis examples with non-triplet units that are valid because they sit in introns or UTRs: `c.1210-33_1210-6GT[11]T[6]`, `c.1210-12_1210-6T[7]`, `c.-136-75952_-136-75878ATTTT[15]`.)

## Scope — deliberately narrow, and here is why

The fix passes the CDS bounds alongside `is_coding` so that **one** site can ask the gate question about the tract it actually decides on. Every other gate site keeps reading `is_coding` unchanged.

That is not tidiness — I first tried the "clean" version, replacing `is_coding` with the bounds everywhere and recomputing per site. It **broke idempotency** for a homopolymer insertion:

```
c.9_10insCC  ->  c.10delinsCCC  ->  c.4_10C[9]
```

caught by `normalize_idempotency_proptest`. The reason: recursive `normalize_na_edit` calls forward the *outer* verdict by design, and recomputing from each inner span silently changes it. So the additive form is the correct one, not a shortcut.

`deletion_to_repeat` has the same latent input-vs-shuffled inconsistency and is **left alone**, with a comment saying so. Re-keying it for symmetry is exactly the change that caused the above; it needs its own investigation.

## Controls

Every control **passed before** these fixes, which is what localises the defects rather than describing them:

- plain `c.8_9del` crosses `cds_end` in one pass — the shuffle machinery was never at fault
- the `n.` axis over the same bases
- a `delins` whose shift stays inside the CDS
- **a non-triplet unit whose tract stays entirely inside the CDS still renders as the spec's `ins` literal** — proves the gate was narrowed, not disabled
- **a codon-aligned unit inside the CDS still gets repeat notation** — proves it still discriminates on unit length

The fixture is hand-rolled rather than built with `SyntheticBuilder`, because a padding artifact of exactly this shape produced a retracted finding earlier in this campaign.

## One control I had to disqualify

The `r.` spelling of the same edit shifts in one pass, and that is what originally made this look like a plain bug. It is a valid control for the **shuffle**, but **not** for the codon-frame gate: `normalize_rna` passes no CDS span at all, so the gate never applies on the `r.` axis. Treating `r.` as an oracle would have "confirmed" whatever `r.` happened to do. Its doc comment now says this explicitly.

Which surfaced a **third, separate defect**: the `r.` axis never wires the codon-frame gate, even though `RNA/repeated.md:24-27` imposes the same multiple-of-3 restriction with the same UTR carve-out. Not addressed here — it changes `r.` repeat output and deserves its own issue and blast-radius check.

## Known wart

`normalize_na_edit` was already at clippy's 7-argument limit, so the added parameter needs `#[allow(clippy::too_many_arguments)]`. The right cleanup is folding `is_coding` + `cds_span` into one `CodonGate` value — they are two views of one question — but that is a mechanical rename across every call site in the function and does not belong in a behaviour fix. Flagged in a comment at the suppression.

## Verification

- Full suite with the real manifest and `FERRO_ASSERT_IDEMPOTENT=1`: **8531 passed, 1 failed**.
- The one failure is `mutalyzer_normalize_tests::axis_errors`, which fails **identically on clean `main`** (`be47233`) with the manifest set — same two rows, `NM_000143.3:c.45del4` / `c.45dup4`. Pre-existing; it is what #1173 addresses.
- `cargo clippy --features dev --all-targets -- -D warnings` clean; `cargo fmt --all` clean.
- RED was watched for both halves before either fix, including re-running the Site 2 test with only the Site 1 commit applied.

## Interaction with #1180

\#1180 added `tests/it/cds_utr3_crossing_shift_idempotency.rs`, which pins the **pre-fix** two-pass behaviour as characterization tests. When both land, that file must be deleted and `c.`-with-3'UTR re-added to `ALL_SYSTEMS` in `normalize_idempotency_proptest.rs` (it is excluded there with a re-add pointer). Whichever merges second should do it; this PR does not touch that file, since it is not on `main`.
