### PR TITLE
fix(dev): make the spec generators usable on a fresh worktree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,32 +19,42 @@ repos:
         types: [rust]
         pass_filenames: false
 
-      # Spec-fixture drift guard (#397 item 7). CI already runs this
-      # check (search for `generate_spec_fixture --check` in
-      # `.github/workflows/ci.yml`), but a push that drifts the
-      # fixture wastes a full CI cycle to discover the drift. The
-      # pre-push stage runs once per `git push` rather than per
-      # commit, so the build cost is paid only when actually pushing.
-      - id: generate-spec-fixture-check
-        name: generate_spec_fixture --check
-        entry: cargo run --features dev --example generate_spec_fixture -- --check
+      # Spec-input guard (#397 item 7). What is worth catching before a push is
+      # a change to the COMMITTED inputs — the spec submodule and the curated
+      # overrides files — since a broken override wastes a full CI cycle to
+      # discover. Plain generation is exactly that guard: it harvests the spec
+      # checkout and resolves every override against it. So these hooks run the
+      # same commands CI runs (see "Generate HGVS v21.0 spec fixture" in
+      # `.github/workflows/ci.yml`), not `--check`.
+      #
+      # `--check` is deliberately NOT used here. It answers a different
+      # question — "is my local artifact current?" — about a gitignored build
+      # artifact whose staleness has no bearing on what is being pushed, and CI
+      # regenerates it from scratch regardless. Gating a push on it also made a
+      # fresh worktree unpushable, because the artifact does not exist yet.
+      #
+      # The pre-push stage runs once per `git push` rather than per commit, so
+      # the build cost is paid only when actually pushing.
+      - id: generate-spec-fixture
+        name: generate_spec_fixture
+        entry: cargo run --features dev --example generate_spec_fixture
         language: system
         # always_run (not types: [rust]) — a push that only touches the
-        # spec submodule or test fixtures still needs the drift guard,
-        # and pre-commit otherwise skips type-filtered hooks when no
-        # matching files are staged in the push range.
+        # spec submodule or the overrides file still needs the guard, and
+        # pre-commit otherwise skips type-filtered hooks when no matching
+        # files are staged in the push range.
         always_run: true
         pass_filenames: false
         stages: [pre-push]
 
-      # Same drift guard for the spec test enumeration. The generator reads
-      # hgvs_spec_normalization.json (a gitignored build artifact, absent on a
-      # fresh checkout) for deduplication, so bootstrap that fixture first —
-      # otherwise --check aborts with "read ...: No such file" instead of a
-      # drift verdict. Generating it in-place is cheap and idempotent.
-      - id: generate-spec-enumeration-check
-        name: generate_spec_enumeration --check
-        entry: bash -c 'cargo run --features dev --example generate_spec_fixture && cargo run --features dev --example generate_spec_enumeration -- --check'
+      # Same guard for the spec test enumeration. Its generator reads
+      # hgvs_spec_normalization.json for deduplication; that input is satisfied
+      # by the hook above, because pre-commit runs hooks in declared order. The
+      # ordering IS the dependency declaration — previously it was hand-rolled
+      # as a `bash -c` chain that re-invoked the fixture generator.
+      - id: generate-spec-enumeration
+        name: generate_spec_enumeration
+        entry: cargo run --features dev --example generate_spec_enumeration
         language: system
         always_run: true
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,11 @@ cargo run --features dev --example generate_spec_fixture            # (re)genera
 cargo run --features dev --example generate_spec_fixture -- --output <path>   # write elsewhere
 ```
 
-The two tests that read it (`tests/idempotency_tests.rs`, `tests/hgvs_spec_normalization_tests.rs`) call a shared helper (`tests/common/spec_fixture.rs`) that regenerates it on demand if missing, so a fresh `cargo test` "just works" (one-time generation). CI regenerates it explicitly before the test run. Requires the `assets/hgvs-nomenclature` submodule (`git submodule update --init`); without it the generator errors with `overrides reference unknown inputs`.
+The tests that read it (`tests/it/hgvs_spec_normalization_tests.rs`, `tests/it/idempotency_tests.rs`, `tests/it/mito_circular_audit.rs`, `tests/it/protein_silent_eq.rs`, `tests/it/protein_unknown_roundtrip.rs`) call a shared helper (`tests/it/common/spec_fixture.rs`) that regenerates it on demand if missing, so a fresh `cargo test` "just works" (one-time generation). CI and the pre-push hook regenerate it explicitly before the test run — plain generation, not `--check`, because generation is what validates the committed overrides against the spec checkout.
+
+Requires the `assets/hgvs-nomenclature` submodule (`git submodule update --init assets/hgvs-nomenclature`); without it the generator fails with `no HGVS strings harvested from …`, naming that command.
+
+`--check` answers a different question — "is my local artifact current?" — and is not a gate: an absent artifact is generated rather than reported as drift, since a gitignored file has no committed baseline to drift from. Use it when you want to know whether a code change moved the fixture.
 
 Because the fixture is no longer in git, per-PR `parse-error → preserved` status transitions are reviewed via the PR description and the accompanying test/parser changes, not a committed diff.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,23 +88,35 @@ cargo bench                              # Benchmarks
 `tests/fixtures/grammar/hgvs_spec_normalization.json` pins ferro's current
 `normalize()` output for every variant string in the HGVS v21.0 spec
 (vendored at `assets/hgvs-nomenclature/`). The companion test
-`tests/hgvs_spec_normalization_tests.rs` fails any time a row's observed
+`tests/it/hgvs_spec_normalization_tests.rs` fails any time a row's observed
 output drifts from the recorded `current`.
 
 If your PR changes any normalization output:
 
-1. Make sure the vendored spec submodule is checked out, then regenerate
-   the fixture:
+1. Make sure the vendored spec submodule is checked out, snapshot the current
+   fixture, then regenerate it:
 
    ```bash
    git submodule update --init assets/hgvs-nomenclature
