### PR TITLE
fix(normalize): apply the codon-frame gate on the r. axis

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -5169,15 +5169,35 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Boundaries::new(0, transcript.sequence_length())
         };
 
-        // Perform normalization (RNA context: codon-frame gate does not apply;
-        // r. is not in the spec's accepted reference types for repeats).
         // Coordinate-only transcripts fall back to the canonicalize-only path.
         let seq = match transcript.sequence.as_deref() {
             Some(s) => s.as_bytes(),
             None => return Ok((HV::Rna(variant.clone()), vec![])),
         };
+
+        // #1192: the codon-frame gate applies on `r.` exactly as it does on
+        // `c.`. `RNA/repeated.md` L24-27 states the restriction for an RNA
+        // reference in the same terms `DNA/repeated.md` uses:
+        //   > using a coding RNA reference sequence, a repeated sequence
+        //   > variant description can be used only for repeat units with a
+        //   > length which is a multiple of 3 [...] This restriction only
+        //   > applies to the coding sequence, which does not include the UTR
+        //   > sequence.
+        // and gives `NM_024312.4:r.2686a[10]` as an explicit counter-example.
+        // (The previous comment here asserted that `r.` is not an accepted
+        // reference type for repeats, which that page contradicts.)
+        //
+        // The condition mirrors `normalize_cds` exactly — deliberately, since
+        // `r.` on a coding transcript is CDS-relative, i.e. the same axis as
+        // `c.` (#469). `cds_info` is `None` for a non-coding transcript, which
+        // has no reading frame to preserve, and a footprint touching either UTR
+        // falls outside `cds_start..=cds_end` and is exempt by the carve-out.
+        let is_coding = match cds_info {
+            Some((cds_start, cds_end)) => tx_start >= cds_start && tx_end <= cds_end,
+            None => false,
+        };
         let (new_tx_start, new_tx_end, new_edit, mut warnings) =
-            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
+            self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
         // substitutions are validated-then-returned-unchanged by

