### PR TITLE
fix(normalize): clamp boundary-saturated insertions at the transcript bounds

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -418,6 +418,159 @@ fn edit_is_del_or_dup(edit: &NaEdit) -> bool {
     )
 }
 
+/// Which side of `anchor` a shuffled insertion payload came to rest on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BoundarySide {
+    /// Payload rests immediately 5' of `anchor` (`…ins` before `ref[anchor]`).
+    FivePrime,
+    /// Payload rests immediately 3' of `anchor` (`…ins` after `ref[anchor]`).
+    ThreePrime,
+}
+
+/// The coordinate identity shared by every boundary clamp in this module:
+/// "insert `A'` immediately outside `anchor`" is *identically* "delete
+/// `ref[anchor]`, insert the concatenation".
+///
+/// - [`BoundarySide::FivePrime`] → `delins(A' ++ ref[anchor])`
+/// - [`BoundarySide::ThreePrime`] → `delins(ref[anchor] ++ A')`
+///
+/// It merely moves the delete boundary one base, so it is exact for **any**
+/// `A'` and needs no equivalence check. That argument is what PR #1170 (5', at
+/// `cds_start`), issue #387 (3', at `cds_end`) and issue #1202 (both, at the
+/// transcript bounds) each rely on — this function is the single place it is
+/// implemented, so the proof lives once rather than once per boundary.
+///
+/// Only the *rewrite* is shared. Each caller keeps its own **detection**,
+/// because the two boundary kinds differ in kind, not degree: `cds_start` /
+/// `cds_end` are *axis-change* boundaries whose far side (`c.-1`, `c.*1`) is
+/// perfectly representable, so clamping there is a policy with carve-outs
+/// (#401 spanning dups, #387's edit-type allow-list, #383's Delins restore);
+/// the transcript bounds are *representability* boundaries with no far side at
+/// all, so that clamp is unconditional. Folding the detections together would
+/// mean threading those carve-outs through a single predicate for no gain.
+///
+/// Returns `None` — leaving the caller's values untouched — when `anchor` lies
+/// outside `seq` or the reference byte there is not a base we can spell.
+fn insertion_to_boundary_delins(
+    seq: &[u8],
+    a_prime: &Sequence,
+    anchor: u64,
+    side: BoundarySide,
+) -> Option<NaEdit> {
+    let anchor_0b = (anchor as usize).saturating_sub(1);
+    let ref_base = Base::from_char(*seq.get(anchor_0b)? as char)?;
+    let payload = a_prime.bases();
+    let mut bases = Vec::with_capacity(payload.len() + 1);
+    match side {
+        BoundarySide::FivePrime => {
+            bases.extend_from_slice(payload);
+            bases.push(ref_base);
+        }
+        BoundarySide::ThreePrime => {
+            bases.push(ref_base);
+            bases.extend_from_slice(payload);
+        }
+    }
+    Some(NaEdit::Delins {
+        sequence: InsertedSequence::Literal(Sequence::new(bases)),
+        deleted: None,
+        deleted_length: None,
+        substitution_reference: None,
+    })
+}
+
+/// Rewrite in place a post-shuffle insertion that has saturated at a
+/// **transcript** boundary, into the equivalent `delins` — the only spelling of
+/// that haplotype the `n.` / `r.` axes, and the `c.` axis outside the CDS, can
+/// express. Leaves `edit`/`start`/`end` untouched for anything that is not a
+/// boundary-saturated literal insertion.
+///
+/// `n.` and `r.` number the transcript directly: there is no position `0` and
+/// no `*`-suffixed overflow axis, so an insertion driven to rest immediately
+/// 5' of base 1 or immediately 3' of the last base has no valid pair of
+/// adjacent anchors. Left alone it escapes in one of two broken shapes (#1202):
+///
+/// - 5': the 0-based shuffle result of `0` clamps back through
+///   `saturating_sub(1)` to the degenerate `start == end == 1`, emitted as
+///   `n.1ins<A'>` — a single-position insertion, which ferro's own parser
+///   rejects (`DNA/insertion.md:95-101` requires two adjacent anchors).
+/// - 3': the shuffle rests against `boundaries.right`, emitted as
+///   `n.<len>_<len+1>ins<A'>`, whose second anchor is past the transcript end
+///   and so raises W4004 `PositionPastEnd` when re-normalized in strict mode.
+///
+/// Both are repaired by applying [`insertion_to_boundary_delins`] at the
+/// transcript bounds — the same identity PR #1170 and issue #387 apply at
+/// `cds_start` / `cds_end` — giving `n.1delins<A' ++ ref[1]>` at the 5' bound
+/// and `n.<len>delins<ref[len] ++ A'>` at the 3' bound.
+///
+/// This is deliberately keyed on the *post-shuffle* edit rather than the input,
+/// so every spelling that shuffles to the same resting payload (a directly
+/// written `ins`, a `dup` routed through the shuffle, any start position)
+/// collapses to the same minimal, idempotent output.
+///
+/// Note this is **not** a non-coding-transcript special case: the `n.` axis
+/// numbers the whole transcript with no CDS sub-axis regardless of whether the
+/// record carries `cds_start`/`cds_end` (#334), so an `n.` variant on a coding
+/// transcript reaches this the same way.
+///
+/// **Relationship to the `c.`-axis clamps.** `normalize_cds` clamps at
+/// `cds_start` (#1170) and `cds_end` (#387), gated on `AxisRegion::Cds`. Those
+/// are a different boundary, not a superset: a `c.` insertion in a **UTR**
+/// region (`AxisRegion::FiveUtr` / `ThreeUtr`) is outside that gate and can
+/// still saturate against the transcript bounds. So `normalize_cds` calls this
+/// helper too, after its own clamps. All three callers therefore hold the same
+/// invariant — a post-shuffle insertion never rests outside `[1, len]` — while
+/// each axis keeps its own axis-specific boundary behavior:
+///
+/// | axis | boundary the axis clamps at | clamped by |
+/// |---|---|---|
+/// | `c.` (CDS region) | `cds_start` / `cds_end` | `normalize_cds` |
+/// | `c.` (UTR regions) | transcript `1` / `len` | this helper |
+/// | `n.`, `r.` | transcript `1` / `len` | this helper |
+/// | `g.` | contig `1` / `len` | **nobody — see #1205** |
+/// | `m.`, `o.` | circular, so position 1 has a valid 5' neighbour | n/a |
+///
+/// The invariant is therefore **per-axis, not global**: `normalize_genome` has
+/// no clamp, so a 5'-saturated insertion at a contig start still escapes as
+/// `g.1ins<A'>` — the same unparseable shape, on the axis the spec uses for its
+/// own counter-example (`DNA/insertion.md:95-101` rejects `g.123insG`).
+/// Tracked in #1205 and deliberately not fixed here: the contig bounds are a
+/// different boundary, it changes output on the hottest axis, and `m.`/`o.`
+/// need a wraparound answer rather than this `delins` rewrite. Nothing in this
+/// helper is transcript-specific — it enforces `[1, seq.len()]` — so #1205 is
+/// expected to add a fourth caller rather than new logic.
+fn clamp_insertion_at_transcript_bounds(
+    seq: &[u8],
+    edit: &mut NaEdit,
+    start: &mut u64,
+    end: &mut u64,
+) {
+    // Cheapest discriminating guard first: only two resting places qualify, and
+    // both are two register compares against values already in hand. `tx_len ==
+    // 0` needs no separate guard — `insertion_to_boundary_delins` bails on an
+    // anchor outside `seq`, which an empty `seq` always is.
+    let tx_len = seq.len() as u64;
+    let (anchor, side) = if *start == 1 && *end == 1 {
+        (1, BoundarySide::FivePrime)
+    } else if *start == tx_len && *end == tx_len + 1 {
+        (tx_len, BoundarySide::ThreePrime)
+    } else {
+        return;
+    };
+    let NaEdit::Insertion {
+        sequence: InsertedSequence::Literal(a_prime),
+    } = &*edit
+    else {
+        return;
+    };
+    let Some(delins) = insertion_to_boundary_delins(seq, a_prime, anchor, side) else {
+        return;
+    };
+    *edit = delins;
+    *start = anchor;
+    *end = anchor;
+}
+
 /// Warning generated during normalization.
 ///
 /// This enum is open-ended: each variant owns the fields its code needs.