+   # The fixture is a gitignored build artifact, so `git diff` will never show
+   # your change. Snapshot the existing copy first — it is the baseline step 2
+   # compares against. (On a fresh worktree there is nothing to snapshot;
+   # regenerate on `main` first if you want a baseline.)
+   cp tests/fixtures/grammar/hgvs_spec_normalization.json /tmp/spec-fixture-before.json
    cargo run --features dev --example generate_spec_fixture
    ```
 
-2. Inspect the diff. For each changed row, verify the new `current` against
-   the v21.0 spec text under `assets/hgvs-nomenclature/docs/recommendations/`.
-   When ferro's new output now matches the spec's canonical form, that row
-   should also have `current == spec_expected` after regen.
+2. Inspect the change against that snapshot — not `git diff`, which shows
+   nothing for an untracked file:
+
+   ```bash
+   diff -u /tmp/spec-fixture-before.json tests/fixtures/grammar/hgvs_spec_normalization.json
+   ```
+
+   For each changed row, verify the new `current` against the v21.0 spec text
+   under `assets/hgvs-nomenclature/docs/recommendations/`. When ferro's new
+   output now matches the spec's canonical form, that row should also have
+   `current == spec_expected` after regen.
 
 3. If a row's spec-canonical form differs from the input string (a "pair" — e.g.
    spec input `c.79GC>TT` is canonicalized to `c.79_80delinsTT`), record the
@@ -172,17 +184,32 @@ v21.0 spec. Re-validate them whenever bumping the spec submodule (see step 5).
 For a row that needs a different accession, set `input_prefixed` in the
 override file.
 
-4. CI verifies byte-identical regeneration via:
+4. CI regenerates the fixture rather than diffing it, because the fixture is a
+   gitignored build artifact with no committed baseline. The generation run is
+   itself the guard: it harvests the spec checkout and resolves every curated
+   override against it, so a stale override fails the build.
+
+   ```bash
+   cargo run --features dev --example generate_spec_fixture
+   ```
+
+   The pre-push hook runs the same command for the same reason. `--check` is a
+   local convenience answering a different question — "is my artifact current?"
+   — and is never a gate:
 
    ```bash
    cargo run --features dev --example generate_spec_fixture -- --check
    ```
 
+   (Contrast the tool-support tables below, whose outputs *are* committed. There
+   `--check` is the right gate, and CI uses it.)
+
 5. To bump the spec to a newer upstream version:
    - update the submodule pointer under `assets/hgvs-nomenclature/`
      (`git -C assets/hgvs-nomenclature checkout <new-tag>`)
    - re-validate the default-prefix table above against the new spec corpus
-   - regenerate the fixture and review the diff
+   - regenerate the fixture and review the change against a snapshot (step 2 —
+     the artifact is untracked, so `git diff` shows nothing)
 
 ## Tool-support comparison tables
 

--- a/examples/common/generated_artifact.rs
+++ b/examples/common/generated_artifact.rs
@@ -1,0 +1,57 @@
+//! Shared `--check` semantics for the gitignored generated spec artifacts.
+//!
+//! `hgvs_spec_normalization.json` and `hgvs_spec_enumeration.json` are build
+//! artifacts, not committed files (see `CLAUDE.md`), so `--check` answers
+//! exactly one question: **is my local artifact current?**
+//!
+//! It deliberately does *not* validate the committed inputs — the plain
+//! (non-`--check`) generation run does that, by harvesting the spec checkout and
+//! resolving the curated overrides against it. That is why CI and the pre-push
+//! hooks run plain generation rather than `--check`: they care about the inputs,
+//! which are committed, not about a local artifact's freshness.
+//!
+//! Keeping those two questions apart is the point. Conflating them is what made
+//! `--check` fail on a fresh worktree: it required the artifact to pre-exist in
+//! order to answer a question about the inputs, so a never-generated file — the
+//! normal state of a gitignored artifact on a new checkout — aborted the run
+//! with a bare `No such file or directory`.
+
+use std::path::Path;
+
+/// Compare `rendered` against the artifact at `path`.
+///
+/// * identical            → `Ok(())`
+/// * present and differs  → error naming the regeneration command; `path` is
+///   left untouched, so the stale content remains available for inspection
+/// * absent               → **not** an error. A gitignored artifact that has
+///   never been generated is a cold cache, not drift: there is no committed
+///   baseline it could have drifted from. Materialise it and say so.
+///
+/// `label` names the artifact in messages; `example` is the generator to rerun.
+pub fn check_up_to_date(
+    path: &Path,
+    rendered: &str,
+    label: &str,
+    example: &str,
+) -> anyhow::Result<()> {
+    match std::fs::read_to_string(path) {
+        Ok(on_disk) if on_disk == rendered => Ok(()),
+        Ok(_) => {
+            eprintln!(
+                "{label} {} is out of date; rerun: cargo run --features dev --example {example}",
+                path.display()
+            );
+            Err(anyhow::anyhow!("{label} out of date"))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::write(path, rendered)
+                .map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+            eprintln!(
+                "{label} {} was absent (gitignored build artifact); generated it",
+                path.display()
+            );
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("read {}: {e}", path.display())),
+    }
+}

--- a/examples/common/spec_harvest.rs
+++ b/examples/common/spec_harvest.rs
@@ -84,6 +84,29 @@ pub mod sources {
             }
         }
         all.extend(extract_from_syntax_yaml(spec_dir)?);
+
+        // Precondition, checked here so no caller can forget it: everything
+        // gathered so far came out of `spec_dir`, so an empty `all` means the
+        // spec checkout yielded nothing — in practice an uninitialised
+        // `assets/hgvs-nomenclature` submodule.
+        //
+        // This guard must sit BEFORE `ported_legacy_probes()`, which is
+        // compiled in rather than harvested and would otherwise mask the
+        // condition. Without it the failure surfaced much later and pointed at
+        // the wrong file: `build_rows` validates the curated overrides against
+        // the harvested inputs, so every override key looked unresolvable and
+        // the generator reported `overrides reference unknown inputs (typo or
+        // spec drift)` — accusing a committed, correct file of being stale when
+        // the real cause was an empty directory.
+        if all.is_empty() {
+            anyhow::bail!(
+                "no HGVS strings harvested from {} — the spec checkout is empty.\n\
+                 If that path is the vendored submodule, initialise it:\n    \
+                 git submodule update --init assets/hgvs-nomenclature",
+                spec_dir.display()
+            );
+        }
+
         all.extend(ported_legacy_probes());
         Ok(all)
     }

