### PR TITLE
fix(normalize): answer the repeat codon gate for the tract, not the input span

### DIFF
--- a/src/normalize/mod.rs
+++ b/src/normalize/mod.rs
@@ -7833,6 +7833,11 @@ impl<P: ReferenceProvider> Normalizer<P> {
                                 original_pos_idx,
                                 &seq_bytes,
                                 is_coding,
+                                // #1210: `is_coding` is the INPUT span's verdict;
+                                // `cds_span` lets the helper re-ask about the tract
+                                // the repeat would actually occupy, which differs
+                                // whenever the edit shifts across `cds_end`.
+                                cds_span,
                                 self.config.shuffle_direction,
                             )
                         {

--- a/src/normalize/rules.rs
+++ b/src/normalize/rules.rs
@@ -313,6 +313,15 @@ pub fn find_homopolymer_at(ref_seq: &[u8], pos: usize) -> Option<RepeatAnalysis>
 /// the tract (#8), which is what makes the emitted repeat a fixed point under
 /// re-normalization.
 ///
+/// # The codon gate is answered for the tract, not the input (#1210)
+///
+/// `is_coding` is the caller's verdict for the *input* edit's span. Where
+/// `cds_span` is supplied it takes precedence, and the gate is re-answered for
+/// the tandem tract this function discovers — the span the emitted repeat
+/// actually occupies. The two differ exactly when the edit shifts across
+/// `cds_end`, which is where the non-idempotency lived. Pass `None` (genomic,
+/// `n.`, or any caller with no CDS context) to keep `is_coding` verbatim.
+///
 /// This function owns only the insertion-specific work: rotation-aware
 /// discovery of the adjacent tandem tract (`find_tandem_extent`) and the #882
 /// preservation gate. The canonicalization arithmetic — the 3'-phase
@@ -328,6 +337,7 @@ pub fn insertion_to_repeat(
     pos: u64,
     inserted_seq: &[u8],
     is_coding: bool,
+    cds_span: Option<(u64, u64)>,
     direction: crate::normalize::config::ShuffleDirection,
 ) -> Option<(u8, u64, u64, u64, Vec<u8>)> {
     if inserted_seq.is_empty() {
@@ -364,6 +374,37 @@ pub fn insertion_to_repeat(
     let (unit, ref_start, ref_count) = best?;
     let ref_end_excl = ref_start + ref_count as usize * unit.len();
 
+    // #1210: answer the codon gate for the span the REPEAT will occupy, not for
+    // the span the input insertion occupied.
+    //
+    // `is_coding` is precomputed by the caller for the *input* edit. That is the
+    // wrong question here: the discovered tandem tract is a different span, and a
+    // CDS-resident input can 3'-shift clean out of the CDS, so the two disagree
+    // precisely at the `cds_end` boundary. `r.15delinsgaa` on a transcript whose
+    // CDS ends at `r.15` reduces to an insertion that lands in the 3'UTR at
+    // `r.*1_*2`; gating it on the input's CDS-residency suppressed the repeat on
+    // pass 1, while pass 2 — whose input was by then UTR-resident — emitted
+    // `r.*1a[3]`, so normalization was not idempotent.
+    //
+    // `cds_span` exists for exactly this ("lets a site that decides about a
+    // DIFFERENT span ask about that span instead", #1185); this is the second
+    // site to need it. `None` keeps the caller's precomputed verdict, so callers
+    // with no CDS context (genomic / `n.`) and the unit tests below are
+    // unaffected.
+    //
+    // Frames line up: `ref_start` / `ref_end_excl` are 0-based indices into the
+    // transcript-frame `ref_seq`, and `cds_span` is 1-based inclusive in that
+    // same frame, so the 1-based inclusive tract is
+    // `(ref_start + 1) ..= ref_end_excl`.
+    let gate_is_coding = match cds_span {
+        Some((cds_start, cds_end)) => {
+            let tract_start = ref_start as u64 + 1;
+            let tract_end = ref_end_excl as u64;
+            tract_start >= cds_start && tract_end <= cds_end
+        }
+        None => is_coding,
+    };
+
     // #866: delegate the canonical-window + count + codon-gate decision to
     // `normalize_repeat` (the single source of truth for ins→repeat
     // canonicalization). Re-express the discovered tract as the well-formed
@@ -384,7 +425,7 @@ pub fn insertion_to_repeat(
         end_pos_incl,
         &unit,
         target,
-        is_coding,
+        gate_is_coding,
         direction,
     ) {
         RepeatNormResult::Repeat {
@@ -3054,7 +3095,7 @@ mod tests {
         // 2-copy reference window. Hand-verified: unit GT, count 5, 1-based 3_6.
         let r = b"CTGTGTT";
         let (base, count, start, end, unit) =
-            insertion_to_repeat(r, 4, b"TGTGTG", false, ShuffleDirection::ThreePrime)
+            insertion_to_repeat(r, 4, b"TGTGTG", false, None, ShuffleDirection::ThreePrime)
                 .expect("repeat");
         assert_eq!(base, b'G');
         assert_eq!(count, 5);
@@ -3204,6 +3245,7 @@ mod tests {
                 c.ins_pos,
                 c.ins_seq,
                 false,
+                None,
                 ShuffleDirection::ThreePrime,
             )
             .unwrap_or_else(|| panic!("insertion_to_repeat None for {:?}", c.ref_seq));
@@ -3239,7 +3281,15 @@ mod tests {
         // `normalize_repeat` routes the expansion to `Insertion`. Kept out of the shared
         // loop above (which unwraps a `Repeat`) since this case is intentionally None.
         assert!(
-            insertion_to_repeat(b"CAAAAAC", 5, b"AA", true, ShuffleDirection::ThreePrime).is_none(),
+            insertion_to_repeat(
+                b"CAAAAAC",
+                5,
+                b"AA",
+                true,
+                None,
+                ShuffleDirection::ThreePrime
+            )
+            .is_none(),
             "coding non-codon-aligned expansion must not be repeat notation"
         );
         match normalize_repeat(
@@ -3679,7 +3729,8 @@ mod tests {
         // insertion point. pos=7 means insert between index 7 and 8 — i.e.,
         // immediately after the last A in the homopolymer. Inserting AA here
         // should become A[7] (5 ref + 2 inserted).
-        let result = insertion_to_repeat(ref_seq, 7, b"AA", false, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 7, b"AA", false, None, ShuffleDirection::ThreePrime);
         assert!(result.is_some());
         let (base, count, start, end, _unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -3688,15 +3739,18 @@ mod tests {
         assert_eq!(end, 8); // 1-indexed end of A region in reference (per HGVS, positions refer to reference tract)
 
         // Single-copy inserts (added_copies < 2) are duplications, not repeats.
-        let result = insertion_to_repeat(ref_seq, 7, b"A", false, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 7, b"A", false, None, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Inserting T (non-matching) should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"T", false, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 7, b"T", false, None, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Inserting mixed bases should return None
-        let result = insertion_to_repeat(ref_seq, 7, b"AT", false, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 7, b"AT", false, None, ShuffleDirection::ThreePrime);
         assert!(result.is_none());
 
         // Multi-base tandem unit: insert ACAC into ACAC tract → AC[4].
@@ -3704,7 +3758,14 @@ mod tests {
         // (pos=3, between A at index 3 and base at index 4). Expected:
         // 2 ref AC units + 2 inserted AC units = AC[4] at ref indices 0..3.
         let ref_ac = b"ACACGGG";
-        let result = insertion_to_repeat(ref_ac, 3, b"ACAC", false, ShuffleDirection::ThreePrime);
+        let result = insertion_to_repeat(
+            ref_ac,
+            3,
+            b"ACAC",
+            false,
+            None,
+            ShuffleDirection::ThreePrime,
+        );
         assert!(result.is_some());
         let (base, count, start, end, unit) = result.unwrap();
         assert_eq!(base, b'A');
@@ -4334,7 +4395,8 @@ mod tests {
         // emit A[7], but unit_len=1 is not a multiple of 3 in c. context,
         // so the gate returns None.
         let ref_seq = b"CAAAAAC";
-        let result = insertion_to_repeat(ref_seq, 5, b"AA", true, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 5, b"AA", true, None, ShuffleDirection::ThreePrime);
         assert!(
             result.is_none(),
             "is_coding=true + unit_len=1 must return None"
@@ -4346,7 +4408,14 @@ mod tests {
         // Reference: AT[3] tandem flanked by Cs. Insert ATAT → unit_len=2,
         // gate blocks in coding context.
         let ref_seq = b"CATATATC";
-        let result = insertion_to_repeat(ref_seq, 6, b"ATAT", true, ShuffleDirection::ThreePrime);
+        let result = insertion_to_repeat(
+            ref_seq,
+            6,
+            b"ATAT",
+            true,
+            None,
+            ShuffleDirection::ThreePrime,
+        );
         assert!(
             result.is_none(),
             "is_coding=true + unit_len=2 must return None"
@@ -4358,7 +4427,14 @@ mod tests {
         // Reference: CAG[3] tandem. Insert CAGCAG → unit_len=3, codon-aligned,
         // gate passes; result is Some(...) carrying CAG[5].
         let ref_seq = b"CCAGCAGCAGT";
-        let result = insertion_to_repeat(ref_seq, 9, b"CAGCAG", true, ShuffleDirection::ThreePrime);
+        let result = insertion_to_repeat(
+            ref_seq,
+            9,
+            b"CAGCAG",
+            true,
+            None,
+            ShuffleDirection::ThreePrime,
+        );
         assert!(
             result.is_some(),
             "is_coding=true + unit_len=3 must allow rewrite"
@@ -4373,7 +4449,8 @@ mod tests {
         // Same A-homopolymer case as the blocking test, but is_coding=false
         // → gate is a no-op, repeat rewrite proceeds.
         let ref_seq = b"CAAAAAC";
-        let result = insertion_to_repeat(ref_seq, 5, b"AA", false, ShuffleDirection::ThreePrime);
+        let result =
+            insertion_to_repeat(ref_seq, 5, b"AA", false, None, ShuffleDirection::ThreePrime);
         assert!(result.is_some(), "is_coding=false must not gate");
     }
 
@@ -5400,7 +5477,9 @@ mod tests {
         // TGCGCA: insGCGC at the G|C cut (pos=1) is out of phase with the GC
         // tract; today it wrongly becomes GC[4]. Must be None now.
         let r = b"TGCGCA";
-        assert!(insertion_to_repeat(r, 1, b"GCGC", false, ShuffleDirection::ThreePrime).is_none());
+        assert!(
+            insertion_to_repeat(r, 1, b"GCGC", false, None, ShuffleDirection::ThreePrime).is_none()
+        );
     }
 
     #[test]
@@ -5408,7 +5487,7 @@ mod tests {
         // In-phase rotation insCGCG reaches the same GC[4] window and is preserved.
         let r = b"TGCGCA";
         let (_b, count, start, end, unit) =
-            insertion_to_repeat(r, 1, b"CGCG", false, ShuffleDirection::ThreePrime)
+            insertion_to_repeat(r, 1, b"CGCG", false, None, ShuffleDirection::ThreePrime)
                 .expect("in-phase should convert");
         assert_eq!(count, 4);
         assert_eq!((start, end), (2, 5));

--- a/tests/it/issue_1210_repeat_gate_tract_span.rs
+++ b/tests/it/issue_1210_repeat_gate_tract_span.rs
@@ -1,0 +1,180 @@
+//! Issue #1210: the codon-frame gate must be answered for the span the emitted
+//! **repeat** occupies, not for the span the input edit occupied.
+//!
+//! ## The defect
+//!
+//! `normalize_na_edit` receives `is_coding` — a verdict precomputed for the
+//! *input* edit's span — and the insertion→repeat site passed it straight to
+//! `rules::insertion_to_repeat`. That is the wrong question whenever the edit
+//! 3'-shifts out of the CDS: the input is CDS-resident, so the gate fires and
+//! suppresses repeat notation, but the tract the repeat would occupy is in the
+//! 3'UTR, where `RNA/repeated.md` L24-27's codon constraint does not apply.
+//!
+//! A second pass, whose input is by then UTR-resident, computes `is_coding =
+//! false` and emits the repeat — so the two passes disagreed:
+//!
+//! ```text
+//! r.15delinsgaa -> r.*1_*2insaa -> r.*1a[3]
+//! ```
+//!
+//! `cds_span` already existed for exactly this — its contract is that it "lets
+//! a site that decides about a DIFFERENT span ask about that span instead"
+//! (#1185). This is the second site to need it.
+//!
+//! ## Which answer is correct
+//!
+//! `r.*1a[3]`. The tract is entirely 3'UTR-resident, so the CDS-only
+//! prohibition on a 1-nt repeat unit does not reach it, and it is the fixed
+//! point both passes now agree on. Pass 1's suppression was the error, not pass
+//! 2's spelling.
+//!
+//! Found by the widened idempotency fuzz in #1180, at ~150k cases — well past
+//! the 12k that suite runs by default, which is why `FERRO_ASSERT_IDEMPOTENT=1`
+//! plus a soak are the gates that actually cover this class.
+
+use crate::common::synthetic::{SyntheticBuilder, PAD_OFFSET};
+use ferro_hgvs::reference::transcript::Strand;
+use ferro_hgvs::{parse_hgvs, HgvsVariant, MockProvider, Normalizer};
+
+/// The proptest-reduced fixture: a coding transcript whose CDS is exactly
+/// `core`, wrapped in a real `ACGT…` 5'UTR and 3'UTR.
+///
+/// The padding is built locally rather than via `common::synthetic::padded`,
+/// which is private on this branch. The `ACGT` period-4 pad is what bounds the
+/// tract: the base immediately 3' of the CDS is `A` and the next is `C`, so an
+/// `a` tract running out of the CDS terminates one base into the UTR.
+fn coding_transcript_with_utrs(core: &str, strand: Strand) -> MockProvider {
+    let pad = "ACGT".repeat(64);
+    assert_eq!(pad.len() as u64, PAD_OFFSET, "pad must be PAD_OFFSET bases");
+    let sequence = format!("{pad}{core}{pad}");
+    let len = core.len() as u64;
+    SyntheticBuilder::cds(&sequence, PAD_OFFSET + 1, PAD_OFFSET + len, strand).build()
+}
+
+/// `CCCCAACACACGGGG` — 15 bases, so `cds_end` is `r.15`/`c.15` (a `G`), and the
+/// 3'UTR begins `A C G T`. A `delins` at the last CDS base that reduces to an
+/// insertion of `aa` therefore shifts into the UTR and meets the lone `A` at
+/// `*1`, forming an `a[3]` tract wholly outside the CDS.
+const CORE: &str = "CCCCAACACACGGGG";
+
+fn normalize_twice(provider: MockProvider, input: &str) -> (String, String) {
+    let normalizer = Normalizer::new(provider);
+    let variant: HgvsVariant = parse_hgvs(input).expect("parse failed");
+    let once = normalizer
+        .normalize(&variant)
+        .expect("first normalize failed");
+    let twice = normalizer.normalize(&once).expect("re-normalize failed");
+    (once.to_string(), twice.to_string())
+}
+
+/// The reported case: repeat notation is emitted on the **first** pass, because
+/// the tract it describes is 3'UTR-resident even though the input was not.
+#[test]
+fn rna_repeat_gate_uses_the_tract_span_not_the_input_span() {
+    assert_eq!(CORE.len(), 15, "cds_end must be r.15");
+    let (once, twice) = normalize_twice(
+        coding_transcript_with_utrs(CORE, Strand::Plus),
+        "NM_TEST.1:r.15delinsgaa",
+    );
+    assert_eq!(
+        once, "NM_TEST.1:r.*1a[3]",
+        "pass 1 must emit the repeat: the tract is in the 3'UTR, not the CDS"
+    );
+    assert_eq!(twice, once, "and it is a fixed point");
+}
+
+/// The `c.` spelling goes through the same site, so it must move with it. On a
+/// coding transcript `r.` *is* the `c.` axis (#469), so this is the same edit
+/// over the byte-identical transcript, and the two must agree.
+#[test]
+fn cds_spelling_agrees_with_the_rna_spelling() {
+    let (c_once, c_twice) = normalize_twice(
+        coding_transcript_with_utrs(CORE, Strand::Plus),
+        "NM_TEST.1:c.15delinsGAA",
+    );
+    assert_eq!(c_once, "NM_TEST.1:c.*1A[3]");
+    assert_eq!(c_twice, c_once, "and is a fixed point");
+
+    let (r_once, _) = normalize_twice(
+        coding_transcript_with_utrs(CORE, Strand::Plus),
+        "NM_TEST.1:r.15delinsgaa",
+    );
+    // Compare only the position+edit tail, so the accession is not folded: the
+    // axes differ exactly by the prefix and the DNA/RNA alphabet.
+    let c_tail = c_once.split_once("c.").expect("c. prefix").1.to_lowercase();
+    let r_tail = r_once.split_once("r.").expect("r. prefix").1;
+    assert_eq!(
+        c_tail, r_tail,
+        "the two spellings of one axis must name the same edit"
+    );
+}
+
+/// Present on the minus strand too, so the fix is not strand-specific.
+#[test]
+fn rna_repeat_gate_tract_span_on_minus_strand() {
+    let (once, twice) = normalize_twice(
+        coding_transcript_with_utrs(CORE, Strand::Minus),
+        "NM_TEST.1:r.15delinsgaa",
+    );
+    assert_eq!(once, "NM_TEST.1:r.*1a[3]");
+    assert_eq!(twice, once, "and is a fixed point");
+}
+
+// ---------------------------------------------------------------------------
+// Guards: the gate must still fire where it should. Re-answering the question
+// for the tract is only correct if a CDS-resident tract still gets gated.
+// ---------------------------------------------------------------------------
+
+/// **The gate is still armed.** The same shape with the tract kept *inside* the
+/// CDS must still be refused repeat notation, because a 1-nt repeat unit in the
+/// CDS is spec-forbidden (`RNA/repeated.md` L24-27, the #1192 gate).
+///
+/// `CCCCAAAAAAAAGGGG` puts a long `A` run at `c.5..c.12`, comfortably interior,
+/// so an inserted `aa` forms a tract that never approaches `cds_end`.
+#[test]
+fn interior_tract_is_still_codon_gated() {
+    let (once, twice) = normalize_twice(
+        coding_transcript_with_utrs("CCCCAAAAAAAAGGGG", Strand::Plus),
+        "NM_TEST.1:r.11_12insaa",
+    );
+    // Gated: the tract is CDS-resident and the unit is 1 nt, so the expansion
+    // stays a literal insertion, 3'-shifted to the end of the `A` run at `c.12`.
+    assert_eq!(
+        once, "NM_TEST.1:r.12_13insaa",
+        "a CDS-interior 1-nt tract must stay an insertion, not become a repeat"
+    );
+    assert_eq!(twice, once, "and is a fixed point");
+}
+
+/// The non-coding axis has no CDS at all, so `cds_span` is `None` and the
+/// helper keeps the caller's verdict verbatim — the `None` branch of the fix.
+///
+/// This doubles as an **independent oracle for the headline case**. `NR_TEST.1`
+/// carries the byte-identical sequence, and `n.271` is the same base as `r.15`
+/// (both are transcript position `PAD_OFFSET + 15`), so `n.271delinsGAA` is the
+/// same edit over the same bases — but reached with the gate never consulted at
+/// all, rather than consulted and answered `false`. It lands on the repeat, at
+/// the transcript position `r.*1` denotes:
+///
+/// ```text
+/// n.271delinsGAA -> n.272A[3]      (no CDS, gate never consulted)
+/// r.15delinsgaa  -> r.*1a[3]       (CDS present, gate answered for the tract)
+/// ```
+///
+/// Before the fix these two disagreed, which is the clearest statement that the
+/// `r.` answer was wrong rather than merely differently spelled.
+#[test]
+fn noncoding_axis_is_unaffected() {
+    let pad = "ACGT".repeat(64);
+    let provider = SyntheticBuilder::noncoding(&format!("{pad}{CORE}{pad}"), Strand::Plus).build();
+    let (once, twice) = normalize_twice(provider, "NR_TEST.1:n.271delinsGAA");
+    assert_eq!(
+        once, "NR_TEST.1:n.272A[3]",
+        "with no CDS the gate never fires, so the repeat is emitted directly"
+    );
+    assert_eq!(twice, once, "n. normalization is idempotent here");
+
+    // The `n.` position and the `r.` `*N` position name the same base:
+    // `n.272` == transcript `PAD_OFFSET + 16` == `r.*1` (cds_end is at +15).
+    assert_eq!(PAD_OFFSET + 16, 272, "n.272 must be the base r.*1 denotes");
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -137,6 +137,7 @@ mod issue_1192_rna_codon_frame_gate;
 mod issue_1202_transcript_bounds_insertion_clamp;
 mod issue_1207_rna_cds_boundary_clamp;
 mod issue_1209_cds_end_insertion_shift;
+mod issue_1210_repeat_gate_tract_span;
 mod issue_129_mt_circular_wraparound;
 mod issue_132_cyclic_rotation_insertion;
 mod issue_163_rna_utr3_flag;


### PR DESCRIPTION
The codon-frame gate was answered for the span the *input* edit occupied rather than the span the emitted **repeat** occupies. Those differ exactly when an edit 3'-shifts out of the CDS, which made normalization non-idempotent there.

Closes #1210.

## The defect

`normalize_na_edit` receives `is_coding`, a verdict precomputed for the input edit's span, and the insertion→repeat site passed it straight through to `rules::insertion_to_repeat`. For a CDS-resident input the gate fires and suppresses repeat notation — but the tandem tract the repeat would describe can lie in the 3'UTR, where `RNA/repeated.md` L24-27's codon constraint does not apply. Pass 2, whose input is by then UTR-resident, computes `is_coding = false` and emits the repeat:

```
r.15delinsgaa  ->  r.*1_*2insaa  ->  r.*1a[3]
```

`r.*1a[3]` is the correct answer: the tract is wholly outside the CDS. Pass 1's suppression was the error, not pass 2's spelling.

## The fix

Thread `cds_span` into `insertion_to_repeat` and re-answer the gate against the tandem tract the helper discovers, rather than the caller's input-span verdict. This is not a new mechanism — `cds_span` was added by #1185 for precisely this, and its contract already says it "lets a site that decides about a DIFFERENT span ask about that span instead". This is simply the second site that needed it.

The change is **additive**: `None` keeps the caller's precomputed verdict verbatim, so callers with no CDS context (genomic, `n.`) and all thirteen existing `rules.rs` unit tests are unaffected by construction. Frames line up without conversion hazard — `ref_start`/`ref_end_excl` are 0-based indices into the transcript-frame `ref_seq`, and `cds_span` is 1-based inclusive in that same frame.

Production call sites touched: **one** (`src/normalize/mod.rs`). The other thirteen references are unit tests, updated mechanically to pass `None`.

## Guards

Re-answering the question for the tract is only correct if a CDS-resident tract still gets gated, so that is pinned explicitly:

- `interior_tract_is_still_codon_gated` — a 1-nt tract kept well inside the CDS must still be refused repeat notation (the #1192 gate).
- `noncoding_axis_is_unaffected` — exercises the `None` branch.
- `cds_spelling_agrees_with_the_rna_spelling` — the same site serves both axes, and on a coding transcript `r.` *is* the `c.` axis (#469), so they must move together: `c.*1A[3]` / `r.*1a[3]`.
- `rna_repeat_gate_tract_span_on_minus_strand` — not strand-specific.

## Verification

Branched from `main` at `5fec184` (#1211).

- Full suite **8636 passed, 0 failed, 145 skipped**, and identical under `FERRO_ASSERT_IDEMPOTENT=1`.
- **Zero regressions:** the pre-change suite on the same base was 8631/0, and the delta is exactly the 5 new tests. No existing expectation moved.
- `cargo clippy --all-features --all-targets -- -D warnings` clean; `cargo fmt --check` clean.

**Interop with #1180 (the important one).** This defect is not reachable from `main`'s proptest, which only fuzzes `g.`/`c.`; it was found by #1180's widened `n.`/`r.` generator at ~150k cases. Verified by stacking #1180's commit on this branch and replaying its recorded seed:

```
cc 8d1ceaa8… # Case { core: "CCCCAACACACGGGG", sys: RnaCodingPlus, hgvs: "NM_TEST.1:r.15delinsgaa" }
```

That seed fails against #1180 alone and passes stacked on this fix. Note the corollary: because the default 12k-case run reproduces this only ~8% of the time, a green `cargo nextest run` is *not* adequate coverage for this class — `FERRO_ASSERT_IDEMPOTENT=1` plus a soak is.

## Relationship to the rest of the campaign

Fourth instance of one root shape — a verdict computed for the input span applied to a shifted output — after #1185 (fixed by #1189), #1207 (#1208), and #1209 (#1211). #1206 folds `is_coding` + `cds_span` into a single `CodonGate` to make the wrong pairing unrepresentable, and is being done separately. Worth flagging for that work: a `CodonGate` that merely *bundles* the two fields does not subsume this fix — the gate has to be **resolved against the span being decided about**, which is what this PR adds.

This also unblocks #1180, which is currently held back by this bug.