@@ -3359,25 +3512,15 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     sequence: InsertedSequence::Literal(a_prime),
                 } = &new_edit
                 {
-                    let cds_start_0b = (cds_start as usize).saturating_sub(1);
-                    if cds_start_0b < seq.len() {
-                        let mut new_alt: Vec<u8> =
-                            a_prime.bases().iter().map(|b| *b as u8).collect();
-                        new_alt.push(seq[cds_start_0b]);
-                        let bases: Vec<Base> = new_alt
-                            .iter()
-                            .filter_map(|b| Base::from_char(*b as char))
-                            .collect();
-                        if bases.len() == new_alt.len() {
-                            new_edit = NaEdit::Delins {
-                                sequence: InsertedSequence::Literal(Sequence::new(bases)),
-                                deleted: None,
-                                deleted_length: None,
-                                substitution_reference: None,
-                            };
-                            new_tx_start = cds_start;
-                            new_tx_end = cds_start;
-                        }
+                    if let Some(delins) = insertion_to_boundary_delins(
+                        seq,
+                        a_prime,
+                        cds_start,
+                        BoundarySide::FivePrime,
+                    ) {
+                        new_edit = delins;
+                        new_tx_start = cds_start;
+                        new_tx_end = cds_start;
                     }
                 }
             }