--- a/examples/generate_spec_enumeration.rs
+++ b/examples/generate_spec_enumeration.rs
@@ -39,6 +39,10 @@ use serde::{Deserialize, Serialize};
 #[path = "common/spec_harvest.rs"]
 mod spec_harvest;
 
+#[path = "common/generated_artifact.rs"]
+mod generated_artifact;
+
+use generated_artifact::check_up_to_date;
 use spec_harvest::{negatives, prefix, sources};
 
 #[derive(ClapParser, Debug)]
@@ -78,7 +82,10 @@ struct Cli {
     )]
     output: PathBuf,
 
-    /// Regenerate in memory and exit non-zero if the on-disk file differs.
+    /// Is the local enumeration current? Exits 1 when an existing file differs
+    /// from a fresh render, leaving it in place for inspection. An absent file is
+    /// generated, not treated as a failure: it is gitignored, so "never built"
+    /// is a cold cache rather than drift.
     #[arg(long)]
     check: bool,
 
@@ -122,16 +129,12 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     }
 
     if cli.check {
-        let on_disk = std::fs::read_to_string(&cli.output)
-            .map_err(|e| anyhow::anyhow!("read {}: {e}", cli.output.display()))?;
-        if on_disk != rendered {
-            eprintln!(
-                "enumeration {} is out of date; rerun: \
-                 cargo run --features dev --example generate_spec_enumeration",
-                cli.output.display()
-            );
-            return Err(anyhow::anyhow!("enumeration out of date"));
-        }
+        check_up_to_date(
+            &cli.output,
+            &rendered,
+            "enumeration",
+            "generate_spec_enumeration",
+        )?;
     } else {
         std::fs::write(&cli.output, rendered)?;
     }

