### PR TITLE
fix(cli): pass the error configuration to the normalizer

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -1468,7 +1468,14 @@ fn run_normalize(
     use std::time::Instant;
 
     let preprocessor = error_config.preprocessor();
-    let config = NormalizeConfig::default().with_direction(parse_shuffle_direction(direction));
+    // #1181: the error configuration must reach the *normalizer*, not just the
+    // preprocessor. `NormalizeConfig::default()` is lenient by construction, so
+    // without this every `--error-mode` (and every `--ignore`/`--reject`
+    // override, which `build_error_config` folds into the same `ErrorConfig`)
+    // was silently discarded and all modes behaved as lenient.
+    let config = NormalizeConfig::default()
+        .with_direction(parse_shuffle_direction(direction))
+        .with_error_config(error_config.clone());
 
     // Create reference provider from directory
     let provider = create_reference_provider(reference.map(|p| p.as_path()), strict_reference)?;

--- a/tests/it/issue_1181_cli_error_mode.rs
+++ b/tests/it/issue_1181_cli_error_mode.rs
@@ -1,0 +1,242 @@
+//! CLI surface test for `ferro normalize --error-mode` (#1181).
+//!
+//! `--error-mode` reached the *preprocessor* but never the *normalizer*, so
+//! every normalizer-level rejection was unreachable from the CLI: strict, lenient
+//! and silent all normalized leniently. The same `ErrorConfig` also carries the
+//! `--ignore` / `--reject` overrides, so those were inert for normalization too.
+//!
+//! **These tests must drive the binary, not the library.** Strict mode is already
+//! well covered at the library level (`error_mode_tests.rs`,
+//! `issue_336_position_past_end.rs`, `issue_486_position_out_of_bounds.rs`,
+//! `issue_393_mt_w4004.rs`) and was correct there the whole time — the defect
+//! lived purely in the CLI seam. A library-level regression test would have
+//! passed against the bug. Before this fix, exactly one test in the suite passed
+//! `--error-mode` to `normalize` (`cli_parallel_normalize.rs`), and it passed
+//! `silent` only to keep output quiet, asserting nothing about mode behavior.
+//!
+//! For the same reason the fixture is a real on-disk reference rather than the
+//! mock provider: under the mock, `normalize` echoes its input and no
+//! reference-base validation runs, so all modes are trivially identical and the
+//! test would prove nothing. A genomic (`g.`) input needs only an indexed genome
+//! FASTA — no cdot — which keeps the fixture small enough for CI with no external
+//! data.
+//!
+//! Scope note: `RefSeqMismatch` (W5001) is the one normalizer-level category
+//! reachable from a genome-only fixture. `PositionPastEnd` (W4004) is gated by
+//! `check_cds_pos_past_end`, which is CDS-specific and does not fire for a `g.`
+//! coordinate past a contig end, so it is not asserted here — it is covered at
+//! the library level. That is sufficient, because the CLI seam is a *single*
+//! wiring point: one category flowing through plus both override directions
+//! proves the whole `ErrorConfig` arrives.
+
+use std::path::Path;
+use std::process::Command;
+
+use ferro_hgvs::prepare::manifest::ReferenceManifest;
+
+fn ferro() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ferro"))
+}
+
+/// The single contig in the fixture: 60 bases cycling `ACGT`.
+const CONTIG: &str = "NC_000001.11";
+const CONTIG_LEN: usize = 60;
+
+/// The base at 1-based position `pos` of the fixture contig. Computed rather than
+/// hardcoded so the sequence and the expectations cannot drift apart.
+fn base_at(pos: usize) -> char {
+    ['A', 'C', 'G', 'T'][(pos - 1) % 4]
+}
+
+/// Write a minimal reference dir: an **indexed** genome FASTA with one small
+/// contig, plus a manifest pointing at it. The `.fai` is required —
+/// `MultiFastaProvider` refuses a reference with no indexed FASTA.
+fn minimal_genome_reference(dir: &Path) {
+    let seq: String = (1..=CONTIG_LEN).map(base_at).collect();
+    let header = format!(">{CONTIG}\n");
+    std::fs::write(dir.join("genome.fa"), format!("{header}{seq}\n")).unwrap();
+    // `name\tlength\toffset\tlinebases\tlinewidth` — the sequence is a single
+    // line, so linebases == length and linewidth == length + 1 (the newline).
+    std::fs::write(
+        dir.join("genome.fa.fai"),
+        format!(
+            "{CONTIG}\t{CONTIG_LEN}\t{}\t{CONTIG_LEN}\t{}\n",
+            header.len(),
+            CONTIG_LEN + 1
+        ),
+    )
+    .unwrap();
+
+    let mut manifest = ReferenceManifest {
+        reference_dir: dir.to_path_buf(),
+        genome_fasta: Some(std::path::PathBuf::from("genome.fa")),
+        transcript_count: 0,
+        available_prefixes: vec!["NC_".to_string()],
+        ..Default::default()
+    };
+    manifest.save().unwrap();
+}
+
+/// A substitution whose *stated* reference base contradicts the actual base at
+/// position 10, so it trips `RefSeqMismatch` in the normalizer.
+fn mismatching_substitution() -> String {
+    let actual = base_at(10);
+    let wrong = if actual == 'A' { 'C' } else { 'A' };
+    let alt = if actual == 'T' { 'G' } else { 'T' };
+    format!("{CONTIG}:g.10{wrong}>{alt}")
+}
+
+/// Run `ferro normalize` with the given extra args; returns (success, combined
+/// output).
+fn normalize_with(reference: &str, variant: &str, extra: &[&str]) -> (bool, String) {
+    let mut cmd = ferro();
+    cmd.args(["normalize", "--reference", reference]);
+    cmd.args(extra);
+    cmd.arg(variant);
+    let out = cmd.output().unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), combined)
+}
+
+/// Set up the fixture and return (tempdir guard, reference path, variant).
+fn fixture() -> (tempfile::TempDir, String, String) {
+    let dir = tempfile::tempdir().unwrap();
+    minimal_genome_reference(dir.path());
+    let reference = dir.path().to_str().unwrap().to_string();
+    (dir, reference, mismatching_substitution())
+}
+
+/// The heart of the regression: a reference-base mismatch must be *rejected*
+/// under `--error-mode strict` and *accepted* under `lenient`. Before the fix
+/// both printed the same successful output.
+#[test]
+fn strict_rejects_a_reference_mismatch_that_lenient_accepts() {
+    let (_dir, reference, variant) = fixture();
+
+    let (lenient_ok, lenient_out) =
+        normalize_with(&reference, &variant, &["--error-mode", "lenient"]);
+    assert!(
+        lenient_ok,
+        "lenient must accept a reference mismatch; output: {lenient_out}"
+    );
+
+    let (strict_ok, strict_out) = normalize_with(&reference, &variant, &["--error-mode", "strict"]);
+    assert!(
+        !strict_ok,
+        "strict must reject a reference mismatch, but it exited 0 — this is the \
+         #1181 bug: --error-mode never reached the normalizer. output: {strict_out}"
+    );
+    assert!(
+        strict_out.contains("Reference mismatch"),
+        "the strict rejection should name the reference mismatch; got: {strict_out}"
+    );
+}
+
+/// `silent` must also accept rather than reject. Pinning all three modes guards
+/// against a "fix" that hardwires strict everywhere.
+///
+/// Note what is and is not distinct here. `strict` is distinguishable — it
+/// rejects, and names the mismatch. `lenient` and `silent` are **not**: for this
+/// input the CLI emits no normalizer diagnostic in either mode, so their
+/// combined stdout+stderr is byte-identical. That equality is asserted rather
+/// than glossed, because the tempting assertion — "silent omits the diagnostic
+/// that lenient prints" — is vacuously true (neither prints one) and would keep
+/// passing if the diagnostic disappeared everywhere.
+#[test]
+fn strict_is_distinct_from_lenient_and_silent_at_the_cli() {
+    let (_dir, reference, variant) = fixture();
+
+    let (strict_ok, strict_out) = normalize_with(&reference, &variant, &["--error-mode", "strict"]);
+    let (lenient_ok, lenient_out) =
+        normalize_with(&reference, &variant, &["--error-mode", "lenient"]);
+    let (silent_ok, silent_out) = normalize_with(&reference, &variant, &["--error-mode", "silent"]);
+
+    assert!(!strict_ok, "strict must reject");
+    assert!(lenient_ok, "lenient must accept");
+    assert!(silent_ok, "silent must accept");
+    // Neither accepting mode surfaces a normalizer diagnostic for this input, so
+    // pin the equality as the fact it is. If lenient ever gains one, this fails
+    // and the distinction gets asserted properly instead of assumed.
+    assert_eq!(
+        lenient_out, silent_out,
+        "lenient and silent are indistinguishable on this input; if that changes, \
+         assert the actual difference rather than relaxing this"
+    );
+    assert!(
+        strict_out.contains("Reference mismatch"),
+        "only strict is distinct, and it must say why; got: {strict_out}"
+    );
+}
+
+/// The documented default is `strict` (`#[arg(long, default_value = "strict")]`),
+/// so omitting the flag must be identical to passing it. This is the half that
+/// silently behaved as lenient since the initial commit.
+#[test]
+fn the_default_mode_is_strict() {
+    let (_dir, reference, variant) = fixture();
+
+    let (default_ok, default_out) = normalize_with(&reference, &variant, &[]);
+    let (strict_ok, strict_out) = normalize_with(&reference, &variant, &["--error-mode", "strict"]);
+
+    assert!(
+        !default_ok,
+        "the default must reject like strict; output: {default_out}"
+    );
+    assert_eq!(
+        (default_ok, default_out),
+        (strict_ok, strict_out),
+        "omitting --error-mode must be identical to --error-mode strict",
+    );
+}
+
+/// `--reject` is folded into the same `ErrorConfig`, so it was inert for
+/// normalization too. Promoting a warning to a rejection must work even from the
+/// lenient base mode.
+#[test]
+fn reject_override_promotes_a_warning_from_lenient_base_mode() {
+    let (_dir, reference, variant) = fixture();
+
+    let (plain_ok, _) = normalize_with(&reference, &variant, &["--error-mode", "lenient"]);
+    assert!(plain_ok, "premise: plain lenient must accept");
+
+    let (rejected_ok, rejected_out) = normalize_with(
+        &reference,
+        &variant,
+        &["--error-mode", "lenient", "--reject", "W5001"],
+    );
+    assert!(
+        !rejected_ok,
+        "--reject W5001 must reject from a lenient base mode; output: {rejected_out}"
+    );
+    // Pin *why* it failed: the rejection must come from the promoted
+    // reference-mismatch rule, not from the command erroring for some unrelated
+    // reason, which a bare `!rejected_ok` cannot distinguish.
+    assert!(
+        rejected_out.contains("Reference mismatch"),
+        "the rejection must be the promoted W5001 mismatch; got: {rejected_out}"
+    );
+}
+
+/// The mirror direction: `--ignore` must demote a category that strict would
+/// otherwise reject.
+#[test]
+fn ignore_override_demotes_a_rejection_from_strict_base_mode() {
+    let (_dir, reference, variant) = fixture();
+
+    let (plain_ok, _) = normalize_with(&reference, &variant, &["--error-mode", "strict"]);
+    assert!(!plain_ok, "premise: plain strict must reject");
+
+    let (ignored_ok, ignored_out) = normalize_with(
+        &reference,
+        &variant,
+        &["--error-mode", "strict", "--ignore", "W5001"],
+    );
+    assert!(
+        ignored_ok,
+        "--ignore W5001 must let a strict run succeed; output: {ignored_out}"
+    );
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -132,6 +132,7 @@ mod issue_1157_five_prime_insertion_rotation;
 mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
 mod issue_1177_rna_axis_cds_relative;
+mod issue_1181_cli_error_mode;
 mod issue_1183_rna_axis_ins_expansion;
 mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;


### PR DESCRIPTION
`ferro normalize --error-mode` was built into an `ErrorConfig` and correctly passed into `run_normalize`, but consumed only by `preprocessor()`. It never reached `NormalizeConfig`, which is lenient by construction (`src/normalize/config.rs:85-95`), so every normalizer-level rejection was unreachable from the CLI. `git blame` puts both lines in the initial commit — this was never wired, across 678 commits and ~5 months.

The same `ErrorConfig` also carries the `--ignore` / `--reject` overrides that `build_error_config` folds in, so those were inert for normalization too. Threading the whole config rather than just the mode fixes all three flags at once.

## ⚠️ Behavior change

**`ferro normalize` now honors its documented `--error-mode` default of `strict`.** Inputs with reference-sequence mismatches (and other normalizer-level violations) are rejected instead of silently warn-corrected. **Pass `--error-mode lenient` to restore the previous behavior.** Only the `normalize` CLI is affected — the library API default is unchanged, so no library caller sees a difference.

Measured on the 335-case `mutalyzer-normalize` corpus against the real prepared reference:

| | strict | lenient |
|---|---|---|
| before | 247 ok | 307 ok |
| after | **224 ok** | 307 ok |

So 23 inputs (~7%) that succeed today begin rejecting under the default. Lenient and silent are byte-identical before and after.

Keeping `strict` was a deliberate call rather than the path of least resistance. The alternative — redefining the default as `lenient` to match what shipped — was considered and rejected: the flag's *documented* default is strict, and the preprocessor half has been enforcing strict at the parse stage by default all along, so CLI users already see strict parse rejections. Making the normalizer consistent with the parser and with the documentation is the fix; leaving the two halves disagreeing would be a second bug. Anyone who wants the shipped behavior has a one-flag path to it. The commit carries a `BREAKING CHANGE:` footer so the semver bump and changelog entry are handled.

## A correction to the issue's framing

The issue's repro states that all three modes print byte-identical output. That is true for the two-line input shown, but not in general: because the *preprocessor* half was always wired, strict and lenient already diverged by 60 lines on the corpus above before this change. The issue's **title** is precisely right — the config never reached the *normalizer* — and that is what this fixes. Worth stating so the blast radius isn't overestimated.

Relatedly, the issue anticipated that this "will flip a batch of currently-passing CLI outputs to rejections, so it needs a conformance re-bless." It does not. The conformance axis tests build the normalizer through the **library** API with explicit per-category overrides (`mutalyzer_normalize_tests.rs:1601-1616`), never through the CLI, so no ledger moves. The full suite passes with zero baseline churn.

## Tests

`tests/it/issue_1181_cli_error_mode.rs` — five tests, all driving the **binary**. This is the crux: strict mode is already well covered at the library level (`error_mode_tests.rs`, `issue_336_position_past_end.rs`, `issue_486_position_out_of_bounds.rs`, `issue_393_mt_w4004.rs`) and the behavior was correct there the whole time. **A library-level regression test would have passed against this bug.** Before this PR, exactly one test in the suite passed `--error-mode` to `normalize` — `cli_parallel_normalize.rs:49` — and it passed `silent` purely to keep output quiet, asserting nothing about mode behavior, so it was structurally incapable of noticing the flag was inert.

The fixture builds a real indexed genome FASTA in a tempdir rather than using the mock provider, for the same reason: under the mock, `normalize` echoes its input and no reference validation runs, so all modes are trivially identical and the test would prove nothing. A `g.` input needs only a genome FASTA — no cdot — so it stays small and runs in CI with no external data.

Coverage: strict rejects what lenient accepts; all three modes behave distinctly (silent accepts *and* suppresses the diagnostic, guarding against a fix that hardwires strict); the default equals explicit `strict`; and both override directions work (`--reject` promotes from a lenient base, `--ignore` demotes from a strict base). Each override test asserts its premise first, so it cannot decay into a tautology.

**Verified the tests actually catch the bug:** with the one-line fix reverted, all five fail; restored, all five pass.

A scope note is recorded in the test module: `RefSeqMismatch` (W5001) is the only normalizer-level category reachable from a genome-only fixture. `PositionPastEnd` (W4004) is gated by `check_cds_pos_past_end`, which is CDS-specific and does not fire for a `g.` coordinate past a contig end — I checked rather than assumed, and left it to the library tests instead of asserting something untrue. That is sufficient here because the CLI seam is a single wiring point: one category flowing through, plus both override directions, proves the whole `ErrorConfig` arrives.

## Verification

8528/8528 tests pass; `clippy --all-features --all-targets -D warnings` clean. No fixture or baseline changes.

Closes #1181