@@ -3459,28 +3602,34 @@ impl<P: ReferenceProvider> Normalizer<P> {
                     sequence: InsertedSequence::Literal(a_prime),
                 } = &new_edit
                 {
-                    let cds_end_0b = (cds_end_tx as usize).saturating_sub(1);
-                    if cds_end_0b < seq.len() {
-                        let mut new_alt: Vec<u8> = vec![seq[cds_end_0b]];
-                        new_alt.extend(a_prime.bases().iter().map(|b| *b as u8));
-                        let bases: Vec<Base> = new_alt
-                            .iter()
-                            .filter_map(|b| Base::from_char(*b as char))
-                            .collect();
-                        if bases.len() == new_alt.len() {
-                            new_edit = NaEdit::Delins {
-                                sequence: InsertedSequence::Literal(Sequence::new(bases)),
-                                deleted: None,
-                                deleted_length: None,
-                                substitution_reference: None,
-                            };
-                            new_tx_start = cds_end_tx;
-                            new_tx_end = cds_end_tx;
-                        }
+                    if let Some(delins) = insertion_to_boundary_delins(
+                        seq,
+                        a_prime,
+                        cds_end_tx,
+                        BoundarySide::ThreePrime,
+                    ) {
+                        new_edit = delins;
+                        new_tx_start = cds_end_tx;
+                        new_tx_end = cds_end_tx;
                     }
                 }
             }
         }
+
+        // #1202: both clamps above are gated on `AxisRegion::Cds`, so a
+        // **UTR-region** insertion is outside them and can still saturate
+        // against the transcript bounds (reachable once `cds_start > 1`).
+        //
+        // Unconditional: the helper is self-gating on shape and position, and
+        // either clamp above has already rewritten `new_edit` to a `Delins`, so
+        // it is inert after them — no double-clamp. Runs before the CDS
+        // conversion so the arithmetic stays in transcript space.
+        clamp_insertion_at_transcript_bounds(
+            seq,
+            &mut new_edit,
+            &mut new_tx_start,
+            &mut new_tx_end,
+        );
 
         // Convert back to CDS coordinates
         let new_start = self.tx_to_cds_pos(new_tx_start, cds_start, transcript.cds_end)?;
@@ -3727,7 +3876,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some(s) => s.as_bytes(),
             None => return Ok((HV::Tx(self.canonicalize_tx_variant(variant)), vec![])),
         };
-        let (new_start, new_end, new_edit, mut warnings) =
+        let (mut new_start, mut new_end, mut new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, false)?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
@@ -3752,6 +3901,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // only if it actually crossed into the intron. The trigger is a rare edge
         // landing, so the hot path is untouched; it is 3'-only (5'/VCF shuffles
         // stay exon-confined), exactly as the `c.` path.
+        //
+        // Ordering constraint (#1202, other half documented at the clamp
+        // below): a 3'-saturated insertion arrives here with
+        // `new_end == boundaries.right + 1`, so it does NOT trip this trigger —
+        // and the clamp below then moves it onto exactly `boundaries.right`.
+        // Neither block may be reordered past the other.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && new_end == boundaries.right
         {
@@ -3799,6 +3954,16 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 }
             }
         }
