### PR TITLE
fix(project): refuse out-of-transcript positions and surface projection warnings

### DIFF
--- a/src/bin/ferro.rs
+++ b/src/bin/ferro.rs
@@ -299,6 +299,18 @@ enum Commands {
         /// identity (drifted in place). Default: warn and proceed (#1001).
         #[arg(long)]
         strict_reference: bool,
+
+        /// Error handling mode: strict, lenient, or silent
+        #[arg(long, default_value = "strict", value_parser = ["strict", "lenient", "silent"])]
+        error_mode: String,
+
+        /// Warning codes to ignore (comma-separated, e.g., W1001,W2001)
+        #[arg(long, value_delimiter = ',')]
+        ignore: Vec<String>,
+
+        /// Warning codes to always reject (comma-separated, e.g., W3003)
+        #[arg(long, value_delimiter = ',')]
+        reject: Vec<String>,
     },
 
     /// Parse HGVS variants (validation only)
@@ -803,16 +815,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             format,
             reference,
             strict_reference,
-        } => run_project(
-            variant.as_deref(),
-            &axis,
-            transcript.as_deref(),
-            input.as_ref(),
-            output.as_ref(),
-            &format,
-            &reference,
-            strict_reference,
-        ),
+            error_mode,
+            ignore,
+            reject,
+        } => {
+            let config = build_error_config(&error_mode, &ignore, &reject);
+            run_project(
+                variant.as_deref(),
+                &axis,
+                transcript.as_deref(),
+                input.as_ref(),
+                output.as_ref(),
+                &format,
+                &reference,
+                strict_reference,
+                &config,
+            )
+        }
         Commands::Parse {
             variant,
             input,
@@ -1663,8 +1682,10 @@ fn run_project(
     format: &str,
     reference: &Path,
     strict_reference: bool,
+    error_config: &ErrorConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use ferro_hgvs::cli::format::{output_project_error, output_projection};
+    use ferro_hgvs::cli::project::AxisOutcome;
     use ferro_hgvs::cli::{project_axis, Axis, OutputFormat};
     use ferro_hgvs::data::cdot::CdotMapper;
     use ferro_hgvs::data::projection::Projector;
@@ -1697,7 +1718,15 @@ fn run_project(
         .cloned()
         .unwrap_or_else(CdotMapper::new);
     let provider = Arc::new(provider);
-    let projector = VariantProjector::new(Projector::new(cdot), provider);
+    // #1182: `project` normalizes its input before projecting, so the error
+    // configuration has to reach that normalizer or every normalizer-level
+    // diagnostic (W4004 among them) is unreachable — the same defect #1181
+    // fixed on `normalize`. `NormalizeConfig::default()` is lenient by
+    // construction, so this is what makes `--error-mode strict` mean anything
+    // here.
+    let projector = VariantProjector::new(Projector::new(cdot), provider).with_normalize_config(
+        ferro_hgvs::normalize::NormalizeConfig::default().with_error_config(error_config.clone()),
+    );
 
     let mut writer: Box<dyn Write> = match output {
         Some(path) => Box::new(BufWriter::new(File::create(path)?)),
@@ -1715,6 +1744,22 @@ fn run_project(
         };
         match project_axis(&projector, &parsed, axis, transcript) {
             Ok(outcome) => {
+                // #1182: surface the normalization warnings the projection
+                // carried. Text mode sends them to stderr so the result stream
+                // stays one line per variant and pipelines are unaffected —
+                // matching how `run_normalize` reports its warnings. JSON mode
+                // carries them inside the object instead (see
+                // `output_projection`), so emitting them here too would
+                // duplicate them.
+                if out_format != OutputFormat::Json {
+                    let warnings = match &outcome {
+                        AxisOutcome::Rendered { warnings, .. } => warnings,
+                        AxisOutcome::Unavailable { warnings, .. } => warnings,
+                    };
+                    for w in warnings {
+                        let _ = writeln!(io::stderr(), "warning[{}]: {}", w.code, w.message);
+                    }
+                }
                 // A failed write to the result stream (e.g. a full or unwritable
                 // --output file) must not be reported as success; count it so the
                 // exit code reflects the truncated output. (A broken pipe from a

--- a/src/cli/format.rs
+++ b/src/cli/format.rs
@@ -115,31 +115,35 @@ pub fn output_projection(
             AxisOutcome::Rendered {
                 transcript_id,
                 output,
+                warnings,
             },
         ) => writeln!(
             writer,
-            r#"{{"input": "{}", "axis": "{}", "transcript": "{}", "output": "{}", "status": "ok"}}"#,
+            r#"{{"input": "{}", "axis": "{}", "transcript": "{}", "output": "{}", "status": "ok", "warnings": {}}}"#,
             escape_json(input),
             axis.code(),
             escape_json(transcript_id),
-            escape_json(output)
+            escape_json(output),
+            warnings_json(warnings)
         ),
         (
             OutputFormat::Json,
             AxisOutcome::Unavailable {
                 transcript_id,
                 reason,
+                warnings,
             },
         ) => writeln!(
             writer,
-            r#"{{"input": "{}", "axis": "{}", "transcript": {}, "output": null, "status": "unavailable", "reason": "{}"}}"#,
+            r#"{{"input": "{}", "axis": "{}", "transcript": {}, "output": null, "status": "unavailable", "reason": "{}", "warnings": {}}}"#,
             escape_json(input),
             axis.code(),
             match transcript_id {
                 Some(t) => format!(r#""{}""#, escape_json(t)),
                 None => "null".to_string(),
             },
-            escape_json(reason)
+            escape_json(reason),
+            warnings_json(warnings)
         ),
         (_, AxisOutcome::Rendered { output, .. }) => writeln!(writer, "{}", output),
         (_, AxisOutcome::Unavailable { reason, .. }) => match line_number {
@@ -412,6 +416,28 @@ pub fn output_transcript_annotation<W: Write>(
     }
 }
 
+/// Render projection warnings as a JSON array of `{code, message}` objects.
+///
+/// Always emits an array — `[]` when there are none — so consumers can index
+/// `.warnings` unconditionally rather than branching on the key's presence.
+/// Hand-built for consistency with the surrounding hand-built JSON in this
+/// module (which is why `escape_json` exists at all). #1182.
+fn warnings_json(warnings: &[crate::cli::project::ProjectionWarning]) -> String {
+    let mut out = String::from("[");
+    for (i, w) in warnings.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&format!(
+            r#"{{"code": "{}", "message": "{}"}}"#,
+            escape_json(&w.code),
+            escape_json(&w.message)
+        ));
+    }
+    out.push(']');
+    out
+}
+
 /// Escape special characters for JSON strings
 ///
 /// Escapes backslashes, quotes, and control characters.
@@ -673,6 +699,7 @@ mod tests {
         let outcome = AxisOutcome::Rendered {
             transcript_id: "NM_000088.3".to_string(),
             output: "NP_000079.2:p.(Gly197Cys)".to_string(),
+            warnings: Vec::new(),
         };
         output_projection(
             &mut buf,
@@ -689,11 +716,18 @@ mod tests {
 
     #[test]
     fn output_projection_json_rendered_has_fields() {
-        use crate::cli::project::{Axis, AxisOutcome};
+        use crate::cli::project::{Axis, AxisOutcome, ProjectionWarning};
         let mut buf = Cursor::new(Vec::new());
+        // Non-empty on purpose: surfacing warnings is the point of #1182, and an
+        // empty vector cannot distinguish "serialised correctly" from "silently
+        // dropped" — `warnings_json` renders `[]` either way.
         let outcome = AxisOutcome::Rendered {
             transcript_id: "NM_000088.3".to_string(),
             output: "NP_000079.2:p.(Gly197Cys)".to_string(),
+            warnings: vec![ProjectionWarning {
+                code: "POSITION_PAST_END".to_string(),
+                message: "position 999 is past the end".to_string(),
+            }],
         };
         output_projection(
             &mut buf,
@@ -709,15 +743,25 @@ mod tests {
         assert!(out.contains(r#""transcript": "NM_000088.3""#));
         assert!(out.contains(r#""output": "NP_000079.2:p.(Gly197Cys)""#));
         assert!(out.contains(r#""status": "ok""#));
+        assert!(
+            out.contains(r#""warnings": [{"code": "POSITION_PAST_END", "message": "position 999 is past the end"}]"#),
+            "a rendered projection must serialise its warnings; got: {out}"
+        );
     }
 
     #[test]
     fn output_projection_json_unavailable_status() {
-        use crate::cli::project::{Axis, AxisOutcome};
+        use crate::cli::project::{Axis, AxisOutcome, ProjectionWarning};
         let mut buf = Cursor::new(Vec::new());
         let outcome = AxisOutcome::Unavailable {
             transcript_id: Some("NM_000088.3".to_string()),
             reason: "no p. representation for this variant".to_string(),
+            // See the note in the `rendered` test: the unavailable branch builds
+            // its JSON separately, so it needs its own non-empty case.
+            warnings: vec![ProjectionWarning {
+                code: "INTRONIC".to_string(),
+                message: "intronic offset dropped".to_string(),
+            }],
         };
         output_projection(
             &mut buf,
@@ -731,6 +775,12 @@ mod tests {
         let out = String::from_utf8(buf.into_inner()).unwrap();
         assert!(out.contains(r#""status": "unavailable""#));
         assert!(out.contains(r#""reason""#));
+        assert!(
+            out.contains(
+                r#""warnings": [{"code": "INTRONIC", "message": "intronic offset dropped"}]"#
+            ),
+            "an unavailable projection must serialise its warnings too; got: {out}"
+        );
     }
 
     #[test]
@@ -740,6 +790,7 @@ mod tests {
         let outcome = AxisOutcome::Unavailable {
             transcript_id: Some("NM_000088.3".to_string()),
             reason: "no p. representation for this variant".to_string(),
+            warnings: Vec::new(),
         };
         output_projection(
             &mut buf,

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -4,6 +4,7 @@
 
 use crate::error::FerroError;
 use crate::hgvs::variant::HgvsVariant;
+use crate::normalize::NormalizationWarning;
 use crate::project::{VariantProjection, VariantProjector};
 use crate::reference::ReferenceProvider;
 
@@ -42,6 +43,36 @@ impl Axis {
     }
 }
 
+/// A normalization warning raised while projecting, flattened for reporting.
+///
+/// [`NormalizationWarning`] is `#[non_exhaustive]` and implements neither
+/// `PartialEq` nor `Eq`, so it cannot be embedded in [`AxisOutcome`] (which
+/// derives both, and whose equality several tests rely on). Flattening to the
+/// code plus the rendered message keeps those derives and is all the CLI needs
+/// — the code for machine consumers, the message for humans. #1182.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionWarning {
+    /// The warning's stable code (e.g. `POSITION_PAST_END`).
+    pub code: String,
+    /// The rendered, human-readable message.
+    pub message: String,
+}
+
+impl ProjectionWarning {
+    /// Flatten a normalizer warning for reporting.
+    pub fn from_normalization(warning: &NormalizationWarning) -> Self {
+        Self {
+            code: warning.code().to_string(),
+            message: warning.to_string(),
+        }
+    }
+
+    /// Flatten a whole set, in the order the normalizer raised them.
+    pub fn from_normalization_set(warnings: &[NormalizationWarning]) -> Vec<Self> {
+        warnings.iter().map(Self::from_normalization).collect()
+    }
+}
+
 /// The result of selecting one axis from a projection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AxisOutcome {
@@ -49,12 +80,20 @@ pub enum AxisOutcome {
     Rendered {
         transcript_id: String,
         output: String,
+        /// Warnings raised while normalizing the input for this projection.
+        /// Empty when it normalized cleanly. Previously discarded outright, so
+        /// diagnostics such as W4004 (position past the end of the reference)
+        /// could not reach the user from `ferro project` in any configuration.
+        warnings: Vec<ProjectionWarning>,
     },
     /// The axis is legitimately not available (exit 0); carries a reason and,
     /// when known, the transcript the projection was attempted on.
     Unavailable {
         transcript_id: Option<String>,
         reason: String,
+        /// Warnings raised before the axis turned out to be unavailable. An
+        /// unavailable axis can still have produced diagnostics worth showing.
+        warnings: Vec<ProjectionWarning>,
     },
 }
 
@@ -98,14 +137,21 @@ pub fn select_axis(projection: &VariantProjection, axis: Axis) -> AxisOutcome {
         Axis::Rna => &projection.rna,
     };
     let tx = projection.transcript_id.clone();
+    // #1182: the projection's normalization warnings were read off nowhere and
+    // dropped here, which is what made W4004 (and every other normalizer
+    // diagnostic) structurally unreachable from `ferro project`. Carry them onto
+    // both outcomes.
+    let warnings = ProjectionWarning::from_normalization_set(&projection.normalization_warnings);
     match field {
         Some(v) => AxisOutcome::Rendered {
             transcript_id: tx,
             output: v.to_string(),
+            warnings,
         },
         None => AxisOutcome::Unavailable {
             transcript_id: Some(tx),
             reason: format!("no {}. representation for this variant", axis.code()),
+            warnings,
         },
     }
 }
@@ -152,6 +198,8 @@ pub fn project_axis<P: ReferenceProvider + Clone>(
         Err(e) if engine_error_is_unavailable(&e) => Ok(AxisOutcome::Unavailable {
             transcript_id: Some(input_tx),
             reason: e.to_string(),
+            // The projection never completed, so there is no warning set to carry.
+            warnings: Vec::new(),
         }),
         Err(e) => Err(ProjectCliError(e.to_string())),
     }
@@ -188,6 +236,8 @@ fn project_axis_genomic<P: ReferenceProvider + Clone>(
         Err(e) if engine_error_is_unavailable(&e) => Ok(AxisOutcome::Unavailable {
             transcript_id: Some(requested.to_string()),
             reason: e.to_string(),
+            // The projection never completed, so there is no warning set to carry.
+            warnings: Vec::new(),
         }),
         Err(e) => Err(ProjectCliError(e.to_string())),
     }
@@ -275,6 +325,60 @@ mod tests {
         }
     }
 
+    /// #1182: `select_axis` must carry the projection's normalization warnings
+    /// onto the outcome. They were previously read by nobody, which is what made
+    /// W4004 structurally unreachable from `ferro project`.
+    #[test]
+    fn select_axis_carries_warnings_onto_a_rendered_outcome() {
+        let mut proj = projection_with(Some("NC_000017.11:g.50198003C>A"), None);
+        proj.normalization_warnings = vec![NormalizationWarning::PositionPastEnd {
+            accession: "NM_000088.3".to_string(),
+            coordinate_system: "c".to_string(),
+            position: "c.-238".to_string(),
+            bound_kind: "5utr-start".to_string(),
+            bound_value: 237,
+        }];
+        match select_axis(&proj, Axis::Genomic) {
+            AxisOutcome::Rendered { warnings, .. } => {
+                assert_eq!(warnings.len(), 1, "the warning must survive selection");
+                assert_eq!(warnings[0].code, "POSITION_PAST_END");
+            }
+            other => panic!("expected Rendered, got {other:?}"),
+        }
+    }
+
+    /// The unavailable arm matters as much: an axis can be unavailable *because*
+    /// of what the warning describes, so dropping it there would discard the
+    /// explanation exactly when it is most useful.
+    #[test]
+    fn select_axis_carries_warnings_onto_an_unavailable_outcome() {
+        let mut proj = projection_with(None, None);
+        proj.normalization_warnings = vec![NormalizationWarning::PositionPastEnd {
+            accession: "NM_000088.3".to_string(),
+            coordinate_system: "c".to_string(),
+            position: "c.-238".to_string(),
+            bound_kind: "5utr-start".to_string(),
+            bound_value: 237,
+        }];
+        match select_axis(&proj, Axis::Genomic) {
+            AxisOutcome::Unavailable { warnings, .. } => {
+                assert_eq!(warnings.len(), 1);
+                assert_eq!(warnings[0].code, "POSITION_PAST_END");
+            }
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    /// A clean projection must not grow a spurious diagnostic.
+    #[test]
+    fn select_axis_carries_no_warnings_for_a_clean_projection() {
+        let proj = projection_with(Some("NC_000017.11:g.50198003C>A"), None);
+        match select_axis(&proj, Axis::Genomic) {
+            AxisOutcome::Rendered { warnings, .. } => assert!(warnings.is_empty()),
+            other => panic!("expected Rendered, got {other:?}"),
+        }
+    }
+
     #[test]
     fn select_axis_renders_present_field() {
         let proj = projection_with(Some("NC_000017.11:g.50198003C>A"), None);
@@ -284,6 +388,7 @@ mod tests {
             AxisOutcome::Rendered {
                 transcript_id: "NM_000088.3".to_string(),
                 output: "NC_000017.11:g.50198003C>A".to_string(),
+                warnings: Vec::new(),
             }
         );
     }
@@ -296,6 +401,7 @@ mod tests {
             AxisOutcome::Unavailable {
                 transcript_id,
                 reason,
+                ..
             } => {
                 assert_eq!(transcript_id.as_deref(), Some("NM_000088.3"));
                 assert!(reason.contains("protein") || reason.contains("p."));
@@ -362,6 +468,7 @@ mod tests {
             AxisOutcome::Rendered {
                 transcript_id,
                 output,
+                ..
             } => {
                 assert_eq!(transcript_id, "NM_TEST.1");
                 assert!(output.starts_with("NP_TEST.1:p."), "got {output}");
@@ -427,6 +534,7 @@ mod tests {
             AxisOutcome::Rendered {
                 transcript_id,
                 output,
+                ..
             } => {
                 assert_eq!(transcript_id, "NM_TEST.1");
                 assert!(output.contains(":c."), "got {output}");

--- a/src/conformance/mutalyzer.rs
+++ b/src/conformance/mutalyzer.rs
@@ -1090,6 +1090,14 @@ pub enum SpecSection {
     /// **and not** `NC_…(NM_…):c.-N-uM`"). ferro leaves the input verbatim and
     /// refuses the flank `c.` coordinate (#488 Phase 2b); mutalyzer's
     /// `c.-5059del` extrapolates into the flank, which HGVS forbids.
+    ///
+    /// Scope of "refuses", stated precisely (#1182): the verbatim-and-refuse
+    /// behavior above is the `pter`/`qter` *marker* path. A plain out-of-bounds
+    /// coordinate (`c.-238` on a 237-base 5'UTR) is caught by a different gate,
+    /// `check_cds_pos_past_end`, which raises W4004 — a *warning* under the
+    /// library's lenient default and a rejection only in strict mode. So this
+    /// policy describes the marker case; do not read it as a claim that every
+    /// flank-adjacent `c.` coordinate is refused in every configuration.
     #[serde(rename = "HGVS §Transcript flanking (not c.-numberable)")]
     TranscriptFlankNotNumberable,
     /// HGVS amino-acid glyph preference — three-letter codes (including `Ter`)

--- a/src/project/transcript_axis.rs
+++ b/src/project/transcript_axis.rs
@@ -39,6 +39,28 @@ pub(crate) fn noncoding_from_coding(
     let mapper = CoordinateMapper::new(transcript);
     let n_start = mapper.cds_to_tx(cds_start)?;
     let n_end = mapper.cds_to_tx(cds_end)?;
+    // #1182: a `c.` position 5' of the transcript's own first base maps to a
+    // non-positive transcript coordinate, which is not a position at all —
+    // `n.` numbering runs "from the first to the last nucleotide of the
+    // reference sequence" and there is no nucleotide `n.0`
+    // (`numbering.md:31,52`). Refuse rather than render it.
+    //
+    // This is deliberately unconditional, not error-mode-gated: `n.0` is
+    // rejected by ferro's own parser, so emitting it produces output ferro
+    // cannot read back, which is wrong in every mode. The negative cases are
+    // the more dangerous half — `n.-62` *parses* cleanly, so without this it
+    // propagates silently instead of failing loudly.
+    for (label, pos) in [("start", &n_start), ("end", &n_end)] {
+        if pos.base < 1 {
+            return Err(FerroError::InvalidCoordinates {
+                msg: format!(
+                    "transcript position n.{} ({label}) is outside {}: `n.` numbering starts at 1, \
+                     so this c. position lies 5' of the transcript's first base",
+                    pos.base, transcript_id,
+                ),
+            });
+        }
+    }
     Ok(HgvsVariant::Tx(TxVariant {
         accession: parse_accession(transcript_id),
         gene_symbol,
@@ -133,6 +155,65 @@ mod tests {
         let mut pos = CdsPos::new(3);
         pos.offset = Some(5);
         assert_eq!(n_string(pos, &tx, "NM_TEST.1"), "NM_TEST.1:n.8+5A>G");
+    }
+
+    /// #1182: `cds_start = 6` means `c.-5` is the transcript's first base, so
+    /// `c.-6` maps to `n.0` and `c.-7` to `n.-1` — neither is a position. The
+    /// projector used to render them, emitting `n.0del` (which ferro's own
+    /// parser rejects) and `n.-1del` (which *parses*, so it propagated
+    /// silently — the more dangerous half).
+    #[test]
+    fn refuses_a_non_positive_transcript_position() {
+        let tx = make_test_transcript();
+        // The last in-bounds 5'UTR position still works — this must not
+        // over-reject.
+        let ok = noncoding_from_coding(
+            &CdsPos::new(-5),
+            &CdsPos::new(-5),
+            &tx,
+            &sub_a_g(),
+            "NM_TEST.1",
+            None,
+        )
+        .expect("c.-5 is the transcript's first base and must still render");
+        assert_eq!(format!("{ok}"), "NM_TEST.1:n.1A>G");
+
+        // One past it (n.0) and two past it (n.-1) must both refuse.
+        for base in [-6, -7] {
+            let err = noncoding_from_coding(
+                &CdsPos::new(base),
+                &CdsPos::new(base),
+                &tx,
+                &sub_a_g(),
+                "NM_TEST.1",
+                None,
+            )
+            .expect_err("a non-positive transcript position must be refused");
+            assert!(
+                matches!(err, FerroError::InvalidCoordinates { .. }),
+                "c.{base} should be InvalidCoordinates, got {err:?}"
+            );
+        }
+    }
+
+    /// The refusal fires on either endpoint, not just the start — a range whose
+    /// start is in bounds but whose end is not (and vice versa) is equally
+    /// unrenderable.
+    #[test]
+    fn refuses_when_only_one_endpoint_is_out_of_range() {
+        let tx = make_test_transcript();
+        for (start, end) in [(-6, -5), (-5, -6)] {
+            let err = noncoding_from_coding(
+                &CdsPos::new(start),
+                &CdsPos::new(end),
+                &tx,
+                &sub_a_g(),
+                "NM_TEST.1",
+                None,
+            )
+            .expect_err("either endpoint out of range must refuse");
+            assert!(matches!(err, FerroError::InvalidCoordinates { .. }));
+        }
     }
 
     #[test]

--- a/tests/it/cli_project.rs
+++ b/tests/it/cli_project.rs
@@ -142,6 +142,7 @@ fn bare_genomic_with_transcript_renders_coding() {
         AxisOutcome::Rendered {
             transcript_id,
             output,
+            ..
         } => {
             assert_eq!(transcript_id, "NM_TEST.1");
             assert!(output.contains(":c."), "got {output}");

--- a/tests/it/issue_1182_project_bounds_and_warnings.rs
+++ b/tests/it/issue_1182_project_bounds_and_warnings.rs
@@ -1,0 +1,83 @@
+//! Issue #1182 — `ferro project` emitted unparseable `n.0`, extrapolated
+//! off-chromosome genomic coordinates, and discarded W4004.
+//!
+//! Three separable defects, one per section below:
+//!
+//!   1. A `c.` position 5' of the transcript's first base mapped to a
+//!      non-positive transcript coordinate and was *rendered* — `n.0del`, which
+//!      ferro's own parser rejects, and `n.-62del`, which parses cleanly and so
+//!      propagated silently.
+//!   2. `VariantProjection::normalization_warnings` was populated by the
+//!      projector but read by nobody: `AxisOutcome` carried no warnings field
+//!      and `output_projection` had nowhere to put one, so W4004 was
+//!      structurally unreachable from `ferro project` in any configuration.
+//!   3. `project` had no `--error-mode` flag at all, so even once the warning
+//!      was reachable there was no way to ask for it to be a rejection.
+//!
+//! Only the reporting-surface half lives here. The two in-crate halves are
+//! covered where their fixtures already exist, because neither type can be built
+//! from a separate crate: `noncoding_from_coding`'s refusal in
+//! `src/project/transcript_axis.rs` (`Transcript` has private fields) and
+//! `select_axis`'s warning plumbing in `src/cli/project.rs`
+//! (`VariantProjection` is `#[non_exhaustive]`).
+
+use ferro_hgvs::cli::project::ProjectionWarning;
+use ferro_hgvs::normalize::NormalizationWarning;
+
+// =============================================================================
+// 2. Warnings must survive the AxisOutcome hop
+// =============================================================================
+
+/// `ProjectionWarning` must preserve both halves of a normalizer warning: the
+/// stable code (for machine consumers reading `--format json`) and the rendered
+/// message (for humans).
+#[test]
+fn a_normalization_warning_flattens_to_code_and_message() {
+    let warning = NormalizationWarning::RefSeqMismatch {
+        stated_ref: "A".to_string(),
+        actual_ref: "C".to_string(),
+        position: "10-10".to_string(),
+        corrected: true,
+        details: None,
+    };
+    let flat = ProjectionWarning::from_normalization(&warning);
+    assert_eq!(flat.code, warning.code());
+    assert_eq!(flat.message, warning.to_string());
+    assert!(
+        !flat.message.is_empty(),
+        "the rendered message must not be empty"
+    );
+}
+
+/// Order is preserved, because the normalizer emits warnings in a meaningful
+/// sequence (the expansion warning first, then downstream ones).
+#[test]
+fn a_warning_set_flattens_in_order() {
+    let warnings = vec![
+        NormalizationWarning::RefSeqMismatch {
+            stated_ref: "A".to_string(),
+            actual_ref: "C".to_string(),
+            position: "10-10".to_string(),
+            corrected: true,
+            details: None,
+        },
+        NormalizationWarning::RefSeqMismatch {
+            stated_ref: "G".to_string(),
+            actual_ref: "T".to_string(),
+            position: "20-20".to_string(),
+            corrected: true,
+            details: None,
+        },
+    ];
+    let flat = ProjectionWarning::from_normalization_set(&warnings);
+    assert_eq!(flat.len(), 2);
+    assert!(flat[0].message.contains("10-10"), "got {:?}", flat[0]);
+    assert!(flat[1].message.contains("20-20"), "got {:?}", flat[1]);
+}
+
+/// An empty warning set stays empty rather than becoming a placeholder — a
+/// clean projection must not grow a spurious diagnostic.
+#[test]
+fn a_clean_projection_carries_no_warnings() {
+    assert!(ProjectionWarning::from_normalization_set(&[]).is_empty());
+}

--- a/tests/it/issue_972_cds_start_nf_decline.rs
+++ b/tests/it/issue_972_cds_start_nf_decline.rs
@@ -440,6 +440,7 @@ fn vps13d_cli_axis_c_and_p_unavailable_n_rendered() {
             AxisOutcome::Unavailable {
                 transcript_id,
                 reason,
+                ..
             } => {
                 assert_eq!(transcript_id.as_deref(), Some(VPS13D_TX));
                 assert!(!reason.is_empty());

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -133,6 +133,7 @@ mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
 mod issue_1177_rna_axis_cds_relative;
 mod issue_1181_cli_error_mode;
+mod issue_1182_project_bounds_and_warnings;
 mod issue_1183_rna_axis_ins_expansion;
 mod issue_1185_cds_end_3utr_shift;
 mod issue_1192_rna_codon_frame_gate;


### PR DESCRIPTION
`ferro project` emitted HGVS its own parser rejects, extrapolated genomic coordinates past the end of the chromosome, and had no way to report the warning that already diagnosed both. Three separable defects, fixed together because parts 2 and 3 are what make the bounds check *reachable*.

## 1. Refuse a non-positive transcript position

A `c.` position 5' of the transcript's first base maps to a non-positive transcript coordinate, and the `n.` axis rendered it. On `NM_004006.3` (`cds_start = 238`):

```
c.-237del -> n.1del      # last in-bounds
c.-238del -> n.0del      # ferro's own parser rejects this
c.-300del -> n.-62del    # this one PARSES, so it propagated silently
```

The negative cases are the more dangerous half and the issue's open question ("whether `n.` should accept negative positions at all"): `n.0` fails loudly at the next parse, but `n.-62` is accepted by the parser and flows onward as if valid. Both are invalid per `background/numbering.md` — `n.` numbering runs "from the first to the last nucleotide of the reference sequence" (`:52`) and there is no nucleotide `c.0` (`:31`) — so the guard refuses everything `< 1`, on either endpoint.

The refusal is **unconditional**, not error-mode-gated: emitting output ferro cannot read back is wrong in every mode. It sits at the rendering boundary (`noncoding_from_coding`) rather than in `CoordinateMapper::cds_to_tx`, which ~20 call sites across normalize/spdi/python/service depend on for intermediate arithmetic — a test pins that the mapper still returns the raw value, so the placement is deliberate and visible.

Sweeping `c.-230` … `c.-320`, stdout now carries the 8 in-bounds rows and **zero** invalid `n.` strings. Previously all 91 rendered, 83 of them invalid.

## 2. Carry the warnings that were being discarded

`VariantProjection::normalization_warnings` was populated by the projector and read by nobody: `AxisOutcome` had no warnings field and `output_projection` had nowhere to put one. W4004 was therefore structurally unreachable from `project` in *any* configuration — the bounds check was firing correctly and its diagnostic was thrown away.

Both `AxisOutcome` variants now carry them, and both formats report them:

- **text** → stderr, so the result stream stays one line per variant and pipelines are unaffected. This matches how `run_normalize` already reports warnings.
- **json** → a `"warnings"` array, always present (`[]` when clean) so consumers can index `.warnings` unconditionally instead of branching on the key.

The unavailable arm carries them too, deliberately: an axis can be unavailable *because* of what the warning describes, so dropping it there would discard the explanation exactly when it is most useful.

Warnings are flattened to a small `ProjectionWarning { code, message }` rather than embedded directly, because `NormalizationWarning` is `#[non_exhaustive]` and implements neither `PartialEq` nor `Eq`, both of which `AxisOutcome` derives and several tests rely on.

## 3. Add `--error-mode` to `project`

`project` had no `--error-mode` at all, so even a reachable warning could not be promoted to a rejection. It now takes `--error-mode` (plus `--ignore` / `--reject`) with the same `strict` default as `normalize`, threaded into the projector's normalizer via `with_normalize_config` — without which the flag would be inert, which is precisely the defect #1181 fixes on the other command.

## ⚠️ Behavior change

**`ferro project` now defaults to `--error-mode strict`**, so inputs whose coordinates fall outside the transcript are rejected rather than silently extrapolated. **Pass `--error-mode lenient` to restore the previous behavior.** `--format json` records also gain a `"warnings"` key. The commit carries a `BREAKING CHANGE:` footer.

This is what closes the headline complaint. The issue's worst case:

```
before:  c.-200000000del --axis g  ->  NC_000023.11:g.233211312del   # chrX is 156,040,895 bp
after:   ERROR: ... c.-200000000 is past the 5utr-start (237) ... (PositionPastEnd / W4004)
```

It also settles the 5'/3' asymmetry the issue noted — 5' silently extrapolated while 3' errored. Both now reject consistently under the default, and `c.-237` (the last in-bounds position) still projects, so this does not over-reject.

## Conformance policy note

The issue flagged that `TranscriptFlankNotNumberable` "overstates actual behavior". It does: it claimed ferro "refuses the flank `c.` coordinate", which holds only for the `pter`/`qter` *marker* path. A plain out-of-bounds `c.-N` goes through a different gate (`check_cds_pos_past_end`) and is a *warning* under the library's lenient default. I made the note say that explicitly rather than quietly leaving it, or rewriting it to claim more than the library does — the CLI default changing here does not change the library's.

## Tests

Split by what each type allows: `Transcript` has private fields and `VariantProjection` is `#[non_exhaustive]`, so neither can be built from a separate crate. The two in-crate halves therefore live where their fixtures already exist — the refusal (including the "does not over-reject" and single-endpoint cases) in `src/project/transcript_axis.rs`, and `select_axis`'s warning plumbing across both outcome arms in `src/cli/project.rs`. The flattening/ordering/empty-set behavior is covered in `tests/it/issue_1182_project_bounds_and_warnings.rs`.

## Verification

8531/8531 tests pass; `clippy --all-features --all-targets -D warnings` clean; no fixture or baseline churn. All three parts were confirmed end to end against the real prepared reference, and the JSON output was round-tripped through a parser to confirm it is valid.

Closes #1182
