### PR TITLE
ci: run CI on pull requests targeting any base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter here on purpose. That filter matches the pull
+  # request's BASE, so `branches: [main]` silently skipped CI for every
+  # stacked PR (one whose base is another feature branch). Because the
+  # `pull_request` event never fired, such a PR had no CI runs at all, yet
+  # GitHub still rendered "All checks have passed" — a green badge that
+  # carried no information. Run on every pull request whatever it targets.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -6,8 +6,11 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actionlint.yaml'
+  # No `branches:` filter — see the note in `ci.yml`. It matches the pull
+  # request's base, so a stacked PR editing a workflow skipped actionlint
+  # entirely. The `paths:` filter below is kept: it matches changed files,
+  # not the base, and is the point of this workflow.
   pull_request:
-    branches: [main]
     paths:
       - '.github/workflows/**'
       - '.github/actionlint.yaml'


### PR DESCRIPTION
## The bug

The `branches:` filter on a `pull_request` trigger matches the pull request's **base**, not its head. Both PR-triggered workflows filtered on `branches: [main]`:

```yaml
# ci.yml and lint-workflows.yml
on:
  pull_request:
    branches: [main]
```

So a **stacked PR** — one opened against another feature branch rather than `main` — never fires the event, and gets no CI runs at all. `push` is `main`-only too, so pushing the branch doesn't trigger anything either.

The failure mode is what makes this worth fixing rather than tolerating: GitHub renders **"All checks have passed"** whenever every check that is *present* passed. On these PRs exactly one check is present — CodeRabbit, reporting that it *skipped* — so they display green while zero build, test or lint jobs have ever run. A PR with no CI is visually indistinguishable from one with a full green matrix.

## Evidence

Three open PRs are in that state right now:

| PR | base | checks present | workflow runs for the head branch |
|---|---|---|---|
| #1172 | `fix/five-prime-shuffle-idempotency` | 1 (CodeRabbit "skipped") | none |
| #1175 | `fix/repeat-input-idempotency` | 1 (CodeRabbit "skipped") | none |
| #1186 | `perf/prepared-index-deletions` | 1 (CodeRabbit "skipped") | none |

`gh run list --branch <head>` returns nothing for any commit on those three branches. The same query against branches known to have run returns results, so that is a real zero rather than a broken query.

To be clear about the scope of the claim: this does **not** mean bad code has merged. Every one of the last 25 merged PRs has a CI run at its merged head SHA. The gap has never been exercised, because a stacked PR is normally rebased once its parent merges, and that force-push fires `synchronize` against a `main` base and finally runs CI. This PR closes the window rather than relying on that habit.

## The fix

Drop the `branches:` filter from the `pull_request` trigger in both workflows.

`lint-workflows.yml` keeps its `paths:` filter — that one matches *changed files*, not the base, and is the entire point of the workflow. Only the base filter is removed. It is included here rather than split into a second PR because it has the identical defect and, being the actionlint job, is precisely what should be validating workflow edits on the stacked PRs most likely to make them.

`push` stays pinned to `main`, so a PR branch continues to fire only the `pull_request` event — nothing runs twice.

## Prior art

This matches the sibling `fgumi` repository, whose `check.yml` uses a bare `pull_request:` for exactly this reason. Its other workflows are `schedule` / `workflow_dispatch` / `push: main`, so one unfiltered PR trigger covers everything — the same shape this PR produces here.

## Verification

- `actionlint` clean on both files locally.
- Both files re-parsed as YAML to confirm the intended trigger structure: `ci.yml` → `pull_request` with no filters; `lint-workflows.yml` → `pull_request` with `paths` retained and `branches` gone.
- This PR targets `main`, so it cannot demonstrate the fix on itself. Once merged, the check to run is `gh pr checks 1172` (or #1175 / #1186) after any push to those branches — they should pick up the full matrix instead of the lone CodeRabbit row.

## Deliberately not included

Branch protection. ferro-hgvs currently has neither legacy protection nor any ruleset on `main` (`gh api .../rulesets` → `[]`), so nothing requires status checks before merge. That is worth a separate conversation, but it must not come first: GitHub *blocks* a PR until each required check reports, and a check that never runs never reports — so adding required checks while this bug is live would make the three PRs above permanently unmergeable rather than red. Trigger fix first; protection, if wanted, afterwards.

Note also that fgumi does not require status checks either. Its ruleset covers deletion, force-push, linear history, signatures and PR-required. It is safe from this class of bug because its CI cannot be falsely green, not because it gates on checks.
