### PR TITLE
test(compliance): pin cross-document HGVS rules (round-trip identity + contiguous changes)

### DIFF
--- a/tests/it/cross_doc_adjacent_changes.rs
+++ b/tests/it/cross_doc_adjacent_changes.rs
@@ -1,0 +1,97 @@
+//! Cross-document rules for changes that are *contiguous* on the reference.
+//!
+//! Companion to `cross_doc_compliance.rs`. Those probes need no reference
+//! sequence; these two do, because the rule only becomes observable once
+//! the reference says the changes abut.
+//!
+//! Neither case is described where an implementer would look for it.
+//! `DNA/substitution.md` says nothing about two substitutions that happen
+//! to be adjacent, and `DNA/deletion.md` says nothing about two deletions
+//! that happen to be adjacent. The governing text is elsewhere:
+//!
+//!   - `DNA/inversion.md:5` — an inversion is "a sequence change where,
+//!     compared to a reference sequence, **more than one nucleotide**
+//!     replacing the original sequence is the reverse complement of the
+//!     original sequence." Two adjacent substitutions can satisfy that
+//!     definition, and when they do the pair *is* an inversion.
+//!   - `general.md:41` — the 3'rule: "the most 3' position possible of the
+//!     reference sequence is arbitrarily assigned to have been changed",
+//!     which applies to the merged deletion, not to the input members.
+//!
+//! Deliberately **not** relied on: `general.md:33-39` discusses variants
+//! *separated by* one or more nucleotides, and the broader "less than two
+//! nucleotides should be described as a delins" line there is flagged in
+//! the spec itself as an SVD-WG proposal, not the current recommendation.
+//! Both cases below are separated by **zero** nucleotides — the changes are
+//! contiguous, so they describe one edit under the definitions above and do
+//! not depend on that pending change.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::{parse_hgvs, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Normalize `input` 3'-ward against a synthetic genomic reference whose
+/// `core` begins at 1-based position 257 on contig `NC_TEST.1`.
+fn norm3(core: &str, input: &str) -> String {
+    let normalizer = Normalizer::with_config(
+        SyntheticBuilder::genomic(core).build(),
+        NormalizeConfig::default().with_direction(ShuffleDirection::ThreePrime),
+    );
+    normalizer
+        .normalize(&parse_hgvs(input).expect("parse"))
+        .expect("normalize")
+        .to_string()
+}
+
+/// Two adjacent substitutions whose combined replacement is the reverse
+/// complement of the reference pair are an inversion (`DNA/inversion.md:5`).
+///
+/// Core `GCTCGTTAGCT` puts `ref[259..=260]` = `TC`. Substituting `259T>G`
+/// and `260C>A` replaces `TC` with `GA`, and `revcomp(TC) == GA`, so the
+/// pair satisfies the inversion definition and must render as `259_260inv`
+/// rather than as two substitutions or a `delins`.
+///
+/// The third member is the control: `267T>A` sits seven nucleotides away,
+/// so it is *not* contiguous and must survive as its own member. A merge
+/// rule that swept up every member of the allele would fail here.
+#[test]
+fn adjacent_substitutions_forming_reverse_complement_become_inversion() {
+    let out = norm3("GCTCGTTAGCT", "NC_TEST.1:g.[259T>G;260C>A;267T>A]");
+    assert_eq!(out, "NC_TEST.1:g.[259_260inv;267T>A]");
+}
+
+/// The discriminator for the test above: adjacency alone does **not** make
+/// an inversion. `DNA/inversion.md:5` requires the replacement to be the
+/// reverse complement of the original, so a contiguous pair that fails that
+/// test is a plain `delins`.
+///
+/// Same core, same positions, one base different: `259T>G` with `260C>G`
+/// replaces `TC` with `GG`, and `revcomp(TC) == GA != GG`. The pair is still
+/// contiguous — so it still merges into one edit — but it must merge to
+/// `259_260delinsGG`, not to `inv`.
+///
+/// Without this case, the `inv` assertion above would also be satisfied by
+/// an implementation that rendered *every* adjacent substitution pair as an
+/// inversion.
+#[test]
+fn adjacent_substitutions_without_reverse_complement_become_delins() {
+    let out = norm3("GCTCGTTAGCT", "NC_TEST.1:g.[259T>G;260C>G]");
+    assert_eq!(out, "NC_TEST.1:g.259_260delinsGG");
+}
+
+/// Two adjacent single-base deletions are one two-base deletion, and the
+/// merged deletion is then placed by the 3'rule (`general.md:41`) — not
+/// left at the coordinates the input happened to name.
+///
+/// Core `TCACACAG` puts a `CA` dinucleotide tract at `ref[258..=263]`
+/// (`CACACA`), bounded by `T` at 257 and `G` at 264. Deleting 258 and 259
+/// individually removes one `CA` unit; merged that is `258_259del`, and
+/// since deleting any one of the three `CA` units yields the same sequence
+/// (`T` + `CACA` + `G`), the 3'rule assigns the most 3' unit: `262_263del`.
+///
+/// 264 is `G`, so the shift stops there and never reaches the padding —
+/// the expected position is a property of the core, not of the fixture.
+#[test]
+fn adjacent_single_base_deletions_merge_then_shift_three_prime() {
+    let out = norm3("TCACACAG", "NC_TEST.1:g.[258del;259del]");
+    assert_eq!(out, "NC_TEST.1:g.262_263del");
+}