+
+        // #1202: rewrite an insertion the shuffle drove off either end of the
+        // transcript; see the helper for the identity and its proof.
+        //
+        // Must stay AFTER the exon/intron junction block above: that block
+        // tests `new_end == boundaries.right`, and the 3' rewrite moves
+        // `new_end` from `len + 1` onto exactly `len` (== `boundaries.right`
+        // for the insertion bounds), so clamping first would divert a saturated
+        // insertion into the junction-crossing engine.
+        clamp_insertion_at_transcript_bounds(seq, &mut new_edit, &mut new_start, &mut new_end);
 
         let new_variant = TxVariant {
             accession: variant.accession.clone(),
@@ -5196,7 +5361,7 @@ impl<P: ReferenceProvider> Normalizer<P> {
             Some((cds_start, cds_end)) => tx_start >= cds_start && tx_end <= cds_end,
             None => false,
         };
-        let (new_tx_start, new_tx_end, new_edit, mut warnings) =
+        let (mut new_tx_start, mut new_tx_end, mut new_edit, mut warnings) =
             self.normalize_na_edit(seq, edit, tx_start, tx_end, &boundaries, is_coding)?;
 
         // See the identical guard + comment in `normalize_cds` (#1052 follow-up):
@@ -5219,6 +5384,12 @@ impl<P: ReferenceProvider> Normalizer<P> {
         // adopt the result only if it actually crossed into the intron. The
         // original endpoints are purely exonic here, so they map to plain
         // (offset-less) `TxPos`. 3'-only; the hot path is untouched.
+        //
+        // Ordering constraint (#1202, other half documented at the clamp
+        // below): a 3'-saturated insertion arrives here with
+        // `new_tx_end == boundaries.right + 1`, so it does NOT trip this
+        // trigger — and the clamp below then moves it onto exactly
+        // `boundaries.right`. Neither block may be reordered past the other.
         if self.config.shuffle_direction == ShuffleDirection::ThreePrime
             && new_tx_end == boundaries.right
         {
@@ -5287,6 +5458,17 @@ impl<P: ReferenceProvider> Normalizer<P> {
                 }
             }
         }
+
+        // #1202: mirror of the `normalize_tx` clamp. Runs in transcript space
+        // (before the `r.` mapping below) so it shares the helper verbatim, and
+        // must stay AFTER the junction block above for the same
+        // `new_tx_end == boundaries.right` reason documented there.
+        clamp_insertion_at_transcript_bounds(
+            seq,
+            &mut new_edit,
+            &mut new_tx_start,
+            &mut new_tx_end,
+        );
 
         // Convert each normalized tx position back to a CDS-relative `r.`
         // position via `tx_to_rna_pos`, which restores the correct region for

--- a/tests/it/issue_1202_transcript_bounds_insertion_clamp.rs
+++ b/tests/it/issue_1202_transcript_bounds_insertion_clamp.rs
@@ -1,0 +1,330 @@
+//! Issue #1202 — a shuffled insertion that saturates at a **transcript**
+//! boundary must be clamped on every axis numbered against the transcript.
+//!
+//! `normalize_cds` has carried a boundary rewrite since #1170 (5', keyed on
+//! `cds_start`) and #387 (3', keyed on `cds_end`), but both are gated on
+//! `AxisRegion::Cds`. Nothing clamped the *transcript* bounds, so a saturated
+//! insertion escaped in two shapes, both of which break the round-trip:
+//!
+//! | direction | escaped as | why it is broken |
+//! |---|---|---|
+//! | 5' | `n.1ins<A'>` | single-position insertion — ferro's own parser rejects it (DNA/insertion.md:95-101) |
+//! | 3' | `n.<len>_<len+1>ins<A'>` | second anchor is past the transcript end — strict re-normalization raises W4004 `PositionPastEnd` |
+//!
+//! Three axes reach it, and none of them is "non-coding transcripts":
+//!
+//! - `n.` — numbers the whole transcript with no CDS sub-axis (#334), so an
+//!   `n.` variant on a **coding** `NM_` fails identically to one on an `NR_`.
+//! - `r.` — same, via `normalize_rna`.
+//! - `c.` in a **UTR** region — outside the `AxisRegion::Cds` gate, so neither
+//!   #1170 nor #387 fires; reachable once `cds_start > 1`.
+//!
+//! Every expectation is the value derived from the fixture by hand (see the
+//! per-test comments), not merely `norm(norm(x)) == norm(x)` — an
+//! idempotency-only assertion is satisfied by a normalizer that returns its
+//! input unchanged, which is exactly the bug class here.
+
+use crate::common::synthetic::SyntheticBuilder;
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, MockProvider, NormalizeConfig, Normalizer, ShuffleDirection};
+
+/// Core used for the 5' cases. Positions 1-4 are `C`, 5-11 `A`, 12-15 `G`.
+const CORE_5P: &str = "CCCCAAAAAAAGGGG";
+
+/// Core used for the 3' cases. Positions 13, 14, 15 are `T`, `G`, `C` — chosen
+/// so a `GCA` insertion phase-walks to the transcript end while the rotated
+/// `AGC` still differs from the preceding `TGC`, i.e. it does NOT promote to a
+/// `dup` on the way and really does saturate as a plain insertion.
+const CORE_3P: &str = "CCCCAAAAAAAATGC";
+
+fn normalize(provider: MockProvider, input: &str, dir: ShuffleDirection) -> String {
+    let normalizer =
+        Normalizer::with_config(provider, NormalizeConfig::default().with_direction(dir));
+    let variant = parse_hgvs(input).unwrap_or_else(|e| panic!("parse {input}: {e}"));
+    normalizer
+        .normalize(&variant)
+        .unwrap_or_else(|e| panic!("normalize {input}: {e}"))
+        .to_string()
+}
+
+/// The RNA spelling of a DNA core: the `r.` axis alphabet is `a/c/g/u`.
+fn as_rna(core: &str) -> String {
+    core.to_lowercase().replace('t', "u")
+}
+
+/// Assert the exact canonical output, that it re-parses, and that a second
+/// pass is a fixed point.
+fn assert_canonical(provider: MockProvider, input: &str, dir: ShuffleDirection, expected: &str) {
+    let once = normalize(provider.clone(), input, dir);
+    assert_eq!(once, expected, "{input} ({dir:?}) canonical form");
+    parse_hgvs(&once)
+        .unwrap_or_else(|e| panic!("normalized output {once} must re-parse, got: {e}"));
+    let twice = normalize(provider, &once, dir);
+    assert_eq!(twice, once, "{once} ({dir:?}) must be a fixed point");
+}
+
+// ---------------------------------------------------------------------------
+// 5' saturation at transcript position 1
+// ---------------------------------------------------------------------------
+
+/// `n.1_2insGC` 5'-shuffles to rest immediately before base 1 with the rotated
+/// payload `A' = CG`. Identity: insert `CG` before base 1 ≡ delete `ref[1]`
+/// (= `C`) and insert `CG ++ C`.
+///
+///   input   `C|GC|CCCAAAAAAAGGGG` -> `CGCCCCAAAAAAAGGGG`
+///   output  `[C->CGC]CCCAAAAAAAGGGG` -> `CGCCCCAAAAAAAGGGG`   (identical)
+#[test]
+fn noncoding_five_prime_saturated_insertion_clamps_to_transcript_start() {
+    assert_canonical(
+        SyntheticBuilder::noncoding(CORE_5P, Strand::Plus).build(),
+        "NR_TEST.1:n.1_2insGC",
+        ShuffleDirection::FivePrime,
+        "NR_TEST.1:n.1delinsCGC",
+    );
+}
+
+/// The `n.` axis numbers the whole transcript with no CDS sub-axis, so an `n.`
+/// variant on a **coding** transcript takes the same path and must clamp the
+/// same way. This is the case that shows the defect was never about
+/// non-coding transcripts.
+#[test]
+fn coding_transcript_n_axis_five_prime_saturated_insertion_clamps() {
+    assert_canonical(
+        SyntheticBuilder::cds(CORE_5P, 1, CORE_5P.len() as u64, Strand::Plus).build(),
+        "NM_TEST.1:n.1_2insGC",
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:n.1delinsCGC",
+    );
+}
+
+/// Same identity on the `r.` axis; the RNA alphabet renders lowercase.
+#[test]
+fn rna_five_prime_saturated_insertion_clamps_to_transcript_start() {
+    assert_canonical(
+        SyntheticBuilder::rna(&as_rna(CORE_5P), Strand::Plus).build(),
+        "NR_TEST.1:r.1_2insgc",
+        ShuffleDirection::FivePrime,
+        "NR_TEST.1:r.1delinscgc",
+    );
+}
+
+/// Minus-strand non-coding transcript: the `n.` axis is transcript-relative, so
+/// the clamp is strand-independent. Paired with
+/// `noncoding_minus_strand_three_prime_saturated_insertion_clamps` below so
+/// that claim is tested at *both* bounds, not only this one.
+#[test]
+fn noncoding_minus_strand_five_prime_saturated_insertion_clamps() {
+    assert_canonical(
+        SyntheticBuilder::noncoding(CORE_5P, Strand::Minus).build(),
+        "NR_TEST.1:n.1_2insGC",
+        ShuffleDirection::FivePrime,
+        "NR_TEST.1:n.1delinsCGC",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3' saturation at the transcript end
+// ---------------------------------------------------------------------------
+
+/// `n.13_14insGCA` 3'-shuffles to rest immediately after base 15 with the
+/// rotated payload `A' = AGC`. Identity: insert `AGC` after base 15 ≡ delete
+/// `ref[15]` (= `C`) and insert `C ++ AGC`.
+///
+///   input   `CCCCAAAAAAAAT|GCA|GC` -> `CCCCAAAAAAAATGCAGC`
+///   output  `CCCCAAAAAAAATG[C->CAGC]` -> `CCCCAAAAAAAATGCAGC`  (identical)
+///
+/// Before the fix this emitted `n.15_16insAGC`, whose `n.16` anchor is past the
+/// 15-base transcript end.
+#[test]
+fn noncoding_three_prime_saturated_insertion_clamps_to_transcript_end() {
+    assert_canonical(
+        SyntheticBuilder::noncoding(CORE_3P, Strand::Plus).build(),
+        "NR_TEST.1:n.13_14insGCA",
+        ShuffleDirection::ThreePrime,
+        "NR_TEST.1:n.15delinsCAGC",
+    );
+}
+
+#[test]
+fn coding_transcript_n_axis_three_prime_saturated_insertion_clamps() {
+    assert_canonical(
+        SyntheticBuilder::cds(CORE_3P, 1, CORE_3P.len() as u64, Strand::Plus).build(),
+        "NM_TEST.1:n.13_14insGCA",
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:n.15delinsCAGC",
+    );
+}
+
+#[test]
+fn rna_three_prime_saturated_insertion_clamps_to_transcript_end() {
+    assert_canonical(
+        SyntheticBuilder::rna(&as_rna(CORE_3P), Strand::Plus).build(),
+        "NR_TEST.1:r.13_14insgca",
+        ShuffleDirection::ThreePrime,
+        "NR_TEST.1:r.15delinscagc",
+    );
+}
+
+/// 3'-bound mirror of the minus-strand 5' case above.
+#[test]
+fn noncoding_minus_strand_three_prime_saturated_insertion_clamps() {
+    assert_canonical(
+        SyntheticBuilder::noncoding(CORE_3P, Strand::Minus).build(),
+        "NR_TEST.1:n.13_14insGCA",
+        ShuffleDirection::ThreePrime,
+        "NR_TEST.1:n.15delinsCAGC",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The `c.` axis: UTR regions saturate at the transcript bounds too
+// ---------------------------------------------------------------------------
+
+/// `normalize_cds`'s own clamps are keyed on `cds_start`/`cds_end` and gated on
+/// `AxisRegion::Cds`, so a **UTR-region** `c.` insertion is outside them and
+/// saturates against the *transcript* bounds instead. Reachable only when a
+/// 5'UTR exists (`cds_start > 1`); with `cds_start == 1` the #1170 clamp sits on
+/// the transcript start and masks it.
+///
+/// With `cds_start = 5`, `c.-4` is transcript position 1. `c.-4_-3insGC`
+/// 5'-shuffles to rest before base 1 with `A' = CG`, so the identity gives
+/// `delete ref[1]` (= `C`), `insert CG ++ C`.
+///
+///   input   `C|GC|CCCAAAAAAAGGGG` -> `CGCCCCAAAAAAAGGGG`
+///   output  `[C->CGC]CCCAAAAAAAGGGG` -> `CGCCCCAAAAAAAGGGG`   (identical)
+///
+/// Before the fix this emitted the degenerate `c.-4insCG`.
+#[test]
+fn cds_five_utr_saturated_insertion_clamps_to_transcript_start() {
+    assert_canonical(
+        SyntheticBuilder::cds(CORE_5P, 5, CORE_5P.len() as u64, Strand::Plus).build(),
+        "NM_TEST.1:c.-4_-3insGC",
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.-4delinsCGC",
+    );
+}
+
+/// 3'UTR mirror. With `cds_end = 11` on a 15-base transcript, `c.*4` is
+/// transcript position 15 and `c.*5` does not exist. `c.*2_*3insGCA`
+/// 3'-shuffles to rest after base 15 with `A' = AGC`, so the identity gives
+/// `delete ref[15]` (= `C`), `insert C ++ AGC`.
+///
+/// Before the fix this emitted `c.*4_*5insAGC`, whose `c.*5` is past the end.
+#[test]
+fn cds_three_utr_saturated_insertion_clamps_to_transcript_end() {
+    assert_canonical(
+        SyntheticBuilder::cds(CORE_3P, 1, 11, Strand::Plus).build(),
+        "NM_TEST.1:c.*2_*3insGCA",
+        ShuffleDirection::ThreePrime,
+        "NM_TEST.1:c.*4delinsCAGC",
+    );
+}
+
+/// The CDS-region clamps (#1170 / #387) must keep their own boundary — adding
+/// the transcript-bound clamp to `normalize_cds` must not move them. With
+/// `cds_start == 1` the two boundaries coincide and #1170 owns the rewrite.
+#[test]
+fn cds_region_clamps_keep_their_own_boundary() {
+    assert_canonical(
+        SyntheticBuilder::cds(CORE_5P, 1, CORE_5P.len() as u64, Strand::Plus).build(),
+        "NM_TEST.1:c.1_2insGC",
+        ShuffleDirection::FivePrime,
+        "NM_TEST.1:c.1delinsCGC",
+    );
+}
+
+/// The clamped output must survive a **strict** re-normalization. This is the
+/// assertion that fails loudest for the 3' shape: the pre-fix
+/// `n.15_16insAGC` is rejected with W4004 `PositionPastEnd`.
+#[test]
+fn clamped_output_survives_strict_renormalization() {
+    // Covers BOTH call sites: the `n.` cases go through `normalize_tx`, the `c.`
+    // UTR cases through `normalize_cds`'s own invocation of the clamp. The `c.`
+    // rows matter most for the 3' shape — a `c.*<n>_*<n+1>ins` that escapes the
+    // clamp is exactly what strict mode rejects with W4004 `PositionPastEnd`.
+    for (input, dir, provider) in [
+        (
+            "NR_TEST.1:n.13_14insGCA",
+            ShuffleDirection::ThreePrime,
+            SyntheticBuilder::noncoding(CORE_3P, Strand::Plus).build(),
+        ),
+        (
+            "NR_TEST.1:n.1_2insGC",
+            ShuffleDirection::FivePrime,
+            SyntheticBuilder::noncoding(CORE_5P, Strand::Plus).build(),
+        ),
+        (
+            "NM_TEST.1:c.-4_-3insGC",
+            ShuffleDirection::FivePrime,
+            SyntheticBuilder::cds(CORE_5P, 5, CORE_5P.len() as u64, Strand::Plus).build(),
+        ),
+        (
+            "NM_TEST.1:c.*2_*3insGCA",
+            ShuffleDirection::ThreePrime,
+            SyntheticBuilder::cds(CORE_3P, 1, 11, Strand::Plus).build(),
+        ),
+    ] {
+        let out = normalize(provider.clone(), input, dir);
+        let strict = Normalizer::with_config(
+            provider.clone(),
+            NormalizeConfig::strict().with_direction(dir),
+        );
+        let variant = parse_hgvs(&out).unwrap_or_else(|e| panic!("re-parse {out}: {e}"));
+        strict
+            .normalize(&variant)
+            .unwrap_or_else(|e| panic!("strict re-normalize of {out} (from {input}): {e}"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-regression: unsaturated insertions are untouched
+// ---------------------------------------------------------------------------
+
+/// An insertion resting on the **last interior anchor pair** — `n.14_15` on a
+/// 15-base transcript, one base short of saturation — must keep its `ins` form.
+///
+/// This is the off-by-one guard for the 3' condition: the clamp tests
+/// `end == tx_len + 1`, and if it were written `end == tx_len` this case would
+/// be wrongly rewritten to `n.14delins…`. None of the other interior cases sit
+/// close enough to the 3' bound to catch that.
+#[test]
+fn insertion_one_base_short_of_the_three_prime_bound_is_not_clamped() {
+    // Core positions 13, 14, 15 are `T`, `G`, `C`; inserting `T` between 14 and
+    // 15 matches neither neighbour, so it neither shifts nor promotes to a dup.
+    assert_canonical(
+        SyntheticBuilder::noncoding(CORE_3P, Strand::Plus).build(),
+        "NR_TEST.1:n.14_15insT",
+        ShuffleDirection::ThreePrime,
+        "NR_TEST.1:n.14_15insT",
+    );
+}
+
+/// An insertion that comes to rest strictly inside the transcript keeps its
+/// two-anchor `ins` (or `dup`/repeat) form — the clamp must not fire early.
+#[test]
+fn interior_insertions_are_not_clamped() {
+    for (input, dir, expected) in [
+        (
+            "NR_TEST.1:n.1_2insCG",
+            ShuffleDirection::FivePrime,
+            "NR_TEST.1:n.1_2insCG",
+        ),
+        (
+            "NR_TEST.1:n.4_5insA",
+            ShuffleDirection::FivePrime,
+            "NR_TEST.1:n.5dup",
+        ),
+        (
+            "NR_TEST.1:n.1_2insA",
+            ShuffleDirection::ThreePrime,
+            "NR_TEST.1:n.1_2insA",
+        ),
+    ] {
+        assert_canonical(
+            SyntheticBuilder::noncoding(CORE_5P, Strand::Plus).build(),
+            input,
+            dir,
+            expected,
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -132,6 +132,7 @@ mod issue_1158_equivalence_resulting_sequence;
 mod issue_1162_bare_ins_diagnostic;
 mod issue_1183_rna_axis_ins_expansion;
 mod issue_1192_rna_codon_frame_gate;
+mod issue_1202_transcript_bounds_insertion_clamp;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
Closes #1202

A shuffled insertion that comes to rest immediately outside the transcript had no valid HGVS spelling on the transcript-numbered axes, and escaped in two broken shapes:

| direction | input | escaped as | why it is broken |
|---|---|---|---|
| 5' | `NR_TEST.1:n.1_2insGC` | `n.1insCG` | single-position insertion — ferro's own parser rejects it (`DNA/insertion.md:95-101` requires two adjacent anchors) |
| 3' | `NR_TEST.1:n.13_14insGCA` | `n.15_16insAGC` | second anchor is past the 15-base transcript end; strict re-normalization rejects it with W4004 `PositionPastEnd` |

## The issue's stated diagnosis was wrong in two ways

The issue attributes this to the `AxisRegion::Cds` gate in `normalize_cds` not covering `AxisRegion::None`. Both halves of that are off, and the difference changes the fix:

1. **`normalize_cds` is not on this path.** `n.` routes to `normalize_tx`, `r.` to `normalize_rna`; `normalize_cds` handles only `c.`. The gap is that nothing clamped the *transcript* bounds anywhere — not that an existing gate missed a variant.
2. **It is not about non-coding transcripts.** Three axes reach it, and `NR_` vs `NM_` is irrelevant to all three:
   - `n.` — numbers the whole transcript with no CDS sub-axis (#334), so `NM_TEST.1:n.1_2insGC` on a **coding** transcript fails identically.
   - `r.` — same, via `normalize_rna`.
   - `c.` **in a UTR region** — outside the `AxisRegion::Cds` gate, so neither #1170 nor #387 fires. Reachable once `cds_start > 1`: `c.-4_-3insGC` → `c.-4insCG` (reparse-fail), and `c.*2_*3insGCA` → `c.*4_*5insAGC` where `c.*5` is past the end.

The `c.`-UTR case was found by self-review after the first draft, which had fixed only `n.`/`r.` — a fix scoped to "non-coding" would have shipped half the bug.

The issue also left the 3' mirror open as "not tested". It **is** reachable and is fixed here. It needs a payload that phase-walks to the transcript end without promoting to `dup` (the obvious probes all promote), and because the degenerate output still re-parses, only an exact-value assertion catches it — the idempotency oracle never could.

## The fix

Extract the identity all four boundary clamps share into `insertion_to_boundary_delins`:

```
insert A' immediately 5' of anchor  ==  delete ref[anchor], insert A' ++ ref[anchor]
insert A' immediately 3' of anchor  ==  delete ref[anchor], insert ref[anchor] ++ A'
```

and route #1170 (`cds_start`), #387 (`cds_end`) and both new transcript-bound clamps through it. Each merely moves the delete boundary one base, so it is exact for **any** `A'` and needs no equivalence check — the same argument #1170 makes. The proof now lives in one place instead of four; net −39 lines of triplicated byte-splicing.

**Only the rewrite is shared — detection stays per-caller**, because the two boundary kinds differ in kind, not degree:

- `cds_start` / `cds_end` are **axis-change** boundaries whose far side (`c.-1`, `c.*1`) is perfectly representable, so clamping there is a *policy* with carve-outs: #401's spanning-dup exception, #387's output-edit-type allow-list, #383's Delins-input restore.
- The transcript bounds are **representability** boundaries with no far side at all, so that clamp is unconditional and self-gating (it matches only an `Insertion` resting exactly at `(1,1)` or `(len, len+1)`; a fired CDS clamp has already rewritten to `Delins`, making it provably inert).

Folding the detections together would mean threading those carve-outs through one predicate for zero semantic gain, and would put #383/#387/#401/#1170 at risk.

### Two things worth a reviewer's attention

**Ordering is load-bearing.** The clamp runs *after* each function's exon/intron junction block. That block tests `new_end == boundaries.right`, and the 3' rewrite moves `new_end` from `len + 1` onto exactly `len`. Clamping first would divert a saturated insertion into `normalize_boundary_spanning_tx` and, on the `!has_genomic_data()` branch, emit a bogus `ReducedCapabilityNoGenome` warning. Both blocks now carry reciprocal comments so neither can be reordered past the other. This is also the order the `c.` axis has always used (#670 junction block, then the #383/#387 clamps).

**No behavior change for user-supplied past-end input.** `n.15_16insTT` is caught by the W4004 bounds gate and early-returns before reaching the clamp, in every error mode. The clamp only ever sees shuffle-produced saturation.

## Tests

`tests/it/issue_1202_transcript_bounds_insertion_clamp.rs` — 14 tests: both directions across `n.`-on-`NR_`, `n.`-on-`NM_`, `r.`, minus strand, and `c.` in both UTRs; a strict-re-normalization round-trip; a case resting one base short of the 3' bound (the off-by-one guard for `end == tx_len + 1` vs `end == tx_len`); and `cds_region_clamps_keep_their_own_boundary`, pinning that #1170/#387 still own the CDS boundary.

Every expectation is the value derived from the fixture by hand, with the identity worked out in a per-test comment — not `norm(norm(x)) == norm(x)`. An idempotency-only assertion is satisfied by a normalizer that returns its input unchanged, which is precisely the bug class here.

## Validation

- `cargo fmt --check` clean; `cargo clippy --all-features --all-targets -- -D warnings` clean
- `cargo nextest run --features dev` — 8580 passed, 0 failed, 145 skipped (reference-aware, no `FERRO_MANIFEST`)
- `FERRO_ASSERT_IDEMPOTENT=1 cargo nextest run --features dev` — 8580 passed, 0 failed
- The 64 pinned CDS-clamp tests (`five_prime_boundary_delins_unification`, `issue_337/383/387/401`, `five_prime_insertion_dup_boundary_anchor`) all pass through the shared rewrite

Sibling-interop checked in throwaway stacks (both since removed):

- **#1180** (the PR whose widened `n.`/`r.` fuzzing found this) — stacked on this fix: 8585 passed, 0 failed under the oracle; `normalization_is_idempotent_five_prime` passes. Unblocked.
- **#1189** (touches the same boundary region) — stacked: 8584 passed, 0 failed. Note #1189 is currently based on `be47233`, which predates #1170's `ins_edit` recursion call site; rebasing it onto `main` needs the new `cds_span` argument added at that call site or the lib will not compile. Independent of this PR, but it will block that rebase.

## Why the new clamp cannot disturb a CDS-region input

#1170's block enters on `insertion_rests_at_cds_start || new_tx_start < cds_start`, but its body only handles a `Delins` input and `insertion_rests_at_cds_start`. Entering via the second disjunct with a non-`Delins` input that does not rest exactly at `cds_start` leaves it a no-op — so it is worth showing the new unconditional clamp cannot then re-axis a CDS-region input onto the UTR axis, which is the drift #1170 exists to prevent.

It cannot, and the reason is the shuffle window rather than the clamp. For `AxisRegion::Cds`, `get_cds_boundaries_with_axis_info` sets `axis_left = cds_start - 1` (0-based) and `axis_right = cds_end`, and `boundaries = axis ∩ exon` (`boundary.rs:163-186`). So for a CDS-region input:

- **5' side.** `new_tx_end >= cds_start`, while the clamp's 5' branch requires `new_tx_end == 1`. Both hold only when `cds_start == 1` — and in exactly that case `insertion_rests_at_cds_start` is satisfied, so #1170 fires first and has already rewritten the edit to a `Delins`, which the clamp skips by construction.
- **3' side.** Symmetrically, `new_tx_end <= cds_end + 1` against a required `tx_len + 1`, so it needs `cds_end == tx_len` — exactly when #387 fires first.

The one branch that widens the window (`mod.rs:3210-3216`, 3'-direction del/dup relaxed to the exon bound) leaves `boundaries.left` untouched, so it cannot affect the 5' side. It can in principle affect the 3' side, since a codon-gated `dup` can return from the shuffle shaped as an `Insertion` that #387 misses when `cds_end < tx_len`. A sweep of ~936 cases (6 cores × 4 `cds_end` values × 13 positions × 3 dup shapes) produced no such output. And were it ever reached, the clamp's result is the correct one regardless: the alternative is `c.*<N+1>ins…`, whose anchor is past the transcript end, and clamping to `cds_end` instead would express a different haplotype.

`cds_region_clamps_keep_their_own_boundary` pins the `cds_start == 1` coincidence case so a future change cannot silently hand the boundary over.