--- a/examples/generate_spec_fixture.rs
+++ b/examples/generate_spec_fixture.rs
@@ -4,10 +4,15 @@
 //! extracts every HGVS string, runs each through ferro's `Normalizer`, merges
 //! hand overrides, and writes `tests/fixtures/grammar/hgvs_spec_normalization.json`.
 //!
-//! Two modes:
-//!   - default:  regenerate the fixture in-place
-//!   - --check:  regenerate in-memory and exit non-zero if the on-disk fixture
-//!     differs (used in CI to catch drift)
+//! Two modes, answering two different questions:
+//!   - default:  regenerate the fixture in-place. This is the run that
+//!     **validates the committed inputs** — it harvests the spec checkout and
+//!     resolves every curated override against it — which is why CI and the
+//!     pre-push hook use it rather than `--check`.
+//!   - --check:  is the *local* artifact current? Exits non-zero only when an
+//!     existing fixture differs from a fresh render. An absent fixture is a cold
+//!     cache, not drift (the file is gitignored, so there is no committed
+//!     baseline), and is simply generated.
 //!
 //! Run: `cargo run --features dev --example generate_spec_fixture`
 //! Check: `cargo run --features dev --example generate_spec_fixture -- --check`
@@ -42,8 +47,10 @@ struct Cli {
     )]
     output: PathBuf,
 
-    /// Check that the on-disk fixture is byte-identical to a fresh regeneration.
-    /// Exits 1 on mismatch. Does not modify the file.
+    /// Is the local fixture current? Exits 1 when an existing fixture differs
+    /// from a fresh render, leaving it in place for inspection. An absent
+    /// fixture is generated, not treated as a failure: the file is gitignored,
+    /// so "never built" is a cold cache rather than drift.
     #[arg(long)]
     check: bool,
 }
@@ -66,15 +73,7 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
     let rendered = render::render(&rows, &cli.spec_dir)?;
 
     if cli.check {
-        let on_disk = std::fs::read_to_string(&cli.output)
-            .map_err(|e| anyhow::anyhow!("read {}: {e}", cli.output.display()))?;
-        if on_disk != rendered {
-            eprintln!(
-                "fixture {} is out of date; rerun: cargo run --features dev --example generate_spec_fixture",
-                cli.output.display()
-            );
-            return Err(anyhow::anyhow!("fixture out of date"));
-        }
+        check_up_to_date(&cli.output, &rendered, "fixture", "generate_spec_fixture")?;
     } else {
         std::fs::write(&cli.output, rendered)?;
     }