--- a/tests/it/issue_1192_rna_codon_frame_gate.rs
+++ b/tests/it/issue_1192_rna_codon_frame_gate.rs
@@ -1,0 +1,228 @@
+//! Issue #1192 — the `r.` axis must apply the codon-frame gate to repeat
+//! notation, exactly as the `c.` axis does.
+//!
+//! `RNA/repeated.md` L24-27 states the restriction for an RNA reference in the
+//! same terms the DNA page uses, including the UTR carve-out:
+//!
+//! > **exception**: using a coding RNA reference sequence, a repeated sequence
+//! > variant description can be used only for repeat units with a length which
+//! > is a multiple of 3, i.e. which can not affect the reading frame.
+//! > Consequently, use `NM_024312.4:r.2692_2693dup` and **not**
+//! > `NM_024312.4:r.2686a[10]` … This restriction only applies to the coding
+//! > sequence, which does not include the UTR sequence. As such,
+//! > `NM_024312.4:r.-6_-3g[6]` is valid as the reading frame is not affected.
+//!
+//! `r.` on a coding transcript is CDS-relative — the same axis as `c.`
+//! (`background/numbering.md` L58/L61, pinned by #469) — so a `c.`/`r.` pair
+//! over the same bases must reach the same decision. `normalize_rna` used to
+//! pass `is_coding = false` unconditionally, so the gate never fired and ferro
+//! emitted, on `r.`, the very form the spec marks invalid: with the real
+//! reference, `NM_024312.4:r.2692_2693dup` rendered as `r.2686_2693a[10]`.
+//!
+//! Each case is asserted on **both** axes. That pairing is what makes this a
+//! spec defect rather than a fixture artifact: the two axes address identical
+//! reference bases, so any divergence between them is the bug itself.
+//!
+//! The repro is a homopolymer duplication because that is the shape the spec's
+//! own counter-example takes — a unit length of 1 is never a multiple of 3, so
+//! it can never be codon-aligned.
+
+use ferro_hgvs::reference::transcript::{Exon, ManeStatus, Strand, Transcript};
+use ferro_hgvs::{parse_hgvs, MockProvider, Normalizer};
+
+/// Length of the 5'UTR, so `c.1` / `r.1` is transcript base `UTR5_LEN + 1`.
+const UTR5_LEN: usize = 30;
+
+/// Build a single-exon coding transcript `C * 30` (5'UTR) ++ `cds` ++ `utr3`.
+///
+/// Hand-rolled rather than built with `SyntheticBuilder`: that helper pads with
+/// `ACGT` repeats, which a tandem unit can cycle straight into, and a padding
+/// artifact of exactly that shape produced a retracted finding once before.
+/// Every tract below is flanked by a base that cannot continue it.
+fn coding_transcript(cds: &str, utr3: &str) -> MockProvider {
+    let sequence = format!("{}{cds}{utr3}", "C".repeat(UTR5_LEN));
+    let tx_len = sequence.len() as u64;
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NM_RFRAME.1".to_string(),
+        Some("RFRAME_TEST".to_string()),
+        Strand::Plus,
+        sequence,
+        Some((UTR5_LEN + 1) as u64),
+        Some((UTR5_LEN + cds.len()) as u64),
+        vec![Exon::new(1, 1, tx_len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// Build a single-exon **non-coding** transcript, with no CDS annotation at all.
+fn noncoding_transcript(sequence: &str) -> MockProvider {
+    let tx_len = sequence.len() as u64;
+    let mut provider = MockProvider::new();
+    provider.add_transcript(Transcript::new(
+        "NR_RFRAME.1".to_string(),
+        Some("RFRAME_NC_TEST".to_string()),
+        Strand::Plus,
+        sequence.to_string(),
+        None,
+        None,
+        vec![Exon::new(1, 1, tx_len)],
+        None,
+        None,
+        None,
+        Default::default(),
+        ManeStatus::None,
+        None,
+        None,
+    ));
+    provider
+}
+
+/// CDS `ATG` ++ `A`×6 ++ `GGGTAA`: a homopolymer tract at `c.4_9`, flanked by
+/// `G` on both sides and well clear of both UTRs. A repeat unit of length 1 is
+/// never a multiple of 3, so the codon-frame gate must block repeat notation.
+fn homopolymer_tract_in_cds() -> MockProvider {
+    coding_transcript("ATGAAAAAAGGGTAA", &"G".repeat(30))
+}
+
+/// CDS `ATG` ++ `AGC`×4 ++ `TAA`: a codon-aligned tri-nucleotide tract at
+/// `c.4_15` that the gate must leave alone.
+fn codon_aligned_tract_in_cds() -> MockProvider {
+    coding_transcript("ATGAGCAGCAGCAGCTAA", &"G".repeat(30))
+}
+
+/// A CDS with no repeat structure, and the homopolymer tract moved into the
+/// 3'UTR at `r.*4_*9` — where the spec's carve-out exempts it from the gate.
+fn homopolymer_tract_in_utr3() -> MockProvider {
+    coding_transcript("ATGGGGTTTTAA", &format!("GGG{}GGGGGGGGGG", "A".repeat(6)))
+}
+
+/// Normalize `input` and render the result.
+fn normalize(provider: MockProvider, input: &str) -> String {
+    let normalizer = Normalizer::new(provider);
+    let variant = parse_hgvs(input).expect("parse");
+    normalizer
+        .normalize(&variant)
+        .expect("normalize")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// The defect: a non-triplet repeat unit inside the CDS proper
+// ---------------------------------------------------------------------------
+
+/// The `c.` spelling, pinning the behaviour the `r.` axis has to match: the
+/// gate fires and the expansion is rerouted to an `ins` literal rather than
+/// `A[8]`.
+#[test]
+fn cds_homopolymer_expansion_inside_cds_is_gated() {
+    assert_eq!(
+        normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:c.8_9dup"),
+        "NM_RFRAME.1:c.9_10insAA",
+    );
+}
+
+/// The same bases on `r.`. Before the fix this rendered as `r.4_9a[8]` — the
+/// shape the spec explicitly forbids on a coding RNA reference.
+#[test]
+fn rna_homopolymer_expansion_inside_cds_is_gated() {
+    assert_eq!(
+        normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:r.8_9dup"),
+        "NM_RFRAME.1:r.9_10insaa",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls — each of these must hold both before and after the fix
+// ---------------------------------------------------------------------------
+
+/// A codon-aligned (multiple-of-3) unit inside the CDS is untouched by the
+/// gate and still earns repeat notation on `c.`.
+#[test]
+fn cds_codon_aligned_repeat_inside_cds_is_allowed() {
+    let rendered = normalize(codon_aligned_tract_in_cds(), "NM_RFRAME.1:c.10_15dup");
+    assert!(
+        rendered.contains('['),
+        "a 3-base repeat unit inside the CDS keeps repeat notation on c., got {rendered}",
+    );
+}
+
+/// …and likewise on `r.`. Wiring the gate must not cost the `r.` axis repeat
+/// notation it is entitled to.
+#[test]
+fn rna_codon_aligned_repeat_inside_cds_is_allowed() {
+    let rendered = normalize(codon_aligned_tract_in_cds(), "NM_RFRAME.1:r.10_15dup");
+    assert!(
+        rendered.contains('['),
+        "a 3-base repeat unit inside the CDS keeps repeat notation on r., got {rendered}",
+    );
+}
+
+/// The spec's carve-out on `c.`: the restriction "only applies to the coding
+/// sequence, which does not include the UTR sequence".
+#[test]
+fn cds_homopolymer_expansion_in_utr3_is_allowed() {
+    let rendered = normalize(homopolymer_tract_in_utr3(), "NM_RFRAME.1:c.*8_*9dup");
+    assert!(
+        rendered.contains('['),
+        "a homopolymer in the 3'UTR keeps repeat notation on c., got {rendered}",
+    );
+}
+
+/// …and the same carve-out on `r.`: the gate must key on the footprint's
+/// position, not merely on the transcript being coding.
+#[test]
+fn rna_homopolymer_expansion_in_utr3_is_allowed() {
+    let rendered = normalize(homopolymer_tract_in_utr3(), "NM_RFRAME.1:r.*8_*9dup");
+    assert!(
+        rendered.contains('['),
+        "a homopolymer in the 3'UTR keeps repeat notation on r., got {rendered}",
+    );
+}
+
+/// The **5'UTR** half of the carve-out, and the case the spec actually cites
+/// (`NM_024312.4:r.-6_-3g[6]` "is valid as the reading frame is not affected").
+/// This exercises the *other* arm of the `is_coding` condition from the 3'UTR
+/// tests above — `tx_start < cds_start` rather than `tx_end > cds_end` — so
+/// neither test alone covers both sides of the footprint check.
+///
+/// Derived, not observed: the 5'UTR is `C`×30 at tx 1..30 == `r.-30_-1`, and
+/// `r.-2_-1` is tx 29_30, so `dup` lands wholly in the UTR (29 < cds_start 31)
+/// and the gate must not fire. The CDS opens with `A`, which cannot continue the
+/// `C` run, so the tract is exactly 30 copies of unit `c` and the dup takes it
+/// to 32.
+#[test]
+fn cds_homopolymer_expansion_in_utr5_is_allowed() {
+    assert_eq!(
+        normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:c.-2_-1dup"),
+        "NM_RFRAME.1:c.-30_-1C[32]",
+    );
+}
+
+/// …and the same on `r.`, where the spec states the rule.
+#[test]
+fn rna_homopolymer_expansion_in_utr5_is_allowed() {
+    assert_eq!(
+        normalize(homopolymer_tract_in_cds(), "NM_RFRAME.1:r.-2_-1dup"),
+        "NM_RFRAME.1:r.-30_-1c[32]",
+    );
+}
+
+/// A non-coding transcript has no reading frame to preserve, so `r.` — which is
+/// `n.`-equivalent there — must never gate.
+#[test]
+fn rna_homopolymer_expansion_on_noncoding_transcript_is_allowed() {
+    let provider = noncoding_transcript("GGGAAAAAAGGGGGGGGGG");
+    let rendered = normalize(provider, "NR_RFRAME.1:r.8_9dup");
+    assert!(
+        rendered.contains('['),
+        "a non-coding transcript has no reading frame and must not gate, got {rendered}",
+    );
+}

--- a/tests/it/issue_736_rna_uracil_normalize.rs
+++ b/tests/it/issue_736_rna_uracil_normalize.rs
@@ -58,9 +58,42 @@ fn rna_insertion_with_u_collapses_to_dup() {
 }
 
 #[test]
-fn rna_two_base_u_insertion_canonicalizes_to_repeat() {
-    // `n.3_4insTT` -> `n.3_5T[5]`; the `r.` analog renders the repeat unit as `u`.
-    assert_eq!(normalize("NM_U.1:r.3_4insuu"), "NM_U.1:r.3_5u[5]");
+fn rna_two_base_u_insertion_is_gated_like_the_c_axis() {
+    // Re-blessed by #1192. The original expectation here was `r.3_5u[5]`,
+    // justified as "the `r.` analog of `n.3_4insTT` -> `n.3_5T[5]`". That
+    // compared `r.` against the wrong axis: `NM_U.1` is coding
+    // (`cds_start = 1`), so `r.` is CDS-relative — the `c.` axis, not the `n.`
+    // axis (#469). `RNA/repeated.md` L24-27 forbids repeat notation on a coding
+    // RNA reference for units whose length is not a multiple of 3, and a
+    // homopolymer unit is length 1, so the codon-frame gate must fire. On the
+    // same transcript and bases the three axes now read:
+    //   c.3_4insTT  -> c.5_6insTT   (gated: coding, unit not codon-aligned)
+    //   r.3_4insuu  -> r.5_6insuu   (must match c.; this assertion)
+    //   n.3_4insTT  -> n.3_5T[5]    (no reading frame, so repeat notation is fine)
+    // The `u` spelling of the inserted bases — the point of #736 — survives the
+    // round trip, which is what this file exists to pin.
+    assert_eq!(normalize("NM_U.1:r.3_4insuu"), "NM_U.1:r.5_6insuu");
+}
+
+/// The two sibling axes the re-blessing above is justified against. They were
+/// asserted only in a comment, which is what let the original `r.3_5u[5]`
+/// expectation look defensible: nothing pinned the `c.` value it was supposed to
+/// match, or the `n.` value it was actually copied from. Pinning both makes the
+/// three-way relationship checkable — `r.` must track `c.` (CDS-relative on a
+/// coding transcript, so gated) and must *not* track `n.` (no reading frame, so
+/// repeat notation is legitimate there).
+#[test]
+fn c_and_n_axes_bracket_the_gated_r_axis_expectation() {
+    assert_eq!(
+        normalize("NM_U.1:c.3_4insTT"),
+        "NM_U.1:c.5_6insTT",
+        "c. is gated: coding footprint, unit length 1 is not codon-aligned",
+    );
+    assert_eq!(
+        normalize("NM_U.1:n.3_4insTT"),
+        "NM_U.1:n.3_5T[5]",
+        "n. has no reading frame, so repeat notation stays available",
+    );
 }
 
 #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -131,6 +131,7 @@ mod issue_1157_five_prime_insertion_rotation;
 mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
 mod issue_1183_rna_axis_ins_expansion;
+mod issue_1192_rna_codon_frame_gate;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Closes #1192.

## The defect

`normalize_rna` passed `is_coding = false` to `normalize_na_edit` unconditionally, so the HGVS restriction that repeat notation on a coding reference may only use repeat units whose length is a multiple of 3 was **never applied on the `r.` axis**. ferro consequently emitted, on `r.`, the exact two descriptions `RNA/repeated.md` L24-27 marks invalid — verified against the real prepared reference on clean `main` (`be47233`):

| input | before | after |
|---|---|---|
| `NM_024312.4:r.2692_2693dup` | `r.2686_2693a[10]` ❌ | `r.2693_2694insaa` |
| `NM_024312.4:r.1741_1742insuauauaua` | `r.1738_1741ua[6]` ❌ | unchanged |
| `NM_024312.4:c.2692_2693dup` | `c.2693_2694insAA` | unchanged |

The spec names those two forbidden forms verbatim:

> **exception**: using a coding RNA reference sequence, a repeated sequence variant description can be used only for repeat units with a length which is a multiple of 3, i.e. which can not affect the reading frame. Consequently, use `NM_024312.4:r.2692_2693dup` and **not** `NM_024312.4:r.2686a[10]`; use `NM_024312.4:r.1741_1742insuauauaua` and **not** `NM_024312.4:r.1738ua[6]`. This restriction only applies to the coding sequence, which does not include the UTR sequence. As such, `NM_024312.4:r.-6_-3g[6]` is valid as the reading frame is not affected.

The comment justifying the hardcoded `false` claimed `r.` "is not in the spec's accepted reference types for repeats". `RNA/repeated.md` is an entire page about repeat notation on an RNA reference and states the same exception the DNA page does, including the same UTR carve-out, so that premise was simply wrong.

## The fix

Derive `is_coding` the way `normalize_cds` already does — deliberately the identical condition, since `r.` on a coding transcript is CDS-relative, i.e. the same axis as `c.` (#469):

```rust
let is_coding = match cds_info {
    Some((cds_start, cds_end)) => tx_start >= cds_start && tx_end <= cds_end,
    None => false,
};
```

A non-coding transcript has no `cds_info` and so never gates; a footprint touching either UTR falls outside `cds_start..=cds_end` and is exempt by the spec's carve-out.

**The change is additive and narrow on purpose.** #1185/#1189 established that `normalize_na_edit`'s recursive calls forward the outer gate verdict *by design*, so a "cleaner" refactor that recomputes the verdict per call site breaks normalization idempotency. Exactly one call site changes here. `normalize_idempotency_proptest` at `PROPTEST_CASES=100000` and the full suite under `FERRO_ASSERT_IDEMPOTENT=1` are both green.

## Tests

`tests/it/issue_1192_rna_codon_frame_gate.rs` — hand-rolled fixtures (not `SyntheticBuilder`, whose `ACGT` padding a tandem unit can cycle straight into; a padding artifact of that shape produced a retracted finding once before). Every case is asserted on **both** axes, which is what makes this a spec defect rather than a fixture artifact: the two axes address identical reference bases, so any divergence between them is the bug.

Before the fix exactly one of the seven fails, with `r.4_9a[8]` against an expected `r.9_10insaa`; the other six — including all four controls — pass unchanged both before and after:

- codon-aligned (multiple-of-3) unit inside the CDS still earns repeat notation, on `c.` and on `r.`
- a homopolymer in the **3'UTR** keeps repeat notation, on `c.` and on `r.` (the spec's carve-out)
- an `NR_` transcript never gates

### Re-blessed test

`issue_736_rna_uracil_normalize::rna_two_base_u_insertion_canonicalizes_to_repeat` pinned the defect and is re-blessed (and renamed to `..._is_gated_like_the_c_axis`). Its expectation `r.3_5u[5]` was justified as "the `r.` analog of `n.3_4insTT` -> `n.3_5T[5]`" — which compared `r.` against the wrong axis. That fixture's transcript is coding (`cds_start = 1`), so `r.` is the `c.` axis, not the `n.` axis. On the same transcript and bases the three axes now read:

```
c.3_4insTT  -> c.5_6insTT   (gated: coding, unit not codon-aligned)
r.3_4insuu  -> r.5_6insuu   (must match c.)
n.3_4insTT  -> n.3_5T[5]    (no reading frame, so repeat notation is fine)
```

The `u` spelling of the inserted bases — the actual point of #736 — survives the round trip, which is what that file exists to pin.

## Blast radius

Measured by toggling only the `src` change in **one** worktree and regenerating both generated spec fixtures each time (never by diffing fixtures across worktrees — both are `.gitignore`d build artifacts, and the enumeration is generated *from* the normalization fixture, so a cross-worktree diff compares two independently-generated files):

- **normalization fixture:** byte-identical.
- **enumeration fixture:** 0 rows added, 0 removed, **16 changed** — 4 spec inputs × 4 axes, and all 4 inputs are `RNA/repeated.md`'s own counter-examples. No budgeted divergence status moves (`projection-pinned` 1203→1207 and `projection-unavailable-pinned` 526→522 are both in `KNOWN_PASSING_STATUSES`, not `DIVERGENCE_BUDGET`).
- **reference-backed conformance:** unchanged. The full suite with `FERRO_MANIFEST` set still fails only `mutalyzer_normalize_tests::axis_errors` on the two rows that already fail on `main` (`NM_000143.3:c.45del4` / `c.45dup4`, #1173's territory). No ledger re-bless needed.

Three of the four changed inputs improve on axes beyond `r.`:

- **`project-c`** previously emitted `c.1546_1549TA[6]` / `c.2494_2501A[10]` — descriptions the `c.` axis would never produce natively, because they are gated there. It now emits the ins literals, matching native `c.` normalization. That is a second, latent spec violation this fix cures.
- **`project-p`** went from `unavailable: no p. representation for this variant` to real predictions (`p.(Lys517IlefsTer33)`, `p.(Pro835SerfsTer5)`) for 4 rows: repeat notation had no protein projection, the ins form does. Both are frameshifts — which is precisely *why* the spec forbids the repeat spelling here.
- **`project-n`** now shows the ins literal (`n.1741_1742insTATATATA`) where it previously showed `n.1738_1741TA[6]`. Flagging this honestly: projection re-expresses an already-normalized edit rather than re-normalizing it, so the `n.` view inherits the gated `r.` spelling. Both describe the same change and neither is invalid on `n.`, but a *native* `n.` normalization of those bases would still produce the repeat form. It is a fidelity change, not a correctness violation.

## Not in scope

The spec's preferred fallback for the first example is `r.2692_2693dup`, whereas ferro's gated fallback renders `insaa` on **both** axes. Whether the fallback should prefer `dup` over an `ins` literal is a pre-existing question about `c.`-axis behavior, unchanged by this PR.

#1183 is a different `r.`-axis gap (the axis skips `ins[...]` cross-reference expansion) with the same underlying theme — machinery `c.` has that `r.` is missing.