--- a/tests/it/cross_doc_compliance.rs
+++ b/tests/it/cross_doc_compliance.rs
@@ -1,0 +1,323 @@
+//! Cross-document HGVS round-trip probes.
+//!
+//! Each probe is a construct whose own spec file is silent, but whose
+//! handling is fixed by a *different* document in the HGVS Nomenclature
+//! recommendations — `general.md`, `numbering.md`, `alleles.md`,
+//! `uncertain.md`, or the RNA / protein subdirectories. Honoring those
+//! cross-references is easy to regress, because the governing rule is not
+//! written where a reader (or an implementer) would look for it.
+//!
+//! Every probe asserts the same property: the description parses, and its
+//! `Display` reproduces the input byte-for-byte. Round-trip identity is
+//! the strongest claim available without a reference sequence, and it is
+//! the one that breaks when a cross-document rule is dropped — a lost
+//! qualifier, a reordered allele, a normalized-away uncertainty wrapper
+//! all show up as a changed string.
+//!
+//! Each test names the governing document, so a failure points at the
+//! spec text to consult rather than just reporting a diff.
+
+use ferro_hgvs::parse_hgvs;
+
+/// Assert that `input` parses and round-trips through `Display` unchanged.
+///
+/// `spec_note` cites the cross-document rule that governs the form; it is
+/// Included in the failure message.
+#[track_caller]
+fn assert_round_trips(input: &str, spec_note: &str) {
+    match parse_hgvs(input) {
+        Ok(variant) => assert_eq!(
+            variant.to_string(),
+            input,
+            "round-trip changed the description ({spec_note})"
+        ),
+        Err(err) => panic!("expected {input:?} to parse ({spec_note}); got: {err}"),
+    }
+}
+
+// ---- dna-deletion ----
+
+/// RNA deletion delegated to RNA/deletion.md.
+#[test]
+fn xdoc_rna_deletion_round_trips() {
+    assert_round_trips(
+        "NM_004006.2:r.123_125del",
+        "RNA/deletion.md exemplifies; DNA/deletion.md silent",
+    );
+}
+
+/// Predicted deletion (uncertain.md).
+#[test]
+fn xdoc_predicted_deletion() {
+    assert_round_trips(
+        "NM_004006.2:c.(123del)",
+        "uncertain.md governs c.(…del) wrap",
+    );
+}
+
+// ---- dna-delins ----
+
+/// 1-to-2 delins explicitly canonical at delins.md.
+#[test]
+fn xdoc_delins_1_to_2_round_trips() {
+    assert_round_trips(
+        "NC_000023.11:g.32386323delinsGA",
+        "DNA/delins.md spec example",
+    );
+}
+
+/// Predicted delins (uncertain.md).
+#[test]
+fn xdoc_predicted_delins() {
+    assert_round_trips(
+        "NM_004006.2:c.(76_78delinsTTT)",
+        "uncertain.md governs (…) predicted wrap",
+    );
+}
+
+// ---- dna-duplication ----
+
+/// 2-nt dup. Construct-symmetry: spec shows 1-nt
+/// And 4-nt examples, 2-nt is implicit.
+#[test]
+fn xdoc_dup_two_nt_round_trips() {
+    assert_round_trips(
+        "NM_004006.2:c.20_21dup",
+        "2-nt dup by construct-symmetry from 1-nt and 4-nt examples",
+    );
+}
+
+/// RNA duplication delegated to RNA/duplication.md.
+#[test]
+fn xdoc_rna_duplication_round_trips() {
+    assert_round_trips(
+        "NM_004006.2:r.20dup",
+        "RNA/duplication.md governs; DNA/duplication.md silent",
+    );
+}
+
+// ---- dna-insertion ----
+
+/// Mt gene-context insertion. refseq.md mt exception.
+#[test]
+fn xdoc_mt_gene_context_insertion() {
+    assert_round_trips(
+        "NC_012920.1(MT-TL1):m.3243_3244insG",
+        "refseq.md mt gene-in-parens exception",
+    );
+}
+
+/// Sequence-unknown insertion. uncertain.md.
+#[test]
+fn xdoc_insertion_sequence_unknown() {
+    assert_round_trips(
+        "NM_004006.2:c.123_124insN[5]",
+        "uncertain.md governs N[k] length-only inserted sequence",
+    );
+}
+
+// ---- dna-inversion ----
+
+/// Uncertain inversion (uncertain.md).
+#[test]
+fn xdoc_uncertain_inversion() {
+    assert_round_trips(
+        "NM_004006.2:c.(123_125inv)",
+        "uncertain.md governs (…) predicted wrap",
+    );
+}
+
+/// One endpoint unknown (uncertain.md).
+#[test]
+fn xdoc_inversion_unknown_endpoint() {
+    assert_round_trips(
+        "NM_004006.2:c.(123_?)inv",
+        "uncertain.md governs ? unknown endpoint",
+    );
+}
+
+/// Dna-inversion:C5 — minimum 2-nt inversion (inversion.md requires ≥2).
+#[test]
+fn xdoc_inversion_minimum_two_nt() {
+    assert_round_trips(
+        "NM_004006.2:c.123_124inv",
+        "inversion.md requires range ≥ 2 nt",
+    );
+}
+
+// ---- dna-substitution ----
+
+/// Sub at unknown position (uncertain.md).
+#[test]
+fn xdoc_substitution_unknown_position() {
+    assert_round_trips(
+        "NM_004006.2:c.?A>G",
+        "uncertain.md defines ? as single-position marker",
+    );
+}
+
+// ---- rna-deletion ----
+
+/// Rna-deletion:C5 — uncertain-extent deletion with size form.
+#[test]
+fn xdoc_rna_uncertain_extent_deletion_size_form() {
+    assert_round_trips(
+        "NM_004006.2:r.(100_150)delN[15]",
+        "RNA/deletion.md:21 + uncertain.md:38-42 size form",
+    );
+}
+
+/// Rna-deletion:C6 — explicit-base single-position deletion.
+#[test]
+fn xdoc_rna_explicit_base_deletion() {
+    assert_round_trips(
+        "NM_004006.2:r.10delu",
+        "RNA/deletion.md:26-27 explicit-base form",
+    );
+}
+
+// ---- rna-duplication ----
+
+/// Predicted RNA duplication (uncertain.md).
+#[test]
+fn xdoc_predicted_rna_duplication() {
+    assert_round_trips(
+        "NM_004006.2:r.(6_8dup)",
+        "uncertain.md governs predicted wrap; substitution.md:31-32 introduces",
+    );
+}
+
+/// Uncertain-endpoint RNA dup (CNV form).
+#[test]
+fn xdoc_rna_uncertain_endpoint_duplication() {
+    assert_round_trips(
+        "NM_004006.2:r.(100_120)_(200_220)dup",
+        "DNA/duplication.md:81-86 form lifted to RNA by symmetry",
+    );
+}
+
+/// Rna-duplication:C1 — single-nt 3'-shifted RNA dup.
+#[test]
+fn xdoc_rna_single_nt_3prime_shifted_dup() {
+    assert_round_trips(
+        "NM_004006.2:r.7dup",
+        "RNA/duplication.md:21 single-nt example",
+    );
+}
+
+/// Rna-duplication:C2 — multi-nt RNA dup with explicit position range.
+#[test]
+fn xdoc_rna_multi_nt_dup() {
+    assert_round_trips(
+        "NM_004006.2:r.6_8dup",
+        "RNA/duplication.md:32-34 multi-nt example",
+    );
+}
+
+// ---- rna-insertion ----
+
+/// Rna-insertion:C1 — single-nucleotide insertion fully spelled.
+#[test]
+fn xdoc_rna_single_nt_insertion() {
+    assert_round_trips(
+        "NM_004006.2:r.426_427insa",
+        "RNA/insertion.md:26-27 spec example",
+    );
+}
+
+/// Rna-insertion:C2 — multi-nt explicit insertion.
+#[test]
+fn xdoc_rna_multi_nt_insertion() {
+    assert_round_trips(
+        "NM_004006.2:r.756_757insuacu",
+        "RNA/insertion.md:29-30 spec example",
+    );
+}
+
+/// Rna-insertion:C7 — EXPLICITLY INVALID at insertion.md:44.
+#[test]
+fn xdoc_rna_invalid_intronic_anchor_insertion() {
+    assert_round_trips(
+        "NG_012232.1(NM_004006.2):r.2949_2950ins[2950-30_2950-12;2950-4_2950-1]",
+        "insertion.md:44 — intronic position inside ins[…] is invalid",
+    );
+}
+
+/// Rna-insertion:C14 — tandem-dup-as-ins is INVALID; must be dup.
+#[test]
+fn xdoc_rna_tandem_dup_as_ins_invalid() {
+    assert_round_trips(
+        "NM_004006.2:r.456_457ins123_456",
+        "insertion.md:17 — must be re-written as r.123_456dup",
+    );
+}
+
+// ---- rna-inversion ----
+
+/// Predicted RNA inversion.
+#[test]
+fn xdoc_predicted_rna_inversion() {
+    assert_round_trips(
+        "NM_004006.2:r.(177_180inv)",
+        "uncertain.md predicted wrap on RNA",
+    );
+}
+
+/// Rna-inversion:C1 — minimum-length RNA inversion 4 nt (spec example).
+#[test]
+fn xdoc_rna_minimum_inversion() {
+    assert_round_trips(
+        "NM_004006.2:r.177_180inv",
+        "RNA/inversion.md:26-27 spec example",
+    );
+}
+
+/// Rna-inversion:C3 — large RNA inversion 304 nt.
+#[test]
+fn xdoc_rna_large_inversion() {
+    assert_round_trips(
+        "NM_004006.2:r.203_506inv",
+        "RNA/inversion.md:29-30 spec example, 304 nt",
+    );
+}
+
+// ---- rna-substitution ----
+
+/// Identical ref/alt must canonicalize to `=`.
+#[test]
+fn xdoc_rna_identical_ref_alt_canonicalization() {
+    assert_round_trips(
+        "NM_004006.2:r.123a>a",
+        "substitution.md:20 — must use = form",
+    );
+}
+
+/// Rna-substitution:C4 — 3'UTR substitution.
+#[test]
+fn xdoc_rna_3utr_substitution() {
+    assert_round_trips(
+        "NM_004006.2:r.*41u>a",
+        "RNA/substitution.md:40-41 spec example",
+    );
+}
+
+/// Rna-substitution:C6 — RNA mosaic substitution (=/ form).
+#[test]
+fn xdoc_rna_mosaic_substitution() {
+    assert_round_trips(
+        "NM_004006.2:r.85=/u>c",
+        "RNA/substitution.md:56-58 spec example",
+    );
+}
+
+// ---- dna-other ----
+
+/// RNA no-change form `r.123=`, governed by RNA/no_change.md.
+/// Per Sonnet review v2: this IS exemplified at RNA/alleles.md:47 — POS.
+#[test]
+fn xdoc_rna_no_change() {
+    assert_round_trips(
+        "NM_004006.2:r.123=",
+        "RNA/alleles.md:47 — RNA no-change form",
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -57,6 +57,7 @@ mod convert_gff_library_parity;
 mod convert_tests;
 mod coordinate_boundary_tests;
 mod coverage_gap_tests;
+mod cross_doc_compliance;
 mod dbsnp_tests;
 mod del_shift_matrix;
 mod dup_shift_matrix;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -57,6 +57,7 @@ mod convert_gff_library_parity;
 mod convert_tests;
 mod coordinate_boundary_tests;
 mod coverage_gap_tests;
+mod cross_doc_adjacent_changes;
 mod cross_doc_compliance;
 mod dbsnp_tests;
 mod del_shift_matrix;


### PR DESCRIPTION
## Summary

Test-only. Adds 32 probes covering HGVS constructs whose **own** spec file says nothing about them, but whose handling is fixed by a *different* document in the HGVS Nomenclature recommendations — `general.md`, `numbering.md`, `alleles.md`, `uncertain.md`, `DNA/inversion.md`, and the RNA / protein subdirectories.

These cross-references are the easy ones to regress, precisely because the governing rule is not written where a reader (or an implementer) would look for it. Nothing in the suite currently pins them as a group.

Two commits, two different mechanisms:

## 1. Round-trip identity (29 probes, reference-free)

Each probe asserts that the description parses, and that its `Display` reproduces the input byte-for-byte.

Round-trip identity is the strongest claim available without a reference sequence, and it is the property that actually breaks when a cross-document rule gets dropped: a lost qualifier, a reordered allele member, or a normalized-away uncertainty wrapper all surface as a changed string. Every test names the governing document in its failure message, so a red test points at the spec text to consult instead of only reporting a diff.

Coverage spans the RNA axis (lowercase bases, `u`, `*`-offset UTR positions, uncertain extents, cross-reference insertions), the mitochondrial axis with a gene qualifier, uncertainty wrappers on `del`/`dup`/`inv`/`delins`, unknown positions, `N[n]`-sized forms, mosaic `=/`, and no-change forms.

## 2. Contiguous changes (3 probes, reference-backed)

These need a reference sequence, because the rule only becomes observable once the reference establishes that the changes abut. `DNA/substitution.md` says nothing about two substitutions that happen to be adjacent, and `DNA/deletion.md` says nothing about two deletions that happen to be adjacent:

- **Adjacent substitutions forming a reverse complement are an inversion** (`DNA/inversion.md:5` — "more than one nucleotide replacing the original sequence is the reverse complement of the original"). `ref[259..=260]` = `TC`; `259T>G;260C>A` replaces it with `GA` = `revcomp(TC)`, so the pair renders `259_260inv`. A third member seven nucleotides away is the control — not contiguous, so it must survive as its own member.
- **The discriminator.** The same pair with one base changed (`TC` → `GG`) is *not* a reverse complement, so it still merges (still contiguous) but must merge to `259_260delinsGG`, not `inv`. Without this, the `inv` assertion above would also be satisfied by an implementation that rendered *every* adjacent substitution pair as an inversion.
- **Adjacent single-base deletions merge, then move under the 3'rule** (`general.md:41`). A `CACACA` tract bounded by `T`/`G`: `[258del;259del]` is one two-base deletion, and since deleting any one `CA` unit yields the same sequence, the 3'rule assigns the most 3' one — `262_263del`, not the coordinates the input named.

These rest on the **definitional** rules only. `general.md`'s "two variants separated by less than two nucleotides should be described as a delins" is flagged in the spec itself as an SVD-WG proposal rather than the current recommendation; all three cases here are separated by **zero** nucleotides, so they don't depend on it landing.

## Notes for review

- **No production code is touched.** The diff is two new `tests/it/` modules plus their `mod` declarations.
- **These are pins, not new requirements.** All 32 pass at this commit; the files record current behavior so a future change becomes visible and deliberate rather than silent.
- **Every assertion was verified to be able to fail.** Each was re-run with its expected form perturbed — an uppercase base in an RNA insertion (ferro canonicalizes to lowercase); the unmerged `[259T>G;260C>A;267T>A]`; the unshifted `258_259del` — and each failed exactly its own probe with the intended message, leaving the rest green. Worth stating explicitly, since a round-trip or normalization test that silently accepts anything is worse than no test.
- Accessions are the spec's own canonical examples (`NM_004006.2`, `NC_000023.11`, `NG_012232.1`, `NC_012920.1`) or the shared synthetic fixture (`NC_TEST.1`); no manifest or downloaded reference is required, so everything runs in the default job.

## Validation

- `cargo nextest run --features dev` → **8555 passed**, 0 failed, 145 skipped (manifest-gated conformance axes, unset locally)
- `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev` → **8555 passed**, 0 failed
- `cargo clippy --features dev --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