@@ -84,6 +83,10 @@ fn run(cli: &Cli) -> anyhow::Result<()> {
 #[path = "common/spec_harvest.rs"]
 mod spec_harvest;
 
+#[path = "common/generated_artifact.rs"]
+mod generated_artifact;
+
+use generated_artifact::check_up_to_date;
 use spec_harvest::{classify, prefix, sources};
 
 // ---------- overrides ----------

--- a/tests/it/hgvs_spec_normalization_tests.rs
+++ b/tests/it/hgvs_spec_normalization_tests.rs
@@ -5,7 +5,10 @@
 //! diverges from `spec_expected` carry a `todo` link to the #83 audit.
 //!
 //! Regenerate the fixture: `cargo run --features dev --example generate_spec_fixture`.
-//! Verify byte-identical regen:    `cargo run --features dev --example generate_spec_fixture -- --check`.
+//! That run is also the guard on the committed overrides, and is what CI and the
+//! pre-push hook use. Adding `-- --check` instead asks only whether the local
+//! (gitignored) artifact is current — useful for spotting whether a code change
+//! moved the fixture, never a gate.
 
 use ferro_hgvs::reference::mock::MockProvider;
 use ferro_hgvs::{parse_hgvs, Normalizer};

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -310,6 +310,7 @@ mod spdi_tests;
 mod spec_canonical_locks;
 mod spec_coverage_misc;
 mod spec_enumeration_tests;
+mod spec_generator_preconditions;
 mod strict_del_size_suffix_mode;
 mod strict_explicit_seq_size_modes;
 mod strict_whitespace_mode;

--- a/tests/it/spec_generator_preconditions.rs
+++ b/tests/it/spec_generator_preconditions.rs
@@ -1,0 +1,373 @@
+//! The spec generators must be usable on a **fresh worktree**, and must blame
+//! the right thing when they cannot run.
+//!
+//! Two failure modes made `git push` impossible on a newly created worktree,
+//! and neither named its actual cause:
+//!
+//! 1. With the `assets/hgvs-nomenclature` submodule uninitialised, the harvest
+//!    yielded only the compiled-in `ported_legacy_probes`, so `build_rows`
+//!    validated the curated overrides against a near-empty input set and
+//!    reported `overrides reference unknown inputs (typo or spec drift)` — a
+//!    committed, correct file accused of being stale because a directory was
+//!    empty.
+//! 2. `--check` then aborted with a bare `No such file or directory` for the
+//!    gitignored output artifact, which on a fresh worktree has simply never
+//!    been generated.
+//!
+//! These tests pin both: the harvest fails with an actionable message naming the
+//! submodule, and `--check` treats an absent artifact as a cold cache rather
+//! than drift.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// A unique scratch directory under `target/`, removed and recreated per test so
+/// reruns are deterministic. Kept inside `target/` so it is gitignored and never
+/// pollutes the worktree.
+fn scratch(name: &str) -> PathBuf {
+    let dir = manifest_dir()
+        .join("target")
+        .join("spec-precond")
+        .join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+/// Run a `--features dev` example with `args`, returning its captured output.
+fn run_example(example: &str, args: &[&str]) -> Output {
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.current_dir(manifest_dir())
+        .args([
+            "run",
+            "--quiet",
+            "--features",
+            "dev",
+            "--example",
+            example,
+            "--",
+        ])
+        .args(args);
+    cmd.output()
+        .unwrap_or_else(|e| panic!("failed to run `{example}`: {e}"))
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// One pre-commit hook, flattened out of the nested `repos[].hooks[]` shape.
+struct Hook {
+    id: String,
+    entry: String,
+    stages: Vec<String>,
+}
+
+/// Every hook in `.pre-commit-config.yaml`, in declared order.
+///
+/// Parsed as YAML rather than substring-matched: the file's comments discuss
+/// `--check` on purpose, so a naive `contains` can match prose, and a hook that
+/// was commented out would still "exist".
+fn pre_commit_hooks() -> Vec<Hook> {
+    let text = std::fs::read_to_string(manifest_dir().join(".pre-commit-config.yaml"))
+        .expect("read .pre-commit-config.yaml");
+    let doc: serde_yaml::Value =
+        serde_yaml::from_str(&text).expect("parse .pre-commit-config.yaml");
+
+    doc.get("repos")
+        .and_then(serde_yaml::Value::as_sequence)
+        .expect("`repos` sequence")
+        .iter()
+        .filter_map(|repo| repo.get("hooks").and_then(serde_yaml::Value::as_sequence))
+        .flatten()
+        .map(|hook| Hook {
+            id: hook
+                .get("id")
+                .and_then(serde_yaml::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            entry: hook
+                .get("entry")
+                .and_then(serde_yaml::Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            stages: hook
+                .get("stages")
+                .and_then(serde_yaml::Value::as_sequence)
+                .map(|s| {
+                    s.iter()
+                        .filter_map(serde_yaml::Value::as_str)
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
+        })
+        .collect()
+}
+
+/// Every `run:` command across every step of every job in `ci.yml`.
+fn ci_run_commands() -> Vec<String> {
+    let text = std::fs::read_to_string(manifest_dir().join(".github/workflows/ci.yml"))
+        .expect("read .github/workflows/ci.yml");
+    let doc: serde_yaml::Value = serde_yaml::from_str(&text).expect("parse ci.yml");
+
+    doc.get("jobs")
+        .and_then(serde_yaml::Value::as_mapping)
+        .expect("`jobs` mapping")
+        .values()
+        .filter_map(|job| job.get("steps").and_then(serde_yaml::Value::as_sequence))
+        .flatten()
+        .filter_map(|step| step.get("run").and_then(serde_yaml::Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The real spec checkout, or `None` when the submodule is not initialised —
+/// in which case the tests that need real inputs are skipped rather than failed,
+/// matching how the rest of the suite treats absent optional inputs.
+fn spec_dir_if_initialised() -> Option<PathBuf> {
+    let dir = manifest_dir().join("assets/hgvs-nomenclature");
+    dir.join("docs/recommendations").is_dir().then_some(dir)
+}
+
+// ---------------------------------------------------------------------------
+// 1. An empty spec checkout blames the submodule, not the overrides file
+// ---------------------------------------------------------------------------
+
+/// An empty `--spec-dir` must fail with a message that names the empty checkout
+/// and the command that fixes it — and must NOT report the overrides file as
+/// carrying unknown inputs, which is what sent the last reader after phantom
+/// spec drift.
+#[test]
+fn empty_spec_checkout_names_the_submodule_not_the_overrides() {
+    let empty = scratch("empty-spec-dir");
+    let out = run_example(
+        "generate_spec_fixture",
+        &[
+            "--spec-dir",
+            empty.to_str().expect("utf-8 scratch path"),
+            "--output",
+            empty
+                .join("unused.json")
+                .to_str()
+                .expect("utf-8 scratch path"),
+        ],
+    );
+    let stderr = stderr_of(&out);
+
+    assert!(
+        !out.status.success(),
+        "an empty spec checkout must fail, got success. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no HGVS strings harvested"),
+        "error must say the harvest came up empty. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("git submodule update --init assets/hgvs-nomenclature"),
+        "error must name the command that fixes it. stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("overrides reference unknown inputs"),
+        "an empty checkout must not be reported as stale overrides — that \
+         misattribution is the bug this pins. stderr:\n{stderr}"
+    );
+}
+
+/// The same guard protects the enumeration generator, which harvests the same
+/// checkout through the same `sources::discover`.
+#[test]
+fn empty_spec_checkout_is_rejected_by_the_enumeration_generator_too() {
+    let empty = scratch("empty-spec-dir-enum");
+    let out = run_example(
+        "generate_spec_enumeration",
+        &[
+            "--spec-dir",
+            empty.to_str().expect("utf-8 scratch path"),
+            "--output",
+            empty
+                .join("unused.json")
+                .to_str()
+                .expect("utf-8 scratch path"),
+        ],
+    );
+    let stderr = stderr_of(&out);
+
+    assert!(
+        !out.status.success(),
+        "an empty spec checkout must fail, got success. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no HGVS strings harvested"),
+        "error must say the harvest came up empty. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("git submodule update --init assets/hgvs-nomenclature"),
+        "error must name the command that fixes it. stderr:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. `--check` treats an absent artifact as a cold cache, not drift
+// ---------------------------------------------------------------------------
+
+/// This is the fresh-worktree case: `--check` pointed at an artifact that has
+/// never been generated must succeed and create it, not abort on ENOENT. A
+/// gitignored build artifact has no committed baseline to have drifted from.
+#[test]
+fn check_generates_an_absent_artifact_instead_of_failing() {
+    let Some(spec_dir) = spec_dir_if_initialised() else {
+        eprintln!("skipping: assets/hgvs-nomenclature not initialised");
+        return;
+    };
+    let dir = scratch("check-absent");
+    let output = dir.join("hgvs_spec_normalization.json");
+    assert!(!output.exists(), "scratch output must start absent");
+
+    let out = run_example(
+        "generate_spec_fixture",
+        &[
+            "--spec-dir",
+            spec_dir.to_str().expect("utf-8 spec path"),
+            "--output",
+            output.to_str().expect("utf-8 scratch path"),
+            "--check",
+        ],
+    );
+    let stderr = stderr_of(&out);
+
+    assert!(
+        out.status.success(),
+        "--check on an absent artifact must succeed. stderr:\n{stderr}"
+    );
+    assert!(
+        output.exists(),
+        "--check must materialise the absent artifact. stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("No such file or directory"),
+        "the raw ENOENT is the bug this pins. stderr:\n{stderr}"
+    );
+}
+
+/// The staleness verdict itself must survive: an artifact that exists and
+/// differs is still a failure, and is left on disk for inspection.
+#[test]
+fn check_still_reports_a_stale_artifact_and_leaves_it_alone() {
+    let Some(spec_dir) = spec_dir_if_initialised() else {
+        eprintln!("skipping: assets/hgvs-nomenclature not initialised");
+        return;
+    };
+    let dir = scratch("check-stale");
+    let output = dir.join("hgvs_spec_normalization.json");
+    let stale = "{\"not\": \"the real fixture\"}\n";
+    std::fs::write(&output, stale).expect("seed a stale artifact");
+
+    let out = run_example(
+        "generate_spec_fixture",
+        &[
+            "--spec-dir",
+            spec_dir.to_str().expect("utf-8 spec path"),
+            "--output",
+            output.to_str().expect("utf-8 scratch path"),
+            "--check",
+        ],
+    );
+    let stderr = stderr_of(&out);
+
+    assert!(
+        !out.status.success(),
+        "--check must fail on a stale artifact. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("is out of date"),
+        "error must say the artifact is out of date. stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&output).expect("read seeded artifact"),
+        stale,
+        "--check must not rewrite a stale artifact; the old content stays \
+         available for inspection",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. The hooks and CI must agree
+// ---------------------------------------------------------------------------
+
+/// The pre-push hooks exist to catch a broken committed input before a CI cycle
+/// is spent, so they must run the same commands CI runs. `--check` answers a
+/// different question (local artifact freshness) about a gitignored file, and
+/// gating a push on it is what made a fresh worktree unpushable.
+#[test]
+fn pre_push_hooks_run_plain_generation_like_ci() {
+    let hooks = pre_commit_hooks();
+    let ci_runs = ci_run_commands();
+
+    for example in ["generate_spec_fixture", "generate_spec_enumeration"] {
+        let plain = format!("cargo run --features dev --example {example}");
+
+        let hook_id = example.replace('_', "-");
+        let hook = hooks
+            .iter()
+            .find(|h| h.id == hook_id)
+            .unwrap_or_else(|| panic!("no pre-commit hook with id `{hook_id}`"));
+        assert_eq!(
+            hook.entry, plain,
+            "hook `{}` must run plain generation, not a variant",
+            hook.id
+        );
+        assert!(
+            hook.stages.iter().any(|s| s == "pre-push"),
+            "hook `{}` must be scoped to the pre-push stage, got {:?}",
+            hook.id,
+            hook.stages,
+        );
+
+        // The agreement has two sides. Asserting only the hook would let CI
+        // drift back to `--check` without this guard noticing — and "the hooks
+        // run what CI runs" is precisely the claim being pinned.
+        assert!(
+            ci_runs.iter().any(|r| r.trim() == plain),
+            "expected CI to run plain `{example}`, matching the pre-push hook",
+        );
+    }
+
+    // Inspect parsed invocations only — the comments in both files discuss
+    // `--check` on purpose, explaining why it is not used here.
+    let gated: Vec<String> = hooks
+        .iter()
+        .map(|h| (format!("hook {}", h.id), h.entry.clone()))
+        .chain(ci_runs.iter().map(|r| ("ci.yml".to_string(), r.clone())))
+        .filter(|(_, cmd)| cmd.contains("generate_spec_") && cmd.contains("--check"))
+        .map(|(origin, cmd)| format!("{origin}: {cmd}"))
+        .collect();
+    assert!(
+        gated.is_empty(),
+        "neither the pre-push hooks nor CI may gate on `--check` for the \
+         gitignored spec artifacts: {gated:?}",
+    );
+}
+
+/// Guard against the dependency ordering silently regressing: the enumeration
+/// generator reads the normalization fixture, and that input is satisfied only
+/// because pre-commit runs hooks in declared order.
+#[test]
+fn fixture_hook_is_declared_before_the_enumeration_hook() {
+    let hooks = pre_commit_hooks();
+    let position = |id: &str| {
+        hooks
+            .iter()
+            .position(|h| h.id == id)
+            .unwrap_or_else(|| panic!("hook `{id}` is declared"))
+    };
+    assert!(
+        position("generate-spec-fixture") < position("generate-spec-enumeration"),
+        "the fixture hook must come first — it produces the input the \
+         enumeration generator reads",
+    );
+}


### PR DESCRIPTION
A newly created worktree could not `git push`. Two pre-push hooks failed in sequence, and neither named its actual cause — so discovering the fix took three push cycles, each recompiling the generators.

## Failure 1 — a committed file blamed for an empty directory

With `assets/hgvs-nomenclature` uninitialised:

```
generate_spec_fixture --check ......... Failed
error: overrides reference unknown inputs (typo or spec drift):
  ["NC_000012.12:g.6128479_6128749con[...]", ... 38 entries ...]
```

`sources::discover` returns `ported_legacy_probes()` — compiled in, not harvested — so the candidate set is never *empty*, just nearly so. `build_rows` then validates the curated overrides against those few probes, every key fails to resolve, and the generator reports the committed, correct `hgvs_spec_normalization_overrides.json` as stale. The message says "spec drift"; the condition is an empty directory.

Fixed by guarding the precondition in `sources::discover` — where the directory is actually read, and which all three generators go through, so no caller can forget it. The guard sits **before** `ported_legacy_probes()` precisely because those would otherwise mask the condition:

```
error: no HGVS strings harvested from assets/hgvs-nomenclature — the spec checkout is empty.
If that path is the vendored submodule, initialise it:
    git submodule update --init assets/hgvs-nomenclature
```

## Failure 2 — `--check` was answering two questions at once

Once the submodule was initialised, the next hook failed:

```
generate_spec_enumeration --check ..... Failed
error: read tests/fixtures/grammar/hgvs_spec_enumeration.json: No such file or directory
```

This is the part worth fixing properly rather than patching. `--check` conflated two independent questions:

1. **Are the committed inputs valid?** — the spec checkout and the curated overrides.
2. **Is my local artifact current?**

It gated (1) on a precondition only (2) needs: that the output file already exists. For a **gitignored** artifact, "does not exist yet" is the normal state of a fresh checkout, so the guard failed on the healthy case.

Separating them:

- **Plain generation answers (1)** by harvesting the spec and resolving every override against it. CI already relied on exactly this, and says so in `ci.yml`: *"the generator also validates the overrides file, which is the guard the old `--check` step provided."* The pre-push hooks now do the same, so hooks and CI run identical commands.
- **`--check` answers only (2).** An absent artifact is a cold cache, not drift — there is no committed baseline it could differ from — so it is generated. A present-and-differing artifact still fails, and is deliberately **not** rewritten, so the stale content stays available for inspection.

**The repo already draws this distinction correctly elsewhere**, which is what convinced me this is the right shape rather than my preference: `generate_tool_support_tables -- --check` *is* a CI gate (`ci.yml:270`) — and its outputs (`README.md`, `docs/BENCHMARK_GUIDE.md`) are committed. The bug was applying the committed-artifact pattern to a gitignored artifact.

## Also retired: a hand-rolled dependency chain

The enumeration hook was:

```yaml
entry: bash -c 'cargo run ... --example generate_spec_fixture
                && cargo run ... --example generate_spec_enumeration -- --check'
```

The prefix existed to satisfy the enumeration generator's *input* (it reads the normalization fixture for dedup). pre-commit runs hooks in declared order, so the ordering already expresses that dependency; the two hooks are now plain and separate, and a test pins the order.

## Tests

`tests/it/spec_generator_preconditions.rs` — 6 tests. **Four fail without this change**, verified by stashing the source and config and re-running:

| test | before |
|---|---|
| `empty_spec_checkout_names_the_submodule_not_the_overrides` | FAIL |
| `empty_spec_checkout_is_rejected_by_the_enumeration_generator_too` | FAIL |
| `check_generates_an_absent_artifact_instead_of_failing` | FAIL |
| `pre_push_hooks_run_plain_generation_like_ci` | FAIL |
| `check_still_reports_a_stale_artifact_and_leaves_it_alone` | pass (control — staleness detection must survive) |
| `fixture_hook_is_declared_before_the_enumeration_hook` | pass (control — ordering guard) |

The empty-checkout test asserts on the *absence* of `overrides reference unknown inputs`, so the specific misattribution cannot come back.

## End-to-end verification

A unit test can't prove the thing that actually broke, so I ran the real flow in a genuinely fresh worktree (`git worktree add --detach`, submodule uninitialised, neither artifact present):

1. Generator with no submodule → the new actionable message naming `git submodule update --init`.
2. After that one legitimate setup step, `pre-commit run --hook-stage pre-push --all-files` → **`generate_spec_fixture` Passed, `generate_spec_enumeration` Passed** on the first attempt, with no manual fixture generation.

Three push cycles before; one after.

## Verification

- Full suite: **8529 passed / 0 failed** (8523 baseline + 6 new).
- `cargo clippy --features dev --all-targets -- -D warnings` clean; `cargo fmt --all` clean.
- No behaviour change to the artifacts themselves: plain generation is byte-identical, and the only new failure path is the previously-misattributed one.

## Docs corrected

`CONTRIBUTING.md` step 4 claimed *"CI verifies byte-identical regeneration via `generate_spec_fixture -- --check`"*. CI has not done that since the fixture became a build artifact. `CLAUDE.md` and the `hgvs_spec_normalization_tests.rs` header carried the same stale framing, and `CLAUDE.md` still documented the old misleading error text. The tool-support-tables reference is untouched, because there `--check` is correct.
